### PR TITLE
feat(knowledge): add citation reference tracking and chunk context viewing

### DIFF
--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -368,6 +368,8 @@ class ChunkInfo(BaseModel):
     title: str
     chunk_id: Optional[int] = None
     doc_ref: Optional[str] = None
+    document_id: Optional[int] = None
+    chunk_index: Optional[int] = None
     metadata: Optional[dict] = None
 
 
@@ -425,6 +427,8 @@ async def get_all_chunks(
                     title=c.get("title", "Unknown"),
                     chunk_id=c.get("chunk_id"),
                     doc_ref=c.get("doc_ref"),
+                    document_id=c.get("document_id"),
+                    chunk_index=c.get("chunk_index"),
                     metadata=c.get("metadata"),
                 )
                 for c in chunks

--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -213,11 +213,20 @@ class ChatStartPayload(BaseModel):
 
 
 class SourceReference(BaseModel):
-    """Reference to a knowledge base source document."""
+    """Reference to a knowledge base source document with chunk location info."""
 
     index: int = Field(..., description="Source index number (e.g., 1, 2, 3)")
     title: str = Field(..., description="Document title/filename")
     kb_id: int = Field(..., description="Knowledge base ID")
+    document_id: Optional[int] = Field(
+        None, description="Document ID (knowledge_documents.id)"
+    )
+    chunk_index: Optional[int] = Field(
+        None, description="Chunk index (corresponds to chunks.items[].index)"
+    )
+    content_preview: Optional[str] = Field(
+        None, description="Chunk content preview (first 100 characters)"
+    )
 
 
 class ChatChunkPayload(BaseModel):

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -431,3 +431,22 @@ class ChunkDeleteResponse(BaseModel):
     chunk_index: int = Field(..., description="Deleted chunk index")
     status: str = Field(..., description="Operation status")
     remaining_chunks: int = Field(..., description="Number of remaining chunks")
+
+
+# ============== Chunk Context Schemas ==============
+
+
+class ChunkContextResponse(BaseModel):
+    """Schema for chunk context response (current chunk with surrounding context)."""
+
+    previous_chunks: list[ChunkItemResponse] = Field(
+        default_factory=list, description="Previous chunks for context"
+    )
+    current_chunk: ChunkItemResponse = Field(..., description="Current chunk")
+    next_chunks: list[ChunkItemResponse] = Field(
+        default_factory=list, description="Next chunks for context"
+    )
+    document_name: str = Field(..., description="Document name")
+    document_id: int = Field(..., description="Document ID")
+    kb_id: int = Field(..., description="Knowledge base ID")
+    total_chunks: int = Field(..., description="Total number of chunks in document")

--- a/backend/app/services/chat/streaming/sse_handler.py
+++ b/backend/app/services/chat/streaming/sse_handler.py
@@ -450,10 +450,42 @@ class BackendStreamHandler:
         )
 
     def _add_sources(self, sources: list[dict[str, Any]]) -> None:
-        """Add sources avoiding duplicates."""
-        existing_keys = {(s.get("kb_id"), s.get("title")) for s in self.sources}
+        """Add sources avoiding duplicates.
+
+        Uses chunk-level deduplication (kb_id, document_id, chunk_index) to ensure
+        each unique chunk is preserved. This is important because the same document
+        may have multiple chunks referenced in the AI response.
+        """
+        # Build existing keys set using chunk-level deduplication
+        existing_keys: set[tuple] = set()
+        for s in self.sources:
+            kb_id = s.get("kb_id")
+            doc_id = s.get("document_id")
+            chunk_idx = s.get("chunk_index")
+            # Use index as fallback key if document_id/chunk_index not available
+            if doc_id is not None and chunk_idx is not None:
+                existing_keys.add((kb_id, doc_id, chunk_idx))
+            else:
+                # Fallback to (kb_id, title, index) for backward compatibility
+                existing_keys.add((kb_id, s.get("title"), s.get("index")))
+
         for source in sources:
-            key = (source.get("kb_id"), source.get("title"))
+            kb_id = source.get("kb_id")
+            title = source.get("title")
+
+            # Skip sources with missing required fields
+            if kb_id is None or title is None:
+                continue
+
+            doc_id = source.get("document_id")
+            chunk_idx = source.get("chunk_index")
+
+            # Use chunk-level key if available, otherwise fallback to index-based key
+            if doc_id is not None and chunk_idx is not None:
+                key: tuple = (kb_id, doc_id, chunk_idx)
+            else:
+                key = (kb_id, title, source.get("index"))
+
             if key not in existing_keys:
                 self.sources.append(source)
                 existing_keys.add(key)

--- a/backend/app/services/rag/storage/elasticsearch_backend.py
+++ b/backend/app/services/rag/storage/elasticsearch_backend.py
@@ -659,12 +659,17 @@ class ElasticsearchBackend(BaseStorageBackend):
                 raw_content = source.get("content", "")
 
                 # Extract document_id from doc_ref
+                # doc_ref can be either a numeric string (e.g., "31") or
+                # a legacy format (e.g., "doc_abc123"). For legacy format,
+                # we need to look up the document ID from the database.
                 doc_ref = metadata.get("doc_ref", "")
                 document_id = None
                 if doc_ref:
                     try:
                         document_id = int(doc_ref)
                     except (ValueError, TypeError):
