### PR TITLE
refactor(backend): remove unused health_check method from mem0 client

### DIFF
--- a/backend/app/services/memory/client.py
+++ b/backend/app/services/memory/client.py
@@ -454,34 +454,3 @@ class LongTermMemoryClient:
         except Exception as e:
             logger.error("Unexpected error getting memories: %s", e, exc_info=True)
             return MemorySearchResponse(results=[])
-
-    @trace_async("mem0.client.health_check")
-    async def health_check(self) -> bool:
-        """Check if mem0 service is healthy.
-
-        Returns:
-            True if service is reachable and healthy, False otherwise
-        """
-        try:
-            session = await self._get_session()
-
-            async with session.get(
-                f"{self.base_url}/health",
-                headers=self._get_headers(),
-                timeout=aiohttp.ClientTimeout(total=self.timeout),
-            ) as resp:
-                return resp.status == 200
-
-        except asyncio.TimeoutError:
-            logger.warning(
-                "Memory service health check timed out after %.1fs", self.timeout
-            )
-            return False
-        except aiohttp.ClientError as e:
-            logger.warning(
-                "Memory service health check failed (connection error): %s", e
-            )
-            return False
-        except Exception:
-            logger.exception("Unexpected error during memory service health check")
-            return False

--- a/backend/tests/services/memory/test_client.py
+++ b/backend/tests/services/memory/test_client.py
@@ -141,28 +141,3 @@ async def test_delete_memory_not_found(memory_client) -> None:
         result = await memory_client.delete_memory("non-existent-id")
 
         assert result is False
-
-
-@pytest.mark.asyncio
-async def test_health_check_success(memory_client) -> None:
-    """Test health check when service is healthy."""
-    mock_response = MagicMock()
-    mock_response.status = 200
-
-    with patch("aiohttp.ClientSession.get") as mock_get:
-        mock_get.return_value.__aenter__.return_value = mock_response
-
-        result = await memory_client.health_check()
-
-        assert result is True
-
-
-@pytest.mark.asyncio
-async def test_health_check_failure(memory_client) -> None:
-    """Test health check when service is unhealthy."""
-    with patch("aiohttp.ClientSession.get") as mock_get:
-        mock_get.side_effect = aiohttp.ClientError("Connection failed")
-
-        result = await memory_client.health_check()
-
-        assert result is False


### PR DESCRIPTION
## Summary

- Remove the unused `health_check` method from `LongTermMemoryClient` class
- The external mem0 service does not actually support the `/health` endpoint
- The method was never used anywhere in the codebase (only in test files)
- Remove corresponding test cases (`test_health_check_success` and `test_health_check_failure`)

## Changes

1. **backend/app/services/memory/client.py**:
   - Removed `health_check` method (31 lines)

2. **backend/tests/services/memory/test_client.py**:
   - Removed `test_health_check_success` test case
   - Removed `test_health_check_failure` test case

## Test plan

- [x] Existing memory client unit tests pass (7 tests)
- [x] No other code references `health_check` method