### PR TITLE
fix(backend): handle null color when creating project

### DIFF
--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -48,11 +48,12 @@ def create_project(
     next_sort_order = (max_sort_order or 0) + 1
 
     # Create project
+    # Use empty string for color if not provided, since DB column is NOT NULL DEFAULT ''
     new_project = Project(
         user_id=user_id,
         name=project_data.name,
         description=project_data.description,
-        color=project_data.color,
+        color=project_data.color or "",
         sort_order=next_sort_order,
         is_expanded=True,
         is_active=True,


### PR DESCRIPTION
## Summary

- Fix IntegrityError when creating a project without selecting a color
- Database column `color` has `NOT NULL DEFAULT ''` constraint, but Python code was passing `None`
- Now uses empty string as fallback when color is not provided

## Root Cause

The migration file defined `color` column as:
```sql
color VARCHAR(20) NOT NULL DEFAULT '' COMMENT 'Project color identifier'
```

But the Python model and service were allowing `None` to be passed, causing the database to reject the INSERT.

## Changes

- Modified `create_project()` in `backend/app/services/project_service.py`
- Changed `color=project_data.color` to `color=project_data.color or ""`

## Test Plan

- [ ] Create a project without selecting a color - should succeed
- [ ] Create a project with a color selected - should work as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Project creation now automatically assigns a default color when one is not provided, improving robustness of the project creation workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->