### PR TITLE
feat-chat-regenerate-reply (#225)

### DIFF
--- a/backend/app/services/subtask.py
+++ b/backend/app/services/subtask.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import List, Optional, Tuple
 
 from fastapi import HTTPException
+from shared.models.db.enums import ContextType
 from shared.models.db.subtask_context import SubtaskContext
 from sqlalchemy.orm import Session, load_only, subqueryload, undefer
 
@@ -410,9 +411,18 @@ class SubtaskService(BaseService[Subtask, SubtaskCreate, SubtaskUpdate]):
         deleted_count = len(subtasks_to_delete)
         subtask_ids_to_delete = [s.id for s in subtasks_to_delete]
 
-        # Delete associated SubtaskContexts first
+        # Handle SubtaskContexts:
+        # - Preserve attachment contexts (reset subtask_id to 0 so they can be re-linked)
+        # - Delete non-attachment contexts (knowledge_base, table, etc.)
+        # This allows attachments to be reused when regenerating responses
         db.query(SubtaskContext).filter(
-            SubtaskContext.subtask_id.in_(subtask_ids_to_delete)
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        ).update({"subtask_id": 0}, synchronize_session=False)
+
+        db.query(SubtaskContext).filter(
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type != ContextType.ATTACHMENT.value,
         ).delete(synchronize_session="fetch")
 
         # Delete the subtasks
@@ -466,9 +476,18 @@ class SubtaskService(BaseService[Subtask, SubtaskCreate, SubtaskUpdate]):
         deleted_count = len(subtasks_to_delete)
         subtask_ids_to_delete = [s.id for s in subtasks_to_delete]
 
-        # Delete associated SubtaskContexts first
+        # Handle SubtaskContexts:
+        # - Preserve attachment contexts (reset subtask_id to 0 so they can be re-linked)
+        # - Delete non-attachment contexts (knowledge_base, table, etc.)
+        # This allows attachments to be reused when regenerating responses
         db.query(SubtaskContext).filter(
-            SubtaskContext.subtask_id.in_(subtask_ids_to_delete)
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        ).update({"subtask_id": 0}, synchronize_session=False)
+
+        db.query(SubtaskContext).filter(
+            SubtaskContext.subtask_id.in_(subtask_ids_to_delete),
+            SubtaskContext.context_type != ContextType.ATTACHMENT.value,
         ).delete(synchronize_session="fetch")
 
         # Delete the subtasks

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -18,6 +18,7 @@ import { useChatStreamHandlers } from './useChatStreamHandlers'
 import { allBotsHavePredefinedModel } from '../selector/ModelSelector'
 import { QuoteProvider, SelectionTooltip, useQuote } from '../text-selection'
 import type { Team, SubtaskContextBrief } from '@/types/api'
+import type { Model } from '../../hooks/useModelSelection'
 import type { ContextItem } from '@/types/context'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useRouter } from 'next/navigation'
