### PR TITLE
fix(sandbox): make container ready wait configurable via env vars

### DIFF
--- a/executor_manager/services/sandbox/manager.py
+++ b/executor_manager/services/sandbox/manager.py
@@ -41,6 +41,10 @@ if TYPE_CHECKING:
 
 logger = setup_logger(__name__)
 
+# Container ready wait configuration from environment variables
+SANDBOX_READY_MAX_RETRIES = int(os.getenv("SANDBOX_READY_MAX_RETRIES", "180"))
+SANDBOX_READY_INTERVAL = float(os.getenv("SANDBOX_READY_INTERVAL", "1"))
+
 
 class SandboxManager(metaclass=SingletonMeta):
     """Manager for sandbox lifecycle and execution management.
@@ -211,16 +215,16 @@ class SandboxManager(metaclass=SingletonMeta):
         self,
         executor,
         container_name: str,
-        max_retries: int = 30,
-        interval: float = 1.0,
+        max_retries: int = SANDBOX_READY_MAX_RETRIES,
+        interval: float = SANDBOX_READY_INTERVAL,
     ) -> Optional[str]:
         """Wait for container to be ready and return base_url.
 
         Args:
             executor: Executor instance
             container_name: Container/Pod name
-            max_retries: Maximum number of retries
-            interval: Interval between retries in seconds
+            max_retries: Maximum number of retries (default from env or 180)
+            interval: Interval between retries in seconds (default from env or 1)
 
         Returns:
             base_url if ready, None otherwise


### PR DESCRIPTION
Add environment variable support for SANDBOX_READY_MAX_RETRIES and SANDBOX_READY_INTERVAL to allow flexible configuration of sandbox readiness checks. Default values remain 180 retries and 1 second interval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Container readiness behavior is now configurable via environment variables, allowing customization of retry limits and intervals without code modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->