### PR TITLE
feat(factory): include reasoning.encrypted_content for Responses API in multi-turn conversations

### DIFF
--- a/backend/tests/services/chat_shell/models/test_factory.py
+++ b/backend/tests/services/chat_shell/models/test_factory.py
@@ -91,3 +91,43 @@ def test_create_from_name():
 
     assert isinstance(model, ChatOpenAI)
     assert model.model_name == "gpt-4o"
+
+
+
+def test_create_openai_model_with_responses_api():
+    """Test creating OpenAI model with Responses API format includes reasoning.encrypted_content."""
+    config = {
+        "model_id": "gpt-5.2",
+        "model": "openai",
+        "api_key": "sk-test",
+        "api_format": "responses",  # Enable Responses API
+    }
+
+    model = LangChainModelFactory.create_from_config(config)
+
+    assert isinstance(model, ChatOpenAI)
+    assert model.model_name == "gpt-5.2"
+    # Verify use_responses_api is enabled
+    assert model.use_responses_api is True
+    # Verify include parameter contains reasoning.encrypted_content
+    # This is required for multi-turn conversations with reasoning models
+    assert model.include == ["reasoning.encrypted_content"]
+
+
+def test_create_openai_model_without_responses_api():
+    """Test creating OpenAI model without Responses API does not set include."""
+    config = {
+        "model_id": "gpt-4o",
+        "model": "openai",
+        "api_key": "sk-test",
+        # No api_format, uses default chat/completions
+    }
+
+    model = LangChainModelFactory.create_from_config(config)
+
+    assert isinstance(model, ChatOpenAI)
+    assert model.model_name == "gpt-4o"
+    # Verify use_responses_api is not set (None or False)
+    assert model.use_responses_api is None or model.use_responses_api is False
+    # Verify include is not set
+    assert model.include is None

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -93,6 +93,14 @@ class LangChainModelFactory:
                 ),
                 # Enable Responses API when api_format is "responses"
                 "use_responses_api": cfg.get("api_format") == "responses" or None,
+                # Include reasoning.encrypted_content for Responses API to properly handle
+                # multi-turn conversations with reasoning models (e.g., GPT-5.x)
+                # Without this, the server returns "unrecognized reasoning ID" errors
+                "include": (
+                    ["reasoning.encrypted_content"]
+                    if cfg.get("api_format") == "responses"
+                    else None
+                ),
             },
         },
         "anthropic": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended OpenAI model configuration to support encrypted reasoning content when using the responses API format.

* **Tests**
  * Added test coverage for OpenAI model creation to validate configuration handling with and without the responses API format setting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->