### PR TITLE
test(shared): add comprehensive unit tests for Gerrit token URL encoding

### DIFF
--- a/shared/tests/utils/test_git_util.py
+++ b/shared/tests/utils/test_git_util.py
@@ -191,3 +191,212 @@ class TestGitUtil:
         # Verify failure
         assert success is False
         assert "Clone failed" in error
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_at_symbol(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test that Gerrit tokens with @ symbol are properly URL encoded"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "https://gerrit.example.com/project"
+        branch = "main"
+        project_path = "/tmp/test-repo"
+        username = "user@domain.com"
+        token = "token@with@at"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+        auth_url = cmd[5]
+
+        # @ symbol should be encoded as %40
+        assert "%40" in auth_url
+        assert "user@domain.com" not in auth_url
+        assert "token@with@at" not in auth_url
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_percent_symbol(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test that Gerrit tokens with % symbol are properly URL encoded"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "https://gerrit.example.com/project"
+        branch = "main"
+        project_path = "/tmp/test-repo"
+        username = "testuser"
+        token = "token%with%percent"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+        auth_url = cmd[5]
+
+        # % symbol should be encoded as %25
+        assert "%25" in auth_url
+        assert "token%with%percent" not in auth_url
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_colon_symbol(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test that Gerrit tokens with : symbol are properly URL encoded"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "https://gerrit.example.com/project"
+        branch = "main"
+        project_path = "/tmp/test-repo"
+        username = "testuser"
+        token = "token:with:colon"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+        auth_url = cmd[5]
+
+        # : symbol should be encoded as %3A
+        assert "%3A" in auth_url
+        assert "token:with:colon" not in auth_url
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_mixed_special_chars(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test that Gerrit tokens with mixed special characters are properly URL encoded"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "https://gerrit.example.com/project"
+        branch = "main"
+        project_path = "/tmp/test-repo"
+        username = "user@company"
+        # Token with multiple special characters: / @ % : + = & ? #
+        token = "abc/def@ghi%jkl:mno+pqr=stu&vwx?yz#123"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+        auth_url = cmd[5]
+
+        # All special characters should be encoded
+        assert "%2F" in auth_url  # / -> %2F
+        assert "%40" in auth_url  # @ -> %40
+        assert "%25" in auth_url  # % -> %25
+        assert "%3A" in auth_url  # : -> %3A
+        assert "%2B" in auth_url  # + -> %2B
+        assert "%3D" in auth_url  # = -> %3D
+        assert "%26" in auth_url  # & -> %26
+        assert "%3F" in auth_url  # ? -> %3F
+        assert "%23" in auth_url  # # -> %23
+
+        # Raw special characters should not appear in the URL
+        assert "abc/def" not in auth_url
+        assert "@ghi" not in auth_url
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_no_branch(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test Gerrit URL encoding when no branch is specified"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "https://gerrit.example.com/project"
+        branch = None  # No branch specified
+        project_path = "/tmp/test-repo"
+        username = "testuser"
+        token = "token/with/slash"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+
+        # When no branch, command is: ['git', 'clone', URL, PATH]
+        auth_url = cmd[2]
+
+        # / should be encoded
+        assert "%2F" in auth_url
+        assert "token/with/slash" not in auth_url
+
+    @patch("shared.utils.git_util.subprocess.run")
+    @patch("shared.utils.git_util.setup_git_hooks")
+    def test_clone_repo_with_token_gerrit_http_protocol(
+        self, mock_setup_hooks, mock_subprocess
+    ):
+        """Test Gerrit URL encoding with HTTP protocol (not HTTPS)"""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_subprocess.return_value = mock_result
+        mock_setup_hooks.return_value = (True, None)
+
+        project_url = "http://gerrit.example.com/project"
+        branch = "main"
+        project_path = "/tmp/test-repo"
+        username = "testuser"
+        token = "token@special"
+
+        success, error = clone_repo_with_token(
+            project_url, branch, project_path, username, token
+        )
+
+        assert success is True
+        assert error is None
+
+        call_args = mock_subprocess.call_args
+        cmd = call_args[0][0]
+        auth_url = cmd[5]
+
+        # Should start with http://
+        assert auth_url.startswith("http://")
+        # @ should be encoded
+        assert "%40" in auth_url
+        assert "token@special" not in auth_url


### PR DESCRIPTION
## Summary

Add comprehensive unit tests to ensure Gerrit HTTP tokens containing special characters are properly URL encoded when constructing git clone URLs.

### Background

Issue #94 reported that Gerrit HTTP tokens containing special characters (like `/`, `@`, `%`, etc.) cause git clone URL parsing failures. The fix was already implemented in commit 50e66ae, but additional test coverage was needed to validate various special character scenarios.

### Changes

Added 6 new unit tests covering:

- **`test_clone_repo_with_token_gerrit_at_symbol`**: Tests `@` symbol encoding (`%40`)
- **`test_clone_repo_with_token_gerrit_percent_symbol`**: Tests `%` symbol encoding (`%25`)
- **`test_clone_repo_with_token_gerrit_colon_symbol`**: Tests `:` symbol encoding (`%3A`)
- **`test_clone_repo_with_token_gerrit_mixed_special_chars`**: Tests all special characters (`/ @ % : + = & ? #`)
- **`test_clone_repo_with_token_gerrit_no_branch`**: Tests URL encoding when no branch is specified
- **`test_clone_repo_with_token_gerrit_http_protocol`**: Tests URL encoding with HTTP (not HTTPS) protocol

### Test Results

All 17 tests pass:

```
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_github PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_gitlab PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_gitee PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_bitbucket PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_gerrit PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_non_gerrit_internal PASSED
tests/utils/test_git_util.py::TestGitUtil::test_is_gerrit_url_ssh PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_url_encoding PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_github_no_encoding PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gitlab_no_encoding PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_failure PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_at_symbol PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_percent_symbol PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_colon_symbol PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_mixed_special_chars PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_no_branch PASSED
tests/utils/test_git_util.py::TestGitUtil::test_clone_repo_with_token_gerrit_http_protocol PASSED
```

Closes #94

## Test plan

- [x] Run `cd shared && uv run pytest tests/utils/test_git_util.py -v` - All 17 tests should pass
- [ ] CI tests should pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests verifying percent-encoding of credentials for Gerrit repository cloning across special characters, protocol variations, username formats, and no-branch scenarios; ensures raw credentials are not exposed and confirms GitHub/GitLab cloning behavior remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->