### PR TITLE
fix(frontend): fix race condition in repository search

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/selector/RepositorySelector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/RepositorySelector.test.tsx
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RepositorySelector from '@/features/tasks/components/selector/RepositorySelector'
+import { githubApis } from '@/apis/github'
+import { GitRepoInfo } from '@/types/api'
+
+// Mock ResizeObserver for cmdk component
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// Mock scrollIntoView for cmdk component
+Element.prototype.scrollIntoView = jest.fn()
+
+// Mock dependencies
+jest.mock('@/apis/github', () => ({
+  githubApis: {
+    getRepositories: jest.fn(),
+    searchRepositories: jest.fn(),
+    refreshRepositories: jest.fn(),
+  },
+}))
+
+jest.mock('@/features/common/UserContext', () => ({
+  useUser: () => ({
+    user: {
+      git_info: [{ id: 1, name: 'github' }],
+    },
+  }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'branches.search_repository': 'Search repository...',
+        'branches.select_repository': 'Select repository',
+        'branches.no_match': 'No match found',
+        'branches.refresh_success': 'Refresh successful',
+        'branches.refresh_failed': 'Refresh failed',
+        'branches.refreshing': 'Refreshing...',
+        'branches.configure_integration': 'Configure Integration',
+        'branches.load_more': 'Load more',
+        'actions.refresh': 'Refresh',
+        'repos.repository_tooltip': 'Select repository',
+      }
+      return translations[key] || key
+    },
+  }),
+}))
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
+
+jest.mock('@/utils/userPreferences', () => ({
+  getLastRepo: jest.fn(() => null),
+}))
+
+jest.mock('@/features/layout/hooks/useMediaQuery', () => ({
+  useIsMobile: () => false,
+}))
+
+// Mock data
+const mockRepos: GitRepoInfo[] = [
+  {
+    git_repo_id: 1,
+    name: 'repo-1',
+    git_repo: 'owner/repo-1',
+    git_url: 'https://github.com/owner/repo-1',
+    git_domain: 'github.com',
+    private: false,
+    type: 'github',
+  },
+  {
+    git_repo_id: 2,
+    name: 'repo-2',
+    git_repo: 'owner/repo-2',
+    git_url: 'https://github.com/owner/repo-2',
+    git_domain: 'github.com',
+    private: false,
+    type: 'github',
+  },
+  {
+    git_repo_id: 3,
+    name: 'repo-3',
+    git_repo: 'owner/repo-3',
+    git_url: 'https://github.com/owner/repo-3',
+    git_domain: 'github.com',
+    private: false,
+    type: 'github',
+  },
+]
+
+const mockSearchResults: GitRepoInfo[] = [
+  {
+    git_repo_id: 4,
+    name: 'video-app',
+    git_repo: 'owner/video-app',
+    git_url: 'https://github.com/owner/video-app',
+    git_domain: 'github.com',
+    private: false,
+    type: 'github',
+  },
+]
+
+describe('RepositorySelector', () => {
+  const mockHandleRepoChange = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(githubApis.getRepositories as jest.Mock).mockResolvedValue(mockRepos)
+    ;(githubApis.searchRepositories as jest.Mock).mockResolvedValue(mockSearchResults)
+    ;(githubApis.refreshRepositories as jest.Mock).mockResolvedValue(undefined)
+  })
+
+  it('should load repositories on initial mount', async () => {
+    render(
+      <RepositorySelector
+        selectedRepo={null}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait for initial load (may be called multiple times due to React StrictMode)
+    await waitFor(() => {
+      expect(githubApis.getRepositories).toHaveBeenCalled()
+    })
+  })
+
+  it('should NOT reload repositories when search returns empty results', async () => {
+    // Mock search to return empty results
+    ;(githubApis.searchRepositories as jest.Mock).mockResolvedValue([])
+
+    const user = userEvent.setup()
+
+    render(
+      <RepositorySelector
+        selectedRepo={null}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(githubApis.getRepositories).toHaveBeenCalled()
+    })
+
+    // Record how many times getRepositories was called during initial load
+    const initialCallCount = (githubApis.getRepositories as jest.Mock).mock.calls.length
+
+    // Find and click the selector to open the popover
+    const trigger = screen.getByRole('combobox')
+    await user.click(trigger)
+
+    // Type a search query that returns no results
+    const searchInput = screen.getByPlaceholderText('Search repository...')
+    await user.type(searchInput, 'nonexistent-repo')
+
+    // Wait for debounce and search to complete
+    await waitFor(
+      () => {
+        expect(githubApis.searchRepositories).toHaveBeenCalledWith('nonexistent-repo', {
+          fullmatch: false,
+          timeout: 30,
+        })
+      },
+      { timeout: 1000 }
+    )
+
+    // Wait a bit more for any potential side effects
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    })
+
+    // The key assertion: getRepositories should NOT be called again after search
+    // even though search returned empty results and repos.length becomes 0
+    expect((githubApis.getRepositories as jest.Mock).mock.calls.length).toBe(initialCallCount)
+  })
+
+  it('should restore cached repos when search is cleared', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <RepositorySelector
+        selectedRepo={null}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(githubApis.getRepositories).toHaveBeenCalled()
+    })
+
+    // Record initial call count
+    const initialCallCount = (githubApis.getRepositories as jest.Mock).mock.calls.length
+
+    // Open selector
+    const trigger = screen.getByRole('combobox')
+    await user.click(trigger)
+
+    // Type a search query
+    const searchInput = screen.getByPlaceholderText('Search repository...')
+    await user.type(searchInput, 'video')
+
+    // Wait for search
+    await waitFor(
+      () => {
+        expect(githubApis.searchRepositories).toHaveBeenCalled()
+      },
+      { timeout: 1000 }
+    )
+
+    // Clear search input
+    await user.clear(searchInput)
+
+    // Wait a bit for any potential side effects
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    })
+
+    // Should NOT call getRepositories - should use cached repos
+    expect((githubApis.getRepositories as jest.Mock).mock.calls.length).toBe(initialCallCount)
+  })
+
+  it('should only load repositories during initial mount, not on rerender with selected repo', async () => {
+    const { rerender } = render(
+      <RepositorySelector
+        selectedRepo={null}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(githubApis.getRepositories).toHaveBeenCalled()
+    })
+
+    // Record initial call count
+    const initialCallCount = (githubApis.getRepositories as jest.Mock).mock.calls.length
+
+    // Rerender with a selected repo
+    rerender(
+      <RepositorySelector
+        selectedRepo={mockRepos[0]}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait a bit for any potential side effects
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    })
+
+    // Should not trigger additional getRepositories calls
+    expect((githubApis.getRepositories as jest.Mock).mock.calls.length).toBe(initialCallCount)
+  })
+
+  it('should not reload full repository list when search returns empty results', async () => {
+    // Mock both local and remote search to return empty
+    ;(githubApis.searchRepositories as jest.Mock).mockResolvedValue([])
+
+    const user = userEvent.setup()
+
+    render(
+      <RepositorySelector
+        selectedRepo={null}
+        handleRepoChange={mockHandleRepoChange}
+        disabled={false}
+      />
+    )
+
+    // Wait for initial load
+    await waitFor(() => {
+      expect(githubApis.getRepositories).toHaveBeenCalled()
+    })
+
+    // Record initial call count
+    const initialCallCount = (githubApis.getRepositories as jest.Mock).mock.calls.length
+
+    // Open selector
+    const trigger = screen.getByRole('combobox')
+    await user.click(trigger)
+
+    // Type a search query that returns no results (not matching any local repos)
+    const searchInput = screen.getByPlaceholderText('Search repository...')
+    await user.type(searchInput, 'zzz-nonexistent')
+
+    // Wait for search to complete
+    await waitFor(
+      () => {
+        expect(githubApis.searchRepositories).toHaveBeenCalled()
+      },
+      { timeout: 1000 }
+    )
+
+    // Wait a bit more for any potential side effects
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 100))
+    })
+
+    // The key assertion: getRepositories should NOT be called again
+    // This is the bug we fixed - empty search results should not trigger a full reload
+    expect((githubApis.getRepositories as jest.Mock).mock.calls.length).toBe(initialCallCount)
+  })
+})

