### PR TITLE
fix(e2e): increase timeout for element visibility checks

### DIFF
--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -72,7 +72,7 @@ test.describe('Authentication', () => {
     await page.goto('/chat')
 
     // Should redirect to login
-    await page.waitForURL(/\/login/, { timeout: 10000 })
+    await page.waitForURL(/\/login/, { timeout: 20000 })
   })
 })
 
@@ -110,7 +110,7 @@ test.describe('Logout', () => {
     // Logout is in UserMenu dropdown - need to click user name button first
     // UserMenu button is a Menu.Button with rounded-full class containing user display name
     const userMenuButton = page.locator('button.rounded-full').first()
-    await expect(userMenuButton).toBeVisible({ timeout: 10000 })
+    await expect(userMenuButton).toBeVisible({ timeout: 20000 })
     await userMenuButton.click()
 
     // Wait for dropdown menu to appear - Menu.Items has position absolute
@@ -120,10 +120,10 @@ test.describe('Logout', () => {
     // Now logout button should be visible in the dropdown
     // Menu.Items appears after clicking Menu.Button
     const logoutButton = page.locator('button:has-text("Logout"), button:has-text("退出")')
-    await expect(logoutButton).toBeVisible({ timeout: 10000 })
+    await expect(logoutButton).toBeVisible({ timeout: 20000 })
     await logoutButton.click()
 
     // Should redirect to login
-    await page.waitForURL(/\/login/, { timeout: 10000 })
+    await page.waitForURL(/\/login/, { timeout: 20000 })
   })
 })

--- a/frontend/e2e/tests/settings-bot.spec.ts
+++ b/frontend/e2e/tests/settings-bot.spec.ts
@@ -42,7 +42,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Click "Manage Bots" button to open bot list dialog
     const manageBots = page.locator(`button:has-text("${texts.manageBots}")`)
-    await expect(manageBots).toBeVisible({ timeout: 10000 })
+    await expect(manageBots).toBeVisible({ timeout: 20000 })
     await manageBots.click()
 
     // Bot list dialog should open
@@ -59,7 +59,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Open Manage Bots dialog
     const manageBots = page.locator(`button:has-text("${texts.manageBots}")`)
-    await expect(manageBots).toBeVisible({ timeout: 10000 })
+    await expect(manageBots).toBeVisible({ timeout: 20000 })
     await manageBots.click()
 
     // Wait for dialog
@@ -85,7 +85,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Open Manage Bots dialog
     const manageBots = page.locator(`button:has-text("${texts.manageBots}")`)
-    await expect(manageBots).toBeVisible({ timeout: 10000 })
+    await expect(manageBots).toBeVisible({ timeout: 20000 })
     await manageBots.click()
 
     // Wait for dialog
