### PR TITLE
feat(backend,frontend): add interactive MCP tools for AI-user messaging

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -119,3 +119,8 @@ api_router.include_router(
 api_router.include_router(
     services_router, prefix="/internal", tags=["internal-services"]
 )
+
+# MCP Interactive Tools API endpoints
+from app.mcp import mcp_router
+
+api_router.include_router(mcp_router, tags=["mcp-interactive"])

--- a/backend/app/mcp/__init__.py
+++ b/backend/app/mcp/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Built-in MCP Server for interactive messaging.
+
+This module provides MCP tools for AI agents to send interactive messages
+to users, including text messages, forms, confirmations, and selections.
+"""
+
+from app.mcp.server import router as mcp_router
+
+__all__ = ["mcp_router"]

--- a/backend/app/mcp/context.py
+++ b/backend/app/mcp/context.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Context management for MCP interactive tools.
+
+This module provides mechanisms for injecting and retrieving task context
+within MCP tool calls.
+"""
+
+import logging
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Context variable to store the current task context
+_task_context: ContextVar[Optional["TaskContext"]] = ContextVar("task_context", default=None)
+
+
+@dataclass
+class TaskContext:
+    """Context information for the current MCP tool execution."""
+
+    task_id: int
+    subtask_id: Optional[int] = None
+    user_id: Optional[int] = None
+
+
+def get_task_context() -> Optional[TaskContext]:
+    """
+    Get the current task context.
+
+    Returns:
+        TaskContext if set, None otherwise
+    """
+    return _task_context.get()
+
+
+def set_task_context(context: TaskContext) -> None:
+    """
+    Set the current task context.
+
+    Args:
+        context: TaskContext to set
+    """
+    _task_context.set(context)
+    logger.debug(f"[MCP] Task context set: task_id={context.task_id}")
+
+
+def clear_task_context() -> None:
+    """Clear the current task context."""
+    _task_context.set(None)
+    logger.debug("[MCP] Task context cleared")
+
+
+class TaskContextManager:
+    """Context manager for task context."""
+
+    def __init__(self, task_id: int, subtask_id: Optional[int] = None, user_id: Optional[int] = None):
+        self.context = TaskContext(task_id=task_id, subtask_id=subtask_id, user_id=user_id)
+        self._token = None
+
+    def __enter__(self) -> TaskContext:
+        self._token = _task_context.set(self.context)
+        return self.context
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        _task_context.reset(self._token)
+        return False
+
+
+def get_task_id() -> Optional[int]:
+    """
+    Convenience function to get the current task ID.
+
+    Returns:
+        Task ID if context is set, None otherwise
+    """
+    ctx = get_task_context()
+    return ctx.task_id if ctx else None

--- a/backend/app/mcp/schemas/__init__.py
+++ b/backend/app/mcp/schemas/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Schema definitions for MCP interactive tools.
+
+This module defines all Pydantic models used by the MCP interactive
+messaging tools.
+"""

--- a/backend/app/mcp/schemas/form.py
+++ b/backend/app/mcp/schemas/form.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Form-related schemas for MCP interactive tools.
+"""
+
+from typing import Any, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class FieldOption(BaseModel):
+    """Option for choice fields."""
+
+    value: str = Field(..., description="Option value")
+    label: str = Field(..., description="Display label for the option")
+    recommended: bool = Field(False, description="Whether this is a recommended option")
+
+
+class FieldValidation(BaseModel):
+    """Validation rules for form fields."""
+
+    required: bool = Field(False, description="Whether this field is required")
+    min_length: Optional[int] = Field(None, description="Minimum length for text fields")
+    max_length: Optional[int] = Field(None, description="Maximum length for text fields")
+    min: Optional[float] = Field(None, description="Minimum value for number fields")
+    max: Optional[float] = Field(None, description="Maximum value for number fields")
+    pattern: Optional[str] = Field(None, description="Regular expression pattern")
+    pattern_message: Optional[str] = Field(
+        None, description="Error message when pattern doesn't match"
+    )
+
+
+class ShowCondition(BaseModel):
+    """Conditional display rule for form fields."""
+
+    field_id: str = Field(..., description="ID of the field to depend on")
+    operator: Literal["equals", "not_equals", "contains", "in"] = Field(
+        ..., description="Comparison operator"
+    )
+    value: Any = Field(..., description="Value to compare against")
+
+
+class FormField(BaseModel):
+    """Definition of a form field."""
+
+    field_id: str = Field(..., description="Unique field identifier")
+    field_type: Literal[
+        "text",
+        "textarea",
+        "number",
+        "single_choice",
+        "multiple_choice",
+        "datetime",
+    ] = Field(..., description="Type of the form field")
+    label: str = Field(..., description="Field label")
+    placeholder: Optional[str] = Field(None, description="Placeholder text")
+    default_value: Optional[Any] = Field(None, description="Default value")
+    options: Optional[List[FieldOption]] = Field(
+        None, description="Options for choice fields (required for single_choice/multiple_choice)"
+    )
+    validation: Optional[FieldValidation] = Field(None, description="Validation rules")
+    show_when: Optional[ShowCondition] = Field(None, description="Conditional display rule")
+
+
+class SendFormInput(BaseModel):
+    """Input parameters for send_form tool."""
+
+    title: str = Field(..., description="Form title")
+    description: Optional[str] = Field(None, description="Form description")
+    fields: List[FormField] = Field(..., description="Form field definitions")
+    submit_button_text: str = Field("Submit", description="Submit button text")
+
+
+class SendFormResult(BaseModel):
+    """Result from send_form tool."""
+
+    success: bool = Field(..., description="Whether the form was sent successfully")
+    form_id: str = Field(..., description="Unique identifier for the form")
+    error: Optional[str] = Field(None, description="Error message if failed")
+
+
+class SelectOption(BaseModel):
+    """Option for selection dialogs."""
+
+    value: str = Field(..., description="Option value")
+    label: str = Field(..., description="Display label")
+    description: Optional[str] = Field(None, description="Optional description")
+    recommended: bool = Field(False, description="Whether this is a recommended option")
+
+
+class SendConfirmInput(BaseModel):
+    """Input parameters for send_confirm tool."""
+
+    title: str = Field(..., description="Confirmation dialog title")
+    message: str = Field(..., description="Confirmation message (supports Markdown)")
+    confirm_text: str = Field("Confirm", description="Confirm button text")
+    cancel_text: str = Field("Cancel", description="Cancel button text")
+
+
+class SendConfirmResult(BaseModel):
+    """Result from send_confirm tool."""
+
+    success: bool = Field(..., description="Whether the confirmation was sent successfully")
+    confirm_id: str = Field(..., description="Unique identifier for the confirmation")
+    error: Optional[str] = Field(None, description="Error message if failed")
+
+
+class SendSelectInput(BaseModel):
+    """Input parameters for send_select tool."""
+
+    title: str = Field(..., description="Selection dialog title")
+    options: List[SelectOption] = Field(..., description="Selection options")
+    multiple: bool = Field(False, description="Whether multiple selection is allowed")
+    description: Optional[str] = Field(None, description="Optional description")
+
+
+class SendSelectResult(BaseModel):
+    """Result from send_select tool."""
+
+    success: bool = Field(..., description="Whether the selection was sent successfully")
+    select_id: str = Field(..., description="Unique identifier for the selection")
+    error: Optional[str] = Field(None, description="Error message if failed")

--- a/backend/app/mcp/schemas/form.py
+++ b/backend/app/mcp/schemas/form.py
@@ -8,7 +8,7 @@ Form-related schemas for MCP interactive tools.
 
 from typing import Any, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class FieldOption(BaseModel):
@@ -63,6 +63,17 @@ class FormField(BaseModel):
     )
     validation: Optional[FieldValidation] = Field(None, description="Validation rules")
     show_when: Optional[ShowCondition] = Field(None, description="Conditional display rule")
+
+    @model_validator(mode="after")
+    def validate_options_for_choice_fields(self) -> "FormField":
+        """Validate that choice fields have options defined."""
+        choice_types = ("single_choice", "multiple_choice")
+        if self.field_type in choice_types:
+            if not self.options or len(self.options) == 0:
+                raise ValueError(
+                    f"Field '{self.field_id}' of type '{self.field_type}' requires non-empty options list"
+                )
+        return self
 
 
 class SendFormInput(BaseModel):

--- a/backend/app/mcp/schemas/message.py
+++ b/backend/app/mcp/schemas/message.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Message-related schemas for MCP interactive tools.
+"""
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class Attachment(BaseModel):
+    """Attachment reference for messages."""
+
+    name: str = Field(..., description="File name")
+    url: str = Field(..., description="File access URL")
+    mime_type: str = Field(..., description="MIME type (e.g., 'image/png', 'application/pdf')")
+    size: Optional[int] = Field(None, description="File size in bytes")
+
+
+class SendMessageInput(BaseModel):
+    """Input parameters for send_message tool."""
+
+    content: str = Field(..., description="Message content (supports Markdown)")
+    message_type: Literal["text", "markdown"] = Field(
+        "markdown", description="Message type: text for plain text, markdown for rich text"
+    )
+    attachments: Optional[List[Attachment]] = Field(
+        None, description="Optional list of attachments"
+    )
+
+
+class SendMessageResult(BaseModel):
+    """Result from send_message tool."""
+
+    success: bool = Field(..., description="Whether the message was sent successfully")
+    message_id: str = Field(..., description="Unique identifier for the sent message")
+    error: Optional[str] = Field(None, description="Error message if failed")

--- a/backend/app/mcp/schemas/response.py
+++ b/backend/app/mcp/schemas/response.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Response schemas for MCP interactive tools.
+"""
+
+from typing import Any, Dict, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class InteractiveResponseData(BaseModel):
+    """Data submitted by user in response to interactive messages."""
+
+    request_id: str = Field(..., description="Original request ID")
+    response_type: Literal["form_submit", "confirm", "select"] = Field(
+        ..., description="Type of response"
+    )
+    data: Dict[str, Any] = Field(..., description="User submitted data")

