### PR TITLE
feat(auth): add JWT authentication for chat_shell backend API calls

### DIFF
--- a/backend/app/api/endpoints/internal/bots.py
+++ b/backend/app/api/endpoints/internal/bots.py
@@ -7,6 +7,10 @@ Internal Bot API endpoints for chat_shell service.
 
 Provides endpoints to query bot configurations for chat_shell HTTP mode.
 These endpoints are intended for service-to-service communication.
+
+Authentication:
+- Uses JWT token verification for all endpoints
+- JWT token should be passed in Authorization header: "Bearer <token>"
 """
 
 import logging
@@ -16,7 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, verify_internal_jwt
 from app.models.kind import Kind
 from app.schemas.kind import Bot, Ghost
 
@@ -35,7 +39,11 @@ class MCPServersResponse(BaseModel):
     )
 
 
-@router.get("/{bot_name}/mcp", response_model=MCPServersResponse)
+@router.get(
+    "/{bot_name}/mcp",
+    response_model=MCPServersResponse,
+    dependencies=[Depends(verify_internal_jwt)],
+)
 async def get_bot_mcp_servers(
     bot_name: str,
     namespace: str = Query(default="default", description="Bot namespace"),

--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -7,6 +7,10 @@ Internal RAG API endpoints for chat_shell service.
 
 Provides a simplified RAG retrieval endpoint for chat_shell HTTP mode.
 These endpoints are intended for service-to-service communication.
+
+Authentication:
+- Uses JWT token verification for all endpoints
+- JWT token should be passed in Authorization header: "Bearer <token>"
 """
 
 import logging
@@ -16,7 +20,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, verify_internal_jwt
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +55,11 @@ class InternalRetrieveResponse(BaseModel):
     total: int
 
 
