### PR TITLE
feat(memory): enable long-term memory by default when mem0 service is configured

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -27,6 +27,35 @@ from app.services.user import user_service
 router = APIRouter()
 
 
+# ==================== Feature Flags ====================
+
+
+class FeatureFlags(BaseModel):
+    """System-level feature flags for the frontend"""
+
+    memory_enabled: bool = False  # Whether long-term memory service is available
+
+
+@router.get("/features", response_model=FeatureFlags)
+async def get_feature_flags(
+    _current_user: User = Depends(security.get_current_user),  # noqa: ARG001
+):
+    """
+    Get system-level feature flags.
+
+    These flags indicate which features are available based on backend configuration.
+    Used by frontend to conditionally enable/show features.
+    """
+    from app.services.memory import get_memory_manager
+
+    # Check if memory service is actually available
+    memory_manager = get_memory_manager()
+
+    return FeatureFlags(
+        memory_enabled=memory_manager.is_enabled,
+    )
+
+
 @router.get("/me", response_model=UserInDB)
 async def read_current_user(current_user: User = Depends(security.get_current_user)):
     """Get current user information"""

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -38,7 +38,7 @@ class FeatureFlags(BaseModel):
 
 @router.get("/features", response_model=FeatureFlags)
 async def get_feature_flags(
-    _current_user: User = Depends(security.get_current_user),  # noqa: ARG001
+    _current_user: User = Depends(security.get_current_user),
 ):
     """
     Get system-level feature flags.

--- a/backend/app/services/memory/__init__.py
+++ b/backend/app/services/memory/__init__.py
@@ -78,7 +78,9 @@ def is_memory_enabled_for_user(user: User) -> bool:
         if "memory_enabled" not in prefs:
             return True  # Default ON when service is available
 
-        return prefs.get("memory_enabled", True)
+        # Normalize the value to boolean to ensure consistent return type
+        value = prefs.get("memory_enabled", True)
+        return value if isinstance(value, bool) else True
     except (json.JSONDecodeError, AttributeError, TypeError) as e:
         logger.warning(
             "Failed to parse user preferences for memory check: %s", e, exc_info=True

--- a/backend/app/services/memory/__init__.py
+++ b/backend/app/services/memory/__init__.py
@@ -15,11 +15,19 @@ Design principles:
 - Graceful degradation (service unavailable → continue normally)
 - Async-first (fire-and-forget writes, timeout reads)
 - Future-proof for conversation groups
+
+Default behavior:
+- When backend has MEMORY_ENABLED=True (mem0 configured):
+  - Users without explicit memory_enabled preference → memory is ON by default
+  - Users with explicit memory_enabled=False → memory is OFF
+- When backend has MEMORY_ENABLED=False (mem0 not configured):
+  - Memory is always OFF regardless of user preference
 """
 
 import json
 import logging
 
+from app.core.config import settings
 from app.models.user import User
 from app.services.memory.client import LongTermMemoryClient
 from app.services.memory.manager import MemoryManager, get_memory_manager
@@ -31,16 +39,29 @@ logger = logging.getLogger(__name__)
 def is_memory_enabled_for_user(user: User) -> bool:
     """Check if long-term memory is enabled for the given user.
 
+    Default behavior:
+    - When backend has MEMORY_ENABLED=True:
+      - If user has NOT explicitly set memory_enabled preference → return True (default ON)
+      - If user has explicitly set memory_enabled=False → return False
+      - If user has explicitly set memory_enabled=True → return True
+    - When backend has MEMORY_ENABLED=False:
+      - Always return False (service not available)
+
     Args:
         user: User model instance
 
     Returns:
-        True if memory is enabled in user preferences, False otherwise
+        True if memory should be enabled for this user, False otherwise
     """
+    # First check if memory service is available at backend level
+    if not settings.MEMORY_ENABLED:
+        return False
+
     try:
         # Check if user has preferences
         if not user.preferences:
-            return False
+            # No preferences set → use default (True when service is available)
+            return True
 
         # Parse preferences JSON string
         if isinstance(user.preferences, str):
@@ -48,15 +69,22 @@ def is_memory_enabled_for_user(user: User) -> bool:
         elif isinstance(user.preferences, dict):
             prefs = user.preferences
         else:
-            return False
+            # Invalid preferences format → use default (True)
+            return True
 
-        # Check memory_enabled field (default: False for new feature)
-        return prefs.get("memory_enabled", False)
+        # Check if memory_enabled is explicitly set
+        # If not set (key doesn't exist), default to True when service is available
+        # If explicitly set, use the user's preference
+        if "memory_enabled" not in prefs:
+            return True  # Default ON when service is available
+
+        return prefs.get("memory_enabled", True)
     except (json.JSONDecodeError, AttributeError, TypeError) as e:
         logger.warning(
             "Failed to parse user preferences for memory check: %s", e, exc_info=True
         )
