### PR TITLE
fix(backend): correct pin migration syntax and non-null constraint

### DIFF
--- a/backend/alembic/versions/w3x4y5z6a7b8_add_pin_functionality_to_tasks.py
+++ b/backend/alembic/versions/w3x4y5z6a7b8_add_pin_functionality_to_tasks.py
@@ -46,7 +46,7 @@ def upgrade() -> None:
         # Add index on is_pinned for faster sorting queries
         op.execute(
             """
-            CREATE INDEX idx_tasks_is_pinned ON tasks(is_pinned)
+            ALTER TABLE tasks ADD INDEX idx_tasks_is_pinned (is_pinned)
             """
         )
 
@@ -55,7 +55,7 @@ def upgrade() -> None:
         op.execute(
             """
             ALTER TABLE tasks
-            ADD COLUMN pinned_at DATETIME NULL DEFAULT NULL COMMENT 'Time when the task was pinned'
+            ADD COLUMN pinned_at DATETIME NOT NULL DEFAULT '1970-01-01 00:00:00' COMMENT 'Time when the task was pinned'
             """
         )
 
@@ -63,7 +63,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     """Remove is_pinned and pinned_at columns from tasks table."""
     # Drop index on is_pinned
-    op.execute("DROP INDEX idx_tasks_is_pinned ON tasks")
+    op.execute("ALTER TABLE tasks DROP INDEX idx_tasks_is_pinned")
 
     # Drop columns
     op.execute("ALTER TABLE tasks DROP COLUMN is_pinned")

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -84,8 +84,8 @@ class TaskResource(Base):
     )
     pinned_at = Column(
         DateTime,
-        nullable=True,
-        default=None,
+        nullable=False,
+        default=datetime(1970, 1, 1, 0, 0, 0),
         comment="Time when the task was pinned",
     )
 


### PR DESCRIPTION
## Summary

- Fix index creation syntax in migration: use `ALTER TABLE ADD INDEX` instead of `CREATE INDEX`
- Fix index drop syntax in downgrade: use `ALTER TABLE DROP INDEX` instead of `DROP INDEX ON`
- Change `pinned_at` column from nullable to NOT NULL with default value `'1970-01-01 00:00:00'`
- Update TaskResource model to align with migration changes

## Business Logic

- `pinned_at = '1970-01-01 00:00:00'` indicates the task is not pinned
- `pinned_at > '1970-01-01 00:00:00'` indicates the task is pinned, value represents pin time
- Use `is_pinned` field for business logic checks, `pinned_at` is only for sorting

## Test plan

- [ ] Verify migration runs successfully on a fresh database
- [ ] Verify downgrade migration works correctly
- [ ] Verify pin functionality works as expected with the updated model