### PR TITLE
feat(skill): add mcpServers support for Skill CRD

### DIFF
--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -575,6 +575,13 @@ class SkillSpec(BaseModel):
         description="Provider configuration for dynamic loading. "
         "If specified, the provider will be loaded from the skill .",
     )
+    mcpServers: Optional[Dict[str, Any]] = Field(
+        None,
+        description="MCP servers configuration for this skill. "
+        "When the skill is loaded, these MCP servers will be connected "
+        "and their tools will be available to the AI. "
+        "Format follows the standard MCP server configuration schema.",
+    )
 
 
 class SkillStatus(Status):

--- a/backend/app/services/adapters/skill_kinds.py
+++ b/backend/app/services/adapters/skill_kinds.py
@@ -88,6 +88,7 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
+                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
             },
             "status": {
@@ -379,6 +380,7 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
+                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
             }
         )

--- a/backend/app/services/chat/config/chat_config.py
+++ b/backend/app/services/chat/config/chat_config.py
@@ -497,6 +497,10 @@ class ChatConfigBuilder:
                 # Include config if present in skill spec
                 if skill_crd.spec.config:
                     skill_data["config"] = skill_crd.spec.config
+                # Include mcpServers if present in skill spec
+                # MCP servers will be loaded when the skill is loaded
+                if skill_crd.spec.mcpServers:
+                    skill_data["mcpServers"] = skill_crd.spec.mcpServers
                 # Include tools configuration if present in skill spec
                 # Convert SkillToolDeclaration objects to dicts for serialization
                 if skill_crd.spec.tools:

--- a/backend/app/services/skill_service.py
+++ b/backend/app/services/skill_service.py
@@ -143,6 +143,9 @@ class SkillValidator:
                     "provider": metadata.get(
                         "provider"
                     ),  # Provider config for dynamic loading
+                    "mcpServers": metadata.get(
+                        "mcpServers"
+                    ),  # MCP servers for skill-level tools
                     "preload": preload,  # Whether to preload into system prompt
                     "file_size": file_size,
                     "file_hash": file_hash,

--- a/chat_shell/chat_shell/schemas/kind.py
+++ b/chat_shell/chat_shell/schemas/kind.py
@@ -154,6 +154,7 @@ class SkillSpec(BaseModel):
     bindShells: Optional[List[str]] = None
     tools: Optional[List[SkillToolDeclaration]] = None
     provider: Optional[SkillProviderConfig] = None
+    mcpServers: Optional[Dict[str, Any]] = None
 
 
 class SkillStatus(Status):

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -373,6 +373,7 @@ class ChatContext:
             preload_skills=self._request.preload_skills,
             user_name=self._request.user_name,
             auth_token=self._request.auth_token,
+            task_data=self._request.task_data,
         )
         add_span_event(
             "skill_tools_prepared",
@@ -410,7 +411,7 @@ class ChatContext:
             if auth:
                 server_config[server_name]["headers"] = auth
 
-            client = MCPClient(server_config)
+            client = MCPClient(server_config, task_data=self._request.task_data)
             await client.connect()
             if client.is_connected:
                 tools = client.get_tools()
@@ -508,7 +509,7 @@ class ChatContext:
         mcp_summary = []
 
         try:
-            client = MCPClient(unified_config)
+            client = MCPClient(unified_config, task_data=self._request.task_data)
             add_span_event("mcp_client_created")
 
             await client.connect()

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -126,7 +126,7 @@ class ChatContext:
             (
                 history,
                 kb_result,
-                skill_tools,
+                skill_result,
                 mcp_result,
             ) = await asyncio.gather(
                 self._load_chat_history(),
@@ -135,12 +135,16 @@ class ChatContext:
                 self._connect_mcp_servers(),
             )
 
+            # Unpack skill result (tools and MCP clients from skills)
+            skill_tools, skill_mcp_clients = skill_result
+
             add_span_event(
                 "parallel_tasks_completed",
                 {
                     "history_count": len(history),
                     "kb_tools_count": len(kb_result[0]) if kb_result else 0,
                     "skill_tools_count": len(skill_tools),
+                    "skill_mcp_clients_count": len(skill_mcp_clients),
                     "mcp_tools_count": len(mcp_result[0]) if mcp_result else 0,
                 },
             )
@@ -159,15 +163,17 @@ class ChatContext:
             if kb_tools:
                 system_prompt = updated_system_prompt
 
-            # Track MCP clients for cleanup
+            # Track MCP clients for cleanup (both from MCP servers and skills)
             _, mcp_clients = mcp_result
-            self._mcp_clients = mcp_clients
+            # Merge skill MCP clients with MCP server clients
+            all_mcp_clients = mcp_clients + skill_mcp_clients
+            self._mcp_clients = all_mcp_clients
 
             add_span_event(
                 "context_prepare_completed",
                 {
                     "total_extra_tools": len(extra_tools),
-                    "mcp_clients_count": len(mcp_clients),
+                    "mcp_clients_count": len(all_mcp_clients),
                 },
             )
 
@@ -175,7 +181,7 @@ class ChatContext:
                 history=history,
                 extra_tools=extra_tools,
                 system_prompt=system_prompt,
-                mcp_clients=mcp_clients,
+                mcp_clients=all_mcp_clients,
             )
 
     @trace_async(
@@ -339,23 +345,26 @@ class ChatContext:
             "context.has_load_skill_tool": load_skill_tool is not None,
         },
     )
