### PR TITLE
fix(chat_shell): disable file tools by default when no workspace context

### DIFF
--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -231,6 +231,9 @@ async def _stream_response(
             enable_deep_thinking=(
                 request.features.deep_thinking if request.features else False
             ),
+            enable_file_skills=(
+                request.features.file_skills if request.features else False
+            ),
             search_engine=(
                 request.features.search_engine if request.features else None
             ),

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -164,6 +164,9 @@ class FeaturesConfig(BaseModel):
     message_compression: bool = Field(True, description="Enable message compression")
     web_search: bool = Field(False, description="Enable web search tool")
     search_engine: Optional[str] = Field(None, description="Preferred search engine")
+    file_skills: bool = Field(
+        False, description="Enable file skills (read_file, list_files)"
+    )
 
 
 class Metadata(BaseModel):

--- a/chat_shell/chat_shell/interface.py
+++ b/chat_shell/chat_shell/interface.py
@@ -60,6 +60,7 @@ class ChatRequest:
     enable_web_search: bool = False
     enable_clarification: bool = False
     enable_deep_thinking: bool = True
+    enable_file_skills: bool = False  # File tools require explicit enablement
     search_engine: Optional[str] = None
 
     # Bot configuration

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -142,10 +142,13 @@ class ChatService(ChatInterface):
             # Get database session for other operations (tools, skills, etc.)
             async for db in get_db():
                 try:
-                    # Create the agent (note: web search is handled separately below)
+                    # Create the agent
+                    # File skills are only enabled when explicitly requested via
+                    # enable_file_skills. This prevents file tools (read_file, list_files)
+                    # from being sent when the request has no workspace context.
                     agent = create_chat_agent(
                         workspace_root=settings.WORKSPACE_ROOT,
-                        enable_skills=settings.ENABLE_SKILLS,
+                        enable_skills=request.enable_file_skills,
                         enable_web_search=False,  # We'll add it manually if needed
                         enable_checkpointing=settings.ENABLE_CHECKPOINTING,
                     )

--- a/chat_shell/tests/test_file_skills_enablement.py
+++ b/chat_shell/tests/test_file_skills_enablement.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for file skills enablement behavior.
+
+This module tests that file skills (read_file, list_files) are only enabled
+when explicitly requested, preventing tools from being sent when no workspace
+context is provided in the request.
+"""
+
+import pytest
+
+from chat_shell.interface import ChatRequest
+
+
+class TestChatRequestFileSkills:
+    """Tests for ChatRequest enable_file_skills field."""
+
+    def test_enable_file_skills_default_is_false(self):
+        """Test that enable_file_skills defaults to False.
+
+        When a request is made without workspace context, file tools should
+        not be sent to the model.
+        """
+        request = ChatRequest(
+            task_id=1,
+            subtask_id=1,
+            message="Hello",
+            user_id=1,
+            user_name="test",
+            team_id=1,
+            team_name="test_team",
+        )
+
+        # Default should be False - no file tools unless explicitly enabled
+        assert request.enable_file_skills is False
+
+    def test_enable_file_skills_can_be_enabled(self):
+        """Test that enable_file_skills can be explicitly enabled."""
+        request = ChatRequest(
+            task_id=1,
+            subtask_id=1,
+            message="Hello",
+            user_id=1,
+            user_name="test",
+            team_id=1,
+            team_name="test_team",
+            enable_file_skills=True,
+        )
+
+        assert request.enable_file_skills is True
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("langchain_core", reason="langchain_core not installed"),
+    reason="langchain_core not installed",
+)
+class TestChatAgentFileSkillsRegistration:
+    """Tests for ChatAgent file skills registration behavior."""
+
+    def test_create_chat_agent_without_skills(self):
+        """Test that ChatAgent without enable_skills has no file tools."""
+        from chat_shell.agent import create_chat_agent
+
+        agent = create_chat_agent(
+            workspace_root="/workspace",
+            enable_skills=False,
+            enable_web_search=False,
+        )
+
+        tool_names = [t.name for t in agent.tool_registry.get_all()]
+
+        # Should not have file tools when enable_skills=False
+        assert "read_file" not in tool_names
+        assert "list_files" not in tool_names
+
+    def test_create_chat_agent_with_skills(self):
+        """Test that ChatAgent with enable_skills has file tools."""
+        from chat_shell.agent import create_chat_agent
+
+        agent = create_chat_agent(
+            workspace_root="/workspace",
+            enable_skills=True,
+            enable_web_search=False,
+        )
+
+        tool_names = [t.name for t in agent.tool_registry.get_all()]
+
+        # Should have file tools when enable_skills=True
+        assert "read_file" in tool_names
+        assert "list_files" in tool_names
+
+
+class TestFeaturesConfigFileSkills:
+    """Tests for FeaturesConfig file_skills field."""
+
+    def test_features_config_file_skills_default_is_false(self):
+        """Test that FeaturesConfig.file_skills defaults to False."""
+        from chat_shell.api.v1.schemas import FeaturesConfig
+
+        config = FeaturesConfig()
+
+        assert config.file_skills is False
+
+    def test_features_config_file_skills_can_be_enabled(self):
+        """Test that FeaturesConfig.file_skills can be set to True."""
+        from chat_shell.api.v1.schemas import FeaturesConfig
+
+        config = FeaturesConfig(file_skills=True)
+
+        assert config.file_skills is True
+
+
+class TestResponseRequestFileSkillsPassthrough:
+    """Tests for file_skills passthrough from API request to ChatRequest."""
+
+    def test_request_without_file_skills_feature(self):
+        """Test that request without file_skills feature results in False.
+
+        When a user makes an API request without specifying file_skills,
+        the ChatRequest should have enable_file_skills=False.
+        """
+        from chat_shell.api.v1.schemas import FeaturesConfig
+
+        # Simulate default features (user didn't specify file_skills)
+        features = FeaturesConfig()
+
+        # This is what the API handler would pass to ChatRequest
+        enable_file_skills = features.file_skills
+
+        assert enable_file_skills is False
+
+    def test_request_with_file_skills_feature_enabled(self):
+        """Test that request with file_skills=True passes through correctly."""
+        from chat_shell.api.v1.schemas import FeaturesConfig
+
+        # Simulate user enabling file_skills
+        features = FeaturesConfig(file_skills=True)
+
+        enable_file_skills = features.file_skills
+
+        assert enable_file_skills is True


### PR DESCRIPTION
## Summary

- Add `enable_file_skills` field to ChatRequest (default: False) to control whether file tools are registered
- Add `file_skills` field to FeaturesConfig in API schemas for explicit enablement via API
- Update ChatService to use `request.enable_file_skills` instead of global `settings.ENABLE_SKILLS`
- Pass `enable_file_skills` from API request features to ChatRequest

## Problem

When making API requests to `/api/v1/responses` without any workspace data (e.g., simple chat queries), file tools (`read_file`, `list_files`) were being sent to the model even though they cannot be used in that context. This caused:
- Unnecessary token usage
- Potential confusion for the model
- Tools appearing in logs when they shouldn't be available

## Solution

File tools will only be registered when explicitly requested via `features.file_skills=true` in the API request. This ensures clean API responses without unnecessary tools when no workspace context is provided.

## Test Plan

- [x] Added unit tests for `ChatRequest.enable_file_skills` default behavior
- [x] Added unit tests for `FeaturesConfig.file_skills` field
- [x] Added unit tests for `ChatAgent` file skills registration
- [x] Verified existing tests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling file-based skills in chat responses, allowing read_file and list_files capabilities to be configured per request.

* **Tests**
  * Comprehensive test coverage for file skills enablement, including default behavior, explicit enablement, and feature configuration validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->