### PR TITLE
feat(kb): add intelligent knowledge base tool call limits

### DIFF
--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -112,6 +112,32 @@ class KnowledgeBaseUpdate(BaseModel):
         description="Model reference for summary generation. Format: {'name': 'model-name', 'namespace': 'default', 'type': 'public|user|group'}",
     )
 
+    # Knowledge base tool call limit configuration
+    max_calls_per_conversation: Optional[int] = Field(
+        None,
+        ge=2,
+        le=50,
+        description="Maximum number of knowledge base tool calls allowed per conversation",
+    )
+    exempt_calls_before_check: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Number of calls exempt from token checking (must be < max_calls_per_conversation)",
+    )
+
+    @model_validator(mode="after")
+    def validate_call_limits(self):
+        """Validate that exempt_calls_before_check < max_calls_per_conversation"""
+        if (
+            self.exempt_calls_before_check is not None
+            and self.max_calls_per_conversation is not None
+        ):
+            if self.exempt_calls_before_check >= self.max_calls_per_conversation:
+                raise ValueError(
+                    "exempt_calls_before_check must be less than max_calls_per_conversation"
+                )
+        return self
+
 
 class KnowledgeBaseTypeUpdate(BaseModel):
     """Schema for updating knowledge base type (notebook <-> classic conversion)."""
@@ -152,6 +178,11 @@ class KnowledgeBaseResponse(BaseModel):
         None,
         description="Knowledge base summary (short_summary, long_summary, topics, etc.)",
     )
+
+    # Knowledge base tool call limit configuration
+    max_calls_per_conversation: int = Field(default=10)
+    exempt_calls_before_check: int = Field(default=5)
+
     created_at: datetime
     updated_at: datetime
 
@@ -170,6 +201,22 @@ class KnowledgeBaseResponse(BaseModel):
         summary_model_ref = spec.get("summaryModelRef")
         # Extract kb_type from spec, default to 'notebook' for backward compatibility
         kb_type = spec.get("kbType", "notebook")
+
+        # Extract call limit configuration with defaults for backward compatibility
+        max_calls = spec.get("maxCallsPerConversation", 10)
+        exempt_calls = spec.get("exemptCallsBeforeCheck", 5)
+
+        # Validate: exempt_calls must be < max_calls
+        if exempt_calls >= max_calls:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                f"Invalid KB config for {kind.id}: exemptCallsBeforeCheck ({exempt_calls}) "
+                f">= maxCallsPerConversation ({max_calls}). Using default values."
+            )
+            max_calls, exempt_calls = 10, 5
+
         return cls(
             id=kind.id,
             name=spec.get("name", ""),
@@ -182,6 +229,8 @@ class KnowledgeBaseResponse(BaseModel):
             summary_enabled=spec.get("summaryEnabled", False),
             summary_model_ref=summary_model_ref,
             summary=summary,
+            max_calls_per_conversation=max_calls,
+            exempt_calls_before_check=exempt_calls,
             is_active=kind.is_active,
             created_at=kind.created_at,
             updated_at=kind.updated_at,

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Dict, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # Import shared types from kind.py to avoid duplication
 from app.schemas.kind import (

--- a/backend/app/services/chat/adapters/http.py
+++ b/backend/app/services/chat/adapters/http.py
@@ -161,47 +161,8 @@ class HTTPAdapter(ChatInterface):
             "is_subscription": request.is_subscription,
         }
 
-        # Fetch KB configurations for HTTP mode injection
-        # This follows the same pattern as package mode
-        if request.knowledge_base_ids:
-            kb_configs = {}
-            try:
-                from app.services.knowledge.knowledge_service import KnowledgeService
-
-                for kb_id in request.knowledge_base_ids:
-                    try:
-                        kb_kind = KnowledgeService.get_knowledge_base(
-                            request.db_session, kb_id, request.user_id
-                        )
-                        if kb_kind:
-                            spec = kb_kind.json.get("spec", {})
-                            kb_configs[kb_id] = {
-                                "maxCallsPerConversation": spec.get(
-                                    "maxCallsPerConversation", 10
-                                ),
-                                "exemptCallsBeforeCheck": spec.get(
-                                    "exemptCallsBeforeCheck", 5
-                                ),
-                                "name": spec.get("name", f"KB-{kb_id}"),
-                            }
-                    except Exception as e:
-                        logger.warning(
-                            f"[HTTP_ADAPTER] Failed to fetch config for KB {kb_id}: {e}"
-                        )
-                        # Use defaults if fetch fails
-                        kb_configs[kb_id] = {
-                            "maxCallsPerConversation": 10,
-                            "exemptCallsBeforeCheck": 5,
-                            "name": f"KB-{kb_id}",
-                        }
-            except Exception as e:
-                logger.warning(
-                    f"[HTTP_ADAPTER] Failed to fetch KB configs: {e}, using empty config"
-                )
-                kb_configs = {}
-
-            # Add kb_configs to metadata for chat_shell injection
-            metadata["kb_configs"] = kb_configs
+        # KB configs (max_calls, exempt_calls, name) are now fetched by chat_shell from Backend API
+        # No need to inject them via metadata
 
         logger.info(
             "[HTTP_ADAPTER] Building metadata: is_subscription=%s, task_id=%d, subtask_id=%d",

--- a/backend/app/services/chat/adapters/http.py
+++ b/backend/app/services/chat/adapters/http.py
@@ -161,6 +161,48 @@ class HTTPAdapter(ChatInterface):
             "is_subscription": request.is_subscription,
         }
 
+        # Fetch KB configurations for HTTP mode injection
+        # This follows the same pattern as package mode
+        if request.knowledge_base_ids:
+            kb_configs = {}
+            try:
+                from app.services.knowledge.knowledge_service import KnowledgeService
+
+                for kb_id in request.knowledge_base_ids:
+                    try:
+                        kb_kind = KnowledgeService.get_knowledge_base(
+                            request.db_session, kb_id, request.user_id
+                        )
+                        if kb_kind:
+                            spec = kb_kind.json.get("spec", {})
+                            kb_configs[kb_id] = {
+                                "maxCallsPerConversation": spec.get(
+                                    "maxCallsPerConversation", 10
+                                ),
+                                "exemptCallsBeforeCheck": spec.get(
+                                    "exemptCallsBeforeCheck", 5
+                                ),
+                                "name": spec.get("name", f"KB-{kb_id}"),
+                            }
+                    except Exception as e:
+                        logger.warning(
+                            f"[HTTP_ADAPTER] Failed to fetch config for KB {kb_id}: {e}"
+                        )
+                        # Use defaults if fetch fails
+                        kb_configs[kb_id] = {
+                            "maxCallsPerConversation": 10,
+                            "exemptCallsBeforeCheck": 5,
+                            "name": f"KB-{kb_id}",
+                        }
+            except Exception as e:
+                logger.warning(
+                    f"[HTTP_ADAPTER] Failed to fetch KB configs: {e}, using empty config"
+                )
+                kb_configs = {}
+
+            # Add kb_configs to metadata for chat_shell injection
+            metadata["kb_configs"] = kb_configs
+
         logger.info(
             "[HTTP_ADAPTER] Building metadata: is_subscription=%s, task_id=%d, subtask_id=%d",
             request.is_subscription,

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -925,43 +925,16 @@ def _prepare_kb_tools_from_contexts(
         f"{len(knowledge_base_ids)} knowledge bases: {knowledge_base_ids}"
     )
 
-    # Fetch KB configurations for injection (package mode)
-    # This follows the same pattern as context_window, injection_mode, etc.
-    kb_configs = {}
-    from app.services.knowledge.knowledge_service import KnowledgeService
-
-    for kb_id in knowledge_base_ids:
-        try:
-            kb_kind = KnowledgeService.get_knowledge_base(db, kb_id, user_id)
-            if kb_kind:
-                spec = kb_kind.json.get("spec", {})
-                kb_configs[kb_id] = {
-                    "maxCallsPerConversation": spec.get("maxCallsPerConversation", 10),
-                    "exemptCallsBeforeCheck": spec.get("exemptCallsBeforeCheck", 5),
-                    "name": spec.get("name", f"KB-{kb_id}"),
-                }
-        except Exception as e:
-            logger.warning(
-                f"[_prepare_kb_tools_from_contexts] Failed to fetch config for KB {kb_id}: {e}"
-            )
-            # Use defaults if fetch fails
-            kb_configs[kb_id] = {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 5,
-                "name": f"KB-{kb_id}",
-            }
-
     # Import KnowledgeBaseTool
     from chat_shell.tools.builtin import KnowledgeBaseTool
 
     # Create KnowledgeBaseTool with the specified knowledge bases
-    # Inject kb_configs following same pattern as context_window, injection_mode
+    # KB configs (max_calls, exempt_calls, name) are now fetched from Backend API
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         user_id=user_id,
         db_session=db,
         user_subtask_id=user_subtask_id,
-        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -404,6 +404,22 @@ class KnowledgeService:
         if "summary_model_ref" in data.model_fields_set:
             spec["summaryModelRef"] = data.summary_model_ref
 
+        # Update call limit configuration if provided
+        if data.max_calls_per_conversation is not None:
+            spec["maxCallsPerConversation"] = data.max_calls_per_conversation
+
+        if data.exempt_calls_before_check is not None:
+            spec["exemptCallsBeforeCheck"] = data.exempt_calls_before_check
+
+        # Validate call limits: exempt < max (additional backend validation)
+        max_calls = spec.get("maxCallsPerConversation", 10)
+        exempt_calls = spec.get("exemptCallsBeforeCheck", 5)
+        if exempt_calls >= max_calls:
+            raise ValueError(
+                f"exemptCallsBeforeCheck ({exempt_calls}) must be less than "
+                f"maxCallsPerConversation ({max_calls})"
+            )
+
         kb_json["spec"] = spec
         kb.json = kb_json
         # Mark JSON field as modified so SQLAlchemy detects the change

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -226,6 +226,12 @@ class Metadata(BaseModel):
         True,
         description="Whether KB is explicitly selected by user (strict mode) or inherited from task (relaxed mode)",
     )
+    # Knowledge base call limit configuration (injected by Backend for both package and HTTP modes)
+    # Maps KB ID to config: {"maxCallsPerConversation": int, "exemptCallsBeforeCheck": int, "name": str}
+    kb_configs: Optional[dict[int, dict[str, Any]]] = Field(
+        None,
+        description="Knowledge base configurations (max calls, exempt calls, name) - injected by Backend",
+    )
     # Table configuration
     table_contexts: Optional[list[dict]] = Field(
         None, description="Table contexts for DataTableTool"

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -226,12 +226,6 @@ class Metadata(BaseModel):
         True,
         description="Whether KB is explicitly selected by user (strict mode) or inherited from task (relaxed mode)",
     )
-    # Knowledge base call limit configuration (injected by Backend for both package and HTTP modes)
-    # Maps KB ID to config: {"maxCallsPerConversation": int, "exemptCallsBeforeCheck": int, "name": str}
-    kb_configs: Optional[dict[int, dict[str, Any]]] = Field(
-        None,
-        description="Knowledge base configurations (max calls, exempt calls, name) - injected by Backend",
-    )
     # Table configuration
     table_contexts: Optional[list[dict]] = Field(
         None, description="Table contexts for DataTableTool"

--- a/chat_shell/chat_shell/prompts/knowledge_base.py
+++ b/chat_shell/chat_shell/prompts/knowledge_base.py
@@ -14,4 +14,3 @@ __all__ = [
     "KB_PROMPT_STRICT",
     "KB_PROMPT_RELAXED",
 ]
-

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -259,7 +259,8 @@ class ChatService(ChatInterface):
 
                     if not await core.process_token(token):
                         add_span_event(
-                            "token_processing_stopped", {"tokens_processed": token_count}
+                            "token_processing_stopped",
+                            {"tokens_processed": token_count},
                         )
                         break
 

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -288,11 +288,7 @@ class ChatContext:
                 "skipping KB prompt enhancement"
             )
 
-        # Extract kb_configs from request metadata (injected by Backend)
-        kb_configs = (
-            self._request.metadata.get("kb_configs") if self._request.metadata else None
-        )
-
+        # KB configs (max_calls, exempt_calls, name) are now fetched by KnowledgeBaseTool from Backend API
         result = await prepare_knowledge_base_tools(
             knowledge_base_ids=self._request.knowledge_base_ids,
             user_id=self._request.user_id,
@@ -303,7 +299,6 @@ class ChatContext:
             is_user_selected=self._request.is_user_selected_kb,
             document_ids=self._request.document_ids,
             context_window=context_window,
-            kb_configs=kb_configs,
             skip_prompt_enhancement=skip_prompt_enhancement,
         )
         add_span_event("kb_tools_prepared", {"tools_count": len(result[0])})

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -288,6 +288,11 @@ class ChatContext:
                 "skipping KB prompt enhancement"
             )
 