-@router.post("/retrieve", response_model=InternalRetrieveResponse)
+@router.post(
+    "/retrieve",
+    response_model=InternalRetrieveResponse,
+    dependencies=[Depends(verify_internal_jwt)],
+)
 async def internal_retrieve(
     request: InternalRetrieveRequest,
     db: Session = Depends(get_db),
@@ -174,7 +182,11 @@ class KnowledgeBaseSizeResponse(BaseModel):
     total_estimated_tokens: int  # Sum of all estimated tokens
 
 
-@router.post("/kb-size", response_model=KnowledgeBaseSizeResponse)
+@router.post(
+    "/kb-size",
+    response_model=KnowledgeBaseSizeResponse,
+    dependencies=[Depends(verify_internal_jwt)],
+)
 async def get_knowledge_base_size(
     request: KnowledgeBaseSizeRequest,
     db: Session = Depends(get_db),
@@ -274,7 +286,11 @@ class SaveRagResultResponse(BaseModel):
     message: str = ""
 
 
-@router.post("/save-result", response_model=SaveRagResultResponse)
+@router.post(
+    "/save-result",
+    response_model=SaveRagResultResponse,
+    dependencies=[Depends(verify_internal_jwt)],
+)
 async def save_rag_result(
     request: SaveRagResultRequest,
     db: Session = Depends(get_db),
@@ -378,7 +394,11 @@ class AllChunksResponse(BaseModel):
     total: int
 
 
-@router.post("/all-chunks", response_model=AllChunksResponse)
+@router.post(
+    "/all-chunks",
+    response_model=AllChunksResponse,
+    dependencies=[Depends(verify_internal_jwt)],
+)
 async def get_all_chunks(
     request: AllChunksRequest,
     db: Session = Depends(get_db),

--- a/backend/app/api/endpoints/internal/skills.py
+++ b/backend/app/api/endpoints/internal/skills.py
@@ -8,7 +8,8 @@ Provides internal API for chat_shell to download skill binaries.
 These endpoints are intended for service-to-service communication.
 
 Authentication:
-- In production, should be protected by network-level security
+- Uses JWT token verification for all endpoints
+- JWT token should be passed in Authorization header: "Bearer <token>"
 """
 
 import io
@@ -18,7 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
-from app.api.dependencies import get_db
+from app.api.dependencies import get_db, verify_internal_jwt
 from app.models.kind import Kind
 from app.models.skill_binary import SkillBinary
 
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/skills", tags=["internal-skills"])
 
 
-@router.get("/{skill_id}/binary")
+@router.get("/{skill_id}/binary", dependencies=[Depends(verify_internal_jwt)])
 def get_skill_binary(
     skill_id: int,
     db: Session = Depends(get_db),

--- a/backend/app/api/endpoints/internal/tables.py
+++ b/backend/app/api/endpoints/internal/tables.py
@@ -9,15 +9,16 @@ Provides internal API for chat_shell's DataTableTool to query table data.
 These endpoints are intended for service-to-service communication, not user access.
 
 Authentication:
-- Uses service-to-service authentication (X-Service-Name header)
-- In production, should be protected by network-level security
+- Uses JWT token verification for all endpoints
+- JWT token should be passed in Authorization header: "Bearer <token>"
 """
 
 import logging
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
+from app.api.dependencies import verify_internal_jwt
 from app.services.tables import DataTableService, TableQueryRequest
 from app.services.tables.providers import DingTalkProvider  # noqa: F401
 
@@ -37,7 +38,7 @@ class InternalTableQueryRequest(BaseModel):
     filters: dict | None = Field(default=None, description="Query filters")
 
 
-@router.post("/query")
+@router.post("/query", dependencies=[Depends(verify_internal_jwt)])
 async def query_table(request: InternalTableQueryRequest):
     """
     Query table data (internal API).

--- a/chat_shell/chat_shell/tools/auth_utils.py
+++ b/chat_shell/chat_shell/tools/auth_utils.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authentication utilities for backend API calls.
+
+This module provides helper functions for adding JWT authentication
+to HTTP requests made to backend internal APIs.
+"""
+
+import logging
+from typing import Dict
+
+from chat_shell.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_backend_auth_headers() -> Dict[str, str]:
+    """
+    Get authentication headers for backend internal API calls.
+
+    Returns JWT token from REMOTE_STORAGE_TOKEN setting in Authorization header.
+    This token is used to authenticate chat_shell service when calling backend
+    internal API endpoints.
+
+    Returns:
+        Dictionary of HTTP headers including Authorization header with JWT token.
+        If token is not configured, returns empty dict (requests will fail with 401).
+
+    Example:
+        >>> headers = get_backend_auth_headers()
+        >>> async with httpx.AsyncClient(headers=headers) as client:
+        >>>     response = await client.get(backend_url)
+    """
+    headers = {}
+
+    # Get JWT token from settings
+    # Priority: REMOTE_STORAGE_TOKEN (primary) > INTERNAL_SERVICE_TOKEN (fallback)
+    auth_token = getattr(settings, "REMOTE_STORAGE_TOKEN", "")
+    if not auth_token:
+        auth_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "")
+
+    if auth_token:
+        headers["Authorization"] = f"Bearer {auth_token}"
+        logger.debug("[auth_utils] Added JWT token to Authorization header")
+    else:
+        logger.warning(
+            "[auth_utils] No JWT token configured (REMOTE_STORAGE_TOKEN or INTERNAL_SERVICE_TOKEN). "
+            "Backend internal API calls will fail with 401 Unauthorized."
+        )
+
+    return headers

--- a/chat_shell/chat_shell/tools/builtin/data_table.py
+++ b/chat_shell/chat_shell/tools/builtin/data_table.py
@@ -18,6 +18,7 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from chat_shell.core.config import settings
+from chat_shell.tools.auth_utils import get_backend_auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -160,15 +161,19 @@ class DataTableTool(BaseTool):
             "max_records": max_records,
         }
 
-        # Call backend internal API (no authentication required for internal endpoints)
+        # Call backend internal API with JWT authentication
         async with httpx.AsyncClient(timeout=60.0) as client:
             try:
                 # Use internal API endpoint for service-to-service communication
                 url = f"{backend_url}/api/internal/tables/query"
+
+                # Get authentication headers
+                headers = get_backend_auth_headers()
+
                 logger.info(f"[DataTableTool] Calling backend internal API: {url}")
                 logger.debug(f"[DataTableTool] Request data: {request_data}")
 
-                response = await client.post(url, json=request_data)
+                response = await client.post(url, json=request_data, headers=headers)
                 response.raise_for_status()
 
                 result = response.json()

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -16,6 +16,7 @@ from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
+from ..auth_utils import get_backend_auth_headers
 from ..knowledge_content_cleaner import get_content_cleaner
 from ..knowledge_injection_strategy import InjectionMode, InjectionStrategy
 
@@ -340,9 +341,13 @@ class KnowledgeBaseTool(BaseTool):
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
+                # Get authentication headers
+                headers = get_backend_auth_headers()
+
                 response = await client.post(
                     f"{backend_url}/api/internal/rag/kb-size",
                     json={"knowledge_base_ids": self.knowledge_base_ids},
+                    headers=headers,
                 )
 
                 if response.status_code == 200:
@@ -441,11 +446,15 @@ class KnowledgeBaseTool(BaseTool):
             backend_url = getattr(settings, "BACKEND_API_URL", "http://localhost:8000")
 
         async with httpx.AsyncClient(timeout=60.0) as client:
+            # Get authentication headers
+            headers = get_backend_auth_headers()
+
             for kb_id in self.knowledge_base_ids:
                 try:
                     response = await client.post(
                         f"{backend_url}/api/internal/rag/all-chunks",
                         json={"knowledge_base_id": kb_id, "max_chunks": 10000},
+                        headers=headers,
                     )
 
                     if response.status_code != 200:
@@ -578,6 +587,9 @@ class KnowledgeBaseTool(BaseTool):
             backend_url = getattr(settings, "BACKEND_API_URL", "http://localhost:8000")
 
         async with httpx.AsyncClient(timeout=30.0) as client:
+            # Get authentication headers
+            headers = get_backend_auth_headers()
+
             for kb_id in self.knowledge_base_ids:
                 try:
                     payload = {
@@ -591,6 +603,7 @@ class KnowledgeBaseTool(BaseTool):
                     response = await client.post(
                         f"{backend_url}/api/internal/rag/retrieve",
                         json=payload,
+                        headers=headers,
                     )
 
                     if response.status_code != 200:
@@ -955,6 +968,9 @@ class KnowledgeBaseTool(BaseTool):
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
+                # Get authentication headers
+                headers = get_backend_auth_headers()
+
                 response = await client.post(
                     f"{backend_url}/api/internal/rag/save-result",
                     json={
@@ -963,6 +979,7 @@ class KnowledgeBaseTool(BaseTool):
                         "extracted_text": extracted_text,
                         "sources": kb_sources,
                     },
+                    headers=headers,
                 )
 
                 if response.status_code == 200:

--- a/chat_shell/chat_shell/tools/mcp/loader.py
+++ b/chat_shell/chat_shell/tools/mcp/loader.py
@@ -16,6 +16,7 @@ from typing import Any
 import httpx
 
 from chat_shell.core.config import settings
+from chat_shell.tools.auth_utils import get_backend_auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -165,15 +166,11 @@ async def _get_bot_mcp_servers(bot_name: str, bot_namespace: str) -> dict[str, A
         MCP servers configuration dict
     """
     base_url = settings.REMOTE_STORAGE_URL.rstrip("/")
-    auth_token = settings.REMOTE_STORAGE_TOKEN
 
-    # Build headers
-    headers = {
-        "X-Service-Name": "chat-shell",
-        "Content-Type": "application/json",
-    }
-    if auth_token:
-        headers["Authorization"] = f"Bearer {auth_token}"
+    # Get authentication headers
+    headers = get_backend_auth_headers()
+    headers["X-Service-Name"] = "chat-shell"
+    headers["Content-Type"] = "application/json"
 
     # Build URL: /internal/bots/{bot_name}/mcp?namespace={bot_namespace}
     url = f"{base_url}/bots/{bot_name}/mcp"

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import httpx
 
 from chat_shell.core.config import settings
+from chat_shell.tools.auth_utils import get_backend_auth_headers
 
 logger = logging.getLogger(__name__)
 
@@ -89,14 +90,8 @@ async def _download_skill_binary(download_url: str, skill_name: str) -> Optional
         Binary data or None if download failed
     """
     try:
-        # Get service token from settings
-        service_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", None)
-        if not service_token:
-            service_token = getattr(settings, "REMOTE_STORAGE_TOKEN", "")
-
-        headers = {}
-        if service_token:
-            headers["Authorization"] = f"Bearer {service_token}"
+        # Get authentication headers
+        headers = get_backend_auth_headers()
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.get(download_url, headers=headers)


### PR DESCRIPTION
## Summary

This PR adds JWT token authentication to all internal API endpoints used by chat_shell for improved security and audit capabilities.

**Key changes:**
- ✅ Backend: Add `verify_internal_jwt` dependency for internal API authentication
- ✅ Backend: Apply JWT auth to all internal endpoints (chat, rag, tables, skills, bots)
- ✅ Chat_shell: Add `auth_utils.py` helper for consistent JWT header management
- ✅ Chat_shell: Update all HTTP calls to include JWT token in Authorization header
- ✅ Security: Full user context validation (JWT signature, expiration, user existence, active status)

## Motivation

Previously, chat_shell called backend internal APIs without authentication, relying only on network-level security. This PR implements JWT-based authentication to:

1. **Improve security**: Verify caller identity before granting access
2. **Enable audit trails**: Track which user triggered each internal API call
3. **Follow best practices**: Use industry-standard JWT authentication for service-to-service communication

## Technical Details

### Backend Implementation

**New authentication dependency** (`backend/app/api/dependencies.py`):
```python
def verify_internal_jwt(
    authorization: str = Header(default=""), db: Session = Depends(get_db)
) -> None:
    """Verify JWT token for internal API endpoints."""
    # 1. Check Authorization header format
    # 2. Verify JWT signature and expiration
    # 3. Validate user exists and is active
```

**Applied to all internal endpoints**:
- `/api/internal/chat/*` - Chat history storage (10 endpoints)
- `/api/internal/rag/*` - RAG retrieval and KB management (4 endpoints)
- `/api/internal/tables/*` - Data table queries (1 endpoint)
- `/api/internal/skills/*` - Skill binary downloads (1 endpoint)
- `/api/internal/bots/*` - Bot MCP configuration (1 endpoint)

**Exception**: `/api/internal/chat/health` remains unauthenticated for monitoring purposes.

### Chat_shell Implementation

**New auth utility** (`chat_shell/tools/auth_utils.py`):
```python
def get_backend_auth_headers() -> Dict[str, str]:
    """Get JWT token from REMOTE_STORAGE_TOKEN setting and format as Authorization header."""
```

**Updated HTTP clients**:
1. `storage/remote.py` - RemoteHistoryStore, RemoteToolResultStore (already using token)
2. `tools/builtin/data_table.py` - DataTableTool
3. `tools/builtin/knowledge_base.py` - KnowledgeBaseTool (4 API calls)
4. `tools/skill_factory.py` - Skill binary download
5. `tools/mcp/loader.py` - MCP server configuration loader

### Configuration

**Backend** (no changes required):
- Uses existing `SECRET_KEY`, `ALGORITHM` for JWT verification
- Reuses `get_current_user_from_token()` function from `app.core.security`

**Chat_shell**:
- Token sourced from `REMOTE_STORAGE_TOKEN` or `INTERNAL_SERVICE_TOKEN` setting
- No code changes needed if token is already configured

## Breaking Changes

⚠️ **All internal API endpoints now require valid JWT token.**

**Required actions**:
1. Ensure `REMOTE_STORAGE_TOKEN` or `INTERNAL_SERVICE_TOKEN` is configured in chat_shell environment
2. Token must be a valid JWT generated by backend (not a static service token)
3. Token user must exist and be active in the database

**Migration path**:
- If using Docker Compose: Token is auto-injected via environment variables
- If using standalone chat_shell: Set `CHAT_SHELL_REMOTE_STORAGE_TOKEN` environment variable

## Testing

### Unit Tests
- [ ] Backend: Test `verify_internal_jwt` with valid/invalid/expired tokens
- [ ] Backend: Test internal endpoints return 401 without token
- [ ] Chat_shell: Test `get_backend_auth_headers()` returns correct format

### Integration Tests
- [ ] E2E: Chat shell can retrieve chat history from backend
- [ ] E2E: Knowledge base tool can query backend RAG API
- [ ] E2E: Data table tool can fetch table data
- [ ] E2E: Skill loading works with authenticated download

### Manual Testing Checklist
- [ ] Start chat shell and backend services
- [ ] Send a chat message and verify history is saved
- [ ] Use knowledge base tool and verify RAG retrieval works
- [ ] Load a skill and verify binary download succeeds
- [ ] Check backend logs for authentication success/failure

## Security Considerations

✅ **Improved**:
- JWT signature verification prevents token forgery
- Expiration checks prevent replay attacks
- User validation ensures only active users can make requests
- Full audit trail with user context

⚠️ **Not addressed** (out of scope):
- Rate limiting per user
- IP allowlisting for internal services
- Mutual TLS for transport security

## Rollback Plan

If issues arise:
1. Revert this PR
2. Internal APIs will accept requests without authentication again
3. No data loss or migration required

## Documentation

Updated inline comments explain:
- JWT authentication flow
- Token configuration sources
- Error handling for 401 responses

## Test plan

- [x] Code formatted with black and isort
- [ ] Backend tests pass
- [ ] Chat_shell tests pass
- [ ] E2E tests pass
- [ ] Manual testing confirms all features work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added JWT authentication to internal service-to-service API endpoints, with Bearer tokens validated via the Authorization header on all requests.
  * Introduced centralized authentication header management utilities to provide consistent authentication handling across service integrations, API communications, and tool interactions.
  * All internal API communications now require valid Bearer token authentication for request validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->