@@ -95,7 +95,7 @@ test.describe('Settings - Bot Management', () => {
     const createButton = page.locator(`[role="dialog"] button:has-text("${texts.newBot}")`)
 
     // Button should be visible
-    await expect(createButton).toBeVisible({ timeout: 10000 })
+    await expect(createButton).toBeVisible({ timeout: 20000 })
     await createButton.click()
 
     // BotEdit component replaces the list content (not a new dialog)
@@ -115,7 +115,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Open Manage Bots dialog
     const manageBots = page.locator(`button:has-text("${texts.manageBots}")`)
-    await expect(manageBots).toBeVisible({ timeout: 10000 })
+    await expect(manageBots).toBeVisible({ timeout: 20000 })
     await manageBots.click()
 
     // Wait for dialog
@@ -123,7 +123,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Click "New Bot" button
     const createButton = page.locator(`[role="dialog"] button:has-text("${texts.newBot}")`)
-    await expect(createButton).toBeVisible({ timeout: 10000 })
+    await expect(createButton).toBeVisible({ timeout: 20000 })
     await createButton.click()
 
     // Wait for BotEdit form
@@ -151,7 +151,7 @@ test.describe('Settings - Bot Management', () => {
 
     // Open Manage Bots dialog
     const manageBots = page.locator(`button:has-text("${texts.manageBots}")`)
-    await expect(manageBots).toBeVisible({ timeout: 10000 })
+    await expect(manageBots).toBeVisible({ timeout: 20000 })
     await manageBots.click()
 
     // Wait for dialog

--- a/frontend/e2e/tests/settings-github.spec.ts
+++ b/frontend/e2e/tests/settings-github.spec.ts
@@ -12,12 +12,12 @@ test.describe('Settings - Git Integration', () => {
     await expect(page).toHaveURL(/\/settings/)
 
     // Wait for integrations content to load - title "Integrations" should be visible
-    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 20000 })
   })
 
   test('should display Git integration section', async ({ page }) => {
     // Look for Git integration section title "Integrations"
-    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 20000 })
   })
 
   test('should display token list or empty state', async ({ page }) => {
@@ -47,13 +47,13 @@ test.describe('Settings - Git Integration', () => {
 
   test('should open add token dialog', async ({ page }) => {
     // Wait for integrations page to load
-    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Integrations")')).toBeVisible({ timeout: 20000 })
 
     // "New Token" button should always be visible after page loads
     const addTokenButton = page.locator('button:has-text("New Token"), button:has-text("新建")')
 
     // Button should be visible - no skip, this is a required UI element
-    await expect(addTokenButton).toBeVisible({ timeout: 10000 })
+    await expect(addTokenButton).toBeVisible({ timeout: 20000 })
 
     await addTokenButton.click()
 
@@ -66,6 +66,6 @@ test.describe('Settings - Git Integration', () => {
     const dialogContent = page.locator(
       '[role="dialog"] .text-xl, [role="dialog"] [class*="DialogTitle"]'
     )
-    await expect(dialogContent.first()).toBeVisible({ timeout: 10000 })
+    await expect(dialogContent.first()).toBeVisible({ timeout: 20000 })
   })
 })

--- a/frontend/e2e/tests/settings-model.spec.ts
+++ b/frontend/e2e/tests/settings-model.spec.ts
@@ -11,7 +11,7 @@ test.describe('Settings - Model Management', () => {
     await expect(page).toHaveURL(/\/settings/)
 
     // Wait for model management title to load
-    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 20000 })
   })
 
   test('should display model list or empty state', async ({ page }) => {
@@ -37,7 +37,7 @@ test.describe('Settings - Model Management', () => {
     )
 
     // Button should be visible - no skip, this is a required UI element
-    await expect(createButton.first()).toBeVisible({ timeout: 10000 })
+    await expect(createButton.first()).toBeVisible({ timeout: 20000 })
 
     await createButton.first().click()
 
@@ -53,7 +53,7 @@ test.describe('Settings - Model Management', () => {
     const createButton = page.locator(
       'button:has-text("Create Model"), button:has-text("新建模型"), button:has-text("Create")'
     )
-    await expect(createButton.first()).toBeVisible({ timeout: 10000 })
+    await expect(createButton.first()).toBeVisible({ timeout: 20000 })
     await createButton.first().click()
 
     // Model edit is a full page form, wait for model ID input
@@ -81,7 +81,7 @@ test.describe('Settings - Model Management', () => {
 
   test('should show test connection button for user models', async ({ page }) => {
     // Wait for page to load
-    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 20000 })
 
     // Test connection button only appears for user models (not public)
     // Check if there are any user model cards with test button
@@ -98,7 +98,7 @@ test.describe('Settings - Model Management', () => {
 
   test('should show delete button for user models', async ({ page }) => {
     // Wait for page to load
-    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Model")')).toBeVisible({ timeout: 20000 })
 
     // Delete button only appears for user models (not public)
     const deleteButton = page.locator('button[title*="Delete"], button:has-text("Delete")').first()

--- a/frontend/e2e/tests/settings-team.spec.ts
+++ b/frontend/e2e/tests/settings-team.spec.ts
@@ -11,7 +11,7 @@ test.describe('Settings - Team Management', () => {
     await expect(page).toHaveURL(/\/settings/)
 
     // Wait for team list title to load
-    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 20000 })
   })
 
   test('should display team list or empty state', async ({ page }) => {
@@ -35,7 +35,7 @@ test.describe('Settings - Team Management', () => {
     const createButton = page.locator('button:has-text("New Team"), button:has-text("新建团队")')
 
     // Button should be visible - no skip, this is a required UI element
-    await expect(createButton).toBeVisible({ timeout: 10000 })
+    await expect(createButton).toBeVisible({ timeout: 20000 })
 
     await createButton.click()
 
@@ -51,7 +51,7 @@ test.describe('Settings - Team Management', () => {
 
     // "New Team" button should always be visible
     const createButton = page.locator('button:has-text("New Team"), button:has-text("新建团队")')
-    await expect(createButton).toBeVisible({ timeout: 10000 })
+    await expect(createButton).toBeVisible({ timeout: 20000 })
     await createButton.click()
 
     // Wait for TeamEdit component (full-page replacement, not dialog)
@@ -78,7 +78,7 @@ test.describe('Settings - Team Management', () => {
 
   test('should show edit and delete buttons for existing teams', async ({ page }) => {
     // Wait for page to load
-    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 20000 })
 
     // Check if there are any teams - if so, edit/delete buttons should exist
     const teamCard = page.locator('[data-testid="team-card"], .team-card').first()


### PR DESCRIPTION
## Summary

- Increase assertion timeout values from 10000ms to 20000ms for waiting on page elements to become visible
- Fixes CI E2E test failures in settings-bot.spec.ts caused by slow API responses in CI environment
- Applied consistent timeout values across related E2E test files

## Changes

1. **settings-bot.spec.ts**: Increased timeout for "Manage Bots" button visibility and "New Bot" button visibility
2. **settings-model.spec.ts**: Increased timeout for Model management page title and Create Model button
3. **settings-team.spec.ts**: Increased timeout for Team list title and New Team button
4. **settings-github.spec.ts**: Increased timeout for Integrations page elements
5. **auth.spec.ts**: Increased timeout for login redirect checks

## Test plan

- [x] All modified timeout values are for element visibility assertions that require API responses
- [x] Short timeouts (3000ms, 5000ms) for optional checks and quick UI feedback remain unchanged
- [ ] CI E2E tests should pass without timeout failures
- [ ] Local E2E tests continue to work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended wait timeouts in end-to-end tests across authentication, bot management, integrations, model settings, and team management features to improve test reliability and reduce timing-related test failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->