### PR TITLE
feat: add Card message type with [card:url] syntax for rich link previews

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -107,7 +107,7 @@ WEB_SEARCH_DEFAULT_MAX_RESULTS=100
 # Start Browserless service: docker run -d -p 8910:3000 browserless/chrome
 # Set BROWSERLESS_ENABLED=False to disable screenshot functionality
 # BROWSERLESS_URL=http://localhost:8910
-# BROWSERLESS_ENABLED=True
+BROWSERLESS_ENABLED=False
 # BROWSERLESS_TIMEOUT=30
 
 # MCP (Model Context Protocol) configuration for Chat Shell

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -102,6 +102,13 @@ WEB_SEARCH_ENGINES={}
 # Default maximum number of search results when not specified by LLM or engine config (default: 100)
 WEB_SEARCH_DEFAULT_MAX_RESULTS=100
 
+# Browserless screenshot service configuration
+# Used for generating website screenshots when og:image is not available
+# Run: docker run -p 8910:3000 browserless/chrome
+BROWSERLESS_URL=http://localhost:8910
+BROWSERLESS_ENABLED=True
+BROWSERLESS_TIMEOUT=30
+
 # MCP (Model Context Protocol) configuration for Chat Shell
 # Enable/disable MCP tools in Chat Shell mode (default: False)
 CHAT_MCP_ENABLED=False

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -104,7 +104,8 @@ WEB_SEARCH_DEFAULT_MAX_RESULTS=100
 
 # Browserless screenshot service configuration
 # Used for generating website screenshots when og:image is not available
-# Run: docker run -p 8910:3000 browserless/chrome
+# Start Browserless service: docker run -d -p 8910:3000 browserless/chrome
+# Set BROWSERLESS_ENABLED=False to disable screenshot functionality
 BROWSERLESS_URL=http://localhost:8910
 BROWSERLESS_ENABLED=True
 BROWSERLESS_TIMEOUT=30

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -106,9 +106,9 @@ WEB_SEARCH_DEFAULT_MAX_RESULTS=100
 # Used for generating website screenshots when og:image is not available
 # Start Browserless service: docker run -d -p 8910:3000 browserless/chrome
 # Set BROWSERLESS_ENABLED=False to disable screenshot functionality
-BROWSERLESS_URL=http://localhost:8910
-BROWSERLESS_ENABLED=True
-BROWSERLESS_TIMEOUT=30
+# BROWSERLESS_URL=http://localhost:8910
+# BROWSERLESS_ENABLED=True
+# BROWSERLESS_TIMEOUT=30
 
 # MCP (Model Context Protocol) configuration for Chat Shell
 # Enable/disable MCP tools in Chat Shell mode (default: False)

--- a/backend/app/api/endpoints/utils.py
+++ b/backend/app/api/endpoints/utils.py
@@ -8,6 +8,7 @@ Utility API endpoints.
 
 from fastapi import APIRouter, Query
 
+from app.core.config import settings
 from app.services.link_preview import LinkPreviewResult, fetch_link_preview
 from app.services.url_metadata import UrlMetadataResult, fetch_url_metadata
 

--- a/backend/app/api/endpoints/utils.py
+++ b/backend/app/api/endpoints/utils.py
@@ -8,6 +8,7 @@ Utility API endpoints.
 
 from fastapi import APIRouter, Query
 
+from app.services.link_preview import LinkPreviewResult, fetch_link_preview
 from app.services.url_metadata import UrlMetadataResult, fetch_url_metadata
 
 router = APIRouter()
