### PR TITLE
fix(frontend): preserve protocol in source_domain to fix SSL handshak…

### DIFF
--- a/frontend/src/features/knowledge/useWikiProjects.ts
+++ b/frontend/src/features/knowledge/useWikiProjects.ts
@@ -39,16 +39,22 @@ function parseSourceType(gitUrl: string): 'github' | 'gitlab' | 'gitee' | 'unkno
 }
 
 /**
- * Extract domain from git URL
+ * Extract domain from git URL (preserves protocol)
+ *
+ * Returns protocol + hostname (e.g., "https://github.com" or "http://gitlab.example.com")
+ * This is important because the backend needs to know whether to use http or https
+ * when making API requests to GitLab/GitHub servers.
  */
 function extractDomain(gitUrl: string): string {
   try {
     const url = new URL(gitUrl)
-    return url.hostname
+    // Return protocol + hostname (e.g., "https://github.com")
+    return `${url.protocol}//${url.hostname}`
   } catch {
-    // Try to extract from git@ format
+    // Try to extract from git@ format (SSH URLs don't have protocol)
     const match = gitUrl.match(/@([^:]+):/)
     if (match) {
+      // For SSH URLs, return just the hostname (backend will default to https)
       return match[1]
     }
     return ''

--- a/frontend/src/features/knowledge/wikiUtils.ts
+++ b/frontend/src/features/knowledge/wikiUtils.ts
@@ -17,12 +17,16 @@ export interface ContentWrite {
 
 /**
  * Parse source URL to identify source_type and source_domain
+ *
+ * source_domain includes protocol (e.g., "https://github.com", "http://gitlab.example.com")
+ * to ensure backend uses correct protocol when making API requests.
  */
 export const parseSourceUrl = (url: string) => {
   try {
     const parsedUrl = new URL(url)
     const hostname = parsedUrl.hostname
     const pathname = parsedUrl.pathname
+    const protocol = parsedUrl.protocol // e.g., "http:" or "https:"
 
     // Identify source_type
     let source_type = 'git'
@@ -32,8 +36,8 @@ export const parseSourceUrl = (url: string) => {
       source_type = 'gitlab'
     }
 
-    // Identify source_domain
-    const source_domain = hostname
+    // Identify source_domain with protocol (e.g., "https://github.com")
+    const source_domain = `${protocol}//${hostname}`
 
     // Identify project_name (extract from path, show up to 2 levels)
     const pathParts = pathname.split('/').filter(part => part)


### PR DESCRIPTION

When adding  GitLab(selfhost) repositories in the code knowledge module, if the project URL uses HTTP protocol (http://), the SSL handshake would fail because the source_domain field was losing the protocol information and the backend was defaulting to HTTPS.

Changes:
- Modified extractDomain() in useWikiProjects.ts to return protocol + hostname (e.g., "https://github.com" or "http://gitlab.example.com")
- Modified parseSourceUrl() in wikiUtils.ts to include protocol in source_domain
- Added detailed comments explaining why protocol preservation is important

This ensures that when the backend GitLabProvider makes API requests, it uses the correct protocol (HTTP or HTTPS) as specified in the original project URL.

Fixes SSL handshake errors when adding repositories with HTTP URLs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain extraction to include protocol information (e.g., https://github.com) for enhanced backend API compatibility when processing knowledge sources. SSH-style URLs remain unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->