### PR TITLE
fix(frontend): enable mouse wheel scroll in SummaryModelSelector

### DIFF
--- a/frontend/src/components/ui/searchable-select.tsx
+++ b/frontend/src/components/ui/searchable-select.tsx
@@ -153,7 +153,12 @@ export function SearchableSelect({
                 'placeholder:text-text-muted text-sm'
               )}
             />
-            <CommandList className="min-h-[36px] max-h-[200px] overflow-y-auto flex-1">
+            <CommandList
+              className="min-h-[36px] max-h-[200px] overflow-y-auto flex-1"
+              onWheel={e => {
+                e.stopPropagation()
+              }}
+            >
               {error ? (
                 <div className="py-4 px-3 text-center text-sm text-error">{error}</div>
               ) : items.length === 0 ? (

--- a/frontend/src/features/knowledge/document/components/SummaryModelSelector.tsx
+++ b/frontend/src/features/knowledge/document/components/SummaryModelSelector.tsx
@@ -136,7 +136,11 @@ export function SummaryModelSelector({
         <PopoverContent className="w-[400px] p-0" align="start">
           <Command>
             <CommandInput placeholder={t('document.summary.modelPlaceholder')} />
-            <CommandList>
+            <CommandList
+              onWheel={e => {
+                e.stopPropagation()
+              }}
+            >
               <CommandEmpty>{t('common:noResults', 'No results found')}</CommandEmpty>
               <CommandGroup>
                 {models.map(model => {


### PR DESCRIPTION
## Summary

- Fix mouse wheel scroll issue in `CommandList`-based dropdown components in knowledge base dialogs
- Add `onWheel` event handler with `e.stopPropagation()` to allow native scroll behavior

## Technical Details

The `cmdk` library's internal event handling can prevent default mouse wheel scrolling when used inside a Popover component. By adding `e.stopPropagation()` on the `onWheel` event, we allow the native scroll behavior to work properly within the `CommandList` container.

## Changes

1. **`SummaryModelSelector.tsx`** - Fix scroll in Summary Model selector
2. **`searchable-select.tsx`** - Fix scroll in SearchableSelect component (used by Retriever and Embedding Model selectors)

## Affected Components

- `SummaryModelSelector.tsx` - used in:
  - `CreateKnowledgeBaseDialog.tsx`
  - `EditKnowledgeBaseDialog.tsx`
- `SearchableSelect` (ui component) - used throughout the application including:
  - Retriever selector in `RetrievalSettingsSection.tsx`
  - Embedding Model selector in `RetrievalSettingsSection.tsx`
  - And other places using this shared component

## Test plan

- [ ] Open knowledge base creation dialog
- [ ] Enable Summary feature and verify mouse wheel scrolling in Summary Model selector
- [ ] Expand Advanced Settings and verify mouse wheel scrolling in:
  - [ ] Retriever selector
  - [ ] Embedding Model selector
- [ ] Repeat for edit knowledge base dialog