### PR TITLE
Wegent/fix task rename doubleclick

### DIFF
--- a/frontend/src/features/projects/contexts/dndContext.tsx
+++ b/frontend/src/features/projects/contexts/dndContext.tsx
@@ -89,10 +89,13 @@ export function TaskDndProvider({ children }: TaskDndProviderProps) {
   }, [])
 
   // Configure sensors for both mouse and touch
+  // Use delay + distance constraint to allow double-click events to fire
+  // before drag activation. This prevents dnd-kit from blocking double-click.
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 8, // Minimum drag distance before activation
+        delay: 150, // Wait 150ms before activating drag to allow double-click
+        tolerance: 5, // Allow 5px movement during the delay
       },
     }),
     useSensor(TouchSensor, {

--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -545,6 +545,16 @@ export default function TaskListSection({
                           handleTaskClick(task)
                         }
                       }}
+                      onDoubleClick={e => {
+                        // Handle double-click on the entire row to start renaming
+                        // This is more reliable than on the span alone because TooltipTrigger
+                        // may interfere with pointer events on child elements
+                        if (editingTaskId !== task.id) {
+                          e.stopPropagation()
+                          e.preventDefault()
+                          handleStartRename(task.id)
+                        }
+                      }}
                       onTouchStart={handleTouchStart(task)}
                       onTouchMove={handleTouchMove}
                       onTouchEnd={handleTouchEnd(task)}
@@ -571,14 +581,7 @@ export default function TaskListSection({
                           }}
                         />
                       ) : (
-                        <span
-                          className="flex-1 min-w-0 text-sm text-text-primary leading-tight truncate"
-                          onDoubleClick={e => {
-                            e.stopPropagation()
-                            e.preventDefault()
-                            handleStartRename(task.id)
-                          }}
-                        >
+                        <span className="flex-1 min-w-0 text-sm text-text-primary leading-tight truncate">
                           {localTitles[task.id] ?? task.title}
                         </span>
                       )}


### PR DESCRIPTION
fixed bug: rename the task by doubleclick problem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed drag activation timing to allow double-click actions to complete before dragging begins.

* **New Features**
  * Double-click to rename tasks directly in the task list.
  * Single-click navigates to task details with improved responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->