### PR TITLE
feat(mermaid): add auto-fix for Mermaid diagram render errors

### DIFF
--- a/backend/app/api/endpoints/adapter/chat.py
+++ b/backend/app/api/endpoints/adapter/chat.py
@@ -490,3 +490,178 @@ async def apply_correction(
     apply_correction_to_subtask(db, subtask, request.improved_answer)
 
     return {"message": "Correction applied", "subtask_id": subtask_id}
+
+
+# Mermaid Diagram Fix Feature
+class FixMermaidRequest(BaseModel):
+    """Request body for fixing Mermaid diagram code."""
+
+    code: str  # The original Mermaid code that failed to render
+    error: str  # The error message from the Mermaid renderer
+    model_id: Optional[str] = None  # Optional model ID (uses default if not provided)
+
+
+class FixMermaidResponse(BaseModel):
+    """Response body for Mermaid diagram fix."""
+
+    success: bool
+    fixed_code: Optional[str] = None
+    error: Optional[str] = None
+
+
+@router.post("/fix-mermaid")
+async def fix_mermaid_code(
+    request: FixMermaidRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Fix Mermaid diagram code that failed to render.
+
+    This endpoint:
+    1. Takes the original Mermaid code and error message
+    2. Sends to LLM to fix the syntax/semantic errors
+    3. Returns the fixed Mermaid code
+
+    Returns:
+        {"success": bool, "fixed_code": str, "error": str}
+    """
+    from app.services.chat.config.model_resolver import (
+        _find_model,
+        extract_and_process_model_config,
+    )
+
+    # Use provided model_id or default to a sensible default model
+    model_id = request.model_id
+    if not model_id:
+        # Try to find a default model - prefer GPT-4o or Claude
+        for default_name in ["gpt-4o", "gpt-4o-mini", "claude-3-5-sonnet", "gpt-4"]:
+            model_spec = _find_model(db, default_name, current_user.id)
+            if model_spec:
+                model_id = default_name
+                break
+
+    if not model_id:
+        return FixMermaidResponse(
+            success=False,
+            error="No model available for Mermaid fix. Please configure a model.",
+        )
+
+    # Find the model
+    model_spec = _find_model(db, model_id, current_user.id)
+    if not model_spec:
+        return FixMermaidResponse(
+            success=False, error=f"Model '{model_id}' not found"
+        )
+
+    # Extract and process model config
+    model_config = extract_and_process_model_config(
+        model_spec=model_spec,
+        user_id=current_user.id,
+        user_name=current_user.user_name or "",
+    )
+
+    # Build the fix prompt
+    fix_prompt = f"""Please fix the following Mermaid diagram code that has a render error.
+
+Error message: {request.error}
+
+Original Mermaid code:
+```mermaid
+{request.code}
+```
+
+Please analyze the error and fix the Mermaid code. Output ONLY the corrected Mermaid code in a mermaid code block, without any explanation or additional text. The output must be a valid Mermaid diagram that will render correctly.
+
+Important rules:
+1. Preserve the original diagram structure and intent
+2. Fix only the syntax/semantic errors that caused the render failure
+3. Use proper Mermaid syntax for the diagram type (flowchart, sequence, etc.)
+4. Do not add any explanations, just output the fixed code in a mermaid code block"""
+
+    try:
+        # Call LLM to fix the code
+        fixed_code = await _call_llm_for_mermaid_fix(model_config, fix_prompt)
+
+        if fixed_code:
+            return FixMermaidResponse(success=True, fixed_code=fixed_code)
+        else:
+            return FixMermaidResponse(
+                success=False,
+                error="Failed to extract fixed Mermaid code from LLM response",
+            )
+
+    except Exception as e:
+        logger.error(f"Mermaid fix failed: {e}", exc_info=True)
+        return FixMermaidResponse(success=False, error=str(e))
+
+
+async def _call_llm_for_mermaid_fix(model_config: dict, prompt: str) -> Optional[str]:
+    """
+    Call LLM to fix Mermaid code.
+
+    Args:
+        model_config: Model configuration dict
+        prompt: The fix prompt
+
+    Returns:
+        Fixed Mermaid code or None
+    """
+    import re
+
+    from langchain_anthropic import ChatAnthropic
+    from langchain_core.messages import HumanMessage
+    from langchain_openai import ChatOpenAI
+
+    model_type = model_config.get("model", "openai")
+    api_key = model_config.get("api_key", "")
+    base_url = model_config.get("base_url", "")
+    model_id = model_config.get("model_id", "gpt-4o-mini")
+    default_headers = model_config.get("default_headers", {})
+
+    # Create LLM client based on model type
+    if model_type == "claude":
+        llm = ChatAnthropic(
+            model=model_id,
+            api_key=api_key,
+            base_url=base_url if base_url else None,
+            max_tokens=4096,
+            timeout=60,
+            default_headers=default_headers if default_headers else None,
+        )
+    else:
+        # Default to OpenAI-compatible
+        llm = ChatOpenAI(
+            model=model_id,
+            api_key=api_key,
+            base_url=base_url if base_url else None,
+            max_tokens=4096,
+            timeout=60,
+            default_headers=default_headers if default_headers else None,
+        )
+
+    # Call LLM
+    messages = [HumanMessage(content=prompt)]
+    response = await llm.ainvoke(messages)
+
+    # Extract Mermaid code from response
+    content = response.content
+    if isinstance(content, str):
+        # Try to extract code from mermaid code block
+        mermaid_match = re.search(r"```mermaid\s*([\s\S]*?)```", content, re.IGNORECASE)
+        if mermaid_match:
+            return mermaid_match.group(1).strip()
+
+        # Fallback: try to extract from any code block
+        code_match = re.search(r"```\s*([\s\S]*?)```", content)
+        if code_match:
+            return code_match.group(1).strip()
+
+        # Last resort: return the entire content if it looks like Mermaid code
+        if any(
+            keyword in content.lower()
+            for keyword in ["graph", "flowchart", "sequencediagram", "classdiagram"]
+        ):
+            return content.strip()
+
+    return None

--- a/frontend/src/__tests__/components/common/MermaidDiagram.test.tsx
+++ b/frontend/src/__tests__/components/common/MermaidDiagram.test.tsx
@@ -168,8 +168,8 @@ describe('MermaidDiagram', () => {
   })
 
   it('renders error state for invalid mermaid code', async () => {
-    // Mock mermaid to throw an error for this test
-    mockRender.mockRejectedValueOnce(new Error('Syntax error'))
+    // Mock mermaid to always throw an error for this test
+    mockRender.mockImplementation(() => Promise.reject(new Error('Syntax error')))
 
     await act(async () => {
       renderWithProviders(<MermaidDiagram code="invalid mermaid code" />)
@@ -181,6 +181,11 @@ describe('MermaidDiagram', () => {
 
     // Check that raw code is displayed
     expect(screen.getByText('invalid mermaid code')).toBeInTheDocument()
+
+    // Reset mock for other tests
+    mockRender.mockResolvedValue({
+      svg: '<svg width="100" height="100"><rect width="100" height="100" fill="blue"></rect></svg>',
+    })
   })
 
   it('applies custom className', async () => {

--- a/frontend/src/apis/chat.ts
+++ b/frontend/src/apis/chat.ts
@@ -340,6 +340,65 @@ export async function getSearchEngines(): Promise<SearchEnginesResponse> {
 }
 
 /**
+ * Request parameters for fixing Mermaid diagram code
+ */
+export interface FixMermaidRequest {
+  /** The original Mermaid code that failed to render */
+  code: string
+  /** The error message from the Mermaid renderer */
+  error: string
+  /** Model ID to use for fixing (optional, uses default if not provided) */
+  model_id?: string
+}
+
+/**
+ * Response from fix Mermaid API
+ */
+export interface FixMermaidResponse {
+  /** Whether the fix was successful */
+  success: boolean
+  /** The fixed Mermaid code (if successful) */
+  fixed_code?: string
+  /** Error message if fix failed */
+  error?: string
+}
+
+/**
+ * Request AI to fix Mermaid diagram code that failed to render.
+ *
+ * @param request - Fix request parameters
+ * @returns Fixed Mermaid code or error
+ */
+export async function fixMermaidCode(request: FixMermaidRequest): Promise<FixMermaidResponse> {
+  const token = getToken()
+
+  const response = await fetch(`${getApiUrl()}/chat/fix-mermaid`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+    body: JSON.stringify(request),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    let errorMsg = errorText
+    try {
+      const json = JSON.parse(errorText)
+      if (json && typeof json.detail === 'string') {
+        errorMsg = json.detail
+      }
+    } catch {
+      // Not JSON
+    }
+    return { success: false, error: errorMsg }
+  }
+
+  return response.json()
+}
+
+/**
  * Chat API exports
  */
 export const chatApis = {
@@ -348,4 +407,5 @@ export const chatApis = {
   getStreamingContent,
   getSearchEngines,
   resumeStreamWithOffset,
+  fixMermaidCode,
 }

--- a/frontend/src/components/common/EnhancedMarkdown.tsx
+++ b/frontend/src/components/common/EnhancedMarkdown.tsx
@@ -39,6 +39,8 @@ interface EnhancedMarkdownProps {
   /** Custom components to override default rendering */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components?: Record<string, React.ComponentType<any>>
+  /** Callback to request AI fix for Mermaid code. Returns fixed code or null if failed. */
+  onMermaidFixRequest?: (code: string, error: string) => Promise<string | null>
 }
 
 /**
@@ -370,6 +372,7 @@ export const EnhancedMarkdown = memo(function EnhancedMarkdown({
   source,
   theme,
   components,
+  onMermaidFixRequest,
 }: EnhancedMarkdownProps) {
   // Pre-process source to convert \[...\] and \(...\) to dollar syntax
   const processedSource = useMemo(() => preprocessLatexSyntax(source), [source])
@@ -541,7 +544,13 @@ export const EnhancedMarkdown = memo(function EnhancedMarkdown({
     <div className="wmde-markdown enhanced-markdown" data-color-mode={theme}>
       {contentParts.map((part, index) => {
         if (part.type === 'mermaid') {
-          return <MermaidDiagram key={`mermaid-${index}`} code={part.content} />
+          return (
+            <MermaidDiagram
+              key={`mermaid-${index}`}
+              code={part.content}
+              onRequestFix={onMermaidFixRequest}
+            />
+          )
         }
 
         if (part.type === 'latex') {

--- a/frontend/src/components/common/MermaidDiagram.tsx
+++ b/frontend/src/components/common/MermaidDiagram.tsx
@@ -363,7 +363,8 @@ export function MermaidDiagram({ code, className = '', onRequestFix }: MermaidDi
         if (isMounted) {
           console.error('Mermaid render error:', errorMessage)
 
-          // Store original error on first failure
+          // Store original error on first failure (used for displaying after all retries)
+          const currentOriginalError = retryCount === 0 ? errorMessage : originalError
           if (retryCount === 0) {
             setOriginalError(errorMessage)
           }
@@ -387,8 +388,8 @@ export function MermaidDiagram({ code, className = '', onRequestFix }: MermaidDi
             setIsFixing(false)
           }
 
-          // Show error (use original error message)
-          setError(originalError || errorMessage)
+          // Show error (use original error message to not expose retry details)
+          setError(currentOriginalError || errorMessage)
           setIsLoading(false)
         }
       }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -418,7 +418,9 @@
     "resetZoom": "Reset Zoom",
     "renderError": "Mermaid render failed",
     "copied": "Copied to clipboard",
-    "exportSuccess": "Image exported"
+    "exportSuccess": "Image exported",
+    "tryFix": "Try to Fix",
+    "fixing": "Fixing..."
   },
   "correction": {
     "enable": "Enable AI correction mode",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -418,7 +418,9 @@
     "resetZoom": "重置缩放",
     "renderError": "Mermaid 渲染失败",
     "copied": "已复制到剪贴板",
-    "exportSuccess": "图片已导出"
+    "exportSuccess": "图片已导出",
+    "tryFix": "尝试修复",
+    "fixing": "修复中..."
   },
   "correction": {
     "enable": "启用 AI 交叉验证",


### PR DESCRIPTION
## Summary

- Add backend API endpoint `/chat/fix-mermaid` to request AI fix for broken Mermaid code
- Update MermaidDiagram component with auto-fix logic (silent retry up to 2 times)
- Show "Try to Fix" button when all auto-retries exhausted
- Add i18n translations for the new feature (zh-CN and en)

## Changes

### Backend
- **backend/app/api/endpoints/adapter/chat.py**: Add `/chat/fix-mermaid` endpoint that:
  - Accepts Mermaid code and error message
  - Uses LLM (supports OpenAI and Claude) to fix syntax/semantic errors
  - Returns fixed Mermaid code or error

### Frontend
- **frontend/src/apis/chat.ts**: Add `fixMermaidCode` API function
- **frontend/src/components/common/MermaidDiagram.tsx**: 
  - Add auto-fix state management (retryCount, isFixing, originalError)
  - Implement silent auto-retry logic (up to 2 times)
  - Add "Try to Fix" button in error state UI
  - Add `onRequestFix` prop for fix callback
- **frontend/src/components/common/EnhancedMarkdown.tsx**: 
  - Add `onMermaidFixRequest` prop
  - Pass callback to MermaidDiagram component
- **frontend/src/features/tasks/components/message/MessageBubble.tsx**:
  - Implement `handleMermaidFixRequest` callback using chat API
  - Pass callback to EnhancedMarkdown components

### i18n
- **frontend/src/i18n/locales/zh-CN/chat.json**: Add `tryFix` and `fixing` translations
- **frontend/src/i18n/locales/en/chat.json**: Add `tryFix` and `fixing` translations

## Test plan

- [ ] Verify auto-fix triggers silently when Mermaid diagram fails to render
- [ ] Verify auto-fix retries up to 2 times before showing error
- [ ] Verify "Try to Fix" button appears in error state
- [ ] Verify clicking "Try to Fix" triggers new AI fix request
- [ ] Verify successful fix renders the corrected diagram
- [ ] Verify translations work for both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mermaid diagrams can be auto-fixed via AI when rendering errors occur, with up to 2 automatic retry attempts and a manual "Try to Fix" button alongside Copy Code; fixes may be requested from message-rendered Markdown.
* **Localization**
  * Added English and Chinese UI strings for the fix flow ("Try to Fix", "Fixing...").
* **Tests**
  * Updated Mermaid rendering test to make error simulation deterministic and avoid cross-test leakage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->