### PR TITLE
fix: compression_enabled set True by default

### DIFF
--- a/chat_shell/chat_shell/agent.py
+++ b/chat_shell/chat_shell/agent.py
@@ -388,7 +388,7 @@ class ChatAgent:
         )
 
         # Apply message compression if enabled and model_id is provided
-        compression_enabled = getattr(settings, "MESSAGE_COMPRESSION_ENABLED", False)
+        compression_enabled = getattr(settings, "MESSAGE_COMPRESSION_ENABLED", True)
         if model_id and compression_enabled:
             # Pass model_config to compressor for context window configuration
             model_config_for_compression = config.model_config if config else None


### PR DESCRIPTION
compression_enabled = getattr(settings, "MESSAGE_COMPRESSION_ENABLED", True)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Message compression is now enabled by default when a model is configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->