### PR TITLE
fix(executor): clean up task state after cancel to prevent 'Request interrupted' error

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -1383,10 +1383,11 @@ class ClaudeCodeAgent(Agent):
                 logger.warning("No auth token available, cannot download attachments")
                 return
 
-            # Determine workspace path
-            workspace = self.project_path or os.path.join(
-                config.WORKSPACE_ROOT, str(self.task_id)
-            )
+            # Determine workspace path for attachments
+            # Attachments should be stored in WORKSPACE_ROOT/task_id, not in the project path
+            # This ensures attachments are accessible at /workspace/{task_id}:executor:attachments/...
+            # instead of /workspace/{task_id}/{repo_name}/{task_id}:executor:attachments/...
+            workspace = os.path.join(config.WORKSPACE_ROOT, str(self.task_id))
 
             # Import and use attachment downloader
             from executor.services.attachment_downloader import \

--- a/start.sh
+++ b/start.sh
@@ -770,8 +770,10 @@ start_services() {
         "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:8000/api/internal && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --host 0.0.0.0 --port 8100"
 
     # 3. Start Executor Manager
+    # TASK_API_DOMAIN uses local IP so docker containers can access the backend
+    # DOCKER_HOST_ADDR=localhost so executor_manager can access docker containers
     start_service "executor_manager" "executor_manager" \
-        "export EXECUTOR_IMAGE=$EXECUTOR_IMAGE && export TASK_API_DOMAIN=http://localhost:8000 && export NETWORK=wegent-network && source .venv/bin/activate && uvicorn main:app --reload --host 0.0.0.0 --port 8001"
+        "export EXECUTOR_IMAGE=$EXECUTOR_IMAGE && export TASK_API_DOMAIN=http://$(get_local_ip):8000 && export DOCKER_HOST_ADDR=localhost && export NETWORK=wegent-network && source .venv/bin/activate && uvicorn main:app --reload --host 0.0.0.0 --port 8001"
 
     # 4. Start Frontend (run in background)
     echo -e "  Starting ${BLUE}frontend${NC}..."


### PR DESCRIPTION
## Summary

- 修复取消任务后发送下一条消息报错 "Request interrupted by user" 的问题
- 在 `send_cancel_callback_async()` 方法中添加任务状态清理逻辑

## Problem

当用户取消 Claude 任务后，`TaskStateManager` 中的任务状态被设置为 `CANCELLED`。但是由于没有清理该状态，当用户发送下一条消息时：

1. Executor 复用已存在的 agent session
2. `_async_execute()` 方法检查 `task_state_manager.is_cancelled(task_id)` 返回 `True`
3. 任务立即返回，导致 "Request interrupted by user" 错误

## Solution

在 `send_cancel_callback_async()` 方法中，取消回调发送后调用 `task_state_manager.cleanup(task_id)` 清理任务状态，确保后续消息可以正常处理。

## Changes

- 在 `executor/services/agent_service.py` 中导入 `TaskStateManager`
- 在取消回调发送后调用 `task_state_manager.cleanup(task_id)`
- 在异常处理中也添加状态清理，确保状态始终被清理

## Test plan

- [ ] 取消正在执行的 Claude 任务
- [ ] 取消后发送新消息，验证消息正常发送和处理
- [ ] 验证不会出现 "Request interrupted by user" 错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of agent creation, cancellation and callback flows with consistent cleanup and clearer error handling.
  * Fixed cases where task state could be left inconsistent after failures or cancel attempts.

* **Improvements**
  * Clearer, more consistent logging and status/result formatting for agent operations.
  * Safer parsing of bot configuration values and standardized handling of missing values.
  * Standardized attachment workspace paths to a task-specific workspace.

* **Chores**
  * Updated startup environment to reference the local network address for manager connectivity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->