@@ -415,6 +416,15 @@ function ChatAreaContent({
     [chatState, streamHandlers]
   )
 
+  // Callback for child components to send messages with a specific model (for regeneration)
+  // Accepts optional existingContexts to preserve attachments/knowledge bases from the original message
+  const handleSendMessageWithModelFromChild = useCallback(
+    async (content: string, model: Model, existingContexts?: SubtaskContextBrief[]) => {
+      await streamHandlers.handleSendMessageWithModel(content, model, existingContexts)
+    },
+    [streamHandlers]
+  )
+
   // Callback for re-selecting a context from a message badge
   const handleContextReselect = useCallback(
     (context: SubtaskContextBrief) => {
@@ -625,6 +635,7 @@ function ChatAreaContent({
               onContentChange={handleMessagesContentChange}
               onShareButtonRender={onShareButtonRender}
               onSendMessage={handleSendMessageFromChild}
+              onSendMessageWithModel={handleSendMessageWithModelFromChild}
               isGroupChat={selectedTaskDetail?.is_group_chat || false}
               onRetry={streamHandlers.handleRetry}
               enableCorrectionMode={chatState.enableCorrectionMode}

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -17,7 +17,7 @@ import { isChatShell } from '../../service/messageService'
 import { Button } from '@/components/ui/button'
 import { DEFAULT_MODEL_NAME } from '../selector/ModelSelector'
 import type { Model } from '../selector/ModelSelector'
-import type { Team, GitRepoInfo, GitBranch, Attachment } from '@/types/api'
+import type { Team, GitRepoInfo, GitBranch, Attachment, SubtaskContextBrief } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 export interface UseChatStreamHandlersOptions {
   // Team and model
@@ -89,6 +89,17 @@ export interface ChatStreamHandlers {
 
   // Actions
   handleSendMessage: (overrideMessage?: string) => Promise<void>
+  /**
+   * Send a message with a temporary model override (used for regeneration).
+   * @param overrideMessage - The message content to send
+   * @param modelOverride - The model to use for this single request
+   * @param existingContexts - Optional existing contexts from original message (attachments, knowledge bases, tables)
+   */
+  handleSendMessageWithModel: (
+    overrideMessage: string,
+    modelOverride: Model,
+    existingContexts?: SubtaskContextBrief[]
+  ) => Promise<void>
   handleRetry: (message: {
     content: string
     type: string
@@ -630,6 +641,235 @@ export function useChatStreamHandlers({
     ]
   )
 
+  /**
+   * Send a message with a temporary model override.
+   * This is used for regeneration where user selects a specific model for that single regeneration.
+   * The model override only affects this single call and does not change the session's model preference.
+   * @param overrideMessage - The message content to send
+   * @param modelOverride - The model to use for this single request
+   * @param existingContexts - Optional existing contexts from original message (for regeneration)
+   */
+  const handleSendMessageWithModel = useCallback(
+    async (
+      overrideMessage: string,
+      modelOverride: Model,
+      existingContexts?: SubtaskContextBrief[]
+    ) => {
+      const message = overrideMessage.trim()
+      if (!message && !shouldHideChatInput) return
+
+      if (!isAttachmentReadyToSend) {
+        toast({
+          variant: 'destructive',
+          title: t('chat:upload.wait_for_upload'),
+        })
+        return
+      }
+
+      // For code type tasks, repository is required
+      const effectiveRepo =
+        selectedRepo ||
+        (selectedTaskDetail
+          ? {
+              git_url: selectedTaskDetail.git_url,
+              git_repo: selectedTaskDetail.git_repo,
+              git_repo_id: selectedTaskDetail.git_repo_id,
+              git_domain: selectedTaskDetail.git_domain,
+            }
+          : null)
+
+      if (taskType === 'code' && showRepositorySelector && !effectiveRepo?.git_repo) {
+        toast({
+          variant: 'destructive',
+          title: t('common:selector.repository') || 'Please select a repository for code tasks',
+        })
+        return
+      }
+
+      setIsLoading(true)
+
+      // Set local pending state immediately
+      setLocalPendingMessage(message)
+      setTaskInputMessage('')
+      // Note: Don't reset attachments/contexts for regeneration since we're reusing existing ones
+
+      // Use the override model instead of the selected model
+      const modelId = modelOverride.name === DEFAULT_MODEL_NAME ? undefined : modelOverride.name
+
+      // Prepare message with external API parameters
+      let finalMessage = message
+      if (Object.keys(externalApiParams).length > 0) {
+        const paramsJson = JSON.stringify(externalApiParams)
+        finalMessage = `[EXTERNAL_API_PARAMS]${paramsJson}[/EXTERNAL_API_PARAMS]\n${message}`
+      }
+
+      try {
+        const immediateTaskId = selectedTaskDetail?.id || -Date.now()
+
+        // Extract attachment IDs from existing contexts (for regeneration)
+        const attachmentIds =
+          existingContexts?.filter(ctx => ctx.context_type === 'attachment').map(ctx => ctx.id) ||
+          []
+
+        // Build context items for backend from existing contexts (knowledge bases, tables)
+        const contextItems: Array<{
+          type: 'knowledge_base' | 'table' | 'selected_documents'
+          data: Record<string, unknown>
+        }> = []
+
+        if (existingContexts) {
+          for (const ctx of existingContexts) {
+            if (ctx.context_type === 'knowledge_base') {
+              contextItems.push({
+                type: 'knowledge_base' as const,
+                data: {
+                  knowledge_id: ctx.id,
+                  name: ctx.name,
+                  document_count: ctx.document_count,
+                },
+              })
+            } else if (ctx.context_type === 'table') {
+              contextItems.push({
+                type: 'table' as const,
+                data: {
+                  document_id: ctx.id,
+                  name: ctx.name,
+                  source_config: ctx.source_config,
+                },
+              })
+            }
+          }
+        }
+
+        // Build pending contexts for immediate display from existing contexts
+        const pendingContexts: Array<{
+          id: number
+          context_type: 'attachment' | 'knowledge_base' | 'table'
+          name: string
+          status: 'pending' | 'ready'
+          file_extension?: string
+          file_size?: number
+          mime_type?: string
+          document_count?: number
+          source_config?: {
+            url?: string
+          }
+        }> =
+          existingContexts?.map(ctx => ({
+            id: ctx.id,
+            context_type: ctx.context_type,
+            name: ctx.name,
+            status: 'ready' as const,
+            file_extension: ctx.file_extension ?? undefined,
+            file_size: ctx.file_size ?? undefined,
+            mime_type: ctx.mime_type ?? undefined,
+            document_count: ctx.document_count ?? undefined,
+            source_config: ctx.source_config ?? undefined,
+          })) || []
+
+        const tempTaskId = await contextSendMessage(
+          {
+            message: finalMessage,
+            team_id: selectedTeam?.id ?? 0,
+            task_id: selectedTaskDetail?.id,
+            model_id: modelId,
+            force_override_bot_model: true, // Always force override when using model override
+            attachment_ids: attachmentIds,
+            enable_deep_thinking: enableDeepThinking,
+            enable_clarification: enableClarification,
+            is_group_chat: selectedTaskDetail?.is_group_chat || false,
+            git_url: showRepositorySelector ? effectiveRepo?.git_url : undefined,
+            git_repo: showRepositorySelector ? effectiveRepo?.git_repo : undefined,
+            git_repo_id: showRepositorySelector ? effectiveRepo?.git_repo_id : undefined,
+            git_domain: showRepositorySelector ? effectiveRepo?.git_domain : undefined,
+            branch_name: showRepositorySelector
+              ? selectedBranch?.name || selectedTaskDetail?.branch_name
+              : undefined,
+            task_type: taskType,
+            knowledge_base_id: taskType === 'knowledge' ? knowledgeBaseId : undefined,
+            contexts: contextItems.length > 0 ? contextItems : undefined,
+          },
+          {
+            pendingUserMessage: message,
+            pendingAttachments: [], // Attachments are already part of pendingContexts
+            pendingContexts: pendingContexts.length > 0 ? pendingContexts : undefined,
+            immediateTaskId: immediateTaskId,
+            currentUserId: user?.id,
+            onMessageSent: (
+              _localMessageId: string,
+              completedTaskId: number,
+              _subtaskId: number
+            ) => {
+              if (completedTaskId > 0) {
+                setPendingTaskId(completedTaskId)
+              }
+
+              // Call onTaskCreated callback when a new task is created
+              if (completedTaskId && !selectedTaskDetail?.id && onTaskCreated) {
+                onTaskCreated(completedTaskId)
+              }
+
+              if (completedTaskId && !selectedTaskDetail?.id) {
+                const params = new URLSearchParams(Array.from(searchParams.entries()))
+                params.set('taskId', String(completedTaskId))
+                router.push(`?${params.toString()}`)
+                refreshTasks()
+              }
+
+              if (selectedTaskDetail?.is_group_chat && completedTaskId) {
+                markTaskAsViewed(
+                  completedTaskId,
+                  selectedTaskDetail.status,
+                  new Date().toISOString()
+                )
+              }
+            },
+            onError: (error: Error) => {
+              handleSendError(error, message)
+            },
+          }
+        )
+
+        if (tempTaskId !== immediateTaskId && tempTaskId > 0) {
+          setPendingTaskId(tempTaskId)
+        }
+
+        setTimeout(() => scrollToBottom(true), 0)
+      } catch (err) {
+        handleSendError(err as Error, message)
+      }
+
+      setIsLoading(false)
+    },
+    [
+      shouldHideChatInput,
+      isAttachmentReadyToSend,
+      toast,
+      selectedTeam,
+      selectedTaskDetail,
+      contextSendMessage,
+      enableDeepThinking,
+      enableClarification,
+      refreshTasks,
+      searchParams,
+      router,
+      showRepositorySelector,
+      selectedRepo,
+      selectedBranch,
+      taskType,
+      knowledgeBaseId,
+      markTaskAsViewed,
+      user?.id,
+      handleSendError,
+      scrollToBottom,
+      setIsLoading,
+      setTaskInputMessage,
+      externalApiParams,
+      onTaskCreated,
+      t,
+    ]
+  )
+
   // Update ref when handleSendMessage changes
   useEffect(() => {
     handleSendMessageRef.current = handleSendMessage
@@ -770,6 +1010,7 @@ export function useChatStreamHandlers({
 
     // Actions
     handleSendMessage,
+    handleSendMessageWithModel,
     handleRetry,
     handleCancelTask,
     stopStream,

--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -5,10 +5,10 @@
 'use client'
 
 import React, { useState } from 'react'
-import { Copy, Check, ThumbsUp, ThumbsDown, Pencil } from 'lucide-react'
+import { Copy, Check, ThumbsUp, ThumbsDown, Pencil, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from '@/hooks/useTranslation'
 import type { FeedbackState } from '@/hooks/useMessageFeedback'
 
 // CopyButton component for copying markdown content
@@ -142,6 +142,17 @@ export interface BubbleToolsProps {
     like: string
     dislike: string
   }
+  /** Handler for regenerate button click (opens model selection popover) */
+  onRegenerateClick?: () => void
+  /** Whether regenerate button should be shown */
+  showRegenerate?: boolean
+  /** Whether regenerate is in progress */
+  isRegenerating?: boolean
+  /** Optional render prop for custom regenerate button with popover */
+  renderRegenerateButton?: (
+    defaultButton: React.ReactNode,
+    tooltipText: string
+  ) => React.ReactNode
 }
 
 // Bubble toolbar: supports copy button, feedback buttons, and extensible tool buttons
@@ -153,6 +164,10 @@ const BubbleTools = ({
   onLike,
   onDislike,
   feedbackLabels,
+  onRegenerateClick,
+  showRegenerate,
+  isRegenerating,
+  renderRegenerateButton,
 }: BubbleToolsProps) => {
   const { t } = useTranslation()
 
@@ -165,6 +180,44 @@ const BubbleTools = ({
         tooltip={t('chat:actions.copy') || 'Copy'}
         className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec"
       />
+      {/* Regenerate button - only shown when showRegenerate is true */}
+      {showRegenerate &&
+        (() => {
+          // When renderRegenerateButton is provided, the button is wrapped in a PopoverTrigger
+          // In that case, we should NOT include onClick since PopoverTrigger handles the open state
+          const hasPopoverWrapper = !!renderRegenerateButton
+
+          // The raw button - onClick is only set when there's no popover wrapper
+          const rawButton = (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={hasPopoverWrapper ? undefined : onRegenerateClick}
+              disabled={isRegenerating}
+              className="h-[30px] w-[30px] !rounded-full bg-fill-tert hover:!bg-fill-sec disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3.5 w-3.5 text-text-muted ${isRegenerating ? 'animate-spin' : ''}`}
+              />
+            </Button>
+          )
+
+          const tooltipText =
+            t('chat:regenerate.tooltip') || t('chat:actions.regenerate') || 'Regenerate'
+
+          // When using renderRegenerateButton (with Popover), tooltip is handled inside the Popover component
+          // When not using renderRegenerateButton, wrap button with Tooltip here
+          if (renderRegenerateButton) {
+            return renderRegenerateButton(rawButton, tooltipText)
+          }
+
+          return (
+            <Tooltip>
+              <TooltipTrigger asChild>{rawButton}</TooltipTrigger>
+              <TooltipContent>{tooltipText}</TooltipContent>
+            </Tooltip>
+          )
+        })()}
       {/* Feedback buttons: like and dislike */}
       <Tooltip>
         <TooltipTrigger asChild>

--- a/frontend/src/features/tasks/components/message/RegenerateModelPopover.tsx
+++ b/frontend/src/features/tasks/components/message/RegenerateModelPopover.tsx
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React from 'react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useTranslation } from '@/hooks/useTranslation'
+import { useModelSelection, type Model } from '../../hooks/useModelSelection'
+import type { Team } from '@/types/api'
+import { cn } from '@/lib/utils'
+import { Globe, User } from 'lucide-react'
+
+export interface RegenerateModelPopoverProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  selectedTeam: Team | null
+  onSelectModel: (model: Model) => void
+  isLoading?: boolean
+  trigger: React.ReactNode
+  /** Tooltip text for the trigger button */
+  tooltipText?: string
+}
+
+/**
+ * A popover component for selecting a model when regenerating AI responses.
+ * Shows a list of compatible models based on the current team's agent type.
+ */
+export function RegenerateModelPopover({
+  open,
+  onOpenChange,
+  selectedTeam,
+  onSelectModel,
+  isLoading = false,
+  trigger,
+  tooltipText,
+}: RegenerateModelPopoverProps) {
+  const { t } = useTranslation('chat')
+
+  // Use the model selection hook to get filtered models
+  const {
+    filteredModels,
+    isLoading: isModelsLoading,
+    getModelDisplayText,
+  } = useModelSelection({
+    teamId: selectedTeam?.id ?? null,
+    taskId: null,
+    selectedTeam,
+  })
+
+  const handleModelSelect = (model: Model) => {
+    onSelectModel(model)
+    onOpenChange(false)
+  }
+
+  const loading = isLoading || isModelsLoading
+
+  // Wrap trigger with Tooltip inside Popover to avoid asChild conflicts
+  // The Tooltip wraps the PopoverTrigger so hover events work correctly
+  const triggerWithTooltip = tooltipText ? (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      </TooltipTrigger>
+      <TooltipContent>{tooltipText}</TooltipContent>
+    </Tooltip>
+  ) : (
+    <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+  )
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      {triggerWithTooltip}
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-64 p-2"
+        onInteractOutside={() => onOpenChange(false)}
+      >
+        {/* Header */}
+        <div className="px-2 py-1.5 mb-1">
+          <h4 className="text-sm font-medium text-text-primary">{t('regenerate.select_model')}</h4>
+          <p className="text-xs text-text-muted mt-0.5">{t('regenerate.select_model_desc')}</p>
+        </div>
+
+        {/* Model list */}
+        <div className="max-h-60 overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center justify-center py-4">
+              <div className="animate-spin h-4 w-4 border-2 border-primary border-t-transparent rounded-full" />
+            </div>
+          ) : filteredModels.length === 0 ? (
+            <div className="text-center text-sm text-text-muted py-4">
+              {t('correction.no_models')}
+            </div>
+          ) : (
+            <div className="space-y-0.5">
+              {filteredModels.map(model => {
+                const isPublic = model.type === 'public'
+                const displayName = getModelDisplayText(model)
+
+                return (
+                  <button
+                    type="button"
+                    key={`${model.name}:${model.type || ''}`}
+                    onClick={() => handleModelSelect(model)}
+                    className={cn(
+                      'w-full flex items-center gap-2 px-2 py-2 rounded-md text-left',
+                      'hover:bg-fill-sec transition-colors',
+                      'focus:outline-none focus:ring-2 focus:ring-primary/20'
+                    )}
+                  >
+                    {/* Model type icon */}
+                    <span className="flex-shrink-0">
+                      {isPublic ? (
+                        <Globe className="h-3.5 w-3.5 text-text-muted" />
+                      ) : (
+                        <User className="h-3.5 w-3.5 text-text-muted" />
+                      )}
+                    </span>
+
+                    {/* Model name */}
+                    <span className="flex-1 text-sm text-text-primary truncate">{displayName}</span>
+
+                    {/* Model type badge */}
+                    <span
+                      className={cn(
+                        'text-xs px-1.5 py-0.5 rounded',
+                        isPublic
+                          ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                          : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+                      )}
+                    >
+                      {isPublic ? t('correction.public_model') : t('correction.user_model')}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default RegenerateModelPopover

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -25,7 +25,14 @@
     "confirm_title": "Confirm Edit",
     "confirm_description": "This edit will clear this message and all subsequent messages. The conversation will restart from this point. Are you sure you want to continue?",
     "confirm_button": "Confirm",
-    "confirming": "Processing..."
+    "confirming": "Processing...",
+    "wait_for_completion": "Please wait for the current response to complete"
+  },
+  "regenerate": {
+    "failed": "Failed to regenerate response",
+    "tooltip": "Regenerate response",
+    "select_model": "Select Model",
+    "select_model_desc": "Choose a model for regeneration"
   },
   "quote": {
     "ask_wegent": "Ask Wegent",
@@ -273,7 +280,8 @@
     "chars": "chars"
   },
   "upload": {
-    "tooltip": "Supported file types: PDF, Word, PPT, Excel, TXT, Markdown, Images(JPG, PNG, GIF, BMP, WebP)\nMax file size: {{maxSize}} MB\nSupports multiple file uploads"
+    "tooltip": "Supported file types: PDF, Word, PPT, Excel, TXT, Markdown, Images(JPG, PNG, GIF, BMP, WebP)\nMax file size: {{maxSize}} MB\nSupports multiple file uploads",
+    "wait_for_upload": "Please wait for file upload to complete"
   },
   "clarification_toggle": {
     "enable": "Enable smart follow-up mode",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -25,7 +25,14 @@
     "confirm_title": "确认编辑",
     "confirm_description": "此编辑操作将清除本条消息及其后的所有消息，对话将从当前位置重新开始。确定要继续吗？",
     "confirm_button": "确认",
-    "confirming": "处理中..."
+    "confirming": "处理中...",
+    "wait_for_completion": "请等待当前回复生成完成"
+  },
+  "regenerate": {
+    "failed": "重新生成失败",
+    "tooltip": "重新生成回复",
+    "select_model": "选择模型",
+    "select_model_desc": "选择用于重新生成的模型"
   },
   "quote": {
     "ask_wegent": "询问 Wegent",
@@ -273,7 +280,8 @@
     "chars": "字符"
   },
   "upload": {
-    "tooltip": "支持的文件类型: PDF, Word, PPT, Excel, TXT, Markdown, 图片(JPG, PNG, GIF, BMP, WebP)\n最大文件大小: {{maxSize}} MB\n支持多文件同时上传"
+    "tooltip": "支持的文件类型: PDF, Word, PPT, Excel, TXT, Markdown, 图片(JPG, PNG, GIF, BMP, WebP)\n最大文件大小: {{maxSize}} MB\n支持多文件同时上传",
+    "wait_for_upload": "请等待文件上传完成"
   },
   "clarification_toggle": {
     "enable": "启用智能追问模式",


### PR DESCRIPTION
* feat(frontend): add regenerate button for single chat AI responses

Add a "Regenerate" button to single chat mode that allows users to regenerate the last AI response. This button appears only on the last AI message when the response is completed and not streaming.

- Add RegenerateButton component to BubbleTools with RefreshCw icon
- Pass regenerate props through MessageBubble to control visibility
- Implement handleRegenerate in MessagesArea using edit API
- Add i18n translations for regenerate feature (en/zh-CN)

* fix(frontend): use Message type for handleRegenerate parameter

Fix type compatibility issue - use Message instead of DisplayMessage and use subtaskId for message matching instead of id field.

* refactor(frontend): address CodeRabbit review feedback

- Use chat:regenerate.tooltip key for more descriptive tooltip text
- Precompute lastAiMessageSubtaskId with useMemo to avoid O(n²) complexity in the render loop

* feat(frontend): add model selection popover for regenerate button

- Add RegenerateModelPopover component for model selection during regeneration
- Modify BubbleTools to support custom regenerate button rendering with popover
- Update MessageBubble to manage popover state and pass selected model
- Add handleSendMessageWithModel to useChatStreamHandlers for model override
- Update MessagesArea to handle model parameter in regeneration flow
- Add i18n translations for regenerate model selection (zh-CN and en)

* fix(frontend): address CodeRabbit review feedback

- Fix useTranslation import in BubbleTools.tsx to use @/hooks/useTranslation
- Remove unnecessary type assertion in RegenerateModelPopover.tsx
- Replace hardcoded error messages with i18n translations in handleSendMessageWithModel
- Add new translation key upload.wait_for_upload for zh-CN and en

* fix(frontend): fix regenerate popover not opening due to asChild conflict

When the regenerate button is wrapped in PopoverTrigger with asChild, the nested Tooltip/TooltipTrigger also uses asChild which causes event handling conflicts. Fix by:

1. Remove onClick handler when button is wrapped in PopoverTrigger (let PopoverTrigger handle open state via onOpenChange)
2. Remove Tooltip wrapper when using PopoverTrigger to avoid multiple asChild nesting conflicts

The PopoverTrigger now naturally controls the open/close state without manual onClick interference.

* fix(frontend): add streaming check before regenerate to prevent race condition

Add a defensive check in handleRegenerate to ensure we don't attempt to regenerate while a stream is still active. This prevents the backend error "Cannot edit while AI is generating a response" when there's a state mismatch between frontend and backend.

Also add i18n translations for the wait_for_completion message.

* fix(frontend): improve regenerate reliability with validation and state sync

- Add subtaskId validation before attempting to find AI message
- Use strict comparison (m.subtaskId !== undefined) in findIndex to avoid undefined matches
- Refresh task detail before calling editMessage API to ensure frontend/backend sync
- Add error handling to refresh state when backend reports AI is generating
- Add detailed console error logs for debugging regenerate failures

* fix(frontend): preserve contexts when regenerating response in single chat (#220)

* fix(frontend): preserve contexts when regenerating response in single chat

When clicking "regenerate response" in single chat, the original message's contexts (attachments, knowledge bases, tables) were not being passed to the new message, causing AI to lose access to the uploaded content.

Changes:
- Extract contexts from original user message during regeneration
- Pass contexts through onSendMessageWithModel callback chain
- Build attachment_ids and contextItems from existing contexts
- Display original contexts in the regenerated user message UI

This ensures that when regenerating a response, all original attachments and context references are preserved and passed to the AI.

* fix(backend): preserve attachment contexts when deleting subtasks

When deleting subtasks (for edit/regenerate), preserve attachment-type SubtaskContext records by resetting their subtask_id to 0 instead of deleting them. This allows attachments to be re-linked to new subtasks when regenerating responses.

Previously, all SubtaskContext records were deleted together with the subtask, which caused attachment IDs passed from frontend during regeneration to become invalid.

Changes:
- Separate handling for attachment vs non-attachment contexts
- Attachment contexts: reset subtask_id to 0 (unlinked state)
- Non-attachment contexts (KB, table): delete as before

This works with the frontend fix that passes original attachment_ids when regenerating responses.

---------



* Wegent/fix regenerate tooltip (#224)

* fix(frontend): add tooltip for regenerate button when wrapped in popover

The regenerate button was missing tooltip hint when wrapped in PopoverTrigger due to asChild conflicts. Fixed by wrapping the entire popover component with Tooltip instead of wrapping the inner button.

* fix(frontend): address CodeRabbit review comments

- Add Boolean(onRegenerate) guard to showRegenerate condition to prevent showing dead UI when no handler is provided
- Add explicit type="button" to model selection buttons in RegenerateModelPopover to prevent form submission issues

* fix(frontend): properly implement tooltip for regenerate button with popover

The previous approach of wrapping the entire Popover with Tooltip didn't work because TooltipTrigger with asChild cannot bind hover events to a Popover container (which is a logical component, not a DOM element).

Solution:
- Add tooltipText prop to RegenerateModelPopover component
- Inside RegenerateModelPopover, wrap PopoverTrigger with Tooltip/TooltipTrigger when tooltipText is provided
- This ensures hover events are correctly bound to the actual button element
- Update renderRegenerateButton signature to pass tooltipText as second parameter

---------



---------

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Regenerate AI messages with model selection—choose an alternative model to reprocess your conversations
  * Attachments now preserved when deleting subtasks, allowing them to be reused in other areas
  * Enhanced regeneration interface with model selector popover and visual feedback during processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->