### PR TITLE
feat(deployment): add share URL environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ WEGENT_FRONTEND_PORT=3000
 # Executor Docker image
 EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 
+# Docker pull policy (always, missing, never, if_not_present)
+# Default: always (ensures latest images are pulled)
+# DOCKER_PULL_POLICY=always
+
 # =============================================================================
 # SERVICE COMMUNICATION (for start.sh local development)
 # =============================================================================
@@ -69,6 +73,21 @@ MYSQL_PASSWORD=task_password
 
 # Elasticsearch Java memory options
 # ES_JAVA_OPTS=-Xms1g -Xmx1g
+
+# =============================================================================
+# SHARING CONFIGURATION
+# =============================================================================
+
+# Team/Task sharing URLs (IMPORTANT: Update these for production deployment!)
+# These URLs are used when generating share links for teams and tasks
+# - Local development: http://localhost:3000
+# - Server deployment: http://your-domain.com or https://your-domain.com
+# TEAM_SHARE_BASE_URL is the base URL for team sharing (includes /chat path)
+TEAM_SHARE_BASE_URL=http://localhost:3000/chat
+# TASK_SHARE_BASE_URL is the base URL for task sharing
+TASK_SHARE_BASE_URL=http://localhost:3000
+# TEAM_SHARE_QUERY_PARAM is the query parameter name for team share tokens
+TEAM_SHARE_QUERY_PARAM=teamShare
 
 # =============================================================================
 # BACKEND
@@ -130,6 +149,10 @@ EXECUTOR_MANAGER_PORT=8001
 
 # Timezone
 # TZ=Asia/Shanghai
+
+# Docker Host Address (default: host.docker.internal)
+# Used by executor manager to connect to executor containers in host mode
+# DOCKER_HOST_ADDR=host.docker.internal
 
 # =============================================================================
 # MCP (Model Context Protocol)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
     # build:
       # dockerfile: docker/backend/Dockerfile
     image: ghcr.io/wecode-ai/wegent-backend:latest
-    pull_policy: always
+    pull_policy: ${DOCKER_PULL_POLICY:-always}
     container_name: wegent-backend
     restart: always
     ports:
@@ -98,6 +98,9 @@ services:
       INIT_DATA_ENABLED: "${BACKEND_INIT_DATA_ENABLED:-True}"
       MAX_UPLOAD_FILE_SIZE_MB: ${BACKEND_MAX_UPLOAD_FILE_SIZE_MB:-50}
       MAX_EXTRACTED_TEXT_LENGTH: ${BACKEND_MAX_EXTRACTED_TEXT_LENGTH:-1000000}
+      TEAM_SHARE_BASE_URL: ${TEAM_SHARE_BASE_URL:-http://localhost:3000/chat}
+      TASK_SHARE_BASE_URL: ${TASK_SHARE_BASE_URL:-http://localhost:3000}
+      TEAM_SHARE_QUERY_PARAM: ${TEAM_SHARE_QUERY_PARAM:-teamShare}
       # Chat Shell Configuration (uncomment to use HTTP mode)
       CHAT_SHELL_MODE: ${CHAT_SHELL_MODE:-http}
       CHAT_SHELL_URL: ${CHAT_SHELL_URL:-http://chat_shell:8100}
@@ -120,7 +123,7 @@ services:
     # build:
     #   dockerfile: docker/frontend/Dockerfile
     image: ghcr.io/wecode-ai/wegent-web:latest
-    pull_policy: always
+    pull_policy: ${DOCKER_PULL_POLICY:-always}
     container_name: wegent-frontend
     restart: always
     ports:
@@ -152,7 +155,7 @@ services:
 
   chat_shell:
     image: ghcr.io/wecode-ai/wegent-chat-shell:latest
-    pull_policy: always
+    pull_policy: ${DOCKER_PULL_POLICY:-always}
     container_name: wegent-chat-shell
     restart: always
     ports:
@@ -184,7 +187,7 @@ services:
     # build:
     #   dockerfile: docker/executor_manager/Dockerfile
     image: ghcr.io/wecode-ai/wegent-executor-manager:latest
-    pull_policy: always
+    pull_policy: ${DOCKER_PULL_POLICY:-always}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     container_name: wegent-executor-manager
@@ -216,6 +219,7 @@ services:
       - EXECUTOR_PORT_RANGE_MIN=${EXECUTOR_PORT_RANGE_MIN:-10001}
       - EXECUTOR_PORT_RANGE_MAX=${EXECUTOR_PORT_RANGE_MAX:-10100}
       - EXECUTOR_WORKSPACE=${EXECUTOR_WORKSPACE:-${HOME}/wecode-bot}
+      - DOCKER_HOST_ADDR=${DOCKER_HOST_ADDR:-host.docker.internal}
       # Seccomp Configuration
       # Set to 'true' (default) to enable seccomp (default Docker behavior)
       # Set to 'false' to disable seccomp (add --security-opt seccomp=unconfined)


### PR DESCRIPTION
Add TEAM_SHARE_BASE_URL, TASK_SHARE_BASE_URL, and TEAM_SHARE_QUERY_PARAM to docker-compose.yml and .env.example for easier production deployment.

These environment variables control the base URLs used when generating share links for teams and tasks, making it configurable for different deployment scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added sharing configuration variables for team and task base URLs and a team-share query parameter to environment and compose settings.
  * Added a configurable Docker pull policy (defaulted) and guidance for host-mode container address configuration.
  * Expanded commented guidance for local development and deployment configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->