### PR TITLE
feat(team): support ClaudeCode type in coordinate mode

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -1650,7 +1650,11 @@ class ClaudeCodeAgent(Agent):
         """
         # Normalize bot name for filename (lowercase, replace spaces/underscores with hyphens)
         raw_name = bot.get("name", "unnamed")
+        bot_id = bot.get("id", "")
         name = raw_name.lower().replace("_", "-").replace(" ", "-")
+        # Append bot ID to prevent filename collisions (e.g., "My Bot" vs "my_bot")
+        if bot_id:
+            name = f"{name}-{bot_id}"
 
         # Get system prompt from bot config
         system_prompt = bot.get("system_prompt", "")

--- a/frontend/src/features/settings/components/TeamEditDialog.tsx
+++ b/frontend/src/features/settings/components/TeamEditDialog.tsx
@@ -16,7 +16,7 @@ import {
 import { Loader2 } from 'lucide-react'
 
 import { Bot, Team } from '@/types/api'
-import { TeamMode, getFilteredBotsForMode, AgentType } from './team-modes'
+import { TeamMode, getFilteredBotsForMode, AgentType, getActualShellType } from './team-modes'
 import { createTeam, updateTeam } from '../services/teams'
 import TeamEditDrawer from './TeamEditDrawer'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -129,7 +129,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
       solo: null,
       pipeline: ['ClaudeCode', 'Agno'],
       route: ['Agno'],
-      coordinate: ['Agno'],
+      coordinate: ['Agno', 'ClaudeCode'],
       collaborate: ['Agno'],
     }
     const allowed = MODE_AGENT_FILTER[mode]
@@ -273,16 +273,41 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
     return leader?.shell_type === 'Dify'
   }, [leaderBotId, filteredBots])
 
+  // Build shell map for looking up actual shell types
+  const shellMap = useMemo(() => {
+    const map = new Map<string, UnifiedShell>()
+    shells.forEach(shell => map.set(shell.name, shell))
+    return map
+  }, [shells])
+
   // Leader change handler
   const onLeaderChange = (botId: number) => {
+    // If new Leader is in selected members, remove it first
     if (selectedBotKeys.some(k => Number(k) === botId)) {
       setSelectedBotKeys(prev => prev.filter(k => Number(k) !== botId))
     }
 
     const newLeader = filteredBots.find((b: Bot) => b.id === botId)
+
+    // Dify Leader does not support members
     if (newLeader?.shell_type === 'Dify') {
       setSelectedBotKeys([])
+      setLeaderBotId(botId)
+      return
     }
+
+    // Get the new Leader's actual shell type
+    const newLeaderShellType = getActualShellType(newLeader?.shell_type || '', shellMap)
+
+    // Clear all selected members that are incompatible with the new Leader type
+    setSelectedBotKeys(prev =>
+      prev.filter(key => {
+        const bot = bots.find(b => b.id === Number(key))
+        if (!bot) return false
+        const botShellType = getActualShellType(bot.shell_type, shellMap)
+        return botShellType === newLeaderShellType
+      })
+    )
 
     setLeaderBotId(botId)
   }
@@ -528,6 +553,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
             <TeamModeEditor
               mode={mode}
               filteredBots={filteredBots}
+              shells={shells}
               setBots={setBots}
               selectedBotKeys={selectedBotKeys}
               setSelectedBotKeys={setSelectedBotKeys}

--- a/frontend/src/features/settings/components/team-edit/TeamModeEditor.tsx
+++ b/frontend/src/features/settings/components/team-edit/TeamModeEditor.tsx
@@ -7,6 +7,7 @@
 import React from 'react'
 import { Label } from '@/components/ui/label'
 import { Bot, Team } from '@/types/api'
+import { UnifiedShell } from '@/apis/shells'
 import { TeamMode, AgentType } from '../team-modes'
 import { useTranslation } from '@/hooks/useTranslation'
 import { BotEditRef } from '../BotEdit'
@@ -19,6 +20,7 @@ import LeaderModeEditor from '../team-modes/LeaderModeEditor'
 interface TeamModeEditorProps {
   mode: TeamMode
   filteredBots: Bot[]
+  shells: UnifiedShell[]
   setBots: React.Dispatch<React.SetStateAction<Bot[]>>
   selectedBotKeys: React.Key[]
   setSelectedBotKeys: React.Dispatch<React.SetStateAction<React.Key[]>>
@@ -48,6 +50,7 @@ interface TeamModeEditorProps {
 export default function TeamModeEditor({
   mode,
   filteredBots,
+  shells,
   setBots,
   selectedBotKeys,
   setSelectedBotKeys,
@@ -122,6 +125,7 @@ export default function TeamModeEditor({
         {(mode === 'route' || mode === 'coordinate' || mode === 'collaborate') && (
           <LeaderModeEditor
             bots={filteredBots}
+            shells={shells}
             selectedBotKeys={selectedBotKeys}
             setSelectedBotKeys={setSelectedBotKeys}
             leaderBotId={leaderBotId}

--- a/frontend/src/features/settings/components/team-modes/index.ts
+++ b/frontend/src/features/settings/components/team-modes/index.ts
@@ -22,13 +22,14 @@ export type AgentType = 'ClaudeCode' | 'Agno' | 'Dify'
  * Mode to supported agent types mapping
  * - solo: All agent types (ClaudeCode, Agno, Dify)
  * - pipeline: ClaudeCode and Agno only (no Dify)
- * - route/coordinate/collaborate: Agno only (multi-agent collaboration modes)
+ * - route/collaborate: Agno only (multi-agent collaboration modes)
+ * - coordinate: Agno and ClaudeCode (supports both agent types)
  */
 const MODE_AGENT_FILTER: Record<TeamMode, AgentType[] | null> = {
   solo: null, // null means all agents are allowed
   pipeline: ['ClaudeCode', 'Agno'],
   route: ['Agno'],
-  coordinate: ['Agno'],
+  coordinate: ['Agno', 'ClaudeCode'],
   collaborate: ['Agno'],
 }
 
@@ -41,7 +42,7 @@ const MODE_AGENT_FILTER: Record<TeamMode, AgentType[] | null> = {
  * @param shellMap - Map of shell name to UnifiedShell object
  * @returns The actual shell type (ClaudeCode, Agno, Dify, etc.)
  */
-function getActualShellType(shellType: string, shellMap: Map<string, UnifiedShell>): string {
+export function getActualShellType(shellType: string, shellMap: Map<string, UnifiedShell>): string {
   // First check if shellType is already a known agent type
   const knownAgentTypes: AgentType[] = ['ClaudeCode', 'Agno', 'Dify']
   if (knownAgentTypes.includes(shellType as AgentType)) {


### PR DESCRIPTION
## Summary

- Allow ClaudeCode bots to be selected as Leader in coordinate mode (in addition to Agno)
- Filter member bots to match Leader's shell type - members must have the same type as Leader
- Auto-clear incompatible members when switching Leader type
- Generate SubAgent config files (`.claude/agents/*.md`) for coordinate mode execution in Executor

## Changes

### Frontend Changes

1. **team-modes/index.ts**:
   - Update `MODE_AGENT_FILTER` to allow `['Agno', 'ClaudeCode']` for coordinate mode
   - Export `getActualShellType` function for use in other components

2. **team-modes/LeaderModeEditor.tsx**:
   - Add `shells` prop to resolve custom shell types
   - Add `filteredMemberBots` computed property that filters bots based on Leader's shell type
   - Pass filtered bots to `BotTransfer` component

3. **team-edit/TeamModeEditor.tsx**:
   - Add `shells` prop and pass to `LeaderModeEditor`

4. **TeamEditDialog.tsx**:
   - Pass `shells` to `TeamModeEditor`
   - Update `onLeaderChange` to clear incompatible members when Leader type changes
   - Update local `MODE_AGENT_FILTER` to match coordinate mode support

### Backend Changes (Executor)

5. **claude_code_agent.py**:
   - Add `_setup_coordinate_mode()` method called during pre_execute
   - Add `_generate_subagent_file()` method to create SubAgent config files
   - Generated files are placed in `.claude/agents/` directory
   - Files include YAML frontmatter with name, description, and `model: inherit`
   - Add `.claude/agents/` to git exclude to prevent showing in git diff

## Test plan

- [ ] Select coordinate mode and verify ClaudeCode bots can be selected as Leader
- [ ] After selecting ClaudeCode Leader, verify member list only shows ClaudeCode bots
- [ ] After selecting Agno Leader, verify member list only shows Agno bots
- [ ] Switch Leader type and verify incompatible members are auto-cleared
- [ ] Execute coordinate mode task and verify `.claude/agents/*.md` files are generated
- [ ] Verify generated files contain correct YAML frontmatter and system prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinate mode now auto-generates per-agent configurations for team members.
  * ClaudeCode agents are supported in coordinate mode (previously Agno-only).
  * Team member selection is shell-type aware, ensuring members match the chosen leader.
  * Team settings UI now passes shell info so leader changes preserve special-case behaviors (e.g., Dify).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->