### PR TITLE
feat(chat): add regenerate button for last AI message in single chat

### DIFF
--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from 'react-i18next'
@@ -142,6 +142,8 @@ export interface BubbleToolsProps {
     like: string
     dislike: string
   }
+  /** Optional callback for regenerating the AI response (only shown when provided) */
+  onRegenerate?: () => void
 }
 
 // Bubble toolbar: supports copy button, feedback buttons, and extensible tool buttons
@@ -153,6 +155,7 @@ const BubbleTools = ({
   onLike,
   onDislike,
   feedbackLabels,
+  onRegenerate,
 }: BubbleToolsProps) => {
   const { t } = useTranslation()
 
@@ -196,6 +199,22 @@ const BubbleTools = ({
         </TooltipTrigger>
         <TooltipContent>{feedbackLabels?.dislike || 'Dislike'}</TooltipContent>
       </Tooltip>
+      {/* Regenerate button - only shown when onRegenerate is provided */}
+      {onRegenerate && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onRegenerate}
+              className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec"
+            >
+              <RefreshCw className="h-3.5 w-3.5 text-text-muted" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('chat:actions.regenerate') || 'Regenerate'}</TooltipContent>
+        </Tooltip>
+      )}
       {/* Additional tool buttons (e.g., download) */}
       {tools.map(tool => (
         <Tooltip key={tool.key}>

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -160,6 +160,8 @@ export interface MessageBubbleProps {
   onEditSave?: (content: string) => Promise<void>
   /** Callback when user cancels editing */
   onEditCancel?: () => void
+  /** Callback when user clicks regenerate button (only for last AI message in single chat) */
+  onRegenerate?: () => void
 }
 
 // Component for rendering a paragraph with hover action button
@@ -279,6 +281,7 @@ const MessageBubble = memo(
     onEdit,
     onEditSave,
     onEditCancel,
+    onRegenerate,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
     const { trace } = useTraceAction()
@@ -612,6 +615,7 @@ const MessageBubble = memo(
               like: t('chat:messages.like') || 'Like',
               dislike: t('chat:messages.dislike') || 'Dislike',
             }}
+            onRegenerate={onRegenerate}
           />
         </>
       )
@@ -1581,7 +1585,8 @@ const MessageBubble = memo(
       prevProps.msg.status === nextProps.msg.status &&
       prevProps.msg.error === nextProps.msg.error &&
       prevProps.isPendingConfirmation === nextProps.isPendingConfirmation &&
-      prevProps.isEditing === nextProps.isEditing
+      prevProps.isEditing === nextProps.isEditing &&
+      prevProps.onRegenerate === nextProps.onRegenerate
 
     return shouldSkipRender
   }

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -1157,9 +1157,11 @@ export default function MessagesArea({
                 onRegenerate={
                   // Only show regenerate button for:
                   // 1. Single chat (not group chat)
-                  // 2. Last completed AI message
-                  // 3. Not streaming
+                  // 2. No messages currently streaming
+                  // 3. Last completed AI message
+                  // 4. Message status is completed
                   !isGroupChat &&
+                  !isStreaming &&
                   msg.type === 'ai' &&
                   index === lastCompletedAiMessageIndex &&
                   msg.status === 'completed'

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -754,11 +754,12 @@ export default function MessagesArea({
       }
     }
 
-    if (!lastUserMessage || !lastUserMessage.content) {
+    // Check all required fields including subtaskId
+    if (!lastUserMessage || !lastUserMessage.content || !lastUserMessage.subtaskId) {
       toast({
         variant: 'destructive',
         title: t('chat:errors.generic_error') || 'Error',
-        description: 'No user message found to regenerate',
+        description: t('chat:errors.no_message_to_regenerate') || 'No user message found to regenerate',
       })
       return
     }
@@ -769,26 +770,24 @@ export default function MessagesArea({
     try {
       // Delete the last user message and AI response using edit API
       // The editMessage API deletes the message and all subsequent messages
-      if (lastUserMessage.subtaskId) {
-        const response = await subtaskApis.editMessage(lastUserMessage.subtaskId, savedContent)
+      const response = await subtaskApis.editMessage(lastUserMessage.subtaskId, savedContent)
 
-        if (response.success) {
-          // Immediately clean up messages from the edited position in local state
-          cleanupMessagesAfterEdit(selectedTaskDetail.id, lastUserMessage.subtaskId)
+      if (response.success) {
+        // Immediately clean up messages from the edited position in local state
+        cleanupMessagesAfterEdit(selectedTaskDetail.id, lastUserMessage.subtaskId)
 
-          // Refresh task detail to reload messages from backend
-          await refreshSelectedTaskDetail(true)
+        // Refresh task detail to reload messages from backend
+        await refreshSelectedTaskDetail(true)
 
-          // Resend the saved user message to trigger new AI response
-          onSendMessage(savedContent)
-        }
+        // Resend the saved user message to trigger new AI response
+        onSendMessage(savedContent)
       }
     } catch (error) {
       console.error('Failed to regenerate response:', error)
       toast({
         variant: 'destructive',
-        title: t('chat:errors.generic_error') || 'Regenerate failed',
-        description: (error as Error)?.message || 'Failed to regenerate response',
+        title: t('chat:actions.regenerate_failed') || 'Regenerate failed',
+        description: (error as Error)?.message || t('chat:errors.regenerate_failed_desc') || 'Failed to regenerate response',
       })
     }
   }, [

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -12,6 +12,7 @@
     "clear": "Clear Chat",
     "copy": "Copy",
     "regenerate": "Regenerate",
+    "regenerate_failed": "Regenerate failed",
     "stop": "Stop",
     "retry": "Retry",
     "edit": "Edit",
@@ -196,7 +197,9 @@
     "network_error": "Network error: Please check your connection and try again",
     "timeout_error": "Request timeout: Service response time exceeded, please try again later",
     "generic_error": "Request failed: Unknown error, please try again or contact administrator",
-    "copy_error": "Copy error details"
+    "copy_error": "Copy error details",
+    "no_message_to_regenerate": "No user message found to regenerate",
+    "regenerate_failed_desc": "Failed to regenerate response"
   },
   "clarification": {
     "title": "Smart Follow-up",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -12,6 +12,7 @@
     "clear": "清空聊天",
     "copy": "复制",
     "regenerate": "重新生成",
+    "regenerate_failed": "重新生成失败",
     "stop": "停止",
     "retry": "重试",
     "edit": "编辑",
@@ -196,7 +197,9 @@
     "network_error": "网络连接失败：请检查网络连接后重试",
     "timeout_error": "请求超时：服务响应时间过长，请稍后重试",
     "generic_error": "请求失败：未知错误，请重试或联系管理员",
-    "copy_error": "复制错误详情"
+    "copy_error": "复制错误详情",
+    "no_message_to_regenerate": "未找到可重新生成的用户消息",
+    "regenerate_failed_desc": "重新生成回复失败"
   },
   "clarification": {
     "title": "智能追问 (Smart Follow-up)",


### PR DESCRIPTION
## Summary

Add a "Regenerate" button to the AI message toolbar that allows users to regenerate the last AI response in single chat mode.

## Changes

### BubbleTools.tsx
- Import `RefreshCw` icon from lucide-react
- Add optional `onRegenerate` callback prop to `BubbleToolsProps` interface
- Render regenerate button with tooltip after like/dislike buttons when `onRegenerate` is provided
- Use existing button style (`h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec`)

### MessageBubble.tsx
- Add `onRegenerate` prop to `MessageBubbleProps` interface
- Pass `onRegenerate` through to `BubbleTools` component in `renderMarkdownResult`
- Update memo comparison function to include `onRegenerate` for proper re-render detection

### MessagesArea.tsx
- Add `lastCompletedAiMessageIndex` memoized calculation to find the index of the last completed AI message
- Add `handleRegenerate` callback that:
  1. Finds the last user message (the question that generated the AI response)
  2. Saves the user message content
  3. Calls `editMessage` API to delete the user message and all subsequent messages
  4. Cleans up local message state
  5. Refreshes task detail
  6. Resends the saved user message to trigger a new AI response
- Pass `onRegenerate` to `MessageBubble` only when:
  - Not in group chat (`!isGroupChat`)
  - Message is AI type (`msg.type === 'ai'`)
  - Message is the last completed AI message (`index === lastCompletedAiMessageIndex`)
  - Message status is completed (`msg.status === 'completed'`)

## Features

- **Icon**: Uses `RefreshCw` icon (same as error retry button for consistency)
- **Position**: Appears after like/dislike buttons in the AI message toolbar
- **Tooltip**: Shows "Regenerate" (EN) / "重新生成" (zh-CN) on hover
- **Visibility conditions**:
  - Only visible in single chat (not group chat)
  - Only on the last completed AI message
  - Hidden during streaming
- **Error handling**: Shows toast notification on failure

## Test Plan

- [ ] Verify regenerate button appears only on the last AI message in single chat
- [ ] Verify regenerate button is hidden in group chat
- [ ] Verify regenerate button is hidden during streaming
- [ ] Verify clicking regenerate deletes the last Q&A pair and resends the user message
- [ ] Verify new AI response is generated after clicking regenerate
- [ ] Verify error toast is shown when regeneration fails
- [ ] Verify tooltip shows correct text in both EN and zh-CN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Regenerate action for AI messages: a Regenerate button appears in the message toolbar for the most recent AI reply, letting users resend their prompt to get a new response.

* **Localization**
  * Added English and Chinese strings for regenerate-related messages and errors (e.g., “Regenerate failed”, “No user message found to regenerate”).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->