### PR TITLE
fix(frontend): enable task selection when clicking on task title

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -349,14 +349,13 @@ export default function TaskListSection({
         handleStartRename(task.id)
         setClickState({ taskId: null, lastClickTime: 0 })
       } else {
-        // First click - record it and handle as single click
+        // First click - record it and select the task
         setClickState({ taskId: task.id, lastClickTime: now })
-        // Delay single click action to allow for double-click detection
-        // Note: We don't trigger task selection here to avoid conflict
-        // Single click on the row (not title) will still select the task
+        // Trigger task selection on single click
+        handleTaskClick(task)
       }
     },
-    [clickState, handleStartRename, DOUBLE_CLICK_THRESHOLD]
+    [clickState, handleStartRename, DOUBLE_CLICK_THRESHOLD, handleTaskClick]
   )
 
   if (tasks.length === 0) return null

--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -111,13 +111,6 @@ export default function TaskListSection({
   // Local task titles for optimistic update during rename
   const [localTitles, setLocalTitles] = useState<Record<number, string>>({})
 
-  // Double-click detection state
-  const [clickState, setClickState] = useState<{
-    taskId: number | null
-    lastClickTime: number
-  }>({ taskId: null, lastClickTime: 0 })
-  const DOUBLE_CLICK_THRESHOLD = 300 // ms
-
   // Touch interaction state
   const [touchState, setTouchState] = useState<{
     startX: number
@@ -336,27 +329,6 @@ export default function TaskListSection({
   const handleCancelRename = useCallback(() => {
     setEditingTaskId(null)
   }, [])
-
-  // Handle title click with double-click detection
-  const handleTitleClick = useCallback(
-    (task: Task, e: React.MouseEvent) => {
-      e.stopPropagation()
-
-      const now = Date.now()
-      if (clickState.taskId === task.id && now - clickState.lastClickTime < DOUBLE_CLICK_THRESHOLD) {
-        // Double-click detected - enter edit mode
-        e.preventDefault()
-        handleStartRename(task.id)
-        setClickState({ taskId: null, lastClickTime: 0 })
-      } else {
-        // First click - record it and select the task
-        setClickState({ taskId: task.id, lastClickTime: now })
-        // Trigger task selection on single click
-        handleTaskClick(task)
-      }
-    },
-    [clickState, handleStartRename, DOUBLE_CLICK_THRESHOLD, handleTaskClick]
-  )
 
   if (tasks.length === 0) return null
 
@@ -583,17 +555,16 @@ export default function TaskListSection({
                           onCancel={handleCancelRename}
                         />
                       ) : (
-                        <p
-                          className="flex-1 min-w-0 text-sm text-text-primary leading-tight truncate m-0"
+                        <span
+                          className="flex-1 min-w-0 text-sm text-text-primary leading-tight truncate"
                           onDoubleClick={e => {
                             e.stopPropagation()
                             e.preventDefault()
                             handleStartRename(task.id)
                           }}
-                          onClick={e => handleTitleClick(task, e)}
                         >
                           {localTitles[task.id] ?? task.title}
-                        </p>
+                        </span>
                       )}
 
                       {/* Status icon on the right - only render container when needed */}


### PR DESCRIPTION
## Summary
- Fixed issue where clicking on task title text in history conversations would not select the task
- The `handleTitleClick` function was blocking event propagation but not triggering task selection on single click
- Now single click on task title properly selects the task, while double click still enters edit mode for renaming

## Test plan
- [ ] Click on a task title text in history conversations - should select the task
- [ ] Double-click on a task title - should enter edit mode for renaming
- [ ] Click on the task row area (not title text) - should still select the task
- [ ] Verify project group tasks still work correctly (not affected by this change)