### PR TITLE
feat(streaming): add real-time streaming output for Claude Code and Agno shells

### DIFF
--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -54,6 +54,10 @@ class ServerEvents:
     CHAT_BOT_COMPLETE = "chat:bot_complete"
     CHAT_SYSTEM = "chat:system"
 
+    # Tool execution events (to task room)
+    TOOL_START = "tool:start"
+    TOOL_DONE = "tool:done"
+
     # Correction events (to task room)
     CORRECTION_START = "correction:start"
     CORRECTION_PROGRESS = "correction:progress"
@@ -291,6 +295,28 @@ class ChatSystemPayload(BaseModel):
     type: str
     content: str
     data: Optional[Dict[str, Any]] = None
+
+
+class ToolStartPayload(BaseModel):
+    """Payload for tool:start event."""
+
+    task_id: int
+    subtask_id: int
+    tool_id: str = Field(..., description="Unique tool execution ID")
+    tool_name: str = Field(..., description="Name of the tool being executed")
+    tool_input: Dict[str, Any] = Field(
+        default_factory=dict, description="Tool input parameters"
+    )
+
+
+class ToolDonePayload(BaseModel):
+    """Payload for tool:done event."""
+
+    task_id: int
+    subtask_id: int
+    tool_id: str = Field(..., description="Tool execution ID (matches tool:start)")
+    tool_output: Optional[str] = Field(None, description="Tool output")
+    tool_error: Optional[str] = Field(None, description="Error message if tool failed")
 
 
 class TaskCreatedPayload(BaseModel):

--- a/backend/app/schemas/streaming.py
+++ b/backend/app/schemas/streaming.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Streaming event schemas for executor streaming output.
+
+This module defines the schemas for streaming events sent from
+executors (Claude Code, Agno) through executor manager to backend.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StreamingEventType(str, Enum):
+    """Streaming event types for executor streaming"""
+
+    STREAM_START = "stream_start"
+    STREAM_CHUNK = "stream_chunk"
+    TOOL_START = "tool_start"
+    TOOL_DONE = "tool_done"
+    STREAM_DONE = "stream_done"
+    STREAM_ERROR = "stream_error"
+
+
+class StreamingEventRequest(BaseModel):
+    """
+    Request schema for streaming events from executor manager.
+
+    This is the unified schema for all streaming event types.
+    Different fields are populated based on event_type.
+    """
+
+    event_type: StreamingEventType = Field(..., description="Type of streaming event")
+    timestamp: datetime = Field(
+        default_factory=datetime.now,
+        description="Timestamp when the event was generated",
+    )
+
+    # For stream_start
+    shell_type: Optional[str] = Field(
+        None, description="Shell type (ClaudeCode, Agno, etc.)"
+    )
+
+    # For stream_chunk
+    content: Optional[str] = Field(None, description="Incremental content chunk")
+    offset: Optional[int] = Field(
+        None, description="Character offset in the full response"
+    )
+
+    # For tool events (tool_start, tool_done)
+    tool_id: Optional[str] = Field(None, description="Unique tool execution ID")
+    tool_name: Optional[str] = Field(
+        None, description="Name of the tool being executed"
+    )
+    tool_input: Optional[Dict[str, Any]] = Field(
+        None, description="Input parameters for the tool"
+    )
+    tool_output: Optional[str] = Field(None, description="Output from tool execution")
+    tool_error: Optional[str] = Field(None, description="Error message if tool failed")
+
+    # For stream_done and stream_chunk with result
+    result: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Result data containing value, thinking, workbench, etc.",
+    )
+
+    # For stream_error
+    error: Optional[str] = Field(
+        None, description="Error message for stream_error event"
+    )
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat(),
+        }
+
+
+class StreamingEventResponse(BaseModel):
+    """Response schema for streaming event handling"""
+
+    success: bool = Field(
+        ..., description="Whether the event was processed successfully"
+    )
+    message: str = Field(default="", description="Optional message")
+    task_id: Optional[int] = Field(None, description="Task ID")
+    subtask_id: Optional[int] = Field(None, description="Subtask ID")
+
+
+class StreamingStateData(BaseModel):
+    """
+    Data model for streaming state stored in Redis.
+
+    This tracks the current state of a streaming session for
+    reconnection support and state recovery.
+    """
+
+    task_id: int = Field(..., description="Task ID")
+    subtask_id: int = Field(..., description="Subtask ID")
+    shell_type: str = Field(..., description="Shell type (ClaudeCode, Agno)")
+    status: str = Field(
+        default="streaming", description="Current status (streaming, completed, error)"
+    )
+    started_at: datetime = Field(
+        default_factory=datetime.now, description="When streaming started"
+    )
+    last_update_at: datetime = Field(
+        default_factory=datetime.now, description="Last update time"
+    )
+    content_length: int = Field(
+        default=0, description="Current accumulated content length"
+    )
+    offset: int = Field(default=0, description="Current offset")
+    thinking_count: int = Field(default=0, description="Number of thinking steps")
+    last_db_save_at: Optional[datetime] = Field(
+        None, description="Last time content was saved to database"
+    )
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.isoformat(),
+        }
+
+
+class StreamingStatusResponse(BaseModel):
+    """Response schema for getting streaming status"""
+
+    is_streaming: bool = Field(..., description="Whether streaming is active")
+    subtask_id: Optional[int] = Field(None, description="Subtask ID if streaming")
+    shell_type: Optional[str] = Field(None, description="Shell type if streaming")
+    started_at: Optional[datetime] = Field(None, description="When streaming started")
+    current_content_length: Optional[int] = Field(
+        None, description="Current content length"
+    )

--- a/backend/app/services/chat/ws_emitter.py
+++ b/backend/app/services/chat/ws_emitter.py
@@ -319,6 +319,82 @@ class WebSocketEmitter:
         logger.debug(f"[WS] emit chat:system task={task_id} type={msg_type}")
 
     # ============================================================
+    # Tool Execution Events (to task room)
+    # ============================================================
+
+    async def emit_tool_start(
+        self,
+        task_id: int,
+        subtask_id: int,
+        tool_id: str,
+        tool_name: str,
+        tool_input: Dict[str, Any],
+    ) -> None:
+        """
+        Emit tool:start event to task room.
+
+        Called when an executor tool begins execution.
+
+        Args:
+            task_id: Task ID
+            subtask_id: Subtask ID
+            tool_id: Unique tool execution ID
+            tool_name: Name of the tool being executed
+            tool_input: Tool input parameters
+        """
+        await self.sio.emit(
+            ServerEvents.TOOL_START,
+            {
+                "task_id": task_id,
+                "subtask_id": subtask_id,
+                "tool_id": tool_id,
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+            },
+            room=f"task:{task_id}",
+            namespace=self.namespace,
+        )
+        logger.debug(
+            f"[WS] emit tool:start task={task_id} subtask={subtask_id} tool={tool_name}"
+        )
+
+    async def emit_tool_done(
+        self,
+        task_id: int,
+        subtask_id: int,
+        tool_id: str,
+        tool_output: Optional[str] = None,
+        tool_error: Optional[str] = None,
+    ) -> None:
+        """
+        Emit tool:done event to task room.
+
+        Called when an executor tool completes execution.
+
+        Args:
+            task_id: Task ID
+            subtask_id: Subtask ID
+            tool_id: Tool execution ID (matches tool:start)
+            tool_output: Tool output
+            tool_error: Error message if tool failed
+        """
+        await self.sio.emit(
+            ServerEvents.TOOL_DONE,
+            {
+                "task_id": task_id,
+                "subtask_id": subtask_id,
+                "tool_id": tool_id,
+                "tool_output": tool_output,
+                "tool_error": tool_error,
+            },
+            room=f"task:{task_id}",
+            namespace=self.namespace,
+        )
+        logger.debug(
+            f"[WS] emit tool:done task={task_id} subtask={subtask_id} tool_id={tool_id}"
+        )
+
+    # ============================================================
     # Task List Events (to user room)
     # ============================================================
 