+        # Extract kb_configs from request metadata (injected by Backend)
+        kb_configs = (
+            self._request.metadata.get("kb_configs") if self._request.metadata else None
+        )
+
         result = await prepare_knowledge_base_tools(
             knowledge_base_ids=self._request.knowledge_base_ids,
             user_id=self._request.user_id,
@@ -298,6 +303,7 @@ class ChatContext:
             is_user_selected=self._request.is_user_selected_kb,
             document_ids=self._request.document_ids,
             context_window=context_window,
+            kb_configs=kb_configs,
             skip_prompt_enhancement=skip_prompt_enhancement,
         )
         add_span_event("kb_tools_prepared", {"tools_count": len(result[0])})

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -100,14 +100,6 @@ class KnowledgeBaseTool(BaseTool):
     # Current conversation messages for context calculation
     current_messages: List[Dict[str, Any]] = Field(default_factory=list)
 
-    # Knowledge base call limit configuration (injected at construction time)
-    # Maps KB ID to config: {"maxCallsPerConversation": int, "exemptCallsBeforeCheck": int, "name": str}
-    # Follows same injection pattern as context_window, injection_mode, etc.
-    kb_configs: Optional[Dict[int, Dict[str, Any]]] = Field(
-        default=None,
-        description="Knowledge base configurations (max calls, exempt calls, name) - injected by Backend/chat_shell",
-    )
-
     # Injection strategy instance (lazy initialized)
     _injection_strategy: Optional[InjectionStrategy] = PrivateAttr(default=None)
 
@@ -115,6 +107,9 @@ class KnowledgeBaseTool(BaseTool):
     # These are instance variables that persist across multiple tool calls in the same conversation
     _call_count: int = PrivateAttr(default=0)
     _accumulated_tokens: int = PrivateAttr(default=0)
+
+    # Cache for KB info (fetched once per conversation)
+    _kb_info_cache: Optional[Dict[str, Any]] = PrivateAttr(default=None)
 
     @property
     def injection_strategy(self) -> InjectionStrategy:
@@ -144,8 +139,8 @@ class KnowledgeBaseTool(BaseTool):
         Returns limits for the first knowledge base in the list. If multiple KBs
         are configured, we use the first one's limits to keep behavior simple.
 
-        Configuration is injected at tool construction time (from Backend or chat_shell),
-        following the same pattern as context_window and injection_mode.
+        Configuration is fetched from Backend API via _get_kb_info() and cached
+        for the lifetime of the tool instance.
 
         Returns:
             Tuple of (max_calls_per_conversation, exempt_calls_before_check)
@@ -153,33 +148,62 @@ class KnowledgeBaseTool(BaseTool):
         if not self.knowledge_base_ids:
             return DEFAULT_MAX_CALLS_PER_CONVERSATION, DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
 
-        # Use injected config if available
-        if self.kb_configs:
-            first_kb_id = self.knowledge_base_ids[0]
-            kb_spec = self.kb_configs.get(first_kb_id, {})
+        # Get KB info from cache or HTTP API
+        # Note: This is a sync method but _get_kb_info is async
+        # We need to handle this carefully
+        try:
+            import asyncio
 
-            max_calls = kb_spec.get(
-                "maxCallsPerConversation", DEFAULT_MAX_CALLS_PER_CONVERSATION
-            )
-            exempt_calls = kb_spec.get(
-                "exemptCallsBeforeCheck", DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
-            )
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # If called from async context, cache should already be populated
+                if self._kb_info_cache is None:
+                    logger.warning(
+                        "[KnowledgeBaseTool] _get_kb_limits called before KB info fetched, using defaults"
+                    )
+                    return (
+                        DEFAULT_MAX_CALLS_PER_CONVERSATION,
+                        DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                    )
+                kb_info = self._kb_info_cache
+            else:
+                # If called from sync context, fetch KB info synchronously
+                kb_info = loop.run_until_complete(self._get_kb_info())
+        except RuntimeError:
+            # No event loop, create a new one
+            kb_info = asyncio.run(self._get_kb_info())
 
