### PR TITLE
feat(frontend): display detailed error messages with copy functionality

### DIFF
--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -1446,6 +1446,12 @@ const MessageBubble = memo(
                     content={msg.error}
                     className="h-7 w-7 flex-shrink-0 !rounded-md bg-red-100 dark:bg-red-900/30 hover:!bg-red-200 dark:hover:!bg-red-900/50"
                     tooltip={t('chat:errors.copy_error') || 'Copy error'}
+                    onCopySuccess={() =>
+                      trace.event('error-copy', {
+                        'error.message': msg.error?.substring(0, 100),
+                        ...(msg.subtaskId && { 'subtask.id': msg.subtaskId }),
+                      })
+                    }
                   />
                 </div>
 
@@ -1527,6 +1533,7 @@ const MessageBubble = memo(
       prevSourcesLen === nextSourcesLen &&
       prevReasoningLen === nextReasoningLen &&
       prevProps.msg.status === nextProps.msg.status &&
+      prevProps.msg.error === nextProps.msg.error &&
       prevProps.isPendingConfirmation === nextProps.isPendingConfirmation
 
     return shouldSkipRender

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -1426,16 +1426,27 @@ const MessageBubble = memo(
             {/* Show error message and retry button for failed messages */}
             {!isUserTypeMessage && msg.status === 'error' && msg.error && (
               <div className="mt-4 space-y-3">
-                {/* Error message */}
+                {/* Error message with details */}
                 <div className="flex items-start gap-2 p-3 rounded-lg bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800">
                   <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" />
-                  <div className="flex-1">
+                  <div className="flex-1 min-w-0">
+                    {/* Generic error message */}
                     <p className="text-sm text-red-800 dark:text-red-200">
                       {onRetry
                         ? t('chat:errors.request_failed_retry')
                         : t('chat:errors.model_unsupported')}
                     </p>
+                    {/* Detailed error message from backend */}
+                    <p className="mt-1 text-xs text-red-600 dark:text-red-300 break-all">
+                      {msg.error}
+                    </p>
                   </div>
+                  {/* Copy error button */}
+                  <CopyButton
+                    content={msg.error}
+                    className="h-7 w-7 flex-shrink-0 !rounded-md bg-red-100 dark:bg-red-900/30 hover:!bg-red-200 dark:hover:!bg-red-900/50"
+                    tooltip={t('chat:errors.copy_error') || 'Copy error'}
+                  />
                 </div>
 
                 {/* Retry button - positioned like BubbleTools for consistency */}

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -178,7 +178,8 @@
     "invalid_parameter": "Invalid parameter: Request parameters are incorrect, please check your input",
     "network_error": "Network error: Please check your connection and try again",
     "timeout_error": "Request timeout: Service response time exceeded, please try again later",
-    "generic_error": "Request failed: Unknown error, please try again or contact administrator"
+    "generic_error": "Request failed: Unknown error, please try again or contact administrator",
+    "copy_error": "Copy error details"
   },
   "clarification": {
     "title": "Smart Follow-up",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -178,7 +178,8 @@
     "invalid_parameter": "参数错误：请求参数不正确，请检查输入内容",
     "network_error": "网络连接失败：请检查网络连接后重试",
     "timeout_error": "请求超时：服务响应时间过长，请稍后重试",
-    "generic_error": "请求失败：未知错误，请重试或联系管理员"
+    "generic_error": "请求失败：未知错误，请重试或联系管理员",
+    "copy_error": "复制错误详情"
   },
   "clarification": {
     "title": "智能追问 (Smart Follow-up)",


### PR DESCRIPTION
## Summary

- Display backend-returned detailed error messages (e.g., API rate limit errors, balance errors) below the generic error hint in the chat message bubble
- Add a copy button next to error messages to easily copy error details for troubleshooting
- Add i18n translations for the copy error button in both English and Chinese

## Changes

1. **MessageBubble.tsx**:
   - Enhanced error display section to show both generic hint and detailed error message
   - Added `CopyButton` component to allow users to copy error details to clipboard
   - Applied proper styling: `break-all` for long error messages, `min-w-0` for proper text wrapping

2. **i18n files (en/zh-CN)**:
   - Added `copy_error` translation key for the copy button tooltip

## Test plan

- [ ] Verify error messages display both generic hint and detailed error from backend
- [ ] Verify long error messages wrap correctly within the error container
- [ ] Verify copy button appears and functions correctly
- [ ] Verify tooltip shows "Copy error details" / "复制错误详情" on hover
- [ ] Verify copied content matches the detailed error message
- [ ] Verify dark mode styling works correctly for error display
- [ ] Verify retry button still works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a “Copy error details” button to AI message error blocks.
  - Expanded error display with a detailed message section.

- Bug Fixes
  - Error messages now update reliably when underlying error content changes.

- Style
  - Improved error layout for better readability and wrapping; buttons aligned with error text.

- Localization
  - Added “Copy error details” translations in English and Simplified Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->