### PR TITLE
fix(shared-task): enable attachment preview and download for shared tasks

### DIFF
--- a/frontend/src/apis/attachments.ts
+++ b/frontend/src/apis/attachments.ts
@@ -303,10 +303,15 @@ export function isImageExtension(extension: string): boolean {
  * Get image preview URL for an attachment
  *
  * @param attachmentId - Attachment ID
+ * @param shareToken - Optional share token for public access
  * @returns Preview URL
  */
-export function getAttachmentPreviewUrl(attachmentId: number): string {
-  return `${API_BASE_URL}/api/attachments/${attachmentId}/download`
+export function getAttachmentPreviewUrl(attachmentId: number, shareToken?: string): string {
+  const baseUrl = `${API_BASE_URL}/api/attachments/${attachmentId}/download`
+  if (shareToken) {
+    return `${baseUrl}?share_token=${encodeURIComponent(shareToken)}`
+  }
+  return baseUrl
 }
 
 /**
@@ -413,10 +418,15 @@ export async function getAttachment(attachmentId: number): Promise<AttachmentDet
  * Get attachment download URL
  *
  * @param attachmentId - Attachment ID
+ * @param shareToken - Optional share token for public access
  * @returns Download URL
  */
-export function getAttachmentDownloadUrl(attachmentId: number): string {
-  return `${API_BASE_URL}/api/attachments/${attachmentId}/download`
+export function getAttachmentDownloadUrl(attachmentId: number, shareToken?: string): string {
+  const baseUrl = `${API_BASE_URL}/api/attachments/${attachmentId}/download`
+  if (shareToken) {
+    return `${baseUrl}?share_token=${encodeURIComponent(shareToken)}`
+  }
+  return baseUrl
 }
 
 /**
@@ -424,14 +434,22 @@ export function getAttachmentDownloadUrl(attachmentId: number): string {
  *
  * @param attachmentId - Attachment ID
  * @param filename - Optional filename for download. If not provided, will be extracted from Content-Disposition header
+ * @param shareToken - Optional share token for public access (no login required)
  */
-export async function downloadAttachment(attachmentId: number, filename?: string): Promise<void> {
+export async function downloadAttachment(
+  attachmentId: number,
+  filename?: string,
+  shareToken?: string
+): Promise<void> {
   const token = getToken()
+  const downloadUrl = getAttachmentDownloadUrl(attachmentId, shareToken)
 
-  const response = await fetch(`${API_BASE_URL}/api/attachments/${attachmentId}/download`, {
+  const response = await fetch(downloadUrl, {
     method: 'GET',
     headers: {
-      ...(token && { Authorization: `Bearer ${token}` }),
+      // Only include Authorization header if we have a token and no shareToken
+      // shareToken-based access doesn't require JWT authentication
+      ...(!shareToken && token && { Authorization: `Bearer ${token}` }),
     },
   })
 

--- a/frontend/src/app/shared/task/page.tsx
+++ b/frontend/src/app/shared/task/page.tsx
@@ -345,6 +345,7 @@ function SharedTaskContent() {
                     selectedBranch={null}
                     theme={theme}
                     t={t}
+                    shareToken={searchParams.get('token') || undefined}
                   />
                 )
               })}

--- a/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
+++ b/frontend/src/features/tasks/components/message/ContextBadgeList.tsx
@@ -47,6 +47,8 @@ interface ContextBadgeListProps {
   contexts?: SubtaskContextBrief[]
   /** Optional callback when user wants to re-select a context */
   onContextReselect?: (context: SubtaskContextBrief) => void
+  /** Share token for public access (no login required) */
+  shareToken?: string
 }
 
 /**
@@ -58,7 +60,7 @@ interface ContextBadgeListProps {
  * - knowledge_base: Displays KB name with document count
  * - table: Displays table name with clickable link to view/reselect
  */
-export function ContextBadgeList({ contexts, onContextReselect }: ContextBadgeListProps) {
+export function ContextBadgeList({ contexts, onContextReselect, shareToken }: ContextBadgeListProps) {
   if (!contexts || contexts.length === 0) {
     return null
   }
@@ -70,6 +72,7 @@ export function ContextBadgeList({ contexts, onContextReselect }: ContextBadgeLi
           key={`${context.context_type}-${context.id}`}
           context={context}
           onReselect={onContextReselect}
+          shareToken={shareToken}
         />
       ))}
     </div>
@@ -82,13 +85,15 @@ export function ContextBadgeList({ contexts, onContextReselect }: ContextBadgeLi
 function ContextBadgeItem({
   context,
   onReselect,
+  shareToken,
 }: {
   context: SubtaskContextBrief
   onReselect?: (context: SubtaskContextBrief) => void
+  shareToken?: string
 }) {
   switch (context.context_type) {
     case 'attachment':
-      return <AttachmentContextBadge context={context} />
+      return <AttachmentContextBadge context={context} shareToken={shareToken} />
     case 'knowledge_base':
       return <KnowledgeBaseBadge context={context} />
     case 'table':
@@ -103,7 +108,13 @@ function ContextBadgeItem({
  *
  * Converts SubtaskContextBrief to Attachment format for AttachmentPreview
  */
-function AttachmentContextBadge({ context }: { context: SubtaskContextBrief }) {
+function AttachmentContextBadge({
+  context,
+  shareToken,
+}: {
+  context: SubtaskContextBrief
+  shareToken?: string
+}) {
   // Map context status to Attachment status
   // SubtaskContextBrief uses lowercase status values (pending, ready, failed)
   // Attachment uses specific status types (uploading, parsing, ready, failed)
@@ -136,7 +147,14 @@ function AttachmentContextBadge({ context }: { context: SubtaskContextBrief }) {
     created_at: '',
   }
 
-  return <AttachmentPreview attachment={attachment} compact={false} showDownload={true} />
+  return (
+    <AttachmentPreview
+      attachment={attachment}
+      compact={false}
+      showDownload={true}
+      shareToken={shareToken}
+    />
+  )
 }
 /**
  * Knowledge base badge - displays KB name and document count

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -168,6 +168,8 @@ export interface MessageBubbleProps {
   onRegenerate?: (msg: Message, model: Model) => void
   /** Whether regenerate is in progress */
   isRegenerating?: boolean
+  /** Share token for public access to attachments (no login required) */
+  shareToken?: string
 }
 
 // Component for rendering a paragraph with hover action button
@@ -290,6 +292,7 @@ const MessageBubble = memo(
     isLastAiMessage,
     onRegenerate,
     isRegenerating,
+    shareToken,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
     const { trace } = useTraceAction()
@@ -1470,6 +1473,7 @@ const MessageBubble = memo(
               <ContextBadgeList
                 contexts={msg.contexts || undefined}
                 onContextReselect={onContextReselect}
+                shareToken={shareToken}
               />
             )}
             {/* Show waiting indicator when streaming but no content yet */}


### PR DESCRIPTION
## Summary

- Fix attachment preview and download functionality in shared task pages
- Add share_token authentication for public access to attachments (no login required)
- Ensure security by validating that attachments belong to the shared task

## Changes

### Backend (`backend/app/api/endpoints/adapter/attachments.py`)
- Add `share_token` query parameter to `/api/attachments/{attachment_id}/download` endpoint
- Implement dual authentication: JWT for logged-in users, share_token for public viewers
- Add `_validate_share_token_access()` helper function to verify:
  - Token decrypts successfully to user_id#task_id
  - Attachment belongs to a subtask of the shared task
  - Task owner matches the user_id in the token

### Backend (`backend/app/core/security.py`)
- Add `get_current_user_optional()` function for optional JWT authentication
- Returns `None` instead of raising exception when no token is provided

### Frontend (`frontend/src/apis/attachments.ts`)
- Update `getAttachmentPreviewUrl()` to accept optional `shareToken` parameter
- Update `getAttachmentDownloadUrl()` to accept optional `shareToken` parameter  
- Update `downloadAttachment()` to accept optional `shareToken` parameter
- Skip Authorization header when using shareToken-based access

### Frontend Components
- `AttachmentPreview.tsx`: Add `shareToken` prop, pass to `useAuthenticatedImage` hook and download function
- `ContextBadgeList.tsx`: Add `shareToken` prop, pass through to `AttachmentContextBadge`
- `MessageBubble.tsx`: Add `shareToken` prop, pass to `ContextBadgeList`
- `SharedTaskPage.tsx`: Extract `token` from URL params and pass to `MessageBubble`

## Test plan

- [ ] Share a task with attachments (images, PDFs, documents)
- [ ] Open shared link in incognito/logged-out browser
- [ ] Verify attachment thumbnails/previews display correctly
- [ ] Verify clicking download button downloads the file
- [ ] Verify image attachments can be previewed in lightbox
- [ ] Test with invalid share_token - should return 404
- [ ] Test accessing attachment from different task - should return 404
- [ ] Verify logged-in users can still download attachments normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public share token support for attachments, enabling users to generate shareable links that allow recipients to access attachment previews and downloads without login.
  * Attachments in shared tasks can now be accessed via tokens, providing a seamless experience for non-authenticated users while preserving existing authenticated access methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->