### PR TITLE
feat(docker): make docker-compose.yml self-contained for deployment

### DIFF
--- a/backend/init_data/README.md
+++ b/backend/init_data/README.md
@@ -4,6 +4,8 @@
 
 This directory contains YAML configuration files for initializing the Wegent system. The system automatically scans this directory on startup and applies all YAML resources using the batch service API.
 
+**Note**: This directory is **built into the Docker image** by default. Users can deploy Wegent with just the `docker-compose.yml` file - no local code repository required.
+
 ## How It Works
 
 1. **Auto-scan**: On startup, the backend scans `INIT_DATA_DIR` (default: `/app/init_data`) for all `.yaml` and `.yml` files
@@ -131,16 +133,49 @@ status:
 
 ## Docker Integration
 
-The directory is mounted as read-only in `docker-compose.yml`:
+### Self-Contained Deployment
 
-```yaml
-volumes:
-  - ./backend/init_data:/app/init_data:ro
+The `init_data` directory is **built into the Docker image**, allowing users to deploy Wegent with just the `docker-compose.yml` file:
+
+```bash
+# Download docker-compose.yml and start Wegent
+curl -O https://raw.githubusercontent.com/wecode-ai/Wegent/main/docker-compose.yml
+docker-compose up -d
 ```
 
-To add custom resources:
-1. Add YAML files to `backend/init_data/`
-2. Restart the backend container
+No local code repository is required - the image contains all default resources and skills.
+
+### Customizing Init Data
+
+To override the built-in init data with your own configuration:
+
+1. Create a custom directory with your YAML files:
+   ```bash
+   mkdir custom_init_data
+   cp my-custom-resources.yaml custom_init_data/
+   ```
+
+2. Uncomment and modify the volume mount in `docker-compose.yml`:
+   ```yaml
+   backend:
+     volumes:
+       - ./custom_init_data:/app/init_data:ro
+   ```
+
+3. Restart the backend container:
+   ```bash
+   docker-compose restart backend
+   ```
+
+### Environment Variables
+
+Control initialization behavior with these environment variables:
+
+```yaml
+environment:
+  INIT_DATA_ENABLED: "True"   # Enable/disable initialization
+  INIT_DATA_DIR: /app/init_data  # Directory path (default)
+```
 
 ## Advantages
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,8 +73,9 @@ services:
     restart: always
     ports:
       - "8000:8000"
-    volumes:
-      - ./backend/init_data:/app/init_data:ro
+    # volumes:
+      # To customize init data, uncomment the following line to override the built-in data:
+      # - ./custom_init_data:/app/init_data:ro
     environment:
       ENVIRONMENT: development
       DB_AUTO_MIGRATE: "True"
@@ -157,6 +158,7 @@ services:
       - CHAT_SHELL_MODE=http
       - CHAT_SHELL_STORAGE_TYPE=remote
       - CHAT_SHELL_REMOTE_STORAGE_URL=http://backend:8000/api/internal
+      - EXECUTOR_MANAGER_URL=http://executor_manager:8001
       # - CHAT_SHELL_REMOTE_STORAGE_TOKEN=${INTERNAL_SERVICE_TOKEN:-chat-shell-token}
       # OpenTelemetry Configuration (uncomment to enable)
       # - OTEL_ENABLED=true
@@ -186,6 +188,8 @@ services:
     environment:
       - TZ=Asia/Shanghai
       - TASK_API_DOMAIN=http://backend:8000
+      - EXECUTOR_MANAGER_EXTERNAL_URL=http://executor_manager:8001
+      - REDIS_URL=redis://redis:6379/0
       - MAX_CONCURRENT_TASKS=30
       - PORT=8001
       - CALLBACK_HOST=http://executor_manager:8001
@@ -203,6 +207,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:
       - backend
+      - redis
     networks:
       - wegent-network
 

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -33,6 +33,13 @@ COPY backend /app
 # Also copy shared to /app/shared for PYTHONPATH imports
 COPY shared /app/shared
 
+# Copy init_data directory with default resources and skills into the image
+# This includes:
+# - 01-default-resources.yaml: Default Ghost, Model, Shell, Bot, Team resources
+# - 02-public-shells.yaml: Public shell configurations
+# - skills/: Skill packages (mermaid-diagram, wiki_submit, subagent)
+COPY backend/init_data /app/init_data
+
 # Create .env file (if it doesn't exist)
 RUN if [ ! -f .env ]; then cp .env.example .env; fi
 


### PR DESCRIPTION
## Summary

- Add `init_data` directory copy to backend Dockerfile to bundle default resources and skills into the image
- Remove local volume mount from `docker-compose.yml`, keeping commented example for custom configuration
- Update `init_data/README.md` with self-contained deployment instructions and customization guide

## Changes

### 1. Backend Dockerfile (`docker/backend/Dockerfile`)
Added `COPY backend/init_data /app/init_data` to include:
- `01-default-resources.yaml`: Default Ghost, Model, Shell, Bot, Team resources
- `02-public-shells.yaml`: Public shell configurations
- `skills/`: Skill packages (mermaid-diagram, wiki_submit, subagent)

### 2. docker-compose.yml
- Removed `./backend/init_data:/app/init_data:ro` volume mount
- Added commented example for custom init data override

### 3. Documentation (`backend/init_data/README.md`)
- Added self-contained deployment section
- Added customization instructions
- Updated Docker integration documentation

## Test plan

- [ ] Build new backend Docker image and verify init_data is included
- [ ] Deploy using only docker-compose.yml (no local repo) and verify system initializes correctly
- [ ] Test custom init_data override by uncommenting volume mount
- [ ] Verify environment variables INIT_DATA_DIR and INIT_DATA_ENABLED still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker image now includes built-in initialization data for self-contained deployments.
  * Added optional Redis support and service URL configuration for the executor manager to enable cross-service connectivity.
  * Ability to override built-in init data with a custom directory at deployment.

* **Documentation**
  * Updated deployment docs with a "Self-Contained Deployment" narrative, guidance for customizing init data, and environment-driven initialization controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->