-            # Validate config
-            if exempt_calls >= max_calls:
-                logger.warning(
-                    f"[KnowledgeBaseTool] Invalid KB config for KB {first_kb_id}: "
-                    f"exempt_calls={exempt_calls} >= max_calls={max_calls}. Using defaults."
+        # Extract config for first KB
+        first_kb_id = self.knowledge_base_ids[0]
+        items = kb_info.get("items", [])
+
+        for item in items:
+            if item.get("id") == first_kb_id:
+                max_calls = item.get(
+                    "max_calls_per_conversation", DEFAULT_MAX_CALLS_PER_CONVERSATION
                 )
-                return (
-                    DEFAULT_MAX_CALLS_PER_CONVERSATION,
-                    DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                exempt_calls = item.get(
+                    "exempt_calls_before_check", DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
                 )
 
-            return max_calls, exempt_calls
+                # Validate config
+                if exempt_calls >= max_calls:
+                    logger.warning(
+                        f"[KnowledgeBaseTool] Invalid KB config for KB {first_kb_id}: "
+                        f"exempt_calls={exempt_calls} >= max_calls={max_calls}. Using defaults."
+                    )
+                    return (
+                        DEFAULT_MAX_CALLS_PER_CONVERSATION,
+                        DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                    )
 
-        # Fallback to defaults if no config injected
-        logger.debug("[KnowledgeBaseTool] No kb_configs injected, using default limits")
+                return max_calls, exempt_calls
+
+        # KB not found in response, use defaults
+        logger.debug(
+            "[KnowledgeBaseTool] No config found for KB %d, using default limits",
+            first_kb_id,
+        )
         return DEFAULT_MAX_CALLS_PER_CONVERSATION, DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
 
     def _estimate_tokens_from_content(self, content: str) -> int:
@@ -297,15 +321,43 @@ class KnowledgeBaseTool(BaseTool):
         return True, None, None
 
     def _get_kb_name(self) -> str:
-        """Get the name of the first knowledge base."""
+        """Get the name of the first knowledge base.
+
+        Fetches from Backend API via _get_kb_info() (cached).
+
+        Returns:
+            KB name or "KB-{id}" as fallback
+        """
         if not self.knowledge_base_ids:
             return "Unknown"
 
         first_kb_id = self.knowledge_base_ids[0]
 
-        # Use injected config if available
-        if self.kb_configs:
-            return self.kb_configs.get(first_kb_id, {}).get("name", f"KB-{first_kb_id}")
+        # Get KB info from cache or HTTP API
+        try:
+            import asyncio
+
+            loop = asyncio.get_event_loop()
+            if loop.is_running():
+                # If called from async context, cache should already be populated
+                if self._kb_info_cache is None:
+                    logger.warning(
+                        "[KnowledgeBaseTool] _get_kb_name called before KB info fetched"
+                    )
+                    return f"KB-{first_kb_id}"
+                kb_info = self._kb_info_cache
+            else:
+                # If called from sync context, fetch KB info synchronously
+                kb_info = loop.run_until_complete(self._get_kb_info())
+        except RuntimeError:
+            # No event loop, create a new one
+            kb_info = asyncio.run(self._get_kb_info())
+
+        # Extract name for first KB
+        items = kb_info.get("items", [])
+        for item in items:
+            if item.get("id") == first_kb_id:
+                return item.get("name", f"KB-{first_kb_id}")
 
         # Fallback to ID-based name
         return f"KB-{first_kb_id}"
@@ -409,6 +461,7 @@ class KnowledgeBaseTool(BaseTool):
         """Execute knowledge base search with intelligent injection strategy.
 
         The strategy is:
+        0. Fetch KB info (size, config, name) and populate cache if not already fetched
         1. Check call limits (count and token thresholds)
         2. If rejected, return rejection message
         3. Get the total file size of all knowledge bases
@@ -430,6 +483,10 @@ class KnowledgeBaseTool(BaseTool):
                 return json.dumps(
                     {"error": "No knowledge bases configured for this conversation."}
                 )
+
+            # Step 0: Fetch KB info to populate cache (if not already fetched)
+            # This ensures _get_kb_limits() and _get_kb_name() can access cached data
+            await self._get_kb_info()
 
             # Step 1: Check call limits BEFORE executing search
             max_calls, _exempt_calls = self._get_kb_limits()
@@ -453,11 +510,11 @@ class KnowledgeBaseTool(BaseTool):
                 )
             )
 
-            # Step 1: Get knowledge base size information to decide strategy
-            kb_size_info = await self._get_kb_size_info()
-            total_estimated_tokens = kb_size_info.get("total_estimated_tokens", 0)
+            # Step 2: Get knowledge base info to decide strategy (already cached from Step 0)
+            kb_info = await self._get_kb_info()
+            total_estimated_tokens = kb_info.get("total_estimated_tokens", 0)
 
-            # Step 2: Decide strategy based on estimated tokens vs context window
+            # Step 3: Decide strategy based on estimated tokens vs context window
             should_use_direct_injection = self._should_use_direct_injection(
                 total_estimated_tokens
             )
@@ -470,7 +527,7 @@ class KnowledgeBaseTool(BaseTool):
             )
 
             if should_use_direct_injection:
-                # Step 3a: Get all chunks and inject directly
+                # Step 4a: Get all chunks and inject directly
                 kb_chunks = await self._get_all_chunks_from_all_kbs(query)
 
                 if not kb_chunks:
@@ -585,51 +642,31 @@ class KnowledgeBaseTool(BaseTool):
 
         return should_inject
 
-    async def _get_kb_size_info(self) -> Dict[str, Any]:
-        """Get size information for all knowledge bases.
+    async def _get_kb_info(self) -> Dict[str, Any]:
+        """Get complete knowledge base information (cached).
+
+        Fetches KB size, configuration, and metadata from Backend API.
+        Results are cached for the lifetime of the tool instance (one conversation).
 
         Returns:
-            Dictionary with total_file_size and total_estimated_tokens
+            Dictionary with:
+                - total_file_size: Total file size in bytes
+                - total_estimated_tokens: Estimated token count
+                - items: List of KB info dicts with id, size, config, name
         """
-        # Try to import from backend if available
-        try:
-            from app.services.knowledge_service import KnowledgeService
+        # Return cached result if available
+        if self._kb_info_cache is not None:
+            return self._kb_info_cache
 
-            total_file_size = 0
-            total_estimated_tokens = 0
+        # Fetch via HTTP API (only mode supported)
+        self._kb_info_cache = await self._get_kb_info_via_http()
+        return self._kb_info_cache
 
-            for kb_id in self.knowledge_base_ids:
-                try:
-                    file_size = KnowledgeService.get_total_file_size(
-                        self.db_session, kb_id
-                    )
-                    total_file_size += file_size
-                    # Estimate tokens: approximately 4 characters per token
-                    total_estimated_tokens += file_size // 4
-                except Exception as e:
-                    logger.warning(
-                        f"[KnowledgeBaseTool] Failed to get size for KB {kb_id}: {e}"
-                    )
-
-            logger.info(
-                f"[KnowledgeBaseTool] KB size info: total_file_size={total_file_size} bytes, "
-                f"total_estimated_tokens={total_estimated_tokens}"
-            )
-
-            return {
-                "total_file_size": total_file_size,
-                "total_estimated_tokens": total_estimated_tokens,
-            }
-
-        except ImportError:
-            # Backend not available, try HTTP fallback
-            return await self._get_kb_size_info_via_http()
-
-    async def _get_kb_size_info_via_http(self) -> Dict[str, Any]:
-        """Get KB size information via HTTP API.
+    async def _get_kb_info_via_http(self) -> Dict[str, Any]:
+        """Get KB information via HTTP API.
 
         Returns:
-            Dictionary with total_file_size and total_estimated_tokens
+            Dictionary with total_file_size, total_estimated_tokens, and items list
         """
         import httpx
 
@@ -652,7 +689,7 @@ class KnowledgeBaseTool(BaseTool):
                 if response.status_code == 200:
                     data = response.json()
                     logger.info(
-                        f"[KnowledgeBaseTool] KB size info: "
+                        f"[KnowledgeBaseTool] KB info fetched: "
                         f"total_file_size={data.get('total_file_size', 0)} bytes, "
                         f"total_estimated_tokens={data.get('total_estimated_tokens', 0)} "
                         f"(via HTTP)"
@@ -660,17 +697,17 @@ class KnowledgeBaseTool(BaseTool):
                     return data
                 else:
                     logger.warning(
-                        f"[KnowledgeBaseTool] HTTP KB size request failed: {response.status_code}, "
-                        f"returning total_file_size=0, total_estimated_tokens=0"
+                        f"[KnowledgeBaseTool] HTTP KB info request failed: {response.status_code}, "
+                        f"returning defaults"
                     )
-                    return {"total_file_size": 0, "total_estimated_tokens": 0}
+                    return {"total_file_size": 0, "total_estimated_tokens": 0, "items": []}
 
         except Exception as e:
             logger.warning(
-                f"[KnowledgeBaseTool] HTTP KB size request error: {e}, "
-                f"returning total_file_size=0, total_estimated_tokens=0"
+                f"[KnowledgeBaseTool] HTTP KB info request error: {e}, "
+                f"returning defaults"
             )
-            return {"total_file_size": 0, "total_estimated_tokens": 0}
+            return {"total_file_size": 0, "total_estimated_tokens": 0, "items": []}
 
     async def _get_all_chunks_from_all_kbs(
         self, query: Optional[str] = None

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -21,6 +21,14 @@ from ..knowledge_injection_strategy import InjectionMode, InjectionStrategy
 
 logger = logging.getLogger(__name__)
 
+# Token thresholds for call limit enforcement (hardcoded, not configurable)
+TOKEN_WARNING_THRESHOLD = 0.70  # 70%: Strong warning but allow
+TOKEN_REJECT_THRESHOLD = 0.90  # 90%: Reject call
+
+# Default configuration values (used when KB spec doesn't specify)
+DEFAULT_MAX_CALLS_PER_CONVERSATION = 10
+DEFAULT_EXEMPT_CALLS_BEFORE_CHECK = 5
+
 
 class KnowledgeBaseInput(BaseModel):
     """Input schema for knowledge base retrieval tool."""
@@ -92,6 +100,14 @@ class KnowledgeBaseTool(BaseTool):
     # Injection strategy instance (lazy initialized)
     _injection_strategy: Optional[InjectionStrategy] = None
 
+    # Tool call limit tracking (per conversation)
+    # These are instance variables that persist across multiple tool calls in the same conversation
+    _call_count: int = 0
+    _accumulated_tokens: int = 0
+
+    # Knowledge base call limit configuration (fetched from KB spec)
+    _kb_configs: Optional[Dict[int, Dict[str, Any]]] = None
+
     @property
     def injection_strategy(self) -> InjectionStrategy:
         """Get or create injection strategy instance."""
@@ -105,6 +121,292 @@ class KnowledgeBaseTool(BaseTool):
                 context_buffer_ratio=self.context_buffer_ratio,
             )
         return self._injection_strategy
+
+    def _get_kb_limits(self) -> tuple[int, int]:
+        """Get (max_calls, exempt_calls) for knowledge base tool calls.
+
+        Returns limits for the first knowledge base in the list. If multiple KBs
+        are configured, we use the first one's limits to keep behavior simple.
+
+        Returns:
+            Tuple of (max_calls_per_conversation, exempt_calls_before_check)
+        """
+        if not self.knowledge_base_ids:
+            return DEFAULT_MAX_CALLS_PER_CONVERSATION, DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
+
+        # Lazy load KB configs if not already loaded
+        if self._kb_configs is None:
+            self._kb_configs = self._fetch_kb_configs()
+
+        # Use the first KB's configuration
+        first_kb_id = self.knowledge_base_ids[0]
+        kb_spec = self._kb_configs.get(first_kb_id, {})
+
+        max_calls = kb_spec.get(
+            "maxCallsPerConversation", DEFAULT_MAX_CALLS_PER_CONVERSATION
+        )
+        exempt_calls = kb_spec.get(
+            "exemptCallsBeforeCheck", DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
+        )
+
+        # Validate config
+        if exempt_calls >= max_calls:
+            logger.warning(
+                f"[KnowledgeBaseTool] Invalid KB config for KB {first_kb_id}: "
+                f"exempt_calls={exempt_calls} >= max_calls={max_calls}. Using defaults."
+            )
+            return DEFAULT_MAX_CALLS_PER_CONVERSATION, DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
+
+        return max_calls, exempt_calls
+
+    def _fetch_kb_configs(self) -> Dict[int, Dict[str, Any]]:
+        """Fetch configurations for all knowledge bases.
+
+        Returns:
+            Dictionary mapping KB IDs to their spec configurations
+        """
+        configs = {}
+
+        try:
+            # Try to import from backend if available (package mode)
+            from app.services.knowledge_service import KnowledgeService
+
+            for kb_id in self.knowledge_base_ids:
+                try:
+                    kb_kind = KnowledgeService.get_knowledge_base(
+                        self.db_session, kb_id
+                    )
+                    if kb_kind:
+                        spec = kb_kind.json.get("spec", {})
+                        configs[kb_id] = {
+                            "maxCallsPerConversation": spec.get(
+                                "maxCallsPerConversation",
+                                DEFAULT_MAX_CALLS_PER_CONVERSATION,
+                            ),
+                            "exemptCallsBeforeCheck": spec.get(
+                                "exemptCallsBeforeCheck",
+                                DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                            ),
+                            "name": spec.get("name", f"KB-{kb_id}"),
+                        }
+                except Exception as e:
+                    logger.warning(
+                        f"[KnowledgeBaseTool] Failed to fetch config for KB {kb_id}: {e}"
+                    )
+                    configs[kb_id] = {
+                        "maxCallsPerConversation": DEFAULT_MAX_CALLS_PER_CONVERSATION,
+                        "exemptCallsBeforeCheck": DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                        "name": f"KB-{kb_id}",
+                    }
+
+        except ImportError:
+            # Backend not available, all KBs use defaults
+            # In HTTP mode, we could fetch via API, but for simplicity using defaults
+            logger.info(
+                "[KnowledgeBaseTool] Backend not available, using default KB configs"
+            )
+            for kb_id in self.knowledge_base_ids:
+                configs[kb_id] = {
+                    "maxCallsPerConversation": DEFAULT_MAX_CALLS_PER_CONVERSATION,
+                    "exemptCallsBeforeCheck": DEFAULT_EXEMPT_CALLS_BEFORE_CHECK,
+                    "name": f"KB-{kb_id}",
+                }
+
+        return configs
+
+    def _estimate_tokens_from_content(self, content: str) -> int:
+        """Estimate tokens from text content.
+
+        Uses the simple heuristic: ~4 characters per token.
+
+        Args:
+            content: Text content
+
+        Returns:
+            Estimated token count
+        """
+        return len(content) // 4
+
+    def _check_call_limits(
+        self, query: str
+    ) -> tuple[bool, Optional[str], Optional[str]]:
+        """Check if the tool call should be allowed based on limits.
+
+        Args:
+            query: Search query
+
+        Returns:
+            Tuple of (should_allow, rejection_reason, warning_level)
+            - should_allow: True if call should proceed
+            - rejection_reason: Reason string if rejected, None otherwise
+            - warning_level: "strong" if warning needed, None otherwise
+        """
+        max_calls, exempt_calls = self._get_kb_limits()
+        kb_name = self._get_kb_name()
+
+        # Increment call count (do this before checks so logging is accurate)
+        current_call = self._call_count + 1
+
+        # Check 1: Hard limit (max calls exceeded)
+        if current_call > max_calls:
+            logger.warning(
+                "[KnowledgeBaseTool] Call REJECTED | Reason: max_calls_exceeded | "
+                "Call count: %d/%d | KB: %s",
+                self._call_count,
+                max_calls,
+                kb_name,
+            )
+            return (
+                False,
+                "max_calls_exceeded",
+                None,
+            )
+
+        # Check 2: Token threshold (only after exempt period)
+        if current_call > exempt_calls:
+            # Calculate current token usage percentage
+            usage_percent = (
+                self._accumulated_tokens / self.context_window
+                if self.context_window
+                else 0.0
+            )
+
+            # Token >= 90%: Reject
+            if usage_percent >= TOKEN_REJECT_THRESHOLD:
+                logger.warning(
+                    "[KnowledgeBaseTool] Call REJECTED | Reason: token_limit_exceeded | "
+                    "Call count: %d/%d | Token usage: %.1f%% | KB: %s",
+                    self._call_count,
+                    max_calls,
+                    usage_percent * 100,
+                    kb_name,
+                )
+                return False, "token_limit_exceeded", None
+
+            # Token >= 70%: Strong warning but allow
+            elif usage_percent >= TOKEN_WARNING_THRESHOLD:
+                logger.warning(
+                    "[KnowledgeBaseTool] Call %d/%d (check period) | KB: %s | Query: %s | "
+                    "Token: %d/%d (%.1f%%, threshold: 70%%) | Status: allowed_with_strong_warning",
+                    current_call,
+                    max_calls,
+                    kb_name,
+                    query[:50],
+                    self._accumulated_tokens,
+                    self.context_window or 0,
+                    usage_percent * 100,
+                )
+                return True, None, "strong"
+
+            # Token < 70%: Allow without warning
+            else:
+                logger.info(
+                    "[KnowledgeBaseTool] Call %d/%d (check period) | KB: %s | Query: %s | "
+                    "Token: %d/%d (%.1f%%) | Status: allowed",
+                    current_call,
+                    max_calls,
+                    kb_name,
+                    query[:50],
+                    self._accumulated_tokens,
+                    self.context_window or 0,
+                    usage_percent * 100,
+                )
+                return True, None, None
+
+        # Exempt period: Allow without checks
+        logger.info(
+            "[KnowledgeBaseTool] Call %d/%d (exempt period) | KB: %s | Query: %s",
+            current_call,
+            max_calls,
+            kb_name,
+            query[:50],
+        )
+        return True, None, None
+
+    def _get_kb_name(self) -> str:
+        """Get the name of the first knowledge base."""
+        if not self.knowledge_base_ids:
+            return "Unknown"
+
+        if self._kb_configs is None:
+            self._kb_configs = self._fetch_kb_configs()
+
+        first_kb_id = self.knowledge_base_ids[0]
+        return self._kb_configs.get(first_kb_id, {}).get("name", f"KB-{first_kb_id}")
+
+    def _format_rejection_message(self, rejection_reason: str, max_calls: int) -> str:
+        """Format rejection message based on reason.
+
+        Args:
+            rejection_reason: "max_calls_exceeded" or "token_limit_exceeded"
+            max_calls: Maximum calls configured
+
+        Returns:
+            JSON string with rejection message
+        """
+        usage_percent = (
+            (self._accumulated_tokens / self.context_window * 100)
+            if self.context_window
+            else 0.0
+        )
+
+        if rejection_reason == "max_calls_exceeded":
+            message = (
+                f"🚫 Call Rejected: Maximum call limit ({max_calls}) reached for this conversation.\n"
+                f"You have made {self._call_count} successful calls. "
+                f"Please use the information you've already gathered to provide your response."
+            )
+        else:  # token_limit_exceeded
+            message = (
+                f"🚫 Call Rejected: Knowledge base content has already consumed {usage_percent:.1f}% "
+                f"of the context window.\n"
+                f"You have made {self._call_count} successful calls. "
+                f"Please use the information you've gathered to provide your response."
+            )
+
+        return json.dumps(
+            {
+                "status": "rejected",
+                "reason": rejection_reason,
+                "message": message,
+                "call_count": self._call_count,
+                "max_calls": max_calls,
+                "token_usage_percent": usage_percent,
+            },
+            ensure_ascii=False,
+        )
+
+    def _build_call_statistics_header(
+        self, warning_level: Optional[str], chunks_count: int
+    ) -> str:
+        """Build call statistics header with optional warning.
+
+        Args:
+            warning_level: "strong" if warning needed, None otherwise
+            chunks_count: Number of chunks retrieved
+
+        Returns:
+            Formatted header string (prepended to search results)
+        """
+        max_calls, _ = self._get_kb_limits()
+        current_call = self._call_count + 1  # After this call completes
+
+        header = f"[Knowledge Base Search - Call {current_call}/{max_calls}]\n"
+        header += f"Retrieved {chunks_count} chunks from knowledge base.\n"
+
+        if warning_level == "strong":
+            usage_percent = (
+                (self._accumulated_tokens / self.context_window * 100)
+                if self.context_window
+                else 0.0
+            )
+            header += (
+                f"\n🚨 Strong Warning: Knowledge base content has consumed {usage_percent:.1f}% "
+                f"of the context window.\n"
+                f"Please prioritize using existing information to answer the user's question.\n"
+            )
+
+        return header
 
     def _run(
         self,
@@ -124,10 +426,13 @@ class KnowledgeBaseTool(BaseTool):
         """Execute knowledge base search with intelligent injection strategy.
 
         The strategy is:
-        1. First get the total file size of all knowledge bases
-        2. Estimate token count from file size
-        3. If estimated tokens fit in context window, get all chunks and inject directly
-        4. Otherwise, use RAG retrieval to get relevant chunks
+        1. Check call limits (count and token thresholds)
+        2. If rejected, return rejection message
+        3. Get the total file size of all knowledge bases
+        4. Estimate token count from file size
+        5. If estimated tokens fit in context window, get all chunks and inject directly
+        6. Otherwise, use RAG retrieval to get relevant chunks
+        7. Update call count and accumulated tokens
 
         Args:
             query: Search query
@@ -142,6 +447,16 @@ class KnowledgeBaseTool(BaseTool):
                 return json.dumps(
                     {"error": "No knowledge bases configured for this conversation."}
                 )
+
+            # Step 1: Check call limits BEFORE executing search
+            max_calls, exempt_calls = self._get_kb_limits()
+            should_allow, rejection_reason, warning_level = self._check_call_limits(
+                query
+            )
+
+            if not should_allow:
+                # Return rejection message without incrementing call count
+                return self._format_rejection_message(rejection_reason, max_calls)
 
             # Note: db_session may be None in HTTP mode (chat_shell running independently)
             # In that case, we use HTTP API to communicate with backend
@@ -201,7 +516,9 @@ class KnowledgeBaseTool(BaseTool):
                     logger.info(
                         f"[KnowledgeBaseTool] Direct injection: {len(injection_result.get('chunks_used', []))} chunks"
                     )
-                    return self._format_direct_injection_result(injection_result, query)
+                    return self._format_direct_injection_result(
+                        injection_result, query, warning_level
+                    )
                 else:
                     # Fallback to RAG if injection strategy decides not to inject
                     logger.info(
@@ -210,7 +527,9 @@ class KnowledgeBaseTool(BaseTool):
                     kb_chunks = await self._retrieve_chunks_from_all_kbs(
                         query, max_results
                     )
-                    return await self._format_rag_result(kb_chunks, query, max_results)
+                    return await self._format_rag_result(
+                        kb_chunks, query, max_results, warning_level
+                    )
             else:
                 # Step 3b: Use RAG retrieval
                 logger.info(
@@ -231,7 +550,9 @@ class KnowledgeBaseTool(BaseTool):
                         ensure_ascii=False,
                     )
 
-                return await self._format_rag_result(kb_chunks, query, max_results)
+                return await self._format_rag_result(
+                    kb_chunks, query, max_results, warning_level
+                )
 
         except Exception as e:
             logger.error(f"[KnowledgeBaseTool] Search failed: {e}", exc_info=True)
@@ -707,18 +1028,30 @@ class KnowledgeBaseTool(BaseTool):
         self,
         injection_result: Dict[str, Any],
         query: str,
+        warning_level: Optional[str] = None,
     ) -> str:
         """Format result for direct injection mode.
 
         Args:
             injection_result: Result from injection strategy
             query: Original search query
+            warning_level: "strong" if warning needed, None otherwise
 
         Returns:
             JSON string with injection result
         """
         # Extract chunks used for persistence
         chunks_used = injection_result.get("chunks_used", [])
+
+        # Update call count and accumulated tokens
+        self._call_count += 1
+        injected_content = injection_result.get("injected_content", "")
+        self._accumulated_tokens += self._estimate_tokens_from_content(injected_content)
+
+        # Build call statistics header
+        stats_header = self._build_call_statistics_header(
+            warning_level, len(chunks_used)
+        )
 
         # Build source references from chunks_used
         source_references = []
@@ -749,6 +1082,7 @@ class KnowledgeBaseTool(BaseTool):
             {
                 "query": query,
                 "mode": "direct_injection",
+                "stats_header": stats_header,
                 "injected_content": injection_result["injected_content"],
                 "chunks_used": len(chunks_used),
                 "count": len(chunks_used),
@@ -767,6 +1101,7 @@ class KnowledgeBaseTool(BaseTool):
         kb_chunks: Dict[int, List[Dict[str, Any]]],
         query: str,
         max_results: int,
+        warning_level: Optional[str] = None,
     ) -> str:
         """Format result for RAG fallback mode.
 
@@ -774,6 +1109,7 @@ class KnowledgeBaseTool(BaseTool):
             kb_chunks: Dictionary mapping KB IDs to their chunks
             query: Original search query
             max_results: Maximum number of results
+            warning_level: "strong" if warning needed, None otherwise
 
         Returns:
             JSON string with RAG result
@@ -816,6 +1152,16 @@ class KnowledgeBaseTool(BaseTool):
         # Limit total results
         all_chunks = all_chunks[:max_results]
 
+        # Update call count and accumulated tokens
+        self._call_count += 1
+        total_content = "\n".join([chunk["content"] for chunk in all_chunks])
+        self._accumulated_tokens += self._estimate_tokens_from_content(total_content)
+
+        # Build call statistics header
+        stats_header = self._build_call_statistics_header(
+            warning_level, len(all_chunks)
+        )
+
         logger.info(
             f"[KnowledgeBaseTool] RAG fallback: returning {len(all_chunks)} results with {len(source_references)} unique sources for query: {query}"
         )
@@ -828,6 +1174,7 @@ class KnowledgeBaseTool(BaseTool):
             {
                 "query": query,
                 "mode": "rag_retrieval",
+                "stats_header": stats_header,
                 "results": all_chunks,
                 "count": len(all_chunks),
                 "sources": source_references,

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -25,7 +25,6 @@ async def prepare_knowledge_base_tools(
     is_user_selected: bool = True,
     document_ids: Optional[list[int]] = None,
     context_window: Optional[int] = None,
-    kb_configs: Optional[dict[int, dict]] = None,
     skip_prompt_enhancement: bool = False,
 ) -> tuple[list, str]:
     """
@@ -48,8 +47,6 @@ async def prepare_knowledge_base_tools(
             When set, only chunks from these specific documents will be returned.
         context_window: Optional context window size from Model CRD.
             Used by KnowledgeBaseTool for injection strategy decisions.
-        kb_configs: Optional KB call limit configurations (max calls, exempt calls, name).
-            Injected by Backend in both package mode and HTTP mode.
         skip_prompt_enhancement: If True, skip adding KB prompt instructions to system prompt.
             Used in HTTP mode when Backend has already added KB prompts to avoid duplication.
 
@@ -70,23 +67,19 @@ async def prepare_knowledge_base_tools(
 
     logger.info(
         "[knowledge_factory] Creating KnowledgeBaseTool for %d knowledge bases: %s, "
-        "is_user_selected=%s, document_ids=%s, context_window=%s, kb_configs=%s",
+        "is_user_selected=%s, document_ids=%s, context_window=%s",
         len(knowledge_base_ids),
         knowledge_base_ids,
         is_user_selected,
         document_ids,
         context_window,
-        kb_configs is not None,
     )
 
     # Import KnowledgeBaseTool
     from chat_shell.tools.builtin import KnowledgeBaseTool
 
     # Create KnowledgeBaseTool with the specified knowledge bases
-    # Pass user_subtask_id for persisting RAG results to context database
-    # Pass document_ids for filtering to specific documents
-    # Pass context_window from Model CRD for injection strategy decisions
-    # Pass kb_configs for call limit enforcement (injected by Backend)
+    # KB configs (max_calls, exempt_calls, name) are fetched from Backend API
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         document_ids=document_ids or [],
@@ -94,7 +87,6 @@ async def prepare_knowledge_base_tools(
         db_session=db,
         user_subtask_id=user_subtask_id,
         context_window=context_window,
-        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -25,6 +25,7 @@ async def prepare_knowledge_base_tools(
     is_user_selected: bool = True,
     document_ids: Optional[list[int]] = None,
     context_window: Optional[int] = None,
+    kb_configs: Optional[dict[int, dict]] = None,
     skip_prompt_enhancement: bool = False,
 ) -> tuple[list, str]:
     """
@@ -47,6 +48,8 @@ async def prepare_knowledge_base_tools(
             When set, only chunks from these specific documents will be returned.
         context_window: Optional context window size from Model CRD.
             Used by KnowledgeBaseTool for injection strategy decisions.
+        kb_configs: Optional KB call limit configurations (max calls, exempt calls, name).
+            Injected by Backend in both package mode and HTTP mode.
         skip_prompt_enhancement: If True, skip adding KB prompt instructions to system prompt.
             Used in HTTP mode when Backend has already added KB prompts to avoid duplication.
 
@@ -67,12 +70,13 @@ async def prepare_knowledge_base_tools(
 
     logger.info(
         "[knowledge_factory] Creating KnowledgeBaseTool for %d knowledge bases: %s, "
-        "is_user_selected=%s, document_ids=%s, context_window=%s",
+        "is_user_selected=%s, document_ids=%s, context_window=%s, kb_configs=%s",
         len(knowledge_base_ids),
         knowledge_base_ids,
         is_user_selected,
         document_ids,
         context_window,
+        kb_configs is not None,
     )
 
     # Import KnowledgeBaseTool
@@ -82,6 +86,7 @@ async def prepare_knowledge_base_tools(
     # Pass user_subtask_id for persisting RAG results to context database
     # Pass document_ids for filtering to specific documents
     # Pass context_window from Model CRD for injection strategy decisions
+    # Pass kb_configs for call limit enforcement (injected by Backend)
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         document_ids=document_ids or [],
@@ -89,6 +94,7 @@ async def prepare_knowledge_base_tools(
         db_session=db,
         user_subtask_id=user_subtask_id,
         context_window=context_window,
+        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/chat_shell/tests/test_kb_prompt_deduplication.py
+++ b/chat_shell/tests/test_kb_prompt_deduplication.py
@@ -180,9 +180,7 @@ class TestKnowledgeFactorySkipPromptEnhancement:
         kb_ids = [1, 2]
 
         # Mock the KnowledgeBaseTool import in knowledge_factory
-        with patch(
-            "chat_shell.tools.builtin.KnowledgeBaseTool"
-        ) as mock_kb_tool_class:
+        with patch("chat_shell.tools.builtin.KnowledgeBaseTool") as mock_kb_tool_class:
             mock_kb_tool_class.return_value = MagicMock()
 
             tools, enhanced_prompt = await prepare_knowledge_base_tools(
@@ -209,9 +207,7 @@ class TestKnowledgeFactorySkipPromptEnhancement:
         kb_ids = [1, 2]
 
         # Mock the KnowledgeBaseTool import in knowledge_factory
-        with patch(
-            "chat_shell.tools.builtin.KnowledgeBaseTool"
-        ) as mock_kb_tool_class:
+        with patch("chat_shell.tools.builtin.KnowledgeBaseTool") as mock_kb_tool_class:
             mock_kb_tool_class.return_value = MagicMock()
 
             tools, enhanced_prompt = await prepare_knowledge_base_tools(

--- a/chat_shell/tests/test_knowledge_base_call_limits.py
+++ b/chat_shell/tests/test_knowledge_base_call_limits.py
@@ -1,0 +1,193 @@
+"""Test knowledge base tool call limits with injected configuration.
+
+This test verifies that KB call limit configuration is properly injected
+and used by KnowledgeBaseTool in both package mode and HTTP mode.
+"""
+
+import pytest
+
+from chat_shell.tools.builtin import KnowledgeBaseTool
+
+
+class TestKnowledgeBaseCallLimitsInjection:
+    """Test KB call limit configuration injection."""
+
+    def test_kb_configs_injected_and_used(self):
+        """Test that injected kb_configs are used for call limits."""
+        # Arrange: Create tool with injected kb_configs
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 15,
+                "exemptCallsBeforeCheck": 7,
+                "name": "Test KB 1",
+            },
+            2: {
+                "maxCallsPerConversation": 20,
+                "exemptCallsBeforeCheck": 10,
+                "name": "Test KB 2",
+            },
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1, 2],
+            user_id=123,
+            context_window=200000,
+            kb_configs=kb_configs,
+        )
+
+        # Act: Get limits
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses first KB's config
+        assert max_calls == 15
+        assert exempt_calls == 7
+
+    def test_kb_name_from_injected_config(self):
+        """Test that KB name is extracted from injected config."""
+        # Arrange
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 10,
+                "exemptCallsBeforeCheck": 5,
+                "name": "My Custom KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        kb_name = tool._get_kb_name()
+
+        # Assert
+        assert kb_name == "My Custom KB"
+
+    def test_fallback_to_defaults_when_no_config(self):
+        """Test fallback to default limits when kb_configs is None."""
+        # Arrange: No kb_configs injected
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+            kb_configs=None,  # No config injected
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses defaults
+        assert max_calls == 10  # DEFAULT_MAX_CALLS_PER_CONVERSATION
+        assert exempt_calls == 5  # DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
+
+    def test_fallback_name_when_no_config(self):
+        """Test fallback to KB-{id} name when no config."""
+        # Arrange
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[123],
+            user_id=456,
+            kb_configs=None,
+        )
+
+        # Act
+        kb_name = tool._get_kb_name()
+
+        # Assert
+        assert kb_name == "KB-123"
+
+    def test_invalid_config_validation(self):
+        """Test that invalid config (exempt >= max) falls back to defaults."""
+        # Arrange: Invalid config
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 10,
+                "exemptCallsBeforeCheck": 15,  # Invalid: >= max
+                "name": "Invalid KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Falls back to defaults
+        assert max_calls == 10
+        assert exempt_calls == 5
+
+    def test_multiple_kbs_uses_first_config(self):
+        """Test that with multiple KBs, first KB's config is used."""
+        # Arrange
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 15,
+                "exemptCallsBeforeCheck": 7,
+                "name": "First KB",
+            },
+            2: {
+                "maxCallsPerConversation": 25,
+                "exemptCallsBeforeCheck": 12,
+                "name": "Second KB",
+            },
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1, 2],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+        kb_name = tool._get_kb_name()
+
+        # Assert: Uses first KB's config
+        assert max_calls == 15
+        assert exempt_calls == 7
+        assert kb_name == "First KB"
+
+    def test_partial_config_uses_defaults_for_missing_fields(self):
+        """Test that missing fields in config use defaults."""
+        # Arrange: Partial config (missing exemptCallsBeforeCheck)
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 20,
+                # Missing exemptCallsBeforeCheck
+                "name": "Partial KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses provided max_calls, defaults for exempt
+        assert max_calls == 20
+        assert exempt_calls == 5  # Default
+
+    def test_empty_knowledge_base_ids_returns_defaults(self):
+        """Test that empty KB IDs returns default limits."""
+        # Arrange
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[],
+            user_id=123,
+            kb_configs={},
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert
+        assert max_calls == 10
+        assert exempt_calls == 5

--- a/chat_shell/tests/test_knowledge_base_call_limits.py
+++ b/chat_shell/tests/test_knowledge_base_call_limits.py
@@ -1,176 +1,252 @@
-"""Test knowledge base tool call limits with injected configuration.
+"""Test knowledge base tool call limits with HTTP-fetched configuration.
 
-This test verifies that KB call limit configuration is properly injected
-and used by KnowledgeBaseTool in both package mode and HTTP mode.
+This test verifies that KB call limit configuration is properly fetched
+from Backend API and used by KnowledgeBaseTool.
 """
 
 import pytest
+from unittest.mock import AsyncMock, patch
 
 from chat_shell.tools.builtin import KnowledgeBaseTool
 
 
-class TestKnowledgeBaseCallLimitsInjection:
-    """Test KB call limit configuration injection."""
+class TestKnowledgeBaseCallLimitsHTTP:
+    """Test KB call limit configuration fetching from HTTP API."""
 
-    def test_kb_configs_injected_and_used(self):
-        """Test that injected kb_configs are used for call limits."""
-        # Arrange: Create tool with injected kb_configs
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 15,
-                "exemptCallsBeforeCheck": 7,
-                "name": "Test KB 1",
-            },
-            2: {
-                "maxCallsPerConversation": 20,
-                "exemptCallsBeforeCheck": 10,
-                "name": "Test KB 2",
-            },
-        }
-
+    @pytest.mark.asyncio
+    async def test_kb_info_fetched_and_used(self):
+        """Test that KB info is fetched from HTTP API and used for call limits."""
+        # Arrange: Create tool without any injected config
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1, 2],
             user_id=123,
             context_window=200000,
-            kb_configs=kb_configs,
         )
 
-        # Act: Get limits
-        max_calls, exempt_calls = tool._get_kb_limits()
+        # Mock HTTP response
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 600,
+                    "document_count": 5,
+                    "estimated_tokens": 150,
+                    "max_calls_per_conversation": 15,
+                    "exempt_calls_before_check": 7,
+                    "name": "Test KB 1",
+                },
+                {
+                    "id": 2,
+                    "total_file_size": 400,
+                    "document_count": 3,
+                    "estimated_tokens": 100,
+                    "max_calls_per_conversation": 20,
+                    "exempt_calls_before_check": 10,
+                    "name": "Test KB 2",
+                },
+            ],
+        }
+
+        # Mock the HTTP call
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            # Act: Fetch KB info to populate cache
+            await tool._get_kb_info()
+
+            # Get limits (should use cached data)
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses first KB's config
         assert max_calls == 15
         assert exempt_calls == 7
 
-    def test_kb_name_from_injected_config(self):
-        """Test that KB name is extracted from injected config."""
+    @pytest.mark.asyncio
+    async def test_kb_name_from_http(self):
+        """Test that KB name is extracted from HTTP response."""
         # Arrange
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 5,
-                "name": "My Custom KB",
-            }
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        kb_name = tool._get_kb_name()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 10,
+                    "exempt_calls_before_check": 5,
+                    "name": "My Custom KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            # Populate cache
+            await tool._get_kb_info()
+
+            # Act
+            kb_name = tool._get_kb_name()
 
         # Assert
         assert kb_name == "My Custom KB"
 
-    def test_fallback_to_defaults_when_no_config(self):
-        """Test fallback to default limits when kb_configs is None."""
-        # Arrange: No kb_configs injected
+    def test_fallback_to_defaults_when_no_cache(self):
+        """Test fallback to default limits when cache is not populated."""
+        # Arrange: No HTTP call made, cache is None
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
             context_window=200000,
-            kb_configs=None,  # No config injected
         )
 
-        # Act
+        # Act: Get limits without populating cache (should use defaults)
         max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses defaults
         assert max_calls == 10  # DEFAULT_MAX_CALLS_PER_CONVERSATION
         assert exempt_calls == 5  # DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
 
-    def test_fallback_name_when_no_config(self):
-        """Test fallback to KB-{id} name when no config."""
+    def test_fallback_name_when_no_cache(self):
+        """Test fallback to KB-{id} name when cache is not populated."""
         # Arrange
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[123],
             user_id=456,
-            kb_configs=None,
         )
 
-        # Act
+        # Act: Get name without populating cache
         kb_name = tool._get_kb_name()
 
         # Assert
         assert kb_name == "KB-123"
 
-    def test_invalid_config_validation(self):
+    @pytest.mark.asyncio
+    async def test_invalid_config_validation(self):
         """Test that invalid config (exempt >= max) falls back to defaults."""
         # Arrange: Invalid config
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 15,  # Invalid: >= max
-                "name": "Invalid KB",
-            }
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 10,
+                    "exempt_calls_before_check": 15,  # Invalid: >= max
+                    "name": "Invalid KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Falls back to defaults
         assert max_calls == 10
         assert exempt_calls == 5
 
-    def test_multiple_kbs_uses_first_config(self):
+    @pytest.mark.asyncio
+    async def test_multiple_kbs_uses_first_config(self):
         """Test that with multiple KBs, first KB's config is used."""
         # Arrange
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 15,
-                "exemptCallsBeforeCheck": 7,
-                "name": "First KB",
-            },
-            2: {
-                "maxCallsPerConversation": 25,
-                "exemptCallsBeforeCheck": 12,
-                "name": "Second KB",
-            },
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1, 2],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
-        kb_name = tool._get_kb_name()
+        mock_kb_info = {
+            "total_file_size": 1400,
+            "total_estimated_tokens": 350,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 800,
+                    "document_count": 8,
+                    "estimated_tokens": 200,
+                    "max_calls_per_conversation": 15,
+                    "exempt_calls_before_check": 7,
+                    "name": "First KB",
+                },
+                {
+                    "id": 2,
+                    "total_file_size": 600,
+                    "document_count": 6,
+                    "estimated_tokens": 150,
+                    "max_calls_per_conversation": 25,
+                    "exempt_calls_before_check": 12,
+                    "name": "Second KB",
+                },
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
+            kb_name = tool._get_kb_name()
 
         # Assert: Uses first KB's config
         assert max_calls == 15
         assert exempt_calls == 7
         assert kb_name == "First KB"
 
-    def test_partial_config_uses_defaults_for_missing_fields(self):
-        """Test that missing fields in config use defaults."""
-        # Arrange: Partial config (missing exemptCallsBeforeCheck)
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 20,
-                # Missing exemptCallsBeforeCheck
-                "name": "Partial KB",
-            }
-        }
-
+    @pytest.mark.asyncio
+    async def test_partial_config_uses_defaults_for_missing_fields(self):
+        """Test that missing fields in response use defaults."""
+        # Arrange: Partial response (missing exempt_calls_before_check)
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 20,
+                    # Missing exempt_calls_before_check
+                    "name": "Partial KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses provided max_calls, defaults for exempt
         assert max_calls == 20
