### PR TITLE
fix: fix markdown table

### DIFF
--- a/frontend/src/components/common/EnhancedMarkdown.tsx
+++ b/frontend/src/components/common/EnhancedMarkdown.tsx
@@ -232,7 +232,10 @@ function CodeBlock({ language, code, theme }: CodeBlockProps) {
       shell: 'bash',
       zsh: 'bash',
       yml: 'yaml',
-      md: 'markdown',
+      // Map markdown to text to avoid syntax highlighting issues with table tokens
+      // The Prism markdown highlighter creates table-related CSS classes that cause display problems
+      md: 'text',
+      markdown: 'text',
       dockerfile: 'docker',
       plaintext: 'text',
       txt: 'text',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Markdown code blocks now render as plain text without syntax highlighting instead of using the Markdown highlighter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->