### PR TITLE
feat(frontend): add regenerate button for single chat AI responses

### DIFF
--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from 'react-i18next'
@@ -142,6 +142,12 @@ export interface BubbleToolsProps {
     like: string
     dislike: string
   }
+  /** Handler for regenerate button click */
+  onRegenerate?: () => void
+  /** Whether regenerate button should be shown */
+  showRegenerate?: boolean
+  /** Whether regenerate is in progress */
+  isRegenerating?: boolean
 }
 
 // Bubble toolbar: supports copy button, feedback buttons, and extensible tool buttons
@@ -153,6 +159,9 @@ const BubbleTools = ({
   onLike,
   onDislike,
   feedbackLabels,
+  onRegenerate,
+  showRegenerate,
+  isRegenerating,
 }: BubbleToolsProps) => {
   const { t } = useTranslation()
 
@@ -165,6 +174,25 @@ const BubbleTools = ({
         tooltip={t('chat:actions.copy') || 'Copy'}
         className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec"
       />
+      {/* Regenerate button - only shown when showRegenerate is true */}
+      {showRegenerate && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onRegenerate}
+              disabled={isRegenerating}
+              className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 text-text-muted ${isRegenerating ? 'animate-spin' : ''}`}
+              />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{t('chat:actions.regenerate') || 'Regenerate'}</TooltipContent>
+        </Tooltip>
+      )}
       {/* Feedback buttons: like and dislike */}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -190,7 +190,9 @@ const BubbleTools = ({
               />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>{t('chat:actions.regenerate') || 'Regenerate'}</TooltipContent>
+          <TooltipContent>
+            {t('chat:regenerate.tooltip') || t('chat:actions.regenerate') || 'Regenerate'}
+          </TooltipContent>
         </Tooltip>
       )}
       {/* Feedback buttons: like and dislike */}

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -160,6 +160,12 @@ export interface MessageBubbleProps {
   onEditSave?: (content: string) => Promise<void>
   /** Callback when user cancels editing */
   onEditCancel?: () => void
+  /** Whether this is the last AI message */
+  isLastAiMessage?: boolean
+  /** Handler for regenerate action */
+  onRegenerate?: (msg: Message) => void
+  /** Whether regenerate is in progress */
+  isRegenerating?: boolean
 }
 
 // Component for rendering a paragraph with hover action button
@@ -279,6 +285,9 @@ const MessageBubble = memo(
     onEdit,
     onEditSave,
     onEditCancel,
+    isLastAiMessage,
+    onRegenerate,
+    isRegenerating,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
     const { trace } = useTraceAction()
@@ -612,6 +621,15 @@ const MessageBubble = memo(
               like: t('chat:messages.like') || 'Like',
               dislike: t('chat:messages.dislike') || 'Dislike',
             }}
+            showRegenerate={
+              !isGroupChat &&
+              isLastAiMessage &&
+              (msg.subtaskStatus === 'COMPLETED' || msg.status === 'completed') &&
+              msg.subtaskStatus !== 'RUNNING' &&
+              msg.status !== 'streaming'
+            }
+            onRegenerate={() => onRegenerate?.(msg)}
+            isRegenerating={isRegenerating}
           />
         </>
       )
@@ -1581,7 +1599,9 @@ const MessageBubble = memo(
       prevProps.msg.status === nextProps.msg.status &&
       prevProps.msg.error === nextProps.msg.error &&
       prevProps.isPendingConfirmation === nextProps.isPendingConfirmation &&
-      prevProps.isEditing === nextProps.isEditing
+      prevProps.isEditing === nextProps.isEditing &&
+      prevProps.isLastAiMessage === nextProps.isLastAiMessage &&
+      prevProps.isRegenerating === nextProps.isRegenerating
 
     return shouldSkipRender
   }

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -1007,6 +1007,16 @@ export default function MessagesArea({
     [appliedCorrections]
   )
 
+  // Pre-compute the last AI message subtaskId to avoid O(n²) complexity in render loop
+  const lastAiMessageSubtaskId = useMemo(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].type === 'ai') {
+        return messages[i].subtaskId
+      }
+    }
+    return null
+  }, [messages])
+
   return (
     <div
       className="flex-1 w-full max-w-3xl mx-auto flex flex-col"
@@ -1029,16 +1039,8 @@ export default function MessagesArea({
               msg.type === 'user' ? (isGroupChat ? msg.senderUserId === user?.id : true) : false
 
             // Calculate if this is the last AI message (for regenerate button)
-            // Find the last AI message index by iterating from the end
-            const isLastAiMessage = (() => {
-              if (msg.type !== 'ai') return false
-              for (let i = messages.length - 1; i >= 0; i--) {
-                if (messages[i].type === 'ai') {
-                  return messages[i].subtaskId === msg.subtaskId
-                }
-              }
-              return false
-            })()
+            const isLastAiMessage =
+              msg.type === 'ai' && msg.subtaskId === lastAiMessageSubtaskId
 
             // Check if this AI message has a correction result
             const hasCorrectionResult =

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -736,9 +736,9 @@ export default function MessagesArea({
 
   // Handle regenerate - find the user message before the AI message and resend it
   const handleRegenerate = useCallback(
-    async (aiMessage: DisplayMessage) => {
-      // 1. Find the index of this AI message
-      const aiIndex = messages.findIndex(m => m.id === aiMessage.id)
+    async (aiMessage: Message) => {
+      // 1. Find the index of this AI message by subtaskId
+      const aiIndex = messages.findIndex(m => m.subtaskId === aiMessage.subtaskId)
       if (aiIndex < 0) return
 
       // 2. Find the preceding user message
@@ -1034,7 +1034,7 @@ export default function MessagesArea({
               if (msg.type !== 'ai') return false
               for (let i = messages.length - 1; i >= 0; i--) {
                 if (messages[i].type === 'ai') {
-                  return messages[i].id === msg.id
+                  return messages[i].subtaskId === msg.subtaskId
                 }
               }
               return false

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -27,6 +27,10 @@
     "confirm_button": "Confirm",
     "confirming": "Processing..."
   },
+  "regenerate": {
+    "failed": "Failed to regenerate response",
+    "tooltip": "Regenerate response"
+  },
   "quote": {
     "ask_wegent": "Ask Wegent",
     "quoted_text": "Quoted text",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -27,6 +27,10 @@
     "confirm_button": "确认",
     "confirming": "处理中..."
   },
+  "regenerate": {
+    "failed": "重新生成失败",
+    "tooltip": "重新生成回复"
+  },
   "quote": {
     "ask_wegent": "询问 Wegent",
     "quoted_text": "引用内容",


### PR DESCRIPTION
## Summary

- Add a "Regenerate" button to single chat mode that allows users to regenerate the last AI response
- The button appears only on the last AI message when the response is completed (not streaming)
- Clicking the button triggers: edit the user message with same content → delete subsequent messages → resend to trigger new AI response
- Add i18n support for both English and Chinese

## Changes

1. **BubbleTools.tsx**:
   - Import `RefreshCw` icon from lucide-react
   - Add new props: `onRegenerate`, `showRegenerate`, `isRegenerating`
   - Add regenerate button with tooltip, placed after copy button and before like/dislike buttons
   - Show spinning animation when regenerating

2. **MessageBubble.tsx**:
   - Add new props: `isLastAiMessage`, `onRegenerate`, `isRegenerating`
   - Calculate `showRegenerate` condition: non-group chat + last AI message + completed status + not streaming
   - Pass regenerate props to BubbleTools component
   - Update memo comparison function to include new props

3. **MessagesArea.tsx**:
   - Add `isRegenerating` state
   - Implement `handleRegenerate` function that:
     - Finds the user message before the AI message
     - Calls edit API with the same content (deletes AI response)
     - Cleans up local messages
     - Resends the user message to trigger new AI response
   - Calculate `isLastAiMessage` in the render loop
   - Pass regenerate props to MessageBubble

4. **i18n files**:
   - Add `regenerate.failed` and `regenerate.tooltip` translations for both English and Chinese

## Test plan

- [ ] Verify regenerate button appears only on the last AI message in single chat mode
- [ ] Verify regenerate button does NOT appear in group chat mode
- [ ] Verify regenerate button does NOT appear during streaming
- [ ] Verify clicking regenerate button triggers new AI response with same question
- [ ] Verify button shows spinning animation during regeneration
- [ ] Verify error toast appears if regeneration fails
- [ ] Verify translations work for both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a "Regenerate response" button to message bubbles for the last completed AI reply in non-group chats.
  * Button triggers regeneration, shows a loading/disabled state while in progress, and respects message completion status.
  * Regeneration can be initiated from message controls and updates conversation state when invoked.
* **Documentation**
  * Added English and Chinese localization for regenerate tooltip and error message.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->