### PR TITLE
refactor(frontend): improve subscription list action buttons layout

### DIFF
--- a/frontend/src/features/feed/components/SubscriptionList.tsx
+++ b/frontend/src/features/feed/components/SubscriptionList.tsx
@@ -290,7 +290,10 @@ export function SubscriptionList({
                         <Play className="mr-2 h-4 w-4" />
                         {t('trigger_now')}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => onEditSubscription(subscription)}>
+                      <DropdownMenuItem
+                        onClick={() => onEditSubscription(subscription)}
+                        disabled={actionLoading === subscription.id}
+                      >
                         <Edit className="mr-2 h-4 w-4" />
                         {t('edit')}
                       </DropdownMenuItem>

--- a/frontend/src/features/feed/components/SubscriptionList.tsx
+++ b/frontend/src/features/feed/components/SubscriptionList.tsx
@@ -43,6 +43,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { useSubscriptionContext } from '../contexts/subscriptionContext'
 import { subscriptionApis } from '@/apis/subscription'
 import type { Subscription, SubscriptionTriggerType } from '@/types/subscription'
@@ -66,6 +68,7 @@ export function SubscriptionList({
   onEditSubscription,
 }: SubscriptionListProps) {
   const { t } = useTranslation('feed')
+  const isMobile = useIsMobile()
   const {
     subscriptions,
     subscriptionsLoading,
@@ -270,55 +273,170 @@ export function SubscriptionList({
                   disabled={actionLoading === subscription.id}
                 />
 
-                {/* Actions */}
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="icon" className="h-8 w-8">
-                      <MoreHorizontal className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onClick={() => handleTrigger(subscription)}
-                      disabled={actionLoading === subscription.id}
-                    >
-                      <Play className="mr-2 h-4 w-4" />
-                      {t('trigger_now')}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => onEditSubscription(subscription)}>
-                      <Edit className="mr-2 h-4 w-4" />
-                      {t('edit')}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => handleCopySubscriptionId(subscription)}>
-                      <Hash className="mr-2 h-4 w-4" />
-                      {t('copy_subscription_id')}
-                    </DropdownMenuItem>
-                    {/* Webhook copy options for event triggers */}
-                    {subscription.trigger_type === 'event' && subscription.webhook_url && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem onClick={() => handleCopyWebhookUrl(subscription)}>
-                          <Copy className="mr-2 h-4 w-4" />
-                          {t('copy_webhook_url')}
-                        </DropdownMenuItem>
-                        {subscription.webhook_secret && (
-                          <DropdownMenuItem onClick={() => handleCopyWebhooksecret(subscription)}>
-                            <Key className="mr-2 h-4 w-4" />
-                            {t('copy_webhook_secret')}
+                {/* Actions - Desktop: Direct buttons, Mobile: Dropdown menu */}
+                {isMobile ? (
+                  // Mobile: Dropdown menu
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => handleTrigger(subscription)}
+                        disabled={actionLoading === subscription.id}
+                      >
+                        <Play className="mr-2 h-4 w-4" />
+                        {t('trigger_now')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => onEditSubscription(subscription)}>
+                        <Edit className="mr-2 h-4 w-4" />
+                        {t('edit')}
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => handleCopySubscriptionId(subscription)}>
+                        <Hash className="mr-2 h-4 w-4" />
+                        {t('copy_subscription_id')}
+                      </DropdownMenuItem>
+                      {/* Webhook copy options for event triggers */}
+                      {subscription.trigger_type === 'event' && subscription.webhook_url && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => handleCopyWebhookUrl(subscription)}>
+                            <Copy className="mr-2 h-4 w-4" />
+                            {t('copy_webhook_url')}
                           </DropdownMenuItem>
-                        )}
-                      </>
-                    )}
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={() => setDeleteConfirmSubscription(subscription)}
-                      className="text-destructive"
-                    >
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      {t('delete')}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                          {subscription.webhook_secret && (
+                            <DropdownMenuItem onClick={() => handleCopyWebhooksecret(subscription)}>
+                              <Key className="mr-2 h-4 w-4" />
+                              {t('copy_webhook_secret')}
+                            </DropdownMenuItem>
+                          )}
+                        </>
+                      )}
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        onClick={() => setDeleteConfirmSubscription(subscription)}
+                        className="text-destructive"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        {t('delete')}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                ) : (
+                  // Desktop: Direct action buttons
+                  <TooltipProvider delayDuration={300}>
+                    <div className="flex items-center gap-1">
+                      {/* Trigger button */}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => handleTrigger(subscription)}
+                            disabled={actionLoading === subscription.id}
+                          >
+                            <Play className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t('trigger_now')}</TooltipContent>
+                      </Tooltip>
+
+                      {/* Edit button */}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={() => onEditSubscription(subscription)}
+                            disabled={actionLoading === subscription.id}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t('edit')}</TooltipContent>
+                      </Tooltip>
+
+                      {/* Copy button - Different behavior for event vs non-event types */}
+                      {subscription.trigger_type === 'event' && subscription.webhook_url ? (
+                        // Event type: Show dropdown with copy options
+                        <DropdownMenu>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-8 w-8"
+                                  disabled={actionLoading === subscription.id}
+                                >
+                                  <Copy className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                            </TooltipTrigger>
+                            <TooltipContent>{t('common:actions.copy')}</TooltipContent>
+                          </Tooltip>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => handleCopySubscriptionId(subscription)}
+                            >
+                              <Hash className="mr-2 h-4 w-4" />
+                              {t('copy_subscription_id')}
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem onClick={() => handleCopyWebhookUrl(subscription)}>
+                              <Copy className="mr-2 h-4 w-4" />
+                              {t('copy_webhook_url')}
+                            </DropdownMenuItem>
+                            {subscription.webhook_secret && (
+                              <DropdownMenuItem
+                                onClick={() => handleCopyWebhooksecret(subscription)}
+                              >
+                                <Key className="mr-2 h-4 w-4" />
+                                {t('copy_webhook_secret')}
+                              </DropdownMenuItem>
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        // Non-event type: Direct copy subscription ID
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => handleCopySubscriptionId(subscription)}
+                              disabled={actionLoading === subscription.id}
+                            >
+                              <Copy className="h-4 w-4" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>{t('copy_subscription_id')}</TooltipContent>
+                        </Tooltip>
+                      )}
+
+                      {/* Delete button */}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 hover:text-destructive"
+                            onClick={() => setDeleteConfirmSubscription(subscription)}
+                            disabled={actionLoading === subscription.id}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{t('delete')}</TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </TooltipProvider>
+                )}
               </div>
             ))}
 

