### PR TITLE
fix(skills): remove sandbox caching and enforce minimum timeout

### DIFF
--- a/backend/init_data/skills/sandbox/SKILL.md
+++ b/backend/init_data/skills/sandbox/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Provides isolated sandbox execution environments for safely executing commands, running code, and managing filesystems. Ideal for code testing, file management, and command execution. The sandbox_claude tool is available for advanced use cases but should only be used when explicitly requested by the user."
+description: "Provides isolated sandbox execution environments (AlmaLinux 9.4) for safely executing commands, running code, and managing filesystems. Ideal for code testing, file management, and command execution. The sandbox_claude tool is available for advanced use cases but should only be used when explicitly requested by the user."
 displayName: "沙箱环境"
 version: "2.1.0"
 author: "Wegent Team"
@@ -41,7 +41,7 @@ tools:
 
 # Sandbox Environment
 
-Execute code, commands, and complex tasks securely in isolated Docker containers.
+Execute code, commands, and complex tasks securely in isolated Docker containers running **AlmaLinux 9.4**.
 
 ## Core Capabilities
 
@@ -111,7 +111,7 @@ Run Claude AI to execute complex tasks in the sandbox.
 - `prompt` (required): Task description for Claude
 - `allowed_tools` (optional): List of tools Claude can use
 - `append_system_prompt` (optional): Additional system prompt
-- `timeout` (optional): Timeout in seconds
+- `timeout` (optional): Timeout in seconds (minimum: 600 seconds / 10 minutes, default: 1800 seconds / 30 minutes)
 
 **Features:**
 - ⚡ Real-time streaming output
@@ -229,7 +229,18 @@ Write content to a file.
 }
 ```
 
-### Scenario 2: File Management
+### Scenario 2: Install System Packages (AlmaLinux)
+
+```json
+{
+  "name": "sandbox_command",
+  "arguments": {
+    "command": "dnf install -y gcc make && gcc --version"
+  }
+}
+```
+
+### Scenario 3: File Management
 
 ```json
 // 1. List files
