### PR TITLE
fix(executor): use correct workspace path for attachment downloads

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -1383,10 +1383,11 @@ class ClaudeCodeAgent(Agent):
                 logger.warning("No auth token available, cannot download attachments")
                 return
 
-            # Determine workspace path
-            workspace = self.project_path or os.path.join(
-                config.WORKSPACE_ROOT, str(self.task_id)
-            )
+            # Determine workspace path for attachments
+            # Attachments should be stored in WORKSPACE_ROOT/task_id, not in the project path
+            # This ensures attachments are accessible at /workspace/{task_id}:executor:attachments/...
+            # instead of /workspace/{task_id}/{repo_name}/{task_id}:executor:attachments/...
+            workspace = os.path.join(config.WORKSPACE_ROOT, str(self.task_id))
 
             # Import and use attachment downloader
             from executor.services.attachment_downloader import \


### PR DESCRIPTION
## Summary
- Fix attachment download path to save files to the correct location
- Changed from `project_path` (repo directory) to `WORKSPACE_ROOT/task_id` (workspace root)
- This ensures attachments are accessible at `/workspace/{task_id}/{task_id}:executor:attachments/{subtask_id}/` instead of being incorrectly nested inside the repository directory

## Problem
- **Expected path:** `/workspace/115794/115794:executor:attachments/119916/filename.png`
- **Actual path (bug):** `/workspace/115794/Wegent/115794:executor:attachments/119916/filename.png`

## Root Cause
The attachment downloader was using `self.project_path` (which points to the cloned repository directory) as the base path, instead of `WORKSPACE_ROOT/task_id`.

## Test plan
- [ ] Verify attachments are downloaded to the correct path
- [ ] Confirm attachment references in prompts resolve correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved attachment storage to use a standardized path structure, simplifying how attachments are organized and accessed within the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->