--- a/frontend/src/features/tasks/components/selector/RepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/RepositorySelector.tsx
@@ -5,38 +5,14 @@
 'use client'
 
 import * as React from 'react'
-import { useState, useEffect, useMemo, useCallback, useRef } from 'react'
-
-/**
- * Truncate text to a maximum length, keeping start and end with ellipsis in the middle
- * @param text - The text to truncate
- * @param maxLength - Maximum length of the text
- * @param startChars - Number of characters to keep at the start (default: 10)
- * @param endChars - Number of characters to keep at the end (default: 8)
- * @returns Truncated text with ellipsis in the middle if needed
- */
-function truncateMiddle(text: string, maxLength: number, startChars = 8, endChars = 10): string {
-  if (text.length <= maxLength) {
-    return text
-  }
-
-  const start = text.slice(0, startChars)
-  const end = text.slice(-endChars)
-  return `${start}...${end}`
-}
+import { useState, useMemo } from 'react'
 import { SearchableSelect, SearchableSelectItem } from '@/components/ui/searchable-select'
 import { FiGithub } from 'react-icons/fi'
-import { Loader2, RefreshCw, Check } from 'lucide-react'
-import { Cog6ToothIcon } from '@heroicons/react/24/outline'
-import { GitRepoInfo, TaskDetail } from '@/types/api'
-import { useUser } from '@/features/common/UserContext'
+import { Loader2, Check } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { paths } from '@/config/paths'
 import { useTranslation } from '@/hooks/useTranslation'
-import { getLastRepo } from '@/utils/userPreferences'
-import { githubApis } from '@/apis/github'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
-import { useToast } from '@/hooks/use-toast'
 import { cn } from '@/lib/utils'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -49,17 +25,15 @@ import {
   CommandList,
 } from '@/components/ui/command'
 
-interface RepositorySelectorProps {
-  selectedRepo: GitRepoInfo | null
-  handleRepoChange: (repo: GitRepoInfo | null) => void
-  disabled: boolean
-  selectedTaskDetail?: TaskDetail | null
-  /** When true, the selector will take full width of its container */
-  fullWidth?: boolean
-  /** When true, display only icon without text (for responsive collapse) */
-  compact?: boolean
-}
+import { truncateMiddle } from '@/utils/stringUtils'
+import { RepositorySelectorProps, RepositorySelectItem } from './types'
+import { RepositorySelectorFooter } from './RepositorySelectorFooter'
+import { useRepositorySearch } from '../../hooks/useRepositorySearch'
 
