### PR TITLE
feat: integrate PPTX generation skill for Chat Shell

### DIFF
--- a/backend/app/schemas/subtask_context.py
+++ b/backend/app/schemas/subtask_context.py
@@ -97,6 +97,7 @@ class SubtaskContextBrief(BaseModel):
     # Generated PPTX fields (from type_data)
     slide_count: Optional[int] = None
     preview_images: Optional[List[int]] = None  # List of attachment IDs for preview thumbnails
+    pptx_attachment_id: Optional[int] = None  # ID of the PPTX file attachment
 
     class Config:
         from_attributes = True
@@ -120,6 +121,7 @@ class SubtaskContextBrief(BaseModel):
         # Handle PPTX-specific fields
         slide_count = None
         preview_images = None
+        pptx_attachment_id = None
 
         if context_type_str == ContextType.TABLE.value:
             url = type_data.get("url")
@@ -141,6 +143,7 @@ class SubtaskContextBrief(BaseModel):
             # For generated PPTX, include slide count and preview images
             slide_count = type_data.get("slide_count")
             preview_images = type_data.get("preview_images", [])
+            pptx_attachment_id = type_data.get("pptx_attachment_id")
 
         return cls(
             id=context.id,
@@ -154,6 +157,7 @@ class SubtaskContextBrief(BaseModel):
             source_config=source_config,
             slide_count=slide_count,
             preview_images=preview_images,
+            pptx_attachment_id=pptx_attachment_id,
         )
 
 

--- a/backend/init_data/skills/pptx/SKILL.md
+++ b/backend/init_data/skills/pptx/SKILL.md
@@ -1,0 +1,139 @@
+---
+description: "Use this skill when you need to generate PowerPoint presentations (PPTX files) from content. The skill can create professional presentations with titles, bullet points, multiple slides, and various themes. Use this when users ask for slides, decks, presentations, or PPTX files."
+displayName: "Generate PPTX"
+version: "1.0.0"
+author: "Wegent Team"
+tags: ["presentation", "pptx", "powerpoint", "slides"]
+bindShells: ["Chat"]
+provider:
+  module: provider
+  class: PPTXToolProvider
+tools:
+  - name: generate_pptx
+    provider: pptx
+    config:
+      max_slides: 50
+      timeout: 120
+dependencies:
+  - python-pptx
+---
+
+# PowerPoint Presentation Generator
+
+Use this skill to create professional PowerPoint presentations from structured content.
+
+## Tool: generate_pptx
+
+Generate a PPTX file from structured slide data.
+
+### Parameters
+
+| Parameter | Type   | Required | Description                                                        |
+| --------- | ------ | -------- | ------------------------------------------------------------------ |
+| `title`   | string | Yes      | The presentation title (appears on title slide)                    |
+| `slides`  | array  | Yes      | Array of slide objects                                             |
+| `author`  | string | No       | Author name (appears on title slide)                               |
+| `theme`   | string | No       | Color theme: 'default', 'professional', 'creative', 'minimal'      |
+
+### Slide Object Structure
+
+Each slide in the `slides` array should have:
+
+| Field     | Type   | Required | Description                                                    |
+| --------- | ------ | -------- | -------------------------------------------------------------- |
+| `title`   | string | Yes      | Slide title                                                    |
+| `content` | string | Yes      | Slide content in markdown format (bullet points with - or *)   |
+| `notes`   | string | No       | Speaker notes for this slide                                   |
+| `layout`  | string | No       | Layout type: 'title', 'title_and_content', 'two_column', 'blank' |
+
+### Example Tool Call
+
+```json
+{
+  "name": "generate_pptx",
+  "arguments": {
+    "title": "Q4 Business Review",
+    "author": "John Smith",
+    "theme": "professional",
+    "slides": [
+      {
+        "title": "Executive Summary",
+        "content": "- Revenue increased by 25%\n- Customer satisfaction at 92%\n- New market expansion successful",
+        "notes": "Highlight the key achievements first"
+      },
+      {
+        "title": "Financial Performance",
+        "content": "- Total Revenue: $10M\n  - Product Sales: $7M\n  - Services: $3M\n- Operating Margin: 18%\n- Cash Flow: Positive",
+        "layout": "title_and_content"
+      },
+      {
+        "title": "Next Steps",
+        "content": "- Launch new product line in Q1\n- Expand to 3 new regions\n- Increase marketing budget by 15%"
+      }
+    ]
+  }
+}
+```
+
+### Response Format
+
+On success, the tool returns a JSON response with:
+
+```json
+{
+  "status": "success",
+  "message": "Generated presentation 'Q4 Business Review' with 4 slides",
+  "pptx_context_id": 123,
+  "filename": "Q4_Business_Review.pptx",
+  "slide_count": 4,
+  "file_size": 45678,
+  "download_url": "/api/attachments/123/download"
+}
+```
+
+## Best Practices
+
+### Content Structure
+
+1. **Keep slides focused**: Each slide should cover one main topic
+2. **Use bullet points**: Format content with `-` or `*` for bullet points
+3. **Nested bullets**: Use indentation (2 spaces + bullet) for sub-points
+4. **Limit text**: Keep to 5-7 bullet points per slide maximum
+
+### Example Content Formatting
+
+```markdown
+- Main point 1
+- Main point 2
+  - Sub-point 2.1
+  - Sub-point 2.2
+- Main point 3
+```
+
+### Theme Selection
+
+- **default**: Classic blue theme, suitable for most presentations
+- **professional**: Dark slate colors, corporate style
+- **creative**: Bold red/orange accents, dynamic feel
+- **minimal**: Grayscale, clean and modern
+
+### Workflow
+
+1. **Understand the requirement**: Clarify what content the user wants
+2. **Structure the content**: Organize into logical slides
+3. **Generate the PPTX**: Call the tool with structured data
+4. **Provide download link**: Share the download URL with the user
+
+### Error Handling
+
+If the tool returns an error:
+- Check that the title is not empty
+- Ensure at least one slide is provided
+- Verify slide content is properly formatted
+
+## Common Use Cases
+
+1. **Business presentations**: Quarterly reviews, project updates
+2. **Educational content**: Lecture slides, training materials
+3. **Proposals**: Project pitches, sales decks
+4. **Reports**: Data summaries, analysis presentations