--- a/backend/app/services/executor_streaming/__init__.py
+++ b/backend/app/services/executor_streaming/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Executor Streaming Service module.
+
+This module provides services for handling streaming output from
+Claude Code and Agno executors.
+"""
+
+from app.services.executor_streaming.service import (
+    ExecutorStreamingService,
+    executor_streaming_service,
+)
+from app.services.executor_streaming.state import (
+    ExecutorStreamingStateManager,
+    executor_streaming_state,
+)
+
+__all__ = [
+    "ExecutorStreamingService",
+    "executor_streaming_service",
+    "ExecutorStreamingStateManager",
+    "executor_streaming_state",
+]

--- a/backend/app/services/executor_streaming/service.py
+++ b/backend/app/services/executor_streaming/service.py
@@ -1,0 +1,599 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Executor streaming service.
+
+Handles streaming events from Claude Code and Agno executors,
+manages Redis state, emits WebSocket events, and persists to database.
+"""
+
+import asyncio
+import logging
+import time
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.subtask import Subtask, SubtaskStatus
+from app.schemas.streaming import (
+    StreamingEventRequest,
+    StreamingEventResponse,
+    StreamingEventType,
+    StreamingStateData,
+)
+from app.services.executor_streaming.state import executor_streaming_state
+
+logger = logging.getLogger(__name__)
+
+# Database save interval (seconds) - save to DB every 5 seconds during streaming
+DB_SAVE_INTERVAL = 5.0
+
+# Redis save interval (seconds) - save to Redis every 1 second
+REDIS_SAVE_INTERVAL = 1.0
+
+
+class ExecutorStreamingService:
+    """
+    Service for handling executor streaming events.
+
+    Processes streaming events from Claude Code and Agno executors,
+    manages state in Redis, emits WebSocket events, and handles
+    database persistence.
+    """
+
+    def __init__(self):
+        self._state_manager = executor_streaming_state
+        # Track last DB save times per subtask
+        self._last_db_save_times: Dict[int, float] = {}
+        # Track last Redis save times per subtask
+        self._last_redis_save_times: Dict[int, float] = {}
+
+    async def handle_streaming_event(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Main dispatcher for streaming events.
+
+        Args:
+            db: Database session
+            task_id: Task ID
+            subtask_id: Subtask ID
+            event: Streaming event request
+
+        Returns:
+            StreamingEventResponse indicating success/failure
+        """
+        try:
+            logger.info(
+                f"[ExecutorStreaming] Handling {event.event_type} event for "
+                f"task={task_id}, subtask={subtask_id}"
+            )
+
+            if event.event_type == StreamingEventType.STREAM_START:
+                return await self._handle_stream_start(db, task_id, subtask_id, event)
+            elif event.event_type == StreamingEventType.STREAM_CHUNK:
+                return await self._handle_stream_chunk(db, task_id, subtask_id, event)
+            elif event.event_type == StreamingEventType.TOOL_START:
+                return await self._handle_tool_start(db, task_id, subtask_id, event)
+            elif event.event_type == StreamingEventType.TOOL_DONE:
+                return await self._handle_tool_done(db, task_id, subtask_id, event)
+            elif event.event_type == StreamingEventType.STREAM_DONE:
+                return await self._handle_stream_done(db, task_id, subtask_id, event)
+            elif event.event_type == StreamingEventType.STREAM_ERROR:
+                return await self._handle_stream_error(db, task_id, subtask_id, event)
+            else:
+                logger.warning(
+                    f"[ExecutorStreaming] Unknown event type: {event.event_type}"
+                )
+                return StreamingEventResponse(
+                    success=False,
+                    message=f"Unknown event type: {event.event_type}",
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                )
+
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Error handling event: {e}", exc_info=True
+            )
+            return StreamingEventResponse(
+                success=False,
+                message=str(e),
+                task_id=task_id,
+                subtask_id=subtask_id,
+            )
+
+    async def _handle_stream_start(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle stream_start event.
+
+        Initializes streaming state in Redis and emits chat:start WebSocket event.
+        """
+        shell_type = event.shell_type or "ClaudeCode"
+
+        # Initialize streaming state in Redis
+        state = StreamingStateData(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            shell_type=shell_type,
+            status="streaming",
+            started_at=datetime.now(),
+            last_update_at=datetime.now(),
+            content_length=0,
+            offset=0,
+            thinking_count=0,
+        )
+        await self._state_manager.set_streaming_state(subtask_id, state)
+
+        # Initialize content cache
+        await self._state_manager.save_streaming_content(subtask_id, "")
+
+        # Emit WebSocket chat:start event
+        await self._emit_chat_start(task_id, subtask_id, shell_type)
+
+        logger.info(
+            f"[ExecutorStreaming] Stream started: task={task_id}, "
+            f"subtask={subtask_id}, shell_type={shell_type}"
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Stream started",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    async def _handle_stream_chunk(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle stream_chunk event.
+
+        Appends content to Redis cache, emits WebSocket event,
+        and periodically saves to database.
+        """
+        content = event.content or ""
+        offset = event.offset or 0
+        result = event.result
+
+        # Append content to Redis cache (throttled)
+        current_time = time.time()
+        last_redis_save = self._last_redis_save_times.get(subtask_id, 0)
+
+        if current_time - last_redis_save >= REDIS_SAVE_INTERVAL:
+            # Append to cached content
+            success, new_length = await self._state_manager.append_streaming_content(
+                subtask_id, content
+            )
+
+            # Update state
+            await self._state_manager.update_streaming_state(
+                subtask_id,
+                {
+                    "content_length": new_length,
+                    "offset": offset + len(content),
+                },
+            )
+
+            self._last_redis_save_times[subtask_id] = current_time
+
+        # Emit WebSocket chat:chunk event
+        await self._emit_chat_chunk(task_id, subtask_id, content, offset, result)
+
+        # Periodically save to database
+        await self._maybe_save_to_db(db, task_id, subtask_id, result)
+
+        # Publish to Redis Pub/Sub for reconnection support
+        await self._state_manager.publish_streaming_event(
+            subtask_id,
+            "chunk",
+            {"content": content, "offset": offset, "result": result},
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Chunk processed",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    async def _handle_tool_start(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle tool_start event.
+
+        Emits tool:start WebSocket event for real-time tool execution display.
+        """
+        tool_id = event.tool_id or ""
+        tool_name = event.tool_name or ""
+        tool_input = event.tool_input or {}
+
+        # Emit WebSocket tool:start event
+        await self._emit_tool_start(task_id, subtask_id, tool_id, tool_name, tool_input)
+
+        logger.debug(
+            f"[ExecutorStreaming] Tool started: task={task_id}, "
+            f"subtask={subtask_id}, tool={tool_name}"
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Tool start processed",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    async def _handle_tool_done(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle tool_done event.
+
+        Emits tool:done WebSocket event when tool execution completes.
+        """
+        tool_id = event.tool_id or ""
+        tool_output = event.tool_output
+        tool_error = event.tool_error
+
+        # Emit WebSocket tool:done event
+        await self._emit_tool_done(
+            task_id, subtask_id, tool_id, tool_output, tool_error
+        )
+
+        logger.debug(
+            f"[ExecutorStreaming] Tool done: task={task_id}, "
+            f"subtask={subtask_id}, tool_id={tool_id}"
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Tool done processed",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    async def _handle_stream_done(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle stream_done event.
+
+        Finalizes streaming: saves to database, emits chat:done,
+        and cleans up Redis state.
+        """
+        offset = event.offset or 0
+        result = event.result or {}
+
+        # Get final content from Redis
+        final_content = await self._state_manager.get_streaming_content(subtask_id)
+
+        # Save final result to database
+        await self._save_final_to_db(db, subtask_id, result)
+
+        # Emit WebSocket chat:done event
+        await self._emit_chat_done(task_id, subtask_id, offset, result)
+
+        # Publish stream done to Redis Pub/Sub
+        await self._state_manager.publish_stream_done(subtask_id, result)
+
+        # Clean up Redis state
+        await self._state_manager.cleanup_streaming_session(subtask_id)
+
+        # Clean up tracking
+        self._last_db_save_times.pop(subtask_id, None)
+        self._last_redis_save_times.pop(subtask_id, None)
+
+        logger.info(
+            f"[ExecutorStreaming] Stream done: task={task_id}, "
+            f"subtask={subtask_id}, offset={offset}"
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Stream completed",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    async def _handle_stream_error(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        event: StreamingEventRequest,
+    ) -> StreamingEventResponse:
+        """
+        Handle stream_error event.
+
+        Saves error to database, emits chat:error, and cleans up.
+        """
+        error = event.error or "Unknown error"
+
+        # Save error to database
+        await self._save_error_to_db(db, subtask_id, error)
+
+        # Emit WebSocket chat:error event
+        await self._emit_chat_error(task_id, subtask_id, error)
+
+        # Clean up Redis state
+        await self._state_manager.cleanup_streaming_session(subtask_id)
+
+        # Clean up tracking
+        self._last_db_save_times.pop(subtask_id, None)
+        self._last_redis_save_times.pop(subtask_id, None)
+
+        logger.error(
+            f"[ExecutorStreaming] Stream error: task={task_id}, "
+            f"subtask={subtask_id}, error={error}"
+        )
+
+        return StreamingEventResponse(
+            success=True,
+            message="Error processed",
+            task_id=task_id,
+            subtask_id=subtask_id,
+        )
+
+    # ==================== Database Operations ====================
+
+    async def _maybe_save_to_db(
+        self,
+        db: Session,
+        task_id: int,
+        subtask_id: int,
+        result: Optional[Dict[str, Any]],
+    ) -> None:
+        """
+        Periodically save streaming content to database (every 5 seconds).
+        """
+        current_time = time.time()
+        last_save = self._last_db_save_times.get(subtask_id, 0)
+
+        if current_time - last_save < DB_SAVE_INTERVAL:
+            return
+
+        try:
+            subtask = db.query(Subtask).get(subtask_id)
+            if subtask:
+                if result:
+                    subtask.result = result
+                subtask.status = SubtaskStatus.RUNNING
+                subtask.updated_at = datetime.now()
+                db.add(subtask)
+                db.commit()
+
+                self._last_db_save_times[subtask_id] = current_time
+                logger.debug(
+                    f"[ExecutorStreaming] Periodic DB save for subtask {subtask_id}"
+                )
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to save to DB for subtask {subtask_id}: {e}"
+            )
+            db.rollback()
+
+    async def _save_final_to_db(
+        self,
+        db: Session,
+        subtask_id: int,
+        result: Dict[str, Any],
+    ) -> None:
+        """
+        Save final result to database on stream completion.
+        """
+        try:
+            subtask = db.query(Subtask).get(subtask_id)
+            if subtask:
+                subtask.result = result
+                subtask.status = SubtaskStatus.COMPLETED
+                subtask.completed_at = datetime.now()
+                subtask.updated_at = datetime.now()
+                db.add(subtask)
+                db.commit()
+                logger.info(
+                    f"[ExecutorStreaming] Final save to DB for subtask {subtask_id}"
+                )
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed final DB save for subtask {subtask_id}: {e}"
+            )
+            db.rollback()
+
+    async def _save_error_to_db(
+        self,
+        db: Session,
+        subtask_id: int,
+        error: str,
+    ) -> None:
+        """
+        Save error to database on stream failure.
+        """
+        try:
+            subtask = db.query(Subtask).get(subtask_id)
+            if subtask:
+                subtask.error_message = error
+                subtask.status = SubtaskStatus.FAILED
+                subtask.updated_at = datetime.now()
+                db.add(subtask)
+                db.commit()
+                logger.info(
+                    f"[ExecutorStreaming] Error saved to DB for subtask {subtask_id}"
+                )
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed error DB save for subtask {subtask_id}: {e}"
+            )
+            db.rollback()
+
+    # ==================== WebSocket Emission ====================
+
+    async def _emit_chat_start(
+        self, task_id: int, subtask_id: int, shell_type: str
+    ) -> None:
+        """Emit chat:start WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter:
+                await ws_emitter.emit_chat_start(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    shell_type=shell_type,
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit chat:start: {e}")
+
+    async def _emit_chat_chunk(
+        self,
+        task_id: int,
+        subtask_id: int,
+        content: str,
+        offset: int,
+        result: Optional[Dict[str, Any]],
+    ) -> None:
+        """Emit chat:chunk WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter:
+                await ws_emitter.emit_chat_chunk(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    content=content,
+                    offset=offset,
+                    result=result,
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit chat:chunk: {e}")
+
+    async def _emit_chat_done(
+        self,
+        task_id: int,
+        subtask_id: int,
+        offset: int,
+        result: Optional[Dict[str, Any]],
+    ) -> None:
+        """Emit chat:done WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter:
+                await ws_emitter.emit_chat_done(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    offset=offset,
+                    result=result,
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit chat:done: {e}")
+
+    async def _emit_chat_error(self, task_id: int, subtask_id: int, error: str) -> None:
+        """Emit chat:error WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter:
+                await ws_emitter.emit_chat_error(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    error=error,
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit chat:error: {e}")
+
+    async def _emit_tool_start(
+        self,
+        task_id: int,
+        subtask_id: int,
+        tool_id: str,
+        tool_name: str,
+        tool_input: Dict[str, Any],
+    ) -> None:
+        """Emit tool:start WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter and hasattr(ws_emitter, "emit_tool_start"):
+                await ws_emitter.emit_tool_start(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    tool_id=tool_id,
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                )
+            else:
+                # Fallback: include tool info in a chat:chunk event
+                logger.debug(
+                    f"[ExecutorStreaming] emit_tool_start not available, "
+                    f"tool={tool_name}"
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit tool:start: {e}")
+
+    async def _emit_tool_done(
+        self,
+        task_id: int,
+        subtask_id: int,
+        tool_id: str,
+        tool_output: Optional[str],
+        tool_error: Optional[str],
+    ) -> None:
+        """Emit tool:done WebSocket event."""
+        try:
+            from app.services.chat.ws_emitter import get_ws_emitter
+
+            ws_emitter = get_ws_emitter()
+            if ws_emitter and hasattr(ws_emitter, "emit_tool_done"):
+                await ws_emitter.emit_tool_done(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    tool_id=tool_id,
+                    tool_output=tool_output,
+                    tool_error=tool_error,
+                )
+            else:
+                logger.debug(
+                    f"[ExecutorStreaming] emit_tool_done not available, "
+                    f"tool_id={tool_id}"
+                )
+        except Exception as e:
+            logger.error(f"[ExecutorStreaming] Failed to emit tool:done: {e}")
+
+
+# Global singleton instance
+executor_streaming_service = ExecutorStreamingService()

--- a/backend/app/services/executor_streaming/state.py
+++ b/backend/app/services/executor_streaming/state.py
@@ -1,0 +1,445 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Executor streaming state manager.
+
+Manages streaming state in Redis for executor tasks,
+including content caching, state tracking, and pub/sub for real-time updates.
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from app.core.cache import cache_manager
+from app.schemas.streaming import StreamingStateData
+
+logger = logging.getLogger(__name__)
+
+# Redis key prefixes for executor streaming
+EXECUTOR_STREAMING_CONTENT_PREFIX = "executor:streaming:"
+EXECUTOR_STREAMING_STATE_PREFIX = "executor:streaming:state:"
+EXECUTOR_STREAMING_CHANNEL_PREFIX = "executor:stream_channel:"
+EXECUTOR_CANCEL_PREFIX = "executor:cancel:"
+
+# TTL values (in seconds)
+STREAMING_CONTENT_TTL = 3600  # 1 hour
+STREAMING_STATE_TTL = 3600  # 1 hour
+CANCEL_FLAG_TTL = 300  # 5 minutes
+
+
+class ExecutorStreamingStateManager:
+    """
+    Manages executor streaming state in Redis.
+
+    Provides methods for:
+    - Storing and retrieving streaming content
+    - Managing streaming session state
+    - Publishing streaming events via Pub/Sub
+    - Handling cancellation flags
+    """
+
+    def __init__(self):
+        self._cache = cache_manager
+
+    # ==================== Content Management ====================
+
+    def _get_content_key(self, subtask_id: int) -> str:
+        """Generate Redis key for streaming content."""
+        return f"{EXECUTOR_STREAMING_CONTENT_PREFIX}{subtask_id}"
+
+    async def save_streaming_content(
+        self, subtask_id: int, content: str, expire: int = STREAMING_CONTENT_TTL
+    ) -> bool:
+        """
+        Save accumulated streaming content to Redis.
+
+        Args:
+            subtask_id: Subtask ID
+            content: Accumulated content string
+            expire: TTL in seconds
+
+        Returns:
+            bool: True if save was successful
+        """
+        try:
+            key = self._get_content_key(subtask_id)
+            result = await self._cache.set(key, content, expire=expire)
+            logger.debug(
+                f"[ExecutorStreaming] Saved content for subtask {subtask_id}, "
+                f"length={len(content)}"
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to save content for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def get_streaming_content(self, subtask_id: int) -> Optional[str]:
+        """
+        Get streaming content from Redis.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            str or None: Cached content, or None if not found
+        """
+        try:
+            key = self._get_content_key(subtask_id)
+            content = await self._cache.get(key)
+            if content is not None and isinstance(content, str):
+                return content
+            return None
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to get content for subtask {subtask_id}: {e}"
+            )
+            return None
+
+    async def append_streaming_content(
+        self, subtask_id: int, chunk: str, expire: int = STREAMING_CONTENT_TTL
+    ) -> tuple:
+        """
+        Append content chunk to existing content.
+
+        Args:
+            subtask_id: Subtask ID
+            chunk: Content chunk to append
+            expire: TTL in seconds
+
+        Returns:
+            Tuple of (success, new_total_length)
+        """
+        try:
+            existing = await self.get_streaming_content(subtask_id) or ""
+            new_content = existing + chunk
+            success = await self.save_streaming_content(subtask_id, new_content, expire)
+            return success, len(new_content)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to append content for subtask {subtask_id}: {e}"
+            )
+            return False, 0
+
+    async def delete_streaming_content(self, subtask_id: int) -> bool:
+        """
+        Delete streaming content from Redis.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if delete was successful
+        """
+        try:
+            key = self._get_content_key(subtask_id)
+            return await self._cache.delete(key)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to delete content for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    # ==================== State Management ====================
+
+    def _get_state_key(self, subtask_id: int) -> str:
+        """Generate Redis key for streaming state."""
+        return f"{EXECUTOR_STREAMING_STATE_PREFIX}{subtask_id}"
+
+    async def set_streaming_state(
+        self,
+        subtask_id: int,
+        state: StreamingStateData,
+        expire: int = STREAMING_STATE_TTL,
+    ) -> bool:
+        """
+        Set streaming state in Redis.
+
+        Args:
+            subtask_id: Subtask ID
+            state: StreamingStateData object
+            expire: TTL in seconds
+
+        Returns:
+            bool: True if save was successful
+        """
+        try:
+            key = self._get_state_key(subtask_id)
+            state_dict = state.model_dump(mode="json")
+            result = await self._cache.set(key, state_dict, expire=expire)
+            logger.debug(
+                f"[ExecutorStreaming] Set state for subtask {subtask_id}: "
+                f"status={state.status}, content_length={state.content_length}"
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to set state for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def get_streaming_state(
+        self, subtask_id: int
+    ) -> Optional[StreamingStateData]:
+        """
+        Get streaming state from Redis.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            StreamingStateData or None if not found
+        """
+        try:
+            key = self._get_state_key(subtask_id)
+            state_dict = await self._cache.get(key)
+            if state_dict and isinstance(state_dict, dict):
+                return StreamingStateData.model_validate(state_dict)
+            return None
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to get state for subtask {subtask_id}: {e}"
+            )
+            return None
+
+    async def update_streaming_state(
+        self, subtask_id: int, updates: Dict[str, Any]
+    ) -> bool:
+        """
+        Update specific fields in streaming state.
+
+        Args:
+            subtask_id: Subtask ID
+            updates: Dictionary of fields to update
+
+        Returns:
+            bool: True if update was successful
+        """
+        try:
+            state = await self.get_streaming_state(subtask_id)
+            if not state:
+                return False
+
+            # Update fields
+            for key, value in updates.items():
+                if hasattr(state, key):
+                    setattr(state, key, value)
+
+            state.last_update_at = datetime.now()
+            return await self.set_streaming_state(subtask_id, state)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to update state for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def delete_streaming_state(self, subtask_id: int) -> bool:
+        """
+        Delete streaming state from Redis.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if delete was successful
+        """
+        try:
+            key = self._get_state_key(subtask_id)
+            return await self._cache.delete(key)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to delete state for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    # ==================== Pub/Sub Management ====================
+
+    def _get_channel_key(self, subtask_id: int) -> str:
+        """Generate Redis Pub/Sub channel key."""
+        return f"{EXECUTOR_STREAMING_CHANNEL_PREFIX}{subtask_id}"
+
+    async def publish_streaming_event(
+        self, subtask_id: int, event_type: str, data: Dict[str, Any]
+    ) -> bool:
+        """
+        Publish a streaming event to Redis Pub/Sub.
+
+        Args:
+            subtask_id: Subtask ID
+            event_type: Type of event (chunk, done, error)
+            data: Event data
+
+        Returns:
+            bool: True if publish was successful
+        """
+        try:
+            channel = self._get_channel_key(subtask_id)
+            message = json.dumps({"event_type": event_type, "data": data})
+
+            redis_client = await self._cache._get_client()
+            try:
+                await redis_client.publish(channel, message)
+                logger.debug(
+                    f"[ExecutorStreaming] Published {event_type} event for subtask {subtask_id}"
+                )
+                return True
+            finally:
+                await redis_client.aclose()
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to publish event for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def publish_stream_done(
+        self, subtask_id: int, result: Optional[Dict[str, Any]] = None
+    ) -> bool:
+        """
+        Publish stream done signal.
+
+        Args:
+            subtask_id: Subtask ID
+            result: Final result data
+
+        Returns:
+            bool: True if publish was successful
+        """
+        try:
+            channel = self._get_channel_key(subtask_id)
+            message = json.dumps({"__type__": "STREAM_DONE", "result": result})
+
+            redis_client = await self._cache._get_client()
+            try:
+                await redis_client.publish(channel, message)
+                logger.info(
+                    f"[ExecutorStreaming] Published stream_done for subtask {subtask_id}"
+                )
+                return True
+            finally:
+                await redis_client.aclose()
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to publish stream_done for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def subscribe_streaming_channel(self, subtask_id: int):
+        """
+        Subscribe to a streaming channel.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            Tuple of (Redis client, PubSub object) or (None, None)
+        """
+        try:
+            channel = self._get_channel_key(subtask_id)
+            redis_client = await self._cache._get_client()
+            pubsub = redis_client.pubsub()
+            await pubsub.subscribe(channel)
+            return redis_client, pubsub
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to subscribe for subtask {subtask_id}: {e}"
+            )
+            return None, None
+
+    # ==================== Cancellation Management ====================
+
+    def _get_cancel_key(self, subtask_id: int) -> str:
+        """Generate Redis key for cancellation flag."""
+        return f"{EXECUTOR_CANCEL_PREFIX}{subtask_id}"
+
+    async def set_cancel_flag(self, subtask_id: int) -> bool:
+        """
+        Set cancellation flag for a streaming session.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if flag was set successfully
+        """
+        try:
+            key = self._get_cancel_key(subtask_id)
+            return await self._cache.set(key, True, expire=CANCEL_FLAG_TTL)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to set cancel flag for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def is_cancelled(self, subtask_id: int) -> bool:
+        """
+        Check if a streaming session has been cancelled.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if cancelled
+        """
+        try:
+            key = self._get_cancel_key(subtask_id)
+            result = await self._cache.get(key)
+            return result is True
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to check cancel flag for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    async def clear_cancel_flag(self, subtask_id: int) -> bool:
+        """
+        Clear cancellation flag.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if cleared successfully
+        """
+        try:
+            key = self._get_cancel_key(subtask_id)
+            return await self._cache.delete(key)
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to clear cancel flag for subtask {subtask_id}: {e}"
+            )
+            return False
+
+    # ==================== Cleanup ====================
+
+    async def cleanup_streaming_session(self, subtask_id: int) -> bool:
+        """
+        Clean up all Redis keys for a streaming session.
+
+        Args:
+            subtask_id: Subtask ID
+
+        Returns:
+            bool: True if cleanup was successful
+        """
+        try:
+            await self.delete_streaming_content(subtask_id)
+            await self.delete_streaming_state(subtask_id)
+            await self.clear_cancel_flag(subtask_id)
+            logger.info(
+                f"[ExecutorStreaming] Cleaned up session for subtask {subtask_id}"
+            )
+            return True
+        except Exception as e:
+            logger.error(
+                f"[ExecutorStreaming] Failed to cleanup session for subtask {subtask_id}: {e}"
+            )
+            return False
+
+
+# Global singleton instance
+executor_streaming_state = ExecutorStreamingStateManager()

--- a/executor/agents/claude_code/response_processor.py
+++ b/executor/agents/claude_code/response_processor.py
@@ -1,30 +1,34 @@
 #!/usr/bin/env python
 import json
 from dataclasses import asdict
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from claude_agent_sdk import ClaudeSDKClient
+from claude_agent_sdk.types import (AssistantMessage, Message, ResultMessage,
+                                    SystemMessage, TextBlock, ToolResultBlock,
+                                    ToolUseBlock, UserMessage)
+from shared.logger import setup_logger
+from shared.models.task import ExecutionResult
+from shared.status import TaskStatus
+from shared.utils.sensitive_data_masker import mask_sensitive_data
+
+from executor.callback.streaming_handler import (StreamingCallbackState,
+                                                 send_stream_chunk_callback,
+                                                 send_stream_done_callback,
+                                                 send_stream_error_callback,
+                                                 send_stream_start_callback,
+                                                 send_tool_done_callback,
+                                                 send_tool_start_callback)
+
 # SPDX-FileCopyrightText: 2025 Weibo, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Any, List, Union, Optional
-from datetime import datetime
 
-from claude_agent_sdk import ClaudeSDKClient
-from shared.status import TaskStatus
-from shared.logger import setup_logger
-from shared.models.task import ExecutionResult
-from shared.utils.sensitive_data_masker import mask_sensitive_data
-from claude_agent_sdk.types import (
-    Message,
-    SystemMessage,
-    AssistantMessage,
-    UserMessage,
-    ResultMessage,
-    ToolUseBlock,
-    TextBlock,
-    ToolResultBlock,
-)
+
 
 logger = setup_logger("claude_response_processor")
 
@@ -44,8 +48,11 @@ def contains_api_error(text: str) -> bool:
 
 
 async def process_response(
-    client: ClaudeSDKClient, state_manager, thinking_manager=None, task_state_manager=None,
-    session_id: str = None
+    client: ClaudeSDKClient,
+    state_manager,
+    thinking_manager=None,
+    task_state_manager=None,
+    session_id: str = None,
 ) -> TaskStatus:
     """
     Process the response messages from Claude
@@ -62,22 +69,62 @@ async def process_response(
     """
     index = 0
     api_error_retry_count = 0  # Track retry count for this session
+
+    # Initialize streaming state
+    streaming_state = StreamingCallbackState(emit_interval=0.5)
+
+    # Extract task metadata for streaming callbacks
+    task_id = state_manager.task_data.get("task_id") if state_manager else None
+    subtask_id = state_manager.task_data.get("subtask_id") if state_manager else None
+    task_title = state_manager.task_data.get("task_title", "") if state_manager else ""
+    subtask_title = (
+        state_manager.task_data.get("subtask_title", "") if state_manager else ""
+    )
+
     try:
         while True:
             retry_requested = False
 
             async for msg in client.receive_response():
                 index += 1
-                
+
                 # Check for cancellation before processing each message
                 if task_state_manager:
-                    task_id = state_manager.task_data.get("task_id") if state_manager else None
-                    if task_id and task_state_manager.is_cancelled(task_id):
-                        logger.info(f"Task {task_id} cancelled during response processing")
+                    task_id_check = (
+                        state_manager.task_data.get("task_id")
+                        if state_manager
+                        else None
+                    )
+                    if task_id_check and task_state_manager.is_cancelled(task_id_check):
+                        logger.info(
+                            f"Task {task_id_check} cancelled during response processing"
+                        )
                         if state_manager:
                             state_manager.update_workbench_status("completed")
+
+                        # Send stream_done on cancellation
+                        if streaming_state.stream_started and task_id and subtask_id:
+                            try:
+                                result_data = (
+                                    state_manager.get_current_state()
+                                    if state_manager
+                                    else {}
+                                )
+                                send_stream_done_callback(
+                                    task_id=task_id,
+                                    subtask_id=subtask_id,
+                                    offset=len(streaming_state.accumulated_content),
+                                    result_data=result_data,
+                                    task_title=task_title,
+                                    subtask_title=subtask_title,
+                                )
+                            except Exception as e:
+                                logger.error(
+                                    f"Failed to send stream_done on cancellation: {e}"
+                                )
+
                         return TaskStatus.COMPLETED
-                
+
                 # Log the number of messages received
                 logger.info(f"claude message index: {index}, received: {msg}")
 
@@ -90,9 +137,17 @@ async def process_response(
                     _handle_user_message(msg, thinking_manager)
 
                 elif isinstance(msg, AssistantMessage):
-                    # Handle assistant message and detect API errors
-                    # Note: Retry logic is handled in ResultMessage processing to avoid duplicate retries
-                    _handle_assistant_message(msg, state_manager, thinking_manager)
+                    # Handle assistant message and send streaming events
+                    await _handle_assistant_message_with_streaming(
+                        msg,
+                        state_manager,
+                        thinking_manager,
+                        streaming_state,
+                        task_id,
+                        subtask_id,
+                        task_title,
+                        subtask_title,
+                    )
 
                 elif isinstance(msg, ResultMessage):
                     # Use specialized function to handle ResultMessage
@@ -108,6 +163,11 @@ async def process_response(
                         current_session_id,
                         api_error_retry_count,
                         MAX_API_ERROR_RETRIES,
+                        streaming_state,
+                        task_id,
+                        subtask_id,
+                        task_title,
+                        subtask_title,
                     )
                     if result_status == "RETRY":
                         # Increment retry count and restart response stream for retry
@@ -130,24 +190,36 @@ async def process_response(
             return TaskStatus.RUNNING
     except Exception as e:
         logger.exception(f"Error processing response: {str(e)}")
-        
+
+        # Send stream_error event
+        if task_id and subtask_id:
+            try:
+                send_stream_error_callback(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    error=str(e),
+                    task_title=task_title,
+                    subtask_title=subtask_title,
+                )
+            except Exception as stream_error:
+                logger.error(f"Failed to send stream_error callback: {stream_error}")
+
         # Add thinking step for error
         if thinking_manager:
             thinking_manager.add_thinking_step_by_key(
-                title_key="thinking.response_processing_error",
-                report_immediately=False
+                title_key="thinking.response_processing_error", report_immediately=False
             )
-        
+
         # Update workbench status to failed
         if state_manager:
             state_manager.update_workbench_status("failed")
-            
+
             # Report error using state manager
             state_manager.report_progress(
                 progress=100,
                 status=TaskStatus.FAILED.value,
                 message=f"Error processing response: {str(e)}",
-                extra_result={"error": str(e)}
+                extra_result={"error": str(e)},
             )
         return TaskStatus.FAILED
 
@@ -159,7 +231,7 @@ def _handle_system_message(msg: SystemMessage, state_manager, thinking_manager=N
     system_detail = {
         "type": "system",
         "subtype": msg.subtype,
-        **msg.data  # 包含原有的系统消息数据
+        **msg.data,  # 包含原有的系统消息数据
     }
 
     # Mask sensitive data in system details before sending
@@ -168,20 +240,22 @@ def _handle_system_message(msg: SystemMessage, state_manager, thinking_manager=N
     # Log with masked data
     msg_dict = asdict(msg)
     masked_msg_dict = mask_sensitive_data(msg_dict)
-    logger.info(f"SystemMessage: subtype = {msg.subtype}. msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}")
+    logger.info(
+        f"SystemMessage: subtype = {msg.subtype}. msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}"
+    )
 
     if thinking_manager:
         thinking_manager.add_thinking_step(
             title="thinking.system_message_received",
             report_immediately=True,
             use_i18n_keys=True,
-            details=masked_system_detail
+            details=masked_system_detail,
         )
 
 
 def _handle_user_message(msg: UserMessage, thinking_manager=None):
     """处理用户消息，提取详细信息"""
-    
+
     # 构建用户消息的详细信息，符合目标格式
     message_details = {
         "type": "user",
@@ -189,75 +263,77 @@ def _handle_user_message(msg: UserMessage, thinking_manager=None):
             "type": "message",
             "role": "user",
             "content": [],
-            "parent_tool_use_id": msg.parent_tool_use_id
-        }
+            "parent_tool_use_id": msg.parent_tool_use_id,
+        },
     }
-    
+
     # 处理内容（可能是字符串或内容块列表）
     if isinstance(msg.content, str):
         # 如果是字符串，直接作为文本内容
-        text_detail = {
-            "type": "text",
-            "text": msg.content
-        }
+        text_detail = {"type": "text", "text": msg.content}
         message_details["message"]["content"].append(text_detail)
         logger.info(f"UserMessage: text content, length = {len(msg.content)}")
     else:
         # 如果是内容块列表，处理每个块
         logger.info(f"UserMessage: {len(msg.content)} content blocks")
-        
+
         for block in msg.content:
             # 添加调试日志：打印 block 的类型和内容
-            logger.info(f"Processing UserMessage block type: {type(block).__name__}, isinstance checks: "
-                       f"ToolUseBlock={isinstance(block, ToolUseBlock)}, "
-                       f"TextBlock={isinstance(block, TextBlock)}, "
-                       f"ToolResultBlock={isinstance(block, ToolResultBlock)}")
+            logger.info(
+                f"Processing UserMessage block type: {type(block).__name__}, isinstance checks: "
+                f"ToolUseBlock={isinstance(block, ToolUseBlock)}, "
+                f"TextBlock={isinstance(block, TextBlock)}, "
+                f"ToolResultBlock={isinstance(block, ToolResultBlock)}"
+            )
 
             # Mask sensitive data in block content for logging
-            block_dict = asdict(block) if hasattr(block, '__dataclass_fields__') else block
+            block_dict = (
+                asdict(block) if hasattr(block, "__dataclass_fields__") else block
+            )
             masked_block_dict = mask_sensitive_data(block_dict)
             logger.info(f"UserMessage Block content: {masked_block_dict}")
-            
+
             if isinstance(block, ToolUseBlock):
                 # 工具使用详情，符合目标格式
                 tool_detail = {
                     "type": "tool_use",
                     "id": block.id,
                     "name": block.name,
-                    "input": block.input
+                    "input": block.input,
                 }
                 message_details["message"]["content"].append(tool_detail)
-                
+
                 logger.info(f"UserMessage ToolUseBlock: tool = {block.name}")
-                    
+
             elif isinstance(block, TextBlock):
                 # 文本内容详情，符合目标格式
-                text_detail = {
-                    "type": "text",
-                    "text": block.text
-                }
+                text_detail = {"type": "text", "text": block.text}
                 message_details["message"]["content"].append(text_detail)
-                
+
                 logger.info(f"UserMessage TextBlock: {len(block.text)} chars")
-            
+
             elif isinstance(block, ToolResultBlock):
                 # 工具结果详情，符合目标格式
                 result_detail = {
                     "type": "tool_result",
                     "tool_use_id": block.tool_use_id,
                     "content": block.content,
-                    "is_error": block.is_error
+                    "is_error": block.is_error,
                 }
                 message_details["message"]["content"].append(result_detail)
-                
-                logger.info(f"UserMessage ToolResultBlock: tool_use_id = {block.tool_use_id}, is_error = {block.is_error}")
-            
+
+                logger.info(
+                    f"UserMessage ToolResultBlock: tool_use_id = {block.tool_use_id}, is_error = {block.is_error}"
+                )
+
             else:
                 # 未知块类型，符合目标格式
                 unknown_detail = {
                     "type": "unknown",
                     "block_type": type(block).__name__,
-                    "block_data": asdict(block) if hasattr(block, '__dict__') else str(block)
+                    "block_data": (
+                        asdict(block) if hasattr(block, "__dict__") else str(block)
+                    ),
                 }
                 message_details["message"]["content"].append(unknown_detail)
 
@@ -272,41 +348,59 @@ def _handle_user_message(msg: UserMessage, thinking_manager=None):
             title="thinking.user_message_received",
             report_immediately=True,
             use_i18n_keys=True,
-            details=masked_message_details
+            details=masked_message_details,
         )
 
 
-def _handle_assistant_message(msg: AssistantMessage, state_manager, thinking_manager=None) -> bool:
-    """处理助手消息，提取详细信息
-    
+async def _handle_assistant_message_with_streaming(
+    msg: AssistantMessage,
+    state_manager,
+    thinking_manager=None,
+    streaming_state: StreamingCallbackState = None,
+    task_id: int = None,
+    subtask_id: int = None,
+    task_title: str = "",
+    subtask_title: str = "",
+) -> bool:
+    """处理助手消息，提取详细信息，并发送流式事件
+
     Args:
         msg: AssistantMessage to process
         state_manager: ProgressStateManager instance
         thinking_manager: Optional ThinkingStepManager instance
-        
+        streaming_state: StreamingCallbackState for tracking streaming progress
+        task_id: Task ID for streaming callbacks
+        subtask_id: Subtask ID for streaming callbacks
+        task_title: Task title for streaming callbacks
+        subtask_title: Subtask title for streaming callbacks
+
     Returns:
         bool: True if API error detected and retry is needed, False otherwise
     """
-    
+
     # 收集所有内容块的详细信息，符合目标格式
     message_details = {
         "type": "assistant",
         "message": {
-            "id": getattr(msg, 'id', ''),
+            "id": getattr(msg, "id", ""),
             "type": "message",
             "role": "assistant",
             "model": msg.model,
             "content": [],
-            "parent_tool_use_id": msg.parent_tool_use_id
-        }
+            "parent_tool_use_id": msg.parent_tool_use_id,
+        },
     }
-    
+
     # Convert content blocks to dict format for JSON serialization
     content_dicts = []
     for block in msg.content:
         content_dicts.append(asdict(block))
-    msg_dict = {"content": content_dicts, "model": msg.model, "parent_tool_use_id": msg.parent_tool_use_id}
-    
+    msg_dict = {
+        "content": content_dicts,
+        "model": msg.model,
+        "parent_tool_use_id": msg.parent_tool_use_id,
+    }
+
     # Check if the message contains API error that needs retry
     msg_json_str = json.dumps(msg_dict, ensure_ascii=False)
     needs_retry = contains_api_error(msg_json_str)
@@ -315,57 +409,129 @@ def _handle_assistant_message(msg: AssistantMessage, state_manager, thinking_man
 
     # Mask sensitive data in message for logging
     masked_msg_dict = mask_sensitive_data(msg_dict)
-    logger.info(f"AssistantMessage: {len(msg.content)} content blocks, msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}")
+    logger.info(
+        f"AssistantMessage: {len(msg.content)} content blocks, msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}"
+    )
 
     # 处理每个内容块
     for block in msg.content:
         # Mask sensitive data in block for logging
-        block_dict = asdict(block) if hasattr(block, '__dataclass_fields__') else block
+        block_dict = asdict(block) if hasattr(block, "__dataclass_fields__") else block
         masked_block_dict = mask_sensitive_data(block_dict)
         logger.info(f"Block content: {masked_block_dict}")
-        
+
         if isinstance(block, ToolUseBlock):
             # 工具使用详情，符合目标格式
             tool_detail = {
                 "type": "tool_use",
                 "id": block.id,
                 "name": block.name,
-                "input": block.input
+                "input": block.input,
             }
             message_details["message"]["content"].append(tool_detail)
-            
+
             logger.info(f"ToolUseBlock: tool = {block.name}")
-                
+
+            # Send tool_start event
+            if task_id and subtask_id:
+                try:
+                    send_tool_start_callback(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        tool_id=block.id,
+                        tool_name=block.name,
+                        tool_input=block.input,
+                        task_title=task_title,
+                        subtask_title=subtask_title,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to send tool_start callback: {e}")
+
         elif isinstance(block, TextBlock):
             # 文本内容详情，符合目标格式
-            text_detail = {
-                "type": "text",
-                "text": block.text
-            }
+            text_detail = {"type": "text", "text": block.text}
             message_details["message"]["content"].append(text_detail)
 
             state_manager.update_workbench_status("running", block.text)
-            
+
             logger.info(f"TextBlock: {len(block.text)} chars")
-        
+
+            # Handle streaming for text content
+            if task_id and subtask_id and streaming_state:
+                # Send stream_start on first content
+                if not streaming_state.stream_started:
+                    try:
+                        send_stream_start_callback(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            shell_type="ClaudeCode",
+                            task_title=task_title,
+                            subtask_title=subtask_title,
+                        )
+                        streaming_state.stream_started = True
+                    except Exception as e:
+                        logger.error(f"Failed to send stream_start callback: {e}")
+
+                # Add content and check if we should emit
+                should_emit, chunk, offset = streaming_state.add_content(block.text)
+
+                if should_emit and chunk:
+                    try:
+                        # Get current state for additional result data
+                        result_data = (
+                            state_manager.get_current_state() if state_manager else {}
+                        )
+
+                        send_stream_chunk_callback(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            content=chunk,
+                            offset=offset,
+                            task_title=task_title,
+                            subtask_title=subtask_title,
+                            result_data=result_data,
+                        )
+                        streaming_state.mark_emitted()
+                    except Exception as e:
+                        logger.error(f"Failed to send stream_chunk callback: {e}")
+
         elif isinstance(block, ToolResultBlock):
             # 工具结果详情，符合目标格式
             result_detail = {
                 "type": "tool_result",
                 "tool_use_id": block.tool_use_id,
                 "content": block.content,
-                "is_error": block.is_error
+                "is_error": block.is_error,
             }
             message_details["message"]["content"].append(result_detail)
-            
-            logger.info(f"ToolResultBlock: tool_use_id = {block.tool_use_id}, is_error = {block.is_error}")
-        
+
+            logger.info(
+                f"ToolResultBlock: tool_use_id = {block.tool_use_id}, is_error = {block.is_error}"
+            )
+
+            # Send tool_done event
+            if task_id and subtask_id:
+                try:
+                    send_tool_done_callback(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        tool_id=block.tool_use_id,
+                        tool_output=block.content if not block.is_error else None,
+                        tool_error=block.content if block.is_error else None,
+                        task_title=task_title,
+                        subtask_title=subtask_title,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to send tool_done callback: {e}")
+
         else:
             # 未知块类型，符合目标格式
             unknown_detail = {
                 "type": "unknown",
                 "block_type": type(block).__name__,
-                "block_data": asdict(block) if hasattr(block, '__dict__') else str(block)
+                "block_data": (
+                    asdict(block) if hasattr(block, "__dict__") else str(block)
+                ),
             }
             message_details["message"]["content"].append(unknown_detail)
 
@@ -380,9 +546,9 @@ def _handle_assistant_message(msg: AssistantMessage, state_manager, thinking_man
             title="thinking.assistant_message_received",
             report_immediately=True,
             use_i18n_keys=True,
-            details=masked_message_details
+            details=masked_message_details,
         )
-    
+
     return needs_retry
 
 
@@ -391,7 +557,9 @@ def _handle_legacy_message(msg: Dict[str, Any], thinking_manager=None):
 
     # Mask sensitive data in legacy message for logging
     masked_msg = mask_sensitive_data(msg)
-    logger.info(f"Legacy Message: type = {msg_type}. msg = {json.dumps(masked_msg, ensure_ascii=False)}")
+    logger.info(
+        f"Legacy Message: type = {msg_type}. msg = {json.dumps(masked_msg, ensure_ascii=False)}"
+    )
 
     if msg_type == "tool_use":
         tool_name = msg.get("tool", {}).get("name", "unknown")
@@ -400,7 +568,7 @@ def _handle_legacy_message(msg: Dict[str, Any], thinking_manager=None):
             thinking_manager.add_thinking_step(
                 title="thinking.legacy_tool_use",
                 report_immediately=False,
-                use_i18n_keys=True
+                use_i18n_keys=True,
             )
 
     elif msg_type == "content":
@@ -410,7 +578,7 @@ def _handle_legacy_message(msg: Dict[str, Any], thinking_manager=None):
             thinking_manager.add_thinking_step(
                 title="thinking.legacy_content",
                 report_immediately=False,
-                use_i18n_keys=True
+                use_i18n_keys=True,
             )
 
     else:
@@ -419,13 +587,23 @@ def _handle_legacy_message(msg: Dict[str, Any], thinking_manager=None):
             thinking_manager.add_thinking_step(
                 title="thinking.unknown_legacy_message",
                 report_immediately=False,
-                use_i18n_keys=True
+                use_i18n_keys=True,
             )
 
 
 async def _process_result_message(
-    msg: ResultMessage, state_manager, thinking_manager=None, client=None,
-    session_id: str = None, api_error_retry_count: int = 0, max_retries: int = 3
+    msg: ResultMessage,
+    state_manager,
+    thinking_manager=None,
+    client=None,
+    session_id: str = None,
+    api_error_retry_count: int = 0,
+    max_retries: int = 3,
+    streaming_state: StreamingCallbackState = None,
+    task_id: int = None,
+    subtask_id: int = None,
+    task_title: str = "",
+    subtask_title: str = "",
 ) -> Union[TaskStatus, str, None]:
     """
     Process a ResultMessage from Claude
@@ -438,12 +616,17 @@ async def _process_result_message(
         session_id: Session ID for retry operations
         api_error_retry_count: Current retry count
         max_retries: Maximum retry attempts
+        streaming_state: StreamingCallbackState for tracking streaming progress
+        task_id: Task ID for streaming callbacks
+        subtask_id: Subtask ID for streaming callbacks
+        task_title: Task title for streaming callbacks
+        subtask_title: Subtask title for streaming callbacks
 
     Returns:
         TaskStatus: Processing status (COMPLETED if successful, otherwise None)
         str: "RETRY" if retry was initiated
     """
-    
+
     # 构建详细的结果信息，符合目标格式
     result_details = {
         "type": "result",
@@ -455,7 +638,7 @@ async def _process_result_message(
         "duration_api_ms": msg.duration_api_ms,
         "total_cost_usd": msg.total_cost_usd,
         "usage": msg.usage,
-        "result": msg.result
+        "result": msg.result,
     }
 
     # Mask sensitive data in result details
@@ -464,22 +647,45 @@ async def _process_result_message(
     # Mask sensitive data in message for logging
     msg_dict = asdict(msg)
     masked_msg_dict = mask_sensitive_data(msg_dict)
-    logger.info(f"Result message received: subtype={msg.subtype}, is_error={msg.is_error}, msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}")
+    logger.info(
+        f"Result message received: subtype={msg.subtype}, is_error={msg.is_error}, msg = {json.dumps(masked_msg_dict, ensure_ascii=False)}"
+    )
 
     # If it's a successful result message, send the result back via callback
     if msg.subtype == "success" and not msg.is_error:
         # Ensure result is string type
         result_str = str(msg.result) if msg.result is not None else "No result"
         logger.info(f"Sending successful result via callback: {result_str}")
-        
+
         # Add thinking step for successful result
         if thinking_manager:
             thinking_manager.add_thinking_step(
                 title="thinking.task_execution_success",
                 report_immediately=False,
                 use_i18n_keys=True,
-                details=masked_result_details
+                details=masked_result_details,
             )
+
+        # Send final stream_chunk if there's pending content
+        if streaming_state and streaming_state.pending_chunk and task_id and subtask_id:
+            try:
+                chunk, offset = streaming_state.get_final_chunk()
+                if chunk:
+                    result_data = (
+                        state_manager.get_current_state() if state_manager else {}
+                    )
+                    send_stream_chunk_callback(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        content=chunk,
+                        offset=offset,
+                        task_title=task_title,
+                        subtask_title=subtask_title,
+                        result_data=result_data,
+                    )
+                    streaming_state.mark_emitted()
+            except Exception as e:
+                logger.error(f"Failed to send final stream_chunk: {e}")
 
         # If there's a result, pass it as result parameter to report_progress
         if msg.result is not None:
@@ -500,49 +706,113 @@ async def _process_result_message(
                     progress=100,
                     status=TaskStatus.COMPLETED.value,
                     message=result_str,
-                    extra_result=result_dict
+                    extra_result=result_dict,
                 )
+
+                # Send stream_done event
+                if (
+                    streaming_state
+                    and streaming_state.stream_started
+                    and task_id
+                    and subtask_id
+                ):
+                    try:
+                        final_result_data = (
+                            state_manager.get_current_state()
+                            if state_manager
+                            else result_dict
+                        )
+                        send_stream_done_callback(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            offset=len(streaming_state.accumulated_content),
+                            result_data=final_result_data,
+                            task_title=task_title,
+                            subtask_title=subtask_title,
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to send stream_done callback: {e}")
+
             except Exception as e:
                 logger.error(f"Failed to parse result as dict: {e}")
                 if thinking_manager:
                     thinking_manager.add_thinking_step(
                         title="thinking.result_parsing_error",
                         report_immediately=False,
-                        use_i18n_keys=True
+                        use_i18n_keys=True,
                     )
-                
+
                 # Update workbench status to failed
                 state_manager.update_workbench_status("failed")
-                
+
                 # Report error using state manager
                 state_manager.report_progress(
-                    progress=100,
-                    status=TaskStatus.FAILED.value,
-                    message=result_str
+                    progress=100, status=TaskStatus.FAILED.value, message=result_str
                 )
+
+                # Send stream_error event
+                if task_id and subtask_id:
+                    try:
+                        send_stream_error_callback(
+                            task_id=task_id,
+                            subtask_id=subtask_id,
+                            error=str(e),
+                            task_title=task_title,
+                            subtask_title=subtask_title,
+                        )
+                    except Exception as stream_error:
+                        logger.error(
+                            f"Failed to send stream_error callback: {stream_error}"
+                        )
         else:
             # Update workbench status to completed
             state_manager.update_workbench_status("completed")
-            
+
             # Report progress using state manager
             state_manager.report_progress(
-                progress=100,
-                status=TaskStatus.COMPLETED.value,
-                message=result_str
+                progress=100, status=TaskStatus.COMPLETED.value, message=result_str
             )
+
+            # Send stream_done event
+            if (
+                streaming_state
+                and streaming_state.stream_started
+                and task_id
+                and subtask_id
+            ):
+                try:
+                    final_result_data = (
+                        state_manager.get_current_state() if state_manager else {}
+                    )
+                    send_stream_done_callback(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        offset=len(streaming_state.accumulated_content),
+                        result_data=final_result_data,
+                        task_title=task_title,
+                        subtask_title=subtask_title,
+                    )
+                except Exception as e:
+                    logger.error(f"Failed to send stream_done callback: {e}")
+
         return TaskStatus.COMPLETED
 
     if msg.is_error:
         logger.error(f"Received error from Claude SDK: {msg.result}")
         result_str = str(msg.result) if msg.result is not None else "No result"
-        
+
         # Check if this is an API error that can be retried
-        if contains_api_error(result_str) and client and session_id and api_error_retry_count < max_retries:
+        if (
+            contains_api_error(result_str)
+            and client
+            and session_id
+            and api_error_retry_count < max_retries
+        ):
             logger.warning(
                 f"Detected retryable API error in ResultMessage for session {session_id}, "
                 f"retry {api_error_retry_count + 1}/{max_retries}"
             )
-            
+
             if thinking_manager:
                 thinking_manager.add_thinking_step(
                     title="thinking.api_error_retry",
@@ -552,19 +822,21 @@ async def _process_result_message(
                         "retry_count": api_error_retry_count + 1,
                         "max_retries": max_retries,
                         "session_id": session_id,
-                        "error": result_str
-                    }
+                        "error": result_str,
+                    },
                 )
-            
+
             # Send retry message to continue the session
             try:
                 await client.query("Retry to proceed", session_id=session_id)
-                logger.info(f"Sent retry message for session {session_id} from ResultMessage handler")
+                logger.info(
+                    f"Sent retry message for session {session_id} from ResultMessage handler"
+                )
                 return "RETRY"  # Signal to continue processing
             except Exception as retry_error:
                 logger.error(f"Failed to send retry message: {retry_error}")
                 # Fall through to fail the task
-        
+
         elif contains_api_error(result_str) and api_error_retry_count >= max_retries:
             logger.error(
                 f"Max API error retries ({max_retries}) reached for session {session_id}"
@@ -577,29 +849,43 @@ async def _process_result_message(
                     details={
                         "retry_count": api_error_retry_count,
                         "max_retries": max_retries,
-                        "session_id": session_id
-                    }
+                        "session_id": session_id,
+                    },
                 )
-        
+
         # Add thinking step for error result
         if thinking_manager:
             thinking_manager.add_thinking_step(
                 title="thinking.task_execution_failed",
                 report_immediately=False,
                 use_i18n_keys=True,
-                details=masked_result_details
+                details=masked_result_details,
             )
-        
+
         # Update workbench status to failed
         state_manager.update_workbench_status("failed")
-        
+
         # Report error using state manager
         state_manager.report_progress(
-            progress=100,
-            status=TaskStatus.FAILED.value,
-            message=result_str
+            progress=100, status=TaskStatus.FAILED.value, message=result_str
         )
-        return TaskStatus.FAILED  # CRITICAL FIX: Return FAILED status to stop task execution
+
+        # Send stream_error event
+        if task_id and subtask_id:
+            try:
+                send_stream_error_callback(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    error=result_str,
+                    task_title=task_title,
+                    subtask_title=subtask_title,
+                )
+            except Exception as e:
+                logger.error(f"Failed to send stream_error callback: {e}")
+
+        return (
+            TaskStatus.FAILED
+        )  # CRITICAL FIX: Return FAILED status to stop task execution
 
     # If it's not a successful result message, return None to let caller continue processing
     return None

--- a/executor/callback/streaming_handler.py
+++ b/executor/callback/streaming_handler.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Streaming callback handler module for executor streaming events.
+
+This module provides helper functions to send streaming events
+(stream_start, stream_chunk, tool_start, tool_done, stream_done, stream_error)
+to the executor manager for real-time streaming output.
+"""
+
+import time
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from shared.logger import setup_logger
+from shared.status import TaskStatus
+
+from executor.callback.callback_client import CallbackClient
+
+logger = setup_logger("streaming_callback_handler")
+
+# Create a singleton callback client instance
+callback_client = CallbackClient()
+
+
+class StreamingEventType:
+    """Streaming event types for executor streaming"""
+
+    STREAM_START = "stream_start"
+    STREAM_CHUNK = "stream_chunk"
+    TOOL_START = "tool_start"
+    TOOL_DONE = "tool_done"
+    STREAM_DONE = "stream_done"
+    STREAM_ERROR = "stream_error"
+
+
+class StreamingCallbackState:
+    """
+    Track streaming state for throttled callbacks.
+
+    This class maintains state for streaming content and implements
+    throttling to avoid sending too many HTTP requests.
+    """
+
+    def __init__(self, emit_interval: float = 0.5):
+        """
+        Initialize streaming state.
+
+        Args:
+            emit_interval: Minimum interval between chunk emissions in seconds (default 0.5s)
+        """
+        self.accumulated_content: str = ""
+        self.last_emit_time: float = 0.0
+        self.emit_interval: float = emit_interval
+        self.offset: int = 0
+        self.thinking_steps: List[Dict[str, Any]] = []
+        self.workbench: Optional[Dict[str, Any]] = None
+        self.stream_started: bool = False
+        self.pending_chunk: str = ""
+
+    def should_emit(self) -> bool:
+        """Check if enough time has passed for next emit."""
+        current_time = time.time()
+        return (current_time - self.last_emit_time) >= self.emit_interval
+
+    def mark_emitted(self) -> None:
+        """Mark that a chunk was just emitted."""
+        self.last_emit_time = time.time()
+        self.pending_chunk = ""
+
+    def add_content(self, new_content: str) -> tuple:
+        """
+        Add content and return (should_emit, chunk, offset).
+
+        Args:
+            new_content: New content to add
+
+        Returns:
+            Tuple of (should_emit, chunk, offset)
+        """
+        previous_length = len(self.accumulated_content)
+        self.accumulated_content += new_content
+        self.pending_chunk += new_content
+
+        if self.should_emit():
+            chunk = self.pending_chunk
+            offset = previous_length
+            return True, chunk, offset
+        return False, "", previous_length
+
+    def get_final_chunk(self) -> tuple:
+        """
+        Get remaining pending content for final emission.
+
+        Returns:
+            Tuple of (chunk, offset)
+        """
+        chunk = self.pending_chunk
+        offset = len(self.accumulated_content) - len(chunk)
+        return chunk, offset
+
+
+def send_stream_start_callback(
+    task_id: int,
+    subtask_id: int,
+    shell_type: str,
+    task_title: str = "",
+    subtask_title: str = "",
+) -> Dict[str, Any]:
+    """
+    Send stream_start event to indicate streaming has begun.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        shell_type: Shell type (e.g., "ClaudeCode", "Agno")
+        task_title: Task title
+        subtask_title: Subtask title
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.STREAM_START,
+            "shell_type": shell_type,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=10,
+            status=TaskStatus.RUNNING.value,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.info(
+            f"Sent stream_start callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, shell_type={shell_type}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send stream_start callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}
+
+
+def send_stream_chunk_callback(
+    task_id: int,
+    subtask_id: int,
+    content: str,
+    offset: int,
+    task_title: str = "",
+    subtask_title: str = "",
+    result_data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Send stream_chunk event with incremental content.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        content: Incremental content chunk
+        offset: Offset in the full response
+        task_title: Task title
+        subtask_title: Subtask title
+        result_data: Optional additional result data (thinking, workbench, etc.)
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.STREAM_CHUNK,
+            "content": content,
+            "offset": offset,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        # Include additional result data if provided
+        if result_data:
+            streaming_event["result"] = result_data
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=50,
+            status=TaskStatus.RUNNING.value,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.debug(
+            f"Sent stream_chunk callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, offset={offset}, content_len={len(content)}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send stream_chunk callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}
+
+
+def send_tool_start_callback(
+    task_id: int,
+    subtask_id: int,
+    tool_id: str,
+    tool_name: str,
+    tool_input: Optional[Dict[str, Any]] = None,
+    task_title: str = "",
+    subtask_title: str = "",
+) -> Dict[str, Any]:
+    """
+    Send tool_start event when a tool execution begins.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        tool_id: Unique tool execution ID
+        tool_name: Name of the tool being executed
+        tool_input: Input parameters for the tool
+        task_title: Task title
+        subtask_title: Subtask title
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.TOOL_START,
+            "tool_id": tool_id,
+            "tool_name": tool_name,
+            "tool_input": tool_input or {},
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=60,
+            status=TaskStatus.RUNNING.value,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.debug(
+            f"Sent tool_start callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, tool_name={tool_name}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send tool_start callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}
+
+
+def send_tool_done_callback(
+    task_id: int,
+    subtask_id: int,
+    tool_id: str,
+    tool_output: Optional[str] = None,
+    tool_error: Optional[str] = None,
+    task_title: str = "",
+    subtask_title: str = "",
+) -> Dict[str, Any]:
+    """
+    Send tool_done event when a tool execution completes.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        tool_id: Unique tool execution ID (matches tool_start)
+        tool_output: Output from the tool execution
+        tool_error: Error message if tool failed
+        task_title: Task title
+        subtask_title: Subtask title
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.TOOL_DONE,
+            "tool_id": tool_id,
+            "tool_output": tool_output,
+            "tool_error": tool_error,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=70,
+            status=TaskStatus.RUNNING.value,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.debug(
+            f"Sent tool_done callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, tool_id={tool_id}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send tool_done callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}
+
+
+def send_stream_done_callback(
+    task_id: int,
+    subtask_id: int,
+    offset: int,
+    result_data: Dict[str, Any],
+    task_title: str = "",
+    subtask_title: str = "",
+) -> Dict[str, Any]:
+    """
+    Send stream_done event when streaming completes successfully.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        offset: Final offset (total content length)
+        result_data: Complete result data (value, thinking, workbench, etc.)
+        task_title: Task title
+        subtask_title: Subtask title
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.STREAM_DONE,
+            "offset": offset,
+            "result": result_data,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=100,
+            status=TaskStatus.COMPLETED.value,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.info(
+            f"Sent stream_done callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, offset={offset}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send stream_done callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}
+
+
+def send_stream_error_callback(
+    task_id: int,
+    subtask_id: int,
+    error: str,
+    task_title: str = "",
+    subtask_title: str = "",
+) -> Dict[str, Any]:
+    """
+    Send stream_error event when streaming encounters an error.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        error: Error message
+        task_title: Task title
+        subtask_title: Subtask title
+
+    Returns:
+        Dict[str, Any]: Callback response
+    """
+    try:
+        streaming_event = {
+            "event_type": StreamingEventType.STREAM_ERROR,
+            "error": error,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        result = callback_client.send_callback(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            task_title=task_title,
+            subtask_title=subtask_title,
+            progress=100,
+            status=TaskStatus.FAILED.value,
+            message=error,
+            result={"streaming_event": streaming_event},
+        )
+
+        logger.error(
+            f"Sent stream_error callback: task_id={task_id}, "
+            f"subtask_id={subtask_id}, error={error}"
+        )
+        return result
+
+    except Exception as e:
+        logger.error(f"Failed to send stream_error callback: {e}")
+        return {"status": TaskStatus.FAILED.value, "error_msg": str(e)}


### PR DESCRIPTION
## Summary

- Implement streaming output architecture for Claude Code and Agno executor shells
- Enable real-time content streaming with 0.5s throttling to match Chat Shell behavior
- Add Redis caching for streaming state to support reconnection and recovery
- Add tool execution progress events (tool:start, tool:done) for frontend display

## Changes

### Backend
- **New streaming endpoint**: `POST /api/executors/tasks/{task_id}/subtasks/{subtask_id}/stream`
- **ExecutorStreamingService**: Handles streaming events, Redis state management, WebSocket emission
- **Streaming schemas**: `StreamingEventType`, `StreamingEventRequest`, `StreamingStateData`
- **WebSocket events**: Added `tool:start` and `tool:done` events with corresponding payloads
- **ws_emitter extensions**: `emit_tool_start()` and `emit_tool_done()` methods

### Executor
- **streaming_handler.py**: New module with `StreamingCallbackState` for throttled callbacks
- **Callback functions**: `stream_start`, `stream_chunk`, `tool_start`, `tool_done`, `stream_done`, `stream_error`
- **Claude Code agent**: Modified response_processor to emit streaming events during execution
- **Agno agent**: Updated to use unified streaming format with same callback pattern

### Executor Manager
- **Streaming forwarding**: `_forward_streaming_callback()` routes events to backend streaming endpoint
- **Callback detection**: Updated callback_handler to identify and forward streaming events

## Architecture

```
Executor (Claude Code/Agno)
    ↓ HTTP Streaming Callbacks
Executor Manager /callback
    ↓ Forward to Backend
Backend POST /api/executors/.../stream
    ↓ ExecutorStreamingService
    ├─→ Redis: Cache streaming state (1s interval)
    ├─→ Redis Pub/Sub: Publish events for reconnection
    ├─→ WebSocket: emit chat:chunk/tool:start/tool:done
    └─→ Database: Periodic save (5s) + final save on done
```

## Streaming Events

| Event Type | Trigger | Data |
|------------|---------|------|
| `stream_start` | First content received | shell_type |
| `stream_chunk` | Content update (throttled 0.5s) | content, offset, result |
| `tool_start` | Tool execution begins | tool_id, tool_name, tool_input |
| `tool_done` | Tool execution completes | tool_id, tool_output, tool_error |
| `stream_done` | Streaming completes | offset, final result |
| `stream_error` | Error occurs | error message |

## Test plan

- [ ] Verify streaming events are emitted during Claude Code execution
- [ ] Verify streaming events are emitted during Agno execution
- [ ] Verify WebSocket clients receive real-time content updates
- [ ] Verify tool:start and tool:done events are sent for tool calls
- [ ] Verify Redis caching works for streaming state
- [ ] Verify page refresh during streaming recovers content
- [ ] Verify no regression in existing Chat Shell streaming
- [ ] Verify database is updated periodically (every 5s) and on completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end streaming support for task execution: start, chunk, done, error, plus tool start/done events and a streaming POST endpoint.
  * Real-time WebSocket broadcasts for streaming and tool activity.

* **Improvements**
  * Persistent streaming state (Redis + DB) with periodic saves and reconnection support.
  * Integrated streaming callbacks across agents and manager for richer real-time feedback and forwarding of streaming events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->