--- a/frontend/src/features/feed/components/SubscriptionList.tsx
+++ b/frontend/src/features/feed/components/SubscriptionList.tsx
@@ -278,7 +278,12 @@ export function SubscriptionList({
                   // Mobile: Dropdown menu
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        aria-label={t('common:actions.more')}
+                      >
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>
@@ -297,7 +302,10 @@ export function SubscriptionList({
                         <Edit className="mr-2 h-4 w-4" />
                         {t('edit')}
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={() => handleCopySubscriptionId(subscription)}>
+                      <DropdownMenuItem
+                        onClick={() => handleCopySubscriptionId(subscription)}
+                        disabled={actionLoading === subscription.id}
+                      >
                         <Hash className="mr-2 h-4 w-4" />
                         {t('copy_subscription_id')}
                       </DropdownMenuItem>
@@ -305,12 +313,18 @@ export function SubscriptionList({
                       {subscription.trigger_type === 'event' && subscription.webhook_url && (
                         <>
                           <DropdownMenuSeparator />
-                          <DropdownMenuItem onClick={() => handleCopyWebhookUrl(subscription)}>
+                          <DropdownMenuItem
+                            onClick={() => handleCopyWebhookUrl(subscription)}
+                            disabled={actionLoading === subscription.id}
+                          >
                             <Copy className="mr-2 h-4 w-4" />
                             {t('copy_webhook_url')}
                           </DropdownMenuItem>
                           {subscription.webhook_secret && (
-                            <DropdownMenuItem onClick={() => handleCopyWebhooksecret(subscription)}>
+                            <DropdownMenuItem
+                              onClick={() => handleCopyWebhooksecret(subscription)}
+                              disabled={actionLoading === subscription.id}
+                            >
                               <Key className="mr-2 h-4 w-4" />
                               {t('copy_webhook_secret')}
                             </DropdownMenuItem>
@@ -321,6 +335,7 @@ export function SubscriptionList({
                       <DropdownMenuItem
                         onClick={() => setDeleteConfirmSubscription(subscription)}
                         className="text-destructive"
+                        disabled={actionLoading === subscription.id}
                       >
                         <Trash2 className="mr-2 h-4 w-4" />
                         {t('delete')}
@@ -340,6 +355,7 @@ export function SubscriptionList({
                             className="h-8 w-8"
                             onClick={() => handleTrigger(subscription)}
                             disabled={actionLoading === subscription.id}
+                            aria-label={t('trigger_now')}
                           >
                             <Play className="h-4 w-4" />
                           </Button>
@@ -356,6 +372,7 @@ export function SubscriptionList({
                             className="h-8 w-8"
                             onClick={() => onEditSubscription(subscription)}
                             disabled={actionLoading === subscription.id}
+                            aria-label={t('edit')}
                           >
                             <Edit className="h-4 w-4" />
                           </Button>
@@ -375,6 +392,7 @@ export function SubscriptionList({
                                   size="icon"
                                   className="h-8 w-8"
                                   disabled={actionLoading === subscription.id}
+                                  aria-label={t('common:actions.copy')}
                                 >
                                   <Copy className="h-4 w-4" />
                                 </Button>
@@ -414,6 +432,7 @@ export function SubscriptionList({
                               className="h-8 w-8"
                               onClick={() => handleCopySubscriptionId(subscription)}
                               disabled={actionLoading === subscription.id}
+                              aria-label={t('copy_subscription_id')}
                             >
                               <Copy className="h-4 w-4" />
                             </Button>
@@ -431,6 +450,7 @@ export function SubscriptionList({
                             className="h-8 w-8 hover:text-destructive"
                             onClick={() => setDeleteConfirmSubscription(subscription)}
                             disabled={actionLoading === subscription.id}
+                            aria-label={t('delete')}
                           >
                             <Trash2 className="h-4 w-4" />
                           </Button>


### PR DESCRIPTION
## Summary

- Refactor subscription list action buttons for better user experience on desktop
- Desktop (≥768px): Display action buttons directly as icon buttons with tooltips
  - Trigger (Play), Edit, Copy, Delete buttons
  - Delete button shows red color on hover (`hover:text-destructive`)
  - Event type subscriptions show a dropdown on copy button for copying subscription ID, webhook URL, and webhook secret
  - Non-event type subscriptions copy ID directly on click
- Mobile (<768px): Keep the existing dropdown menu with all actions (three-dot menu)

## Changes

1. **SubscriptionList.tsx**:
   - Added `useIsMobile` hook to detect device type
   - Added `Tooltip` components for desktop icon buttons
   - Desktop: Direct action buttons (Play, Edit, Copy, Delete) with `variant="ghost"` and `size="icon"`
   - Mobile: Preserved existing dropdown menu behavior
   - Event type subscriptions: Copy button shows dropdown with copy options
   - Non-event type: Copy button directly copies subscription ID

## Test plan

- [ ] Verify desktop (≥768px) shows direct action buttons with tooltips
- [ ] Verify mobile (<768px) shows three-dot dropdown menu
- [ ] Verify trigger button executes subscription immediately
- [ ] Verify edit button opens edit dialog
- [ ] Verify delete button opens confirmation dialog
- [ ] Verify copy button for event type shows dropdown with copy options
- [ ] Verify copy button for non-event type copies subscription ID directly
- [ ] Verify delete button hover shows red color
- [ ] Verify all buttons are disabled when `actionLoading === subscription.id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-responsive subscription management with dropdown action menu on small screens
  * Desktop retains inline action buttons enhanced with tooltips
  * All actions preserved across devices: trigger, edit, copy, and delete
  * Event-type subscriptions now surface webhook copy options (URL/secret) where applicable

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->