### PR TITLE
fix(backend): change teams API default scope from 'personal' to 'all'

### DIFF
--- a/backend/app/api/endpoints/adapter/teams.py
+++ b/backend/app/api/endpoints/adapter/teams.py
@@ -39,8 +39,8 @@ def list_teams(
     page: int = Query(1, ge=1, description="Page number"),
     limit: int = Query(10, ge=1, le=100, description="Items per page"),
     scope: str = Query(
-        "personal",
-        description="Query scope: 'personal' (default), 'group', or 'all'",
+        "all",
+        description="Query scope: 'personal', 'group', or 'all' (default)",
     ),
     group_name: Optional[str] = Query(
         None, description="Group name (required when scope='group')"
@@ -52,9 +52,9 @@ def list_teams(
     Get current user's Team list (paginated) with scope support.
 
     Scope behavior:
-    - scope='personal' (default): personal teams + shared teams
+    - scope='personal': personal teams + shared teams
     - scope='group': group teams (requires group_name)
-    - scope='all': personal + shared + all user's groups
+    - scope='all' (default): personal + shared + all user's groups
     """
     api_start = time.time()
     logger.info(


### PR DESCRIPTION
## Summary

- Change the default value of `scope` parameter in `/api/teams` list endpoint from `'personal'` to `'all'`
- Update parameter description and docstring to reflect the new default behavior

## Changes

**File:** `backend/app/api/endpoints/adapter/teams.py`

1. Changed `scope` parameter default value from `"personal"` to `"all"`
2. Updated description from `"Query scope: 'personal' (default), 'group', or 'all'"` to `"Query scope: 'personal', 'group', or 'all' (default)"`
3. Updated docstring to mark `scope='all'` as the default option

## Impact

- Frontend clients that don't explicitly pass a `scope` parameter will now receive all teams (personal + shared + user's groups) by default
- Existing clients can still use `scope=personal` to get the previous default behavior
- No breaking changes for clients that explicitly specify the scope parameter

## Test plan

- [ ] Verify `/api/teams` returns all teams when no scope parameter is provided
- [ ] Verify `/api/teams?scope=personal` returns only personal + shared teams
- [ ] Verify `/api/teams?scope=group&group_name=xxx` returns group-specific teams
- [ ] Verify `/api/teams?scope=all` returns all teams (same as new default)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default behavior of the teams listing endpoint to display all teams when no scope parameter is specified, instead of personal teams only.

* **Documentation**
  * Updated API documentation to reflect the new default scope selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->