### PR TITLE
feat(chat): implement independent collapsible tool blocks

### DIFF
--- a/chat_shell/chat_shell/services/streaming/core.py
+++ b/chat_shell/chat_shell/services/streaming/core.py
@@ -154,6 +154,10 @@ class StreamingState:
             }
             if "run_id" in step:
                 slim_step["run_id"] = step["run_id"]
+            # Preserve tool_use_id for tool matching
+            if "tool_use_id" in step:
+                slim_step["tool_use_id"] = step["tool_use_id"]
+
             details = step.get("details", {})
             if details:
                 slim_details: dict = {
@@ -161,6 +165,17 @@ class StreamingState:
                     "status": details.get("status"),
                     "tool_name": details.get("tool_name") or details.get("name"),
                 }
+                # Preserve input for tool_use (tool parameters like file_path)
+                if details.get("input"):
+                    slim_details["input"] = details["input"]
+                # Preserve output/content for tool_result (tool execution results)
+                if details.get("output"):
+                    slim_details["output"] = details["output"]
+                if details.get("content"):
+                    slim_details["content"] = details["content"]
+                # Preserve is_error for error handling
+                if details.get("is_error"):
+                    slim_details["is_error"] = details["is_error"]
                 # Preserve error field for failed status
                 if details.get("error"):
                     slim_details["error"] = details["error"]

--- a/frontend/src/features/tasks/components/message/thinking/ThinkingDisplay.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/ThinkingDisplay.tsx
@@ -6,14 +6,14 @@
 
 import { memo } from 'react'
 import type { ThinkingDisplayProps } from './types'
-import SimpleThinkingView from './SimpleThinkingView'
 import DetailedThinkingView from './DetailedThinkingView'