+                        # Legacy format (doc_xxx) - document_id will remain None
+                        # Frontend will handle this gracefully by showing content preview
                         pass
 
                 chunks.append(

--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -515,6 +515,9 @@ async def _stream_response(
                     index=source.get("index"),
                     title=source.get("title", "Unknown"),
                     kb_id=source.get("kb_id"),
+                    document_id=source.get("document_id"),
+                    chunk_index=source.get("chunk_index"),
+                    content_preview=source.get("content_preview"),
                     url=source.get("url"),
                     snippet=source.get("snippet"),
                 )

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -414,6 +414,15 @@ class SourceItem(BaseModel):
     index: Optional[int] = Field(None, description="Source index number (1, 2, 3...)")
     title: str = Field(..., description="Source title/document name")
     kb_id: Optional[int] = Field(None, description="Knowledge base ID")
+    document_id: Optional[int] = Field(
+        None, description="Document ID (knowledge_documents.id)"
+    )
+    chunk_index: Optional[int] = Field(
+        None, description="Chunk index (corresponds to chunks.items[].index)"
+    )
+    content_preview: Optional[str] = Field(
+        None, description="Chunk content preview (first 100 characters)"
+    )
     url: Optional[str] = Field(None, description="Source URL (for web sources)")
     snippet: Optional[str] = Field(None, description="Content snippet")
 

--- a/chat_shell/chat_shell/prompts/knowledge_base.py
+++ b/chat_shell/chat_shell/prompts/knowledge_base.py
@@ -13,7 +13,7 @@ This module provides prompt templates for knowledge base tool usage:
 # AI must use KB only and cannot use general knowledge
 KB_PROMPT_STRICT = """
 
-# IMPORTANT: Knowledge Base Requirement
+# IMPORTANT: Knowledge Base Requirement (STRICT MODE)
 
 The user has selected specific knowledge bases for this conversation. You MUST use the `knowledge_base_search` tool to retrieve information from these knowledge bases before answering any questions.
 
@@ -24,18 +24,42 @@ The user has selected specific knowledge bases for this conversation. You MUST u
 4. If the search returns no results or irrelevant information, clearly state: "I cannot find relevant information in the selected knowledge base to answer this question."
 5. **DO NOT** use your general knowledge or make assumptions beyond what's in the knowledge base
 
+## Citation Rules:
+1. **Mandatory citations**: Every factual statement from the knowledge base MUST have a citation marker [n] at the end
+2. **Citation format**: Use `[n]` format where n is the source index number (e.g., [1], [2], [1][2])
+3. **Multiple sources**: When multiple sources support the same point, use `[1][2]` format
+4. **Citation placement**: Place citations at the end of sentences or paragraphs, before the period
+
+### Example Response:
+```
+According to the knowledge base, the system supports batch file uploads [1].
+The configuration steps include:
+- Setting up the storage backend [1]
+- Configuring the embedding model [2]
+- Running the indexing process [1][2]
+```
+
 ## Critical Rules:
 - You MUST search the knowledge base for EVERY user question
 - You MUST NOT answer without searching first
 - You MUST NOT make up information if the knowledge base doesn't contain it
+- You MUST add citation markers for all facts from the knowledge base
+- You MUST NOT use phrases like "as far as I know" or "generally speaking"
 - If unsure, search again with different keywords
+
+## Supplementary Information:
+If you need to add information not from the knowledge base (e.g., formatting guidance), you MUST clearly mark it:
+```
+【Supplementary Info】The following is not from the knowledge base, for reference only:
+...your supplementary content...
+```
 
 The user expects answers based on the selected knowledge base content only."""
 
 # Relaxed mode prompt: KB inherited from task, AI can use general knowledge as fallback
 KB_PROMPT_RELAXED = """
 
-# Knowledge Base Available
+# Knowledge Base Available (RELAXED MODE)
 
 You have access to knowledge bases from previous conversations in this task. You can use the `knowledge_base_search` tool to retrieve information from these knowledge bases.
 
@@ -45,8 +69,21 @@ You have access to knowledge bases from previous conversations in this task. You
 3. If the search returns no results or irrelevant information, you may use your general knowledge to answer the question
 4. Be transparent about whether your answer is based on knowledge base content or general knowledge
 
+## Citation Rules:
+1. **Knowledge base content**: Add citation markers [n] for facts from the knowledge base
+2. **Citation format**: Use `[n]` format where n is the source index number
+3. **General knowledge**: When using general knowledge, clearly mark it as supplementary
+
+### Example Response with Mixed Sources:
+```
+Based on the knowledge base, the API supports REST endpoints [1].
+
+【Supplementary Info】For general best practices on API design, consider using versioning in your endpoint paths.
+```
+
 ## Guidelines:
 - Search the knowledge base when the question seems related to its content
 - If the knowledge base doesn't contain relevant information, feel free to answer using your general knowledge
 - Clearly indicate when your answer is based on knowledge base content vs. general knowledge
+- Add citation markers [n] for knowledge base content to help users verify sources
 - The knowledge base is a helpful resource, but you are not limited to it when it doesn't have relevant information"""

--- a/chat_shell/chat_shell/services/streaming/core.py
+++ b/chat_shell/chat_shell/services/streaming/core.py
@@ -91,14 +91,41 @@ class StreamingState:
         self.thinking.append(step)
 
     def add_sources(self, sources: list) -> None:
-        """Add knowledge base sources for citation."""
-        existing_keys = {(s.get("kb_id"), s.get("title")) for s in self.sources}
+        """Add knowledge base sources for citation.
+
+        Uses chunk-level deduplication (kb_id, document_id, chunk_index) to ensure
+        each unique chunk is preserved. This is important because the same document
+        may have multiple chunks referenced in the AI response.
+        """
+        # Build existing keys set using chunk-level deduplication
+        # Use (kb_id, document_id, chunk_index) for precise deduplication
+        existing_keys = set()
+        for s in self.sources:
+            kb_id = s.get("kb_id")
+            doc_id = s.get("document_id")
+            chunk_idx = s.get("chunk_index")
+            # Use index as fallback key if document_id/chunk_index not available
+            if doc_id is not None and chunk_idx is not None:
+                existing_keys.add((kb_id, doc_id, chunk_idx))
+            else:
+                # Fallback to (kb_id, title, index) for backward compatibility
+                existing_keys.add((kb_id, s.get("title"), s.get("index")))
+
         for source in sources:
             kb_id = source.get("kb_id")
             title = source.get("title")
             if kb_id is None or title is None:
                 continue
-            key = (kb_id, title)
+
+            doc_id = source.get("document_id")
+            chunk_idx = source.get("chunk_index")
+
+            # Use chunk-level key if available, otherwise fallback to index-based key
+            if doc_id is not None and chunk_idx is not None:
+                key = (kb_id, doc_id, chunk_idx)
+            else:
+                key = (kb_id, title, source.get("index"))
+
             if key not in existing_keys:
                 self.sources.append(source)
                 existing_keys.add(key)

--- a/chat_shell/chat_shell/tools/events.py
+++ b/chat_shell/chat_shell/tools/events.py
@@ -226,28 +226,32 @@ def _process_tool_output(
     sources: list[dict[str, Any]] = []
 
     # Extract sources from knowledge_base_search results
+    # Extract sources from knowledge_base_search results
     if tool_name == "knowledge_base_search":
         if isinstance(tool_output, str):
             try:
                 parsed = json.loads(tool_output)
+                kb_sources = parsed.get("sources", [])
+                source_indices = (
+                    [s.get("index") for s in kb_sources] if kb_sources else []
+                )
                 logger.info(
                     f"[TOOL_OUTPUT] knowledge_base_search parsed output: "
                     f"has_sources={'sources' in parsed}, "
-                    f"sources_count={len(parsed.get('sources', []))}, "
-                    f"sources={parsed.get('sources', [])}"
+                    f"sources_count={len(kb_sources)}, "
+                    f"source_indices={source_indices}"
                 )
                 if isinstance(parsed, dict) and "sources" in parsed:
-                    kb_sources = parsed.get("sources", [])
                     if isinstance(kb_sources, list):
                         sources.extend(kb_sources)
                         logger.info(
-                            f"[TOOL_OUTPUT] Extracted {len(kb_sources)} sources from knowledge_base_search"
+                            f"[TOOL_OUTPUT] Extracted {len(kb_sources)} sources from knowledge_base_search, "
+                            f"indices={source_indices}"
                         )
                     result_count = parsed.get("count", 0)
                     title = f"检索完成，找到 {result_count} 条结果"
             except json.JSONDecodeError as e:
                 logger.warning(f"[TOOL_OUTPUT] Failed to parse tool output: {e}")
-
     # Extract sources from web_search results
     elif tool_name == "web_search":
         if isinstance(tool_output, str):

--- a/chat_shell/chat_shell/tools/knowledge_injection_strategy.py
+++ b/chat_shell/chat_shell/tools/knowledge_injection_strategy.py
@@ -217,7 +217,7 @@ class InjectionStrategy:
         """Format chunks for direct injection into context.
 
         Args:
-            chunks: Prepared chunks
+            chunks: Prepared chunks (should have 'index' field set by caller)
             include_sources: Whether to include source information
 
         Returns:
@@ -234,8 +234,14 @@ class InjectionStrategy:
             score = chunk.get("score")
             kb_id = chunk.get("knowledge_base_id", 0)
 
+            # Use 1-based index for display to match citation format [1], [2], etc.
+            # The display_index is used in the chunk header that AI sees
+            # We use loop index + 1 to ensure consistent 1-based numbering
+            # The 'source_index' field will be set by the caller to match this display_index
+            display_index = i + 1
+
             # Format chunk with metadata
-            chunk_header = f"[Knowledge Chunk {i+1}]"
+            chunk_header = f"[Knowledge Chunk {display_index}]"
             if include_sources:
                 # Score may be None for direct injection chunks (non-RAG retrieval)
                 if score is None:

--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -9,6 +9,7 @@
 import { apiClient } from './client'
 import type {
   AccessibleKnowledgeResponse,
+  ChunkContextResponse,
   ChunkDeleteResponse,
   DocumentChunksResponse,
   KnowledgeBase,
@@ -249,5 +250,24 @@ export async function deleteDocumentChunk(
 ): Promise<ChunkDeleteResponse> {
   return apiClient.delete<ChunkDeleteResponse>(
     `/knowledge-documents/${documentId}/chunks/${chunkIndex}`
+  )
+}
+
+/**
+ * Get chunk context for a specific chunk
+ * Returns the current chunk along with surrounding chunks for context
+ * Useful for displaying citation sources with their surrounding text
+ * @param documentId The document ID (knowledge_documents.id)
+ * @param chunkIndex The chunk index (0-based, corresponds to chunks.items[].index)
+ * @param contextSize Number of chunks to include before and after (default: 1, max: 3)
+ * @returns ChunkContextResponse with previous_chunks, current_chunk, next_chunks
+ */
+export async function getChunkContext(
+  documentId: number,
+  chunkIndex: number,
+  contextSize: number = 1
+): Promise<ChunkContextResponse> {
+  return apiClient.get<ChunkContextResponse>(
+    `/knowledge-documents/${documentId}/chunks/${chunkIndex}/context?context_size=${contextSize}`
   )
 }

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
@@ -28,7 +28,6 @@ import { teamService } from '@/features/tasks/service/teamService'
 import { useKnowledgeBaseDetail } from '@/features/knowledge/document/hooks'
 import { DocumentPanel, KnowledgeBaseSummaryCard } from '@/features/knowledge/document/components'
 import { BoundKnowledgeBaseSummary } from '@/features/tasks/components/group-chat'
-import { taskKnowledgeBaseApi } from '@/apis/task-knowledge-base'
 import { listGroups } from '@/apis/groups'
 import type { Team } from '@/types/api'
 import type { GroupRole } from '@/types/group'
@@ -293,18 +292,6 @@ export function KnowledgeBaseChatPageDesktop() {
                 document_count: knowledgeBase.document_count,
               }}
               selectedDocumentIds={selectedDocumentIds}
-              onTaskCreated={async (taskId: number) => {
-                // Bind the knowledge base to the newly created task
-                try {
-                  await taskKnowledgeBaseApi.bindKnowledgeBase(
-                    taskId,
-                    knowledgeBase.name,
-                    knowledgeBase.namespace
-                  )
-                } catch (error) {
-                  console.error('Failed to bind knowledge base to task:', error)
-                }
-              }}
             />
           </div>
 

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
@@ -30,7 +30,6 @@ import { teamService } from '@/features/tasks/service/teamService'
 import { useKnowledgeBaseDetail } from '@/features/knowledge/document/hooks'
 import { DocumentList, KnowledgeBaseSummaryCard } from '@/features/knowledge/document/components'
 import { BoundKnowledgeBaseSummary } from '@/features/tasks/components/group-chat'
-import { taskKnowledgeBaseApi } from '@/apis/task-knowledge-base'
 import { listGroups } from '@/apis/groups'
 import type { Team } from '@/types/api'
 import type { GroupRole } from '@/types/group'
@@ -279,18 +278,6 @@ export function KnowledgeBaseChatPageMobile() {
               name: knowledgeBase.name,
               namespace: knowledgeBase.namespace,
               document_count: knowledgeBase.document_count,
-            }}
-            onTaskCreated={async (taskId: number) => {
-              // Bind the knowledge base to the newly created task
-              try {
-                await taskKnowledgeBaseApi.bindKnowledgeBase(
-                  taskId,
-                  knowledgeBase.name,
-                  knowledgeBase.namespace
-                )
-              } catch (error) {
-                console.error('Failed to bind knowledge base to task:', error)
-              }
             }}
           />
         </div>

--- a/frontend/src/features/tasks/components/chat/ChunkPreviewTooltip.tsx
+++ b/frontend/src/features/tasks/components/chat/ChunkPreviewTooltip.tsx
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+/**
+ * Chunk Preview Tooltip Component
+ *
+ * Displays a preview of a knowledge base chunk when hovering over a citation reference.
+ * Shows chunk content preview with options to view full details or original document.
+ */
+
+import React, { useEffect, useRef } from 'react'
+import { FileText, ExternalLink, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { SourceReference } from '@/types/socket'
+
+interface ChunkPreviewTooltipProps {
+  source: SourceReference
+  anchorRef: React.RefObject<HTMLElement | null>
+  onClose: () => void
+  onViewDetail: () => void
+}
+
+export function ChunkPreviewTooltip({
+  source,
+  anchorRef,
+  onClose,
+  onViewDetail,
+}: ChunkPreviewTooltipProps) {
+  const { t } = useTranslation('chat')
+  const tooltipRef = useRef<HTMLDivElement>(null)
+
+  // Click outside to close
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (
+        tooltipRef.current &&
+        !tooltipRef.current.contains(e.target as Node) &&
+        anchorRef.current &&
+        !anchorRef.current.contains(e.target as Node)
+      ) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [onClose, anchorRef])
+
+  // ESC to close
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  // Position tooltip relative to anchor
+  const [position, setPosition] = React.useState({ top: 0, left: 0 })
+  useEffect(() => {
+    if (anchorRef.current) {
+      const rect = anchorRef.current.getBoundingClientRect()
+      const tooltipWidth = 320
+      const viewportWidth = window.innerWidth
+
+      // Calculate left position, ensuring tooltip stays within viewport
+      let left = rect.left
+      if (left + tooltipWidth > viewportWidth - 16) {
+        left = viewportWidth - tooltipWidth - 16
+      }
+      if (left < 16) {
+        left = 16
+      }
+
+      setPosition({
+        top: rect.bottom + 4,
+        left,
+      })
+    }
+  }, [anchorRef])
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="fixed z-50 w-80 bg-surface border border-border rounded-lg shadow-sm p-3"
+      style={{ top: position.top, left: position.left }}
+      role="dialog"
+      aria-label={`Source ${source.index} preview`}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <FileText className="w-4 h-4 text-primary" />
+          <span className="text-primary font-mono">[{source.index}]</span>
+          <span className="text-text-primary truncate max-w-[180px]">{source.title}</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="text-text-muted hover:text-text-primary p-1 rounded transition-colors"
+          aria-label={t('citation.close', 'Close')}
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Chunk preview with highlight style */}
+      <div className="text-sm text-text-secondary bg-primary/5 border-l-2 border-primary p-2 rounded-r mb-3 max-h-32 overflow-y-auto">
+        {source.content_preview || t('citation.noPreview', 'No preview available')}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <Button variant="outline" size="sm" className="flex-1 h-9" onClick={onViewDetail}>
+          {t('citation.viewDetail', 'View Details')}
+        </Button>
+        {source.document_id !== undefined && source.chunk_index !== undefined && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-9 px-3"
+            onClick={() => {
+              window.open(
+                `/knowledge/document/${source.kb_id}?doc=${source.document_id}&chunk=${source.chunk_index}`,
+                '_blank'
+              )
+            }}
+            aria-label={t('citation.viewOriginal', 'View Original Document')}
+          >
+            <ExternalLink className="w-4 h-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/chat/CitationLink.tsx
+++ b/frontend/src/features/tasks/components/chat/CitationLink.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+/**
+ * Citation Link Component
+ *
+ * Renders a clickable citation marker [n] that shows a preview tooltip
+ * and allows navigation to chunk details.
+ */
+
+import React, { useState, useRef, useCallback } from 'react'
+import type { SourceReference } from '@/types/socket'
+import { ChunkPreviewTooltip } from './ChunkPreviewTooltip'
+import { SourceChunkDialog } from './SourceChunkDialog'
+
+interface CitationLinkProps {
+  /** The citation index number (1-based) */
+  index: number
+  /** All source references for this message */
+  sources: SourceReference[]
+}
+
+export function CitationLink({ index, sources }: CitationLinkProps) {
+  const [tooltipSource, setTooltipSource] = useState<SourceReference | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(index)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // Find the source with matching index
+  const source = sources.find(s => s.index === index)
+
+  const handleClick = useCallback(() => {
+    if (!source) {
+      // If no source found, just open dialog at this index
+      setSelectedIndex(index)
+      setDialogOpen(true)
+      return
+    }
+
+    // If content_preview is available, show tooltip first
+    if (source.content_preview) {
+      setTooltipSource(source)
+    } else {
+      // Otherwise, go directly to dialog
+      setSelectedIndex(source.index)
+      setDialogOpen(true)
+    }
+  }, [source, index])
+
+  const handleViewDetail = useCallback(() => {
+    if (tooltipSource) {
+      setSelectedIndex(tooltipSource.index)
+      setTooltipSource(null)
+      setDialogOpen(true)
+    }
+  }, [tooltipSource])
+
+  const handleCloseTooltip = useCallback(() => {
+    setTooltipSource(null)
+  }, [])
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        onClick={handleClick}
+        className="inline-flex items-center justify-center font-mono text-xs text-primary hover:text-primary-dark hover:bg-primary/10 px-0.5 rounded cursor-pointer transition-colors"
+        title={source?.title || `Reference ${index}`}
+      >
+        [{index}]
+      </button>
+
+      {/* Tooltip for quick preview */}
+      {tooltipSource && (
+        <ChunkPreviewTooltip
+          source={tooltipSource}
+          anchorRef={buttonRef}
+          onClose={handleCloseTooltip}
+          onViewDetail={handleViewDetail}
+        />
+      )}
+
+      {/* Dialog for detailed view */}
+      <SourceChunkDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        sources={sources}
+        initialSourceIndex={selectedIndex}
+      />
+    </>
+  )
+}

--- a/frontend/src/features/tasks/components/chat/CitationParser.tsx
+++ b/frontend/src/features/tasks/components/chat/CitationParser.tsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+/**
+ * Citation Parser Component
+ *
+ * Parses text content and converts citation markers [n] into clickable CitationLink components.
+ * Used to make knowledge base references interactive within message content.
+ */
+
+import React from 'react'
+import type { SourceReference } from '@/types/socket'
+import { CitationLink } from './CitationLink'
+
+interface CitationParserProps {
+  /** The text content that may contain citation markers like [1], [2], etc. */
+  text: string
+  /** All source references for this message */
+  sources: SourceReference[]
+}
+
+/**
+ * Parse text and replace citation markers [n] with clickable components
+ */
+export function CitationParser({ text, sources }: CitationParserProps) {
+  // If no sources, just return plain text
+  if (!sources || sources.length === 0) {
+    return <>{text}</>
+  }
+
+  // Get all valid indices from sources
+  const validIndices = new Set(sources.map(s => s.index))
+
+  // Pattern to match citation markers like [1], [2], [12], etc.
+  // Only match if the number is a valid source index
+  const citationPattern = /\[(\d+)\]/g
+
+  const parts: React.ReactNode[] = []
+  let lastIndex = 0
+  let match
+
+  while ((match = citationPattern.exec(text)) !== null) {
+    const citationIndex = parseInt(match[1], 10)
+
+    // Only create a clickable link if this index exists in sources
+    if (validIndices.has(citationIndex)) {
+      // Add text before the citation
+      if (match.index > lastIndex) {
+        parts.push(text.slice(lastIndex, match.index))
+      }
+
+      // Add the clickable citation link
+      parts.push(
+        <CitationLink key={`citation-${match.index}`} index={citationIndex} sources={sources} />
+      )
+
+      lastIndex = match.index + match[0].length
+    }
+  }
+
+  // Add remaining text after the last citation
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  // If no citations were found, return plain text
+  if (parts.length === 0) {
+    return <>{text}</>
+  }
+
+  return <>{parts}</>
+}

--- a/frontend/src/features/tasks/components/chat/SourceChunkDialog.tsx
+++ b/frontend/src/features/tasks/components/chat/SourceChunkDialog.tsx
@@ -9,22 +9,37 @@
  *
  * Displays detailed chunk context with previous and next chunks for better understanding.
  * Allows users to navigate between different sources and view original documents.
+ * Redesigned with Wegent Calm UI philosophy: low saturation, generous whitespace, teal accent.
  */
 
 import React, { useState, useEffect } from 'react'
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
 import { Spinner } from '@/components/ui/spinner'
-import { FileText, ExternalLink } from 'lucide-react'
+import {
+  FileText,
+  ExternalLink,
+  Copy,
+  Check,
+  ChevronUp,
+  ChevronDown,
+  BookOpen,
+  Hash,
+  Layers,
+} from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
+import { toast } from 'sonner'
 import type { SourceReference } from '@/types/socket'
 import type { ChunkContextResponse, ChunkItem } from '@/types/knowledge'
 import { getChunkContext } from '@/apis/knowledge'
+import { cn } from '@/lib/utils'
 
 interface SourceChunkDialogProps {
   open: boolean
@@ -44,94 +59,222 @@ export function SourceChunkDialog({
   const [context, setContext] = useState<ChunkContextResponse | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [copiedContent, setCopiedContent] = useState(false)
+  const [expandedChunks, setExpandedChunks] = useState<Set<string>>(new Set(['current']))
 
   const currentSource = sources.find(s => s.index === selectedIndex)
 
-  // Reset selected state when dialog opens
+  // Reset selected state and load content when dialog opens with new initialSourceIndex
   useEffect(() => {
     if (open) {
       setSelectedIndex(initialSourceIndex)
+      setExpandedChunks(new Set(['current']))
+      // Reset context to trigger reload
+      setContext(null)
     }
   }, [open, initialSourceIndex])
 
-  // Load chunk context
+  // Check if document_id and chunk_index are valid numbers (not null/undefined)
+  const hasValidChunkInfo =
+    currentSource?.document_id != null &&
+    currentSource?.chunk_index != null &&
+    typeof currentSource.document_id === 'number' &&
+    typeof currentSource.chunk_index === 'number'
+
+  // Load chunk context when selectedIndex changes
+  // Use selectedIndex and source's document_id/chunk_index as dependencies for precise control
   useEffect(() => {
-    if (
-      open &&
-      currentSource &&
-      currentSource.document_id !== undefined &&
-      currentSource.chunk_index !== undefined
-    ) {
+    if (open && currentSource && hasValidChunkInfo) {
       setLoading(true)
       setError(null)
 
-      getChunkContext(currentSource.document_id, currentSource.chunk_index, 1)
+      getChunkContext(currentSource.document_id!, currentSource.chunk_index!, 1)
         .then(setContext)
         .catch(err => {
           console.error('Failed to load chunk context:', err)
           setError(err.message || 'Failed to load context')
         })
         .finally(() => setLoading(false))
+    } else if (open && currentSource) {
+      // Reset context when chunk info is not available
+      setContext(null)
+      setError(null)
+      setLoading(false)
     }
-  }, [open, currentSource])
+    // Include selectedIndex to ensure re-fetch when user clicks different source in the list
+    // Include document_id and chunk_index to ensure re-fetch when source data changes
+  }, [
+    open,
+    selectedIndex,
+    currentSource?.document_id,
+    currentSource?.chunk_index,
+    hasValidChunkInfo,
+  ])
 
-  // Render chunk block
-  const renderChunk = (chunk: ChunkItem, type: 'previous' | 'current' | 'next') => {
+  // Copy content to clipboard
+  const handleCopyContent = async () => {
+    const content = context?.current_chunk?.content || currentSource?.content_preview
+    if (!content) return
+
+    try {
+      await navigator.clipboard.writeText(content)
+      setCopiedContent(true)
+      toast.success(t('citation.copySuccess', 'Copied to clipboard'))
+      setTimeout(() => setCopiedContent(false), 2000)
+    } catch {
+      toast.error(t('citation.copyError', 'Failed to copy'))
+    }
+  }
+
+  // Toggle chunk expansion
+  const toggleChunkExpand = (key: string) => {
+    setExpandedChunks(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  // Render chunk block with improved design
+  const renderChunk = (chunk: ChunkItem, type: 'previous' | 'current' | 'next', index?: number) => {
     const isHighlighted = type === 'current'
+    const key = type === 'current' ? 'current' : `${type}-${index}`
+    const isExpanded = expandedChunks.has(key)
 
     return (
       <div
-        className={`p-3 rounded-lg ${
+        className={cn(
+          'rounded-xl transition-all duration-200',
           isHighlighted
-            ? 'bg-primary/10 border-l-2 border-primary'
-            : 'bg-surface/50 border border-border/50'
-        }`}
+            ? 'bg-primary/5 border border-primary/20 shadow-sm'
+            : 'bg-surface/50 border border-border/50 hover:border-border'
+        )}
       >
+        {/* Chunk Header */}
         <div
-          className={`text-xs mb-1 ${isHighlighted ? 'text-primary font-medium' : 'text-text-muted'}`}
+          className={cn(
+            'flex items-center justify-between px-4 py-3 cursor-pointer',
+            !isHighlighted && 'hover:bg-surface/80'
+          )}
+          onClick={() => !isHighlighted && toggleChunkExpand(key)}
         >
-          {type === 'previous' && t('citation.previousChunk', 'Previous')}
-          {type === 'current' && t('citation.currentChunk', 'Current Reference')}
-          {type === 'next' && t('citation.nextChunk', 'Next')}
-          {' '}#{chunk.chunk_index + 1}
-          <span className="ml-2 text-text-muted">({chunk.token_count} tokens)</span>
+          <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                'flex items-center justify-center w-6 h-6 rounded-full text-xs font-medium',
+                isHighlighted ? 'bg-primary text-white' : 'bg-text-muted/10 text-text-muted'
+              )}
+            >
+              {chunk.chunk_index + 1}
+            </div>
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  'text-sm font-medium',
+                  isHighlighted ? 'text-primary' : 'text-text-secondary'
+                )}
+              >
+                {type === 'previous' && t('citation.previousChunk', 'Previous')}
+                {type === 'current' && t('citation.currentChunk', 'Current Reference')}
+                {type === 'next' && t('citation.nextChunk', 'Next')}
+              </span>
+              <Badge variant="secondary" size="sm" className="text-xs font-normal bg-surface">
+                {chunk.token_count} tokens
+              </Badge>
+            </div>
+          </div>
+          {!isHighlighted && (
+            <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
+              {isExpanded ? (
+                <ChevronUp className="w-4 h-4 text-text-muted" />
+              ) : (
+                <ChevronDown className="w-4 h-4 text-text-muted" />
+              )}
+            </Button>
+          )}
         </div>
-        <div
-          className={`text-sm whitespace-pre-wrap ${isHighlighted ? 'text-text-primary' : 'text-text-secondary'}`}
-        >
-          {chunk.content}
-        </div>
+
+        {/* Chunk Content */}
+        {(isHighlighted || isExpanded) && (
+          <div className={cn('px-4 pb-4 pt-0', !isHighlighted && 'border-t border-border/30')}>
+            <div
+              className={cn(
+                'text-sm leading-relaxed whitespace-pre-wrap',
+                isHighlighted ? 'text-text-primary' : 'text-text-secondary'
+              )}
+            >
+              {chunk.content}
+            </div>
+          </div>
+        )}
       </div>
     )
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl max-h-[80vh] overflow-hidden flex flex-col">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <FileText className="w-5 h-5" />
-            {t('citation.sourceList', 'Source References')}
-          </DialogTitle>
+      <DialogContent className="max-w-5xl max-h-[85vh] flex flex-col p-0 gap-0">
+        {/* Header */}
+        <DialogHeader className="px-6 py-4 border-b border-border flex-shrink-0">
+          <div className="flex items-start gap-3">
+            <div className="p-2.5 bg-primary/10 rounded-xl flex-shrink-0">
+              <BookOpen className="w-5 h-5 text-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <DialogTitle className="text-lg font-semibold text-text-primary">
+                {t('citation.sourceList', 'Source References')}
+              </DialogTitle>
+              <DialogDescription className="flex items-center gap-2 mt-1 text-sm text-text-muted">
+                <Layers className="w-3.5 h-3.5" />
+                <span>
+                  {t('citation.sourceCount', '{{count}} sources', {
+                    count: sources.length,
+                  })}
+                </span>
+              </DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className="flex flex-1 gap-4 overflow-hidden min-h-0">
+        {/* Main Content */}
+        <div className="flex flex-1 overflow-hidden min-h-0">
           {/* Left: Source list */}
-          <div className="w-56 flex-shrink-0 border-r border-border pr-4 overflow-y-auto">
-            <div className="space-y-1">
+          <div className="w-64 flex-shrink-0 border-r border-border bg-surface/30 overflow-y-auto">
+            <div className="p-3 space-y-1">
               {sources.map(source => (
                 <button
                   key={source.index}
-                  className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                  className={cn(
+                    'w-full text-left px-3 py-2.5 rounded-lg text-sm transition-all duration-150',
                     selectedIndex === source.index
-                      ? 'bg-primary/10 text-primary border-l-2 border-primary'
-                      : 'hover:bg-surface text-text-secondary'
-                  }`}
+                      ? 'bg-primary/10 text-primary shadow-sm'
+                      : 'hover:bg-surface text-text-secondary hover:text-text-primary'
+                  )}
                   onClick={() => setSelectedIndex(source.index)}
                 >
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-xs">[{source.index}]</span>
-                    <span className="truncate">{source.title}</span>
+                  <div className="flex items-start gap-2.5">
+                    <div
+                      className={cn(
+                        'flex items-center justify-center w-5 h-5 rounded text-xs font-mono flex-shrink-0 mt-0.5',
+                        selectedIndex === source.index
+                          ? 'bg-primary text-white'
+                          : 'bg-text-muted/10 text-text-muted'
+                      )}
+                    >
+                      {source.index}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium truncate">{source.title}</div>
+                      {source.content_preview && (
+                        <div className="text-xs text-text-muted mt-0.5 line-clamp-2">
+                          {source.content_preview.slice(0, 60)}...
+                        </div>
+                      )}
+                    </div>
                   </div>
                 </button>
               ))}
@@ -139,68 +282,167 @@ export function SourceChunkDialog({
           </div>
 
           {/* Right: Chunk details */}
-          <div className="flex-1 overflow-y-auto pr-2">
-            {loading ? (
-              <div className="flex items-center justify-center h-full">
-                <Spinner />
-              </div>
-            ) : error ? (
-              <div className="text-center text-destructive py-8">{error}</div>
-            ) : context ? (
-              <div className="space-y-4">
-                {/* Document info */}
-                <div className="text-sm text-text-muted">
-                  {context.document_name} · {t('citation.chunkContext', 'Context')} (
-                  {context.current_chunk.chunk_index + 1}/{context.total_chunks})
+          <div className="flex-1 overflow-y-auto">
+            <div className="p-6">
+              {loading ? (
+                <div className="flex flex-col items-center justify-center py-16">
+                  <Spinner className="w-8 h-8" />
+                  <p className="mt-3 text-sm text-text-muted">
+                    {t('citation.loading', 'Loading content...')}
+                  </p>
                 </div>
-
-                {/* Previous chunks */}
-                {context.previous_chunks.map((chunk, i) => (
-                  <div key={`prev-${i}`}>{renderChunk(chunk, 'previous')}</div>
-                ))}
-
-                {/* Current chunk (highlighted) */}
-                {renderChunk(context.current_chunk, 'current')}
-
-                {/* Next chunks */}
-                {context.next_chunks.map((chunk, i) => (
-                  <div key={`next-${i}`}>{renderChunk(chunk, 'next')}</div>
-                ))}
-
-                {/* View original document button */}
-                <div className="pt-4 border-t border-border">
-                  <Button
-                    variant="outline"
-                    onClick={() => {
-                      window.open(
-                        `/knowledge/document/${currentSource?.kb_id}?doc=${currentSource?.document_id}&chunk=${currentSource?.chunk_index}`,
-                        '_blank'
-                      )
-                    }}
-                  >
-                    <ExternalLink className="w-4 h-4 mr-2" />
-                    {t('citation.viewOriginal', 'View Original Document')}
-                  </Button>
-                </div>
-              </div>
-            ) : currentSource?.content_preview ? (
-              // Show content preview when detailed context is not available
-              <div className="space-y-4">
-                <div className="text-sm text-text-muted">{currentSource.title}</div>
-                <div className="p-3 rounded-lg bg-primary/10 border-l-2 border-primary">
-                  <div className="text-xs text-primary font-medium mb-1">
-                    {t('citation.currentChunk', 'Current Reference')}
+              ) : error ? (
+                <div className="flex flex-col items-center justify-center py-16">
+                  <div className="p-3 bg-destructive/10 rounded-full mb-3">
+                    <FileText className="w-6 h-6 text-destructive" />
                   </div>
-                  <div className="text-sm text-text-primary whitespace-pre-wrap">
-                    {currentSource.content_preview}
+                  <p className="text-sm text-destructive">{error}</p>
+                  <p className="text-xs text-text-muted mt-1">
+                    {t('citation.errorHint', 'Please try again later')}
+                  </p>
+                </div>
+              ) : context ? (
+                <div className="space-y-4">
+                  {/* Document info card */}
+                  <div className="flex items-center justify-between p-4 bg-surface rounded-xl border border-border">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-primary/10 rounded-lg">
+                        <FileText className="w-4 h-4 text-primary" />
+                      </div>
+                      <div>
+                        <div className="font-medium text-text-primary">{context.document_name}</div>
+                        <div className="flex items-center gap-2 text-xs text-text-muted mt-0.5">
+                          <Hash className="w-3 h-3" />
+                          <span>
+                            {t('citation.chunkPosition', 'Chunk {{current}} of {{total}}', {
+                              current: context.current_chunk.chunk_index + 1,
+                              total: context.total_chunks,
+                            })}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleCopyContent}
+                        disabled={copiedContent}
+                        className="h-8"
+                      >
+                        {copiedContent ? (
+                          <>
+                            <Check className="w-3.5 h-3.5 mr-1.5" />
+                            {t('citation.copied', 'Copied')}
+                          </>
+                        ) : (
+                          <>
+                            <Copy className="w-3.5 h-3.5 mr-1.5" />
+                            {t('citation.copy', 'Copy')}
+                          </>
+                        )}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          window.open(
+                            `/knowledge/document/${currentSource?.kb_id}?doc=${currentSource?.document_id}&chunk=${currentSource?.chunk_index}`,
+                            '_blank'
+                          )
+                        }}
+                        className="h-8"
+                      >
+                        <ExternalLink className="w-3.5 h-3.5 mr-1.5" />
+                        {t('citation.viewOriginal', 'View Document')}
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Chunk context */}
+                  <div className="space-y-3">
+                    {/* Previous chunks */}
+                    {context.previous_chunks.map((chunk, i) => (
+                      <div key={`prev-${i}`}>{renderChunk(chunk, 'previous', i)}</div>
+                    ))}
+
+                    {/* Current chunk (highlighted) */}
+                    {renderChunk(context.current_chunk, 'current')}
+
+                    {/* Next chunks */}
+                    {context.next_chunks.map((chunk, i) => (
+                      <div key={`next-${i}`}>{renderChunk(chunk, 'next', i)}</div>
+                    ))}
                   </div>
                 </div>
-              </div>
-            ) : (
-              <div className="text-center text-text-muted py-8">
-                {t('citation.selectSource', 'Select a source to view details')}
-              </div>
-            )}
+              ) : currentSource?.content_preview ? (
+                // Show content preview when detailed context is not available
+                <div className="space-y-4">
+                  {/* Document info card */}
+                  <div className="flex items-center justify-between p-4 bg-surface rounded-xl border border-border">
+                    <div className="flex items-center gap-3">
+                      <div className="p-2 bg-primary/10 rounded-lg">
+                        <FileText className="w-4 h-4 text-primary" />
+                      </div>
+                      <div>
+                        <div className="font-medium text-text-primary">{currentSource.title}</div>
+                        <div className="flex items-center gap-2 text-xs text-text-muted mt-0.5">
+                          <Hash className="w-3 h-3" />
+                          <span>
+                            {t('citation.reference', 'Reference')} [{currentSource.index}]
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleCopyContent}
+                      disabled={copiedContent}
+                      className="h-8"
+                    >
+                      {copiedContent ? (
+                        <>
+                          <Check className="w-3.5 h-3.5 mr-1.5" />
+                          {t('citation.copied', 'Copied')}
+                        </>
+                      ) : (
+                        <>
+                          <Copy className="w-3.5 h-3.5 mr-1.5" />
+                          {t('citation.copy', 'Copy')}
+                        </>
+                      )}
+                    </Button>
+                  </div>
+
+                  {/* Content preview */}
+                  <div className="rounded-xl bg-primary/5 border border-primary/20 shadow-sm">
+                    <div className="flex items-center gap-3 px-4 py-3">
+                      <div className="flex items-center justify-center w-6 h-6 rounded-full bg-primary text-white text-xs font-medium">
+                        {currentSource.index}
+                      </div>
+                      <span className="text-sm font-medium text-primary">
+                        {t('citation.currentChunk', 'Current Reference')}
+                      </span>
+                    </div>
+                    <div className="px-4 pb-4">
+                      <div className="text-sm text-text-primary leading-relaxed whitespace-pre-wrap">
+                        {currentSource.content_preview}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-16">
+                  <div className="p-3 bg-surface rounded-full mb-3">
+                    <FileText className="w-6 h-6 text-text-muted" />
+                  </div>
+                  <p className="text-sm text-text-muted">
+                    {t('citation.selectSource', 'Select a source to view details')}
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/frontend/src/features/tasks/components/chat/SourceChunkDialog.tsx
+++ b/frontend/src/features/tasks/components/chat/SourceChunkDialog.tsx
@@ -1,0 +1,209 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+/**
+ * Source Chunk Dialog Component
+ *
+ * Displays detailed chunk context with previous and next chunks for better understanding.
+ * Allows users to navigate between different sources and view original documents.
+ */
+
+import React, { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import { FileText, ExternalLink } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { SourceReference } from '@/types/socket'
+import type { ChunkContextResponse, ChunkItem } from '@/types/knowledge'
+import { getChunkContext } from '@/apis/knowledge'
+
+interface SourceChunkDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  sources: SourceReference[]
+  initialSourceIndex?: number
+}
+
+export function SourceChunkDialog({
+  open,
+  onOpenChange,
+  sources,
+  initialSourceIndex = 1,
+}: SourceChunkDialogProps) {
+  const { t } = useTranslation('chat')
+  const [selectedIndex, setSelectedIndex] = useState(initialSourceIndex)
+  const [context, setContext] = useState<ChunkContextResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const currentSource = sources.find(s => s.index === selectedIndex)
+
+  // Reset selected state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSelectedIndex(initialSourceIndex)
+    }
+  }, [open, initialSourceIndex])
+
+  // Load chunk context
+  useEffect(() => {
+    if (
+      open &&
+      currentSource &&
+      currentSource.document_id !== undefined &&
+      currentSource.chunk_index !== undefined
+    ) {
+      setLoading(true)
+      setError(null)
+
+      getChunkContext(currentSource.document_id, currentSource.chunk_index, 1)
+        .then(setContext)
+        .catch(err => {
+          console.error('Failed to load chunk context:', err)
+          setError(err.message || 'Failed to load context')
+        })
+        .finally(() => setLoading(false))
+    }
+  }, [open, currentSource])
+
+  // Render chunk block
+  const renderChunk = (chunk: ChunkItem, type: 'previous' | 'current' | 'next') => {
+    const isHighlighted = type === 'current'
+
+    return (
+      <div
+        className={`p-3 rounded-lg ${
+          isHighlighted
+            ? 'bg-primary/10 border-l-2 border-primary'
+            : 'bg-surface/50 border border-border/50'
+        }`}
+      >
+        <div
+          className={`text-xs mb-1 ${isHighlighted ? 'text-primary font-medium' : 'text-text-muted'}`}
+        >
+          {type === 'previous' && t('citation.previousChunk', 'Previous')}
+          {type === 'current' && t('citation.currentChunk', 'Current Reference')}
+          {type === 'next' && t('citation.nextChunk', 'Next')}
+          {' '}#{chunk.chunk_index + 1}
+          <span className="ml-2 text-text-muted">({chunk.token_count} tokens)</span>
+        </div>
+        <div
+          className={`text-sm whitespace-pre-wrap ${isHighlighted ? 'text-text-primary' : 'text-text-secondary'}`}
+        >
+          {chunk.content}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[80vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="w-5 h-5" />
+            {t('citation.sourceList', 'Source References')}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-1 gap-4 overflow-hidden min-h-0">
+          {/* Left: Source list */}
+          <div className="w-56 flex-shrink-0 border-r border-border pr-4 overflow-y-auto">
+            <div className="space-y-1">
+              {sources.map(source => (
+                <button
+                  key={source.index}
+                  className={`w-full text-left px-3 py-2 rounded-lg text-sm transition-colors ${
+                    selectedIndex === source.index
+                      ? 'bg-primary/10 text-primary border-l-2 border-primary'
+                      : 'hover:bg-surface text-text-secondary'
+                  }`}
+                  onClick={() => setSelectedIndex(source.index)}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs">[{source.index}]</span>
+                    <span className="truncate">{source.title}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Right: Chunk details */}
+          <div className="flex-1 overflow-y-auto pr-2">
+            {loading ? (
+              <div className="flex items-center justify-center h-full">
+                <Spinner />
+              </div>
+            ) : error ? (
+              <div className="text-center text-destructive py-8">{error}</div>
+            ) : context ? (
+              <div className="space-y-4">
+                {/* Document info */}
+                <div className="text-sm text-text-muted">
+                  {context.document_name} · {t('citation.chunkContext', 'Context')} (
+                  {context.current_chunk.chunk_index + 1}/{context.total_chunks})
+                </div>
+
+                {/* Previous chunks */}
+                {context.previous_chunks.map((chunk, i) => (
+                  <div key={`prev-${i}`}>{renderChunk(chunk, 'previous')}</div>
+                ))}
+
+                {/* Current chunk (highlighted) */}
+                {renderChunk(context.current_chunk, 'current')}
+
+                {/* Next chunks */}
+                {context.next_chunks.map((chunk, i) => (
+                  <div key={`next-${i}`}>{renderChunk(chunk, 'next')}</div>
+                ))}
+
+                {/* View original document button */}
+                <div className="pt-4 border-t border-border">
+                  <Button
+                    variant="outline"
+                    onClick={() => {
+                      window.open(
+                        `/knowledge/document/${currentSource?.kb_id}?doc=${currentSource?.document_id}&chunk=${currentSource?.chunk_index}`,
+                        '_blank'
+                      )
+                    }}
+                  >
+                    <ExternalLink className="w-4 h-4 mr-2" />
+                    {t('citation.viewOriginal', 'View Original Document')}
+                  </Button>
+                </div>
+              </div>
+            ) : currentSource?.content_preview ? (
+              // Show content preview when detailed context is not available
+              <div className="space-y-4">
+                <div className="text-sm text-text-muted">{currentSource.title}</div>
+                <div className="p-3 rounded-lg bg-primary/10 border-l-2 border-primary">
+                  <div className="text-xs text-primary font-medium mb-1">
+                    {t('citation.currentChunk', 'Current Reference')}
+                  </div>
+                  <div className="text-sm text-text-primary whitespace-pre-wrap">
+                    {currentSource.content_preview}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="text-center text-text-muted py-8">
+                {t('citation.selectSource', 'Select a source to view details')}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/tasks/components/chat/SourceReferences.tsx
+++ b/frontend/src/features/tasks/components/chat/SourceReferences.tsx
@@ -9,17 +9,15 @@
  *
  * Displays knowledge base source references for RAG-enhanced responses.
  * Shows document titles with index numbers (e.g., [1], [2], [3]).
+ * Supports clicking to view chunk details in a dialog.
  */
 
-import React from 'react'
+import React, { useState, useRef } from 'react'
 import { FileText } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
-
-interface SourceReference {
-  index: number
-  title: string
-  kb_id: number
-}
+import type { SourceReference } from '@/types/socket'
+import { ChunkPreviewTooltip } from './ChunkPreviewTooltip'
+import { SourceChunkDialog } from './SourceChunkDialog'
 
 interface SourceReferencesProps {
   sources: SourceReference[]
@@ -27,28 +25,80 @@ interface SourceReferencesProps {
 }
 
 export function SourceReferences({ sources, className = '' }: SourceReferencesProps) {
-  const { t } = useTranslation()
+  const { t } = useTranslation('chat')
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [selectedIndex, setSelectedIndex] = useState(1)
+  const [tooltipSource, setTooltipSource] = useState<SourceReference | null>(null)
+  const anchorRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
 
   if (!sources || sources.length === 0) {
     return null
   }
 
+  const handleSourceClick = (source: SourceReference, element: HTMLButtonElement) => {
+    anchorRefs.current.set(source.index, element)
+    // If content_preview is available, show tooltip first
+    if (source.content_preview) {
+      setTooltipSource(source)
+    } else {
+      // Otherwise, go directly to dialog
+      setSelectedIndex(source.index)
+      setDialogOpen(true)
+    }
+  }
+
+  const handleViewDetail = () => {
+    if (tooltipSource) {
+      setSelectedIndex(tooltipSource.index)
+      setTooltipSource(null)
+      setDialogOpen(true)
+    }
+  }
+
   return (
-    <div className={`mt-3 pt-3 border-t border-border ${className}`}>
-      <div className="flex items-start gap-2 text-xs text-text-muted">
-        <FileText className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
-        <div className="flex-1">
-          <div className="font-medium mb-1.5">{t('chat.sourceReferences', '资料来源')}:</div>
-          <div className="flex flex-wrap gap-x-3 gap-y-1">
-            {sources.map(source => (
-              <div key={source.index} className="flex items-baseline gap-1">
-                <span className="font-mono text-primary">[{source.index}]</span>
-                <span className="text-text-secondary">{source.title}</span>
-              </div>
-            ))}
+    <>
+      <div className={`mt-3 pt-3 border-t border-border ${className}`}>
+        <div className="flex items-start gap-2 text-xs text-text-muted">
+          <FileText className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <div className="font-medium mb-1.5">{t('sourceReferences', '资料来源')}:</div>
+            <div className="flex flex-wrap gap-x-3 gap-y-1">
+              {sources.map(source => (
+                <button
+                  key={source.index}
+                  className="flex items-baseline gap-1 hover:bg-surface px-1.5 py-0.5 rounded cursor-pointer transition-colors"
+                  onClick={e => handleSourceClick(source, e.currentTarget)}
+                >
+                  <span className="font-mono text-primary">[{source.index}]</span>
+                  <span className="text-text-secondary hover:text-text-primary">
+                    {source.title}
+                  </span>
+                </button>
+              ))}
+            </div>
           </div>
         </div>
       </div>
-    </div>
+
+      {/* Tooltip for quick preview */}
+      {tooltipSource && (
+        <ChunkPreviewTooltip
+          source={tooltipSource}
+          anchorRef={{
+            current: anchorRefs.current.get(tooltipSource.index) || null,
+          }}
+          onClose={() => setTooltipSource(null)}
+          onViewDetail={handleViewDetail}
+        />
+      )}
+
+      {/* Dialog for detailed view */}
+      <SourceChunkDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        sources={sources}
+        initialSourceIndex={selectedIndex}
+      />
+    </>
   )
 }

--- a/frontend/src/features/tasks/components/chat/SourceReferences.tsx
+++ b/frontend/src/features/tasks/components/chat/SourceReferences.tsx
@@ -8,11 +8,11 @@
  * Source References Component
  *
  * Displays knowledge base source references for RAG-enhanced responses.
- * Shows document titles with index numbers (e.g., [1], [2], [3]).
+ * Groups sources by document and shows each document only once.
  * Supports clicking to view chunk details in a dialog.
  */
 
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useMemo } from 'react'
 import { FileText } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { SourceReference } from '@/types/socket'
@@ -24,25 +24,64 @@ interface SourceReferencesProps {
   className?: string
 }
 
+/**
+ * Unique document info for display
+ */
+interface UniqueDocument {
+  key: string
+  title: string
+  firstSource: SourceReference // First source of this document (for click handling)
+}
+
+/**
+ * Get unique documents from sources (deduplicated by document)
+ */
+function getUniqueDocuments(sources: SourceReference[]): UniqueDocument[] {
+  const documentMap = new Map<string, UniqueDocument>()
+
+  for (const source of sources) {
+    // Create a unique key for each document
+    // Prefer document_id if available, otherwise use title
+    const docKey =
+      source.document_id !== undefined
+        ? `${source.kb_id}-${source.document_id}`
+        : `${source.kb_id}-${source.title}`
+
+    // Only keep the first occurrence of each document
+    if (!documentMap.has(docKey)) {
+      documentMap.set(docKey, {
+        key: docKey,
+        title: source.title,
+        firstSource: source,
+      })
+    }
+  }
+
+  return Array.from(documentMap.values())
+}
+
 export function SourceReferences({ sources, className = '' }: SourceReferencesProps) {
   const { t } = useTranslation('chat')
   const [dialogOpen, setDialogOpen] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(1)
   const [tooltipSource, setTooltipSource] = useState<SourceReference | null>(null)
-  const anchorRefs = useRef<Map<number, HTMLButtonElement>>(new Map())
+  const anchorRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
+
+  // Get unique documents (deduplicated by document)
+  const uniqueDocuments = useMemo(() => getUniqueDocuments(sources), [sources])
 
   if (!sources || sources.length === 0) {
     return null
   }
 
-  const handleSourceClick = (source: SourceReference, element: HTMLButtonElement) => {
-    anchorRefs.current.set(source.index, element)
+  const handleDocumentClick = (doc: UniqueDocument, element: HTMLButtonElement) => {
+    anchorRefs.current.set(doc.key, element)
     // If content_preview is available, show tooltip first
-    if (source.content_preview) {
-      setTooltipSource(source)
+    if (doc.firstSource.content_preview) {
+      setTooltipSource(doc.firstSource)
     } else {
       // Otherwise, go directly to dialog
-      setSelectedIndex(source.index)
+      setSelectedIndex(doc.firstSource.index)
       setDialogOpen(true)
     }
   }
@@ -63,16 +102,13 @@ export function SourceReferences({ sources, className = '' }: SourceReferencesPr
           <div className="flex-1">
             <div className="font-medium mb-1.5">{t('sourceReferences', '资料来源')}:</div>
             <div className="flex flex-wrap gap-x-3 gap-y-1">
-              {sources.map(source => (
+              {uniqueDocuments.map(doc => (
                 <button
-                  key={source.index}
+                  key={doc.key}
                   className="flex items-baseline gap-1 hover:bg-surface px-1.5 py-0.5 rounded cursor-pointer transition-colors"
-                  onClick={e => handleSourceClick(source, e.currentTarget)}
+                  onClick={e => handleDocumentClick(doc, e.currentTarget)}
                 >
-                  <span className="font-mono text-primary">[{source.index}]</span>
-                  <span className="text-text-secondary hover:text-text-primary">
-                    {source.title}
-                  </span>
+                  <span className="text-text-secondary hover:text-text-primary">{doc.title}</span>
                 </button>
               ))}
             </div>
@@ -85,7 +121,12 @@ export function SourceReferences({ sources, className = '' }: SourceReferencesPr
         <ChunkPreviewTooltip
           source={tooltipSource}
           anchorRef={{
-            current: anchorRefs.current.get(tooltipSource.index) || null,
+            current:
+              anchorRefs.current.get(
+                tooltipSource.document_id !== undefined
+                  ? `${tooltipSource.kb_id}-${tooltipSource.document_id}`
+                  : `${tooltipSource.kb_id}-${tooltipSource.title}`
+              ) || null,
           }}
           onClose={() => setTooltipSource(null)}
           onViewDetail={handleViewDetail}

--- a/frontend/src/features/tasks/contexts/chatStreamContext.tsx
+++ b/frontend/src/features/tasks/contexts/chatStreamContext.tsx
@@ -111,6 +111,9 @@ export interface UnifiedMessage {
       index: number
       title: string
       kb_id: number
+      document_id?: number
+      chunk_index?: number
+      content_preview?: string
     }>
     /** Reasoning content from models like DeepSeek R1 */
     reasoning_content?: string
@@ -120,6 +123,9 @@ export interface UnifiedMessage {
     index: number
     title: string
     kb_id: number
+    document_id?: number
+    chunk_index?: number
+    content_preview?: string
   }>
 }
 

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -477,5 +477,19 @@
     "proceeding_to_stage": "Proceeding to stage: {{stage}}",
     "pipeline_completed": "Pipeline completed",
     "no_task_id": "No task ID available"
+  },
+  "sourceReferences": "Sources",
+  "citation": {
+    "viewDetail": "View Details",
+    "viewOriginal": "View Original Document",
+    "sourceList": "Source References",
+    "chunkContext": "Context",
+    "currentChunk": "Current Reference",
+    "previousChunk": "Previous",
+    "nextChunk": "Next",
+    "selectSource": "Select a source to view details",
+    "supplementInfo": "Supplementary Info",
+    "noPreview": "No preview available",
+    "close": "Close"
   }
 }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -480,8 +480,11 @@
   },
   "sourceReferences": "Sources",
   "citation": {
+    "content": "Content",
+    "documentContent": "Document Content",
+    "sourceReference": "Source Reference",
     "viewDetail": "View Details",
-    "viewOriginal": "View Original Document",
+    "viewOriginal": "View Document",
     "sourceList": "Source References",
     "chunkContext": "Context",
     "currentChunk": "Current Reference",
@@ -490,6 +493,18 @@
     "selectSource": "Select a source to view details",
     "supplementInfo": "Supplementary Info",
     "noPreview": "No preview available",
-    "close": "Close"
+    "close": "Close",
+    "sourceCount": "{{count}} sources",
+    "chunkPosition": "Chunk {{current}} of {{total}}",
+    "reference": "Reference",
+    "loading": "Loading content...",
+    "errorHint": "Please try again later",
+    "copy": "Copy",
+    "copied": "Copied",
+    "copySuccess": "Copied to clipboard",
+    "copyError": "Failed to copy",
+    "truncated": "Truncated",
+    "contentLength": "Content length",
+    "characters": "characters"
   }
 }

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -32,7 +32,11 @@
     "retry": "Retry",
     "toggle_theme": "Toggle Theme",
     "upload": "Upload",
-    "view": "View"
+    "view": "View",
+    "previous": "Previous",
+    "next": "Next",
+    "expand": "Expand",
+    "collapse": "Collapse"
   },
   "errors": {
     "request_failed": "LLM API request failed, please click retry"

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -480,6 +480,9 @@
   },
   "sourceReferences": "资料来源",
   "citation": {
+    "content": "内容",
+    "documentContent": "文档内容",
+    "sourceReference": "引用来源",
     "viewDetail": "查看详情",
     "viewOriginal": "查看原文档",
     "sourceList": "引用来源详情",
@@ -490,6 +493,18 @@
     "selectSource": "请选择一个来源查看详情",
     "supplementInfo": "补充信息",
     "noPreview": "暂无预览",
-    "close": "关闭"
+    "close": "关闭",
+    "sourceCount": "共 {{count}} 个来源",
+    "chunkPosition": "第 {{current}} / {{total}} 段",
+    "reference": "引用",
+    "loading": "正在加载内容...",
+    "errorHint": "请稍后重试",
+    "copy": "复制",
+    "copied": "已复制",
+    "copySuccess": "已复制到剪贴板",
+    "copyError": "复制失败",
+    "truncated": "内容已截断",
+    "contentLength": "内容长度",
+    "characters": "字符"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -477,5 +477,19 @@
     "proceeding_to_stage": "正在进入阶段: {{stage}}",
     "pipeline_completed": "流水线已完成",
     "no_task_id": "没有可用的任务 ID"
+  },
+  "sourceReferences": "资料来源",
+  "citation": {
+    "viewDetail": "查看详情",
+    "viewOriginal": "查看原文档",
+    "sourceList": "引用来源详情",
+    "chunkContext": "上下文",
+    "currentChunk": "当前引用",
+    "previousChunk": "上文",
+    "nextChunk": "下文",
+    "selectSource": "请选择一个来源查看详情",
+    "supplementInfo": "补充信息",
+    "noPreview": "暂无预览",
+    "close": "关闭"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -32,7 +32,11 @@
     "retry": "重试",
     "toggle_theme": "切换主题",
     "upload": "上传",
-    "view": "查看"
+    "view": "查看",
+    "previous": "上一页",
+    "next": "下一页",
+    "expand": "展开",
+    "collapse": "收起"
   },
   "errors": {
     "request_failed": "请求大模型接口失败，请点击重试"

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -325,3 +325,14 @@ export interface WebScrapeResponse {
     | 'NOT_HTML'
   error_message?: string
 }
+
+// Chunk Context types (for citation references)
+export interface ChunkContextResponse {
+  previous_chunks: ChunkItem[]
+  current_chunk: ChunkItem
+  next_chunks: ChunkItem[]
+  document_name: string
+  document_id: number
+  kb_id: number
+  total_chunks: number
+}

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -151,6 +151,12 @@ export interface SourceReference {
   title: string
   /** Knowledge base ID */
   kb_id: number
+  /** Document ID (knowledge_documents.id) */
+  document_id?: number
+  /** Chunk index (corresponds to chunks.items[].index) */
+  chunk_index?: number
+  /** Chunk content preview (first 100 characters) */
+  content_preview?: string
 }
 
 export interface ChatStartPayload {

--- a/shared/telemetry/context/events.py
+++ b/shared/telemetry/context/events.py
@@ -15,6 +15,8 @@ class TelemetryEventNames:
 
     # Error events
     BOT_NOT_FOUND = "BotNotFound"
+    TEAM_NOT_FOUND = "TeamNotFound"
+    CONFIG_BUILD_FAILED = "ConfigBuildFailed"
     PROVIDER_CREATION_FAILED = "ProviderCreationFailed"
     STREAM_CHUNK_ERROR = "StreamChunkError"
     STREAM_ERROR = "StreamError"


### PR DESCRIPTION
## Summary

This PR implements knowledge base citation reference tracking and chunk context viewing functionality to help users trace AI responses back to their source documents.

### Key Features:
- **Citation Reference Tracking**: Extended SourceReference schema with document_id, chunk_index, and content_preview fields for precise chunk-level citation
- **Chunk Context API**: New API endpoint to retrieve chunk with surrounding context (previous/next chunks)
- **LLM Citation Rules**: Updated System Prompts for STRICT/RELAXED modes with mandatory citation marker `[n]` rules
- **Interactive UI Components**: 
  - ChunkPreviewTooltip: Quick preview on hover/click
  - SourceChunkDialog: Detailed view with previous/current/next chunks
- **Source Reference Improvements**: Clickable source references with tooltip and dialog support

### Changes by Module:

**Backend:**
- Extend `SourceReference` schema with document_id, chunk_index, content_preview
- Add `ChunkContextResponse` schema for chunk context API
- Add `GET /documents/{id}/chunks/{index}/context` endpoint
- Update Elasticsearch backend to return document_id and chunk_index in search results

**Chat Shell:**
- Enhance `KB_PROMPT_STRICT` and `KB_PROMPT_RELAXED` with citation rules
- Update `KnowledgeBaseTool` to build chunk-level source references with content preview

**Frontend:**
- Add `ChunkPreviewTooltip` component for quick chunk preview
- Add `SourceChunkDialog` component for detailed chunk context viewing
- Update `SourceReferences` to support click-to-view functionality
- Add `getChunkContext` API function
- Add i18n translations for citation features (zh-CN and en)

## Test plan

- [ ] Verify citation markers `[n]` appear in AI responses when using knowledge base
- [ ] Verify clicking on source reference shows ChunkPreviewTooltip with content preview
- [ ] Verify "View Details" opens SourceChunkDialog with chunk context
- [ ] Verify chunk context API returns correct previous/current/next chunks
- [ ] Verify "View Original Document" button navigates to document page
- [ ] Verify translations work for both Chinese and English
- [ ] Verify STRICT mode enforces citation rules
- [ ] Verify RELAXED mode allows mixed sources with proper marking