### PR TITLE
feat(knowledge): optimize knowledge base auto-summary functionality

### DIFF
--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -213,3 +213,26 @@ export async function refreshWebDocument(documentId: number): Promise<WebDocumen
     document_id: documentId,
   })
 }
+
+// ============== Summary Refresh APIs ==============
+
+/**
+ * Response type for knowledge base summary refresh
+ */
+export interface KnowledgeBaseSummaryRefreshResponse {
+  message: string
+  status: string
+}
+
+/**
+ * Refresh knowledge base summary by re-aggregating document summaries
+ * @param kbId The knowledge base ID to refresh summary for
+ * @returns Refresh result with status
+ */
+export async function refreshKnowledgeBaseSummary(
+  kbId: number
+): Promise<KnowledgeBaseSummaryRefreshResponse> {
+  return apiClient.post<KnowledgeBaseSummaryRefreshResponse>(
+    `/knowledge-bases/${kbId}/summary/refresh`
+  )
+}

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
@@ -202,6 +202,19 @@ export function KnowledgeBaseChatPageDesktop() {
     return groupRole === 'Owner' || groupRole === 'Maintainer' || groupRole === 'Developer'
   }, [knowledgeBase, user, groupRoleMap])
 
+  // Compute initial model reference from knowledge base's summary model
+  // This is used to auto-inherit the summary model for new chats in notebook mode
+  const initialModelRef = useMemo(() => {
+    // Only use initial model ref when:
+    // 1. Knowledge base has summary enabled
+    // 2. Knowledge base has a valid summary_model_ref
+    // 3. No task is currently open (new chat)
+    if (!hasOpenTask && knowledgeBase?.summary_enabled && knowledgeBase?.summary_model_ref) {
+      return knowledgeBase.summary_model_ref
+    }
+    return null
+  }, [hasOpenTask, knowledgeBase?.summary_enabled, knowledgeBase?.summary_model_ref])
+
   // Loading state
   if (kbLoading) {
     return (
@@ -293,6 +306,7 @@ export function KnowledgeBaseChatPageDesktop() {
                 document_count: knowledgeBase.document_count,
               }}
               selectedDocumentIds={selectedDocumentIds}
+              initialModelRef={initialModelRef}
               onTaskCreated={async (taskId: number) => {
                 // Bind the knowledge base to the newly created task
                 try {

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
@@ -181,6 +181,19 @@ export function KnowledgeBaseChatPageMobile() {
     return groupRole === 'Owner' || groupRole === 'Maintainer' || groupRole === 'Developer'
   }, [knowledgeBase, user, groupRoleMap])
 
+  // Compute initial model reference from knowledge base's summary model
+  // This is used to auto-inherit the summary model for new chats in notebook mode
+  const initialModelRef = useMemo(() => {
+    // Only use initial model ref when:
+    // 1. Knowledge base has summary enabled
+    // 2. Knowledge base has a valid summary_model_ref
+    // 3. No task is currently open (new chat)
+    if (!hasOpenTask && knowledgeBase?.summary_enabled && knowledgeBase?.summary_model_ref) {
+      return knowledgeBase.summary_model_ref
+    }
+    return null
+  }, [hasOpenTask, knowledgeBase?.summary_enabled, knowledgeBase?.summary_model_ref])
+
   // Loading state
   if (kbLoading) {
     return (
@@ -280,6 +293,7 @@ export function KnowledgeBaseChatPageMobile() {
               namespace: knowledgeBase.namespace,
               document_count: knowledgeBase.document_count,
             }}
+            initialModelRef={initialModelRef}
             onTaskCreated={async (taskId: number) => {
               // Bind the knowledge base to the newly created task
               try {

--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -120,7 +120,8 @@ export function CreateKnowledgeBaseDialog({
       })
       setName('')
       setDescription('')
-      setSummaryEnabled(false)
+      // Reset summaryEnabled based on kbType: enabled for notebook, disabled for classic
+      setSummaryEnabled(kbType === 'notebook')
       setSummaryModelRef(null)
       setRetrievalConfig({
         retrieval_mode: 'vector',

--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -58,7 +58,8 @@ export function CreateKnowledgeBaseDialog({
   const { t } = useTranslation()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const [summaryEnabled, setSummaryEnabled] = useState(false)
+  // Default enable summary for notebook type, disable for classic type
+  const [summaryEnabled, setSummaryEnabled] = useState(kbType === 'notebook')
   const [summaryModelRef, setSummaryModelRef] = useState<SummaryModelRef | null>(null)
   const [summaryModelError, setSummaryModelError] = useState('')
   const [retrievalConfig, setRetrievalConfig] = useState<Partial<RetrievalConfig>>({
@@ -139,7 +140,8 @@ export function CreateKnowledgeBaseDialog({
     if (!newOpen) {
       setName('')
       setDescription('')
-      setSummaryEnabled(false)
+      // Reset summaryEnabled based on kbType: enabled for notebook, disabled for classic
+      setSummaryEnabled(kbType === 'notebook')
       setSummaryModelRef(null)
       setSummaryModelError('')
       setRetrievalConfig({

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
@@ -4,12 +4,19 @@
 
 'use client'
 
-import { BookOpen, FileText, Info } from 'lucide-react'
+import { useState } from 'react'
+import { BookOpen, FileText, Info, AlertTriangle, RefreshCw } from 'lucide-react'
 import type { KnowledgeBase } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { refreshKnowledgeBaseSummary } from '@/apis/knowledge'
+import { toast } from '@/hooks/use-toast'
 
 interface KnowledgeBaseSummaryCardProps {
   knowledgeBase: KnowledgeBase
+  /** Callback to refresh knowledge base details after retry */
+  onRefresh?: () => void
 }
 
 /**
@@ -20,15 +27,50 @@ interface KnowledgeBaseSummaryCardProps {
  * - Knowledge base name and description
  * - Document count
  * - AI-generated summary (if available)
+ * - Summary failure warning with retry button (if failed)
  *
  * Styled as a system message without avatar/sender info
  */
-export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummaryCardProps) {
+export function KnowledgeBaseSummaryCard({
+  knowledgeBase,
+  onRefresh,
+}: KnowledgeBaseSummaryCardProps) {
   const { t } = useTranslation('knowledge')
+  const [isRetrying, setIsRetrying] = useState(false)
 
   const longSummary = knowledgeBase.summary?.long_summary
   const shortSummary = knowledgeBase.summary?.short_summary
   const topics = knowledgeBase.summary?.topics
+  const summaryStatus = knowledgeBase.summary?.status
+  const summaryError = knowledgeBase.summary?.error
+
+  // Check if summary generation failed
+  const isSummaryFailed = summaryStatus === 'failed'
+
+  // Handle retry summary generation
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await refreshKnowledgeBaseSummary(knowledgeBase.id)
+      toast({
+        description: t('chatPage.summaryRetrying'),
+      })
+      // Refresh knowledge base details after a short delay
+      if (onRefresh) {
+        setTimeout(() => {
+          onRefresh()
+        }, 2000)
+      }
+    } catch (error) {
+      console.error('Failed to refresh summary:', error)
+      toast({
+        variant: 'destructive',
+        description: t('chatPage.summaryFailed'),
+      })
+    } finally {
+      setIsRetrying(false)
+    }
+  }
 
   return (
     <div className="w-full max-w-3xl mx-auto mb-6">
@@ -64,7 +106,7 @@ export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummary
         </div>
 
         {/* Summary Section */}
-        {(longSummary || shortSummary) && (
+        {(longSummary || shortSummary) && !isSummaryFailed && (
           <div className="pt-3 border-t border-border/50">
             <div className="flex items-center gap-2 mb-2">
               <Info className="w-4 h-4 text-text-muted" />
@@ -78,8 +120,43 @@ export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummary
           </div>
         )}
 
+        {/* Summary Failed Warning */}
+        {isSummaryFailed && (
+          <div className="pt-3 border-t border-border/50">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertTriangle className="w-4 h-4 text-amber-500 cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="max-w-xs">
+                        {summaryError || t('chatPage.summaryFailedHint')}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <span className="text-sm text-amber-500 font-medium">
+                  {t('chatPage.summaryFailed')}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRetry}
+                disabled={isRetrying}
+                className="h-8 text-xs"
+              >
+                <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${isRetrying ? 'animate-spin' : ''}`} />
+                {isRetrying ? t('chatPage.summaryRetrying') : t('chatPage.summaryRetry')}
+              </Button>
+            </div>
+          </div>
+        )}
+
         {/* Topics */}
-        {topics && topics.length > 0 && (
+        {topics && topics.length > 0 && !isSummaryFailed && (
           <div className="flex flex-wrap gap-2">
             {topics.slice(0, 5).map((topic, index) => (
               <span

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -55,6 +55,15 @@ interface ChatAreaProps {
   knowledgeBaseId?: number
   /** Selected document IDs from DocumentPanel (for notebook mode context injection) */
   selectedDocumentIds?: number[]
+  /**
+   * Initial model reference for auto-selecting model (e.g., from knowledge base summary model).
+   * Used when creating a new task in notebook mode to inherit the summary model.
+   */
+  initialModelRef?: {
+    name: string
+    namespace: string
+    type: 'public' | 'user' | 'group'
+  } | null
 }
 
 /**
@@ -73,6 +82,7 @@ function ChatAreaContent({
   onTaskCreated,
   knowledgeBaseId,
   selectedDocumentIds,
+  initialModelRef,
 }: ChatAreaProps) {
   const { t } = useTranslation()
   const router = useRouter()
@@ -99,6 +109,7 @@ function ChatAreaContent({
     taskType,
     selectedTeamForNewTask,
     initialKnowledgeBase,
+    initialModelRef,
   })
 
   // Compute subtask info for scroll management

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1081,6 +1081,11 @@
       "confirmMessage": "Are you sure you want to delete this group chat? This action cannot be undone."
     }
   },
+  "model": {
+    "typePublic": "Public",
+    "typePersonal": "Personal",
+    "typeGroup": "Group"
+  },
   "attachment": {
     "errors": {
       "unsupported_type": "Unsupported file format",

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -366,6 +366,10 @@
     "notFound": "Knowledge base not found",
     "createTaskError": "Failed to create conversation",
     "bindKnowledgeBaseError": "Failed to bind knowledge base",
-    "newNote": "New Note"
+    "newNote": "New Note",
+    "summaryFailed": "Summary generation failed",
+    "summaryFailedHint": "Click retry to regenerate summary",
+    "summaryRetry": "Retry",
+    "summaryRetrying": "Retrying..."
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1075,6 +1075,11 @@
       "confirmMessage": "确定要删除这个群聊吗？此操作无法撤销。"
     }
   },
+  "model": {
+    "typePublic": "公共",
+    "typePersonal": "个人",
+    "typeGroup": "组"
+  },
   "attachment": {
     "errors": {
       "unsupported_type": "文件格式不支持",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -366,6 +366,10 @@
     "notFound": "知识库未找到",
     "createTaskError": "创建对话失败",
     "bindKnowledgeBaseError": "绑定知识库失败",
-    "newNote": "新笔记"
+    "newNote": "新笔记",
+    "summaryFailed": "摘要生成失败",
+    "summaryFailedHint": "点击重试按钮重新生成摘要",
+    "summaryRetry": "重试",
+    "summaryRetrying": "重试中..."
   }
 }


### PR DESCRIPTION
## Summary

This PR implements knowledge base auto-summary optimization with four key improvements:

1. **Default Enable Summary for Notebook Type**: When creating a notebook type knowledge base, `summaryEnabled` defaults to `true`, requiring model selection before submission. Classic type knowledge bases retain the original default of `false`.

2. **Model Type Label Translations**: Added missing i18n translations for model type labels (`public`, `personal`, `group`) used in the `SummaryModelSelector` component.

3. **Auto-inherit Summary Model**: In notebook mode chat pages, new conversations automatically inherit the knowledge base's summary model configuration when:
   - Knowledge base has `summary_enabled === true`
   - Knowledge base has a valid `summary_model_ref`
   - No existing task is selected (new conversation)

4. **Summary Failure Warning with Retry**: Added visual feedback for failed summary generation:
   - Warning icon with tooltip showing error message
   - Retry button to regenerate summary
   - Applied to both `KnowledgeBaseSummaryCard` (chat page) and `DocumentList` (document management)

## Changes

### Frontend Changes

**Requirement 1 - Default Summary Enable:**
- `CreateKnowledgeBaseDialog.tsx`: Set `summaryEnabled` default based on `kbType`

**Requirement 2 - Model Type Translations:**
- `en/common.json` & `zh-CN/common.json`: Added `model.typePublic`, `model.typePersonal`, `model.typeGroup`

**Requirement 3 - Auto-inherit Summary Model:**
- `ChatArea.tsx`: Added `initialModelRef` prop
- `useChatAreaState.ts`: Added logic to initialize model from `initialModelRef`
- `KnowledgeBaseChatPageDesktop.tsx` & `KnowledgeBaseChatPageMobile.tsx`: Pass `initialModelRef` from knowledge base config

**Requirement 4 - Summary Failure Warning:**
- `KnowledgeBaseSummaryCard.tsx`: Added failure status check, warning UI, and retry button
- `DocumentList.tsx`: Added failure warning in header with retry functionality
- `knowledge.ts` (API): Added `refreshKnowledgeBaseSummary` function
- `en/knowledge.json` & `zh-CN/knowledge.json`: Added translation keys for failure messages

## Test plan

- [ ] Create notebook type KB - verify summary is enabled by default and model selection is required
- [ ] Create classic type KB - verify summary is disabled by default
- [ ] Check SummaryModelSelector dropdown - verify model type labels are properly translated
- [ ] Open notebook KB chat with summary enabled - verify model is auto-selected for new conversations
- [ ] Switch to existing task - verify model selection follows task's original model
- [ ] Simulate summary failure - verify warning icon appears in both summary card and document list
- [ ] Click retry button - verify summary refresh API is called and status updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry failed knowledge-base summaries with a retry button and status feedback
  * Auto-inherit the knowledge-base summary model for new notebook-style chats
  * Summaries enabled by default for notebook-type knowledge bases

* **Improvements**
  * Warning indicators, tooltips and retry states for summary failures
  * Parent views refresh after a successful summary retry
  * Added localized labels for model types and summary-retry UI texts

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->