### PR TITLE
refactor(backend): extract memory context building logic to shared ut…

### DIFF
--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -680,7 +680,7 @@ async def create_task_and_subtasks(
     import asyncio
 
     from app.core.config import settings
-    from app.services.memory import get_memory_manager
+    from app.services.memory import build_context_messages, get_memory_manager
 
     memory_manager = get_memory_manager()
     if memory_manager.is_enabled:
@@ -692,65 +692,15 @@ async def create_task_and_subtasks(
         )
         is_group_chat = task_crd.spec.is_group_chat
 
-        # Build context messages (recent history + current message)
-        context_messages = []
-        context_limit = settings.MEMORY_CONTEXT_MESSAGES
-
-        # Collect recent completed messages for context
-        # Filter for completed USER and ASSISTANT messages only
-        completed_subtasks = [
-            st
-            for st in existing_subtasks
-            if st.status == SubtaskStatus.COMPLETED
-            and st.role in (SubtaskRole.USER, SubtaskRole.ASSISTANT)
-        ]
-
-        # Get the last (context_limit - 1) completed messages as history
-        history_count = min(context_limit - 1, len(completed_subtasks))
-        for i in range(history_count):
-            subtask = completed_subtasks[i]
-            role = "user" if subtask.role == SubtaskRole.USER else "assistant"
-
-            # Extract content based on role
-            if subtask.role == SubtaskRole.USER:
-                content = subtask.prompt or ""
-            else:  # ASSISTANT
-                content = ""
-                if subtask.result and isinstance(subtask.result, dict):
-                    content = subtask.result.get("value", "")
-
-            # Skip empty messages
-            if not content:
-                continue
-
-            # For group chat user messages, add sender name prefix if not already present
-            if role == "user" and is_group_chat:
-                # Get sender user_name from user table
-                sender = (
-                    db.query(User).filter(User.id == subtask.sender_user_id).first()
-                )
-                sender_name = (
-                    sender.user_name if sender else f"User{subtask.sender_user_id}"
-                )
-                # Add prefix if not already present
-                if not content.startswith(f"User[{sender_name}]:"):
-                    content = f"User[{sender_name}]: {content}"
-
-            context_messages.append({"role": role, "content": content})
-
-        # Reverse to maintain chronological order (oldest to newest)
-        context_messages.reverse()
-
-        # Add current user message
-        current_content = message
-        if is_group_chat:
-            # Add sender name prefix to current message
-            # Use user_name if available, otherwise fall back to user_id
-            sender_name = user.user_name if user.user_name else str(user.user_id)
-            if not current_content.startswith(f"User[{sender_name}]:"):
-                current_content = f"User[{sender_name}]: {current_content}"
-
-        context_messages.append({"role": "user", "content": current_content})
+        # Build context messages using shared utility
+        context_messages = build_context_messages(
+            db=db,
+            existing_subtasks=existing_subtasks,
+            current_message=message,
+            current_user=user,
+            is_group_chat=is_group_chat,
+            context_limit=settings.MEMORY_CONTEXT_MESSAGES,
+        )
 
         # Create task with proper exception handling
         def _log_memory_task_exception(task_obj: asyncio.Task) -> None:

--- a/backend/app/services/memory/__init__.py
+++ b/backend/app/services/memory/__init__.py
@@ -19,5 +19,11 @@ Design principles:
 
 from app.services.memory.client import LongTermMemoryClient
 from app.services.memory.manager import MemoryManager, get_memory_manager
+from app.services.memory.utils import build_context_messages
 
-__all__ = ["LongTermMemoryClient", "MemoryManager", "get_memory_manager"]
+__all__ = [
+    "LongTermMemoryClient",
+    "MemoryManager",
+    "get_memory_manager",
+    "build_context_messages",
+]

--- a/backend/tests/services/memory/test_utils.py
+++ b/backend/tests/services/memory/test_utils.py
@@ -5,11 +5,15 @@
 """Unit tests for memory utility functions."""
 
 import re
+from datetime import datetime
+from unittest.mock import MagicMock
 
 import pytest
 
+from app.models.subtask import SenderType, Subtask, SubtaskRole, SubtaskStatus
+from app.models.user import User
 from app.services.memory.schemas import MemorySearchResult
-from app.services.memory.utils import inject_memories_to_prompt
+from app.services.memory.utils import build_context_messages, inject_memories_to_prompt
 
 
 def test_inject_memories_to_prompt_with_dates():
@@ -109,3 +113,241 @@ def test_inject_memories_to_prompt_invalid_date():
     # Should still include the memory, just without formatted date
     assert "Test memory" in result
     assert "<memory>" in result
+
+
+def test_build_context_messages_basic():
+    """Test building context messages with basic history."""
+    # Mock database session
+    db = MagicMock()
+
+    # Create mock user
+    current_user = User(id=1, user_name="alice")
+
+    # Create mock subtasks (existing history)
+    existing_subtasks = [
+        # Most recent first (sorted by message_id desc)
+        Subtask(
+            id=4,
+            message_id=4,
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.COMPLETED,
+            result={"value": "That's great!"},
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        ),
+        Subtask(
+            id=3,
+            message_id=3,
+            role=SubtaskRole.USER,
+            status=SubtaskStatus.COMPLETED,
+            prompt="I like Python",
+            sender_type=SenderType.USER,
+            sender_user_id=1,
+        ),
+        Subtask(
+            id=2,
+            message_id=2,
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.COMPLETED,
+            result={"value": "Hello!"},
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        ),
+        Subtask(
+            id=1,
+            message_id=1,
+            role=SubtaskRole.USER,
+            status=SubtaskStatus.COMPLETED,
+            prompt="Hi there",
+            sender_type=SenderType.USER,
+            sender_user_id=1,
+        ),
+    ]
+
+    # Build context with limit of 3 messages (2 history + 1 current)
+    result = build_context_messages(
+        db=db,
+        existing_subtasks=existing_subtasks,
+        current_message="How are you?",
+        current_user=current_user,
+        is_group_chat=False,
+        context_limit=3,
+    )
+
+    # Should have 3 messages total (2 from history + 1 current)
+    assert len(result) == 3
+
+    # Check chronological order (oldest to newest)
+    assert result[0] == {"role": "user", "content": "I like Python"}
+    assert result[1] == {"role": "assistant", "content": "That's great!"}
+    assert result[2] == {"role": "user", "content": "How are you?"}
+
+
+def test_build_context_messages_group_chat():
+    """Test building context messages for group chat with sender prefixes."""
+    # Mock database session
+    db = MagicMock()
+
+    # Create mock users
+    current_user = User(id=1, user_name="alice")
+    sender_bob = User(id=2, user_name="bob")
+
+    # Mock db.query().filter().first() to return sender_bob
+    db.query.return_value.filter.return_value.first.return_value = sender_bob
+
+    # Create mock subtasks with different senders
+    existing_subtasks = [
+        Subtask(
+            id=2,
+            message_id=2,
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.COMPLETED,
+            result={"value": "Hello Bob!"},
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        ),
+        Subtask(
+            id=1,
+            message_id=1,
+            role=SubtaskRole.USER,
+            status=SubtaskStatus.COMPLETED,
+            prompt="Hi everyone",
+            sender_type=SenderType.USER,
+            sender_user_id=2,  # Bob sent this
+        ),
+    ]
+
+    # Build context with group chat enabled
+    result = build_context_messages(
+        db=db,
+        existing_subtasks=existing_subtasks,
+        current_message="How are you all?",
+        current_user=current_user,
+        is_group_chat=True,
+        context_limit=3,
+    )
+
+    # Should have 3 messages
+    assert len(result) == 3
+
+    # Check sender prefixes are added
+    assert result[0] == {"role": "user", "content": "User[bob]: Hi everyone"}
+    assert result[1] == {"role": "assistant", "content": "Hello Bob!"}
+    assert result[2] == {"role": "user", "content": "User[alice]: How are you all?"}
+
+
+def test_build_context_messages_skip_incomplete():
+    """Test that incomplete subtasks are skipped."""
+    db = MagicMock()
+    current_user = User(id=1, user_name="alice")
+
+    # Mix of completed and incomplete subtasks
+    existing_subtasks = [
+        Subtask(
+            id=3,
+            message_id=3,
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.PENDING,  # Not completed
+            result={"value": "Incomplete response"},
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        ),
+        Subtask(
+            id=2,
+            message_id=2,
+            role=SubtaskRole.USER,
+            status=SubtaskStatus.COMPLETED,
+            prompt="Hello",
+            sender_type=SenderType.USER,
+            sender_user_id=1,
+        ),
+        Subtask(
+            id=1,
+            message_id=1,
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.FAILED,  # Failed
+            result={"value": "Failed response"},
+            sender_type=SenderType.TEAM,
+            sender_user_id=0,
+        ),
+    ]
+
+    result = build_context_messages(
+        db=db,
+        existing_subtasks=existing_subtasks,
+        current_message="Are you there?",
+        current_user=current_user,
+        is_group_chat=False,
+        context_limit=5,
+    )
+
+    # Should only have 2 messages: 1 completed history + 1 current
+    assert len(result) == 2
+    assert result[0] == {"role": "user", "content": "Hello"}
+    assert result[1] == {"role": "user", "content": "Are you there?"}
+
+
+def test_build_context_messages_empty_history():
+    """Test building context with no existing history."""
+    db = MagicMock()
+    current_user = User(id=1, user_name="alice")
+
+    result = build_context_messages(
+        db=db,
+        existing_subtasks=[],
+        current_message="First message",
+        current_user=current_user,
+        is_group_chat=False,
+        context_limit=3,
+    )
+
+    # Should only have the current message
+    assert len(result) == 1
+    assert result[0] == {"role": "user", "content": "First message"}
+
+
+def test_build_context_messages_exceeds_limit():
+    """Test that only the most recent messages are kept when exceeding limit."""
+    db = MagicMock()
+    current_user = User(id=1, user_name="alice")
+
+    # Create 10 completed subtasks
+    existing_subtasks = []
+    for i in range(10, 0, -1):  # Descending order (most recent first)
+        role = SubtaskRole.USER if i % 2 == 1 else SubtaskRole.ASSISTANT
+        existing_subtasks.append(
+            Subtask(
+                id=i,
+                message_id=i,
+                role=role,
+                status=SubtaskStatus.COMPLETED,
+                prompt=f"Message {i}" if role == SubtaskRole.USER else "",
+                result=(
+                    {"value": f"Response {i}"}
+                    if role == SubtaskRole.ASSISTANT
+                    else None
+                ),
+                sender_type=(
+                    SenderType.USER if role == SubtaskRole.USER else SenderType.TEAM
+                ),
+                sender_user_id=1 if role == SubtaskRole.USER else 0,
+            )
+        )
+
+    # Limit to 3 messages (2 history + 1 current)
+    result = build_context_messages(
+        db=db,
+        existing_subtasks=existing_subtasks,
+        current_message="Latest message",
+        current_user=current_user,
+        is_group_chat=False,
+        context_limit=3,
+    )
+
+    # Should have exactly 3 messages
+    assert len(result) == 3
+
+    # Should have the 2 most recent completed messages + current
+    assert result[0]["content"] == "Message 9"
+    assert result[1]["content"] == "Response 10"
+    assert result[2]["content"] == "Latest message"


### PR DESCRIPTION
…ility

Extract the context message building logic from task_manager.py and chat_session.py into a shared utility function build_context_messages() in app/services/memory/utils.py. This eliminates code duplication and ensures both modules follow the MEMORY_CONTEXT_MESSAGES configuration consistently.

Key changes:
- Add build_context_messages() function to memory/utils.py with proper telemetry support
- Update chat_session.py to use the shared utility instead of only sending the last message
- Update task_manager.py to use the shared utility, removing 58 lines of duplicated code
- Add comprehensive tests for the new utility function covering basic history, group chat, incomplete subtasks, empty history, and message limit scenarios

This fix ensures OpenAPI v1/responses endpoint respects the MEMORY_CONTEXT_MESSAGES setting (default: 3), providing better context for long-term memory storage.