### PR TITLE
feat(backend,frontend): add default team configuration for each mode

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -173,10 +173,6 @@ WIKI_CONTENT_WRITE_BASE_URL=http://backend:8000
 DATA_TABLE_CONFIG={"dingtalk":{"appKey":"YOUR_APP_KEY","appSecret":"YOUR_APP_secret","operatorId":"YOUR_OPERATOR_ID","userMapping":{"baseId":"YOUR_BASE_ID","sheetId":"YOUR_SHEET_ID"}}}
 
 # Default team configuration for each mode
-# Format: name#namespace (namespace is optional, defaults to "default")
-# Example: DEFAULT_TEAM_CHAT=通用助手#default
-# Example: DEFAULT_TEAM_CODE=Code Assistant
-# If not set, the first available team for each mode will be used
-DEFAULT_TEAM_CHAT=
-DEFAULT_TEAM_CODE=
-DEFAULT_TEAM_KNOWLEDGE=
+DEFAULT_TEAM_CHAT=chat-team
+DEFAULT_TEAM_KNOWLEDGE=chat-team
+

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -171,3 +171,12 @@ WIKI_CONTENT_WRITE_BASE_URL=http://backend:8000
 # Format: {"dingtalk":{"appKey":"YOUR_APP_KEY","appSecret":"YOUR_APP_secret","operatorId":"YOUR_OPERATOR_ID","userMapping":{"baseId":"YOUR_BASE_ID","sheetId":"YOUR_SHEET_ID"}}}
 # See backend/app/services/tables/DATA_TABLE_CONFIG_EXAMPLE.md for detailed configuration guide
 DATA_TABLE_CONFIG={"dingtalk":{"appKey":"YOUR_APP_KEY","appSecret":"YOUR_APP_secret","operatorId":"YOUR_OPERATOR_ID","userMapping":{"baseId":"YOUR_BASE_ID","sheetId":"YOUR_SHEET_ID"}}}
