### PR TITLE
chore(executor): standardize image version to latest across codebase

### DIFF
--- a/docs/en/concepts/architecture.md
+++ b/docs/en/concepts/architecture.md
@@ -194,7 +194,7 @@ MAX_CONCURRENT_TASKS: 5              # Maximum concurrent tasks
 EXECUTOR_PORT_RANGE_MIN: 10001      # Port range start
 EXECUTOR_PORT_RANGE_MAX: 10100      # Port range end
 NETWORK: wegent-network              # Docker network
-EXECUTOR_IMAGE: wegent-executor:1.0.13 # Executor image
+EXECUTOR_IMAGE: wegent-executor:latest # Executor image
 ```
 
 ---

--- a/docs/en/guides/developer/setup.md
+++ b/docs/en/guides/developer/setup.md
@@ -267,7 +267,7 @@ uv sync
 export TASK_API_DOMAIN=http://localhost:8000
 export CALLBACK_HOST=http://localhost:8001
 export MAX_CONCURRENT_TASKS=5
-export EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:1.0.13
+export EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 export EXECUTOR_WORKSPCE=${HOME}/wecode-bot
 
 # Run service

--- a/docs/zh/concepts/architecture.md
+++ b/docs/zh/concepts/architecture.md
@@ -194,7 +194,7 @@ MAX_CONCURRENT_TASKS: 5              # 最大并发任务数
 EXECUTOR_PORT_RANGE_MIN: 10001      # 端口范围起始
 EXECUTOR_PORT_RANGE_MAX: 10100      # 端口范围结束
 NETWORK: wegent-network              # Docker 网络
-EXECUTOR_IMAGE: wegent-executor:1.0.13 # 执行器镜像
+EXECUTOR_IMAGE: wegent-executor:latest # 执行器镜像
 ```
 
 ---

--- a/docs/zh/guides/developer/setup.md
+++ b/docs/zh/guides/developer/setup.md
@@ -267,7 +267,7 @@ uv sync
 export TASK_API_DOMAIN=http://localhost:8000
 export CALLBACK_HOST=http://localhost:8001
 export MAX_CONCURRENT_TASKS=5
-export EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:1.0.13
+export EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 export EXECUTOR_WORKSPCE=${HOME}/wecode-bot
 
 # 运行服务

--- a/executor_manager/README.md
+++ b/executor_manager/README.md
@@ -27,7 +27,7 @@ The script will automatically:
 ./start.sh --port 8002
 
 # Use custom executor image
-./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:1.0.18
+./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:latest
 
 # Use custom backend API
 ./start.sh --task-api-domain http://backend:8000
@@ -71,7 +71,7 @@ Run the application (example with environment variables):
 cd executor_manager
 
 # Run with uv
-EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:{version} DOCKER_HOST_ADDR={LocalHost IP} uv run main.py
+EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest DOCKER_HOST_ADDR={LocalHost IP} uv run main.py
 ```
 
 > EXECUTOR_IMAGE: Check docker-compose.yml for the latest wegent-executor image version

--- a/executor_manager/README_zh.md
+++ b/executor_manager/README_zh.md
@@ -27,7 +27,7 @@ cd executor_manager
 ./start.sh --port 8002
 
 # 使用自定义 executor 镜像
-./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:1.0.18
+./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:latest
 
 # 使用自定义后端 API
 ./start.sh --task-api-domain http://backend:8000
@@ -71,7 +71,7 @@ cd executor_manager
 cd executor_manager
 
 # 使用 uv 运行
-EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:{version} DOCKER_HOST_ADDR={LocalHost IP} uv run main.py
+EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest DOCKER_HOST_ADDR={LocalHost IP} uv run main.py
 ```
 
 > EXECUTOR_IMAGE: 查看 docker-compose.yml 获取最新的 wegent-executor 镜像版本

--- a/executor_manager/START_SCRIPT_USAGE.md
+++ b/executor_manager/START_SCRIPT_USAGE.md
@@ -20,7 +20,7 @@ cd executor_manager
 ### Change Executor Image
 
 ```bash
-./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:1.0.18
+./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:latest
 ```
 
 ### Change Backend API Domain
@@ -48,7 +48,7 @@ Usage: ./start.sh [OPTIONS]
 Options:
   --port PORT              Executor Manager port (default: 8001)
   --host HOST              Executor Manager host (default: 0.0.0.0)