@@ -34,3 +35,34 @@ async def get_url_metadata(
         - success: Whether the fetch was successful
     """
     return await fetch_url_metadata(url)
+
+
+@router.get("/link-preview", response_model=LinkPreviewResult)
+async def get_link_preview(
+    url: str = Query(..., description="The URL to fetch preview for"),
+) -> LinkPreviewResult:
+    """
+    Fetch rich link preview metadata including Open Graph image.
+
+    This endpoint is used by the frontend to render [card:url] syntax
+    as rich preview cards in chat messages.
+
+    Supports:
+    - Standard web pages with Open Graph metadata (og:image, og:title, etc.)
+    - Direct image URLs (jpg, png, gif, webp, etc.)
+    - Video platform URLs (YouTube, Bilibili, Vimeo) with thumbnail extraction
+
+    - **url**: The full URL to fetch preview for
+
+    Returns:
+        LinkPreviewResult containing:
+        - url: The original URL
+        - title: Page title
+        - description: Page description
+        - image: Preview image URL (og:image or video thumbnail)
+        - favicon: Site favicon URL
+        - site_name: Site name (og:site_name)
+        - type: URL type ("website", "image", or "video")
+        - success: Whether the fetch was successful
+    """
+    return await fetch_link_preview(url)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -259,6 +259,12 @@ class Settings(BaseSettings):
     # See backend/app/services/tables/DATA_TABLE_CONFIG_EXAMPLE.md for details
     DATA_TABLE_CONFIG: str = ""
 
+    # Browserless screenshot service configuration
+    # Used for generating website screenshots when og:image is not available
+    BROWSERLESS_URL: str = "http://localhost:8910"
+    BROWSERLESS_ENABLED: bool = True
+    BROWSERLESS_TIMEOUT: int = 30  # Screenshot timeout in seconds
+
     # OpenTelemetry configuration is centralized in shared/telemetry/config.py
     # Use: from shared.telemetry.config import get_otel_config
     # All OTEL_* environment variables are read from there

--- a/backend/app/services/link_preview.py
+++ b/backend/app/services/link_preview.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Link preview service for fetching Open Graph metadata including images.
+Supports detection of image URLs, video platforms (YouTube, Bilibili, Vimeo),
+and standard web pages with og:image support.
+
+This service extends the basic url_metadata service with:
+- og:image extraction for rich preview cards
+- URL type detection (website, image, video)
+- Video platform thumbnail extraction
+- Site name extraction
+"""
+
+import hashlib
+import logging
+import re
+from typing import Literal, Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+import httpx
+import redis
+from pydantic import BaseModel
+
+from app.core.config import settings
+from app.services.url_metadata import (
+    MAX_CONTENT_SIZE,
+    URL_FETCH_TIMEOUT,
+    URL_METADATA_SSL_VERIFY,
+    _extract_description,
+    _extract_favicon,
+    _extract_meta_content,
+    _extract_title,
+    _validate_url_for_ssrf,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL for link preview (24 hours as per requirements)
+LINK_PREVIEW_CACHE_TTL = 86400
+
+# Image file extensions
+IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".bmp", ".ico"}
+
+# Video platform patterns
+VIDEO_PLATFORMS = {
+    "youtube": {
+        "domains": ["youtube.com", "www.youtube.com", "youtu.be", "m.youtube.com"],
+        "thumbnail_pattern": "https://img.youtube.com/vi/{video_id}/maxresdefault.jpg",
+    },
+    "bilibili": {
+        "domains": ["bilibili.com", "www.bilibili.com", "b23.tv"],
+        "thumbnail_pattern": None,  # Bilibili requires API call or og:image
+    },
+    "vimeo": {
+        "domains": ["vimeo.com", "www.vimeo.com", "player.vimeo.com"],
+        "thumbnail_pattern": None,  # Vimeo requires oEmbed API
+    },
+}
+
+
+class LinkPreviewResult(BaseModel):
+    """Link preview result schema with extended metadata"""
+
+    url: str
+    title: Optional[str] = None
+    description: Optional[str] = None
+    image: Optional[str] = None
+    favicon: Optional[str] = None
+    site_name: Optional[str] = None
+    type: Literal["website", "image", "video"] = "website"
+    success: bool = True
+
+
+def _get_cache_key(url: str) -> str:
+    """Generate a cache key for link preview"""
+    url_hash = hashlib.md5(url.encode()).hexdigest()
+    return f"link_preview:{url_hash}"
+
+
+def _get_redis_client():
+    """Get Redis client instance"""
+    try:
+        return redis.from_url(settings.REDIS_URL)
+    except Exception as e:
+        logger.warning(f"Failed to connect to Redis: {e}")
+        return None
+
+
+def _is_image_url(url: str) -> bool:
+    """Check if URL points to an image based on extension"""
+    try:
+        parsed = urlparse(url)
+        path = parsed.path.lower()
+        return any(path.endswith(ext) for ext in IMAGE_EXTENSIONS)
+    except Exception:
+        return False
+
+
+def _detect_video_platform(url: str) -> Optional[tuple[str, Optional[str]]]:
+    """
+    Detect if URL is from a video platform and extract video ID.
+
+    Returns:
+        Tuple of (platform_name, video_id) or None if not a video platform
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname or ""
+        hostname = hostname.lower()
+
+        # YouTube
+        if any(domain in hostname for domain in VIDEO_PLATFORMS["youtube"]["domains"]):
+            video_id = None
+
+            # youtu.be/VIDEO_ID
+            if "youtu.be" in hostname:
+                video_id = parsed.path.strip("/").split("/")[0] if parsed.path else None
+
+            # youtube.com/watch?v=VIDEO_ID
+            elif "v" in parse_qs(parsed.query):
+                video_id = parse_qs(parsed.query)["v"][0]
+
+            # youtube.com/embed/VIDEO_ID or youtube.com/v/VIDEO_ID
+            elif "/embed/" in parsed.path or "/v/" in parsed.path:
+                parts = parsed.path.split("/")
+                for i, part in enumerate(parts):
+                    if part in ("embed", "v") and i + 1 < len(parts):
+                        video_id = parts[i + 1]
+                        break
+
+            # youtube.com/shorts/VIDEO_ID
+            elif "/shorts/" in parsed.path:
+                parts = parsed.path.split("/shorts/")
+                if len(parts) > 1:
+                    video_id = parts[1].split("/")[0].split("?")[0]
+
+            return ("youtube", video_id)
+
+        # Bilibili
+        if any(domain in hostname for domain in VIDEO_PLATFORMS["bilibili"]["domains"]):
+            video_id = None
+
+            # bilibili.com/video/BV... or bilibili.com/video/av...
+            match = re.search(r"/video/(BV[\w]+|av\d+)", parsed.path)
+            if match:
+                video_id = match.group(1)
+
+            # b23.tv/xxx (short URL - need to follow redirect)
+            elif "b23.tv" in hostname:
+                video_id = parsed.path.strip("/")
+
+            return ("bilibili", video_id)
+
+        # Vimeo
+        if any(domain in hostname for domain in VIDEO_PLATFORMS["vimeo"]["domains"]):
+            video_id = None
+
+            # vimeo.com/VIDEO_ID
+            match = re.search(r"vimeo\.com/(\d+)", url)
+            if match:
+                video_id = match.group(1)
+
+            # player.vimeo.com/video/VIDEO_ID
+            match = re.search(r"player\.vimeo\.com/video/(\d+)", url)
+            if match:
+                video_id = match.group(1)
+
+            return ("vimeo", video_id)
+
+        return None
+    except Exception:
+        return None
+
+
+def _get_youtube_thumbnail(video_id: str) -> str:
+    """Get YouTube video thumbnail URL"""
+    return f"https://img.youtube.com/vi/{video_id}/maxresdefault.jpg"
+
+
+def _extract_og_image(html: str, base_url: str) -> Optional[str]:
+    """Extract Open Graph image from HTML"""
+    # Try og:image first
+    og_image = _extract_meta_content(html, "og:image")
+    if og_image:
+        # Handle relative URLs
+        if not og_image.startswith(("http://", "https://", "//")):
+            og_image = urljoin(base_url, og_image)
+        elif og_image.startswith("//"):
+            og_image = "https:" + og_image
+        return og_image
+
+    # Try twitter:image
+    twitter_image = _extract_meta_content(html, "twitter:image", "name")
+    if twitter_image:
+        if not twitter_image.startswith(("http://", "https://", "//")):
+            twitter_image = urljoin(base_url, twitter_image)
+        elif twitter_image.startswith("//"):
+            twitter_image = "https:" + twitter_image
+        return twitter_image
+
+    # Try twitter:image:src
+    twitter_image_src = _extract_meta_content(html, "twitter:image:src", "name")
+    if twitter_image_src:
+        if not twitter_image_src.startswith(("http://", "https://", "//")):
+            twitter_image_src = urljoin(base_url, twitter_image_src)
+        elif twitter_image_src.startswith("//"):
+            twitter_image_src = "https:" + twitter_image_src
+        return twitter_image_src
+
+    return None
+
+
+def _extract_site_name(html: str) -> Optional[str]:
+    """Extract site name from HTML"""
+    # Try og:site_name
+    site_name = _extract_meta_content(html, "og:site_name")
+    if site_name:
+        return site_name
+
+    # Try application-name
+    app_name = _extract_meta_content(html, "application-name", "name")
+    if app_name:
+        return app_name
+
+    return None
+
+
+def _cache_result(redis_client, url: str, result: LinkPreviewResult):
+    """Cache the link preview result in Redis"""
+    if not redis_client:
+        return
+
+    try:
+        import json
+
+        cache_key = _get_cache_key(url)
+        redis_client.setex(
+            cache_key,
+            LINK_PREVIEW_CACHE_TTL,
+            json.dumps(result.model_dump()),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to cache link preview: {e}")
+
+
+async def fetch_link_preview(url: str) -> LinkPreviewResult:
+    """
+    Fetch link preview metadata from a URL.
+
+    Supports:
+    - Standard web pages with Open Graph metadata
+    - Direct image URLs
+    - Video platform URLs (YouTube, Bilibili, Vimeo)
+
+    Args:
+        url: The URL to fetch preview for
+
+    Returns:
+        LinkPreviewResult with title, description, image, type, etc.
+    """
+    # Validate URL for SSRF protection
+    if not _validate_url_for_ssrf(url):
+        return LinkPreviewResult(url=url, success=False)
+
+    # Check cache first
+    redis_client = _get_redis_client()
+    if redis_client:
+        cache_key = _get_cache_key(url)
+        try:
+            cached = redis_client.get(cache_key)
+            if cached:
+                import json
+
+                data = json.loads(cached)
+                return LinkPreviewResult(**data)
+        except Exception as e:
+            logger.warning(f"Failed to read from cache: {e}")
+
+    # Handle direct image URLs
+    if _is_image_url(url):
+        result = LinkPreviewResult(
+            url=url,
+            image=url,
+            type="image",
+            success=True,
+        )
+        _cache_result(redis_client, url, result)
+        return result
+
+    # Detect video platforms
+    video_info = _detect_video_platform(url)
+    if video_info:
+        platform, video_id = video_info
+
+        # For YouTube, we can directly generate thumbnail URL
+        if platform == "youtube" and video_id:
+            thumbnail = _get_youtube_thumbnail(video_id)
+            # Still fetch the page to get title and description
+            page_result = await _fetch_page_metadata(url)
+            result = LinkPreviewResult(
+                url=url,
+                title=page_result.get("title"),
+                description=page_result.get("description"),
+                image=thumbnail,
+                favicon=page_result.get("favicon"),
+                site_name=page_result.get("site_name") or "YouTube",
+                type="video",
+                success=True,
+            )
+            _cache_result(redis_client, url, result)
+            return result
+
+        # For other video platforms, fetch og:image from page
+        page_result = await _fetch_page_metadata(url)
+        result = LinkPreviewResult(
+            url=url,
+            title=page_result.get("title"),
+            description=page_result.get("description"),
+            image=page_result.get("image"),
+            favicon=page_result.get("favicon"),
+            site_name=page_result.get("site_name") or platform.capitalize(),
+            type="video",
+            success=page_result.get("success", False),
+        )
+        _cache_result(redis_client, url, result)
+        return result
+
+    # Standard web page - fetch metadata
+    page_result = await _fetch_page_metadata(url)
+    result = LinkPreviewResult(
+        url=url,
+        title=page_result.get("title"),
+        description=page_result.get("description"),
+        image=page_result.get("image"),
+        favicon=page_result.get("favicon"),
+        site_name=page_result.get("site_name"),
+        type="website",
+        success=page_result.get("success", False),
+    )
+    _cache_result(redis_client, url, result)
+    return result
+
+
+async def _fetch_page_metadata(url: str) -> dict:
+    """
+    Fetch page metadata from URL.
+
+    Returns dict with title, description, image, favicon, site_name, success
+    """
+    # Log SSL verification status if disabled
+    if not URL_METADATA_SSL_VERIFY:
+        logger.warning(f"SSL verification disabled for link preview fetch: {url}")
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=URL_FETCH_TIMEOUT,
+            follow_redirects=True,
+            verify=URL_METADATA_SSL_VERIFY,
+        ) as client:
+            async with client.stream(
+                "GET",
+                url,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; WegentBot/1.0; +https://wegent.ai)",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.5",
+                },
+            ) as response:
+                # Re-validate the final URL after redirects
+                final_url = str(response.url)
+                if final_url != url and not _validate_url_for_ssrf(final_url):
+                    logger.warning(
+                        f"Blocked redirect to internal URL: {url} -> {final_url}"
+                    )
+                    return {"success": False}
+
+                # Check content type
+                content_type = response.headers.get("content-type", "")
+                if (
+                    "text/html" not in content_type
+                    and "application/xhtml" not in content_type
+                ):
+                    return {"success": True}
+
+                # Read limited content
+                content_bytes = b""
+                async for chunk in response.aiter_bytes():
+                    content_bytes += chunk
+                    if len(content_bytes) > MAX_CONTENT_SIZE:
+                        break
+
+                html = content_bytes.decode("utf-8", errors="ignore")
+
+        # Extract metadata
+        title = _extract_title(html)
+        description = _extract_description(html)
+        image = _extract_og_image(html, url)
+        favicon = _extract_favicon(html, url)
+        site_name = _extract_site_name(html)
+
+        # Truncate long descriptions
+        if description and len(description) > 200:
+            description = description[:197] + "..."
+
+        return {
+            "title": title,
+            "description": description,
+            "image": image,
+            "favicon": favicon,
+            "site_name": site_name,
+            "success": True,
+        }
+
+    except httpx.TimeoutException:
+        logger.warning(f"Timeout fetching link preview: {url}")
+        return {"success": False}
+    except httpx.RequestError as e:
+        logger.warning(f"Error fetching link preview: {url} - {e}")
+        return {"success": False}
+    except Exception as e:
+        logger.error(f"Unexpected error fetching link preview: {url} - {e}")
+        return {"success": False}

--- a/backend/app/services/link_preview.py
+++ b/backend/app/services/link_preview.py
@@ -162,6 +162,19 @@ async def fetch_link_preview(url: str) -> LinkPreviewResult:
     Returns:
         LinkPreviewResult with title, description, image, etc.
     """
+    # If Browserless is disabled, return failure to trigger fallback to plain URL
+    if not settings.BROWSERLESS_ENABLED or not settings.BROWSERLESS_URL:
+        logger.warning("Browserless is disabled, returning failure for link preview")
+        return LinkPreviewResult(
+            url=url,
+            title=None,
+            description=None,
+            image=None,
+            favicon=None,
+            site_name=None,
+            success=False,
+        )
+
     # Check cache first
     redis_client = _get_redis_client()
     if redis_client:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,26 @@ services:
       retries: 5
       start_period: 40s
 
+  browserless:
+    image: browserless/chrome
+    container_name: wegent-browserless
+    restart: always
+    profiles:
+      - browserless
+    ports:
+      - "8910:3000"
+    environment:
+      - MAX_CONCURRENT_SESSIONS=10
+      - CONNECTION_TIMEOUT=60000
+    networks:
+      - wegent-network
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/pressure || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
   backend:
     # build:
       # dockerfile: docker/backend/Dockerfile

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /* tslint:disable */
 
 /**
@@ -73,7 +74,7 @@ addEventListener('message', async function (event) {
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
-      const remainingClients = allClients.filter(client => {
+      const remainingClients = allClients.filter((client) => {
         return client.id !== clientId
       })
 
@@ -97,7 +98,10 @@ addEventListener('fetch', function (event) {
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
     return
   }
 
@@ -120,7 +124,12 @@ addEventListener('fetch', function (event) {
 async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId, requestInterceptedAt)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -150,7 +159,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : []
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
     )
   }
 
@@ -181,11 +190,11 @@ async function resolveMainClient(event) {
   })
 
   return allClients
-    .filter(client => {
+    .filter((client) => {
       // Get only those clients that are currently visible.
       return client.visibilityState === 'visible'
     })
-    .find(client => {
+    .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
       return activeClientIds.has(client.id)
@@ -214,8 +223,10 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
     // user-defined CORS policies.
     const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map(value => value.trim())
-      const filteredValues = values.filter(value => value !== 'msw/passthrough')
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
 
       if (filteredValues.length > 0) {
         headers.set('accept', filteredValues.join(', '))
@@ -252,7 +263,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
         ...serializedRequest,
       },
     },
-    [serializedRequest.body]
+    [serializedRequest.body],
   )
 
   switch (clientMessage.type) {
@@ -278,7 +289,7 @@ function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
 
-    channel.port1.onmessage = event => {
+    channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
         return reject(event.data.error)
       }
@@ -286,7 +297,10 @@ function sendToClient(client, message, transferrables = []) {
       resolve(event.data)
     }
 
-    client.postMessage(message, [channel.port2, ...transferrables.filter(Boolean)])
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
   })
 }
 

--- a/frontend/src/components/common/LinkPreviewCard.tsx
+++ b/frontend/src/components/common/LinkPreviewCard.tsx
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useMemo } from 'react'
+import { ExternalLink, Globe, Loader2, Play, ImageIcon } from 'lucide-react'
+import { useLinkPreview, type LinkPreviewType } from '@/hooks/useLinkPreview'
+
+interface LinkPreviewCardProps {
+  /** The URL to display as a preview card */
+  url: string
+  /**
+   * Whether to disable metadata fetching.
+   * When true, renders as a simple link without fetching metadata.
+   * Useful during streaming to avoid excessive API calls.
+   */
+  disabled?: boolean
+}
+
+/**
+ * Extract domain from URL for display
+ */
+function getDomain(url: string): string {
+  try {
+    const urlObj = new URL(url)
+    return urlObj.hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Get icon for content type
+ */
+function TypeIcon({ type }: { type: LinkPreviewType }) {
+  switch (type) {
+    case 'video':
+      return (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 rounded-l-lg">
+          <div className="w-10 h-10 rounded-full bg-white/90 flex items-center justify-center">
+            <Play className="w-5 h-5 text-text-primary fill-current ml-0.5" />
+          </div>
+        </div>
+      )
+    case 'image':
+      return null // Image type shows the full image without overlay
+    default:
+      return null
+  }
+}
+
+/**
+ * Skeleton loader for the card
+ */
+function CardSkeleton() {
+  return (
+    <span className="block my-2 rounded-lg border border-border bg-surface animate-pulse w-full max-w-md overflow-hidden">
+      <span className="flex">
+        {/* Thumbnail skeleton */}
+        <span className="w-[120px] h-[90px] bg-muted flex-shrink-0" />
+        {/* Content skeleton */}
+        <span className="flex-1 p-3 space-y-2">
+          <span className="block h-4 bg-muted rounded w-3/4" />
+          <span className="block h-3 bg-muted rounded w-full" />
+          <span className="block h-3 bg-muted rounded w-1/3" />
+        </span>
+      </span>
+    </span>
+  )
+}
+
+/**
+ * Simple link fallback component
+ */
+function SimpleLinkFallback({ url, children }: { url: string; children?: React.ReactNode }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 text-primary hover:underline hover:!decoration-current text-sm break-all"
+    >
+      <Globe className="h-4 w-4 flex-shrink-0" />
+      <span>{children || url}</span>
+      <ExternalLink className="h-3 w-3 flex-shrink-0" />
+    </a>
+  )
+}
+
+/**
+ * LinkPreviewCard component for rendering URLs as rich horizontal preview cards.
+ *
+ * Features:
+ * - Horizontal layout with thumbnail on left
+ * - Supports website, image, and video URL types
+ * - Video URLs show play button overlay on thumbnail
+ * - Loading skeleton state
+ * - Graceful fallback to simple link on error
+ *
+ * @param disabled - When true, skips metadata fetching and renders as simple link.
+ */
+export default function LinkPreviewCard({ url, disabled = false }: LinkPreviewCardProps) {
+  // Only fetch preview when not disabled
+  const { data, isLoading, error } = useLinkPreview(disabled ? '' : url)
+  const domain = useMemo(() => getDomain(url), [url])
+
+  // When disabled, render as simple link
+  if (disabled) {
+    return <SimpleLinkFallback url={url} />
+  }
+
+  // Loading state
+  if (isLoading) {
+    return <CardSkeleton />
+  }
+
+  // Error state or no data - fallback to simple link
+  if (error || !data?.success) {
+    return <SimpleLinkFallback url={url} />
+  }
+
+  // Image type - render full image preview
+  if (data.type === 'image') {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block my-2 rounded-lg border border-border bg-surface hover:border-primary/50 transition-all overflow-hidden w-full max-w-md group"
+      >
+        <span className="block relative">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={data.image || url}
+            alt=""
+            className="w-full h-auto max-h-[300px] object-contain bg-muted"
+            onError={e => {
+              const img = e.target as HTMLImageElement
+              img.style.display = 'none'
+            }}
+          />
+          <span className="absolute bottom-2 right-2 flex items-center gap-1 px-2 py-1 rounded bg-black/60 text-white text-xs">
+            <ImageIcon className="w-3 h-3" />
+            <span>{domain}</span>
+          </span>
+        </span>
+      </a>
+    )
+  }
+
+  // Website or video type - render horizontal card
+  const hasThumbnail = !!data.image
+  const displayTitle = data.title || domain
+  const displaySiteName = data.site_name || domain
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block my-2 rounded-lg border border-border bg-surface hover:bg-muted/50 hover:border-primary/50 hover:!no-underline transition-all overflow-hidden w-full max-w-md group"
+    >
+      <span className="flex">
+        {/* Thumbnail area */}
+        {hasThumbnail ? (
+          <span className="relative flex-shrink-0 w-[120px] h-[90px] bg-muted overflow-hidden">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={data.image!}
+              alt=""
+              className="w-full h-full object-cover"
+              onError={e => {
+                const img = e.target as HTMLImageElement
+                img.style.display = 'none'
+              }}
+            />
+            <TypeIcon type={data.type} />
+          </span>
+        ) : (
+          <span className="relative flex-shrink-0 w-[120px] h-[90px] bg-muted flex items-center justify-center">
+            {data.favicon ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.favicon}
+                alt=""
+                className="w-10 h-10 object-contain"
+                onError={e => {
+                  const img = e.target as HTMLImageElement
+                  img.style.display = 'none'
+                  const parent = img.parentElement
+                  if (parent) {
+                    const fallback = document.createElement('span')
+                    fallback.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="text-text-muted"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`
+                    parent.appendChild(fallback)
+                  }
+                }}
+              />
+            ) : (
+              <Globe className="w-8 h-8 text-text-muted" />
+            )}
+            {data.type === 'video' && <TypeIcon type={data.type} />}
+          </span>
+        )}
+
+        {/* Content area */}
+        <span className="flex-1 min-w-0 p-3 flex flex-col justify-center space-y-1">
+          {/* Title - single line with truncation */}
+          <span className="block text-sm font-medium text-text-primary truncate group-hover:text-primary transition-colors">
+            {displayTitle}
+          </span>
+
+          {/* Description - max 2 lines */}
+          {data.description && (
+            <span className="block text-xs text-text-muted line-clamp-2">{data.description}</span>
+          )}
+
+          {/* Site name / domain */}
+          <span className="flex items-center gap-1 text-xs text-text-muted">
+            {data.favicon && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.favicon}
+                alt=""
+                className="w-3 h-3 rounded-sm"
+                onError={e => {
+                  ;(e.target as HTMLImageElement).style.display = 'none'
+                }}
+              />
+            )}
+            <span className="truncate">{displaySiteName}</span>
+            <ExternalLink className="h-3 w-3 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
+          </span>
+        </span>
+      </span>
+    </a>
+  )
+}
+
+/**
+ * Inline loading indicator for streaming state
+ */
+export function LinkPreviewCardLoading() {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-text-muted text-sm">
+      <Loader2 className="h-3 w-3 animate-spin" />
+      <span>Loading preview...</span>
+    </span>
+  )
+}

--- a/frontend/src/components/common/LinkPreviewCard.tsx
+++ b/frontend/src/components/common/LinkPreviewCard.tsx
@@ -5,8 +5,8 @@
 'use client'
 
 import React, { useMemo } from 'react'
-import { ExternalLink, Globe, Loader2, Play, ImageIcon } from 'lucide-react'
-import { useLinkPreview, type LinkPreviewType } from '@/hooks/useLinkPreview'
+import { ExternalLink, Globe, Loader2 } from 'lucide-react'
+import { useLinkPreview } from '@/hooks/useLinkPreview'
 
 interface LinkPreviewCardProps {
   /** The URL to display as a preview card */
@@ -32,41 +32,21 @@ function getDomain(url: string): string {
 }
 
 /**
- * Get icon for content type
- */
-function TypeIcon({ type }: { type: LinkPreviewType }) {
-  switch (type) {
-    case 'video':
-      return (
-        <div className="absolute inset-0 flex items-center justify-center bg-black/40 rounded-l-lg">
-          <div className="w-10 h-10 rounded-full bg-white/90 flex items-center justify-center">
-            <Play className="w-5 h-5 text-text-primary fill-current ml-0.5" />
-          </div>
-        </div>
-      )
-    case 'image':
-      return null // Image type shows the full image without overlay
-    default:
-      return null
-  }
-}
-
-/**
- * Skeleton loader for the card
+ * Skeleton loader for the card - vertical layout
  */
 function CardSkeleton() {
   return (
-    <span className="block my-2 rounded-lg border border-border bg-surface animate-pulse w-full max-w-md overflow-hidden">
-      <span className="flex">
-        {/* Thumbnail skeleton */}
-        <span className="w-[120px] h-[90px] bg-muted flex-shrink-0" />
-        {/* Content skeleton */}
-        <span className="flex-1 p-3 space-y-2">
-          <span className="block h-4 bg-muted rounded w-3/4" />
-          <span className="block h-3 bg-muted rounded w-full" />
-          <span className="block h-3 bg-muted rounded w-1/3" />
+    <span className="block my-3 rounded-xl border border-border bg-surface animate-pulse w-full max-w-lg overflow-hidden shadow-sm">
+      {/* Header skeleton */}
+      <span className="flex items-center gap-2 p-3 border-b border-border">
+        <span className="w-5 h-5 bg-muted rounded" />
+        <span className="flex-1 space-y-1">
+          <span className="block h-4 bg-muted rounded w-1/3" />
+          <span className="block h-3 bg-muted rounded w-2/3" />
         </span>
       </span>
+      {/* Screenshot skeleton */}
+      <span className="block h-[240px] bg-muted" />
     </span>
   )
 }
@@ -90,12 +70,11 @@ function SimpleLinkFallback({ url, children }: { url: string; children?: React.R
 }
 
 /**
- * LinkPreviewCard component for rendering URLs as rich horizontal preview cards.
+ * LinkPreviewCard component for rendering URLs as rich preview cards.
  *
  * Features:
- * - Horizontal layout with thumbnail on left
- * - Supports website, image, and video URL types
- * - Video URLs show play button overlay on thumbnail
+ * - Vertical layout with header and large screenshot
+ * - Header shows favicon, title, and domain
  * - Loading skeleton state
  * - Graceful fallback to simple link on error
  *
@@ -121,119 +100,80 @@ export default function LinkPreviewCard({ url, disabled = false }: LinkPreviewCa
     return <SimpleLinkFallback url={url} />
   }
 
-  // Image type - render full image preview
-  if (data.type === 'image') {
-    return (
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block my-2 rounded-lg border border-border bg-surface hover:border-primary/50 transition-all overflow-hidden w-full max-w-md group"
-      >
-        <span className="block relative">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={data.image || url}
-            alt=""
-            className="w-full h-auto max-h-[300px] object-contain bg-muted"
-            onError={e => {
-              const img = e.target as HTMLImageElement
-              img.style.display = 'none'
-            }}
-          />
-          <span className="absolute bottom-2 right-2 flex items-center gap-1 px-2 py-1 rounded bg-black/60 text-white text-xs">
-            <ImageIcon className="w-3 h-3" />
-            <span>{domain}</span>
-          </span>
-        </span>
-      </a>
-    )
-  }
-
-  // Website or video type - render horizontal card
-  const hasThumbnail = !!data.image
+  // Website card - render vertical card with header and screenshot
+  const hasScreenshot = !!data.image
   const displayTitle = data.title || domain
-  const displaySiteName = data.site_name || domain
 
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="block my-2 rounded-lg border border-border bg-surface hover:bg-muted/50 hover:border-primary/50 hover:!no-underline transition-all overflow-hidden w-full max-w-md group"
+      className="block my-3 rounded-xl border border-border bg-surface hover:border-primary/50 hover:shadow-md hover:!no-underline transition-all overflow-hidden w-full max-w-lg group shadow-sm"
     >
-      <span className="flex">
-        {/* Thumbnail area */}
-        {hasThumbnail ? (
-          <span className="relative flex-shrink-0 w-[120px] h-[90px] bg-muted overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
+      {/* Header section */}
+      <span className="flex items-center gap-2.5 px-3 py-2.5 border-b border-border bg-surface">
+        {/* Favicon */}
+        <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center">
+          {data.favicon ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
-              src={data.image!}
+              src={data.favicon}
               alt=""
-              className="w-full h-full object-cover"
+              className="w-5 h-5 rounded object-contain"
               onError={e => {
                 const img = e.target as HTMLImageElement
                 img.style.display = 'none'
+                const parent = img.parentElement
+                if (parent) {
+                  parent.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="text-text-muted"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`
+                }
               }}
             />
-            <TypeIcon type={data.type} />
-          </span>
-        ) : (
-          <span className="relative flex-shrink-0 w-[120px] h-[90px] bg-muted flex items-center justify-center">
-            {data.favicon ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={data.favicon}
-                alt=""
-                className="w-10 h-10 object-contain"
-                onError={e => {
-                  const img = e.target as HTMLImageElement
-                  img.style.display = 'none'
-                  const parent = img.parentElement
-                  if (parent) {
-                    const fallback = document.createElement('span')
-                    fallback.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="text-text-muted"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>`
-                    parent.appendChild(fallback)
-                  }
-                }}
-              />
-            ) : (
-              <Globe className="w-8 h-8 text-text-muted" />
-            )}
-            {data.type === 'video' && <TypeIcon type={data.type} />}
-          </span>
-        )}
+          ) : (
+            <Globe className="w-[18px] h-[18px] text-text-muted" />
+          )}
+        </span>
 
-        {/* Content area */}
-        <span className="flex-1 min-w-0 p-3 flex flex-col justify-center space-y-1">
-          {/* Title - single line with truncation */}
+        {/* Title and domain */}
+        <span className="flex-1 min-w-0">
           <span className="block text-sm font-medium text-text-primary truncate group-hover:text-primary transition-colors">
             {displayTitle}
           </span>
-
-          {/* Description - max 2 lines */}
-          {data.description && (
-            <span className="block text-xs text-text-muted line-clamp-2">{data.description}</span>
-          )}
-
-          {/* Site name / domain */}
           <span className="flex items-center gap-1 text-xs text-text-muted">
-            {data.favicon && (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img
-                src={data.favicon}
-                alt=""
-                className="w-3 h-3 rounded-sm"
-                onError={e => {
-                  ;(e.target as HTMLImageElement).style.display = 'none'
-                }}
-              />
-            )}
-            <span className="truncate">{displaySiteName}</span>
+            <span className="truncate">{domain}</span>
             <ExternalLink className="h-3 w-3 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
           </span>
         </span>
       </span>
+
+      {/* Screenshot area */}
+      {hasScreenshot ? (
+        <span className="block relative bg-muted">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={data.image!}
+            alt=""
+            className="w-full h-auto max-h-[300px] object-cover object-top"
+            onError={e => {
+              const img = e.target as HTMLImageElement
+              img.style.display = 'none'
+            }}
+          />
+        </span>
+      ) : (
+        // No screenshot - show placeholder
+        <span className="block h-[120px] bg-muted/50 flex items-center justify-center">
+          <Globe className="w-10 h-10 text-text-muted/50" />
+        </span>
+      )}
+
+      {/* Description section (if available) */}
+      {data.description && (
+        <span className="block px-3 py-2 border-t border-border">
+          <span className="block text-xs text-text-muted line-clamp-2">{data.description}</span>
+        </span>
+      )}
     </a>
   )
 }

--- a/frontend/src/components/common/MarkdownWithMermaid.tsx
+++ b/frontend/src/components/common/MarkdownWithMermaid.tsx
@@ -83,7 +83,9 @@ function parseContentParts(source: string): ContentPart[] {
 
   // Combined regex to match both mermaid blocks and card syntax
   // Card syntax: [card:url] where url is an http(s) URL
-  const specialBlockRegex = /```mermaid\s*\n([\s\S]*?)```|\[card:(https?:\/\/[^\]\s]+)\]/g
+  // - Case insensitive for "card" keyword (Card, CARD, card all work)
+  // - Allows optional whitespace after the colon
+  const specialBlockRegex = /```mermaid\s*\n([\s\S]*?)```|\[[cC][aA][rR][dD]:\s*(https?:\/\/[^\]\s]+)\]/g
 
   let lastIndex = 0
   let match

--- a/frontend/src/components/common/MarkdownWithMermaid.tsx
+++ b/frontend/src/components/common/MarkdownWithMermaid.tsx
@@ -21,66 +21,140 @@ const MermaidDiagram = dynamic(() => import('./MermaidDiagram'), {
   ),
 })
 
+// Dynamically import LinkPreviewCard to avoid SSR issues
+const LinkPreviewCard = dynamic(() => import('./LinkPreviewCard'), {
+  ssr: false,
+  loading: () => (
+    <span className="block my-2 rounded-lg border border-border bg-surface animate-pulse w-full max-w-md overflow-hidden">
+      <span className="flex">
+        <span className="w-[120px] h-[90px] bg-muted flex-shrink-0" />
+        <span className="flex-1 p-3 space-y-2">
+          <span className="block h-4 bg-muted rounded w-3/4" />
+          <span className="block h-3 bg-muted rounded w-full" />
+          <span className="block h-3 bg-muted rounded w-1/3" />
+        </span>
+      </span>
+    </span>
+  ),
+})
+
+/** Content part types for markdown parsing */
+type ContentPartType = 'markdown' | 'mermaid' | 'card'
+
+interface ContentPart {
+  type: ContentPartType
+  content: string
+}
+
 interface MarkdownWithMermaidProps {
   source: string
   theme: 'light' | 'dark'
   /** Custom components to override default rendering */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components?: Record<string, React.ComponentType<any>>
+  /**
+   * Whether to disable link preview fetching.
+   * Useful during streaming to avoid excessive API calls.
+   */
+  disableLinkPreview?: boolean
 }
 
 /**
- * Enhanced Markdown renderer with Mermaid diagram support
+ * Check if a URL is valid for card rendering
+ */
+function isValidCardUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url)
+    return urlObj.protocol === 'http:' || urlObj.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse source to extract special blocks (mermaid, card) and regular markdown
  *
- * Detects ```mermaid code blocks and renders them using MermaidDiagram component.
- * All other markdown is rendered using the standard MarkdownEditor.Markdown.
+ * Supports:
+ * - ```mermaid code blocks for diagrams
+ * - [card:url] syntax for rich link preview cards
+ */
+function parseContentParts(source: string): ContentPart[] {
+  const parts: ContentPart[] = []
+
+  // Combined regex to match both mermaid blocks and card syntax
+  // Card syntax: [card:url] where url is an http(s) URL
+  const specialBlockRegex = /```mermaid\s*\n([\s\S]*?)```|\[card:(https?:\/\/[^\]\s]+)\]/g
+
+  let lastIndex = 0
+  let match
+
+  while ((match = specialBlockRegex.exec(source)) !== null) {
+    // Add markdown content before this special block
+    if (match.index > lastIndex) {
+      const markdownContent = source.slice(lastIndex, match.index)
+      if (markdownContent.trim()) {
+        parts.push({ type: 'markdown', content: markdownContent })
+      }
+    }
+
+    // Check which type of block was matched
+    if (match[1] !== undefined) {
+      // Mermaid block matched (group 1)
+      const mermaidCode = match[1].trim()
+      if (mermaidCode) {
+        parts.push({ type: 'mermaid', content: mermaidCode })
+      }
+    } else if (match[2] !== undefined) {
+      // Card syntax matched (group 2)
+      const cardUrl = match[2].trim()
+      if (cardUrl && isValidCardUrl(cardUrl)) {
+        parts.push({ type: 'card', content: cardUrl })
+      } else {
+        // Invalid URL - treat as regular text
+        parts.push({ type: 'markdown', content: match[0] })
+      }
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  // Add remaining markdown content after the last special block
+  if (lastIndex < source.length) {
+    const remainingContent = source.slice(lastIndex)
+    if (remainingContent.trim()) {
+      parts.push({ type: 'markdown', content: remainingContent })
+    }
+  }
+
+  // If no special blocks found, return the entire source as markdown
+  if (parts.length === 0 && source.trim()) {
+    parts.push({ type: 'markdown', content: source })
+  }
+
+  return parts
+}
+
+/**
+ * Enhanced Markdown renderer with Mermaid diagram and Link Preview Card support
+ *
+ * Features:
+ * - Detects ```mermaid code blocks and renders them using MermaidDiagram component
+ * - Detects [card:url] syntax and renders rich link preview cards
+ * - All other markdown is rendered using the standard MarkdownEditor.Markdown
+ *
+ * Card Syntax:
+ * - Format: [card:url]
+ * - Example: [card:https://github.com/wecode-ai/Wegent]
+ * - Supports: websites with Open Graph metadata, images, video platforms (YouTube, Bilibili, Vimeo)
  */
 export const MarkdownWithMermaid = memo(function MarkdownWithMermaid({
   source,
   theme,
   components,
+  disableLinkPreview = false,
 }: MarkdownWithMermaidProps) {
-  // Parse the source to extract mermaid blocks and regular content
-  const contentParts = useMemo(() => {
-    const parts: Array<{ type: 'markdown' | 'mermaid'; content: string }> = []
-    const mermaidRegex = /```mermaid\s*\n([\s\S]*?)```/g
-
-    let lastIndex = 0
-    let match
-
-    while ((match = mermaidRegex.exec(source)) !== null) {
-      // Add markdown content before this mermaid block
-      if (match.index > lastIndex) {
-        const markdownContent = source.slice(lastIndex, match.index)
-        if (markdownContent.trim()) {
-          parts.push({ type: 'markdown', content: markdownContent })
-        }
-      }
-
-      // Add the mermaid block
-      const mermaidCode = match[1].trim()
-      if (mermaidCode) {
-        parts.push({ type: 'mermaid', content: mermaidCode })
-      }
-
-      lastIndex = match.index + match[0].length
-    }
-
-    // Add remaining markdown content after the last mermaid block
-    if (lastIndex < source.length) {
-      const remainingContent = source.slice(lastIndex)
-      if (remainingContent.trim()) {
-        parts.push({ type: 'markdown', content: remainingContent })
-      }
-    }
-
-    // If no mermaid blocks found, return the entire source as markdown
-    if (parts.length === 0 && source.trim()) {
-      parts.push({ type: 'markdown', content: source })
-    }
-
-    return parts
-  }, [source])
+  // Parse the source to extract special blocks and regular content
+  const contentParts = useMemo(() => parseContentParts(source), [source])
 
   // Default components with link handling
   const defaultComponents = useMemo(
@@ -95,8 +169,11 @@ export const MarkdownWithMermaid = memo(function MarkdownWithMermaid({
     [components]
   )
 
-  // If no mermaid blocks, render normally
-  if (contentParts.length === 1 && contentParts[0].type === 'markdown') {
+  // Check if we have any special blocks
+  const hasSpecialBlocks = contentParts.some(part => part.type !== 'markdown')
+
+  // If no special blocks, render normally (optimized path)
+  if (!hasSpecialBlocks && contentParts.length === 1) {
     return (
       <MarkdownEditor.Markdown
         source={source}
@@ -107,12 +184,22 @@ export const MarkdownWithMermaid = memo(function MarkdownWithMermaid({
     )
   }
 
-  // Render mixed content with mermaid diagrams
+  // Render mixed content with special blocks
   return (
     <div className="markdown-with-mermaid">
       {contentParts.map((part, index) => {
         if (part.type === 'mermaid') {
           return <MermaidDiagram key={`mermaid-${index}`} code={part.content} />
+        }
+
+        if (part.type === 'card') {
+          return (
+            <LinkPreviewCard
+              key={`card-${index}`}
+              url={part.content}
+              disabled={disableLinkPreview}
+            />
+          )
         }
 
         return (

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -502,6 +502,7 @@ const MessageBubble = memo(
         <MarkdownWithMermaid
           source={normalizedResult}
           theme={theme}
+          disableLinkPreview={isStreaming}
           components={
             paragraphAction
               ? {
@@ -1299,6 +1300,7 @@ const MessageBubble = memo(
               <MarkdownWithMermaid
                 source={contentToRender}
                 theme={theme}
+                disableLinkPreview={isStreaming}
                 components={{
                   a: ({ href, children }) => {
                     if (!href) {

--- a/frontend/src/hooks/useLinkPreview.ts
+++ b/frontend/src/hooks/useLinkPreview.ts
@@ -7,8 +7,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { apiClient } from '@/apis/client'
 
-export type LinkPreviewType = 'website' | 'image' | 'video'
-
 export interface LinkPreviewData {
   url: string
   title: string | null
@@ -16,7 +14,6 @@ export interface LinkPreviewData {
   image: string | null
   favicon: string | null
   site_name: string | null
-  type: LinkPreviewType
   success: boolean
 }
 
@@ -130,7 +127,6 @@ export function useLinkPreview(url: string): UseLinkPreviewResult {
           image: null,
           favicon: null,
           site_name: null,
-          type: 'website',
           success: false,
         }
         previewCache.set(url, failedResult)

--- a/frontend/src/hooks/useLinkPreview.ts
+++ b/frontend/src/hooks/useLinkPreview.ts
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import { apiClient } from '@/apis/client'
+
+export type LinkPreviewType = 'website' | 'image' | 'video'
+
+export interface LinkPreviewData {
+  url: string
+  title: string | null
+  description: string | null
+  image: string | null
+  favicon: string | null
+  site_name: string | null
+  type: LinkPreviewType
+  success: boolean
+}
+
+interface UseLinkPreviewResult {
+  data: LinkPreviewData | null
+  isLoading: boolean
+  error: Error | null
+}
+
+// In-memory cache for link preview data
+const previewCache = new Map<string, LinkPreviewData>()
+
+// Track pending requests to avoid duplicate fetches
+const pendingRequests = new Map<string, Promise<LinkPreviewData>>()
+
+/**
+ * Custom hook to fetch link preview data from the backend API.
+ * Includes caching and deduplication of requests.
+ *
+ * @param url - The URL to fetch preview for (empty string to skip)
+ * @returns Object containing data, isLoading state, and error
+ */
+export function useLinkPreview(url: string): UseLinkPreviewResult {
+  const [data, setData] = useState<LinkPreviewData | null>(() => {
+    // Check cache on initial render
+    return previewCache.get(url) || null
+  })
+  const [isLoading, setIsLoading] = useState(!previewCache.has(url) && !!url)
+  const [error, setError] = useState<Error | null>(null)
+  const mountedRef = useRef(false)
+
+  // Separate effect for mount/unmount tracking
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    // Skip if URL is empty or invalid
+    if (!url || !url.startsWith('http')) {
+      setIsLoading(false)
+      if (url) {
+        setError(new Error('Invalid URL'))
+      }
+      return
+    }
+
+    // Return cached result if available
+    const cached = previewCache.get(url)
+    if (cached) {
+      setData(cached)
+      setIsLoading(false)
+      return
+    }
+
+    // Check if there's already a pending request for this URL
+    const pendingRequest = pendingRequests.get(url)
+    if (pendingRequest) {
+      setIsLoading(true)
+      pendingRequest
+        .then(result => {
+          if (mountedRef.current) {
+            setData(result)
+            setIsLoading(false)
+          }
+        })
+        .catch(err => {
+          if (mountedRef.current) {
+            setError(err)
+            setIsLoading(false)
+          }
+        })
+      return
+    }
+
+    // Create new request
+    setIsLoading(true)
+    setError(null)
+
+    const fetchPreview = async (): Promise<LinkPreviewData> => {
+      const result = await apiClient.get<LinkPreviewData>(
+        `/utils/link-preview?url=${encodeURIComponent(url)}`
+      )
+      return result
+    }
+
+    const request = fetchPreview()
+    pendingRequests.set(url, request)
+
+    request
+      .then(result => {
+        // Cache the result
+        previewCache.set(url, result)
+        pendingRequests.delete(url)
+
+        if (mountedRef.current) {
+          setData(result)
+          setIsLoading(false)
+        }
+      })
+      .catch(err => {
+        pendingRequests.delete(url)
+
+        // Cache failed requests to avoid retrying
+        const failedResult: LinkPreviewData = {
+          url,
+          title: null,
+          description: null,
+          image: null,
+          favicon: null,
+          site_name: null,
+          type: 'website',
+          success: false,
+        }
+        previewCache.set(url, failedResult)
+
+        if (mountedRef.current) {
+          setError(err)
+          setData(failedResult)
+          setIsLoading(false)
+        }
+      })
+  }, [url])
+
+  return { data, isLoading, error }
+}
+
+/**
+ * Clear the link preview cache (useful for testing or manual refresh)
+ */
+export function clearLinkPreviewCache(): void {
+  previewCache.clear()
+}
+
+/**
+ * Prefetch link preview for a URL without waiting for result.
+ */
+export function prefetchLinkPreview(url: string): void {
+  if (!url || !url.startsWith('http') || previewCache.has(url) || pendingRequests.has(url)) {
+    return
+  }
+
+  const request = apiClient
+    .get<LinkPreviewData>(`/utils/link-preview?url=${encodeURIComponent(url)}`)
+    .then(result => {
+      previewCache.set(url, result)
+      pendingRequests.delete(url)
+      return result
+    })
+    .catch(() => {
+      const failedResult: LinkPreviewData = {
+        url,
+        title: null,
+        description: null,
+        image: null,
+        favicon: null,
+        site_name: null,
+        type: 'website',
+        success: false,
+      }
+      previewCache.set(url, failedResult)
+      pendingRequests.delete(url)
+      return failedResult
+    })
+
+  pendingRequests.set(url, request)
+}

--- a/frontend/src/hooks/useLinkPreview.ts
+++ b/frontend/src/hooks/useLinkPreview.ts
@@ -172,7 +172,6 @@ export function prefetchLinkPreview(url: string): void {
         image: null,
         favicon: null,
         site_name: null,
-        type: 'website',
         success: false,
       }
       previewCache.set(url, failedResult)


### PR DESCRIPTION
## Summary
- Add new Card message type that renders rich link preview cards when the model outputs content containing `[card:url]` format
- Backend: New `/api/v1/utils/link-preview` API with Open Graph metadata extraction, video platform detection, Redis caching
- Frontend: `LinkPreviewCard` component with horizontal layout, loading skeleton, graceful fallback

## Features
| Feature | Description |
|---------|-------------|
| URL Types | website, image, video |
| Video Platforms | YouTube, Bilibili, Vimeo (thumbnail extraction) |
| Card Syntax | `[card:https://example.com]` |
| Caching | Redis with 24-hour TTL |
| Streaming | Disabled during streaming to avoid excessive API calls |

## Test plan
- [ ] Model outputs `[card:https://github.com]` renders GitHub link preview card
- [ ] Model outputs `[card:https://example.com/image.png]` renders image preview
- [ ] Model outputs `[card:https://youtube.com/watch?v=xxx]` renders video thumbnail + play icon
- [ ] Click Card opens URL in new tab
- [ ] Metadata fetch failure falls back to simple link
- [ ] Card renders skeleton during loading
- [ ] Card style follows Calm UI design (rounded corners, bg-surface, border-border)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link preview API, frontend preview card (with loading helper), client hook for fetch/prefetch, and markdown support for embedded cards with optional disable flag.
* **Behavior**
  * Previews disabled during streaming; client deduplication and in-memory caching to avoid duplicate requests.
* **Bug Fixes / Reliability**
  * Safer proxied request timeouts, robust preview error handling, screenshot fallback when metadata is missing, and cached results.
* **Chores**
  * Browserless screenshot service added with config and local container setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->