### PR TITLE
Feat user message edit

### DIFF
--- a/backend/app/api/endpoints/subtasks.py
+++ b/backend/app/api/endpoints/subtasks.py
@@ -15,6 +15,8 @@ from app.core import security
 from app.models.subtask import Subtask
 from app.models.user import User
 from app.schemas.subtask import (
+    MessageEditRequest,
+    MessageEditResponse,
     PollMessagesResponse,
     StreamingStatus,
     SubtaskInDB,
@@ -125,6 +127,41 @@ def delete_subtask(
         db=db, subtask_id=subtask_id, user_id=current_user.id
     )
     return {"message": "Subtask deleted successfully"}
+
+
+@router.post("/{subtask_id}/edit", response_model=MessageEditResponse)
+def edit_user_message(
+    subtask_id: int,
+    request: MessageEditRequest,
+    current_user: User = Depends(security.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Edit a user message by deleting it and all subsequent messages.
+
+    This implements ChatGPT-style message editing. The edited message and all
+    messages after it are deleted. The frontend should then send a new message
+    with the edited content to trigger a fresh AI response.
+
+    Constraints:
+    - Only USER role messages can be edited
+    - Not available in group chat
+    - Cannot edit while AI is generating a response
+    """
+    returned_subtask_id, message_id, deleted_count = subtask_service.edit_user_message(
+        db=db,
+        subtask_id=subtask_id,
+        new_content=request.new_content,
+        user_id=current_user.id,
+    )
+
+    return MessageEditResponse(
+        success=True,
+        subtask_id=returned_subtask_id,
+        message_id=message_id,
+        deleted_count=deleted_count,
+        new_content=request.new_content,
+    )
 
 
 @router.get("/tasks/{task_id}/messages/poll", response_model=PollMessagesResponse)

--- a/backend/app/schemas/subtask.py
+++ b/backend/app/schemas/subtask.py
@@ -295,3 +295,19 @@ class SubtaskExecutorUpdate(BaseModel):
     executor_name: Optional[str] = None
     result: Optional[dict[str, Any]] = None
     error_message: Optional[str] = None
+
+
+class MessageEditRequest(BaseModel):
+    """Request model for editing a user message"""
+
+    new_content: str = Field(..., min_length=1, description="New message content")
+
+
+class MessageEditResponse(BaseModel):
+    """Response model for message edit operation"""
+
+    success: bool = True
+    subtask_id: int
+    message_id: int
+    deleted_count: int = Field(description="Number of subsequent messages deleted")
+    new_content: str = Field(description="The updated message content")

--- a/frontend/e2e/tests/settings-bot.spec.ts
+++ b/frontend/e2e/tests/settings-bot.spec.ts
@@ -5,17 +5,18 @@ test.describe('Settings - Bot Management', () => {
     // Bot management is accessed through "Manage Bots" button in team tab
     await page.goto('/settings?tab=team')
     await page.waitForLoadState('domcontentloaded')
+    // Wait for team page content to fully load - the title is "Team List" or "智能体列表"
+    await expect(
+      page.locator('h2:has-text("Team List"), h2:has-text("智能体列表")')
+    ).toBeVisible({ timeout: 15000 })
   })
 
   test('should access bot management via manage bots button', async ({ page }) => {
     await expect(page).toHaveURL(/\/settings/)
 
-    // Wait for team page to load
-    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 10000 })
-
     // Click "Manage Bots" button to open bot list dialog
     const manageBots = page.locator('button:has-text("Manage Bots"), button:has-text("管理机器人")')
-    await expect(manageBots).toBeVisible({ timeout: 5000 })
+    await expect(manageBots).toBeVisible({ timeout: 10000 })
     await manageBots.click()
 
     // Bot list dialog should open

--- a/frontend/src/apis/subtasks.ts
+++ b/frontend/src/apis/subtasks.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import apiClient from './client'
+
+export interface MessageEditRequest {
+  new_content: string
+}
+
+export interface MessageEditResponse {
+  success: boolean
+  subtask_id: number
+  message_id: number
+  deleted_count: number
+  new_content: string
+}
+
+export const subtaskApis = {
+  /**
+   * Edit a user message and delete all subsequent messages.
+   * This implements ChatGPT-style message editing.
+   *
+   * @param subtaskId - The subtask ID of the message to edit
+   * @param newContent - The new message content
+   * @returns The edit response with deleted count
+   */
+  editMessage: async (subtaskId: number, newContent: string): Promise<MessageEditResponse> => {
+    return apiClient.post<MessageEditResponse>(`/subtasks/${subtaskId}/edit`, {
+      new_content: newContent,
+    })
+  },
+}

--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from 'react-i18next'
@@ -75,6 +75,45 @@ export const CopyButton = ({
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent>{copied ? 'Copied!' : tooltip}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return button
+}
+
+// EditButton component for editing user messages
+export const EditButton = ({
+  onEdit,
+  className,
+  tooltip,
+  disabled,
+}: {
+  onEdit: () => void
+  className?: string
+  tooltip?: string
+  disabled?: boolean
+}) => {
+  const button = (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onEdit}
+      disabled={disabled}
+      className={
+        className ??
+        'h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec disabled:opacity-50'
+      }
+    >
+      <Pencil className="h-3.5 w-3.5 text-text-muted" />
+    </Button>
+  )
+
+  if (tooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
       </Tooltip>
     )
   }

--- a/frontend/src/features/tasks/components/message/InlineMessageEdit.tsx
+++ b/frontend/src/features/tasks/components/message/InlineMessageEdit.tsx
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { Button } from '@/components/ui/button'
+import { Textarea } from '@/components/ui/textarea'
+import { useTranslation } from 'react-i18next'
+import { Loader2 } from 'lucide-react'
+
+export interface InlineMessageEditProps {
+  initialContent: string
+  onSave: (content: string) => Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * Inline message edit component that replaces the message content
+ * with an editable textarea. Supports:
+ * - Multi-line input with auto-expanding height
+ * - Save and Cancel buttons
+ * - Keyboard shortcuts: Enter to save (without Shift), Escape to cancel
+ * - Loading state during save
+ */
+const InlineMessageEdit: React.FC<InlineMessageEditProps> = ({
+  initialContent,
+  onSave,
+  onCancel,
+}) => {
+  const { t } = useTranslation()
+  const [content, setContent] = useState(initialContent)
+  const [isSaving, setIsSaving] = useState(false)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // Focus textarea on mount
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus()
+      // Place cursor at the end
+      textareaRef.current.selectionStart = textareaRef.current.value.length
+      textareaRef.current.selectionEnd = textareaRef.current.value.length
+    }
+  }, [])
+
+  // Auto-resize textarea
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`
+    }
+  }, [content])
+
+  const handleSave = useCallback(async () => {
+    const trimmedContent = content.trim()
+    if (!trimmedContent || trimmedContent === initialContent.trim()) {
+      onCancel()
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      await onSave(trimmedContent)
+    } catch (error) {
+      console.error('Failed to save message:', error)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [content, initialContent, onSave, onCancel])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      } else if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        handleSave()
+      }
+    },
+    [onCancel, handleSave]
+  )
+
+  return (
+    <div className="flex flex-col gap-2 w-full">
+      <Textarea
+        ref={textareaRef}
+        value={content}
+        onChange={e => setContent(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={isSaving}
+        className="min-h-[60px] resize-none bg-fill-sec border-border-muted focus:border-primary"
+        placeholder={t('chat:placeholder.input')}
+      />
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" size="sm" onClick={onCancel} disabled={isSaving}>
+          {t('chat:actions.cancel') || 'Cancel'}
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={isSaving || !content.trim()}>
+          {isSaving ? (
+            <>
+              <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+              {t('chat:actions.save') || 'Save'}
+            </>
+          ) : (
+            t('chat:actions.save') || 'Save'
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default InlineMessageEdit

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -18,7 +18,11 @@
   "edit": {
     "tooltip": "Edit message",
     "success": "Message edited successfully",
-    "failed": "Failed to edit message"
+    "failed": "Failed to edit message",
+    "confirm_title": "Confirm Edit",
+    "confirm_description": "This edit will clear this message and all subsequent messages. The conversation will restart from this point. Are you sure you want to continue?",
+    "confirm_button": "Confirm",
+    "confirming": "Processing..."
   },
   "quote": {
     "ask_wegent": "Ask Wegent",

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -10,7 +10,15 @@
     "copy": "Copy",
     "regenerate": "Regenerate",
     "stop": "Stop",
-    "retry": "Retry"
+    "retry": "Retry",
+    "edit": "Edit",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "edit": {
+    "tooltip": "Edit message",
+    "success": "Message edited successfully",
+    "failed": "Failed to edit message"
   },
   "quote": {
     "ask_wegent": "Ask Wegent",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -18,7 +18,11 @@
   "edit": {
     "tooltip": "编辑消息",
     "success": "消息编辑成功",
-    "failed": "编辑消息失败"
+    "failed": "编辑消息失败",
+    "confirm_title": "确认编辑",
+    "confirm_description": "此编辑操作将清除本条消息及其后的所有消息，对话将从当前位置重新开始。确定要继续吗？",
+    "confirm_button": "确认",
+    "confirming": "处理中..."
   },
   "quote": {
     "ask_wegent": "询问 Wegent",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -10,7 +10,15 @@
     "copy": "复制",
     "regenerate": "重新生成",
     "stop": "停止",
-    "retry": "重试"
+    "retry": "重试",
+    "edit": "编辑",
+    "save": "保存",
+    "cancel": "取消"
+  },
+  "edit": {
+    "tooltip": "编辑消息",
+    "success": "消息编辑成功",
+    "failed": "编辑消息失败"
   },
   "quote": {
     "ask_wegent": "询问 Wegent",


### PR DESCRIPTION
Implement ChatGPT-style message editing functionality that allows users to edit their sent messages
After editing a message, all subsequent messages in the conversation are automatically deleted before the edited message is resent
Add inline editing component (InlineMessageEdit) with save/cancel actions
Add backend API endpoint for deleting subtasks after a specific message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline message editing with Edit button, autofocus, auto-resizing textarea, keyboard shortcuts, confirm/save/cancel and loading states.
  * Backend support and API to submit edited messages and trigger refreshed AI responses.

* **Sync & Cleanup**
  * Client now prunes messages after an edit to keep chat state consistent and resyncs from backend.

* **Localization**
  * Added edit-related translations (en, zh-CN).

* **Tests**
  * Improved E2E wait logic for more reliable UI readiness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->