+/**
+ * RepositorySelector component
+ * Provides repository selection with search, caching, and refresh functionality
+ */
 export default function RepositorySelector({
   selectedRepo,
   handleRepoChange,
@@ -68,343 +42,33 @@ export default function RepositorySelector({
   fullWidth = false,
   compact = false,
 }: RepositorySelectorProps) {
-  const { toast } = useToast()
   const { t } = useTranslation()
-  const { user } = useUser()
   const router = useRouter()
-  const [repos, setRepos] = useState<GitRepoInfo[]>([])
-  const [cachedRepos, setCachedRepos] = useState<GitRepoInfo[]>([]) // Cache initially loaded repositories
-  const [loading, setLoading] = useState<boolean>(false)
-  const [isSearching, setIsSearching] = useState<boolean>(false) // User is searching (includes waiting period)
-  const [isRefreshing, setIsRefreshing] = useState<boolean>(false) // Refreshing repository cache
-  const [currentSearchQuery, setCurrentSearchQuery] = useState<string>('') // Current search query for refresh
-  const [error, setError] = useState<string | null>(null)
-  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
-  // Check if user has git_info configured
-  const hasGitInfo = () => {
-    return user && user.git_info && user.git_info.length > 0
-  }
-
-  /**
-   * Load repositories from API
-   * Returns the loaded repos for chaining
-   */
-  const loadRepositories = async (): Promise<GitRepoInfo[]> => {
-    if (!hasGitInfo()) {
-      return []
-    }
-
-    setLoading(true)
-    setError(null)
-
-    try {
-      const data = await githubApis.getRepositories()
-      setRepos(data)
-      setCachedRepos(data) // Cache initial repository list
-      setError(null)
-      return data
-    } catch {
-      setError('Failed to load repositories')
-      toast({
-        variant: 'destructive',
-        title: 'Failed to load repositories',
-      })
-      return []
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  /**
-   * Search repositories locally (in cache)
-   */
-  const searchLocalRepos = useCallback(
-    (query: string): GitRepoInfo[] => {
-      if (!query.trim()) {
-        return cachedRepos
-      }
-      const lowerQuery = query.toLowerCase()
-      return cachedRepos.filter(repo => repo.git_repo.toLowerCase().includes(lowerQuery))
-    },
-    [cachedRepos]
-  )
-
-  /**
-   * Search repositories remotely (delayed execution)
-   */
-  const searchRemoteRepos = useCallback(
-    async (query: string) => {
-      if (!query.trim()) {
-        setRepos(cachedRepos)
-        return
-      }
-
-      try {
-        const results = await githubApis.searchRepositories(query, {
-          fullmatch: false,
-          timeout: 30,
-        })
-
-        // Merge local and remote results, remove duplicates
-        const localResults = searchLocalRepos(query)
-        const mergedResults = [...localResults]
-
-        results.forEach(remoteRepo => {
-          if (!mergedResults.find(r => r.git_repo_id === remoteRepo.git_repo_id)) {
-            mergedResults.push(remoteRepo)
-          }
-        })
-
-        setRepos(mergedResults)
-        setError(null)
-      } catch {
-        // Keep local results when remote search fails
-        console.error('Remote search failed, keeping local results')
-      } finally {
-        setIsSearching(false) // Hide loading indicator when remote search completes
-      }
-    },
-    [cachedRepos, searchLocalRepos]
-  )
-
-  /**
-   * Handle search input changes
-   */
-  const handleSearchChange = useCallback(
-    (query: string) => {
-      // Track current search query for refresh functionality
-      setCurrentSearchQuery(query)
-
-      // Clear previous timer
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current)
-      }
-
-      // If search is empty, restore cached repos immediately
-      if (!query.trim()) {
-        setRepos(cachedRepos)
-        setIsSearching(false)
-        return
-      }
-
-      // Show loading indicator immediately when user starts typing
-      setIsSearching(true)
-
-      // Immediately perform local search
-      const localResults = searchLocalRepos(query)
-      setRepos(localResults)
-
-      // Delay 1 second before remote search (regardless of local results)
-      searchTimeoutRef.current = setTimeout(() => {
-        searchRemoteRepos(query)
-      }, 1000)
-    },
-    [searchLocalRepos, searchRemoteRepos, cachedRepos]
-  )
-
-  /**
-   * Handle refresh cache button click
-   * Clears backend Redis cache and reloads repository list
-   */
-  const handleRefreshCache = useCallback(async () => {
-    if (isRefreshing) return // Prevent duplicate clicks
-
-    setIsRefreshing(true)
-    try {
-      // 1. Call backend API to clear cache
-      await githubApis.refreshRepositories()
-
-      // 2. Reload data based on current search state
-      if (currentSearchQuery.trim()) {
-        // Has search query: re-execute search
-        const results = await githubApis.searchRepositories(currentSearchQuery, {
-          fullmatch: false,
-          timeout: 30,
-        })
-        setRepos(results)
-      } else {
-        // No search query: reload all repositories
-        const data = await githubApis.getRepositories()
-        setRepos(data)
-        setCachedRepos(data)
-      }
-
-      toast({ title: t('branches.refresh_success') })
-    } catch {
-      toast({ variant: 'destructive', title: t('branches.refresh_failed') })
-    } finally {
-      setIsRefreshing(false)
-    }
-  }, [isRefreshing, currentSearchQuery, toast, t])
-
-  // Cleanup timer
-  useEffect(() => {
-    return () => {
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleChange = (value: string) => {
-    // First try to find in current repos list (includes search results)
-    let repo = repos.find(r => r.git_repo_id === Number(value))
-
-    // If not found in current list, try cached repos (all initially loaded repos)
-    if (!repo) {
-      repo = cachedRepos.find(r => r.git_repo_id === Number(value))
-    }
-
-    if (repo) {
-      handleRepoChange(repo)
-    }
-  }
-
-  /**
-   * Centralized repository selection logic
-   * Handles all scenarios: mount, task selection, and restoration
-   */
-  useEffect(() => {
-    let canceled = false
-
-    const selectRepository = async () => {
-      const hasGit = hasGitInfo()
-      console.log('[RepositorySelector] Effect triggered', {
-        hasGitInfo: hasGit,
-        user: user ? 'loaded' : 'null',
-        gitInfoLength: user?.git_info?.length || 0,
-        selectedTaskDetail: selectedTaskDetail?.git_repo || 'none',
-        selectedRepo: selectedRepo?.git_repo || 'none',
-        disabled,
-        reposLength: repos.length,
-      })
-
-      if (!hasGit) {
-        console.log('[RepositorySelector] No git info, exiting')
-        return
-      }
-
-      // Scenario 1: Task is selected - use task's repository
-      if (selectedTaskDetail?.git_repo) {
-        console.log(
-          '[RepositorySelector] Scenario 1: Task selected, repo:',
-          selectedTaskDetail.git_repo
-        )
-
-        // Check if already selected
-        if (selectedRepo?.git_repo === selectedTaskDetail.git_repo) {
-          console.log('[RepositorySelector] Already selected, no change needed')
-          return
-        }
-
-        // Try to find in existing repos list
-        const repoInList = repos.find(r => r.git_repo === selectedTaskDetail.git_repo)
-        if (repoInList) {
-          console.log('[RepositorySelector] Found in list, selecting:', repoInList.git_repo)
-          handleRepoChange(repoInList)
-          return
-        }
-
-        // Not found locally - search via API
-        console.log('[RepositorySelector] Not in list, searching via API')
-        try {
-          setLoading(true)
-          const result = await githubApis.searchRepositories(selectedTaskDetail.git_repo, {
-            fullmatch: true,
-          })
-
-          if (canceled) return
-
-          if (result && result.length > 0) {
-            const matched =
-              result.find(r => r.git_repo === selectedTaskDetail.git_repo) ?? result[0]
-            console.log('[RepositorySelector] Found via API, selecting:', matched.git_repo)
-            handleRepoChange(matched)
-            setError(null)
-          } else {
-            toast({
-              variant: 'destructive',
-              title: 'No repositories found',
-            })
-          }
-        } catch {
-          setError('Failed to search repositories')
-          toast({
-            variant: 'destructive',
-            title: 'Failed to search repositories',
-          })
-        } finally {
-          if (!canceled) {
-            setLoading(false)
-          }
-        }
-        return
-      }
-
-      // Scenario 2: No task selected and no repo selected - load repos and optionally restore from localStorage
-      if (!selectedTaskDetail && !selectedRepo && !disabled) {
-        console.log('[RepositorySelector] Scenario 2: Load repos and restore from localStorage')
-
-        // Load repositories if not already loaded
-        let repoList = repos
-        if (repoList.length === 0) {
-          console.log('[RepositorySelector] Repos not loaded, loading now...')
-          repoList = await loadRepositories()
-          console.log('[RepositorySelector] Loaded repos count:', repoList.length)
-          if (canceled || repoList.length === 0) {
-            console.log('[RepositorySelector] Load failed or canceled')
-            return
-          }
-        }
-
-        // Try to restore from localStorage if available
-        const lastRepo = getLastRepo()
-        console.log('[RepositorySelector] Last repo from storage:', lastRepo)
-
-        if (lastRepo) {
-          // Find and select the last repo
-          const repoToRestore = repoList.find(r => r.git_repo_id === lastRepo.repoId)
-          if (repoToRestore) {
-            console.log(
-              '[RepositorySelector] ✅ Restoring repo from localStorage:',
-              repoToRestore.git_repo
-            )
-            handleRepoChange(repoToRestore)
-          } else {
-            console.log('[RepositorySelector] ❌ Repo not found in list, ID:', lastRepo.repoId)
-          }
-        } else {
-          console.log('[RepositorySelector] No last repo in storage, repos loaded but no selection')
-        }
-      } else {
-        console.log('[RepositorySelector] Scenario 2 conditions not met:', {
-          hasTaskDetail: !!selectedTaskDetail,
-          hasSelectedRepo: !!selectedRepo,
-          disabled,
-        })
-      }
-    }
-
-    selectRepository()
-
-    return () => {
-      canceled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTaskDetail?.git_repo, disabled, user, repos.length])
-
-  /**
-   * Navigate to settings page to configure git integration
-   */
-  const handleIntegrationClick = () => {
-    router.push(paths.settings.integrations.getHref())
-  }
   const isMobile = useIsMobile()
 
+  // Use the custom hook for all repository search logic
+  const {
+    repos,
+    loading,
+    isSearching,
+    isRefreshing,
+    error,
+    handleSearchChange,
+    handleRefreshCache,
+    handleChange,
+  } = useRepositorySearch({
+    selectedRepo,
+    handleRepoChange,
+    disabled,
+    selectedTaskDetail,
+  })
+
+  // State for compact mode popover
+  const [compactOpen, setCompactOpen] = useState(false)
+
   // Convert repos to SearchableSelectItem format
-  // Always include the selected repo to ensure it displays correctly
   const selectItems: SearchableSelectItem[] = useMemo(() => {
-    const items = repos.map(repo => ({
+    const items: RepositorySelectItem[] = repos.map(repo => ({
       value: repo.git_repo_id.toString(),
       label: repo.git_repo,
       searchText: repo.git_repo,
@@ -414,7 +78,6 @@ export default function RepositorySelector({
     if (selectedRepo) {
       const hasSelected = items.some(item => item.value === selectedRepo.git_repo_id.toString())
       if (!hasSelected) {
-        // Add selected repo at the beginning if not in current list
         items.unshift({
           value: selectedRepo.git_repo_id.toString(),
           label: selectedRepo.git_repo,
@@ -426,17 +89,18 @@ export default function RepositorySelector({
     return items
   }, [repos, selectedRepo])
 
-  // State for compact mode popover
-  const [compactOpen, setCompactOpen] = React.useState(false)
+  // Navigate to settings page to configure git integration
+  const handleIntegrationClick = () => {
+    router.push(paths.settings.integrations.getHref())
+  }
 
   // Tooltip content for repository selector
-  // In compact mode, show selected repo name in tooltip
   const tooltipContent =
     compact && selectedRepo
       ? `${t('repos.repository_tooltip', '选择代码仓库')}: ${selectedRepo.git_repo}`
       : t('repos.repository_tooltip', '选择代码仓库')
 
-  // In compact mode, use Popover directly instead of hidden SearchableSelect
+  // Compact mode: use Popover with Command
   if (compact) {
     return (
       <div className="flex items-center min-w-0" data-tour="repo-selector">
@@ -539,53 +203,18 @@ export default function RepositorySelector({
                 )}
               </CommandList>
             </Command>
-            <div className="border-t border-border bg-base flex items-center justify-between px-2.5 py-2 text-xs text-text-secondary">
-              <div
-                className="cursor-pointer group flex items-center space-x-2 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1 py-0.5"
-                onClick={handleIntegrationClick}
-                role="button"
-                tabIndex={0}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    handleIntegrationClick()
-                  }
-                }}
-              >
-                <Cog6ToothIcon className="w-4 h-4 text-text-secondary group-hover:text-text-primary" />
-                <span className="font-medium group-hover:text-text-primary">
-                  {t('branches.configure_integration')}
-                </span>
-              </div>
-              <div
-                className="cursor-pointer flex items-center gap-1.5 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1.5 py-0.5"
-                onClick={e => {
-                  e.stopPropagation()
-                  handleRefreshCache()
-                }}
-                role="button"
-                tabIndex={0}
-                title={t('branches.load_more')}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    handleRefreshCache()
-                  }
-                }}
-              >
-                <RefreshCw className={cn('w-3.5 h-3.5', isRefreshing && 'animate-spin')} />
-                <span className="text-xs">
-                  {isRefreshing ? t('branches.refreshing') : t('actions.refresh')}
-                </span>
-              </div>
-            </div>
+            <RepositorySelectorFooter
+              onConfigureClick={handleIntegrationClick}
+              onRefreshClick={handleRefreshCache}
+              isRefreshing={isRefreshing}
+            />
           </PopoverContent>
         </Popover>
       </div>
     )
   }
 
+  // Normal mode: use SearchableSelect
   return (
     <div
       className={cn('flex items-center min-w-0', fullWidth && 'w-full')}
@@ -632,47 +261,11 @@ export default function RepositorySelector({
             </span>
           )}
           footer={
-            <div className="border-t border-border bg-base flex items-center justify-between px-2.5 py-2 text-xs text-text-secondary">
-              <div
-                className="cursor-pointer group flex items-center space-x-2 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1 py-0.5"
-                onClick={handleIntegrationClick}
-                role="button"
-                tabIndex={0}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    handleIntegrationClick()
-                  }
-                }}
-              >
-                <Cog6ToothIcon className="w-4 h-4 text-text-secondary group-hover:text-text-primary" />
-                <span className="font-medium group-hover:text-text-primary">
-                  {t('branches.configure_integration')}
-                </span>
-              </div>
-              <div
-                className="cursor-pointer flex items-center gap-1.5 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1.5 py-0.5"
-                onClick={e => {
-                  e.stopPropagation()
-                  handleRefreshCache()
-                }}
-                role="button"
-                tabIndex={0}
-                title={t('branches.load_more')}
-                onKeyDown={e => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault()
-                    e.stopPropagation()
-                    handleRefreshCache()
-                  }
-                }}
-              >
-                <RefreshCw className={cn('w-3.5 h-3.5', isRefreshing && 'animate-spin')} />
-                <span className="text-xs">
-                  {isRefreshing ? t('branches.refreshing') : t('actions.refresh')}
-                </span>
-              </div>
-            </div>
+            <RepositorySelectorFooter
+              onConfigureClick={handleIntegrationClick}
+              onRefreshClick={handleRefreshCache}
+              isRefreshing={isRefreshing}
+            />
           }
         />
         {isSearching && (

--- a/frontend/src/features/tasks/components/selector/RepositorySelectorFooter.tsx
+++ b/frontend/src/features/tasks/components/selector/RepositorySelectorFooter.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+import { Cog6ToothIcon } from '@heroicons/react/24/outline'
+import { cn } from '@/lib/utils'
+import { useTranslation } from '@/hooks/useTranslation'
+import { RepositorySelectorFooterProps } from './types'
+
+/**
+ * Shared footer component for RepositorySelector
+ * Contains configure integration link and refresh button
+ */
+export function RepositorySelectorFooter({
+  onConfigureClick,
+  onRefreshClick,
+  isRefreshing,
+}: RepositorySelectorFooterProps) {
+  const { t } = useTranslation()
+
+  const handleKeyDown = (e: React.KeyboardEvent, onClick: () => void) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick()
+    }
+  }
+
+  return (
+    <div className="border-t border-border bg-base flex items-center justify-between px-2.5 py-2 text-xs text-text-secondary">
+      <div
+        className="cursor-pointer group flex items-center space-x-2 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1 py-0.5"
+        onClick={onConfigureClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={e => handleKeyDown(e, onConfigureClick)}
+      >
+        <Cog6ToothIcon className="w-4 h-4 text-text-secondary group-hover:text-text-primary" />
+        <span className="font-medium group-hover:text-text-primary">
+          {t('branches.configure_integration')}
+        </span>
+      </div>
+      <div
+        className="cursor-pointer flex items-center gap-1.5 hover:bg-muted transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded px-1.5 py-0.5"
+        onClick={e => {
+          e.stopPropagation()
+          onRefreshClick()
+        }}
+        role="button"
+        tabIndex={0}
+        title={t('branches.load_more')}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            e.stopPropagation()
+            onRefreshClick()
+          }
+        }}
+      >
+        <RefreshCw className={cn('w-3.5 h-3.5', isRefreshing && 'animate-spin')} />
+        <span className="text-xs">
+          {isRefreshing ? t('branches.refreshing') : t('actions.refresh')}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/selector/types.ts
+++ b/frontend/src/features/tasks/components/selector/types.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { GitRepoInfo, TaskDetail } from '@/types/api'
+
+/**
+ * Props for RepositorySelector component
+ */
+export interface RepositorySelectorProps {
+  selectedRepo: GitRepoInfo | null
+  handleRepoChange: (repo: GitRepoInfo | null) => void
+  disabled: boolean
+  selectedTaskDetail?: TaskDetail | null
+  /** When true, the selector will take full width of its container */
+  fullWidth?: boolean
+  /** When true, display only icon without text (for responsive collapse) */
+  compact?: boolean
+}
+
+/**
+ * Item format for searchable select
+ */
+export interface RepositorySelectItem {
+  value: string
+  label: string
+  searchText: string
+}
+
+/**
+ * Props for RepositorySelectorFooter component
+ */
+export interface RepositorySelectorFooterProps {
+  onConfigureClick: () => void
+  onRefreshClick: () => void
+  isRefreshing: boolean
+}

--- a/frontend/src/features/tasks/hooks/useRepositorySearch.ts
+++ b/frontend/src/features/tasks/hooks/useRepositorySearch.ts
@@ -1,0 +1,406 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { GitRepoInfo, TaskDetail } from '@/types/api'
+import { useUser } from '@/features/common/UserContext'
+import { useToast } from '@/hooks/use-toast'
+import { useTranslation } from '@/hooks/useTranslation'
+import { githubApis } from '@/apis/github'
+import { getLastRepo } from '@/utils/userPreferences'
+
+export interface UseRepositorySearchOptions {
+  selectedRepo: GitRepoInfo | null
+  handleRepoChange: (repo: GitRepoInfo | null) => void
+  disabled: boolean
+  selectedTaskDetail?: TaskDetail | null
+}
+
+export interface UseRepositorySearchReturn {
+  // State
+  repos: GitRepoInfo[]
+  cachedRepos: GitRepoInfo[]
+  loading: boolean
+  isSearching: boolean
+  isRefreshing: boolean
+  error: string | null
+  currentSearchQuery: string
+
+  // Methods
+  handleSearchChange: (query: string) => void
+  handleRefreshCache: () => Promise<void>
+  handleChange: (value: string) => void
+
+  // Helpers
+  hasGitInfo: () => boolean
+}
+
+/**
+ * Custom hook for repository search functionality
+ * Handles loading, caching, searching (local + remote), and refreshing repositories
+ */
+export function useRepositorySearch({
+  selectedRepo,
+  handleRepoChange,
+  disabled,
+  selectedTaskDetail,
+}: UseRepositorySearchOptions): UseRepositorySearchReturn {
+  const { toast } = useToast()
+  const { t } = useTranslation()
+  const { user } = useUser()
+
+  // State
+  const [repos, setRepos] = useState<GitRepoInfo[]>([])
+  const [cachedRepos, setCachedRepos] = useState<GitRepoInfo[]>([])
+  const [loading, setLoading] = useState<boolean>(false)
+  const [isSearching, setIsSearching] = useState<boolean>(false)
+  const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
+  const [currentSearchQuery, setCurrentSearchQuery] = useState<string>('')
+  const [error, setError] = useState<string | null>(null)
+  const [hasInitiallyLoaded, setHasInitiallyLoaded] = useState<boolean>(false)
+
+  // Refs for debouncing and race condition handling
+  const searchTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const searchRequestIdRef = useRef<number>(0)
+
+  /**
+   * Check if user has git_info configured
+   */
+  const hasGitInfo = useCallback((): boolean => {
+    return !!(user && user.git_info && user.git_info.length > 0)
+  }, [user])
+
+  /**
+   * Load repositories from API
+   */
+  const loadRepositories = useCallback(async (): Promise<GitRepoInfo[]> => {
+    if (!hasGitInfo()) {
+      return []
+    }
+
+    setLoading(true)
+    setError(null)
+
+    try {
+      const data = await githubApis.getRepositories()
+      setRepos(data)
+      setCachedRepos(data)
+      setHasInitiallyLoaded(true)
+      setError(null)
+      return data
+    } catch {
+      setError('Failed to load repositories')
+      toast({
+        variant: 'destructive',
+        title: 'Failed to load repositories',
+      })
+      return []
+    } finally {
+      setLoading(false)
+    }
+  }, [hasGitInfo, toast])
+
+  /**
+   * Search repositories locally (in cache)
+   */
+  const searchLocalRepos = useCallback(
+    (query: string): GitRepoInfo[] => {
+      if (!query.trim()) {
+        return cachedRepos
+      }
+      const lowerQuery = query.toLowerCase()
+      return cachedRepos.filter(repo => repo.git_repo.toLowerCase().includes(lowerQuery))
+    },
+    [cachedRepos]
+  )
+
+  /**
+   * Search repositories remotely (delayed execution)
+   */
+  const searchRemoteRepos = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setRepos(cachedRepos)
+        setIsSearching(false)
+        return
+      }
+
+      const requestId = ++searchRequestIdRef.current
+
+      try {
+        const results = await githubApis.searchRepositories(query, {
+          fullmatch: false,
+          timeout: 30,
+        })
+
+        if (requestId !== searchRequestIdRef.current) {
+          return
+        }
+
+        // Merge local and remote results, remove duplicates
+        const localResults = searchLocalRepos(query)
+        const mergedResults = [...localResults]
+
+        results.forEach(remoteRepo => {
+          if (!mergedResults.find(r => r.git_repo_id === remoteRepo.git_repo_id)) {
+            mergedResults.push(remoteRepo)
+          }
+        })
+
+        setRepos(mergedResults)
+        setError(null)
+      } catch {
+        if (requestId === searchRequestIdRef.current) {
+          console.error('Remote search failed, keeping local results')
+        }
+      } finally {
+        if (requestId === searchRequestIdRef.current) {
+          setIsSearching(false)
+        }
+      }
+    },
+    [cachedRepos, searchLocalRepos]
+  )
+
+  /**
+   * Handle search input changes with debouncing
+   */
+  const handleSearchChange = useCallback(
+    (query: string) => {
+      setCurrentSearchQuery(query)
+
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
+
+      if (!query.trim()) {
+        searchRequestIdRef.current++
+        setRepos(cachedRepos)
+        setIsSearching(false)
+        return
+      }
+
+      setIsSearching(true)
+
+      // Immediately perform local search
+      const localResults = searchLocalRepos(query)
+      setRepos(localResults)
+
+      // Delay remote search for better responsiveness
+      searchTimeoutRef.current = setTimeout(() => {
+        searchRemoteRepos(query)
+      }, 300)
+    },
+    [searchLocalRepos, searchRemoteRepos, cachedRepos]
+  )
+
+  /**
+   * Handle refresh cache button click
+   */
+  const handleRefreshCache = useCallback(async () => {
+    if (isRefreshing) return
+
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current)
+    }
+    searchRequestIdRef.current++
+    setIsSearching(false)
+
+    setIsRefreshing(true)
+    try {
+      await githubApis.refreshRepositories()
+
+      if (currentSearchQuery.trim()) {
+        const requestId = ++searchRequestIdRef.current
+        const results = await githubApis.searchRepositories(currentSearchQuery, {
+          fullmatch: false,
+          timeout: 30,
+        })
+        if (requestId === searchRequestIdRef.current) {
+          setRepos(results)
+        }
+      } else {
+        const data = await githubApis.getRepositories()
+        setRepos(data)
+        setCachedRepos(data)
+      }
+
+      toast({ title: t('branches.refresh_success') })
+    } catch {
+      toast({ variant: 'destructive', title: t('branches.refresh_failed') })
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [isRefreshing, currentSearchQuery, toast, t])
+
+  /**
+   * Handle repository selection change
+   */
+  const handleChange = useCallback(
+    (value: string) => {
+      let repo = repos.find(r => r.git_repo_id === Number(value))
+
+      if (!repo) {
+        repo = cachedRepos.find(r => r.git_repo_id === Number(value))
+      }
+
+      if (repo) {
+        handleRepoChange(repo)
+      }
+    },
+    [repos, cachedRepos, handleRepoChange]
+  )
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  /**
+   * Centralized repository selection logic
+   * Handles all scenarios: mount, task selection, and restoration
+   */
+  useEffect(() => {
+    let canceled = false
+
+    const selectRepository = async () => {
+      const hasGit = hasGitInfo()
+      console.log('[RepositorySelector] Effect triggered', {
+        hasGitInfo: hasGit,
+        user: user ? 'loaded' : 'null',
+        gitInfoLength: user?.git_info?.length || 0,
+        selectedTaskDetail: selectedTaskDetail?.git_repo || 'none',
+        selectedRepo: selectedRepo?.git_repo || 'none',
+        disabled,
+        reposLength: repos.length,
+      })
+
+      if (!hasGit) {
+        console.log('[RepositorySelector] No git info, exiting')
+        return
+      }
+
+      // Scenario 1: Task is selected - use task's repository
+      if (selectedTaskDetail?.git_repo) {
+        console.log(
+          '[RepositorySelector] Scenario 1: Task selected, repo:',
+          selectedTaskDetail.git_repo
+        )
+
+        if (selectedRepo?.git_repo === selectedTaskDetail.git_repo) {
+          console.log('[RepositorySelector] Already selected, no change needed')
+          return
+        }
+
+        const repoInList = repos.find(r => r.git_repo === selectedTaskDetail.git_repo)
+        if (repoInList) {
+          console.log('[RepositorySelector] Found in list, selecting:', repoInList.git_repo)
+          handleRepoChange(repoInList)
+          return
+        }
+
+        console.log('[RepositorySelector] Not in list, searching via API')
+        try {
+          setLoading(true)
+          const result = await githubApis.searchRepositories(selectedTaskDetail.git_repo, {
+            fullmatch: true,
+          })
+
+          if (canceled) return
+
+          if (result && result.length > 0) {
+            const matched =
+              result.find(r => r.git_repo === selectedTaskDetail.git_repo) ?? result[0]
+            console.log('[RepositorySelector] Found via API, selecting:', matched.git_repo)
+            handleRepoChange(matched)
+            setError(null)
+          } else {
+            toast({
+              variant: 'destructive',
+              title: 'No repositories found',
+            })
+          }
+        } catch {
+          setError('Failed to search repositories')
+          toast({
+            variant: 'destructive',
+            title: 'Failed to search repositories',
+          })
+        } finally {
+          if (!canceled) {
+            setLoading(false)
+          }
+        }
+        return
+      }
+
+      // Scenario 2: No task selected and no repo selected - load repos and restore from localStorage
+      if (!selectedTaskDetail && !selectedRepo && !disabled) {
+        console.log('[RepositorySelector] Scenario 2: Load repos and restore from localStorage')
+
+        let repoList = repos
+        if (repoList.length === 0 && !hasInitiallyLoaded) {
+          console.log('[RepositorySelector] Repos not loaded, loading now...')
+          repoList = await loadRepositories()
+          console.log('[RepositorySelector] Loaded repos count:', repoList.length)
+          if (canceled || repoList.length === 0) {
+            console.log('[RepositorySelector] Load failed or canceled')
+            return
+          }
+        }
+
+        const lastRepo = getLastRepo()
+        console.log('[RepositorySelector] Last repo from storage:', lastRepo)
+
+        if (lastRepo) {
+          const repoToRestore = repoList.find(r => r.git_repo_id === lastRepo.repoId)
+          if (repoToRestore) {
+            console.log(
+              '[RepositorySelector] ✅ Restoring repo from localStorage:',
+              repoToRestore.git_repo
+            )
+            handleRepoChange(repoToRestore)
+          } else {
+            console.log('[RepositorySelector] ❌ Repo not found in list, ID:', lastRepo.repoId)
+          }
+        } else {
+          console.log('[RepositorySelector] No last repo in storage, repos loaded but no selection')
+        }
+      } else {
+        console.log('[RepositorySelector] Scenario 2 conditions not met:', {
+          hasTaskDetail: !!selectedTaskDetail,
+          hasSelectedRepo: !!selectedRepo,
+          disabled,
+        })
+      }
+    }
+
+    selectRepository()
+
+    return () => {
+      canceled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTaskDetail?.git_repo, disabled, user, hasInitiallyLoaded])
+
+  return {
+    repos,
+    cachedRepos,
+    loading,
+    isSearching,
+    isRefreshing,
+    error,
+    currentSearchQuery,
+    handleSearchChange,
+    handleRefreshCache,
+    handleChange,
+    hasGitInfo,
+  }
+}

--- a/frontend/src/utils/stringUtils.ts
+++ b/frontend/src/utils/stringUtils.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Truncate text to a maximum length, keeping start and end with ellipsis in the middle
+ * @param text - The text to truncate
+ * @param maxLength - Maximum length of the text
+ * @param startChars - Number of characters to keep at the start (default: 8)
+ * @param endChars - Number of characters to keep at the end (default: 10)
+ * @returns Truncated text with ellipsis in the middle if needed
+ */
+export function truncateMiddle(
+  text: string,
+  maxLength: number,
+  startChars = 8,
+  endChars = 10
+): string {
+  if (text.length <= maxLength) {
+    return text
+  }
+
+  const start = text.slice(0, startChars)
+  const end = text.slice(-endChars)
+  return `${start}...${end}`
+}


### PR DESCRIPTION
## Summary

- Add `searchRequestIdRef` to track and validate search requests
- Discard stale API responses when search query has changed
- Reduce debounce delay from 1000ms to 300ms for better responsiveness
- Cancel in-flight requests when search is cleared or cache is refreshed
- Properly reset `isSearching` state when requests are invalidated

## Problem

In the `/code` page repository selector, the search functionality occasionally triggers two API calls: one for the search keyword and one for the full list. The full list response would overwrite the search results, making the page appear unresponsive.

### Root Cause

1. `searchable-select.tsx` line 90-95: When Popover closes, `onSearchChange?.('')` is called, triggering `handleSearchChange('')`
2. `handleSearchChange('')` calls `setRepos(cachedRepos)` to restore the full cached data
3. If a remote search API request is still in progress, its response returns without checking the current search state, directly calling `setRepos()`, causing data to be overwritten

## Solution

- Use a `useRef` to track request IDs, incrementing on each new request
- When API response returns, check if the request ID matches the current one
- If mismatched, discard the response (the request is stale)
- Also invalidate requests when:
  - Search is cleared (empty string)
  - Refresh cache button is clicked

## Test plan

- [ ] User inputs search term → only matching results are displayed, not overwritten by full data
- [ ] Fast typing → only the last search result is displayed
- [ ] Close dropdown and reopen → displays correct data (full list or last selected state)
- [ ] Click refresh button → doesn't conflict with in-progress searches
- [ ] Search response speed improved (300ms debounce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New repository search/selection flow with configurable footer actions (configure + refresh) and truncated repo display.

* **Bug Fixes**
  * Prevented stale remote search results and redundant reloads; restored cached repositories when clearing searches.
  * Improved refresh to avoid interfering with in-progress searches.

* **Performance**
  * Faster, debounced remote search (300ms) for more responsive results.

* **Tests**
  * Added comprehensive tests covering loading, search, caching, and refresh behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->