### PR TITLE
fix(frontend): add namespace parameter to downloadSkill for group skill support

### DIFF
--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -420,6 +420,9 @@ def get_group_endpoint(
             detail="Group not found",
         )
 
+    # Set the current user's role in the group
+    group.my_role = user_role
+
     return group
 
 

--- a/backend/app/services/adapters/public_skill.py
+++ b/backend/app/services/adapters/public_skill.py
@@ -37,6 +37,7 @@ class PublicSkillAdapter:
             "bindShells": spec.get("bindShells"),
             "is_active": kind.is_active,
             "is_public": True,
+            "user_id": kind.user_id,
             "created_at": kind.created_at,
             "updated_at": kind.updated_at,
         }

--- a/backend/app/services/adapters/skill_kinds.py
+++ b/backend/app/services/adapters/skill_kinds.py
@@ -695,7 +695,10 @@ class SkillKindsService:
         metadata = ObjectMeta(
             name=kind.name,
             namespace=kind.namespace,
-            labels={"id": str(kind.id)},  # Store database ID in labels
+            labels={
+                "id": str(kind.id),
+                "user_id": str(kind.user_id),
+            },  # Store database ID and user_id in labels
         )
         return Skill(
             apiVersion=kind.json.get("apiVersion", "agent.wecode.io/v1"),

--- a/frontend/src/apis/skills.ts
+++ b/frontend/src/apis/skills.ts
@@ -300,6 +300,7 @@ export interface UnifiedSkill {
   bindShells?: string[]
   is_active: boolean
   is_public: boolean
+  user_id: number // ID of the user who uploaded this skill
   created_at?: string
   updated_at?: string
 }

--- a/frontend/src/apis/skills.ts
+++ b/frontend/src/apis/skills.ts
@@ -231,12 +231,23 @@ export async function deleteSkill(skillId: number): Promise<void> {
 
 /**
  * Download a skill ZIP file
+ * @param skillId - Skill ID
+ * @param skillName - Skill name (used for the downloaded file name)
+ * @param namespace - Namespace for group skill lookup (optional; when omitted, backend uses 'default')
  */
-export async function downloadSkill(skillId: number, skillName: string): Promise<void> {
+export async function downloadSkill(
+  skillId: number,
+  skillName: string,
+  namespace?: string
+): Promise<void> {
   const token = getToken()
   if (!token) throw new Error('No authentication token')
 
-  const url = `${getApiUrl()}/v1/kinds/skills/${skillId}/download`
+  const queryParams = new URLSearchParams()
+  if (namespace) queryParams.append('namespace', namespace)
+
+  const queryString = queryParams.toString()
+  const url = `${getApiUrl()}/v1/kinds/skills/${skillId}/download${queryString ? `?${queryString}` : ''}`
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${token}` },
   })

--- a/frontend/src/features/settings/components/SkillListWithScope.tsx
+++ b/frontend/src/features/settings/components/SkillListWithScope.tsx
@@ -16,6 +16,8 @@ import {
   parseSkillReferenceError,
   ReferencedGhost,
 } from '@/apis/skills'
+import { getGroup } from '@/apis/groups'
+import { Group } from '@/types/group'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
@@ -32,6 +34,7 @@ import { Download, Trash2, Sparkles, Globe, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import SkillUploadModal from './skills/SkillUploadModal'
 import { SkillReferenceConflictDialog } from './skills/SkillReferenceConflictDialog'
+import { useUser } from '@/features/common/UserContext'
 
 interface SkillListWithScopeProps {
   scope: 'personal' | 'group' | 'all'
@@ -41,6 +44,7 @@ interface SkillListWithScopeProps {
 
 export function SkillListWithScope({ scope, selectedGroup }: SkillListWithScopeProps) {
   const { t } = useTranslation('common')
+  const { user } = useUser()
   const [skills, setSkills] = useState<UnifiedSkill[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -48,10 +52,29 @@ export function SkillListWithScope({ scope, selectedGroup }: SkillListWithScopeP
   const [skillToDelete, setSkillToDelete] = useState<UnifiedSkill | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [uploadModalOpen, setUploadModalOpen] = useState(false)
+  const [currentGroup, setCurrentGroup] = useState<Group | null>(null)
 
   // Reference conflict dialog state
   const [referenceConflictOpen, setReferenceConflictOpen] = useState(false)
   const [referencedGhosts, setReferencedGhosts] = useState<ReferencedGhost[]>([])
+
+  // Fetch group details when selectedGroup changes
+  useEffect(() => {
+    const fetchGroupDetails = async () => {
+      if (selectedGroup && scope === 'group') {
+        try {
+          const groupData = await getGroup(selectedGroup)
+          setCurrentGroup(groupData)
+        } catch (err) {
+          console.error('Failed to fetch group details:', err)
+          setCurrentGroup(null)
+        }
+      } else {
+        setCurrentGroup(null)
+      }
+    }
+    fetchGroupDetails()
+  }, [selectedGroup, scope])
 
   const loadSkills = useCallback(async () => {
     try {
@@ -72,6 +95,24 @@ export function SkillListWithScope({ scope, selectedGroup }: SkillListWithScopeP
   useEffect(() => {
     loadSkills()
   }, [loadSkills])
+
+  // Check if current user can delete a skill
+  const canDeleteSkill = (skill: UnifiedSkill): boolean => {
+    if (!user) return false
+
+    // User can delete their own skills
+    if (skill.user_id === user.id) return true
+
+    // In group scope, check if user is group admin (Owner or Maintainer)
+    if (scope === 'group' && currentGroup?.my_role) {
+      return currentGroup.my_role === 'Owner' || currentGroup.my_role === 'Maintainer'
+    }
+
+    // System admin can delete any skill
+    if (user.role === 'admin') return true
+
+    return false
+  }
 
   const handleDelete = async () => {
     if (!skillToDelete || skillToDelete.is_public) return
@@ -266,14 +307,17 @@ export function SkillListWithScope({ scope, selectedGroup }: SkillListWithScopeP
                     >
                       <Download className="w-4 h-4" />
                     </Button>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => openDeleteDialog(skill)}
-                      className="text-red-500 hover:text-red-600"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
+                    {/* Show delete button if user has permission */}
+                    {canDeleteSkill(skill) && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => openDeleteDialog(skill)}
+                        className="text-red-500 hover:text-red-600"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    )}
                   </>
                 )}
                 {skill.is_public && (

--- a/frontend/src/features/settings/components/SkillListWithScope.tsx
+++ b/frontend/src/features/settings/components/SkillListWithScope.tsx
@@ -133,7 +133,10 @@ export function SkillListWithScope({ scope, selectedGroup }: SkillListWithScopeP
       return
     }
     try {
-      await downloadSkill(skill.id, skill.name)
+      // For group scope, use the selectedGroup as namespace
+      // For personal scope, use the skill's namespace (usually 'default')
+      const namespace = scope === 'group' && selectedGroup ? selectedGroup : skill.namespace
+      await downloadSkill(skill.id, skill.name, namespace)
       toast.success(t('skills.download_success'))
     } catch (err) {
       toast.error(err instanceof Error ? err.message : t('skills.download_failed'))


### PR DESCRIPTION
## Summary

- Fix the issue where group members cannot download skills uploaded by other group members
- Add optional `namespace` parameter to the `downloadSkill` API function
- Pass the correct namespace when downloading skills in group scope to enable backend group skill lookup

## Problem

When a user uploads a Skill to a Group, other group members could see the Skill in the list but received `{"detail":"Skill not found"}` error when trying to download it.

**Root Cause**: The frontend `downloadSkill` API was not passing the `namespace` parameter to the backend. The backend download endpoint uses a fallback search order:
1. User's personal skill (user_id=current_user)
2. Group skill in namespace (if namespace != 'default')
3. Public skill (user_id=0)

Without the `namespace` parameter, step 2 was skipped, causing group members to fail when downloading skills they didn't upload themselves.

## Changes

1. **`frontend/src/apis/skills.ts`**:
   - Added optional `namespace` parameter to `downloadSkill` function
   - Pass namespace as query parameter when making the download request

2. **`frontend/src/features/settings/components/SkillListWithScope.tsx`**:
   - Pass `selectedGroup` as namespace when downloading in group scope
   - Use `skill.namespace` for personal scope downloads

## Test plan

- [ ] Verify user A can upload a skill to a group
- [ ] Verify user B (group member) can see the skill in the group skill list
- [ ] Verify user B can successfully download the skill uploaded by user A
- [ ] Verify personal skill download still works correctly
- [ ] Verify public skill download still works correctly
- [ ] Verify non-group members cannot download group skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now include an optional namespace and respect your selected scope (personal vs group), so downloaded items are labeled and grouped correctly.
  * Skill listings now surface the uploader’s ID for clearer ownership context.

* **Bug Fixes / Permissions**
  * Delete actions and UI controls now honor ownership, group roles, and admin privileges — delete options appear only when permitted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->