### PR TITLE
feat(frontend): add scroll-to-bottom indicator and gradient fade effect

### DIFF
--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -12,6 +12,7 @@ import { QuickAccessCards } from './QuickAccessCards'
 import { SloganDisplay } from './SloganDisplay'
 import { ChatInputCard } from '../input/ChatInputCard'
 import PipelineStageIndicator from './PipelineStageIndicator'
+import { ScrollToBottomIndicator } from './ScrollToBottomIndicator'
 import type { PipelineStageInfo } from '@/apis/tasks'
 import { useChatAreaState } from './useChatAreaState'
 import { useChatStreamHandlers } from './useChatStreamHandlers'
@@ -276,6 +277,7 @@ function ChatAreaContent({
   const {
     scrollContainerRef,
     isUserNearBottomRef,
+    showScrollIndicator,
     scrollToBottom,
     handleMessagesContentChange: _baseHandleMessagesContentChange,
   } = useScrollManagement({
@@ -743,7 +745,22 @@ function ChatAreaContent({
               width: floatingMetrics.width,
             }}
           >
-            <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-4">
+            {/* Bottom gradient fade effect - text fades as it approaches the input */}
+            <div
+              className="absolute top-0 left-0 right-0 h-12 -translate-y-full pointer-events-none"
+              style={{
+                background:
+                  'linear-gradient(to top, rgb(var(--color-bg-base)) 0%, rgb(var(--color-bg-base) / 0.8) 40%, rgb(var(--color-bg-base) / 0) 100%)',
+              }}
+            />
+            {/* Scroll to bottom indicator */}
+            <div className="absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full pointer-events-auto">
+              <ScrollToBottomIndicator
+                visible={showScrollIndicator}
+                onClick={() => scrollToBottom(true)}
+              />
+            </div>
+            <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-4 bg-base">
               <ChatInputCard {...inputCardProps} />
             </div>
           </div>

--- a/frontend/src/features/tasks/components/chat/ScrollToBottomIndicator.tsx
+++ b/frontend/src/features/tasks/components/chat/ScrollToBottomIndicator.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React from 'react'
+import { ChevronDown } from 'lucide-react'
+
+interface ScrollToBottomIndicatorProps {
+  /**
+   * Whether the indicator should be visible.
+   * When true, shows the indicator with animation.
+   */
+  visible: boolean
+
+  /**
+   * Callback function when the indicator is clicked.
+   * Should scroll to the bottom of the message list.
+   */
+  onClick: () => void
+}
+
+/**
+ * ScrollToBottomIndicator Component
+ *
+ * A small circular button that appears when the user scrolls up in the chat.
+ * Clicking it scrolls the message list to the bottom (most recent messages).
+ *
+ * Design inspired by Doubao chat interface:
+ * - Circular button with downward chevron icon
+ * - Appears above the input area with smooth fade animation
+ * - Provides visual feedback on hover
+ */
+export function ScrollToBottomIndicator({ visible, onClick }: ScrollToBottomIndicatorProps) {
+  if (!visible) return null
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        flex items-center justify-center
+        w-8 h-8 rounded-full
+        bg-surface border border-border
+        shadow-sm
+        text-text-secondary hover:text-text-primary
+        hover:bg-base hover:border-border-hover
+        transition-all duration-200
+        cursor-pointer
+        animate-in fade-in slide-in-from-bottom-2 duration-200
+      "
+      aria-label="Scroll to bottom"
+    >
+      <ChevronDown className="w-4 h-4" />
+    </button>
+  )
+}
+
+export default ScrollToBottomIndicator

--- a/frontend/src/features/tasks/components/hooks/useScrollManagement.ts
+++ b/frontend/src/features/tasks/components/hooks/useScrollManagement.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, useCallback, useEffect } from 'react'
+import { useRef, useCallback, useEffect, useState } from 'react'
 
 /**
  * Threshold in pixels for determining if user is near the bottom of the scroll container.
@@ -55,6 +55,12 @@ export interface UseScrollManagementReturn {
   isUserNearBottomRef: React.RefObject<boolean>
 
   /**
+   * Whether to show the scroll-to-bottom indicator button.
+   * True when user has scrolled up and is not near the bottom.
+   */
+  showScrollIndicator: boolean
+
+  /**
    * Function to scroll to the bottom of the container.
    * @param force - If true, scrolls regardless of user position.
    */
@@ -88,6 +94,8 @@ export function useScrollManagement({
 }: UseScrollManagementOptions): UseScrollManagementReturn {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const isUserNearBottomRef = useRef<boolean>(true)
+  // State for showing/hiding the scroll-to-bottom indicator
+  const [showScrollIndicator, setShowScrollIndicator] = useState(false)
 
   /**
    * Scrolls the container to the bottom.
@@ -106,6 +114,7 @@ export function useScrollManagement({
           container.scrollTop = container.scrollHeight
           if (force) {
             isUserNearBottomRef.current = true
+            setShowScrollIndicator(false)
           }
         }
       })
@@ -127,6 +136,7 @@ export function useScrollManagement({
    *
    * This replaces the original useEffect at lines 400-414 in ChatArea.tsx.
    * Updates isUserNearBottomRef based on scroll position.
+   * Also updates showScrollIndicator state for UI display.
    */
   useEffect(() => {
     const container = scrollContainerRef.current
@@ -135,7 +145,10 @@ export function useScrollManagement({
     const handleScroll = () => {
       const distanceFromBottom =
         container.scrollHeight - container.scrollTop - container.clientHeight
-      isUserNearBottomRef.current = distanceFromBottom <= AUTO_SCROLL_THRESHOLD
+      const isNearBottom = distanceFromBottom <= AUTO_SCROLL_THRESHOLD
+      isUserNearBottomRef.current = isNearBottom
+      // Show indicator when user has scrolled up (not near bottom)
+      setShowScrollIndicator(!isNearBottom && hasMessages)
     }
 
     container.addEventListener('scroll', handleScroll)
@@ -177,6 +190,7 @@ export function useScrollManagement({
   return {
     scrollContainerRef,
     isUserNearBottomRef,
+    showScrollIndicator,
     scrollToBottom,
     handleMessagesContentChange,
   }


### PR DESCRIPTION
Add a scroll-to-bottom indicator button and bottom gradient fade effect to the chat interface, inspired by Doubao chat UI design.

Changes:
- Add ScrollToBottomIndicator component with chevron-down icon
- Update useScrollManagement hook to track showScrollIndicator state
- Add bottom gradient fade effect above floating input area
- Show indicator when user scrolls up, hide when at bottom

The indicator appears as a small circular button above the input area when the user scrolls up to view older messages. Clicking it smoothly scrolls back to the latest messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a scroll-to-bottom indicator button in the chat that appears when messages are above the current view, enabling quick navigation to the latest messages.
  * Added a gradient fade effect at the bottom of the chat area for improved visual hierarchy and text readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->