--- a/backend/app/mcp/server.py
+++ b/backend/app/mcp/server.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MCP Server for interactive messaging.
+
+This module implements a built-in MCP Server that provides tools for
+AI agents to send interactive messages to users.
+
+The server is registered as FastAPI routes and can be accessed by
+executors through HTTP or as built-in tools.
+"""
+
+import logging
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.mcp.context import TaskContextManager, get_task_context
+from app.mcp.schemas.form import (
+    FieldOption,
+    FormField,
+    SelectOption,
+    SendConfirmInput,
+    SendConfirmResult,
+    SendFormInput,
+    SendFormResult,
+    SendSelectInput,
+    SendSelectResult,
+)
+from app.mcp.schemas.message import (
+    Attachment,
+    SendMessageInput,
+    SendMessageResult,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/mcp/interactive", tags=["MCP Interactive"])
+
+
+# ============================================================
+# Tool Definitions for MCP Protocol
+# ============================================================
+
+
+class MCPToolDefinition(BaseModel):
+    """MCP tool definition."""
+
+    name: str
+    description: str
+    input_schema: Dict[str, Any]
+
+
+class MCPToolsResponse(BaseModel):
+    """Response containing available MCP tools."""
+
+    tools: List[MCPToolDefinition]
+
+
+class MCPToolCallRequest(BaseModel):
+    """Request to call an MCP tool."""
+
+    tool_name: str = Field(..., description="Name of the tool to call")
+    arguments: Dict[str, Any] = Field(..., description="Tool arguments")
+    task_id: int = Field(..., description="Task ID for context")
+    subtask_id: int | None = Field(None, description="Optional subtask ID")
+
+
+class MCPToolCallResponse(BaseModel):
+    """Response from MCP tool call."""
+
+    success: bool
+    result: Dict[str, Any] | None = None
+    error: str | None = None
+
+
+# Tool definitions for MCP protocol
+TOOL_DEFINITIONS: List[MCPToolDefinition] = [
+    MCPToolDefinition(
+        name="send_message",
+        description="Send a message to the user. The message can be plain text or markdown format with optional attachments.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string",
+                    "description": "Message content (supports Markdown)",
+                },
+                "message_type": {
+                    "type": "string",
+                    "enum": ["text", "markdown"],
+                    "default": "markdown",
+                    "description": "Message type: text for plain text, markdown for rich text",
+                },
+                "attachments": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "description": "File name"},
+                            "url": {"type": "string", "description": "File URL"},
+                            "mime_type": {"type": "string", "description": "MIME type"},
+                            "size": {"type": "integer", "description": "File size in bytes"},
+                        },
+                        "required": ["name", "url", "mime_type"],
+                    },
+                    "description": "Optional list of attachments",
+                },
+            },
+            "required": ["content"],
+        },
+    ),
+    MCPToolDefinition(
+        name="send_form",
+        description="Send an interactive form to the user. The user's response will be sent as a new message in the conversation.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Form title"},
+                "description": {"type": "string", "description": "Form description"},
+                "fields": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field_id": {"type": "string", "description": "Unique field ID"},
+                            "field_type": {
+                                "type": "string",
+                                "enum": ["text", "textarea", "number", "single_choice", "multiple_choice", "datetime"],
+                                "description": "Field type",
+                            },
+                            "label": {"type": "string", "description": "Field label"},
+                            "placeholder": {"type": "string", "description": "Placeholder text"},
+                            "default_value": {"description": "Default value"},
+                            "options": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "value": {"type": "string"},
+                                        "label": {"type": "string"},
+                                        "recommended": {"type": "boolean", "default": False},
+                                    },
+                                    "required": ["value", "label"],
+                                },
+                                "description": "Options for choice fields",
+                            },
+                            "validation": {
+                                "type": "object",
+                                "properties": {
+                                    "required": {"type": "boolean"},
+                                    "min_length": {"type": "integer"},
+                                    "max_length": {"type": "integer"},
+                                    "min": {"type": "number"},
+                                    "max": {"type": "number"},
+                                    "pattern": {"type": "string"},
+                                    "pattern_message": {"type": "string"},
+                                },
+                            },
+                        },
+                        "required": ["field_id", "field_type", "label"],
+                    },
+                    "description": "Form field definitions",
+                },
+                "submit_button_text": {
+                    "type": "string",
+                    "default": "Submit",
+                    "description": "Submit button text",
+                },
+            },
+            "required": ["title", "fields"],
+        },
+    ),
+    MCPToolDefinition(
+        name="send_confirm",
+        description="Send a confirmation dialog to the user. The user's choice (confirm/cancel) will be sent as a message.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Dialog title"},
+                "message": {"type": "string", "description": "Confirmation message (supports Markdown)"},
+                "confirm_text": {"type": "string", "default": "Confirm", "description": "Confirm button text"},
+                "cancel_text": {"type": "string", "default": "Cancel", "description": "Cancel button text"},
+            },
+            "required": ["title", "message"],
+        },
+    ),
+    MCPToolDefinition(
+        name="send_select",
+        description="Send a selection dialog to the user. The user's selection will be sent as a message.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "title": {"type": "string", "description": "Selection title"},
+                "options": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "value": {"type": "string"},
+                            "label": {"type": "string"},
+                            "description": {"type": "string"},
+                            "recommended": {"type": "boolean", "default": False},
+                        },
+                        "required": ["value", "label"],
+                    },
+                    "description": "Selection options",
+                },
+                "multiple": {"type": "boolean", "default": False, "description": "Allow multiple selection"},
+                "description": {"type": "string", "description": "Optional description"},
+            },
+            "required": ["title", "options"],
+        },
+    ),
+]
+
+
+@router.get("/tools", response_model=MCPToolsResponse)
+async def list_tools() -> MCPToolsResponse:
+    """
+    List available MCP tools.
+
+    Returns the list of interactive messaging tools that can be called
+    by AI agents.
+    """
+    return MCPToolsResponse(tools=TOOL_DEFINITIONS)
+
+
+@router.post("/call", response_model=MCPToolCallResponse)
+async def call_tool(request: MCPToolCallRequest) -> MCPToolCallResponse:
+    """
+    Call an MCP tool.
+
+    This endpoint allows executors to call MCP tools with the specified
+    arguments. The task_id is used to establish the context for the tool.
+    """
+    logger.info(
+        f"[MCP] Tool call: tool={request.tool_name}, task_id={request.task_id}"
+    )
+
+    # Set up task context
+    with TaskContextManager(
+        task_id=request.task_id, subtask_id=request.subtask_id
+    ):
+        try:
+            if request.tool_name == "send_message":
+                from app.mcp.tools.send_message import send_message
+
+                # Parse attachments if provided
+                attachments = None
+                if "attachments" in request.arguments and request.arguments["attachments"]:
+                    attachments = [
+                        Attachment(**att) for att in request.arguments["attachments"]
+                    ]
+
+                result = await send_message(
+                    content=request.arguments.get("content", ""),
+                    message_type=request.arguments.get("message_type", "markdown"),
+                    attachments=attachments,
+                )
+                return MCPToolCallResponse(
+                    success=result.success,
+                    result=result.model_dump(),
+                    error=result.error,
+                )
+
+            elif request.tool_name == "send_form":
+                from app.mcp.tools.send_form import send_form
+
+                # Parse fields
+                fields = []
+                for field_data in request.arguments.get("fields", []):
+                    # Parse options if present
+                    options = None
+                    if "options" in field_data and field_data["options"]:
+                        options = [FieldOption(**opt) for opt in field_data["options"]]
+                    field_data_copy = field_data.copy()
+                    field_data_copy["options"] = options
+                    fields.append(FormField(**field_data_copy))
+
+                result = await send_form(
+                    title=request.arguments.get("title", ""),
+                    fields=fields,
+                    description=request.arguments.get("description"),
+                    submit_button_text=request.arguments.get(
+                        "submit_button_text", "Submit"
+                    ),
+                )
+                return MCPToolCallResponse(
+                    success=result.success,
+                    result=result.model_dump(),
+                    error=result.error,
+                )
+
+            elif request.tool_name == "send_confirm":
+                from app.mcp.tools.send_confirm import send_confirm
+
+                result = await send_confirm(
+                    title=request.arguments.get("title", ""),
+                    message=request.arguments.get("message", ""),
+                    confirm_text=request.arguments.get("confirm_text", "Confirm"),
+                    cancel_text=request.arguments.get("cancel_text", "Cancel"),
+                )
+                return MCPToolCallResponse(
+                    success=result.success,
+                    result=result.model_dump(),
+                    error=result.error,
+                )
+
+            elif request.tool_name == "send_select":
+                from app.mcp.tools.send_select import send_select
+
+                # Parse options
+                options = [
+                    SelectOption(**opt)
+                    for opt in request.arguments.get("options", [])
+                ]
+
+                result = await send_select(
+                    title=request.arguments.get("title", ""),
+                    options=options,
+                    multiple=request.arguments.get("multiple", False),
+                    description=request.arguments.get("description"),
+                )
+                return MCPToolCallResponse(
+                    success=result.success,
+                    result=result.model_dump(),
+                    error=result.error,
+                )
+
+            else:
+                return MCPToolCallResponse(
+                    success=False,
+                    error=f"Unknown tool: {request.tool_name}",
+                )
+
+        except Exception as e:
+            logger.exception(f"[MCP] Tool call failed: {e}")
+            return MCPToolCallResponse(success=False, error=str(e))

--- a/backend/app/mcp/tools/__init__.py
+++ b/backend/app/mcp/tools/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MCP tools for interactive messaging.
+"""
+
+from app.mcp.tools.send_message import send_message
+from app.mcp.tools.send_form import send_form
+from app.mcp.tools.send_confirm import send_confirm
+from app.mcp.tools.send_select import send_select
+
+__all__ = ["send_message", "send_form", "send_confirm", "send_select"]

