### PR TITLE
feat(backend): add user ID prefix for mem0 resource isolation

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -312,6 +312,10 @@ class Settings(BaseSettings):
     # Number of recent messages to include as context when saving memory (default: 3 total)
     # This includes 2 history messages + 1 current message for better memory quality
     MEMORY_CONTEXT_MESSAGES: int = 3
+    # User ID prefix for resource isolation in shared mem0 service
+    # Since mem0 may be shared across multiple systems, this prefix ensures
+    # wegent resources are isolated from other systems' resources
+    MEMORY_USER_ID_PREFIX: str = "wegent_user:"
 
     # OpenTelemetry configuration is centralized in shared/telemetry/config.py
     # Use: from shared.telemetry.config import get_otel_config


### PR DESCRIPTION
## Summary

- Add configurable `MEMORY_USER_ID_PREFIX` environment variable for resource isolation in shared mem0 service
- Default prefix is `wegent_user:` to distinguish wegent resources from other systems
- Apply prefix to all mem0 API calls (search, save, cleanup) while keeping metadata fields (task_id, team_id, project_id, etc.) unchanged

## Changes

1. **backend/app/core/config.py**:
   - Added `MEMORY_USER_ID_PREFIX` config with default value `wegent_user:`

2. **backend/app/services/memory/manager.py**:
   - Added `_get_prefixed_user_id()` method to build prefixed user ID
   - Applied prefix in `search_memories()`, `save_user_message_async()`, and `cleanup_task_memories()`

3. **backend/tests/services/memory/test_manager.py**:
   - Added `MEMORY_USER_ID_PREFIX` to mock settings
   - Updated test assertions to verify prefixed user ID
   - Added dedicated tests for prefix functionality

## Why This Change

Since mem0 may be a shared service across multiple systems, adding a configurable user ID prefix ensures wegent's resources are isolated from other systems' resources, preventing potential data conflicts.

## Test plan

- [x] Run `pytest tests/services/memory/test_manager.py` - All 13 tests pass
- [ ] Verify prefix is applied in actual mem0 API calls
- [ ] Verify custom prefix configuration works as expected