### PR TITLE
feat(frontend): add unified repository selector with workspace requirement logic

### DIFF
--- a/backend/app/api/endpoints/adapter/shells.py
+++ b/backend/app/api/endpoints/adapter/shells.py
@@ -43,6 +43,9 @@ class UnifiedShell(BaseModel):
         None  # 'local_engine' or 'external_api' (from labels)
     )
     namespace: Optional[str] = None  # Resource namespace (group name or 'default')
+    requiresWorkspace: Optional[bool] = (
+        None  # Whether this shell requires a workspace. Defaults based on executionType.
+    )
 
 
 class ShellCreateRequest(BaseModel):
@@ -131,6 +134,7 @@ def _public_shell_to_unified(shell: Kind) -> UnifiedShell:
         supportModel=shell_crd.spec.supportModel,
         executionType=labels.get("type"),
         namespace=shell.namespace,
+        requiresWorkspace=shell_crd.spec.requiresWorkspace,
     )
 
 
@@ -152,6 +156,7 @@ def _user_shell_to_unified(kind: Kind) -> UnifiedShell:
         supportModel=shell_crd.spec.supportModel,
         executionType=labels.get("type"),
         namespace=kind.namespace,
+        requiresWorkspace=shell_crd.spec.requiresWorkspace,
     )
 
 

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -239,6 +239,10 @@ class ShellSpec(BaseModel):
     baseShellRef: Optional[str] = (
         None  # Reference to base public shell (e.g., "ClaudeCode")
     )
+    requiresWorkspace: Optional[bool] = Field(
+        default=None,
+        description="Whether this shell requires a workspace/repository. Defaults to True for local_engine types (ClaudeCode, Agno), False for external_api types (Dify, Chat).",
+    )
 
 
 class ShellStatus(Status):

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -343,6 +343,12 @@ class TeamSpec(BaseModel):
     bind_mode: Optional[List[str]] = None  # ['chat', 'code'] or empty list for none
     description: Optional[str] = None  # Team description
     icon: Optional[str] = None  # Icon ID from preset icon library
+    requiresWorkspace: Optional[bool] = Field(
+        default=None,
+        description="Whether this team requires a workspace/repository. "
+        "If not set (None), it will be inferred from the underlying shell types. "
+        "Set to True to always require workspace, False to never require workspace.",
+    )
 
 
 class TeamStatus(Status):

--- a/backend/app/schemas/team.py
+++ b/backend/app/schemas/team.py
@@ -49,6 +49,9 @@ class TeamBase(BaseModel):
     bind_mode: Optional[List[str]] = None  # ['chat', 'code'] or empty list for none
     is_active: bool = True
     icon: Optional[str] = None  # Icon ID from preset icon library
+    requires_workspace: Optional[bool] = (
+        None  # Whether this team requires a workspace/repository (None = auto-infer)
+    )
 
 
 class TeamCreate(TeamBase):
@@ -70,6 +73,9 @@ class TeamUpdate(BaseModel):
     is_active: Optional[bool] = None
     namespace: Optional[str] = None  # Group namespace
     icon: Optional[str] = None  # Icon ID from preset icon library
+    requires_workspace: Optional[bool] = (
+        None  # Whether this team requires a workspace/repository (None = auto-infer)
+    )
 
 
 class TeamInDB(TeamBase):

--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -176,6 +176,11 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
         if icon is not None:
             spec["icon"] = icon
 
+        # Handle requires_workspace - get from obj_in directly
+        requires_workspace = getattr(obj_in, "requires_workspace", None)
+        if requires_workspace is not None:
+            spec["requiresWorkspace"] = requires_workspace
+
         # Create Team JSON
         team_json = {
             "kind": "Team",
@@ -898,6 +903,10 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
         if "icon" in update_data:
             team_crd.spec.icon = update_data["icon"]
 
+        # Handle requires_workspace update
+        if "requires_workspace" in update_data:
+            team_crd.spec.requiresWorkspace = update_data["requires_workspace"]
+
         # Save the updated team CRD
         team.json = team_crd.model_dump(mode="json")
         team.updated_at = datetime.now()
@@ -1376,6 +1385,9 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
         # Get icon from spec
         icon = team_crd.spec.icon
 
+        # Get requires_workspace from spec
+        requires_workspace = team_crd.spec.requiresWorkspace
+
         total_convert_time = time.time() - convert_start
         if total_convert_time > 0.2:
             logger.info(
@@ -1398,6 +1410,7 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
             "updated_at": team.updated_at,
             "agent_type": agent_type,  # Add agent_type field
             "icon": icon,  # Add icon field
+            "requires_workspace": requires_workspace,  # Add requires_workspace field
         }
 
     def _convert_to_team_dict_with_cache(
@@ -1570,6 +1583,9 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
         # Get icon from spec
         icon = team_crd.spec.icon
 
+        # Get requires_workspace from spec
+        requires_workspace = team_crd.spec.requiresWorkspace
+
         return {
             "id": team.id,
             "user_id": team.user_id,
@@ -1586,6 +1602,7 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
             "updated_at": team.updated_at,
             "agent_type": agent_type,
             "icon": icon,
+            "requires_workspace": requires_workspace,  # Add requires_workspace field
         }
 
     def _get_bot_summary_with_cache(

--- a/frontend/src/apis/shells.ts
+++ b/frontend/src/apis/shells.ts
@@ -17,6 +17,7 @@ export interface UnifiedShell {
   supportModel?: string[] | null
   executionType?: 'local_engine' | 'external_api' | null // Shell execution type
   namespace?: string // Resource namespace (group name or 'default')
+  requiresWorkspace?: boolean // Whether this shell requires a workspace (default: true for local_engine)
 }
 
 export interface UnifiedShellListResponse {

--- a/frontend/src/apis/shells.ts
+++ b/frontend/src/apis/shells.ts
@@ -29,11 +29,13 @@ export interface ShellCreateRequest {
   displayName?: string
   baseShellRef: string // Required: base public shell name (e.g., "ClaudeCode")
   baseImage: string // Required: custom base image address
+  requiresWorkspace?: boolean // Whether this shell requires a workspace
 }
 
 export interface ShellUpdateRequest {
   displayName?: string
   baseImage?: string
+  requiresWorkspace?: boolean // Whether this shell requires a workspace
 }
 
 // Image Validation Types

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -16,6 +16,7 @@ export interface CreateTeamRequest {
   is_active?: boolean
   namespace?: string // Group namespace, defaults to 'default' for personal teams
   icon?: string // Icon ID from preset icon library
+  requires_workspace?: boolean // Whether this team requires a workspace/repository (null = auto-infer from shell)
 }
 
 export interface TeamListResponse {

--- a/frontend/src/features/settings/components/TeamEditDialog.tsx
+++ b/frontend/src/features/settings/components/TeamEditDialog.tsx
@@ -72,6 +72,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
   const [mode, setMode] = useState<TeamMode>('solo')
   const [bindMode, setBindMode] = useState<('chat' | 'code' | 'knowledge')[]>(['chat', 'code'])
   const [icon, setIcon] = useState<string | null>(null)
+  const [requiresWorkspace, setRequiresWorkspace] = useState<boolean | null>(null)
 
   // Bot selection state
   const [selectedBotKeys, setSelectedBotKeys] = useState<React.Key[]>([])
@@ -188,6 +189,8 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
         }
       })
       setRequireConfirmationMap(confirmMap)
+      // Initialize requiresWorkspace from existing team data
+      setRequiresWorkspace(formTeam.requires_workspace ?? null)
     } else {
       setName('')
       setDescription('')
@@ -197,6 +200,8 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
       setSelectedBotKeys([])
       setLeaderBotId(null)
       setRequireConfirmationMap({})
+      // Default to true for new teams (requires workspace by default)
+      setRequiresWorkspace(true)
     }
     setUnsavedPrompts({})
   }, [open, formTeam])
