### PR TITLE
feat(executor): improve attachment prompt with clearer guidance for model

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -1383,10 +1383,11 @@ class ClaudeCodeAgent(Agent):
                 logger.warning("No auth token available, cannot download attachments")
                 return
 
-            # Determine workspace path
-            workspace = self.project_path or os.path.join(
-                config.WORKSPACE_ROOT, str(self.task_id)
-            )
+            # Determine workspace path for attachments
+            # Attachments should be stored in WORKSPACE_ROOT/task_id, not in the project path
+            # This ensures attachments are accessible at /workspace/{task_id}:executor:attachments/...
+            # instead of /workspace/{task_id}/{repo_name}/{task_id}:executor:attachments/...
+            workspace = os.path.join(config.WORKSPACE_ROOT, str(self.task_id))
 
             # Import and use attachment downloader
             from executor.services.attachment_downloader import \

--- a/executor/services/attachment_prompt_processor.py
+++ b/executor/services/attachment_prompt_processor.py
@@ -104,7 +104,13 @@ class AttachmentPromptProcessor:
         if not success_attachments:
             return ""
 
-        context_lines = ["\n\n📎 Available attachments:"]
+        # Build header with clear instructions for the model
+        context_lines = [
+            "\n\n📎 User-uploaded attachments:",
+            "The following files have been uploaded by the user and downloaded to the local filesystem.",
+            "You can read these files using the Read tool or appropriate file reading commands.",
+        ]
+
         for att in success_attachments:
             filename = att.get("original_filename", "unknown")
             local_path = att.get("local_path", "")
@@ -120,7 +126,7 @@ class AttachmentPromptProcessor:
                 size_str = f"{file_size} bytes"
 
             context_lines.append(
-                f"- {filename} ({mime_type}, {size_str}): {local_path}"
+                f"- {filename} ({mime_type}, {size_str})\n  Path: {local_path}"
             )
 
         return "\n".join(context_lines)


### PR DESCRIPTION
## Summary

- Update the attachment context prompt to provide clearer instructions for the AI model
- Add explicit guidance on using Read tool or file commands to access attachments
- Clarify that files are downloaded to local filesystem
- Improve path formatting with dedicated line for each file path

## Changes

The `build_attachment_context` method in `AttachmentPromptProcessor` now generates more informative prompt text:

**Before:**
```
📎 Available attachments:
- example.pdf (application/pdf, 1.2 MB): /workspace/123/123:executor:attachments/456/example.pdf
```

**After:**
```
📎 User-uploaded attachments:
The following files have been uploaded by the user and downloaded to the local filesystem.
You can read these files using the Read tool or appropriate file reading commands.
- example.pdf (application/pdf, 1.2 MB)
  Path: /workspace/123/123:executor:attachments/456/example.pdf
```

## Test plan

- [ ] Verify attachment prompt formatting in executor logs
- [ ] Test with different file types (PDF, images, text files)
- [ ] Confirm AI model can successfully access files using the provided paths