### PR TITLE
fix(chat): prevent duplicate KB prompts and standardize Markdown heading levels

### DIFF
--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -32,18 +32,18 @@ logger = logging.getLogger(__name__)
 # Strict mode prompt: User explicitly selected KB for this message
 KB_PROMPT_STRICT = """
 
-# IMPORTANT: Knowledge Base Requirement
+## Knowledge Base Requirement
 
 The user has selected specific knowledge bases for this conversation. You MUST use the `knowledge_base_search` tool to retrieve information from these knowledge bases before answering any questions.
 
-## Required Workflow:
+### Required Workflow:
 1. **ALWAYS** call `knowledge_base_search` first with the user's query
 2. Wait for the search results
 3. Base your answer **ONLY** on the retrieved information
 4. If the search returns no results or irrelevant information, clearly state: "I cannot find relevant information in the selected knowledge base to answer this question."
 5. **DO NOT** use your general knowledge or make assumptions beyond what's in the knowledge base
 
-## Critical Rules:
+### Critical Rules:
 - You MUST search the knowledge base for EVERY user question
 - You MUST NOT answer without searching first
 - You MUST NOT make up information if the knowledge base doesn't contain it
@@ -54,17 +54,17 @@ The user expects answers based on the selected knowledge base content only."""
 # Relaxed mode prompt: KB inherited from task, AI can use general knowledge as fallback
 KB_PROMPT_RELAXED = """
 
-# Knowledge Base Available
+## Knowledge Base Available
 
 You have access to knowledge bases from previous conversations in this task. You can use the `knowledge_base_search` tool to retrieve information from these knowledge bases.
 
-## Recommended Workflow:
+### Recommended Workflow:
 1. When the user's question might be related to the knowledge base content, consider calling `knowledge_base_search` with relevant keywords
 2. If relevant information is found, prioritize using it in your answer and cite the sources
 3. If the search returns no results or irrelevant information, you may use your general knowledge to answer the question
 4. Be transparent about whether your answer is based on knowledge base content or general knowledge
 
-## Guidelines:
+### Guidelines:
 - Search the knowledge base when the question seems related to its content
 - If the knowledge base doesn't contain relevant information, feel free to answer using your general knowledge
 - Clearly indicate when your answer is based on knowledge base content vs. general knowledge

--- a/chat_shell/chat_shell/prompts/knowledge_base.py
+++ b/chat_shell/chat_shell/prompts/knowledge_base.py
@@ -13,18 +13,18 @@ This module provides prompt templates for knowledge base tool usage:
 # AI must use KB only and cannot use general knowledge
 KB_PROMPT_STRICT = """
 
-# IMPORTANT: Knowledge Base Requirement
+## Knowledge Base Requirement
 
 The user has selected specific knowledge bases for this conversation. You MUST use the `knowledge_base_search` tool to retrieve information from these knowledge bases before answering any questions.
 
-## Required Workflow:
+### Required Workflow:
 1. **ALWAYS** call `knowledge_base_search` first with the user's query
 2. Wait for the search results
 3. Base your answer **ONLY** on the retrieved information
 4. If the search returns no results or irrelevant information, clearly state: "I cannot find relevant information in the selected knowledge base to answer this question."
 5. **DO NOT** use your general knowledge or make assumptions beyond what's in the knowledge base
 
-## Critical Rules:
+### Critical Rules:
 - You MUST search the knowledge base for EVERY user question
 - You MUST NOT answer without searching first
 - You MUST NOT make up information if the knowledge base doesn't contain it
@@ -35,17 +35,17 @@ The user expects answers based on the selected knowledge base content only."""
 # Relaxed mode prompt: KB inherited from task, AI can use general knowledge as fallback
 KB_PROMPT_RELAXED = """
 
-# Knowledge Base Available
+## Knowledge Base Available
 
 You have access to knowledge bases from previous conversations in this task. You can use the `knowledge_base_search` tool to retrieve information from these knowledge bases.
 
