### PR TITLE
fix(executor): resolve JSON serialization error for agno SDK response objects

### DIFF
--- a/executor/agents/agno/agno_agent.py
+++ b/executor/agents/agno/agno_agent.py
@@ -40,7 +40,7 @@ db = SqliteDb(db_file="/tmp/agno_data.db")
 class SafeJSONEncoder(json.JSONEncoder):
     """Custom JSON encoder that handles non-serializable objects from agno library."""
 
-    def default(self, obj):
+    def default(self, obj: Any) -> Any:
         # Handle objects with __dict__ attribute
         if hasattr(obj, "__dict__"):
             return str(obj)


### PR DESCRIPTION
## Summary

- Add `SafeJSONEncoder` class to handle non-serializable objects (e.g., `ServerToolUsage`) from agno SDK
- Apply custom encoder to 4 locations where `json.dumps()` is called on agno response objects
- Add try-except blocks for logging statements to prevent crashes even if serialization fails

## Changes

**Root Cause:** The agno SDK returns response objects that, when converted via `to_dict()`, may contain custom types like `ServerToolUsage` that cannot be directly serialized by standard `json.dumps()`.

**Solution:** Created a `SafeJSONEncoder` that converts non-serializable objects to their string representations, preventing `TypeError: Object of type ServerToolUsage is not JSON serializable` crashes.

| Location | Change |
|----------|--------|
| Line 562 | `_normalize_result_content` - Added `cls=SafeJSONEncoder` |
| Line 971 | Agent non-streaming log - Added `cls=SafeJSONEncoder` + try-except |
| Line 1108 | Team non-streaming log - Added `cls=SafeJSONEncoder` + try-except |
| Line 1221 | Team streaming event log - Added `cls=SafeJSONEncoder` + try-except |

## Test Plan

- [x] Code formatting passes (black + isort)
- [x] Existing agno agent tests pass
- [x] Verified SafeJSONEncoder correctly handles mock ServerToolUsage objects
- [ ] Manual test with actual agno SDK response containing ServerToolUsage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent logging and streaming now tolerate failures when serializing complex or non-standard data, preventing crashes and preserving operation continuity.
  * Serialization errors in both streaming and non-streaming paths are handled with safe fallbacks and clear fallback content.

* **Improvements**
  * Improved extraction of agent tracing attributes for more reliable observability and debugging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->