### PR TITLE
feat(frontend): auto-refresh task list on page visibility and WebSocket reconnect

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -76,6 +76,7 @@ export default function TaskSidebar({
     markAllTasksAsViewed,
     viewStatusVersion,
     setSelectedTask,
+    isRefreshing,
   } = useTaskContext()
   const scrollRef = useRef<HTMLDivElement>(null)
 
@@ -351,6 +352,28 @@ export default function TaskSidebar({
         className={`flex-1 ${isCollapsed ? 'px-0' : 'px-2.5'} pt-4 overflow-y-auto task-list-scrollbar border-t border-border mt-3`}
         ref={scrollRef}
       >
+        {/* Auto-refresh indicator - shows when refreshing after page visibility or reconnect */}
+        {isRefreshing && !isCollapsed && (
+          <div className="px-1 pb-2">
+            <div className="flex items-center gap-2 text-xs text-primary">
+              <div className="h-1 w-full bg-surface rounded-full overflow-hidden">
+                <div
+                  className="h-full bg-primary/60 rounded-full animate-pulse"
+                  style={{ width: '100%' }}
+                />
+              </div>
+              <span className="text-text-muted whitespace-nowrap">
+                {t('common:tasks.refreshing')}
+              </span>
+            </div>
+          </div>
+        )}
+        {/* Collapsed mode refresh indicator */}
+        {isRefreshing && isCollapsed && (
+          <div className="flex justify-center pb-2">
+            <div className="h-1 w-6 bg-primary/60 rounded-full animate-pulse" />
+          </div>
+        )}
         {/* Search Result Header */}
         {!isCollapsed && isSearchResult && (
           <div className="px-1 pb-2 flex items-center justify-between">

--- a/frontend/src/features/tasks/contexts/taskContext.tsx
+++ b/frontend/src/features/tasks/contexts/taskContext.tsx
@@ -26,6 +26,7 @@ import {
 } from '@/utils/taskViewStatus'
 import { useSocket } from '@/contexts/SocketContext'
 import { TaskCreatedPayload, TaskInvitedPayload, TaskStatusPayload } from '@/types/socket'
+import { usePageVisibility } from '@/hooks/usePageVisibility'
 
 type TaskContextType = {
   tasks: Task[]
@@ -60,6 +61,8 @@ type TaskContextType = {
   // Access denied state for 403 errors when accessing shared tasks
   accessDenied: boolean
   clearAccessDenied: () => void
+  // Refreshing state for auto-refresh indicator
+  isRefreshing: boolean
 }
 
 const TaskContext = createContext<TaskContextType | undefined>(undefined)
@@ -80,15 +83,23 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
   const [viewStatusVersion, setViewStatusVersion] = useState<number>(0)
   // Access denied state for 403 errors when accessing shared tasks
   const [accessDenied, setAccessDenied] = useState<boolean>(false)
+  // Refreshing state for auto-refresh (page visibility or WebSocket reconnect)
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
 
   // Track task status for notification
   const taskStatusMapRef = useRef<Map<number, TaskStatus>>(new Map())
 
   // WebSocket connection for real-time task updates
-  const { registerTaskHandlers, isConnected, leaveTask, joinTask } = useSocket()
+  const { registerTaskHandlers, isConnected, leaveTask, joinTask, onReconnect } = useSocket()
 
   // Track previous task ID for leaving WebSocket room when switching tasks
   const previousTaskIdRef = useRef<number | null>(null)
+
+  // Track if auto-refresh is in progress to prevent duplicate requests
+  const isAutoRefreshingRef = useRef<boolean>(false)
+
+  // Minimum hidden duration (30 seconds) before triggering refresh on page visibility
+  const MIN_HIDDEN_DURATION_MS = 30000
 
   // Pagination related - legacy combined list
   const [hasMore, setHasMore] = useState(true)
@@ -322,6 +333,55 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
     refreshTasks()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  /**
+   * Auto-refresh task list with debounce protection.
+   * Called when page becomes visible after being hidden or when WebSocket reconnects.
+   */
+  const triggerAutoRefresh = useCallback(async () => {
+    // Prevent duplicate refreshes
+    if (isAutoRefreshingRef.current) {
+      console.log('[TaskContext] Auto-refresh already in progress, skipping')
+      return
+    }
+
+    isAutoRefreshingRef.current = true
+    setIsRefreshing(true)
+    console.log('[TaskContext] Starting auto-refresh...')
+
+    try {
+      await refreshTasks()
+      console.log('[TaskContext] Auto-refresh completed')
+    } catch (error) {
+      // Silent error handling - don't affect user operation
+      console.error('[TaskContext] Auto-refresh failed:', error)
+    } finally {
+      isAutoRefreshingRef.current = false
+      setIsRefreshing(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Page visibility recovery: refresh task list when page becomes visible after 30+ seconds hidden
+  usePageVisibility({
+    minHiddenTime: MIN_HIDDEN_DURATION_MS,
+    onVisible: (wasHiddenFor: number) => {
+      console.log(`[TaskContext] Page became visible after ${wasHiddenFor}ms hidden`)
+      if (wasHiddenFor >= MIN_HIDDEN_DURATION_MS) {
+        triggerAutoRefresh()
+      }
+    },
+  })
+
+  // WebSocket reconnect recovery: refresh task list when WebSocket reconnects
+  useEffect(() => {
+    const unsubscribe = onReconnect(() => {
+      console.log('[TaskContext] WebSocket reconnected, refreshing task list...')
+      triggerAutoRefresh()
+    })
+
+    return unsubscribe
+  }, [onReconnect, triggerAutoRefresh])
 
   // Handle new task created via WebSocket
   const handleTaskCreated = useCallback((data: TaskCreatedPayload) => {
@@ -776,6 +836,7 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
         viewStatusVersion,
         accessDenied,
         clearAccessDenied,
+        isRefreshing,
       }}
     >
       {children}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -396,6 +396,7 @@
     "cancel_task": "Cancel Task",
     "delete_task": "Delete Task",
     "searching": "Searching...",
+    "refreshing": "Syncing...",
     "press_enter_to_search": "Press Enter to search",
     "search_hint": "Enter keywords to search conversations",
     "clear_search": "Clear",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -396,6 +396,7 @@
     "cancel_task": "取消任务",
     "delete_task": "删除任务",
     "searching": "搜索中...",
+    "refreshing": "同步中...",
     "press_enter_to_search": "按 Enter 键搜索",
     "search_hint": "输入关键词搜索对话",
     "clear_search": "清除",


### PR DESCRIPTION
## Summary

- Implement auto-refresh mechanism for task list when page becomes visible after being hidden for 30+ seconds (mobile app background switching, browser tab switching)
- Implement auto-refresh when WebSocket reconnects to recover from network disconnection
- Add subtle loading indicator in the sidebar to show refresh progress
- Single source of truth for reconnection events via SocketContext's onReconnect callback

## Changes

### SocketContext.tsx
- Add `ReconnectCallback` type and `onReconnect` callback registration mechanism
- Use `reconnectCallbacksRef` to store callbacks for reconnection events
- Notify all registered callbacks when WebSocket reconnects

### TaskContext.tsx
- Import and use `usePageVisibility` hook for page visibility detection
- Add `isRefreshing` state for UI indicator
- Add `triggerAutoRefresh` function with debounce protection (using ref to prevent duplicate requests)
- Listen to WebSocket reconnect via `onReconnect` callback
- Minimum hidden duration threshold: 30 seconds

### TaskSidebar.tsx
- Add auto-refresh indicator UI using animated progress bar
- Support both expanded and collapsed sidebar modes
- Use Calm UI style with teal primary color and subtle animation

### i18n translations
- Add `refreshing` key: "Syncing..." (en) / "同步中..." (zh-CN)

## Test plan

- [ ] Hide page for less than 30 seconds, then show - should NOT trigger refresh
- [ ] Hide page for more than 30 seconds, then show - should trigger refresh with loading indicator
- [ ] Disconnect WebSocket, then reconnect - should trigger refresh with loading indicator
- [ ] Trigger refresh while another refresh is in progress - should NOT duplicate the request
- [ ] Refresh fails - should NOT affect normal page operation (silent error handling)
- [ ] Loading indicator hides correctly after refresh completes