### PR TITLE
feat(frontend): render attachment download links as interactive cards

### DIFF
--- a/backend/init_data/skills/document/document_tool.py
+++ b/backend/init_data/skills/document/document_tool.py
@@ -243,8 +243,20 @@ Example:
                     },
                     "expected_outcome": "success=true and download_url field contains the URL",
                     "user_presentation": {
-                        "format": "Provide the download link to user in a clickable format",
-                        "example": "文档已生成完成！\n\n📄 **{filename}**\n\n[点击下载]({download_url})",
+                        "format": "Provide the download link to user with the URL on a separate line",
+                        "example": (
+                            "文档已生成完成！\n\n"
+                            "📄 **{filename}**\n\n"
+                            "[点击下载]({download_url})"
+                        ),
+                        "critical_formatting_rules": [
+                            "⚠️ The download URL link MUST be on its own line",
+                            "⚠️ Do NOT put other text before or after the link on the same line",
+                            "⚠️ Frontend will automatically render the link as an interactive card",
+                            "✅ Correct: '文档已生成！\\n\\n[点击下载](/api/attachments/123/download)'",
+                            "❌ Wrong: '文档已生成！[点击下载](/api/attachments/123/download)'",
+                            "❌ Wrong: '[点击下载](/api/attachments/123/download) 下载完成'",
+                        ],
                     },
                     "critical_importance": (
                         "⚠️ THIS STEP IS MANDATORY ⚠️\n"
@@ -286,8 +298,10 @@ Example:
                 f"5️⃣ STEP 5: ⚠️ UPLOAD AND RETURN URL ⚠️ (MANDATORY)\n"
                 f"   → Call: sandbox_upload_attachment(file_path='{{generated_file_path}}')\n"
                 f"   → Get the 'download_url' from response\n"
-                f"   → Present the download link to user in a clickable format\n"
-                f"   → Example: '文档已生成！[点击下载]({{download_url}})'\n\n"
+                f"   → ⚠️ CRITICAL: Put the download link on its own line with no other text\n"
+                f"   → ✅ Correct format: '文档已生成！\\n\\n[点击下载]({{download_url}})'\n"
+                f"   → ❌ Wrong format: '文档已生成！[点击下载]({{download_url}})' (link not on separate line)\n"
+                f"   → Frontend will automatically render the link as an interactive card\n\n"
                 f"⚠️ DO NOT generate {document_type.upper()} files before completing step 3!\n"
                 f"⚠️ DO NOT skip step 5 - users cannot access sandbox files directly!\n"
                 f"⚠️ Your existing knowledge may be OUTDATED - trust the loaded documentation!"

--- a/chat_shell/start.sh
+++ b/chat_shell/start.sh
@@ -53,7 +53,7 @@ get_local_ip() {
 }
 
 # Get local IP for backend URL (used by executor containers in Docker)
-export BACKEND_API_URL=$(get_local_ip)
+export BACKEND_API_URL=$(get_local_ip):8000
 
 # Default configuration
 DEFAULT_PORT=8100

--- a/frontend/src/apis/attachments.ts
+++ b/frontend/src/apis/attachments.ts
@@ -423,9 +423,9 @@ export function getAttachmentDownloadUrl(attachmentId: number): string {
  * Download attachment file
  *
  * @param attachmentId - Attachment ID
- * @param filename - Filename for download
+ * @param filename - Optional filename for download. If not provided, will be extracted from Content-Disposition header
  */
-export async function downloadAttachment(attachmentId: number, filename: string): Promise<void> {
+export async function downloadAttachment(attachmentId: number, filename?: string): Promise<void> {
   const token = getToken()
 
   const response = await fetch(`${API_BASE_URL}/api/attachments/${attachmentId}/download`, {
@@ -439,11 +439,37 @@ export async function downloadAttachment(attachmentId: number, filename: string)
     throw new Error('Failed to download attachment')
   }
 
+  // Extract filename from Content-Disposition header if not provided
+  let downloadFilename = filename
+  if (!downloadFilename) {
+    const contentDisposition = response.headers.get('Content-Disposition')
+    if (contentDisposition) {
+      // Parse filename from Content-Disposition header
+      // Format: attachment; filename="example.pdf" or attachment; filename*=UTF-8''example.pdf
+      const filenameMatch =
+        contentDisposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/) ||
+        contentDisposition.match(/filename\*=UTF-8''(.+)/)
+      if (filenameMatch && filenameMatch[1]) {
+        downloadFilename = filenameMatch[1].replace(/['"]/g, '')
+        // Decode URI component if it's encoded
+        try {
+          downloadFilename = decodeURIComponent(downloadFilename)
+        } catch {
+          // Keep original if decode fails
+        }
+      }
+    }
+    // Fallback filename if extraction fails
+    if (!downloadFilename) {
+      downloadFilename = `attachment-${attachmentId}.file`
+    }
+  }
+
   const blob = await response.blob()
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = filename
+  a.download = downloadFilename
   document.body.appendChild(a)
   a.click()
   document.body.removeChild(a)

--- a/frontend/src/components/common/AttachmentCard.tsx
+++ b/frontend/src/components/common/AttachmentCard.tsx
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { Download, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { downloadAttachment, getAttachment, getFileIcon } from '@/apis/attachments'
+import type { AttachmentDetailResponse } from '@/apis/attachments'
+
+// Global cache for attachment details to avoid redundant API calls
+const attachmentCache = new Map<number, AttachmentDetailResponse>()
+
+interface AttachmentCardProps {
+  /** Attachment ID */
+  attachmentId: number
+}
+
+/**
+ * AttachmentCard component displays a file attachment as a card with preview and download options
+ *
+ * Features:
+ * - Fetches attachment details from API (with caching)
+ * - File icon based on extension
+ * - Filename and type label
+ * - Preview button (opens in new tab)
+ * - Download button (downloads with authentication)
+ */
+export function AttachmentCard({ attachmentId }: AttachmentCardProps) {
+  const [attachment, setAttachment] = useState<AttachmentDetailResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Fetch attachment details on mount (with caching)
+  useEffect(() => {
+    const fetchAttachment = async () => {
+      try {
+        setLoading(true)
+
+        // Check cache first
+        const cached = attachmentCache.get(attachmentId)
+        if (cached) {
+          setAttachment(cached)
+          setLoading(false)
+          return
+        }
+
+        // Fetch from API if not cached
+        const data = await getAttachment(attachmentId)
+        attachmentCache.set(attachmentId, data) // Cache the result
+        setAttachment(data)
+      } catch (err) {
+        console.error('Failed to fetch attachment:', err)
+        setError(err instanceof Error ? err.message : 'Failed to load attachment')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchAttachment()
+  }, [attachmentId])
+
+  const handleDownload = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    try {
+      await downloadAttachment(attachmentId)
+    } catch (error) {
+      console.error('Failed to download attachment:', error)
+    }
+  }
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="flex items-center gap-4 p-4 rounded-xl border border-border bg-surface">
+        <div className="flex-shrink-0 w-16 h-16 flex items-center justify-center bg-base rounded-lg border border-border">
+          <Loader2 className="h-6 w-6 animate-spin text-text-muted" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="h-5 bg-border rounded animate-pulse mb-2 w-3/4" />
+          <div className="h-4 bg-border rounded animate-pulse w-1/2" />
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (error || !attachment) {
+    return (
+      <div className="flex items-center gap-4 p-4 rounded-xl border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/20">
+        <div className="flex-shrink-0 w-16 h-16 flex items-center justify-center bg-base rounded-lg border border-border">
+          <span className="text-3xl">⚠️</span>
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-medium text-red-800 dark:text-red-200">
+            Failed to load attachment
+          </h3>
+          <p className="text-sm text-red-600 dark:text-red-400">{error || 'Unknown error'}</p>
+        </div>
+      </div>
+    )
+  }
+
+  // Get file icon emoji
+  const fileIcon = getFileIcon(attachment.file_extension)
+
+  // Get file type label
+  const fileTypeLabel = getFileTypeLabel(attachment.file_extension)
+
+  return (
+    <div className="flex items-center gap-4 p-4 rounded-xl border border-border bg-surface hover:bg-surface-hover transition-colors">
+      {/* File Icon */}
+      <div className="flex-shrink-0 w-16 h-16 flex items-center justify-center bg-base rounded-lg border border-border">
+        <span className="text-3xl">{fileIcon}</span>
+      </div>
+
+      {/* File Info */}
+      <div className="flex-1 min-w-0">
+        <h3
+          className="text-base font-medium text-text-primary truncate"
+          title={attachment.filename}
+        >
+          {attachment.filename}
+        </h3>
+        <p className="text-sm text-text-secondary">
+          {fileTypeLabel} · {attachment.file_extension.replace('.', '').toUpperCase()}
+        </p>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        {/* Preview Button */}
+        {/* <Button
+          variant="ghost"
+          size="icon"
+          onClick={handlePreview}
+          className="h-10 w-10 rounded-lg hover:bg-primary/10"
+          title="Preview"
+        >
+          <ExternalLink className="h-5 w-5 text-text-secondary" />
+        </Button> */}
+
+        {/* Download Button */}
+        <Button
+          variant="outline"
+          onClick={handleDownload}
+          className="h-10 px-4 rounded-lg hover:bg-primary/10"
+        >
+          <Download className="h-4 w-4 mr-2" />
+          Download
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Get file type label based on extension
+ */
+function getFileTypeLabel(extension: string): string {
+  const ext = extension.toLowerCase().replace('.', '')
+
+  // Document types
+  if (['pdf'].includes(ext)) return 'Document'
+  if (['doc', 'docx'].includes(ext)) return 'Word Document'
+  if (['xls', 'xlsx', 'csv'].includes(ext)) return 'Spreadsheet'
+  if (['ppt', 'pptx'].includes(ext)) return 'Presentation'
+  if (['txt', 'md'].includes(ext)) return 'Text'
+
+  // Image types
+  if (['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp'].includes(ext)) return 'Image'
+
+  // Code types
+  if (['js', 'ts', 'jsx', 'tsx', 'py', 'java', 'c', 'cpp'].includes(ext)) return 'Code'
+
+  // Config types
+  if (['json', 'yaml', 'yml', 'xml', 'toml'].includes(ext)) return 'Configuration'
+
+  // Default
+  return 'File'
+}
+
+export default AttachmentCard

--- a/frontend/src/features/tasks/components/message/BubbleTools.tsx
+++ b/frontend/src/features/tasks/components/message/BubbleTools.tsx
@@ -149,10 +149,7 @@ export interface BubbleToolsProps {
   /** Whether regenerate is in progress */
   isRegenerating?: boolean
   /** Optional render prop for custom regenerate button with popover */
-  renderRegenerateButton?: (
-    defaultButton: React.ReactNode,
-    tooltipText: string
-  ) => React.ReactNode
+  renderRegenerateButton?: (defaultButton: React.ReactNode, tooltipText: string) => React.ReactNode
 }
 
 // Bubble toolbar: supports copy button, feedback buttons, and extensible tool buttons


### PR DESCRIPTION
- Add AttachmentCard component with file info and download button
- Automatically fetch and cache attachment details to avoid redundant API calls
- Render /api/attachments/{id}/download links as cards in markdown
- Update downloadAttachment to extract filename from Content-Disposition header
- Update document_tool.py to instruct AI to format download links on separate lines

Changes:
- frontend/src/components/common/AttachmentCard.tsx: New component with caching
- frontend/src/components/common/SmartUrlRenderer.tsx: Detect and render attachment links as cards
- frontend/src/apis/attachments.ts: Make filename parameter optional, extract from response header
- backend/init_data/skills/document/document_tool.py: Add formatting rules for download links