### PR TITLE
fix(frontend): preserve contexts when regenerating response in single chat

### DIFF
--- a/backend/app/services/subtask.py
+++ b/backend/app/services/subtask.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple
 
 from fastapi import HTTPException
+from shared.models.db.enums import ContextType
 from shared.models.db.subtask_context import SubtaskContext
 from sqlalchemy.orm import Session, load_only, subqueryload, undefer
 
@@ -410,9 +411,18 @@ class SubtaskService(BaseService[Subtask, SubtaskCreate, SubtaskUpdate]):
         deleted_count = len(subtasks_to_delete)
         subtask_ids_to_delete = [s.id for s in subtasks_to_delete]
 
-        # Delete associated SubtaskContexts first
+        # Handle SubtaskContexts:
+        # - Preserve attachment contexts (reset subtask_id to 0 so they can be re-linked)
+        # - Delete non-attachment contexts (knowledge_base, table, etc.)
+        # This allows attachments to be reused when regenerating responses
         db.query(SubtaskContext).filter(
-            SubtaskContext.subtask_id.in_(subtask_ids_to_delete)
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        ).update({"subtask_id": 0}, synchronize_session=False)
+
+        db.query(SubtaskContext).filter(
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type != ContextType.ATTACHMENT.value,
         ).delete(synchronize_session="fetch")
 
         # Delete the subtasks
@@ -466,9 +476,18 @@ class SubtaskService(BaseService[Subtask, SubtaskCreate, SubtaskUpdate]):
         deleted_count = len(subtasks_to_delete)
         subtask_ids_to_delete = [s.id for s in subtasks_to_delete]
 
-        # Delete associated SubtaskContexts first
+        # Handle SubtaskContexts:
+        # - Preserve attachment contexts (reset subtask_id to 0 so they can be re-linked)
+        # - Delete non-attachment contexts (knowledge_base, table, etc.)
+        # This allows attachments to be reused when regenerating responses
         db.query(SubtaskContext).filter(
-            SubtaskContext.subtask_id.in_(subtask_ids_to_delete)
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        ).update({"subtask_id": 0}, synchronize_session=False)
+
+        db.query(SubtaskContext).filter(
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type != ContextType.ATTACHMENT.value,
         ).delete(synchronize_session="fetch")
 
         # Delete the subtasks

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -417,9 +417,10 @@ function ChatAreaContent({
   )
 
   // Callback for child components to send messages with a specific model (for regeneration)
+  // Accepts optional existingContexts to preserve attachments/knowledge bases from the original message
   const handleSendMessageWithModelFromChild = useCallback(
-    async (content: string, model: Model) => {
-      await streamHandlers.handleSendMessageWithModel(content, model)
+    async (content: string, model: Model, existingContexts?: SubtaskContextBrief[]) => {
+      await streamHandlers.handleSendMessageWithModel(content, model, existingContexts)
     },
     [streamHandlers]
   )

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -149,7 +149,11 @@ interface MessagesAreaProps {
   onContentChange?: () => void
   onSendMessage?: (content: string) => void
   /** Callback for sending message with a specific model override (used for regenerate) */
-  onSendMessageWithModel?: (content: string, model: Model) => void
+  onSendMessageWithModel?: (
+    content: string,
+    model: Model,
+    existingContexts?: import('@/types/api').SubtaskContextBrief[]
+  ) => void
   isGroupChat?: boolean
   onRetry?: (message: Message) => void
   // Correction mode props
@@ -782,8 +786,10 @@ export default function MessagesArea({
         return
       }
 
-      // 4. Save original content for potential recovery
+      // 4. Save original content and contexts for potential recovery
       const originalUserContent = userMessage.content
+      // Extract contexts from the original user message (attachments, knowledge bases, tables)
+      const originalContexts = userMessage.contexts || []
 
       setIsRegenerating(true)
       try {
@@ -804,8 +810,9 @@ export default function MessagesArea({
           await refreshSelectedTaskDetail(true)
 
           // 8. Resend the same user message with the selected model to trigger new AI response
+          // Pass the original contexts (attachments, knowledge bases, etc.) to preserve them
           if (onSendMessageWithModel) {
-            onSendMessageWithModel(originalUserContent, selectedModel)
+            onSendMessageWithModel(originalUserContent, selectedModel, originalContexts)
           } else if (onSendMessage) {
             // Fallback to regular send if model override is not supported
             onSendMessage(originalUserContent)


### PR DESCRIPTION
## Summary

- Fix regenerate response functionality losing attachments and contexts in single chat
- Extract contexts (attachments, knowledge bases, tables) from original user message
- Pass contexts through `onSendMessageWithModel` callback chain to preserve them
- Build `attachment_ids` and `contextItems` from existing contexts for backend API
- Display original contexts in the regenerated user message UI

## Problem

When clicking "regenerate response" in single chat, if the user's last message had attachments or other contexts (knowledge base, table), these were not being passed to the new message. This caused the AI to lose access to the attachment content when regenerating.

## Root Cause

1. `MessagesArea.tsx` `handleRegenerate` only extracted message text, not contexts
2. `useChatStreamHandlers.tsx` `handleSendMessageWithModel` had hardcoded empty arrays for `attachment_ids`, `pendingAttachments`, and `pendingContexts`

## Solution

1. Extended `onSendMessageWithModel` signature to accept optional `existingContexts` parameter
2. Modified `handleRegenerate` to extract and pass `userMessage.contexts`
3. Updated `handleSendMessageWithModel` to:
   - Extract `attachment_ids` from existing contexts
   - Build `contextItems` for knowledge bases and tables
   - Build `pendingContexts` for immediate UI display

## Test plan

- [ ] Send a message with an attachment → wait for response → click regenerate → verify attachment is passed
- [ ] Send a message with multiple attachments → regenerate → verify all attachments are preserved
- [ ] Send a message with knowledge base reference → regenerate → verify KB is preserved
- [ ] Send a message with both attachment and KB → regenerate → verify both are preserved
- [ ] Verify regenerated user message shows original attachment/context badges in UI