### PR TITLE
fix(auth): add token expiry check for WebSocket connections

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -54,6 +54,7 @@ from app.schemas.kind import Task, Team
 from app.services.chat.access import (
     can_access_task,
     get_active_streaming,
+    get_token_expiry,
     verify_jwt_token,
 )
 from app.services.chat.operations import (
@@ -101,6 +102,44 @@ class ChatNamespace(socketio.AsyncNamespace):
             "history:sync": "on_history_sync",
             "skill:response": "on_skill_response",
         }
+
+    async def _check_token_expiry(self, sid: str) -> bool:
+        """
+        Check if session token is expired.
+
+        Args:
+            sid: Socket ID
+
+        Returns:
+            True if token is expired, False otherwise
+        """
+        session = await self.get_session(sid)
+        token_exp = session.get("token_exp")
+        if not token_exp:
+            # No expiry stored, assume expired
+            return True
+        return datetime.now().timestamp() > token_exp
+
+    async def _handle_token_expired(self, sid: str) -> dict:
+        """
+        Handle token expiry: emit auth_error event and disconnect client.
+
+        Args:
+            sid: Socket ID
+
+        Returns:
+            Error dict to return to client
+        """
+        logger.warning(f"[WS] Token expired for sid={sid}, disconnecting")
+        from app.api.ws.events import ServerEvents
+
+        await self.emit(
+            ServerEvents.AUTH_ERROR,
+            {"error": "Token expired", "code": "TOKEN_EXPIRED"},
+            to=sid,
+        )
+        await self.disconnect(sid)
+        return {"error": "Token expired"}
 
     @trace_websocket_event(
         exclude_events={"connect"},  # connect is handled separately in on_connect
@@ -188,6 +227,9 @@ class ChatNamespace(socketio.AsyncNamespace):
             logger.warning(f"[WS] Invalid token sid={sid}")
             raise ConnectionRefusedError("Invalid or expired token")
 
+        # Extract token expiry for later validation
+        token_exp = get_token_expiry(token)
+
         # Save user info to session
         await self.save_session(
             sid,
@@ -195,6 +237,7 @@ class ChatNamespace(socketio.AsyncNamespace):
                 "user_id": user.id,
                 "user_name": user.user_name,
                 "request_id": request_id,
+                "token_exp": token_exp,  # Store token expiry for later checks
             },
         )
 
@@ -250,6 +293,10 @@ class ChatNamespace(socketio.AsyncNamespace):
         payload = data  # Already validated by decorator
 
         logger.info(f"[WS] task:join received: sid={sid}, task_id={payload.task_id}")
+
+        # Check token expiry before processing
+        if await self._check_token_expiry(sid):
+            return await self._handle_token_expired(sid)
 
         session = await self.get_session(sid)
         user_id = session.get("user_id")
@@ -347,6 +394,10 @@ class ChatNamespace(socketio.AsyncNamespace):
             {"task_id": int, "subtask_id": int} or {"error": "..."}
         """
         logger.info(f"[WS] chat:send received sid={sid} data={data}")
+
+        # Check token expiry before processing
+        if await self._check_token_expiry(sid):
+            return await self._handle_token_expired(sid)
 
         payload = data  # Already validated by decorator
         logger.info(
@@ -830,6 +881,10 @@ class ChatNamespace(socketio.AsyncNamespace):
         """
         payload = data  # Already validated by decorator
 
+        # Check token expiry before processing
+        if await self._check_token_expiry(sid):
+            return await self._handle_token_expired(sid)
+
         session = await self.get_session(sid)
         user_id = session.get("user_id")
 
@@ -1021,6 +1076,10 @@ class ChatNamespace(socketio.AsyncNamespace):
             f"force_override_bot_model={payload.force_override_bot_model} (type={type(payload.force_override_bot_model)}), "
             f"force_override_bot_model_type={payload.force_override_bot_model_type} (type={type(payload.force_override_bot_model_type)})"
         )
+
+        # Check token expiry before processing
+        if await self._check_token_expiry(sid):
+            return await self._handle_token_expired(sid)
 
         session = await self.get_session(sid)
         user_id = session.get("user_id")

--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -42,6 +42,9 @@ class ClientEvents:
 class ServerEvents:
     """Server -> Client event names."""
 
+    # Authentication events
+    AUTH_ERROR = "auth:error"  # Token expired or invalid
+
     # Chat streaming events (to task room)
     CHAT_START = "chat:start"
     CHAT_CHUNK = "chat:chunk"