@@ -258,7 +269,7 @@ Write content to a file.
 }
 ```
 
-### Scenario 3: Git Operations
+### Scenario 4: Git Operations
 
 ```json
 {
@@ -269,7 +280,7 @@ Write content to a file.
 }
 ```
 
-### Scenario 4: Using Claude (Only When Explicitly Requested)
+### Scenario 5: Using Claude (Only When Explicitly Requested)
 
 **Example user request**: "Please use Claude to generate a presentation about AI"
 
@@ -288,6 +299,14 @@ Write content to a file.
 
 ## Sandbox Environment
 
+### System Environment
+- **Operating System**: AlmaLinux 9.4 (RHEL 9 compatible)
+- **Architecture**: x86_64
+- **Package Manager**: dnf/yum
+- **Init System**: systemd
+- **Python**: 3.12+ (pre-installed)
+- **Shell**: bash
+
 ### Lifecycle
 - New sandbox created on first tool call
 - Subsequent calls in the same session reuse the sandbox
@@ -299,11 +318,11 @@ Write content to a file.
 - **Read file limit**: 1MB (configurable)
 - **Write file limit**: 10MB (configurable)
 - **Command timeout**: 300 seconds (5 minutes)
-- **Claude timeout**: 1800 seconds (30 minutes)
+- **Claude timeout**: 1800 seconds (30 minutes, minimum: 600 seconds / 10 minutes)
 - **Total task timeout**: 7200 seconds (2 hours)
 
 ### Security Features
-- ✅ Fully isolated Docker containers
+- ✅ Fully isolated Docker containers (AlmaLinux 9.4)
 - ✅ Network access control
 - ✅ Resource constraints
 - ✅ Automatic cleanup

--- a/backend/init_data/skills/sandbox/claude_tool.py
+++ b/backend/init_data/skills/sandbox/claude_tool.py
@@ -87,7 +87,7 @@ Parameters:
 
 Example:
 {
-  "prompt": "做一个chatgpt相关的ppt,5页左右，介绍chatgpt发展历史"
+  "prompt": "Create a PowerPoint presentation about ChatGPT with around 5 slides, introducing the history of ChatGPT"
 }"""
 
     args_schema: type[BaseModel] = SandboxClaudeInput

--- a/backend/init_data/skills/sandbox/claude_tool.py
+++ b/backend/init_data/skills/sandbox/claude_tool.py
@@ -73,28 +73,21 @@ class SandboxClaudeTool(BaseSandboxTool):
 
     name: str = "sandbox_claude"
     display_name: str = "执行 Claude 命令"
-    description: str = """Execute a Claude command in an isolated sandbox environment with streaming output.
+    description: str = """Execute a Claude command in an isolated sandbox environment.
 
-Use this tool to delegate tasks to Claude in a containerized environment, such as generating presentations, writing code, or creating documents.
+⚠️ ONLY use when user EXPLICITLY requests Claude by name (e.g., "use Claude to...", "让Claude帮我...").
+DO NOT use for normal sandbox operations - use sandbox_command, sandbox_read_file, etc. instead.
 
 Parameters:
-- prompt (required): The task prompt to send to Claude
-- allowed_tools (optional): Comma-separated list of allowed tools (default: "Edit,Write,MultiEdit,Bash(*),skills,Read,Glob,Grep,LS")
-- append_system_prompt (optional): Additional instructions for Claude
+- prompt (required): Task prompt for Claude
+- allowed_tools (optional): Allowed tools (default: "Edit,Write,MultiEdit,Bash(*),skills,Read,Glob,Grep,LS")
+- append_system_prompt (optional): Additional instructions
 - working_dir (optional): Working directory (default: /home/user)
-- timeout_seconds (optional): Command timeout in seconds
-
-Returns:
-- success: Whether the command executed successfully
-- output: Combined output from Claude execution
-- exit_code: Command exit code
-- execution_time: Time taken to execute
+- timeout_seconds (optional): Timeout in seconds (min: 600, default: 1800)
 
 Example:
 {
-  "prompt": "做一个chatgpt相关的ppt,5页左右，介绍chatgpt发展历史",
-  "allowed_tools": "Edit,Write,MultiEdit,Bash(*),skills,Read,Glob,Grep,LS",
-  "append_system_prompt": "执行任务时：\\n1. 首先检查并读取 .claude/skills/ 目录下的相关技能文件\\n2. 在回复开头明确说明【已加载的 Skill】和【应用的规范】\\n3. 如果没有找到相关 Skill，也请说明"
+  "prompt": "做一个chatgpt相关的ppt,5页左右，介绍chatgpt发展历史"
 }"""
 
     args_schema: type[BaseModel] = SandboxClaudeInput

--- a/backend/init_data/skills/sandbox/claude_tool.py
+++ b/backend/init_data/skills/sandbox/claude_tool.py
@@ -100,7 +100,9 @@ Example:
     args_schema: type[BaseModel] = SandboxClaudeInput
 
     # Default command timeout (30 minutes for Claude tasks)
+    # Minimum timeout is 10 minutes (600 seconds)
     default_command_timeout: int = 1800
+    min_command_timeout: int = 600
 
     def _run(
         self,
@@ -138,6 +140,14 @@ Example:
         """
         start_time = time.time()
         effective_timeout = timeout_seconds or self.default_command_timeout
+
+        # Ensure minimum timeout of 10 minutes
+        if effective_timeout < self.min_command_timeout:
+            logger.warning(
+                f"[SandboxClaudeTool] Requested timeout {effective_timeout}s is less than minimum {self.min_command_timeout}s, "
+                f"using minimum timeout instead"
+            )
+            effective_timeout = self.min_command_timeout
 
         logger.info(
             f"[SandboxClaudeTool] Executing Claude command: prompt={prompt[:100]}..., "


### PR DESCRIPTION
  ## Summary
  - Remove sandbox caching/reuse logic in Sandbox Skill to prevent stale reference issues
  - Enforce minimum timeout of 600 seconds (10 minutes) for sandbox_claude tool
  - Update documentation to specify AlmaLinux 9.4 as the sandbox operating system

  ## Changes
  - **backend/init_data/skills/sandbox/_base.py**: Removed `_sandbox` and `_sandbox_shell_type` caching fields, now always get or create sandbox from executor-manager
  - **backend/init_data/skills/sandbox/claude_tool.py**: Added `min_command_timeout = 600` and validation logic to enforce minimum timeout
  - **backend/init_data/skills/sandbox/SKILL.md**: Updated documentation to specify AlmaLinux 9.4, added system environment details, and package installation examples

  ## Test plan
  - Verify sandbox_claude tool creates fresh sandboxes on each invocation
  - Verify timeout validation rejects values below 600 seconds
  - Verify AlmaLinux-specific package installation (dnf) works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Sandbox docs updated to specify AlmaLinux 9.4, add system environment details, lifecycle/resource limits, and expanded AlmaLinux-focused example scenarios.

* **Bug Fixes**
  * Sandbox command timeout now enforces a 600s minimum.
  * Sandboxes are no longer reused between operations—each request gets a fresh sandbox to improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->