### PR TITLE
feat(marketplace): implement agent marketplace feature

### DIFF
--- a/backend/alembic/versions/q7r8s9t0u1v2_add_marketplace_tables.py
+++ b/backend/alembic/versions/q7r8s9t0u1v2_add_marketplace_tables.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add marketplace tables for Agent Marketplace feature
+
+Revision ID: q7r8s9t0u1v2
+Revises: p6q7r8s9t0u1
+Create Date: 2025-01-11 10:00:00.000000
+
+This migration adds:
+1. team_marketplace table for marketplace team extended information
+2. installed_teams table for user installation records
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "q7r8s9t0u1v2"
+down_revision: Union[str, None] = "p6q7r8s9t0u1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create team_marketplace and installed_teams tables."""
+
+    # Create team_marketplace table
+    op.execute(
+        """
+    CREATE TABLE IF NOT EXISTS team_marketplace (
+        id INT NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
+        team_id INT NOT NULL COMMENT 'Reference to kinds.id (user_id=0 Team)',
+        category VARCHAR(50) NOT NULL DEFAULT 'other' COMMENT 'Category: development, office, creative, data_analysis, education, other',
+        description TEXT NULL COMMENT 'Marketplace display description',
+        icon VARCHAR(100) NULL COMMENT 'Marketplace display icon',
+        allow_reference TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'Allow reference mode installation',
+        allow_copy TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'Allow copy mode installation',
+        install_count INT NOT NULL DEFAULT 0 COMMENT 'Installation count for statistics',
+        is_active TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'Is published/active',
+        published_at DATETIME NULL COMMENT 'Publish timestamp',
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Creation timestamp',
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Last update timestamp',
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_team_id (team_id),
+        KEY idx_tm_category (category),
+        KEY idx_tm_is_active (is_active)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """
+    )
+
+    # Create installed_teams table
+    op.execute(
+        """
+    CREATE TABLE IF NOT EXISTS installed_teams (
+        id INT NOT NULL AUTO_INCREMENT COMMENT 'Primary key',
+        user_id INT NOT NULL COMMENT 'Installing user ID',
+        marketplace_team_id INT NOT NULL COMMENT 'Reference to team_marketplace.id',
+        install_mode VARCHAR(20) NOT NULL DEFAULT 'reference' COMMENT 'Installation mode: reference or copy',
+        copied_team_id INT NULL COMMENT 'Team ID in user space for copy mode',
+        is_active TINYINT(1) NOT NULL DEFAULT 1 COMMENT 'Is active (false when uninstalled)',
+        installed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Installation timestamp',
+        uninstalled_at DATETIME NULL COMMENT 'Uninstallation timestamp',
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_it_user_marketplace (user_id, marketplace_team_id),
+        KEY idx_it_user_id (user_id),
+        KEY idx_it_is_active (is_active)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """
+    )
+
+
+def downgrade() -> None:
+    """Drop team_marketplace and installed_teams tables."""
+    op.execute("DROP TABLE IF EXISTS installed_teams")
+    op.execute("DROP TABLE IF EXISTS team_marketplace")

--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -9,6 +9,7 @@ from app.api.endpoints import (
     groups,
     health,
     knowledge,
+    marketplace,
     oidc,
     openapi_responses,
     quota,
@@ -96,6 +97,9 @@ api_router.include_router(
 api_router.include_router(tables.router, prefix="/tables", tags=["tables"])
 api_router.include_router(rag.router, prefix="/rag", tags=["rag"])
 api_router.include_router(utils.router, prefix="/utils", tags=["utils"])
+api_router.include_router(
+    marketplace.router, prefix="/marketplace", tags=["marketplace"]
+)
 api_router.include_router(k_router)
 
 # Internal API endpoints (for service-to-service communication)

--- a/backend/app/api/endpoints/marketplace.py
+++ b/backend/app/api/endpoints/marketplace.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Marketplace API endpoints for Agent Marketplace feature.
+
+This module provides:
+- Public endpoints for browsing and installing marketplace teams
+- Admin endpoints for publishing and managing marketplace teams
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.core.security import get_admin_user
+from app.models.user import User
+from app.schemas.marketplace import (
+    CategoryListResponse,
+    InstalledTeamListResponse,
+    InstallTeamRequest,
+    InstallTeamResponse,
+    MarketplaceTeamDetail,
+    MarketplaceTeamListResponse,
+    PublishTeamRequest,
+    UninstallTeamResponse,
+    UpdateMarketplaceTeamRequest,
+)
+from app.services.marketplace_service import marketplace_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ==================== Public Endpoints ====================
+
+
+@router.get("/teams", response_model=MarketplaceTeamListResponse)
+def list_marketplace_teams(
+    page: int = Query(1, ge=1, description="Page number"),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    search: Optional[str] = Query(None, description="Search keyword"),
+    category: Optional[str] = Query(None, description="Category filter"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get marketplace teams list with pagination, search, and filtering.
+
+    All logged-in users can browse the marketplace.
+    """
+    items, total = marketplace_service.get_marketplace_teams(
+        db=db,
+        user_id=current_user.id,
+        page=page,
+        limit=limit,
+        search=search,
+        category=category,
+    )
+    return MarketplaceTeamListResponse(total=total, items=items)
+
+
+@router.get("/teams/{marketplace_id}", response_model=MarketplaceTeamDetail)
+def get_marketplace_team_detail(
+    marketplace_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get detailed information for a marketplace team.
+
+    All logged-in users can view team details.
+    """
+    return marketplace_service.get_marketplace_team_detail(
+        db=db, marketplace_id=marketplace_id, user_id=current_user.id
+    )
+
+
+@router.get("/categories", response_model=CategoryListResponse)
+def list_categories(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get all categories with their team counts.
+    """
+    categories = marketplace_service.get_categories(db=db)
+    return CategoryListResponse(categories=categories)
+
+
+# ==================== Installation Endpoints ====================
+
+
+@router.post(
+    "/teams/{marketplace_id}/install",
+    response_model=InstallTeamResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def install_team(
+    marketplace_id: int,
+    request: InstallTeamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Install a marketplace team.
+
+    Users can choose between reference mode (direct use, auto-sync) or
+    copy mode (private copy, can modify).
+    """
+    return marketplace_service.install_team(
+        db=db,
+        marketplace_id=marketplace_id,
+        user_id=current_user.id,
+        request=request,
+    )
+
+
+@router.delete(
+    "/teams/{marketplace_id}/uninstall", response_model=UninstallTeamResponse
+)
+def uninstall_team(
+    marketplace_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Uninstall a marketplace team.
+
+    For reference mode: removes from user's team list.
+    For copy mode: marks as uninstalled but keeps the copied team (user can delete manually).
+    """
+    return marketplace_service.uninstall_team(
+        db=db, marketplace_id=marketplace_id, user_id=current_user.id
+    )
+
+
+@router.get("/installed", response_model=InstalledTeamListResponse)
+def list_installed_teams(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get user's installed marketplace teams.
+    """
+    items = marketplace_service.get_user_installed_teams(db=db, user_id=current_user.id)
+    return InstalledTeamListResponse(total=len(items), items=items)
+
+
+# ==================== Admin Endpoints ====================
+
+
+@router.post("/admin/teams", status_code=status.HTTP_201_CREATED)
+def publish_team_to_marketplace(
+    request: PublishTeamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_admin_user),
+):
+    """
+    Publish a team to the marketplace (admin only).
+
+    The team must have user_id=0 (system team).
+    """
+    mp_team = marketplace_service.publish_team(db=db, request=request)
+    return {"success": True, "marketplace_id": mp_team.id, "team_id": mp_team.team_id}
+
+
+@router.put("/admin/teams/{marketplace_id}")
+def update_marketplace_team(
+    marketplace_id: int,
+    request: UpdateMarketplaceTeamRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_admin_user),
+):
+    """
+    Update marketplace team information (admin only).
+    """
+    mp_team = marketplace_service.update_marketplace_team(
+        db=db, marketplace_id=marketplace_id, request=request
+    )
+    return {"success": True, "marketplace_id": mp_team.id}
+
+
+@router.delete("/admin/teams/{marketplace_id}")
+def unpublish_marketplace_team(
+    marketplace_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_admin_user),
+):
+    """
+    Unpublish/deactivate a marketplace team (admin only).
+
+    This soft-deletes the marketplace entry. Existing installations
+    will still work but the team won't appear in marketplace listings.
+    """
+    marketplace_service.unpublish_team(db=db, marketplace_id=marketplace_id)
+    return {"success": True, "message": "Team unpublished from marketplace"}
+
+
+@router.get("/admin/teams")
+def list_admin_marketplace_teams(
+    page: int = Query(1, ge=1, description="Page number"),
+    limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    include_inactive: bool = Query(True, description="Include inactive teams"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_admin_user),
+):
+    """
+    Get all marketplace teams for admin management (admin only).
+
+    Includes inactive teams by default.
+    """
+    items, total = marketplace_service.get_admin_marketplace_teams(
+        db=db, page=page, limit=limit, include_inactive=include_inactive
+    )
+    return {"total": total, "items": items}

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ Models with relationships should be imported after their related models.
 from app.models.api_key import APIKey
 from app.models.kind import Kind
 from app.models.knowledge import KnowledgeDocument
+from app.models.marketplace import InstalledTeam, TeamMarketplace
 from app.models.namespace import Namespace
 from app.models.namespace_member import NamespaceMember
 from app.models.shared_task import SharedTask
@@ -42,4 +43,6 @@ __all__ = [
     "APIKey",
     "TaskMember",
     "KnowledgeDocument",
+    "TeamMarketplace",
+    "InstalledTeam",
 ]

--- a/backend/app/models/marketplace.py
+++ b/backend/app/models/marketplace.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Marketplace models for Agent Marketplace feature.
+
+This module defines the database models for:
+- TeamMarketplace: Extended information for marketplace teams (user_id=0)
+- InstalledTeam: User installation records for marketplace teams
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, Text
+
+from app.db.base import Base
+
+
+class MarketplaceCategory(str, Enum):
+    """Predefined categories for marketplace teams"""
+
+    DEVELOPMENT = "development"  # Development tools
+    OFFICE = "office"  # Office productivity
+    CREATIVE = "creative"  # Creative tools
+    DATA_ANALYSIS = "data_analysis"  # Data analysis
+    EDUCATION = "education"  # Education
+    OTHER = "other"  # Other
+
+
+class InstallMode(str, Enum):
+    """Installation modes for marketplace teams"""
+
+    REFERENCE = "reference"  # Direct reference, cannot modify
+    COPY = "copy"  # Copy to user space, can modify
+
+
+class TeamMarketplace(Base):
+    """
+    Extended information for marketplace teams.
+
+    Marketplace teams are teams with user_id=0 that are published
+    to the marketplace for all users to browse and install.
+    """
+
+    __tablename__ = "team_marketplace"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_id = Column(Integer, nullable=False, unique=True)  # Reference to kinds.id
+    category = Column(
+        String(50), nullable=False, default=MarketplaceCategory.OTHER.value
+    )
+    description = Column(Text, nullable=True)  # Marketplace display description
+    icon = Column(String(100), nullable=True)  # Marketplace display icon
+    allow_reference = Column(Boolean, default=True)  # Allow reference mode
+    allow_copy = Column(Boolean, default=True)  # Allow copy mode
+    install_count = Column(Integer, default=0)  # Installation count for statistics
+    is_active = Column(Boolean, default=True)  # Is published/active
+    published_at = Column(DateTime, nullable=True)  # Publish time
+    created_at = Column(DateTime, default=datetime.now)
+    updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
+
+    __table_args__ = (
+        Index("idx_tm_category", "category"),
+        Index("idx_tm_is_active", "is_active"),
+        {
+            "mysql_engine": "InnoDB",
+            "mysql_charset": "utf8mb4",
+            "mysql_collate": "utf8mb4_unicode_ci",
+        },
+    )
+
+
+class InstalledTeam(Base):
+    """
+    User installation records for marketplace teams.
+
+    Tracks which marketplace teams each user has installed,
+    the installation mode (reference or copy), and the copied
+    team ID if using copy mode.
+    """
+
+    __tablename__ = "installed_teams"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, nullable=False, index=True)  # Installing user
+    marketplace_team_id = Column(
+        Integer, nullable=False
+    )  # Reference to team_marketplace.id
+    install_mode = Column(
+        String(20), nullable=False, default=InstallMode.REFERENCE.value
+    )
+    copied_team_id = Column(
+        Integer, nullable=True
+    )  # Team ID in user space for copy mode
+    is_active = Column(Boolean, default=True)  # Is active (false when uninstalled)
+    installed_at = Column(DateTime, default=datetime.now)
+    uninstalled_at = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "uk_it_user_marketplace",
+            "user_id",
+            "marketplace_team_id",
+            unique=True,
+        ),
+        Index("idx_it_user_id", "user_id"),
+        Index("idx_it_is_active", "is_active"),
+        {
+            "mysql_engine": "InnoDB",
+            "mysql_charset": "utf8mb4",
+            "mysql_collate": "utf8mb4_unicode_ci",
+        },
+    )

