### PR TITLE
feat(canvas): implement Canvas collaborative document editing feature

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -25,6 +25,7 @@ from app.api.endpoints.adapter import (
     agents,
     attachments,
     bots,
+    canvas,
     chat,
     dify,
     executors,
@@ -69,6 +70,7 @@ api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
 api_router.include_router(
     attachments.router, prefix="/attachments", tags=["attachments"]
 )
+api_router.include_router(canvas.router, prefix="/canvas", tags=["canvas"])
 api_router.include_router(repository.router, prefix="/git", tags=["repository"])
 api_router.include_router(executors.router, prefix="/executors", tags=["executors"])
 api_router.include_router(quota.router, prefix="/quota", tags=["quota"])

--- a/backend/app/api/endpoints/adapter/canvas.py
+++ b/backend/app/api/endpoints/adapter/canvas.py
@@ -1,0 +1,416 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Canvas API endpoints for collaborative document editing.
+
+Provides REST API endpoints for creating, updating, and managing canvas documents.
+Supports version history, rollback, and export functionality.
+"""
+
+import io
+import logging
+from typing import List, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.models.subtask import Subtask
+from app.models.task import TaskResource
+from app.models.task_member import MemberStatus, TaskMember
+from app.models.user import User
+from app.schemas.canvas import (
+    CanvasBrief,
+    CanvasCreateRequest,
+    CanvasResponse,
+    CanvasRollbackRequest,
+    CanvasUpdateRequest,
+    CanvasUpdateResult,
+    CanvasVersionDetailResponse,
+    CanvasVersionResponse,
+)
+from app.services.canvas import (
+    CanvasNotFoundException,
+    CanvasUpdateError,
+    canvas_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _check_canvas_access(
+    db: Session,
+    canvas,
+    current_user: User,
+) -> bool:
+    """
+    Check if user has access to the canvas.
+
+    Access is granted if:
+    1. User is the canvas creator
+    2. User is the task owner
+    3. User is a task member
+
+    Args:
+        db: Database session
+        canvas: SubtaskContext record
+        current_user: Current user
+
+    Returns:
+        True if user has access
+    """
+    # Check if user is the creator
+    if canvas.user_id == current_user.id:
+        return True
+
+    # Get subtask to find task
+    if canvas.subtask_id > 0:
+        subtask = db.query(Subtask).filter(Subtask.id == canvas.subtask_id).first()
+        if subtask:
+            # Check if user is task owner
+            task = (
+                db.query(TaskResource)
+                .filter(
+                    TaskResource.id == subtask.task_id,
+                    TaskResource.kind == "Task",
+                    TaskResource.user_id == current_user.id,
+                )
+                .first()
+            )
+            if task:
+                return True
+
+            # Check if user is task member
+            task_member = (
+                db.query(TaskMember)
+                .filter(
+                    TaskMember.task_id == subtask.task_id,
+                    TaskMember.user_id == current_user.id,
+                    TaskMember.status == MemberStatus.ACTIVE,
+                )
+                .first()
+            )
+            if task_member:
+                return True
+
+    return False
+
+
+@router.post("/create", response_model=CanvasResponse)
+async def create_canvas(
+    request: CanvasCreateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Create a new canvas document.
+
+    Args:
+        request: Canvas creation request with subtask_id and optional filename/content
+
+    Returns:
+        Created canvas response
+    """
+    logger.info(
+        f"[canvas] create_canvas: user_id={current_user.id}, "
+        f"subtask_id={request.subtask_id}, filename={request.filename}"
+    )
+
+    # Verify subtask exists and user has access
+    subtask = db.query(Subtask).filter(Subtask.id == request.subtask_id).first()
+    if not subtask:
+        raise HTTPException(status_code=404, detail="Subtask not found")
+
+    # Check if user has access to the task
+    has_access = subtask.user_id == current_user.id
+    if not has_access:
+        task = (
+            db.query(TaskResource)
+            .filter(
+                TaskResource.id == subtask.task_id,
+                TaskResource.kind == "Task",
+                TaskResource.user_id == current_user.id,
+            )
+            .first()
+        )
+        if task:
+            has_access = True
+        else:
+            task_member = (
+                db.query(TaskMember)
+                .filter(
+                    TaskMember.task_id == subtask.task_id,
+                    TaskMember.user_id == current_user.id,
+                    TaskMember.status == MemberStatus.ACTIVE,
+                )
+                .first()
+            )
+            has_access = task_member is not None
+
+    if not has_access:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    try:
+        canvas = canvas_service.create_canvas(
+            db=db,
+            user_id=current_user.id,
+            subtask_id=request.subtask_id,
+            filename=request.filename,
+            content=request.content,
+        )
+        return canvas_service.to_response(canvas)
+    except Exception as e:
+        logger.error(f"Error creating canvas: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to create canvas") from e
+
+
+@router.get("/{canvas_id}", response_model=CanvasResponse)
+async def get_canvas(
+    canvas_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get canvas by ID.
+
+    Args:
+        canvas_id: Canvas context ID
+
+    Returns:
+        Canvas response with content and metadata
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    return canvas_service.to_response(canvas)
+
+
+@router.put("/{canvas_id}", response_model=CanvasResponse)
+async def update_canvas(
+    canvas_id: int,
+    request: CanvasUpdateRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Update canvas content (user edit).
+
+    Creates a new version entry and updates the current content.
+
+    Args:
+        canvas_id: Canvas context ID
+        request: Update request with new content
+
+    Returns:
+        Updated canvas response
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    try:
+        updated_canvas = canvas_service.update_canvas_user(
+            db=db,
+            canvas_id=canvas_id,
+            content=request.content,
+        )
+        return canvas_service.to_response(updated_canvas)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+    except Exception as e:
+        logger.error(f"Error updating canvas: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update canvas") from e
+
+
+@router.get("/{canvas_id}/versions", response_model=CanvasVersionResponse)
+async def get_canvas_versions(
+    canvas_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get version history for a canvas.
+
+    Args:
+        canvas_id: Canvas context ID
+
+    Returns:
+        List of version entries
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    versions = canvas_service.get_versions(db, canvas_id)
+    return CanvasVersionResponse(versions=versions)
+
+
+@router.get("/{canvas_id}/versions/{version}", response_model=CanvasVersionDetailResponse)
+async def get_canvas_version(
+    canvas_id: int,
+    version: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get a specific version.
+
+    Args:
+        canvas_id: Canvas context ID
+        version: Version number
+
+    Returns:
+        Version detail with content
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    version_info = canvas_service.get_version(db, canvas_id, version)
+    if not version_info:
+        raise HTTPException(status_code=404, detail="Version not found")
+
+    return CanvasVersionDetailResponse(
+        version=version_info.version,
+        content=version_info.content,
+        timestamp=version_info.timestamp,
+        source=version_info.source,
+    )
+
+
+@router.post("/{canvas_id}/rollback", response_model=CanvasResponse)
+async def rollback_canvas(
+    canvas_id: int,
+    request: CanvasRollbackRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Rollback canvas to a specific version.
+
+    Creates a new version with the content from the target version.
+
+    Args:
+        canvas_id: Canvas context ID
+        request: Rollback request with target version
+
+    Returns:
+        Updated canvas response
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    try:
+        updated_canvas = canvas_service.rollback_to_version(
+            db=db,
+            canvas_id=canvas_id,
+            version=request.version,
+        )
+        return canvas_service.to_response(updated_canvas)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+    except CanvasUpdateError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error rolling back canvas: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to rollback canvas") from e
+
+
+@router.get("/{canvas_id}/export")
+async def export_canvas(
+    canvas_id: int,
+    format: Literal["md", "txt"] = "txt",
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Export canvas as a file.
+
+    Args:
+        canvas_id: Canvas context ID
+        format: Export format (md or txt)
+
+    Returns:
+        File download response
+    """
+    try:
+        canvas = canvas_service.get_canvas(db, canvas_id)
+    except CanvasNotFoundException:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    type_data = canvas.type_data or {}
+    content = type_data.get("content", "")
+    filename = type_data.get("filename", "document")
+
+    # Remove extension from filename if present
+    if "." in filename:
+        filename = filename.rsplit(".", 1)[0]
+
+    if format == "md":
+        media_type = "text/markdown"
+        filename = f"{filename}.md"
+    else:
+        media_type = "text/plain"
+        filename = f"{filename}.txt"
+
+    return StreamingResponse(
+        io.BytesIO(content.encode("utf-8")),
+        media_type=media_type,
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+@router.get("/subtask/{subtask_id}", response_model=CanvasResponse)
+async def get_canvas_by_subtask(
+    subtask_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get canvas by subtask ID.
+
+    Args:
+        subtask_id: Subtask ID
+
+    Returns:
+        Canvas response or 404 if not found
+    """
+    canvas = canvas_service.get_canvas_by_subtask(db, subtask_id)
+    if not canvas:
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    if not _check_canvas_access(db, canvas, current_user):
+        raise HTTPException(status_code=404, detail="Canvas not found")
+
+    return canvas_service.to_response(canvas)

--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -54,6 +54,11 @@ class ServerEvents:
     CHAT_BOT_COMPLETE = "chat:bot_complete"
     CHAT_SYSTEM = "chat:system"
 
+    # Canvas events (to task room)
+    CANVAS_CREATE = "canvas:create"
+    CANVAS_UPDATE = "canvas:update"
+    CANVAS_ROLLBACK = "canvas:rollback"
+
     # Correction events (to task room)
     CORRECTION_START = "correction:start"
     CORRECTION_PROGRESS = "correction:progress"
@@ -451,6 +456,44 @@ class CorrectionErrorPayload(BaseModel):
     task_id: int
     subtask_id: int
     error: str
+
+
+# ============================================================
+# Canvas Event Payloads
+# ============================================================
+
+
+class CanvasCreatePayload(BaseModel):
+    """Payload for canvas:create event."""
+
+    task_id: int
+    subtask_id: int
+    canvas_id: int
+    filename: str
+    content: str
+
+
+class CanvasUpdatePayload(BaseModel):
+    """Payload for canvas:update event."""
+
+    task_id: int
+    subtask_id: int
+    canvas_id: int
+    new_content: str
+    version: int
+    diff_info: Dict[str, str] = Field(
+        default_factory=dict, description="Diff information (old_str, new_str)"
+    )
+
+
+class CanvasRollbackPayload(BaseModel):
+    """Payload for canvas:rollback event."""
+
+    task_id: int
+    subtask_id: int
+    canvas_id: int
+    version: int
+    content: str
 
 
 # ============================================================

--- a/backend/app/schemas/canvas.py
+++ b/backend/app/schemas/canvas.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Canvas schemas for API requests and responses.
+
+Canvas is a collaborative document editing feature that supports
+AI and user bidirectional editing with diff display and version history.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CanvasVersionSource(str, Enum):
+    """Source of canvas version modification."""
+
+    USER = "user"
+    AI = "ai"
+
+
+class VersionInfo(BaseModel):
+    """Version history entry."""
+
+    version: int = Field(..., description="Version number")
+    content: str = Field(..., description="Document content at this version")
+    timestamp: str = Field(..., description="ISO 8601 timestamp")
+    source: CanvasVersionSource = Field(..., description="Modification source")
+    old_str: Optional[str] = Field(None, description="Replaced text (for AI edits)")
+    new_str: Optional[str] = Field(None, description="Replacement text (for AI edits)")
+
+
+class CanvasTypeData(BaseModel):
+    """Type data structure for canvas context."""
+
+    filename: str = Field(default="untitled.txt", description="Document filename")
+    content: str = Field(default="", description="Current document content")
+    version: int = Field(default=1, description="Current version number")
+    versions: List[VersionInfo] = Field(
+        default_factory=list, description="Version history"
+    )
+    created_at: str = Field(..., description="Creation timestamp")
+    updated_at: str = Field(..., description="Last update timestamp")
+
+
+# ============================================================
+# Request Schemas
+# ============================================================
+
+
+class CanvasCreateRequest(BaseModel):
+    """Request to create a new canvas."""
+
+    subtask_id: int = Field(..., description="Subtask ID to associate canvas with")
+    filename: Optional[str] = Field(
+        default="untitled.txt", description="Initial filename"
+    )
+    content: Optional[str] = Field(default="", description="Initial content")
+
+
+class CanvasUpdateRequest(BaseModel):
+    """Request to update canvas content (user edit)."""
+
+    content: str = Field(..., description="New document content")
+
+
+class CanvasRollbackRequest(BaseModel):
+    """Request to rollback to a specific version."""
+
+    version: int = Field(..., description="Version number to rollback to")
+
+
+class UpdateCanvasToolInput(BaseModel):
+    """Input for update_canvas tool (AI edit)."""
+
+    old_str: str = Field(
+        ..., description="Text to replace, must uniquely match in document"
+    )
+    new_str: str = Field(..., description="Replacement text")
+
+
+# ============================================================
+# Response Schemas
+# ============================================================
+
+
+class CanvasResponse(BaseModel):
+    """Canvas response with full content."""
+
+    id: int = Field(..., description="Canvas context ID")
+    subtask_id: int = Field(..., description="Associated subtask ID")
+    filename: str = Field(..., description="Document filename")
+    content: str = Field(..., description="Current document content")
+    version: int = Field(..., description="Current version number")
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    class Config:
+        from_attributes = True
+
+
+class CanvasVersionResponse(BaseModel):
+    """Response for version history listing."""
+
+    versions: List[VersionInfo] = Field(..., description="List of version entries")
+
+
+class CanvasVersionDetailResponse(BaseModel):
+    """Response for a specific version."""
+
+    version: int = Field(..., description="Version number")
+    content: str = Field(..., description="Document content at this version")
+    timestamp: str = Field(..., description="Version timestamp")
+    source: CanvasVersionSource = Field(..., description="Modification source")
+
+
+class CanvasUpdateResult(BaseModel):
+    """Result of canvas update operation."""
+
+    success: bool = Field(..., description="Whether the update succeeded")
+    new_content: Optional[str] = Field(None, description="Updated document content")
+    version: Optional[int] = Field(None, description="New version number")
+    diff_info: Optional[Dict[str, str]] = Field(
+        None, description="Diff information (old_str, new_str)"
+    )
+    error: Optional[str] = Field(None, description="Error message if failed")
+
+
+class CanvasBrief(BaseModel):
+    """Brief canvas info for listing."""
+
+    id: int = Field(..., description="Canvas context ID")
+    subtask_id: int = Field(..., description="Associated subtask ID")
+    filename: str = Field(..., description="Document filename")
+    version: int = Field(..., description="Current version number")
+    content_preview: str = Field(
+        ..., description="First 100 characters of content"
+    )
+    created_at: datetime = Field(..., description="Creation timestamp")
+    updated_at: datetime = Field(..., description="Last update timestamp")
+
+    class Config:
+        from_attributes = True

--- a/backend/app/services/canvas/__init__.py
+++ b/backend/app/services/canvas/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Canvas service module.
+"""
+
+from app.services.canvas.canvas_service import (
+    CANVAS_CONTEXT_TYPE,
+    CanvasNotFoundException,
+    CanvasService,
+    CanvasUpdateError,
+    canvas_service,
+)
+
+__all__ = [
+    "CanvasService",
+    "canvas_service",
+    "CanvasNotFoundException",
+    "CanvasUpdateError",
+    "CANVAS_CONTEXT_TYPE",
+]

--- a/backend/app/services/canvas/canvas_service.py
+++ b/backend/app/services/canvas/canvas_service.py
@@ -1,0 +1,542 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Canvas service for managing canvas documents.
+
+Handles canvas creation, updates, version management, and rollback operations.
+Uses SubtaskContext with context_type='canvas' for storage.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.subtask_context import ContextStatus, SubtaskContext
+from app.schemas.canvas import (
+    CanvasCreateRequest,
+    CanvasResponse,
+    CanvasUpdateResult,
+    CanvasVersionResponse,
+    VersionInfo,
+)
+
+logger = logging.getLogger(__name__)
+
+# Canvas context type constant
+CANVAS_CONTEXT_TYPE = "canvas"
+
+
+class CanvasNotFoundException(Exception):
+    """Exception raised when a canvas is not found."""
+
+    pass
+
+
+class CanvasUpdateError(Exception):
+    """Exception raised when canvas update fails."""
+
+    pass
+
+
+class CanvasService:
+    """
+    Canvas service for managing collaborative document editing.
+
+    Uses SubtaskContext model with context_type='canvas' for storage.
+    Supports version history and AI/user bidirectional editing.
+    """
+
+    def create_canvas(
+        self,
+        db: Session,
+        user_id: int,
+        subtask_id: int,
+        filename: Optional[str] = None,
+        content: Optional[str] = None,
+    ) -> SubtaskContext:
+        """
+        Create a new canvas document.
+
+        Args:
+            db: Database session
+            user_id: User ID
+            subtask_id: Subtask ID to associate canvas with
+            filename: Optional initial filename
+            content: Optional initial content
+
+        Returns:
+            Created SubtaskContext record
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        filename = filename or "untitled.txt"
+        content = content or ""
+
+        # Initial version
+        initial_version = {
+            "version": 1,
+            "content": content,
+            "timestamp": now,
+            "source": "user",
+        }
+
+        type_data = {
+            "filename": filename,
+            "content": content,
+            "version": 1,
+            "versions": [initial_version],
+            "created_at": now,
+            "updated_at": now,
+        }
+
+        context = SubtaskContext(
+            subtask_id=subtask_id,
+            user_id=user_id,
+            context_type=CANVAS_CONTEXT_TYPE,
+            name=filename,
+            status=ContextStatus.READY.value,
+            binary_data=b"",
+            image_base64="",
+            extracted_text=content,
+            text_length=len(content),
+            error_message="",
+            type_data=type_data,
+        )
+
+        db.add(context)
+        db.commit()
+        db.refresh(context)
+
+        logger.info(
+            f"Canvas created: id={context.id}, subtask_id={subtask_id}, "
+            f"filename={filename}"
+        )
+
+        return context
+
+    def get_canvas(
+        self,
+        db: Session,
+        canvas_id: int,
+        user_id: Optional[int] = None,
+    ) -> SubtaskContext:
+        """
+        Get canvas by ID.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            SubtaskContext record
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+        """
+        query = db.query(SubtaskContext).filter(
+            SubtaskContext.id == canvas_id,
+            SubtaskContext.context_type == CANVAS_CONTEXT_TYPE,
+        )
+
+        if user_id is not None:
+            query = query.filter(SubtaskContext.user_id == user_id)
+
+        canvas = query.first()
+        if not canvas:
+            raise CanvasNotFoundException(f"Canvas {canvas_id} not found")
+
+        return canvas
+
+    def get_canvas_optional(
+        self,
+        db: Session,
+        canvas_id: int,
+        user_id: Optional[int] = None,
+    ) -> Optional[SubtaskContext]:
+        """
+        Get canvas by ID, returning None if not found.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            SubtaskContext record or None
+        """
+        try:
+            return self.get_canvas(db, canvas_id, user_id)
+        except CanvasNotFoundException:
+            return None
+
+    def get_canvas_by_subtask(
+        self,
+        db: Session,
+        subtask_id: int,
+    ) -> Optional[SubtaskContext]:
+        """
+        Get canvas by subtask ID.
+
+        Args:
+            db: Database session
+            subtask_id: Subtask ID
+
+        Returns:
+            SubtaskContext record or None
+        """
+        return (
+            db.query(SubtaskContext)
+            .filter(
+                SubtaskContext.subtask_id == subtask_id,
+                SubtaskContext.context_type == CANVAS_CONTEXT_TYPE,
+            )
+            .first()
+        )
+
+    def update_canvas_user(
+        self,
+        db: Session,
+        canvas_id: int,
+        content: str,
+        user_id: Optional[int] = None,
+    ) -> SubtaskContext:
+        """
+        Update canvas content (user edit).
+
+        Creates a new version entry and updates the current content.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            content: New document content
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            Updated SubtaskContext record
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+        """
+        canvas = self.get_canvas(db, canvas_id, user_id)
+        type_data = canvas.type_data or {}
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Create new version
+        new_version_num = type_data.get("version", 0) + 1
+        versions = type_data.get("versions", [])
+        versions.append(
+            {
+                "version": new_version_num,
+                "content": content,
+                "timestamp": now,
+                "source": "user",
+            }
+        )
+
+        # Update type_data
+        type_data.update(
+            {
+                "content": content,
+                "version": new_version_num,
+                "versions": versions,
+                "updated_at": now,
+            }
+        )
+
+        canvas.type_data = type_data
+        canvas.extracted_text = content
+        canvas.text_length = len(content)
+
+        db.commit()
+        db.refresh(canvas)
+
+        logger.info(
+            f"Canvas {canvas_id} updated by user: version={new_version_num}, "
+            f"content_length={len(content)}"
+        )
+
+        return canvas
+
+    def update_canvas_ai(
+        self,
+        db: Session,
+        canvas_id: int,
+        old_str: str,
+        new_str: str,
+    ) -> CanvasUpdateResult:
+        """
+        Update canvas content (AI edit) using string replacement.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            old_str: Text to replace (must uniquely match in document)
+            new_str: Replacement text
+
+        Returns:
+            CanvasUpdateResult with success status and new content
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+        """
+        canvas = self.get_canvas(db, canvas_id)
+        type_data = canvas.type_data or {}
+        current_content = type_data.get("content", "")
+
+        # Validate old_str uniqueness
+        occurrences = current_content.count(old_str)
+        if occurrences == 0:
+            return CanvasUpdateResult(
+                success=False,
+                error=f"old_str not found in document",
+            )
+        if occurrences > 1:
+            return CanvasUpdateResult(
+                success=False,
+                error=f"old_str matches {occurrences} locations, please provide more context",
+            )
+
+        # Execute replacement
+        new_content = current_content.replace(old_str, new_str, 1)
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Create new version
+        new_version_num = type_data.get("version", 0) + 1
+        versions = type_data.get("versions", [])
+        versions.append(
+            {
+                "version": new_version_num,
+                "content": new_content,
+                "timestamp": now,
+                "source": "ai",
+                "old_str": old_str,
+                "new_str": new_str,
+            }
+        )
+
+        # Update type_data
+        type_data.update(
+            {
+                "content": new_content,
+                "version": new_version_num,
+                "versions": versions,
+                "updated_at": now,
+            }
+        )
+
+        canvas.type_data = type_data
+        canvas.extracted_text = new_content
+        canvas.text_length = len(new_content)
+
+        db.commit()
+        db.refresh(canvas)
+
+        logger.info(
+            f"Canvas {canvas_id} updated by AI: version={new_version_num}, "
+            f"old_str_len={len(old_str)}, new_str_len={len(new_str)}"
+        )
+
+        return CanvasUpdateResult(
+            success=True,
+            new_content=new_content,
+            version=new_version_num,
+            diff_info={
+                "old_str": old_str,
+                "new_str": new_str,
+            },
+        )
+
+    def get_versions(
+        self,
+        db: Session,
+        canvas_id: int,
+        user_id: Optional[int] = None,
+    ) -> List[VersionInfo]:
+        """
+        Get version history for a canvas.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            List of VersionInfo objects
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+        """
+        canvas = self.get_canvas(db, canvas_id, user_id)
+        type_data = canvas.type_data or {}
+        versions_data = type_data.get("versions", [])
+
+        return [VersionInfo(**v) for v in versions_data]
+
+    def get_version(
+        self,
+        db: Session,
+        canvas_id: int,
+        version: int,
+        user_id: Optional[int] = None,
+    ) -> Optional[VersionInfo]:
+        """
+        Get a specific version.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            version: Version number
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            VersionInfo or None if version not found
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+        """
+        versions = self.get_versions(db, canvas_id, user_id)
+        for v in versions:
+            if v.version == version:
+                return v
+        return None
+
+    def rollback_to_version(
+        self,
+        db: Session,
+        canvas_id: int,
+        version: int,
+        user_id: Optional[int] = None,
+    ) -> SubtaskContext:
+        """
+        Rollback canvas to a specific version.
+
+        Creates a new version entry with the content from the target version.
+
+        Args:
+            db: Database session
+            canvas_id: Canvas context ID
+            version: Version number to rollback to
+            user_id: Optional user ID for ownership check
+
+        Returns:
+            Updated SubtaskContext record
+
+        Raises:
+            CanvasNotFoundException: If canvas not found
+            CanvasUpdateError: If version not found
+        """
+        canvas = self.get_canvas(db, canvas_id, user_id)
+        type_data = canvas.type_data or {}
+        versions = type_data.get("versions", [])
+
+        # Find target version
+        target_version = None
+        for v in versions:
+            if v.get("version") == version:
+                target_version = v
+                break
+
+        if not target_version:
+            raise CanvasUpdateError(f"Version {version} not found")
+
+        target_content = target_version.get("content", "")
+        now = datetime.now(timezone.utc).isoformat()
+
+        # Create new version (rollback)
+        new_version_num = type_data.get("version", 0) + 1
+        versions.append(
+            {
+                "version": new_version_num,
+                "content": target_content,
+                "timestamp": now,
+                "source": "user",
+                "rollback_from": version,
+            }
+        )
+
+        # Update type_data
+        type_data.update(
+            {
+                "content": target_content,
+                "version": new_version_num,
+                "versions": versions,
+                "updated_at": now,
+            }
+        )
+
+        canvas.type_data = type_data
+        canvas.extracted_text = target_content
+        canvas.text_length = len(target_content)
+
+        db.commit()
+        db.refresh(canvas)
+
+        logger.info(
+            f"Canvas {canvas_id} rolled back to version {version}: "
+            f"new_version={new_version_num}"
+        )
+
+        return canvas
+
+    def to_response(self, canvas: SubtaskContext) -> CanvasResponse:
+        """
+        Convert SubtaskContext to CanvasResponse.
+
+        Args:
+            canvas: SubtaskContext record
+
+        Returns:
+            CanvasResponse object
+        """
+        type_data = canvas.type_data or {}
+        return CanvasResponse(
+            id=canvas.id,
+            subtask_id=canvas.subtask_id,
+            filename=type_data.get("filename", "untitled.txt"),
+            content=type_data.get("content", ""),
+            version=type_data.get("version", 1),
+            created_at=canvas.created_at,
+            updated_at=canvas.updated_at,
+        )
+
+    def build_canvas_prompt_context(
+        self,
+        canvas: SubtaskContext,
+    ) -> str:
+        """
+        Build prompt context for LLM including canvas content.
+
+        Adds line numbers for precise location reference.
+
+        Args:
+            canvas: SubtaskContext record
+
+        Returns:
+            Formatted context string
+        """
+        type_data = canvas.type_data or {}
+        content = type_data.get("content", "")
+        filename = type_data.get("filename", "untitled.txt")
+        version = type_data.get("version", 1)
+
+        # Add line numbers
+        content_with_lines = "\n".join(
+            f"{idx+1} | {line}" for idx, line in enumerate(content.split("\n"))
+        )
+
+        return f"""[Canvas Document Context]
+Filename: {filename}
+Version: {version}
+Content:
+```
+{content_with_lines}
+```
+"""
+
+
+# Global service instance
+canvas_service = CanvasService()

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -4,6 +4,7 @@
 
 """Built-in tools module."""
 
+from .canvas import UpdateCanvasTool, create_canvas_tool
 from .data_table import DataTableTool
 from .evaluation import SubmitEvaluationResultTool
 from .file_reader import FileListSkill, FileReaderSkill
@@ -19,4 +20,6 @@ __all__ = [
     "FileListSkill",
     "SubmitEvaluationResultTool",
     "LoadSkillTool",
+    "UpdateCanvasTool",
+    "create_canvas_tool",
 ]

--- a/chat_shell/chat_shell/tools/builtin/canvas.py
+++ b/chat_shell/chat_shell/tools/builtin/canvas.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canvas document editing tool for AI-assisted document modification.
+
+This tool allows AI agents to modify canvas documents using string replacement.
+The actual execution is handled by the Backend, which validates the replacement
+and updates the canvas content.
+"""
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateCanvasInput(BaseModel):
+    """Input schema for update_canvas tool."""
+
+    old_str: str = Field(
+        description="The text to replace. Must uniquely match content in the document. "
+        "Provide sufficient surrounding context to ensure unique matching."
+    )
+    new_str: str = Field(
+        description="The replacement text. Use empty string to delete content."
+    )
+
+
+class UpdateCanvasTool(BaseTool):
+    """Canvas document editing tool for AI agents.
+
+    This tool allows AI to modify canvas documents by specifying:
+    - old_str: The exact text to replace (must uniquely match in document)
+    - new_str: The replacement text
+
+    The replacement is atomic and creates a new version in the document history.
+    If old_str matches multiple locations, the operation fails and asks for more context.
+
+    The tool execution is delegated to the Backend, which:
+    1. Validates old_str uniqueness
+    2. Performs the string replacement
+    3. Creates a new version entry
+    4. Emits WebSocket event for real-time updates
+
+    This tool should only be registered when a canvas is active in the conversation.
+    """
+
+    name: str = "update_canvas"
+    display_name: str = "编辑画布文档"
+    description: str = (
+        "Modify the canvas document content using string replacement. "
+        "Use this tool when the user asks you to edit, update, add, or delete content in the canvas. "
+        "Parameters:\n"
+        "- old_str: The exact text to replace. Must uniquely match in the document. "
+        "Include enough surrounding context (a few lines before and after) to ensure uniqueness.\n"
+        "- new_str: The replacement text. Use empty string '' to delete content.\n"
+        "\n"
+        "Examples:\n"
+        "- To insert text: Set old_str to the line after which you want to insert, "
+        "and new_str to that line plus the new content.\n"
+        "- To delete text: Set old_str to the text to delete, and new_str to empty string ''.\n"
+        "- To modify text: Set old_str to the original text, and new_str to the modified version.\n"
+        "\n"
+        "IMPORTANT: The old_str must exactly match the document content, including whitespace and newlines."
+    )
+    args_schema: type[BaseModel] = UpdateCanvasInput
+
+    # Canvas context ID (set when creating the tool)
+    canvas_id: int = 0
+
+    # Subtask ID for context
+    subtask_id: int = 0
+
+    # Task ID for WebSocket events
+    task_id: int = 0
+
+    # Callback to execute the update (set by Backend when creating tool)
+    # This callback handles the actual database update and WebSocket emission
+    execute_callback: Optional[Any] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _run(
+        self,
+        old_str: str,
+        new_str: str,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        """Execute canvas update synchronously.
+
+        Args:
+            old_str: Text to replace
+            new_str: Replacement text
+            run_manager: Callback manager
+
+        Returns:
+            JSON string with operation result
+        """
+        try:
+            if not self.canvas_id:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "No canvas is currently active. Please open a canvas first.",
+                    }
+                )
+
+            # Validate inputs
+            if not old_str:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": "old_str cannot be empty. Please provide the text to replace.",
+                    }
+                )
+
+            logger.info(
+                f"[UpdateCanvasTool] Updating canvas {self.canvas_id}: "
+                f"old_str_len={len(old_str)}, new_str_len={len(new_str)}"
+            )
+
+            # If callback is set, use it for execution
+            if self.execute_callback:
+                result = self.execute_callback(
+                    canvas_id=self.canvas_id,
+                    old_str=old_str,
+                    new_str=new_str,
+                    task_id=self.task_id,
+                    subtask_id=self.subtask_id,
+                )
+                return json.dumps(result, ensure_ascii=False)
+
+            # Fallback: Return tool call info for Backend to execute
+            # This happens when tool is invoked without callback (e.g., in planning mode)
+            return json.dumps(
+                {
+                    "success": True,
+                    "message": "Canvas update request prepared. "
+                    "The actual update will be executed by the Backend.",
+                    "canvas_id": self.canvas_id,
+                    "old_str_preview": old_str[:100] + "..." if len(old_str) > 100 else old_str,
+                    "new_str_preview": new_str[:100] + "..." if len(new_str) > 100 else new_str,
+                },
+                ensure_ascii=False,
+            )
+
+        except Exception as e:
+            logger.error(f"[UpdateCanvasTool] Error: {e}", exc_info=True)
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Canvas update failed: {str(e)}",
+                }
+            )
+
+    async def _arun(
+        self,
+        old_str: str,
+        new_str: str,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> str:
+        """Execute canvas update asynchronously.
+
+        Delegates to sync version as database operations are handled by Backend.
+        """
+        return self._run(old_str, new_str, run_manager)
+
+
+def create_canvas_tool(
+    canvas_id: int,
+    task_id: int,
+    subtask_id: int,
+    execute_callback: Optional[Any] = None,
+) -> UpdateCanvasTool:
+    """Factory function to create a configured UpdateCanvasTool.
+
+    Args:
+        canvas_id: Canvas context ID
+        task_id: Task ID for WebSocket events
+        subtask_id: Subtask ID for context
+        execute_callback: Optional callback for executing updates
+
+    Returns:
+        Configured UpdateCanvasTool instance
+    """
+    return UpdateCanvasTool(
+        canvas_id=canvas_id,
+        task_id=task_id,
+        subtask_id=subtask_id,
+        execute_callback=execute_callback,
+    )

--- a/frontend/src/apis/canvas.ts
+++ b/frontend/src/apis/canvas.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas API endpoints for document editing.
+ */
+
+import apiClient from './client'
+import type {
+  Canvas,
+  CanvasCreateRequest,
+  CanvasUpdateRequest,
+  CanvasRollbackRequest,
+  CanvasVersionsResponse,
+} from '@/types/canvas'
+
+const CANVAS_BASE_URL = '/canvas'
+
+/**
+ * Create a new canvas document.
+ */
+export async function createCanvas(request: CanvasCreateRequest): Promise<Canvas> {
+  return apiClient.post<Canvas>(`${CANVAS_BASE_URL}/create`, request)
+}
+
+/**
+ * Get canvas by ID.
+ */
+export async function getCanvas(canvasId: number): Promise<Canvas> {
+  return apiClient.get<Canvas>(`${CANVAS_BASE_URL}/${canvasId}`)
+}
+
+/**
+ * Update canvas content (user edit).
+ */
+export async function updateCanvas(canvasId: number, request: CanvasUpdateRequest): Promise<Canvas> {
+  return apiClient.put<Canvas>(`${CANVAS_BASE_URL}/${canvasId}`, request)
+}
+
+/**
+ * Get canvas version history.
+ */
+export async function getCanvasVersions(canvasId: number): Promise<CanvasVersionsResponse> {
+  return apiClient.get<CanvasVersionsResponse>(`${CANVAS_BASE_URL}/${canvasId}/versions`)
+}
+
+/**
+ * Get a specific canvas version.
+ */
+export async function getCanvasVersion(canvasId: number, version: number): Promise<Canvas> {
+  return apiClient.get<Canvas>(`${CANVAS_BASE_URL}/${canvasId}/versions/${version}`)
+}
+
+/**
+ * Rollback canvas to a specific version.
+ */
+export async function rollbackCanvas(canvasId: number, request: CanvasRollbackRequest): Promise<Canvas> {
+  return apiClient.post<Canvas>(`${CANVAS_BASE_URL}/${canvasId}/rollback`, request)
+}
+
+/**
+ * Get canvas by subtask ID.
+ */
+export async function getCanvasBySubtask(subtaskId: number): Promise<Canvas> {
+  return apiClient.get<Canvas>(`${CANVAS_BASE_URL}/subtask/${subtaskId}`)
+}
+
+/**
+ * Export canvas as file.
+ * Returns a download URL.
+ */
+export function getCanvasExportUrl(canvasId: number, format: 'md' | 'txt' = 'txt'): string {
+  return `/api${CANVAS_BASE_URL}/${canvasId}/export?format=${format}`
+}

--- a/frontend/src/features/tasks/components/canvas/Canvas.tsx
+++ b/frontend/src/features/tasks/components/canvas/Canvas.tsx
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Main Canvas container component.
+ * Manages the canvas panel with editor, diff view, and version history.
+ */
+
+'use client'
+
+import React, { useState, useCallback, useEffect } from 'react'
+import { cn } from '@/lib/utils'
+import { CanvasEditor } from './CanvasEditor'
+import { CanvasDiffView } from './CanvasDiffView'
+import { CanvasToolbar } from './CanvasToolbar'
+import { CanvasVersionHistory } from './CanvasVersionHistory'
+import { useCanvasState } from './useCanvasState'
+import { useSocket } from '@/contexts/SocketContext'
+import { CanvasServerEvents } from '@/types/canvas'
+import type { CanvasUpdatePayload, CanvasRollbackPayload } from '@/types/canvas'
+
+interface CanvasProps {
+  subtaskId: number
+  canvasId?: number
+  onClose?: () => void
+  className?: string
+}
+
+export function Canvas({ subtaskId, canvasId, onClose, className }: CanvasProps) {
+  const [showHistory, setShowHistory] = useState(false)
+  const {
+    state,
+    loadCanvas,
+    updateContent,
+    handleAIUpdate,
+    handleRollback,
+    rollbackToVersion,
+    loadVersions,
+    exportFile,
+    acceptDiff,
+    rejectDiff,
+    closeCanvas,
+  } = useCanvasState()
+
+  const { socket } = useSocket()
+
+  // Load canvas on mount if canvasId is provided
+  useEffect(() => {
+    if (canvasId) {
+      loadCanvas(canvasId)
+    }
+  }, [canvasId, loadCanvas])
+
+  // Register WebSocket event handlers
+  useEffect(() => {
+    if (!socket) return
+
+    const handleCanvasUpdate = (payload: CanvasUpdatePayload) => {
+      if (payload.canvas_id === state.canvasId) {
+        handleAIUpdate(payload)
+      }
+    }
+
+    const handleCanvasRollback = (payload: CanvasRollbackPayload) => {
+      if (payload.canvas_id === state.canvasId) {
+        handleRollback(payload)
+      }
+    }
+
+    socket.on(CanvasServerEvents.CANVAS_UPDATE, handleCanvasUpdate)
+    socket.on(CanvasServerEvents.CANVAS_ROLLBACK, handleCanvasRollback)
+
+    return () => {
+      socket.off(CanvasServerEvents.CANVAS_UPDATE, handleCanvasUpdate)
+      socket.off(CanvasServerEvents.CANVAS_ROLLBACK, handleCanvasRollback)
+    }
+  }, [socket, state.canvasId, handleAIUpdate, handleRollback])
+
+  // Debounced content update
+  const handleContentChange = useCallback(
+    (content: string) => {
+      // Update local state immediately for responsive editing
+      // The actual save will be triggered on blur or after a delay
+      // For now, we just update the content
+      updateContent(content)
+    },
+    [updateContent]
+  )
+
+  const handleShowHistory = useCallback(() => {
+    loadVersions()
+    setShowHistory(true)
+  }, [loadVersions])
+
+  const handleCloseHistory = useCallback(() => {
+    setShowHistory(false)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    closeCanvas()
+    onClose?.()
+  }, [closeCanvas, onClose])
+
+  const handleRollbackToVersion = useCallback(
+    async (version: number) => {
+      await rollbackToVersion(version)
+      // Reload versions to show the new rollback entry
+      loadVersions()
+    },
+    [rollbackToVersion, loadVersions]
+  )
+
+  if (!state.canvasId && !canvasId) {
+    return null
+  }
+
+  return (
+    <div className={cn('flex h-full bg-base', className)}>
+      {/* Main canvas area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Toolbar */}
+        <CanvasToolbar
+          filename={state.filename}
+          version={state.version}
+          onExport={exportFile}
+          onShowHistory={handleShowHistory}
+          onClose={handleClose}
+        />
+
+        {/* Editor or Diff view */}
+        <div className="flex-1 overflow-hidden p-4">
+          {state.isDiffMode && state.diffInfo ? (
+            <CanvasDiffView
+              diffInfo={state.diffInfo}
+              onAccept={acceptDiff}
+              onReject={rejectDiff}
+            />
+          ) : (
+            <CanvasEditor
+              content={state.content}
+              onChange={handleContentChange}
+              readOnly={state.isLoading}
+            />
+          )}
+        </div>
+
+        {/* Error display */}
+        {state.error && (
+          <div className="px-4 pb-4">
+            <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-600 dark:text-red-400">
+              {state.error}
+            </div>
+          </div>
+        )}
+
+        {/* Loading indicator */}
+        {state.isLoading && (
+          <div className="absolute inset-0 bg-base/50 flex items-center justify-center">
+            <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+      </div>
+
+      {/* Version history panel */}
+      {showHistory && (
+        <CanvasVersionHistory
+          versions={state.versions}
+          currentVersion={state.version}
+          onRollback={handleRollbackToVersion}
+          onClose={handleCloseHistory}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/canvas/CanvasDiffView.tsx
+++ b/frontend/src/features/tasks/components/canvas/CanvasDiffView.tsx
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas diff view component for showing AI modifications.
+ * Highlights changes between old and new content.
+ */
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { CheckIcon, XIcon } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { CanvasDiffInfo } from '@/types/canvas'
+
+interface CanvasDiffViewProps {
+  diffInfo: CanvasDiffInfo
+  onAccept: () => void
+  onReject: () => void
+  className?: string
+}
+
+interface DiffLine {
+  type: 'unchanged' | 'added' | 'removed'
+  content: string
+  lineNumber?: number
+}
+
+export function CanvasDiffView({ diffInfo, onAccept, onReject, className }: CanvasDiffViewProps) {
+  const { t } = useTranslation('canvas')
+
+  // Simple diff algorithm that highlights changed sections
+  const diffLines = useMemo(() => {
+    const oldLines = diffInfo.oldContent.split('\n')
+    const newLines = diffInfo.newContent.split('\n')
+    const result: DiffLine[] = []
+
+    // Find the position of the change
+    const oldStr = diffInfo.oldStr
+    const newStr = diffInfo.newStr
+
+    // Get line ranges that contain the change
+    let oldStart = 0
+    let charCount = 0
+    for (let i = 0; i < oldLines.length; i++) {
+      const lineStart = charCount
+      charCount += oldLines[i].length + 1 // +1 for newline
+      if (diffInfo.oldContent.indexOf(oldStr) >= lineStart && diffInfo.oldContent.indexOf(oldStr) < charCount) {
+        oldStart = i
+        break
+      }
+    }
+
+    // Find how many lines the old/new strings span
+    const oldStrLines = oldStr.split('\n').length
+    const newStrLines = newStr.split('\n').length
+
+    // Build diff output
+    let lineNum = 1
+
+    // Lines before the change
+    for (let i = 0; i < oldStart; i++) {
+      result.push({ type: 'unchanged', content: oldLines[i], lineNumber: lineNum++ })
+    }
+
+    // Removed lines
+    for (let i = oldStart; i < oldStart + oldStrLines && i < oldLines.length; i++) {
+      result.push({ type: 'removed', content: oldLines[i] })
+    }
+
+    // Added lines (new content at the same position)
+    const newStart = oldStart
+    for (let i = newStart; i < newStart + newStrLines && i < newLines.length; i++) {
+      result.push({ type: 'added', content: newLines[i], lineNumber: lineNum++ })
+    }
+
+    // Lines after the change (from new content)
+    for (let i = newStart + newStrLines; i < newLines.length; i++) {
+      result.push({ type: 'unchanged', content: newLines[i], lineNumber: lineNum++ })
+    }
+
+    return result
+  }, [diffInfo])
+
+  return (
+    <div className={cn('flex flex-col h-full', className)}>
+      {/* Diff content */}
+      <div className="flex-1 overflow-auto bg-surface border rounded-lg">
+        <div className="font-mono text-sm">
+          {diffLines.map((line, index) => (
+            <div
+              key={index}
+              className={cn(
+                'flex px-4 py-0.5 leading-6',
+                line.type === 'added' && 'bg-green-50 dark:bg-green-950/30',
+                line.type === 'removed' && 'bg-red-50 dark:bg-red-950/30 line-through opacity-60'
+              )}
+            >
+              {/* Line indicator */}
+              <span
+                className={cn(
+                  'w-6 flex-shrink-0 text-center mr-2',
+                  line.type === 'added' && 'text-green-600 dark:text-green-400',
+                  line.type === 'removed' && 'text-red-600 dark:text-red-400',
+                  line.type === 'unchanged' && 'text-text-muted'
+                )}
+              >
+                {line.type === 'added' && '+'}
+                {line.type === 'removed' && '-'}
+                {line.type === 'unchanged' && ' '}
+              </span>
+
+              {/* Line number */}
+              {line.lineNumber && (
+                <span className="w-8 flex-shrink-0 text-text-muted text-right mr-4">
+                  {line.lineNumber}
+                </span>
+              )}
+              {!line.lineNumber && <span className="w-8 flex-shrink-0 mr-4" />}
+
+              {/* Content */}
+              <span
+                className={cn(
+                  'flex-1 whitespace-pre-wrap break-all',
+                  line.type === 'added' && 'text-green-800 dark:text-green-200',
+                  line.type === 'removed' && 'text-red-800 dark:text-red-200'
+                )}
+              >
+                {line.content || ' '}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex items-center justify-end gap-3 py-3 px-4 border-t bg-surface">
+        <Button variant="outline" size="sm" onClick={onReject} className="h-9">
+          <XIcon className="h-4 w-4 mr-2" />
+          {t('diff.reject')}
+        </Button>
+        <Button size="sm" onClick={onAccept} className="h-9">
+          <CheckIcon className="h-4 w-4 mr-2" />
+          {t('diff.accept')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/canvas/CanvasEditor.tsx
+++ b/frontend/src/features/tasks/components/canvas/CanvasEditor.tsx
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas editor component using a simple textarea.
+ * Provides line numbers and basic editing functionality.
+ */
+
+'use client'
+
+import React, { useRef, useEffect, useState, useCallback } from 'react'
+import { cn } from '@/lib/utils'
+
+interface CanvasEditorProps {
+  content: string
+  onChange: (content: string) => void
+  readOnly?: boolean
+  className?: string
+}
+
+export function CanvasEditor({ content, onChange, readOnly = false, className }: CanvasEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const lineNumbersRef = useRef<HTMLDivElement>(null)
+  const [lineCount, setLineCount] = useState(1)
+
+  // Update line count when content changes
+  useEffect(() => {
+    const lines = content.split('\n').length
+    setLineCount(Math.max(lines, 1))
+  }, [content])
+
+  // Sync scroll between textarea and line numbers
+  const handleScroll = useCallback(() => {
+    if (textareaRef.current && lineNumbersRef.current) {
+      lineNumbersRef.current.scrollTop = textareaRef.current.scrollTop
+    }
+  }, [])
+
+  // Handle tab key for indentation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Tab' && !readOnly) {
+        e.preventDefault()
+        const textarea = textareaRef.current
+        if (!textarea) return
+
+        const start = textarea.selectionStart
+        const end = textarea.selectionEnd
+        const value = textarea.value
+
+        // Insert tab at cursor position
+        const newValue = value.substring(0, start) + '  ' + value.substring(end)
+        onChange(newValue)
+
+        // Move cursor after the inserted tab
+        requestAnimationFrame(() => {
+          textarea.selectionStart = textarea.selectionEnd = start + 2
+        })
+      }
+    },
+    [onChange, readOnly]
+  )
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e.target.value)
+    },
+    [onChange]
+  )
+
+  // Generate line numbers
+  const lineNumbers = Array.from({ length: lineCount }, (_, i) => i + 1)
+
+  return (
+    <div className={cn('flex h-full w-full overflow-hidden bg-surface rounded-lg border', className)}>
+      {/* Line numbers column */}
+      <div
+        ref={lineNumbersRef}
+        className="flex-shrink-0 w-12 bg-bg-muted overflow-hidden select-none border-r"
+        style={{ overflowY: 'hidden' }}
+      >
+        <div className="py-3 px-2 text-right">
+          {lineNumbers.map(num => (
+            <div
+              key={num}
+              className="text-xs text-text-muted leading-6 font-mono"
+              style={{ height: '24px' }}
+            >
+              {num}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Editor area */}
+      <div className="flex-1 overflow-hidden">
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={handleChange}
+          onScroll={handleScroll}
+          onKeyDown={handleKeyDown}
+          readOnly={readOnly}
+          className={cn(
+            'w-full h-full resize-none outline-none bg-transparent',
+            'py-3 px-4 text-sm font-mono leading-6',
+            'text-text-primary placeholder:text-text-muted',
+            readOnly && 'cursor-default'
+          )}
+          style={{
+            minHeight: '100%',
+            lineHeight: '24px',
+          }}
+          placeholder="Start typing..."
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/canvas/CanvasToolbar.tsx
+++ b/frontend/src/features/tasks/components/canvas/CanvasToolbar.tsx
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas toolbar component with actions like export, version history, etc.
+ */
+
+'use client'
+
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { HistoryIcon, DownloadIcon, XIcon, ChevronDownIcon } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+
+interface CanvasToolbarProps {
+  filename: string
+  version: number
+  onExport: (format: 'md' | 'txt') => void
+  onShowHistory: () => void
+  onClose: () => void
+  className?: string
+}
+
+export function CanvasToolbar({
+  filename,
+  version,
+  onExport,
+  onShowHistory,
+  onClose,
+  className,
+}: CanvasToolbarProps) {
+  const { t } = useTranslation('canvas')
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between h-12 px-4 border-b bg-surface',
+        className
+      )}
+    >
+      {/* Left: Filename and version */}
+      <div className="flex items-center gap-3">
+        <span className="font-medium text-sm text-text-primary">{filename}</span>
+        <span className="text-xs text-text-muted bg-bg-muted px-2 py-0.5 rounded">
+          v{version}
+        </span>
+      </div>
+
+      {/* Right: Actions */}
+      <div className="flex items-center gap-2">
+        {/* Version History */}
+        <Button variant="ghost" size="sm" onClick={onShowHistory} className="h-8 px-3">
+          <HistoryIcon className="h-4 w-4 mr-2" />
+          <span className="hidden sm:inline">{t('toolbar.history')}</span>
+        </Button>
+
+        {/* Export dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="h-8 px-3">
+              <DownloadIcon className="h-4 w-4 mr-2" />
+              <span className="hidden sm:inline">{t('toolbar.export')}</span>
+              <ChevronDownIcon className="h-3 w-3 ml-1" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onExport('txt')}>
+              {t('export.format_txt')}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onExport('md')}>
+              {t('export.format_md')}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        {/* Close */}
+        <Button variant="ghost" size="icon" onClick={onClose} className="h-8 w-8">
+          <XIcon className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/canvas/CanvasVersionHistory.tsx
+++ b/frontend/src/features/tasks/components/canvas/CanvasVersionHistory.tsx
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas version history panel component.
+ */
+
+'use client'
+
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { XIcon, RotateCcwIcon, UserIcon, BotIcon } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { CanvasVersionInfo } from '@/types/canvas'
+
+interface CanvasVersionHistoryProps {
+  versions: CanvasVersionInfo[]
+  currentVersion: number
+  onRollback: (version: number) => void
+  onClose: () => void
+  className?: string
+}
+
+export function CanvasVersionHistory({
+  versions,
+  currentVersion,
+  onRollback,
+  onClose,
+  className,
+}: CanvasVersionHistoryProps) {
+  const { t } = useTranslation('canvas')
+
+  // Sort versions in descending order (newest first)
+  const sortedVersions = [...versions].sort((a, b) => b.version - a.version)
+
+  const formatTimestamp = (timestamp: string) => {
+    const date = new Date(timestamp)
+    return date.toLocaleString()
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col h-full w-80 border-l bg-surface',
+        className
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between h-12 px-4 border-b">
+        <span className="font-medium text-sm">{t('history.title')}</span>
+        <Button variant="ghost" size="icon" onClick={onClose} className="h-8 w-8">
+          <XIcon className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Version list */}
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {sortedVersions.map(version => (
+            <div
+              key={version.version}
+              className={cn(
+                'p-3 rounded-lg mb-2 border',
+                version.version === currentVersion
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border hover:bg-bg-muted/50'
+              )}
+            >
+              {/* Version header */}
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  {/* Source icon */}
+                  {version.source === 'ai' ? (
+                    <BotIcon className="h-4 w-4 text-primary" />
+                  ) : (
+                    <UserIcon className="h-4 w-4 text-text-muted" />
+                  )}
+
+                  {/* Version number */}
+                  <span className="font-medium text-sm">
+                    {t('history.version', { version: version.version })}
+                  </span>
+
+                  {/* Current badge */}
+                  {version.version === currentVersion && (
+                    <span className="text-xs bg-primary text-white px-1.5 py-0.5 rounded">
+                      Current
+                    </span>
+                  )}
+                </div>
+
+                {/* Rollback button */}
+                {version.version !== currentVersion && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onRollback(version.version)}
+                    className="h-7 px-2 text-xs"
+                  >
+                    <RotateCcwIcon className="h-3 w-3 mr-1" />
+                    {t('history.rollback')}
+                  </Button>
+                )}
+              </div>
+
+              {/* Metadata */}
+              <div className="text-xs text-text-muted space-y-1">
+                <div>{formatTimestamp(version.timestamp)}</div>
+                <div>
+                  {version.source === 'ai'
+                    ? t('history.source_ai')
+                    : t('history.source_user')}
+                </div>
+                {version.rollback_from && (
+                  <div className="text-amber-600 dark:text-amber-400">
+                    Rolled back from v{version.rollback_from}
+                  </div>
+                )}
+              </div>
+
+              {/* Change preview for AI edits */}
+              {version.source === 'ai' && version.old_str && version.new_str && (
+                <div className="mt-2 text-xs bg-bg-muted rounded p-2 space-y-1">
+                  <div className="text-red-600 dark:text-red-400 line-through truncate">
+                    - {version.old_str.slice(0, 50)}
+                    {version.old_str.length > 50 && '...'}
+                  </div>
+                  <div className="text-green-600 dark:text-green-400 truncate">
+                    + {version.new_str.slice(0, 50)}
+                    {version.new_str.length > 50 && '...'}
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+
+          {sortedVersions.length === 0 && (
+            <div className="text-center text-text-muted py-8 text-sm">
+              No version history available
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/canvas/index.ts
+++ b/frontend/src/features/tasks/components/canvas/index.ts
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas components module exports.
+ */
+
+export { Canvas } from './Canvas'
+export { CanvasEditor } from './CanvasEditor'
+export { CanvasDiffView } from './CanvasDiffView'
+export { CanvasToolbar } from './CanvasToolbar'
+export { CanvasVersionHistory } from './CanvasVersionHistory'
+export { useCanvasState } from './useCanvasState'

--- a/frontend/src/features/tasks/components/canvas/useCanvasState.ts
+++ b/frontend/src/features/tasks/components/canvas/useCanvasState.ts
@@ -1,0 +1,267 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Hook for managing canvas document state.
+ */
+
+import { useState, useCallback, useEffect } from 'react'
+import {
+  createCanvas,
+  getCanvas,
+  updateCanvas,
+  getCanvasVersions,
+  rollbackCanvas,
+  getCanvasExportUrl,
+} from '@/apis/canvas'
+import type {
+  Canvas,
+  CanvasState,
+  CanvasDiffInfo,
+  CanvasVersionInfo,
+  CanvasUpdatePayload,
+  CanvasRollbackPayload,
+} from '@/types/canvas'
+
+interface UseCanvasStateReturn {
+  state: CanvasState
+  createNewCanvas: (subtaskId: number, filename?: string, content?: string) => Promise<Canvas | null>
+  loadCanvas: (canvasId: number) => Promise<void>
+  updateContent: (content: string) => Promise<void>
+  handleAIUpdate: (payload: CanvasUpdatePayload) => void
+  handleRollback: (payload: CanvasRollbackPayload) => void
+  rollbackToVersion: (version: number) => Promise<void>
+  loadVersions: () => Promise<void>
+  exportFile: (format: 'md' | 'txt') => void
+  acceptDiff: () => void
+  rejectDiff: () => void
+  closeCanvas: () => void
+  isOpen: boolean
+}
+
+const initialState: CanvasState = {
+  canvasId: null,
+  filename: 'untitled.txt',
+  content: '',
+  version: 0,
+  versions: [],
+  isLoading: false,
+  isDiffMode: false,
+  diffInfo: null,
+  error: null,
+}
+
+export function useCanvasState(): UseCanvasStateReturn {
+  const [state, setState] = useState<CanvasState>(initialState)
+
+  const createNewCanvas = useCallback(
+    async (subtaskId: number, filename?: string, content?: string): Promise<Canvas | null> => {
+      setState(prev => ({ ...prev, isLoading: true, error: null }))
+
+      try {
+        const canvas = await createCanvas({
+          subtask_id: subtaskId,
+          filename: filename || 'untitled.txt',
+          content: content || '',
+        })
+
+        setState({
+          canvasId: canvas.id,
+          filename: canvas.filename,
+          content: canvas.content,
+          version: canvas.version,
+          versions: [],
+          isLoading: false,
+          isDiffMode: false,
+          diffInfo: null,
+          error: null,
+        })
+
+        return canvas
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to create canvas'
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          error: errorMessage,
+        }))
+        return null
+      }
+    },
+    []
+  )
+
+  const loadCanvas = useCallback(async (canvasId: number) => {
+    setState(prev => ({ ...prev, isLoading: true, error: null }))
+
+    try {
+      const canvas = await getCanvas(canvasId)
+      setState({
+        canvasId: canvas.id,
+        filename: canvas.filename,
+        content: canvas.content,
+        version: canvas.version,
+        versions: [],
+        isLoading: false,
+        isDiffMode: false,
+        diffInfo: null,
+        error: null,
+      })
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load canvas'
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        error: errorMessage,
+      }))
+    }
+  }, [])
+
+  const updateContent = useCallback(
+    async (content: string) => {
+      if (!state.canvasId) return
+
+      setState(prev => ({ ...prev, isLoading: true, error: null }))
+
+      try {
+        const canvas = await updateCanvas(state.canvasId, { content })
+        setState(prev => ({
+          ...prev,
+          content: canvas.content,
+          version: canvas.version,
+          isLoading: false,
+        }))
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to update canvas'
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          error: errorMessage,
+        }))
+      }
+    },
+    [state.canvasId]
+  )
+
+  const handleAIUpdate = useCallback((payload: CanvasUpdatePayload) => {
+    if (payload.canvas_id !== state.canvasId) return
+
+    const diffInfo: CanvasDiffInfo = {
+      oldStr: payload.diff_info.old_str,
+      newStr: payload.diff_info.new_str,
+      oldContent: state.content,
+      newContent: payload.new_content,
+    }
+
+    setState(prev => ({
+      ...prev,
+      content: payload.new_content,
+      version: payload.version,
+      isDiffMode: true,
+      diffInfo,
+    }))
+  }, [state.canvasId, state.content])
+
+  const handleRollback = useCallback((payload: CanvasRollbackPayload) => {
+    if (payload.canvas_id !== state.canvasId) return
+
+    setState(prev => ({
+      ...prev,
+      content: payload.content,
+      version: payload.version,
+      isDiffMode: false,
+      diffInfo: null,
+    }))
+  }, [state.canvasId])
+
+  const rollbackToVersion = useCallback(
+    async (version: number) => {
+      if (!state.canvasId) return
+
+      setState(prev => ({ ...prev, isLoading: true, error: null }))
+
+      try {
+        const canvas = await rollbackCanvas(state.canvasId, { version })
+        setState(prev => ({
+          ...prev,
+          content: canvas.content,
+          version: canvas.version,
+          isLoading: false,
+          isDiffMode: false,
+          diffInfo: null,
+        }))
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to rollback'
+        setState(prev => ({
+          ...prev,
+          isLoading: false,
+          error: errorMessage,
+        }))
+      }
+    },
+    [state.canvasId]
+  )
+
+  const loadVersions = useCallback(async () => {
+    if (!state.canvasId) return
+
+    try {
+      const response = await getCanvasVersions(state.canvasId)
+      setState(prev => ({
+        ...prev,
+        versions: response.versions,
+      }))
+    } catch (err) {
+      console.error('Failed to load versions:', err)
+    }
+  }, [state.canvasId])
+
+  const exportFile = useCallback(
+    (format: 'md' | 'txt') => {
+      if (!state.canvasId) return
+      const url = getCanvasExportUrl(state.canvasId, format)
+      window.open(url, '_blank')
+    },
+    [state.canvasId]
+  )
+
+  const acceptDiff = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      isDiffMode: false,
+      diffInfo: null,
+    }))
+  }, [])
+
+  const rejectDiff = useCallback(() => {
+    if (!state.diffInfo) return
+
+    setState(prev => ({
+      ...prev,
+      content: prev.diffInfo?.oldContent || prev.content,
+      isDiffMode: false,
+      diffInfo: null,
+    }))
+  }, [state.diffInfo])
+
+  const closeCanvas = useCallback(() => {
+    setState(initialState)
+  }, [])
+
+  return {
+    state,
+    createNewCanvas,
+    loadCanvas,
+    updateContent,
+    handleAIUpdate,
+    handleRollback,
+    rollbackToVersion,
+    loadVersions,
+    exportFile,
+    acceptDiff,
+    rejectDiff,
+    closeCanvas,
+    isOpen: state.canvasId !== null,
+  }
+}

--- a/frontend/src/i18n/locales/en/canvas.json
+++ b/frontend/src/i18n/locales/en/canvas.json
@@ -1,0 +1,32 @@
+{
+  "open": "Open Canvas",
+  "close": "Close Canvas",
+  "toolbar": {
+    "export": "Export",
+    "history": "History",
+    "undo": "Undo",
+    "redo": "Redo"
+  },
+  "export": {
+    "title": "Export Document",
+    "format_md": "Markdown (.md)",
+    "format_txt": "Plain Text (.txt)"
+  },
+  "history": {
+    "title": "Version History",
+    "version": "Version {{version}}",
+    "source_ai": "AI Edit",
+    "source_user": "User Edit",
+    "rollback": "Rollback"
+  },
+  "diff": {
+    "accept": "Accept Changes",
+    "reject": "Reject Changes"
+  },
+  "errors": {
+    "create_failed": "Failed to create canvas",
+    "load_failed": "Failed to load canvas",
+    "update_failed": "Failed to update canvas",
+    "rollback_failed": "Failed to rollback"
+  }
+}

--- a/frontend/src/i18n/locales/zh-CN/canvas.json
+++ b/frontend/src/i18n/locales/zh-CN/canvas.json
@@ -1,0 +1,32 @@
+{
+  "open": "开启画布",
+  "close": "关闭画布",
+  "toolbar": {
+    "export": "导出",
+    "history": "版本历史",
+    "undo": "撤销",
+    "redo": "重做"
+  },
+  "export": {
+    "title": "导出文档",
+    "format_md": "Markdown (.md)",
+    "format_txt": "纯文本 (.txt)"
+  },
+  "history": {
+    "title": "版本历史",
+    "version": "版本 {{version}}",
+    "source_ai": "AI 修改",
+    "source_user": "用户编辑",
+    "rollback": "回滚到此版本"
+  },
+  "diff": {
+    "accept": "确认修改",
+    "reject": "撤销修改"
+  },
+  "errors": {
+    "create_failed": "创建画布失败",
+    "load_failed": "加载画布失败",
+    "update_failed": "更新画布失败",
+    "rollback_failed": "回滚失败"
+  }
+}

--- a/frontend/src/i18n/setup.ts
+++ b/frontend/src/i18n/setup.ts
@@ -16,6 +16,7 @@ async function loadTranslations() {
   const namespaces = [
     'common',
     'chat',
+    'canvas',
     'settings',
     'history',
     'prompts',
@@ -65,6 +66,7 @@ export async function initI18n() {
     ns: [
       'common',
       'chat',
+      'canvas',
       'settings',
       'history',
       'prompts',

--- a/frontend/src/types/canvas.ts
+++ b/frontend/src/types/canvas.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canvas document editing types and payload definitions
+ */
+
+// ============================================================
+// Canvas Data Types
+// ============================================================
+
+export type CanvasVersionSource = 'user' | 'ai'
+
+export interface CanvasVersionInfo {
+  version: number
+  content: string
+  timestamp: string
+  source: CanvasVersionSource
+  old_str?: string
+  new_str?: string
+  rollback_from?: number
+}
+
+export interface Canvas {
+  id: number
+  subtask_id: number
+  filename: string
+  content: string
+  version: number
+  created_at: string
+  updated_at: string
+}
+
+export interface CanvasBrief {
+  id: number
+  subtask_id: number
+  filename: string
+  version: number
+  content_preview: string
+  created_at: string
+  updated_at: string
+}
+
+// ============================================================
+// Canvas API Request/Response Types
+// ============================================================
+
+export interface CanvasCreateRequest {
+  subtask_id: number
+  filename?: string
+  content?: string
+}
+
+export interface CanvasUpdateRequest {
+  content: string
+}
+
+export interface CanvasRollbackRequest {
+  version: number
+}
+
+export interface CanvasVersionsResponse {
+  versions: CanvasVersionInfo[]
+}
+
+export interface CanvasUpdateResult {
+  success: boolean
+  new_content?: string
+  version?: number
+  diff_info?: {
+    old_str: string
+    new_str: string
+  }
+  error?: string
+}
+
+// ============================================================
+// Canvas WebSocket Payloads
+// ============================================================
+
+export interface CanvasCreatePayload {
+  task_id: number
+  subtask_id: number
+  canvas_id: number
+  filename: string
+  content: string
+}
+
+export interface CanvasUpdatePayload {
+  task_id: number
+  subtask_id: number
+  canvas_id: number
+  new_content: string
+  version: number
+  diff_info: {
+    old_str: string
+    new_str: string
+  }
+}
+
+export interface CanvasRollbackPayload {
+  task_id: number
+  subtask_id: number
+  canvas_id: number
+  version: number
+  content: string
+}
+
+// ============================================================
+// Canvas State Types
+// ============================================================
+
+export interface CanvasDiffInfo {
+  oldStr: string
+  newStr: string
+  oldContent: string
+  newContent: string
+}
+
+export interface CanvasState {
+  canvasId: number | null
+  filename: string
+  content: string
+  version: number
+  versions: CanvasVersionInfo[]
+  isLoading: boolean
+  isDiffMode: boolean
+  diffInfo: CanvasDiffInfo | null
+  error: string | null
+}
+
+// Canvas Server Events
+export const CanvasServerEvents = {
+  CANVAS_CREATE: 'canvas:create',
+  CANVAS_UPDATE: 'canvas:update',
+  CANVAS_ROLLBACK: 'canvas:rollback',
+} as const


### PR DESCRIPTION
## Summary

- Implement Canvas as a collaborative document editing panel embedded in the conversation interface
- Support AI and user bidirectional editing with diff display and version management
- Provide export functionality (Markdown and plain text formats)

### Backend Changes
- Add Canvas API endpoints for CRUD operations, version history, rollback, and export
- Add Canvas service using SubtaskContext with context_type='canvas' for storage
- Add WebSocket events (canvas:create, canvas:update, canvas:rollback) for real-time updates

### Chat Shell Changes
- Add UpdateCanvasTool for AI document modifications using string replacement
- Implement uniqueness validation for replacement strings

### Frontend Changes
- Add Canvas component with editor, diff view, and version history panel
- Add useCanvasState hook for state management
- Add Canvas API client and TypeScript types
- Add i18n translations for English and Chinese

## Test plan

- [ ] Test creating a new canvas document
- [ ] Test user editing and saving content
- [ ] Test AI editing via the update_canvas tool
- [ ] Test diff display and accept/reject functionality
- [ ] Test version history display and rollback
- [ ] Test export to Markdown and plain text
- [ ] Test WebSocket real-time updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collaborative canvas editor with create, update, and read functionality
  * Introduced version history with rollback capability to restore previous document states
  * Added AI-assisted editing with visual diff preview before accepting changes
  * Added export functionality supporting Markdown and plain text formats
  * Enabled real-time collaboration through WebSocket event updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->