--- a/backend/app/mcp/tools/send_confirm.py
+++ b/backend/app/mcp/tools/send_confirm.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+send_confirm MCP tool implementation.
+
+This tool allows AI agents to send confirmation dialogs to users.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+
+from app.mcp.context import get_task_context
+from app.mcp.schemas.form import SendConfirmResult
+
+logger = logging.getLogger(__name__)
+
+
+async def send_confirm(
+    title: str,
+    message: str,
+    confirm_text: str = "Confirm",
+    cancel_text: str = "Cancel",
+) -> SendConfirmResult:
+    """
+    Send a confirmation dialog to the user.
+
+    The user's choice will be sent as a new user message in the conversation,
+    formatted as: "User selected: [Confirm/Cancel]"
+
+    Args:
+        title: Dialog title
+        message: Confirmation message (supports Markdown)
+        confirm_text: Text for the confirm button
+        cancel_text: Text for the cancel button
+
+    Returns:
+        SendConfirmResult containing success status and confirm_id
+    """
+    # Get task context
+    ctx = get_task_context()
+    if not ctx:
+        logger.error("[MCP] send_confirm called without task context")
+        return SendConfirmResult(
+            success=False,
+            confirm_id="",
+            error="No task context available. This tool must be called within a task.",
+        )
+
+    task_id = ctx.task_id
+    confirm_id = f"confirm_{uuid.uuid4().hex[:12]}"
+
+    logger.info(f"[MCP] send_confirm: task_id={task_id}, title={title}")
+
+    try:
+        # Import WebSocket emitter
+        from app.services.chat.ws_emitter import get_ws_emitter
+
+        ws_emitter = get_ws_emitter()
+        if not ws_emitter:
+            logger.error("[MCP] WebSocket emitter not available")
+            return SendConfirmResult(
+                success=False,
+                confirm_id=confirm_id,
+                error="WebSocket emitter not available",
+            )
+
+        # Build confirm definition payload
+        confirm_definition = {
+            "title": title,
+            "message": message,
+            "confirm_text": confirm_text,
+            "cancel_text": cancel_text,
+        }
+
+        # Build payload for interactive message
+        payload = {
+            "request_id": confirm_id,
+            "message_type": "confirm",
+            "confirm": confirm_definition,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        # Emit interactive:message event to task room
+        await ws_emitter.emit_interactive_message(task_id=task_id, payload=payload)
+
+        logger.info(f"[MCP] send_confirm successful: confirm_id={confirm_id}")
+        return SendConfirmResult(success=True, confirm_id=confirm_id)
+
+    except Exception as e:
+        logger.exception(f"[MCP] send_confirm failed: {e}")
+        return SendConfirmResult(success=False, confirm_id=confirm_id, error=str(e))

--- a/backend/app/mcp/tools/send_form.py
+++ b/backend/app/mcp/tools/send_form.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+send_form MCP tool implementation.
+
+This tool allows AI agents to send interactive forms to users.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from app.mcp.context import get_task_context
+from app.mcp.schemas.form import FormField, SendFormResult
+
+logger = logging.getLogger(__name__)
+
+
+async def send_form(
+    title: str,
+    fields: List[FormField],
+    description: Optional[str] = None,
+    submit_button_text: str = "Submit",
+) -> SendFormResult:
+    """
+    Send an interactive form to the user.
+
+    This tool allows AI agents to send forms with various field types
+    to collect structured input from users.
+
+    Note: This tool is asynchronous notification mode. It returns immediately
+    after sending the form. The user's submitted data will be sent as a new
+    user message in the conversation.
+
+    Args:
+        title: Form title
+        description: Optional form description
+        fields: List of form field definitions
+        submit_button_text: Text for the submit button
+
+    Returns:
+        SendFormResult containing success status and form_id
+    """
+    # Get task context
+    ctx = get_task_context()
+    if not ctx:
+        logger.error("[MCP] send_form called without task context")
+        return SendFormResult(
+            success=False,
+            form_id="",
+            error="No task context available. This tool must be called within a task.",
+        )
+
+    task_id = ctx.task_id
+    form_id = f"form_{uuid.uuid4().hex[:12]}"
+
+    logger.info(
+        f"[MCP] send_form: task_id={task_id}, title={title}, "
+        f"fields_count={len(fields)}"
+    )
+
+    try:
+        # Import WebSocket emitter
+        from app.services.chat.ws_emitter import get_ws_emitter
+
+        ws_emitter = get_ws_emitter()
+        if not ws_emitter:
+            logger.error("[MCP] WebSocket emitter not available")
+            return SendFormResult(
+                success=False,
+                form_id=form_id,
+                error="WebSocket emitter not available",
+            )
+
+        # Build form definition payload
+        form_definition = {
+            "title": title,
+            "description": description,
+            "fields": [field.model_dump() for field in fields],
+            "submit_button_text": submit_button_text,
+        }
+
+        # Build payload for interactive message
+        payload = {
+            "request_id": form_id,
+            "message_type": "form",
+            "form": form_definition,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        # Emit interactive:message event to task room
+        await ws_emitter.emit_interactive_message(task_id=task_id, payload=payload)
+
+        logger.info(f"[MCP] send_form successful: form_id={form_id}")
+        return SendFormResult(success=True, form_id=form_id)
+
+    except Exception as e:
+        logger.exception(f"[MCP] send_form failed: {e}")
+        return SendFormResult(success=False, form_id=form_id, error=str(e))

--- a/backend/app/mcp/tools/send_message.py
+++ b/backend/app/mcp/tools/send_message.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+send_message MCP tool implementation.
+
+This tool allows AI agents to send text or markdown messages to users
+with optional attachments.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import List, Literal, Optional
+
+from app.mcp.context import get_task_context
+from app.mcp.schemas.message import Attachment, SendMessageResult
+
+logger = logging.getLogger(__name__)
+
+
+async def send_message(
+    content: str,
+    message_type: Literal["text", "markdown"] = "markdown",
+    attachments: Optional[List[Attachment]] = None,
+) -> SendMessageResult:
+    """
+    Send a message to the user in the current task.
+
+    This tool allows AI agents to proactively send messages to users,
+    including text, markdown content, and attachments.
+
+    Args:
+        content: Message content (supports Markdown format)
+        message_type: Message type - 'text' for plain text, 'markdown' for rich text
+        attachments: Optional list of attachments, each containing name, url, mime_type
+
+    Returns:
+        SendMessageResult containing success status and message_id
+
+    Note:
+        The task_id is automatically obtained from the execution context.
+        No need to explicitly pass it.
+    """
+    # Get task context
+    ctx = get_task_context()
+    if not ctx:
+        logger.error("[MCP] send_message called without task context")
+        return SendMessageResult(
+            success=False,
+            message_id="",
+            error="No task context available. This tool must be called within a task.",
+        )
+
+    task_id = ctx.task_id
+    message_id = f"msg_{uuid.uuid4().hex[:12]}"
+
+    logger.info(
+        f"[MCP] send_message: task_id={task_id}, message_type={message_type}, "
+        f"content_length={len(content)}, attachments_count={len(attachments) if attachments else 0}"
+    )
+
+    try:
+        # Import WebSocket emitter
+        from app.services.chat.ws_emitter import get_ws_emitter
+
+        ws_emitter = get_ws_emitter()
+        if not ws_emitter:
+            logger.error("[MCP] WebSocket emitter not available")
+            return SendMessageResult(
+                success=False,
+                message_id=message_id,
+                error="WebSocket emitter not available",
+            )
+
+        # Build payload for interactive message
+        payload = {
+            "request_id": message_id,
+            "message_type": message_type,
+            "content": content,
+            "attachments": (
+                [att.model_dump() for att in attachments] if attachments else []
+            ),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        # Emit interactive:message event to task room
+        await ws_emitter.emit_interactive_message(task_id=task_id, payload=payload)
+
+        logger.info(f"[MCP] send_message successful: message_id={message_id}")
+        return SendMessageResult(success=True, message_id=message_id)
+
+    except Exception as e:
+        logger.exception(f"[MCP] send_message failed: {e}")
+        return SendMessageResult(
+            success=False, message_id=message_id, error=str(e)
+        )

--- a/backend/app/mcp/tools/send_select.py
+++ b/backend/app/mcp/tools/send_select.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+send_select MCP tool implementation.
+
+This tool allows AI agents to send selection dialogs to users.
+"""
+
+import logging
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from app.mcp.context import get_task_context
+from app.mcp.schemas.form import SelectOption, SendSelectResult
+
+logger = logging.getLogger(__name__)
+
+
+async def send_select(
+    title: str,
+    options: List[SelectOption],
+    multiple: bool = False,
+    description: Optional[str] = None,
+) -> SendSelectResult:
+    """
+    Send a selection dialog to the user.
+
+    The user's selection will be sent as a new user message in the conversation.
+
+    Args:
+        title: Selection dialog title
+        options: List of options, each containing value, label, and optional recommended flag
+        multiple: Whether multiple selection is allowed
+        description: Optional description text
+
+    Returns:
+        SendSelectResult containing success status and select_id
+    """
+    # Get task context
+    ctx = get_task_context()
+    if not ctx:
+        logger.error("[MCP] send_select called without task context")
+        return SendSelectResult(
+            success=False,
+            select_id="",
+            error="No task context available. This tool must be called within a task.",
+        )
+
+    task_id = ctx.task_id
+    select_id = f"select_{uuid.uuid4().hex[:12]}"
+
+    logger.info(
+        f"[MCP] send_select: task_id={task_id}, title={title}, "
+        f"options_count={len(options)}, multiple={multiple}"
+    )
+
+    try:
+        # Import WebSocket emitter
+        from app.services.chat.ws_emitter import get_ws_emitter
+
+        ws_emitter = get_ws_emitter()
+        if not ws_emitter:
+            logger.error("[MCP] WebSocket emitter not available")
+            return SendSelectResult(
+                success=False,
+                select_id=select_id,
+                error="WebSocket emitter not available",
+            )
+
+        # Build select definition payload
+        select_definition = {
+            "title": title,
+            "options": [opt.model_dump() for opt in options],
+            "multiple": multiple,
+            "description": description,
+        }
+
+        # Build payload for interactive message
+        payload = {
+            "request_id": select_id,
+            "message_type": "select",
+            "select": select_definition,
+            "timestamp": datetime.now().isoformat(),
+        }
+
+        # Emit interactive:message event to task room
+        await ws_emitter.emit_interactive_message(task_id=task_id, payload=payload)
+
+        logger.info(f"[MCP] send_select successful: select_id={select_id}")
+        return SendSelectResult(success=True, select_id=select_id)
+
+    except Exception as e:
+        logger.exception(f"[MCP] send_select failed: {e}")
+        return SendSelectResult(success=False, select_id=select_id, error=str(e))

--- a/backend/app/services/chat/ws_emitter.py
+++ b/backend/app/services/chat/ws_emitter.py
@@ -726,6 +726,44 @@ class WebSocketEmitter:
             f"[WS] emit correction:error task={task_id} subtask={subtask_id} error={error}"
         )
 
+    # ============================================================
+    # Interactive Message Events (MCP tools)
+    # ============================================================
+
+    async def emit_interactive_message(
+        self,
+        task_id: int,
+        payload: Dict[str, Any],
+    ) -> None:
+        """
+        Emit interactive:message event to task room.
+
+        This is used by MCP tools (send_message, send_form, send_confirm, send_select)
+        to send interactive messages to users.
+
+        Args:
+            task_id: Task ID (used to determine the room)
+            payload: Interactive message payload containing:
+                - request_id: Unique request ID
+                - message_type: Type of message (text, markdown, form, confirm, select)
+                - content: Message content (for text/markdown)
+                - attachments: Attachments (for text/markdown)
+                - form: Form definition (for form type)
+                - confirm: Confirm definition (for confirm type)
+                - select: Select definition (for select type)
+                - timestamp: ISO timestamp
+        """
+        await self.sio.emit(
+            ServerEvents.INTERACTIVE_MESSAGE,
+            payload,
+            room=f"task:{task_id}",
+            namespace=self.namespace,
+        )
+        logger.info(
+            f"[WS] emit interactive:message task={task_id} "
+            f"type={payload.get('message_type')} request_id={payload.get('request_id')}"
+        )
+
 
 # Global emitter instance (lazy initialized)
 _ws_emitter: Optional[WebSocketEmitter] = None

--- a/backend/tests/mcp/__init__.py
+++ b/backend/tests/mcp/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP tests package."""

--- a/backend/tests/mcp/test_interactive_tools.py
+++ b/backend/tests/mcp/test_interactive_tools.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for MCP interactive tools.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.mcp.context import (
+    TaskContext,
+    TaskContextManager,
+    get_task_context,
+    set_task_context,
+    clear_task_context,
+    get_task_id,
+)
+from app.mcp.schemas.message import Attachment, SendMessageInput, SendMessageResult
+from app.mcp.schemas.form import (
+    FormField,
+    FieldOption,
+    FieldValidation,
+    SendFormInput,
+    SendFormResult,
+    SendConfirmInput,
+    SendConfirmResult,
+    SendSelectInput,
+    SelectOption,
+    SendSelectResult,
+)
+
+
+class TestTaskContext:
+    """Tests for task context management."""
+
+    def test_get_task_context_when_not_set(self):
+        """Test that get_task_context returns None when not set."""
+        clear_task_context()
+        assert get_task_context() is None
+
+    def test_set_and_get_task_context(self):
+        """Test setting and getting task context."""
+        ctx = TaskContext(task_id=123, subtask_id=456, user_id=789)
+        set_task_context(ctx)
+
+        result = get_task_context()
+        assert result is not None
+        assert result.task_id == 123
+        assert result.subtask_id == 456
+        assert result.user_id == 789
+
+        clear_task_context()
+
+    def test_clear_task_context(self):
+        """Test clearing task context."""
+        ctx = TaskContext(task_id=123)
+        set_task_context(ctx)
+        assert get_task_context() is not None
+
+        clear_task_context()
+        assert get_task_context() is None
+
+    def test_get_task_id_convenience(self):
+        """Test get_task_id convenience function."""
+        clear_task_context()
+        assert get_task_id() is None
+
+        ctx = TaskContext(task_id=999)
+        set_task_context(ctx)
+        assert get_task_id() == 999
+
+        clear_task_context()
+
+    def test_task_context_manager(self):
+        """Test TaskContextManager as context manager."""
+        clear_task_context()
+        assert get_task_context() is None
+
+        with TaskContextManager(task_id=100, subtask_id=200) as ctx:
+            assert ctx.task_id == 100
+            assert ctx.subtask_id == 200
+            assert get_task_id() == 100
+
+        # Context should be cleared after exiting
+        assert get_task_context() is None
+
+
+class TestSchemas:
+    """Tests for MCP schemas."""
+
+    def test_attachment_schema(self):
+        """Test Attachment schema."""
+        attachment = Attachment(
+            name="test.pdf",
+            url="https://example.com/test.pdf",
+            mime_type="application/pdf",
+            size=1024,
+        )
+        assert attachment.name == "test.pdf"
+        assert attachment.url == "https://example.com/test.pdf"
+        assert attachment.mime_type == "application/pdf"
+        assert attachment.size == 1024
+
+    def test_attachment_schema_without_size(self):
+        """Test Attachment schema without optional size."""
+        attachment = Attachment(
+            name="image.png",
+            url="https://example.com/image.png",
+            mime_type="image/png",
+        )
+        assert attachment.name == "image.png"
+        assert attachment.size is None
+
+    def test_send_message_input_schema(self):
+        """Test SendMessageInput schema."""
+        input_data = SendMessageInput(
+            content="Hello, world!",
+            message_type="markdown",
+            attachments=[
+                Attachment(
+                    name="file.txt",
+                    url="https://example.com/file.txt",
+                    mime_type="text/plain",
+                )
+            ],
+        )
+        assert input_data.content == "Hello, world!"
+        assert input_data.message_type == "markdown"
+        assert len(input_data.attachments) == 1
+
+    def test_send_message_result_schema(self):
+        """Test SendMessageResult schema."""
+        result = SendMessageResult(
+            success=True,
+            message_id="msg_abc123",
+        )
+        assert result.success is True
+        assert result.message_id == "msg_abc123"
+        assert result.error is None
+
+    def test_form_field_schema(self):
+        """Test FormField schema."""
+        field = FormField(
+            field_id="username",
+            field_type="text",
+            label="Username",
+            placeholder="Enter your username",
+            validation=FieldValidation(required=True, min_length=3, max_length=20),
+            options=None,
+        )
+        assert field.field_id == "username"
+        assert field.field_type == "text"
+        assert field.validation.required is True
+        assert field.validation.min_length == 3
+
+    def test_form_field_with_options(self):
+        """Test FormField with options for choice fields."""
+        field = FormField(
+            field_id="color",
+            field_type="single_choice",
+            label="Favorite Color",
+            options=[
+                FieldOption(value="red", label="Red", recommended=False),
+                FieldOption(value="blue", label="Blue", recommended=True),
+                FieldOption(value="green", label="Green", recommended=False),
+            ],
+        )
+        assert field.field_type == "single_choice"
+        assert len(field.options) == 3
+        assert field.options[1].recommended is True
+
+    def test_send_form_input_schema(self):
+        """Test SendFormInput schema."""
+        form_input = SendFormInput(
+            title="User Registration",
+            description="Please fill out the form",
+            fields=[
+                FormField(
+                    field_id="name",
+                    field_type="text",
+                    label="Name",
+                )
+            ],
+            submit_button_text="Register",
+        )
+        assert form_input.title == "User Registration"
+        assert form_input.submit_button_text == "Register"
+        assert len(form_input.fields) == 1
+
+    def test_send_confirm_input_schema(self):
+        """Test SendConfirmInput schema."""
+        confirm_input = SendConfirmInput(
+            title="Confirm Action",
+            message="Are you sure you want to proceed?",
+            confirm_text="Yes, proceed",
+            cancel_text="No, cancel",
+        )
+        assert confirm_input.title == "Confirm Action"
+        assert confirm_input.confirm_text == "Yes, proceed"
+        assert confirm_input.cancel_text == "No, cancel"
+
+    def test_send_select_input_schema(self):
+        """Test SendSelectInput schema."""
+        select_input = SendSelectInput(
+            title="Select Options",
+            options=[
+                SelectOption(value="opt1", label="Option 1", recommended=True),
+                SelectOption(value="opt2", label="Option 2", description="Description"),
+            ],
+            multiple=True,
+            description="Select one or more options",
+        )
+        assert select_input.title == "Select Options"
+        assert select_input.multiple is True
+        assert len(select_input.options) == 2
+        assert select_input.options[0].recommended is True
+
+
+class TestSendMessageTool:
+    """Tests for send_message MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_without_context(self):
+        """Test send_message fails without task context."""
+        from app.mcp.tools.send_message import send_message
+
+        clear_task_context()
+        result = await send_message(content="Hello")
+
+        assert result.success is False
+        assert "No task context" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_context(self):
+        """Test send_message succeeds with task context."""
+        from app.mcp.tools.send_message import send_message
+
+        # Mock the WebSocket emitter
+        mock_emitter = AsyncMock()
+        mock_emitter.emit_interactive_message = AsyncMock()
+
+        with patch("app.services.chat.ws_emitter.get_ws_emitter", return_value=mock_emitter):
+            with TaskContextManager(task_id=123):
+                result = await send_message(
+                    content="Hello, world!",
+                    message_type="markdown",
+                )
+
+        assert result.success is True
+        assert result.message_id.startswith("msg_")
+        mock_emitter.emit_interactive_message.assert_called_once()
+
+
+class TestSendFormTool:
+    """Tests for send_form MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_send_form_without_context(self):
+        """Test send_form fails without task context."""
+        from app.mcp.tools.send_form import send_form
+
+        clear_task_context()
+        result = await send_form(
+            title="Test Form",
+            fields=[
+                FormField(field_id="test", field_type="text", label="Test"),
+            ],
+        )
+
+        assert result.success is False
+        assert "No task context" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_form_with_context(self):
+        """Test send_form succeeds with task context."""
+        from app.mcp.tools.send_form import send_form
+
+        mock_emitter = AsyncMock()
+        mock_emitter.emit_interactive_message = AsyncMock()
+
+        with patch("app.services.chat.ws_emitter.get_ws_emitter", return_value=mock_emitter):
+            with TaskContextManager(task_id=456):
+                result = await send_form(
+                    title="User Survey",
+                    fields=[
+                        FormField(
+                            field_id="rating",
+                            field_type="single_choice",
+                            label="Rating",
+                            options=[
+                                FieldOption(value="1", label="Poor"),
+                                FieldOption(value="5", label="Excellent"),
+                            ],
+                        ),
+                    ],
+                    submit_button_text="Submit Survey",
+                )
+
+        assert result.success is True
+        assert result.form_id.startswith("form_")
+
+
+class TestSendConfirmTool:
+    """Tests for send_confirm MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_send_confirm_without_context(self):
+        """Test send_confirm fails without task context."""
+        from app.mcp.tools.send_confirm import send_confirm
+
+        clear_task_context()
+        result = await send_confirm(
+            title="Confirm",
+            message="Are you sure?",
+        )
+
+        assert result.success is False
+        assert "No task context" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_confirm_with_context(self):
+        """Test send_confirm succeeds with task context."""
+        from app.mcp.tools.send_confirm import send_confirm
+
+        mock_emitter = AsyncMock()
+        mock_emitter.emit_interactive_message = AsyncMock()
+
+        with patch("app.services.chat.ws_emitter.get_ws_emitter", return_value=mock_emitter):
+            with TaskContextManager(task_id=789):
+                result = await send_confirm(
+                    title="Delete Confirmation",
+                    message="This action cannot be undone.",
+                    confirm_text="Delete",
+                    cancel_text="Keep",
+                )
+
+        assert result.success is True
+        assert result.confirm_id.startswith("confirm_")
+
+
+class TestSendSelectTool:
+    """Tests for send_select MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_send_select_without_context(self):
+        """Test send_select fails without task context."""
+        from app.mcp.tools.send_select import send_select
+
+        clear_task_context()
+        result = await send_select(
+            title="Select",
+            options=[SelectOption(value="a", label="A")],
+        )
+
+        assert result.success is False
+        assert "No task context" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_select_with_context(self):
+        """Test send_select succeeds with task context."""
+        from app.mcp.tools.send_select import send_select
+
+        mock_emitter = AsyncMock()
+        mock_emitter.emit_interactive_message = AsyncMock()
+
+        with patch("app.services.chat.ws_emitter.get_ws_emitter", return_value=mock_emitter):
+            with TaskContextManager(task_id=999):
+                result = await send_select(
+                    title="Choose Database",
+                    options=[
+                        SelectOption(value="mysql", label="MySQL", recommended=True),
+                        SelectOption(value="postgres", label="PostgreSQL"),
+                    ],
+                    multiple=False,
+                    description="Select your preferred database",
+                )
+
+        assert result.success is True
+        assert result.select_id.startswith("select_")

--- a/frontend/src/features/tasks/components/interactive/AttachmentDisplay.tsx
+++ b/frontend/src/features/tasks/components/interactive/AttachmentDisplay.tsx
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { FileIcon, Download, ExternalLink } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import type { InteractiveAttachment } from './types'
+
+interface AttachmentDisplayProps {
+  attachments: InteractiveAttachment[]
+}
+
+/**
+ * Display attachments in an interactive message.
+ */
+export function AttachmentDisplay({ attachments }: AttachmentDisplayProps) {
+  if (!attachments || attachments.length === 0) {
+    return null
+  }
+
+  const formatFileSize = (bytes?: number): string => {
+    if (!bytes) return ''
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+
+  const getFileIcon = (mimeType: string) => {
+    if (mimeType.startsWith('image/')) {
+      return '🖼️'
+    } else if (mimeType.startsWith('video/')) {
+      return '🎬'
+    } else if (mimeType.startsWith('audio/')) {
+      return '🎵'
+    } else if (mimeType === 'application/pdf') {
+      return '📄'
+    } else if (
+      mimeType.includes('spreadsheet') ||
+      mimeType.includes('excel') ||
+      mimeType === 'text/csv'
+    ) {
+      return '📊'
+    } else if (mimeType.includes('document') || mimeType.includes('word')) {
+      return '📝'
+    } else if (mimeType.includes('zip') || mimeType.includes('archive')) {
+      return '📦'
+    }
+    return <FileIcon className="w-4 h-4" />
+  }
+
+  return (
+    <div className="mt-2 space-y-2">
+      {attachments.map((attachment, index) => (
+        <div
+          key={`${attachment.name}-${index}`}
+          className="flex items-center gap-3 p-2 rounded-lg bg-surface/50 border border-border"
+        >
+          <span className="text-lg">{getFileIcon(attachment.mime_type)}</span>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-text-primary truncate">{attachment.name}</p>
+            {attachment.size && (
+              <p className="text-xs text-text-muted">{formatFileSize(attachment.size)}</p>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            <Button variant="ghost" size="sm" asChild className="h-8 w-8 p-0">
+              <a
+                href={attachment.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Open in new tab"
+              >
+                <ExternalLink className="w-4 h-4" />
+              </a>
+            </Button>
+            <Button variant="ghost" size="sm" asChild className="h-8 w-8 p-0">
+              <a href={attachment.url} download={attachment.name} title="Download">
+                <Download className="w-4 h-4" />
+              </a>
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/interactive/AttachmentDisplay.tsx
+++ b/frontend/src/features/tasks/components/interactive/AttachmentDisplay.tsx
@@ -21,7 +21,7 @@ export function AttachmentDisplay({ attachments }: AttachmentDisplayProps) {
   }
 
   const formatFileSize = (bytes?: number): string => {
-    if (!bytes) return ''
+    if (bytes == null) return ''
     if (bytes < 1024) return `${bytes} B`
     if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
@@ -60,7 +60,7 @@ export function AttachmentDisplay({ attachments }: AttachmentDisplayProps) {
           <span className="text-lg">{getFileIcon(attachment.mime_type)}</span>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-text-primary truncate">{attachment.name}</p>
-            {attachment.size && (
+            {attachment.size != null && (
               <p className="text-xs text-text-muted">{formatFileSize(attachment.size)}</p>
             )}
           </div>

--- a/frontend/src/features/tasks/components/interactive/InteractiveConfirm.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveConfirm.tsx
@@ -8,7 +8,8 @@ import { useState, useCallback } from 'react'
 import { Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
-import { MarkdownRenderer } from '@/components/MarkdownRenderer'
+import { useTheme } from '@/features/theme/ThemeProvider'
+import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
 import type { InteractiveConfirmDefinition, InteractiveResponsePayload } from './types'
 
 interface InteractiveConfirmProps {
@@ -30,6 +31,7 @@ export function InteractiveConfirm({
   disabled = false,
 }: InteractiveConfirmProps) {
   const { t } = useTranslation('chat')
+  const { theme } = useTheme()
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [choice, setChoice] = useState<boolean | null>(null)
 
@@ -71,7 +73,7 @@ export function InteractiveConfirm({
       </div>
 
       <div className="prose prose-sm dark:prose-invert max-w-none">
-        <MarkdownRenderer content={confirm.message} />
+        <EnhancedMarkdown source={confirm.message} theme={theme} />
       </div>
 
       {!isSubmitted ? (

--- a/frontend/src/features/tasks/components/interactive/InteractiveConfirm.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveConfirm.tsx
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Check, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
+import { MarkdownRenderer } from '@/components/MarkdownRenderer'
+import type { InteractiveConfirmDefinition, InteractiveResponsePayload } from './types'
+
+interface InteractiveConfirmProps {
+  requestId: string
+  confirm: InteractiveConfirmDefinition
+  taskId: number
+  onSubmit: (response: InteractiveResponsePayload) => void
+  disabled?: boolean
+}
+
+/**
+ * Interactive confirmation dialog component.
+ */
+export function InteractiveConfirm({
+  requestId,
+  confirm,
+  taskId,
+  onSubmit,
+  disabled = false,
+}: InteractiveConfirmProps) {
+  const { t } = useTranslation('chat')
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [choice, setChoice] = useState<boolean | null>(null)
+
+  const handleConfirm = useCallback(() => {
+    setIsSubmitted(true)
+    setChoice(true)
+
+    const response: InteractiveResponsePayload = {
+      request_id: requestId,
+      response_type: 'confirm',
+      data: { confirmed: true },
+      task_id: taskId,
+    }
+
+    onSubmit(response)
+  }, [requestId, taskId, onSubmit])
+
+  const handleCancel = useCallback(() => {
+    setIsSubmitted(true)
+    setChoice(false)
+
+    const response: InteractiveResponsePayload = {
+      request_id: requestId,
+      response_type: 'confirm',
+      data: { confirmed: false },
+      task_id: taskId,
+    }
+
+    onSubmit(response)
+  }, [requestId, taskId, onSubmit])
+
+  const isDisabled = disabled || isSubmitted
+
+  return (
+    <div className="space-y-4 p-4 rounded-lg border border-amber-500/30 bg-amber-500/5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-lg">❓</span>
+        <h3 className="text-base font-semibold text-amber-600">{confirm.title}</h3>
+      </div>
+
+      <div className="prose prose-sm dark:prose-invert max-w-none">
+        <MarkdownRenderer content={confirm.message} />
+      </div>
+
+      {!isSubmitted ? (
+        <div className="flex justify-end gap-3 pt-2">
+          <Button variant="outline" onClick={handleCancel} disabled={isDisabled}>
+            <X className="w-4 h-4 mr-2" />
+            {confirm.cancel_text || t('interactive.cancel') || 'Cancel'}
+          </Button>
+          <Button variant="default" onClick={handleConfirm} disabled={isDisabled}>
+            <Check className="w-4 h-4 mr-2" />
+            {confirm.confirm_text || t('interactive.confirm') || 'Confirm'}
+          </Button>
+        </div>
+      ) : (
+        <div className="text-center text-sm pt-2">
+          {choice ? (
+            <span className="text-green-600 flex items-center justify-center gap-1">
+              <Check className="w-4 h-4" />
+              {t('interactive.confirmed') || 'Confirmed'}
+            </span>
+          ) : (
+            <span className="text-text-muted flex items-center justify-center gap-1">
+              <X className="w-4 h-4" />
+              {t('interactive.cancelled') || 'Cancelled'}
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
@@ -9,11 +9,7 @@ import { Send } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
 import { InteractiveFormField } from './InteractiveFormField'
-import type {
-  InteractiveFormDefinition,
-  InteractiveFormField as FormFieldType,
-  InteractiveResponsePayload,
-} from './types'
+import type { InteractiveFormDefinition, InteractiveResponsePayload } from './types'
 
 interface InteractiveFormProps {
   requestId: string

--- a/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useCallback, useEffect, useMemo } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Send } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'

--- a/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveForm.tsx
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useCallback, useEffect } from 'react'
+import { Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
+import { InteractiveFormField } from './InteractiveFormField'
+import type {
+  InteractiveFormDefinition,
+  InteractiveFormField as FormFieldType,
+  InteractiveResponsePayload,
+} from './types'
+
+interface InteractiveFormProps {
+  requestId: string
+  form: InteractiveFormDefinition
+  taskId: number
+  onSubmit: (response: InteractiveResponsePayload) => void
+  disabled?: boolean
+}
+
+/**
+ * Interactive form component for collecting structured user input.
+ */
+export function InteractiveForm({
+  requestId,
+  form,
+  taskId,
+  onSubmit,
+  disabled = false,
+}: InteractiveFormProps) {
+  const { t } = useTranslation('chat')
+  const [values, setValues] = useState<Record<string, unknown>>({})
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  // Initialize default values
+  useEffect(() => {
+    const initialValues: Record<string, unknown> = {}
+    form.fields.forEach(field => {
+      if (field.default_value !== undefined) {
+        initialValues[field.field_id] = field.default_value
+      } else if (field.field_type === 'multiple_choice') {
+        // Initialize with recommended options for multiple choice
+        const recommended = field.options?.filter(o => o.recommended).map(o => o.value) ?? []
+        initialValues[field.field_id] = recommended
+      } else if (field.field_type === 'single_choice') {
+        // Initialize with recommended option for single choice
+        const recommended = field.options?.find(o => o.recommended)
+        if (recommended) {
+          initialValues[field.field_id] = recommended.value
+        }
+      }
+    })
+    setValues(initialValues)
+  }, [form.fields])
+
+  const handleFieldChange = useCallback((fieldId: string, value: unknown) => {
+    setValues(prev => ({
+      ...prev,
+      [fieldId]: value,
+    }))
+    // Clear error when field is modified
+    setErrors(prev => {
+      const newErrors = { ...prev }
+      delete newErrors[fieldId]
+      return newErrors
+    })
+  }, [])
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {}
+
+    form.fields.forEach(field => {
+      const value = values[field.field_id]
+      const validation = field.validation
+
+      if (!validation) return
+
+      // Check required
+      if (validation.required) {
+        if (value === undefined || value === null || value === '') {
+          newErrors[field.field_id] = t('interactive.field_required') || 'This field is required'
+          return
+        }
+        if (Array.isArray(value) && value.length === 0) {
+          newErrors[field.field_id] =
+            t('interactive.select_at_least_one') || 'Please select at least one option'
+          return
+        }
+      }
+
+      // Check string validations
+      if (typeof value === 'string') {
+        if (validation.min_length && value.length < validation.min_length) {
+          newErrors[field.field_id] =
+            t('interactive.min_length', { min: validation.min_length }) ||
+            `Minimum ${validation.min_length} characters required`
+        }
+        if (validation.max_length && value.length > validation.max_length) {
+          newErrors[field.field_id] =
+            t('interactive.max_length', { max: validation.max_length }) ||
+            `Maximum ${validation.max_length} characters allowed`
+        }
+        if (validation.pattern) {
+          const regex = new RegExp(validation.pattern)
+          if (!regex.test(value)) {
+            newErrors[field.field_id] =
+              validation.pattern_message || t('interactive.invalid_format') || 'Invalid format'
+          }
+        }
+      }
+
+      // Check number validations
+      if (typeof value === 'number') {
+        if (validation.min !== undefined && value < validation.min) {
+          newErrors[field.field_id] =
+            t('interactive.min_value', { min: validation.min }) || `Minimum value is ${validation.min}`
+        }
+        if (validation.max !== undefined && value > validation.max) {
+          newErrors[field.field_id] =
+            t('interactive.max_value', { max: validation.max }) || `Maximum value is ${validation.max}`
+        }
+      }
+    })
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }, [form.fields, values, t])
+
+  const handleSubmit = useCallback(() => {
+    if (!validateForm()) return
+
+    setIsSubmitted(true)
+
+    const response: InteractiveResponsePayload = {
+      request_id: requestId,
+      response_type: 'form_submit',
+      data: values,
+      task_id: taskId,
+    }
+
+    onSubmit(response)
+  }, [validateForm, requestId, values, taskId, onSubmit])
+
+  const isDisabled = disabled || isSubmitted
+
+  return (
+    <div className="space-y-4 p-4 rounded-lg border border-primary/30 bg-primary/5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-lg">📝</span>
+        <h3 className="text-base font-semibold text-primary">{form.title}</h3>
+      </div>
+
+      {form.description && (
+        <p className="text-sm text-text-secondary mb-4">{form.description}</p>
+      )}
+
+      <div className="space-y-4">
+        {form.fields.map(field => (
+          <div
+            key={field.field_id}
+            className={`p-3 rounded bg-surface/50 border ${
+              errors[field.field_id] ? 'border-red-500 bg-red-500/5' : 'border-border'
+            }`}
+          >
+            <InteractiveFormField
+              field={field}
+              value={values[field.field_id]}
+              onChange={value => handleFieldChange(field.field_id, value)}
+              formValues={values}
+              disabled={isDisabled}
+              error={errors[field.field_id]}
+            />
+          </div>
+        ))}
+      </div>
+
+      {!isSubmitted && (
+        <div className="flex justify-end pt-2">
+          <Button variant="secondary" onClick={handleSubmit} size="lg" disabled={isDisabled}>
+            <Send className="w-4 h-4 mr-2" />
+            {form.submit_button_text || t('interactive.submit') || 'Submit'}
+          </Button>
+        </div>
+      )}
+
+      {isSubmitted && (
+        <div className="text-center text-sm text-text-muted pt-2">
+          {t('interactive.form_submitted') || 'Form submitted'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
@@ -4,18 +4,14 @@
 
 'use client'
 
-import { useState, useCallback, useMemo, useEffect } from 'react'
+import { useMemo } from 'react'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
-import type {
-  InteractiveFormField as FormFieldType,
-  InteractiveFieldOption,
-  InteractiveShowCondition,
-} from './types'
+import type { InteractiveFormField as FormFieldType } from './types'
 
 interface InteractiveFormFieldProps {
   field: FormFieldType

--- a/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
@@ -1,0 +1,216 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useCallback, useMemo, useEffect } from 'react'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Badge } from '@/components/ui/badge'
+import type {
+  InteractiveFormField as FormFieldType,
+  InteractiveFieldOption,
+  InteractiveShowCondition,
+} from './types'
+
+interface InteractiveFormFieldProps {
+  field: FormFieldType
+  value: unknown
+  onChange: (value: unknown) => void
+  formValues: Record<string, unknown>
+  disabled?: boolean
+  error?: string
+}
+
+/**
+ * Render a single form field based on its type.
+ */
+export function InteractiveFormField({
+  field,
+  value,
+  onChange,
+  formValues,
+  disabled = false,
+  error,
+}: InteractiveFormFieldProps) {
+  // Check if field should be shown based on show_when condition
+  const isVisible = useMemo(() => {
+    if (!field.show_when) return true
+
+    const { field_id, operator, value: conditionValue } = field.show_when
+    const dependentValue = formValues[field_id]
+
+    switch (operator) {
+      case 'equals':
+        return dependentValue === conditionValue
+      case 'not_equals':
+        return dependentValue !== conditionValue
+      case 'contains':
+        if (typeof dependentValue === 'string') {
+          return dependentValue.includes(String(conditionValue))
+        }
+        if (Array.isArray(dependentValue)) {
+          return dependentValue.includes(conditionValue)
+        }
+        return false
+      case 'in':
+        if (Array.isArray(conditionValue)) {
+          return conditionValue.includes(dependentValue)
+        }
+        return false
+      default:
+        return true
+    }
+  }, [field.show_when, formValues])
+
+  if (!isVisible) {
+    return null
+  }
+
+  const isRequired = field.validation?.required
+
+  return (
+    <div className="space-y-2">
+      <Label className="flex items-center gap-1">
+        {field.label}
+        {isRequired && <span className="text-red-500">*</span>}
+      </Label>
+
+      {renderFieldInput(field, value, onChange, disabled)}
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}
+
+function renderFieldInput(
+  field: FormFieldType,
+  value: unknown,
+  onChange: (value: unknown) => void,
+  disabled: boolean
+) {
+  switch (field.field_type) {
+    case 'text':
+      return (
+        <Input
+          type="text"
+          placeholder={field.placeholder}
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value)}
+          disabled={disabled}
+          maxLength={field.validation?.max_length}
+        />
+      )
+
+    case 'textarea':
+      return (
+        <Textarea
+          placeholder={field.placeholder}
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value)}
+          disabled={disabled}
+          maxLength={field.validation?.max_length}
+          rows={4}
+        />
+      )
+
+    case 'number':
+      return (
+        <Input
+          type="number"
+          placeholder={field.placeholder}
+          value={(value as number) ?? ''}
+          onChange={e => onChange(e.target.value ? Number(e.target.value) : undefined)}
+          disabled={disabled}
+          min={field.validation?.min}
+          max={field.validation?.max}
+        />
+      )
+
+    case 'single_choice':
+      return (
+        <RadioGroup
+          value={(value as string) ?? ''}
+          onValueChange={onChange}
+          disabled={disabled}
+          className="space-y-2"
+        >
+          {field.options?.map(option => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <RadioGroupItem value={option.value} id={`${field.field_id}-${option.value}`} />
+              <Label
+                htmlFor={`${field.field_id}-${option.value}`}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                {option.label}
+                {option.recommended && (
+                  <Badge variant="secondary" className="text-xs">
+                    Recommended
+                  </Badge>
+                )}
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      )
+
+    case 'multiple_choice':
+      const selectedValues = (value as string[]) ?? []
+      return (
+        <div className="space-y-2">
+          {field.options?.map(option => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <Checkbox
+                id={`${field.field_id}-${option.value}`}
+                checked={selectedValues.includes(option.value)}
+                onCheckedChange={checked => {
+                  if (checked) {
+                    onChange([...selectedValues, option.value])
+                  } else {
+                    onChange(selectedValues.filter(v => v !== option.value))
+                  }
+                }}
+                disabled={disabled}
+              />
+              <Label
+                htmlFor={`${field.field_id}-${option.value}`}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                {option.label}
+                {option.recommended && (
+                  <Badge variant="secondary" className="text-xs">
+                    Recommended
+                  </Badge>
+                )}
+              </Label>
+            </div>
+          ))}
+        </div>
+      )
+
+    case 'datetime':
+      return (
+        <Input
+          type="datetime-local"
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value)}
+          disabled={disabled}
+        />
+      )
+
+    default:
+      return (
+        <Input
+          type="text"
+          placeholder={field.placeholder}
+          value={(value as string) ?? ''}
+          onChange={e => onChange(e.target.value)}
+          disabled={disabled}
+        />
+      )
+  }
+}

--- a/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveFormField.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Badge } from '@/components/ui/badge'
+import { useTranslation } from '@/hooks/useTranslation'
 import type { InteractiveFormField as FormFieldType } from './types'
 
 interface InteractiveFormFieldProps {
@@ -33,6 +34,8 @@ export function InteractiveFormField({
   disabled = false,
   error,
 }: InteractiveFormFieldProps) {
+  const { t } = useTranslation('chat')
+
   // Check if field should be shown based on show_when condition
   const isVisible = useMemo(() => {
     if (!field.show_when) return true
@@ -76,7 +79,7 @@ export function InteractiveFormField({
         {isRequired && <span className="text-red-500">*</span>}
       </Label>
 
-      {renderFieldInput(field, value, onChange, disabled)}
+      {renderFieldInput(field, value, onChange, disabled, t('interactive.recommended'))}
 
       {error && <p className="text-xs text-red-500">{error}</p>}
     </div>
@@ -87,7 +90,8 @@ function renderFieldInput(
   field: FormFieldType,
   value: unknown,
   onChange: (value: unknown) => void,
-  disabled: boolean
+  disabled: boolean,
+  recommendedLabel: string
 ) {
   switch (field.field_type) {
     case 'text':
@@ -145,7 +149,7 @@ function renderFieldInput(
                 {option.label}
                 {option.recommended && (
                   <Badge variant="secondary" className="text-xs">
-                    Recommended
+                    {recommendedLabel}
                   </Badge>
                 )}
               </Label>
@@ -154,7 +158,7 @@ function renderFieldInput(
         </RadioGroup>
       )
 
-    case 'multiple_choice':
+    case 'multiple_choice': {
       const selectedValues = (value as string[]) ?? []
       return (
         <div className="space-y-2">
@@ -179,7 +183,7 @@ function renderFieldInput(
                 {option.label}
                 {option.recommended && (
                   <Badge variant="secondary" className="text-xs">
-                    Recommended
+                    {recommendedLabel}
                   </Badge>
                 )}
               </Label>
@@ -187,6 +191,7 @@ function renderFieldInput(
           ))}
         </div>
       )
+    }
 
     case 'datetime':
       return (

--- a/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
@@ -5,8 +5,9 @@
 'use client'
 
 import { useCallback, useContext } from 'react'
-import { MarkdownRenderer } from '@/components/MarkdownRenderer'
 import { SocketContext } from '@/contexts/SocketContext'
+import { useTheme } from '@/features/theme/ThemeProvider'
+import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
 import { InteractiveForm } from './InteractiveForm'
 import { InteractiveConfirm } from './InteractiveConfirm'
 import { InteractiveSelect } from './InteractiveSelect'
@@ -26,6 +27,7 @@ interface InteractiveMessageProps {
 export function InteractiveMessage({ payload, taskId, disabled = false }: InteractiveMessageProps) {
   const socketContext = useContext(SocketContext)
   const socket = socketContext?.socket
+  const { theme } = useTheme()
 
   const handleSubmit = useCallback(
     (response: InteractiveResponsePayload) => {
@@ -47,7 +49,7 @@ export function InteractiveMessage({ payload, taskId, disabled = false }: Intera
         <div className="space-y-2">
           {payload.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              <MarkdownRenderer content={payload.content} />
+              <EnhancedMarkdown source={payload.content} theme={theme} />
             </div>
           )}
           {payload.attachments && payload.attachments.length > 0 && (

--- a/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useCallback, useContext } from 'react'
+import { MarkdownRenderer } from '@/components/MarkdownRenderer'
+import { SocketContext } from '@/contexts/SocketContext'
+import { InteractiveForm } from './InteractiveForm'
+import { InteractiveConfirm } from './InteractiveConfirm'
+import { InteractiveSelect } from './InteractiveSelect'
+import { AttachmentDisplay } from './AttachmentDisplay'
+import type { InteractiveMessagePayload, InteractiveResponsePayload } from './types'
+
+interface InteractiveMessageProps {
+  payload: InteractiveMessagePayload
+  taskId: number
+  disabled?: boolean
+}
+
+/**
+ * Container component for interactive messages.
+ * Routes to the appropriate component based on message type.
+ */
+export function InteractiveMessage({ payload, taskId, disabled = false }: InteractiveMessageProps) {
+  const socketContext = useContext(SocketContext)
+  const socket = socketContext?.socket
+
+  const handleSubmit = useCallback(
+    (response: InteractiveResponsePayload) => {
+      if (!socket) {
+        console.error('[InteractiveMessage] Socket not available')
+        return
+      }
+
+      console.log('[InteractiveMessage] Submitting response:', response)
+      socket.emit('interactive:response', response)
+    },
+    [socket]
+  )
+
+  switch (payload.message_type) {
+    case 'text':
+    case 'markdown':
+      return (
+        <div className="space-y-2">
+          {payload.content && (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <MarkdownRenderer content={payload.content} />
+            </div>
+          )}
+          {payload.attachments && payload.attachments.length > 0 && (
+            <AttachmentDisplay attachments={payload.attachments} />
+          )}
+        </div>
+      )
+
+    case 'form':
+      if (!payload.form) {
+        console.error('[InteractiveMessage] Form payload missing form definition')
+        return <div className="text-red-500">Error: Form definition missing</div>
+      }
+      return (
+        <InteractiveForm
+          requestId={payload.request_id}
+          form={payload.form}
+          taskId={taskId}
+          onSubmit={handleSubmit}
+          disabled={disabled}
+        />
+      )
+
+    case 'confirm':
+      if (!payload.confirm) {
+        console.error('[InteractiveMessage] Confirm payload missing confirm definition')
+        return <div className="text-red-500">Error: Confirm definition missing</div>
+      }
+      return (
+        <InteractiveConfirm
+          requestId={payload.request_id}
+          confirm={payload.confirm}
+          taskId={taskId}
+          onSubmit={handleSubmit}
+          disabled={disabled}
+        />
+      )
+
+    case 'select':
+      if (!payload.select) {
+        console.error('[InteractiveMessage] Select payload missing select definition')
+        return <div className="text-red-500">Error: Select definition missing</div>
+      }
+      return (
+        <InteractiveSelect
+          requestId={payload.request_id}
+          select={payload.select}
+          taskId={taskId}
+          onSubmit={handleSubmit}
+          disabled={disabled}
+        />
+      )
+
+    default:
+      console.warn('[InteractiveMessage] Unknown message type:', payload.message_type)
+      return (
+        <div className="text-text-muted">
+          Unknown interactive message type: {payload.message_type}
+        </div>
+      )
+  }
+}

--- a/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveMessage.tsx
@@ -4,8 +4,8 @@
 
 'use client'
 
-import { useCallback, useContext } from 'react'
-import { SocketContext } from '@/contexts/SocketContext'
+import { useCallback } from 'react'
+import { useSocket } from '@/contexts/SocketContext'
 import { useTheme } from '@/features/theme/ThemeProvider'
 import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
 import { InteractiveForm } from './InteractiveForm'
@@ -25,8 +25,7 @@ interface InteractiveMessageProps {
  * Routes to the appropriate component based on message type.
  */
 export function InteractiveMessage({ payload, taskId, disabled = false }: InteractiveMessageProps) {
-  const socketContext = useContext(SocketContext)
-  const socket = socketContext?.socket
+  const { socket } = useSocket()
   const { theme } = useTheme()
 
   const handleSubmit = useCallback(

--- a/frontend/src/features/tasks/components/interactive/InteractiveSelect.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveSelect.tsx
@@ -103,7 +103,7 @@ export function InteractiveSelect({
                   {option.label}
                   {option.recommended && (
                     <Badge variant="secondary" className="text-xs">
-                      Recommended
+                      {t('interactive.recommended')}
                     </Badge>
                   )}
                 </Label>

--- a/frontend/src/features/tasks/components/interactive/InteractiveSelect.tsx
+++ b/frontend/src/features/tasks/components/interactive/InteractiveSelect.tsx
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useCallback } from 'react'
+import { Check, Send } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { Label } from '@/components/ui/label'
+import { Badge } from '@/components/ui/badge'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { InteractiveSelectDefinition, InteractiveResponsePayload } from './types'
+
+interface InteractiveSelectProps {
+  requestId: string
+  select: InteractiveSelectDefinition
+  taskId: number
+  onSubmit: (response: InteractiveResponsePayload) => void
+  disabled?: boolean
+}
+
+/**
+ * Interactive selection dialog component.
+ */
+export function InteractiveSelect({
+  requestId,
+  select,
+  taskId,
+  onSubmit,
+  disabled = false,
+}: InteractiveSelectProps) {
+  const { t } = useTranslation('chat')
+  const [selected, setSelected] = useState<string[]>(() => {
+    // Initialize with recommended options
+    return select.options.filter(o => o.recommended).map(o => o.value)
+  })
+  const [isSubmitted, setIsSubmitted] = useState(false)
+
+  const handleSingleSelect = useCallback((value: string) => {
+    setSelected([value])
+  }, [])
+
+  const handleMultiSelect = useCallback((value: string, checked: boolean) => {
+    if (checked) {
+      setSelected(prev => [...prev, value])
+    } else {
+      setSelected(prev => prev.filter(v => v !== value))
+    }
+  }, [])
+
+  const handleSubmit = useCallback(() => {
+    setIsSubmitted(true)
+
+    const response: InteractiveResponsePayload = {
+      request_id: requestId,
+      response_type: 'select',
+      data: { selected: select.multiple ? selected : selected[0] },
+      task_id: taskId,
+    }
+
+    onSubmit(response)
+  }, [requestId, selected, select.multiple, taskId, onSubmit])
+
+  const isDisabled = disabled || isSubmitted
+
+  return (
+    <div className="space-y-4 p-4 rounded-lg border border-blue-500/30 bg-blue-500/5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="text-lg">📋</span>
+        <h3 className="text-base font-semibold text-blue-600">{select.title}</h3>
+      </div>
+
+      {select.description && (
+        <p className="text-sm text-text-secondary mb-4">{select.description}</p>
+      )}
+
+      <div className="space-y-2">
+        {select.multiple ? (
+          // Multiple selection with checkboxes
+          select.options.map(option => (
+            <div
+              key={option.value}
+              className={`flex items-start space-x-3 p-3 rounded-lg border transition-colors ${
+                selected.includes(option.value)
+                  ? 'border-blue-500 bg-blue-500/10'
+                  : 'border-border bg-surface/50'
+              }`}
+            >
+              <Checkbox
+                id={`select-${option.value}`}
+                checked={selected.includes(option.value)}
+                onCheckedChange={checked => handleMultiSelect(option.value, !!checked)}
+                disabled={isDisabled}
+              />
+              <div className="flex-1">
+                <Label
+                  htmlFor={`select-${option.value}`}
+                  className="flex items-center gap-2 cursor-pointer font-medium"
+                >
+                  {option.label}
+                  {option.recommended && (
+                    <Badge variant="secondary" className="text-xs">
+                      Recommended
+                    </Badge>
+                  )}
+                </Label>
+                {option.description && (
+                  <p className="text-sm text-text-muted mt-1">{option.description}</p>
+                )}
+              </div>
+            </div>
+          ))
+        ) : (
+          // Single selection with radio buttons
+          <RadioGroup
+            value={selected[0] ?? ''}
+            onValueChange={handleSingleSelect}
+            disabled={isDisabled}
+            className="space-y-2"
+          >
+            {select.options.map(option => (
+              <div
+                key={option.value}
+                className={`flex items-start space-x-3 p-3 rounded-lg border transition-colors ${
+                  selected.includes(option.value)
+                    ? 'border-blue-500 bg-blue-500/10'
+                    : 'border-border bg-surface/50'
+                }`}
+              >
+                <RadioGroupItem value={option.value} id={`select-${option.value}`} />
+                <div className="flex-1">
+                  <Label
+                    htmlFor={`select-${option.value}`}
+                    className="flex items-center gap-2 cursor-pointer font-medium"
+                  >
+                    {option.label}
+                    {option.recommended && (
+                      <Badge variant="secondary" className="text-xs">
+                        Recommended
+                      </Badge>
+                    )}
+                  </Label>
+                  {option.description && (
+                    <p className="text-sm text-text-muted mt-1">{option.description}</p>
+                  )}
+                </div>
+              </div>
+            ))}
+          </RadioGroup>
+        )}
+      </div>
+
+      {!isSubmitted ? (
+        <div className="flex justify-end pt-2">
+          <Button
+            variant="secondary"
+            onClick={handleSubmit}
+            disabled={isDisabled || selected.length === 0}
+          >
+            <Send className="w-4 h-4 mr-2" />
+            {t('interactive.submit_selection') || 'Submit Selection'}
+          </Button>
+        </div>
+      ) : (
+        <div className="text-center text-sm text-text-muted pt-2 flex items-center justify-center gap-1">
+          <Check className="w-4 h-4 text-green-600" />
+          {t('interactive.selection_submitted') || 'Selection submitted'}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/interactive/index.ts
+++ b/frontend/src/features/tasks/components/interactive/index.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { InteractiveMessage } from './InteractiveMessage'
+export { InteractiveForm } from './InteractiveForm'
+export { InteractiveFormField } from './InteractiveFormField'
+export { InteractiveConfirm } from './InteractiveConfirm'
+export { InteractiveSelect } from './InteractiveSelect'
+export { AttachmentDisplay } from './AttachmentDisplay'
+export type {
+  InteractiveMessagePayload,
+  InteractiveFormDefinition,
+  InteractiveConfirmDefinition,
+  InteractiveSelectDefinition,
+  InteractiveFormFieldType,
+  InteractiveFieldOption,
+  InteractiveFieldValidation,
+  InteractiveShowCondition,
+  InteractiveAttachment,
+} from './types'

--- a/frontend/src/features/tasks/components/interactive/types.ts
+++ b/frontend/src/features/tasks/components/interactive/types.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for interactive messages from MCP tools.
+ */
+
+export interface InteractiveAttachment {
+  name: string
+  url: string
+  mime_type: string
+  size?: number
+}
+
+export interface InteractiveFieldOption {
+  value: string
+  label: string
+  recommended?: boolean
+}
+
+export interface InteractiveFieldValidation {
+  required?: boolean
+  min_length?: number
+  max_length?: number
+  min?: number
+  max?: number
+  pattern?: string
+  pattern_message?: string
+}
+
+export interface InteractiveShowCondition {
+  field_id: string
+  operator: 'equals' | 'not_equals' | 'contains' | 'in'
+  value: unknown
+}
+
+export type InteractiveFormFieldType =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'datetime'
+
+export interface InteractiveFormField {
+  field_id: string
+  field_type: InteractiveFormFieldType
+  label: string
+  placeholder?: string
+  default_value?: unknown
+  options?: InteractiveFieldOption[]
+  validation?: InteractiveFieldValidation
+  show_when?: InteractiveShowCondition
+}
+
+export interface InteractiveFormDefinition {
+  title: string
+  description?: string
+  fields: InteractiveFormField[]
+  submit_button_text?: string
+}
+
+export interface InteractiveConfirmDefinition {
+  title: string
+  message: string
+  confirm_text?: string
+  cancel_text?: string
+}
+
+export interface InteractiveSelectOption {
+  value: string
+  label: string
+  description?: string
+  recommended?: boolean
+}
+
+export interface InteractiveSelectDefinition {
+  title: string
+  options: InteractiveSelectOption[]
+  multiple?: boolean
+  description?: string
+}
+
+export type InteractiveMessageType = 'text' | 'markdown' | 'form' | 'confirm' | 'select'
+
+export interface InteractiveMessagePayload {
+  request_id: string
+  message_type: InteractiveMessageType
+  content?: string
+  attachments?: InteractiveAttachment[]
+  form?: InteractiveFormDefinition
+  confirm?: InteractiveConfirmDefinition
+  select?: InteractiveSelectDefinition
+  timestamp: string
+}
+
+export interface InteractiveResponsePayload {
+  request_id: string
+  response_type: 'form_submit' | 'confirm' | 'select'
+  data: Record<string, unknown>
+  task_id: number
+}

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -477,5 +477,22 @@
     "proceeding_to_stage": "Proceeding to stage: {{stage}}",
     "pipeline_completed": "Pipeline completed",
     "no_task_id": "No task ID available"
+  },
+  "interactive": {
+    "submit": "Submit",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "confirmed": "Confirmed",
+    "cancelled": "Cancelled",
+    "form_submitted": "Form submitted",
+    "submit_selection": "Submit Selection",
+    "selection_submitted": "Selection submitted",
+    "field_required": "This field is required",
+    "select_at_least_one": "Please select at least one option",
+    "min_length": "Minimum {{min}} characters required",
+    "max_length": "Maximum {{max}} characters allowed",
+    "min_value": "Minimum value is {{min}}",
+    "max_value": "Maximum value is {{max}}",
+    "invalid_format": "Invalid format"
   }
 }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -493,6 +493,7 @@
     "max_length": "Maximum {{max}} characters allowed",
     "min_value": "Minimum value is {{min}}",
     "max_value": "Maximum value is {{max}}",
-    "invalid_format": "Invalid format"
+    "invalid_format": "Invalid format",
+    "recommended": "Recommended"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -477,5 +477,22 @@
     "proceeding_to_stage": "正在进入阶段: {{stage}}",
     "pipeline_completed": "流水线已完成",
     "no_task_id": "没有可用的任务 ID"
+  },
+  "interactive": {
+    "submit": "提交",
+    "cancel": "取消",
+    "confirm": "确认",
+    "confirmed": "已确认",
+    "cancelled": "已取消",
+    "form_submitted": "表单已提交",
+    "submit_selection": "提交选择",
+    "selection_submitted": "选择已提交",
+    "field_required": "此字段为必填项",
+    "select_at_least_one": "请至少选择一个选项",
+    "min_length": "最少需要 {{min}} 个字符",
+    "max_length": "最多允许 {{max}} 个字符",
+    "min_value": "最小值为 {{min}}",
+    "max_value": "最大值为 {{max}}",
+    "invalid_format": "格式无效"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -493,6 +493,7 @@
     "max_length": "最多允许 {{max}} 个字符",
     "min_value": "最小值为 {{min}}",
     "max_value": "最大值为 {{max}}",
-    "invalid_format": "格式无效"
+    "invalid_format": "格式无效",
+    "recommended": "推荐"
   }
 }

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -59,6 +59,9 @@ export const ServerEvents = {
   // Generic Skill Events
   SKILL_REQUEST: 'skill:request', // Server -> Client: generic skill request
 
+  // Interactive Message Events (MCP tools)
+  INTERACTIVE_MESSAGE: 'interactive:message', // Server -> Client: interactive message
+
   // Mermaid rendering events (deprecated, use SKILL_REQUEST instead)
   MERMAID_RENDER: 'mermaid:render',
 } as const
@@ -510,4 +513,119 @@ export interface SkillResponsePayload {
   result?: unknown
   /** Error message if failed */
   error?: string | Record<string, unknown>
+}
+
+// ============================================================
+// Interactive Message Payloads (MCP tools)
+// ============================================================
+
+export const InteractiveEvents = {
+  /** Server -> Client: interactive message */
+  INTERACTIVE_MESSAGE: 'interactive:message',
+  /** Client -> Server: user response */
+  INTERACTIVE_RESPONSE: 'interactive:response',
+} as const
+
+export interface InteractiveAttachment {
+  name: string
+  url: string
+  mime_type: string
+  size?: number
+}
+
+export interface InteractiveFieldOption {
+  value: string
+  label: string
+  recommended?: boolean
+}
+
+export interface InteractiveFieldValidation {
+  required?: boolean
+  min_length?: number
+  max_length?: number
+  min?: number
+  max?: number
+  pattern?: string
+  pattern_message?: string
+}
+
+export interface InteractiveShowCondition {
+  field_id: string
+  operator: 'equals' | 'not_equals' | 'contains' | 'in'
+  value: unknown
+}
+
+export type InteractiveFormFieldType =
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'single_choice'
+  | 'multiple_choice'
+  | 'datetime'
+
+export interface InteractiveFormField {
+  field_id: string
+  field_type: InteractiveFormFieldType
+  label: string
+  placeholder?: string
+  default_value?: unknown
+  options?: InteractiveFieldOption[]
+  validation?: InteractiveFieldValidation
+  show_when?: InteractiveShowCondition
+}
+
+export interface InteractiveFormDefinition {
+  title: string
+  description?: string
+  fields: InteractiveFormField[]
+  submit_button_text?: string
+}
+
+export interface InteractiveConfirmDefinition {
+  title: string
+  message: string
+  confirm_text?: string
+  cancel_text?: string
+}
+
+export interface InteractiveSelectOption {
+  value: string
+  label: string
+  description?: string
+  recommended?: boolean
+}
+
+export interface InteractiveSelectDefinition {
+  title: string
+  options: InteractiveSelectOption[]
+  multiple?: boolean
+  description?: string
+}
+
+export type InteractiveMessageType = 'text' | 'markdown' | 'form' | 'confirm' | 'select'
+
+/**
+ * Payload for interactive:message event - Server to Client
+ * Sent by AI agents via MCP tools to display interactive content
+ */
+export interface InteractiveMessagePayload {
+  request_id: string
+  message_type: InteractiveMessageType
+  content?: string
+  attachments?: InteractiveAttachment[]
+  form?: InteractiveFormDefinition
+  confirm?: InteractiveConfirmDefinition
+  select?: InteractiveSelectDefinition
+  timestamp: string
+}
+
+/**
+ * Payload for interactive:response event - Client to Server
+ * Sent by frontend when user responds to an interactive message
+ */
+export interface InteractiveResponsePayload {
+  request_id: string
+  response_type: 'form_submit' | 'confirm' | 'select'
+  data: Record<string, unknown>
+  task_id: number
 }


### PR DESCRIPTION
## Summary

Implement a built-in MCP Server that provides tools for AI agents to send interactive messages to users. This feature enables AI agents (Chat Shell, Claude Code, Agno) to proactively send messages, forms, confirmations, and selections to users, providing a more general AI-user interaction capability.

### Key Features

- **send_message**: Send text/markdown messages with optional attachments
- **send_form**: Send interactive forms with various field types (text, textarea, number, single_choice, multiple_choice, datetime)
- **send_confirm**: Send confirmation dialogs with customizable buttons
- **send_select**: Send selection dialogs (single or multiple)

### Architecture

- MCP Server located at `backend/app/mcp/`
- Tools communicate via WebSocket events (`interactive:message`, `interactive:response`)
- Task context injection via `WEGENT_TASK_ID` environment variable
- Frontend components in `frontend/src/features/tasks/components/interactive/`

### Changes

**Backend:**
- New MCP module with server, tools, schemas, and context management
- WebSocket event handlers for interactive messages
- MCP router registered at `/api/mcp/interactive`

**Frontend:**
- InteractiveMessage container component
- InteractiveForm, InteractiveConfirm, InteractiveSelect components
- AttachmentDisplay component
- SocketContext integration for interactive events
- i18n translations (English and Chinese)

**Tests:**
- Unit tests for MCP context management
- Unit tests for all schemas
- Unit tests for all tools with mocked WebSocket emitter

## Test Plan

- [ ] Verify MCP Server endpoints are accessible at `/api/mcp/interactive/tools` and `/api/mcp/interactive/call`
- [ ] Test send_message tool sends WebSocket events correctly
- [ ] Test send_form renders form in frontend with all field types
- [ ] Test send_confirm displays confirmation dialog
- [ ] Test send_select displays selection options
- [ ] Test user responses are converted to user messages
- [ ] Test i18n translations work for both English and Chinese
- [ ] Run backend unit tests: `cd backend && uv run pytest tests/mcp/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive messaging: in-chat forms, confirmations, selection dialogs, rich messages with attachments, and client response emission.
  * Server APIs to discover and invoke interactive tools (send message/form/confirm/select).

* **Frontend**
  * New interactive UI components: message router, form, form fields, confirm, select, and attachment display.
  * Socket client: register handlers for interactive messages.

* **Localization**
  * Added English and Chinese interactive UI and validation strings.

* **Tests**
  * Unit tests covering context, schemas, and all interactive tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->