### PR TITLE
fix(backend): set project_id to 0 instead of NULL when removing task from project

### DIFF
--- a/backend/app/api/endpoints/projects.py
+++ b/backend/app/api/endpoints/projects.py
@@ -191,7 +191,7 @@ def remove_task_from_project_endpoint(
 ):
     """
     Remove a task from a project.
-    The task itself is not deleted, only the project_id is set to NULL.
+    The task itself is not deleted, only the project_id is set to 0 (no project).
     """
     try:
         project_service.remove_task_from_project(

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -256,9 +256,9 @@ def delete_project(db: Session, project_id: int, user_id: int) -> None:
     if not project:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    # Clear project_id for all tasks in this project
+    # Clear project_id for all tasks in this project (set to 0, not NULL)
     db.query(TaskResource).filter(TaskResource.project_id == project_id).update(
-        {TaskResource.project_id: None}
+        {TaskResource.project_id: 0}
     )
 
     # Soft delete the project

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -378,8 +378,8 @@ def remove_task_from_project(
     if not task:
         raise HTTPException(status_code=404, detail="Task not found in project")
 
-    # Remove task from project by setting project_id to NULL
-    task.project_id = None
+    # Remove task from project by setting project_id to 0 (default value for no project)
+    task.project_id = 0
     db.commit()
 
 


### PR DESCRIPTION
## Summary

Fix IntegrityError when removing a task from a project. The error occurred because the code tried to set `project_id` to NULL, but the database column is defined as `NOT NULL` with a default value of 0.

**Error message:**
```
Failed to remove task from project: (pymysql.err.IntegrityError) (1048, "Column 'project_id' cannot be null")
```

## Root Cause

In the `TaskResource` model (`app/models/task.py`), the `project_id` column is defined as:
```python
project_id = Column(
    Integer,
    nullable=False,
    default=0,
    index=True,
    comment="Project ID for task grouping",
)
```

The field has `nullable=False`, meaning NULL values are not allowed. The default value of `0` is used to represent tasks that don't belong to any project.

## Changes

### app/services/project_service.py
- Changed `task.project_id = None` to `task.project_id = 0`
- Updated comment to clarify that 0 represents "no project"

### app/api/endpoints/projects.py
- Updated docstring to reflect that `project_id` is set to 0 instead of NULL

## Test plan

- [x] Code formatting verified with `black` and `isort`
- [ ] Manual testing: Remove a task from a project via UI (should succeed without error)
- [ ] Verify task appears in task list with project_id = 0
- [ ] CI/CD pipeline tests pass

## Related

This fix aligns with the existing database schema design where `project_id = 0` means "no project assignment".