### PR TITLE
fix(knowledge): auto-enable summary switch when opening notebook dialog

### DIFF
--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -213,3 +213,26 @@ export async function refreshWebDocument(documentId: number): Promise<WebDocumen
     document_id: documentId,
   })
 }
+
+// ============== Summary Refresh APIs ==============
+
+/**
+ * Response type for knowledge base summary refresh
+ */
+export interface KnowledgeBaseSummaryRefreshResponse {
+  message: string
+  status: string
+}
+
+/**
+ * Refresh knowledge base summary by re-aggregating document summaries
+ * @param kbId The knowledge base ID to refresh summary for
+ * @returns Refresh result with status
+ */
+export async function refreshKnowledgeBaseSummary(
+  kbId: number
+): Promise<KnowledgeBaseSummaryRefreshResponse> {
+  return apiClient.post<KnowledgeBaseSummaryRefreshResponse>(
+    `/knowledge-bases/${kbId}/summary/refresh`
+  )
+}

--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { BookOpen, FolderOpen } from 'lucide-react'
 import {
   Dialog,
@@ -44,6 +44,8 @@ interface CreateKnowledgeBaseDialogProps {
   groupName?: string
   /** Knowledge base type selected from dropdown menu (read-only in dialog) */
   kbType?: KnowledgeBaseType
+  /** Optional team ID for reading cached model preference */
+  knowledgeDefaultTeamId?: number | null
 }
 
 export function CreateKnowledgeBaseDialog({
@@ -54,11 +56,13 @@ export function CreateKnowledgeBaseDialog({
   scope,
   groupName,
   kbType = 'notebook',
+  knowledgeDefaultTeamId,
 }: CreateKnowledgeBaseDialogProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
-  const [summaryEnabled, setSummaryEnabled] = useState(false)
+  // Default enable summary for notebook type, disable for classic type
+  const [summaryEnabled, setSummaryEnabled] = useState(kbType === 'notebook')
   const [summaryModelRef, setSummaryModelRef] = useState<SummaryModelRef | null>(null)
   const [summaryModelError, setSummaryModelError] = useState('')
   const [retrievalConfig, setRetrievalConfig] = useState<Partial<RetrievalConfig>>({
@@ -72,6 +76,15 @@ export function CreateKnowledgeBaseDialog({
   })
   const [error, setError] = useState('')
   const [accordionValue, setAccordionValue] = useState<string>('')
+
+  // Reset summaryEnabled when dialog opens based on kbType
+  // This is necessary because useState initial value only applies on first mount,
+  // but the dialog component persists and kbType can change between opens
+  useEffect(() => {
+    if (open) {
+      setSummaryEnabled(kbType === 'notebook')
+    }
+  }, [open, kbType])
 
   // Note: Auto-selection of retriever and embedding model is handled by RetrievalSettingsSection
 
@@ -119,7 +132,8 @@ export function CreateKnowledgeBaseDialog({
       })
       setName('')
       setDescription('')
-      setSummaryEnabled(false)
+      // Reset summaryEnabled based on kbType: enabled for notebook, disabled for classic
+      setSummaryEnabled(kbType === 'notebook')
       setSummaryModelRef(null)
       setRetrievalConfig({
         retrieval_mode: 'vector',
@@ -139,7 +153,8 @@ export function CreateKnowledgeBaseDialog({
     if (!newOpen) {
       setName('')
       setDescription('')
-      setSummaryEnabled(false)
+      // Reset summaryEnabled based on kbType: enabled for notebook, disabled for classic
+      setSummaryEnabled(kbType === 'notebook')
       setSummaryModelRef(null)
       setSummaryModelError('')
       setRetrievalConfig({
@@ -259,6 +274,7 @@ export function CreateKnowledgeBaseDialog({
                       setSummaryModelError('')
                     }}
                     error={summaryModelError}
+                    knowledgeDefaultTeamId={knowledgeDefaultTeamId}
                   />
                 </div>
               )}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import {
   ArrowLeft,
   Upload,
@@ -88,6 +88,15 @@ export function DocumentList({
   // Track if summary is being retried
   const [isSummaryRetrying, setIsSummaryRetrying] = useState(false)
 
+  // Track component mounted state to prevent updates after unmount
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   // Check if summary generation failed
   const isSummaryFailed = knowledgeBase.summary?.status === 'failed'
   const summaryError = knowledgeBase.summary?.error
@@ -103,7 +112,9 @@ export function DocumentList({
       // Refresh knowledge base details after a short delay
       if (onRefreshKnowledgeBase) {
         setTimeout(() => {
-          onRefreshKnowledgeBase()
+          if (isMountedRef.current) {
+            onRefreshKnowledgeBase()
+          }
         }, 2000)
       }
     } catch (err) {
@@ -113,7 +124,9 @@ export function DocumentList({
         description: t('chatPage.summaryFailed'),
       })
     } finally {
-      setIsSummaryRetrying(false)
+      if (isMountedRef.current) {
+        setIsSummaryRetrying(false)
+      }
     }
   }
 

--- a/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
@@ -34,6 +34,8 @@ interface EditKnowledgeBaseDialogProps {
   knowledgeBase: KnowledgeBase | null
   onSubmit: (data: KnowledgeBaseUpdate) => Promise<void>
   loading?: boolean
+  /** Optional team ID for reading cached model preference (only used when KB has no existing summary_model_ref) */
+  knowledgeDefaultTeamId?: number | null
 }
 
 export function EditKnowledgeBaseDialog({
@@ -42,6 +44,7 @@ export function EditKnowledgeBaseDialog({
   knowledgeBase,
   onSubmit,
   loading,
+  knowledgeDefaultTeamId,
 }: EditKnowledgeBaseDialogProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
@@ -205,6 +208,11 @@ export function EditKnowledgeBaseDialog({
                       setSummaryModelError('')
                     }}
                     error={summaryModelError}
+                    knowledgeDefaultTeamId={
+                      // Only pass teamId when KB has no existing summary_model_ref
+                      // Priority: existing KB config > cached preference
+                      !knowledgeBase?.summary_model_ref ? knowledgeDefaultTeamId : undefined
+                    }
                   />
                 </div>
               )}

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { BookOpen, FileText, Info, AlertTriangle, RefreshCw } from 'lucide-react'
 import type { KnowledgeBase } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -38,6 +38,15 @@ export function KnowledgeBaseSummaryCard({
   const { t } = useTranslation('knowledge')
   const [isRetrying, setIsRetrying] = useState(false)
 
+  // Track component mounted state to prevent updates after unmount
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const longSummary = knowledgeBase.summary?.long_summary
   const shortSummary = knowledgeBase.summary?.short_summary
   const topics = knowledgeBase.summary?.topics
@@ -58,7 +67,9 @@ export function KnowledgeBaseSummaryCard({
       // Refresh knowledge base details after a short delay
       if (onRefresh) {
         setTimeout(() => {
-          onRefresh()
+          if (isMountedRef.current) {
+            onRefresh()
+          }
         }, 2000)
       }
     } catch (error) {
@@ -68,7 +79,9 @@ export function KnowledgeBaseSummaryCard({
         description: t('chatPage.summaryFailed'),
       })
     } finally {
-      setIsRetrying(false)
+      if (isMountedRef.current) {
+        setIsRetrying(false)
+      }
     }
   }
 

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseSummaryCard.tsx
@@ -4,12 +4,19 @@
 
 'use client'
 
-import { BookOpen, FileText, Info } from 'lucide-react'
+import { useState } from 'react'
+import { BookOpen, FileText, Info, AlertTriangle, RefreshCw } from 'lucide-react'
 import type { KnowledgeBase } from '@/types/knowledge'
 import { useTranslation } from '@/hooks/useTranslation'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { refreshKnowledgeBaseSummary } from '@/apis/knowledge'
+import { toast } from '@/hooks/use-toast'
 
 interface KnowledgeBaseSummaryCardProps {
   knowledgeBase: KnowledgeBase
+  /** Callback to refresh knowledge base details after retry */
+  onRefresh?: () => void
 }
 
 /**
@@ -20,15 +27,50 @@ interface KnowledgeBaseSummaryCardProps {
  * - Knowledge base name and description
  * - Document count
  * - AI-generated summary (if available)
+ * - Summary failure warning with retry button (if failed)
  *
  * Styled as a system message without avatar/sender info
  */
-export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummaryCardProps) {
+export function KnowledgeBaseSummaryCard({
+  knowledgeBase,
+  onRefresh,
+}: KnowledgeBaseSummaryCardProps) {
   const { t } = useTranslation('knowledge')
+  const [isRetrying, setIsRetrying] = useState(false)
 
   const longSummary = knowledgeBase.summary?.long_summary
   const shortSummary = knowledgeBase.summary?.short_summary
   const topics = knowledgeBase.summary?.topics
+  const summaryStatus = knowledgeBase.summary?.status
+  const summaryError = knowledgeBase.summary?.error
+
+  // Check if summary generation failed
+  const isSummaryFailed = summaryStatus === 'failed'
+
+  // Handle retry summary generation
+  const handleRetry = async () => {
+    setIsRetrying(true)
+    try {
+      await refreshKnowledgeBaseSummary(knowledgeBase.id)
+      toast({
+        description: t('chatPage.summaryRetrying'),
+      })
+      // Refresh knowledge base details after a short delay
+      if (onRefresh) {
+        setTimeout(() => {
+          onRefresh()
+        }, 2000)
+      }
+    } catch (error) {
+      console.error('Failed to refresh summary:', error)
+      toast({
+        variant: 'destructive',
+        description: t('chatPage.summaryFailed'),
+      })
+    } finally {
+      setIsRetrying(false)
+    }
+  }
 
   return (
     <div className="w-full max-w-3xl mx-auto mb-6">
@@ -64,7 +106,7 @@ export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummary
         </div>
 
         {/* Summary Section */}
-        {(longSummary || shortSummary) && (
+        {(longSummary || shortSummary) && !isSummaryFailed && (
           <div className="pt-3 border-t border-border/50">
             <div className="flex items-center gap-2 mb-2">
               <Info className="w-4 h-4 text-text-muted" />
@@ -78,8 +120,43 @@ export function KnowledgeBaseSummaryCard({ knowledgeBase }: KnowledgeBaseSummary
           </div>
         )}
 
+        {/* Summary Failed Warning */}
+        {isSummaryFailed && (
+          <div className="pt-3 border-t border-border/50">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <AlertTriangle className="w-4 h-4 text-amber-500 cursor-help" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="max-w-xs">
+                        {summaryError || t('chatPage.summaryFailedHint')}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                <span className="text-sm text-amber-500 font-medium">
+                  {t('chatPage.summaryFailed')}
+                </span>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRetry}
+                disabled={isRetrying}
+                className="h-8 text-xs"
+              >
+                <RefreshCw className={`w-3.5 h-3.5 mr-1.5 ${isRetrying ? 'animate-spin' : ''}`} />
+                {isRetrying ? t('chatPage.summaryRetrying') : t('chatPage.summaryRetry')}
+              </Button>
+            </div>
+          </div>
+        )}
+
         {/* Topics */}
-        {topics && topics.length > 0 && (
+        {topics && topics.length > 0 && !isSummaryFailed && (
           <div className="flex flex-wrap gap-2">
             {topics.slice(0, 5).map((topic, index) => (
               <span

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
@@ -137,11 +137,6 @@ export function KnowledgeDocumentPage() {
     }
 
     saveGlobalModelPreference(knowledgeDefaultTeamId, preference)
-    console.log(
-      '[KnowledgeDocumentPage] Saved summary model to preference:',
-      knowledgeDefaultTeamId,
-      preference.modelName
-    )
   }
 
   // Load user's groups

--- a/frontend/src/features/knowledge/document/components/SummaryModelSelector.tsx
+++ b/frontend/src/features/knowledge/document/components/SummaryModelSelector.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { Check, ChevronsUpDown, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -20,6 +20,7 @@ import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import { modelApis, UnifiedModel } from '@/apis/models'
 import { useTranslation } from '@/hooks/useTranslation'
+import { getGlobalModelPreference } from '@/utils/modelPreferences'
 import type { SummaryModelRef } from '@/types/knowledge'
 
 interface SummaryModelSelectorProps {
@@ -27,6 +28,8 @@ interface SummaryModelSelectorProps {
   onChange: (value: SummaryModelRef | null) => void
   disabled?: boolean
   error?: string
+  /** Optional team ID to read cached model preference from localStorage */
+  knowledgeDefaultTeamId?: number | null
 }
 
 export function SummaryModelSelector({
@@ -34,11 +37,14 @@ export function SummaryModelSelector({
   onChange,
   disabled = false,
   error,
+  knowledgeDefaultTeamId,
 }: SummaryModelSelectorProps) {
   const { t } = useTranslation('knowledge')
   const [open, setOpen] = useState(false)
   const [models, setModels] = useState<UnifiedModel[]>([])
   const [loading, setLoading] = useState(false)
+  // Track if auto-preselect has been attempted to avoid repeated attempts
+  const hasAttemptedPreselect = useRef(false)
 
   // Fetch models on mount
   useEffect(() => {
@@ -64,6 +70,60 @@ export function SummaryModelSelector({
 
     fetchModels()
   }, [])
+
+  // Auto-preselect model from cached preference when:
+  // 1. Models are loaded
+  // 2. No value is currently selected
+  // 3. Valid knowledgeDefaultTeamId is provided
+  // 4. Haven't attempted preselection yet
+  useEffect(() => {
+    // Skip if already attempted, value exists, still loading, or no teamId
+    if (
+      hasAttemptedPreselect.current ||
+      value ||
+      loading ||
+      models.length === 0 ||
+      !knowledgeDefaultTeamId
+    ) {
+      return
+    }
+
+    // Mark as attempted to prevent repeated attempts
+    hasAttemptedPreselect.current = true
+
+    // Read cached preference from localStorage
+    const cachedPreference = getGlobalModelPreference(knowledgeDefaultTeamId)
+    if (!cachedPreference?.modelName) {
+      return
+    }
+
+    // Find matching model in the models list
+    const matchedModel = models.find(model => {
+      // Match by modelName (required)
+      if (model.name !== cachedPreference.modelName) {
+        return false
+      }
+      // If modelType is specified in preference, also match by type
+      if (cachedPreference.modelType && model.type !== cachedPreference.modelType) {
+        return false
+      }
+      return true
+    })
+
+    if (matchedModel) {
+      // Auto-select the matched model
+      onChange({
+        name: matchedModel.name,
+        namespace: matchedModel.namespace || 'default',
+        type: matchedModel.type,
+      })
+      console.log(
+        '[SummaryModelSelector] Auto-preselected model from cache:',
+        matchedModel.name,
+        matchedModel.type
+      )
+    }
+  }, [models, value, loading, knowledgeDefaultTeamId, onChange])
 
   // Find selected model
   const selectedModel = useMemo(() => {
@@ -97,11 +157,11 @@ export function SummaryModelSelector({
   const getTypeLabel = (type: string) => {
     switch (type) {
       case 'public':
-        return t('common:model.typePublic', 'Public')
+        return t('common:models.public')
       case 'user':
-        return t('common:model.typePersonal', 'Personal')
+        return t('common:models.my_models')
       case 'group':
-        return t('common:model.typeGroup', 'Group')
+        return t('common:models.group')
       default:
         return type
     }

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -366,6 +366,10 @@
     "notFound": "Knowledge base not found",
     "createTaskError": "Failed to create conversation",
     "bindKnowledgeBaseError": "Failed to bind knowledge base",
-    "newNote": "New Note"
+    "newNote": "New Note",
+    "summaryFailed": "Summary generation failed",
+    "summaryFailedHint": "Click retry to regenerate summary",
+    "summaryRetry": "Retry",
+    "summaryRetrying": "Retrying..."
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -366,6 +366,10 @@
     "notFound": "知识库未找到",
     "createTaskError": "创建对话失败",
     "bindKnowledgeBaseError": "绑定知识库失败",
-    "newNote": "新笔记"
+    "newNote": "新笔记",
+    "summaryFailed": "摘要生成失败",
+    "summaryFailedHint": "点击重试按钮重新生成摘要",
+    "summaryRetry": "重试",
+    "summaryRetrying": "重试中..."
   }
 }


### PR DESCRIPTION
## Summary

- Fix "Auto-generate Summary" switch not auto-enabled when creating Notebook knowledge base
- Fix model selector not pre-selecting the knowledge base's summary model in notebook chat page

## Problem

### Issue 1: Summary Switch Not Auto-Enabled

When creating a Notebook type knowledge base, the "Auto-generate Summary" switch should be automatically enabled, but it wasn't working correctly.

**Root cause:**
- `summaryEnabled` state was initialized with `useState(kbType === 'notebook')`
- React's `useState` initial value only applies on first component mount
- Dialog component persists via `open` prop, so `kbType` changes didn't update state

### Issue 2: Model Not Pre-Selected in Notebook Chat Page

After creating a Notebook knowledge base with a summary model configured, entering the notebook chat page would show "Please select a model" instead of the pre-configured model.

**Requirements:**
1. If chat's `selectedModel` already has a value (user preference, task model, etc.), do NOT override it
2. Only pre-select KB's summary model when `selectedModel` is empty (showing "Please select a model")

## Solution

### Fix 1: CreateKnowledgeBaseDialog.tsx

Add `useEffect` to reset `summaryEnabled` when dialog opens:

```typescript
useEffect(() => {
  if (open) {
    setSummaryEnabled(kbType === 'notebook')
  }
}, [open, kbType])
```

### Fix 2: KnowledgeDocumentPage.tsx (Simple Approach)

Instead of passing `initialModelRef` through multiple component layers, directly save the summary model to the knowledge mode's default team preference when creating/editing a notebook KB:

```typescript
// When saving KB with summary model enabled
if (createKbType === 'notebook' && data.summary_enabled && data.summary_model_ref) {
  saveSummaryModelToPreference(data.summary_model_ref)
}
```

This approach:
- Uses the existing model preference system (`wegent_model_pref_{teamId}`)
- Leverages `useModelSelection`'s existing priority logic (which checks global preference)
- No need for complex prop passing or reverse sync logic
- Model selection persists across page refreshes

**How it works:**
1. Get knowledge mode's default team ID from server config
2. When user saves a notebook KB with summary model, save it to `localStorage` as that team's preference
3. When user enters notebook chat, `useModelSelection` automatically loads the preference

## Changed Files

| File | Changes |
|------|---------|
| `frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx` | Add useEffect to reset summaryEnabled when dialog opens |
| `frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx` | Add logic to save summary model to team preference |
| `frontend/src/features/tasks/components/selector/ModelSelector.tsx` | Remove unnecessary reverse sync useEffect |
| `frontend/src/features/tasks/components/selector/MobileModelSelector.tsx` | Remove unnecessary reverse sync useEffect |

## Test plan

### Summary Switch Test
- [ ] Create Notebook type knowledge base → dialog opens → "Auto-generate Summary" should be enabled
- [ ] Create Classic type knowledge base → dialog opens → "Auto-generate Summary" should be disabled
- [ ] Create Classic → close dialog → Create Notebook → switch should be enabled

### Model Pre-Selection Test
- [ ] Create Notebook KB with summary model enabled → Enter notebook chat page → Model selector should show the configured model
- [ ] Edit existing Notebook KB and change summary model → Enter notebook chat page → Model should update to new selection
- [ ] Verify preference is saved to correct team ID (check `wegent_model_pref_{teamId}` in localStorage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add manual retry flow to refresh knowledge-base summaries, including success/failure feedback and optional refresh of related data.
  * Added API-driven summary re-aggregation and automatic summary-model preference persistence per team.

* **UX Improvements**
  * Visual failure indicators, tooltips, loading states, and retry buttons for summary failures.
  * Auto-preselect summary model from cached team preference.
  * New localized messages for summary retry/failure (en / zh-CN).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->