### PR TITLE
fix: 组模式下配置 Bot 的 Skills 时报错 "The following Skills do not exist

### DIFF
--- a/backend/app/api/endpoints/adapter/models.py
+++ b/backend/app/api/endpoints/adapter/models.py
@@ -604,7 +604,9 @@ def fetch_available_models(
                     models.append(
                         {
                             "id": model.get("id"),
-                            "name": model.get("id"),  # OpenAI doesn't provide display names
+                            "name": model.get(
+                                "id"
+                            ),  # OpenAI doesn't provide display names
                             "created": model.get("created"),
                             "owned_by": model.get("owned_by"),
                         }

--- a/backend/app/services/adapters/bot_kinds.py
+++ b/backend/app/services/adapters/bot_kinds.py
@@ -288,7 +288,7 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
 
         # Validate skills if provided
         if obj_in.skills:
-            self._validate_skills(db, obj_in.skills, user_id)
+            self._validate_skills(db, obj_in.skills, user_id, namespace)
 
         # Encrypt sensitive data in agent_config before storing
         encrypted_agent_config = self._encrypt_agent_config(obj_in.agent_config)
@@ -937,7 +937,7 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
             # Validate that all referenced skills exist for this user
             skills = update_data["skills"] or []
             if skills:
-                self._validate_skills(db, skills, user_id)
+                self._validate_skills(db, skills, user_id, bot.namespace or "default")
             ghost_crd = Ghost.model_validate(ghost.json)
             ghost_crd.spec.skills = skills
             ghost.json = ghost_crd.model_dump()
@@ -1608,15 +1608,25 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
         }
 
     def _validate_skills(
-        self, db: Session, skill_names: List[str], user_id: int
+        self,
+        db: Session,
+        skill_names: List[str],
+        user_id: int,
+        namespace: str = "default",
     ) -> None:
         """
         Validate that all skill names exist for the user or as system skills.
+
+        Search order (consistent with /api/v1/kinds/skills/unified):
+        1. User's personal skills (user_id=user_id, namespace='default')
+        2. Group skills in namespace (any user, if namespace != 'default')
+        3. Public/system skills (user_id=0, namespace='default')
 
         Args:
             db: Database session
             skill_names: List of skill names to validate
             user_id: User ID
+            namespace: Bot's namespace (for group skills lookup)
 
         Raises:
             HTTPException: If any skill does not exist
@@ -1624,12 +1634,13 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
         if not skill_names:
             return
 
-        # Query all skills at once for efficiency
-        # Include both user's skills (user_id == user_id) and system skills (user_id == 0)
-        existing_skills = (
+        existing_skill_names = set()
+
+        # 1. Query user's personal skills (user_id=user_id, namespace='default')
+        personal_skills = (
             db.query(Kind)
             .filter(
-                or_(Kind.user_id == user_id, Kind.user_id == 0),
+                Kind.user_id == user_id,
                 Kind.kind == "Skill",
                 Kind.name.in_(skill_names),
                 Kind.namespace == "default",
@@ -1637,8 +1648,45 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
             )
             .all()
         )
+        existing_skill_names.update(skill.name for skill in personal_skills)
 
-        existing_skill_names = {skill.name for skill in existing_skills}
+        # 2. Query group skills if namespace is not 'default'
+        # Group skills can be from any user in that namespace
+        if namespace != "default":
+            remaining_names = [
+                name for name in skill_names if name not in existing_skill_names
+            ]
+            if remaining_names:
+                group_skills = (
+                    db.query(Kind)
+                    .filter(
+                        Kind.kind == "Skill",
+                        Kind.name.in_(remaining_names),
+                        Kind.namespace == namespace,
+                        Kind.is_active == True,
+                    )
+                    .all()
+                )
+                existing_skill_names.update(skill.name for skill in group_skills)
+
+        # 3. Query public/system skills (user_id=0)
+        remaining_names = [
+            name for name in skill_names if name not in existing_skill_names
+        ]
+        if remaining_names:
+            public_skills = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == 0,
+                    Kind.kind == "Skill",
+                    Kind.name.in_(remaining_names),
+                    Kind.namespace == "default",
+                    Kind.is_active == True,
+                )
+                .all()
+            )
+            existing_skill_names.update(skill.name for skill in public_skills)
+
         missing_skills = [
             name for name in skill_names if name not in existing_skill_names
         ]

--- a/frontend/src/features/settings/components/BotEdit.tsx
+++ b/frontend/src/features/settings/components/BotEdit.tsx
@@ -1467,6 +1467,8 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
       <SkillManagementModal
         open={skillManagementModalOpen}
         onClose={() => setSkillManagementModalOpen(false)}
+        scope={scope}
+        groupName={groupName}
         onSkillsChange={() => {
           // Reload skills list when skills are changed
           const fetchSkills = async () => {

--- a/frontend/src/features/settings/components/skills/SkillManagementModal.tsx
+++ b/frontend/src/features/settings/components/skills/SkillManagementModal.tsx
@@ -7,8 +7,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { PencilIcon, TrashIcon, DownloadIcon, PackageIcon } from 'lucide-react'
 import LoadingState from '@/features/common/LoadingState'
-import { Skill } from '@/types/api'
-import { fetchSkillsList, deleteSkill, downloadSkill, formatFileSize } from '@/apis/skills'
+import { fetchUnifiedSkillsList, UnifiedSkill, deleteSkill, downloadSkill } from '@/apis/skills'
 import SkillUploadModal from './SkillUploadModal'
 import UnifiedAddButton from '@/components/common/UnifiedAddButton'
 import { Button } from '@/components/ui/button'
@@ -29,28 +28,39 @@ interface SkillManagementModalProps {
   open: boolean
   onClose: () => void
   onSkillsChange?: () => void
+  scope?: 'personal' | 'group' | 'all'
+  groupName?: string | null
 }
 
 export default function SkillManagementModal({
   open,
   onClose,
   onSkillsChange,
+  scope = 'personal',
+  groupName,
 }: SkillManagementModalProps) {
   const { t } = useTranslation()
   const { toast } = useToast()
-  const [skills, setSkills] = useState<Skill[]>([])
+  const [skills, setSkills] = useState<UnifiedSkill[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [uploadModalOpen, setUploadModalOpen] = useState(false)
-  const [editingSkill, setEditingSkill] = useState<Skill | null>(null)
+  const [editingSkill, setEditingSkill] = useState<UnifiedSkill | null>(null)
   const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false)
-  const [skillToDelete, setSkillToDelete] = useState<Skill | null>(null)
+  const [skillToDelete, setSkillToDelete] = useState<UnifiedSkill | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
+
+  // Determine the namespace for uploading skills
+  const uploadNamespace = scope === 'group' && groupName ? groupName : 'default'
 
   const loadSkills = useCallback(async () => {
     setIsLoading(true)
     try {
-      const skillsData = await fetchSkillsList()
-      setSkills(skillsData)
+      const skillsData = await fetchUnifiedSkillsList({
+        scope: scope,
+        groupName: groupName || undefined,
+      })
+      // Filter out public skills for management (only show user's own skills)
+      setSkills(skillsData.filter(s => !s.is_public))
     } catch (error) {
       toast({
         variant: 'destructive',
@@ -60,7 +70,7 @@ export default function SkillManagementModal({
     } finally {
       setIsLoading(false)
     }
-  }, [toast])
+  }, [toast, scope, groupName, t])
 
   useEffect(() => {
     if (open) {
@@ -73,12 +83,12 @@ export default function SkillManagementModal({
     setUploadModalOpen(true)
   }
 
-  const handleEditSkill = (skill: Skill) => {
+  const handleEditSkill = (skill: UnifiedSkill) => {
     setEditingSkill(skill)
     setUploadModalOpen(true)
   }
 
-  const handleDeleteSkill = (skill: Skill) => {
+  const handleDeleteSkill = (skill: UnifiedSkill) => {
     setSkillToDelete(skill)
     setDeleteConfirmVisible(true)
   }
@@ -88,11 +98,10 @@ export default function SkillManagementModal({
 
     setIsDeleting(true)
     try {
-      const skillId = parseInt(skillToDelete.metadata.labels?.id || '0')
-      await deleteSkill(skillId)
+      await deleteSkill(skillToDelete.id)
       toast({
         title: t('common:common.success'),
-        description: t('common:skills.success_delete', { skillName: skillToDelete.metadata.name }),
+        description: t('common:skills.success_delete', { skillName: skillToDelete.name }),
       })
       await loadSkills()
       onSkillsChange?.()
@@ -109,13 +118,12 @@ export default function SkillManagementModal({
     }
   }
 
-  const handleDownloadSkill = async (skill: Skill) => {
+  const handleDownloadSkill = async (skill: UnifiedSkill) => {
     try {
-      const skillId = parseInt(skill.metadata.labels?.id || '0')
-      await downloadSkill(skillId, skill.metadata.name)
+      await downloadSkill(skill.id, skill.name)
       toast({
         title: t('common:common.success'),
-        description: t('common:skills.success_download', { skillName: skill.metadata.name }),
+        description: t('common:skills.success_download', { skillName: skill.name }),
       })
     } catch (error) {
       toast({
@@ -174,7 +182,7 @@ export default function SkillManagementModal({
                   <div className="space-y-3">
                     {skills.map(skill => (
                       <Card
-                        key={skill.metadata.labels?.id || skill.metadata.name}
+                        key={skill.id || skill.name}
                         className="p-4 hover:shadow-md transition-shadow"
                       >
                         <div className="flex items-start justify-between">
@@ -183,25 +191,25 @@ export default function SkillManagementModal({
                             <PackageIcon className="w-5 h-5 text-primary flex-shrink-0 mt-0.5" />
                             <div className="min-w-0 flex-1">
                               <h3 className="text-base font-medium text-text-primary truncate">
-                                {skill.metadata.name}
+                                {skill.name}
                               </h3>
                               <p className="text-sm text-text-secondary mt-1 line-clamp-2">
-                                {skill.spec.description}
+                                {skill.description}
                               </p>
 
                               {/* Tags and Metadata */}
                               <div className="flex flex-wrap gap-1.5 mt-2">
-                                {skill.spec.version && (
+                                {skill.version && (
                                   <Tag variant="default">
-                                    {t('common:skills.version', { version: skill.spec.version })}
+                                    {t('common:skills.version', { version: skill.version })}
                                   </Tag>
                                 )}
-                                {skill.spec.author && (
+                                {skill.author && (
                                   <Tag variant="default">
-                                    {t('common:skills.author', { author: skill.spec.author })}
+                                    {t('common:skills.author', { author: skill.author })}
                                   </Tag>
                                 )}
-                                {skill.spec.tags?.map(tag => (
+                                {skill.tags?.map(tag => (
                                   <Tag key={tag} variant="info">
                                     {tag}
                                   </Tag>
@@ -213,8 +221,8 @@ export default function SkillManagementModal({
                                 <span className="text-xs text-text-muted">
                                   {t('skills.bind_shells')}:
                                 </span>
-                                {skill.spec.bindShells && skill.spec.bindShells.length > 0 ? (
-                                  skill.spec.bindShells.map(shell => (
+                                {skill.bindShells && skill.bindShells.length > 0 ? (
+                                  skill.bindShells.map(shell => (
                                     <Tag key={shell} variant="success">
                                       {shell}
                                     </Tag>
@@ -226,25 +234,16 @@ export default function SkillManagementModal({
                                 )}
                               </div>
 
-                              {/* File Info */}
-                              <div className="flex items-center gap-4 mt-2 text-xs text-text-muted">
-                                {skill.status?.fileSize && (
-                                  <span>{formatFileSize(skill.status.fileSize)}</span>
+                              {/* Namespace info for group skills */}
+                              {scope === 'group' &&
+                                skill.namespace &&
+                                skill.namespace !== 'default' && (
+                                  <div className="flex items-center gap-1.5 mt-2">
+                                    <span className="text-xs text-text-muted">
+                                      {t('common:skills.namespace')}: {skill.namespace}
+                                    </span>
+                                  </div>
                                 )}
-                                {skill.status?.state && (
-                                  <span
-                                    className={
-                                      skill.status.state === 'Available'
-                                        ? 'text-success'
-                                        : 'text-error'
-                                    }
-                                  >
-                                    {skill.status.state === 'Available'
-                                      ? t('common:skills.state_available')
-                                      : t('common:skills.state_unavailable')}
-                                  </span>
-                                )}
-                              </div>
                             </div>
                           </div>
 
@@ -297,7 +296,12 @@ export default function SkillManagementModal({
 
       {/* Upload/Edit Modal */}
       {uploadModalOpen && (
-        <SkillUploadModal open={uploadModalOpen} onClose={handleModalClose} skill={editingSkill} />
+        <SkillUploadModal
+          open={uploadModalOpen}
+          onClose={handleModalClose}
+          skill={editingSkill}
+          namespace={uploadNamespace}
+        />
       )}
 
       {/* Delete Confirmation Dialog */}
@@ -310,7 +314,7 @@ export default function SkillManagementModal({
             <DialogTitle>{t('common:skills.delete_confirm_title')}</DialogTitle>
             <DialogDescription>
               {t('common:skills.delete_confirm_message', {
-                skillName: skillToDelete?.metadata.name,
+                skillName: skillToDelete?.name,
               })}
               {skillToDelete && (
                 <div className="mt-3 p-3 bg-muted rounded-md text-sm">


### PR DESCRIPTION
  修复内容

  1. 后端：bot_kinds.py

  _validate_skills 方法重构

  - 新增 namespace 参数，支持组模式下的 skill 验证
  - 查询顺序与 /api/v1/kinds/skills/unified 接口保持一致：
    a. 用户个人 skills (user_id=user_id, namespace='default')
    b. 组 skills (namespace=group_name，不限用户)
    c. 公共 skills (user_id=0)
  - 更新 create_with_user 和 update_with_user 调用处传入 namespace

  2. 前端：SkillManagementModal.tsx

  支持组模式

  - 新增 scope 和 groupName 属性
  - 改用 fetchUnifiedSkillsList API（支持 scope 参数）
  - 类型从 Skill 改为 UnifiedSkill
  - 过滤掉公共 skills，只显示可管理的用户/组 skills
  - 上传时使用正确的 namespace

  3. 前端：SkillUploadModal.tsx

  兼容两种 Skill 类型

  - skill 属性支持 Skill | UnifiedSkill 两种类型
  - 添加 helper 函数 getSkillName() 和 getSkillId() 处理类型差异

  4. 前端：BotEdit.tsx

  传递组信息

  - 将 scope 和 groupName 传递给 SkillManagementModal

  效果

  - 组模式下创建/编辑 Bot 时可正确引用组命名空间下的 skills
  - "管理技能"功能在组模式下显示组内 skills 而非个人 skills
  - 上传技能时自动使用正确的 namespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill management now supports namespace/scope (personal, group, all) and group-specific behavior.
  * Upload/edit modal accepts unified skill format and respects namespace when uploading.

* **Improvements**
  * Validation now resolves skills across personal, group, and public/system sources respecting namespace.
  * UI shows namespace for group-scoped skills and uses unified skill metadata for display and actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->