### PR TITLE
refactor: 配置Celery日志以使用request_id

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -25,7 +25,7 @@ class RequestIdFilter(logging.Filter):
             True (always allow the record to be logged)
         """
         try:
-            from shared.telemetry.context import get_request_id
+            from shared.telemetry.context.span import get_request_id
 
             request_id = get_request_id()
             record.request_id = request_id if request_id else "-"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket events now capture server IP and request body information.
  * Background tasks now include request identifiers in log output.

* **Tests**
  * Added verification for enhanced WebSocket event data collection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->