### PR TITLE
feat(i18n): add internationalization support for tool display names

### DIFF
--- a/backend/app/services/chat/trigger/core.py
+++ b/backend/app/services/chat/trigger/core.py
@@ -942,9 +942,14 @@ async def _stream_with_http_adapter(
                             and step.get("details", {}).get("status") == "started"
                         ):
                             orig_title = step.get("title", "")
-                            if orig_title.startswith("正在"):
-                                display_name = orig_title[2:]
-                            else:
+                            # Handle both string and i18n object format
+                            if isinstance(orig_title, str):
+                                if orig_title.startswith("正在"):
+                                    display_name = orig_title[2:]
+                                else:
+                                    display_name = orig_title
+                            elif isinstance(orig_title, dict):
+                                # i18n object format - use as-is
                                 display_name = orig_title
                             break
                     if not display_name:

--- a/backend/init_data/skills/mermaid-diagram/read_reference.py
+++ b/backend/init_data/skills/mermaid-diagram/read_reference.py
@@ -1553,7 +1553,7 @@ class ReadMermaidReferenceTool(BaseTool):
     """
 
     name: str = "read_mermaid_reference"
-    display_name: str = "查阅参考文档"
+    display_name: str = "tools.read_reference.display_name"
     description: str = (
         "Read documentation and examples for specific Mermaid diagram types."
     )

--- a/backend/init_data/skills/mermaid-diagram/render_mermaid.py
+++ b/backend/init_data/skills/mermaid-diagram/render_mermaid.py
@@ -87,7 +87,7 @@ class RenderMermaidTool(BaseTool):
     """
 
     name: str = "render_mermaid"
-    display_name: str = "渲染图表"
+    display_name: str = "tools.render_mermaid.display_name"
     description: str = """Render a Mermaid diagram. Use this tool when you need to create visual diagrams.
 
 Before calling render_mermaid, you SHOULD call read_mermaid_reference first to learn the correct syntax!

--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -401,7 +401,7 @@ async def _stream_response(
                             run_id[:20] if run_id else "N/A",
                             status,
                             tool_name,
-                            title[:30] if title else "N/A",
+                            str(title)[:30] if title else "N/A",
                         )
 
                         if status == "started":

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -376,7 +376,10 @@ class ToolStart(BaseModel):
     id: str = Field(..., description="Tool call ID")
     name: str = Field(..., description="Tool name")
     input: dict = Field(..., description="Tool input")
-    display_name: Optional[str] = Field(None, description="Display name for UI")
+    display_name: Optional[Union[str, dict]] = Field(
+        None,
+        description="Display name for UI (can be string or i18n object with key and params)",
+    )
 
 
 class ToolProgress(BaseModel):
@@ -395,8 +398,9 @@ class ToolDone(BaseModel):
     duration_ms: Optional[int] = Field(None, description="Execution duration in ms")
     error: Optional[str] = Field(None, description="Error message if failed")
     sources: Optional[list[dict]] = Field(None, description="Source references")
-    display_name: Optional[str] = Field(
-        None, description="Display name for UI (updates title on completion)"
+    display_name: Optional[Union[str, dict]] = Field(
+        None,
+        description="Display name for UI (can be string or i18n object with key and params)",
     )
 
 

--- a/chat_shell/chat_shell/tools/builtin/data_table.py
+++ b/chat_shell/chat_shell/tools/builtin/data_table.py
@@ -46,7 +46,7 @@ class DataTableTool(BaseTool):
     """
 
     name: str = "data_table_query"
