### PR TITLE
chore(docker): add pull_policy always for latest images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
     # build:
       # dockerfile: docker/backend/Dockerfile
     image: ghcr.io/wecode-ai/wegent-backend:latest
+    pull_policy: always
     container_name: wegent-backend
     restart: always
     ports:
@@ -119,6 +120,7 @@ services:
     # build:
     #   dockerfile: docker/frontend/Dockerfile
     image: ghcr.io/wecode-ai/wegent-web:latest
+    pull_policy: always
     container_name: wegent-frontend
     restart: always
     ports:
@@ -150,6 +152,7 @@ services:
 
   chat_shell:
     image: ghcr.io/wecode-ai/wegent-chat-shell:latest
+    pull_policy: always
     container_name: wegent-chat-shell
     restart: always
     ports:
@@ -181,6 +184,7 @@ services:
     # build:
     #   dockerfile: docker/executor_manager/Dockerfile
     image: ghcr.io/wecode-ai/wegent-executor-manager:latest
+    pull_policy: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
     container_name: wegent-executor-manager


### PR DESCRIPTION
## Summary

- Add `pull_policy: always` to all services using `:latest` tag images in docker-compose.yml
- Affected services: backend, frontend, chat_shell, executor_manager

## Problem

When using `image: xxx:latest` without specifying `pull_policy`, Docker Compose will use the locally cached image if it exists, even if a newer version is available in the registry. This can lead to users running outdated versions of the services.

## Solution

Set `pull_policy: always` to ensure Docker always pulls the latest image from the registry when starting services.

## Test plan

- [ ] Run `docker-compose pull` to verify images are pulled
- [ ] Run `docker-compose up -d` to verify services start correctly
- [ ] Verify that subsequent `docker-compose up -d` commands also pull latest images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image deployment process to ensure the latest versions are pulled on each startup, improving deployment consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->