@@ -405,6 +410,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
               bots: botsData,
               namespace: scope === 'group' && groupName ? groupName : undefined,
               icon: icon || undefined,
+              requires_workspace: requiresWorkspace ?? undefined,
             })
             setTeams(prev => prev.map(team => (team.id === updated.id ? updated : team)))
           } else {
@@ -416,6 +422,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
               bots: botsData,
               namespace: scope === 'group' && groupName ? groupName : undefined,
               icon: icon || undefined,
+              requires_workspace: requiresWorkspace ?? undefined,
             })
             setTeams(prev => [created, ...prev])
           }
@@ -486,6 +493,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
           bots: botsData,
           namespace: scope === 'group' && groupName ? groupName : undefined,
           icon: icon || undefined,
+          requires_workspace: requiresWorkspace ?? undefined,
         })
         setTeams(prev => prev.map(team => (team.id === updated.id ? updated : team)))
       } else {
@@ -497,6 +505,7 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
           bots: botsData,
           namespace: scope === 'group' && groupName ? groupName : undefined,
           icon: icon || undefined,
+          requires_workspace: requiresWorkspace ?? undefined,
         })
         setTeams(prev => [created, ...prev])
       }
@@ -539,6 +548,8 @@ export default function TeamEditDialog(props: TeamEditDialogProps) {
               setBindMode={setBindMode}
               icon={icon}
               setIcon={setIcon}
+              requiresWorkspace={requiresWorkspace}
+              setRequiresWorkspace={setRequiresWorkspace}
             />
 
             {/* Mode Selection Section */}

--- a/frontend/src/features/settings/components/team-edit/TeamBasicInfoForm.tsx
+++ b/frontend/src/features/settings/components/team-edit/TeamBasicInfoForm.tsx
@@ -7,8 +7,11 @@
 import React from 'react'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { useTranslation } from '@/hooks/useTranslation'
 import { TeamIconPicker } from '../teams/TeamIconPicker'
+import { HelpCircle } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface TeamBasicInfoFormProps {
   name: string
@@ -19,6 +22,8 @@ interface TeamBasicInfoFormProps {
   setBindMode: (bindMode: ('chat' | 'code' | 'knowledge')[]) => void
   icon?: string | null
   setIcon?: (icon: string) => void
+  requiresWorkspace?: boolean | null
+  setRequiresWorkspace?: (value: boolean | null) => void
 }
 
 export default function TeamBasicInfoForm({
@@ -30,8 +35,13 @@ export default function TeamBasicInfoForm({
   setBindMode,
   icon,
   setIcon,
+  requiresWorkspace,
+  setRequiresWorkspace,
 }: TeamBasicInfoFormProps) {
   const { t } = useTranslation()
+
+  // Show requires_workspace toggle only when 'code' mode is selected
+  const showRequiresWorkspace = bindMode.includes('code') && setRequiresWorkspace
 
   return (
     <div className="space-y-4">
@@ -101,6 +111,32 @@ export default function TeamBasicInfoForm({
           className="bg-base"
         />
       </div>
+
+      {/* Requires Workspace Toggle - Only show when code mode is selected */}
+      {showRequiresWorkspace && (
+        <div className="flex items-center justify-between py-2">
+          <div className="flex items-center gap-2">
+            <Label htmlFor="requiresWorkspace" className="text-sm font-medium">
+              {t('common:team.requires_workspace')}
+            </Label>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <HelpCircle className="h-4 w-4 text-text-muted cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs">
+                  <p className="text-xs">{t('common:team.requires_workspace_hint')}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+          <Switch
+            id="requiresWorkspace"
+            checked={requiresWorkspace === true}
+            onCheckedChange={checked => setRequiresWorkspace(checked)}
+          />
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -286,6 +286,7 @@ function ChatAreaContent({
     selectedRepo: chatState.selectedRepo,
     selectedBranch: chatState.selectedBranch,
     showRepositorySelector,
+    effectiveRequiresWorkspace: chatState.effectiveRequiresWorkspace,
     taskInputMessage: chatState.taskInputMessage,
     setTaskInputMessage: chatState.setTaskInputMessage,
     setIsLoading: chatState.setIsLoading,
@@ -566,6 +567,10 @@ function ChatAreaContent({
     selectedBranch: chatState.selectedBranch,
     setSelectedBranch: chatState.setSelectedBranch,
     selectedTaskDetail,
+    effectiveRequiresWorkspace: chatState.effectiveRequiresWorkspace,
+    onRequiresWorkspaceChange: (value: boolean) => {
+      chatState.setRequiresWorkspaceOverride(value)
+    },
     enableDeepThinking: chatState.enableDeepThinking,
     setEnableDeepThinking: chatState.setEnableDeepThinking,
     enableClarification: chatState.enableClarification,

--- a/frontend/src/features/tasks/components/chat/useChatAreaState.ts
+++ b/frontend/src/features/tasks/components/chat/useChatAreaState.ts
@@ -21,6 +21,7 @@ import { correctionApis } from '@/apis/correction'
 import { saveLastRepo } from '@/utils/userPreferences'
 import { useTaskContext } from '../../contexts/taskContext'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { teamRequiresWorkspace } from '../../service/messageService'
 
 const SHOULD_HIDE_QUOTA_NAME_LIMIT = 18
 
@@ -412,6 +413,7 @@ export function useChatAreaState({
   }, [defaultTeam])
 
   // Handle team change - marks user as not using default team
+  // Also clears repository if the new team doesn't require a workspace
   const handleTeamChange = useCallback(
     (team: Team | null) => {
       console.log('[ChatArea] handleTeamChange called:', team?.name || 'null', team?.id || 'null')
@@ -420,6 +422,14 @@ export function useChatAreaState({
       // Reset external API params when team changes
       setExternalApiParams({})
       setAppMode(undefined)
+
+      // Clear repository and branch if the new team doesn't require a workspace
+      // This handles switching from code agents (ClaudeCode, Agno) to chat-only agents (Chat, Dify)
+      if (team && !teamRequiresWorkspace(team)) {
+        console.log('[ChatArea] Team does not require workspace, clearing repo and branch')
+        setSelectedRepo(null)
+        setSelectedBranch(null)
+      }
 
       // Check if the selected team is the same as the default team
       if (team && defaultTeam && team.id === defaultTeam.id) {

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -29,6 +29,8 @@ export interface UseChatStreamHandlersOptions {
   selectedRepo: GitRepoInfo | null
   selectedBranch: GitBranch | null
   showRepositorySelector: boolean
+  /** Effective requires workspace value (considering user override) */
+  effectiveRequiresWorkspace?: boolean
 
   // Input
   taskInputMessage: string
@@ -139,6 +141,7 @@ export function useChatStreamHandlers({
   selectedRepo,
   selectedBranch,
   showRepositorySelector,
+  effectiveRequiresWorkspace,
   taskInputMessage,
   setTaskInputMessage,
   setIsLoading,
@@ -408,7 +411,7 @@ export function useChatStreamHandlers({
       if (
         taskType === 'code' &&
         showRepositorySelector &&
-        teamRequiresWorkspace(selectedTeam) &&
+        (effectiveRequiresWorkspace ?? teamRequiresWorkspace(selectedTeam)) &&
         !effectiveRepo?.git_repo
       ) {
         toast({
@@ -688,7 +691,7 @@ export function useChatStreamHandlers({
       if (
         taskType === 'code' &&
         showRepositorySelector &&
-        teamRequiresWorkspace(selectedTeam) &&
+        (effectiveRequiresWorkspace ?? teamRequiresWorkspace(selectedTeam)) &&
         !effectiveRepo?.git_repo
       ) {
         toast({

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -13,7 +13,7 @@ import { useUser } from '@/features/common/UserContext'
 import { useTraceAction } from '@/hooks/useTraceAction'
 import { parseError, getErrorDisplayMessage } from '@/utils/errorParser'
 import { taskApis } from '@/apis/tasks'
-import { isChatShell } from '../../service/messageService'
+import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
 import { Button } from '@/components/ui/button'
 import { DEFAULT_MODEL_NAME } from '../selector/ModelSelector'
 import type { Model } from '../selector/ModelSelector'
@@ -405,7 +405,12 @@ export function useChatStreamHandlers({
             }
           : null)
 
-      if (taskType === 'code' && showRepositorySelector && !effectiveRepo?.git_repo) {
+      if (
+        taskType === 'code' &&
+        showRepositorySelector &&
+        teamRequiresWorkspace(selectedTeam) &&
+        !effectiveRepo?.git_repo
+      ) {
         toast({
           variant: 'destructive',
           title: 'Please select a repository for code tasks',
@@ -680,7 +685,12 @@ export function useChatStreamHandlers({
             }
           : null)
 
-      if (taskType === 'code' && showRepositorySelector && !effectiveRepo?.git_repo) {
+      if (
+        taskType === 'code' &&
+        showRepositorySelector &&
+        teamRequiresWorkspace(selectedTeam) &&
+        !effectiveRepo?.git_repo
+      ) {
         toast({
           variant: 'destructive',
           title: t('common:selector.repository') || 'Please select a repository for code tasks',

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -119,6 +119,8 @@ export function ChatInputCard({
   selectedBranch,
   setSelectedBranch,
   selectedTaskDetail,
+  effectiveRequiresWorkspace,
+  onRequiresWorkspaceChange,
   enableDeepThinking,
   setEnableDeepThinking,
   enableClarification,
@@ -260,6 +262,8 @@ export function ChatInputCard({
             selectedBranch={selectedBranch}
             setSelectedBranch={setSelectedBranch}
             selectedTaskDetail={selectedTaskDetail}
+            effectiveRequiresWorkspace={effectiveRequiresWorkspace}
+            onRequiresWorkspaceChange={onRequiresWorkspaceChange}
             enableDeepThinking={enableDeepThinking}
             setEnableDeepThinking={setEnableDeepThinking}
             enableClarification={enableClarification}

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -24,7 +24,7 @@ import type {
   MultiAttachmentUploadState,
 } from '@/types/api'
 import type { ContextItem } from '@/types/context'
-import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
+import { isChatShell } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { MobileChatInputControls } from './MobileChatInputControls'
@@ -53,6 +53,10 @@ export interface ChatInputControlsProps {
   selectedBranch: GitBranch | null
   setSelectedBranch: (branch: GitBranch | null) => void
   selectedTaskDetail: TaskDetail | null
+  /** Effective requires workspace value (considering user override) */
+  effectiveRequiresWorkspace?: boolean
+  /** Callback when user toggles the requires workspace switch */
+  onRequiresWorkspaceChange?: (value: boolean) => void
 
   // Deep Thinking and Clarification
   enableDeepThinking: boolean
@@ -128,6 +132,8 @@ export function ChatInputControls({
   selectedBranch,
   setSelectedBranch,
   selectedTaskDetail,
+  effectiveRequiresWorkspace,
+  onRequiresWorkspaceChange,
   enableClarification,
   setEnableClarification,
   enableCorrectionMode = false,
@@ -244,6 +250,8 @@ export function ChatInputControls({
         selectedBranch={selectedBranch}
         setSelectedBranch={setSelectedBranch}
         selectedTaskDetail={selectedTaskDetail}
+        effectiveRequiresWorkspace={effectiveRequiresWorkspace}
+        onRequiresWorkspaceChange={hasMessages ? undefined : onRequiresWorkspaceChange}
         enableClarification={enableClarification}
         setEnableClarification={setEnableClarification}
         enableCorrectionMode={enableCorrectionMode}
@@ -327,8 +335,9 @@ export function ChatInputControls({
           />
         )}
 
-        {/* Repository and Branch Unified Selector - show based on team requiresWorkspace */}
-        {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && (
+        {/* Repository and Branch Unified Selector - show when repository selector is enabled */}
+        {/* Always show when showRepositorySelector is true, let component handle the display */}
+        {showRepositorySelector && (
           <UnifiedRepositorySelector
             selectedRepo={selectedRepo}
             selectedBranch={selectedBranch}
@@ -337,6 +346,8 @@ export function ChatInputControls({
             disabled={hasMessages}
             taskDetail={selectedTaskDetail}
             compact={shouldCollapseSelectors}
+            requiresWorkspace={effectiveRequiresWorkspace}
+            onRequiresWorkspaceChange={hasMessages ? undefined : onRequiresWorkspaceChange}
           />
         )}
       </div>

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -319,22 +319,6 @@ export function ChatInputControls({
           />
         )}
 
-        {/* Model Selector */}
-        {selectedTeam && (
-          <ModelSelector
-            selectedModel={selectedModel}
-            setSelectedModel={setSelectedModel}
-            forceOverride={forceOverride}
-            setForceOverride={setForceOverride}
-            selectedTeam={selectedTeam}
-            disabled={isLoading || isStreaming || (hasMessages && !isChatShell(selectedTeam))}
-            compact={shouldCollapseSelectors}
-            teamId={teamId}
-            taskId={taskId}
-            taskModelId={taskModelId}
-          />
-        )}
-
         {/* Repository and Branch Unified Selector - show when repository selector is enabled */}
         {/* Always show when showRepositorySelector is true, let component handle the display */}
         {showRepositorySelector && (
@@ -348,6 +332,22 @@ export function ChatInputControls({
             compact={shouldCollapseSelectors}
             requiresWorkspace={effectiveRequiresWorkspace}
             onRequiresWorkspaceChange={hasMessages ? undefined : onRequiresWorkspaceChange}
+          />
+        )}
+
+        {/* Model Selector */}
+        {selectedTeam && (
+          <ModelSelector
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
+            forceOverride={forceOverride}
+            setForceOverride={setForceOverride}
+            selectedTeam={selectedTeam}
+            disabled={isLoading || isStreaming || (hasMessages && !isChatShell(selectedTeam))}
+            compact={shouldCollapseSelectors}
+            teamId={teamId}
+            taskId={taskId}
+            taskModelId={taskModelId}
           />
         )}
       </div>

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -7,8 +7,7 @@
 import React from 'react'
 import { CircleStop } from 'lucide-react'
 import ModelSelector, { Model } from '../selector/ModelSelector'
-import RepositorySelector from '../selector/RepositorySelector'
-import BranchSelector from '../selector/BranchSelector'
+import UnifiedRepositorySelector from '../selector/UnifiedRepositorySelector'
 import ClarificationToggle from '../clarification/ClarificationToggle'
 import CorrectionModeToggle from '../CorrectionModeToggle'
 import ChatContextInput from '../chat/ChatContextInput'
@@ -25,7 +24,7 @@ import type {
   MultiAttachmentUploadState,
 } from '@/types/api'
 import type { ContextItem } from '@/types/context'
-import { isChatShell } from '../../service/messageService'
+import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { MobileChatInputControls } from './MobileChatInputControls'
@@ -328,27 +327,17 @@ export function ChatInputControls({
           />
         )}
 
-        {/* Repository and Branch Selectors - inside input box */}
-        {showRepositorySelector && (
-          <>
-            <RepositorySelector
-              selectedRepo={selectedRepo}
-              handleRepoChange={setSelectedRepo}
-              disabled={hasMessages}
-              selectedTaskDetail={selectedTaskDetail}
-              compact={shouldCollapseSelectors}
-            />
-
-            {selectedRepo && (
-              <BranchSelector
-                selectedRepo={selectedRepo}
-                selectedBranch={selectedBranch}
-                handleBranchChange={setSelectedBranch}
-                disabled={hasMessages}
-                compact={shouldCollapseSelectors}
-              />
-            )}
-          </>
+        {/* Repository and Branch Unified Selector - show based on team requiresWorkspace */}
+        {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && (
+          <UnifiedRepositorySelector
+            selectedRepo={selectedRepo}
+            selectedBranch={selectedBranch}
+            onRepoChange={setSelectedRepo}
+            onBranchChange={setSelectedBranch}
+            disabled={hasMessages}
+            taskDetail={selectedTaskDetail}
+            compact={shouldCollapseSelectors}
+          />
         )}
       </div>
 

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -49,6 +49,10 @@ export interface MobileChatInputControlsProps {
   selectedBranch: GitBranchType | null
   setSelectedBranch: (branch: GitBranchType | null) => void
   selectedTaskDetail: TaskDetail | null
+  /** Effective requires workspace value (considering user override) */
+  effectiveRequiresWorkspace?: boolean
+  /** Callback when user toggles the requires workspace switch */
+  onRequiresWorkspaceChange?: (value: boolean) => void
 
   // Clarification
   enableClarification: boolean
@@ -105,6 +109,8 @@ export function MobileChatInputControls({
   selectedBranch,
   setSelectedBranch,
   selectedTaskDetail,
+  effectiveRequiresWorkspace,
+  onRequiresWorkspaceChange: _onRequiresWorkspaceChange,
   enableClarification,
   setEnableClarification,
   enableCorrectionMode = false,
@@ -247,29 +253,34 @@ export function MobileChatInputControls({
             )}
 
             {/* Repository Selector - full row clickable, only show if team requires workspace */}
-            {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && (
-              <>
-                {/* Only show separator if there's content above (chat shell features) */}
-                {isChatShell(selectedTeam) && <DropdownMenuSeparator />}
-                <MobileRepositorySelector
-                  selectedRepo={selectedRepo}
-                  handleRepoChange={setSelectedRepo}
-                  disabled={hasMessages}
-                  selectedTaskDetail={selectedTaskDetail}
-                />
-              </>
-            )}
+            {showRepositorySelector &&
+              teamRequiresWorkspace(selectedTeam) &&
+              effectiveRequiresWorkspace !== false && (
+                <>
+                  {/* Only show separator if there's content above (chat shell features) */}
+                  {isChatShell(selectedTeam) && <DropdownMenuSeparator />}
+                  <MobileRepositorySelector
+                    selectedRepo={selectedRepo}
+                    handleRepoChange={setSelectedRepo}
+                    disabled={hasMessages}
+                    selectedTaskDetail={selectedTaskDetail}
+                  />
+                </>
+              )}
 
             {/* Branch Selector - full row clickable, only show if team requires workspace */}
-            {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && selectedRepo && (
-              <MobileBranchSelector
-                selectedRepo={selectedRepo}
-                selectedBranch={selectedBranch}
-                handleBranchChange={setSelectedBranch}
-                disabled={hasMessages}
-                taskDetail={selectedTaskDetail}
-              />
-            )}
+            {showRepositorySelector &&
+              teamRequiresWorkspace(selectedTeam) &&
+              effectiveRequiresWorkspace !== false &&
+              selectedRepo && (
+                <MobileBranchSelector
+                  selectedRepo={selectedRepo}
+                  selectedBranch={selectedBranch}
+                  handleBranchChange={setSelectedBranch}
+                  disabled={hasMessages}
+                  taskDetail={selectedTaskDetail}
+                />
+              )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -26,7 +26,7 @@ import {
 } from '@/components/ui/dropdown'
 import type { Team, GitRepoInfo, GitBranch as GitBranchType, TaskDetail } from '@/types/api'
 import type { ContextItem } from '@/types/context'
-import { isChatShell } from '../../service/messageService'
+import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 
 export interface MobileChatInputControlsProps {
@@ -246,8 +246,8 @@ export function MobileChatInputControls({
               />
             )}
 
-            {/* Repository Selector - full row clickable */}
-            {showRepositorySelector && (
+            {/* Repository Selector - full row clickable, only show if team requires workspace */}
+            {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && (
               <>
                 {/* Only show separator if there's content above (chat shell features) */}
                 {isChatShell(selectedTeam) && <DropdownMenuSeparator />}
@@ -260,8 +260,8 @@ export function MobileChatInputControls({
               </>
             )}
 
-            {/* Branch Selector - full row clickable */}
-            {showRepositorySelector && selectedRepo && (
+            {/* Branch Selector - full row clickable, only show if team requires workspace */}
+            {showRepositorySelector && teamRequiresWorkspace(selectedTeam) && selectedRepo && (
               <MobileBranchSelector
                 selectedRepo={selectedRepo}
                 selectedBranch={selectedBranch}

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -138,10 +138,13 @@ export default function UnifiedRepositorySelector({
 
   // Fetch branches when repo changes
   useEffect(() => {
+    // Clear previous branches immediately when repo changes to avoid showing stale data
+    setBranches([])
+    setBranchError(null)
+    setUserCleared(false)
     onBranchChange(null)
+
     if (!selectedRepo) {
-      setBranches([])
-      setBranchError(null)
       setBranchLoading(false)
       return
     }
@@ -155,7 +158,6 @@ export default function UnifiedRepositorySelector({
         if (!ignore) {
           setBranches(data)
           setBranchError(null)
-          setUserCleared(false)
         }
       })
       .catch(() => {
@@ -415,8 +417,9 @@ export default function UnifiedRepositorySelector({
           {/* Branch View */}
           {currentView === 'branch' && (
             <Command className="border-0 flex flex-col flex-1 min-h-0 overflow-hidden">
-              <div
-                className="flex items-center border-b border-border px-3 py-2 cursor-pointer hover:bg-hover"
+              <button
+                type="button"
+                className="flex items-center border-b border-border px-3 py-2 cursor-pointer hover:bg-hover w-full text-left"
                 onClick={handleBackToRepo}
               >
                 <ChevronLeft className="w-4 h-4 text-text-muted mr-1" />
@@ -429,7 +432,7 @@ export default function UnifiedRepositorySelector({
                     ({truncateMiddle(selectedRepo.git_repo, 20)})
                   </span>
                 )}
-              </div>
+              </button>
               <CommandInput
                 placeholder={t('common:branches.search_branch')}
                 className={cn(

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -325,21 +325,16 @@ export default function UnifiedRepositorySelector({
           <Tooltip>
             <TooltipTrigger asChild>
               <PopoverTrigger asChild>
-                <button
-                  type="button"
-                  role="combobox"
-                  aria-expanded={isOpen}
-                  aria-controls="unified-repo-selector-popover"
-                  disabled={disabled || isLoading}
+                <div
                   className={cn(
                     'flex items-center gap-1.5 min-w-0 rounded-full pl-2.5 pr-3 py-2.5 h-9',
-                    'transition-colors',
+                    'transition-colors cursor-pointer',
                     isNotSelected
                       ? 'border border-dashed border-border bg-muted/30 text-text-muted'
                       : 'border border-border bg-base text-text-primary hover:bg-hover',
                     isLoading ? 'animate-pulse' : '',
                     'focus:outline-none focus:ring-0',
-                    'disabled:cursor-not-allowed disabled:opacity-50'
+                    (disabled || isLoading) && 'cursor-not-allowed opacity-50'
                   )}
                 >
                   {requiresWorkspace ? (
@@ -352,13 +347,34 @@ export default function UnifiedRepositorySelector({
                   ) : (
                     <FolderX className="w-4 h-4 flex-shrink-0 text-text-muted" />
                   )}
+                  {/* Embedded Toggle - show when onRequiresWorkspaceChange is provided (new chat) */}
+                  {!compact && onRequiresWorkspaceChange && (
+                    <>
+                      <span className="text-xs text-text-primary whitespace-nowrap">
+                        {t('common:repos.repository')}
+                      </span>
+                      <Switch
+                        checked={requiresWorkspace}
+                        onCheckedChange={handleRequiresWorkspaceToggle}
+                        className="scale-75"
+                        disabled={disabled}
+                        onClick={e => e.stopPropagation()}
+                      />
+                    </>
+                  )}
+                  {/* Repository/Branch display text and chevron */}
                   {!compact && (
                     <>
-                      <span className="truncate text-xs min-w-0">{getDisplayText()}</span>
+                      {/* Show repo/branch text only when:
+                          1. Has selected repo (show repo/branch name)
+                          2. Or no toggle (hasMessages), show current state text */}
+                      {(selectedRepo || !onRequiresWorkspaceChange) && (
+                        <span className="truncate text-xs min-w-0">{getDisplayText()}</span>
+                      )}
                       <ChevronDown className="h-2.5 w-2.5 flex-shrink-0 opacity-60" />
                     </>
                   )}
-                </button>
+                </div>
               </PopoverTrigger>
             </TooltipTrigger>
             <TooltipContent side="top">
@@ -386,23 +402,6 @@ export default function UnifiedRepositorySelector({
               className="border-0 flex flex-col flex-1 min-h-0 overflow-hidden"
               shouldFilter={false}
             >
-              {/* Requires Workspace Toggle */}
-              {onRequiresWorkspaceChange && (
-                <div className="flex items-center justify-between border-b border-border px-3 py-2.5 bg-surface/50">
-                  <div className="flex items-center gap-2">
-                    <FolderGit2 className="w-4 h-4 text-text-muted" />
-                    <span className="text-sm text-text-primary">
-                      {t('common:repos.requires_workspace')}
-                    </span>
-                  </div>
-                  <Switch
-                    checked={requiresWorkspace}
-                    onCheckedChange={handleRequiresWorkspaceToggle}
-                    className="scale-90"
-                  />
-                </div>
-              )}
-
               {/* Repository Selection - only show when workspace is required */}
               {requiresWorkspace ? (
                 <>

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import * as React from 'react'
+import { useState, useEffect, useMemo, useCallback, useContext } from 'react'
+import { FiGithub, FiGitBranch } from 'react-icons/fi'
+import { Check, ChevronDown, ChevronLeft, Loader2 } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useTranslation } from '@/hooks/useTranslation'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
+import { cn } from '@/lib/utils'
+import { paths } from '@/config/paths'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+
+import { truncateMiddle } from '@/utils/stringUtils'
+import { GitRepoInfo, GitBranch, TaskDetail } from '@/types/api'
+import { githubApis } from '@/apis/github'
+import { useToast } from '@/hooks/use-toast'
+import { useRepositorySearch } from '../../hooks/useRepositorySearch'
+import { RepositorySelectorFooter } from './RepositorySelectorFooter'
+import { TaskContext } from '../../contexts/taskContext'
+
+/**
+ * Props for UnifiedRepositorySelector component
+ */
+export interface UnifiedRepositorySelectorProps {
+  selectedRepo: GitRepoInfo | null
+  selectedBranch: GitBranch | null
+  onRepoChange: (repo: GitRepoInfo | null) => void
+  onBranchChange: (branch: GitBranch | null) => void
+  disabled?: boolean
+  className?: string
+  /** Optional task detail for auto-sync */
+  taskDetail?: TaskDetail | null
+  /** When true, display only icon without text (for responsive collapse) */
+  compact?: boolean
+}
+
+/**
+ * View state for the unified selector
+ */
+type SelectorView = 'repo' | 'branch'
+
+/**
+ * UnifiedRepositorySelector component
+ * Provides unified repository and branch selection in a single Popover
+ */
+export default function UnifiedRepositorySelector({
+  selectedRepo,
+  selectedBranch,
+  onRepoChange,
+  onBranchChange,
+  disabled = false,
+  className,
+  taskDetail,
+  compact = false,
+}: UnifiedRepositorySelectorProps) {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { toast } = useToast()
+  const isMobile = useIsMobile()
+
+  // Popover state
+  const [isOpen, setIsOpen] = useState(false)
+  const [currentView, setCurrentView] = useState<SelectorView>('repo')
+
+  // Branch state
+  const [branches, setBranches] = useState<GitBranch[]>([])
+  const [branchLoading, setBranchLoading] = useState(false)
+  const [branchError, setBranchError] = useState<string | null>(null)
+  const [userCleared, setUserCleared] = useState(false)
+
+  // Try to get context, but don't throw if not available
+  const taskContext = useContext(TaskContext)
+  const selectedTaskDetail = taskDetail ?? taskContext?.selectedTaskDetail ?? null
+
+  // Use the custom hook for repository search logic
+  const {
+    repos,
+    loading: repoLoading,
+    isSearching,
+    isRefreshing,
+    error: repoError,
+    handleSearchChange,
+    handleRefreshCache,
+    handleChange: handleRepoSelectFromSearch,
+  } = useRepositorySearch({
+    selectedRepo,
+    handleRepoChange: onRepoChange,
+    disabled,
+    selectedTaskDetail,
+  })
+
+  // Convert repos to items
+  const repoItems = useMemo(() => {
+    const items = repos.map(repo => ({
+      value: repo.git_repo_id.toString(),
+      label: repo.git_repo,
+      searchText: repo.git_repo,
+    }))
+
+    // Ensure selected repo is in the items list
+    if (selectedRepo) {
+      const hasSelected = items.some(item => item.value === selectedRepo.git_repo_id.toString())
+      if (!hasSelected) {
+        items.unshift({
+          value: selectedRepo.git_repo_id.toString(),
+          label: selectedRepo.git_repo,
+          searchText: selectedRepo.git_repo,
+        })
+      }
+    }
+
+    return items
+  }, [repos, selectedRepo])
+
+  // Convert branches to items
+  const branchItems = useMemo(() => {
+    return branches.map(branch => ({
+      value: branch.name,
+      label: branch.name,
+      searchText: branch.name,
+      isDefault: branch.default,
+    }))
+  }, [branches])
+
+  // Fetch branches when repo changes
+  useEffect(() => {
+    onBranchChange(null)
+    if (!selectedRepo) {
+      setBranches([])
+      setBranchError(null)
+      setBranchLoading(false)
+      return
+    }
+
+    let ignore = false
+    setBranchLoading(true)
+
+    githubApis
+      .getBranches(selectedRepo)
+      .then(data => {
+        if (!ignore) {
+          setBranches(data)
+          setBranchError(null)
+          setUserCleared(false)
+        }
+      })
+      .catch(() => {
+        if (!ignore) {
+          setBranchError(t('common:branches.load_failed'))
+          toast({
+            variant: 'destructive',
+            title: t('common:branches.load_failed'),
+          })
+        }
+      })
+      .finally(() => {
+        if (!ignore) setBranchLoading(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedRepo])
+
+  // Auto-select branch from task detail or default
+  useEffect(() => {
+    if (!branches || branches.length === 0) return
+    if (userCleared) return
+
+    if (
+      selectedTaskDetail &&
+      'branch_name' in selectedTaskDetail &&
+      selectedTaskDetail.branch_name
+    ) {
+      const foundBranch = branches.find(b => b.name === selectedTaskDetail.branch_name) || null
+      if (foundBranch) {
+        onBranchChange(foundBranch)
+        return
+      }
+    }
+
+    // If no task or not found, select default branch
+    if (!selectedBranch) {
+      const defaultBranch = branches.find(b => b.default)
+      if (defaultBranch) {
+        onBranchChange(defaultBranch)
+      } else {
+        onBranchChange(null)
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTaskDetail, branches, userCleared])
+
+  // Reset userCleared when repo or task changes
+  useEffect(() => {
+    setUserCleared(false)
+  }, [selectedRepo, selectedTaskDetail?.branch_name])
+
+  // Reset view when popover closes
+  useEffect(() => {
+    if (!isOpen) {
+      setCurrentView('repo')
+    }
+  }, [isOpen])
+
+  // Navigate to settings page
+  const handleIntegrationClick = () => {
+    router.push(paths.settings.integrations.getHref())
+    setIsOpen(false)
+  }
+
+  // Handle repo selection
+  const handleRepoSelect = useCallback(
+    (value: string) => {
+      handleRepoSelectFromSearch(value)
+      // After selecting repo, automatically switch to branch view
+      setCurrentView('branch')
+    },
+    [handleRepoSelectFromSearch]
+  )
+
+  // Handle branch selection
+  const handleBranchSelect = useCallback(
+    (value: string) => {
+      const branch = branches.find(b => b.name === value)
+      if (branch) {
+        setUserCleared(false)
+        onBranchChange(branch)
+        setIsOpen(false)
+      }
+    },
+    [branches, onBranchChange]
+  )
+
+  // Go back to repo view
+  const handleBackToRepo = useCallback(() => {
+    setCurrentView('repo')
+  }, [])
+
+  // Determine the display text
+  const getDisplayText = useCallback(() => {
+    if (!selectedRepo) {
+      return t('common:repos.select_repository')
+    }
+    if (!selectedBranch) {
+      return truncateMiddle(selectedRepo.git_repo, isMobile ? 15 : 25)
+    }
+    const repoName = truncateMiddle(selectedRepo.git_repo, isMobile ? 10 : 15)
+    const branchName = truncateMiddle(selectedBranch.name, isMobile ? 8 : 12)
+    return `${repoName} / ${branchName}`
+  }, [selectedRepo, selectedBranch, t, isMobile])
+
+  // Tooltip content
+  const tooltipContent = useMemo(() => {
+    if (selectedRepo && selectedBranch) {
+      return `${selectedRepo.git_repo} / ${selectedBranch.name}`
+    }
+    if (selectedRepo) {
+      return selectedRepo.git_repo
+    }
+    return t('common:repos.select_repository')
+  }, [selectedRepo, selectedBranch, t])
+
+  // Determine if selector is in "not selected" state
+  const isNotSelected = !selectedRepo
+
+  // Loading state
+  const isLoading = repoLoading || branchLoading
+
+  return (
+    <div className={cn('flex items-center min-w-0', className)} data-tour="unified-repo-selector">
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  role="combobox"
+                  aria-expanded={isOpen}
+                  aria-controls="unified-repo-selector-popover"
+                  disabled={disabled || isLoading}
+                  className={cn(
+                    'flex items-center gap-1.5 min-w-0 rounded-full pl-2.5 pr-3 py-2.5 h-9',
+                    'transition-colors',
+                    isNotSelected
+                      ? 'border border-dashed border-border bg-muted/30 text-text-muted'
+                      : 'border border-border bg-base text-text-primary hover:bg-hover',
+                    isLoading ? 'animate-pulse' : '',
+                    'focus:outline-none focus:ring-0',
+                    'disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                >
+                  <FiGithub
+                    className={cn(
+                      'w-4 h-4 flex-shrink-0',
+                      isNotSelected ? 'text-text-muted' : 'text-primary'
+                    )}
+                  />
+                  {!compact && (
+                    <>
+                      <span className="truncate text-xs min-w-0">{getDisplayText()}</span>
+                      <ChevronDown className="h-2.5 w-2.5 flex-shrink-0 opacity-60" />
+                    </>
+                  )}
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>{tooltipContent}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+
+        <PopoverContent
+          className={cn(
+            'p-0 w-auto min-w-[300px] max-w-[400px] border border-border bg-base',
+            'shadow-xl rounded-xl overflow-hidden',
+            'max-h-[var(--radix-popover-content-available-height,400px)]',
+            'flex flex-col'
+          )}
+          align="start"
+          sideOffset={4}
+          collisionPadding={8}
+          avoidCollisions={true}
+          sticky="partial"
+        >
+          {/* Repository View */}
+          {currentView === 'repo' && (
+            <Command
+              className="border-0 flex flex-col flex-1 min-h-0 overflow-hidden"
+              shouldFilter={false}
+            >
+              <div className="flex items-center border-b border-border px-3 py-2">
+                <FiGithub className="w-4 h-4 text-text-muted mr-2" />
+                <span className="text-sm font-medium text-text-primary">
+                  {t('common:repos.repository')}
+                </span>
+              </div>
+              <CommandInput
+                placeholder={t('common:branches.search_repository')}
+                onValueChange={handleSearchChange}
+                className={cn(
+                  'h-9 rounded-none border-b border-border flex-shrink-0',
+                  'placeholder:text-text-muted text-sm'
+                )}
+              />
+              <CommandList className="min-h-[36px] max-h-[200px] overflow-y-auto flex-1">
+                {repoError ? (
+                  <div className="py-4 px-3 text-center text-sm text-error">{repoError}</div>
+                ) : repoItems.length === 0 ? (
+                  <CommandEmpty className="py-4 text-center text-sm text-text-muted">
+                    {repoLoading ? 'Loading...' : t('common:branches.select_repository')}
+                  </CommandEmpty>
+                ) : (
+                  <>
+                    <CommandEmpty className="py-4 text-center text-sm text-text-muted">
+                      {t('common:branches.no_match')}
+                    </CommandEmpty>
+                    <CommandGroup>
+                      {repoItems.map(item => (
+                        <CommandItem
+                          key={item.value}
+                          value={item.searchText || item.label}
+                          onSelect={() => handleRepoSelect(item.value)}
+                          className={cn(
+                            'group cursor-pointer select-none',
+                            'px-3 py-1.5 text-sm text-text-primary',
+                            'rounded-md mx-1 my-[2px]',
+                            'data-[selected=true]:bg-primary/10 data-[selected=true]:text-primary',
+                            'aria-selected:bg-hover',
+                            '!flex !flex-row !items-center !gap-3'
+                          )}
+                        >
+                          <Check
+                            className={cn(
+                              'h-3 w-3 shrink-0',
+                              selectedRepo?.git_repo_id.toString() === item.value
+                                ? 'opacity-100 text-primary'
+                                : 'opacity-0 text-text-muted'
+                            )}
+                          />
+                          <span className="flex-1 min-w-0 truncate" title={item.label}>
+                            {item.label}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                )}
+              </CommandList>
+              <RepositorySelectorFooter
+                onConfigureClick={handleIntegrationClick}
+                onRefreshClick={handleRefreshCache}
+                isRefreshing={isRefreshing}
+              />
+            </Command>
+          )}
+
+          {/* Branch View */}
+          {currentView === 'branch' && (
+            <Command className="border-0 flex flex-col flex-1 min-h-0 overflow-hidden">
+              <div
+                className="flex items-center border-b border-border px-3 py-2 cursor-pointer hover:bg-hover"
+                onClick={handleBackToRepo}
+              >
+                <ChevronLeft className="w-4 h-4 text-text-muted mr-1" />
+                <FiGitBranch className="w-4 h-4 text-text-muted mr-2" />
+                <span className="text-sm font-medium text-text-primary">
+                  {t('common:repos.branch')}
+                </span>
+                {selectedRepo && (
+                  <span className="ml-2 text-xs text-text-muted truncate">
+                    ({truncateMiddle(selectedRepo.git_repo, 20)})
+                  </span>
+                )}
+              </div>
+              <CommandInput
+                placeholder={t('common:branches.search_branch')}
+                className={cn(
+                  'h-9 rounded-none border-b border-border flex-shrink-0',
+                  'placeholder:text-text-muted text-sm'
+                )}
+              />
+              <CommandList className="min-h-[36px] max-h-[200px] overflow-y-auto flex-1">
+                {branchError ? (
+                  <div className="py-4 px-3 text-center text-sm text-error">{branchError}</div>
+                ) : branchItems.length === 0 ? (
+                  <CommandEmpty className="py-4 text-center text-sm text-text-muted">
+                    {branchLoading ? 'Loading...' : t('common:branches.no_branch')}
+                  </CommandEmpty>
+                ) : (
+                  <>
+                    <CommandEmpty className="py-4 text-center text-sm text-text-muted">
+                      {t('common:branches.no_match')}
+                    </CommandEmpty>
+                    <CommandGroup>
+                      {branchItems.map(item => (
+                        <CommandItem
+                          key={item.value}
+                          value={item.searchText || item.label}
+                          onSelect={() => handleBranchSelect(item.value)}
+                          className={cn(
+                            'group cursor-pointer select-none',
+                            'px-3 py-1.5 text-sm text-text-primary',
+                            'rounded-md mx-1 my-[2px]',
+                            'data-[selected=true]:bg-primary/10 data-[selected=true]:text-primary',
+                            'aria-selected:bg-hover',
+                            '!flex !flex-row !items-center !gap-3'
+                          )}
+                        >
+                          <Check
+                            className={cn(
+                              'h-3 w-3 shrink-0',
+                              selectedBranch?.name === item.value
+                                ? 'opacity-100 text-primary'
+                                : 'opacity-0 text-text-muted'
+                            )}
+                          />
+                          <span className="flex-1 min-w-0 truncate" title={item.label}>
+                            {item.label}
+                            {item.isDefault && (
+                              <span className="ml-2 text-green-400 text-[10px]">
+                                {t('common:branches.default')}
+                              </span>
+                            )}
+                          </span>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
+                )}
+              </CommandList>
+              {/* Footer for branch view - just a divider line */}
+              <div className="border-t border-border py-2 px-3 text-xs text-text-muted">
+                {branches.length > 0 &&
+                  `${branches.length} ${t('common:branches.select_branch').toLowerCase()}`}
+              </div>
+            </Command>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* Loading indicator */}
+      {isSearching && (
+        <Loader2 className="w-3 h-3 text-text-muted animate-spin flex-shrink-0 ml-1" />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -315,10 +315,7 @@ export default function UnifiedRepositorySelector({
                   )}
                 >
                   <FolderGit2
-                    className={cn(
-                      'w-4 h-4 flex-shrink-0',
-                      isNotSelected ? 'text-text-muted' : 'text-primary'
-                    )}
+                    className={cn('w-4 h-4 flex-shrink-0', isNotSelected ? 'text-text-muted' : '')}
                   />
                   {!compact && (
                     <>

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -6,8 +6,14 @@
 
 import * as React from 'react'
 import { useState, useEffect, useMemo, useCallback, useContext } from 'react'
-import { FiGithub, FiGitBranch } from 'react-icons/fi'
-import { Check, ChevronDown, ChevronLeft, Loader2 } from 'lucide-react'
+import {
+  Check,
+  ChevronDown,
+  ChevronLeft,
+  Loader2,
+  GitBranch as GitBranchIcon,
+  FolderGit2,
+} from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
@@ -308,7 +314,7 @@ export default function UnifiedRepositorySelector({
                     'disabled:cursor-not-allowed disabled:opacity-50'
                   )}
                 >
-                  <FiGithub
+                  <FolderGit2
                     className={cn(
                       'w-4 h-4 flex-shrink-0',
                       isNotSelected ? 'text-text-muted' : 'text-primary'
@@ -349,7 +355,7 @@ export default function UnifiedRepositorySelector({
               shouldFilter={false}
             >
               <div className="flex items-center border-b border-border px-3 py-2">
-                <FiGithub className="w-4 h-4 text-text-muted mr-2" />
+                <FolderGit2 className="w-4 h-4 text-text-muted mr-2" />
                 <span className="text-sm font-medium text-text-primary">
                   {t('common:repos.repository')}
                 </span>
@@ -423,7 +429,7 @@ export default function UnifiedRepositorySelector({
                 onClick={handleBackToRepo}
               >
                 <ChevronLeft className="w-4 h-4 text-text-muted mr-1" />
-                <FiGitBranch className="w-4 h-4 text-text-muted mr-2" />
+                <GitBranchIcon className="w-4 h-4 text-text-muted mr-2" />
                 <span className="text-sm font-medium text-text-primary">
                   {t('common:repos.branch')}
                 </span>

--- a/frontend/src/features/tasks/components/selector/index.ts
+++ b/frontend/src/features/tasks/components/selector/index.ts
@@ -8,6 +8,8 @@ export {
 export type { Model, ModelRegion, TeamWithBotDetails, ModelSelectorProps } from './ModelSelector'
 export { default as BranchSelector } from './BranchSelector'
 export { default as RepositorySelector } from './RepositorySelector'
+export { default as UnifiedRepositorySelector } from './UnifiedRepositorySelector'
+export type { UnifiedRepositorySelectorProps } from './UnifiedRepositorySelector'
 export { default as SearchEngineSelector } from './SearchEngineSelector'
 export { default as DifyAppSelector } from './DifyAppSelector'
 export { SelectedTeamBadge } from './SelectedTeamBadge'

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -9,7 +9,10 @@
     "repository_tooltip": "Select code repository",
     "branch_tooltip": "Select branch",
     "select_repository": "Select repository",
-    "unified_selector_placeholder": "Select repo / branch"
+    "unified_selector_placeholder": "Select repo / branch",
+    "requires_workspace": "Requires Repository",
+    "no_workspace_needed": "No repository needed",
+    "no_workspace_description": "This task will run without a code repository"
   },
   "actions": {
     "save": "Save",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -332,7 +332,9 @@
     "bind_mode_chat": "Chat",
     "bind_mode_code": "Code",
     "bind_mode_required": "Please select at least one bind mode (Chat or Code)",
-    "require_confirmation_tooltip": "When enabled, the task will pause after this stage completes, waiting for user confirmation before proceeding to the next stage"
+    "require_confirmation_tooltip": "When enabled, the task will pause after this stage completes, waiting for user confirmation before proceeding to the next stage",
+    "requires_workspace": "Requires Repository",
+    "requires_workspace_hint": "When enabled, this agent requires a code repository to be selected in code mode before starting a task. When disabled, tasks can start without selecting a repository."
   },
   "team_model": {
     "solo": "Solo",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -7,7 +7,9 @@
     "repository": "Select Repository",
     "branch": "Select Branch",
     "repository_tooltip": "Select code repository",
-    "branch_tooltip": "Select branch"
+    "branch_tooltip": "Select branch",
+    "select_repository": "Select repository",
+    "unified_selector_placeholder": "Select repo / branch"
   },
   "actions": {
     "save": "Save",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -955,7 +955,9 @@
     "software_requirements_hint": "The following software must be pre-installed in your base image and meet minimum version requirements",
     "required": "Required",
     "optional": "Optional",
-    "copy_command": "Copy command"
+    "copy_command": "Copy command",
+    "requires_workspace": "Requires Workspace",
+    "requires_workspace_hint": "When enabled, this shell requires selecting a code repository to run tasks"
   },
   "inAppBrowser": {
     "title": "Open in Default Browser",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -9,7 +9,10 @@
     "repository_tooltip": "选择代码仓库",
     "branch_tooltip": "选择分支",
     "select_repository": "选择仓库",
-    "unified_selector_placeholder": "选择仓库 / 分支"
+    "unified_selector_placeholder": "选择仓库 / 分支",
+    "requires_workspace": "需要仓库",
+    "no_workspace_needed": "无需仓库",
+    "no_workspace_description": "此任务将在不使用代码仓库的情况下运行"
   },
   "actions": {
     "save": "保存",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -7,7 +7,9 @@
     "repository": "选择仓库",
     "branch": "选择分支",
     "repository_tooltip": "选择代码仓库",
-    "branch_tooltip": "选择分支"
+    "branch_tooltip": "选择分支",
+    "select_repository": "选择仓库",
+    "unified_selector_placeholder": "选择仓库 / 分支"
   },
   "actions": {
     "save": "保存",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -332,7 +332,9 @@
     "bind_mode_chat": "聊天",
     "bind_mode_code": "编码",
     "bind_mode_required": "请至少选择一个绑定模式（聊天或编码）",
-    "require_confirmation_tooltip": "启用后，该阶段完成时任务将暂停，等待用户确认后再继续执行下一阶段"
+    "require_confirmation_tooltip": "启用后，该阶段完成时任务将暂停，等待用户确认后再继续执行下一阶段",
+    "requires_workspace": "需要仓库",
+    "requires_workspace_hint": "启用后，该智能体在编码模式下必须选择代码仓库才能开始任务。关闭后，无需选择仓库即可开始。"
   },
   "team_model": {
     "solo": "独立",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -955,7 +955,9 @@
     "software_requirements_hint": "以下软件需要在您的 Base Image 中预先安装并满足最低版本要求",
     "required": "必需",
     "optional": "可选",
-    "copy_command": "复制命令"
+    "copy_command": "复制命令",
+    "requires_workspace": "需要代码仓库",
+    "requires_workspace_hint": "启用后，此执行环境需要选择代码仓库才能运行任务"
   },
   "inAppBrowser": {
     "title": "默认浏览器打开",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -142,6 +142,7 @@ export interface Team {
   recommended_mode?: 'chat' | 'code' | 'both' // Recommended usage mode (for QuickAccess)
   bind_mode?: ('chat' | 'code' | 'knowledge')[] // Allowed modes for this team
   icon?: string // Icon ID from preset icon library
+  requires_workspace?: boolean // Whether this team requires a workspace/repository (null = auto-infer from shell)
   user?: {
     user_name: string
   }


### PR DESCRIPTION
## Summary

- Add UnifiedRepositorySelector component that combines repository and branch selection into a single Popover (similar to ModelSelector design)
- Add teamRequiresWorkspace utility to determine if a team needs workspace based on agent_type/shell_type
- Update ChatInputControls to conditionally show repo selector based on team configuration
- Auto-clear repository when switching to teams that don't require workspace (Chat, Dify agents)
- Add i18n translations for unified selector

## Changes

1. **UnifiedRepositorySelector.tsx** (new file):
   - Single Popover with two views: repository selection and branch selection
   - Three visual states: not_selected (dashed border), selected (solid border), not_required (hidden)
   - Repository search with local + remote search capability
   - Branch auto-selection based on task detail or default branch
   - Compact mode support for responsive collapse

2. **messageService.ts**:
   - Add `teamRequiresWorkspace()` function to check if a team needs workspace
   - Returns false for Chat Shell and Dify agents, true for ClaudeCode and Agno

3. **ChatInputControls.tsx & MobileChatInputControls.tsx**:
   - Replace separate RepositorySelector + BranchSelector with UnifiedRepositorySelector
   - Add teamRequiresWorkspace check to conditionally render repo selector

4. **useChatAreaState.ts**:
   - Add auto-clear repository logic when team changes to one that doesn't require workspace

5. **shells.ts**:
   - Add requiresWorkspace field to UnifiedShell type for future backend support

6. **i18n updates**:
   - Add translations for unified selector in en and zh-CN

## Test plan

- [ ] Verify unified selector displays correctly in code task mode
- [ ] Verify clicking repository shows search with local + remote results
- [ ] Verify selecting repository auto-switches to branch view
- [ ] Verify branch selection closes popover and shows full selection
- [ ] Verify compact mode shows icon-only button with tooltip
- [ ] Verify switching from ClaudeCode agent to Chat agent clears repository
- [ ] Verify repository selector is hidden for Chat/Dify agents
- [ ] Verify translations work for both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified repository & branch selector with search, lazy-loading, keyboard navigation, and a workspace toggle.
  * Teams and shells can declare a "requires workspace" setting; surfaces in settings, create/edit flows, and API payloads.
  * Chat UI supports overriding workspace requirement; this state flows into input controls and send validation.

* **Localization**
  * Added English and Chinese strings for selector UI, placeholders, and workspace hints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->