### PR TITLE
fix(sandbox): improve error handling for container port retrieval

### DIFF
--- a/backend/init_data/skills/sandbox/_base.py
+++ b/backend/init_data/skills/sandbox/_base.py
@@ -280,7 +280,7 @@ class SandboxManager:
         self,
         shell_type: str,
         workspace_ref: Optional[str] = None,
-        task_type: str = "generic",
+        task_type: str = "sandbox",
     ) -> tuple[Any, Optional[str]]:
         """Create a fresh sandbox instance using E2B SDK.
 

--- a/backend/init_data/skills/sandbox/claude_tool.py
+++ b/backend/init_data/skills/sandbox/claude_tool.py
@@ -194,7 +194,6 @@ Example:
             sandbox, error = await sandbox_manager.get_or_create_sandbox(
                 shell_type=self.default_shell_type,
                 workspace_ref=None,
-                task_type="claude_command",
             )
 
             if error:

--- a/backend/init_data/skills/sandbox/command_tool.py
+++ b/backend/init_data/skills/sandbox/command_tool.py
@@ -152,7 +152,6 @@ Example:
             sandbox, error = await sandbox_manager.get_or_create_sandbox(
                 shell_type=self.default_shell_type,
                 workspace_ref=None,
-                task_type="command",
             )
 
             if error:

--- a/backend/init_data/skills/sandbox/list_files_tool.py
+++ b/backend/init_data/skills/sandbox/list_files_tool.py
@@ -140,7 +140,6 @@ Example:
             sandbox, error = await sandbox_manager.get_or_create_sandbox(
                 shell_type=self.default_shell_type,
                 workspace_ref=None,
-                task_type="list_files",
             )
 
             if error:

--- a/backend/init_data/skills/sandbox/read_file_tool.py
+++ b/backend/init_data/skills/sandbox/read_file_tool.py
@@ -136,7 +136,6 @@ Example:
             sandbox, error = await sandbox_manager.get_or_create_sandbox(
                 shell_type=self.default_shell_type,
                 workspace_ref=None,
-                task_type="read_file",
             )
 
             if error:

--- a/backend/init_data/skills/sandbox/write_file_tool.py
+++ b/backend/init_data/skills/sandbox/write_file_tool.py
@@ -158,7 +158,6 @@ Example:
             sandbox, error = await sandbox_manager.get_or_create_sandbox(
                 shell_type=self.default_shell_type,
                 workspace_ref=None,
-                task_type="write_file",
             )
 
             if error:

--- a/executor_manager/executors/docker/executor.py
+++ b/executor_manager/executors/docker/executor.py
@@ -946,12 +946,15 @@ class DockerExecutor(Executor):
                 }
 
             # Get container port
-            port = self._get_container_port(container_name)
+            port, error_msg = self._get_container_port(container_name)
             if not port:
-                logger.error(f"Could not find port for container {container_name}")
+                logger.error(
+                    f"Could not find port for container {container_name}: {error_msg}"
+                )
                 return {
                     "status": "failed",
-                    "error_msg": f"Could not find port for container {container_name}",
+                    "error_msg": error_msg
+                    or f"Could not find port for container {container_name}",
                 }
 
             # Call the executor's cancel API
@@ -1060,11 +1063,12 @@ class DockerExecutor(Executor):
             Dict with status and base_url (e.g., http://localhost:8080)
         """
         try:
-            port = self._get_container_port(executor_name)
+            port, error_msg = self._get_container_port(executor_name)
             if not port:
                 return {
                     "status": "failed",
-                    "error_msg": f"Container {executor_name} port not available",
+                    "error_msg": error_msg
+                    or f"Container {executor_name} port not available",
                 }
 
             return {


### PR DESCRIPTION
- Remove redundant task_type parameter from sandbox tool calls
- Enhance _get_container_port to return detailed error messages
- Improve error logging for container port retrieval failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when Docker container port information retrieval fails, providing more detailed diagnostic information.

* **Refactor**
  * Consolidated sandbox creation logic to use standardized default task type across sandbox tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->