### PR TITLE
feat(frontend): add prompt editing support for non-pipeline mode in FinalPromptMessage

### DIFF
--- a/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
+++ b/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Copy, Check, Plus, Star, RefreshCw, Edit3, X, Save } from 'lucide-react'
+import { Copy, Check, Plus, Star, RefreshCw, Edit3, X, Save, RotateCcw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import type { FinalPromptData, Team, GitRepoInfo, GitBranch } from '@/types/api'
 import MarkdownEditor from '@uiw/react-markdown-editor'
@@ -48,6 +48,8 @@ export default function FinalPromptMessage({
   const [copied, setCopied] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editedPrompt, setEditedPrompt] = useState(data.final_prompt)
+  // Track if user has saved edited content that differs from original
+  const [savedPrompt, setSavedPrompt] = useState<string | null>(null)
   const [isConfirming, setIsConfirming] = useState(false)
   // Track if confirmation was already submitted to prevent duplicate submissions
   const [hasConfirmed, setHasConfirmed] = useState(false)
@@ -55,9 +57,19 @@ export default function FinalPromptMessage({
   // Single source of truth: isPendingConfirmation from pipeline_stage_info.is_pending_confirmation
   const showPipelineActions = isPendingConfirmation
 
+  // Check if prompt has been edited (saved and different from original)
+  const hasBeenEdited = savedPrompt !== null && savedPrompt !== data.final_prompt
+
+  // Get the prompt to use for copy/create task operations
+  const getEffectivePrompt = () => {
+    if (isEditing) return editedPrompt
+    if (savedPrompt !== null) return savedPrompt
+    return data.final_prompt
+  }
+
   const handleCopy = async () => {
     try {
-      const textToCopy = isEditing ? editedPrompt : data.final_prompt
+      const textToCopy = getEffectivePrompt()
       if (
         typeof navigator !== 'undefined' &&
         navigator.clipboard &&
@@ -98,7 +110,7 @@ export default function FinalPromptMessage({
 
     // Store prompt data in sessionStorage for the new task page
     const promptData = {
-      prompt: isEditing ? editedPrompt : data.final_prompt,
+      prompt: getEffectivePrompt(),
       teamId: selectedTeam.id,
       repoId: selectedRepo.git_repo_id,
       branch: selectedBranch.name,
@@ -132,7 +144,7 @@ export default function FinalPromptMessage({
     setIsConfirming(true)
     try {
       const response = await taskApis.confirmPipelineStage(taskId, {
-        confirmed_prompt: isEditing ? editedPrompt : data.final_prompt,
+        confirmed_prompt: getEffectivePrompt(),
         action: 'continue',
       })
 
@@ -160,18 +172,26 @@ export default function FinalPromptMessage({
   }
 
   const handleStartEdit = () => {
-    setEditedPrompt(data.final_prompt)
+    // Start editing from the current effective prompt (saved or original)
+    setEditedPrompt(savedPrompt !== null ? savedPrompt : data.final_prompt)
     setIsEditing(true)
   }
 
   const handleCancelEdit = () => {
-    setEditedPrompt(data.final_prompt)
+    // Discard changes, restore to saved state (or original if no saved state)
+    setEditedPrompt(savedPrompt !== null ? savedPrompt : data.final_prompt)
     setIsEditing(false)
   }
 
   const handleSaveEdit = () => {
+    // Save the edited prompt
+    setSavedPrompt(editedPrompt)
     setIsEditing(false)
-    // Keep edited prompt for submission
+  }
+
+  const handleRestoreOriginal = () => {
+    // Restore to original prompt while staying in edit mode
+    setEditedPrompt(data.final_prompt)
   }
 
   return (
@@ -183,8 +203,13 @@ export default function FinalPromptMessage({
           <h3 className="text-base font-semibold text-blue-400">
             {t('clarification.final_prompt_title')}
           </h3>
+          {hasBeenEdited && (
+            <span className="text-xs text-amber-500 font-medium">
+              {t('clarification.edited')}
+            </span>
+          )}
         </div>
-        {showPipelineActions && !isEditing && (
+        {!isEditing && (
           <Button
             variant="ghost"
             size="sm"
@@ -212,6 +237,16 @@ export default function FinalPromptMessage({
                 <X className="w-4 h-4 mr-1" />
                 {t('common:cancel')}
               </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRestoreOriginal}
+                disabled={editedPrompt === data.final_prompt}
+                className="text-amber-600 hover:text-amber-500"
+              >
+                <RotateCcw className="w-4 h-4 mr-1" />
+                {t('clarification.restore_original')}
+              </Button>
               <Button variant="secondary" size="sm" onClick={handleSaveEdit}>
                 <Save className="w-4 h-4 mr-1" />
                 {t('pipeline.save_changes')}
@@ -220,7 +255,7 @@ export default function FinalPromptMessage({
           </div>
         ) : (
           <MarkdownEditor.Markdown
-            source={data.final_prompt}
+            source={savedPrompt !== null ? savedPrompt : data.final_prompt}
             style={{ background: 'transparent' }}
             wrapperElement={{ 'data-color-mode': theme }}
             components={{

--- a/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
+++ b/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
@@ -184,6 +184,15 @@ export default function FinalPromptMessage({
   }
 
   const handleSaveEdit = () => {
+    // Validate non-empty prompt before saving
+    const trimmed = editedPrompt.trim()
+    if (!trimmed) {
+      toast({
+        variant: 'destructive',
+        title: t('clarification.prompt_empty_error'),
+      })
+      return
+    }
     // Save the edited prompt
     setSavedPrompt(editedPrompt)
     setIsEditing(false)

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -226,7 +226,9 @@
     "question": "Q",
     "required_field": "This question is required",
     "additional_thoughts": "Additional Thoughts or Remarks",
-    "additional_placeholder": "Enter additional thoughts, requirements, or special notes here..."
+    "additional_placeholder": "Enter additional thoughts, requirements, or special notes here...",
+    "restore_original": "Restore Original",
+    "edited": "(Edited)"
   },
   "export": {
     "export": "Export",

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -228,7 +228,8 @@
     "additional_thoughts": "Additional Thoughts or Remarks",
     "additional_placeholder": "Enter additional thoughts, requirements, or special notes here...",
     "restore_original": "Restore Original",
-    "edited": "(Edited)"
+    "edited": "(Edited)",
+    "prompt_empty_error": "Prompt cannot be empty"
   },
   "export": {
     "export": "Export",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -228,7 +228,8 @@
     "additional_thoughts": "其他想法或补充说明",
     "additional_placeholder": "在此输入其他想法、补充需求或特殊说明...",
     "restore_original": "恢复原文",
-    "edited": "(已编辑)"
+    "edited": "(已编辑)",
+    "prompt_empty_error": "提示词不能为空"
   },
   "export": {
     "export": "导出",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -226,7 +226,9 @@
     "question": "问题",
     "required_field": "此问题必须回答",
     "additional_thoughts": "其他想法或补充说明",
-    "additional_placeholder": "在此输入其他想法、补充需求或特殊说明..."
+    "additional_placeholder": "在此输入其他想法、补充需求或特殊说明...",
+    "restore_original": "恢复原文",
+    "edited": "(已编辑)"
   },
   "export": {
     "export": "导出",


### PR DESCRIPTION
## Summary

- Enable edit button in non-pipeline mode for FinalPromptMessage component (previously only available in pipeline mode)
- Add savedPrompt state to track user's edited content after saving
- Add hasBeenEdited indicator to show "(Edited)" label when content differs from original
- Add "Restore Original" button (RotateCcw icon) to reset content to original while staying in edit mode
- Refactor to use getEffectivePrompt() helper function for consistent prompt retrieval in copy/create task operations
- Add i18n translations for `clarification.restore_original` and `clarification.edited` keys in both English and Chinese

## Changes

### FinalPromptMessage.tsx
- Import `RotateCcw` icon from lucide-react
- Add `savedPrompt` state to track edited content separately from editing state
- Add `hasBeenEdited` computed property to check if saved content differs from original
- Add `getEffectivePrompt()` helper function for unified prompt retrieval
- Add `handleRestoreOriginal()` function to restore original content in edit mode
- Update header to always show edit button (not just in pipeline mode) and display "(Edited)" indicator
- Add "Restore Original" button in edit mode with disabled state when content matches original
- Update Markdown preview to show saved content when available

### i18n files
- Add `clarification.restore_original`: "恢复原文" / "Restore Original"
- Add `clarification.edited`: "(已编辑)" / "(Edited)"

## Test plan

- [ ] Verify edit button appears in non-pipeline mode (when `isPendingConfirmation` is false)
- [ ] Verify clicking edit button enters edit mode with current content
- [ ] Verify saving edited content shows "(Edited)" indicator in header
- [ ] Verify "Restore Original" button is disabled when content matches original
- [ ] Verify "Restore Original" resets textarea to original content while staying in edit mode
- [ ] Verify "Cancel" discards changes and restores to last saved state (or original)
- [ ] Verify "Copy Prompt" copies the edited/saved content (not original)
- [ ] Verify "Create New Task" uses the edited/saved content
- [ ] Verify Markdown preview shows saved content after saving edits
- [ ] Verify both English and Chinese translations display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now edit final prompts with changes saved independently
  * New "Restore Original" button allows reverting edited prompts to their original state
  * Visual "(Edited)" indicator displays when prompts have been modified

* **Localization**
  * Added English and Chinese translations for new editing interface features

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->