### PR TITLE
feat(frontend): add regenerate button for single chat

### DIFF
--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from 'react-i18next'
@@ -106,6 +106,45 @@ export const EditButton = ({
       }
     >
       <Pencil className="h-3.5 w-3.5 text-text-muted" />
+    </Button>
+  )
+
+  if (tooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  return button
+}
+
+// RegenerateButton component for regenerating the last AI response
+export const RegenerateButton = ({
+  onRegenerate,
+  className,
+  tooltip,
+  disabled,
+}: {
+  onRegenerate: () => void
+  className?: string
+  tooltip?: string
+  disabled?: boolean
+}) => {
+  const button = (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onRegenerate}
+      disabled={disabled}
+      className={
+        className ??
+        'h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec disabled:opacity-50'
+      }
+    >
+      <RefreshCw className="h-3.5 w-3.5 text-text-muted" />
     </Button>
   )
 

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -149,6 +149,8 @@ interface MessagesAreaProps {
   onSendMessage?: (content: string) => void
   isGroupChat?: boolean
   onRetry?: (message: Message) => void
+  /** Callback for regenerating the last AI message (single chat only) */
+  onRegenerate?: () => void
   // Correction mode props
   enableCorrectionMode?: boolean
   correctionModelId?: string | null
@@ -181,6 +183,7 @@ export default function MessagesArea({
   onSendMessage,
   isGroupChat = false,
   onRetry,
+  onRegenerate,
   enableCorrectionMode = false,
   correctionModelId = null,
   enableCorrectionWebSearch = false,
@@ -973,6 +976,15 @@ export default function MessagesArea({
               ? correctionResults.get(msg.subtaskId)
               : undefined
 
+            // Check if this is the last completed AI message (for regenerate button)
+            // Only show regenerate for single chat, not streaming, and completed AI messages
+            const isLastCompletedAIMessage =
+              msg.type === 'ai' &&
+              msg.status === 'completed' &&
+              !isGroupChat &&
+              !isStreaming &&
+              !messages.slice(index + 1).some(m => m.type === 'ai' && m.status === 'completed')
+
             // Use StreamingMessageBubble for streaming AI messages
             if (msg.type === 'ai' && msg.status === 'streaming') {
               return (
@@ -1085,6 +1097,8 @@ export default function MessagesArea({
                 onEdit={handleEditMessage}
                 onEditSave={handleEditSave}
                 onEditCancel={handleEditCancel}
+                isLastAIMessage={isLastCompletedAIMessage}
+                onRegenerate={isLastCompletedAIMessage ? onRegenerate : undefined}
               />
             )
           })}


### PR DESCRIPTION
## Summary
- Add "Regenerate" feature for the last AI message in single chat mode
- Regenerate button appears in the AI message action bar (after the download button)
- Only visible for the last completed AI message when not in streaming state and not in group chat
- Click to resend the corresponding user message and trigger a new AI response

## Changes Made
- **BubbleTools.tsx**: Added `RegenerateButton` component with RefreshCw icon
- **MessageBubble.tsx**: Extended props with `onRegenerate` and `isLastAIMessage`; integrated regenerate button into AI message toolbar
- **MessagesArea.tsx**: Added logic to identify the last completed AI message and pass regenerate handler
- **ChatArea.tsx**: Implemented `handleRegenerate` callback that finds and resends the last user message

## Display Conditions
- Single chat mode only (not displayed in group chat)
- Only on the last completed AI message
- Hidden during streaming state

## Interaction
1. User clicks regenerate icon
2. System finds the last user message before the AI response
3. Resends that user message to generate a new AI response

## i18n
Tooltip text uses existing translation keys:
- English: `Regenerate` (chat:actions.regenerate)
- Chinese: `重新生成` (chat:actions.regenerate)

## Test plan
- [ ] Verify regenerate button only appears on the last AI message in single chat
- [ ] Verify regenerate button is hidden in group chat mode
- [ ] Verify regenerate button is hidden during streaming
- [ ] Click regenerate and verify a new AI response is generated
- [ ] Verify tooltip shows correct translation in both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Regenerate button for AI messages, enabling users to generate fresh responses without retyping their original message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->