### PR TITLE
feat(frontend): add task rename feature to project groups

### DIFF
--- a/frontend/src/components/common/TaskInlineRename.tsx
+++ b/frontend/src/components/common/TaskInlineRename.tsx
@@ -1,0 +1,165 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useRef, useEffect, useCallback, KeyboardEvent } from 'react'
+import { cn } from '@/lib/utils'
+import { useTranslation } from '@/hooks/useTranslation'
+
+const MAX_TITLE_LENGTH = 100
+
+interface TaskInlineRenameProps {
+  taskId: number
+  initialTitle: string
+  isEditing: boolean
+  onEditEnd: () => void
+  onSave: (newTitle: string) => Promise<void>
+  className?: string
+}
+
+/**
+ * Shared inline rename component for task titles.
+ * Supports editing with validation, keyboard navigation, and error handling.
+ */
+export function TaskInlineRename({
+  initialTitle,
+  isEditing,
+  onEditEnd,
+  onSave,
+  className,
+}: TaskInlineRenameProps) {
+  const { t } = useTranslation('common')
+  const [value, setValue] = useState(initialTitle)
+  const [error, setError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus and select all text when entering edit mode
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isEditing])
+
+  // Reset value when initialTitle changes or when entering edit mode
+  useEffect(() => {
+    if (isEditing) {
+      setValue(initialTitle)
+      setError(null)
+    }
+  }, [isEditing, initialTitle])
+
+  const handleSave = useCallback(async () => {
+    const trimmedValue = value.trim()
+
+    // Validate empty
+    if (!trimmedValue) {
+      setError(t('tasks.rename_empty_error'))
+      return
+    }
+
+    // If value unchanged, just exit
+    if (trimmedValue === initialTitle) {
+      onEditEnd()
+      return
+    }
+
+    setIsSaving(true)
+    setError(null)
+
+    try {
+      await onSave(trimmedValue)
+      onEditEnd()
+    } catch (err) {
+      console.error('[TaskInlineRename] Save failed:', err)
+      setError(t('tasks.rename_save_error'))
+    } finally {
+      setIsSaving(false)
+    }
+  }, [value, initialTitle, onSave, onEditEnd, t])
+
+  const handleCancel = useCallback(() => {
+    setValue(initialTitle)
+    setError(null)
+    onEditEnd()
+  }, [initialTitle, onEditEnd])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        e.stopPropagation()
+        handleSave()
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        e.stopPropagation()
+        handleCancel()
+      }
+    },
+    [handleSave, handleCancel]
+  )
+
+  const handleBlur = useCallback(() => {
+    // Only save if not already saving (to avoid double saves)
+    if (!isSaving) {
+      handleSave()
+    }
+  }, [handleSave, isSaving])
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value
+    // Enforce max length
+    if (newValue.length <= MAX_TITLE_LENGTH) {
+      setValue(newValue)
+      setError(null)
+    }
+  }, [])
+
+  // Prevent click events from bubbling (to avoid task selection/navigation)
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
+
+  if (!isEditing) {
+    return null
+  }
+
+  return (
+    <div className={cn('flex-1 min-w-0', className)} onClick={handleClick}>
+      <div className="relative">
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={handleBlur}
+          disabled={isSaving}
+          className={cn(
+            'w-full px-1 py-0.5 text-sm bg-transparent rounded',
+            'border-2 outline-none transition-colors',
+            error
+              ? 'border-red-500 focus:border-red-500'
+              : 'border-primary focus:border-primary',
+            isSaving && 'opacity-50 cursor-not-allowed'
+          )}
+          onClick={handleClick}
+        />
+        {/* Character counter */}
+        <div
+          className={cn(
+            'absolute right-1 -bottom-4 text-xs',
+            value.length > 90 ? 'text-amber-500' : 'text-text-muted'
+          )}
+        >
+          {value.length}/{MAX_TITLE_LENGTH}
+        </div>
+      </div>
+      {/* Error message */}
+      {error && <div className="mt-4 text-xs text-red-500">{error}</div>}
+    </div>
+  )
+}

--- a/frontend/src/features/projects/components/ProjectTaskMenu.tsx
+++ b/frontend/src/features/projects/components/ProjectTaskMenu.tsx
@@ -12,6 +12,7 @@ import {
   FolderIcon,
   FolderMinusIcon,
   PlusIcon,
+  PencilIcon,
 } from '@heroicons/react/24/outline'
 import { HiOutlineEllipsisVertical } from 'react-icons/hi2'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -35,9 +36,10 @@ import { useRouter } from 'next/navigation'
 interface ProjectTaskMenuProps {
   taskId: number
   projectId: number
+  onRename?: () => void
 }
 
-export function ProjectTaskMenu({ taskId, projectId }: ProjectTaskMenuProps) {
+export function ProjectTaskMenu({ taskId, projectId, onRename }: ProjectTaskMenuProps) {
   const { t } = useTranslation()
   const { t: tProjects } = useTranslation('projects')
   const router = useRouter()
@@ -164,6 +166,19 @@ export function ProjectTaskMenu({ taskId, projectId }: ProjectTaskMenuProps) {
             <FolderMinusIcon className="h-3.5 w-3.5 mr-2" />
             {tProjects('menu.removeFromGroup')}
           </DropdownMenuItem>
+
+          {/* Rename Task */}
+          {onRename && (
+            <DropdownMenuItem
+              onClick={e => {
+                e.stopPropagation()
+                onRename()
+              }}
+            >
+              <PencilIcon className="h-3.5 w-3.5 mr-2" />
+              {t('common:tasks.rename_task')}
+            </DropdownMenuItem>
+          )}
 
           {/* Delete Task */}
           <DropdownMenuItem


### PR DESCRIPTION
## Summary
- Add inline rename functionality for tasks within project groups
- Create shared `TaskInlineRename` component for consistent rename UX
- Support both menu-triggered and double-click-triggered rename
- Include validation, character counter, and keyboard shortcuts

## Changes
- **New file**: `frontend/src/components/common/TaskInlineRename.tsx` - Shared inline rename component
- **Modified**: `frontend/src/features/projects/components/ProjectTaskMenu.tsx` - Added rename menu item
- **Modified**: `frontend/src/features/projects/components/ProjectSection.tsx` - Integrated inline rename with double-click support

## Test plan
- [ ] Click three-dot menu on a project task, select "Rename Task"
- [ ] Verify input appears with existing title selected
- [ ] Enter new name and press Enter to save
- [ ] Press Escape to cancel rename
- [ ] Double-click on task title to trigger rename
- [ ] Verify empty name shows error message
- [ ] Verify character counter appears and turns orange when near limit (90+ chars)