### PR TITLE
fix(backend): increase database connection pool size

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -12,9 +12,16 @@ from app.core.config import settings
 SQLALCHEMY_DATABASE_URL = settings.DATABASE_URL
 
 # Create sync database engine with timezone configuration
+# Increase pool size to handle concurrent requests in E2E tests and production
+# Default SQLAlchemy: pool_size=5, max_overflow=10 (total 15 connections)
+# New settings: pool_size=10, max_overflow=20 (total 30 connections)
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
     pool_pre_ping=True,
+    pool_size=10,
+    max_overflow=20,
+    pool_timeout=30,
+    pool_recycle=3600,  # Recycle connections after 1 hour to avoid stale connections
     connect_args={"charset": "utf8mb4", "init_command": "SET time_zone = '+08:00'"},
 )
 


### PR DESCRIPTION
## Summary

- Increase SQLAlchemy connection pool size to prevent connection exhaustion during concurrent requests
- Fix intermittent E2E test failures caused by database connection pool timeout

## Problem

E2E tests running with 4 parallel workers were experiencing intermittent failures with:
```
QueuePool limit of size 5 overflow 10 reached, connection timed out, timeout 30.00
```

This caused API requests to wait up to 30 seconds for available database connections, resulting in page load timeouts (e.g., "Loading teams..." stuck for 20+ seconds).

## Solution

Updated `backend/app/db/session.py` to increase connection pool capacity:

| Setting | Before | After |
|---------|--------|-------|
| pool_size | 5 (default) | 10 |
| max_overflow | 10 (default) | 20 |
| **Total max connections** | **15** | **30** |

Also added:
- `pool_timeout=30` - explicit timeout setting
- `pool_recycle=3600` - recycle connections after 1 hour to avoid stale connections

## Test plan

- [ ] Verify backend starts successfully with new pool settings
- [ ] Run E2E tests to confirm intermittent failures are resolved
- [ ] Monitor database connection usage in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved database connection pool configuration to enhance application stability and performance, allowing for better handling of concurrent requests and preventing stale connection issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->