### PR TITLE
fix(frontend): hide move-to-group menu for pinned conversations

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskMenu.tsx
@@ -101,8 +101,8 @@ export default function TaskMenu({
             </DropdownMenuItem>
           )}
 
-          {/* Move to Group - only for non-group chats */}
-          {!isGroupChat && (
+          {/* Move to Group - only for non-group chats and non-pinned tasks */}
+          {!isGroupChat && !isPinned && (
             <DropdownMenuSub>
               <DropdownMenuSubTrigger onClick={e => e.stopPropagation()}>
                 <FolderPlusIcon className="h-3.5 w-3.5 mr-2" />


### PR DESCRIPTION
## Summary

- Remove "Move to Group" menu item from pinned conversations' dropdown menu
- Update condition from `!isGroupChat` to `!isGroupChat && !isPinned`
- Pinned tasks remain in the pinned section and should not be moved to groups

## Changes

**File:** `frontend/src/features/tasks/components/sidebar/TaskMenu.tsx`
- Modified line 104-105: Added `&& !isPinned` condition to hide "Move to Group" for pinned tasks

## Retained Features for Pinned Conversations
- Copy Task ID
- Unpin
- Rename
- Delete

## Test plan

- [ ] Verify pinned conversations do NOT show "Move to Group" option in menu
- [ ] Verify non-pinned conversations still show "Move to Group" option
- [ ] Verify group chats still do NOT show "Move to Group" option (existing behavior)