### PR TITLE
feat(chat): add regenerate button for last AI message in single chat

### DIFF
--- a/frontend/src/apis/subtasks.ts
+++ b/frontend/src/apis/subtasks.ts
@@ -16,6 +16,10 @@ export interface MessageEditResponse {
   new_content: string
 }
 
+export interface DeleteSubtaskResponse {
+  message: string
+}
+
 export const subtaskApis = {
   /**
    * Edit a user message and delete all subsequent messages.
@@ -29,5 +33,16 @@ export const subtaskApis = {
     return apiClient.post<MessageEditResponse>(`/subtasks/${subtaskId}/edit`, {
       new_content: newContent,
     })
+  },
+
+  /**
+   * Delete a subtask (message).
+   * Used for regenerate feature to delete the last AI response before resending.
+   *
+   * @param subtaskId - The subtask ID to delete
+   * @returns Success message
+   */
+  deleteSubtask: async (subtaskId: number): Promise<DeleteSubtaskResponse> => {
+    return apiClient.delete<DeleteSubtaskResponse>(`/subtasks/${subtaskId}`)
   },
 }

--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from 'react-i18next'
@@ -142,6 +142,10 @@ export interface BubbleToolsProps {
     like: string
     dislike: string
   }
+  /** Handler for regenerate button click - only shown when provided */
+  onRegenerate?: () => void
+  /** Whether regenerate action is in progress */
+  isRegenerating?: boolean
 }
 
 // Bubble toolbar: supports copy button, feedback buttons, and extensible tool buttons
@@ -153,6 +157,8 @@ const BubbleTools = ({
   onLike,
   onDislike,
   feedbackLabels,
+  onRegenerate,
+  isRegenerating,
 }: BubbleToolsProps) => {
   const { t } = useTranslation()
 
@@ -196,6 +202,25 @@ const BubbleTools = ({
         </TooltipTrigger>
         <TooltipContent>{feedbackLabels?.dislike || 'Dislike'}</TooltipContent>
       </Tooltip>
+      {/* Regenerate button - only shown when onRegenerate is provided */}
+      {onRegenerate && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onRegenerate}
+              disabled={isRegenerating}
+              className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 text-text-muted ${isRegenerating ? 'animate-spin' : ''}`}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('chat:actions.regenerate') || 'Regenerate'}</TooltipContent>
+        </Tooltip>
+      )}
       {/* Additional tool buttons (e.g., download) */}
       {tools.map(tool => (
         <Tooltip key={tool.key}>

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -159,6 +159,10 @@ export interface MessageBubbleProps {
   onEditSave?: (content: string) => Promise<void>
   /** Callback when user cancels editing */
   onEditCancel?: () => void
+  /** Callback when user clicks regenerate button (only for last AI message in single chat) */
+  onRegenerate?: () => void
+  /** Whether regenerate action is in progress */
+  isRegenerating?: boolean
 }
 
 // Component for rendering a paragraph with hover action button
@@ -278,6 +282,8 @@ const MessageBubble = memo(
     onEdit,
     onEditSave,
     onEditCancel,
+    onRegenerate,
+    isRegenerating,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
     const { trace } = useTraceAction()
@@ -611,6 +617,8 @@ const MessageBubble = memo(
               like: t('chat:messages.like') || 'Like',
               dislike: t('chat:messages.dislike') || 'Dislike',
             }}
+            onRegenerate={onRegenerate}
+            isRegenerating={isRegenerating}
           />
         </>
       )
@@ -1575,7 +1583,9 @@ const MessageBubble = memo(
       prevProps.msg.status === nextProps.msg.status &&
       prevProps.msg.error === nextProps.msg.error &&
       prevProps.isPendingConfirmation === nextProps.isPendingConfirmation &&
-      prevProps.isEditing === nextProps.isEditing
+      prevProps.isEditing === nextProps.isEditing &&
+      prevProps.onRegenerate === nextProps.onRegenerate &&
+      prevProps.isRegenerating === nextProps.isRegenerating
 
     return shouldSkipRender
   }


### PR DESCRIPTION
## Summary

为 Wegent 单聊功能的最后一条 AI 回复消息添加"重新生成"功能。

### 功能实现

1. **图标位置与样式**
   - 在单聊消息底部操作栏中，"回复/反馈"图标后面新增"重新生成"图标
   - 使用 lucide-react 的 `RefreshCw` 图标（两个箭头回旋）
   - 鼠标悬停时显示 tooltip 文案

2. **显示条件**
   - 仅在单聊中显示，群聊中不显示
   - 仅在最后一条 AI 回复消息上显示
   - AI 消息正在生成中（streaming 状态）时隐藏

3. **交互行为**
   - 点击后删除当前最后一条 AI 回复消息
   - 获取用户最后发送的消息内容并重新发送给 AI
   - 显示 loading 状态（图标旋转动画）

4. **错误处理**
   - 失败时显示错误提示通知用户
   - 刷新任务详情恢复状态

5. **国际化支持**
   - 已有翻译支持：中文 `重新生成` / 英文 `Regenerate`

### 修改文件

- `frontend/src/apis/subtasks.ts`: 添加 deleteSubtask API
- `frontend/src/features/tasks/components/message/BubbleTools.tsx`: 添加重新生成按钮
- `frontend/src/features/tasks/components/message/MessageBubble.tsx`: 传递 onRegenerate props
- `frontend/src/features/tasks/components/message/MessagesArea.tsx`: 实现重新生成逻辑

## Test plan

- [ ] 在单聊中发送消息，AI 回复后验证最后一条 AI 消息显示重新生成按钮
- [ ] 点击重新生成按钮，验证 AI 消息被删除并触发新的 AI 回复
- [ ] 验证重新生成过程中按钮显示 loading 状态
- [ ] 验证群聊中不显示重新生成按钮
- [ ] 验证 AI streaming 状态时不显示重新生成按钮
- [ ] 验证历史 AI 消息（非最后一条）不显示重新生成按钮
- [ ] 验证中英文 tooltip 显示正确

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to regenerate AI-generated messages. Users can now refresh the last completed AI response to receive a new message generation, with a regenerate button and loading indicator displayed during the process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->