### PR TITLE
fix(kb): persist RAG results and add task-level KB fallback in HTTP mode

### DIFF
--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -256,7 +256,9 @@ class SaveRagResultRequest(BaseModel):
     """Request for saving RAG retrieval results to context database."""
 
     user_subtask_id: int = Field(..., description="User subtask ID")
-    knowledge_base_id: int = Field(..., description="Knowledge base ID that was searched")
+    knowledge_base_id: int = Field(
+        ..., description="Knowledge base ID that was searched"
+    )
     extracted_text: str = Field(..., description="Concatenated retrieval text")
     sources: list[dict] = Field(
         default_factory=list,

--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -252,6 +252,103 @@ async def get_knowledge_base_size(
     )
 
 
+class SaveRagResultRequest(BaseModel):
+    """Request for saving RAG retrieval results to context database."""
+
+    user_subtask_id: int = Field(..., description="User subtask ID")
+    knowledge_base_id: int = Field(..., description="Knowledge base ID that was searched")
+    extracted_text: str = Field(..., description="Concatenated retrieval text")
+    sources: list[dict] = Field(
+        default_factory=list,
+        description="List of source info dicts with title, kb_id, score",
+    )
+
+
+class SaveRagResultResponse(BaseModel):
+    """Response for save RAG result endpoint."""
+
+    success: bool
+    context_id: Optional[int] = None
+    message: str = ""
+
+
+@router.post("/save-result", response_model=SaveRagResultResponse)
+async def save_rag_result(
+    request: SaveRagResultRequest,
+    db: Session = Depends(get_db),
+):
+    """
+    Save RAG retrieval results to context database.
+
+    This endpoint is called by chat_shell in HTTP mode after RAG retrieval
+    to persist the results for historical context.
+
+    Args:
+        request: Request with subtask ID, KB ID, and retrieval results
+        db: Database session
+
+    Returns:
+        Success status and context ID if saved
+    """
+    try:
+        from app.services.context.context_service import context_service
+
+        # Find the context record for this subtask and knowledge base
+        context = context_service.get_knowledge_base_context_by_subtask_and_kb_id(
+            db=db,
+            subtask_id=request.user_subtask_id,
+            knowledge_id=request.knowledge_base_id,
+        )
+
+        if context is None:
+            logger.warning(
+                "[internal_rag] No context found for subtask_id=%d, kb_id=%d",
+                request.user_subtask_id,
+                request.knowledge_base_id,
+            )
+            return SaveRagResultResponse(
+                success=False,
+                message=f"No context found for subtask_id={request.user_subtask_id}, kb_id={request.knowledge_base_id}",
+            )
+
+        # Update the context with RAG results
+        updated_context = context_service.update_knowledge_base_retrieval_result(
+            db=db,
+            context_id=context.id,
+            extracted_text=request.extracted_text,
+            sources=request.sources,
+        )
+
+        if updated_context:
+            logger.info(
+                "[internal_rag] Saved RAG result: context_id=%d, subtask_id=%d, kb_id=%d, text_length=%d",
+                updated_context.id,
+                request.user_subtask_id,
+                request.knowledge_base_id,
+                len(request.extracted_text),
+            )
+            return SaveRagResultResponse(
+                success=True,
+                context_id=updated_context.id,
+                message="RAG result saved successfully",
+            )
+        else:
+            return SaveRagResultResponse(
+                success=False,
+                message="Failed to update context record",
+            )
+
+    except Exception as e:
+        logger.error(
+            "[internal_rag] Save RAG result failed: subtask_id=%d, kb_id=%d, error=%s",
+            request.user_subtask_id,
+            request.knowledge_base_id,
+            e,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+
 class AllChunksRequest(BaseModel):
     """Request for getting all chunks from a knowledge base."""
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -40,7 +40,9 @@ class GitInfo(BaseModel):
     git_id: Optional[str] = None
     git_login: Optional[str] = None
     git_email: Optional[str] = None
-    auth_type: Optional[str] = None  # Authentication type for Gerrit: 'digest' or 'basic'
+    auth_type: Optional[str] = (
+        None  # Authentication type for Gerrit: 'digest' or 'basic'
+    )
 
 
 class UserBase(BaseModel):

--- a/backend/app/services/chat/adapters/http.py
+++ b/backend/app/services/chat/adapters/http.py
@@ -133,6 +133,7 @@ class HTTPAdapter(ChatInterface):
         metadata = {
             "task_id": request.task_id,
             "subtask_id": request.subtask_id,
+            "user_subtask_id": request.user_subtask_id,  # User subtask ID for RAG persistence
             "user_id": request.user_id,
             "user_name": request.user_name,
             "team_id": request.team_id,
@@ -147,6 +148,7 @@ class HTTPAdapter(ChatInterface):
             "preload_skills": request.preload_skills,
             "knowledge_base_ids": request.knowledge_base_ids,
             "document_ids": request.document_ids,
+            "is_user_selected_kb": request.is_user_selected_kb,
             "table_contexts": request.table_contexts,
             "task_data": request.task_data,
         }

--- a/backend/app/services/chat/adapters/interface.py
+++ b/backend/app/services/chat/adapters/interface.py
@@ -44,6 +44,8 @@ class ChatRequest:
     request_id: str = ""
     message_id: Optional[int] = None
     is_group_chat: bool = False
+    # User subtask ID for RAG result persistence (different from subtask_id which is AI response's subtask)
+    user_subtask_id: Optional[int] = None
 
     # Model configuration
     model_config: dict = field(default_factory=dict)
@@ -77,6 +79,7 @@ class ChatRequest:
     # Knowledge base configuration
     knowledge_base_ids: Optional[list] = None  # Knowledge base IDs to search
     document_ids: Optional[list] = None  # Document IDs to filter retrieval
+    is_user_selected_kb: bool = True  # True = strict mode (user selected), False = relaxed mode (inherited)
 
     # Table configuration
     table_contexts: list = field(
@@ -86,18 +89,19 @@ class ChatRequest:
     # Task data for MCP tools
     task_data: Optional[dict] = None
 
-    # Extra tools to add
-    extra_tools: list = field(default_factory=list)
-
     # MCP server configuration for HTTP mode
     # Format: [{"name": "...", "url": "http://...", "type": "streamable-http", "auth": {...}}]
     mcp_servers: list = field(default_factory=list)
+
+    # Extra tools to add
+    extra_tools: list = field(default_factory=list)
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
         return {
             "task_id": self.task_id,
             "subtask_id": self.subtask_id,
+            "user_subtask_id": self.user_subtask_id,
             "message": self.message,
             "user_id": self.user_id,
             "user_name": self.user_name,
@@ -123,6 +127,7 @@ class ChatRequest:
             "preload_skills": self.preload_skills,
             "knowledge_base_ids": self.knowledge_base_ids,
             "document_ids": self.document_ids,
+            "is_user_selected_kb": self.is_user_selected_kb,
             "table_contexts": self.table_contexts,
             "task_data": self.task_data,
             "extra_tools": self.extra_tools,

--- a/backend/app/services/chat/adapters/interface.py
+++ b/backend/app/services/chat/adapters/interface.py
@@ -79,7 +79,9 @@ class ChatRequest:
     # Knowledge base configuration
     knowledge_base_ids: Optional[list] = None  # Knowledge base IDs to search
     document_ids: Optional[list] = None  # Document IDs to filter retrieval
-    is_user_selected_kb: bool = True  # True = strict mode (user selected), False = relaxed mode (inherited)
+    is_user_selected_kb: bool = (
+        True  # True = strict mode (user selected), False = relaxed mode (inherited)
+    )
 
     # Table configuration
     table_contexts: list = field(

--- a/backend/app/services/chat/trigger/core.py
+++ b/backend/app/services/chat/trigger/core.py
@@ -994,10 +994,13 @@ async def _stream_with_http_adapter(
                 # Preserve sources from result (knowledge base citations)
                 # Sources are passed through from chat_shell's ResponseDone event
                 if result.get("sources"):
-                    logger.debug(
-                        "[HTTP_ADAPTER] Sources in result: %d items",
+                    logger.info(
+                        "[HTTP_ADAPTER] Sources in result: %d items, sources=%s",
                         len(result["sources"]),
+                        result["sources"],
                     )
+                else:
+                    logger.info("[HTTP_ADAPTER] No sources in result")
 
                 # Update subtask status to COMPLETED in database
                 # This is critical for persistence - without this, messages show as "running" after refresh

--- a/backend/app/services/rag/storage/base.py
+++ b/backend/app/services/rag/storage/base.py
@@ -6,6 +6,7 @@
 Base storage backend interface for RAG functionality.
 """
 
+import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Dict, List, Optional
@@ -44,6 +45,45 @@ class BaseStorageBackend(ABC):
         self.api_key = config.get("apiKey")
         self.index_strategy = config.get("indexStrategy", {})
         self.ext = config.get("ext", {})
+
+    def extract_chunk_text(self, raw_content: Any) -> str:
+        """Extract normalized plain text from raw chunk content.
+
+        Some storage providers (e.g., LlamaIndex-based backends) may store
+        serialized node objects (such as TextNode JSON) in the content field
+        when using get_all_chunks. For direct injection we only want the
+        human-readable `text` field and should drop internal fields
+        (id_, embedding, relationships, etc.).
+
+        This helper attempts to parse such JSON structures and extract the
+        `text` value. If parsing fails or the expected structure is missing,
+        it falls back to the original content.
+        """
+        if raw_content is None:
+            return ""
+
+        # Most backends already return plain text
+        if not isinstance(raw_content, str):
+            return str(raw_content)
+
+        stripped = raw_content.strip()
+        # Fast path: not a JSON object or does not contain a `text` key
+        if not stripped.startswith("{") or '"text"' not in stripped:
+            return raw_content
+
+        try:
+            data = json.loads(stripped)
+        except Exception:
+            # If parsing fails, fall back to original content
+            return raw_content
+
+        if isinstance(data, dict):
+            text = data.get("text")
+            if isinstance(text, str):
+                return text
+
+        # Fallback: return original content
+        return raw_content
 
     def _validate_prefix(self, mode: str) -> str:
         """

--- a/backend/app/services/rag/storage/elasticsearch_backend.py
+++ b/backend/app/services/rag/storage/elasticsearch_backend.py
@@ -556,9 +556,15 @@ class ElasticsearchBackend(BaseStorageBackend):
                 source = hit.get("_source", {})
                 metadata = source.get("metadata", {})
 
+                # Normalize content to plain text. In most cases Elasticsearch
+                # stores human-readable text in the "content" field. However,
+                # for robustness we still pass it through extract_chunk_text
+                # to handle potential serialized node payloads.
+                raw_content = source.get("content", "")
+
                 chunks.append(
                     {
-                        "content": source.get("content", ""),
+                        "content": self.extract_chunk_text(raw_content),
                         "title": metadata.get("source_file", ""),
                         "chunk_id": metadata.get("chunk_index", 0),
                         "doc_ref": metadata.get("doc_ref", ""),

--- a/backend/app/services/rag/storage/qdrant_backend.py
+++ b/backend/app/services/rag/storage/qdrant_backend.py
@@ -552,9 +552,16 @@ class QdrantBackend(BaseStorageBackend):
             for point in all_points[:max_chunks]:
                 payload = point.payload or {}
 
+                # Normalize content to plain text. Qdrant stores the original
+                # LlamaIndex node payload in `_node_content`, which may be a
+                # serialized TextNode JSON. We use extract_chunk_text to
+                # extract the human-readable `text` field and drop internal
+                # fields (id_, relationships, embeddings, etc.).
+                raw_content = payload.get("_node_content", "")
+
                 chunks.append(
                     {
-                        "content": payload.get("_node_content", ""),
+                        "content": self.extract_chunk_text(raw_content),
                         "title": payload.get("source_file", ""),
                         "chunk_id": payload.get("chunk_index", 0),
                         "doc_ref": payload.get("doc_ref", ""),

--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -502,6 +502,22 @@ async def _stream_response(
                 return
 
         # Send response.done event with accumulated sources
+        # Convert accumulated_sources to SourceItem format for proper serialization
+        formatted_sources = None
+        if accumulated_sources:
+            from chat_shell.api.v1.schemas import SourceItem
+
+            formatted_sources = [
+                SourceItem(
+                    index=source.get("index"),
+                    title=source.get("title", "Unknown"),
+                    kb_id=source.get("kb_id"),
+                    url=source.get("url"),
+                    snippet=source.get("snippet"),
+                )
+                for source in accumulated_sources
+            ]
+
         yield _format_sse_event(
             ResponseEventType.RESPONSE_DONE.value,
             ResponseDone(
@@ -516,7 +532,7 @@ async def _stream_response(
                     else None
                 ),
                 stop_reason="end_turn",
-                sources=accumulated_sources if accumulated_sources else None,
+                sources=formatted_sources,
             ).model_dump(),
         )
 

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -179,6 +179,10 @@ class Metadata(BaseModel):
     team_name: Optional[str] = Field(None, description="Team name")
     task_id: Optional[int] = Field(None, description="Task ID")
     subtask_id: Optional[int] = Field(None, description="Subtask ID")
+    user_subtask_id: Optional[int] = Field(
+        None,
+        description="User subtask ID for RAG result persistence (different from subtask_id which is AI response's subtask)",
+    )
     message_id: Optional[int] = Field(None, description="Message ID")
     bot_name: Optional[str] = Field(None, description="Bot name")
     bot_namespace: Optional[str] = Field(None, description="Bot namespace")
@@ -206,6 +210,10 @@ class Metadata(BaseModel):
     document_ids: Optional[list[int]] = Field(
         None,
         description="Document IDs to filter retrieval (when user references specific documents)",
+    )
+    is_user_selected_kb: Optional[bool] = Field(
+        True,
+        description="Whether KB is explicitly selected by user (strict mode) or inherited from task (relaxed mode)",
     )
     # Table configuration
     table_contexts: Optional[list[dict]] = Field(

--- a/chat_shell/chat_shell/interface.py
+++ b/chat_shell/chat_shell/interface.py
@@ -46,6 +46,8 @@ class ChatRequest:
     request_id: str = ""
     message_id: Optional[int] = None
     is_group_chat: bool = False
+    # User subtask ID for RAG result persistence (different from subtask_id which is AI response's subtask)
+    user_subtask_id: Optional[int] = None
 
     # Model configuration
     model_config: dict = field(default_factory=dict)
@@ -79,6 +81,7 @@ class ChatRequest:
     # Knowledge base configuration
     knowledge_base_ids: Optional[list] = None  # Knowledge base IDs to search
     document_ids: Optional[list] = None  # Document IDs to filter retrieval
+    is_user_selected_kb: bool = True  # True = strict mode (user selected), False = relaxed mode (inherited)
 
     # Table configuration
     table_contexts: list = field(

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -254,7 +254,8 @@ class ChatContext:
             db=db,
             base_system_prompt=base_system_prompt,
             task_id=self._request.task_id,
-            user_subtask_id=self._request.subtask_id,
+            user_subtask_id=self._request.user_subtask_id,  # Use user_subtask_id for RAG persistence
+            is_user_selected=self._request.is_user_selected_kb,
             document_ids=self._request.document_ids,
             context_window=context_window,
         )

--- a/chat_shell/chat_shell/services/streaming/core.py
+++ b/chat_shell/chat_shell/services/streaming/core.py
@@ -108,8 +108,16 @@ class StreamingState:
         include_value: bool = True,
         include_thinking: bool = True,
         slim_thinking: bool = False,
+        include_sources: bool = True,
     ) -> dict:
-        """Get current result with thinking steps and sources."""
+        """Get current result with thinking steps and sources.
+
+        Args:
+            include_value: Include the full response value
+            include_thinking: Include thinking steps (tool calls)
+            slim_thinking: Use slimmed down thinking data (for Chat mode)
+            include_sources: Include knowledge base sources (independent of thinking)
+        """
         result: dict = {"shell_type": self.shell_type}
         if include_value:
             result["value"] = self.full_response
@@ -119,8 +127,10 @@ class StreamingState:
                     result["thinking"] = self._slim_thinking_data(self.thinking)
                 else:
                     result["thinking"] = self.thinking
-            if self.sources:
-                result["sources"] = self.sources
+        # Sources should be included independently of thinking steps
+        # This ensures knowledge base citations are always available
+        if include_sources and self.sources:
+            result["sources"] = self.sources
         if self.reasoning_content:
             result["reasoning_content"] = self.reasoning_content
         return result

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -82,7 +82,6 @@ class KnowledgeBaseTool(BaseTool):
     injection_mode: str = (
         InjectionMode.HYBRID
     )  # Default: auto-decide based on token count
-    aggressive_cleaning: bool = True
     min_chunk_score: float = 0.5
     max_direct_chunks: int = 500
     context_buffer_ratio: float = 0.1
@@ -101,7 +100,6 @@ class KnowledgeBaseTool(BaseTool):
                 model_id=self.model_id,
                 context_window=self.context_window,
                 injection_mode=self.injection_mode,
-                aggressive_cleaning=self.aggressive_cleaning,
                 min_chunk_score=self.min_chunk_score,
                 max_direct_chunks=self.max_direct_chunks,
                 context_buffer_ratio=self.context_buffer_ratio,
@@ -201,7 +199,7 @@ class KnowledgeBaseTool(BaseTool):
 
                 if injection_result["mode"] == InjectionMode.DIRECT_INJECTION:
                     logger.info(
-                        f"[KnowledgeBaseTool] ✅ Direct injection: {len(injection_result.get('chunks_used', []))} chunks"
+                        f"[KnowledgeBaseTool] Direct injection: {len(injection_result.get('chunks_used', []))} chunks"
                     )
                     return self._format_direct_injection_result(injection_result, query)
                 else:
@@ -397,12 +395,13 @@ class KnowledgeBaseTool(BaseTool):
                     )
 
                     # Process chunks into the expected format
+                    # Direct injection uses null score to indicate non-RAG retrieval
                     processed_chunks = []
                     for chunk in chunks:
                         processed_chunk = {
                             "content": chunk.get("content", ""),
                             "source": chunk.get("title", "Unknown"),
-                            "score": 1.0,  # All chunks have equal score for direct injection
+                            "score": None,  # null for direct injection (not RAG similarity)
                             "knowledge_base_id": kb_id,
                         }
                         processed_chunks.append(processed_chunk)
@@ -462,13 +461,13 @@ class KnowledgeBaseTool(BaseTool):
                         f"[KnowledgeBaseTool] HTTP retrieved all {len(chunks)} chunks from KB {kb_id}"
                     )
 
-                    # Process chunks
+                    # Process chunks with null score for direct injection
                     processed_chunks = []
                     for chunk in chunks:
                         processed_chunk = {
                             "content": chunk.get("content", ""),
                             "source": chunk.get("title", "Unknown"),
-                            "score": 1.0,
+                            "score": None,  # null for direct injection (not RAG similarity)
                             "knowledge_base_id": kb_id,
                         }
                         processed_chunks.append(processed_chunk)
@@ -654,6 +653,41 @@ class KnowledgeBaseTool(BaseTool):
             ],
         }
 
+    def _build_extracted_data(
+        self,
+        chunks: List[Dict[str, Any]],
+        source_references: List[Dict[str, Any]],
+        kb_id: int,
+    ) -> str:
+        """Build structured JSON for extracted_text field.
+
+        Args:
+            chunks: List of chunks with content and metadata
+            source_references: List of source references
+            kb_id: Knowledge base ID to filter by
+
+        Returns:
+            JSON string with structured data
+        """
+        # Filter chunks and sources for this KB
+        kb_chunks = [c for c in chunks if c.get("knowledge_base_id") == kb_id]
+        kb_sources = [s for s in source_references if s.get("kb_id") == kb_id]
+
+        extracted_data = {
+            "chunks": [
+                {
+                    "content": c.get("content", ""),
+                    "source": c.get("source", "Unknown"),
+                    "score": c.get("score"),  # None for direct injection
+                    "knowledge_base_id": kb_id,
+                    "source_index": c.get("source_index", 0),
+                }
+                for c in kb_chunks
+            ],
+            "sources": kb_sources,  # [{index, title, kb_id}, ...]
+        }
+        return json.dumps(extracted_data, ensure_ascii=False)
+
     def _format_direct_injection_result(
         self,
         injection_result: Dict[str, Any],
@@ -671,6 +705,27 @@ class KnowledgeBaseTool(BaseTool):
         # Extract chunks used for persistence
         chunks_used = injection_result.get("chunks_used", [])
 
+        # Build source references from chunks_used
+        source_references = []
+        seen_sources: dict[tuple[int, str], int] = {}
+        source_index = 1
+
+        for chunk in chunks_used:
+            kb_id = chunk.get("knowledge_base_id")
+            source_file = chunk.get("source", "Unknown")
+            source_key = (kb_id, source_file)
+
+            if source_key not in seen_sources:
+                seen_sources[source_key] = source_index
+                source_references.append(
+                    {
+                        "index": source_index,
+                        "title": source_file,
+                        "kb_id": kb_id,
+                    }
+                )
+                source_index += 1
+
         # Persist RAG results if user_subtask_id is available
         if self.user_subtask_id and chunks_used:
             self._persist_rag_results_sync(chunks_used, query)
@@ -681,6 +736,8 @@ class KnowledgeBaseTool(BaseTool):
                 "mode": "direct_injection",
                 "injected_content": injection_result["injected_content"],
                 "chunks_used": len(chunks_used),
+                "count": len(chunks_used),
+                "sources": source_references,
                 "decision_details": injection_result["decision_details"],
                 "strategy_stats": self.injection_strategy.get_injection_statistics(),
                 "message": "All knowledge base content has been fully injected above. "
@@ -739,13 +796,13 @@ class KnowledgeBaseTool(BaseTool):
                 )
 
         # Sort by score (descending)
-        all_chunks.sort(key=lambda x: x.get("score", 0.0), reverse=True)
+        all_chunks.sort(key=lambda x: x.get("score", 0.0) or 0.0, reverse=True)
 
         # Limit total results
         all_chunks = all_chunks[:max_results]
 
         logger.info(
-            f"[KnowledgeBaseTool] ✅ RAG fallback: returning {len(all_chunks)} results with {len(source_references)} unique sources for query: {query}"
+            f"[KnowledgeBaseTool] RAG fallback: returning {len(all_chunks)} results with {len(source_references)} unique sources for query: {query}"
         )
 
         # Persist RAG results if user_subtask_id is available
@@ -828,11 +885,8 @@ class KnowledgeBaseTool(BaseTool):
 
         from app.services.context.context_service import context_service
 
-        # Build extracted text from chunks
-        extracted_text = "\n\n".join(
-            f"[Source: {c.get('source', 'Unknown')} (Score: {c.get('score', 0.0):.3f})]\n{c.get('content', '')}"
-            for c in chunks
-        )
+        # Build structured JSON for extracted_text
+        extracted_text = self._build_extracted_data(chunks, source_references, kb_id)
 
         # Filter source references for this KB
         kb_sources = [s for s in source_references if s.get("kb_id") == kb_id]
@@ -860,7 +914,7 @@ class KnowledgeBaseTool(BaseTool):
             )
 
             logger.info(
-                f"[KnowledgeBaseTool] ✅ Persisted RAG result: context_id={context.id}, "
+                f"[KnowledgeBaseTool] Persisted RAG result: context_id={context.id}, "
                 f"subtask_id={self.user_subtask_id}, kb_id={kb_id}, text_length={len(extracted_text)}"
             )
 
@@ -886,11 +940,8 @@ class KnowledgeBaseTool(BaseTool):
 
         from chat_shell.core.config import settings
 
-        # Build extracted text from chunks
-        extracted_text = "\n\n".join(
-            f"[Source: {c.get('source', 'Unknown')} (Score: {c.get('score', 0.0):.3f})]\n{c.get('content', '')}"
-            for c in chunks
-        )
+        # Build structured JSON for extracted_text
+        extracted_text = self._build_extracted_data(chunks, source_references, kb_id)
 
         # Filter source references for this KB
         kb_sources = [s for s in source_references if s.get("kb_id") == kb_id]
@@ -918,7 +969,7 @@ class KnowledgeBaseTool(BaseTool):
                     data = response.json()
                     if data.get("success"):
                         logger.info(
-                            f"[KnowledgeBaseTool] ✅ Persisted RAG result via HTTP: "
+                            f"[KnowledgeBaseTool] Persisted RAG result via HTTP: "
                             f"context_id={data.get('context_id')}, subtask_id={self.user_subtask_id}, "
                             f"kb_id={kb_id}, text_length={len(extracted_text)}"
                         )
@@ -958,6 +1009,8 @@ class KnowledgeBaseTool(BaseTool):
         seen_sources: dict[tuple[int, str], int] = {}
         source_index = 1
 
+        # Add source_index to each chunk
+        chunks_with_index = []
         for chunk in chunks_used:
             kb_id = chunk.get("knowledge_base_id")
             source_file = chunk.get("source", "Unknown")
@@ -974,6 +1027,10 @@ class KnowledgeBaseTool(BaseTool):
                 )
                 source_index += 1
 
+            chunk_with_index = chunk.copy()
+            chunk_with_index["source_index"] = seen_sources[source_key]
+            chunks_with_index.append(chunk_with_index)
+
         # Helper callback to log exceptions from fire-and-forget tasks
         def _log_task_exception(task: asyncio.Task) -> None:
             if task.exception():
@@ -987,16 +1044,20 @@ class KnowledgeBaseTool(BaseTool):
             if loop.is_running():
                 # If event loop is running, create a task with exception handler
                 task = asyncio.create_task(
-                    self._persist_rag_results(chunks_used, source_references, query)
+                    self._persist_rag_results(
+                        chunks_with_index, source_references, query
+                    )
                 )
                 task.add_done_callback(_log_task_exception)
             else:
                 # Run synchronously
                 loop.run_until_complete(
-                    self._persist_rag_results(chunks_used, source_references, query)
+                    self._persist_rag_results(
+                        chunks_with_index, source_references, query
+                    )
                 )
         except RuntimeError:
             # No event loop, create a new one
             asyncio.run(
-                self._persist_rag_results(chunks_used, source_references, query)
+                self._persist_rag_results(chunks_with_index, source_references, query)
             )

--- a/chat_shell/chat_shell/tools/events.py
+++ b/chat_shell/chat_shell/tools/events.py
@@ -230,14 +230,23 @@ def _process_tool_output(
         if isinstance(tool_output, str):
             try:
                 parsed = json.loads(tool_output)
+                logger.info(
+                    f"[TOOL_OUTPUT] knowledge_base_search parsed output: "
+                    f"has_sources={'sources' in parsed}, "
+                    f"sources_count={len(parsed.get('sources', []))}, "
+                    f"sources={parsed.get('sources', [])}"
+                )
                 if isinstance(parsed, dict) and "sources" in parsed:
                     kb_sources = parsed.get("sources", [])
                     if isinstance(kb_sources, list):
                         sources.extend(kb_sources)
+                        logger.info(
+                            f"[TOOL_OUTPUT] Extracted {len(kb_sources)} sources from knowledge_base_search"
+                        )
                     result_count = parsed.get("count", 0)
                     title = f"检索完成，找到 {result_count} 条结果"
-            except json.JSONDecodeError:
-                pass
+            except json.JSONDecodeError as e:
+                logger.warning(f"[TOOL_OUTPUT] Failed to parse tool output: {e}")
 
     # Extract sources from web_search results
     elif tool_name == "web_search":

--- a/chat_shell/tests/test_knowledge_base_persistence.py
+++ b/chat_shell/tests/test_knowledge_base_persistence.py
@@ -1,0 +1,642 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for RAG result persistence data format.
+
+These tests ensure that the extracted_text field uses the correct JSON structure
+with chunks and sources arrays, matching the frontend SourceReference interface.
+"""
+
+import json
+
+import pytest
+
+from chat_shell.tools.builtin.knowledge_base import KnowledgeBaseTool
+
+
+class TestRagPersistenceFormat:
+    """Test RAG result persistence data format."""
+
+    def setup_method(self):
+        self.tool = KnowledgeBaseTool()
+
+    def test_build_extracted_data_returns_valid_json(self):
+        """_build_extracted_data should return valid JSON string."""
+        chunks = [
+            {
+                "content": "test content",
+                "source": "test.md",
+                "score": 0.85,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "test.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+
+        # Should be valid JSON
+        data = json.loads(result)
+        assert isinstance(data, dict)
+
+    def test_extracted_data_has_correct_structure(self):
+        """extracted_text should have chunks and sources arrays."""
+        chunks = [
+            {
+                "content": "test content",
+                "source": "test.md",
+                "score": 0.85,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "test.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        assert "chunks" in data
+        assert "sources" in data
+        assert isinstance(data["chunks"], list)
+        assert isinstance(data["sources"], list)
+
+    def test_chunk_has_required_fields(self):
+        """Each chunk should have content, source, score, knowledge_base_id, source_index."""
+        chunks = [
+            {
+                "content": "test content",
+                "source": "test.md",
+                "score": 0.85,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "test.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        assert len(data["chunks"]) == 1
+        chunk = data["chunks"][0]
+        assert chunk["content"] == "test content"
+        assert chunk["source"] == "test.md"
+        assert chunk["score"] == 0.85
+        assert chunk["knowledge_base_id"] == 1
+        assert chunk["source_index"] == 1
+
+    def test_direct_injection_score_is_null(self):
+        """Direct injection mode should have null score."""
+        chunks = [
+            {
+                "content": "injected content",
+                "source": "doc.md",
+                "score": None,  # Direct injection
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "doc.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        assert data["chunks"][0]["score"] is None
+
+    def test_rag_retrieval_score_is_float(self):
+        """RAG retrieval mode should have float score."""
+        chunks = [
+            {
+                "content": "retrieved content",
+                "source": "doc.md",
+                "score": 0.75,  # RAG similarity score
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "doc.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        assert data["chunks"][0]["score"] == 0.75
+        assert isinstance(data["chunks"][0]["score"], float)
+
+    def test_sources_match_frontend_format(self):
+        """Sources should match SourceReference interface for frontend."""
+        # Frontend expects: {index: number, title: string, kb_id: number}
+        chunks = [
+            {
+                "content": "content",
+                "source": "doc1.md",
+                "score": 0.8,
+                "knowledge_base_id": 10,
+                "source_index": 1,
+            }
+        ]
+        source_references = [
+            {"index": 1, "title": "doc1.md", "kb_id": 10},
+            {"index": 2, "title": "doc2.md", "kb_id": 10},
+        ]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 10)
+        data = json.loads(result)
+
+        for source in data["sources"]:
+            assert isinstance(source["index"], int)
+            assert isinstance(source["title"], str)
+            assert isinstance(source["kb_id"], int)
+
+    def test_content_is_plain_text_not_json(self):
+        """Content should be plain text, not serialized TextNode."""
+        content = "这是纯文本内容"
+        chunks = [
+            {
+                "content": content,
+                "source": "doc.md",
+                "score": 0.8,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "doc.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        chunk_content = data["chunks"][0]["content"]
+        # Should NOT contain LlamaIndex TextNode fields
+        assert "id_" not in chunk_content
+        assert "embedding" not in chunk_content
+        assert "class_name" not in chunk_content
+        assert "TextNode" not in chunk_content
+        assert "excluded_embed_metadata_keys" not in chunk_content
+        # Should contain the actual text
+        assert "这是纯文本内容" in chunk_content
+
+    def test_multiple_chunks_from_same_source(self):
+        """Multiple chunks from same source should share source_index."""
+        chunks = [
+            {
+                "content": "chunk 1",
+                "source": "doc.md",
+                "score": 0.9,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            },
+            {
+                "content": "chunk 2",
+                "source": "doc.md",
+                "score": 0.8,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            },
+            {
+                "content": "chunk 3",
+                "source": "other.md",
+                "score": 0.7,
+                "knowledge_base_id": 1,
+                "source_index": 2,
+            },
+        ]
+        source_references = [
+            {"index": 1, "title": "doc.md", "kb_id": 1},
+            {"index": 2, "title": "other.md", "kb_id": 1},
+        ]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        # First two chunks should have same source_index
+        assert (
+            data["chunks"][0]["source_index"] == data["chunks"][1]["source_index"] == 1
+        )
+        # Third chunk should have different source_index
+        assert data["chunks"][2]["source_index"] == 2
+        # Sources should be deduplicated
+        assert len(data["sources"]) == 2
+
+    def test_filters_chunks_by_kb_id(self):
+        """_build_extracted_data should filter chunks by knowledge_base_id."""
+        chunks = [
+            {
+                "content": "kb1 content",
+                "source": "doc1.md",
+                "score": 0.9,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            },
+            {
+                "content": "kb2 content",
+                "source": "doc2.md",
+                "score": 0.8,
+                "knowledge_base_id": 2,
+                "source_index": 2,
+            },
+        ]
+        source_references = [
+            {"index": 1, "title": "doc1.md", "kb_id": 1},
+            {"index": 2, "title": "doc2.md", "kb_id": 2},
+        ]
+
+        # Only get KB 1 data
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        assert len(data["chunks"]) == 1
+        assert data["chunks"][0]["content"] == "kb1 content"
+        assert len(data["sources"]) == 1
+        assert data["sources"][0]["title"] == "doc1.md"
+
+    def test_filters_sources_by_kb_id(self):
+        """_build_extracted_data should filter sources by kb_id."""
+        chunks = [
+            {
+                "content": "content",
+                "source": "doc.md",
+                "score": 0.9,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [
+            {"index": 1, "title": "doc1.md", "kb_id": 1},
+            {"index": 2, "title": "doc2.md", "kb_id": 2},
+            {"index": 3, "title": "doc3.md", "kb_id": 1},
+        ]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        # Should only have sources for KB 1
+        assert len(data["sources"]) == 2
+        kb_ids = [s["kb_id"] for s in data["sources"]]
+        assert all(kb_id == 1 for kb_id in kb_ids)
+
+    def test_empty_chunks_returns_empty_arrays(self):
+        """Empty chunks should return empty arrays in JSON."""
+        result = self.tool._build_extracted_data([], [], 1)
+        data = json.loads(result)
+
+        assert data["chunks"] == []
+        assert data["sources"] == []
+
+    def test_json_ensure_ascii_false(self):
+        """JSON should preserve non-ASCII characters."""
+        chunks = [
+            {
+                "content": "中文内容 和 日本語",
+                "source": "文档.md",
+                "score": 0.8,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "文档.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+
+        # Should contain actual Chinese characters, not escaped
+        assert "中文内容" in result
+        assert "日本語" in result
+        assert "文档.md" in result
+
+    def test_score_precision_preserved(self):
+        """Score precision should be preserved in JSON."""
+        chunks = [
+            {
+                "content": "content",
+                "source": "doc.md",
+                "score": 0.123456789,
+                "knowledge_base_id": 1,
+                "source_index": 1,
+            }
+        ]
+        source_references = [{"index": 1, "title": "doc.md", "kb_id": 1}]
+
+        result = self.tool._build_extracted_data(chunks, source_references, 1)
+        data = json.loads(result)
+
+        # Score should be preserved with precision
+        assert data["chunks"][0]["score"] == 0.123456789
+
+
+class TestKnowledgeBaseToolDirectInjection:
+    """Test KnowledgeBaseTool direct injection behavior."""
+
+    def test_direct_injection_chunks_have_null_score(self):
+        """Chunks from direct injection should have null score."""
+        # This tests the behavior when processing all chunks
+        # In _get_all_chunks_from_all_kbs, score should be set to None
+        chunk = {
+            "content": "test",
+            "source": "doc.md",
+            "score": None,  # Should be None for direct injection
+            "knowledge_base_id": 1,
+        }
+
+        assert chunk["score"] is None
+
+    def test_rag_retrieval_chunks_have_float_score(self):
+        """Chunks from RAG retrieval should have float score."""
+        # In _retrieve_chunks_from_all_kbs, score comes from similarity
+        chunk = {
+            "content": "test",
+            "source": "doc.md",
+            "score": 0.85,  # Should be float for RAG
+            "knowledge_base_id": 1,
+        }
+
+        assert isinstance(chunk["score"], float)
+        assert chunk["score"] == 0.85
+
+
+class TestKnowledgeBaseToolSourcesField:
+    """Test that both Direct Injection and RAG modes return sources field."""
+
+    def setup_method(self):
+        self.tool = KnowledgeBaseTool()
+
+    def test_format_direct_injection_result_includes_sources(self):
+        """_format_direct_injection_result should include sources field."""
+        injection_result = {
+            "mode": "direct_injection",
+            "injected_content": "Test content",
+            "chunks_used": [
+                {
+                    "content": "chunk 1",
+                    "source": "doc1.md",
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "chunk 2",
+                    "source": "doc2.md",
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "chunk 3",
+                    "source": "doc1.md",  # Duplicate source
+                    "knowledge_base_id": 1,
+                },
+            ],
+            "decision_details": {},
+        }
+
+        result_json = self.tool._format_direct_injection_result(
+            injection_result, "test query"
+        )
+        result = json.loads(result_json)
+
+        # Should have sources field
+        assert "sources" in result
+        assert isinstance(result["sources"], list)
+        # Should have 2 unique sources (doc1.md and doc2.md)
+        assert len(result["sources"]) == 2
+
+    def test_direct_injection_sources_have_correct_format(self):
+        """Direct injection sources should have index, title, kb_id fields."""
+        injection_result = {
+            "mode": "direct_injection",
+            "injected_content": "Test content",
+            "chunks_used": [
+                {
+                    "content": "chunk",
+                    "source": "test.md",
+                    "knowledge_base_id": 10,
+                }
+            ],
+            "decision_details": {},
+        }
+
+        result_json = self.tool._format_direct_injection_result(
+            injection_result, "test query"
+        )
+        result = json.loads(result_json)
+
+        source = result["sources"][0]
+        assert "index" in source
+        assert "title" in source
+        assert "kb_id" in source
+        assert isinstance(source["index"], int)
+        assert isinstance(source["title"], str)
+        assert isinstance(source["kb_id"], int)
+        assert source["title"] == "test.md"
+        assert source["kb_id"] == 10
+
+    def test_direct_injection_sources_deduplicated(self):
+        """Direct injection should deduplicate sources by (kb_id, title)."""
+        injection_result = {
+            "mode": "direct_injection",
+            "injected_content": "Test content",
+            "chunks_used": [
+                {"content": "c1", "source": "doc.md", "knowledge_base_id": 1},
+                {
+                    "content": "c2",
+                    "source": "doc.md",
+                    "knowledge_base_id": 1,
+                },  # Duplicate
+                {"content": "c3", "source": "other.md", "knowledge_base_id": 1},
+                {
+                    "content": "c4",
+                    "source": "doc.md",
+                    "knowledge_base_id": 2,
+                },  # Different KB
+            ],
+            "decision_details": {},
+        }
+
+        result_json = self.tool._format_direct_injection_result(
+            injection_result, "test query"
+        )
+        result = json.loads(result_json)
+
+        # Should have 3 unique sources: (1, doc.md), (1, other.md), (2, doc.md)
+        assert len(result["sources"]) == 3
+        titles = [(s["kb_id"], s["title"]) for s in result["sources"]]
+        assert (1, "doc.md") in titles
+        assert (1, "other.md") in titles
+        assert (2, "doc.md") in titles
+
+    def test_direct_injection_sources_have_sequential_index(self):
+        """Direct injection sources should have sequential index starting from 1."""
+        injection_result = {
+            "mode": "direct_injection",
+            "injected_content": "Test content",
+            "chunks_used": [
+                {"content": "c1", "source": "doc1.md", "knowledge_base_id": 1},
+                {"content": "c2", "source": "doc2.md", "knowledge_base_id": 1},
+                {"content": "c3", "source": "doc3.md", "knowledge_base_id": 1},
+            ],
+            "decision_details": {},
+        }
+
+        result_json = self.tool._format_direct_injection_result(
+            injection_result, "test query"
+        )
+        result = json.loads(result_json)
+
+        indices = [s["index"] for s in result["sources"]]
+        assert indices == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_format_rag_result_includes_sources(self):
+        """_format_rag_result should include sources field."""
+        kb_chunks = {
+            1: [
+                {
+                    "content": "chunk 1",
+                    "source": "doc1.md",
+                    "score": 0.9,
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "chunk 2",
+                    "source": "doc2.md",
+                    "score": 0.8,
+                    "knowledge_base_id": 1,
+                },
+            ]
+        }
+
+        result_json = await self.tool._format_rag_result(kb_chunks, "test query", 20)
+        result = json.loads(result_json)
+
+        # Should have sources field
+        assert "sources" in result
+        assert isinstance(result["sources"], list)
+        assert len(result["sources"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_rag_result_sources_have_correct_format(self):
+        """RAG result sources should have index, title, kb_id fields."""
+        kb_chunks = {
+            10: [
+                {
+                    "content": "chunk",
+                    "source": "test.md",
+                    "score": 0.85,
+                    "knowledge_base_id": 10,
+                }
+            ]
+        }
+
+        result_json = await self.tool._format_rag_result(kb_chunks, "test query", 20)
+        result = json.loads(result_json)
+
+        source = result["sources"][0]
+        assert "index" in source
+        assert "title" in source
+        assert "kb_id" in source
+        assert source["title"] == "test.md"
+        assert source["kb_id"] == 10
+
+    @pytest.mark.asyncio
+    async def test_rag_result_sources_deduplicated(self):
+        """RAG result should deduplicate sources by (kb_id, title)."""
+        kb_chunks = {
+            1: [
+                {
+                    "content": "c1",
+                    "source": "doc.md",
+                    "score": 0.9,
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "c2",
+                    "source": "doc.md",
+                    "score": 0.8,
+                    "knowledge_base_id": 1,
+                },  # Duplicate
+                {
+                    "content": "c3",
+                    "source": "other.md",
+                    "score": 0.7,
+                    "knowledge_base_id": 1,
+                },
+            ]
+        }
+
+        result_json = await self.tool._format_rag_result(kb_chunks, "test query", 20)
+        result = json.loads(result_json)
+
+        # Should have 2 unique sources
+        assert len(result["sources"]) == 2
+        titles = [s["title"] for s in result["sources"]]
+        assert "doc.md" in titles
+        assert "other.md" in titles
+
+    @pytest.mark.asyncio
+    async def test_rag_result_count_matches_sources(self):
+        """RAG result count field should match number of chunks."""
+        kb_chunks = {
+            1: [
+                {
+                    "content": "c1",
+                    "source": "doc1.md",
+                    "score": 0.9,
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "c2",
+                    "source": "doc2.md",
+                    "score": 0.8,
+                    "knowledge_base_id": 1,
+                },
+                {
+                    "content": "c3",
+                    "source": "doc3.md",
+                    "score": 0.7,
+                    "knowledge_base_id": 1,
+                },
+            ]
+        }
+
+        result_json = await self.tool._format_rag_result(kb_chunks, "test query", 20)
+        result = json.loads(result_json)
+
+        assert result["count"] == 3
+        assert len(result["results"]) == 3
+        assert len(result["sources"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_direct_injection_and_rag_sources_format_consistent(self):
+        """Direct injection and RAG should return sources in the same format."""
+        # Direct injection
+        injection_result = {
+            "mode": "direct_injection",
+            "injected_content": "Test",
+            "chunks_used": [
+                {"content": "c", "source": "doc.md", "knowledge_base_id": 1}
+            ],
+            "decision_details": {},
+        }
+        direct_json = self.tool._format_direct_injection_result(
+            injection_result, "query"
+        )
+        direct_result = json.loads(direct_json)
+
+        # RAG
+        kb_chunks = {
+            1: [
+                {
+                    "content": "c",
+                    "source": "doc.md",
+                    "score": 0.8,
+                    "knowledge_base_id": 1,
+                }
+            ]
+        }
+        rag_json = await self.tool._format_rag_result(kb_chunks, "query", 20)
+        rag_result = json.loads(rag_json)
+
+        # Both should have sources with same structure
+        assert "sources" in direct_result
+        assert "sources" in rag_result
+        direct_source = direct_result["sources"][0]
+        rag_source = rag_result["sources"][0]
+        assert set(direct_source.keys()) == set(rag_source.keys())
+        assert set(direct_source.keys()) == {"index", "title", "kb_id"}
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/chat_shell/tests/test_knowledge_content_cleaner.py
+++ b/chat_shell/tests/test_knowledge_content_cleaner.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for KnowledgeContentCleaner functionality.
+
+These tests ensure that the content cleaner properly preserves important content
+(URLs, code blocks, emails) while cleaning unnecessary elements (HTML, whitespace).
+"""
+
+import pytest
+
+from chat_shell.tools.knowledge_content_cleaner import KnowledgeContentCleaner
+
+
+class TestKnowledgeContentCleaner:
+    """Test KnowledgeContentCleaner functionality."""
+
+    def setup_method(self):
+        self.cleaner = KnowledgeContentCleaner()
+
+    # URL preservation tests
+    def test_urls_are_preserved(self):
+        """URLs should NOT be removed from content."""
+        content = "访问 http://minio.internal.com 获取详情"
+        cleaned = self.cleaner.clean_content(content)
+        assert "http://minio.internal.com" in cleaned
+
+    def test_internal_urls_preserved(self):
+        """Internal URLs should be preserved."""
+        content = "[[ 地址：http://minio.tomas.com ]]"
+        cleaned = self.cleaner.clean_content(content)
+        assert "http://minio.tomas.com" in cleaned
+
+    def test_https_urls_preserved(self):
+        """HTTPS URLs should be preserved."""
+        content = "文档地址: https://docs.example.com/api/v1"
+        cleaned = self.cleaner.clean_content(content)
+        assert "https://docs.example.com/api/v1" in cleaned
+
+    def test_urls_with_query_params_preserved(self):
+        """URLs with query parameters should be preserved."""
+        content = "链接: https://api.example.com/search?q=test&page=1"
+        cleaned = self.cleaner.clean_content(content)
+        assert "https://api.example.com/search?q=test&page=1" in cleaned
+
+    def test_multiple_urls_preserved(self):
+        """Multiple URLs should all be preserved."""
+        content = "参考 http://a.com 和 https://b.com 两个地址"
+        cleaned = self.cleaner.clean_content(content)
+        assert "http://a.com" in cleaned
+        assert "https://b.com" in cleaned
+
+    # Code block preservation tests
+    def test_code_blocks_are_preserved(self):
+        """Code blocks should NOT be removed."""
+        content = "示例代码：\n```python\nprint('hello')\n```"
+        cleaned = self.cleaner.clean_content(content)
+        assert "```python" in cleaned
+        assert "print('hello')" in cleaned
+
+    def test_inline_code_is_preserved(self):
+        """Inline code should NOT be removed."""
+        content = "使用 `kubectl get pods` 命令"
+        cleaned = self.cleaner.clean_content(content)
+        assert "`kubectl get pods`" in cleaned
+
+    def test_multiline_code_block_preserved(self):
+        """Multiline code blocks should be preserved."""
+        content = """```yaml
+server:
+  host: localhost
+  port: 8080
+```"""
+        cleaned = self.cleaner.clean_content(content)
+        assert "```yaml" in cleaned
+        assert "host: localhost" in cleaned
+        assert "port: 8080" in cleaned
+
+    def test_code_block_with_url_preserved(self):
+        """Code blocks containing URLs should preserve both."""
+        content = "示例：`curl http://api.internal.com/health`"
+        cleaned = self.cleaner.clean_content(content)
+        assert "`curl http://api.internal.com/health`" in cleaned
+
+    # Email preservation tests
+    def test_emails_are_preserved(self):
+        """Email addresses should NOT be removed."""
+        content = "联系人：admin@company.com"
+        cleaned = self.cleaner.clean_content(content)
+        assert "admin@company.com" in cleaned
+
+    def test_multiple_emails_preserved(self):
+        """Multiple email addresses should all be preserved."""
+        content = "联系 user1@example.com 或 user2@example.org"
+        cleaned = self.cleaner.clean_content(content)
+        assert "user1@example.com" in cleaned
+        assert "user2@example.org" in cleaned
+
+    # Punctuation normalization tests
+    def test_repeated_exclamation_normalized(self):
+        """!!! should become ! (not .)"""
+        content = "注意!!!"
+        cleaned = self.cleaner.clean_content(content)
+        assert "注意!" in cleaned
+        assert "注意." not in cleaned
+        assert "!!!" not in cleaned
+
+    def test_repeated_question_normalized(self):
+        """??? should become ? (not .)"""
+        content = "真的吗???"
+        cleaned = self.cleaner.clean_content(content)
+        assert "真的吗?" in cleaned
+        assert "真的吗." not in cleaned
+        assert "???" not in cleaned
+
+    def test_repeated_period_normalized(self):
+        """... should become ."""
+        content = "等等..."
+        cleaned = self.cleaner.clean_content(content)
+        assert cleaned.endswith(".")
+        assert "..." not in cleaned
+
+    def test_mixed_punctuation_preserved(self):
+        """Mixed punctuation like ?! or !? should be preserved."""
+        content = "真的吗?!"
+        cleaned = self.cleaner.clean_content(content)
+        # Mixed punctuation should remain as-is (not normalized)
+        assert "?!" in cleaned
+
+    def test_exclamation_then_question_preserved(self):
+        """!? should be preserved as mixed punctuation."""
+        content = "不可能!?"
+        cleaned = self.cleaner.clean_content(content)
+        assert "!?" in cleaned
+
+    def test_single_punctuation_unchanged(self):
+        """Single punctuation marks should not be modified."""
+        content = "这是问题? 这是感叹! 这是句号."
+        cleaned = self.cleaner.clean_content(content)
+        assert "问题?" in cleaned
+        assert "感叹!" in cleaned
+        assert "句号." in cleaned
+
+    # HTML cleaning tests (preserved functionality)
+    def test_html_tags_removed(self):
+        """HTML tags should be removed."""
+        content = "<p>段落</p><div>内容</div>"
+        cleaned = self.cleaner.clean_content(content)
+        assert "<p>" not in cleaned
+        assert "</p>" not in cleaned
+        assert "<div>" not in cleaned
+        assert "段落" in cleaned
+        assert "内容" in cleaned
+
+    def test_html_entities_removed(self):
+        """HTML entities should be removed."""
+        content = "空格&nbsp;和&lt;符号"
+        cleaned = self.cleaner.clean_content(content)
+        assert "&nbsp;" not in cleaned
+        assert "&lt;" not in cleaned
+
+    def test_complex_html_removed(self):
+        """Complex HTML with attributes should be removed."""
+        content = '<a href="http://example.com" class="link">点击这里</a>'
+        cleaned = self.cleaner.clean_content(content)
+        assert "<a" not in cleaned
+        assert "</a>" not in cleaned
+        assert "点击这里" in cleaned
+        # URL in href attribute is removed with the tag
+        # but URLs in text content are preserved
+
+    # Whitespace normalization tests (preserved functionality)
+    def test_whitespace_normalized(self):
+        """Multiple whitespace should be normalized."""
+        content = "多个   空格   和\n\n换行"
+        cleaned = self.cleaner.clean_content(content)
+        assert "   " not in cleaned
+        # All whitespace (spaces, newlines) are normalized to single space
+        assert "多个 空格 和" in cleaned
+
+    def test_tabs_normalized(self):
+        """Tabs should be normalized to single space."""
+        content = "有\t\t制表符"
+        cleaned = self.cleaner.clean_content(content)
+        assert "\t" not in cleaned
+        # Tabs are normalized to single space
+        assert "有" in cleaned
+        assert "制表符" in cleaned
+
+    def test_leading_trailing_whitespace_stripped(self):
+        """Leading and trailing whitespace should be stripped."""
+        content = "   内容前后有空格   "
+        cleaned = self.cleaner.clean_content(content)
+        assert cleaned == "内容前后有空格"
+
+    # Non-printable character tests
+    def test_non_printable_removed(self):
+        """Non-printable characters should be removed."""
+        content = "正常文本\x00包含\x1f控制字符"
+        cleaned = self.cleaner.clean_content(content)
+        assert "\x00" not in cleaned
+        assert "\x1f" not in cleaned
+        assert "正常文本" in cleaned
+        assert "控制字符" in cleaned
+
+    # Complex content tests
+    def test_complex_content_preserved(self):
+        """Complex content with URLs, code, and email should be preserved."""
+        content = """
+        服务地址: http://api.internal.com
+        联系人: admin@company.com
+
+        配置示例:
+        ```yaml
+        server:
+          host: localhost
+          port: 8080
+        ```
+
+        使用 `curl http://api.internal.com/health` 检查服务状态。
+        """
+        cleaned = self.cleaner.clean_content(content)
+        assert "http://api.internal.com" in cleaned
+        assert "admin@company.com" in cleaned
+        assert "```yaml" in cleaned
+        assert "`curl http://api.internal.com/health`" in cleaned
+
+    def test_mixed_html_and_content(self):
+        """HTML should be removed while preserving URLs and code."""
+        content = "<p>访问 http://example.com</p> 或运行 `npm install`"
+        cleaned = self.cleaner.clean_content(content)
+        assert "<p>" not in cleaned
+        assert "</p>" not in cleaned
+        assert "http://example.com" in cleaned
+        assert "`npm install`" in cleaned
+
+    # clean_knowledge_chunk tests
+    def test_clean_knowledge_chunk_preserves_metadata(self):
+        """clean_knowledge_chunk should preserve chunk metadata."""
+        chunk = {
+            "content": "访问 http://example.com 获取详情",
+            "source": "test.md",
+            "score": 0.85,
+            "knowledge_base_id": 1,
+        }
+        cleaned_chunk = self.cleaner.clean_knowledge_chunk(chunk)
+
+        assert "http://example.com" in cleaned_chunk["content"]
+        assert cleaned_chunk["source"] == "test.md"
+        assert cleaned_chunk["score"] == 0.85
+        assert cleaned_chunk["knowledge_base_id"] == 1
+
+    def test_clean_knowledge_chunk_handles_empty_content(self):
+        """clean_knowledge_chunk should handle empty content gracefully."""
+        chunk = {
+            "content": "",
+            "source": "empty.md",
+            "score": 0.5,
+        }
+        cleaned_chunk = self.cleaner.clean_knowledge_chunk(chunk)
+        assert cleaned_chunk["content"] == ""
+        assert cleaned_chunk["source"] == "empty.md"
+
+    def test_clean_knowledge_chunk_non_dict_returns_unchanged(self):
+        """clean_knowledge_chunk should return non-dict input unchanged."""
+        result = self.cleaner.clean_knowledge_chunk("not a dict")
+        assert result == "not a dict"
+
+    # clean_knowledge_chunks tests
+    def test_clean_knowledge_chunks_multiple(self):
+        """clean_knowledge_chunks should process multiple chunks."""
+        chunks = [
+            {"content": "URL: http://a.com", "source": "a.md"},
+            {"content": "Email: test@example.com", "source": "b.md"},
+        ]
+        cleaned = self.cleaner.clean_knowledge_chunks(chunks)
+
+        assert len(cleaned) == 2
+        assert "http://a.com" in cleaned[0]["content"]
+        assert "test@example.com" in cleaned[1]["content"]
+
+    def test_clean_knowledge_chunks_empty_list(self):
+        """clean_knowledge_chunks should handle empty list."""
+        result = self.cleaner.clean_knowledge_chunks([])
+        assert result == []
+
+    # estimate_token_reduction tests
+    def test_estimate_token_reduction(self):
+        """estimate_token_reduction should return reasonable estimates."""
+        content = "<p>正常内容</p>   多余空格"
+        original, cleaned = self.cleaner.estimate_token_reduction(content)
+
+        # Cleaned should have fewer or equal tokens
+        assert cleaned <= original
+        assert original > 0
+
+    def test_estimate_token_reduction_empty(self):
+        """estimate_token_reduction should handle empty content."""
+        original, cleaned = self.cleaner.estimate_token_reduction("")
+        assert original == 0
+        assert cleaned == 0
+
+    # Optional parameter tests
+    def test_disable_html_removal(self):
+        """Should be able to disable HTML removal."""
+        content = "<p>保留HTML</p>"
+        cleaned = self.cleaner.clean_content(content, remove_html=False)
+        assert "<p>" in cleaned
+        assert "</p>" in cleaned
+
+    def test_disable_whitespace_normalization(self):
+        """Should be able to disable whitespace normalization."""
+        content = "多个   空格"
+        cleaned = self.cleaner.clean_content(content, normalize_whitespace=False)
+        assert "   " in cleaned
+
+    def test_disable_punctuation_normalization(self):
+        """Should be able to disable punctuation normalization."""
+        content = "注意!!!"
+        cleaned = self.cleaner.clean_content(content, normalize_punctuation=False)
+        assert "!!!" in cleaned
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/chat_shell/tests/test_knowledge_injection_strategy_clean.py
+++ b/chat_shell/tests/test_knowledge_injection_strategy_clean.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for knowledge injection strategy."""
+"""Tests for knowledge injection strategy - clean test version."""
 
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -20,11 +20,11 @@ from chat_shell.tools.knowledge_injection_strategy import (
 )
 
 
-class TestKnowledgeContentCleaner:
-    """Test knowledge content cleaner."""
+class TestKnowledgeContentCleanerClean:
+    """Test knowledge content cleaner - clean version preserving URLs."""
 
-    def test_clean_content_basic(self):
-        """Test basic content cleaning."""
+    def test_clean_content_preserves_urls(self):
+        """Test that content cleaning preserves URLs."""
         cleaner = KnowledgeContentCleaner()
 
         content = """
@@ -37,25 +37,25 @@ class TestKnowledgeContentCleaner:
 
         cleaned = cleaner.clean_content(content)
 
-        # Check that URLs are removed
-        assert "https://example.com" not in cleaned
-        assert "http://test.org/page" not in cleaned
+        # Check that URLs are preserved
+        assert "https://example.com" in cleaned
+        assert "http://test.org/page" in cleaned
 
         # Check that HTML tags are removed
         assert "<p>" not in cleaned
         assert "</p>" not in cleaned
         assert "<div>" not in cleaned
 
-        # Check that repeated punctuation is normalized
+        # Check that repeated punctuation is normalized to original type
         assert "Hello!!!" not in cleaned
-        assert "Hello." in cleaned
+        assert "Hello!" in cleaned  # ! preserved, not changed to .
 
         # Check that whitespace is normalized
         assert "extra   whitespace   here" not in cleaned
         assert "extra whitespace here" in cleaned
 
-    def test_clean_knowledge_chunk(self):
-        """Test cleaning knowledge base chunk."""
+    def test_clean_knowledge_chunk_preserves_urls(self):
+        """Test cleaning knowledge base chunk preserves URLs."""
         cleaner = KnowledgeContentCleaner()
 
         chunk = {
@@ -67,7 +67,9 @@ class TestKnowledgeContentCleaner:
 
         cleaned_chunk = cleaner.clean_knowledge_chunk(chunk)
 
-        assert "https://example.com" not in cleaned_chunk["content"]
+        # URL should be preserved
+        assert "https://example.com" in cleaned_chunk["content"]
+        # HTML should be removed
         assert "<p>" not in cleaned_chunk["content"]
         assert cleaned_chunk["source"] == "test.txt"
         assert cleaned_chunk["score"] == 0.8
@@ -77,15 +79,16 @@ class TestKnowledgeContentCleaner:
         """Test token reduction estimation."""
         cleaner = KnowledgeContentCleaner()
 
-        content = "Content with URL: https://example.com and HTML: <p>test</p>"
+        content = "Content with HTML: <p>test</p> and   extra   spaces"
         original_tokens, cleaned_tokens = cleaner.estimate_token_reduction(content)
 
-        assert cleaned_tokens < original_tokens
+        # Cleaned should have fewer or equal tokens (HTML and spaces removed)
+        assert cleaned_tokens <= original_tokens
         assert original_tokens > 0
 
 
-class TestInjectionStrategy:
-    """Test injection strategy."""
+class TestInjectionStrategyClean:
+    """Test injection strategy - clean version without aggressive mode."""
 
     def test_calculate_available_space(self):
         """Test available space calculation."""
@@ -224,8 +227,8 @@ class TestInjectionStrategy:
         assert result["injected_content"] is None
 
 
-class TestKnowledgeBaseTool:
-    """Test KnowledgeBaseTool with injection strategy."""
+class TestKnowledgeBaseToolClean:
+    """Test KnowledgeBaseTool with injection strategy - clean version."""
 
     def test_injection_strategy_property(self):
         """Test injection strategy lazy initialization."""


### PR DESCRIPTION
## Summary

- Fix RAG result persistence: retrieval results are now saved to `SubtaskContext.extracted_text` for historical context
- Fix task-level knowledge base fallback in HTTP mode: task-bound KBs are now correctly passed to chat_shell when users don't explicitly select KBs
- Add `is_user_selected_kb` parameter to distinguish strict mode (user-selected) from relaxed mode (inherited from task)

## Problem

1. **RAG results not persisted**: `user_subtask_id` was passed to `KnowledgeBaseTool` but never used, causing RAG results to be lost after the current message
2. **Task-level KB missing in HTTP mode**: The fallback logic from `_prepare_kb_tools_from_contexts()` was not replicated in the HTTP mode code path

## Changes

### Backend
- `backend/app/api/endpoints/internal/rag.py`: New `/api/internal/rag/save-result` endpoint for HTTP mode persistence
- `backend/app/services/chat/trigger/core.py`: Add task-level KB fallback with proper priority handling
- `backend/app/services/chat/adapters/interface.py`: Add `is_user_selected_kb` field to `ChatRequest`
- `backend/app/services/chat/adapters/http.py`: Pass `is_user_selected_kb` in metadata

### Chat Shell
- `chat_shell/chat_shell/tools/builtin/knowledge_base.py`: Add persistence methods for both package and HTTP mode
- `chat_shell/chat_shell/interface.py`: Add `is_user_selected_kb` field
- `chat_shell/chat_shell/api/v1/schemas.py`: Add `is_user_selected_kb` to `Metadata`
- `chat_shell/chat_shell/api/v1/response.py`: Extract and pass `is_user_selected_kb`
- `chat_shell/chat_shell/services/chat_service.py`: Pass `is_user_selected` to `prepare_knowledge_base_tools`

## Test plan

- [ ] Send a message with KB selection, verify RAG results are saved to database (`subtask_contexts.extracted_text`)
- [ ] Verify subsequent messages include historical RAG content
- [ ] Create a task with bound KBs (group chat KB binding)
- [ ] Send message without KB selection, verify task-level KBs are used (check logs for "task-level KB fallback")
- [ ] Verify AI can use `knowledge_base_search` tool with inherited KBs
- [ ] Test both package mode and HTTP mode scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist RAG retrieval results per knowledge base via both in-process and HTTP paths; include user subtask IDs and a KB-selection flag in request metadata.

* **Refactor / Behavior changes**
  * Content normalization and cleaning updated: URLs and code blocks preserved, repeated-punctuation normalized, aggressive-cleaning option removed; chunk content extraction normalized across backends.

* **Tests**
  * Added comprehensive tests covering RAG persistence, content cleaning, injection, and result formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->