-## Recommended Workflow:
+### Recommended Workflow:
 1. When the user's question might be related to the knowledge base content, consider calling `knowledge_base_search` with relevant keywords
 2. If relevant information is found, prioritize using it in your answer and cite the sources
 3. If the search returns no results or irrelevant information, you may use your general knowledge to answer the question
 4. Be transparent about whether your answer is based on knowledge base content or general knowledge
 
-## Guidelines:
+### Guidelines:
 - Search the knowledge base when the question seems related to its content
 - If the knowledge base doesn't contain relevant information, feel free to answer using your general knowledge
 - Clearly indicate when your answer is based on knowledge base content vs. general knowledge

--- a/chat_shell/tests/test_kb_prompt_deduplication.py
+++ b/chat_shell/tests/test_kb_prompt_deduplication.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for KB prompt deduplication logic.
+
+These tests verify that KB prompts are not duplicated when Backend already adds them
+to the system prompt before calling chat_shell in HTTP mode.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestKBPromptMarkerDetection:
+    """Test KB prompt marker detection logic."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        # Import here to avoid import issues in non-package tests
+        from chat_shell.interface import ChatRequest
+        from chat_shell.services.context import ChatContext
+
+        self.ChatContext = ChatContext
+        self.ChatRequest = ChatRequest
+
+    def _create_context(self, system_prompt: str = "") -> "ChatContext":
+        """Create ChatContext with given system prompt."""
+        request = MagicMock()
+        request.system_prompt = system_prompt
+        request.knowledge_base_ids = [1, 2]
+        request.user_id = 1
+        request.task_id = 1
+        request.subtask_id = 1
+        request.user_subtask_id = 1
+        request.is_user_selected_kb = True
+        request.document_ids = None
+        request.model_config = None
+        return self.ChatContext(request)
+
+    @patch("chat_shell.services.context.settings")
+    def test_skip_when_strict_marker_present_http_mode(self, mock_settings):
+        """Should skip KB prompt enhancement when strict marker present in HTTP mode."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "remote"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n## Knowledge Base Requirement\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is True
+
+    @patch("chat_shell.services.context.settings")
+    def test_skip_when_relaxed_marker_present_http_mode(self, mock_settings):
+        """Should skip KB prompt enhancement when relaxed marker present in HTTP mode."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "remote"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n## Knowledge Base Available\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is True
+
+    @patch("chat_shell.services.context.settings")
+    def test_skip_when_old_strict_marker_present_http_mode(self, mock_settings):
+        """Should skip KB prompt enhancement when old strict marker present."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "remote"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n# IMPORTANT: Knowledge Base Requirement\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is True
+
+    @patch("chat_shell.services.context.settings")
+    def test_skip_when_old_relaxed_marker_present_http_mode(self, mock_settings):
+        """Should skip KB prompt enhancement when old relaxed marker present."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "remote"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n# Knowledge Base Available\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is True
+
+    @patch("chat_shell.services.context.settings")
+    def test_no_skip_without_marker_http_mode(self, mock_settings):
+        """Should not skip KB prompt enhancement when no marker present in HTTP mode."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "remote"
+
+        context = self._create_context(system_prompt="Base prompt without KB marker")
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is False
+
+    @patch("chat_shell.services.context.settings")
+    def test_no_skip_in_package_mode(self, mock_settings):
+        """Should not skip KB prompt enhancement in package mode (non-HTTP)."""
+        mock_settings.CHAT_SHELL_MODE = "package"
+        mock_settings.STORAGE_TYPE = "local"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n## Knowledge Base Requirement\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is False
+
+    @patch("chat_shell.services.context.settings")
+    def test_no_skip_with_http_mode_but_local_storage(self, mock_settings):
+        """Should not skip when HTTP mode but local storage."""
+        mock_settings.CHAT_SHELL_MODE = "http"
+        mock_settings.STORAGE_TYPE = "local"
+
+        context = self._create_context(
+            system_prompt="Base prompt\n## Knowledge Base Requirement\nKB instructions"
+        )
+        result = context._should_skip_kb_prompt_enhancement(
+            context._request.system_prompt
+        )
+
+        assert result is False
+
+
+class TestKBPromptMarkdownLevel:
+    """Test that KB prompts use correct Markdown heading level (##)."""
+
+    def test_chat_shell_strict_prompt_uses_h2(self):
+        """KB_PROMPT_STRICT should use ## for main heading."""
+        from chat_shell.prompts import KB_PROMPT_STRICT
+
+        # Should start with ## (H2) not # (H1)
+        assert "## Knowledge Base Requirement" in KB_PROMPT_STRICT
+        assert "# IMPORTANT:" not in KB_PROMPT_STRICT
+        # Sub-sections should use ### (H3)
+        assert "### Required Workflow:" in KB_PROMPT_STRICT
+        assert "### Critical Rules:" in KB_PROMPT_STRICT
+
+    def test_chat_shell_relaxed_prompt_uses_h2(self):
+        """KB_PROMPT_RELAXED should use ## for main heading."""
+        from chat_shell.prompts import KB_PROMPT_RELAXED
+
+        # Should start with ## (H2) not # (H1)
+        assert "## Knowledge Base Available" in KB_PROMPT_RELAXED
+        # Sub-sections should use ### (H3)
+        assert "### Recommended Workflow:" in KB_PROMPT_RELAXED
+        assert "### Guidelines:" in KB_PROMPT_RELAXED
+
+
+class TestKnowledgeFactorySkipPromptEnhancement:
+    """Test skip_prompt_enhancement parameter in knowledge_factory."""
+
+    @pytest.mark.asyncio
+    async def test_skip_prompt_enhancement_returns_base_prompt(self):
+        """When skip_prompt_enhancement=True, should return base_system_prompt unchanged."""
+        from chat_shell.tools.knowledge_factory import prepare_knowledge_base_tools
+
+        base_prompt = "This is the base system prompt."
+        kb_ids = [1, 2]
+
+        # Mock the KnowledgeBaseTool import in knowledge_factory
+        with patch(
+            "chat_shell.tools.builtin.KnowledgeBaseTool"
+        ) as mock_kb_tool_class:
+            mock_kb_tool_class.return_value = MagicMock()
+
+            tools, enhanced_prompt = await prepare_knowledge_base_tools(
+                knowledge_base_ids=kb_ids,
+                user_id=1,
+                db=MagicMock(),
+                base_system_prompt=base_prompt,
+                skip_prompt_enhancement=True,
+            )
+
+            # Should return KB tool but not modify prompt
+            assert len(tools) == 1
+            assert enhanced_prompt == base_prompt
+            # Should NOT contain KB prompt markers
+            assert "## Knowledge Base Requirement" not in enhanced_prompt
+            assert "## Knowledge Base Available" not in enhanced_prompt
+
+    @pytest.mark.asyncio
+    async def test_no_skip_prompt_enhancement_adds_kb_prompt(self):
+        """When skip_prompt_enhancement=False, should add KB prompt."""
+        from chat_shell.tools.knowledge_factory import prepare_knowledge_base_tools
+
+        base_prompt = "This is the base system prompt."
+        kb_ids = [1, 2]
+
+        # Mock the KnowledgeBaseTool import in knowledge_factory
+        with patch(
+            "chat_shell.tools.builtin.KnowledgeBaseTool"
+        ) as mock_kb_tool_class:
+            mock_kb_tool_class.return_value = MagicMock()
+
+            tools, enhanced_prompt = await prepare_knowledge_base_tools(
+                knowledge_base_ids=kb_ids,
+                user_id=1,
+                db=MagicMock(),
+                base_system_prompt=base_prompt,
+                skip_prompt_enhancement=False,
+                is_user_selected=True,
+            )
+
+            # Should return KB tool and add prompt
+            assert len(tools) == 1
+            # Should contain KB prompt marker (strict mode because is_user_selected=True)
+            assert "## Knowledge Base Requirement" in enhanced_prompt
+
+    @pytest.mark.asyncio
+    async def test_empty_kb_ids_with_skip_skips_historical_meta(self):
+        """When no KB IDs and skip=True, should skip historical KB meta prompt."""
+        from chat_shell.tools.knowledge_factory import prepare_knowledge_base_tools
+
+        base_prompt = "This is the base system prompt."
+
+        with patch(
+            "chat_shell.tools.knowledge_factory._build_historical_kb_meta_prompt"
+        ) as mock_meta:
+            mock_meta.return_value = "\nHistorical KB meta"
+
+            _, enhanced_prompt = await prepare_knowledge_base_tools(
+                knowledge_base_ids=None,
+                user_id=1,
+                db=MagicMock(),
+                base_system_prompt=base_prompt,
+                task_id=1,
+                skip_prompt_enhancement=True,
+            )
+
+            # Should not call _build_historical_kb_meta_prompt
+            mock_meta.assert_not_called()
+            # Should return base prompt unchanged
+            assert enhanced_prompt == base_prompt
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Fix duplicate Knowledge Base prompt issue in Chat by adding skip_prompt_enhancement mechanism
- Standardize KB prompt Markdown heading levels from H1 (`#`) to H2 (`##`) for consistent hierarchy
- Add comprehensive unit tests for KB prompt deduplication logic