--- a/backend/init_data/skills/pptx/__init__.py
+++ b/backend/init_data/skills/pptx/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PPTX skill package."""
+
+from .provider import PPTXToolProvider
+from .pptx_tool import PPTXGenerateTool
+
+__all__ = ["PPTXToolProvider", "PPTXGenerateTool"]

--- a/backend/init_data/skills/pptx/__init__.py
+++ b/backend/init_data/skills/pptx/__init__.py
@@ -7,4 +7,4 @@
 from .provider import PPTXToolProvider
 from .pptx_tool import PPTXGenerateTool
 
-__all__ = ["PPTXToolProvider", "PPTXGenerateTool"]
+__all__ = ["PPTXGenerateTool", "PPTXToolProvider"]

--- a/backend/init_data/skills/pptx/pptx_tool.py
+++ b/backend/init_data/skills/pptx/pptx_tool.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PPTX generation tool for the pptx skill."""
+
+from __future__ import annotations
+
+import json
+import logging
+from io import BytesIO
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class SlideInput(BaseModel):
+    """Schema for a single slide."""
+
+    title: str = Field(description="Slide title")
+    content: str = Field(
+        description="Slide content in markdown format (use - or * for bullets)"
+    )
+    notes: Optional[str] = Field(default=None, description="Speaker notes")
+    layout: str = Field(
+        default="title_and_content",
+        description="Layout: 'title', 'title_and_content', 'two_column', 'blank'",
+    )
+
+
+class PPTXGenerateInput(BaseModel):
+    """Input schema for PPTX generation tool."""
+
+    title: str = Field(description="Presentation title")
+    slides: list[dict[str, Any]] = Field(
+        description="Array of slide objects with title, content, optional notes and layout"
+    )
+    author: Optional[str] = Field(default=None, description="Author name")
+    theme: str = Field(
+        default="default",
+        description="Theme: 'default', 'professional', 'creative', 'minimal'",
+    )
+
+
+class PPTXGenerateTool(BaseTool):
+    """Tool for generating PowerPoint presentations."""
+
+    name: str = "generate_pptx"
+    display_name: str = "Generate PPTX"
+    description: str = (
+        "Generate a PowerPoint presentation from structured content. "
+        "Provide title, slides array (each with title, content as markdown), "
+        "optional author, and theme."
+    )
+    args_schema: type[BaseModel] = PPTXGenerateInput
+
+    # Configuration
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    user_name: str = ""
+    ws_emitter: Any = None
+    max_slides: int = 50
+    timeout: int = 120
+
+    def __init__(
+        self,
+        task_id: int = 0,
+        subtask_id: int = 0,
+        user_id: int = 0,
+        user_name: str = "",
+        ws_emitter: Any = None,
+        max_slides: int = 50,
+        timeout: int = 120,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.task_id = task_id
+        self.subtask_id = subtask_id
+        self.user_id = user_id
+        self.user_name = user_name
+        self.ws_emitter = ws_emitter
+        self.max_slides = max_slides
+        self.timeout = timeout
+
+    def _run(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: Optional[str] = None,
+        theme: str = "default",
+        **_,
+    ) -> str:
+        """Synchronous execution."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(title, slides, author, theme)
+        )
+
+    async def _arun(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: Optional[str] = None,
+        theme: str = "default",
+        **_,
+    ) -> str:
+        """Generate PPTX asynchronously."""
+        try:
+            # Validate input
+            if not title:
+                return json.dumps(
+                    {"status": "error", "error": "Presentation title is required"},
+                    ensure_ascii=False,
+                )
+            if not slides:
+                return json.dumps(
+                    {"status": "error", "error": "At least one slide is required"},
+                    ensure_ascii=False,
+                )
+            if len(slides) > self.max_slides:
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "error": f"Too many slides. Maximum allowed: {self.max_slides}",
+                    },
+                    ensure_ascii=False,
+                )
+
+            # Emit progress if ws_emitter available
+            if self.ws_emitter:
+                await self._emit_progress("starting", f"Generating '{title}'...")
+
+            # Generate PPTX
+            pptx_binary, slide_count = self._generate_pptx(
+                title=title,
+                slides=slides,
+                author=author or self.user_name,
+                theme=theme,
+            )
+
+            # Try to store via backend API
+            result = await self._store_pptx(title, pptx_binary, slide_count)
+
+            if self.ws_emitter:
+                await self._emit_progress("completed", f"Generated {slide_count} slides")
+
+            return json.dumps(result, ensure_ascii=False)
+
+        except Exception as e:
+            logger.exception(f"PPTX generation failed: {e}")
+            return json.dumps(
+                {"status": "error", "error": f"Generation failed: {str(e)}"},
+                ensure_ascii=False,
+            )
+
+    def _generate_pptx(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: str,
+        theme: str,
+    ) -> tuple[bytes, int]:
+        """Generate PPTX binary using python-pptx."""
+        from pptx import Presentation
+        from pptx.dml.color import RGBColor
+        from pptx.enum.text import PP_ALIGN
+        from pptx.util import Inches, Pt
+
+        # Theme colors
+        themes = {
+            "default": {"primary": "1F497D", "secondary": "4F81BD", "text": "333333"},
+            "professional": {
+                "primary": "2C3E50",
+                "secondary": "3498DB",
+                "text": "2C3E50",
+            },
+            "creative": {"primary": "E74C3C", "secondary": "F39C12", "text": "333333"},
+            "minimal": {"primary": "333333", "secondary": "666666", "text": "333333"},
+        }
+        colors = themes.get(theme, themes["default"])
+
+        # Create presentation
+        prs = Presentation()
+        prs.slide_width = Inches(13.333)  # 16:9
+        prs.slide_height = Inches(7.5)
+
+        # Title slide
+        title_slide = prs.slides.add_slide(prs.slide_layouts[6])  # Blank
+
+        title_box = title_slide.shapes.add_textbox(
+            Inches(0.5), Inches(2.5), Inches(12.333), Inches(1.5)
+        )
+        tf = title_box.text_frame
+        p = tf.paragraphs[0]
+        p.text = title
+        p.font.size = Pt(44)
+        p.font.bold = True
+        p.font.color.rgb = RGBColor.from_string(colors["primary"])
+        p.alignment = PP_ALIGN.CENTER
+
+        if author:
+            author_box = title_slide.shapes.add_textbox(
+                Inches(0.5), Inches(4.5), Inches(12.333), Inches(0.5)
+            )
+            af = author_box.text_frame
+            ap = af.paragraphs[0]
+            ap.text = author
+            ap.font.size = Pt(20)
+            ap.font.color.rgb = RGBColor.from_string(colors["secondary"])
+            ap.alignment = PP_ALIGN.CENTER
+
+        # Content slides
+        for slide_data in slides:
+            slide_title = slide_data.get("title", "")
+            content = slide_data.get("content", "")
+            notes = slide_data.get("notes", "")
+
+            content_slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+            # Slide title
+            if slide_title:
+                stb = content_slide.shapes.add_textbox(
+                    Inches(0.5), Inches(0.3), Inches(12.333), Inches(1)
+                )
+                stf = stb.text_frame
+                sp = stf.paragraphs[0]
+                sp.text = slide_title
+                sp.font.size = Pt(32)
+                sp.font.bold = True
+                sp.font.color.rgb = RGBColor.from_string(colors["primary"])
+
+            # Slide content
+            if content:
+                cb = content_slide.shapes.add_textbox(
+                    Inches(0.5), Inches(1.5), Inches(12.333), Inches(5.5)
+                )
+                cf = cb.text_frame
+                cf.word_wrap = True
+
+                lines = content.strip().split("\n")
+                for i, line in enumerate(lines):
+                    if i == 0:
+                        cp = cf.paragraphs[0]
+                    else:
+                        cp = cf.add_paragraph()
+
+                    line_text = line.strip()
+                    # Handle bullets
+                    if line_text.startswith("- ") or line_text.startswith("* "):
+                        cp.text = "• " + line_text[2:]
+                        cp.level = 0
+                    elif line_text.startswith("  - ") or line_text.startswith("  * "):
+                        cp.text = "  • " + line_text[4:]
+                        cp.level = 1
+                    else:
+                        cp.text = line_text
+
+                    cp.font.size = Pt(20)
+                    cp.font.color.rgb = RGBColor.from_string(colors["text"])
+
+            # Speaker notes
+            if notes and content_slide.has_notes_slide:
+                notes_slide = content_slide.notes_slide
+                notes_frame = notes_slide.notes_text_frame
+                notes_frame.text = notes
+
+        # Save to bytes
+        output = BytesIO()
+        prs.save(output)
+        return output.getvalue(), len(slides) + 1
+
+    async def _store_pptx(
+        self,
+        title: str,
+        pptx_binary: bytes,
+        slide_count: int,
+    ) -> dict[str, Any]:
+        """Store PPTX via backend API or return base64."""
+        import base64
+        import os
+
+        import httpx
+
+        filename = f"{title.replace(' ', '_')}.pptx"
+        api_url = os.environ.get("BACKEND_API_URL", "http://localhost:8000")
+        auth_token = os.environ.get("TASK_AUTH_TOKEN", "")
+
+        if api_url and auth_token:
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    files = {
+                        "file": (
+                            filename,
+                            pptx_binary,
+                            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+                        )
+                    }
+                    headers = {"Authorization": f"Bearer {auth_token}"}
+
+                    response = await client.post(
+                        f"{api_url}/api/attachments/upload",
+                        files=files,
+                        headers=headers,
+                    )
+
+                    if response.status_code == 200:
+                        data = response.json()
+                        return {
+                            "status": "success",
+                            "message": f"Generated presentation '{title}' with {slide_count} slides",
+                            "pptx_context_id": data.get("id"),
+                            "filename": filename,
+                            "slide_count": slide_count,
+                            "file_size": len(pptx_binary),
+                            "download_url": f"/api/attachments/{data.get('id')}/download",
+                        }
+            except Exception as e:
+                logger.warning(f"Failed to store via API: {e}")
+
+        # Fallback: return base64
+        return {
+            "status": "success",
+            "message": f"Generated presentation '{title}' with {slide_count} slides",
+            "filename": filename,
+            "slide_count": slide_count,
+            "file_size": len(pptx_binary),
+            "pptx_base64": base64.b64encode(pptx_binary).decode("utf-8"),
+            "note": "Download by decoding base64 and saving as .pptx",
+        }
+
+    async def _emit_progress(self, status: str, message: str) -> None:
+        """Emit progress via WebSocket."""
+        if self.ws_emitter:
+            try:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_output={"status": status, "message": message},
+                    status=status,
+                )
+            except Exception:
+                pass

--- a/backend/init_data/skills/pptx/provider.py
+++ b/backend/init_data/skills/pptx/provider.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PPTX skill provider for generating PowerPoint presentations."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+
+from chat_shell.skills.context import SkillToolContext
+from chat_shell.skills.provider import SkillToolProvider
+
+from .pptx_tool import PPTXGenerateTool
+
+
+class PPTXToolProvider(SkillToolProvider):
+    """Provider for PPTX generation tools."""
+
+    @property
+    def provider_name(self) -> str:
+        """Return the provider name for tool registration."""
+        return "pptx"
+
+    @property
+    def supported_tools(self) -> list[str]:
+        """Return list of tool names this provider supports."""
+        return ["generate_pptx"]
+
+    def create_tool(
+        self,
+        tool_name: str,
+        context: SkillToolContext,
+        tool_config: Optional[dict[str, Any]] = None,
+    ) -> BaseTool:
+        """Create a tool instance.
+
+        Args:
+            tool_name: Name of the tool to create
+            context: Skill execution context with task/user info
+            tool_config: Optional configuration for the tool
+
+        Returns:
+            BaseTool instance
+
+        Raises:
+            ValueError: If tool_name is not supported
+        """
+        config = tool_config or {}
+
+        if tool_name == "generate_pptx":
+            return PPTXGenerateTool(
+                task_id=context.task_id,
+                subtask_id=context.subtask_id,
+                user_id=context.user_id,
+                user_name=context.user_name,
+                ws_emitter=context.ws_emitter,
+                max_slides=config.get("max_slides", 50),
+                timeout=config.get("timeout", 120),
+            )
+        else:
+            raise ValueError(
+                f"Unknown tool '{tool_name}'. Supported tools: {self.supported_tools}"
+            )

--- a/backend/tests/services/test_pptx_context.py
+++ b/backend/tests/services/test_pptx_context.py
@@ -80,6 +80,7 @@ class TestSubtaskContextBriefPPTX:
         mock_context.type_data = {
             "slide_count": 15,
             "preview_images": [301, 302, 303],
+            "pptx_attachment_id": 400,
             "file_size": 100000,
             "file_extension": ".pptx",
             "mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -93,6 +94,7 @@ class TestSubtaskContextBriefPPTX:
         assert brief.status == "ready"
         assert brief.slide_count == 15
         assert brief.preview_images == [301, 302, 303]
+        assert brief.pptx_attachment_id == 400
         assert brief.file_size == 100000
         assert brief.file_extension == ".pptx"
 
@@ -118,6 +120,7 @@ class TestSubtaskContextBriefPPTX:
         # PPTX-specific fields should be None for attachment type
         assert brief.slide_count is None
         assert brief.preview_images is None
+        assert brief.pptx_attachment_id is None
 
 
 class TestContextTypeEnum:

--- a/backend/tests/services/test_pptx_context.py
+++ b/backend/tests/services/test_pptx_context.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for PPTX context storage functionality."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from app.schemas.subtask_context import (
+    ContextType,
+    GeneratedPPTXContextCreate,
+    GeneratedPPTXResponse,
+    SubtaskContextBrief,
+)
+
+
+class TestGeneratedPPTXSchemas:
+    """Tests for PPTX-related schema classes."""
+
+    def test_generated_pptx_context_create_minimal(self):
+        """Test minimal GeneratedPPTXContextCreate creation."""
+        data = GeneratedPPTXContextCreate(
+            name="test.pptx",
+            slide_count=5,
+            pptx_attachment_id=123,
+        )
+        assert data.name == "test.pptx"
+        assert data.slide_count == 5
+        assert data.pptx_attachment_id == 123
+        assert data.preview_images == []
+
+    def test_generated_pptx_context_create_with_previews(self):
+        """Test GeneratedPPTXContextCreate with preview images."""
+        data = GeneratedPPTXContextCreate(
+            name="presentation.pptx",
+            slide_count=10,
+            pptx_attachment_id=456,
+            preview_images=[101, 102, 103],
+        )
+        assert len(data.preview_images) == 3
+        assert data.preview_images == [101, 102, 103]
+
+    def test_generated_pptx_response_from_context(self):
+        """Test GeneratedPPTXResponse.from_context method."""
+        # Mock a SubtaskContext object
+        mock_context = MagicMock()
+        mock_context.id = 1
+        mock_context.name = "test_presentation.pptx"
+        mock_context.status = "ready"
+        mock_context.type_data = {
+            "slide_count": 8,
+            "pptx_attachment_id": 789,
+            "preview_images": [201, 202],
+            "file_size": 50000,
+        }
+        mock_context.created_at = None
+
+        response = GeneratedPPTXResponse.from_context(mock_context)
+
+        assert response.id == 1
+        assert response.name == "test_presentation.pptx"
+        assert response.status == "ready"
+        assert response.slide_count == 8
+        assert response.pptx_attachment_id == 789
+        assert response.preview_images == [201, 202]
+        assert response.file_size == 50000
+
+
+class TestSubtaskContextBriefPPTX:
+    """Tests for SubtaskContextBrief with PPTX type."""
+
+    def test_from_model_generated_pptx(self):
+        """Test SubtaskContextBrief.from_model for GENERATED_PPTX type."""
+        mock_context = MagicMock()
+        mock_context.id = 10
+        mock_context.context_type = ContextType.GENERATED_PPTX
+        mock_context.name = "quarterly_report.pptx"
+        mock_context.status = "ready"
+        mock_context.type_data = {
+            "slide_count": 15,
+            "preview_images": [301, 302, 303],
+            "file_size": 100000,
+            "file_extension": ".pptx",
+            "mime_type": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        }
+
+        brief = SubtaskContextBrief.from_model(mock_context)
+
+        assert brief.id == 10
+        assert brief.context_type == ContextType.GENERATED_PPTX
+        assert brief.name == "quarterly_report.pptx"
+        assert brief.status == "ready"
+        assert brief.slide_count == 15
+        assert brief.preview_images == [301, 302, 303]
+        assert brief.file_size == 100000
+        assert brief.file_extension == ".pptx"
+
+    def test_from_model_attachment_unchanged(self):
+        """Test that attachment type still works correctly."""
+        mock_context = MagicMock()
+        mock_context.id = 20
+        mock_context.context_type = ContextType.ATTACHMENT
+        mock_context.name = "document.pdf"
+        mock_context.status = "ready"
+        mock_context.type_data = {
+            "file_size": 25000,
+            "file_extension": ".pdf",
+            "mime_type": "application/pdf",
+        }
+
+        brief = SubtaskContextBrief.from_model(mock_context)
+
+        assert brief.id == 20
+        assert brief.context_type == ContextType.ATTACHMENT
+        assert brief.name == "document.pdf"
+        assert brief.file_size == 25000
+        # PPTX-specific fields should be None for attachment type
+        assert brief.slide_count is None
+        assert brief.preview_images is None
+
+
+class TestContextTypeEnum:
+    """Tests for ContextType enum."""
+
+    def test_generated_pptx_type_exists(self):
+        """Test that GENERATED_PPTX type is available."""
+        assert hasattr(ContextType, "GENERATED_PPTX")
+        assert ContextType.GENERATED_PPTX.value == "generated_pptx"
+
+    def test_all_context_types(self):
+        """Test all expected context types exist."""
+        expected_types = [
+            "attachment",
+            "knowledge_base",
+            "table",
+            "selected_documents",
+            "generated_pptx",
+        ]
+        for type_value in expected_types:
+            assert any(ct.value == type_value for ct in ContextType)

--- a/chat_shell/chat_shell/interface.py
+++ b/chat_shell/chat_shell/interface.py
@@ -63,6 +63,7 @@ class ChatRequest:
     enable_web_search: bool = False
     enable_clarification: bool = False
     enable_deep_thinking: bool = True
+    enable_pptx_generation: bool = False  # Enable PPTX generation tool
     search_engine: Optional[str] = None
 
     # Bot configuration

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -565,6 +565,21 @@ class ChatContext:
                 len(self._request.table_contexts),
             )
 
+        # Add PPTXGeneratorTool if enabled
+        if self._request.enable_pptx_generation:
+            from chat_shell.tools.builtin import PPTXGeneratorTool
+
+            pptx_tool = PPTXGeneratorTool(
+                task_id=self._request.task_id,
+                subtask_id=self._request.subtask_id,
+                user_id=self._request.user_id,
+            )
+            extra_tools.append(pptx_tool)
+            logger.debug(
+                "[CHAT_CONTEXT] Added PPTXGeneratorTool for task %d",
+                self._request.task_id,
+            )
+
         # === External Tools ===
 
         # Add KB tools

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -9,6 +9,7 @@ from .evaluation import SubmitEvaluationResultTool
 from .file_reader import FileListSkill, FileReaderSkill
 from .knowledge_base import KnowledgeBaseTool
 from .load_skill import LoadSkillTool
+from .pptx_generator import PPTXGeneratorTool
 from .web_search import WebSearchTool
 
 __all__ = [
@@ -19,4 +20,5 @@ __all__ = [
     "FileListSkill",
     "SubmitEvaluationResultTool",
     "LoadSkillTool",
+    "PPTXGeneratorTool",
 ]

--- a/chat_shell/chat_shell/tools/builtin/pptx_generator.py
+++ b/chat_shell/chat_shell/tools/builtin/pptx_generator.py
@@ -1,0 +1,351 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PPTX generation tool for creating PowerPoint presentations from structured content."""
+
+import json
+import logging
+from typing import Any, Optional
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class SlideContent(BaseModel):
+    """Content for a single slide."""
+
+    title: str = Field(description="Slide title")
+    content: str = Field(
+        description="Main content of the slide in markdown format (bullet points, text, etc.)"
+    )
+    notes: Optional[str] = Field(
+        default=None, description="Speaker notes for this slide"
+    )
+    layout: str = Field(
+        default="title_and_content",
+        description="Slide layout type: 'title', 'title_and_content', 'two_column', 'blank'",
+    )
+
+
+class PPTXGeneratorInput(BaseModel):
+    """Input schema for PPTX generator tool."""
+
+    title: str = Field(description="Presentation title")
+    slides: list[dict[str, Any]] = Field(
+        description=(
+            "List of slides, each containing 'title' (string), "
+            "'content' (markdown string), optional 'notes' (string), "
+            "and optional 'layout' (string: 'title', 'title_and_content', 'two_column', 'blank')"
+        )
+    )
+    author: Optional[str] = Field(default=None, description="Presentation author name")
+    theme: str = Field(
+        default="default",
+        description="Color theme: 'default', 'professional', 'creative', 'minimal'",
+    )
+
+
+class PPTXGeneratorTool(BaseTool):
+    """
+    Generate a PowerPoint presentation from structured content.
+
+    This tool creates PPTX files from structured slide data.
+    The generated presentation includes:
+    - Title slide with presentation title and author
+    - Content slides with titles, bullet points, and notes
+    - Professional styling based on selected theme
+
+    The tool outputs a JSON response with the generated file information,
+    including context ID for downloading the PPTX and preview images.
+    """
+
+    name: str = "generate_pptx"
+    display_name: str = "Generate PPTX"
+    description: str = (
+        "Generate a PowerPoint presentation from structured content. "
+        "Provide a title, list of slides (each with title, content in markdown format, "
+        "optional notes, and layout), optional author name, and theme. "
+        "Returns file information including download ID and preview images."
+    )
+    args_schema: type[BaseModel] = PPTXGeneratorInput
+
+    # Configuration
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    api_base_url: str = "http://localhost:8000"
+    auth_token: Optional[str] = None
+
+    def __init__(
+        self,
+        task_id: int = 0,
+        subtask_id: int = 0,
+        user_id: int = 0,
+        api_base_url: str = "http://localhost:8000",
+        auth_token: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.task_id = task_id
+        self.subtask_id = subtask_id
+        self.user_id = user_id
+        self.api_base_url = api_base_url
+        self.auth_token = auth_token
+
+    def _run(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: Optional[str] = None,
+        theme: str = "default",
+        **_,
+    ) -> str:
+        """Synchronous execution - not recommended, use _arun instead."""
+        import asyncio
+
+        return asyncio.get_event_loop().run_until_complete(
+            self._arun(title, slides, author, theme)
+        )
+
+    async def _arun(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: Optional[str] = None,
+        theme: str = "default",
+        **_,
+    ) -> str:
+        """
+        Generate PPTX asynchronously.
+
+        This implementation generates the PPTX using python-pptx library directly,
+        without requiring a sandbox. For more complex presentations with charts
+        and advanced layouts, the sandbox skill should be used instead.
+        """
+        try:
+            # Validate input
+            if not title:
+                return json.dumps(
+                    {"error": "Presentation title is required"}, ensure_ascii=False
+                )
+            if not slides:
+                return json.dumps(
+                    {"error": "At least one slide is required"}, ensure_ascii=False
+                )
+
+            # Generate PPTX using python-pptx
+            pptx_binary, slide_count = await self._generate_pptx(
+                title=title,
+                slides=slides,
+                author=author,
+                theme=theme,
+            )
+
+            # Generate preview thumbnails
+            preview_images = await self._generate_previews(pptx_binary)
+
+            # Store the generated files using backend API
+            result = await self._store_generated_files(
+                title=title,
+                pptx_binary=pptx_binary,
+                preview_images=preview_images,
+                slide_count=slide_count,
+            )
+
+            return json.dumps(result, ensure_ascii=False)
+
+        except Exception as e:
+            logger.exception(f"PPTX generation failed: {e}")
+            return json.dumps(
+                {"error": f"Failed to generate presentation: {str(e)}"},
+                ensure_ascii=False,
+            )
+
+    async def _generate_pptx(
+        self,
+        title: str,
+        slides: list[dict[str, Any]],
+        author: Optional[str],
+        theme: str,
+    ) -> tuple[bytes, int]:
+        """Generate PPTX binary using python-pptx."""
+        from io import BytesIO
+
+        from pptx import Presentation
+        from pptx.util import Inches, Pt
+        from pptx.dml.color import RGBColor
+        from pptx.enum.text import PP_ALIGN
+
+        # Theme colors
+        themes = {
+            "default": {"primary": "1F497D", "secondary": "4F81BD", "bg": "FFFFFF"},
+            "professional": {"primary": "2C3E50", "secondary": "3498DB", "bg": "F5F5F5"},
+            "creative": {"primary": "E74C3C", "secondary": "F39C12", "bg": "FFFFFF"},
+            "minimal": {"primary": "333333", "secondary": "666666", "bg": "FFFFFF"},
+        }
+        colors = themes.get(theme, themes["default"])
+
+        # Create presentation
+        prs = Presentation()
+        prs.slide_width = Inches(13.333)  # 16:9 aspect ratio
+        prs.slide_height = Inches(7.5)
+
+        # Add title slide
+        title_slide_layout = prs.slide_layouts[6]  # Blank layout
+        slide = prs.slides.add_slide(title_slide_layout)
+
+        # Add title text box
+        title_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(2.5), Inches(12.333), Inches(1.5)
+        )
+        title_frame = title_box.text_frame
+        title_para = title_frame.paragraphs[0]
+        title_para.text = title
+        title_para.font.size = Pt(44)
+        title_para.font.bold = True
+        title_para.font.color.rgb = RGBColor.from_string(colors["primary"])
+        title_para.alignment = PP_ALIGN.CENTER
+
+        # Add author if provided
+        if author:
+            author_box = slide.shapes.add_textbox(
+                Inches(0.5), Inches(4.5), Inches(12.333), Inches(0.5)
+            )
+            author_frame = author_box.text_frame
+            author_para = author_frame.paragraphs[0]
+            author_para.text = author
+            author_para.font.size = Pt(20)
+            author_para.font.color.rgb = RGBColor.from_string(colors["secondary"])
+            author_para.alignment = PP_ALIGN.CENTER
+
+        # Add content slides
+        for slide_data in slides:
+            slide_title = slide_data.get("title", "")
+            content = slide_data.get("content", "")
+            layout = slide_data.get("layout", "title_and_content")
+
+            content_slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+            # Add slide title
+            if slide_title:
+                title_box = content_slide.shapes.add_textbox(
+                    Inches(0.5), Inches(0.3), Inches(12.333), Inches(1)
+                )
+                title_frame = title_box.text_frame
+                title_para = title_frame.paragraphs[0]
+                title_para.text = slide_title
+                title_para.font.size = Pt(32)
+                title_para.font.bold = True
+                title_para.font.color.rgb = RGBColor.from_string(colors["primary"])
+
+            # Add content
+            if content:
+                content_box = content_slide.shapes.add_textbox(
+                    Inches(0.5), Inches(1.5), Inches(12.333), Inches(5.5)
+                )
+                content_frame = content_box.text_frame
+                content_frame.word_wrap = True
+
+                # Parse markdown-like content
+                lines = content.strip().split("\n")
+                for i, line in enumerate(lines):
+                    if i == 0:
+                        p = content_frame.paragraphs[0]
+                    else:
+                        p = content_frame.add_paragraph()
+
+                    # Handle bullet points
+                    line_text = line.strip()
+                    if line_text.startswith("- ") or line_text.startswith("* "):
+                        p.text = "• " + line_text[2:]
+                        p.level = 0
+                    elif line_text.startswith("  - ") or line_text.startswith("  * "):
+                        p.text = "  • " + line_text[4:]
+                        p.level = 1
+                    else:
+                        p.text = line_text
+
+                    p.font.size = Pt(20)
+                    p.font.color.rgb = RGBColor.from_string("333333")
+
+        # Save to bytes
+        output = BytesIO()
+        prs.save(output)
+        pptx_binary = output.getvalue()
+
+        return pptx_binary, len(slides) + 1  # +1 for title slide
+
+    async def _generate_previews(self, pptx_binary: bytes) -> list[bytes]:
+        """
+        Generate preview thumbnails for the PPTX.
+
+        For simplicity, this returns an empty list. The full implementation
+        would use LibreOffice or a similar tool to convert slides to images.
+        The PPTX skill package provides full thumbnail generation support.
+        """
+        # Preview generation requires LibreOffice or similar tools
+        # This is better handled in the sandbox skill for reliability
+        return []
+
+    async def _store_generated_files(
+        self,
+        title: str,
+        pptx_binary: bytes,
+        preview_images: list[bytes],
+        slide_count: int,
+    ) -> dict[str, Any]:
+        """
+        Store generated PPTX and preview images via backend API.
+
+        Returns context information for display in chat.
+        """
+        import httpx
+
+        filename = f"{title.replace(' ', '_')}.pptx"
+
+        # If we have access to the backend API, store the files
+        if self.api_base_url and self.auth_token:
+            try:
+                async with httpx.AsyncClient(timeout=60.0) as client:
+                    # Create form data for PPTX upload
+                    files = {"file": (filename, pptx_binary, "application/vnd.openxmlformats-officedocument.presentationml.presentation")}
+                    headers = {"Authorization": f"Bearer {self.auth_token}"}
+
+                    response = await client.post(
+                        f"{self.api_base_url}/api/attachments/upload",
+                        files=files,
+                        headers=headers,
+                    )
+
+                    if response.status_code == 200:
+                        attachment_data = response.json()
+                        return {
+                            "status": "success",
+                            "message": f"Generated presentation '{title}' with {slide_count} slides",
+                            "pptx_context_id": attachment_data.get("id"),
+                            "filename": filename,
+                            "slide_count": slide_count,
+                            "file_size": len(pptx_binary),
+                            "download_url": f"/api/attachments/{attachment_data.get('id')}/download",
+                        }
+                    else:
+                        logger.error(f"Failed to upload PPTX: {response.status_code} - {response.text}")
+
+            except Exception as e:
+                logger.error(f"Failed to store PPTX via API: {e}")
+
+        # Fallback: Return the PPTX binary as base64 for client-side download
+        import base64
+
+        return {
+            "status": "success",
+            "message": f"Generated presentation '{title}' with {slide_count} slides",
+            "filename": filename,
+            "slide_count": slide_count,
+            "file_size": len(pptx_binary),
+            "pptx_base64": base64.b64encode(pptx_binary).decode("utf-8"),
+            "note": "PPTX data included as base64. Decode and save as .pptx file.",
+        }

--- a/chat_shell/pyproject.toml
+++ b/chat_shell/pyproject.toml
@@ -57,6 +57,7 @@ dependencies = [
     # Document parsing
     "pypdf2>=3.0.0",
     "python-docx>=1.1.0",
+    "python-pptx>=1.0.0",
     "openpyxl>=3.1.2",
     "chardet>=5.0.0",
     "pillow>=12.0.0",
@@ -91,6 +92,7 @@ dev = [
     "isort>=5.12.0",
     "flake8>=6.0.0",
     "mypy>=1.5.0",
+    "python-pptx",
 ]
 
 [tool.black]

--- a/chat_shell/pyproject.toml
+++ b/chat_shell/pyproject.toml
@@ -92,7 +92,6 @@ dev = [
     "isort>=5.12.0",
     "flake8>=6.0.0",
     "mypy>=1.5.0",
-    "python-pptx",
 ]
 
 [tool.black]

--- a/chat_shell/tests/test_pptx_generator.py
+++ b/chat_shell/tests/test_pptx_generator.py
@@ -1,0 +1,260 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for PPTX generator tool."""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from chat_shell.tools.builtin.pptx_generator import (
+    PPTXGeneratorTool,
+    PPTXGeneratorInput,
+    SlideContent,
+)
+
+
+class TestPPTXGeneratorInput:
+    """Tests for PPTXGeneratorInput schema validation."""
+
+    def test_valid_input_minimal(self):
+        """Test minimal valid input."""
+        data = PPTXGeneratorInput(
+            title="Test Presentation",
+            slides=[{"title": "Slide 1", "content": "Content"}],
+        )
+        assert data.title == "Test Presentation"
+        assert len(data.slides) == 1
+        assert data.theme == "default"
+        assert data.author is None
+
+    def test_valid_input_full(self):
+        """Test full input with all optional fields."""
+        data = PPTXGeneratorInput(
+            title="Full Presentation",
+            slides=[
+                {
+                    "title": "Slide 1",
+                    "content": "- Point 1\n- Point 2",
+                    "notes": "Speaker notes",
+                    "layout": "title_and_content",
+                }
+            ],
+            author="Test Author",
+            theme="professional",
+        )
+        assert data.title == "Full Presentation"
+        assert data.author == "Test Author"
+        assert data.theme == "professional"
+
+    def test_multiple_slides(self):
+        """Test input with multiple slides."""
+        data = PPTXGeneratorInput(
+            title="Multi-slide Presentation",
+            slides=[
+                {"title": "Intro", "content": "Introduction content"},
+                {"title": "Main", "content": "Main content"},
+                {"title": "Conclusion", "content": "Conclusion content"},
+            ],
+        )
+        assert len(data.slides) == 3
+
+
+class TestPPTXGeneratorTool:
+    """Tests for PPTXGeneratorTool."""
+
+    @pytest.fixture
+    def tool(self):
+        """Create a PPTXGeneratorTool instance for testing."""
+        return PPTXGeneratorTool(
+            task_id=1,
+            subtask_id=1,
+            user_id=1,
+        )
+
+    def test_tool_properties(self, tool):
+        """Test tool has correct properties."""
+        assert tool.name == "generate_pptx"
+        assert tool.display_name == "Generate PPTX"
+        assert "PowerPoint" in tool.description
+        assert tool.args_schema == PPTXGeneratorInput
+
+    def test_tool_configuration(self, tool):
+        """Test tool configuration parameters."""
+        assert tool.task_id == 1
+        assert tool.subtask_id == 1
+        assert tool.user_id == 1
+
+    @pytest.mark.asyncio
+    async def test_arun_empty_title_error(self, tool):
+        """Test error when title is empty."""
+        result = await tool._arun(
+            title="",
+            slides=[{"title": "Slide", "content": "Content"}],
+        )
+        result_data = json.loads(result)
+        assert "error" in result_data
+        assert "title" in result_data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_arun_empty_slides_error(self, tool):
+        """Test error when slides list is empty."""
+        result = await tool._arun(
+            title="Test",
+            slides=[],
+        )
+        result_data = json.loads(result)
+        assert "error" in result_data
+        assert "slide" in result_data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_arun_generates_pptx(self, tool):
+        """Test successful PPTX generation."""
+        result = await tool._arun(
+            title="Test Presentation",
+            slides=[
+                {"title": "Slide 1", "content": "- Point 1\n- Point 2"},
+                {"title": "Slide 2", "content": "Content for slide 2"},
+            ],
+            author="Test Author",
+            theme="professional",
+        )
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        assert "Test Presentation" in result_data["message"]
+        assert result_data["slide_count"] == 3  # Title + 2 content slides
+        assert result_data["filename"] == "Test_Presentation.pptx"
+        assert result_data["file_size"] > 0
+
+    @pytest.mark.asyncio
+    async def test_arun_with_themes(self, tool):
+        """Test PPTX generation with different themes."""
+        themes = ["default", "professional", "creative", "minimal"]
+
+        for theme in themes:
+            result = await tool._arun(
+                title=f"{theme.title()} Theme Test",
+                slides=[{"title": "Test", "content": "Content"}],
+                theme=theme,
+            )
+            result_data = json.loads(result)
+            assert result_data["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_arun_returns_base64_without_api(self, tool):
+        """Test fallback to base64 when API is not configured."""
+        result = await tool._arun(
+            title="Base64 Test",
+            slides=[{"title": "Test", "content": "Content"}],
+        )
+        result_data = json.loads(result)
+
+        assert result_data["status"] == "success"
+        # Without API, should return base64
+        assert "pptx_base64" in result_data or "pptx_context_id" in result_data
+
+    @pytest.mark.asyncio
+    async def test_arun_with_bullet_points(self, tool):
+        """Test PPTX generation with properly formatted bullet points."""
+        result = await tool._arun(
+            title="Bullet Points Test",
+            slides=[
+                {
+                    "title": "Main Points",
+                    "content": "- First point\n- Second point\n  - Sub point 1\n  - Sub point 2\n- Third point",
+                }
+            ],
+        )
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_arun_with_asterisk_bullets(self, tool):
+        """Test PPTX generation with asterisk-style bullets."""
+        result = await tool._arun(
+            title="Asterisk Bullets Test",
+            slides=[
+                {
+                    "title": "Points",
+                    "content": "* Point one\n* Point two\n  * Nested point",
+                }
+            ],
+        )
+        result_data = json.loads(result)
+        assert result_data["status"] == "success"
+
+
+class TestPPTXGeneratorToolIntegration:
+    """Integration tests for PPTX generator tool."""
+
+    @pytest.mark.asyncio
+    async def test_generate_pptx_binary_valid(self):
+        """Test that generated PPTX binary is valid."""
+        tool = PPTXGeneratorTool()
+
+        # Use the internal method to generate PPTX
+        pptx_binary, slide_count = await tool._generate_pptx(
+            title="Valid PPTX Test",
+            slides=[
+                {"title": "Test Slide", "content": "Test content"},
+            ],
+            author="Test Author",
+            theme="default",
+        )
+
+        # Verify the binary is a valid PPTX (ZIP format starts with PK)
+        assert pptx_binary[:2] == b"PK"
+        assert slide_count == 2  # Title slide + 1 content slide
+        assert len(pptx_binary) > 1000  # Should be at least a few KB
+
+    @pytest.mark.asyncio
+    async def test_generate_pptx_with_unicode(self):
+        """Test PPTX generation with unicode characters."""
+        tool = PPTXGeneratorTool()
+
+        pptx_binary, slide_count = await tool._generate_pptx(
+            title="中文演示文稿",
+            slides=[
+                {"title": "第一页", "content": "- 要点一\n- 要点二"},
+                {"title": "日本語スライド", "content": "- ポイント1\n- ポイント2"},
+            ],
+            author="测试作者",
+            theme="default",
+        )
+
+        assert pptx_binary[:2] == b"PK"
+        assert slide_count == 3
+
+    @pytest.mark.asyncio
+    async def test_store_with_mock_api(self):
+        """Test storing PPTX via mocked API."""
+        tool = PPTXGeneratorTool(
+            task_id=1,
+            subtask_id=1,
+            user_id=1,
+            api_base_url="http://test-api:8000",
+            auth_token="test-token",
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": 123}
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post.return_value = mock_response
+            mock_client_instance.__aenter__.return_value = mock_client_instance
+            mock_client_instance.__aexit__.return_value = None
+            mock_client.return_value = mock_client_instance
+
+            result = await tool._store_generated_files(
+                title="API Test",
+                pptx_binary=b"PK test binary",
+                preview_images=[],
+                slide_count=2,
+            )
+
+            assert result["status"] == "success"
+            assert result["pptx_context_id"] == 123

--- a/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
+++ b/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
@@ -241,7 +241,7 @@ function GeneratedPPTXBadge({ context }: { context: SubtaskContextBrief }) {
   const subtitleParts: string[] = []
 
   if (slideCount !== undefined && slideCount > 0) {
-    subtitleParts.push(`${slideCount} ${t('common:slides', { count: slideCount }) || 'slides'}`)
+    subtitleParts.push(t('common:slides', { count: slideCount }) || `${slideCount} slides`)
   }
   if (fileSize !== undefined && fileSize !== null && fileSize > 0) {
     subtitleParts.push(formatFileSize(fileSize))

--- a/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
+++ b/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
@@ -243,7 +243,7 @@ function GeneratedPPTXBadge({ context }: { context: SubtaskContextBrief }) {
   if (slideCount !== undefined && slideCount > 0) {
     subtitleParts.push(`${slideCount} ${t('common:slides', { count: slideCount }) || 'slides'}`)
   }
-  if (fileSize !== undefined && fileSize > 0) {
+  if (fileSize !== undefined && fileSize !== null && fileSize > 0) {
     subtitleParts.push(formatFileSize(fileSize))
   }
 

--- a/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
+++ b/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
@@ -10,8 +10,7 @@ import AttachmentPreview from '../input/AttachmentPreview'
 import type { SubtaskContextBrief, Attachment } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
 import { formatDocumentCount } from '@/lib/i18n-helpers'
-import { formatFileSize } from '@/lib/utils'
-import { downloadAttachment } from '@/apis/attachments'
+import { downloadAttachment, formatFileSize } from '@/apis/attachments'
 
 /**
  * Base preview component for context items (attachments, knowledge bases, etc.)

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -187,7 +187,9 @@
     "subtask_completed": "Subtask completed",
     "subtask_failed": "Subtask failed:",
     "unknown_error": "Unknown error",
-    "download": "Download"
+    "download": "Download",
+    "slides": "{{count}} slide(s)",
+    "pptx_download": "Download Presentation"
   },
   "teams": {
     "title": "Team List",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -187,7 +187,9 @@
     "subtask_completed": "子任务已完成",
     "subtask_failed": "子任务失败：",
     "unknown_error": "未知错误",
-    "download": "下载"
+    "download": "下载",
+    "slides": "{{count}} 页幻灯片",
+    "pptx_download": "下载演示文稿"
   },
   "teams": {
     "title": "智能体列表",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -514,7 +514,7 @@ export interface MultiAttachmentUploadState {
 }
 
 // Subtask Context Types (unified context system)
-export type ContextType = 'attachment' | 'knowledge_base' | 'table'
+export type ContextType = 'attachment' | 'knowledge_base' | 'table' | 'generated_pptx'
 export type ContextStatus = 'pending' | 'uploading' | 'parsing' | 'ready' | 'failed'
 
 export interface SubtaskContextBrief {
@@ -532,6 +532,10 @@ export interface SubtaskContextBrief {
   source_config?: {
     url?: string
   } | null
+  // Generated PPTX fields (from type_data)
+  slide_count?: number | null
+  preview_images?: number[] | null // List of attachment IDs for preview thumbnails
+  pptx_attachment_id?: number | null // ID for downloading the PPTX
 }
 
 // Quick Access Types

--- a/shared/models/db/enums.py
+++ b/shared/models/db/enums.py
@@ -41,6 +41,7 @@ class ContextType(str, PyEnum):
     KNOWLEDGE_BASE = "knowledge_base"
     TABLE = "table"
     SELECTED_DOCUMENTS = "selected_documents"  # Selected documents from notebook mode for direct injection
+    GENERATED_PPTX = "generated_pptx"  # AI-generated PowerPoint presentation with preview images
 
 
 class ContextStatus(str, PyEnum):


### PR DESCRIPTION
## Summary

- Add comprehensive PPTX generation capability to Chat Shell using python-pptx library
- Implement PPTXGeneratorTool with support for multiple themes (default, professional, creative, minimal)
- Add GENERATED_PPTX context type for unified context management in chat history
- Create PPTX skill package for skill system integration
- Implement frontend GeneratedPPTXBadge component for displaying generated presentations with download support
- Add 22 unit tests covering backend schemas and Chat Shell tool functionality

## Changes

### Backend
- **`shared/models/db/enums.py`**: Add `GENERATED_PPTX` to ContextType enum
- **`backend/app/schemas/subtask_context.py`**: Extend SubtaskContextBrief with `slide_count`, `preview_images`, `pptx_attachment_id` fields; add `GeneratedPPTXContextCreate` and `GeneratedPPTXResponse` schemas
- **`backend/app/services/context/context_service.py`**: Add methods for PPTX storage (`store_generated_pptx`), retrieval, and updates
- **`backend/app/api/endpoints/adapter/attachments.py`**: Add PPTX download and preview endpoints

### Chat Shell
- **`chat_shell/chat_shell/tools/builtin/pptx_generator.py`**: New PPTXGeneratorTool implementation
- **`chat_shell/chat_shell/interface.py`**: Add `enable_pptx_generation` feature flag
- **`chat_shell/chat_shell/services/context.py`**: Register PPTXGeneratorTool when enabled
- **`chat_shell/pyproject.toml`**: Add python-pptx dependency

### Skill Package
- **`backend/init_data/skills/pptx/`**: Complete skill package with SKILL.md, provider.py, pptx_tool.py

### Frontend
- **`frontend/src/features/tasks/components/message/ContextBadgeList.tsx`**: Add GeneratedPPTXBadge component
- **`frontend/src/types/api.ts`**: Add `generated_pptx` to ContextType union
- **`frontend/src/i18n/locales/*/common.json`**: Add i18n translations for slides and download

### Tests
- **`chat_shell/tests/test_pptx_generator.py`**: 15 tests for tool functionality
- **`backend/tests/services/test_pptx_context.py`**: 7 tests for schema validation

## Test plan

- [x] Run `uv run pytest tests/test_pptx_generator.py -v` in chat_shell - 15 passed
- [x] Run `uv run pytest tests/services/test_pptx_context.py -v` in backend - 7 passed
- [ ] Manual test: Enable PPTX generation in chat interface and generate a presentation
- [ ] Manual test: Download generated PPTX from chat history
- [ ] Manual test: Verify slide count and file size display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generate PPTX presentations (title, slides, themes, optional author) with slide counts, metadata, downloadable PPTX and preview images; access-controlled retrieval via API and chat tool.

* **Frontend**
  * Conversation badges show PPTX entries with slide count, file size, and a download action; i18n keys added for slides and download label.

* **Documentation**
  * Added comprehensive PPTX skill usage and best-practices guide.

* **Tests**
  * Unit and integration tests for generation, storage, previewing, and context serialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->