### PR TITLE
fix(backend): remove metadata prefix from memory filters

### DIFF
--- a/backend/app/services/memory/client.py
+++ b/backend/app/services/memory/client.py
@@ -188,7 +188,8 @@ class LongTermMemoryClient:
         Args:
             user_id: User ID (mem0 identifier)
             query: Search query text
-            filters: Optional metadata filters (e.g., {"metadata.task_id": 123})
+            filters: Optional metadata filters (e.g., {"task_id": "123", "project_id": "456"})
+                    Note: mem0 automatically adds "metadata." prefix, so use field names directly
             limit: Max results to return
             timeout: Override default timeout for this request
 
@@ -199,7 +200,7 @@ class LongTermMemoryClient:
             results = await client.search_memories(
                 user_id="123",
                 query="Python preferences",
-                filters={"metadata.task_id": 456},
+                filters={"task_id": "456"},
                 limit=5,
                 timeout=2.0
             )
@@ -367,7 +368,8 @@ class LongTermMemoryClient:
             user_id: Optional user ID filter
             agent_id: Optional agent ID filter
             run_id: Optional run ID filter
-            filters: Optional metadata filters (e.g., {"metadata.task_id": "123"})
+            filters: Optional metadata filters (e.g., {"task_id": "123", "project_id": "456"})
+                    Note: mem0 automatically adds "metadata." prefix, so use field names directly
                     This is a custom extension for metadata filtering.
             limit: Max results to return
             timeout: Override default timeout for this request
@@ -379,7 +381,7 @@ class LongTermMemoryClient:
             # Get all memories for a user with metadata filter
             results = await client.get_memories(
                 user_id="123",
-                filters={"metadata.task_id": "456"},
+                filters={"task_id": "456"},
                 limit=100
             )
         """

--- a/backend/app/services/memory/manager.py
+++ b/backend/app/services/memory/manager.py
@@ -143,7 +143,7 @@ class MemoryManager:
                 project_result = await self._client.search_memories(
                     user_id=user_id,
                     query=query,
-                    filters={"metadata.project_id": project_id},
+                    filters={"project_id": project_id},
                     limit=max_results,
                     timeout=search_timeout / 2,  # Use half timeout for first search
                 )
@@ -345,7 +345,7 @@ class MemoryManager:
                 # Step 1: Get memories with this task_id (metadata-only retrieval)
                 search_result = await self._client.get_memories(
                     user_id=user_id,
-                    filters={"metadata.task_id": task_id},
+                    filters={"task_id": task_id},
                     limit=batch_size,
                 )
 

--- a/backend/tests/services/memory/test_manager.py
+++ b/backend/tests/services/memory/test_manager.py
@@ -145,7 +145,7 @@ async def test_search_memories_with_project_id(memory_manager):
 
     # First call should filter by project_id
     first_call_filters = mock_client.search_memories.call_args_list[0][1]["filters"]
-    assert first_call_filters == {"metadata.project_id": "proj-1"}
+    assert first_call_filters == {"project_id": "proj-1"}
 
     # Second call should have no filters (search all)
     second_call_filters = mock_client.search_memories.call_args_list[1][1]["filters"]


### PR DESCRIPTION
## Summary

Fixed memory filter prefix issue where `metadata.` prefix was incorrectly included in filter dictionaries. mem0 automatically adds the `metadata.` prefix to filter keys, so including it manually results in queries like `metadata.metadata.project_id` which fail to match any records.

This issue was discovered after PR #179 was merged and affects:
- Project-specific memory search (by `project_id`)
- Task memory cleanup (by `task_id`)

## Changes

1. **app/services/memory/manager.py**:
   - Removed `metadata.` prefix from `search_memories()` filters: `{"metadata.project_id": ...}` → `{"project_id": ...}`
   - Removed `metadata.` prefix from `cleanup_task_memories()` filters: `{"metadata.task_id": ...}` → `{"task_id": ...}`

2. **app/services/memory/client.py**:
   - Updated `search_memories()` docstring to show correct filter format
   - Updated `get_memories()` docstring to show correct filter format
   - Added note explaining mem0's automatic prefix behavior

3. **tests/services/memory/test_manager.py**:
   - Fixed test assertion to match new filter format: `{"project_id": "proj-1"}`

## Root Cause

mem0 API automatically adds `metadata.` prefix to all filter keys when processing queries. By manually including the prefix in our code, the actual query becomes:
- Intended: `metadata.project_id = "proj-1"`
- Actual (with manual prefix): `metadata.metadata.project_id = "proj-1"` ❌

This causes all filtered memory searches and cleanup operations to fail silently.

## Test plan

- [x] Run all memory service tests: `pytest tests/services/memory/ -v`
- [x] All 23 tests pass successfully
- [x] Verify filter format matches mem0 API expectations
- [x] Test assertions updated to reflect correct behavior

## Related

- Follow-up fix to PR #179 (timezone display fix)
- Discovered during code review of memory service implementation