### PR TITLE
feat: add notebook inject

### DIFF
--- a/backend/app/schemas/subtask.py
+++ b/backend/app/schemas/subtask.py
@@ -161,6 +161,14 @@ class SubtaskContextBrief(BaseModel):
                     f"[SubtaskContextBrief/subtask.py] Building table context: id={context.id}, "
                     f"url={url}, source_config={base_data['source_config']}"
                 )
+        elif context.context_type == "selected_documents":
+            # Selected documents context for notebook mode
+            # Contains knowledge_base_id and document_ids in type_data
+            base_data.update(
+                {
+                    "document_count": len(type_data.get("document_ids", [])),
+                }
+            )
 
         return cls(**base_data)
 

--- a/backend/app/services/chat/preprocessing/selected_documents.py
+++ b/backend/app/services/chat/preprocessing/selected_documents.py
@@ -1,0 +1,362 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Selected documents processing module for notebook mode.
+
+This module handles the processing of selected documents from the DocumentPanel
+in notebook mode. It implements intelligent context injection that:
+1. Loads document content from the knowledge base
+2. Estimates token count to determine if direct injection is feasible
+3. Either injects content directly into the message or falls back to RAG retrieval
+
+The injection strategy follows the same threshold as KnowledgeBaseTool:
+- If estimated tokens <= 30% of context window, inject directly
+- Otherwise, create KnowledgeBaseTool with document_ids filter for RAG retrieval
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from langchain_core.tools import BaseTool
+from sqlalchemy.orm import Session
+
+from app.models.knowledge import KnowledgeDocument
+from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
+
+logger = logging.getLogger(__name__)
+
+# Default context window size (same as InjectionStrategy.DEFAULT_CONTEXT_WINDOW)
+DEFAULT_CONTEXT_WINDOW = 128000
+
+# Maximum ratio of context window that can be used for document injection
+MAX_INJECTION_RATIO = 0.3
+
+# Prompt template for selected documents context
+SELECTED_DOCUMENTS_PROMPT = """
+# Reference Documents
+
+The following documents have been selected as context for this conversation.
+Please use this information to answer the user's questions.
+
+"""
+
+
+def process_selected_documents_contexts(
+    db: Session,
+    selected_docs_contexts: List[SubtaskContext],
+    user_id: int,
+    message: str | dict[str, Any],
+    base_system_prompt: str,
+    extra_tools: List[BaseTool],
+    user_subtask_id: Optional[int] = None,
+    context_window: int = DEFAULT_CONTEXT_WINDOW,
+) -> Tuple[str | dict[str, Any], str, List[BaseTool]]:
+    """
+    Process selected_documents contexts for notebook mode.
+
+    This function implements the intelligent injection strategy:
+    1. Load document content from knowledge base documents
+    2. Estimate total token count
+    3. If within threshold (30% of context window), inject directly into message
+    4. If exceeds threshold, create KnowledgeBaseTool with document_ids filter
+
+    Args:
+        db: Database session
+        selected_docs_contexts: List of selected_documents SubtaskContext records
+        user_id: User ID for access control
+        message: Original user message (string or vision structure)
+        base_system_prompt: Current system prompt (may already be enhanced)
+        extra_tools: Current list of extra tools (may already contain KB tool)
+        user_subtask_id: User subtask ID for RAG persistence
+        context_window: Model context window size
+
+    Returns:
+        Tuple of (final_message, enhanced_system_prompt, extra_tools)
+    """
+    if not selected_docs_contexts:
+        return message, base_system_prompt, extra_tools
+
+    # Collect all document IDs and knowledge base IDs from contexts
+    all_document_ids: List[int] = []
+    knowledge_base_ids: set[int] = set()
+
+    for ctx in selected_docs_contexts:
+        if ctx.type_data:
+            kb_id = ctx.type_data.get("knowledge_base_id")
+            doc_ids = ctx.type_data.get("document_ids", [])
+            if kb_id:
+                knowledge_base_ids.add(kb_id)
+            if doc_ids:
+                all_document_ids.extend(doc_ids)
+
+    if not all_document_ids:
+        logger.info(
+            "[process_selected_documents_contexts] No document IDs found in contexts"
+        )
+        return message, base_system_prompt, extra_tools
+
+    logger.info(
+        f"[process_selected_documents_contexts] Processing {len(all_document_ids)} documents "
+        f"from {len(knowledge_base_ids)} knowledge base(s)"
+    )
+
+    # Load document content
+    documents_content = _load_documents_content(db, all_document_ids)
+
+    if not documents_content:
+        logger.warning(
+            "[process_selected_documents_contexts] No document content loaded, "
+            "falling back to RAG"
+        )
+        return _create_rag_fallback(
+            db=db,
+            knowledge_base_ids=list(knowledge_base_ids),
+            document_ids=all_document_ids,
+            user_id=user_id,
+            message=message,
+            base_system_prompt=base_system_prompt,
+            extra_tools=extra_tools,
+            user_subtask_id=user_subtask_id,
+        )
+
+    # Estimate token count
+    total_chars = sum(len(doc["content"]) for doc in documents_content)
+    # Estimate tokens: approximately 4 characters per token
+    estimated_tokens = total_chars // 4
+
+    # Calculate threshold
+    max_tokens_for_injection = int(context_window * MAX_INJECTION_RATIO)
+
+    logger.info(
+        f"[process_selected_documents_contexts] Token estimation: "
+        f"total_chars={total_chars}, estimated_tokens={estimated_tokens}, "
+        f"threshold={max_tokens_for_injection}, context_window={context_window}"
+    )
+
+    if estimated_tokens <= max_tokens_for_injection:
+        # Direct injection
+        logger.info(
+            f"[process_selected_documents_contexts] Using direct injection: "
+            f"{len(documents_content)} documents, {estimated_tokens} estimated tokens"
+        )
+        return _inject_documents_directly(
+            documents_content=documents_content,
+            message=message,
+            base_system_prompt=base_system_prompt,
+            extra_tools=extra_tools,
+        )
+    else:
+        # Fall back to RAG
+        logger.info(
+            f"[process_selected_documents_contexts] Falling back to RAG: "
+            f"estimated_tokens={estimated_tokens} exceeds threshold={max_tokens_for_injection}"
+        )
+        return _create_rag_fallback(
+            db=db,
+            knowledge_base_ids=list(knowledge_base_ids),
+            document_ids=all_document_ids,
+            user_id=user_id,
+            message=message,
+            base_system_prompt=base_system_prompt,
+            extra_tools=extra_tools,
+            user_subtask_id=user_subtask_id,
+        )
+
+
+def _load_documents_content(
+    db: Session,
+    document_ids: List[int],
+) -> List[Dict[str, Any]]:
+    """
+    Load document content from knowledge base documents.
+
+    Document content is stored in SubtaskContext.extracted_text,
+    linked via KnowledgeDocument.attachment_id.
+
+    Args:
+        db: Database session
+        document_ids: List of document IDs to load
+
+    Returns:
+        List of dicts with document name and content
+    """
+    documents_content = []
+
+    # Query documents with their attachment IDs (no is_active filter for notebook mode)
+    documents = (
+        db.query(KnowledgeDocument).filter(KnowledgeDocument.id.in_(document_ids)).all()
+    )
+
+    logger.info(
+        f"[_load_documents_content] Found {len(documents)} documents "
+        f"out of {len(document_ids)} requested"
+    )
+
+    # Collect attachment IDs
+    attachment_ids = [doc.attachment_id for doc in documents if doc.attachment_id]
+
+    if not attachment_ids:
+        logger.warning("[_load_documents_content] No attachment IDs found")
+        return documents_content
+
+    # Query attachment contexts to get extracted_text
+    attachment_contexts = (
+        db.query(SubtaskContext)
+        .filter(
+            SubtaskContext.id.in_(attachment_ids),
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        )
+        .all()
+    )
+
+    # Build attachment_id -> extracted_text mapping
+    attachment_text_map = {
+        ctx.id: ctx.extracted_text for ctx in attachment_contexts if ctx.extracted_text
+    }
+
+    logger.info(
+        f"[_load_documents_content] Found {len(attachment_text_map)} attachments "
+        f"with extracted text"
+    )
+
+    # Build result
+    for doc in documents:
+        if doc.attachment_id and doc.attachment_id in attachment_text_map:
+            content = attachment_text_map[doc.attachment_id]
+            documents_content.append(
+                {
+                    "id": doc.id,
+                    "name": doc.name,
+                    "content": content,
+                    "file_extension": doc.file_extension,
+                }
+            )
+
+    logger.info(
+        f"[_load_documents_content] Loaded content for {len(documents_content)} documents"
+    )
+
+    return documents_content
+
+
+def _inject_documents_directly(
+    documents_content: List[Dict[str, Any]],
+    message: str | dict[str, Any],
+    base_system_prompt: str,
+    extra_tools: List[BaseTool],
+) -> Tuple[str | dict[str, Any], str, List[BaseTool]]:
+    """
+    Inject document content directly into the message.
+
+    Args:
+        documents_content: List of document content dicts
+        message: Original user message
+        base_system_prompt: Current system prompt
+        extra_tools: Current list of extra tools
+
+    Returns:
+        Tuple of (final_message, enhanced_system_prompt, extra_tools)
+    """
+    # Build document content string
+    doc_parts = []
+    for idx, doc in enumerate(documents_content, start=1):
+        doc_header = f"## Document {idx}: {doc['name']}"
+        if doc.get("file_extension"):
+            doc_header += f" ({doc['file_extension']})"
+        doc_parts.append(f"{doc_header}\n\n{doc['content']}")
+
+    documents_text = SELECTED_DOCUMENTS_PROMPT + "\n\n".join(doc_parts) + "\n\n"
+
+    # Inject into message
+    if isinstance(message, dict) and message.get("type") == "multi_vision":
+        # Vision structure - prepend to text
+        message["text"] = documents_text + message["text"]
+        final_message = message
+    else:
+        # String message - prepend documents
+        final_message = documents_text + f"[User Question]:\n{message}"
+
+    logger.info(
+        f"[_inject_documents_directly] Injected {len(documents_content)} documents "
+        f"({len(documents_text)} chars) into message"
+    )
+
+    return final_message, base_system_prompt, extra_tools
+
+
+def _create_rag_fallback(
+    db: Session,
+    knowledge_base_ids: List[int],
+    document_ids: List[int],
+    user_id: int,
+    message: str | dict[str, Any],
+    base_system_prompt: str,
+    extra_tools: List[BaseTool],
+    user_subtask_id: Optional[int] = None,
+) -> Tuple[str | dict[str, Any], str, List[BaseTool]]:
+    """
+    Create KnowledgeBaseTool with document_ids filter for RAG fallback.
+
+    Args:
+        db: Database session
+        knowledge_base_ids: List of knowledge base IDs
+        document_ids: List of document IDs to filter
+        user_id: User ID for access control
+        message: Original user message
+        base_system_prompt: Current system prompt
+        extra_tools: Current list of extra tools
+        user_subtask_id: User subtask ID for RAG persistence
+
+    Returns:
+        Tuple of (final_message, enhanced_system_prompt, extra_tools)
+    """
+    from chat_shell.tools.builtin import KnowledgeBaseTool
+
+    # Check if there's already a KnowledgeBaseTool in extra_tools
+    existing_kb_tool = None
+    for tool in extra_tools:
+        if isinstance(tool, KnowledgeBaseTool):
+            existing_kb_tool = tool
+            break
+
+    if existing_kb_tool:
+        # Update existing tool with document_ids filter
+        existing_kb_tool.document_ids = document_ids
+        logger.info(
+            f"[_create_rag_fallback] Updated existing KnowledgeBaseTool with "
+            f"{len(document_ids)} document_ids filter"
+        )
+    else:
+        # Create new KnowledgeBaseTool with document_ids filter
+        kb_tool = KnowledgeBaseTool(
+            knowledge_base_ids=knowledge_base_ids,
+            document_ids=document_ids,
+            user_id=user_id,
+            db_session=db,
+            user_subtask_id=user_subtask_id,
+        )
+        extra_tools.append(kb_tool)
+        logger.info(
+            f"[_create_rag_fallback] Created KnowledgeBaseTool for "
+            f"{len(knowledge_base_ids)} KBs with {len(document_ids)} document_ids filter"
+        )
+
+    # Add prompt instruction for RAG mode
+    rag_prompt = """
+
+# Selected Documents Context
+
+The user has selected specific documents from the knowledge base for this conversation.
+You MUST use the `knowledge_base_search` tool to retrieve information from these documents.
+The search will automatically filter to only the selected documents.
+
+## Required Workflow:
+1. Call `knowledge_base_search` with the user's query
+2. Base your answer on the retrieved information
+3. If no relevant information is found, clearly state that the selected documents don't contain relevant information
+"""
+
+    enhanced_prompt = base_system_prompt + rag_prompt
+
+    return message, enhanced_prompt, extra_tools

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -545,6 +545,9 @@ class KnowledgeService:
 
     # ============== Knowledge Document Operations ==============
 