--- a/backend/app/schemas/marketplace.py
+++ b/backend/app/schemas/marketplace.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Marketplace schemas for Agent Marketplace feature.
+
+This module defines the Pydantic schemas for:
+- Marketplace team listing and detail responses
+- Installation/uninstallation requests
+- Admin publishing requests
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MarketplaceCategory(str, Enum):
+    """Predefined categories for marketplace teams"""
+
+    DEVELOPMENT = "development"
+    OFFICE = "office"
+    CREATIVE = "creative"
+    DATA_ANALYSIS = "data_analysis"
+    EDUCATION = "education"
+    OTHER = "other"
+
+
+class InstallMode(str, Enum):
+    """Installation modes for marketplace teams"""
+
+    REFERENCE = "reference"
+    COPY = "copy"
+
+
+# ==================== Request Schemas ====================
+
+
+class InstallTeamRequest(BaseModel):
+    """Request schema for installing a marketplace team"""
+
+    mode: InstallMode = Field(
+        default=InstallMode.REFERENCE, description="Installation mode"
+    )
+
+
+class PublishTeamRequest(BaseModel):
+    """Request schema for publishing a team to marketplace (admin only)"""
+
+    team_id: int = Field(..., description="Team ID to publish (must be user_id=0)")
+    category: MarketplaceCategory = Field(
+        default=MarketplaceCategory.OTHER, description="Marketplace category"
+    )
+    description: Optional[str] = Field(
+        None, description="Marketplace display description"
+    )
+    icon: Optional[str] = Field(None, description="Marketplace display icon")
+    allow_reference: bool = Field(True, description="Allow reference mode installation")
+    allow_copy: bool = Field(True, description="Allow copy mode installation")
+
+
+class UpdateMarketplaceTeamRequest(BaseModel):
+    """Request schema for updating marketplace team info (admin only)"""
+
+    category: Optional[MarketplaceCategory] = Field(None, description="Category")
+    description: Optional[str] = Field(None, description="Description")
+    icon: Optional[str] = Field(None, description="Icon")
+    allow_reference: Optional[bool] = Field(None, description="Allow reference mode")
+    allow_copy: Optional[bool] = Field(None, description="Allow copy mode")
+    is_active: Optional[bool] = Field(None, description="Is active/published")
+
+
+# ==================== Response Schemas ====================
+
+
+class MarketplaceTeamBase(BaseModel):
+    """Base schema for marketplace team"""
+
+    id: int
+    team_id: int
+    name: str
+    category: str
+    description: Optional[str] = None
+    icon: Optional[str] = None
+    allow_reference: bool = True
+    allow_copy: bool = True
+    install_count: int = 0
+    is_active: bool = True
+    published_at: Optional[datetime] = None
+
+
+class MarketplaceTeamListItem(MarketplaceTeamBase):
+    """Schema for marketplace team list item"""
+
+    # Extended fields from Team CRD
+    bind_mode: Optional[List[str]] = None
+    agent_type: Optional[str] = None
+    bots_count: int = 0
+
+    # User installation status
+    is_installed: bool = False
+    installed_mode: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class MarketplaceTeamDetail(MarketplaceTeamListItem):
+    """Schema for marketplace team detail"""
+
+    # Full team data
+    team_data: Optional[Dict[str, Any]] = None
+    # Bot details
+    bots: Optional[List[Dict[str, Any]]] = None
+
+    class Config:
+        from_attributes = True
+
+
+class MarketplaceTeamListResponse(BaseModel):
+    """Response schema for marketplace team list"""
+
+    total: int
+    items: List[MarketplaceTeamListItem]
+
+
+class InstalledTeamBase(BaseModel):
+    """Base schema for installed team"""
+
+    id: int
+    user_id: int
+    marketplace_team_id: int
+    install_mode: str
+    copied_team_id: Optional[int] = None
+    is_active: bool = True
+    installed_at: datetime
+    uninstalled_at: Optional[datetime] = None
+
+
+class InstalledTeamResponse(InstalledTeamBase):
+    """Response schema for installed team"""
+
+    # Extended marketplace team info
+    marketplace_team: Optional[MarketplaceTeamListItem] = None
+
+    class Config:
+        from_attributes = True
+
+
+class InstalledTeamListResponse(BaseModel):
+    """Response schema for installed team list"""
+
+    total: int
+    items: List[InstalledTeamResponse]
+
+
+class InstallTeamResponse(BaseModel):
+    """Response schema for install operation"""
+
+    success: bool
+    message: str
+    installed_team_id: int
+    install_mode: str
+    # For copy mode, the new team ID in user space
+    copied_team_id: Optional[int] = None
+
+
+class UninstallTeamResponse(BaseModel):
+    """Response schema for uninstall operation"""
+
+    success: bool
+    message: str
+
+
+class CategoryItem(BaseModel):
+    """Schema for category list item"""
+
+    value: str
+    label: str
+    count: int = 0
+
+
+class CategoryListResponse(BaseModel):
+    """Response schema for category list"""
+
+    categories: List[CategoryItem]
+
+
+# ==================== Admin Response Schemas ====================
+
+
+class AdminMarketplaceTeamResponse(MarketplaceTeamDetail):
+    """Response schema for admin marketplace team (includes all fields)"""
+
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class AdminMarketplaceTeamListResponse(BaseModel):
+    """Response schema for admin marketplace team list"""
+
+    total: int
+    items: List[AdminMarketplaceTeamResponse]

--- a/backend/app/schemas/team.py
+++ b/backend/app/schemas/team.py
@@ -81,7 +81,9 @@ class TeamInDB(TeamBase):
     created_at: datetime
     updated_at: datetime
     user: Optional[dict[str, Any]] = None
-    share_status: int = 0  # 0-private, 1-sharing, 2-shared from others
+    share_status: int = (
+        0  # 0-private, 1-sharing, 2-shared from others, 3-marketplace installed
+    )
     agent_type: Optional[str] = None  # agno, claude, dify, etc.
     bind_mode: Optional[List[str]] = None  # ['chat', 'code'] or empty list for none
 
@@ -101,7 +103,9 @@ class TeamDetail(BaseModel):
     created_at: datetime
     updated_at: datetime
     user: Optional[UserInDB] = None
-    share_status: int = 0  # 0-private, 1-sharing, 2-shared from others
+    share_status: int = (
+        0  # 0-private, 1-sharing, 2-shared from others, 3-marketplace installed
+    )
 
     class Config:
         from_attributes = True

