### PR TITLE
feat: add custom placeholder parameter system for rental/sharing

### DIFF
--- a/backend/alembic/versions/w3x4y5z6a7b8_add_input_parameters_to_shared_teams.py
+++ b/backend/alembic/versions/w3x4y5z6a7b8_add_input_parameters_to_shared_teams.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add input_parameters to shared_teams
+
+Revision ID: w3x4y5z6a7b8
+Revises: v2w3x4y5z6a7
+Create Date: 2025-01-26
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "w3x4y5z6a7b8"
+down_revision: Union[str, None] = "v2w3x4y5z6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add input_parameters column to shared_teams table
+    op.add_column(
+        "shared_teams",
+        sa.Column("input_parameters", mysql.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # Remove input_parameters column from shared_teams table
+    op.drop_column("shared_teams", "input_parameters")

--- a/backend/app/api/endpoints/adapter/subscription_market.py
+++ b/backend/app/api/endpoints/adapter/subscription_market.py
@@ -151,3 +151,23 @@ def get_rental_count(
         db,
         subscription_id=subscription_id,
     )
+
+
+@router.get("/subscriptions/{subscription_id}/input-parameters")
+def get_subscription_input_parameters(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get custom placeholder parameters from the subscription's promptTemplate.
+
+    Returns a list of input parameters parsed from {{name:label:type}} syntax
+    in the promptTemplate. These parameters can be filled by users when
+    renting the subscription.
+    """
+    return subscription_market_service.get_subscription_input_parameters(
+        db,
+        subscription_id=subscription_id,
+        user_id=current_user.id,
+    )

--- a/backend/app/api/endpoints/adapter/teams.py
+++ b/backend/app/api/endpoints/adapter/teams.py
@@ -189,6 +189,24 @@ def get_team_input_parameters(
     )
 
 
+@router.get("/{team_id}/placeholder-parameters")
+def get_team_placeholder_parameters(
+    team_id: int,
+    current_user: User = Depends(security.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get custom placeholder parameters from the team's Ghost systemPrompt.
+
+    Returns a list of input parameters parsed from {{name:label:type}} syntax
+    in the Ghost's systemPrompt. These parameters can be filled by users when
+    joining a shared team.
+    """
+    return team_kinds_service.get_team_placeholder_parameters(
+        db=db, team_id=team_id, user_id=current_user.id
+    )
+
+
 @router.get("/share/info")
 def get_share_info(
     share_token: str = Query(..., description="Share token"),
@@ -206,5 +224,8 @@ def join_shared_team(
 ):
     """Join a shared team"""
     return shared_team_service.join_shared_team(
-        db=db, share_token=request.share_token, user_id=current_user.id
+        db=db,
+        share_token=request.share_token,
+        user_id=current_user.id,
+        input_parameters=request.input_parameters,
     )

--- a/backend/app/models/shared_team.py
+++ b/backend/app/models/shared_team.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer
+from sqlalchemy.dialects.mysql import JSON
 from sqlalchemy.orm import relationship
 
 from app.db.base import Base
@@ -24,6 +25,9 @@ class SharedTeam(Base):
     )  # Original user who created the team
     team_id = Column(Integer, nullable=False, index=True)  # Team that was shared
     is_active = Column(Boolean, default=True)
+    # Input parameters filled by user when joining the shared team
+    # Format: {"param_name": "param_value", ...}
+    input_parameters = Column(JSON, nullable=True)
     created_at = Column(DateTime, default=datetime.now)
     updated_at = Column(DateTime, default=datetime.now, onupdate=datetime.now)
 

--- a/backend/app/schemas/input_parameter.py
+++ b/backend/app/schemas/input_parameter.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Input Parameter schemas for custom placeholder parameter system.
+
+This module defines schemas for:
+- Input parameter types (text, textarea, select)
+- Input parameter definition (parsed from templates)
+- API request/response models for input parameters
+"""
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class InputParameterType(str, Enum):
+    """Input parameter type enumeration."""
+
+    TEXT = "text"
+    TEXTAREA = "textarea"
+    SELECT = "select"
+
+
+class InputParameter(BaseModel):
+    """
+    Input parameter definition parsed from template.
+
+    Syntax formats:
+    - text: {{name:label:text}}
+    - textarea: {{name:label:textarea}}
+    - select: {{name:label:select:option1|option2|option3}}
+    """
+
+    name: str = Field(..., description="Parameter unique identifier (variable name)")
+    label: str = Field(..., description="Display label for the parameter")
+    type: InputParameterType = Field(..., description="Parameter input type")
+    options: Optional[List[str]] = Field(
+        None, description="Options list for select type (pipe-separated in template)"
+    )
+
+
+class InputParametersResponse(BaseModel):
+    """Response for listing input parameters."""
+
+    parameters: List[InputParameter] = Field(
+        default_factory=list, description="List of input parameters"
+    )
+
+
+class InputParameterValues(BaseModel):
+    """Input parameter values provided by user."""
+
+    values: Dict[str, str] = Field(
+        default_factory=dict, description="Parameter name to value mapping"
+    )

--- a/backend/app/schemas/shared_team.py
+++ b/backend/app/schemas/shared_team.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import Optional
+from typing import Dict, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SharedTeamCreate(BaseModel):
@@ -14,6 +14,7 @@ class SharedTeamCreate(BaseModel):
     user_id: int
     original_user_id: int
     team_id: int
+    input_parameters: Optional[Dict[str, str]] = None
 
 
 class SharedTeamInDB(BaseModel):
@@ -24,6 +25,7 @@ class SharedTeamInDB(BaseModel):
     original_user_id: int
     team_id: int
     is_active: bool
+    input_parameters: Optional[Dict[str, str]] = None
     created_at: datetime
     updated_at: datetime
 
@@ -57,6 +59,11 @@ class JoinSharedTeamRequest(BaseModel):
     """Join shared team request model"""
 
     share_token: str
+    input_parameters: Optional[Dict[str, str]] = Field(
+        None,
+        description="Input parameters to fill in the template placeholders. "
+        "Keys are parameter names, values are the user-provided values.",
+    )
 
 
 class JoinSharedTeamResponse(BaseModel):

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -670,6 +670,11 @@ class RentSubscriptionRequest(BaseModel):
     model_ref: Optional[Dict[str, str]] = Field(
         None, description="Optional model reference (name, namespace)"
     )
+    input_parameters: Optional[Dict[str, str]] = Field(
+        None,
+        description="Input parameters to fill in the template placeholders. "
+        "Keys are parameter names, values are the user-provided values.",
+    )
 
 
 class RentalSubscriptionResponse(BaseModel):

--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -2041,5 +2041,102 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
             # has_parameters is true as long as external API bot exists, even if API call fails
             return {"has_parameters": True, "parameters": []}
 
+    def get_team_placeholder_parameters(
+        self, db: Session, *, team_id: int, user_id: int
+    ) -> Dict[str, Any]:
+        """
+        Get custom placeholder parameters from the team's Ghost systemPrompt.
+
+        This parses the Ghost's systemPrompt for custom placeholders using the
+        {{name:label:type}} syntax and returns them as a list of InputParameter objects.
+
+        Supported syntax:
+        - {{name:label:text}} - Single line text input
+        - {{name:label:textarea}} - Multi-line text input
+        - {{name:label:select:option1|option2|option3}} - Dropdown select
+
+        Args:
+            db: Database session
+            team_id: Team ID
+            user_id: Current user ID
+
+        Returns:
+            Dict with "parameters" list containing InputParameter objects
+        """
+        from app.schemas.input_parameter import InputParametersResponse
+        from app.services.subscription.helpers import parse_input_parameters
+
+        # Get team details
+        team = kindReader.get_by_id(db, KindType.TEAM, team_id)
+
+        if not team:
+            raise HTTPException(status_code=404, detail="Team not found")
+
+        # Check if user has access to this team
+        is_author = team.user_id == user_id
+        shared_team = None
+
+        if not is_author:
+            shared_team = sharedTeamReader.get_by_team_and_user(db, team_id, user_id)
+            if not shared_team:
+                raise HTTPException(
+                    status_code=403, detail="Access denied to this team"
+                )
+
+        # Get original user context
+        original_user_id = team.user_id if is_author else shared_team.original_user_id
+
+        # Parse Team CRD
+        team_crd = Team.model_validate(team.json)
+        all_parameters = []
+
+        # Iterate through all bots to get their Ghost's systemPrompt
+        for member in team_crd.spec.members or []:
+            bot_ref = member.botRef
+            if not bot_ref:
+                continue
+
+            # Get bot using kindReader (handles public fallback)
+            bot = kindReader.get_by_name_and_namespace(
+                db, original_user_id, KindType.BOT, bot_ref.namespace, bot_ref.name
+            )
+
+            if not bot:
+                continue
+
+            bot_crd = Bot.model_validate(bot.json)
+            ghost_ref = bot_crd.spec.ghostRef
+            if not ghost_ref:
+                continue
+
+            # Get ghost using kindReader (handles public fallback)
+            ghost = kindReader.get_by_name_and_namespace(
+                db,
+                original_user_id,
+                KindType.GHOST,
+                ghost_ref.namespace,
+                ghost_ref.name,
+            )
+
+            if not ghost:
+                continue
+
+            ghost_crd = Ghost.model_validate(ghost.json)
+            system_prompt = ghost_crd.spec.systemPrompt or ""
+
+            # Parse input parameters from system prompt
+            params = parse_input_parameters(system_prompt)
+            all_parameters.extend(params)
+
+        # Deduplicate by parameter name
+        seen_names = set()
+        unique_parameters = []
+        for param in all_parameters:
+            if param.name not in seen_names:
+                seen_names.add(param.name)
+                unique_parameters.append(param)
+
+        return InputParametersResponse(parameters=unique_parameters).model_dump()
+
 
 team_kinds_service = TeamKindsService(Kind)

--- a/backend/app/services/subscription/execution.py
+++ b/backend/app/services/subscription/execution.py
@@ -95,6 +95,17 @@ class BackgroundExecutionManager:
                         f"[Subscription] Using source subscription {source_subscription_id} "
                         f"promptTemplate for rental {subscription.id}"
                     )
+
+                    # Merge rental's input_parameters into extra_variables
+                    rental_input_params = internal.get("input_parameters")
+                    if rental_input_params:
+                        if extra_variables is None:
+                            extra_variables = {}
+                        # Rental input parameters take precedence
+                        extra_variables = {**rental_input_params, **extra_variables}
+                        logger.info(
+                            f"[Subscription] Merging rental input_parameters for subscription {subscription.id}"
+                        )
                 else:
                     logger.warning(
                         f"[Subscription] Source subscription {source_subscription_id} not found "

--- a/frontend/src/__tests__/components/common/MermaidDiagram.test.tsx
+++ b/frontend/src/__tests__/components/common/MermaidDiagram.test.tsx
@@ -7,6 +7,9 @@ import { render, screen, waitFor, fireEvent, act } from '@testing-library/react'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import MermaidDiagram from '@/components/common/MermaidDiagram'
 
+// Set a higher default timeout for all tests in this file
+jest.setTimeout(15000)
+
 // Mock the theme context
 jest.mock('@/features/theme/ThemeProvider', () => ({
   useTheme: () => ({ theme: 'light', setTheme: jest.fn() }),
@@ -58,6 +61,9 @@ const renderWithProviders = (ui: React.ReactElement) => {
   return render(<TooltipProvider>{ui}</TooltipProvider>)
 }
 
+// Common waitFor timeout for async operations
+const waitForOptions = { timeout: 10000 }
+
 describe('MermaidDiagram', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -84,7 +90,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Check that the diagram container is rendered
     expect(screen.getByText('Diagram')).toBeInTheDocument()
@@ -97,7 +103,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Check zoom controls exist
     expect(screen.getByText('100%')).toBeInTheDocument()
@@ -110,7 +116,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Find zoom in button and click
     const zoomInButtons = screen.getAllByRole('button')
@@ -131,7 +137,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Find zoom out button and click
     const zoomOutButtons = screen.getAllByRole('button')
@@ -152,7 +158,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Find copy button and click
     const copyButtons = screen.getAllByRole('button')
@@ -177,7 +183,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Mermaid render failed/)).toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Check that raw code is displayed
     expect(screen.getByText('invalid mermaid code')).toBeInTheDocument()
@@ -190,7 +196,7 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.queryByText('Loading diagram...')).not.toBeInTheDocument()
-    })
+    }, waitForOptions)
 
     // Check for custom class on the container
     const diagramContainer = document.querySelector('.custom-class')
@@ -204,6 +210,6 @@ describe('MermaidDiagram', () => {
 
     await waitFor(() => {
       expect(screen.getByText(/Empty diagram code/)).toBeInTheDocument()
-    })
+    }, waitForOptions)
   })
 })

--- a/frontend/src/__tests__/features/common/AuthGuard.test.tsx
+++ b/frontend/src/__tests__/features/common/AuthGuard.test.tsx
@@ -2,7 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { render, waitFor } from '@testing-library/react'
+import { render, waitFor, act } from '@testing-library/react'
+
+// Set a higher default timeout for all tests in this file
+jest.setTimeout(15000)
+
 import { useRouter, usePathname, useSearchParams } from 'next/navigation'
 import AuthGuard from '@/features/common/AuthGuard'
 import { userApis } from '@/apis/user'
@@ -29,6 +33,9 @@ jest.mock('@/hooks/useTranslation', () => ({
   }),
 }))
 
+// Common waitFor timeout for async operations
+const waitForOptions = { timeout: 10000 }
+
 describe('AuthGuard', () => {
   const mockRouter = {
     replace: jest.fn(),
@@ -52,11 +59,13 @@ describe('AuthGuard', () => {
       ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
 
       // Act
-      render(
-        <AuthGuard>
-          <div>Protected Content</div>
-        </AuthGuard>
-      )
+      await act(async () => {
+        render(
+          <AuthGuard>
+            <div>Protected Content</div>
+          </AuthGuard>
+        )
+      })
 
       // Assert
       await waitFor(() => {
@@ -64,7 +73,7 @@ describe('AuthGuard', () => {
         expect(mockRouter.replace).toHaveBeenCalledWith(
           expect.stringContaining(paths.auth.login.getHref())
         )
-      })
+      }, waitForOptions)
     })
 
     it('should render children when isAuthenticated returns true', async () => {
@@ -73,18 +82,22 @@ describe('AuthGuard', () => {
       ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(true)
 
       // Act
-      const { getByText } = render(
-        <AuthGuard>
-          <div>Protected Content</div>
-        </AuthGuard>
-      )
+      let getByText: (text: string) => HTMLElement
+      await act(async () => {
+        const result = render(
+          <AuthGuard>
+            <div>Protected Content</div>
+          </AuthGuard>
+        )
+        getByText = result.getByText
+      })
 
       // Assert
       await waitFor(() => {
         expect(userApis.isAuthenticated).toHaveBeenCalled()
         expect(mockRouter.replace).not.toHaveBeenCalled()
         expect(getByText('Protected Content')).toBeInTheDocument()
-      })
+      }, waitForOptions)
     })
 
     it('should include redirect path in login URL', async () => {
@@ -94,11 +107,13 @@ describe('AuthGuard', () => {
       ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
 
       // Act
-      render(
-        <AuthGuard>
-          <div>Protected Content</div>
-        </AuthGuard>
-      )
+      await act(async () => {
+        render(
+          <AuthGuard>
+            <div>Protected Content</div>
+          </AuthGuard>
+        )
+      })
 
       // Assert
       await waitFor(() => {
@@ -106,7 +121,7 @@ describe('AuthGuard', () => {
         expect(mockRouter.replace).toHaveBeenCalledWith(
           expect.stringContaining(encodeURIComponent('/tasks/123?tab=details'))
         )
-      })
+      }, waitForOptions)
     })
 
     it('should allow access to login page without authentication', async () => {
@@ -115,18 +130,22 @@ describe('AuthGuard', () => {
       ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
 
       // Act
-      const { getByText } = render(
-        <AuthGuard>
-          <div>Login Page</div>
-        </AuthGuard>
-      )
+      let getByText: (text: string) => HTMLElement
+      await act(async () => {
+        const result = render(
+          <AuthGuard>
+            <div>Login Page</div>
+          </AuthGuard>
+        )
+        getByText = result.getByText
+      })
 
       // Assert
       await waitFor(() => {
         // Should not call isAuthenticated for allowed paths
         expect(mockRouter.replace).not.toHaveBeenCalled()
         expect(getByText('Login Page')).toBeInTheDocument()
-      })
+      }, waitForOptions)
     })
 
     it('should allow access to shared task page without authentication', async () => {
@@ -135,17 +154,21 @@ describe('AuthGuard', () => {
       ;(userApis.isAuthenticated as jest.Mock).mockReturnValue(false)
 
       // Act
-      const { getByText } = render(
-        <AuthGuard>
-          <div>Shared Task</div>
-        </AuthGuard>
-      )
+      let getByText: (text: string) => HTMLElement
+      await act(async () => {
+        const result = render(
+          <AuthGuard>
+            <div>Shared Task</div>
+          </AuthGuard>
+        )
+        getByText = result.getByText
+      })
 
       // Assert
       await waitFor(() => {
         expect(mockRouter.replace).not.toHaveBeenCalled()
         expect(getByText('Shared Task')).toBeInTheDocument()
-      })
+      }, waitForOptions)
     })
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/selector/RepositorySelector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/RepositorySelector.test.tsx
@@ -9,6 +9,9 @@ import RepositorySelector from '@/features/tasks/components/selector/RepositoryS
 import { githubApis } from '@/apis/github'
 import { GitRepoInfo } from '@/types/api'
 
+// Set a higher default timeout for all tests in this file
+jest.setTimeout(15000)
+
 // Mock ResizeObserver for cmdk component
 global.ResizeObserver = class ResizeObserver {
   observe() {}

--- a/frontend/src/apis/subscription.ts
+++ b/frontend/src/apis/subscription.ts
@@ -349,4 +349,14 @@ export const subscriptionApis = {
   async getRentalCount(subscriptionId: number): Promise<RentalCountResponse> {
     return apiClient.get(`/subscriptions/${subscriptionId}/rental-count`)
   },
+
+  /**
+   * Get input parameters for a market subscription's promptTemplate.
+   * These parameters use {{name:label:type}} syntax.
+   */
+  async getSubscriptionInputParameters(
+    subscriptionId: number
+  ): Promise<import('@/types/input-parameter').InputParametersResponse> {
+    return apiClient.get(`/market/subscriptions/${subscriptionId}/input-parameters`)
+  },
 }

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -5,6 +5,7 @@
 import { apiClient } from './client'
 import type { TeamBot, Team, PaginationParams } from '@/types/api'
 import type { CheckRunningTasksResponse } from './common'
+import type { InputParametersResponse } from '@/types/input-parameter'
 
 // Team Request/Response Types
 export interface CreateTeamRequest {
@@ -40,9 +41,10 @@ export interface TeamShareInfoResponse {
 // Team Share Join Request Type
 export interface TeamShareJoinRequest {
   share_token: string
+  input_parameters?: Record<string, string>
 }
 
-// Team Input Parameters Response Type
+// Team Input Parameters Response Type (for Dify external API bots)
 export interface TeamInputParametersResponse {
   has_parameters: boolean
   parameters: Array<{
@@ -108,6 +110,13 @@ export const teamApis = {
   },
   async getTeamInputParameters(teamId: number): Promise<TeamInputParametersResponse> {
     return apiClient.get(`/teams/${teamId}/input-parameters`)
+  },
+  /**
+   * Get custom placeholder parameters from the team's Ghost systemPrompt.
+   * These parameters use {{name:label:type}} syntax.
+   */
+  async getTeamPlaceholderParameters(teamId: number): Promise<InputParametersResponse> {
+    return apiClient.get(`/teams/${teamId}/placeholder-parameters`)
   },
   async checkRunningTasks(id: number): Promise<CheckRunningTasksResponse> {
     return apiClient.get(`/teams/${id}/running-tasks`)

--- a/frontend/src/features/common/components/InputParameterForm.tsx
+++ b/frontend/src/features/common/components/InputParameterForm.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * InputParameterForm component for rendering dynamic input forms
+ * based on input parameter definitions.
+ *
+ * Supports three parameter types:
+ * - text: Single-line text input
+ * - textarea: Multi-line text input
+ * - select: Dropdown select with predefined options
+ */
+import { useTranslation } from '@/hooks/useTranslation'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { InputParameter } from '@/types/input-parameter'
+
+interface InputParameterFormProps {
+  /** List of input parameter definitions */
+  parameters: InputParameter[]
+  /** Current values for each parameter (keyed by parameter name) */
+  values: Record<string, string>
+  /** Callback when any parameter value changes */
+  onChange: (values: Record<string, string>) => void
+  /** Whether the form is disabled */
+  disabled?: boolean
+}
+
+/**
+ * Renders a dynamic form based on input parameter definitions.
+ * Each parameter is rendered as an appropriate input control based on its type.
+ */
+export function InputParameterForm({
+  parameters,
+  values,
+  onChange,
+  disabled = false,
+}: InputParameterFormProps) {
+  const { t } = useTranslation('common')
+
+  if (!parameters || parameters.length === 0) {
+    return null
+  }
+
+  const handleChange = (name: string, value: string) => {
+    onChange({
+      ...values,
+      [name]: value,
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="text-sm text-text-secondary mb-2">{t('input_parameters.description')}</div>
+      {parameters.map(param => (
+        <div key={param.name} className="space-y-2">
+          <Label htmlFor={`param-${param.name}`} className="text-sm font-medium">
+            {param.label}
+          </Label>
+          {param.type === 'text' && (
+            <Input
+              id={`param-${param.name}`}
+              value={values[param.name] || ''}
+              onChange={e => handleChange(param.name, e.target.value)}
+              placeholder={param.label}
+              disabled={disabled}
+            />
+          )}
+          {param.type === 'textarea' && (
+            <Textarea
+              id={`param-${param.name}`}
+              value={values[param.name] || ''}
+              onChange={e => handleChange(param.name, e.target.value)}
+              placeholder={param.label}
+              disabled={disabled}
+              className="min-h-[100px]"
+            />
+          )}
+          {param.type === 'select' && param.options && (
+            <Select
+              value={values[param.name] || ''}
+              onValueChange={value => handleChange(param.name, value)}
+              disabled={disabled}
+            >
+              <SelectTrigger id={`param-${param.name}`}>
+                <SelectValue placeholder={param.label} />
+              </SelectTrigger>
+              <SelectContent>
+                {param.options.map(option => (
+                  <SelectItem key={option} value={option}>
+                    {option}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1134,5 +1134,11 @@
       "hint_description": "Use hjkl to navigate, i for insert mode, Esc for normal mode. :w to save, :q to close.",
       "commands_hint": ":w save | :q close | :wq save & close"
     }
+  },
+  "input_parameters": {
+    "title": "Parameter Settings",
+    "description": "Please fill in the following parameters to personalize your experience",
+    "required": "Required",
+    "optional": "Optional"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1128,5 +1128,11 @@
       "hint_description": "使用 hjkl 导航，i 进入插入模式，Esc 返回普通模式。:w 保存，:q 关闭。",
       "commands_hint": ":w 保存 | :q 关闭 | :wq 保存并关闭"
     }
+  },
+  "input_parameters": {
+    "title": "参数设置",
+    "description": "请填写以下参数以个性化您的使用体验",
+    "required": "必填",
+    "optional": "选填"
   }
 }

--- a/frontend/src/types/input-parameter.ts
+++ b/frontend/src/types/input-parameter.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for input parameters used in share/rent functionality.
+ */
+
+export type InputParameterType = 'text' | 'textarea' | 'select'
+
+export interface InputParameter {
+  name: string
+  label: string
+  type: InputParameterType
+  options?: string[] // Only for select type
+}
+
+export interface InputParametersResponse {
+  parameters: InputParameter[]
+}

--- a/frontend/src/types/subscription.ts
+++ b/frontend/src/types/subscription.ts
@@ -336,6 +336,7 @@ export interface RentSubscriptionRequest {
   trigger_type: SubscriptionTriggerType
   trigger_config: Record<string, unknown>
   model_ref?: SubscriptionModelRef
+  input_parameters?: Record<string, string>
 }
 
 // Rental subscription response


### PR DESCRIPTION
## Summary

This PR implements a custom placeholder parameter system that allows publishers to define dynamic placeholders in Ghost systemPrompt or Subscription promptTemplate. Renters and joiners can fill parameter values when joining a shared team or renting a subscription, and the system will automatically replace placeholders at runtime.

### Supported placeholder syntax:
- `{{name:label:text}}` - Single line text input
- `{{name:label:textarea}}` - Multi-line text input
- `{{name:label:select:option1|option2|...}}` - Dropdown select

### Key Changes:

**Backend (13 files):**
- Added `InputParameter` schema with parsing and resolution utilities
- Added database migration for `shared_teams.input_parameters` JSON column
- Implemented APIs for retrieving team and subscription placeholder parameters
- Integrated parameter replacement in `ChatConfigBuilder` for Chat Shell
- Integrated parameter replacement in `BackgroundExecutionManager` for executors

**Frontend (12 files):**
- Created `InputParameterForm` component for dynamic parameter input
- Integrated parameter input flow in share join dialog (`JoinDialog.tsx`)
- Integrated parameter input flow in subscription rent dialog (`RentDialog.tsx`)
- Added i18n translations for input parameter UI

## Test plan

- [ ] Create a Ghost with systemPrompt containing placeholders like `Hello {{name:Your Name:text}}`
- [ ] Create a Team using this Ghost and share it
- [ ] When joining the shared team, verify the parameter form appears
- [ ] Fill in the parameter values and verify they are saved
- [ ] Create a task with the joined shared team and verify placeholders are replaced at runtime
- [ ] Test subscription rent flow with subscriptions that have promptTemplate with placeholders
- [ ] Verify all three parameter types work: text, textarea, and select

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added input parameters support for shared teams and subscriptions—users can now provide custom values when joining shared teams or renting subscriptions.
  * Integrated parameter-based form with text, textarea, and dropdown field types for personalized configuration.
  * Automatically populates placeholders in prompts using provided parameter values.
  * Added parameter retrieval endpoints and UI components for displaying available parameters.

* **Internationalization**
  * Added English and Chinese translations for parameter settings interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->