-    display_name: str = "查询数据表"
+    display_name: str = "tools.data_table.display_name"
     description: str = (
         "Query data from a data table. Use this tool to retrieve records "
         "from the selected table. Returns table schema (field definitions) "

--- a/chat_shell/chat_shell/tools/builtin/evaluation.py
+++ b/chat_shell/chat_shell/tools/builtin/evaluation.py
@@ -78,7 +78,7 @@ class SubmitEvaluationResultTool(BaseTool):
     """
 
     name: str = "submit_evaluation_result"
-    display_name: str = "正在提交评估结果"
+    display_name: str = "tools.evaluation.display_name"
     description: str = (
         "Submit the evaluation critique and correction for an AI response. "
         "This function MUST be called to return the final analysis."

--- a/chat_shell/chat_shell/tools/builtin/file_reader.py
+++ b/chat_shell/chat_shell/tools/builtin/file_reader.py
@@ -45,7 +45,7 @@ class FileReaderSkill(BaseTool):
     """Read file contents with chunked pagination support."""
 
     name: str = "read_file"
-    display_name: str = "读取文件"
+    display_name: str = "tools.file_reader.display_name"
     description: str = (
         "Read file content with pagination. Returns lines range with metadata."
     )
@@ -126,7 +126,7 @@ class FileListSkill(BaseTool):
     """List files in a directory with optional pattern filtering."""
 
     name: str = "list_files"
-    display_name: str = "列出文件"
+    display_name: str = "tools.list_files.display_name"
     description: str = (
         "List files in a directory. Returns file names, sizes, and modification times."
     )

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -44,7 +44,7 @@ class KnowledgeBaseTool(BaseTool):
     """
 
     name: str = "knowledge_base_search"
-    display_name: str = "检索知识库"
+    display_name: str = "tools.knowledge_base.display_name"
     description: str = (
         "Search the knowledge base for relevant information. "
         "This tool uses intelligent context injection - it may inject content directly "

--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -44,7 +44,7 @@ class LoadSkillTool(BaseTool):
     """
 
     name: str = "load_skill"
-    display_name: str = "加载技能"
+    display_name: str = "tools.load_skill.display_name"
     description: str = (
         "Load a skill's full instructions when you need specialized guidance. "
         "Call this tool when your task matches one of the available skills' descriptions. "

--- a/chat_shell/chat_shell/tools/builtin/web_search.py
+++ b/chat_shell/chat_shell/tools/builtin/web_search.py
@@ -37,7 +37,7 @@ class WebSearchTool(BaseTool):
     """
 
     name: str = "web_search"
-    display_name: str = "搜索网页"
+    display_name: str = "tools.web_search.display_name"
     description: str = (
         "Search the web for information. Returns a list of relevant web pages with titles, URLs, and snippets."
     )

--- a/chat_shell/chat_shell/tools/events.py
+++ b/chat_shell/chat_shell/tools/events.py
@@ -312,7 +312,7 @@ def _build_tool_start_title(
 
     if display_name:
         title = display_name
-        # For load_skill, append the skill's friendly display name
+        # For load_skill, append the skill's friendly display name using i18n format
         if tool_name == "load_skill" and tool_instance:
             skill_name_param = (
                 serializable_input.get("skill_name", "")
@@ -328,7 +328,11 @@ def _build_tool_start_title(
                         )
                     except Exception:
                         pass
-                title = f"{display_name}：{skill_display}"
+                # Use i18n object format for proper frontend translation
+                title = {
+                    "key": "tools.load_skill.completed_with_name",
+                    "params": {"name": skill_display},
+                }
     elif tool_name == "web_search":
         query = (
             serializable_input if isinstance(serializable_input, dict) else {}

--- a/frontend/src/features/tasks/components/input/AttachmentPreview.tsx
+++ b/frontend/src/features/tasks/components/input/AttachmentPreview.tsx
@@ -7,6 +7,7 @@
 import React, { useCallback, useState, useEffect } from 'react'
 import { Download, X, ZoomIn, ZoomOut, RotateCw, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
 import {
   formatFileSize,
   getFileIcon,
@@ -34,11 +35,13 @@ function ImageLightbox({
   alt,
   onClose,
   onDownload,
+  t,
 }: {
   src: string
   alt: string
   onClose: () => void
   onDownload: () => void
+  t: (key: string) => string
 }) {
   const [scale, setScale] = useState(1)
   const [rotation, setRotation] = useState(0)
@@ -107,7 +110,7 @@ function ImageLightbox({
           size="icon"
           onClick={handleZoomOut}
           className="h-10 w-10 bg-black/50 hover:bg-black/70 text-white"
-          title="缩小 (-)"
+          title={t('common:preview.zoom_out')}
         >
           <ZoomOut className="h-5 w-5" />
         </Button>
@@ -119,7 +122,7 @@ function ImageLightbox({
           size="icon"
           onClick={handleZoomIn}
           className="h-10 w-10 bg-black/50 hover:bg-black/70 text-white"
-          title="放大 (+)"
+          title={t('common:preview.zoom_in')}
         >
           <ZoomIn className="h-5 w-5" />
         </Button>
@@ -128,7 +131,7 @@ function ImageLightbox({
           size="icon"
           onClick={handleRotate}
           className="h-10 w-10 bg-black/50 hover:bg-black/70 text-white"
-          title="旋转 (R)"
+          title={t('common:preview.rotate')}
         >
           <RotateCw className="h-5 w-5" />
         </Button>
@@ -137,7 +140,7 @@ function ImageLightbox({
           size="icon"
           onClick={onDownload}
           className="h-10 w-10 bg-black/50 hover:bg-black/70 text-white"
-          title="下载"
+          title={t('common:preview.download')}
         >
           <Download className="h-5 w-5" />
         </Button>
@@ -146,7 +149,7 @@ function ImageLightbox({
           size="icon"
           onClick={onClose}
           className="h-10 w-10 bg-black/50 hover:bg-black/70 text-white"
-          title="关闭 (Esc)"
+          title={t('common:preview.close')}
         >
           <X className="h-5 w-5" />
         </Button>
@@ -248,6 +251,7 @@ export default function AttachmentPreview({
   showDownload = true,
   compact = false,
 }: AttachmentPreviewProps) {
+  const { t } = useTranslation()
   const [showLightbox, setShowLightbox] = useState(false)
 
   const handleDownload = useCallback(async () => {
@@ -312,6 +316,7 @@ export default function AttachmentPreview({
                 alt={attachment.filename}
                 onClose={handleCloseLightbox}
                 onDownload={handleDownload}
+                t={t}
               />
             )}
           </>
@@ -350,7 +355,7 @@ export default function AttachmentPreview({
                       handleDownload()
                     }}
                     className="h-6 w-6 text-white hover:bg-white/20 flex-shrink-0"
-                    title="下载"
+                    title={t('common:preview.download')}
                   >
                     <Download className="h-4 w-4" />
                   </Button>
@@ -364,6 +369,7 @@ export default function AttachmentPreview({
               alt={attachment.filename}
               onClose={handleCloseLightbox}
               onDownload={handleDownload}
+              t={t}
             />
           )}
         </>
@@ -386,7 +392,7 @@ export default function AttachmentPreview({
             size="icon"
             onClick={handleDownload}
             className="h-4 w-4 p-0 hover:bg-transparent"
-            title="下载"
+            title={t('common:preview.download')}
           >
             <Download className="h-3 w-3 text-text-muted" />
           </Button>
@@ -406,7 +412,7 @@ export default function AttachmentPreview({
           {formatFileSize(attachment.file_size)}
           {showDownload && (
             <button onClick={handleDownload} className="ml-2 text-link hover:underline">
-              点击下载
+              {t('common:preview.click_to_download')}
             </button>
           )}
         </div>

--- a/frontend/src/features/tasks/components/message/thinking/SimpleThinkingView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/SimpleThinkingView.tsx
@@ -7,6 +7,7 @@
 import { memo, useState, useMemo } from 'react'
 import { Search, ChevronDown, ChevronUp } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { parseI18nTitle, type I18nTitle } from '@/utils/i18nTitle'
 import type { ThinkingStep } from './types'
 import { extractToolCalls, isRunningStatus, isTerminalStatus } from './utils/thinkingUtils'
 
@@ -22,10 +23,10 @@ interface ToolEntry {
   resultCount?: number
   startIndex: number
   endIndex?: number
-  // Display name from backend (e.g., "正在渲染图表", "正在搜索网页")
-  displayTitle?: string
-  // Completed display title from backend (e.g., "渲染图表完成", "搜索网页完成")
-  completedTitle?: string
+  // Display name from backend (can be i18n key or object with key and params)
+  displayTitle?: I18nTitle
+  // Completed display title from backend (can be i18n key or object with key and params)
+  completedTitle?: I18nTitle
   // Error message for failed status
   errorMessage?: string
 }
@@ -69,8 +70,8 @@ const SimpleThinkingView = memo(function SimpleThinkingView({
             query = titleStr || toolName
           }
 
-          // Get display title from backend (e.g., "正在渲染图表")
-          const displayTitle = typeof step.title === 'string' ? step.title : undefined
+          // Get display title from backend (can be string or object with i18n key)
+          const displayTitle = step.title as I18nTitle | undefined
 
           toolStartMap.set(runId, entries.length)
           entries.push({
@@ -117,8 +118,8 @@ const SimpleThinkingView = memo(function SimpleThinkingView({
             }
           }
 
-          // Get completed title from backend (e.g., "渲染图表完成" or "任务失败: xxx")
-          const completedTitle = typeof step.title === 'string' ? step.title : undefined
+          // Get completed title from backend (can be string or object with i18n key)
+          const completedTitle = step.title as I18nTitle | undefined
           // Get error message if failed
           const errorMessage =
             details.status === 'failed' ? (details.error as string | undefined) : undefined
@@ -209,9 +210,11 @@ const SimpleThinkingView = memo(function SimpleThinkingView({
                     }`}
                   >
                     {entry.status === 'running'
-                      ? entry.displayTitle ||
+                      ? parseI18nTitle(entry.displayTitle, t) ||
                         `${t('chat:messages.using_tool') || 'Using tool'}: ${entry.toolName}`
-                      : entry.completedTitle || entry.displayTitle || entry.toolName}
+                      : parseI18nTitle(entry.completedTitle, t) ||
+                        parseI18nTitle(entry.displayTitle, t) ||
+                        entry.toolName}
                   </div>
                 </div>
               </div>

--- a/frontend/src/features/tasks/components/message/thinking/SimpleThinkingView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/SimpleThinkingView.tsx
@@ -87,12 +87,6 @@ const SimpleThinkingView = memo(function SimpleThinkingView({
           details.type === 'tool_result' &&
           (details.status === 'completed' || details.status === 'failed')
         ) {
-          console.log('[SimpleThinkingView] Processing tool_result:', {
-            status: details.status,
-            tool_name: details.tool_name,
-            error: details.error,
-            title: step.title,
-          })
           const toolName: string =
             (typeof details.tool_name === 'string' ? details.tool_name : '') ||
             (typeof details.name === 'string' ? details.name : '') ||

--- a/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
@@ -140,7 +140,7 @@ export default function MobileTeamSelector({
         >
           {searchFilteredTeams.length === 0 ? (
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] p-4 text-center text-sm text-[#8e8e93]">
-              {isLoading ? t('common:loading') : t('common:teams.no_match')}
+              {isLoading ? t('common:actions.loading') : t('common:teams.no_match')}
             </div>
           ) : (
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] overflow-hidden">

--- a/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
@@ -140,9 +140,7 @@ export default function MobileTeamSelector({
         >
           {searchFilteredTeams.length === 0 ? (
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] p-4 text-center text-sm text-[#8e8e93]">
-              {isLoading
-                ? t('common:loading', '加载中...')
-                : t('common:teams.no_match', '暂无匹配的智能体')}
+              {isLoading ? t('common:loading') : t('common:teams.no_match')}
             </div>
           ) : (
             <div className="rounded-xl bg-white dark:bg-[#2c2c2e] overflow-hidden">
@@ -212,7 +210,7 @@ export default function MobileTeamSelector({
                 className="flex items-center gap-1.5 text-[#007aff] active:opacity-70"
               >
                 <Settings className="h-4 w-4" />
-                <span className="text-[13px]">{t('common:teams.manage', '管理')}</span>
+                <span className="text-[13px]">{t('common:teams.manage')}</span>
               </button>
             </div>
           </div>

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -472,5 +472,40 @@
     "proceeding_to_stage": "Proceeding to stage: {{stage}}",
     "pipeline_completed": "Pipeline completed",
     "no_task_id": "No task ID available"
+  },
+  "tools": {
+    "using": "Using tool: {{name}}",
+    "knowledge_base": {
+      "display_name": "Searching Knowledge Base",
+      "completed": "Retrieval complete, found {{count}} results"
+    },
+    "web_search": {
+      "display_name": "Web Search",
+      "searching": "Searching: {{query}}",
+      "searching_default": "Searching the web",
+      "completed": "Search complete, found {{count}} results"
+    },
+    "load_skill": {
+      "display_name": "Loading Skill",
+      "completed_with_name": "Loaded skill: {{name}}"
+    },
+    "data_table": {
+      "display_name": "Querying Data Table"
+    },
+    "file_reader": {
+      "display_name": "Reading File"
+    },
+    "list_files": {
+      "display_name": "Listing Files"
+    },
+    "evaluation": {
+      "display_name": "Submitting Evaluation"
+    },
+    "render_mermaid": {
+      "display_name": "Rendering Diagram"
+    },
+    "read_reference": {
+      "display_name": "Reading Reference"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -34,6 +34,14 @@
     "upload": "Upload",
     "view": "View"
   },
+  "preview": {
+    "zoom_in": "Zoom In (+)",
+    "zoom_out": "Zoom Out (-)",
+    "rotate": "Rotate (R)",
+    "download": "Download",
+    "close": "Close (Esc)",
+    "click_to_download": "Click to download"
+  },
   "errors": {
     "request_failed": "LLM API request failed, please click retry"
   },

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -472,5 +472,40 @@
     "proceeding_to_stage": "正在进入阶段: {{stage}}",
     "pipeline_completed": "流水线已完成",
     "no_task_id": "没有可用的任务 ID"
+  },
+  "tools": {
+    "using": "正在使用工具: {{name}}",
+    "knowledge_base": {
+      "display_name": "检索知识库",
+      "completed": "检索完成，找到 {{count}} 条结果"
+    },
+    "web_search": {
+      "display_name": "搜索网页",
+      "searching": "正在搜索: {{query}}",
+      "searching_default": "正在进行网页搜索",
+      "completed": "搜索完成，找到 {{count}} 个结果"
+    },
+    "load_skill": {
+      "display_name": "加载技能",
+      "completed_with_name": "加载技能：{{name}}"
+    },
+    "data_table": {
+      "display_name": "查询数据表"
+    },
+    "file_reader": {
+      "display_name": "读取文件"
+    },
+    "list_files": {
+      "display_name": "列出文件"
+    },
+    "evaluation": {
+      "display_name": "提交评估结果"
+    },
+    "render_mermaid": {
+      "display_name": "渲染图表"
+    },
+    "read_reference": {
+      "display_name": "查阅参考文档"
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -34,6 +34,14 @@
     "upload": "上传",
     "view": "查看"
   },
+  "preview": {
+    "zoom_in": "放大 (+)",
+    "zoom_out": "缩小 (-)",
+    "rotate": "旋转 (R)",
+    "download": "下载",
+    "close": "关闭 (Esc)",
+    "click_to_download": "点击下载"
+  },
   "errors": {
     "request_failed": "请求大模型接口失败，请点击重试"
   },

--- a/frontend/src/utils/i18nTitle.ts
+++ b/frontend/src/utils/i18nTitle.ts
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TFunction } from 'i18next'
+
+/**
+ * I18n title structure returned from backend
+ * Can be either a plain i18n key string or an object with key and params
+ */
+export type I18nTitle =
+  | string
+  | {
+      key: string
+      params?: Record<string, string | number>
+    }
+
+/**
+ * Check if a string looks like an i18n key
+ * I18n keys are in the format "namespace.key.subkey" (e.g., "tools.knowledge_base.display_name")
+ */
+function isI18nKey(value: string): boolean {
+  // Must contain dots and no spaces, and start with a valid namespace prefix
+  return /^tools\.[a-z_]+\.[a-z_]+$/.test(value)
+}
+
+/**
+ * Parse and translate i18n title from backend
+ *
+ * The title can be in three formats:
+ * 1. A plain string that is NOT an i18n key (e.g., "Custom tool name") - returned as-is
+ * 2. An i18n key string (e.g., "tools.knowledge_base.display_name") - translated
+ * 3. An object with key and params (e.g., { key: "tools.web_search.completed", params: { count: 5 } }) - translated with interpolation
+ *
+ * @param title - The title from backend (string or object)
+ * @param t - i18next translation function
+ * @param namespace - Optional namespace prefix (default: 'chat')
+ * @returns Translated string
+ */
+export function parseI18nTitle(
+  title: I18nTitle | undefined | null,
+  t: TFunction,
+  namespace: string = 'chat'
+): string {
+  if (!title) {
+    return ''
+  }
+
+  // Handle object format: { key: "...", params: { ... } }
+  if (typeof title === 'object' && 'key' in title) {
+    const fullKey = `${namespace}:${title.key}`
+    const translated = t(fullKey, title.params || {})
+    // If translation returns the key itself, it means no translation was found
+    return translated !== fullKey ? translated : title.key
+  }
+
+  // Handle string format
+  if (typeof title === 'string') {
+    // Check if it looks like an i18n key
+    if (isI18nKey(title)) {
+      const fullKey = `${namespace}:${title}`
+      const translated = t(fullKey)
+      // If translation returns the key itself, return the original value
+      return translated !== fullKey ? translated : title
+    }
+    // Not an i18n key, return as-is
+    return title
+  }
+
+  return String(title)
+}


### PR DESCRIPTION
## Summary

- Add complete i18n support for tool display names and dynamic messages
- Backend returns i18n keys instead of hardcoded Chinese text
- Frontend parses and translates i18n keys based on user's language setting
- Resolves issue where "使用工具", "检索知识库" appear in English environment

## Changes

### Backend (chat_shell & backend/skills)

1. **Tool display_name changes**: Changed from Chinese text to i18n keys
   - `knowledge_base.py`: "检索知识库" → "tools.knowledge_base.display_name"
   - `web_search.py`: "搜索网页" → "tools.web_search.display_name"
   - `load_skill.py`: "加载技能" → "tools.load_skill.display_name"
   - `data_table.py`: "查询数据表" → "tools.data_table.display_name"
   - `file_reader.py`: "读取文件" / "列出文件" → i18n keys
   - `evaluation.py`: "正在提交评估结果" → "tools.evaluation.display_name"
   - `render_mermaid.py`: "渲染图表" → "tools.render_mermaid.display_name"
   - `read_reference.py`: "查阅参考文档" → "tools.read_reference.display_name"

2. **events.py changes**: Dynamic messages return structured i18n format
   - Knowledge base completion: `{"key": "tools.knowledge_base.completed", "params": {"count": N}}`
   - Web search messages: i18n keys with query/count params
   - Generic tool usage: `{"key": "tools.using", "params": {"name": tool_name}}`

### Frontend

1. **New i18nTitle.ts utility**: Parses i18n titles from backend
   - Handles plain i18n key strings
   - Handles objects with key and params

2. **SimpleThinkingView.tsx**: Updated to use `parseI18nTitle()` for tool status

3. **i18n translations added**:
   - `chat.json`: Added `tools.*` namespace with all tool translations
   - `common.json`: Added `preview.*` for attachment lightbox

4. **AttachmentPreview.tsx**: Added i18n for lightbox controls

5. **MobileTeamSelector.tsx**: Removed Chinese fallback values

## Test Plan

- [ ] Verify tool status displays correctly in Chinese environment
- [ ] Switch to English, verify "Searching Knowledge Base", "Web Search" etc. display
- [ ] Test knowledge base search shows "Retrieval complete, found X results" in English
- [ ] Test web search shows "Search complete, found X results" in English
- [ ] Verify attachment lightbox buttons show localized tooltips
- [ ] Run frontend lint and typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive internationalization for tool titles and messages, plus a utility to parse/render translatable titles.
  * Added preview action translations (zoom, rotate, download, close) and wired translations into attachment preview/lightbox.

* **Improvements**
  * Replaced literal tool labels with localization keys across the app for consistent multi-language display.
  * Updated UI flows to resolve and display i18n-aware tool start/end titles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->