### PR TITLE
feat(teams): add copy personal team to group functionality

### DIFF
--- a/backend/app/api/endpoints/adapter/teams.py
+++ b/backend/app/api/endpoints/adapter/teams.py
@@ -22,6 +22,8 @@ from app.schemas.shared_team import (
     TeamShareResponse,
 )
 from app.schemas.team import (
+    CopyToGroupRequest,
+    CopyToGroupResponse,
     TeamCreate,
     TeamDetail,
     TeamInDB,
@@ -174,6 +176,28 @@ def share_team(
         db=db,
         team_id=team_id,
         user_id=current_user.id,
+    )
+
+
+@router.post("/{team_id}/copy-to-group", response_model=CopyToGroupResponse)
+def copy_team_to_group(
+    team_id: int,
+    request: CopyToGroupRequest,
+    current_user: User = Depends(security.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Copy a personal team to a group.
+
+    The user must:
+    - Be the owner of the source team
+    - Have Developer or higher role in the target group
+    """
+    return team_kinds_service.copy_to_group(
+        db=db,
+        team_id=team_id,
+        user_id=current_user.id,
+        target_group_name=request.target_group_name,
     )
 
 

--- a/backend/app/schemas/team.py
+++ b/backend/app/schemas/team.py
@@ -112,3 +112,34 @@ class TeamListResponse(BaseModel):
 
     total: int
     items: list[TeamInDB]
+
+
+class CopyToGroupRequest(BaseModel):
+    """Request model for copying a team to a group"""
+
+    target_group_name: str  # Target group name to copy the team to
+
+
+class CopiedBotInfo(BaseModel):
+    """Information about a copied bot"""
+
+    original_bot_id: int
+    new_bot_id: int
+    name: str
+
+
+class ReferencedBotInfo(BaseModel):
+    """Information about a referenced (not copied) bot"""
+
+    bot_id: int
+    name: str
+
+
+class CopyToGroupResponse(BaseModel):
+    """Response model for copy team to group operation"""
+
+    id: int  # New team ID
+    name: str  # Team name
+    namespace: str  # Target group namespace
+    copied_bots: List[CopiedBotInfo]  # Bots that were copied
+    referenced_bots: List[ReferencedBotInfo]  # Bots that were referenced

--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -2232,8 +2232,16 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
             .first()
         )
         if existing_bot:
-            # Bot already exists in target namespace, return it
-            return existing_bot
+            # Bot already exists - check if user owns it and can reuse
+            if existing_bot.user_id == user_id:
+                # User owns the existing bot, safe to reference it
+                return existing_bot
+            else:
+                # Bot exists but owned by different user, cannot copy
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"A bot with name '{bot.name}' already exists in group '{target_namespace}'",
+                )
 
         # Get source ghost
         source_ghost = (

--- a/backend/tests/services/test_team_copy_to_group.py
+++ b/backend/tests/services/test_team_copy_to_group.py
@@ -1,0 +1,495 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the copy_to_group functionality in TeamKindsService.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.models.namespace import Namespace
+from app.models.namespace_member import NamespaceMember
+from app.models.user import User
+from app.services.adapters.team_kinds import team_kinds_service
+
+
+@pytest.fixture
+def test_group(test_db: Session, test_user: User) -> Namespace:
+    """Create a test group."""
+    group = Namespace(
+        name="test-group",
+        display_name="Test Group",
+        owner_user_id=test_user.id,
+        visibility="private",
+        is_active=True,
+    )
+    test_db.add(group)
+    test_db.commit()
+    test_db.refresh(group)
+    return group
+
+
+@pytest.fixture
+def test_group_membership(
+    test_db: Session, test_user: User, test_group: Namespace
+) -> NamespaceMember:
+    """Create a group membership with Developer role."""
+    member = NamespaceMember(
+        group_name=test_group.name,
+        user_id=test_user.id,
+        role="Developer",
+        is_active=True,
+    )
+    test_db.add(member)
+    test_db.commit()
+    test_db.refresh(member)
+    return member
+
+
+@pytest.fixture
+def test_shell(test_db: Session) -> Kind:
+    """Create a public shell for testing."""
+    shell = Kind(
+        user_id=0,  # Public shell
+        kind="Shell",
+        name="test-shell",
+        namespace="default",
+        json={
+            "kind": "Shell",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {"name": "test-shell", "namespace": "default"},
+            "spec": {"shellType": "ClaudeCode"},
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+    test_db.add(shell)
+    test_db.commit()
+    test_db.refresh(shell)
+    return shell
+
+
+@pytest.fixture
+def test_ghost(test_db: Session, test_user: User) -> Kind:
+    """Create a ghost for the test bot."""
+    ghost = Kind(
+        user_id=test_user.id,
+        kind="Ghost",
+        name="test-bot-ghost",
+        namespace="default",
+        json={
+            "kind": "Ghost",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {"name": "test-bot-ghost", "namespace": "default"},
+            "spec": {"systemPrompt": "Test prompt", "mcpServers": {}},
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+    test_db.add(ghost)
+    test_db.commit()
+    test_db.refresh(ghost)
+    return ghost
+
+
+@pytest.fixture
+def test_bot(
+    test_db: Session, test_user: User, test_shell: Kind, test_ghost: Kind
+) -> Kind:
+    """Create a personal bot for testing."""
+    bot = Kind(
+        user_id=test_user.id,
+        kind="Bot",
+        name="test-bot",
+        namespace="default",
+        json={
+            "kind": "Bot",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {"name": "test-bot", "namespace": "default"},
+            "spec": {
+                "ghostRef": {"name": "test-bot-ghost", "namespace": "default"},
+                "shellRef": {"name": "test-shell", "namespace": "default"},
+            },
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+    test_db.add(bot)
+    test_db.commit()
+    test_db.refresh(bot)
+    return bot
+
+
+@pytest.fixture
+def test_team(test_db: Session, test_user: User, test_bot: Kind) -> Kind:
+    """Create a personal team for testing."""
+    team = Kind(
+        user_id=test_user.id,
+        kind="Team",
+        name="test-team",
+        namespace="default",
+        json={
+            "kind": "Team",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {
+                "name": "test-team",
+                "namespace": "default",
+                "labels": {"share_status": "0"},
+            },
+            "spec": {
+                "members": [
+                    {
+                        "botRef": {"name": "test-bot", "namespace": "default"},
+                        "prompt": "Test prompt",
+                        "role": "worker",
+                        "requireConfirmation": False,
+                    }
+                ],
+                "collaborationModel": "pipeline",
+                "description": "Test team description",
+                "bind_mode": ["chat", "code"],
+            },
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+    test_db.add(team)
+    test_db.commit()
+    test_db.refresh(team)
+    return team
+
+
+class TestCopyToGroup:
+    """Test cases for copy_to_group method."""
+
+    def test_copy_team_to_group_success(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_team: Kind,
+        test_bot: Kind,
+        test_ghost: Kind,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test successful copy of a team to a group."""
+        result = team_kinds_service.copy_to_group(
+            db=test_db,
+            team_id=test_team.id,
+            user_id=test_user.id,
+            target_group_name=test_group.name,
+        )
+
+        assert result["name"] == "test-team"
+        assert result["namespace"] == test_group.name
+        assert len(result["copied_bots"]) == 1
+        assert result["copied_bots"][0]["name"] == "test-bot"
+
+        # Verify new team was created
+        new_team = (
+            test_db.query(Kind)
+            .filter(
+                Kind.kind == "Team",
+                Kind.name == "test-team",
+                Kind.namespace == test_group.name,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+        assert new_team is not None
+        assert new_team.user_id == test_user.id
+
+        # Verify new bot was created
+        new_bot = (
+            test_db.query(Kind)
+            .filter(
+                Kind.kind == "Bot",
+                Kind.name == "test-bot",
+                Kind.namespace == test_group.name,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+        assert new_bot is not None
+        assert new_bot.user_id == test_user.id
+
+    def test_copy_team_not_found(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test copy with non-existent team."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=99999,
+                user_id=test_user.id,
+                target_group_name=test_group.name,
+            )
+        assert exc_info.value.status_code == 404
+        assert "Team not found" in str(exc_info.value.detail)
+
+    def test_copy_team_not_owned(
+        self,
+        test_db: Session,
+        test_team: Kind,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test copy when user doesn't own the team."""
+        from fastapi import HTTPException
+
+        # Create another user
+        other_user = User(
+            user_name="otheruser",
+            password_hash="hash",
+            email="other@example.com",
+            is_active=True,
+        )
+        test_db.add(other_user)
+        test_db.commit()
+        test_db.refresh(other_user)
+
+        # Add other user to group
+        other_membership = NamespaceMember(
+            group_name=test_group.name,
+            user_id=other_user.id,
+            role="Developer",
+            is_active=True,
+        )
+        test_db.add(other_membership)
+        test_db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=test_team.id,
+                user_id=other_user.id,
+                target_group_name=test_group.name,
+            )
+        assert exc_info.value.status_code == 403
+        assert "You can only copy your own teams" in str(exc_info.value.detail)
+
+    def test_copy_group_team_fails(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test that copying a group team (non-personal) fails."""
+        from fastapi import HTTPException
+
+        # Create a team in the group namespace
+        group_team = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="group-team",
+            namespace=test_group.name,
+            json={
+                "kind": "Team",
+                "apiVersion": "agent.wecode.io/v1",
+                "metadata": {"name": "group-team", "namespace": test_group.name},
+                "spec": {"members": [], "collaborationModel": "pipeline"},
+                "status": {"state": "Available"},
+            },
+            is_active=True,
+        )
+        test_db.add(group_team)
+        test_db.commit()
+        test_db.refresh(group_team)
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=group_team.id,
+                user_id=test_user.id,
+                target_group_name=test_group.name,
+            )
+        assert exc_info.value.status_code == 400
+        assert "Only personal teams can be copied" in str(exc_info.value.detail)
+
+    def test_copy_insufficient_permission(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_team: Kind,
+        test_group: Namespace,
+    ):
+        """Test copy when user doesn't have Developer+ permission in target group."""
+        from fastapi import HTTPException
+
+        # Create membership with Reporter role (insufficient)
+        reporter_membership = NamespaceMember(
+            group_name=test_group.name,
+            user_id=test_user.id,
+            role="Reporter",
+            is_active=True,
+        )
+        test_db.add(reporter_membership)
+        test_db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=test_team.id,
+                user_id=test_user.id,
+                target_group_name=test_group.name,
+            )
+        assert exc_info.value.status_code == 403
+        assert "Developer role" in str(exc_info.value.detail)
+
+    def test_copy_target_group_not_exists(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_team: Kind,
+    ):
+        """Test copy when target group doesn't exist."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=test_team.id,
+                user_id=test_user.id,
+                target_group_name="non-existent-group",
+            )
+        # Will fail on permission check first
+        assert exc_info.value.status_code in [403, 404]
+
+    def test_copy_duplicate_team_name(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_team: Kind,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test copy when team with same name already exists in target group."""
+        from fastapi import HTTPException
+
+        # Create a team with same name in target group
+        existing_team = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="test-team",
+            namespace=test_group.name,
+            json={
+                "kind": "Team",
+                "apiVersion": "agent.wecode.io/v1",
+                "metadata": {"name": "test-team", "namespace": test_group.name},
+                "spec": {"members": [], "collaborationModel": "pipeline"},
+                "status": {"state": "Available"},
+            },
+            is_active=True,
+        )
+        test_db.add(existing_team)
+        test_db.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            team_kinds_service.copy_to_group(
+                db=test_db,
+                team_id=test_team.id,
+                user_id=test_user.id,
+                target_group_name=test_group.name,
+            )
+        assert exc_info.value.status_code == 400
+        assert "already exists" in str(exc_info.value.detail)
+
+    def test_copy_with_public_bot_reference(
+        self,
+        test_db: Session,
+        test_user: User,
+        test_shell: Kind,
+        test_group: Namespace,
+        test_group_membership: NamespaceMember,
+    ):
+        """Test copy when team has a public bot (should reference, not copy)."""
+        # Create a public ghost
+        public_ghost = Kind(
+            user_id=0,
+            kind="Ghost",
+            name="public-bot-ghost",
+            namespace="default",
+            json={
+                "kind": "Ghost",
+                "apiVersion": "agent.wecode.io/v1",
+                "metadata": {"name": "public-bot-ghost", "namespace": "default"},
+                "spec": {"systemPrompt": "Public bot", "mcpServers": {}},
+                "status": {"state": "Available"},
+            },
+            is_active=True,
+        )
+        test_db.add(public_ghost)
+        test_db.commit()
+
+        # Create a public bot
+        public_bot = Kind(
+            user_id=0,
+            kind="Bot",
+            name="public-bot",
+            namespace="default",
+            json={
+                "kind": "Bot",
+                "apiVersion": "agent.wecode.io/v1",
+                "metadata": {"name": "public-bot", "namespace": "default"},
+                "spec": {
+                    "ghostRef": {"name": "public-bot-ghost", "namespace": "default"},
+                    "shellRef": {"name": "test-shell", "namespace": "default"},
+                },
+                "status": {"state": "Available"},
+            },
+            is_active=True,
+        )
+        test_db.add(public_bot)
+        test_db.commit()
+        test_db.refresh(public_bot)
+
+        # Create team with public bot
+        team_with_public_bot = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="team-with-public-bot",
+            namespace="default",
+            json={
+                "kind": "Team",
+                "apiVersion": "agent.wecode.io/v1",
+                "metadata": {"name": "team-with-public-bot", "namespace": "default"},
+                "spec": {
+                    "members": [
+                        {
+                            "botRef": {"name": "public-bot", "namespace": "default"},
+                            "prompt": "",
+                            "role": "worker",
+                            "requireConfirmation": False,
+                        }
+                    ],
+                    "collaborationModel": "pipeline",
+                },
+                "status": {"state": "Available"},
+            },
+            is_active=True,
+        )
+        test_db.add(team_with_public_bot)
+        test_db.commit()
+        test_db.refresh(team_with_public_bot)
+
+        result = team_kinds_service.copy_to_group(
+            db=test_db,
+            team_id=team_with_public_bot.id,
+            user_id=test_user.id,
+            target_group_name=test_group.name,
+        )
+
+        # Public bot should be referenced, not copied
+        assert len(result["copied_bots"]) == 0
+        assert len(result["referenced_bots"]) == 1
+        assert result["referenced_bots"][0]["name"] == "public-bot"

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -59,6 +59,30 @@ export interface TeamInputParametersResponse {
   app_mode?: string // Dify app mode: 'chat', 'chatflow', 'workflow', 'completion', 'agent'
 }
 
+// Copy to Group Request/Response Types
+export interface CopyToGroupRequest {
+  target_group_name: string
+}
+
+export interface CopiedBotInfo {
+  original_bot_id: number
+  new_bot_id: number
+  name: string
+}
+
+export interface ReferencedBotInfo {
+  bot_id: number
+  name: string
+}
+
+export interface CopyToGroupResponse {
+  id: number
+  name: string
+  namespace: string
+  copied_bots: CopiedBotInfo[]
+  referenced_bots: ReferencedBotInfo[]
+}
+
 export const teamApis = {
   /**
    * Get teams list
@@ -111,5 +135,15 @@ export const teamApis = {
   },
   async checkRunningTasks(id: number): Promise<CheckRunningTasksResponse> {
     return apiClient.get(`/teams/${id}/running-tasks`)
+  },
+  /**
+   * Copy a personal team to a group
+   * @param teamId - Team ID to copy
+   * @param targetGroupName - Target group name
+   */
+  async copyToGroup(teamId: number, targetGroupName: string): Promise<CopyToGroupResponse> {
+    return apiClient.post(`/teams/${teamId}/copy-to-group`, {
+      target_group_name: targetGroupName,
+    })
   },
 }

--- a/frontend/src/features/settings/components/CopyToGroupDialog.tsx
+++ b/frontend/src/features/settings/components/CopyToGroupDialog.tsx
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState, useEffect, useMemo } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useTranslation } from '@/hooks/useTranslation'
+import { listGroups } from '@/apis/groups'
+import { teamApis } from '@/apis/team'
+import type { Group, GroupRole } from '@/types/group'
+import type { Team } from '@/types/api'
+import { useRouter } from 'next/navigation'
+
+interface CopyToGroupDialogProps {
+  open: boolean
+  onClose: () => void
+  team: Team | null
+  onSuccess?: (newTeamId: number, groupName: string) => void
+}
+
+// Roles that have permission to create resources
+const ALLOWED_ROLES: GroupRole[] = ['Owner', 'Maintainer', 'Developer']
+
+export default function CopyToGroupDialog({
+  open,
+  onClose,
+  team,
+  onSuccess,
+}: CopyToGroupDialogProps) {
+  const { t } = useTranslation('common')
+  const router = useRouter()
+  const [groups, setGroups] = useState<Group[]>([])
+  const [selectedGroup, setSelectedGroup] = useState<string>('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [isCopying, setIsCopying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch groups when dialog opens
+  useEffect(() => {
+    if (open) {
+      setIsLoading(true)
+      setError(null)
+      setSelectedGroup('')
+      listGroups({ limit: 100 })
+        .then(response => {
+          setGroups(response.items)
+        })
+        .catch(() => {
+          setError(t('teams.copy_to_group.load_groups_failed'))
+        })
+        .finally(() => {
+          setIsLoading(false)
+        })
+    }
+  }, [open, t])
+
+  // Filter groups where user has Developer+ role
+  const availableGroups = useMemo(() => {
+    return groups.filter(group => group.my_role && ALLOWED_ROLES.includes(group.my_role))
+  }, [groups])
+
+  const handleCopy = async () => {
+    if (!team || !selectedGroup) return
+
+    setIsCopying(true)
+    setError(null)
+
+    try {
+      const result = await teamApis.copyToGroup(team.id, selectedGroup)
+      onSuccess?.(result.id, result.namespace)
+      onClose()
+      // Navigate to the group's team list
+      router.push(`/settings?tab=teams&scope=group&group=${selectedGroup}`)
+    } catch (err: unknown) {
+      const errorMessage =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'detail' in err
+            ? String((err as { detail: string }).detail)
+            : t('teams.copy_to_group.copy_failed')
+      setError(errorMessage)
+    } finally {
+      setIsCopying(false)
+    }
+  }
+
+  const handleClose = () => {
+    if (!isCopying) {
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('teams.copy_to_group.title')}</DialogTitle>
+          <DialogDescription>
+            {t('teams.copy_to_group.description', { teamName: team?.name || '' })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="py-4">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <svg
+                className="animate-spin h-5 w-5 text-primary"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                ></path>
+              </svg>
+            </div>
+          ) : availableGroups.length === 0 ? (
+            <div className="text-center py-4 text-text-muted">
+              <p>{t('teams.copy_to_group.no_groups')}</p>
+              <p className="text-sm mt-1">{t('teams.copy_to_group.no_groups_hint')}</p>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-2">
+                  {t('teams.copy_to_group.select_group')}
+                </label>
+                <Select value={selectedGroup} onValueChange={setSelectedGroup}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t('teams.copy_to_group.select_placeholder')} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableGroups.map(group => (
+                      <SelectItem key={group.name} value={group.name}>
+                        <div className="flex items-center gap-2">
+                          <span>{group.display_name || group.name}</span>
+                          <span className="text-xs text-text-muted">({group.my_role})</span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {error && (
+                <div className="bg-error/10 text-error text-sm p-3 rounded-md">{error}</div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" onClick={handleClose} disabled={isCopying}>
+            {t('common.cancel')}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleCopy}
+            disabled={!selectedGroup || isCopying || isLoading || availableGroups.length === 0}
+          >
+            {isCopying ? (
+              <div className="flex items-center">
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-4 w-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                {t('teams.copy_to_group.copying')}
+              </div>
+            ) : (
+              t('teams.copy_to_group.confirm')
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -18,6 +18,7 @@ import {
   LinkSlashIcon,
   SparklesIcon,
   ClipboardDocumentIcon,
+  ArrowUpOnSquareIcon,
 } from '@heroicons/react/24/outline'
 import { Bot, Team } from '@/types/api'
 import { fetchTeamsList, deleteTeam, shareTeam, checkTeamRunningTasks } from '../services/teams'
@@ -25,6 +26,7 @@ import { CheckRunningTasksResponse } from '@/apis/common'
 import { fetchBotsList } from '../services/bots'
 import TeamEditDialog from './TeamEditDialog'
 import BotList from './BotList'
+import CopyToGroupDialog from './CopyToGroupDialog'
 import UnifiedAddButton from '@/components/common/UnifiedAddButton'
 import TeamShareModal from './TeamShareModal'
 import TeamCreationWizard from './wizard/TeamCreationWizard'
@@ -84,6 +86,8 @@ export default function TeamList({
   const [editDialogOpen, setEditDialogOpen] = useState(false)
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
   const [wizardOpen, setWizardOpen] = useState(false)
+  const [copyToGroupDialogOpen, setCopyToGroupDialogOpen] = useState(false)
+  const [teamToCopy, setTeamToCopy] = useState<Team | null>(null)
   const router = useRouter()
 
   const setTeamsSorted = useCallback<React.Dispatch<React.SetStateAction<Team[]>>>(
@@ -434,6 +438,27 @@ export default function TeamList({
     return true
   }
 
+  // Check if "Copy to Group" button should be shown
+  // Only for personal teams (namespace === 'default')
+  const shouldShowCopyToGroup = (team: Team) => {
+    // Only show for personal teams
+    return !isGroupTeam(team) && team.share_status !== 2
+  }
+
+  // Handle copy to group button click
+  const handleCopyToGroup = (team: Team) => {
+    setTeamToCopy(team)
+    setCopyToGroupDialogOpen(true)
+  }
+
+  // Handle copy to group success
+  const handleCopyToGroupSuccess = (newTeamId: number, groupName: string) => {
+    toast({
+      title: t('teams.copy_to_group.success_title'),
+      description: t('teams.copy_to_group.success_description', { groupName }),
+    })
+  }
+
   return (
     <>
       <div className="flex flex-col h-full min-h-0 overflow-hidden w-full max-w-full">
@@ -618,6 +643,17 @@ export default function TeamList({
                               disabled={sharingId === team.id}
                             >
                               <ShareIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
+                            </Button>
+                          )}
+                          {shouldShowCopyToGroup(team) && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleCopyToGroup(team)}
+                              title={t('teams.copy_to_group.button')}
+                              className="h-7 w-7 sm:h-8 sm:w-8"
+                            >
+                              <ArrowUpOnSquareIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                             </Button>
                           )}
                           {shouldShowDelete(team) && (
@@ -869,6 +905,17 @@ export default function TeamList({
         onSuccess={handleWizardSuccess}
         scope={scope === 'all' ? undefined : scope}
         groupName={groupName}
+      />
+
+      {/* Copy to Group Dialog */}
+      <CopyToGroupDialog
+        open={copyToGroupDialogOpen}
+        onClose={() => {
+          setCopyToGroupDialogOpen(false)
+          setTeamToCopy(null)
+        }}
+        team={teamToCopy}
+        onSuccess={handleCopyToGroupSuccess}
       />
       {/* Error prompt unified with antd message, no local rendering */}
     </>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -265,6 +265,21 @@
       "confirm_suffix": " to execute tasks?",
       "join_description_prefix": "After confirmation, ",
       "join_description_suffix": " will be added to your team list, and you can use this team to create and execute tasks."
+    },
+    "copy_to_group": {
+      "button": "Copy to Group",
+      "title": "Copy to Group",
+      "description": "Copy agent \"{{teamName}}\" to a group. You must have Developer or higher role in the target group.",
+      "select_group": "Select Target Group",
+      "select_placeholder": "Choose a group...",
+      "no_groups": "No available groups",
+      "no_groups_hint": "You need Developer or higher role in at least one group to copy agents.",
+      "confirm": "Copy",
+      "copying": "Copying...",
+      "copy_failed": "Failed to copy agent to group",
+      "load_groups_failed": "Failed to load groups",
+      "success_title": "Copy Successful",
+      "success_description": "Agent has been copied to group \"{{groupName}}\""
     }
   },
   "team": {

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -265,6 +265,21 @@
       "confirm_suffix": "执行任务吗？",
       "join_description_prefix": "确定加入后，",
       "join_description_suffix": " 将添加到您的智能体列表中，您可以使用该智能体创建和执行任务。"
+    },
+    "copy_to_group": {
+      "button": "复制到群组",
+      "title": "复制到群组",
+      "description": "将智能体 \"{{teamName}}\" 复制到群组。您需要在目标群组中拥有开发者或更高权限。",
+      "select_group": "选择目标群组",
+      "select_placeholder": "选择群组...",
+      "no_groups": "没有可用的群组",
+      "no_groups_hint": "您需要在至少一个群组中拥有开发者或更高权限才能复制智能体。",
+      "confirm": "复制",
+      "copying": "复制中...",
+      "copy_failed": "复制智能体到群组失败",
+      "load_groups_failed": "加载群组列表失败",
+      "success_title": "复制成功",
+      "success_description": "智能体已复制到群组 \"{{groupName}}\""
     }
   },
   "team": {


### PR DESCRIPTION
## Summary

- Add "Copy to Group" feature allowing users to copy their personal agents (Teams) to Groups where they have Developer or higher permission
- Implement smart Bot copying strategy:
  - Copy personal Bots and their Ghosts to the target group
  - Reference public Bots and existing group Bots directly (no duplication)
  - Block copying when Bots belong to other inaccessible groups
- Add CopyToGroupDialog component with group selection dropdown
- Add copy to group button (ArrowUpOnSquareIcon) in TeamList for personal teams only

## Changes

### Backend
- `backend/app/services/adapters/team_kinds.py`:
  - Add `copy_to_group()` method with permission validation and smart bot handling
  - Add `_copy_bot_to_group()` helper for copying personal bots and their ghosts
- `backend/app/api/endpoints/adapter/teams.py`:
  - Add `POST /teams/{team_id}/copy-to-group` endpoint
- `backend/app/schemas/team.py`:
  - Add `CopyToGroupRequest`, `CopyToGroupResponse`, `CopiedBotInfo`, `ReferencedBotInfo` schemas

### Frontend
- `frontend/src/features/settings/components/CopyToGroupDialog.tsx`:
  - New dialog component for selecting target group
  - Filter groups by Developer/Maintainer/Owner role
- `frontend/src/features/settings/components/TeamList.tsx`:
  - Add copy to group button for personal teams
  - Add state management for dialog
- `frontend/src/apis/team.ts`:
  - Add `copyToGroup()` API function
- `frontend/src/i18n/locales/en/common.json` & `zh-CN/common.json`:
  - Add translations for copy to group feature

### Tests
- `backend/tests/services/test_team_copy_to_group.py`:
  - Add comprehensive unit tests covering success, permission, and edge cases

## Test plan

- [ ] Create a personal team with personal bots
- [ ] Click "Copy to Group" button on the team
- [ ] Verify dialog shows only groups with Developer+ role
- [ ] Select a group and confirm copy
- [ ] Verify team and bots are copied to target group
- [ ] Verify public bots are referenced, not copied
- [ ] Verify error when team name conflicts
- [ ] Run backend unit tests: `cd backend && uv run pytest tests/services/test_team_copy_to_group.py -v`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can copy personal teams into existing groups via a new "Copy to Group" action and modal; eligible groups are listed and the flow handles selection, progress, errors, and navigation to the target group's settings on success.
  * Backend API support added for initiating team-to-group copies and returning a summary of copied/referenced items.

* **Localization**
  * Added English and Chinese translations for the copy flow UI.

* **Tests**
  * Added comprehensive tests covering success paths and multiple error scenarios for the copy-to-group flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->