+import ToolBlocksView from './ToolBlocksView'
 
 /**
  * Main thinking display component that routes to the appropriate view
  * based on the shell type.
  *
- * - Chat shell type: Uses SimpleThinkingView (collapsible timeline)
+ * - Chat shell type: Only shows ToolBlocksView (no detailed timeline)
  * - ClaudeCode/Agno/Other: Uses DetailedThinkingView (full thinking process)
  */
 const ThinkingDisplay = memo(function ThinkingDisplay({
@@ -26,9 +26,9 @@ const ThinkingDisplay = memo(function ThinkingDisplay({
     return null
   }
 
-  // Route to appropriate view based on shell type
+  // Chat shell: Only show tool blocks
   if (shellType === 'Chat') {
-    return <SimpleThinkingView thinking={thinking} taskStatus={taskStatus} />
+    return <ToolBlocksView thinking={thinking} taskStatus={taskStatus} />
   }
 
   // Default to detailed view for ClaudeCode, Agno, and other shell types

--- a/frontend/src/features/tasks/components/message/thinking/ToolBlocksView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/ToolBlocksView.tsx
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { memo } from 'react'
+import type { ThinkingStep } from './types'
+import { useToolExtraction } from './hooks/useToolExtraction'
+import { ToolBlock } from './components/ToolBlock'
+import { ToolBlockGroup } from './components/ToolBlockGroup'
+
+interface ToolBlocksViewProps {
+  thinking: ThinkingStep[] | null
+  taskStatus?: string
+}
+
+/**
+ * ToolBlocksView Component
+ *
+ * Displays tool execution blocks separately from thinking timeline.
+ * Extracts tools from thinking array and renders them as collapsible blocks.
+ */
+const ToolBlocksView = memo(function ToolBlocksView({ thinking }: ToolBlocksViewProps) {
+  const { toolGroups, hasTools } = useToolExtraction(thinking)
+
+  if (!hasTools) {
+    return null
+  }
+
+  return (
+    <div className="w-full mb-3" data-tool-blocks>
+      {toolGroups.map(group => {
+        // Single tool - render as ToolBlock (collapsed by default)
+        if (group.tools.length === 1) {
+          return <ToolBlock key={group.id} tool={group.tools[0]} defaultExpanded={false} />
+        }
+
+        // Multiple tools - render as ToolBlockGroup (group expanded, but tools inside collapsed)
+        return <ToolBlockGroup key={group.id} group={group} defaultExpanded={true} />
+      })}
+    </div>
+  )
+})
+
+export default ToolBlocksView

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { memo, useState } from 'react'
+import { ChevronDown, ChevronRight, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolBlockProps, ToolStatus, ToolRendererProps } from '../types'
+import { GenericToolRenderer } from './tools/GenericToolRenderer'
+import { BashToolRenderer } from './tools/BashToolRenderer'
+import { ReadToolRenderer } from './tools/ReadToolRenderer'
+import { EditToolRenderer } from './tools/EditToolRenderer'
+import { WriteToolRenderer } from './tools/WriteToolRenderer'
+import { GrepToolRenderer } from './tools/GrepToolRenderer'
+import { GlobToolRenderer } from './tools/GlobToolRenderer'
+import { TodoWriteToolRenderer } from './tools/TodoWriteToolRenderer'
+
+/**
+ * ToolBlock Component
+ *
+ * Displays a single tool execution as a collapsible block.
+ * Routes to specialized renderers based on tool name.
+ */
+export const ToolBlock = memo(function ToolBlock({
+  tool,
+  defaultExpanded = false,
+}: ToolBlockProps) {
+  const { t } = useTranslation('chat')
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  // Get status icon component
+  const StatusIcon = getStatusIcon(tool.status)
+  const statusColor = getStatusColor(tool.status)
+
+  // Get tool display name
+  const toolDisplayName = getToolDisplayName(tool, t)
+
+  // Get specialized renderer
+  const ToolRenderer = getToolRenderer(tool.toolName)
+
+  return (
+    <div className="border border-border rounded-lg bg-surface overflow-hidden mb-2">
+      {/* Header */}
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-fill-tert transition-colors"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <div className="flex items-center gap-2">
+          <StatusIcon className={`h-4 w-4 ${statusColor}`} />
+          <span className="text-sm font-medium text-text-primary">{toolDisplayName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {/* Expand/collapse icon */}
+          {isExpanded ? (
+            <ChevronDown className="h-4 w-4 text-text-muted" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-text-muted" />
+          )}
+        </div>
+      </div>
+
+      {/* Content (Specialized Renderer) */}
+      {isExpanded && (
+        <div className="px-4 py-3 border-t border-border bg-base">
+          <ToolRenderer tool={tool} />
+        </div>
+      )}
+    </div>
+  )
+})
+
+/**
+ * Get status icon component based on tool status
+ */
+function getStatusIcon(status: ToolStatus) {
+  switch (status) {
+    case 'done':
+      return CheckCircle2
+    case 'error':
+      return AlertCircle // Changed from XCircle to AlertCircle for softer warning style
+    case 'invoking':
+    case 'streaming':
+    case 'pending':
+      return Loader2
+    default:
+      return Loader2
+  }
+}
+
+/**
+ * Get status color classes
+ */
+function getStatusColor(status: ToolStatus): string {
+  switch (status) {
+    case 'done':
+      return 'text-primary'
+    case 'error':
+      return 'text-yellow-600' // Changed from text-red-500 to yellow for softer warning
+    case 'invoking':
+    case 'streaming':
+    case 'pending':
+      return 'text-primary animate-spin'
+    default:
+      return 'text-text-muted'
+  }
+}
+
+/**
+ * Get friendly display name for tool
+ */
+function getToolDisplayName(tool: ToolRendererProps['tool'], t: (key: string) => string): string {
+  const toolName = tool.toolName
+
+  // Map tool names to friendly display names
+  const displayNames: Record<string, string> = {
+    Bash: t('thinking.tools.bash') || 'Execute Command',
+    Read: t('thinking.tools.read') || 'Read File',
+    Edit: t('thinking.tools.edit') || 'Edit File',
+    Write: t('thinking.tools.write') || 'Write File',
+    Grep: t('thinking.tools.grep') || 'Search Code',
+    Glob: t('thinking.tools.glob') || 'Find Files',
+    TodoWrite: t('thinking.tools.todo') || 'Update Tasks',
+    knowledge_base_search: t('thinking.tools.kb_search') || 'Search Knowledge Base',
+    web_search: t('thinking.tools.web_search') || 'Web Search',
+  }
+
+  // If we have a known tool name, use it
+  if (displayNames[toolName]) {
+    return displayNames[toolName]
+  }
+
+  // For unknown tools, try to extract from title
+  if (tool.toolUse.title && typeof tool.toolUse.title === 'string') {
+    // Remove common prefixes like "正在", "使用", etc.
+    const cleanTitle = tool.toolUse.title.replace(/^(正在|使用|调用)/, '').trim()
+    if (cleanTitle && cleanTitle !== 'unknown') {
+      return cleanTitle
+    }
+  }
+
+  return toolName || 'Unknown Tool'
+}
+
+/**
+ * Get specialized renderer for tool type
+ * Returns component that renders tool input/output
+ */
+function getToolRenderer(
+  toolName: string
+): React.ComponentType<{ tool: ToolRendererProps['tool'] }> {
+  switch (toolName) {
+    case 'Bash':
+      return BashToolRenderer
+    case 'Read':
+      return ReadToolRenderer
+    case 'Edit':
+      return EditToolRenderer
+    case 'Write':
+      return WriteToolRenderer
+    case 'Grep':
+      return GrepToolRenderer
+    case 'Glob':
+      return GlobToolRenderer
+    case 'TodoWrite':
+      return TodoWriteToolRenderer
+    default:
+      return GenericToolRenderer
+  }
+}
+
+export default ToolBlock

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { memo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolGroup } from '../types'
+import { ToolBlock } from './ToolBlock'
+
+interface ToolBlockGroupProps {
+  group: ToolGroup
+  defaultExpanded?: boolean
+}
+
+/**
+ * ToolBlockGroup Component
+ *
+ * Groups consecutive tool calls into a collapsible accordion.
+ */
+export const ToolBlockGroup = memo(function ToolBlockGroup({
+  group,
+  defaultExpanded = true,
+}: ToolBlockGroupProps) {
+  const { t } = useTranslation('chat')
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  // Count total tools
+  const totalCount = group.tools.length
+
+  return (
+    <div className="border border-border rounded-lg bg-surface overflow-hidden mb-3">
+      {/* Group Header */}
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-fill-tert transition-colors bg-surface/50"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <div className="flex items-center gap-2">
+          {isExpanded ? (
+            <ChevronDown className="h-4 w-4 text-text-muted" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-text-muted" />
+          )}
+          <span className="text-sm font-medium text-text-primary">
+            {t('thinking.tool_group') || 'Tool Group'} ({totalCount}{' '}
+            {t('thinking.tools_count') || 'tools'})
+          </span>
+        </div>
+      </div>
+
+      {/* Tools List */}
+      {isExpanded && (
+        <div className="p-3 space-y-2 bg-base">
+          {group.tools.map(tool => (
+            <ToolBlock key={tool.toolUseId} tool={tool} defaultExpanded={false} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default ToolBlockGroup

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/BashToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/BashToolRenderer.tsx
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Bash tool renderer
+ * Shows command and output with syntax highlighting
+ */
+export function BashToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isOutputExpanded, setIsOutputExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  const command = input?.command as string | undefined
+  const description = input?.description as string | undefined
+
+  const output = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  const isOutputCollapsible = output ? shouldCollapse(output) : false
+  const displayOutput =
+    output && isOutputCollapsible && !isOutputExpanded ? getContentPreview(output) : output
+
+  return (
+    <div className="space-y-3">
+      {/* Description */}
+      {description && <div className="text-xs text-text-secondary italic mb-1">{description}</div>}
+
+      {/* Command */}
+      {command && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">
+            {t('thinking.tool_input') || 'Command'}
+          </div>
+          <pre className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            <code>{command}</code>
+          </pre>
+        </div>
+      )}
+
+      {/* Output */}
+      {output && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div
+              className={`text-xs font-medium ${
+                isError ? 'text-yellow-600' : 'text-text-secondary'
+              }`}
+            >
+              {isError
+                ? t('thinking.tool_error') || 'Error'
+                : t('thinking.tool_output') || 'Output'}
+            </div>
+            {isOutputCollapsible && (
+              <button
+                onClick={() => setIsOutputExpanded(!isOutputExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isOutputExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre
+            className={`text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+            style={{ maxHeight: isOutputExpanded ? 'none' : '300px' }}
+          >
+            {displayOutput}
+            {isOutputCollapsible && !isOutputExpanded && <span className="text-blue-400">...</span>}
+          </pre>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Executing...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BashToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/EditToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/EditToolRenderer.tsx
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Edit tool renderer
+ * Shows file path, old/new strings, and replace mode
+ */
+export function EditToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isOldExpanded, setIsOldExpanded] = useState(false)
+  const [isNewExpanded, setIsNewExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  const filePath = input?.file_path as string | undefined
+  const oldString = input?.old_string as string | undefined
+  const newString = input?.new_string as string | undefined
+  const replaceAll = input?.replace_all as boolean | undefined
+
+  const output = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  const isOldCollapsible = oldString ? shouldCollapse(oldString) : false
+  const isNewCollapsible = newString ? shouldCollapse(newString) : false
+
+  const displayOld =
+    oldString && isOldCollapsible && !isOldExpanded ? getContentPreview(oldString) : oldString
+  const displayNew =
+    newString && isNewCollapsible && !isNewExpanded ? getContentPreview(newString) : newString
+
+  return (
+    <div className="space-y-3">
+      {/* File Path */}
+      {filePath && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">File Path</div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            {filePath}
+          </div>
+        </div>
+      )}
+
+      {/* Replace Mode */}
+      {replaceAll !== undefined && (
+        <div className="text-xs text-text-muted">
+          Mode: {replaceAll ? 'Replace All' : 'Replace First Match'}
+        </div>
+      )}
+
+      {/* Old String */}
+      {oldString && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div className="text-xs font-medium text-red-600">Old String</div>
+            {isOldCollapsible && (
+              <button
+                onClick={() => setIsOldExpanded(!isOldExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isOldExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre className="text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono bg-red-50 border border-red-200 text-red-700">
+            {displayOld}
+            {isOldCollapsible && !isOldExpanded && <span className="text-blue-400">...</span>}
+          </pre>
+        </div>
+      )}
+
+      {/* New String */}
+      {newString && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div className="text-xs font-medium text-green-600">New String</div>
+            {isNewCollapsible && (
+              <button
+                onClick={() => setIsNewExpanded(!isNewExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isNewExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre className="text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono bg-green-50 border border-green-200 text-green-700">
+            {displayNew}
+            {isNewCollapsible && !isNewExpanded && <span className="text-blue-400">...</span>}
+          </pre>
+        </div>
+      )}
+
+      {/* Result */}
+      {output && (
+        <div>
+          <div
+            className={`text-xs font-medium mb-1 ${
+              isError ? 'text-yellow-600' : 'text-text-secondary'
+            }`}
+          >
+            {isError ? t('thinking.tool_error') || 'Error' : 'Result'}
+          </div>
+          <div
+            className={`text-xs p-2 rounded ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+          >
+            {output}
+          </div>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Editing file...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default EditToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/GenericToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/GenericToolRenderer.tsx
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+
+/**
+ * Generic tool renderer (fallback)
+ * Displays tool input and output as JSON
+ */
+export function GenericToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+
+  // Extract input from multiple possible sources
+  const inputRaw = tool.toolUse.details?.input
+  const input =
+    inputRaw && Object.keys(inputRaw).length > 0
+      ? typeof inputRaw === 'string'
+        ? inputRaw
+        : JSON.stringify(inputRaw, null, 2)
+      : undefined
+
+  // Extract output from multiple possible sources
+  const outputRaw = tool.toolResult?.details?.content || tool.toolResult?.details?.output
+  const output = outputRaw
+    ? typeof outputRaw === 'string'
+      ? outputRaw
+      : JSON.stringify(outputRaw, null, 2)
+    : undefined
+
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  // For Chat shell, use title as display name if no input/output
+  const displayTitle = typeof tool.toolUse.title === 'string' ? tool.toolUse.title : undefined
+  const completedTitle =
+    tool.toolResult && typeof tool.toolResult.title === 'string' ? tool.toolResult.title : undefined
+
+  return (
+    <div className="space-y-3">
+      {/* Display title from tool_use (Chat shell format) */}
+      {displayTitle && !input && (
+        <div className="text-xs text-text-secondary italic">{displayTitle}</div>
+      )}
+
+      {/* Tool Input */}
+      {input && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">
+            {t('thinking.tool_input') || 'Input'}
+          </div>
+          <pre className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words">
+            {input}
+          </pre>
+        </div>
+      )}
+
+      {/* Tool Output or completed title */}
+      {(output || completedTitle) && (
+        <div>
+          <div
+            className={`text-xs font-medium mb-1 ${
+              isError ? 'text-yellow-600' : 'text-text-secondary'
+            }`}
+          >
+            {isError ? t('thinking.tool_error') || 'Error' : t('thinking.tool_output') || 'Output'}
+          </div>
+          {output ? (
+            <pre
+              className={`text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words ${
+                isError
+                  ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                  : 'text-text-tertiary bg-fill-tert'
+              }`}
+            >
+              {output}
+            </pre>
+          ) : completedTitle ? (
+            <div className="text-xs text-text-tertiary">{completedTitle}</div>
+          ) : null}
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && !completedTitle && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Executing...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GenericToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/GlobToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/GlobToolRenderer.tsx
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Glob tool renderer
+ * Shows file pattern and matched files
+ */
+export function GlobToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isResultsExpanded, setIsResultsExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  const pattern = input?.pattern as string | undefined
+  const path = input?.path as string | undefined
+
+  const outputRaw = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  // Try to parse output as JSON (for sandbox tools)
+  let parsedOutput: Record<string, unknown> | null = null
+  let output = outputRaw
+  let fileCount = 0
+
+  if (outputRaw && !isError) {
+    try {
+      parsedOutput = JSON.parse(outputRaw) as Record<string, unknown>
+
+      // Handle sandbox_list_files format
+      if (parsedOutput.success && parsedOutput.entries && Array.isArray(parsedOutput.entries)) {
+        fileCount = parsedOutput.entries.length
+        // Format as readable list
+        output = parsedOutput.entries
+          .map((entry: Record<string, unknown>) => {
+            const typeIcon = entry.type === 'dir' ? '📁' : '📄'
+            const size = entry.size ? ` (${(Number(entry.size) / 1024).toFixed(1)} KB)` : ''
+            return `${typeIcon} ${entry.name}${size}`
+          })
+          .join('\n')
+      } else {
+        // Keep original output if not recognized format
+        output = outputRaw
+        const lines = output.trim().split('\n')
+        fileCount = lines.filter(line => line.trim()).length
+      }
+    } catch {
+      // Not JSON, try to count lines
+      if (outputRaw) {
+        const lines = outputRaw.trim().split('\n')
+        fileCount = lines.filter(line => line.trim()).length
+      }
+      output = outputRaw
+    }
+  }
+
+  const isResultsCollapsible = output ? shouldCollapse(output) : false
+  const displayResults =
+    output && isResultsCollapsible && !isResultsExpanded ? getContentPreview(output) : output
+
+  return (
+    <div className="space-y-3">
+      {/* File Pattern or Path */}
+      {(pattern || path) && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">
+            {pattern ? 'Pattern' : 'Directory'}
+          </div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            {pattern || path}
+          </div>
+        </div>
+      )}
+
+      {/* Matched Files */}
+      {output && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div
+              className={`text-xs font-medium ${
+                isError ? 'text-yellow-600' : 'text-text-secondary'
+              }`}
+            >
+              {isError
+                ? t('thinking.tool_error') || 'Error'
+                : fileCount > 0
+                  ? `Files (${fileCount})`
+                  : 'Files'}
+            </div>
+            {isResultsCollapsible && (
+              <button
+                onClick={() => setIsResultsExpanded(!isResultsExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isResultsExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre
+            className={`text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+            style={{ maxHeight: isResultsExpanded ? 'none' : '300px' }}
+          >
+            {displayResults}
+            {isResultsCollapsible && !isResultsExpanded && (
+              <span className="text-blue-400">...</span>
+            )}
+          </pre>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Finding files...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GlobToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/GrepToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/GrepToolRenderer.tsx
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Grep tool renderer
+ * Shows search pattern and results
+ */
+export function GrepToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isResultsExpanded, setIsResultsExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  const pattern = input?.pattern as string | undefined
+  const path = input?.path as string | undefined
+  const glob = input?.glob as string | undefined
+  const outputMode = input?.output_mode as string | undefined
+
+  const output = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  const isResultsCollapsible = output ? shouldCollapse(output) : false
+  const displayResults =
+    output && isResultsCollapsible && !isResultsExpanded ? getContentPreview(output) : output
+
+  return (
+    <div className="space-y-3">
+      {/* Search Pattern */}
+      {pattern && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">Search Pattern</div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            {pattern}
+          </div>
+        </div>
+      )}
+
+      {/* Search Parameters */}
+      <div className="text-xs text-text-muted space-y-0.5">
+        {path && <div>Path: {path}</div>}
+        {glob && <div>Glob: {glob}</div>}
+        {outputMode && <div>Mode: {outputMode}</div>}
+      </div>
+
+      {/* Search Results */}
+      {output && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div
+              className={`text-xs font-medium ${
+                isError ? 'text-yellow-600' : 'text-text-secondary'
+              }`}
+            >
+              {isError ? t('thinking.tool_error') || 'Error' : 'Search Results'}
+            </div>
+            {isResultsCollapsible && (
+              <button
+                onClick={() => setIsResultsExpanded(!isResultsExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isResultsExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre
+            className={`text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+            style={{ maxHeight: isResultsExpanded ? 'none' : '400px' }}
+          >
+            {displayResults}
+            {isResultsCollapsible && !isResultsExpanded && (
+              <span className="text-blue-400">...</span>
+            )}
+          </pre>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Searching...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default GrepToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/ReadToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/ReadToolRenderer.tsx
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Read tool renderer
+ * Shows file path and content preview
+ */
+export function ReadToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isContentExpanded, setIsContentExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  let filePath = input?.file_path as string | undefined
+  const offset = input?.offset as number | undefined
+  const limit = input?.limit as number | undefined
+
+  const outputRaw = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  // Try to parse output as JSON (for sandbox tools)
+  let output = outputRaw
+  let parsedOutput: Record<string, unknown> | null = null
+
+  if (outputRaw && !isError) {
+    try {
+      parsedOutput = JSON.parse(outputRaw) as Record<string, unknown>
+      // Handle sandbox_read_file format
+      if (parsedOutput.success && parsedOutput.content) {
+        output = parsedOutput.content as string
+        filePath = (parsedOutput.path as string) || filePath
+      }
+    } catch {
+      // Not JSON, use raw output
+      output = outputRaw
+    }
+  }
+
+  const isContentCollapsible = output ? shouldCollapse(output) : false
+  const displayContent =
+    output && isContentCollapsible && !isContentExpanded ? getContentPreview(output) : output
+
+  return (
+    <div className="space-y-3">
+      {/* File Path */}
+      {filePath && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">File Path</div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            {filePath}
+          </div>
+        </div>
+      )}
+
+      {/* Range Info */}
+      {(offset !== undefined || limit !== undefined) && (
+        <div className="text-xs text-text-muted">
+          {offset !== undefined && `Offset: ${offset}`}
+          {offset !== undefined && limit !== undefined && ' | '}
+          {limit !== undefined && `Limit: ${limit} lines`}
+        </div>
+      )}
+
+      {/* File Content */}
+      {output && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div
+              className={`text-xs font-medium ${
+                isError ? 'text-yellow-600' : 'text-text-secondary'
+              }`}
+            >
+              {isError ? t('thinking.tool_error') || 'Error' : 'File Content'}
+            </div>
+            {isContentCollapsible && (
+              <button
+                onClick={() => setIsContentExpanded(!isContentExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isContentExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre
+            className={`text-xs p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+            style={{ maxHeight: isContentExpanded ? 'none' : '400px' }}
+          >
+            {displayContent}
+            {isContentCollapsible && !isContentExpanded && (
+              <span className="text-blue-400">...</span>
+            )}
+          </pre>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Reading file...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default ReadToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/TodoWriteToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/TodoWriteToolRenderer.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import TodoListDisplay from '../TodoListDisplay'
+
+/**
+ * TodoWrite tool renderer
+ * Displays the task list using existing TodoListDisplay component
+ */
+export function TodoWriteToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  const todos = input?.todos as
+    | Array<{
+        content: string
+        status: 'pending' | 'in_progress' | 'completed'
+        activeForm: string
+      }>
+    | undefined
+
+  const output = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  return (
+    <div className="space-y-3">
+      {/* Todo List */}
+      {todos && Array.isArray(todos) && todos.length > 0 && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-2">
+            {t('thinking.todo_list') || 'Task List'}
+          </div>
+          <TodoListDisplay todos={todos} />
+        </div>
+      )}
+
+      {/* Result */}
+      {output && (
+        <div>
+          <div
+            className={`text-xs font-medium mb-1 ${
+              isError ? 'text-yellow-600' : 'text-text-secondary'
+            }`}
+          >
+            {isError ? t('thinking.tool_error') || 'Error' : 'Result'}
+          </div>
+          <div
+            className={`text-xs p-2 rounded ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+          >
+            {output}
+          </div>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Updating tasks...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default TodoWriteToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolRendererProps } from '../../types'
+import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+
+/**
+ * Write tool renderer
+ * Shows file path and content to write
+ */
+export function WriteToolRenderer({ tool }: ToolRendererProps) {
+  const { t } = useTranslation('chat')
+  const [isContentExpanded, setIsContentExpanded] = useState(false)
+
+  const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
+  let filePath = input?.file_path as string | undefined
+  const content = input?.content as string | undefined
+
+  const outputRaw = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
+    | string
+    | undefined
+  const isError = tool.toolResult?.details?.is_error || tool.toolResult?.details?.error
+
+  // Try to parse output as JSON (for sandbox tools)
+  let output = outputRaw
+  let parsedOutput: Record<string, unknown> | null = null
+
+  if (outputRaw && !isError) {
+    try {
+      parsedOutput = JSON.parse(outputRaw) as Record<string, unknown>
+      // Handle sandbox_write_file format
+      if (parsedOutput.success && parsedOutput.path) {
+        filePath = (parsedOutput.path as string) || filePath
+        // For write operations, output is usually just a success message
+        output =
+          (parsedOutput.message as string) ||
+          `File written successfully (${parsedOutput.size || 0} bytes)`
+      }
+    } catch {
+      // Not JSON, use raw output
+      output = outputRaw
+    }
+  }
+
+  const isContentCollapsible = content ? shouldCollapse(content) : false
+  const displayContent =
+    content && isContentCollapsible && !isContentExpanded ? getContentPreview(content) : content
+
+  return (
+    <div className="space-y-3">
+      {/* File Path */}
+      {filePath && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">File Path</div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono">
+            {filePath}
+          </div>
+        </div>
+      )}
+
+      {/* Content to Write */}
+      {content && (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <div className="text-xs font-medium text-text-secondary">Content</div>
+            {isContentCollapsible && (
+              <button
+                onClick={() => setIsContentExpanded(!isContentExpanded)}
+                className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
+              >
+                {isContentExpanded
+                  ? t('thinking.collapse') || 'Collapse'
+                  : t('thinking.expand') || 'Expand'}
+              </button>
+            )}
+          </div>
+          <pre
+            className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono"
+            style={{ maxHeight: isContentExpanded ? 'none' : '400px' }}
+          >
+            {displayContent}
+            {isContentCollapsible && !isContentExpanded && (
+              <span className="text-blue-400">...</span>
+            )}
+          </pre>
+        </div>
+      )}
+
+      {/* Result */}
+      {output && (
+        <div>
+          <div
+            className={`text-xs font-medium mb-1 ${
+              isError ? 'text-yellow-600' : 'text-text-secondary'
+            }`}
+          >
+            {isError ? t('thinking.tool_error') || 'Error' : 'Result'}
+          </div>
+          <div
+            className={`text-xs p-2 rounded ${
+              isError
+                ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
+                : 'text-text-tertiary bg-fill-tert'
+            }`}
+          >
+            {output}
+          </div>
+        </div>
+      )}
+
+      {/* No output yet (streaming) */}
+      {!output && tool.status === 'invoking' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_executing') || 'Writing file...'}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default WriteToolRenderer

--- a/frontend/src/features/tasks/components/message/thinking/hooks/useToolExtraction.ts
+++ b/frontend/src/features/tasks/components/message/thinking/hooks/useToolExtraction.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useToolExtraction Hook
+ *
+ * Hook for extracting and grouping tools from thinking steps.
+ */
+
+import { useMemo } from 'react'
+import type { ThinkingStep, ToolGroup } from '../types'
+import { extractToolPairs, groupConsecutiveTools, filterNonToolSteps } from '../utils/toolExtractor'
+
+interface UseToolExtractionResult {
+  toolGroups: ToolGroup[]
+  nonToolSteps: ThinkingStep[]
+  hasTools: boolean
+}
+
+export function useToolExtraction(thinking: ThinkingStep[] | null): UseToolExtractionResult {
+  return useMemo(() => {
+    if (!thinking || thinking.length === 0) {
+      return {
+        toolGroups: [],
+        nonToolSteps: [],
+        hasTools: false,
+      }
+    }
+
+    const pairs = extractToolPairs(thinking)
+    const toolGroups = groupConsecutiveTools(pairs)
+    const nonToolSteps = filterNonToolSteps(thinking)
+
+    return {
+      toolGroups,
+      nonToolSteps,
+      hasTools: toolGroups.length > 0 && toolGroups.some(g => g.tools.length > 0),
+    }
+  }, [thinking])
+}

--- a/frontend/src/features/tasks/components/message/thinking/types.ts
+++ b/frontend/src/features/tasks/components/message/thinking/types.ts
@@ -8,6 +8,8 @@
 export interface ThinkingStep {
   title: string
   next_action: string
+  run_id?: string // Legacy: LangChain run_id
+  tool_use_id?: string // NEW: Anthropic standard tool_use_id
   details?: {
     type?: string
     subtype?: string
@@ -36,11 +38,15 @@ export interface ThinkingStep {
     // Tool use details
     id?: string
     name?: string
+    tool_name?: string
+    status?: string
     input?: string | Record<string, unknown>
     // Tool result details
     tool_use_id?: string
     content?: string
+    output?: unknown
     is_error?: boolean
+    error?: string
     // Result message details
     session_id?: string
     num_turns?: number
@@ -73,6 +79,48 @@ export interface ThinkingStep {
   reasoning?: string
   confidence?: number
   value?: unknown
+}
+
+/**
+ * Tool execution status
+ */
+export type ToolStatus = 'pending' | 'streaming' | 'invoking' | 'done' | 'error'
+
+/**
+ * Paired tool use + tool result
+ */
+export interface ToolPair {
+  toolUseId: string
+  toolName: string
+  status: ToolStatus
+  toolUse: ThinkingStep // tool_use type step
+  toolResult?: ThinkingStep // tool_result type step (may be incomplete during streaming)
+  startTime?: number
+  endTime?: number
+}
+
+/**
+ * Group of consecutive tools
+ */
+export interface ToolGroup {
+  id: string // Unique group ID
+  tools: ToolPair[]
+  isComplete: boolean // All tools in group are done
+}
+
+/**
+ * Props for ToolBlock component
+ */
+export interface ToolBlockProps {
+  tool: ToolPair
+  defaultExpanded?: boolean
+}
+
+/**
+ * Props for ToolRenderer component
+ */
+export interface ToolRendererProps {
+  tool: ToolPair
 }
 
 /**

--- a/frontend/src/features/tasks/components/message/thinking/utils/toolExtractor.ts
+++ b/frontend/src/features/tasks/components/message/thinking/utils/toolExtractor.ts
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tool extraction utilities
+ *
+ * Extracts tool call pairs from thinking steps and groups consecutive tools.
+ */
+
+import type { ThinkingStep, ToolPair, ToolGroup, ToolStatus } from '../types'
+
+/**
+ * Normalize tool names from Chat shell (Chinese) to standard English names
+ * This ensures specialized renderers are invoked correctly
+ */
+function normalizeToolName(toolName: string, title?: string): string {
+  // Direct mapping for known English names
+  const englishTools = [
+    'Bash',
+    'Read',
+    'Write',
+    'Edit',
+    'Grep',
+    'Glob',
+    'TodoWrite',
+    'Task',
+    'WebFetch',
+    'WebSearch',
+  ]
+  if (englishTools.includes(toolName)) {
+    return toolName
+  }
+
+  // Map Chinese tool names to English equivalents
+  const chineseToEnglish: Record<string, string> = {
+    读取文件: 'Read',
+    写入文件: 'Write',
+    编辑文件: 'Edit',
+    列出文件: 'Glob',
+    搜索代码: 'Grep',
+    执行命令: 'Bash',
+    更新任务: 'TodoWrite',
+    网页搜索: 'WebSearch',
+    知识库搜索: 'knowledge_base_search',
+  }
+
+  // Try to match from toolName first
+  if (chineseToEnglish[toolName]) {
+    return chineseToEnglish[toolName]
+  }
+
+  // Try pattern matching for tool names
+  // Match patterns like: sandbox_read_file, sandbox_write_file, sandbox_list_files
+  // Check specific patterns first, then broader patterns
+  if (toolName.includes('list') || toolName.includes('glob') || toolName.includes('find')) {
+    return 'Glob'
+  }
+  if (toolName.includes('read') || toolName.includes('Read')) {
+    return 'Read'
+  }
+  if (toolName.includes('write') || toolName.includes('Write')) {
+    return 'Write'
+  }
+  if (toolName.includes('edit') || toolName.includes('Edit')) {
+    return 'Edit'
+  }
+  if (toolName.includes('grep')) {
+    return 'Grep'
+  }
+  if (toolName.includes('bash') || toolName.includes('exec') || toolName.includes('command')) {
+    return 'Bash'
+  }
+  // Keep knowledge_base_search and web_search as-is
+  if (toolName.includes('knowledge') || toolName.includes('kb')) {
+    return 'knowledge_base_search'
+  }
+  if (toolName.includes('web') && toolName.includes('search')) {
+    return 'WebSearch'
+  }
+
+  // Try to extract from title if available
+  if (title && typeof title === 'string') {
+    // Remove common prefixes
+    const cleanTitle = title.replace(/^(正在|使用|调用)/, '').trim()
+    if (chineseToEnglish[cleanTitle]) {
+      return chineseToEnglish[cleanTitle]
+    }
+
+    // Try pattern matching on title
+    if (cleanTitle.includes('读取') || cleanTitle.includes('查看')) {
+      return 'Read'
+    }
+    if (cleanTitle.includes('写入') || cleanTitle.includes('创建')) {
+      return 'Write'
+    }
+    if (cleanTitle.includes('编辑') || cleanTitle.includes('修改')) {
+      return 'Edit'
+    }
+    if (cleanTitle.includes('列出') || cleanTitle.includes('查找')) {
+      return 'Glob'
+    }
+  }
+
+  // Return original if no mapping found
+  return toolName
+}
+
+/**
+ * Extract tool pairs from thinking steps
+ * Matches tool_use with tool_result using tool_use_id (or run_id as fallback)
+ */
+export function extractToolPairs(thinking: ThinkingStep[]): ToolPair[] {
+  const pairs: ToolPair[] = []
+  const toolUseMap = new Map<string, { step: ThinkingStep; index: number }>()
+
+  thinking.forEach((step, index) => {
+    const details = step.details
+    if (!details) return
+
+    // Get identifier (prefer tool_use_id, fallback to run_id)
+    const toolId = step.tool_use_id || step.run_id
+    if (!toolId) {
+      return
+    }
+
+    const rawToolName = details.tool_name || details.name || 'unknown'
+    const toolName = normalizeToolName(rawToolName, step.title)
+
+    // Handle tool_use (both new format and Chat shell format)
+    if (details.type === 'tool_use') {
+      // For Chat shell: status === 'started'
+      // For new format: no status check needed
+      if (!details.status || details.status === 'started') {
+        toolUseMap.set(toolId, { step, index })
+      }
+    }
+    // Handle tool_result (both new format and Chat shell format)
+    else if (details.type === 'tool_result') {
+      // For Chat shell: status === 'completed' or 'failed'
+      // For new format: any status
+      const toolUse = toolUseMap.get(toolId)
+      if (toolUse) {
+        const status = getToolStatus(details)
+        pairs.push({
+          toolUseId: toolId,
+          toolName,
+          status,
+          toolUse: toolUse.step,
+          toolResult: step,
+        })
+      }
+    }
+    // Handle assistant message with content array (existing data structure)
+    else if (details.type === 'assistant' && details.message?.content) {
+      const content = details.message.content
+      if (Array.isArray(content)) {
+        content.forEach((item: { type?: string; id?: string; name?: string }) => {
+          if (item.type === 'tool_use') {
+            const itemToolId = item.id || step.run_id
+            if (itemToolId) {
+              toolUseMap.set(itemToolId, { step, index })
+            }
+          }
+        })
+      }
+    }
+    // Handle tool_result in user message
+    else if (details.type === 'user' && details.message?.content) {
+      const content = details.message.content
+      if (Array.isArray(content)) {
+        content.forEach((item: { type?: string; tool_use_id?: string; is_error?: boolean }) => {
+          if (item.type === 'tool_result') {
+            const itemToolId = item.tool_use_id || step.run_id
+            if (itemToolId) {
+              const toolUse = toolUseMap.get(itemToolId)
+              if (toolUse) {
+                const status = item.is_error ? 'error' : 'done'
+                pairs.push({
+                  toolUseId: itemToolId,
+                  toolName: 'Tool', // Will be determined from tool_use
+                  status,
+                  toolUse: toolUse.step,
+                  toolResult: step,
+                })
+              }
+            }
+          }
+        })
+      }
+    }
+  })
+
+  // Handle incomplete pairs (tool_use without result - still streaming)
+  toolUseMap.forEach((toolUse, toolId) => {
+    if (!pairs.find(p => p.toolUseId === toolId)) {
+      const rawToolName = toolUse.step.details?.tool_name || toolUse.step.details?.name || 'unknown'
+      const toolName = normalizeToolName(rawToolName, toolUse.step.title)
+      pairs.push({
+        toolUseId: toolId,
+        toolName,
+        status: 'invoking',
+        toolUse: toolUse.step,
+      })
+    }
+  })
+
+  return pairs
+}
+
+/**
+ * Group consecutive tool pairs into ToolGroups
+ * For now, we group all tools into a single group
+ * TODO: Implement smart grouping based on thinking step indices
+ */
+export function groupConsecutiveTools(pairs: ToolPair[]): ToolGroup[] {
+  if (pairs.length === 0) return []
+
+  // Simple grouping: all tools in one group
+  // In the future, we can analyze thinking array indices to group consecutive tools
+  const group: ToolGroup = {
+    id: `group-${pairs[0].toolUseId}`,
+    tools: pairs,
+    isComplete: pairs.every(t => t.status === 'done' || t.status === 'error'),
+  }
+
+  return [group]
+}
+
+/**
+ * Determine tool status from tool_result details
+ */
+function getToolStatus(details: ThinkingStep['details']): ToolStatus {
+  if (details?.status === 'failed' || details?.is_error || details?.error) {
+    return 'error'
+  }
+  if (details?.status === 'completed') {
+    return 'done'
+  }
+  if (details?.status === 'started') {
+    return 'invoking'
+  }
+  return 'invoking'
+}
+
+/**
+ * Check if a thinking step is a tool-related step
+ */
+export function isToolStep(step: ThinkingStep): boolean {
+  return step.details?.type === 'tool_use' || step.details?.type === 'tool_result'
+}
+
+/**
+ * Filter out tool steps from thinking array (for non-tool timeline rendering)
+ */
+export function filterNonToolSteps(thinking: ThinkingStep[]): ThinkingStep[] {
+  return thinking.filter(step => !isToolStep(step))
+}

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -97,6 +97,28 @@
     "collapse_content": "Collapse",
     "lines": "lines"
   },
+  "thinking": {
+    "tool_group": "Tool Group",
+    "tools": "tools",
+    "completed": "Completed",
+    "running": "Running",
+    "has_errors": "Has Errors",
+    "tool_input": "Input",
+    "tool_output": "Output",
+    "tool_error": "Error",
+    "tool_executing": "Executing...",
+    "tools": {
+      "bash": "Execute Command",
+      "read": "Read File",
+      "edit": "Edit File",
+      "write": "Write File",
+      "grep": "Search Code",
+      "glob": "Find Files",
+      "todo": "Update Tasks",
+      "kb_search": "Search Knowledge Base",
+      "web_search": "Web Search"
+    }
+  },
   "shared_task": {
     "share_task": "Share",
     "sharing": "Sharing...",
@@ -153,7 +175,7 @@
     "tool_call": "🔧 Tool Call",
     "tool_use": "🔧 Tool Use",
     "tool_result": "🔧 Tool Result",
-    "tool_error": "❌ Tool Error",
+    "tool_error": "⚠️ Tool Error",
     "model_reasoning": "💭 Model Thinking",
     "text_response": "Text Response",
     "expand": "Expand",
@@ -178,7 +200,26 @@
     "execution_type": "Execution Type",
     "mcp_init_fail": "❌ MCP initialization failed. ",
     "attachments_downloaded": "📎 Attachments Downloaded",
-    "generating_content": "✨ Generating Content"
+    "generating_content": "✨ Generating Content",
+    "tool_group": "Tool Group",
+    "tools_count": "Tools",
+    "completed": "Completed",
+    "running": "Running",
+    "has_errors": "Has Errors",
+    "tool_input": "Input",
+    "tool_output": "Output",
+    "tool_executing": "Executing...",
+    "tools": {
+      "bash": "Execute Command",
+      "read": "Read File",
+      "edit": "Edit File",
+      "write": "Write File",
+      "grep": "Search Code",
+      "glob": "Find Files",
+      "todo": "Update Tasks",
+      "kb_search": "Search Knowledge Base",
+      "web_search": "Web Search"
+    }
   },
   "send_button": {
     "shortcut_title": "Send Shortcut",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -153,7 +153,7 @@
     "tool_call": "🔧 工具调用",
     "tool_use": "🔧 工具使用",
     "tool_result": "🔧 工具结果",
-    "tool_error": "❌ 工具错误",
+    "tool_error": "⚠️ 工具错误",
     "model_reasoning": "💭 模型思考",
     "text_response": "文本响应",
     "expand": "展开",
@@ -178,7 +178,26 @@
     "execution_type": "执行类型",
     "mcp_init_fail": "❌ MCP 初始化失败。",
     "attachments_downloaded": "📎 已下载附件",
-    "generating_content": "✨ 正在生成内容"
+    "generating_content": "✨ 正在生成内容",
+    "tool_group": "工具组",
+    "tools_count": "工具",
+    "completed": "已完成",
+    "running": "执行中",
+    "has_errors": "有错误",
+    "tool_input": "输入",
+    "tool_output": "输出",
+    "tool_executing": "执行中...",
+    "tools": {
+      "bash": "执行命令",
+      "read": "读取文件",
+      "edit": "编辑文件",
+      "write": "写入文件",
+      "grep": "搜索代码",
+      "glob": "查找文件",
+      "todo": "更新待办事项",
+      "kb_search": "搜索知识库",
+      "web_search": "网页搜索"
+    }
   },
   "send_button": {
     "shortcut_title": "发送快捷键",

--- a/shared/models/task.py
+++ b/shared/models/task.py
@@ -85,6 +85,13 @@ class ThinkingStep(BaseModel):
     details: Optional[Dict[str, Any]] = Field(
         default=None, description="Detailed structured data for this step"
     )
+    run_id: Optional[str] = Field(
+        default=None,
+        description="LangChain run_id for matching tool start/end (legacy)",
+    )
+    tool_use_id: Optional[str] = Field(
+        default=None, description="Anthropic tool_use_id (standard identifier)"
+    )
 
     def dict(self, **kwargs) -> Dict[str, Any]:
         """Override dict method to exclude None values"""


### PR DESCRIPTION
Refactor tool message display to show tools as independent collapsible blocks instead of inline thinking timeline items, improving UX and readability.

Backend Changes:
- Preserve tool_use_id in thinking steps for better tool matching
- Fix _slim_thinking_data() to retain input/output/content fields
- Add support for Anthropic standard tool_use_id alongside run_id

Frontend Changes:
- Add ToolBlock component for single tool display with collapse/expand
- Add ToolBlockGroup component for grouping consecutive tools
- Create specialized renderers for different tool types:
  * BashToolRenderer - command execution with syntax highlighting
  * ReadToolRenderer - file reading with content preview
  * WriteToolRenderer - file writing with content display
  * EditToolRenderer - file editing with old/new diff view
  * GrepToolRenderer - code search with results
  * GlobToolRenderer - file pattern matching
  * TodoWriteToolRenderer - task list updates
  * GenericToolRenderer - fallback for unknown tools
- Add tool name normalization for Chinese names and sandbox tools
- Implement tool extraction and grouping logic
- Update ThinkingDisplay to route Chat shell to ToolBlocksView
- Add i18n translations for tool-related UI elements

UX Improvements:
- Tools default to collapsed state (groups expanded, individual tools collapsed)
- Error styling changed to softer yellow warning (was red)
- Error icon changed to AlertCircle (was XCircle)
- Removed error/completion status badges from tool groups
- Fixed i18n key conflict (thinking.tools vs thinking.tools_count)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tool execution display in Chat shell with block-based view and specialized renderings for different tool types.
  * Improved tool tracking with better correlation between tool execution start and end events.
  * Added support for displaying tool input, output, and error details.

* **Internationalization**
  * Added Chinese and English localization for tool-related UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->