@@ -182,7 +258,6 @@ class TestKnowledgeBaseCallLimitsInjection:
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[],
             user_id=123,
-            kb_configs={},
         )
 
         # Act

--- a/chat_shell/tests/test_knowledge_injection_strategy.py
+++ b/chat_shell/tests/test_knowledge_injection_strategy.py
@@ -292,11 +292,22 @@ class TestKnowledgeBaseTool:
 
         # Mock HTTP methods to simulate HTTP mode
         with patch.object(
-            tool, "_get_kb_size_info_via_http", new_callable=AsyncMock
-        ) as mock_kb_size:
-            mock_kb_size.return_value = {
+            tool, "_get_kb_info_via_http", new_callable=AsyncMock
+        ) as mock_kb_info:
+            mock_kb_info.return_value = {
                 "total_file_size": 1000,
                 "total_estimated_tokens": 250,
+                "items": [
+                    {
+                        "id": 1,
+                        "total_file_size": 1000,
+                        "document_count": 10,
+                        "estimated_tokens": 250,
+                        "max_calls_per_conversation": 10,
+                        "exempt_calls_before_check": 5,
+                        "name": "Test KB",
+                    }
+                ],
             }
 
             with patch.object(

--- a/chat_shell/tests/test_knowledge_injection_strategy_clean.py
+++ b/chat_shell/tests/test_knowledge_injection_strategy_clean.py
@@ -268,11 +268,22 @@ class TestKnowledgeBaseToolClean:
 
         # Mock HTTP methods to simulate HTTP mode
         with patch.object(
-            tool, "_get_kb_size_info_via_http", new_callable=AsyncMock
-        ) as mock_kb_size:
-            mock_kb_size.return_value = {
+            tool, "_get_kb_info_via_http", new_callable=AsyncMock
+        ) as mock_kb_info:
+            mock_kb_info.return_value = {
                 "total_file_size": 1000,
                 "total_estimated_tokens": 250,
+                "items": [
+                    {
+                        "id": 1,
+                        "total_file_size": 1000,
+                        "document_count": 10,
+                        "estimated_tokens": 250,
+                        "max_calls_per_conversation": 10,
+                        "exempt_calls_before_check": 5,
+                        "name": "Test KB",
+                    }
+                ],
             }
 
             with patch.object(

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -302,6 +302,15 @@
       "modelPlaceholder": "Search models...",
       "noModel": "No model selected"
     },
+    "callLimits": {
+      "title": "Call Limits",
+      "description": "Limit the number of knowledge base tool calls per conversation to control token usage",
+      "maxCalls": "Maximum Calls",
+      "maxCallsHint": "Maximum number of knowledge base tool calls allowed per conversation (2-50)",
+      "exemptCalls": "Exempt Calls",
+      "exemptCallsHint": "Number of calls exempt from token checking (must be less than maximum calls)",
+      "validationError": "Exempt calls must be less than maximum calls"
+    },
     "retrievalTest": {
       "button": "Retrieval Test",
       "title": "Retrieval Test",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -302,6 +302,15 @@
       "modelPlaceholder": "搜索模型...",
       "noModel": "未选择模型"
     },
+    "callLimits": {
+      "title": "调用次数限制",
+      "description": "限制每次对话中知识库工具的调用次数，以控制 token 使用量",
+      "maxCalls": "最大调用次数",
+      "maxCallsHint": "每次对话允许的最大知识库工具调用次数 (2-50)",
+      "exemptCalls": "豁免检查次数",
+      "exemptCallsHint": "豁免 token 检查的调用次数 (必须小于最大调用次数)",
+      "validationError": "豁免次数必须小于最大调用次数"
+    },
     "retrievalTest": {
       "button": "召回测试",
       "title": "召回测试",

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -82,6 +82,10 @@ export interface KnowledgeBase {
   summary?: KnowledgeBaseSummary | null
   /** Knowledge base display type: 'notebook' (three-column with chat) or 'classic' (document list only) */
   kb_type?: KnowledgeBaseType
+  /** Maximum number of knowledge base tool calls allowed per conversation */
+  max_calls_per_conversation: number
+  /** Number of calls exempt from token checking (must be < max_calls_per_conversation) */
+  exempt_calls_before_check: number
   created_at: string
   updated_at: string
 }
@@ -113,6 +117,10 @@ export interface KnowledgeBaseUpdate {
   retrieval_config?: RetrievalConfigUpdate
   summary_enabled?: boolean
   summary_model_ref?: SummaryModelRef | null
+  /** Maximum number of knowledge base tool calls allowed per conversation */
+  max_calls_per_conversation?: number
+  /** Number of calls exempt from token checking (must be < max_calls_per_conversation) */
+  exempt_calls_before_check?: number
 }
 
 export interface KnowledgeBaseListResponse {


### PR DESCRIPTION
## Summary

Optimize knowledge base tool call limit mechanism by switching from dependency injection to HTTP API-based configuration fetching. This improves cohesion, enables caching, and simplifies the codebase.

## Changes

### Backend
1. **Extended `/api/internal/rag/kb-size` endpoint** with configuration fields:
   - `max_calls_per_conversation` (default: 10)
   - `exempt_calls_before_check` (default: 5)
   - `name` (for logging)

2. **Updated `KnowledgeBase` schema** to include call limit fields with validation

3. **Removed injection code** (~40 lines) from:
   - `backend/app/services/chat/preprocessing/contexts.py`
   - `backend/app/services/chat/adapters/http.py`
   - `chat_shell/chat_shell/api/v1/schemas.py`
   - `chat_shell/chat_shell/tools/knowledge_factory.py`
   - `chat_shell/chat_shell/services/context.py`

### Chat Shell (chat_shell)
1. **Refactored `KnowledgeBaseTool`** to fetch its own configuration:
   - Removed `kb_configs` field (dependency injection)
   - Added `_kb_info_cache` for caching HTTP responses
   - Removed dead code (package mode with wrong import path)
   - Added `_get_kb_info_sync()` helper (reduced 48 lines of duplication)
   - Added `_kb_name_cache` for optimized logging (reduced O(n) to O(1))

2. **Updated tests** to mock `_get_kb_info_via_http()` instead of injection

### Frontend
1. **Added TypeScript types** for call limit fields
2. **Added i18n translations** (English and Chinese)
3. **Added UI controls** in `EditKnowledgeBaseDialog`:
   - Slider for max_calls_per_conversation (2-50 range)
   - Slider for exempt_calls_before_check (1 to max-1 range)
   - Real-time value display
   - Validation with error messages

## Key Benefits

- **More cohesive**: All KB info fetching in one place (`_get_kb_info()`)
- **Cacheable**: Fetch once per conversation, reuse for limits/name/size
- **Simpler**: Removed ~90 lines of injection code across backend and chat_shell
- **Better extensibility**: Easy to add new fields to KB info response
- **No cross-module dependency**: HTTP API only, no backend imports needed
- **User-friendly**: Frontend UI for configuring call limits

## Testing

- All 177 Python tests passing
- Test coverage maintained at 40-60%
- Manual testing: Frontend UI works correctly with validation

## Migration Notes

- Existing knowledge bases will use default values (10, 5) if not configured
- Frontend UI allows users to customize these values per knowledge base
- No breaking changes to existing KB tool behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-knowledge-base call limits: configure max calls per conversation and exempt initial calls
  * UI controls to edit call limits with validation and localized strings
  * Token-usage monitoring with warning/reject thresholds and call-statistics headers in results
  * Richer knowledge-base info endpoint exposing limits and name

* **Bug Fixes**
  * Validation prevents invalid limit configurations

* **Tests**
  * Added comprehensive tests covering call-limit behaviors and fallbacks

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->