### PR TITLE
fix(frontend): unify ProjectSection title color with GroupSection and HistorySection

### DIFF
--- a/frontend/src/features/projects/components/ProjectSection.tsx
+++ b/frontend/src/features/projects/components/ProjectSection.tsx
@@ -105,7 +105,7 @@ export function ProjectSection({ onTaskSelect }: ProjectSectionProps) {
       <div className="flex items-center justify-between px-1 py-1.5 group">
         <button
           onClick={() => setSectionCollapsed(!sectionCollapsed)}
-          className="flex items-center gap-1 text-xs font-medium text-text-secondary hover:text-text-primary transition-colors"
+          className="flex items-center gap-1 text-xs font-medium text-text-muted hover:text-text-primary transition-colors"
         >
           {sectionCollapsed ? (
             <ChevronRight className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Summary
- 统一左侧菜单中"对话分组"标题的字体颜色与"群聊"、"历史对话"保持一致
- 将 `text-text-secondary` 修改为 `text-text-muted`

## Changes
| 属性 | 修改前 | 修改后 |
|------|--------|--------|
| 颜色 | text-text-secondary | text-text-muted |

## Test Plan
- [ ] 验证"对话分组"标题颜色与"群聊"、"历史对话"标题颜色一致
- [ ] 验证 hover 状态下颜色切换正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the section collapse toggle button's text styling for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->