+
+# Default team configuration for each mode
+# Format: name#namespace (namespace is optional, defaults to "default")
+# Example: DEFAULT_TEAM_CHAT=通用助手#default
+# Example: DEFAULT_TEAM_CODE=Code Assistant
+# If not set, the first available team for each mode will be used
+DEFAULT_TEAM_CHAT=
+DEFAULT_TEAM_CODE=
+DEFAULT_TEAM_KNOWLEDGE=

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -347,7 +347,7 @@ def parse_default_team_config(config_value: str) -> Optional[DefaultTeamConfig]:
 
 @router.get("/default-teams", response_model=DefaultTeamsResponse)
 async def get_default_teams(
-    current_user: User = Depends(security.get_current_user),
+    _current_user: User = Depends(security.get_current_user),  # noqa: ARG001
 ):
     """
     Get default team configuration for each mode (chat, code, knowledge).

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -312,6 +312,59 @@ class SearchUsersResponse(BaseModel):
     total: int
 
 
+# ==================== Default Teams Configuration ====================
+
+
+class DefaultTeamConfig(BaseModel):
+    """Default team configuration for a single mode"""
+
+    name: str
+    namespace: str
+
+
+class DefaultTeamsResponse(BaseModel):
+    """Response model for default teams configuration"""
+
+    chat: Optional[DefaultTeamConfig] = None
+    code: Optional[DefaultTeamConfig] = None
+    knowledge: Optional[DefaultTeamConfig] = None
+
+
+def parse_default_team_config(config_value: str) -> Optional[DefaultTeamConfig]:
+    """Parse default team config from environment variable format 'name#namespace'"""
+    if not config_value or not config_value.strip():
+        return None
+
+    parts = config_value.strip().split("#", 1)
+    name = parts[0].strip()
+    namespace = parts[1].strip() if len(parts) > 1 else "default"
+
+    if not name:
+        return None
+
+    return DefaultTeamConfig(name=name, namespace=namespace)
+
+
+@router.get("/default-teams", response_model=DefaultTeamsResponse)
+async def get_default_teams(
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get default team configuration for each mode (chat, code, knowledge).
+    These are system-level configurations from environment variables.
+    """
+    from app.core.config import settings
+
+    return DefaultTeamsResponse(
+        chat=parse_default_team_config(settings.DEFAULT_TEAM_CHAT),
+        code=parse_default_team_config(settings.DEFAULT_TEAM_CODE),
+        knowledge=parse_default_team_config(settings.DEFAULT_TEAM_KNOWLEDGE),
+    )
+
+
+# ==================== User Search ====================
+
+
 @router.get("/search", response_model=SearchUsersResponse)
 async def search_users(
     q: str = Query(..., min_length=1, description="Search query"),

--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -547,6 +547,7 @@ class ChatNamespace(socketio.AsyncNamespace):
                     git_domain=payload.git_domain,
                     branch_name=payload.branch_name,
                     task_type=payload.task_type,
+                    knowledge_base_id=payload.knowledge_base_id,
                 )
 
                 result = await create_task_and_subtasks(

--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -132,6 +132,9 @@ class ChatSendPayload(BaseModel):
     task_type: Optional[Literal["chat", "code", "knowledge"]] = Field(
         None, description="Task type: chat, code, or knowledge"
     )
+    knowledge_base_id: Optional[int] = Field(
+        None, description="Knowledge base ID for knowledge type tasks"
+    )
     preload_skills: Optional[List[str]] = Field(
         None, description="List of skill names to preload into system prompt"
     )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -240,6 +240,13 @@ class Settings(BaseSettings):
     # "bridge" - StreamingCore publishes to Redis channel, WebSocketBridge forwards to WebSocket
     STREAMING_MODE: str = "legacy"
 
+    # Default team configuration for each mode
+    # Format: "name#namespace" (namespace is optional, defaults to "default")
+    # Example: "通用助手#default" or "Code Assistant"
+    DEFAULT_TEAM_CHAT: str = ""  # Default team for chat mode
+    DEFAULT_TEAM_CODE: str = ""  # Default team for code mode
+    DEFAULT_TEAM_KNOWLEDGE: str = ""  # Default team for knowledge mode
+
     # JSON configuration for MCP servers (similar to Claude Desktop format)
     # Example:
     # {

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -172,6 +172,9 @@ class TaskLite(BaseModel):
     team_id: Optional[int] = None
     git_repo: Optional[str] = None
     is_group_chat: bool = False  # Whether this is a group chat task
+    knowledge_base_id: Optional[int] = (
+        None  # Knowledge base ID for knowledge type tasks
+    )
 
     class Config:
         from_attributes = True

--- a/backend/app/services/adapters/task_kinds.py
+++ b/backend/app/services/adapters/task_kinds.py
@@ -604,6 +604,13 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
             if not is_group_chat:
                 is_group_chat = member_counts.get(task.id, 0) > 0
 
+            # Extract knowledge_base_id from knowledgeBaseRefs for knowledge type tasks
+            knowledge_base_id = None
+            if task_type == "knowledge" and task_crd.spec.knowledgeBaseRefs:
+                # Get the first knowledge base reference's id
+                first_kb_ref = task_crd.spec.knowledgeBaseRefs[0]
+                knowledge_base_id = first_kb_ref.id
+
             result.append(
                 {
                     "id": task.id,
@@ -617,6 +624,7 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
                     "team_id": team_id,
                     "git_repo": git_repo,
                     "is_group_chat": is_group_chat,
+                    "knowledge_base_id": knowledge_base_id,
                 }
             )
 
@@ -969,6 +977,13 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
             if not is_group_chat:
                 is_group_chat = member_counts.get(task.id, 0) > 0
 
+            # Extract knowledge_base_id from knowledgeBaseRefs for knowledge type tasks
+            knowledge_base_id = None
+            if task_type == "knowledge" and task_crd.spec.knowledgeBaseRefs:
+                # Get the first knowledge base reference's id
+                first_kb_ref = task_crd.spec.knowledgeBaseRefs[0]
+                knowledge_base_id = first_kb_ref.id
+
             result.append(
                 {
                     "id": task.id,
@@ -982,6 +997,7 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
                     "team_id": team_id,
                     "git_repo": git_repo,
                     "is_group_chat": is_group_chat,
+                    "knowledge_base_id": knowledge_base_id,
                 }
             )
 
@@ -1166,6 +1182,13 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
             if not is_group_chat:
                 is_group_chat = member_counts.get(task.id, 0) > 0
 
+            # Extract knowledge_base_id from knowledgeBaseRefs for knowledge type tasks
+            knowledge_base_id = None
+            if task_type == "knowledge" and task_crd.spec.knowledgeBaseRefs:
+                # Get the first knowledge base reference's id
+                first_kb_ref = task_crd.spec.knowledgeBaseRefs[0]
+                knowledge_base_id = first_kb_ref.id
+
             result.append(
                 {
                     "id": task.id,
@@ -1179,6 +1202,7 @@ class TaskKindsService(BaseService[Kind, TaskCreate, TaskUpdate]):
                     "team_id": team_id,
                     "git_repo": git_repo,
                     "is_group_chat": is_group_chat,
+                    "knowledge_base_id": knowledge_base_id,
                 }
             )
 

--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -51,6 +51,9 @@ class TaskCreationParams:
     git_domain: Optional[str] = None
     branch_name: Optional[str] = None
     task_type: Optional[str] = None  # 'chat', 'code', or 'knowledge'
+    knowledge_base_id: Optional[int] = (
+        None  # Knowledge base ID for knowledge type tasks
+    )
 
 
 def get_bot_ids_from_team(db: Session, team: Kind) -> List[int]:
@@ -244,6 +247,33 @@ def create_new_task(
         f"[create_new_task] Creating task_json with is_group_chat={params.is_group_chat}"
     )
 
+    # Build knowledgeBaseRefs if knowledge_base_id is provided
+    knowledge_base_refs = None
+    if params.knowledge_base_id and task_type == "knowledge":
+        # Query the knowledge base to get its name and namespace
+        kb = (
+            db.query(Kind)
+            .filter(
+                Kind.id == params.knowledge_base_id,
+                Kind.kind == "KnowledgeBase",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+        if kb:
+            knowledge_base_refs = [
+                {
+                    "id": kb.id,
+                    "name": kb.name,
+                    "namespace": kb.namespace,
+                    "boundBy": user.user_name,
+                    "boundAt": datetime.now().isoformat(),
+                }
+            ]
+            logger.info(
+                f"[create_new_task] Added knowledgeBaseRefs for kb_id={kb.id}, name={kb.name}"
+            )
+
     task_json = {
         "kind": "Task",
         "spec": {
@@ -252,6 +282,11 @@ def create_new_task(
             "teamRef": {"name": team.name, "namespace": team.namespace},
             "workspaceRef": {"name": workspace_name, "namespace": "default"},
             "is_group_chat": params.is_group_chat,
+            **(
+                {"knowledgeBaseRefs": knowledge_base_refs}
+                if knowledge_base_refs
+                else {}
+            ),
         },
         "status": {
             "state": "Available",

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -13,6 +13,7 @@ import type {
   UserPreferences,
   QuickAccessResponse,
   WelcomeConfigResponse,
+  DefaultTeamsResponse,
 } from '@/types/api'
 
 // Type definitions
@@ -163,6 +164,10 @@ export const userApis = {
 
   async getWelcomeConfig(): Promise<WelcomeConfigResponse> {
     return apiClient.get('/users/welcome-config')
+  },
+
+  async getDefaultTeams(): Promise<DefaultTeamsResponse> {
+    return apiClient.get('/users/default-teams')
   },
 
   async searchUsers(query: string): Promise<SearchUsersResponse> {

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -19,15 +19,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      'z-50 overflow-hidden rounded-md bg-tooltip px-3 py-1.5 text-xs text-tooltip-foreground border border-border shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-tooltip px-3 py-1.5 text-xs text-tooltip-foreground border border-border shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -505,6 +505,7 @@ function ChatAreaContent({
     onExternalApiParamsChange: chatState.handleExternalApiParamsChange,
     onAppModeChange: chatState.handleAppModeChange,
     onRestoreDefaultTeam: chatState.restoreDefaultTeam,
+    isUsingDefaultTeam: chatState.isUsingDefaultTeam,
     taskType,
     tipText: chatState.randomTip,
     isGroupChat: selectedTaskDetail?.is_group_chat || false,
@@ -570,6 +571,8 @@ function ChatAreaContent({
     },
     // Whether there are no available teams for current mode
     hasNoTeams: filteredTeams.length === 0,
+    // Knowledge base ID to exclude from context selector (used in notebook mode)
+    knowledgeBaseId,
   }
 
   return (
@@ -664,6 +667,7 @@ function ChatAreaContent({
                   hideSelected={true}
                   onRefreshTeams={onRefreshTeams}
                   showWizardButton={taskType === 'chat'}
+                  defaultTeam={chatState.defaultTeam}
                 />
               )}
             </div>

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -27,7 +27,6 @@ import { Button } from '@/components/ui/button'
 import { useScrollManagement } from '../hooks/useScrollManagement'
 import { useFloatingInput } from '../hooks/useFloatingInput'
 import { useAttachmentUpload } from '../hooks/useAttachmentUpload'
-import { getLastTeamIdByMode, saveLastTeamByMode } from '@/utils/userPreferences'
 
 /**
  * Threshold in pixels for determining when to collapse selectors.
@@ -140,8 +139,10 @@ function ChatAreaContent({
   // Extract values for dependency array
   const selectedTeam = chatState.selectedTeam
   const handleTeamChange = chatState.handleTeamChange
+  const defaultTeam = chatState.defaultTeam
+  const findDefaultTeamForMode = chatState.findDefaultTeamForMode
 
-  // Team selection logic - simplified and direct
+  // Team selection logic - using default team from server configuration
   useEffect(() => {
     if (filteredTeams.length === 0) return
 
@@ -191,21 +192,19 @@ function ChatAreaContent({
       }
     }
 
-    // Case 2: New chat (no taskId in URL) - restore from localStorage
+    // Case 2: New chat (no taskId in URL) - use default team from server config
     if (!taskIdFromUrl && !hasInitializedTeamRef.current) {
-      const lastTeamId = getLastTeamIdByMode(taskType)
-      if (lastTeamId) {
-        const lastTeam = filteredTeams.find(t => t.id === lastTeamId)
-        if (lastTeam) {
-          console.log('[ChatArea] Restoring team from localStorage:', lastTeam.name)
-          handleTeamChange(lastTeam)
-          hasInitializedTeamRef.current = true
-          lastSyncedTaskIdRef.current = null
-          return
-        }
+      // Use the default team computed from server config
+      const defaultTeamForMode = findDefaultTeamForMode(filteredTeams)
+      if (defaultTeamForMode) {
+        console.log('[ChatArea] Using default team from server config:', defaultTeamForMode.name)
+        handleTeamChange(defaultTeamForMode)
+        hasInitializedTeamRef.current = true
+        lastSyncedTaskIdRef.current = null
+        return
       }
-      // No saved preference or team not found, select first team
-      if (!selectedTeam) {
+      // No default found, select first team
+      if (!selectedTeam && filteredTeams.length > 0) {
         console.log('[ChatArea] Selecting first team:', filteredTeams[0].name)
         handleTeamChange(filteredTeams[0])
       }
@@ -218,15 +217,24 @@ function ChatAreaContent({
     if (selectedTeam) {
       const exists = filteredTeams.some(t => t.id === selectedTeam.id)
       if (!exists) {
-        console.log('[ChatArea] Current team not in filtered list, selecting first')
-        handleTeamChange(filteredTeams[0])
+        console.log('[ChatArea] Current team not in filtered list, selecting default')
+        const defaultTeamForMode = findDefaultTeamForMode(filteredTeams)
+        handleTeamChange(defaultTeamForMode || filteredTeams[0])
       }
     } else if (!taskIdFromUrl) {
-      // No selection and no task - select first team
-      console.log('[ChatArea] No selection, selecting first team')
-      handleTeamChange(filteredTeams[0])
+      // No selection and no task - select default team
+      console.log('[ChatArea] No selection, selecting default team')
+      const defaultTeamForMode = findDefaultTeamForMode(filteredTeams)
+      handleTeamChange(defaultTeamForMode || filteredTeams[0])
     }
-  }, [filteredTeams, selectedTaskDetail, taskIdFromUrl, selectedTeam, handleTeamChange, taskType])
+  }, [
+    filteredTeams,
+    selectedTaskDetail,
+    taskIdFromUrl,
+    selectedTeam,
+    handleTeamChange,
+    findDefaultTeamForMode,
+  ])
 
   // Reset initialization when switching from task to new chat
   useEffect(() => {
@@ -235,13 +243,12 @@ function ChatAreaContent({
     }
   }, [taskIdFromUrl])
 
-  // Save team preference when user manually selects (via QuickAccessCards)
+  // Handle team selection from QuickAccessCards
   const handleTeamSelect = useCallback(
     (team: Team) => {
       handleTeamChange(team)
-      saveLastTeamByMode(team.id, taskType)
     },
-    [handleTeamChange, taskType]
+    [handleTeamChange]
   )
 
   // Use scroll management hook - consolidates 4 useEffect calls
@@ -498,6 +505,7 @@ function ChatAreaContent({
     onTeamChange: chatState.handleTeamChange,
     onExternalApiParamsChange: chatState.handleExternalApiParamsChange,
     onAppModeChange: chatState.handleAppModeChange,
+    onRestoreDefaultTeam: chatState.restoreDefaultTeam,
     taskType,
     tipText: chatState.randomTip,
     isGroupChat: selectedTaskDetail?.is_group_chat || false,

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -504,7 +504,8 @@ function ChatAreaContent({
     onTeamChange: chatState.handleTeamChange,
     onExternalApiParamsChange: chatState.handleExternalApiParamsChange,
     onAppModeChange: chatState.handleAppModeChange,
-    onRestoreDefaultTeam: chatState.restoreDefaultTeam,
+    // Only enable restore when default team exists
+    onRestoreDefaultTeam: chatState.defaultTeam ? chatState.restoreDefaultTeam : undefined,
     taskType,
     tipText: chatState.randomTip,
     isGroupChat: selectedTaskDetail?.is_group_chat || false,

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -139,7 +139,6 @@ function ChatAreaContent({
   // Extract values for dependency array
   const selectedTeam = chatState.selectedTeam
   const handleTeamChange = chatState.handleTeamChange
-  const defaultTeam = chatState.defaultTeam
   const findDefaultTeamForMode = chatState.findDefaultTeamForMode
 
   // Team selection logic - using default team from server configuration

--- a/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
@@ -13,6 +13,8 @@ import { isChatContextEnabled } from '@/lib/runtime-config'
 interface ChatContextInputProps {
   selectedContexts: ContextItem[]
   onContextsChange: (contexts: ContextItem[]) => void
+  /** Knowledge base ID to exclude from the list (used in notebook mode to hide current KB) */
+  excludeKnowledgeBaseId?: number
 }
 
 /**
@@ -26,6 +28,7 @@ interface ChatContextInputProps {
 export default function ChatContextInput({
   selectedContexts,
   onContextsChange,
+  excludeKnowledgeBaseId,
 }: ChatContextInputProps) {
   const [selectorOpen, setSelectorOpen] = useState(false)
 
@@ -49,6 +52,7 @@ export default function ChatContextInput({
       selectedContexts={selectedContexts}
       onSelect={handleSelect}
       onDeselect={handleDeselect}
+      excludeKnowledgeBaseId={excludeKnowledgeBaseId}
     >
       <div>
         <AddContextButton onClick={() => setSelectorOpen(true)} />

--- a/frontend/src/features/tasks/components/chat/ContextSelector.tsx
+++ b/frontend/src/features/tasks/components/chat/ContextSelector.tsx
@@ -39,6 +39,8 @@ interface ContextSelectorProps {
   taskId?: number
   /** Whether this is a group chat - if true, shows bound knowledge bases section */
   isGroupChat?: boolean
+  /** Knowledge base ID to exclude from the list (used in notebook mode to hide current KB) */
+  excludeKnowledgeBaseId?: number
 }
 
 interface KnowledgeBaseItemProps {
@@ -110,6 +112,7 @@ export default function ContextSelector({
   children,
   taskId,
   isGroupChat,
+  excludeKnowledgeBaseId,
 }: ContextSelectorProps) {
   const { t } = useTranslation()
   const [knowledgeBases, setKnowledgeBases] = useState<KnowledgeBase[]>([])
@@ -182,13 +185,14 @@ export default function ContextSelector({
     fetchTables()
   }, [fetchTables])
 
-  // Sort knowledge bases by name and exclude bound ones from user list
+  // Sort knowledge bases by name and exclude bound ones and current notebook KB from user list
   const sortedKnowledgeBases = useMemo(() => {
     const boundIds = new Set(boundKnowledgeBases.map(kb => kb.id))
     return [...knowledgeBases]
       .filter(kb => !boundIds.has(kb.id))
+      .filter(kb => excludeKnowledgeBaseId === undefined || kb.id !== excludeKnowledgeBaseId)
       .sort((a, b) => a.name.localeCompare(b.name))
-  }, [knowledgeBases, boundKnowledgeBases])
+  }, [knowledgeBases, boundKnowledgeBases, excludeKnowledgeBaseId])
 
   // Check if a context item is selected
   const isSelected = (id: number | string) => {

--- a/frontend/src/features/tasks/components/chat/useChatAreaState.ts
+++ b/frontend/src/features/tasks/components/chat/useChatAreaState.ts
@@ -321,14 +321,22 @@ export function useChatAreaState({
   const isTeamCompatibleWithMode = useCallback(
     (team: Team): boolean => {
       if (!team.bind_mode || team.bind_mode.length === 0) return false
-      return team.bind_mode.includes(taskType)
+      // Knowledge mode uses chat mode teams
+      const modeToCheck = taskType === 'knowledge' ? 'chat' : taskType
+      return team.bind_mode.includes(modeToCheck)
     },
     [taskType]
   )
 
+  // Get teams compatible with current mode
+  const compatibleTeams = useMemo(() => {
+    return _teams.filter(isTeamCompatibleWithMode)
+  }, [_teams, isTeamCompatibleWithMode])
+
   // Find default team for current mode from teams list
   const findDefaultTeamForMode = useCallback(
     (teams: Team[]): Team | null => {
+      if (teams.length === 0) return null
       if (!defaultTeamsConfig) return teams[0] || null
 
       // Get the default config for current mode
@@ -367,10 +375,10 @@ export function useChatAreaState({
     [defaultTeamsConfig, taskType]
   )
 
-  // Compute default team for current mode
+  // Compute default team for current mode (only from compatible teams)
   const defaultTeam = useMemo(() => {
-    return findDefaultTeamForMode(_teams)
-  }, [findDefaultTeamForMode, _teams])
+    return findDefaultTeamForMode(compatibleTeams)
+  }, [findDefaultTeamForMode, compatibleTeams])
 
   // Restore to default team
   const restoreDefaultTeam = useCallback(() => {

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -213,7 +213,12 @@ export default function ChatInput({
     // 2. nativeEvent.isComposing - native browser flag (more reliable in some browsers)
     // 3. compositionJustEndedRef - handles Safari where compositionend fires before keydown
     //    This prevents the Enter key that confirms IME selection from also sending the message
-    if (isInputDisabled || isComposing || e.nativeEvent.isComposing || compositionJustEndedRef.current)
+    if (
+      isInputDisabled ||
+      isComposing ||
+      e.nativeEvent.isComposing ||
+      compositionJustEndedRef.current
+    )
       return
 
     // On mobile, Enter always creates new line (no easy Shift+Enter on mobile keyboards)
@@ -489,60 +494,60 @@ export default function ChatInput({
   }, [sendKey, t])
 
   return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="w-full relative" data-tour="task-input">
-            {/* Placeholder - shown when empty */}
-            {showPlaceholder && (
-              <div
-                className="absolute pointer-events-none text-text-muted text-base leading-[26px]"
-                style={{
-                  top: '0.25rem',
-                  left: badge ? `${badgeWidth}px` : '0',
-                }}
-              >
-                {placeholder}
-              </div>
-            )}
+    <div className="w-full relative" data-tour="task-input">
+      {/* Placeholder - shown when empty */}
+      {showPlaceholder && (
+        <div
+          className="absolute pointer-events-none text-text-muted text-base leading-[26px]"
+          style={{
+            top: '0.25rem',
+            left: badge ? `${badgeWidth}px` : '0',
+          }}
+        >
+          {placeholder}
+        </div>
+      )}
 
-            {/* Mention autocomplete menu */}
-            {showMentionMenu && isGroupChat && team && (
-              <MentionAutocomplete
-                team={team}
-                query={mentionQuery}
-                onSelect={handleMentionSelect}
-                onClose={() => {
-                  setShowMentionMenu(false)
-                  setMentionQuery('')
-                }}
-                position={mentionMenuPosition}
-              />
-            )}
+      {/* Mention autocomplete menu */}
+      {showMentionMenu && isGroupChat && team && (
+        <MentionAutocomplete
+          team={team}
+          query={mentionQuery}
+          onSelect={handleMentionSelect}
+          onClose={() => {
+            setShowMentionMenu(false)
+            setMentionQuery('')
+          }}
+          position={mentionMenuPosition}
+        />
+      )}
 
-            {/* Scrollable container that includes both badge and editable content */}
-            <div
-              className="w-full custom-scrollbar"
-              style={{
-                minHeight,
-                maxHeight,
-                overflowY: 'auto',
-              }}
+      {/* Scrollable container that includes both badge and editable content */}
+      <div
+        className="w-full custom-scrollbar"
+        style={{
+          minHeight,
+          maxHeight,
+          overflowY: 'auto',
+        }}
+      >
+        {/* Inner content wrapper with badge and text */}
+        <div className="relative">
+          {/* Badge - positioned absolutely so it doesn't affect text flow */}
+          {badge && (
+            <span
+              ref={badgeRef}
+              className="absolute left-0 top-0.5 pointer-events-auto z-10"
+              style={{ userSelect: 'none' }}
             >
-              {/* Inner content wrapper with badge and text */}
-              <div className="relative">
-                {/* Badge - positioned absolutely so it doesn't affect text flow */}
-                {badge && (
-                  <span
-                    ref={badgeRef}
-                    className="absolute left-0 top-0.5 pointer-events-auto z-10"
-                    style={{ userSelect: 'none' }}
-                  >
-                    {badge}
-                  </span>
-                )}
+              {badge}
+            </span>
+          )}
 
-                {/* Editable content area */}
+          {/* Editable content area - wrapped in Tooltip for send shortcut hint */}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
                 <div
                   ref={editableRef}
                   contentEditable={!isInputDisabled}
@@ -566,14 +571,14 @@ export default function ChatInput({
                   }}
                   suppressContentEditableWarning
                 />
-              </div>
-            </div>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent side="top" className="text-xs">
-          <p>{tooltipText}</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="text-xs">
+                <p>{tooltipText}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -30,9 +30,15 @@ export interface ChatInputCardProps extends Omit<ChatInputControlsProps, 'taskIn
   // Restore to default team
   onRestoreDefaultTeam?: () => void
 
+  // Whether the current team is the default team (hide badge when true)
+  isUsingDefaultTeam?: boolean
+
   // Task type
   taskType: 'chat' | 'code' | 'knowledge'
   autoFocus?: boolean
+
+  // Knowledge base ID to exclude from context selector (used in notebook mode)
+  knowledgeBaseId?: number
 
   // Tips
   tipText: ChatTipItem | null
@@ -84,8 +90,10 @@ export function ChatInputCard({
   onExternalApiParamsChange,
   onAppModeChange,
   onRestoreDefaultTeam,
+  isUsingDefaultTeam = false,
   taskType,
   autoFocus = false,
+  knowledgeBaseId,
   tipText,
   isGroupChat,
   isDragging,
@@ -207,7 +215,7 @@ export function ChatInputCard({
               canSubmit={canSubmit}
               tipText={tipText}
               badge={
-                selectedTeam ? (
+                selectedTeam && !isUsingDefaultTeam ? (
                   <SelectedTeamBadge
                     team={selectedTeam}
                     showClearButton={true}
@@ -223,8 +231,8 @@ export function ChatInputCard({
           </div>
         )}
 
-        {/* Selected Team Badge only - show when chat input is hidden (workflow mode) */}
-        {shouldHideChatInput && selectedTeam && (
+        {/* Selected Team Badge only - show when chat input is hidden (workflow mode) and not using default team */}
+        {shouldHideChatInput && selectedTeam && !isUsingDefaultTeam && (
           <div className="px-4 pt-3">
             <SelectedTeamBadge
               team={selectedTeam}
@@ -278,6 +286,7 @@ export function ChatInputCard({
             onStopStream={onStopStream}
             onSendMessage={onSendMessage}
             hasNoTeams={hasNoTeams}
+            knowledgeBaseId={knowledgeBaseId}
           />
         </div>
       </div>

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -27,6 +27,9 @@ export interface ChatInputCardProps extends Omit<ChatInputControlsProps, 'taskIn
   onExternalApiParamsChange: (params: Record<string, string>) => void
   onAppModeChange: (mode: string | undefined) => void
 
+  // Restore to default team
+  onRestoreDefaultTeam?: () => void
+
   // Task type
   taskType: 'chat' | 'code' | 'knowledge'
   autoFocus?: boolean
@@ -80,6 +83,7 @@ export function ChatInputCard({
   externalApiParams,
   onExternalApiParamsChange,
   onAppModeChange,
+  onRestoreDefaultTeam,
   taskType,
   autoFocus = false,
   tipText,
@@ -202,7 +206,15 @@ export function ChatInputCard({
               autoFocus={autoFocus}
               canSubmit={canSubmit}
               tipText={tipText}
-              badge={selectedTeam ? <SelectedTeamBadge team={selectedTeam} /> : undefined}
+              badge={
+                selectedTeam ? (
+                  <SelectedTeamBadge
+                    team={selectedTeam}
+                    showClearButton={true}
+                    onClear={onRestoreDefaultTeam}
+                  />
+                ) : undefined
+              }
               isGroupChat={isGroupChat}
               team={selectedTeam}
               onPasteFile={onPasteFile}
@@ -214,7 +226,11 @@ export function ChatInputCard({
         {/* Selected Team Badge only - show when chat input is hidden (workflow mode) */}
         {shouldHideChatInput && selectedTeam && (
           <div className="px-4 pt-3">
-            <SelectedTeamBadge team={selectedTeam} />
+            <SelectedTeamBadge
+              team={selectedTeam}
+              showClearButton={true}
+              onClear={onRestoreDefaultTeam}
+            />
           </div>
         )}
 

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -44,6 +44,8 @@ export interface ChatInputControlsProps {
   taskId?: number | null
   /** Task's model_id from backend - used as fallback when no session preference exists */
   taskModelId?: string | null
+  /** Knowledge base ID to exclude from context selector (used in notebook mode) */
+  knowledgeBaseId?: number
 
   // Repository and Branch
   showRepositorySelector: boolean
@@ -120,6 +122,7 @@ export function ChatInputControls({
   teamId,
   taskId,
   taskModelId,
+  knowledgeBaseId,
   showRepositorySelector,
   selectedRepo,
   setSelectedRepo,
@@ -235,6 +238,7 @@ export function ChatInputControls({
         teamId={teamId}
         taskId={taskId}
         taskModelId={taskModelId}
+        knowledgeBaseId={knowledgeBaseId}
         showRepositorySelector={showRepositorySelector}
         selectedRepo={selectedRepo}
         setSelectedRepo={setSelectedRepo}
@@ -279,6 +283,7 @@ export function ChatInputControls({
           <ChatContextInput
             selectedContexts={selectedContexts}
             onContextsChange={setSelectedContexts}
+            excludeKnowledgeBaseId={knowledgeBaseId}
           />
         )}
 

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -39,6 +39,8 @@ export interface MobileChatInputControlsProps {
   teamId?: number | null
   taskId?: number | null
   taskModelId?: string | null
+  /** Knowledge base ID to exclude from context selector (used in notebook mode) */
+  knowledgeBaseId?: number
 
   // Repository and Branch
   showRepositorySelector: boolean
@@ -96,6 +98,7 @@ export function MobileChatInputControls({
   teamId,
   taskId,
   taskModelId,
+  knowledgeBaseId,
   showRepositorySelector,
   selectedRepo,
   setSelectedRepo,
@@ -202,12 +205,12 @@ export function MobileChatInputControls({
         {supportsAttachments(selectedTeam) && (
           <AttachmentButton onFileSelect={onFileSelect} disabled={isLoading || isStreaming} />
         )}
-
         {/* Context (Knowledge base) */}
         {isChatShell(selectedTeam) && (
           <ChatContextInput
             selectedContexts={selectedContexts}
             onContextsChange={setSelectedContexts}
+            excludeKnowledgeBaseId={knowledgeBaseId}
           />
         )}
 

--- a/frontend/src/features/tasks/components/selector/SelectedTeamBadge.tsx
+++ b/frontend/src/features/tasks/components/selector/SelectedTeamBadge.tsx
@@ -12,6 +12,8 @@ interface SelectedTeamBadgeProps {
   team: Team
   onClear?: () => void
   showClearButton?: boolean
+  /** Whether to show tooltip on hover. Set to false when used inside another Tooltip to avoid nesting issues. */
+  showTooltip?: boolean
 }
 
 /**
@@ -23,6 +25,7 @@ export function SelectedTeamBadge({
   team,
   onClear,
   showClearButton = false,
+  showTooltip = true,
 }: SelectedTeamBadgeProps) {
   const badgeContent = (
     <div className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-full bg-base text-primary text-base leading-[18px]">
@@ -42,8 +45,13 @@ export function SelectedTeamBadge({
     </div>
   )
 
-  // Tooltip content: prioritize description, fallback to name
-  const tooltipText = team.description || team.name
+  // If tooltip is disabled, just return the badge content
+  if (!showTooltip) {
+    return <div className="cursor-default">{badgeContent}</div>
+  }
+
+  // Tooltip content: prioritize description (if not empty), fallback to name
+  const tooltipText = team.description?.trim() || team.name
 
   return (
     <TooltipProvider>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -571,6 +571,18 @@ export interface WelcomeConfigResponse {
   tips: ChatTipItem[]
 }
 
+// Default Teams Configuration Types
+export interface DefaultTeamConfig {
+  name: string
+  namespace: string
+}
+
+export interface DefaultTeamsResponse {
+  chat: DefaultTeamConfig | null
+  code: DefaultTeamConfig | null
+  knowledge: DefaultTeamConfig | null
+}
+
 export interface SystemConfigResponse {
   version: number
   teams: number[]


### PR DESCRIPTION
## Summary

- Add support for configuring default agents per mode (chat/code/knowledge) via environment variables
- Backend: Add `DEFAULT_TEAM_CHAT`, `DEFAULT_TEAM_CODE`, `DEFAULT_TEAM_KNOWLEDGE` environment variables
- Backend: Add `GET /users/default-teams` API endpoint to retrieve default team configuration
- Frontend: Fetch default teams from server and use them instead of localStorage
- Frontend: Add "restore to default" functionality via badge clear button
- Support "name#namespace" format in config (namespace defaults to "default")

## Changes

### Backend
1. **backend/app/core/config.py**
   - Add `DEFAULT_TEAM_CHAT`, `DEFAULT_TEAM_CODE`, `DEFAULT_TEAM_KNOWLEDGE` settings

2. **backend/app/api/endpoints/users.py**
   - Add `GET /users/default-teams` endpoint
   - Add `DefaultTeamConfig` and `DefaultTeamsResponse` response models
   - Parse "name#namespace" format from environment variables

3. **backend/.env.example**
   - Add example configuration for default teams

### Frontend
1. **frontend/src/types/api.ts**
   - Add `DefaultTeamConfig` and `DefaultTeamsResponse` types

2. **frontend/src/apis/user.ts**
   - Add `getDefaultTeams()` API method

3. **frontend/src/features/tasks/components/chat/useChatAreaState.ts**
   - Fetch default teams config on mount
   - Add `defaultTeam`, `isUsingDefaultTeam`, `restoreDefaultTeam` state
   - Add `findDefaultTeamForMode` helper function
   - Remove localStorage-based team persistence

4. **frontend/src/features/tasks/components/chat/ChatArea.tsx**
   - Use server-based default team instead of localStorage
   - Pass `onRestoreDefaultTeam` callback to ChatInputCard

5. **frontend/src/features/tasks/components/input/ChatInputCard.tsx**
   - Add `onRestoreDefaultTeam` prop
   - Always show clear button on SelectedTeamBadge
   - Clear button restores to default team

## Interaction Logic

| Scenario | Behavior |
|----------|----------|
| Enter page (new chat) | Auto-select default team for current mode, show badge with clear button |
| Enter page (existing task) | Show task's associated team, show badge with clear button |
| User manually selects team | Switch to selected team, show badge with clear button |
| Click badge clear button | Restore to default team for current mode |
| Page refresh | Restore to default team (manual selection not persisted) |
| Switch mode | Load default team for new mode |

## Test plan

- [ ] Verify default teams API returns correct configuration
- [ ] Verify entering chat page selects configured default team
- [ ] Verify entering code page selects configured default team
- [ ] Verify clicking badge clear button restores default team
- [ ] Verify opening existing task shows task's team (not default)
- [ ] Verify page refresh restores default team (not last selected)
- [ ] Verify unconfigured modes fall back to first available team

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat, Code, and Knowledge flows now use server-configured default teams with a UI restore action to revert to the default.
  * Knowledge-base support added: tasks can be associated with a knowledge base and UI selectors can exclude a specific knowledge base.

* **Chores**
  * Added server-side placeholders for configuring default teams via deployment settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->