### PR TITLE
fix(frontend): fix project task delete UI not refreshing

### DIFF
--- a/frontend/src/features/projects/components/ProjectTaskMenu.tsx
+++ b/frontend/src/features/projects/components/ProjectTaskMenu.tsx
@@ -86,6 +86,11 @@ export function ProjectTaskMenu({ taskId, projectId, onRename }: ProjectTaskMenu
   const handleDeleteTask = async () => {
     try {
       await taskApis.deleteTask(taskId)
+      // Immediately remove from project's local state (same pattern as removeTaskFromProject)
+      // This ensures the UI updates immediately without waiting for refreshTasks
+      removeTaskFromProject(projectId, taskId).catch(() => {
+        // Ignore error since task is already deleted, just updating local state
+      })
       setSelectedTask(null)
       if (typeof window !== 'undefined') {
         const url = new URL(window.location.href)

--- a/frontend/src/features/projects/contexts/projectContext.tsx
+++ b/frontend/src/features/projects/contexts/projectContext.tsx
@@ -9,6 +9,7 @@ import { ProjectWithTasks, ProjectTask } from '@/types/api'
 import { projectApis, CreateProjectRequest, UpdateProjectRequest } from '@/apis/projects'
 import { useToast } from '@/hooks/use-toast'
 import { useTranslation } from '@/hooks/useTranslation'
+import { ApiError } from '@/apis/client'
 
 interface ProjectContextValue {
   // Data
@@ -245,8 +246,10 @@ export function ProjectProvider({ children }: { children: React.ReactNode }) {
         // since the task should no longer be associated with the project anyway
         const message = err instanceof Error ? err.message : 'Failed to remove task from project'
         // Only show error toast for unexpected errors, not for 404 (task not found)
+        // Check both ApiError status code and error message for "not found" (case-insensitive)
         const isNotFoundError =
-          err instanceof Error && (err.message.includes('404') || err.message.includes('not found'))
+          (err instanceof ApiError && err.status === 404) ||
+          (err instanceof Error && err.message.toLowerCase().includes('not found'))
         if (!isNotFoundError) {
           toast({
             title: t('toast.removeTaskFailed'),


### PR DESCRIPTION
## Summary

- Fix issue where deleting a task from project group doesn't immediately update the UI
- Call `removeTaskFromProject` after `deleteTask` to update project's local state
- Use optimistic update pattern in `removeTaskFromProject` for better UX
- Ignore 404 errors when removing task from project (task may already be deleted)

## Problem

When clicking "Delete Task" in a project group, the task remains visible in the UI until the page is refreshed. However, using "Remove from Group" works correctly and updates the UI immediately.

## Root Cause

In `ProjectTaskMenu.tsx`, the `handleDeleteTask` function only called `taskApis.deleteTask()` and `refreshTasks()`, but didn't update the `projectContext` local state. The "Remove from Group" feature calls `removeTaskFromProject()` which immediately updates the `projects` state in context.

## Solution

1. **ProjectTaskMenu.tsx**: Call `removeTaskFromProject()` after deleting the task to update the project's local state
2. **projectContext.tsx**: Use optimistic update pattern - update local state first, then call API. Also ignore 404 errors since the task may already be deleted

## Test plan

- [ ] Delete a task from a project group and verify the task disappears immediately
- [ ] Verify "Remove from Group" still works correctly
- [ ] Verify moving a task between groups still works correctly
- [ ] Verify deleting a task that was already removed doesn't show error toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Deleted tasks are removed from the UI immediately via optimistic updates for a snappier experience.
  * Error handling for deletions refined: missing/not-found cases are treated silently, while other failures surface contextual destructive notifications.
  * Existing deletion flow preserved; a subsequent refresh ensures eventual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->