### PR TITLE
fix(chat_shell): show skill displayName in chat loading indicator

### DIFF
--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -154,15 +154,28 @@ class LoadSkillTool(BaseTool):
         This method returns the skill's displayName if available,
         otherwise falls back to the skill_name itself.
 
+        Priority:
+        1. Check cache (_skill_display_names) for previously loaded skills
+        2. Check skill_metadata for skills not yet loaded
+        3. Fall back to skill_name
+
         Args:
             skill_name: The technical name of the skill
 
         Returns:
             The friendly display name or the skill_name if not found
         """
-        # First check cache
+        # First check cache (for already loaded skills)
         if skill_name in self._skill_display_names:
             return self._skill_display_names[skill_name]
+
+        # Then check skill_metadata (for skills not yet loaded)
+        skill_info = self.skill_metadata.get(skill_name, {})
+        display_name = skill_info.get("displayName")
+        if display_name:
+            # Cache it for future use
+            self._skill_display_names[skill_name] = display_name
+            return display_name
 
         # Fallback to skill_name
         return skill_name


### PR DESCRIPTION
## Summary

- Fix skill loading indicator to show user-friendly `displayName` instead of technical skill name
- Update `get_skill_display_name()` in `LoadSkillTool` to check `skill_metadata` when cache misses
- Enables displayName to be retrieved before skill `_run()` is executed

## Problem

When a skill starts loading in the chat interface, the UI showed the technical skill name (e.g., "加载技能：mermaid-diagram") instead of the user-friendly displayName (e.g., "加载技能：绘制图表").

**Root cause**: The `get_skill_display_name()` method only checked the `_skill_display_names` cache, which is only populated after `_run()` executes. When the `tool_start` event fires (before `_run()`), the cache is empty.

## Solution

Enhanced `get_skill_display_name()` to:
1. First check the cache for already loaded skills
2. If cache miss, check `skill_metadata` (which contains displayName from ChatRequest)
3. Cache the displayName for future use
4. Fall back to skill_name if displayName not found

## Changes

**chat_shell/chat_shell/tools/builtin/load_skill.py:**
- Updated `get_skill_display_name()` method to query `skill_metadata` on cache miss
- Added caching of displayName when retrieved from metadata
- Improved docstring to document the priority lookup order

## Test plan

- [x] Existing unit tests pass: `uv run pytest tests/test_prompt_modifier_tool.py -v` (17 passed)
- [x] Verify skill loading shows displayName (e.g., "加载技能：绘制图表" instead of "mermaid-diagram")
- [x] Verify skill completion shows displayName (e.g., "加载技能：绘制图表" instead of "mermaid-diagram：已加载")
- [ ] Verify skills without displayName fall back to technical name
- [ ] Test on both desktop and mobile interfaces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill display name resolution with enhanced caching and fallback handling for more reliable display naming.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->