### PR TITLE
perf: optimize thinking streaming and storage

### DIFF
--- a/backend/tests/services/test_merge_thinking_steps.py
+++ b/backend/tests/services/test_merge_thinking_steps.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for merge_thinking_steps function."""
+
+import pytest
+
+from app.services.adapters.executor_kinds import merge_thinking_steps
+
+
+class TestMergeThinkingSteps:
+    """Test cases for merge_thinking_steps function."""
+
+    def test_empty_list(self):
+        """Test with empty list returns empty list."""
+        result = merge_thinking_steps([])
+        assert result == []
+
+    def test_single_step(self):
+        """Test with single step returns that step."""
+        steps = [{"title": "thinking.initialize_agent", "next_action": "continue"}]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 1
+        assert result[0]["title"] == "thinking.initialize_agent"
+
+    def test_no_merge_different_titles(self):
+        """Test that steps with different titles are not merged."""
+        steps = [
+            {"title": "thinking.initialize_agent", "next_action": "continue"},
+            {"title": "thinking.async_execution_started", "next_action": "continue"},
+        ]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 2
+        assert result[0]["title"] == "thinking.initialize_agent"
+        assert result[1]["title"] == "thinking.async_execution_started"
+
+    def test_no_merge_without_details_type(self):
+        """Test that steps without details.type are not merged even with same title."""
+        steps = [
+            {"title": "thinking.initialize_agent", "next_action": "continue"},
+            {"title": "thinking.initialize_agent", "next_action": "continue"},
+        ]
+        result = merge_thinking_steps(steps)
+        # Should not merge because no details.type
+        assert len(result) == 2
+
+    def test_merge_same_reasoning_type(self):
+        """Test that adjacent reasoning steps are merged."""
+        steps = [
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Hello"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": " World"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "!"},
+            },
+        ]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 1
+        assert result[0]["title"] == "thinking.model_reasoning"
+        assert result[0]["details"]["content"] == "Hello World!"
+
+    def test_no_merge_different_details_type(self):
+        """Test that steps with different details.type are not merged."""
+        steps = [
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Hello"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "tool_call", "content": "World"},
+            },
+        ]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 2
+
+    def test_no_merge_different_next_action(self):
+        """Test that steps with different next_action are not merged."""
+        steps = [
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Hello"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "stop",
+                "details": {"type": "reasoning", "content": " World"},
+            },
+        ]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 2
+
+    def test_mixed_steps(self):
+        """Test realistic scenario with mixed step types."""
+        steps = [
+            {"title": "thinking.initialize_agent", "next_action": "continue"},
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Let me "},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "think about "},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "this."},
+            },
+            {
+                "title": "thinking.agent_tool_call",
+                "next_action": "continue",
+                "details": {"type": "tool", "name": "Read"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Now I "},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "understand."},
+            },
+        ]
+        result = merge_thinking_steps(steps)
+
+        # Expected: 4 steps after merging
+        # 1. initialize_agent
+        # 2. merged reasoning "Let me think about this."
+        # 3. agent_tool_call
+        # 4. merged reasoning "Now I understand."
+        assert len(result) == 4
+        assert result[0]["title"] == "thinking.initialize_agent"
+        assert result[1]["title"] == "thinking.model_reasoning"
+        assert result[1]["details"]["content"] == "Let me think about this."
+        assert result[2]["title"] == "thinking.agent_tool_call"
+        assert result[3]["title"] == "thinking.model_reasoning"
+        assert result[3]["details"]["content"] == "Now I understand."
+
+    def test_preserves_other_details_fields(self):
+        """Test that other fields in details are preserved after merge."""
+        steps = [
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Hello", "extra": "value1"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": " World", "extra": "value2"},
+            },
+        ]
+        result = merge_thinking_steps(steps)
+        assert len(result) == 1
+        # Content should be merged
+        assert result[0]["details"]["content"] == "Hello World"
+        # Other fields from the first step should be preserved
+        assert result[0]["details"]["type"] == "reasoning"
+        # extra from first step is preserved (we keep the first step's other fields)
+        assert result[0]["details"]["extra"] == "value1"
+
+    def test_does_not_mutate_input(self):
+        """Test that input list is not mutated."""
+        steps = [
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": "Hello"},
+            },
+            {
+                "title": "thinking.model_reasoning",
+                "next_action": "continue",
+                "details": {"type": "reasoning", "content": " World"},
+            },
+        ]
+        original_first_content = steps[0]["details"]["content"]
+        merge_thinking_steps(steps)
+        # Original should not be modified
+        assert steps[0]["details"]["content"] == original_first_content
+        assert len(steps) == 2

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 
 /**
  * Hook to provide a smooth typewriter effect for streaming content.
@@ -11,12 +11,15 @@ import { useState, useEffect, useRef } from 'react'
  * smoothly updating string (displayedContent) that "types" out characters.
  *
  * @param content The full content string that updates over time
- * @param speed Base speed in milliseconds per tick (default: 15ms)
+ * @param speed Base speed in milliseconds per tick (default: 30ms)
  * @returns The content to display
  */
-export function useTypewriter(content: string, speed = 15) {
+export function useTypewriter(content: string, speed = 30) {
   const [displayedContent, setDisplayedContent] = useState('')
   const contentRef = useRef(content)
+  const rafIdRef = useRef<number | null>(null)
+  const lastTimeRef = useRef<number>(0)
+  const isRunningRef = useRef(false)
 
   // Update ref when content changes
   useEffect(() => {
@@ -27,14 +30,22 @@ export function useTypewriter(content: string, speed = 15) {
     }
   }, [content, displayedContent.length])
 
-  useEffect(() => {
-    const timer = setInterval(() => {
+  // Animation frame callback
+  const animate = useCallback(
+    (timestamp: number) => {
+      // Throttle updates based on speed
+      if (timestamp - lastTimeRef.current < speed) {
+        rafIdRef.current = requestAnimationFrame(animate)
+        return
+      }
+      lastTimeRef.current = timestamp
+
       setDisplayedContent(current => {
         const target = contentRef.current
 
-        // If current is longer than target (e.g. content truncated/reset but not caught above),
-        // or equal, just return target or current.
+        // If caught up or ahead, stop animation
         if (current.length >= target.length) {
+          isRunningRef.current = false
           return current.length > target.length ? target : current
         }
 
@@ -44,7 +55,6 @@ export function useTypewriter(content: string, speed = 15) {
         // - Small lag (< 5 chars): Type 1 char at a time (smooth typing feel)
         // - Medium lag (5-20 chars): Speed up slightly
         // - Large lag (> 20 chars): Catch up quickly (bulk render)
-        // This prevents the display from falling too far behind the stream.
         let step = 1
         if (lag > 50) {
           step = Math.ceil(lag / 5) // Very fast catchup
@@ -58,10 +68,31 @@ export function useTypewriter(content: string, speed = 15) {
         const nextLength = Math.min(current.length + step, target.length)
         return target.slice(0, nextLength)
       })
-    }, speed)
 
-    return () => clearInterval(timer)
-  }, [speed])
+      // Continue animation if still running
+      if (isRunningRef.current) {
+        rafIdRef.current = requestAnimationFrame(animate)
+      }
+    },
+    [speed]
+  )
+
+  // Start animation when content changes and we're behind
+  useEffect(() => {
+    const shouldAnimate = content.length > displayedContent.length
+
+    if (shouldAnimate && !isRunningRef.current) {
+      isRunningRef.current = true
+      rafIdRef.current = requestAnimationFrame(animate)
+    }
+
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [content, displayedContent.length, animate])
 
   return displayedContent
 }


### PR DESCRIPTION
## Summary

- **Backend**: Add `merge_thinking_steps()` to combine adjacent thinking steps before saving to DB (559 steps → 4 steps)
- **Backend**: Fix content truncation bug on COMPLETED status
- **Executor**: Add 300ms throttle for thinking callbacks (3000+ → ~20 callbacks)

## Performance Impact

- DB updates: ~6000 → ~150 (96% reduction)
- Storage size: 99% reduction
- Frontend CPU: significantly reduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized thinking step storage through intelligent merging of adjacent steps, reducing memory footprint
  * Reduced frequency of thinking progress reporting to improve overall system responsiveness during task execution

* **Observability**
  * Enhanced logging for thinking step updates to provide better visibility into execution flow

* **Tests**
  * Expanded test coverage for thinking step management operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->