### PR TITLE
fix: remove deprecated query_cache_size and optimize MySQL config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     image: mysql:9.4
     container_name: wegent-mysql
     restart: always
+    command: >
+      --innodb_buffer_pool_size=256M
+      --max_connections=200
+      --sort_buffer_size=8M
     environment:
       MYSQL_ROOT_PASSWORD: 123456
       MYSQL_DATABASE: task_manager

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -401,6 +401,17 @@ SET GLOBAL slow_query_log = 'ON';
 SET GLOBAL long_query_time = 2;
 ```
 
+**MySQL Configuration Optimization**
+```yaml
+# Add MySQL configuration in docker-compose.yml
+services:
+  mysql:
+    command: >
+      --innodb_buffer_pool_size=256M
+      --max_connections=200
+      --sort_buffer_size=8M
+```
+
 **3. Optimize Redis**
 ```bash
 # Check Redis performance

--- a/docs/zh/troubleshooting.md
+++ b/docs/zh/troubleshooting.md
@@ -200,7 +200,7 @@ services:
     command: >
       --innodb_buffer_pool_size=256M
       --max_connections=200
-      --query_cache_size=32M
+      --sort_buffer_size=8M
 ```
 
 **3. 定期清理**


### PR DESCRIPTION
## Summary

- Remove deprecated `--query_cache_size=32M` parameter (deprecated in MySQL 8.0+, removed in 9.4)
- Replace with `--sort_buffer_size=8M` for better sort performance
- Add MySQL optimization configuration to docker-compose.yml for out-of-box performance
- Sync EN/ZH documentation with consistent MySQL configuration examples

This fixes MySQL 9.4 startup failures caused by using deprecated parameters.

## Changes

### 1. Chinese Documentation (docs/zh/troubleshooting.md)
- Remove: `--query_cache_size=32M`
- Add: `--sort_buffer_size=8M`

### 2. English Documentation (docs/en/troubleshooting.md)
- Add MySQL configuration optimization example, consistent with Chinese documentation

### 3. Main Configuration File (docker-compose.yml)
- Add MySQL command optimization parameters:
  - `--innodb_buffer_pool_size=256M` - InnoDB buffer pool size
  - `--max_connections=200` - Maximum connections
  - `--sort_buffer_size=8M` - Sort buffer size

## Why query_cache_size was removed

MySQL 8.0+ deprecated the query cache feature, and MySQL 9.4 removed it completely. The reasons:
- In modern high-concurrency scenarios, query cache lock contention overhead > cache hit benefits
- Removing the special caching mechanism and letting all queries go through a unified path is actually faster and simpler
- This aligns with the design philosophy of "eliminating special cases"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guides with MySQL optimization recommendations including memory allocation, connection limits, and buffer configuration
  * Updates available in multiple languages

* **Configuration**
  * Enhanced MySQL service startup parameters for improved database performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->