### PR TITLE
fix(backend): allow empty email in admin user creation/update

### DIFF
--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from typing import List, Literal, Optional
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 
 # User Management Schemas
@@ -14,18 +14,34 @@ class AdminUserCreate(BaseModel):
 
     user_name: str = Field(..., min_length=2, max_length=50)
     password: Optional[str] = Field(None, min_length=6)
-    email: Optional[EmailStr] = None
+    email: Optional[EmailStr] = Field(None, validate_default=True)
     role: Literal["admin", "user"] = "user"
     auth_source: Literal["password", "oidc"] = "password"
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        """Convert empty string to None for optional email field"""
+        if v == "":
+            return None
+        return v
 
 
 class AdminUserUpdate(BaseModel):
     """Admin user update model"""
 
     user_name: Optional[str] = Field(None, min_length=2, max_length=50)
-    email: Optional[EmailStr] = None
+    email: Optional[EmailStr] = Field(None, validate_default=True)
     role: Optional[Literal["admin", "user"]] = None
     is_active: Optional[bool] = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def empty_string_to_none(cls, v):
+        """Convert empty string to None for optional email field"""
+        if v == "":
+            return None
+        return v
 
 
 class PasswordReset(BaseModel):


### PR DESCRIPTION
When creating or updating users via admin API, the email field is optional in the frontend but Pydantic's EmailStr validator would fail when receiving an empty string. This commit adds field validators to convert empty strings to None before email validation, allowing the frontend to send empty email values without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email field validation for admin user creation and updates to properly handle empty email submissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->