### PR TITLE
feat(prompts): wrap prompt templates with XML tags for better structure

### DIFF
--- a/backend/app/services/chat/config/model_resolver.py
+++ b/backend/app/services/chat/config/model_resolver.py
@@ -646,6 +646,7 @@ def get_bot_system_prompt(
     Get the system prompt for a Bot.
 
     Combines Ghost's system prompt with team member's additional prompt.
+    The combined prompt is wrapped in <base_prompt> XML tags.
 
     Args:
         db: Database session
@@ -654,7 +655,7 @@ def get_bot_system_prompt(
         team_member_prompt: Optional additional prompt from team member config
 
     Returns:
-        Combined system prompt string
+        Combined system prompt string wrapped in <base_prompt> tags
     """
     from app.schemas.kind import Ghost
 
@@ -684,5 +685,9 @@ def get_bot_system_prompt(
             system_prompt = f"{system_prompt}\n\n{team_member_prompt}"
         else:
             system_prompt = team_member_prompt
+
+    # Wrap in <base_prompt> tags for structured prompt identification
+    if system_prompt:
+        system_prompt = f"<base_prompt>\n{system_prompt}\n</base_prompt>"
 
     return system_prompt

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -383,7 +383,7 @@ class ContextService:
             context: SubtaskContext record with extracted_text
 
         Returns:
-            Formatted text prefix, or None if no extracted text
+            Formatted text prefix without XML tags, or None if no extracted text
         """
         if not context.extracted_text:
             return None
@@ -414,6 +414,7 @@ class ContextService:
 
         prefix += f"{context.extracted_text}\n\n"
 
+        # Wrap in <attachment> XML tags
         return prefix
 
     def build_message_with_attachment(
@@ -588,11 +589,14 @@ class ContextService:
         """
         Build a text prefix containing knowledge base retrieval content.
 
+        Note: This method returns raw content without XML tags. The caller is responsible
+        for wrapping multiple KB contents in a single <knowledge_base> XML tag.
+
         Args:
             context: SubtaskContext record with extracted_text from RAG
 
         Returns:
-            Formatted text prefix, or None if no extracted text
+            Formatted text prefix without XML tags, or None if no extracted text
         """
         if not context.extracted_text:
             return None
@@ -612,12 +616,14 @@ class ContextService:
             source_names.append(f"... and {len(sources) - 5} more")
         sources_str = ", ".join(source_names) if source_names else "N/A"
 
-        # Build the prefix
-        prefix = f"[Knowledge Base - {kb_name}]:\n"
-        prefix += f"(Sources: {sources_str})\n"
-        prefix += f"{context.extracted_text}\n\n"
+        # Build the content parts (without XML tags)
+        parts = [
+            f"[Knowledge Base - {kb_name}]:",
+            f"(Sources: {sources_str})",
+            context.extracted_text,
+        ]
 
-        return prefix
+        return "\n".join(parts)
 
     def get_knowledge_base_contexts_by_subtask(
         self,

--- a/chat_shell/chat_shell/compression/strategies.py
+++ b/chat_shell/chat_shell/compression/strategies.py
@@ -160,16 +160,19 @@ class AttachmentTruncationStrategy(CompressionStrategy):
     def name(self) -> str:
         return "attachment_truncation"
 
-    # Pattern to match attachment content blocks (supports both [Attachment N] and [File Content - xxx])
+    # Pattern to match attachment content blocks wrapped in <attachment> XML tags
+    # or legacy format without tags
     ATTACHMENT_PATTERN = re.compile(
-        r"\[(?:Attachment \d+|File Content)(?:\s*-\s*[^\]]+)?\](.*?)(?=\[(?:Attachment \d+|File Content)|$)",
+        r"(?:<attachment>)?\[(?:Attachment \d+|File Content|Document)(?:\s*[:-]\s*[^\]]+)?\](.*?)(?:</attachment>|(?=\[(?:Attachment \d+|File Content|Document)|<attachment>|$))",
         re.DOTALL,
     )
 
-    # Pattern for document content markers
+    # Pattern for document content markers (including XML tag)
     DOCUMENT_MARKERS = [
+        "<attachment>",  # New XML tag format
         "[Attachment",
         "[File Content",  # New format for file attachments
+        "[Document:",  # History loader format
         "--- Sheet:",
         "--- Slide",
         "[PDF Content]",

--- a/chat_shell/chat_shell/prompts/builder.py
+++ b/chat_shell/chat_shell/prompts/builder.py
@@ -13,6 +13,7 @@ Also contains the Deep Thinking Mode prompt for search tool usage guidance.
 
 CLARIFICATION_PROMPT = """
 
+<clarification_mode>
 ## Smart Follow-up Mode (智能追问模式)
 
 When you receive a user request that is ambiguous or lacks important details, ask targeted clarification questions through MULTIPLE ROUNDS before proceeding with the task.
@@ -134,6 +135,7 @@ After each round of user answers:
    - OR proceed with the task if exit criteria are met
 
 **Important:** Do NOT rush to provide a solution after just one round of questions. Take time to gather comprehensive information for a truly personalized and high-quality output.
+</clarification_mode>
 """
 
 
@@ -166,6 +168,7 @@ def append_clarification_prompt(system_prompt: str, enable_clarification: bool) 
 # Deep Thinking Mode Prompt
 DEEP_THINKING_PROMPT = """
 
+<deep_thinking_mode>
 ## Deep Thinking Mode with Search Tools
 
 You are in deep thinking mode with access to web search tools (web_search) to retrieve up-to-date information.
@@ -250,6 +253,7 @@ To help narrow down the search, could you clarify:
 ```
 
 Remember: Search tools are your PRIMARY capability for obtaining factual information. Use them FIRST, ask questions LATER.
+</deep_thinking_mode>
 """
 
 
@@ -282,6 +286,7 @@ def append_deep_thinking_prompt(system_prompt: str, enable_deep_thinking: bool) 
 # Skill Metadata Prompt Template
 SKILL_METADATA_PROMPT = """
 
+<skill>
 ## Available Skills
 
 The following skills provide specialized guidance for specific tasks. When your task matches a skill's description, use the `load_skill` tool to load the full instructions.
@@ -291,6 +296,7 @@ The following skills provide specialized guidance for specific tasks. When your 
 ### How to Use Skills
 
 **Load the skill**: Call `load_skill(skill_name="<skill-name>")` to load detailed instructions
+</skill>
 """
 
 
@@ -347,7 +353,7 @@ def build_system_prompt(
         The final system prompt with all enhancements applied
 
     Injection Order:
-        1. Base prompt
+        1. Base prompt (caller should wrap Ghost systemPrompt in <base_prompt> tags if needed)
         2. Clarification mode instructions (if enabled)
         3. Deep thinking mode instructions (if enabled)
         4. On-demand skill metadata (for load_skill tool)

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -323,8 +323,9 @@ class ChatContext:
             return False
 
         # Check for KB prompt markers in system_prompt
-        # Using both old (# IMPORTANT:) and new (## Knowledge Base) markers for compatibility
+        # Using both XML tag and legacy markers for compatibility
         kb_prompt_markers = [
+            "<knowledge_base>",
             "## Knowledge Base Requirement",
             "## Knowledge Base Available",
             "# IMPORTANT: Knowledge Base Requirement",

--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -218,7 +218,8 @@ class LoadSkillTool(BaseTool):
         for dynamic prompt modification.
 
         Returns:
-            Combined string of all loaded skill prompts, or empty string if none loaded
+            Combined string of all loaded skill prompts wrapped in <skill> tags,
+            or empty string if none loaded
         """
         if not self._loaded_skill_prompts:
             logger.debug("[LoadSkillTool.get_combined_skill_prompt] No loaded skills")
@@ -229,8 +230,9 @@ class LoadSkillTool(BaseTool):
             parts.append(f"\n\n## Skill: {skill_name}\n\n{prompt}")
 
         return (
-            "\n\n# Loaded Skill Instructions\n\nThe following skills have been loaded. "
+            "\n\n<skill>\n# Loaded Skill Instructions\n\nThe following skills have been loaded. "
             + "".join(parts)
+            + "\n</skill>"
         )
 
     # Alias for backward compatibility

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -116,13 +116,15 @@ async def prepare_knowledge_base_tools(
             "[knowledge_factory] Using RELAXED mode prompt (KB inherited from task)"
         )
 
-    enhanced_system_prompt = f"{base_system_prompt}{kb_instruction}"
-
-    # Add historical knowledge base meta info if available
+    # Get historical knowledge base meta info if available
+    kb_meta_prompt = ""
     if task_id:
         kb_meta_prompt = await _build_historical_kb_meta_prompt(db, task_id)
-        if kb_meta_prompt:
-            enhanced_system_prompt = f"{enhanced_system_prompt}{kb_meta_prompt}"
+
+    # Inject KB meta list into the template using format method
+    # This ensures the KB list appears inside the <knowledge_base> tag
+    kb_instruction_with_meta = kb_instruction.format(kb_meta_list=kb_meta_prompt)
+    enhanced_system_prompt = f"{base_system_prompt}{kb_instruction_with_meta}"
 
     return extra_tools, enhanced_system_prompt
 

--- a/chat_shell/tests/test_agent.py
+++ b/chat_shell/tests/test_agent.py
@@ -64,8 +64,12 @@ class TestDeepThinkingPrompt:
             enable_deep_thinking=False,
         )
 
-        # Should be same as base (no enhancements when both flags are False)
+        # Result should be same as base prompt (no enhancements when both flags are False)
+        # Note: <base_prompt> tag is NOT added here - it's added by Backend's get_bot_system_prompt()
         assert result == base_prompt
+        # Should NOT contain deep thinking or clarification prompts
+        assert "<deep_thinking_mode>" not in result
+        assert "<clarification_mode>" not in result
 
 
 class TestMessageBuilding:

--- a/executor/services/attachment_prompt_processor.py
+++ b/executor/services/attachment_prompt_processor.py
@@ -99,12 +99,13 @@ class AttachmentPromptProcessor:
             success_attachments: Successfully downloaded attachments
 
         Returns:
-            Context string describing available attachments and their paths
+            Context string describing available attachments and their paths,
+            wrapped in <attachment> tags
         """
         if not success_attachments:
             return ""
 
-        context_lines = ["\n\n📎 Available attachments:"]
+        context_lines = ["📎 Available attachments:"]
         for att in success_attachments:
             filename = att.get("original_filename", "unknown")
             local_path = att.get("local_path", "")
@@ -123,7 +124,7 @@ class AttachmentPromptProcessor:
                 f"- {filename} ({mime_type}, {size_str}): {local_path}"
             )
 
-        return "\n".join(context_lines)
+        return "\n\n<attachment>\n" + "\n".join(context_lines) + "\n</attachment>"
 
     @classmethod
     def build_image_content_blocks(

--- a/shared/prompts/knowledge_base.py
+++ b/shared/prompts/knowledge_base.py
@@ -10,8 +10,10 @@ shared across backend and chat_shell modules.
 
 # Strict mode prompt: User explicitly selected KB for this message
 # AI must use KB only and cannot use general knowledge
+# Note: Use .format(kb_meta_list=...) to inject KB list content
 KB_PROMPT_STRICT = """
 
+<knowledge_base>
 ## Knowledge Base Requirement
 
 The user has selected specific knowledge bases for this conversation. You MUST use the `knowledge_base_search` tool to retrieve information from these knowledge bases before answering any questions.
@@ -29,11 +31,16 @@ The user has selected specific knowledge bases for this conversation. You MUST u
 - You MUST NOT make up information if the knowledge base doesn't contain it
 - If unsure, search again with different keywords
 
-The user expects answers based on the selected knowledge base content only."""
+The user expects answers based on the selected knowledge base content only.
+{kb_meta_list}
+</knowledge_base>
+"""
 
 # Relaxed mode prompt: KB inherited from task, AI can use general knowledge as fallback
+# Note: Use .format(kb_meta_list=...) to inject KB list content
 KB_PROMPT_RELAXED = """
 
+<knowledge_base>
 ## Knowledge Base Available
 
 You have access to knowledge bases from previous conversations in this task. You can use the `knowledge_base_search` tool to retrieve information from these knowledge bases.
@@ -48,4 +55,7 @@ You have access to knowledge bases from previous conversations in this task. You
 - Search the knowledge base when the question seems related to its content
 - If the knowledge base doesn't contain relevant information, feel free to answer using your general knowledge
 - Clearly indicate when your answer is based on knowledge base content vs. general knowledge
-- The knowledge base is a helpful resource, but you are not limited to it when it doesn't have relevant information"""
+- The knowledge base is a helpful resource, but you are not limited to it when it doesn't have relevant information
+{kb_meta_list}
+</knowledge_base>
+"""


### PR DESCRIPTION
## Summary

Refactor the prompt template system by adding XML tags to wrap different prompt modules for better identification and structure.

### XML Tags Structure

| Module | XML Tag | Source |
|--------|---------|--------|
| Base system prompt | `<base_prompt>` | Ghost CRD `systemPrompt` |
| Knowledge base prompt | `<knowledge_base>` | `KB_PROMPT_STRICT` / `KB_PROMPT_RELAXED` |
| Data table prompt | `<table_context>` | `TABLE_PROMPT_TEMPLATE` |
| Clarification mode prompt | `<clarification_mode>` | `CLARIFICATION_PROMPT` |
| Deep thinking mode prompt | `<deep_thinking_mode>` | `DEEP_THINKING_PROMPT` |
| Skill prompt | `<skill>` | Skill metadata + loaded skill prompts |
| Attachment context | `<attachment>` | `AttachmentPromptProcessor` |

### Changes

**Chat Shell Module:**
- `chat_shell/chat_shell/prompts/builder.py`: Add XML tags to `CLARIFICATION_PROMPT`, `DEEP_THINKING_PROMPT`, `SKILL_METADATA_PROMPT`, and wrap `base_prompt` in `build_system_prompt()`
- `chat_shell/chat_shell/prompts/knowledge_base.py`: Add XML tags to `KB_PROMPT_STRICT` and `KB_PROMPT_RELAXED`
- `chat_shell/chat_shell/tools/builtin/load_skill.py`: Wrap returned skill prompts with `<skill>` tags
- `chat_shell/chat_shell/services/context.py`: Update KB prompt detection markers to include `<knowledge_base>` tag

**Backend Module:**
- `backend/app/services/chat/preprocessing/contexts.py`: Add XML tags to `KB_PROMPT_STRICT`, `KB_PROMPT_RELAXED`, and `TABLE_PROMPT_TEMPLATE`

**Executor Module:**
- `executor/services/attachment_prompt_processor.py`: Wrap attachment context with `<attachment>` tags

### Processing Rules

- Empty content modules do not generate XML tags
- Each XML tag block is separated by a blank line
- KB prompt detection mechanism still works (recognizes new XML tag format)

## Test plan

- [x] Verify that XML tags are correctly generated when each module is enabled individually
- [x] Verify that empty content modules do not generate XML tags
- [x] Verify that there is a blank line between multiple module tags
- [x] Verify that KB prompt deduplication detection mechanism still works (can recognize new XML tag format)
- [x] Verify that dynamically injected skill prompts are correctly wrapped in `<skill>` tags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved prompt structure and formatting for clearer separation of attachments, tables, and knowledge-base content
  * Unified attachment handling so attachments are grouped and wrapped consistently
  * Integrated historical knowledge-base metadata into system prompts for more relevant context
  * Added structured wrappers for clarification, deep-thinking, and skill instructions

* **Tests**
  * Updated system-prompt tests to reflect new wrapped prompt behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->