--- a/backend/app/services/marketplace_service.py
+++ b/backend/app/services/marketplace_service.py
@@ -1,0 +1,1082 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Marketplace service for Agent Marketplace feature.
+
+This module provides business logic for:
+- Browsing and searching marketplace teams
+- Installing/uninstalling marketplace teams
+- Admin publishing and management
+"""
+
+import copy
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.models.marketplace import InstalledTeam, TeamMarketplace
+from app.schemas.kind import Bot, Team
+from app.schemas.marketplace import (
+    CategoryItem,
+    InstalledTeamResponse,
+    InstallMode,
+    InstallTeamRequest,
+    InstallTeamResponse,
+    MarketplaceCategory,
+    MarketplaceTeamDetail,
+    MarketplaceTeamListItem,
+    PublishTeamRequest,
+    UninstallTeamResponse,
+    UpdateMarketplaceTeamRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class MarketplaceService:
+    """Service for managing marketplace teams"""
+
+    # ==================== Public API Methods ====================
+
+    def get_marketplace_teams(
+        self,
+        db: Session,
+        user_id: int,
+        page: int = 1,
+        limit: int = 20,
+        search: Optional[str] = None,
+        category: Optional[str] = None,
+    ) -> Tuple[List[MarketplaceTeamListItem], int]:
+        """
+        Get marketplace teams list with pagination, search, and filtering.
+
+        Args:
+            db: Database session
+            user_id: Current user ID (for checking installation status)
+            page: Page number (1-indexed)
+            limit: Items per page
+            search: Search keyword (matches name and description)
+            category: Category filter
+
+        Returns:
+            Tuple of (list of marketplace teams, total count)
+        """
+        # Build base query for active marketplace teams
+        query = db.query(TeamMarketplace).filter(TeamMarketplace.is_active == True)
+
+        # Apply category filter
+        if category:
+            query = query.filter(TeamMarketplace.category == category)
+
+        # Apply search filter (need to join with Kind to search team name)
+        if search:
+            # Get team IDs that match search criteria
+            matching_team_ids = (
+                db.query(Kind.id)
+                .filter(
+                    Kind.user_id == 0,
+                    Kind.kind == "Team",
+                    Kind.is_active == True,
+                    Kind.name.ilike(f"%{search}%"),
+                )
+                .all()
+            )
+            matching_ids = [tid[0] for tid in matching_team_ids]
+
+            # Also search in marketplace description
+            query = query.filter(
+                (TeamMarketplace.team_id.in_(matching_ids))
+                | (TeamMarketplace.description.ilike(f"%{search}%"))
+            )
+
+        # Get total count before pagination
+        total = query.count()
+
+        # Apply pagination and ordering
+        skip = (page - 1) * limit
+        marketplace_teams = (
+            query.order_by(TeamMarketplace.install_count.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+        # Get user's installed teams for status checking
+        user_installed = self._get_user_installed_map(db, user_id)
+
+        # Convert to response items
+        items = []
+        for mp_team in marketplace_teams:
+            item = self._convert_to_list_item(db, mp_team, user_installed)
+            if item:
+                items.append(item)
+
+        return items, total
+
+    def get_marketplace_team_detail(
+        self, db: Session, marketplace_id: int, user_id: int
+    ) -> MarketplaceTeamDetail:
+        """
+        Get detailed information for a marketplace team.
+
+        Args:
+            db: Database session
+            marketplace_id: Marketplace team ID (team_marketplace.id)
+            user_id: Current user ID
+
+        Returns:
+            MarketplaceTeamDetail with full team and bot information
+        """
+        # Get marketplace team
+        mp_team = (
+            db.query(TeamMarketplace)
+            .filter(
+                TeamMarketplace.id == marketplace_id, TeamMarketplace.is_active == True
+            )
+            .first()
+        )
+
+        if not mp_team:
+            raise HTTPException(status_code=404, detail="Marketplace team not found")
+
+        # Get team from kinds table
+        team = (
+            db.query(Kind)
+            .filter(
+                Kind.id == mp_team.team_id,
+                Kind.user_id == 0,
+                Kind.kind == "Team",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not team:
+            raise HTTPException(status_code=404, detail="Team not found")
+
+        # Get user's installed status
+        user_installed = self._get_user_installed_map(db, user_id)
+
+        # Convert to detail response
+        return self._convert_to_detail(db, mp_team, team, user_installed)
+
+    def get_categories(self, db: Session) -> List[CategoryItem]:
+        """
+        Get all categories with their team counts.
+
+        Args:
+            db: Database session
+
+        Returns:
+            List of categories with counts
+        """
+        # Get counts per category
+        category_counts = (
+            db.query(TeamMarketplace.category, func.count(TeamMarketplace.id))
+            .filter(TeamMarketplace.is_active == True)
+            .group_by(TeamMarketplace.category)
+            .all()
+        )
+
+        count_map = {cat: count for cat, count in category_counts}
+
+        # Build category list with all predefined categories
+        categories = []
+        for cat in MarketplaceCategory:
+            categories.append(
+                CategoryItem(
+                    value=cat.value, label=cat.value, count=count_map.get(cat.value, 0)
+                )
+            )
+
+        return categories
+
+    # ==================== Installation Methods ====================
+
+    def install_team(
+        self,
+        db: Session,
+        marketplace_id: int,
+        user_id: int,
+        request: InstallTeamRequest,
+    ) -> InstallTeamResponse:
+        """
+        Install a marketplace team for a user.
+
+        Args:
+            db: Database session
+            marketplace_id: Marketplace team ID
+            user_id: User ID
+            request: Installation request with mode
+
+        Returns:
+            InstallTeamResponse with installation details
+        """
+        # Get marketplace team
+        mp_team = (
+            db.query(TeamMarketplace)
+            .filter(
+                TeamMarketplace.id == marketplace_id, TeamMarketplace.is_active == True
+            )
+            .first()
+        )
+
+        if not mp_team:
+            raise HTTPException(status_code=404, detail="Marketplace team not found")
+
+        # Validate installation mode is allowed
+        if request.mode == InstallMode.REFERENCE and not mp_team.allow_reference:
+            raise HTTPException(
+                status_code=400, detail="Reference mode is not allowed for this team"
+            )
+        if request.mode == InstallMode.COPY and not mp_team.allow_copy:
+            raise HTTPException(
+                status_code=400, detail="Copy mode is not allowed for this team"
+            )
+
+        # Check if already installed
+        existing = (
+            db.query(InstalledTeam)
+            .filter(
+                InstalledTeam.user_id == user_id,
+                InstalledTeam.marketplace_team_id == marketplace_id,
+                InstalledTeam.is_active == True,
+            )
+            .first()
+        )
+
+        if existing:
+            raise HTTPException(status_code=400, detail="Team is already installed")
+
+        # Check if previously installed (reactivate)
+        previous = (
+            db.query(InstalledTeam)
+            .filter(
+                InstalledTeam.user_id == user_id,
+                InstalledTeam.marketplace_team_id == marketplace_id,
+                InstalledTeam.is_active == False,
+            )
+            .first()
+        )
+
+        copied_team_id = None
+
+        if request.mode == InstallMode.COPY:
+            # Copy team and related resources to user space
+            copied_team_id = self._copy_team_to_user(db, mp_team.team_id, user_id)
+
+        if previous:
+            # Reactivate previous installation
+            previous.is_active = True
+            previous.install_mode = request.mode.value
+            previous.copied_team_id = copied_team_id
+            previous.installed_at = datetime.now()
+            previous.uninstalled_at = None
+            installed_team = previous
+        else:
+            # Create new installation record
+            installed_team = InstalledTeam(
+                user_id=user_id,
+                marketplace_team_id=marketplace_id,
+                install_mode=request.mode.value,
+                copied_team_id=copied_team_id,
+                is_active=True,
+            )
+            db.add(installed_team)
+
+        # Increment install count
+        mp_team.install_count += 1
+
+        db.commit()
+        db.refresh(installed_team)
+
+        return InstallTeamResponse(
+            success=True,
+            message="Team installed successfully",
+            installed_team_id=installed_team.id,
+            install_mode=request.mode.value,
+            copied_team_id=copied_team_id,
+        )
+
+    def uninstall_team(
+        self, db: Session, marketplace_id: int, user_id: int
+    ) -> UninstallTeamResponse:
+        """
+        Uninstall a marketplace team for a user.
+
+        Args:
+            db: Database session
+            marketplace_id: Marketplace team ID
+            user_id: User ID
+
+        Returns:
+            UninstallTeamResponse
+        """
+        # Get installation record
+        installed = (
+            db.query(InstalledTeam)
+            .filter(
+                InstalledTeam.user_id == user_id,
+                InstalledTeam.marketplace_team_id == marketplace_id,
+                InstalledTeam.is_active == True,
+            )
+            .first()
+        )
+
+        if not installed:
+            raise HTTPException(status_code=404, detail="Installation record not found")
+
+        # Soft delete - mark as inactive
+        installed.is_active = False
+        installed.uninstalled_at = datetime.now()
+
+        # Note: For copy mode, we keep the copied team in user space
+        # User can manually delete it if needed
+
+        db.commit()
+
+        return UninstallTeamResponse(
+            success=True, message="Team uninstalled successfully"
+        )
+
+    def get_user_installed_teams(
+        self, db: Session, user_id: int
+    ) -> List[InstalledTeamResponse]:
+        """
+        Get all installed teams for a user.
+
+        Args:
+            db: Database session
+            user_id: User ID
+
+        Returns:
+            List of installed team records with marketplace info
+        """
+        installed_teams = (
+            db.query(InstalledTeam)
+            .filter(InstalledTeam.user_id == user_id, InstalledTeam.is_active == True)
+            .order_by(InstalledTeam.installed_at.desc())
+            .all()
+        )
+
+        result = []
+        for installed in installed_teams:
+            # Get marketplace team info
+            mp_team = (
+                db.query(TeamMarketplace)
+                .filter(TeamMarketplace.id == installed.marketplace_team_id)
+                .first()
+            )
+
+            mp_item = None
+            if mp_team:
+                mp_item = self._convert_to_list_item(db, mp_team, {})
+
+            result.append(
+                InstalledTeamResponse(
+                    id=installed.id,
+                    user_id=installed.user_id,
+                    marketplace_team_id=installed.marketplace_team_id,
+                    install_mode=installed.install_mode,
+                    copied_team_id=installed.copied_team_id,
+                    is_active=installed.is_active,
+                    installed_at=installed.installed_at,
+                    uninstalled_at=installed.uninstalled_at,
+                    marketplace_team=mp_item,
+                )
+            )
+
+        return result
+
+    # ==================== Admin Methods ====================
+
+    def publish_team(self, db: Session, request: PublishTeamRequest) -> TeamMarketplace:
+        """
+        Publish a team to the marketplace (admin only).
+
+        Args:
+            db: Database session
+            request: Publish request with team info
+
+        Returns:
+            Created TeamMarketplace record
+        """
+        # Validate team exists and is a system team (user_id=0)
+        team = (
+            db.query(Kind)
+            .filter(
+                Kind.id == request.team_id,
+                Kind.user_id == 0,
+                Kind.kind == "Team",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not team:
+            raise HTTPException(
+                status_code=404,
+                detail="Team not found or is not a system team (user_id must be 0)",
+            )
+
+        # Check if already published
+        existing = (
+            db.query(TeamMarketplace)
+            .filter(TeamMarketplace.team_id == request.team_id)
+            .first()
+        )
+
+        if existing:
+            raise HTTPException(
+                status_code=400, detail="Team is already published to marketplace"
+            )
+
+        # Validate at least one mode is allowed
+        if not request.allow_reference and not request.allow_copy:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one installation mode must be enabled",
+            )
+
+        # Create marketplace entry
+        mp_team = TeamMarketplace(
+            team_id=request.team_id,
+            category=request.category.value,
+            description=request.description,
+            icon=request.icon,
+            allow_reference=request.allow_reference,
+            allow_copy=request.allow_copy,
+            is_active=True,
+            published_at=datetime.now(),
+        )
+
+        db.add(mp_team)
+        db.commit()
+        db.refresh(mp_team)
+
+        return mp_team
+
+    def update_marketplace_team(
+        self, db: Session, marketplace_id: int, request: UpdateMarketplaceTeamRequest
+    ) -> TeamMarketplace:
+        """
+        Update marketplace team info (admin only).
+
+        Args:
+            db: Database session
+            marketplace_id: Marketplace team ID
+            request: Update request
+
+        Returns:
+            Updated TeamMarketplace record
+        """
+        mp_team = (
+            db.query(TeamMarketplace)
+            .filter(TeamMarketplace.id == marketplace_id)
+            .first()
+        )
+
+        if not mp_team:
+            raise HTTPException(status_code=404, detail="Marketplace team not found")
+
+        # Update fields if provided
+        if request.category is not None:
+            mp_team.category = request.category.value
+        if request.description is not None:
+            mp_team.description = request.description
+        if request.icon is not None:
+            mp_team.icon = request.icon
+        if request.allow_reference is not None:
+            mp_team.allow_reference = request.allow_reference
+        if request.allow_copy is not None:
+            mp_team.allow_copy = request.allow_copy
+        if request.is_active is not None:
+            mp_team.is_active = request.is_active
+
+        # Validate at least one mode is still allowed
+        if not mp_team.allow_reference and not mp_team.allow_copy:
+            raise HTTPException(
+                status_code=400,
+                detail="At least one installation mode must be enabled",
+            )
+
+        db.commit()
+        db.refresh(mp_team)
+
+        return mp_team
+
+    def unpublish_team(self, db: Session, marketplace_id: int) -> bool:
+        """
+        Unpublish/deactivate a marketplace team (admin only).
+
+        Args:
+            db: Database session
+            marketplace_id: Marketplace team ID
+
+        Returns:
+            True if successful
+        """
+        mp_team = (
+            db.query(TeamMarketplace)
+            .filter(TeamMarketplace.id == marketplace_id)
+            .first()
+        )
+
+        if not mp_team:
+            raise HTTPException(status_code=404, detail="Marketplace team not found")
+
+        mp_team.is_active = False
+        db.commit()
+
+        return True
+
+    def get_admin_marketplace_teams(
+        self,
+        db: Session,
+        page: int = 1,
+        limit: int = 20,
+        include_inactive: bool = True,
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        """
+        Get all marketplace teams for admin (includes inactive).
+
+        Args:
+            db: Database session
+            page: Page number
+            limit: Items per page
+            include_inactive: Include inactive teams
+
+        Returns:
+            Tuple of (list of marketplace teams, total count)
+        """
+        query = db.query(TeamMarketplace)
+
+        if not include_inactive:
+            query = query.filter(TeamMarketplace.is_active == True)
+
+        total = query.count()
+
+        skip = (page - 1) * limit
+        marketplace_teams = (
+            query.order_by(TeamMarketplace.created_at.desc())
+            .offset(skip)
+            .limit(limit)
+            .all()
+        )
+
+        items = []
+        for mp_team in marketplace_teams:
+            item = self._convert_to_admin_item(db, mp_team)
+            if item:
+                items.append(item)
+
+        return items, total
+
+    # ==================== Helper Methods ====================
+
+    def _get_user_installed_map(
+        self, db: Session, user_id: int
+    ) -> Dict[int, InstalledTeam]:
+        """Get a map of marketplace_team_id -> InstalledTeam for a user"""
+        installed = (
+            db.query(InstalledTeam)
+            .filter(InstalledTeam.user_id == user_id, InstalledTeam.is_active == True)
+            .all()
+        )
+        return {i.marketplace_team_id: i for i in installed}
+
+    def _convert_to_list_item(
+        self,
+        db: Session,
+        mp_team: TeamMarketplace,
+        user_installed: Dict[int, InstalledTeam],
+    ) -> Optional[MarketplaceTeamListItem]:
+        """Convert TeamMarketplace to list item response"""
+        # Get team from kinds table
+        team = (
+            db.query(Kind)
+            .filter(
+                Kind.id == mp_team.team_id,
+                Kind.user_id == 0,
+                Kind.kind == "Team",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not team:
+            return None
+
+        # Parse team JSON
+        try:
+            team_crd = Team.model_validate(team.json)
+        except Exception:
+            return None
+
+        # Check installation status
+        installed = user_installed.get(mp_team.id)
+        is_installed = installed is not None
+        installed_mode = installed.install_mode if installed else None
+
+        # Get agent_type from first bot's shell
+        agent_type = self._get_team_agent_type(db, team_crd)
+
+        return MarketplaceTeamListItem(
+            id=mp_team.id,
+            team_id=mp_team.team_id,
+            name=team.name,
+            category=mp_team.category,
+            description=mp_team.description or team_crd.spec.description,
+            icon=mp_team.icon or team_crd.spec.icon,
+            allow_reference=mp_team.allow_reference,
+            allow_copy=mp_team.allow_copy,
+            install_count=mp_team.install_count,
+            is_active=mp_team.is_active,
+            published_at=mp_team.published_at,
+            bind_mode=team_crd.spec.bind_mode,
+            agent_type=agent_type,
+            bots_count=len(team_crd.spec.members),
+            is_installed=is_installed,
+            installed_mode=installed_mode,
+        )
+
+    def _convert_to_detail(
+        self,
+        db: Session,
+        mp_team: TeamMarketplace,
+        team: Kind,
+        user_installed: Dict[int, InstalledTeam],
+    ) -> MarketplaceTeamDetail:
+        """Convert to detail response with full team and bot info"""
+        # Parse team JSON
+        team_crd = Team.model_validate(team.json)
+
+        # Check installation status
+        installed = user_installed.get(mp_team.id)
+        is_installed = installed is not None
+        installed_mode = installed.install_mode if installed else None
+
+        # Get agent_type
+        agent_type = self._get_team_agent_type(db, team_crd)
+
+        # Get bot details
+        bots = self._get_team_bots_info(db, team_crd)
+
+        return MarketplaceTeamDetail(
+            id=mp_team.id,
+            team_id=mp_team.team_id,
+            name=team.name,
+            category=mp_team.category,
+            description=mp_team.description or team_crd.spec.description,
+            icon=mp_team.icon or team_crd.spec.icon,
+            allow_reference=mp_team.allow_reference,
+            allow_copy=mp_team.allow_copy,
+            install_count=mp_team.install_count,
+            is_active=mp_team.is_active,
+            published_at=mp_team.published_at,
+            bind_mode=team_crd.spec.bind_mode,
+            agent_type=agent_type,
+            bots_count=len(team_crd.spec.members),
+            is_installed=is_installed,
+            installed_mode=installed_mode,
+            team_data=team.json,
+            bots=bots,
+        )
+
+    def _convert_to_admin_item(
+        self, db: Session, mp_team: TeamMarketplace
+    ) -> Optional[Dict[str, Any]]:
+        """Convert to admin response with all fields"""
+        item = self._convert_to_list_item(db, mp_team, {})
+        if not item:
+            return None
+
+        return {
+            **item.model_dump(),
+            "created_at": mp_team.created_at,
+            "updated_at": mp_team.updated_at,
+        }
+
+    def _get_team_agent_type(self, db: Session, team_crd: Team) -> Optional[str]:
+        """Get agent_type from team's first bot's shell"""
+        if not team_crd.spec.members:
+            return None
+
+        first_member = team_crd.spec.members[0]
+        bot_ref = first_member.botRef
+
+        # Get bot
+        bot = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == 0,
+                Kind.kind == "Bot",
+                Kind.name == bot_ref.name,
+                Kind.namespace == bot_ref.namespace,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not bot:
+            return None
+
+        try:
+            bot_crd = Bot.model_validate(bot.json)
+            shell_ref = bot_crd.spec.shellRef
+
+            # Get shell
+            shell = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == 0,
+                    Kind.kind == "Shell",
+                    Kind.name == shell_ref.name,
+                    Kind.namespace == shell_ref.namespace,
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+
+            if shell:
+                from app.schemas.kind import Shell
+
+                shell_crd = Shell.model_validate(shell.json)
+                shell_type = shell_crd.spec.shellType
+
+                # Map shellType to agent_type
+                type_map = {
+                    "Agno": "agno",
+                    "ClaudeCode": "claude",
+                    "Dify": "dify",
+                    "Chat": "chat",
+                }
+                return type_map.get(
+                    shell_type, shell_type.lower() if shell_type else None
+                )
+        except Exception:
+            pass
+
+        return None
+
+    def _get_team_bots_info(self, db: Session, team_crd: Team) -> List[Dict[str, Any]]:
+        """Get basic bot information for team"""
+        bots = []
+        for member in team_crd.spec.members:
+            bot_ref = member.botRef
+
+            bot = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == 0,
+                    Kind.kind == "Bot",
+                    Kind.name == bot_ref.name,
+                    Kind.namespace == bot_ref.namespace,
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+
+            if bot:
+                bots.append(
+                    {
+                        "id": bot.id,
+                        "name": bot.name,
+                        "role": member.role,
+                        "prompt": member.prompt,
+                    }
+                )
+
+        return bots
+
+    def _copy_team_to_user(
+        self, db: Session, marketplace_team_id: int, user_id: int
+    ) -> int:
+        """
+        Deep copy a marketplace team and its related resources to user space.
+
+        Args:
+            db: Database session
+            marketplace_team_id: Source team ID (user_id=0)
+            user_id: Target user ID
+
+        Returns:
+            New team ID in user space
+        """
+        # Get source team
+        source_team = (
+            db.query(Kind)
+            .filter(
+                Kind.id == marketplace_team_id,
+                Kind.user_id == 0,
+                Kind.kind == "Team",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not source_team:
+            raise HTTPException(status_code=404, detail="Source team not found")
+
+        team_crd = Team.model_validate(source_team.json)
+
+        # Track copied resources to update references
+        bot_name_map = {}  # old_name -> new_name
+
+        # Copy bots and their related resources (Ghost, Model)
+        for member in team_crd.spec.members:
+            bot_ref = member.botRef
+
+            # Get source bot
+            source_bot = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == 0,
+                    Kind.kind == "Bot",
+                    Kind.name == bot_ref.name,
+                    Kind.namespace == bot_ref.namespace,
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+
+            if not source_bot:
+                continue
+
+            bot_crd = Bot.model_validate(source_bot.json)
+
+            # Copy Ghost
+            new_ghost_name = self._copy_ghost_to_user(
+                db, bot_crd.spec.ghostRef.name, bot_crd.spec.ghostRef.namespace, user_id
+            )
+
+            # Copy Model if exists
+            new_model_name = None
+            if bot_crd.spec.modelRef:
+                new_model_name = self._copy_model_to_user(
+                    db,
+                    bot_crd.spec.modelRef.name,
+                    bot_crd.spec.modelRef.namespace,
+                    user_id,
+                )
+
+            # Create new bot with updated references
+            new_bot_json = copy.deepcopy(source_bot.json)
+            new_bot_name = self._generate_unique_name(
+                db, user_id, "Bot", source_bot.name
+            )
+            new_bot_json["metadata"]["name"] = new_bot_name
+            new_bot_json["spec"]["ghostRef"]["name"] = new_ghost_name
+            if new_model_name:
+                new_bot_json["spec"]["modelRef"]["name"] = new_model_name
+
+            new_bot = Kind(
+                user_id=user_id,
+                kind="Bot",
+                name=new_bot_name,
+                namespace="default",
+                json=new_bot_json,
+                is_active=True,
+            )
+            db.add(new_bot)
+            db.flush()
+
+            bot_name_map[bot_ref.name] = new_bot_name
+
+        # Create new team with updated bot references
+        new_team_json = copy.deepcopy(source_team.json)
+        new_team_name = self._generate_unique_name(
+            db, user_id, "Team", source_team.name
+        )
+        new_team_json["metadata"]["name"] = new_team_name
+
+        # Update member bot references
+        for member in new_team_json["spec"]["members"]:
+            old_bot_name = member["botRef"]["name"]
+            if old_bot_name in bot_name_map:
+                member["botRef"]["name"] = bot_name_map[old_bot_name]
+            member["botRef"]["namespace"] = "default"
+
+        new_team = Kind(
+            user_id=user_id,
+            kind="Team",
+            name=new_team_name,
+            namespace="default",
+            json=new_team_json,
+            is_active=True,
+        )
+        db.add(new_team)
+        db.flush()
+
+        return new_team.id
+
+    def _copy_ghost_to_user(
+        self, db: Session, ghost_name: str, ghost_namespace: str, user_id: int
+    ) -> str:
+        """Copy a ghost to user space, return new ghost name"""
+        source_ghost = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == 0,
+                Kind.kind == "Ghost",
+                Kind.name == ghost_name,
+                Kind.namespace == ghost_namespace,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not source_ghost:
+            # If ghost not found, use the original name
+            return ghost_name
+
+        new_ghost_json = copy.deepcopy(source_ghost.json)
+        new_ghost_name = self._generate_unique_name(
+            db, user_id, "Ghost", source_ghost.name
+        )
+        new_ghost_json["metadata"]["name"] = new_ghost_name
+        new_ghost_json["metadata"]["namespace"] = "default"
+
+        new_ghost = Kind(
+            user_id=user_id,
+            kind="Ghost",
+            name=new_ghost_name,
+            namespace="default",
+            json=new_ghost_json,
+            is_active=True,
+        )
+        db.add(new_ghost)
+        db.flush()
+
+        return new_ghost_name
+
+    def _copy_model_to_user(
+        self, db: Session, model_name: str, model_namespace: str, user_id: int
+    ) -> str:
+        """Copy a model to user space, return new model name"""
+        source_model = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == 0,
+                Kind.kind == "Model",
+                Kind.name == model_name,
+                Kind.namespace == model_namespace,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not source_model:
+            # If model not found, use the original name
+            return model_name
+
+        new_model_json = copy.deepcopy(source_model.json)
+        new_model_name = self._generate_unique_name(
+            db, user_id, "Model", source_model.name
+        )
+        new_model_json["metadata"]["name"] = new_model_name
+        new_model_json["metadata"]["namespace"] = "default"
+
+        new_model = Kind(
+            user_id=user_id,
+            kind="Model",
+            name=new_model_name,
+            namespace="default",
+            json=new_model_json,
+            is_active=True,
+        )
+        db.add(new_model)
+        db.flush()
+
+        return new_model_name
+
+    def _generate_unique_name(
+        self, db: Session, user_id: int, kind: str, base_name: str
+    ) -> str:
+        """Generate a unique name for a resource in user space"""
+        # Check if base name is available
+        existing = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == user_id,
+                Kind.kind == kind,
+                Kind.name == base_name,
+                Kind.namespace == "default",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not existing:
+            return base_name
+
+        # Add suffix to make it unique
+        suffix = 1
+        while True:
+            new_name = f"{base_name}_{suffix}"
+            existing = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == user_id,
+                    Kind.kind == kind,
+                    Kind.name == new_name,
+                    Kind.namespace == "default",
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+            if not existing:
+                return new_name
+            suffix += 1
+
+    def get_installed_marketplace_team_ids(
+        self, db: Session, user_id: int
+    ) -> List[int]:
+        """
+        Get list of marketplace team_ids (from kinds table) that user has installed
+        in reference mode.
+
+        Args:
+            db: Database session
+            user_id: User ID
+
+        Returns:
+            List of team IDs from kinds table
+        """
+        # Get installed teams in reference mode
+        installed = (
+            db.query(InstalledTeam)
+            .join(
+                TeamMarketplace,
+                TeamMarketplace.id == InstalledTeam.marketplace_team_id,
+            )
+            .filter(
+                InstalledTeam.user_id == user_id,
+                InstalledTeam.is_active == True,
+                InstalledTeam.install_mode == InstallMode.REFERENCE.value,
+            )
+            .all()
+        )
+
+        # Get team IDs from marketplace
+        team_ids = []
+        for inst in installed:
+            mp_team = (
+                db.query(TeamMarketplace)
+                .filter(TeamMarketplace.id == inst.marketplace_team_id)
+                .first()
+            )
+            if mp_team:
+                team_ids.append(mp_team.team_id)
+
+        return team_ids
+
+
+marketplace_service = MarketplaceService()

--- a/frontend/src/apis/marketplace.ts
+++ b/frontend/src/apis/marketplace.ts
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { apiClient } from '@/lib/api-client'
+import type {
+  CategoryListResponse,
+  InstallMode,
+  InstallTeamResponse,
+  InstalledTeamListResponse,
+  MarketplaceTeamDetail,
+  MarketplaceTeamListResponse,
+  UninstallTeamResponse,
+} from '@/types/marketplace'
+
+// ==================== Public APIs ====================
+
+/**
+ * Get marketplace teams list with pagination, search, and filtering
+ */
+export async function fetchMarketplaceTeams(params?: {
+  page?: number
+  limit?: number
+  search?: string
+  category?: string
+}): Promise<MarketplaceTeamListResponse> {
+  const searchParams = new URLSearchParams()
+  if (params?.page) searchParams.set('page', String(params.page))
+  if (params?.limit) searchParams.set('limit', String(params.limit))
+  if (params?.search) searchParams.set('search', params.search)
+  if (params?.category) searchParams.set('category', params.category)
+
+  const queryString = searchParams.toString()
+  const url = `/marketplace/teams${queryString ? `?${queryString}` : ''}`
+
+  const response = await apiClient.get<MarketplaceTeamListResponse>(url)
+  return response.data
+}
+
+/**
+ * Get marketplace team detail
+ */
+export async function fetchMarketplaceTeamDetail(marketplaceId: number): Promise<MarketplaceTeamDetail> {
+  const response = await apiClient.get<MarketplaceTeamDetail>(`/marketplace/teams/${marketplaceId}`)
+  return response.data
+}
+
+/**
+ * Get all categories with their team counts
+ */
+export async function fetchMarketplaceCategories(): Promise<CategoryListResponse> {
+  const response = await apiClient.get<CategoryListResponse>('/marketplace/categories')
+  return response.data
+}
+
+// ==================== Installation APIs ====================
+
+/**
+ * Install a marketplace team
+ */
+export async function installMarketplaceTeam(
+  marketplaceId: number,
+  mode: InstallMode
+): Promise<InstallTeamResponse> {
+  const response = await apiClient.post<InstallTeamResponse>(
+    `/marketplace/teams/${marketplaceId}/install`,
+    { mode }
+  )
+  return response.data
+}
+
+/**
+ * Uninstall a marketplace team
+ */
+export async function uninstallMarketplaceTeam(marketplaceId: number): Promise<UninstallTeamResponse> {
+  const response = await apiClient.delete<UninstallTeamResponse>(
+    `/marketplace/teams/${marketplaceId}/uninstall`
+  )
+  return response.data
+}
+
+/**
+ * Get user's installed marketplace teams
+ */
+export async function fetchInstalledTeams(): Promise<InstalledTeamListResponse> {
+  const response = await apiClient.get<InstalledTeamListResponse>('/marketplace/installed')
+  return response.data
+}
+
+// ==================== Admin APIs ====================
+
+/**
+ * Publish a team to marketplace (admin only)
+ */
+export async function publishTeamToMarketplace(data: {
+  team_id: number
+  category: string
+  description?: string
+  icon?: string
+  allow_reference?: boolean
+  allow_copy?: boolean
+}): Promise<{ success: boolean; marketplace_id: number; team_id: number }> {
+  const response = await apiClient.post('/marketplace/admin/teams', data)
+  return response.data
+}
+
+/**
+ * Update marketplace team info (admin only)
+ */
+export async function updateMarketplaceTeam(
+  marketplaceId: number,
+  data: {
+    category?: string
+    description?: string
+    icon?: string
+    allow_reference?: boolean
+    allow_copy?: boolean
+    is_active?: boolean
+  }
+): Promise<{ success: boolean; marketplace_id: number }> {
+  const response = await apiClient.put(`/marketplace/admin/teams/${marketplaceId}`, data)
+  return response.data
+}
+
+/**
+ * Unpublish marketplace team (admin only)
+ */
+export async function unpublishMarketplaceTeam(
+  marketplaceId: number
+): Promise<{ success: boolean; message: string }> {
+  const response = await apiClient.delete(`/marketplace/admin/teams/${marketplaceId}`)
+  return response.data
+}
+
+/**
+ * Get all marketplace teams for admin (admin only)
+ */
+export async function fetchAdminMarketplaceTeams(params?: {
+  page?: number
+  limit?: number
+  include_inactive?: boolean
+}): Promise<{ total: number; items: MarketplaceTeamDetail[] }> {
+  const searchParams = new URLSearchParams()
+  if (params?.page) searchParams.set('page', String(params.page))
+  if (params?.limit) searchParams.set('limit', String(params.limit))
+  if (params?.include_inactive !== undefined)
+    searchParams.set('include_inactive', String(params.include_inactive))
+
+  const queryString = searchParams.toString()
+  const url = `/marketplace/admin/teams${queryString ? `?${queryString}` : ''}`
+
+  const response = await apiClient.get(url)
+  return response.data
+}

--- a/frontend/src/app/(tasks)/marketplace/page.tsx
+++ b/frontend/src/app/(tasks)/marketplace/page.tsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { Suspense, useState, useEffect, useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import TopNavigation from '@/features/layout/TopNavigation'
+import {
+  TaskSidebar,
+  ResizableSidebar,
+  CollapsedSidebarButtons,
+} from '@/features/tasks/components/sidebar'
+import { useTranslation } from '@/hooks/useTranslation'
+import { GithubStarButton } from '@/features/layout/GithubStarButton'
+import { ThemeToggle } from '@/features/theme/ThemeToggle'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
+import { paths } from '@/config/paths'
+import { MarketplaceGrid } from '@/features/marketplace/components/MarketplaceGrid'
+import '@/app/tasks/tasks.css'
+import '@/features/common/scrollbar.css'
+
+function MarketplaceContent() {
+  const router = useRouter()
+  const { t } = useTranslation('marketplace')
+  const isMobile = useIsMobile()
+
+  // Mobile sidebar state
+  const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
+
+  // Collapsed sidebar state
+  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  // Load collapsed state from localStorage
+  useEffect(() => {
+    const savedCollapsed = localStorage.getItem('task-sidebar-collapsed')
+    if (savedCollapsed === 'true') {
+      setIsCollapsed(true)
+    }
+  }, [])
+
+  const handleToggleCollapsed = useCallback(() => {
+    setIsCollapsed(prev => {
+      const newValue = !prev
+      localStorage.setItem('task-sidebar-collapsed', String(newValue))
+      return newValue
+    })
+  }, [])
+
+  // Handle new task from collapsed sidebar button
+  const handleNewTask = useCallback(() => {
+    router.replace(paths.chat.getHref())
+  }, [router])
+
+  return (
+    <div className="flex smart-h-screen bg-base text-text-primary box-border">
+      {/* Collapsed sidebar floating buttons */}
+      {isCollapsed && !isMobile && (
+        <CollapsedSidebarButtons onExpand={handleToggleCollapsed} onNewTask={handleNewTask} />
+      )}
+
+      {/* Resizable sidebar with TaskSidebar */}
+      <ResizableSidebar isCollapsed={isCollapsed} onToggleCollapsed={handleToggleCollapsed}>
+        <TaskSidebar
+          isMobileSidebarOpen={isMobileSidebarOpen}
+          setIsMobileSidebarOpen={setIsMobileSidebarOpen}
+          pageType="chat"
+          isCollapsed={isCollapsed}
+          onToggleCollapsed={handleToggleCollapsed}
+        />
+      </ResizableSidebar>
+
+      {/* Main content area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Top navigation */}
+        <TopNavigation
+          activePage="dashboard"
+          variant="with-sidebar"
+          title={t('title')}
+          onMobileSidebarToggle={() => setIsMobileSidebarOpen(true)}
+          isSidebarCollapsed={isCollapsed}
+        >
+          {isMobile ? <ThemeToggle /> : <GithubStarButton />}
+        </TopNavigation>
+
+        {/* Marketplace content area */}
+        <div className="flex-1 overflow-y-auto px-4 py-4 md:px-8 md:py-6">
+          <MarketplaceGrid />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default function MarketplacePage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MarketplaceContent />
+    </Suspense>
+  )
+}

--- a/frontend/src/config/paths.ts
+++ b/frontend/src/config/paths.ts
@@ -32,6 +32,9 @@ export const paths = {
   wiki: {
     getHref: () => '/knowledge',
   },
+  marketplace: {
+    getHref: () => '/marketplace',
+  },
   settings: {
     root: {
       getHref: () => '/settings',

--- a/frontend/src/features/marketplace/components/InstallModeDialog.tsx
+++ b/frontend/src/features/marketplace/components/InstallModeDialog.tsx
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState } from 'react'
+import { LinkIcon, DocumentDuplicateIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { MarketplaceTeam, InstallMode } from '@/types/marketplace'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface InstallModeDialogProps {
+  open: boolean
+  onClose: () => void
+  team: MarketplaceTeam
+  onInstall: (mode: InstallMode) => void
+  isInstalling: boolean
+}
+
+export function InstallModeDialog({
+  open,
+  onClose,
+  team,
+  onInstall,
+  isInstalling,
+}: InstallModeDialogProps) {
+  const { t } = useTranslation('marketplace')
+  const [selectedMode, setSelectedMode] = useState<InstallMode>(
+    team.allow_reference ? 'reference' : 'copy'
+  )
+
+  const handleInstall = () => {
+    onInstall(selectedMode)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('install_mode.title')}</DialogTitle>
+          <DialogDescription>
+            {t('install_mode.description', { name: team.name })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3 py-4">
+          {/* Reference mode option */}
+          {team.allow_reference && (
+            <button
+              type="button"
+              onClick={() => setSelectedMode('reference')}
+              className={`w-full p-4 rounded-lg border-2 text-left transition-colors ${
+                selectedMode === 'reference'
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/50'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <LinkIcon className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                <div className="flex-1">
+                  <h4 className="font-medium text-text-primary">{t('install_mode.reference')}</h4>
+                  <p className="text-sm text-text-muted mt-1">
+                    {t('install_mode.reference_desc')}
+                  </p>
+                </div>
+                <div
+                  className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                    selectedMode === 'reference' ? 'border-primary' : 'border-border'
+                  }`}
+                >
+                  {selectedMode === 'reference' && (
+                    <div className="w-2.5 h-2.5 rounded-full bg-primary" />
+                  )}
+                </div>
+              </div>
+            </button>
+          )}
+
+          {/* Copy mode option */}
+          {team.allow_copy && (
+            <button
+              type="button"
+              onClick={() => setSelectedMode('copy')}
+              className={`w-full p-4 rounded-lg border-2 text-left transition-colors ${
+                selectedMode === 'copy'
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:border-primary/50'
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <DocumentDuplicateIcon className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                <div className="flex-1">
+                  <h4 className="font-medium text-text-primary">{t('install_mode.copy')}</h4>
+                  <p className="text-sm text-text-muted mt-1">{t('install_mode.copy_desc')}</p>
+                </div>
+                <div
+                  className={`w-5 h-5 rounded-full border-2 flex items-center justify-center ${
+                    selectedMode === 'copy' ? 'border-primary' : 'border-border'
+                  }`}
+                >
+                  {selectedMode === 'copy' && (
+                    <div className="w-2.5 h-2.5 rounded-full bg-primary" />
+                  )}
+                </div>
+              </div>
+            </button>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={onClose} disabled={isInstalling}>
+            {t('common:common.cancel')}
+          </Button>
+          <Button variant="primary" onClick={handleInstall} disabled={isInstalling}>
+            {isInstalling ? t('installing') : t('install')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/marketplace/components/MarketplaceGrid.tsx
+++ b/frontend/src/features/marketplace/components/MarketplaceGrid.tsx
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { MagnifyingGlassIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import { useToast } from '@/hooks/use-toast'
+import {
+  fetchMarketplaceTeams,
+  fetchMarketplaceCategories,
+  installMarketplaceTeam,
+  uninstallMarketplaceTeam,
+} from '@/apis/marketplace'
+import type { MarketplaceTeam, CategoryItem, InstallMode } from '@/types/marketplace'
+import { MarketplaceTeamCard } from './MarketplaceTeamCard'
+import { InstallModeDialog } from './InstallModeDialog'
+import LoadingState from '@/features/common/LoadingState'
+import '@/features/common/scrollbar.css'
+
+export function MarketplaceGrid() {
+  const { t } = useTranslation('marketplace')
+  const { toast } = useToast()
+
+  // State
+  const [teams, setTeams] = useState<MarketplaceTeam[]>([])
+  const [categories, setCategories] = useState<CategoryItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+
+  // Install dialog state
+  const [installDialogOpen, setInstallDialogOpen] = useState(false)
+  const [selectedTeam, setSelectedTeam] = useState<MarketplaceTeam | null>(null)
+  const [isInstalling, setIsInstalling] = useState(false)
+
+  const limit = 20
+
+  // Load categories
+  useEffect(() => {
+    async function loadCategories() {
+      try {
+        const response = await fetchMarketplaceCategories()
+        setCategories(response.categories)
+      } catch (error) {
+        console.error('Failed to load categories:', error)
+      }
+    }
+    loadCategories()
+  }, [])
+
+  // Load teams
+  const loadTeams = useCallback(
+    async (reset = false) => {
+      const currentPage = reset ? 1 : page
+      setIsLoading(true)
+      try {
+        const response = await fetchMarketplaceTeams({
+          page: currentPage,
+          limit,
+          search: searchQuery || undefined,
+          category: selectedCategory || undefined,
+        })
+
+        if (reset) {
+          setTeams(response.items)
+          setPage(1)
+        } else {
+          setTeams(prev => [...prev, ...response.items])
+        }
+        setTotal(response.total)
+        setHasMore(currentPage * limit < response.total)
+      } catch (error) {
+        console.error('Failed to load marketplace teams:', error)
+        toast({
+          variant: 'destructive',
+          title: t('error_loading'),
+        })
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [page, searchQuery, selectedCategory, t, toast]
+  )
+
+  // Initial load and reload on filter change
+  useEffect(() => {
+    loadTeams(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery, selectedCategory])
+
+  // Handle search
+  const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value)
+  }, [])
+
+  // Handle category change
+  const handleCategoryChange = useCallback((category: string | null) => {
+    setSelectedCategory(category)
+  }, [])
+
+  // Handle install click
+  const handleInstallClick = useCallback((team: MarketplaceTeam) => {
+    setSelectedTeam(team)
+    // If only one mode is available, install directly
+    if (team.allow_reference && !team.allow_copy) {
+      handleInstall(team, 'reference')
+    } else if (!team.allow_reference && team.allow_copy) {
+      handleInstall(team, 'copy')
+    } else {
+      // Both modes available, show dialog
+      setInstallDialogOpen(true)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Handle install
+  const handleInstall = useCallback(
+    async (team: MarketplaceTeam, mode: InstallMode) => {
+      setIsInstalling(true)
+      try {
+        await installMarketplaceTeam(team.id, mode)
+        toast({
+          title: t('install_success'),
+          description: team.name,
+        })
+        // Update team status in list
+        setTeams(prev =>
+          prev.map(t =>
+            t.id === team.id ? { ...t, is_installed: true, installed_mode: mode, install_count: t.install_count + 1 } : t
+          )
+        )
+        setInstallDialogOpen(false)
+      } catch (error) {
+        console.error('Failed to install team:', error)
+        toast({
+          variant: 'destructive',
+          title: t('install_failed'),
+        })
+      } finally {
+        setIsInstalling(false)
+      }
+    },
+    [t, toast]
+  )
+
+  // Handle uninstall
+  const handleUninstall = useCallback(
+    async (team: MarketplaceTeam) => {
+      try {
+        await uninstallMarketplaceTeam(team.id)
+        toast({
+          title: t('uninstall_success'),
+          description: team.name,
+        })
+        // Update team status in list
+        setTeams(prev =>
+          prev.map(t => (t.id === team.id ? { ...t, is_installed: false, installed_mode: null } : t))
+        )
+      } catch (error) {
+        console.error('Failed to uninstall team:', error)
+        toast({
+          variant: 'destructive',
+          title: t('uninstall_failed'),
+        })
+      }
+    },
+    [t, toast]
+  )
+
+  // Load more
+  const handleLoadMore = useCallback(() => {
+    if (!isLoading && hasMore) {
+      setPage(prev => prev + 1)
+      loadTeams(false)
+    }
+  }, [isLoading, hasMore, loadTeams])
+
+  // Category tabs with "All" option
+  const categoryTabs = useMemo(() => {
+    const allCount = categories.reduce((sum, cat) => sum + cat.count, 0)
+    return [{ value: null, label: t('categories.all'), count: allCount }, ...categories]
+  }, [categories, t])
+
+  return (
+    <div className="flex flex-col h-full min-h-0 overflow-hidden w-full max-w-full">
+      {/* Header with search */}
+      <div className="flex-shrink-0 mb-4">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+          <div>
+            <h2 className="text-xl font-semibold text-text-primary">{t('title')}</h2>
+            <p className="text-sm text-text-muted">{t('description')}</p>
+          </div>
+          {/* Search box */}
+          <div className="relative w-full sm:w-64">
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={handleSearch}
+              placeholder={t('search_placeholder')}
+              className="w-full pl-9 pr-3 py-2 text-sm border border-border rounded-md bg-surface focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
+        </div>
+
+        {/* Category tabs */}
+        <div className="flex items-center gap-1 overflow-x-auto pb-2 custom-scrollbar">
+          {categoryTabs.map(cat => (
+            <button
+              key={cat.value ?? 'all'}
+              type="button"
+              onClick={() => handleCategoryChange(cat.value as string | null)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md transition-colors whitespace-nowrap ${
+                selectedCategory === cat.value
+                  ? 'bg-primary text-white'
+                  : 'bg-muted text-text-secondary hover:text-text-primary hover:bg-hover'
+              }`}
+            >
+              {t(`categories.${cat.value || 'all'}`)}
+              <span className="text-xs opacity-75">({cat.count})</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Teams grid */}
+      <div className="flex-1 overflow-y-auto custom-scrollbar">
+        {isLoading && teams.length === 0 ? (
+          <LoadingState fullScreen={false} message={t('loading')} />
+        ) : teams.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-text-muted">
+            <p className="text-lg">{t('no_teams')}</p>
+            <p className="text-sm mt-2">{t('no_teams_hint')}</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+              {teams.map(team => (
+                <MarketplaceTeamCard
+                  key={team.id}
+                  team={team}
+                  onInstall={() => handleInstallClick(team)}
+                  onUninstall={() => handleUninstall(team)}
+                />
+              ))}
+            </div>
+
+            {/* Load more */}
+            {hasMore && (
+              <div className="flex justify-center py-6">
+                <button
+                  type="button"
+                  onClick={handleLoadMore}
+                  disabled={isLoading}
+                  className="px-6 py-2 text-sm font-medium text-primary border border-primary rounded-md hover:bg-primary/5 disabled:opacity-50"
+                >
+                  {isLoading ? t('loading_more') : t('load_more')}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Install mode dialog */}
+      {selectedTeam && (
+        <InstallModeDialog
+          open={installDialogOpen}
+          onClose={() => setInstallDialogOpen(false)}
+          team={selectedTeam}
+          onInstall={mode => handleInstall(selectedTeam, mode)}
+          isInstalling={isInstalling}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/marketplace/components/MarketplaceTeamCard.tsx
+++ b/frontend/src/features/marketplace/components/MarketplaceTeamCard.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React from 'react'
+import { CheckIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline'
+import { ChatBubbleLeftEllipsisIcon, CodeBracketIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { MarketplaceTeam } from '@/types/marketplace'
+import { Card } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { TeamIconDisplay } from '@/features/settings/components/teams/TeamIconDisplay'
+import { Badge } from '@/components/ui/badge'
+
+interface MarketplaceTeamCardProps {
+  team: MarketplaceTeam
+  onInstall: () => void
+  onUninstall: () => void
+}
+
+export function MarketplaceTeamCard({ team, onInstall, onUninstall }: MarketplaceTeamCardProps) {
+  const { t } = useTranslation('marketplace')
+
+  // Get mode badges
+  const bindMode = team.bind_mode || ['chat', 'code']
+
+  return (
+    <Card className="p-4 bg-base hover:bg-hover transition-colors flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-start gap-3 mb-3">
+        <TeamIconDisplay iconId={team.icon} size="lg" className="text-primary flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-text-primary truncate">{team.name}</h3>
+          <div className="flex items-center gap-2 mt-1">
+            <Badge variant="secondary" className="text-xs">
+              {t(`categories.${team.category}`)}
+            </Badge>
+            {/* Mode badges */}
+            {bindMode.includes('chat') && (
+              <ChatBubbleLeftEllipsisIcon className="w-4 h-4 text-text-muted" title="Chat" />
+            )}
+            {bindMode.includes('code') && (
+              <CodeBracketIcon className="w-4 h-4 text-text-muted" title="Code" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Description */}
+      <p className="text-sm text-text-secondary line-clamp-2 flex-1 mb-3">
+        {team.description || t('no_description')}
+      </p>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between mt-auto pt-3 border-t border-border">
+        <div className="text-xs text-text-muted">
+          {t('install_count', { count: team.install_count })}
+        </div>
+
+        {team.is_installed ? (
+          <div className="flex items-center gap-2">
+            <span className="flex items-center gap-1 text-xs text-success">
+              <CheckIcon className="w-4 h-4" />
+              {t('installed')}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onUninstall}
+              className="text-text-muted hover:text-error h-7 px-2"
+            >
+              {t('uninstall')}
+            </Button>
+          </div>
+        ) : (
+          <Button variant="primary" size="sm" onClick={onInstall} className="h-7 gap-1">
+            <ArrowDownTrayIcon className="w-3.5 h-3.5" />
+            {t('install')}
+          </Button>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -282,13 +282,13 @@ export default function TeamList({
     setTeamToDelete(teamId)
     setIsCheckingTasks(true)
 
-    // Check if this is a shared team
+    // Check if this is a shared team or marketplace team
     const team = teams.find(t => t.id === teamId)
-    const isShared = team?.share_status === 2
-    setIsUnbindingSharedTeam(isShared)
+    const isSharedOrMarketplace = team?.share_status === 2 || team?.share_status === 3
+    setIsUnbindingSharedTeam(isSharedOrMarketplace)
 
-    // For shared teams, skip running tasks check and show unbind confirmation directly
-    if (isShared) {
+    // For shared/marketplace teams, skip running tasks check and show unbind confirmation directly
+    if (isSharedOrMarketplace) {
       setIsCheckingTasks(false)
       setDeleteConfirmVisible(true)
       return
@@ -391,8 +391,8 @@ export default function TeamList({
 
   // Check if edit button should be shown
   const shouldShowEdit = (team: Team) => {
-    // Shared teams don't show edit button
-    if (team.share_status === 2) return false
+    // Shared teams and marketplace teams don't show edit button
+    if (team.share_status === 2 || team.share_status === 3) return false
     // For group teams, check group permissions
     if (isGroupTeam(team)) {
       return canEditGroupResource(team.namespace!)
@@ -411,9 +411,9 @@ export default function TeamList({
     return true
   }
 
-  // Check if this is a shared team (need to show "unbind" instead of "delete")
-  const isSharedTeam = (team: Team) => {
-    return team.share_status === 2
+  // Check if this is a shared team or marketplace team (need to show "unbind" instead of "delete")
+  const isSharedOrMarketplaceTeam = (team: Team) => {
+    return team.share_status === 2 || team.share_status === 3
   }
 
   // Check if share button should be shown
@@ -533,6 +533,15 @@ export default function TeamList({
                                   },
                                 ]
                               : []),
+                            ...(team.share_status === 3
+                              ? [
+                                  {
+                                    key: 'marketplace',
+                                    label: t('marketplace:marketplace_tag'),
+                                    variant: 'secondary' as const,
+                                  },
+                                ]
+                              : []),
                             ...(team.bots.length > 0
                               ? [
                                   {
@@ -626,10 +635,10 @@ export default function TeamList({
                               size="icon"
                               onClick={() => handleDelete(team.id)}
                               disabled={isCheckingTasks}
-                              title={isSharedTeam(team) ? t('teams.unbind') : t('teams.delete')}
+                              title={isSharedOrMarketplaceTeam(team) ? t('teams.unbind') : t('teams.delete')}
                               className="h-7 w-7 sm:h-8 sm:w-8 hover:text-error"
                             >
-                              {isSharedTeam(team) ? (
+                              {isSharedOrMarketplaceTeam(team) ? (
                                 <LinkSlashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                               ) : (
                                 <TrashIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />

--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -20,6 +20,7 @@ import {
   BookOpen,
   ChevronDown,
   ChevronUp,
+  Store,
 } from 'lucide-react'
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContext'
@@ -114,6 +115,12 @@ export default function TaskSidebar({
       icon: BookOpen,
       path: paths.wiki.getHref(),
       isActive: pageType === 'knowledge',
+    },
+    {
+      label: t('common:navigation.marketplace'),
+      icon: Store,
+      path: paths.marketplace.getHref(),
+      isActive: false,
     },
   ]
 

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -56,6 +56,7 @@
     "chat": "Chat",
     "code": "Code",
     "wiki": "Knowledge",
+    "marketplace": "Marketplace",
     "settings": "Settings",
     "docs": "Docs",
     "feedback": "Feedback",

--- a/frontend/src/i18n/locales/en/marketplace.json
+++ b/frontend/src/i18n/locales/en/marketplace.json
@@ -1,0 +1,39 @@
+{
+  "title": "Agent Marketplace",
+  "description": "Browse and install AI agents from the marketplace",
+  "search_placeholder": "Search agents...",
+  "categories": {
+    "all": "All",
+    "development": "Development",
+    "office": "Office",
+    "creative": "Creative",
+    "data_analysis": "Data Analysis",
+    "education": "Education",
+    "other": "Other"
+  },
+  "install": "Install",
+  "uninstall": "Uninstall",
+  "installed": "Installed",
+  "installing": "Installing...",
+  "install_count": "{{count}} installs",
+  "install_success": "Agent installed successfully",
+  "install_failed": "Failed to install agent",
+  "uninstall_success": "Agent uninstalled successfully",
+  "uninstall_failed": "Failed to uninstall agent",
+  "install_mode": {
+    "title": "Choose Install Mode",
+    "description": "How would you like to install \"{{name}}\"?",
+    "reference": "Reference Mode",
+    "reference_desc": "Use directly, auto-sync updates, cannot modify",
+    "copy": "Copy Mode",
+    "copy_desc": "Create a private copy, can freely modify"
+  },
+  "no_teams": "No agents found",
+  "no_teams_hint": "Try adjusting your search or category filter",
+  "no_description": "No description available",
+  "loading": "Loading agents...",
+  "loading_more": "Loading...",
+  "load_more": "Load More",
+  "error_loading": "Failed to load marketplace agents",
+  "marketplace_tag": "Marketplace"
+}

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -56,6 +56,7 @@
     "chat": "聊天",
     "code": "编码",
     "wiki": "知识",
+    "marketplace": "市场",
     "settings": "设置",
     "docs": "文档",
     "feedback": "问题反馈",

--- a/frontend/src/i18n/locales/zh-CN/marketplace.json
+++ b/frontend/src/i18n/locales/zh-CN/marketplace.json
@@ -1,0 +1,39 @@
+{
+  "title": "智能体市场",
+  "description": "浏览并安装市场中的 AI 智能体",
+  "search_placeholder": "搜索智能体...",
+  "categories": {
+    "all": "全部",
+    "development": "开发",
+    "office": "办公",
+    "creative": "创意",
+    "data_analysis": "数据分析",
+    "education": "教育",
+    "other": "其他"
+  },
+  "install": "安装",
+  "uninstall": "卸载",
+  "installed": "已安装",
+  "installing": "安装中...",
+  "install_count": "{{count}} 次安装",
+  "install_success": "智能体安装成功",
+  "install_failed": "安装智能体失败",
+  "uninstall_success": "智能体卸载成功",
+  "uninstall_failed": "卸载智能体失败",
+  "install_mode": {
+    "title": "选择安装模式",
+    "description": "您希望如何安装「{{name}}」？",
+    "reference": "引用模式",
+    "reference_desc": "直接使用，自动同步更新，不可修改",
+    "copy": "复制模式",
+    "copy_desc": "复制为私有副本，可自由修改"
+  },
+  "no_teams": "未找到智能体",
+  "no_teams_hint": "请尝试调整搜索条件或分类筛选",
+  "no_description": "暂无描述",
+  "loading": "正在加载智能体...",
+  "loading_more": "加载中...",
+  "load_more": "加载更多",
+  "error_loading": "加载市场智能体失败",
+  "marketplace_tag": "市场"
+}

--- a/frontend/src/i18n/setup.ts
+++ b/frontend/src/i18n/setup.ts
@@ -26,6 +26,7 @@ async function loadTranslations() {
     'knowledge',
     'shared-task',
     'promptTune',
+    'marketplace',
   ]
 
   for (const lng of supportedLanguages) {
@@ -75,6 +76,7 @@ export async function initI18n() {
       'knowledge',
       'shared-task',
       'promptTune',
+      'marketplace',
     ],
   })
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -132,7 +132,7 @@ export interface Team {
   user_id: number
   created_at: string
   updated_at: string
-  share_status?: number // 0: 个人团队, 1: 分享中, 2: 共享团队
+  share_status?: number // 0: private, 1: sharing, 2: shared from others, 3: marketplace installed
   agent_type?: string // agno, claude, dify, etc.
   is_mix_team?: boolean // true if team has multiple different agent types (e.g., ClaudeCode + Agno)
   recommended_mode?: 'chat' | 'code' | 'both' // Recommended usage mode (for QuickAccess)

--- a/frontend/src/types/marketplace.ts
+++ b/frontend/src/types/marketplace.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Marketplace types for Agent Marketplace feature
+
+export type MarketplaceCategory =
+  | 'development'
+  | 'office'
+  | 'creative'
+  | 'data_analysis'
+  | 'education'
+  | 'other'
+
+export type InstallMode = 'reference' | 'copy'
+
+// Marketplace team list item
+export interface MarketplaceTeam {
+  id: number
+  team_id: number
+  name: string
+  category: string
+  description: string | null
+  icon: string | null
+  allow_reference: boolean
+  allow_copy: boolean
+  install_count: number
+  is_active: boolean
+  published_at: string | null
+  bind_mode: ('chat' | 'code')[] | null
+  agent_type: string | null
+  bots_count: number
+  is_installed: boolean
+  installed_mode: InstallMode | null
+}
+
+// Marketplace team detail
+export interface MarketplaceTeamDetail extends MarketplaceTeam {
+  team_data: Record<string, unknown> | null
+  bots:
+    | {
+        id: number
+        name: string
+        role: string
+        prompt: string
+      }[]
+    | null
+}
+
+// Category item
+export interface CategoryItem {
+  value: string
+  label: string
+  count: number
+}
+
+// Installed team record
+export interface InstalledTeam {
+  id: number
+  user_id: number
+  marketplace_team_id: number
+  install_mode: InstallMode
+  copied_team_id: number | null
+  is_active: boolean
+  installed_at: string
+  uninstalled_at: string | null
+  marketplace_team: MarketplaceTeam | null
+}
+
+// API Response types
+export interface MarketplaceTeamListResponse {
+  total: number
+  items: MarketplaceTeam[]
+}
+
+export interface CategoryListResponse {
+  categories: CategoryItem[]
+}
+
+export interface InstalledTeamListResponse {
+  total: number
+  items: InstalledTeam[]
+}
+
+export interface InstallTeamRequest {
+  mode: InstallMode
+}
+
+export interface InstallTeamResponse {
+  success: boolean
+  message: string
+  installed_team_id: number
+  install_mode: InstallMode
+  copied_team_id: number | null
+}
+
+export interface UninstallTeamResponse {
+  success: boolean
+  message: string
+}


### PR DESCRIPTION
## Summary

- Implement a new Agent Marketplace feature similar to an App Store
- Add database tables `team_marketplace` and `installed_teams` for storing marketplace metadata and user installations
- Create marketplace service with full CRUD operations and installation logic
- Add API endpoints for browsing, searching, installing, and admin management
- Create frontend marketplace page `/marketplace` with search and category filtering
- Support two installation modes: reference (direct use) and copy (private copy)
- Integrate installed marketplace agents into user's agent list (share_status=3)
- Add sidebar navigation entry and i18n translations (English/Chinese)

## Changes

### Backend
- `backend/alembic/versions/q7r8s9t0u1v2_add_marketplace_tables.py`: Database migration for marketplace tables
- `backend/app/models/marketplace.py`: SQLAlchemy models for TeamMarketplace and InstalledTeam
- `backend/app/schemas/marketplace.py`: Pydantic schemas for marketplace API
- `backend/app/services/marketplace_service.py`: Business logic for marketplace operations
- `backend/app/api/endpoints/marketplace.py`: REST API endpoints
- `backend/app/services/adapters/team_kinds.py`: Updated to include installed marketplace teams

### Frontend
- `frontend/src/app/(tasks)/marketplace/page.tsx`: Marketplace page
- `frontend/src/features/marketplace/components/`: MarketplaceGrid, MarketplaceTeamCard, InstallModeDialog
- `frontend/src/apis/marketplace.ts`: API client functions
- `frontend/src/types/marketplace.ts`: TypeScript type definitions
- `frontend/src/features/settings/components/TeamList.tsx`: Show marketplace tag for installed agents
- `frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx`: Add marketplace navigation

### Key Features
1. **Categories**: development, office, creative, data_analysis, education, other
2. **Install Modes**:
   - Reference: Direct use, auto-sync updates, cannot modify
   - Copy: Create private copy, can freely modify
3. **Admin Controls**: Publish/unpublish teams, set allowed install modes

## Test plan

- [ ] Verify marketplace page loads and displays agents
- [ ] Verify search and category filtering work correctly
- [ ] Verify install in reference mode adds agent to user's list
- [ ] Verify install in copy mode creates a private copy
- [ ] Verify uninstall removes agent from user's list
- [ ] Verify marketplace tag shows on installed agents in settings
- [ ] Verify admin can publish/unpublish marketplace teams
- [ ] Verify i18n translations work for both English and Chinese