+    # Maximum number of documents allowed in notebook mode knowledge base
+    NOTEBOOK_MAX_DOCUMENTS = 50
+
     @staticmethod
     def create_document(
         db: Session,
@@ -578,6 +581,17 @@ class KnowledgeService:
             ):
                 raise ValueError(
                     "Only Owner or Maintainer can add documents to this knowledge base"
+                )
+
+        # Check document limit for notebook mode knowledge base
+        kb_spec = kb.json.get("spec", {})
+        kb_type = kb_spec.get("kbType", "notebook")
+        if kb_type == "notebook":
+            current_count = KnowledgeService.get_document_count(db, knowledge_base_id)
+            if current_count >= KnowledgeService.NOTEBOOK_MAX_DOCUMENTS:
+                raise ValueError(
+                    f"Notebook mode knowledge base can have at most {KnowledgeService.NOTEBOOK_MAX_DOCUMENTS} documents. "
+                    f"Current count: {current_count}"
                 )
 
         document = KnowledgeDocument(

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
@@ -52,6 +52,9 @@ export function KnowledgeBaseChatPageDesktop() {
     ? parseInt(params.knowledgeBaseId as string, 10)
     : null
 
+  // State for selected document IDs from DocumentPanel (for notebook mode context injection)
+  const [selectedDocumentIds, setSelectedDocumentIds] = useState<number[]>([])
+
   // Fetch knowledge base details
   const {
     knowledgeBase,
@@ -288,6 +291,7 @@ export function KnowledgeBaseChatPageDesktop() {
                 namespace: knowledgeBase.namespace,
                 document_count: knowledgeBase.document_count,
               }}
+              selectedDocumentIds={selectedDocumentIds}
               onTaskCreated={async (taskId: number) => {
                 // Bind the knowledge base to the newly created task
                 try {
@@ -304,7 +308,12 @@ export function KnowledgeBaseChatPageDesktop() {
           </div>
 
           {/* Right panel - Document management */}
-          <DocumentPanel knowledgeBase={knowledgeBase} canManage={canManageKb} />
+          <DocumentPanel
+            knowledgeBase={knowledgeBase}
+            canManage={canManageKb}
+            onDocumentSelectionChange={setSelectedDocumentIds}
+            onNewChat={handleNewTask}
+          />
         </div>
       </div>
 

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -4,9 +4,15 @@
 
 'use client'
 
-import { FileText, Trash2, Pencil, ExternalLink, Table2 } from 'lucide-react'
+import { FileText, Trash2, Pencil, ExternalLink, Table2, MoreVertical } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown'
 import type { KnowledgeDocument } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -90,11 +96,11 @@ export function DocumentItem({
     onViewDetail?.(document)
   }
 
-  // Compact mode: Card layout for sidebar
+  // Compact mode: Card layout for sidebar (notebook mode)
   if (compact) {
     return (
       <div
-        className={`flex items-center gap-3 px-3 py-2.5 bg-base hover:bg-surface transition-colors rounded-lg border border-border group ${onViewDetail ? 'cursor-pointer' : ''}`}
+        className={`flex items-center gap-2 px-2 py-2 bg-base hover:bg-surface transition-colors rounded-lg border border-border group ${onViewDetail ? 'cursor-pointer' : ''}`}
         onClick={handleRowClick}
       >
         {/* Checkbox for batch selection */}
@@ -103,58 +109,49 @@ export function DocumentItem({
             <Checkbox
               checked={selected}
               onCheckedChange={handleCheckboxChange}
-              className="data-[state=checked]:bg-primary data-[state=checked]:border-primary"
+              className="data-[state=checked]:bg-primary data-[state=checked]:border-primary h-3.5 w-3.5"
             />
           </div>
         )}
 
-        {/* File icon */}
-        <div className="p-1.5 bg-primary/10 rounded flex-shrink-0">
-          {isTable ? (
-            <Table2 className="w-3.5 h-3.5 text-primary" />
-          ) : (
-            <FileText className="w-3.5 h-3.5 text-primary" />
-          )}
-        </div>
-
         {/* File name and info */}
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
-            <span className="text-sm font-medium text-text-primary truncate">{document.name}</span>
+          <div className="flex items-center gap-1">
+            <span className="text-xs font-medium text-text-primary truncate">{document.name}</span>
             {tableUrl && (
               <button
                 className="p-0.5 rounded text-primary hover:bg-primary/10 transition-colors flex-shrink-0"
                 onClick={handleOpenLink}
                 title={t('knowledge:document.document.openLink')}
               >
-                <ExternalLink className="w-3 h-3" />
+                <ExternalLink className="w-2.5 h-2.5" />
               </button>
             )}
           </div>
-          <div className="flex items-center gap-2 mt-0.5">
+          <div className="flex items-center gap-1.5 mt-0.5">
             {/* Type badge */}
             {isTable ? (
               <Badge
                 variant="default"
                 size="sm"
-                className="bg-blue-500/10 text-blue-600 border-blue-500/20 text-[10px] px-1.5 py-0"
+                className="bg-blue-500/10 text-blue-600 border-blue-500/20 text-[9px] px-1 py-0"
               >
                 {t('knowledge:document.document.type.table')}
               </Badge>
             ) : (
-              <span className="text-[10px] text-text-muted uppercase">
+              <span className="text-[9px] text-text-muted uppercase">
                 {document.file_extension}
               </span>
             )}
             {/* Size */}
             {!isTable && (
-              <span className="text-[10px] text-text-muted">
+              <span className="text-[9px] text-text-muted">
                 {formatFileSize(document.file_size)}
               </span>
             )}
             {/* Status indicator */}
             <span
-              className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${document.is_active ? 'bg-green-500' : 'bg-yellow-500'}`}
+              className={`w-1 h-1 rounded-full flex-shrink-0 ${document.is_active ? 'bg-green-500' : 'bg-yellow-500'}`}
               title={
                 document.is_active
                   ? t('knowledge:document.document.indexStatus.available')
@@ -164,25 +161,44 @@ export function DocumentItem({
           </div>
         </div>
 
-        {/* Action buttons */}
-        {canManage && (
-          <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-            <button
-              className="p-1 rounded text-primary hover:bg-primary/10 transition-colors"
-              onClick={handleEdit}
-              title={t('common:actions.edit')}
-            >
-              <Pencil className="w-3.5 h-3.5" />
-            </button>
-            <button
-              className="p-1 rounded text-text-muted hover:text-error hover:bg-error/10 transition-colors"
-              onClick={handleDelete}
-              title={t('common:actions.delete')}
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-            </button>
+        {/* File icon / More actions - icon shown by default, more actions on hover */}
+        <div className="flex-shrink-0 relative w-6 h-6 flex items-center justify-center">
+          {/* File icon - hidden on hover when canManage */}
+          <div
+            className={`p-1 bg-primary/10 rounded ${canManage ? 'group-hover:opacity-0' : ''} transition-opacity`}
+          >
+            {isTable ? (
+              <Table2 className="w-3 h-3 text-primary" />
+            ) : (
+              <FileText className="w-3 h-3 text-primary" />
+            )}
           </div>
-        )}
+          {/* More actions dropdown - shown on hover, replaces icon */}
+          {canManage && (
+            <div className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className="p-1 rounded text-text-muted hover:text-text-primary hover:bg-surface transition-colors"
+                    onClick={e => e.stopPropagation()}
+                  >
+                    <MoreVertical className="w-3.5 h-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[120px]">
+                  <DropdownMenuItem onClick={handleEdit}>
+                    <Pencil className="w-3.5 h-3.5 mr-2" />
+                    {t('common:actions.edit')}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem danger onClick={handleDelete}>
+                    <Trash2 className="w-3.5 h-3.5 mr-2" />
+                    {t('common:actions.delete')}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
+        </div>
       </div>
     )
   }

--- a/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
-import { ArrowLeft, PanelRightClose, PanelRightOpen, BookOpen } from 'lucide-react'
+import { ArrowLeft, PanelRightClose, PanelRightOpen, BookOpen, Plus } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { DocumentList } from './DocumentList'
 import type { KnowledgeBase } from '@/types/knowledge'
@@ -51,11 +51,15 @@ const getInitialCollapsed = (storageKey: string, defaultCollapsed: boolean): boo
 interface DocumentPanelProps {
   knowledgeBase: KnowledgeBase
   canManage?: boolean
+  /** Callback when document selection changes */
+  onDocumentSelectionChange?: (documentIds: number[]) => void
+  /** Callback when new chat button is clicked */
+  onNewChat?: () => void
 }
 
 const MIN_WIDTH = 280
 const MAX_WIDTH = 600
-const DEFAULT_WIDTH = 380
+const DEFAULT_WIDTH = 420
 const STORAGE_KEY_WIDTH = 'kb-document-panel-width'
 const STORAGE_KEY_COLLAPSED = 'kb-document-panel-collapsed'
 
@@ -68,7 +72,12 @@ const STORAGE_KEY_COLLAPSED = 'kb-document-panel-collapsed'
  * - Collapsible to save space
  * - Width and collapsed state persisted in localStorage
  */
-export function DocumentPanel({ knowledgeBase, canManage = true }: DocumentPanelProps) {
+export function DocumentPanel({
+  knowledgeBase,
+  canManage = true,
+  onDocumentSelectionChange,
+  onNewChat,
+}: DocumentPanelProps) {
   const { t } = useTranslation('knowledge')
 
   // Initialize state with localStorage values
@@ -199,7 +208,7 @@ export function DocumentPanel({ knowledgeBase, canManage = true }: DocumentPanel
         <div className="absolute inset-y-0 -left-1 -right-1 opacity-0 group-hover:opacity-100 transition-opacity" />
       </div>
 
-      {/* Panel Header with Back Button */}
+      {/* Panel Header with Back Button and New Chat Button */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border">
         <div className="flex items-center gap-2">
           {/* Back button */}
@@ -214,15 +223,31 @@ export function DocumentPanel({ knowledgeBase, canManage = true }: DocumentPanel
             <span className="text-sm">{t('chatPage.backToList')}</span>
           </Button>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={toggleCollapsed}
-          className="h-8 w-8 p-0"
-          title={t('chatPage.hideDocuments')}
-        >
-          <PanelRightClose className="w-4 h-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          {/* New Note button */}
+          {onNewChat && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onNewChat}
+              className="h-8 px-2 gap-1"
+              title={t('chatPage.newNote')}
+            >
+              <Plus className="w-4 h-4" />
+              <span className="text-sm">{t('chatPage.newNote')}</span>
+            </Button>
+          )}
+          {/* Collapse button */}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleCollapsed}
+            className="h-8 w-8 p-0"
+            title={t('chatPage.hideDocuments')}
+          >
+            <PanelRightClose className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {/* Document List */}
@@ -231,6 +256,7 @@ export function DocumentPanel({ knowledgeBase, canManage = true }: DocumentPanel
           knowledgeBase={knowledgeBase}
           canManage={canManage}
           compact={true}
+          onSelectionChange={onDocumentSelectionChange}
           // No onBack in panel mode - always show document list
         />
       </div>

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -53,6 +53,8 @@ interface ChatAreaProps {
   onTaskCreated?: (taskId: number) => void
   /** Knowledge base ID for knowledge type tasks */
   knowledgeBaseId?: number
+  /** Selected document IDs from DocumentPanel (for notebook mode context injection) */
+  selectedDocumentIds?: number[]
 }
 
 /**
@@ -70,6 +72,7 @@ function ChatAreaContent({
   initialKnowledgeBase,
   onTaskCreated,
   knowledgeBaseId,
+  selectedDocumentIds,
 }: ChatAreaProps) {
   const { t } = useTranslation()
   const router = useRouter()
@@ -300,6 +303,7 @@ function ChatAreaContent({
     selectedContexts: chatState.selectedContexts,
     resetContexts: chatState.resetContexts,
     onTaskCreated,
+    selectedDocumentIds,
   })
 
   // Determine if there are messages to display (full computation)

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -72,7 +72,7 @@
       },
       "indexStatus": {
         "available": "Indexed",
-        "unavailable": "Not Indexed"
+        "unavailable": "Index Unavailable"
       },
       "openLink": "Open Link",
       "columns": {
@@ -106,6 +106,7 @@
       "uploadSuccess": "File uploaded successfully",
       "batch": {
         "selected": "{{count}} selected",
+        "selectAll": "Select All",
         "enable": "Enable",
         "disable": "Disable",
         "delete": "Delete"
@@ -185,7 +186,9 @@
         "provider": {
           "dingtalk": "DingTalk Table"
         }
-      }
+      },
+      "documentCount": "Document Count",
+      "notebookLimitReached": "Notebook mode knowledge base supports up to 50 documents"
     },
     "permission": {
       "noAccess": "You do not have permission to perform this action"
@@ -337,6 +340,7 @@
     "backToList": "Back",
     "notFound": "Knowledge base not found",
     "createTaskError": "Failed to create conversation",
-    "bindKnowledgeBaseError": "Failed to bind knowledge base"
+    "bindKnowledgeBaseError": "Failed to bind knowledge base",
+    "newNote": "New Note"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -72,7 +72,7 @@
       },
       "indexStatus": {
         "available": "可用",
-        "unavailable": "不可用"
+        "unavailable": "索引不可用"
       },
       "openLink": "打开链接",
       "columns": {
@@ -106,6 +106,7 @@
       "uploadSuccess": "文件上传成功",
       "batch": {
         "selected": "已选择 {{count}} 项",
+        "selectAll": "选择所有",
         "enable": "批量启用",
         "disable": "批量停用",
         "delete": "批量删除"
@@ -185,7 +186,9 @@
         "provider": {
           "dingtalk": "钉钉多维表"
         }
-      }
+      },
+      "documentCount": "文档数量",
+      "notebookLimitReached": "Notebook 模式知识库最多支持 50 篇文档"
     },
     "permission": {
       "noAccess": "您没有操作权限"
@@ -337,6 +340,7 @@
     "backToList": "返回",
     "notFound": "知识库未找到",
     "createTaskError": "创建对话失败",
-    "bindKnowledgeBaseError": "绑定知识库失败"
+    "bindKnowledgeBaseError": "绑定知识库失败",
+    "newNote": "新笔记"
   }
 }

--- a/shared/models/db/enums.py
+++ b/shared/models/db/enums.py
@@ -40,6 +40,7 @@ class ContextType(str, PyEnum):
     ATTACHMENT = "attachment"
     KNOWLEDGE_BASE = "knowledge_base"
     TABLE = "table"
+    SELECTED_DOCUMENTS = "selected_documents"  # Selected documents from notebook mode for direct injection
 
 
 class ContextStatus(str, PyEnum):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added document selection capability in notebook-mode knowledge bases, allowing users to select specific documents and inject them directly into chat conversations.
  * Introduced "New Note" button for quick note creation within the knowledge base panel.
  * Added "Select All" option for bulk document selection.
  * Implemented document count indicator with visual progress tracking against a 50-document limit per notebook.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->