## Problem

When using knowledge bases in Chat, the system prompt contained duplicate KB instructions:
1. First pass: Backend adds KB prompt with specific KB info (e.g., `KB Name: usergraph测试, KB ID: 103596`)
2. Second pass: chat_shell adds the same KB prompt again (without KB-specific info)

Additionally, KB prompts used H1 headings (`# IMPORTANT: Knowledge Base Requirement`) while other sections like Deep Thinking Mode used H2 (`## Deep Thinking Mode`), causing inconsistent markdown hierarchy.

## Solution

1. **Fix duplication**: Add `skip_prompt_enhancement` parameter to `prepare_knowledge_base_tools()` and detection logic in `ChatContext._should_skip_kb_prompt_enhancement()` to skip KB prompt enhancement when Backend has already added them (detected via KB prompt markers in system_prompt)

2. **Fix heading levels**: Change KB prompts from H1 to H2 in both `chat_shell/prompts/knowledge_base.py` and `backend/app/services/chat/preprocessing/contexts.py`

## Changes

- `chat_shell/chat_shell/tools/knowledge_factory.py`: Add `skip_prompt_enhancement` parameter
- `chat_shell/chat_shell/services/context.py`: Add `_should_skip_kb_prompt_enhancement()` method
- `chat_shell/chat_shell/prompts/knowledge_base.py`: Change `# IMPORTANT:` to `## Knowledge Base Requirement` and `# Knowledge Base Available` to `## Knowledge Base Available`
- `backend/app/services/chat/preprocessing/contexts.py`: Sync KB prompt heading changes
- `chat_shell/tests/test_kb_prompt_deduplication.py`: Add unit tests for deduplication logic

## Test plan

- [x] Run chat_shell unit tests - all 153 tests pass
- [x] Run KB prompt deduplication tests - all 12 tests pass
- [ ] Manual testing: Verify KB prompt appears only once in system prompt
- [ ] Manual testing: Verify KB prompt uses H2 heading (`##`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined knowledge-base prompt wording and heading levels in strict and relaxed modes; added explicit fallback guidance and a "search again" tip.

* **Bug Fixes**
  * Avoided duplicate knowledge-base prompt injection in HTTP/remote-storage scenarios by detecting and skipping redundant enhancements; added related logging.

* **Tests**
  * Added comprehensive tests for prompt deduplication, heading levels, and skip-enhancement behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->