--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -489,3 +489,17 @@ class GenericAck(BaseModel):
 
     success: bool = True
     error: Optional[str] = None
+
+
+# ============================================================
+# Authentication Error Payloads
+# ============================================================
+
+
+class AuthErrorPayload(BaseModel):
+    """Payload for auth:error event."""
+
+    error: str = Field(..., description="Error message")
+    code: Literal["TOKEN_EXPIRED", "INVALID_TOKEN"] = Field(
+        ..., description="Error code for identifying the type of auth error"
+    )

--- a/backend/app/services/chat/access/__init__.py
+++ b/backend/app/services/chat/access/__init__.py
@@ -8,11 +8,13 @@ This module provides utilities for checking task access permissions
 and JWT authentication.
 """
 
-from .auth import verify_jwt_token
+from .auth import get_token_expiry, is_token_expired, verify_jwt_token
 from .permissions import can_access_task, can_access_task_sync, get_active_streaming
 
 __all__ = [
     "verify_jwt_token",
+    "is_token_expired",
+    "get_token_expiry",
     "can_access_task",
     "can_access_task_sync",
     "get_active_streaming",

--- a/backend/app/services/chat/access/auth.py
+++ b/backend/app/services/chat/access/auth.py
@@ -11,6 +11,7 @@ import logging
 from typing import Optional
 
 from jose import jwt
+from jose.exceptions import ExpiredSignatureError
 
 from app.core.config import settings
 from app.db.session import SessionLocal
@@ -47,4 +48,48 @@ def verify_jwt_token(token: str) -> Optional[User]:
 
     except Exception as e:
         logger.warning(f"JWT verification failed: {e}")
+        return None
+
+
+def is_token_expired(token: str) -> bool:
+    """
+    Check if JWT token is expired without throwing exception.
+
+    Args:
+        token: JWT token string
+
+    Returns:
+        True if token is expired or invalid, False otherwise
+    """
+    try:
+        jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        )
+        return False
+    except ExpiredSignatureError:
+        return True
+    except Exception:
+        return True
+
+
+def get_token_expiry(token: str) -> Optional[int]:
+    """
+    Extract expiry timestamp from JWT token without verifying signature.
+
+    Args:
+        token: JWT token string
+
+    Returns:
+        Expiry timestamp in seconds (Unix timestamp), or None if invalid
+    """
+    try:
+        # Decode without verification to extract expiry
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_exp": False},
+        )
+        return payload.get("exp")
+    except Exception:
         return None

--- a/backend/tests/services/chat/access/test_auth_token_expiry.py
+++ b/backend/tests/services/chat/access/test_auth_token_expiry.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for JWT token expiry functions."""
+
+import time
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from jose import jwt
+
+from app.core.config import settings
+from app.services.chat.access.auth import get_token_expiry, is_token_expired
+
+
+def create_test_token(exp_delta_seconds: int) -> str:
+    """Create a test JWT token with specified expiry delta from now."""
+    # Use timezone-aware UTC datetime for consistency
+    exp_time = datetime.now(timezone.utc) + timedelta(seconds=exp_delta_seconds)
+    payload = {
+        "sub": "testuser",
+        "user_id": 1,
+        "exp": exp_time,
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+class TestIsTokenExpired:
+    """Tests for is_token_expired function."""
+
+    def test_valid_token_not_expired(self):
+        """Token with future expiry should return False."""
+        token = create_test_token(exp_delta_seconds=3600)  # Expires in 1 hour
+        assert is_token_expired(token) is False
+
+    def test_expired_token(self):
+        """Token with past expiry should return True."""
+        token = create_test_token(exp_delta_seconds=-60)  # Expired 1 minute ago
+        assert is_token_expired(token) is True
+
+    def test_invalid_token_returns_true(self):
+        """Invalid token should be treated as expired."""
+        assert is_token_expired("invalid.token.here") is True
+
+    def test_empty_token_returns_true(self):
+        """Empty token should be treated as expired."""
+        assert is_token_expired("") is True
+
+    def test_token_about_to_expire(self):
+        """Token expiring very soon should still be valid."""
+        token = create_test_token(exp_delta_seconds=1)  # Expires in 1 second
+        assert is_token_expired(token) is False
+
+
+class TestGetTokenExpiry:
+    """Tests for get_token_expiry function."""
+
+    def test_extract_expiry_from_valid_token(self):
+        """Should extract expiry timestamp from valid token."""
+        # Create token that expires 1 hour from now
+        exp_time = datetime.now(timezone.utc) + timedelta(hours=1)
+        expected_exp = int(exp_time.timestamp())
+
+        token = create_test_token(exp_delta_seconds=3600)
+        actual_exp = get_token_expiry(token)
+
+        # Allow 2 second tolerance for test execution time
+        assert actual_exp is not None
+        assert abs(actual_exp - expected_exp) <= 2
+
+    def test_extract_expiry_from_expired_token(self):
+        """Should extract expiry even from expired token."""
+        token = create_test_token(exp_delta_seconds=-3600)  # Expired 1 hour ago
+        exp = get_token_expiry(token)
+
+        # Should still return the expiry timestamp even if expired
+        assert exp is not None
+        # The expiry should be in the past (relative to now)
+        assert exp < datetime.now(timezone.utc).timestamp()
+
+    def test_invalid_token_returns_none(self):
+        """Invalid token should return None."""
+        assert get_token_expiry("invalid.token.here") is None
+
+    def test_empty_token_returns_none(self):
+        """Empty token should return None."""
+        assert get_token_expiry("") is None
+
+    def test_token_without_exp_claim(self):
+        """Token without exp claim should return None."""
+        # Create token without exp claim
+        payload = {"sub": "testuser", "user_id": 1}
+        token = jwt.encode(
+            payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM
+        )
+        assert get_token_expiry(token) is None

--- a/frontend/src/__tests__/contexts/SocketContext.auth.test.ts
+++ b/frontend/src/__tests__/contexts/SocketContext.auth.test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for auth error handling utilities in SocketContext
+ *
+ * These tests verify the auth error detection logic used in the socket
+ * connect_error handler to ensure proper identification of authentication
+ * failures vs other connection errors.
+ */
+
+import { ServerEvents, AuthErrorPayload } from '@/types/socket'
+
+describe('Socket Auth Error Types', () => {
+  describe('ServerEvents.AUTH_ERROR', () => {
+    it('should have correct event name', () => {
+      expect(ServerEvents.AUTH_ERROR).toBe('auth:error')
+    })
+  })
+
+  describe('AuthErrorPayload', () => {
+    it('should accept valid TOKEN_EXPIRED payload', () => {
+      const payload: AuthErrorPayload = {
+        error: 'Token expired',
+        code: 'TOKEN_EXPIRED',
+      }
+      expect(payload.error).toBe('Token expired')
+      expect(payload.code).toBe('TOKEN_EXPIRED')
+    })
+
+    it('should accept valid INVALID_TOKEN payload', () => {
+      const payload: AuthErrorPayload = {
+        error: 'Invalid token',
+        code: 'INVALID_TOKEN',
+      }
+      expect(payload.error).toBe('Invalid token')
+      expect(payload.code).toBe('INVALID_TOKEN')
+    })
+  })
+})
+
+describe('Auth Error Detection Logic', () => {
+  /**
+   * This helper function mirrors the logic used in SocketContext
+   * to detect authentication errors from connection error messages.
+   */
+  function isAuthError(errorMessage: string): boolean {
+    const errorMsg = errorMessage?.toLowerCase() || ''
+    return (
+      errorMsg.includes('expired') ||
+      errorMsg.includes('unauthorized') ||
+      errorMsg.includes('jwt') ||
+      errorMsg.includes('authentication')
+    )
+  }
+
+  describe('Should detect auth errors', () => {
+    it('should detect "expired" in error message', () => {
+      expect(isAuthError('Token expired')).toBe(true)
+      expect(isAuthError('JWT token has expired')).toBe(true)
+      expect(isAuthError('Session expired')).toBe(true)
+    })
+
+    it('should detect "unauthorized" in error message', () => {
+      expect(isAuthError('Unauthorized')).toBe(true)
+      expect(isAuthError('401 Unauthorized')).toBe(true)
+      expect(isAuthError('Request unauthorized')).toBe(true)
+    })
+
+    it('should detect "jwt" in error message', () => {
+      expect(isAuthError('Invalid JWT')).toBe(true)
+      expect(isAuthError('JWT verification failed')).toBe(true)
+      expect(isAuthError('Malformed jwt token')).toBe(true)
+    })
+
+    it('should detect "authentication" in error message', () => {
+      expect(isAuthError('Authentication failed')).toBe(true)
+      expect(isAuthError('Authentication required')).toBe(true)
+      expect(isAuthError('Invalid authentication credentials')).toBe(true)
+    })
+
+    it('should be case insensitive', () => {
+      expect(isAuthError('TOKEN EXPIRED')).toBe(true)
+      expect(isAuthError('UNAUTHORIZED')).toBe(true)
+      expect(isAuthError('JWT Invalid')).toBe(true)
+      expect(isAuthError('AUTHENTICATION FAILED')).toBe(true)
+    })
+  })
+
+  describe('Should NOT detect non-auth errors', () => {
+    it('should not detect network errors as auth errors', () => {
+      expect(isAuthError('Network error')).toBe(false)
+      expect(isAuthError('Connection refused')).toBe(false)
+      expect(isAuthError('ECONNRESET')).toBe(false)
+      expect(isAuthError('Socket timeout')).toBe(false)
+    })
+
+    it('should not detect server errors as auth errors', () => {
+      expect(isAuthError('Internal server error')).toBe(false)
+      expect(isAuthError('500 Server Error')).toBe(false)
+      expect(isAuthError('Service unavailable')).toBe(false)
+    })
+
+    it('should not detect generic errors as auth errors', () => {
+      expect(isAuthError('Something went wrong')).toBe(false)
+      expect(isAuthError('Unknown error')).toBe(false)
+      expect(isAuthError('Invalid payload')).toBe(false)
+      expect(isAuthError('Bad request')).toBe(false)
+    })
+
+    it('should handle empty or null messages', () => {
+      expect(isAuthError('')).toBe(false)
+      expect(isAuthError(null as unknown as string)).toBe(false)
+      expect(isAuthError(undefined as unknown as string)).toBe(false)
+    })
+  })
+
+  describe('Edge cases from previous implementation', () => {
+    it('should NOT detect "invalid" alone (removed to avoid false positives)', () => {
+      // Previously detected 'invalid' which caused false positives like "invalid payload"
+      // Now we only detect specific auth-related patterns
+      expect(isAuthError('invalid payload')).toBe(false)
+      expect(isAuthError('invalid format')).toBe(false)
+    })
+
+    it('should NOT detect "token" alone (removed to avoid false positives)', () => {
+      // Previously detected 'token' which could match non-auth contexts
+      // Now we rely on 'jwt' or 'expired' for token-related auth errors
+      expect(isAuthError('missing token in request')).toBe(false)
+      expect(isAuthError('token processing error')).toBe(false)
+    })
+  })
+})
+
+describe('Redirect Path Preservation', () => {
+  /**
+   * Test that the auth error handling logic properly saves the current path
+   * for post-login redirect.
+   */
+
+  it('should construct correct redirect path with pathname only', () => {
+    const pathname = '/chat'
+    const search = ''
+    const currentPath = pathname + search
+    expect(currentPath).toBe('/chat')
+  })
+
+  it('should construct correct redirect path with query params', () => {
+    const pathname = '/tasks/123'
+    const search = '?tab=details'
+    const currentPath = pathname + search
+    expect(currentPath).toBe('/tasks/123?tab=details')
+  })
+
+  it('should construct correct redirect path with complex query', () => {
+    const pathname = '/chat'
+    const search = '?taskShare=abc123&mode=view'
+    const currentPath = pathname + search
+    expect(currentPath).toBe('/chat?taskShare=abc123&mode=view')
+  })
+})

--- a/frontend/src/__tests__/features/common/AuthGuard.test.tsx
+++ b/frontend/src/__tests__/features/common/AuthGuard.test.tsx
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, waitFor } from '@testing-library/react'
+import { useRouter, usePathname, useSearchParams } from 'next/navigation'
+import AuthGuard from '@/features/common/AuthGuard'
+import { userApis } from '@/apis/user'
+import { paths } from '@/config/paths'
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+}))
+
+// Mock user APIs
+jest.mock('@/apis/user', () => ({
+  userApis: {
+    isAuthenticated: jest.fn(),
+  },
+}))
+
+// Mock useTranslation
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+describe('AuthGuard', () => {
+  const mockRouter = {
+    replace: jest.fn(),
+    push: jest.fn(),
+  }
+
+  const mockSearchParams = {
+    toString: jest.fn(() => ''),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    ;(useSearchParams as jest.Mock).mockReturnValue(mockSearchParams)
+  })
+
+  describe('Token expiry validation', () => {
+    it('should redirect to login when isAuthenticated returns false', async () => {
+      // Arrange
+      ;(usePathname as jest.Mock).mockReturnValue('/chat')
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      render(
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(userApis.isAuthenticated).toHaveBeenCalled()
+        expect(mockRouter.replace).toHaveBeenCalledWith(
+          expect.stringContaining(paths.auth.login.getHref())
+        )
+      })
+    })
+
+    it('should render children when isAuthenticated returns true', async () => {
+      // Arrange
+      ;(usePathname as jest.Mock).mockReturnValue('/chat')
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(true)
+
+      // Act
+      const { getByText } = render(
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(userApis.isAuthenticated).toHaveBeenCalled()
+        expect(mockRouter.replace).not.toHaveBeenCalled()
+        expect(getByText('Protected Content')).toBeInTheDocument()
+      })
+    })
+
+    it('should include redirect path in login URL', async () => {
+      // Arrange
+      ;(usePathname as jest.Mock).mockReturnValue('/tasks/123')
+      mockSearchParams.toString.mockReturnValue('tab=details')
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      render(
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining('redirect='))
+        expect(mockRouter.replace).toHaveBeenCalledWith(
+          expect.stringContaining(encodeURIComponent('/tasks/123?tab=details'))
+        )
+      })
+    })
+
+    it('should allow access to login page without authentication', async () => {
+      // Arrange
+      ;(usePathname as jest.Mock).mockReturnValue(paths.auth.login.getHref())
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      const { getByText } = render(
+        <AuthGuard>
+          <div>Login Page</div>
+        </AuthGuard>
+      )
+
+      // Assert
+      await waitFor(() => {
+        // Should not call isAuthenticated for allowed paths
+        expect(mockRouter.replace).not.toHaveBeenCalled()
+        expect(getByText('Login Page')).toBeInTheDocument()
+      })
+    })
+
+    it('should allow access to shared task page without authentication', async () => {
+      // Arrange
+      ;(usePathname as jest.Mock).mockReturnValue('/shared/task')
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      const { getByText } = render(
+        <AuthGuard>
+          <div>Shared Task</div>
+        </AuthGuard>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(mockRouter.replace).not.toHaveBeenCalled()
+        expect(getByText('Shared Task')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/frontend/src/__tests__/features/common/UserContext.test.tsx
+++ b/frontend/src/__tests__/features/common/UserContext.test.tsx
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, act, waitFor } from '@testing-library/react'
+import { UserProvider, useUser } from '@/features/common/UserContext'
+import { userApis } from '@/apis/user'
+import { useRouter } from 'next/navigation'
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+// Mock user APIs
+jest.mock('@/apis/user', () => ({
+  userApis: {
+    isAuthenticated: jest.fn(),
+    getCurrentUser: jest.fn(),
+    login: jest.fn(),
+    logout: jest.fn(),
+  },
+}))
+
+// Mock useToast
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}))
+
+// Mock paths
+jest.mock('@/config/paths', () => ({
+  paths: {
+    auth: {
+      login: {
+        getHref: () => '/login',
+      },
+    },
+    home: {
+      getHref: () => '/',
+    },
+  },
+}))
+
+// Test component to access context
+function TestComponent({ onUserChange }: { onUserChange?: (user: unknown) => void }) {
+  const { user, isLoading } = useUser()
+  if (onUserChange) {
+    onUserChange(user)
+  }
+  return <div>{isLoading ? 'Loading...' : user ? `User: ${user.user_name}` : 'No user'}</div>
+}
+
+describe('UserContext', () => {
+  const mockRouter = {
+    replace: jest.fn(),
+    push: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers()
+    ;(useRouter as jest.Mock).mockReturnValue(mockRouter)
+    // Mock window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: '/chat',
+        href: 'http://localhost/chat',
+      },
+      writable: true,
+    })
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('Token expiry periodic check with useRef fix', () => {
+    it('should detect token expiry using userRef (fixes closure issue)', async () => {
+      // Arrange - User is initially authenticated
+      const mockUser = { id: 1, user_name: 'testuser', email: 'test@test.com' }
+      ;(userApis.getCurrentUser as jest.Mock).mockResolvedValue(mockUser)
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(true)
+
+      // Act - Render the provider
+      render(
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      )
+
+      // Wait for initial user fetch
+      await waitFor(() => {
+        expect(userApis.getCurrentUser).toHaveBeenCalled()
+      })
+
+      // Now simulate token expiry
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Fast-forward time to trigger the interval check (10 seconds)
+      act(() => {
+        jest.advanceTimersByTime(10000)
+      })
+
+      // Assert - Should have called isAuthenticated during the interval
+      expect(userApis.isAuthenticated).toHaveBeenCalled()
+    })
+
+    it('should not redirect when user is null (not logged in)', async () => {
+      // Arrange - User not authenticated from the start
+      // When isAuthenticated returns false, fetchUser() returns early without calling getCurrentUser
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      render(
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      )
+
+      // Wait for initial auth check (isAuthenticated is called in fetchUser)
+      await waitFor(() => {
+        expect(userApis.isAuthenticated).toHaveBeenCalled()
+      })
+
+      // Clear previous calls to track interval behavior
+      ;(userApis.isAuthenticated as jest.Mock).mockClear()
+
+      // Fast-forward time to trigger the interval check (10 seconds)
+      act(() => {
+        jest.advanceTimersByTime(10000)
+      })
+
+      // Assert - isAuthenticated should be called during interval
+      // But since userRef.current is null (user was never set), no redirect should happen
+      // The condition is: if (!isAuth && userRef.current) - userRef.current is null
+      expect(userApis.isAuthenticated).toHaveBeenCalled()
+      // getCurrentUser is NOT called when isAuthenticated returns false initially
+      expect(userApis.getCurrentUser).not.toHaveBeenCalled()
+    })
+
+    it('should call isAuthenticated periodically every 10 seconds', async () => {
+      // Arrange
+      const mockUser = { id: 1, user_name: 'testuser', email: 'test@test.com' }
+      ;(userApis.getCurrentUser as jest.Mock).mockResolvedValue(mockUser)
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(true)
+
+      // Act
+      render(
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      )
+
+      await waitFor(() => {
+        expect(userApis.getCurrentUser).toHaveBeenCalled()
+      })
+
+      // Clear previous calls
+      ;(userApis.isAuthenticated as jest.Mock).mockClear()
+
+      // Fast-forward 30 seconds (should trigger 3 checks)
+      act(() => {
+        jest.advanceTimersByTime(30000)
+      })
+
+      // Assert - Should have been called 3 times (at 10s, 20s, 30s)
+      expect(userApis.isAuthenticated).toHaveBeenCalledTimes(3)
+    })
+  })
+
+  describe('User state management', () => {
+    it('should fetch user on mount', async () => {
+      // Arrange
+      const mockUser = { id: 1, user_name: 'testuser', email: 'test@test.com' }
+      ;(userApis.getCurrentUser as jest.Mock).mockResolvedValue(mockUser)
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(true)
+
+      // Act
+      const { getByText } = render(
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText('User: testuser')).toBeInTheDocument()
+      })
+    })
+
+    it('should show no user when fetch fails', async () => {
+      // Arrange
+      ;(userApis.getCurrentUser as jest.Mock).mockRejectedValue(new Error('Unauthorized'))
+      ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
+
+      // Act
+      const { getByText } = render(
+        <UserProvider>
+          <TestComponent />
+        </UserProvider>
+      )
+
+      // Assert
+      await waitFor(() => {
+        expect(getByText('No user')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/frontend/src/contexts/SocketContext.tsx
+++ b/frontend/src/contexts/SocketContext.tsx
@@ -292,18 +292,23 @@ export function SocketProvider({ children }: { children: ReactNode }) {
       setIsConnected(false)
 
       // Check if error message indicates auth failure
+      // Use specific auth-related error patterns to avoid false positives
       const errorMsg = error.message?.toLowerCase() || ''
-      if (
+      const isAuthError =
         errorMsg.includes('expired') ||
-        errorMsg.includes('invalid') ||
         errorMsg.includes('unauthorized') ||
-        errorMsg.includes('token')
-      ) {
+        errorMsg.includes('jwt') ||
+        errorMsg.includes('authentication')
+
+      if (isAuthError) {
         console.log('[Socket.IO] Auth error on connect, redirecting to login')
         removeToken()
 
         const loginPath = paths.auth.login.getHref()
         if (typeof window !== 'undefined' && window.location.pathname !== loginPath) {
+          // Save current path for redirect after login (consistent with AUTH_ERROR handler)
+          const currentPath = window.location.pathname + window.location.search
+          sessionStorage.setItem(POST_LOGIN_REDIRECT_KEY, currentPath)
           window.location.href = loginPath
         }
       }

--- a/frontend/src/features/common/AuthGuard.tsx
+++ b/frontend/src/features/common/AuthGuard.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useState } from 'react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { getToken } from '@/apis/user'
+import { userApis } from '@/apis/user'
 import { paths } from '@/config/paths'
 import { useTranslation } from '@/hooks/useTranslation'
 import { Spinner } from '@/components/ui/spinner'
@@ -32,8 +32,9 @@ export default function AuthGuard({ children }: AuthGuardProps) {
       '/shared/task', // Allow public shared task page without authentication
     ]
     if (!allowedPaths.includes(pathname)) {
-      const token = getToken()
-      if (!token) {
+      // Use isAuthenticated() to check both token existence and expiry
+      const isAuth = userApis.isAuthenticated()
+      if (!isAuth) {
         const search = searchParams.toString()
         const redirectTarget = search ? `${pathname}?${search}` : pathname
         router.replace(`${loginPath}?redirect=${encodeURIComponent(redirectTarget)}`)

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -24,6 +24,9 @@ export const ClientEvents = {
 // Server -> Client Events
 // ============================================================
 export const ServerEvents = {
+  // Authentication events
+  AUTH_ERROR: 'auth:error', // Token expired or invalid
+
   // Chat streaming events (to task room)
   CHAT_START: 'chat:start',
   CHAT_CHUNK: 'chat:chunk',
@@ -132,6 +135,11 @@ export interface HistorySyncPayload {
 // ============================================================
 // Server -> Client Payloads
 // ============================================================
+
+export interface AuthErrorPayload {
+  error: string
+  code: 'TOKEN_EXPIRED' | 'INVALID_TOKEN' | string
+}
 
 export interface SourceReference {
   /** Source index number (e.g., 1, 2, 3) */


### PR DESCRIPTION
## Summary

- Add WebSocket session-level token expiry validation to detect expired tokens during long-lived connections
- Store token expiry timestamp in WebSocket session and check before processing key events (chat:send, task:join, chat:retry, chat:cancel)
- Emit `auth:error` event to frontend when token expires during session, triggering automatic redirect to login
- Fix closure issue in UserContext periodic token check that prevented proper detection of token expiry
- Update AuthGuard to use `isAuthenticated()` which validates both token existence and expiry

## Problem

When users stay on the page for a long time, the token expires but there's no automatic redirect to the login page. The root cause is that WebSocket only validates the token once during connection (`on_connect`), without ongoing validation after the connection is established.

| Component | Previous Behavior | Issue |
|-----------|-------------------|-------|
| HTTP API | Validates token on each request | ✅ Works correctly, 401 triggers redirect |
| WebSocket | Only validates on `on_connect` | ❌ **No detection of token expiry after connection** |
| UserContext interval | 10s check interval | ❌ **Closure captured stale user state** |
| AuthGuard | Only checks token existence | ❌ **Doesn't check if token is expired** |

## Solution

### Backend Changes
1. **auth.py**: Added `is_token_expired()` and `get_token_expiry()` functions
2. **chat_namespace.py**: 
   - Store `token_exp` in session during `on_connect`
   - Add `_check_token_expiry()` helper method
   - Add `_handle_token_expired()` to emit `auth:error` and disconnect
   - Check token expiry in key event handlers

### Frontend Changes
1. **socket.ts**: Added `AUTH_ERROR` event and `AuthErrorPayload` type
2. **SocketContext.tsx**: Listen for `auth:error` event and redirect to login
3. **UserContext.tsx**: Use `useRef` to fix closure issue in setInterval callback
4. **AuthGuard.tsx**: Use `isAuthenticated()` instead of `getToken()`

## Test plan

- [ ] Login and stay on page until token expires, verify auto-redirect to login
- [ ] Send chat message after token expires, verify auth:error event and redirect
- [ ] Join task room after token expires, verify auth:error event and redirect
- [ ] Page refresh with expired token, verify AuthGuard redirects to login
- [ ] Verify periodic token check in UserContext works correctly
- [ ] Verify redirect preserves original path for post-login navigation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat now detects expired credentials and stops chat actions, automatically signing out and redirecting users to login.
  * Authentication checks now consider token expiry to avoid stale-session behavior.

* **New Features**
  * Clients receive explicit authentication error notifications; the app clears expired tokens and preserves the current page for post-login redirect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->