### PR TITLE
fix(e2e): update bot management test selectors for correct page title

### DIFF
--- a/frontend/e2e/tests/settings-bot.spec.ts
+++ b/frontend/e2e/tests/settings-bot.spec.ts
@@ -5,17 +5,18 @@ test.describe('Settings - Bot Management', () => {
     // Bot management is accessed through "Manage Bots" button in team tab
     await page.goto('/settings?tab=team')
     await page.waitForLoadState('domcontentloaded')
+    // Wait for team page content to fully load - the title is "Team List" or "智能体列表"
+    await expect(
+      page.locator('h2:has-text("Team List"), h2:has-text("智能体列表")')
+    ).toBeVisible({ timeout: 15000 })
   })
 
   test('should access bot management via manage bots button', async ({ page }) => {
     await expect(page).toHaveURL(/\/settings/)
 
-    // Wait for team page to load
-    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 10000 })
-
     // Click "Manage Bots" button to open bot list dialog
     const manageBots = page.locator('button:has-text("Manage Bots"), button:has-text("管理机器人")')
-    await expect(manageBots).toBeVisible({ timeout: 5000 })
+    await expect(manageBots).toBeVisible({ timeout: 10000 })
     await manageBots.click()
 
     // Bot list dialog should open


### PR DESCRIPTION
## Summary
- Fixed E2E test failures in `settings-bot.spec.ts` where tests were waiting for incorrect page heading text
- Updated `beforeEach` hook to wait for the actual page title "Team List" or "智能体列表" instead of just "Team"
- Increased timeout to 15 seconds to ensure page content loads before tests run

## Test plan
- [ ] Run E2E tests to verify bot management tests now pass
- [ ] Verify tests work with both English and Chinese locales