### PR TITLE
feat(tasks): add task deletion for completed tasks in Feed

### DIFF
--- a/backend/app/services/adapters/task_kinds/operations.py
+++ b/backend/app/services/adapters/task_kinds/operations.py
@@ -548,6 +548,7 @@ class TaskOperationsMixin:
         ).update(
             {
                 BackgroundExecution.status: "CANCELLED",
+                BackgroundExecution.completed_at: datetime.now(),
                 BackgroundExecution.updated_at: datetime.now(),
             }
         )

--- a/frontend/src/features/tasks/components/sidebar/DeleteTaskDialog.tsx
+++ b/frontend/src/features/tasks/components/sidebar/DeleteTaskDialog.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { taskApis } from '@/apis/tasks'
+import { toast } from 'sonner'
+import type { Task } from '@/types/api'
+
+interface DeleteTaskDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  onSuccess: () => void
+  task: Task | null
+  isGroupChat?: boolean
+}
+
+export function DeleteTaskDialog({
+  isOpen,
+  onClose,
+  onSuccess,
+  task,
+  isGroupChat = false,
+}: DeleteTaskDialogProps) {
+  const { t } = useTranslation('tasks')
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleConfirm = async () => {
+    if (!task) return
+
+    setIsDeleting(true)
+    try {
+      await taskApis.deleteTask(task.id)
+      toast.success(
+        isGroupChat ? t('deleteConfirm.leaveSuccess') : t('deleteConfirm.deleteSuccess')
+      )
+      onSuccess()
+      onClose()
+    } catch (error: unknown) {
+      console.error('Failed to delete task:', error)
+      const err = error as { response?: { data?: { detail?: string } }; message?: string }
+      const errorMessage =
+        err?.response?.data?.detail ||
+        err?.message ||
+        (isGroupChat ? t('deleteConfirm.leaveFailed') : t('deleteConfirm.deleteFailed'))
+      toast.error(errorMessage)
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  if (!task) {
+    return null
+  }
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={open => !open && !isDeleting && onClose()}>
+      <AlertDialogContent className="max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {isGroupChat ? t('deleteConfirm.leaveTitle') : t('deleteConfirm.title')}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="space-y-3">
+            <p>{isGroupChat ? t('deleteConfirm.leaveMessage') : t('deleteConfirm.message')}</p>
+
+            <div className="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-200 px-3 py-2 rounded-md text-sm">
+              <p className="font-medium">{t('common:common.warning')}:</p>
+              <p className="mt-1">{t('common:common.cannotUndo')}</p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={onClose} disabled={isDeleting}>
+            {t('common:actions.cancel')}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={isDeleting}
+            className="bg-error hover:bg-error/90 text-white"
+          >
+            {isDeleting ? (
+              <div className="flex items-center">
+                <svg
+                  className="animate-spin -ml-1 mr-2 h-4 w-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                {isGroupChat ? t('deleteConfirm.leaving') : t('common:actions.deleting')}
+              </div>
+            ) : isGroupChat ? (
+              t('common:groupChat.leave')
+            ) : (
+              t('common:actions.delete')
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
@@ -51,6 +51,9 @@ export default function TaskMenu({
   const { projects, addTaskToProject } = useProjectContext()
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
+  // Check if task can be deleted (terminal status only)
+  const isDeletable = ['COMPLETED', 'FAILED', 'CANCELLED'].includes(task.status)
+
   const handleMoveToGroup = async (projectId: number) => {
     await addTaskToProject(projectId, task.id)
   }
@@ -127,24 +130,27 @@ export default function TaskMenu({
             </DropdownMenuItem>
           )}
 
-          <DropdownMenuItem
-            onClick={e => {
-              e.stopPropagation()
-              handleDeleteTask(task)
-            }}
-          >
-            {isGroupChat ? (
-              <>
-                <ArrowRightOnRectangleIcon className="h-3.5 w-3.5 mr-2" />
-                {t('common:groupChat.leave')}
-              </>
-            ) : (
-              <>
-                <TrashIcon className="h-3.5 w-3.5 mr-2" />
-                {t('common:tasks.delete_task')}
-              </>
-            )}
-          </DropdownMenuItem>
+          {/* Delete/Leave - only show for terminal status tasks */}
+          {isDeletable && (
+            <DropdownMenuItem
+              onClick={e => {
+                e.stopPropagation()
+                handleDeleteTask(task)
+              }}
+            >
+              {isGroupChat ? (
+                <>
+                  <ArrowRightOnRectangleIcon className="h-3.5 w-3.5 mr-2" />
+                  {t('common:groupChat.leave')}
+                </>
+              ) : (
+                <>
+                  <TrashIcon className="h-3.5 w-3.5 mr-2" />
+                  {t('common:tasks.delete_task')}
+                </>
+              )}
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
@@ -29,17 +29,18 @@ import {
 } from '@/components/ui/dropdown'
 import { useProjectContext } from '@/features/projects'
 import { ProjectCreateDialog } from '@/features/projects/components/ProjectCreateDialog'
+import type { Task } from '@/types/api'
 
 interface TaskMenuProps {
-  taskId: number
+  task: Task
   handleCopyTaskId: (taskId: number) => void
-  handleDeleteTask: (taskId: number) => void
+  handleDeleteTask: (task: Task) => void
   onRename?: () => void
   isGroupChat?: boolean
 }
 
 export default function TaskMenu({
-  taskId,
+  task,
   handleCopyTaskId,
   handleDeleteTask,
   onRename,
@@ -51,7 +52,7 @@ export default function TaskMenu({
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
 
   const handleMoveToGroup = async (projectId: number) => {
-    await addTaskToProject(projectId, taskId)
+    await addTaskToProject(projectId, task.id)
   }
 
   return (
@@ -67,7 +68,7 @@ export default function TaskMenu({
           <DropdownMenuItem
             onClick={e => {
               e.stopPropagation()
-              handleCopyTaskId(taskId)
+              handleCopyTaskId(task.id)
             }}
           >
             <ClipboardDocumentIcon className="h-3.5 w-3.5 mr-2" />
@@ -129,7 +130,7 @@ export default function TaskMenu({
           <DropdownMenuItem
             onClick={e => {
               e.stopPropagation()
-              handleDeleteTask(taskId)
+              handleDeleteTask(task)
             }}
           >
             {isGroupChat ? (

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -5,6 +5,17 @@
   "attachment": {
     "characters": "characters"
   },
+  "deleteConfirm": {
+    "title": "Delete Task",
+    "message": "Are you sure you want to delete this task? This action cannot be undone.",
+    "leaveTitle": "Leave Conversation",
+    "leaveMessage": "Are you sure you want to leave this conversation?",
+    "deleteSuccess": "Task deleted successfully",
+    "deleteFailed": "Failed to delete task",
+    "leaveSuccess": "Left conversation successfully",
+    "leaveFailed": "Failed to leave conversation",
+    "leaving": "Leaving..."
+  },
   "workbench": {
     "overview": "Overview",
     "files_changed": "Files Changed",

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -5,6 +5,17 @@
   "attachment": {
     "characters": "字符"
   },
+  "deleteConfirm": {
+    "title": "删除任务",
+    "message": "确定要删除此任务吗？此操作无法撤消。",
+    "leaveTitle": "离开对话",
+    "leaveMessage": "确定要离开此对话吗？",
+    "deleteSuccess": "任务删除成功",
+    "deleteFailed": "删除任务失败",
+    "leaveSuccess": "已成功离开对话",
+    "leaveFailed": "离开对话失败",
+    "leaving": "离开中..."
+  },
   "workbench": {
     "overview": "概览",
     "files_changed": "文件变更",


### PR DESCRIPTION
## Summary

- Add task status validation for deletion: only allow deletion for tasks with COMPLETED, FAILED, or CANCELLED status
- Add BackgroundExecution record cleanup when deleting tasks to prevent orphaned execution records
- Add delete icon button directly on task items in Feed list (visible on hover/touch)
- Add DeleteTaskDialog confirmation component with loading state and error handling
- Add i18n translations for task deletion in English and Chinese
- Show leave icon (ArrowRightOnRectangleIcon) for group chat members instead of delete icon
- Support touch-friendly 44px minimum tap target on mobile devices

## Changes

### Backend Changes
1. **`backend/app/services/adapters/task_kinds/operations.py`**:
   - Added task status validation in `delete_task()` method - returns HTTP 400 if attempting to delete tasks with PENDING or RUNNING status
   - Added BackgroundExecution record cleanup - updates associated records to CANCELLED status when a task is deleted
   - Import BackgroundExecution model from subscription module

### Frontend Changes
1. **`frontend/src/features/tasks/components/sidebar/TaskListSection.tsx`**:
   - Added delete icon button directly on task items (not in dropdown menu)
   - Delete button only visible for deletable tasks (COMPLETED, FAILED, CANCELLED)
   - Added `isTaskDeletable()` helper function for status checking
   - Added `DeleteTaskDialog` state management
   - Updated `handleDeleteTask()` to open confirmation dialog instead of direct deletion
   - Touch-friendly button with 44px × 44px minimum tap target

2. **`frontend/src/features/tasks/components/sidebar/TaskMenu.tsx`**:
   - Updated to accept `task` object instead of `taskId` for better type safety
   - Updated type signature for `handleDeleteTask` prop

3. **`frontend/src/features/tasks/components/sidebar/DeleteTaskDialog.tsx`** (NEW):
   - Confirmation dialog component following existing patterns
   - Loading state with spinner animation during API call
   - Toast notifications for success/error feedback
   - Different titles/messages for delete vs leave scenarios
   - Warning banner about irreversible action

4. **`frontend/src/i18n/locales/en/tasks.json`**:
   - Added `deleteConfirm` section with all required keys

5. **`frontend/src/i18n/locales/zh-CN/tasks.json`**:
   - Added Chinese translations for delete confirmation

## Test plan

- [ ] Verify only completed, failed, or cancelled tasks show the delete icon
- [ ] Verify clicking delete icon opens confirmation dialog
- [ ] Verify confirming deletion removes task from Feed list
- [ ] Verify subtask messages in conversation are hidden after task deletion
- [ ] Verify BackgroundExecution records are cleaned up after task deletion
- [ ] Verify group chat members see "Leave" instead of "Delete" and can only leave (not delete)
- [ ] Verify task owner can delete group chat task entirely
- [ ] Verify delete button has proper loading state during API call
- [ ] Verify error handling for failed deletions (show toast notification)
- [ ] Mobile: Verify delete icon has minimum 44px tap target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task deletion confirmation dialog to prevent accidental deletions
  * Delete option now available only for completed, failed, or cancelled tasks
  * Improved deletion process with enhanced backend cleanup
  * Added English and Chinese translations for deletion workflow

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->