-        return False
+        # On parse error, default to True when service is available
+        return True
 
 
 __all__ = [

--- a/backend/tests/services/memory/test_is_memory_enabled.py
+++ b/backend/tests/services/memory/test_is_memory_enabled.py
@@ -125,3 +125,26 @@ class TestIsMemoryEnabledForUser:
             # Non-dict type
             mock_user.preferences = 12345
             assert is_memory_enabled_for_user(mock_user) is False
+
+    def test_normalizes_non_boolean_memory_enabled_values(self, mock_user):
+        """Should normalize non-boolean memory_enabled values to True."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", True
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # String value should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": "true"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Integer value should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": 1})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # None value should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": None})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Dict preferences with non-bool value
+            mock_user.preferences = {"memory_enabled": "yes"}
+            assert is_memory_enabled_for_user(mock_user) is True

--- a/backend/tests/services/memory/test_is_memory_enabled.py
+++ b/backend/tests/services/memory/test_is_memory_enabled.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for is_memory_enabled_for_user function."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestIsMemoryEnabledForUser:
+    """Test cases for is_memory_enabled_for_user function."""
+
+    @pytest.fixture
+    def mock_user(self) -> MagicMock:
+        """Create a mock user object."""
+        user = MagicMock()
+        user.preferences = None
+        return user
+
+    def test_returns_false_when_memory_service_disabled(self, mock_user):
+        """When backend has MEMORY_ENABLED=False, should always return False."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", False
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # No preferences
+            mock_user.preferences = None
+            assert is_memory_enabled_for_user(mock_user) is False
+
+            # Preferences with memory_enabled=True
+            mock_user.preferences = json.dumps({"memory_enabled": True})
+            assert is_memory_enabled_for_user(mock_user) is False
+
+    def test_returns_true_by_default_when_memory_service_enabled(self, mock_user):
+        """When backend has MEMORY_ENABLED=True and user has no preference, should return True."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", True
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # No preferences at all
+            mock_user.preferences = None
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Empty preferences string
+            mock_user.preferences = "{}"
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Empty dict
+            mock_user.preferences = {}
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Preferences without memory_enabled key
+            mock_user.preferences = json.dumps({"send_key": "enter"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+    def test_respects_explicit_user_preference_when_service_enabled(self, mock_user):
+        """When user explicitly sets memory_enabled, should respect their choice."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", True
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # User explicitly enables memory
+            mock_user.preferences = json.dumps({"memory_enabled": True})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # User explicitly disables memory
+            mock_user.preferences = json.dumps({"memory_enabled": False})
+            assert is_memory_enabled_for_user(mock_user) is False
+
+    def test_handles_dict_preferences(self, mock_user):
+        """Should handle preferences as dict (not JSON string)."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", True
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # Dict without memory_enabled
+            mock_user.preferences = {"send_key": "cmd_enter"}
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Dict with memory_enabled=True
+            mock_user.preferences = {"memory_enabled": True}
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Dict with memory_enabled=False
+            mock_user.preferences = {"memory_enabled": False}
+            assert is_memory_enabled_for_user(mock_user) is False
+
+    def test_handles_invalid_preferences_gracefully(self, mock_user):
+        """Should handle invalid preferences and default to True when service is enabled."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", True
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # Invalid JSON string
+            mock_user.preferences = "not valid json"
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # Non-dict, non-string type (should default to True)
+            mock_user.preferences = 12345
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # List type (invalid)
+            mock_user.preferences = ["item1", "item2"]
+            assert is_memory_enabled_for_user(mock_user) is True
+
+    def test_handles_invalid_preferences_when_service_disabled(self, mock_user):
+        """Should return False for invalid preferences when service is disabled."""
+        with patch(
+            "app.services.memory.settings.MEMORY_ENABLED", False
+        ):
+            from app.services.memory import is_memory_enabled_for_user
+
+            # Invalid JSON string
+            mock_user.preferences = "not valid json"
+            assert is_memory_enabled_for_user(mock_user) is False
+
+            # Non-dict type
+            mock_user.preferences = 12345
+            assert is_memory_enabled_for_user(mock_user) is False

--- a/backend/tests/services/memory/test_is_memory_enabled.py
+++ b/backend/tests/services/memory/test_is_memory_enabled.py
@@ -127,24 +127,56 @@ class TestIsMemoryEnabledForUser:
             assert is_memory_enabled_for_user(mock_user) is False
 
     def test_normalizes_non_boolean_memory_enabled_values(self, mock_user):
-        """Should normalize non-boolean memory_enabled values to True."""
+        """Should normalize non-boolean memory_enabled values correctly."""
         with patch(
             "app.services.memory.settings.MEMORY_ENABLED", True
         ):
             from app.services.memory import is_memory_enabled_for_user
 
-            # String value should be normalized to True
+            # String "true" should be normalized to True
             mock_user.preferences = json.dumps({"memory_enabled": "true"})
             assert is_memory_enabled_for_user(mock_user) is True
 
-            # Integer value should be normalized to True
+            # String "TRUE" (uppercase) should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": "TRUE"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # String "yes" should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": "yes"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # String "1" should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": "1"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # String "on" should be normalized to True
+            mock_user.preferences = json.dumps({"memory_enabled": "on"})
+            assert is_memory_enabled_for_user(mock_user) is True
+
+            # String "false" should be normalized to False
+            mock_user.preferences = json.dumps({"memory_enabled": "false"})
+            assert is_memory_enabled_for_user(mock_user) is False
+
+            # String "no" should be normalized to False
+            mock_user.preferences = json.dumps({"memory_enabled": "no"})
+            assert is_memory_enabled_for_user(mock_user) is False
+
+            # Integer 1 should be normalized to True
             mock_user.preferences = json.dumps({"memory_enabled": 1})
             assert is_memory_enabled_for_user(mock_user) is True
 
-            # None value should be normalized to True
+            # Integer 0 should be normalized to False
+            mock_user.preferences = json.dumps({"memory_enabled": 0})
+            assert is_memory_enabled_for_user(mock_user) is False
+
+            # None value should be normalized to True (default)
             mock_user.preferences = json.dumps({"memory_enabled": None})
             assert is_memory_enabled_for_user(mock_user) is True
 
-            # Dict preferences with non-bool value
+            # Dict preferences with non-bool string value
             mock_user.preferences = {"memory_enabled": "yes"}
             assert is_memory_enabled_for_user(mock_user) is True
+
+            # Dict preferences with "false" string
+            mock_user.preferences = {"memory_enabled": "false"}
+            assert is_memory_enabled_for_user(mock_user) is False

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -44,6 +44,14 @@ export interface SearchUsersResponse {
   total: number
 }
 
+/**
+ * System-level feature flags from backend configuration
+ */
+export interface FeatureFlags {
+  /** Whether long-term memory service (mem0) is available */
+  memory_enabled: boolean
+}
+
 const TOKEN_KEY = 'auth_token'
 const TOKEN_EXPIRE_KEY = 'auth_token_expire'
 const TOKEN_COOKIE_NAME = 'auth_token'
@@ -172,6 +180,14 @@ export const userApis = {
 
   async searchUsers(query: string): Promise<SearchUsersResponse> {
     return apiClient.get(`/users/search?q=${encodeURIComponent(query)}`)
+  },
+
+  /**
+   * Get system-level feature flags
+   * These flags indicate which features are available based on backend configuration
+   */
+  async getFeatureFlags(): Promise<FeatureFlags> {
+    return apiClient.get('/users/features')
   },
 
   isAuthenticated(): boolean {

--- a/frontend/src/features/settings/components/NotificationSettings.tsx
+++ b/frontend/src/features/settings/components/NotificationSettings.tsx
@@ -19,7 +19,7 @@ import { Switch } from '@/components/ui/switch'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Label } from '@/components/ui/label'
 import { useUser } from '@/features/common/UserContext'
-import { userApis } from '@/apis/user'
+import { userApis, type FeatureFlags } from '@/apis/user'
 import type { UserPreferences } from '@/types/api'
 
 export default function NotificationSettings() {
@@ -33,25 +33,49 @@ export default function NotificationSettings() {
   const [searchKey, setSearchKey] = useState<'cmd_k' | 'cmd_f' | 'disabled'>('cmd_k')
   const [memoryEnabled, setMemoryEnabled] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  // Feature flags from backend
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlags | null>(null)
+  const [featureFlagsLoading, setFeatureFlagsLoading] = useState(true)
 
   useEffect(() => {
     setSupported(isNotificationSupported())
     setEnabled(isNotificationEnabled())
+
+    // Fetch feature flags from backend
+    const fetchFeatureFlags = async () => {
+      try {
+        const flags = await userApis.getFeatureFlags()
+        setFeatureFlags(flags)
+      } catch (error) {
+        console.error('Failed to fetch feature flags:', error)
+        // Default to memory disabled if fetch fails
+        setFeatureFlags({ memory_enabled: false })
+      } finally {
+        setFeatureFlagsLoading(false)
+      }
+    }
+    fetchFeatureFlags()
   }, [])
 
   useEffect(() => {
     // Only update sendKey and searchKey when user data is loaded and has preferences
     // Use 'enter' as default if send_key is not set
     // Use 'cmd_k' as default if search_key is not set
-    if (user) {
+    if (user && featureFlags) {
       const userSendKey = user.preferences?.send_key || 'enter'
       const userSearchKey = user.preferences?.search_key || 'cmd_k'
-      const userMemoryEnabled = user.preferences?.memory_enabled ?? false
+      // Memory default: true when backend has memory service enabled, false otherwise
+      // If user has explicitly set memory_enabled, use their preference
+      // If not set (undefined), use the backend's memory_enabled as default
+      const userMemoryEnabled =
+        user.preferences?.memory_enabled !== undefined
+          ? user.preferences.memory_enabled
+          : featureFlags.memory_enabled
       setSendKey(userSendKey)
       setSearchKey(userSearchKey)
       setMemoryEnabled(userMemoryEnabled)
     }
-  }, [user])
+  }, [user, featureFlags])
 
   const handleToggle = async () => {
     if (!supported) {
@@ -152,8 +176,12 @@ export default function NotificationSettings() {
         variant: 'destructive',
         title: t('common:memory.save_failed'),
       })
-      // Revert to previous value
-      setMemoryEnabled(user?.preferences?.memory_enabled ?? false)
+      // Revert to previous value - use same logic as initial load
+      const revertValue =
+        user?.preferences?.memory_enabled !== undefined
+          ? user.preferences.memory_enabled
+          : (featureFlags?.memory_enabled ?? false)
+      setMemoryEnabled(revertValue)
     } finally {
       setIsSaving(false)
     }
@@ -255,14 +283,20 @@ export default function NotificationSettings() {
         </RadioGroup>
       </div>
 
-      {/* Long-term Memory Setting */}
-      <div className="flex items-center justify-between p-4 bg-base border border-border rounded-lg">
-        <div className="flex-1">
-          <h3 className="text-sm font-medium text-text-primary">{t('common:memory.title')}</h3>
-          <p className="text-xs text-text-muted mt-1">{t('common:memory.description')}</p>
+      {/* Long-term Memory Setting - Only show when backend has memory service enabled */}
+      {featureFlags?.memory_enabled && (
+        <div className="flex items-center justify-between p-4 bg-base border border-border rounded-lg">
+          <div className="flex-1">
+            <h3 className="text-sm font-medium text-text-primary">{t('common:memory.title')}</h3>
+            <p className="text-xs text-text-muted mt-1">{t('common:memory.description')}</p>
+          </div>
+          <Switch
+            checked={memoryEnabled}
+            onCheckedChange={handleMemoryToggle}
+            disabled={isSaving || featureFlagsLoading}
+          />
         </div>
-        <Switch checked={memoryEnabled} onCheckedChange={handleMemoryToggle} disabled={isSaving} />
-      </div>
+      )}
 
       {/* Restart Onboarding Button */}
       <div className="flex items-center justify-between p-4 bg-base border border-border rounded-lg">


### PR DESCRIPTION
## Summary

- Add `/users/features` API endpoint to expose system-level feature flags
- Update `is_memory_enabled_for_user()` default logic: when backend has `MEMORY_ENABLED=True` and user hasn't explicitly set preference, memory is now ON by default
- Update frontend NotificationSettings to conditionally show memory toggle based on feature flags
- Add unit tests for the new default behavior

## Changes

### Backend

**1. New API endpoint: `GET /users/features`**
- Returns system-level feature flags including `memory_enabled`
- Checks actual memory service availability via `get_memory_manager().is_enabled`

**2. Updated `is_memory_enabled_for_user()` logic:**

| Backend MEMORY_ENABLED | User preference | Result |
|------------------------|-----------------|--------|
| False | Any | False |
| True | Not set (None or missing key) | **True** (NEW default) |
| True | Explicitly True | True |
| True | Explicitly False | False |

### Frontend

**1. Settings page updates:**
- Fetch feature flags on mount via `userApis.getFeatureFlags()`
- Only show Long-term Memory toggle when `featureFlags.memory_enabled` is true
- Default memory toggle state follows backend service availability

## Test plan

- [x] Backend: Unit tests for `is_memory_enabled_for_user()` with new default behavior
- [x] Backend: Memory manager tests still pass
- [ ] E2E: Verify settings page shows/hides memory toggle based on backend config
- [ ] E2E: Verify memory functionality works correctly with new defaults

## Breaking Changes

None. This is a backward-compatible change:
- Users who have already set `memory_enabled: false` will keep their preference
- Users who never set the preference will now have memory enabled by default (when service is available)
- When backend doesn't configure mem0 service, behavior is unchanged (memory disabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backend feature-flags endpoint and frontend API to fetch flags.
  * Memory availability now respects a global toggle and user preferences; UI conditionally shows the long-term memory setting based on the backend flag.

* **Tests**
  * Added comprehensive unit tests covering memory enablement behavior, preference parsing, and defaulting under enabled/disabled states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->