### PR TITLE
fix(bot): 机器人列表多个标题，修复技能上传弹窗报错

### DIFF
--- a/frontend/src/features/settings/components/BotList.tsx
+++ b/frontend/src/features/settings/components/BotList.tsx
@@ -247,10 +247,6 @@ export default function BotList({ scope = 'personal', groupName, groupRoleMap }:
   return (
     <>
       <div className="space-y-3">
-        {/*<div>*/}
-        {/*  <h2 className="text-xl font-semibold text-text-primary mb-1">{t('common:bots.title')}</h2>*/}
-        {/*  <p className="text-sm text-text-muted mb-1">{t('common:bots.description')}</p>*/}
-        {/*</div>*/}
         <div
           className={`bg-base border border-border rounded-md p-2 w-full ${
             isEditing

--- a/frontend/src/features/settings/components/BotList.tsx
+++ b/frontend/src/features/settings/components/BotList.tsx
@@ -247,10 +247,10 @@ export default function BotList({ scope = 'personal', groupName, groupRoleMap }:
   return (
     <>
       <div className="space-y-3">
-        <div>
-          <h2 className="text-xl font-semibold text-text-primary mb-1">{t('common:bots.title')}</h2>
-          <p className="text-sm text-text-muted mb-1">{t('common:bots.description')}</p>
-        </div>
+        {/*<div>*/}
+        {/*  <h2 className="text-xl font-semibold text-text-primary mb-1">{t('common:bots.title')}</h2>*/}
+        {/*  <p className="text-sm text-text-muted mb-1">{t('common:bots.description')}</p>*/}
+        {/*</div>*/}
         <div
           className={`bg-base border border-border rounded-md p-2 w-full ${
             isEditing

--- a/frontend/src/features/settings/components/skills/SkillUploadModal.tsx
+++ b/frontend/src/features/settings/components/skills/SkillUploadModal.tsx
@@ -205,30 +205,35 @@ export default function SkillUploadModal({
                 ? t('common:skills.update_modal_title')
                 : t('common:skills.upload_modal_title')}
             </DialogTitle>
-            <DialogDescription>
-              {isEditMode
-                ? t('common:skills.update_modal_description')
-                : t('common:skills.upload_modal_description')}
-              <div className="mt-2 text-xs text-text-muted">
-                <strong>Expected ZIP structure:</strong>
-                <div className="font-mono bg-muted p-2 rounded mt-1">
-                  my-skill.zip
-                  <br />
-                  └── my-skill/
-                  <br />
-                  &nbsp;&nbsp;&nbsp;&nbsp;├── SKILL.md
-                  <br />
-                  &nbsp;&nbsp;&nbsp;&nbsp;└── resources/
-                </div>
-                <div className="mt-2">
-                  <a
-                    href="https://support.claude.com/en/articles/12512198-how-to-create-custom-skills"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-link hover:underline"
-                  >
-                    Learn how to create custom skills →
-                  </a>
+            <DialogDescription asChild>
+              <div>
+                <p>
+                  {isEditMode
+                    ? t('common:skills.update_modal_description')
+                    : t('common:skills.upload_modal_description')}
+                </p>
+
+                <div className="mt-2 text-xs text-text-muted">
+                  <strong>Expected ZIP structure:</strong>
+                  <div className="font-mono bg-muted p-2 rounded mt-1">
+                    my-skill.zip
+                    <br />
+                    └── my-skill/
+                    <br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;├── SKILL.md
+                    <br />
+                    &nbsp;&nbsp;&nbsp;&nbsp;└── resources/
+                  </div>
+                  <div className="mt-2">
+                    <a
+                      href="https://support.claude.com/en/articles/12512198-how-to-create-custom-skills"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-link hover:underline"
+                    >
+                      Learn how to create custom skills →
+                    </a>
+                  </div>
                 </div>
               </div>
             </DialogDescription>


### PR DESCRIPTION
**Summary**
-----
Bug Fixes

- Fixed invalid HTML structure where DialogDescription rendered as `<p>` containing nested `<div>` elements by switching to asChild and wrapping content in a single `<div>`.Ensured DialogDescription receives exactly one React element child to prevent React.Children.only expected to receive a single React element child errors.

- Removed duplicated DialogTitle / DialogDescription rendering in the bots dialog so the title is displayed only once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the header (title and description) from the bots list to simplify the bots settings view while leaving controls and layout intact.
  * Reorganized the skill upload modal's descriptive content into a clearer DOM structure, preserving the existing text and links without changing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->