-  --executor-image IMAGE   Executor Docker image (default: ghcr.io/wecode-ai/wegent-executor:1.0.16)
+  --executor-image IMAGE   Executor Docker image (default: ghcr.io/wecode-ai/wegent-executor:latest)
   --task-api-domain URL    Backend API domain (default: http://localhost:8000)
   -h, --help               Show this help message
 
@@ -196,7 +196,7 @@ sudo systemctl start docker
 
 A: Use the `--executor-image` parameter:
 ```bash
-./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:1.0.18
+./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:latest
 ./start.sh --executor-image my-custom-executor:latest
 ```
 
@@ -241,7 +241,7 @@ Start the service on a different port.
 ### Scenario 3: Using Custom Executor Image
 
 ```bash
-./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:1.0.18
+./start.sh --executor-image ghcr.io/wecode-ai/wegent-executor:latest
 ```
 
 Use a specific version of the executor image.

--- a/executor_manager/start.sh
+++ b/executor_manager/start.sh
@@ -30,7 +30,7 @@ NC='\033[0m' # No Color
 # Default configuration
 DEFAULT_PORT=8001
 DEFAULT_HOST="0.0.0.0"
-DEFAULT_EXECUTOR_IMAGE="ghcr.io/wecode-ai/wegent-executor:1.1.1"
+DEFAULT_EXECUTOR_IMAGE="ghcr.io/wecode-ai/wegent-executor:latest"
 DEFAULT_TASK_API_DOMAIN="http://localhost:8000"
 PYTHON_PATH=""
 
@@ -68,7 +68,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --port PORT              Executor Manager port (default: 8001)"
             echo "  --host HOST              Executor Manager host (default: 0.0.0.0)"
-            echo "  --executor-image IMAGE   Executor Docker image (default: ghcr.io/wecode-ai/wegent-executor:1.0.16)"
+            echo "  --executor-image IMAGE   Executor Docker image (default: ghcr.io/wecode-ai/wegent-executor:latest)"
             echo "  --task-api-domain URL    Backend API domain (default: http://localhost:8000)"
             echo "  --python PATH            Python executable path (default: auto-detect)"
             echo "  -h, --help               Show this help message"

--- a/start.sh
+++ b/start.sh
@@ -381,7 +381,7 @@ check_frontend_dependencies() {
 
 # Default configuration
 DEFAULT_FRONTEND_PORT=3000
-DEFAULT_EXECUTOR_IMAGE="ghcr.io/wecode-ai/wegent-executor:1.1.1"
+DEFAULT_EXECUTOR_IMAGE="ghcr.io/wecode-ai/wegent-executor:latest"
 
 FRONTEND_PORT=$DEFAULT_FRONTEND_PORT
 EXECUTOR_IMAGE=$DEFAULT_EXECUTOR_IMAGE


### PR DESCRIPTION
## Summary

Standardize executor Docker image version references across the codebase by replacing hardcoded version numbers with `latest` tag, except for production deployment configuration which retains fixed version for reproducibility.

### Changes Made

- **Startup Scripts**: Updated default values in `start.sh` and `executor_manager/start.sh` from `1.1.1` to `latest`
- **Help Documentation**: Synchronized help text in startup scripts to reflect `latest` as default
- **Developer Guides**: Updated both English and Chinese developer setup guides from outdated versions (`1.0.13`) to `latest`
- **Architecture Documentation**: Updated architecture docs (EN/ZH) to use `latest` tag
- **Executor Manager Documentation**: Updated README files and usage guide, replacing `1.0.16`, `1.0.18` references with `latest`

### Preserved

- `docker-compose.yml` continues to use fixed version `1.1.1` for production deployment reproducibility

### Rationale

This change eliminates documentation drift and reduces maintenance overhead by:
1. Removing the need to update version numbers across multiple files when executor image is updated
2. Ensuring development environments automatically use the latest stable version
3. Maintaining production stability through fixed version in deployment configuration
4. Aligning with the CI/CD workflow which already publishes both versioned and `latest` tags

## Test Plan

- [x] Verify all startup scripts default to `latest` tag
- [x] Confirm help documentation matches actual default values
- [x] Check no hardcoded versions remain in non-production files
- [x] Validate production deployment still uses fixed version `1.1.1`

### Verification Commands

```bash
# Confirm latest tag usage (23 occurrences expected)
grep -r "wegent-executor:latest" --exclude-dir=".git" . | wc -l

# Verify production config unchanged
grep "EXECUTOR_IMAGE" docker-compose.yml
# Expected: EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:1.1.1

# Check for remaining hardcoded versions (should only find build scripts with ${VERSION})
grep -r "wegent-executor:[0-9]" --exclude="docker-compose.yml" --exclude-dir=".git" .
```

### Manual Testing

1. **Local Development Startup**
   ```bash
   ./start.sh
   # Should pull/use ghcr.io/wecode-ai/wegent-executor:latest
   ```

2. **Executor Manager Standalone**
   ```bash
   cd executor_manager && ./start.sh
   # Verify logs show latest tag
   ```

3. **Production Deployment**
   ```bash
   docker-compose up executor_manager
   # Verify uses version 1.1.1
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guides and architecture documentation to reference the latest executor image tag.

* **Chores**
  * Updated default executor image configuration from specific version tags to latest across deployment scripts and configuration examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->