### PR TITLE
feat(frontend): add WebSocket connection status banner

### DIFF
--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -184,7 +184,7 @@ export function ChatInputCard({
         {!shouldHideChatInput && <QuoteCard />}
 
         {/* Connection Status Banner - shows WebSocket connection status */}
-        <ConnectionStatusBanner />
+        {!shouldHideChatInput && <ConnectionStatusBanner />}
 
         {/* Chat Input with inline badge */}
         {!shouldHideChatInput && (

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -12,6 +12,7 @@ import ExternalApiParamsInput from '../params/ExternalApiParamsInput'
 import { SelectedTeamBadge } from '../selector/SelectedTeamBadge'
 import ChatInputControls, { ChatInputControlsProps } from './ChatInputControls'
 import { QuoteCard } from '../text-selection'
+import { ConnectionStatusBanner } from './ConnectionStatusBanner'
 import type { Team, ChatTipItem } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -181,6 +182,9 @@ export function ChatInputCard({
 
         {/* Quote Card - shows quoted text from text selection */}
         {!shouldHideChatInput && <QuoteCard />}
+
+        {/* Connection Status Banner - shows WebSocket connection status */}
+        <ConnectionStatusBanner />
 
         {/* Chat Input with inline badge */}
         {!shouldHideChatInput && (

--- a/frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx
+++ b/frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { WifiOff, Wifi, Check } from 'lucide-react'
+import { useSocket } from '@/contexts/SocketContext'
+import { useTranslation } from '@/hooks/useTranslation'
+
+/**
+ * ConnectionStatusBanner Component
+ *
+ * Displays WebSocket connection status to users in the chat input area.
+ * Shows different states:
+ * - Disconnected: When connection is lost
+ * - Reconnecting: During reconnection attempts with attempt count
+ * - Reconnected: Briefly shown after successful reconnection (auto-hides after 3s)
+ */
+export function ConnectionStatusBanner() {
+  const { isConnected, reconnectAttempts } = useSocket()
+  const { t } = useTranslation('chat')
+  const [showReconnected, setShowReconnected] = useState(false)
+  const prevConnectedRef = useRef(isConnected)
+
+  useEffect(() => {
+    // Detect state change from disconnected to connected
+    if (isConnected && !prevConnectedRef.current) {
+      setShowReconnected(true)
+      const timer = setTimeout(() => setShowReconnected(false), 3000)
+      return () => clearTimeout(timer)
+    }
+    prevConnectedRef.current = isConnected
+  }, [isConnected])
+
+  // Don't render anything when connected and no success message to show
+  if (isConnected && !showReconnected) return null
+
+  // Reconnection success message
+  if (isConnected && showReconnected) {
+    return (
+      <div className="mx-4 mb-2 px-3 py-2 rounded-lg bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400 text-sm flex items-center gap-2 animate-in fade-in duration-200">
+        <Check className="h-4 w-4" />
+        <span>{t('status.reconnected')}</span>
+      </div>
+    )
+  }
+
+  // Disconnected or reconnecting state
+  return (
+    <div className="mx-4 mb-2 px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm flex items-center gap-2 animate-in fade-in duration-200">
+      {reconnectAttempts > 0 ? (
+        <>
+          <Wifi className="h-4 w-4 animate-pulse" />
+          <span>{t('status.reconnecting', { count: reconnectAttempts })}</span>
+        </>
+      ) : (
+        <>
+          <WifiOff className="h-4 w-4" />
+          <span>{t('status.disconnected')}</span>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default ConnectionStatusBanner

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -34,7 +34,9 @@
     "thinking": "AI is thinking...",
     "error": "Failed to send message",
     "connecting": "Connecting...",
-    "disconnected": "Disconnected"
+    "disconnected": "Disconnected",
+    "reconnecting": "Reconnecting... (attempt {{count}})",
+    "reconnected": "Reconnected"
   },
   "messages": {
     "assistant": "AI Assistant",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -34,7 +34,9 @@
     "thinking": "AI 正在思考...",
     "error": "发送消息失败",
     "connecting": "连接中...",
-    "disconnected": "连接断开"
+    "disconnected": "连接断开",
+    "reconnecting": "正在重连...（第 {{count}} 次尝试）",
+    "reconnected": "已重新连接"
   },
   "messages": {
     "assistant": "AI 助手",


### PR DESCRIPTION
## Summary

- Add a ConnectionStatusBanner component that displays WebSocket connection status in the chat input area
- Show different states: disconnected, reconnecting (with attempt count), and reconnected
- Integrate banner into ChatInputCard between QuoteCard and ChatInput
- Add i18n translations for new status messages (reconnecting/reconnected) in both Chinese and English
- Auto-hide reconnected success message after 3 seconds

## Changes

1. **New Component**: `frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx`
   - Uses `useSocket()` hook to get connection status
   - Detects state changes from disconnected to connected to show success message
   - Displays amber background for warning states, green for success

2. **ChatInputCard.tsx**: Integrated ConnectionStatusBanner component

3. **i18n files**: Added `status.reconnecting` and `status.reconnected` translations

## Test plan

- [ ] Verify banner appears when WebSocket connection is lost
- [ ] Verify reconnecting message shows attempt count during reconnection
- [ ] Verify reconnected success message appears after successful reconnection
- [ ] Verify success message auto-hides after 3 seconds
- [ ] Verify translations work in both English and Chinese
- [ ] Verify dark mode styling works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a connection status indicator in the chat input area showing real-time WebSocket status with icons and subtle animations.
  * Alerts users when disconnected, displays reconnection attempts with a counter and pulsing icon, and briefly shows a green confirmation when reconnected.
  * Messages are localized for English and Simplified Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->