### PR TITLE
feat(frontend): add mark-all-read button to group chats section

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -645,8 +645,16 @@ function TaskHistorySection({
       {filteredGroupTasks.length > 0 && (
         <>
           {!isCollapsed && (
-            <div className="px-1 pb-1 text-xs font-medium text-text-muted">
-              {t('common:tasks.group_chats')}
+            <div className="px-1 pb-1 text-xs font-medium text-text-muted flex items-center justify-between">
+              <span>{t('common:tasks.group_chats')}</span>
+              {unreadGroupChats.length > 0 && (
+                <button
+                  onClick={handleMarkAllAsViewed}
+                  className="text-xs text-text-muted hover:text-text-primary transition-colors"
+                >
+                  {t('common:tasks.mark_all_read')} ({unreadGroupChats.length})
+                </button>
+              )}
             </div>
           )}
           <TaskListSection

--- a/frontend/src/features/tasks/contexts/taskContext.tsx
+++ b/frontend/src/features/tasks/contexts/taskContext.tsx
@@ -151,9 +151,15 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
     try {
       const results = await Promise.all(requests)
       const allItems = results.flatMap(res => res.items || [])
+      // Ensure is_group_chat is set for all group tasks
+      // This is needed because the API may not return this field
+      const itemsWithGroupFlag = allItems.map(item => ({
+        ...item,
+        is_group_chat: true,
+      }))
       const lastPageItems = results[results.length - 1]?.items || []
       return {
-        items: allItems,
+        items: itemsWithGroupFlag,
         hasMore: lastPageItems.length === limit,
         pages: pagesArr,
         error: false,

--- a/frontend/src/utils/taskViewStatus.ts
+++ b/frontend/src/utils/taskViewStatus.ts
@@ -148,12 +148,20 @@ export function isTaskUnread(task: Task): boolean {
 /**
  * Mark all tasks as viewed
  * Uses task's own timestamp (completed_at or updated_at) to avoid client/server time sync issues
+ * Supports both regular tasks (terminal states) and group chat tasks
  */
 export function markAllTasksAsViewed(tasks: Task[]): void {
   const statusMap = getTaskViewStatusMap()
 
   tasks.forEach(task => {
-    if (['COMPLETED', 'FAILED', 'CANCELLED'].includes(task.status)) {
+    // For group chat tasks, always mark as viewed using updated_at
+    if (task.is_group_chat) {
+      statusMap[task.id] = {
+        viewedAt: task.updated_at,
+        status: task.status,
+      }
+    } else if (['COMPLETED', 'FAILED', 'CANCELLED'].includes(task.status)) {
+      // For non-group-chat tasks, only mark terminal states
       // Use task's timestamp to ensure viewedAt >= taskUpdatedAt
       const viewedAt = task.completed_at || task.updated_at
       statusMap[task.id] = {


### PR DESCRIPTION
## Summary
- Add "Mark all as read" button to the group chats section header
- The button shows the unread count for group chats and allows marking all as read with one click
- Ensure `is_group_chat` flag is properly set for tasks loaded from group API
- Support group chat tasks in `markAllTasksAsViewed` function

## Changes
- `TaskSidebar.tsx`: Add mark-all-read button with flex layout to group chats header
- `taskContext.tsx`: Set `is_group_chat = true` for all tasks from `loadGroupPages`
- `taskViewStatus.ts`: Handle group chat tasks in `markAllTasksAsViewed` using `updated_at`

## Test plan
- [ ] Verify the "Mark all as read" button appears in the group chats section when there are unread messages
- [ ] Click the button and confirm all group chat messages are marked as read
- [ ] Verify the button disappears when there are no unread messages
- [ ] Verify the unread count displayed on the button is correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Mark all read" button in the Group Chats section. When unread group chats are present, users can now quickly mark all of them as viewed with a single click.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->