### PR TITLE
fix(frontend): optimize repository selector dropdown width for long URLs

### DIFF
--- a/frontend/src/features/tasks/components/selector/MobileRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileRepositorySelector.tsx
@@ -116,7 +116,7 @@ export default function MobileRepositorySelector({
       </PopoverTrigger>
       <PopoverContent
         className={cn(
-          'p-0 w-[280px] border border-border bg-base',
+          'p-0 w-auto min-w-[280px] max-w-[min(500px,90vw)] border border-border bg-base',
           'shadow-xl rounded-xl overflow-hidden',
           'max-h-[400px] flex flex-col'
         )}

--- a/frontend/src/features/tasks/components/selector/RepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/RepositorySelector.tsx
@@ -132,7 +132,7 @@ export default function RepositorySelector({
           </TooltipProvider>
           <PopoverContent
             className={cn(
-              'p-0 w-auto min-w-[280px] max-w-[90vw] border border-border bg-base',
+              'p-0 w-auto min-w-[280px] max-w-[min(500px,90vw)] border border-border bg-base',
               'shadow-xl rounded-xl overflow-hidden',
               'max-h-[var(--radix-popover-content-available-height,400px)]',
               'flex flex-col'
@@ -254,7 +254,7 @@ export default function RepositorySelector({
           noMatchText={t('branches.no_match')}
           className={fullWidth ? 'w-full' : undefined}
           triggerClassName="w-full border-0 shadow-none h-auto py-0 px-0 hover:bg-transparent focus:ring-0"
-          contentClassName={fullWidth ? 'max-w-[400px]' : 'max-w-[280px]'}
+          contentClassName="min-w-[280px] max-w-[min(500px,90vw)] w-auto"
           renderTriggerValue={item => (
             <span className="block" title={item?.label}>
               {item?.label ? truncateMiddle(item.label, fullWidth ? 60 : isMobile ? 20 : 25) : ''}


### PR DESCRIPTION
Adjust dropdown width settings for better display of long Git repository URLs:
- Set min-width to 280px and max-width to 500px for all modes
- Use CSS min() function: max-w-[min(500px,90vw)] to properly constrain width to smaller of 500px or 90vw on small screens
- Use w-auto for flexible width based on content
- Applied to desktop normal mode, desktop compact mode, and mobile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive layout for repository selection components. Width constraints now dynamically adapt to screen size while maintaining appropriate minimum and maximum limits, ensuring optimal usability and visual consistency across all device sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->