-    async def _prepare_skill_tools(self, load_skill_tool) -> list:
+    async def _prepare_skill_tools(self, load_skill_tool) -> tuple[list, list]:
         """Prepare skill tools asynchronously.
 
         This method also handles preloading skill prompts for skills
         specified in request.preload_skills.
+
+        Returns:
+            Tuple of (skill_tools, skill_mcp_clients)
         """
         from chat_shell.tools.skill_factory import prepare_skill_tools
 
         if not self._request.skill_configs:
             add_span_event("no_skill_configs_skipped")
-            return []
+            return [], []
 
         add_span_event(
             "preparing_skill_tools",
             {"skill_configs_count": len(self._request.skill_configs)},
         )
-        tools = await prepare_skill_tools(
+        tools, skill_mcp_clients = await prepare_skill_tools(
             task_id=self._request.task_id,
             subtask_id=self._request.subtask_id,
             user_id=self._request.user_id,
@@ -365,8 +374,14 @@ class ChatContext:
             user_name=self._request.user_name,
             auth_token=self._request.auth_token,
         )
-        add_span_event("skill_tools_prepared", {"tools_count": len(tools)})
-        return tools
+        add_span_event(
+            "skill_tools_prepared",
+            {
+                "tools_count": len(tools),
+                "skill_mcp_clients_count": len(skill_mcp_clients),
+            },
+        )
+        return tools, skill_mcp_clients
 
     @trace_async(
         span_name="chat_context.connect_single_mcp_server",

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -7,10 +7,12 @@
 Responsible for:
 - Creating LoadSkillTool
 - Dynamically creating skill tools
+- Loading MCP servers from skill configurations
 
 In HTTP mode, skill binaries are downloaded from backend API.
 """
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -138,13 +140,17 @@ async def prepare_skill_tools(
     preload_skills: Optional[list[str]] = None,
     user_name: str = "",
     auth_token: str = "",
-) -> list[Any]:
+    task_data: dict[str, Any] | None = None,
+) -> tuple[list[Any], list[Any]]:
     """
     Prepare skill tools dynamically using SkillToolRegistry.
 
     This function creates tool instances for all skills that have tool declarations
     in their SKILL.md configuration. It uses the plugin-based SkillToolRegistry
     to dynamically load and create tools.
+
+    Additionally, if a skill has mcpServers configured, the MCP servers will be
+    connected and their tools will be included in the returned tools list.
 
     Skill binaries are downloaded from backend API using REMOTE_STORAGE_URL.
 
@@ -158,20 +164,24 @@ async def prepare_skill_tools(
         user_id: User ID for access control
         skill_configs: List of skill configurations from ChatConfig.skill_configs
             Each config contains: {"name": "...", "description": "...", "tools": [...],
-                                   "provider": {...}, "skill_id": int}
+                                   "provider": {...}, "skill_id": int, "mcpServers": {...}}
         ws_emitter: Optional WebSocket emitter for real-time communication
         load_skill_tool: Optional LoadSkillTool instance to preload skill prompts
         preload_skills: Optional list of skill names to preload into system prompt.
                        Skills in this list will have their prompts injected automatically.
         user_name: Username for identifying the user
         auth_token: JWT token for API authentication (e.g., attachment upload/download)
+        task_data: Optional task data for MCP variable substitution
 
     Returns:
-        List of tool instances created from skill configurations
+        Tuple of (tools, mcp_clients) where:
+        - tools: List of tool instances created from skill configurations and MCP servers
+        - mcp_clients: List of MCPClient instances that need to be cleaned up
     """
     from chat_shell.skills import SkillToolContext, SkillToolRegistry
 
     tools: list[Any] = []
+    mcp_clients: list[Any] = []
 
     if not ws_emitter:
         # In HTTP mode, WebSocket is not used, so this is expected
@@ -185,6 +195,9 @@ async def prepare_skill_tools(
     # Get base URL for skill binary downloads
     remote_url = getattr(settings, "REMOTE_STORAGE_URL", "").rstrip("/")
 
+    # Collect all skill MCP server configs for batch loading
+    skill_mcp_configs: dict[str, dict[str, Any]] = {}
+
     # Process each skill configuration
     for skill_config in skill_configs:
         skill_name = skill_config.get("name", "unknown")
@@ -192,9 +205,23 @@ async def prepare_skill_tools(
         provider_config = skill_config.get("provider")
         skill_id = skill_config.get("skill_id")
         skill_user_id = skill_config.get("skill_user_id")
+        mcp_servers = skill_config.get("mcpServers")
+
+        # Collect MCP servers from skill config
+        if mcp_servers:
+            logger.info(
+                "[skill_factory] Skill '%s' has %d MCP server(s) configured",
+                skill_name,
+                len(mcp_servers),
+            )
+            # Prefix MCP server names with skill name to avoid conflicts
+            for server_name, server_config in mcp_servers.items():
+                prefixed_name = f"{skill_name}_{server_name}"
+                skill_mcp_configs[prefixed_name] = server_config
 
         if not tool_declarations:
-            # No tools declared for this skill, skip
+            # No tools declared for this skill, skip tool creation
+            # but MCP servers may still be loaded above
             continue
 
         logger.debug(
@@ -295,13 +322,95 @@ async def prepare_skill_tools(
                     skill_name,
                 )
 
+    # Load MCP tools from all skills if any MCP servers are configured
+    if skill_mcp_configs:
+        mcp_tools, skill_mcp_clients = await _load_skill_mcp_tools(
+            skill_mcp_configs, task_id, task_data
+        )
+        tools.extend(mcp_tools)
+        mcp_clients.extend(skill_mcp_clients)
+
     # Log summary of all skills loaded
     if tools:
         tool_names = [t.name for t in tools]
         logger.info(
-            "[skill_factory] Loaded %d skill tools: %s",
+            "[skill_factory] Loaded %d skill tools (including MCP): %s",
             len(tools),
             tool_names,
         )
 
-    return tools
+    return tools, mcp_clients
+
+
+async def _load_skill_mcp_tools(
+    mcp_configs: dict[str, dict[str, Any]],
+    task_id: int,
+    task_data: dict[str, Any] | None = None,
+) -> tuple[list[Any], list[Any]]:
+    """
+    Load MCP tools from skill-level MCP server configurations.
+
+    This function connects to MCP servers specified in skill configurations
+    and returns the tools provided by those servers.
+
+    Args:
+        mcp_configs: Merged MCP server configurations from all skills
+        task_id: Task ID for logging
+        task_data: Optional task data for variable substitution
+
+    Returns:
+        Tuple of (mcp_tools, mcp_clients)
+    """
+    from chat_shell.tools.mcp import MCPClient
+
+    if not mcp_configs:
+        return [], []
+
+    logger.info(
+        "[skill_factory] Loading MCP tools from %d skill MCP server(s): %s",
+        len(mcp_configs),
+        list(mcp_configs.keys()),
+    )
+
+    mcp_tools: list[Any] = []
+    mcp_clients: list[Any] = []
+
+    try:
+        # Create MCPClient with all skill MCP servers
+        client = MCPClient(mcp_configs, task_data=task_data)
+
+        try:
+            await asyncio.wait_for(client.connect(), timeout=30.0)
+            if client.is_connected:
+                tools = client.get_tools()
+                mcp_tools.extend(tools)
+                mcp_clients.append(client)
+                logger.info(
+                    "[skill_factory] Loaded %d MCP tools from skill servers for task %d",
+                    len(tools),
+                    task_id,
+                )
+            else:
+                logger.warning(
+                    "[skill_factory] Failed to connect to skill MCP servers for task %d",
+                    task_id,
+                )
+        except asyncio.TimeoutError:
+            logger.error(
+                "[skill_factory] Timeout connecting to skill MCP servers for task %d",
+                task_id,
+            )
+        except Exception as e:
+            logger.error(
+                "[skill_factory] Failed to connect to skill MCP servers for task %d: %s",
+                task_id,
+                str(e),
+            )
+
+    except Exception:
+        logger.exception(
+            "[skill_factory] Unexpected error loading skill MCP tools for task %d",
+            task_id,
+        )
+
+    return mcp_tools, mcp_clients

--- a/chat_shell/tests/test_skill_mcp_loader.py
+++ b/chat_shell/tests/test_skill_mcp_loader.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for skill MCP servers loading functionality.
+
+This module tests the ability to load MCP servers from skill configurations.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat_shell.tools.skill_factory import (
+    _load_skill_mcp_tools,
+    prepare_skill_tools,
+)
+
+
+class TestLoadSkillMcpTools:
+    """Test cases for _load_skill_mcp_tools function."""
+
+    @pytest.mark.asyncio
+    async def test_empty_mcp_configs_returns_empty(self):
+        """Test that empty MCP configs returns empty lists."""
+        tools, clients = await _load_skill_mcp_tools({}, task_id=1)
+        assert tools == []
+        assert clients == []
+
+    @pytest.mark.asyncio
+    async def test_mcp_client_created_with_config(self):
+        """Test that MCPClient is created with skill MCP configs."""
+        mcp_configs = {
+            "test_skill_server1": {
+                "type": "stdio",
+                "command": "python",
+                "args": ["-m", "test_server"],
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="test_tool")]
+
+        with patch(
+            "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+        ) as mock_mcp_class:
+            mock_client.connect = AsyncMock()
+            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+
+            mock_mcp_class.assert_called_once_with(mcp_configs, task_data=None)
+            mock_client.connect.assert_called_once()
+            assert len(tools) == 1
+            assert len(clients) == 1
+            assert clients[0] == mock_client
+
+    @pytest.mark.asyncio
+    async def test_mcp_connection_failure_returns_empty(self):
+        """Test that connection failure returns empty lists gracefully."""
+        mcp_configs = {
+            "test_skill_server1": {
+                "type": "stdio",
+                "command": "nonexistent_command",
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = False
+        mock_client.connect = AsyncMock()
+
+        with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
+            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+
+            assert tools == []
+            assert clients == []
+
+    @pytest.mark.asyncio
+    async def test_mcp_connection_timeout_returns_empty(self):
+        """Test that connection timeout returns empty lists gracefully."""
+        import asyncio
+
+        mcp_configs = {
+            "test_skill_server1": {
+                "type": "stdio",
+                "command": "python",
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.connect = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
+            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+
+            assert tools == []
+            assert clients == []
+
+
+class TestPrepareSkillToolsWithMcp:
+    """Test cases for prepare_skill_tools with MCP servers."""
+
+    @pytest.mark.asyncio
+    async def test_skill_with_mcp_servers_config(self):
+        """Test that skill with mcpServers config triggers MCP loading."""
+        skill_configs = [
+            {
+                "name": "test_skill",
+                "description": "A test skill",
+                "mcpServers": {
+                    "server1": {
+                        "type": "stdio",
+                        "command": "python",
+                        "args": ["-m", "test_server"],
+                    }
+                },
+            }
+        ]
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="mcp_tool")]
+
+        with patch(
+            "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+        ) as mock_mcp_class:
+            mock_client.connect = AsyncMock()
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+            )
+
+            # MCP client should be created with prefixed server name
+            mock_mcp_class.assert_called_once()
+            call_args = mock_mcp_class.call_args
+            assert "test_skill_server1" in call_args[0][0]
+
+            # Should return MCP tools and clients
+            assert len(tools) == 1
+            assert len(clients) == 1
+
+    @pytest.mark.asyncio
+    async def test_skill_without_mcp_servers(self):
+        """Test that skill without mcpServers doesn't trigger MCP loading."""
+        skill_configs = [
+            {
+                "name": "test_skill",
+                "description": "A test skill without MCP",
+                # No mcpServers field
+            }
+        ]
+
+        with patch("chat_shell.tools.mcp.MCPClient") as mock_mcp_class:
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+            )
+
+            # MCP client should NOT be created
+            mock_mcp_class.assert_not_called()
+
+            # Should return empty lists
+            assert tools == []
+            assert clients == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_skills_with_mcp_servers(self):
+        """Test that multiple skills' MCP servers are merged."""
+        skill_configs = [
+            {
+                "name": "skill_a",
+                "description": "Skill A",
+                "mcpServers": {
+                    "server_a": {"type": "stdio", "command": "cmd_a"},
+                },
+            },
+            {
+                "name": "skill_b",
+                "description": "Skill B",
+                "mcpServers": {
+                    "server_b": {"type": "stdio", "command": "cmd_b"},
+                },
+            },
+        ]
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [
+            MagicMock(name="tool_a"),
+            MagicMock(name="tool_b"),
+        ]
+
+        with patch(
+            "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+        ) as mock_mcp_class:
+            mock_client.connect = AsyncMock()
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+            )
+
+            # MCP client should be created once with merged configs
+            mock_mcp_class.assert_called_once()
+            call_args = mock_mcp_class.call_args
+            merged_config = call_args[0][0]
+
+            # Should have both prefixed server names
+            assert "skill_a_server_a" in merged_config
+            assert "skill_b_server_b" in merged_config
+
+            # Should return combined tools
+            assert len(tools) == 2
+            assert len(clients) == 1
+
+    @pytest.mark.asyncio
+    async def test_return_type_is_tuple(self):
+        """Test that prepare_skill_tools returns tuple even with empty configs."""
+        result = await prepare_skill_tools(
+            task_id=1,
+            subtask_id=1,
+            user_id=1,
+            skill_configs=[],
+        )
+
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        tools, clients = result
+        assert isinstance(tools, list)
+        assert isinstance(clients, list)


### PR DESCRIPTION
## Summary

Add ability for Skills to define MCP servers in their SKILL.md metadata. When a skill is loaded, the system automatically connects to the configured MCP servers and makes their tools available to the AI.

### Changes

- **SkillSpec schema**: Add `mcpServers` field (`Optional[Dict[str, Any]]`) to both backend and chat_shell schemas
- **ChatConfigBuilder**: Include `mcpServers` in skill_data during configuration building
- **skill_factory**: Extend `prepare_skill_tools` to:
  - Collect MCP servers from skill configs with prefixed names (e.g., `skill_name_server_name`)
  - Connect to skill MCP servers and return tools along with MCP clients
  - Return `tuple[list, list]` (tools, mcp_clients) instead of just tools list
- **context.py**: Handle skill MCP clients lifecycle (merge with bot MCP clients for cleanup)
- **Tests**: Add unit tests for skill MCP loading functionality

### Example Usage

In SKILL.md metadata:
```yaml
---
description: "A skill with MCP tools"
mcpServers:
  my_server:
    type: stdio
    command: python
    args: ["-m", "my_mcp_server"]
---
```

### Why This Feature

This enables Skills to provide MCP-based tools without requiring separate Ghost configuration, making Skills more self-contained and easier to distribute.

## Test plan

- [x] Run existing skill service tests: `uv run pytest tests/services/test_skill_service.py`
- [x] Run chat service tests: `uv run pytest tests/services/chat/`
- [x] Run new skill MCP tests: `uv run pytest tests/test_skill_mcp_loader.py`
- [ ] Manual test: Create a skill with mcpServers config and verify tools are loaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills can declare optional MCP server configurations to expose additional tools.
  * MCP-provided tools from skills are loaded and integrated into chat toolsets.
  * MCP clients from skills and servers are merged, tracked, and cleaned up as part of chat sessions.

* **Tests**
  * Added comprehensive tests covering MCP loading, error handling, merging, and deterministic tool/client behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->