### PR TITLE
feat(subscription): add notification level settings for subscription followers

### DIFF
--- a/backend/alembic/versions/x4y5z6a7b8c9_add_subscription_follow_notification_config.py
+++ b/backend/alembic/versions/x4y5z6a7b8c9_add_subscription_follow_notification_config.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add subscription follow notification config column
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2025-01-30
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "x4y5z6a7b8c9"
+down_revision: Union[str, None] = "w3x4y5z6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add config column to subscription_follows table
+    # JSON structure:
+    # {
+    #   "notification_level": "silent" | "default" | "notify",
+    #   "notification_channel_ids": [1, 2, ...]
+    # }
+    op.add_column(
+        "subscription_follows",
+        sa.Column("config", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("subscription_follows", "config")

--- a/backend/app/api/endpoints/adapter/subscription_follows.py
+++ b/backend/app/api/endpoints/adapter/subscription_follows.py
@@ -23,12 +23,18 @@ from app.models.user import User
 from app.schemas.subscription import (
     DiscoverSubscriptionsListResponse,
     FollowingSubscriptionsListResponse,
+    FollowSettingsResponse,
+    FollowSubscriptionRequest,
     InviteNamespaceRequest,
     InviteUserRequest,
     SubscriptionFollowersListResponse,
     SubscriptionInvitationsListResponse,
+    UpdateFollowSettingsRequest,
 )
 from app.services.subscription.follow_service import subscription_follow_service
+from app.services.subscription.notification_service import (
+    subscription_notification_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +47,7 @@ router = APIRouter()
 @router.post("/{subscription_id}/follow", status_code=status.HTTP_200_OK)
 def follow_subscription(
     subscription_id: int,
+    request: Optional[FollowSubscriptionRequest] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(security.get_current_user),
 ):
@@ -48,12 +55,20 @@ def follow_subscription(
     Follow a public subscription.
 
     Users can follow public subscriptions to see their execution results
-    in their Feed timeline.
+    in their Feed timeline. Optionally specify notification settings.
     """
+    notification_level = None
+    notification_channel_ids = None
+    if request:
+        notification_level = request.notification_level
+        notification_channel_ids = request.notification_channel_ids
+
     return subscription_follow_service.follow_subscription(
         db=db,
         subscription_id=subscription_id,
         user_id=current_user.id,
+        notification_level=notification_level,
+        notification_channel_ids=notification_channel_ids,
     )
 
 
@@ -117,6 +132,54 @@ def get_followers_count(
         subscription_id=subscription_id,
     )
     return {"count": count}
+
+
+# ========== Follow Settings Endpoints ==========
+
+
+@router.get("/{subscription_id}/follow/settings", response_model=FollowSettingsResponse)
+def get_follow_settings(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get notification settings for a subscription follow.
+
+    Returns the current notification level, selected channels, and
+    all available Messager channels with binding status.
+    """
+    return subscription_notification_service.get_follow_settings(
+        db=db,
+        subscription_id=subscription_id,
+        user_id=current_user.id,
+    )
+
+
+@router.put("/{subscription_id}/follow/settings", response_model=FollowSettingsResponse)
+def update_follow_settings(
+    subscription_id: int,
+    request: UpdateFollowSettingsRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Update notification settings for a subscription follow.
+
+    Allows changing the notification level and selecting notification channels.
+    """
+    try:
+        return subscription_notification_service.update_follow_settings(
+            db=db,
+            subscription_id=subscription_id,
+            user_id=current_user.id,
+            notification_level=request.notification_level,
+            notification_channel_ids=request.notification_channel_ids,
+        )
+    except ValueError as e:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 # ========== Invitation Endpoints ==========

--- a/backend/app/models/subscription_follow.py
+++ b/backend/app/models/subscription_follow.py
@@ -18,9 +18,18 @@ from sqlalchemy import (
     Index,
     Integer,
     String,
+    Text,
 )
 
 from app.db.base import Base
+
+
+class NotificationLevel(str, Enum):
+    """Notification level enumeration for subscription followers."""
+
+    SILENT = "silent"  # Execute but mark as COMPLETED_SILENT, hidden from timeline
+    DEFAULT = "default"  # Normal behavior, shows in Feed timeline
+    NOTIFY = "notify"  # Send notification via Messager channels
 
 
 class FollowType(str, Enum):
@@ -74,6 +83,10 @@ class SubscriptionFollow(Base):
     updated_at = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
+
+    # Notification settings (JSON)
+    # Structure: {"notification_level": "default", "notification_channel_ids": [1, 2]}
+    config = Column(Text, nullable=True)
 
     __table_args__ = (
         # Index for querying followers of a subscription

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -716,3 +716,87 @@ class RentalCountResponse(BaseModel):
 
     subscription_id: int
     rental_count: int
+
+
+# ========== Notification Level Schemas ==========
+
+
+class NotificationLevel(str, Enum):
+    """Notification level enumeration for subscription followers."""
+
+    SILENT = "silent"  # Execute but mark as COMPLETED_SILENT, hidden from timeline
+    DEFAULT = "default"  # Normal behavior, shows in Feed timeline
+    NOTIFY = "notify"  # Send notification via Messager channels
+
+
+class SubscriptionFollowConfig(BaseModel):
+    """Configuration for subscription follow notification settings."""
+
+    notification_level: NotificationLevel = Field(
+        NotificationLevel.DEFAULT, description="Notification level for this follow"
+    )
+    notification_channel_ids: Optional[List[int]] = Field(
+        None, description="Messager channel IDs for notify level"
+    )
+
+
+class FollowSubscriptionRequest(BaseModel):
+    """Request to follow a subscription with optional notification settings."""
+
+    notification_level: Optional[NotificationLevel] = Field(
+        None, description="Notification level (default: 'default')"
+    )
+    notification_channel_ids: Optional[List[int]] = Field(
+        None, description="Messager channel IDs for notify level"
+    )
+
+
+class UpdateFollowSettingsRequest(BaseModel):
+    """Request to update follow notification settings."""
+
+    notification_level: NotificationLevel = Field(..., description="Notification level")
+    notification_channel_ids: Optional[List[int]] = Field(
+        None, description="Messager channel IDs for notify level"
+    )
+
+
+class NotificationChannelInfo(BaseModel):
+    """Information about a notification channel (Messager)."""
+
+    id: int = Field(..., description="Messager Kind ID")
+    name: str = Field(..., description="Channel display name")
+    channel_type: str = Field(..., description="Channel type (dingtalk, feishu, etc.)")
+    is_bound: bool = Field(False, description="Whether user has bound to this channel")
+
+
+class FollowSettingsResponse(BaseModel):
+    """Response for follow notification settings."""
+
+    notification_level: NotificationLevel = Field(
+        NotificationLevel.DEFAULT, description="Current notification level"
+    )
+    notification_channel_ids: List[int] = Field(
+        default_factory=list, description="Selected channel IDs"
+    )
+    notification_channels: List[NotificationChannelInfo] = Field(
+        default_factory=list, description="Selected channels info"
+    )
+    available_channels: List[NotificationChannelInfo] = Field(
+        default_factory=list, description="All available Messager channels"
+    )
+
+
+class IMChannelBinding(BaseModel):
+    """IM channel binding information in user preferences."""
+
+    channel_type: str = Field(..., description="Channel type (dingtalk, feishu, etc.)")
+    sender_id: str = Field(..., description="Sender ID in the IM platform")
+    sender_staff_id: Optional[str] = Field(
+        None, description="Staff ID (for enterprise channels)"
+    )
+    last_conversation_id: Optional[str] = Field(
+        None, description="Last conversation/task ID"
+    )
+    last_active_at: Optional[str] = Field(
+        None, description="Last activity timestamp (ISO format)"
+    )

--- a/backend/app/services/channels/dingtalk/service.py
+++ b/backend/app/services/channels/dingtalk/service.py
@@ -191,6 +191,7 @@ class DingTalkChannelProvider(BaseChannelProvider):
                 get_default_model_name=lambda: _get_channel_default_model_name(
                     channel_id
                 ),
+                channel_id=channel_id,
             )
             self._client.register_callback_handler(
                 dingtalk_stream.chatbot.ChatbotMessage.TOPIC,

--- a/backend/app/services/subscription/notification_dispatcher.py
+++ b/backend/app/services/subscription/notification_dispatcher.py
@@ -1,0 +1,383 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Subscription notification dispatcher for sending notifications to followers.
+
+This module provides functionality to:
+- Dispatch notifications to followers based on their notification settings
+- Send notifications via Messager channels (DingTalk, Feishu, etc.)
+- Handle notification failures gracefully
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.cache import cache_manager
+from app.models.kind import Kind
+from app.models.subscription_follow import InvitationStatus, SubscriptionFollow
+from app.models.user import User
+from app.schemas.subscription import (
+    NotificationLevel,
+    SubscriptionFollowConfig,
+)
+from app.services.subscription.notification_service import (
+    subscription_notification_service,
+)
+
+logger = logging.getLogger(__name__)
+
+# Redis key prefix for DingTalk conversation -> task_id mapping
+DINGTALK_CONV_TASK_PREFIX = "dingtalk:conv_task:"
+
+# Messager CRD kind
+MESSAGER_KIND = "Messager"
+MESSAGER_USER_ID = 0
+
+
+class SubscriptionNotificationDispatcher:
+    """Dispatcher for sending subscription execution notifications to followers."""
+
+    async def dispatch_execution_notifications(
+        self,
+        db: Session,
+        *,
+        subscription_id: int,
+        execution_id: int,
+        subscription_display_name: str,
+        result_summary: str,
+        status: str,
+        detail_url: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Dispatch notifications to all followers based on their settings.
+
+        Args:
+            db: Database session
+            subscription_id: Subscription ID
+            execution_id: Background execution ID
+            subscription_display_name: Display name of the subscription
+            result_summary: Summary of the execution result
+            status: Execution status (COMPLETED, FAILED, etc.)
+            detail_url: URL to view execution details
+
+        Returns:
+            Dict with notification dispatch results
+        """
+        # Get all accepted followers with their settings
+        followers_with_settings = (
+            subscription_notification_service.get_followers_with_settings(
+                db, subscription_id=subscription_id
+            )
+        )
+
+        results = {
+            "total_followers": len(followers_with_settings),
+            "silent_count": 0,
+            "default_count": 0,
+            "notify_count": 0,
+            "notify_success": 0,
+            "notify_failed": 0,
+            "errors": [],
+        }
+
+        for user_id, config in followers_with_settings:
+            level = config.notification_level
+
+            if level == NotificationLevel.SILENT:
+                results["silent_count"] += 1
+                # Silent: no notification sent, execution marked as COMPLETED_SILENT
+                continue
+
+            elif level == NotificationLevel.DEFAULT:
+                results["default_count"] += 1
+                # Default: no special notification, WebSocket handles it
+                continue
+
+            elif level == NotificationLevel.NOTIFY:
+                results["notify_count"] += 1
+                # Notify: send notification via Messager channels
+                if config.notification_channel_ids:
+                    try:
+                        await self._send_messager_notifications(
+                            db=db,
+                            user_id=user_id,
+                            channel_ids=config.notification_channel_ids,
+                            subscription_id=subscription_id,
+                            execution_id=execution_id,
+                            subscription_display_name=subscription_display_name,
+                            result_summary=result_summary,
+                            status=status,
+                            detail_url=detail_url,
+                        )
+                        results["notify_success"] += 1
+                    except Exception as e:
+                        results["notify_failed"] += 1
+                        results["errors"].append(
+                            f"Failed to notify user {user_id}: {str(e)}"
+                        )
+                        logger.warning(
+                            f"[SubscriptionNotificationDispatcher] Failed to notify user {user_id}: {e}"
+                        )
+                else:
+                    # No channels configured, log warning
+                    logger.warning(
+                        f"[SubscriptionNotificationDispatcher] User {user_id} has notify level "
+                        f"but no channels configured"
+                    )
+
+        logger.info(
+            f"[SubscriptionNotificationDispatcher] Dispatched notifications for "
+            f"subscription {subscription_id} execution {execution_id}: "
+            f"silent={results['silent_count']}, default={results['default_count']}, "
+            f"notify={results['notify_count']} (success={results['notify_success']}, "
+            f"failed={results['notify_failed']})"
+        )
+
+        return results
+
+    async def _send_messager_notifications(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        channel_ids: List[int],
+        subscription_id: int,
+        execution_id: int,
+        subscription_display_name: str,
+        result_summary: str,
+        status: str,
+        detail_url: Optional[str] = None,
+    ) -> None:
+        """
+        Send notifications via Messager channels.
+
+        Args:
+            db: Database session
+            user_id: User ID to notify
+            channel_ids: List of Messager channel IDs
+            subscription_id: Subscription ID
+            execution_id: Background execution ID
+            subscription_display_name: Display name of the subscription
+            result_summary: Summary of the execution result
+            status: Execution status
+            detail_url: URL to view execution details
+        """
+        # Get user's IM bindings
+        user_bindings = subscription_notification_service.get_user_im_bindings(
+            db, user_id=user_id
+        )
+
+        # Format the notification message
+        message = self._format_notification_message(
+            subscription_display_name=subscription_display_name,
+            status=status,
+            result_summary=result_summary,
+            detail_url=detail_url,
+        )
+
+        # Send to each configured channel
+        tasks = []
+        for channel_id in channel_ids:
+            channel_id_str = str(channel_id)
+
+            # Check if user has binding for this channel
+            if channel_id_str not in user_bindings:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] User {user_id} has no binding "
+                    f"for channel {channel_id}"
+                )
+                continue
+
+            binding = user_bindings[channel_id_str]
+
+            # Get channel info
+            channel = (
+                db.query(Kind)
+                .filter(
+                    Kind.id == channel_id,
+                    Kind.kind == MESSAGER_KIND,
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+
+            if not channel:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] Channel {channel_id} not found"
+                )
+                continue
+
+            spec = channel.json.get("spec", {})
+            channel_type = spec.get("channelType", "")
+
+            # Dispatch based on channel type
+            if channel_type == "dingtalk":
+                tasks.append(
+                    self._send_dingtalk_notification(
+                        db=db,
+                        channel=channel,
+                        binding=binding,
+                        user_id=user_id,
+                        message=message,
+                        subscription_id=subscription_id,
+                        execution_id=execution_id,
+                    )
+                )
+            else:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] Unsupported channel type: {channel_type}"
+                )
+
+        # Run all notification tasks concurrently
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _send_dingtalk_notification(
+        self,
+        db: Session,
+        *,
+        channel: Kind,
+        binding: Any,
+        user_id: int,
+        message: str,
+        subscription_id: int,
+        execution_id: int,
+    ) -> None:
+        """
+        Send notification via DingTalk.
+
+        Args:
+            db: Database session
+            channel: Messager Kind
+            binding: User's IM binding info
+            user_id: User ID
+            message: Notification message
+            subscription_id: Subscription ID
+            execution_id: Background execution ID
+        """
+        try:
+            # Get conversation task_id from binding
+            conversation_id = binding.last_conversation_id
+            if not conversation_id:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] User {user_id} has no "
+                    f"conversation_id for DingTalk channel {channel.id}"
+                )
+                return
+
+            # Get task_id from Redis cache
+            key = f"{DINGTALK_CONV_TASK_PREFIX}{conversation_id}"
+            task_id = await cache_manager.get(key)
+
+            if not task_id:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] No cached task for "
+                    f"conversation {conversation_id}"
+                )
+                return
+
+            # Create a subtask in the user's Messager conversation
+            from app.models.task import Subtask, TaskResource
+
+            task = (
+                db.query(TaskResource).filter(TaskResource.id == int(task_id)).first()
+            )
+            if not task:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] Task {task_id} not found"
+                )
+                return
+
+            # Create notification subtask
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
+            result_json = {
+                "type": "subscription_notification",
+                "subscription_id": subscription_id,
+                "execution_id": execution_id,
+                "message": message,
+            }
+
+            notification_subtask = Subtask(
+                task_id=int(task_id),
+                sender_type="SYSTEM",
+                role="assistant",
+                content=message,
+                status="COMPLETED",
+                result=json.dumps(result_json),
+                started_at=now,
+                completed_at=now,
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(notification_subtask)
+            db.commit()
+
+            logger.info(
+                f"[SubscriptionNotificationDispatcher] Created notification subtask "
+                f"for user {user_id} in task {task_id}"
+            )
+
+            # TODO: Send actual DingTalk message via API
+            # This would require implementing proactive messaging via DingTalk's
+            # robot send message API, which needs additional setup
+
+        except Exception as e:
+            logger.error(
+                f"[SubscriptionNotificationDispatcher] Failed to send DingTalk "
+                f"notification to user {user_id}: {e}"
+            )
+            raise
+
+    def _format_notification_message(
+        self,
+        *,
+        subscription_display_name: str,
+        status: str,
+        result_summary: str,
+        detail_url: Optional[str] = None,
+    ) -> str:
+        """
+        Format the notification message.
+
+        Args:
+            subscription_display_name: Display name of the subscription
+            status: Execution status
+            result_summary: Summary of the execution result
+            detail_url: URL to view execution details
+
+        Returns:
+            Formatted notification message
+        """
+        status_emoji = "✅" if status == "COMPLETED" else "❌"
+        status_text = "Success" if status == "COMPLETED" else "Failed"
+
+        # Truncate summary to 200 characters
+        truncated_summary = (
+            result_summary[:200] + "..."
+            if len(result_summary) > 200
+            else result_summary
+        )
+
+        message = f"""📬 Subscription Update
+
+**Subscription**: {subscription_display_name}
+**Status**: {status_emoji} {status_text}
+
+**Summary**:
+{truncated_summary}"""
+
+        if detail_url:
+            message += f"\n\n[View Details]({detail_url})"
+
+        return message
+
+
+# Singleton instance
+subscription_notification_dispatcher = SubscriptionNotificationDispatcher()

--- a/backend/app/services/subscription/notification_service.py
+++ b/backend/app/services/subscription/notification_service.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Subscription notification service for managing follower notifications.
+
+This module provides:
+- Follow notification settings management
+- IM channel binding detection
+- Notification dispatch for subscription executions
+"""
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.models.subscription_follow import (
+    InvitationStatus,
+    NotificationLevel,
+    SubscriptionFollow,
+)
+from app.models.user import User
+from app.schemas.subscription import (
+    FollowSettingsResponse,
+    IMChannelBinding,
+    NotificationChannelInfo,
+)
+from app.schemas.subscription import NotificationLevel as SchemaNotificationLevel
+from app.schemas.subscription import (
+    SubscriptionFollowConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Messager CRD kind
+MESSAGER_KIND = "Messager"
+MESSAGER_USER_ID = 0
+
+
+class SubscriptionNotificationService:
+    """Service for managing subscription follower notifications."""
+
+    def get_follow_settings(
+        self,
+        db: Session,
+        *,
+        subscription_id: int,
+        user_id: int,
+    ) -> FollowSettingsResponse:
+        """
+        Get notification settings for a subscription follow.
+
+        Args:
+            db: Database session
+            subscription_id: Subscription ID
+            user_id: Follower user ID
+
+        Returns:
+            Follow settings with available channels
+        """
+        # Get the follow record
+        follow = (
+            db.query(SubscriptionFollow)
+            .filter(
+                SubscriptionFollow.subscription_id == subscription_id,
+                SubscriptionFollow.follower_user_id == user_id,
+                SubscriptionFollow.invitation_status == InvitationStatus.ACCEPTED.value,
+            )
+            .first()
+        )
+
+        if not follow:
+            # Return default settings if not following
+            return FollowSettingsResponse(
+                notification_level=SchemaNotificationLevel.DEFAULT,
+                notification_channel_ids=[],
+                notification_channels=[],
+                available_channels=self._get_available_channels(db, user_id),
+            )
+
+        # Parse config
+        config = self._parse_follow_config(follow.config)
+
+        # Get selected channel info
+        selected_channels = []
+        if config.notification_channel_ids:
+            selected_channels = self._get_channels_info(
+                db, config.notification_channel_ids, user_id
+            )
+
+        return FollowSettingsResponse(
+            notification_level=config.notification_level,
+            notification_channel_ids=config.notification_channel_ids or [],
+            notification_channels=selected_channels,
+            available_channels=self._get_available_channels(db, user_id),
+        )
+
+    def update_follow_settings(
+        self,
+        db: Session,
+        *,
+        subscription_id: int,
+        user_id: int,
+        notification_level: SchemaNotificationLevel,
+        notification_channel_ids: Optional[List[int]] = None,
+    ) -> FollowSettingsResponse:
+        """
+        Update notification settings for a subscription follow.
+
+        Args:
+            db: Database session
+            subscription_id: Subscription ID
+            user_id: Follower user ID
+            notification_level: New notification level
+            notification_channel_ids: Messager channel IDs (for notify level)
+
+        Returns:
+            Updated follow settings
+
+        Raises:
+            ValueError: If not following the subscription
+        """
+        # Get the follow record
+        follow = (
+            db.query(SubscriptionFollow)
+            .filter(
+                SubscriptionFollow.subscription_id == subscription_id,
+                SubscriptionFollow.follower_user_id == user_id,
+                SubscriptionFollow.invitation_status == InvitationStatus.ACCEPTED.value,
+            )
+            .first()
+        )
+
+        if not follow:
+            raise ValueError("Not following this subscription")
+
+        # Build new config
+        config = SubscriptionFollowConfig(
+            notification_level=notification_level,
+            notification_channel_ids=notification_channel_ids,
+        )
+
+        # Update follow record
+        follow.config = config.model_dump_json()
+        follow.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        db.commit()
+
+        logger.info(
+            f"[SubscriptionNotification] Updated settings for user {user_id} on subscription {subscription_id}: "
+            f"level={notification_level.value}, channels={notification_channel_ids}"
+        )
+
+        # Return updated settings
+        selected_channels = []
+        if notification_channel_ids:
+            selected_channels = self._get_channels_info(
+                db, notification_channel_ids, user_id
+            )
+
+        return FollowSettingsResponse(
+            notification_level=notification_level,
+            notification_channel_ids=notification_channel_ids or [],
+            notification_channels=selected_channels,
+            available_channels=self._get_available_channels(db, user_id),
+        )
+
+    def get_followers_with_settings(
+        self,
+        db: Session,
+        *,
+        subscription_id: int,
+    ) -> List[Tuple[int, SubscriptionFollowConfig]]:
+        """
+        Get all accepted followers and their notification settings for a subscription.
+
+        Args:
+            db: Database session
+            subscription_id: Subscription ID
+
+        Returns:
+            List of (user_id, config) tuples
+        """
+        follows = (
+            db.query(SubscriptionFollow)
+            .filter(
+                SubscriptionFollow.subscription_id == subscription_id,
+                SubscriptionFollow.invitation_status == InvitationStatus.ACCEPTED.value,
+            )
+            .all()
+        )
+
+        result = []
+        for follow in follows:
+            config = self._parse_follow_config(follow.config)
+            result.append((follow.follower_user_id, config))
+
+        return result
+
+    def get_user_im_bindings(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+    ) -> Dict[str, IMChannelBinding]:
+        """
+        Get user's IM channel bindings from preferences.
+
+        Args:
+            db: Database session
+            user_id: User ID
+
+        Returns:
+            Dict mapping channel_id (string) to IMChannelBinding
+        """
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user or not user.preferences:
+            return {}
+
+        try:
+            preferences = json.loads(user.preferences)
+            im_channels = preferences.get("im_channels", {})
+            result = {}
+            for channel_id, binding_data in im_channels.items():
+                try:
+                    result[channel_id] = IMChannelBinding.model_validate(binding_data)
+                except Exception as e:
+                    logger.warning(
+                        f"[SubscriptionNotification] Invalid IM binding for user {user_id}, "
+                        f"channel {channel_id}: {e}"
+                    )
+            return result
+        except json.JSONDecodeError:
+            return {}
+
+    def update_user_im_binding(
+        self,
+        db: Session,
+        *,
+        user_id: int,
+        channel_id: int,
+        channel_type: str,
+        sender_id: str,
+        sender_staff_id: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+    ) -> None:
+        """
+        Update user's IM channel binding in preferences.
+
+        Called when user sends a message via Messager channel.
+
+        Args:
+            db: Database session
+            user_id: User ID
+            channel_id: Messager Kind ID
+            channel_type: Channel type (dingtalk, feishu, etc.)
+            sender_id: User's ID in the IM platform
+            sender_staff_id: Staff ID (for enterprise channels)
+            conversation_id: Current conversation/task ID
+        """
+        user = db.query(User).filter(User.id == user_id).first()
+        if not user:
+            logger.warning(
+                f"[SubscriptionNotification] User {user_id} not found for IM binding update"
+            )
+            return
+
+        try:
+            preferences = json.loads(user.preferences or "{}")
+        except json.JSONDecodeError:
+            preferences = {}
+
+        im_channels = preferences.get("im_channels", {})
+        im_channels[str(channel_id)] = {
+            "channel_type": channel_type,
+            "sender_id": sender_id,
+            "sender_staff_id": sender_staff_id,
+            "last_conversation_id": conversation_id,
+            "last_active_at": datetime.now(timezone.utc).isoformat(),
+        }
+        preferences["im_channels"] = im_channels
+
+        user.preferences = json.dumps(preferences)
+        db.commit()
+
+        logger.debug(
+            f"[SubscriptionNotification] Updated IM binding for user {user_id}, "
+            f"channel {channel_id} ({channel_type})"
+        )
+
+    def _parse_follow_config(
+        self, config_json: Optional[str]
+    ) -> SubscriptionFollowConfig:
+        """Parse follow config from JSON string."""
+        if not config_json:
+            return SubscriptionFollowConfig()
+
+        try:
+            data = json.loads(config_json)
+            return SubscriptionFollowConfig.model_validate(data)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning(f"[SubscriptionNotification] Invalid config JSON: {e}")
+            return SubscriptionFollowConfig()
+
+    def _get_available_channels(
+        self,
+        db: Session,
+        user_id: int,
+    ) -> List[NotificationChannelInfo]:
+        """
+        Get all available Messager channels with binding status.
+
+        Args:
+            db: Database session
+            user_id: User ID to check bindings
+
+        Returns:
+            List of channel info with binding status
+        """
+        # Get all enabled Messager channels
+        channels = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == MESSAGER_KIND,
+                Kind.user_id == MESSAGER_USER_ID,
+                Kind.is_active == True,
+            )
+            .all()
+        )
+
+        # Get user's IM bindings
+        user_bindings = self.get_user_im_bindings(db, user_id=user_id)
+
+        result = []
+        for channel in channels:
+            spec = channel.json.get("spec", {})
+            if not spec.get("isEnabled", True):
+                continue
+
+            channel_info = NotificationChannelInfo(
+                id=channel.id,
+                name=channel.json.get("metadata", {}).get("name", channel.name),
+                channel_type=spec.get("channelType", "unknown"),
+                is_bound=str(channel.id) in user_bindings,
+            )
+            result.append(channel_info)
+
+        return result
+
+    def _get_channels_info(
+        self,
+        db: Session,
+        channel_ids: List[int],
+        user_id: int,
+    ) -> List[NotificationChannelInfo]:
+        """
+        Get channel info for specific channel IDs.
+
+        Args:
+            db: Database session
+            channel_ids: List of Messager Kind IDs
+            user_id: User ID to check bindings
+
+        Returns:
+            List of channel info
+        """
+        if not channel_ids:
+            return []
+
+        channels = (
+            db.query(Kind)
+            .filter(
+                Kind.id.in_(channel_ids),
+                Kind.kind == MESSAGER_KIND,
+                Kind.is_active == True,
+            )
+            .all()
+        )
+
+        # Get user's IM bindings
+        user_bindings = self.get_user_im_bindings(db, user_id=user_id)
+
+        result = []
+        for channel in channels:
+            spec = channel.json.get("spec", {})
+            channel_info = NotificationChannelInfo(
+                id=channel.id,
+                name=channel.json.get("metadata", {}).get("name", channel.name),
+                channel_type=spec.get("channelType", "unknown"),
+                is_bound=str(channel.id) in user_bindings,
+            )
+            result.append(channel_info)
+
+        return result
+
+
+# Singleton instance
+subscription_notification_service = SubscriptionNotificationService()

--- a/frontend/src/apis/subscription.ts
+++ b/frontend/src/apis/subscription.ts
@@ -18,6 +18,7 @@ import type {
   SubscriptionUpdateRequest,
   DiscoverSubscriptionsListResponse,
   FollowingSubscriptionsListResponse,
+  FollowSubscriptionRequest,
   InviteUserRequest,
   InviteNamespaceRequest,
   SubscriptionFollowersListResponse,
@@ -28,6 +29,8 @@ import type {
   RentalSubscriptionResponse,
   RentalSubscriptionsListResponse,
   RentalCountResponse,
+  FollowSettingsResponse,
+  UpdateFollowSettingsRequest,
 } from '@/types/subscription'
 import type { PaginationParams } from '@/types/api'
 
@@ -154,8 +157,11 @@ export const subscriptionApis = {
   /**
    * Follow a public subscription
    */
-  async followSubscription(subscriptionId: number): Promise<{ message: string }> {
-    return apiClient.post(`/subscriptions/${subscriptionId}/follow`)
+  async followSubscription(
+    subscriptionId: number,
+    request?: FollowSubscriptionRequest
+  ): Promise<{ message: string }> {
+    return apiClient.post(`/subscriptions/${subscriptionId}/follow`, request || {})
   },
 
   /**
@@ -163,6 +169,23 @@ export const subscriptionApis = {
    */
   async unfollowSubscription(subscriptionId: number): Promise<{ message: string }> {
     return apiClient.delete(`/subscriptions/${subscriptionId}/follow`)
+  },
+
+  /**
+   * Get follow settings for a subscription
+   */
+  async getFollowSettings(subscriptionId: number): Promise<FollowSettingsResponse> {
+    return apiClient.get(`/subscriptions/${subscriptionId}/follow/settings`)
+  },
+
+  /**
+   * Update follow settings for a subscription
+   */
+  async updateFollowSettings(
+    subscriptionId: number,
+    request: UpdateFollowSettingsRequest
+  ): Promise<FollowSettingsResponse> {
+    return apiClient.put(`/subscriptions/${subscriptionId}/follow/settings`, request)
   },
 
   /**

--- a/frontend/src/features/feed/components/FollowNotificationSettingsDialog.tsx
+++ b/frontend/src/features/feed/components/FollowNotificationSettingsDialog.tsx
@@ -1,0 +1,277 @@
+'use client'
+
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Follow notification settings dialog component.
+ * Allows users to configure notification level and channels for followed subscriptions.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { Bell, BellOff, BellRing, Loader2, MessageSquare } from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from '@/hooks/useTranslation'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Label } from '@/components/ui/label'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
+import { subscriptionApis } from '@/apis/subscription'
+import type {
+  NotificationLevel,
+  NotificationChannelInfo,
+  FollowSettingsResponse,
+} from '@/types/subscription'
+
+interface FollowNotificationSettingsDialogProps {
+  subscriptionId: number
+  subscriptionName: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSettingsUpdated?: () => void
+}
+
+export function FollowNotificationSettingsDialog({
+  subscriptionId,
+  subscriptionName,
+  open,
+  onOpenChange,
+  onSettingsUpdated,
+}: FollowNotificationSettingsDialogProps) {
+  const { t } = useTranslation('feed')
+
+  // State
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [settings, setSettings] = useState<FollowSettingsResponse | null>(null)
+  const [selectedLevel, setSelectedLevel] = useState<NotificationLevel>('default')
+  const [selectedChannels, setSelectedChannels] = useState<number[]>([])
+
+  // Load settings when dialog opens
+  useEffect(() => {
+    if (open && subscriptionId) {
+      loadSettings()
+    }
+  }, [open, subscriptionId])
+
+  const loadSettings = async () => {
+    try {
+      setLoading(true)
+      const response = await subscriptionApis.getFollowSettings(subscriptionId)
+      setSettings(response)
+      setSelectedLevel(response.notification_level)
+      setSelectedChannels(response.notification_channel_ids)
+    } catch (error) {
+      console.error('Failed to load follow settings:', error)
+      toast.error(t('common:errors.load_failed'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Handle save
+  const handleSave = useCallback(async () => {
+    try {
+      setSaving(true)
+      await subscriptionApis.updateFollowSettings(subscriptionId, {
+        notification_level: selectedLevel,
+        notification_channel_ids: selectedLevel === 'notify' ? selectedChannels : undefined,
+      })
+      toast.success(t('notification_settings.save_success'))
+      onOpenChange(false)
+      onSettingsUpdated?.()
+    } catch (error) {
+      console.error('Failed to save follow settings:', error)
+      toast.error(t('notification_settings.save_failed'))
+    } finally {
+      setSaving(false)
+    }
+  }, [subscriptionId, selectedLevel, selectedChannels, t, onOpenChange, onSettingsUpdated])
+
+  // Handle channel toggle
+  const handleChannelToggle = useCallback((channelId: number, checked: boolean) => {
+    setSelectedChannels(prev =>
+      checked ? [...prev, channelId] : prev.filter(id => id !== channelId)
+    )
+  }, [])
+
+  // Get icon for notification level
+  const getLevelIcon = (level: NotificationLevel) => {
+    switch (level) {
+      case 'silent':
+        return <BellOff className="h-4 w-4" />
+      case 'default':
+        return <Bell className="h-4 w-4" />
+      case 'notify':
+        return <BellRing className="h-4 w-4" />
+    }
+  }
+
+  // Get channel type icon
+  const getChannelIcon = (channelType: string) => {
+    // For now, use a generic message icon
+    // Can be extended to show specific icons for dingtalk, feishu, etc.
+    return <MessageSquare className="h-4 w-4" />
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>{t('notification_settings.title')}</DialogTitle>
+          <DialogDescription>
+            {t('notification_settings.description', { name: subscriptionName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex h-40 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-primary" />
+          </div>
+        ) : (
+          <div className="space-y-6 py-4">
+            {/* Notification Level Selection */}
+            <div className="space-y-3">
+              <Label className="text-sm font-medium">
+                {t('notification_settings.level_label')}
+              </Label>
+              <RadioGroup
+                value={selectedLevel}
+                onValueChange={value => setSelectedLevel(value as NotificationLevel)}
+                className="space-y-2"
+              >
+                <div className="flex items-center space-x-3 rounded-lg border p-3 hover:bg-surface/50">
+                  <RadioGroupItem value="silent" id="level-silent" />
+                  <Label
+                    htmlFor="level-silent"
+                    className="flex flex-1 cursor-pointer items-center gap-2"
+                  >
+                    <BellOff className="h-4 w-4 text-text-muted" />
+                    <div>
+                      <div className="font-medium">{t('notification_settings.level_silent')}</div>
+                      <div className="text-xs text-text-muted">
+                        {t('notification_settings.level_silent_desc')}
+                      </div>
+                    </div>
+                  </Label>
+                </div>
+
+                <div className="flex items-center space-x-3 rounded-lg border p-3 hover:bg-surface/50">
+                  <RadioGroupItem value="default" id="level-default" />
+                  <Label
+                    htmlFor="level-default"
+                    className="flex flex-1 cursor-pointer items-center gap-2"
+                  >
+                    <Bell className="h-4 w-4 text-text-muted" />
+                    <div>
+                      <div className="font-medium">{t('notification_settings.level_default')}</div>
+                      <div className="text-xs text-text-muted">
+                        {t('notification_settings.level_default_desc')}
+                      </div>
+                    </div>
+                  </Label>
+                </div>
+
+                <div className="flex items-center space-x-3 rounded-lg border p-3 hover:bg-surface/50">
+                  <RadioGroupItem value="notify" id="level-notify" />
+                  <Label
+                    htmlFor="level-notify"
+                    className="flex flex-1 cursor-pointer items-center gap-2"
+                  >
+                    <BellRing className="h-4 w-4 text-text-muted" />
+                    <div>
+                      <div className="font-medium">{t('notification_settings.level_notify')}</div>
+                      <div className="text-xs text-text-muted">
+                        {t('notification_settings.level_notify_desc')}
+                      </div>
+                    </div>
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+
+            {/* Channel Selection (only shown when notify level is selected) */}
+            {selectedLevel === 'notify' && settings?.available_channels && (
+              <div className="space-y-3">
+                <Label className="text-sm font-medium">
+                  {t('notification_settings.channels_label')}
+                </Label>
+                {settings.available_channels.length === 0 ? (
+                  <div className="rounded-lg border border-dashed p-4 text-center text-sm text-text-muted">
+                    {t('notification_settings.no_channels')}
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    {settings.available_channels.map(channel => (
+                      <div
+                        key={channel.id}
+                        className={`flex items-center space-x-3 rounded-lg border p-3 ${
+                          !channel.is_bound ? 'opacity-50' : 'hover:bg-surface/50'
+                        }`}
+                      >
+                        <Checkbox
+                          id={`channel-${channel.id}`}
+                          checked={selectedChannels.includes(channel.id)}
+                          onCheckedChange={checked =>
+                            handleChannelToggle(channel.id, checked as boolean)
+                          }
+                          disabled={!channel.is_bound}
+                        />
+                        <Label
+                          htmlFor={`channel-${channel.id}`}
+                          className="flex flex-1 cursor-pointer items-center gap-2"
+                        >
+                          {getChannelIcon(channel.channel_type)}
+                          <div>
+                            <div className="font-medium">{channel.name}</div>
+                            <div className="text-xs text-text-muted">
+                              {channel.channel_type}
+                              {!channel.is_bound && (
+                                <span className="ml-2 text-warning">
+                                  ({t('notification_settings.not_bound')})
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        </Label>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {settings.available_channels.some(c => !c.is_bound) && (
+                  <p className="text-xs text-text-muted">
+                    {t('notification_settings.bind_hint')}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            {t('common:actions.cancel')}
+          </Button>
+          <Button variant="primary" onClick={handleSave} disabled={loading || saving}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                {t('common:actions.saving')}
+              </>
+            ) : (
+              t('common:actions.save')
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/feed/components/FollowNotificationSettingsDialog.tsx
+++ b/frontend/src/features/feed/components/FollowNotificationSettingsDialog.tsx
@@ -25,11 +25,7 @@ import {
 import { Label } from '@/components/ui/label'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { subscriptionApis } from '@/apis/subscription'
-import type {
-  NotificationLevel,
-  NotificationChannelInfo,
-  FollowSettingsResponse,
-} from '@/types/subscription'
+import type { NotificationLevel, FollowSettingsResponse } from '@/types/subscription'
 
 interface FollowNotificationSettingsDialogProps {
   subscriptionId: number
@@ -56,13 +52,7 @@ export function FollowNotificationSettingsDialog({
   const [selectedChannels, setSelectedChannels] = useState<number[]>([])
 
   // Load settings when dialog opens
-  useEffect(() => {
-    if (open && subscriptionId) {
-      loadSettings()
-    }
-  }, [open, subscriptionId])
-
-  const loadSettings = async () => {
+  const loadSettings = useCallback(async () => {
     try {
       setLoading(true)
       const response = await subscriptionApis.getFollowSettings(subscriptionId)
@@ -75,7 +65,13 @@ export function FollowNotificationSettingsDialog({
     } finally {
       setLoading(false)
     }
-  }
+  }, [subscriptionId, t])
+
+  useEffect(() => {
+    if (open && subscriptionId) {
+      loadSettings()
+    }
+  }, [open, subscriptionId, loadSettings])
 
   // Handle save
   const handleSave = useCallback(async () => {
@@ -103,20 +99,8 @@ export function FollowNotificationSettingsDialog({
     )
   }, [])
 
-  // Get icon for notification level
-  const getLevelIcon = (level: NotificationLevel) => {
-    switch (level) {
-      case 'silent':
-        return <BellOff className="h-4 w-4" />
-      case 'default':
-        return <Bell className="h-4 w-4" />
-      case 'notify':
-        return <BellRing className="h-4 w-4" />
-    }
-  }
-
   // Get channel type icon
-  const getChannelIcon = (channelType: string) => {
+  const getChannelIcon = (_channelType: string) => {
     // For now, use a generic message icon
     // Can be extended to show specific icons for dingtalk, feishu, etc.
     return <MessageSquare className="h-4 w-4" />

--- a/frontend/src/features/feed/components/FollowingSubscriptionList.tsx
+++ b/frontend/src/features/feed/components/FollowingSubscriptionList.tsx
@@ -15,6 +15,7 @@ import {
   Clock,
   Compass,
   Loader2,
+  Settings,
   Share2,
   Timer,
   UserMinus,
@@ -44,6 +45,7 @@ import type {
 import { paths } from '@/config/paths'
 import { parseUTCDate } from '@/lib/utils'
 import { DiscoverHistoryDialog, type HistoryDialogSubscription } from './DiscoverHistoryDialog'
+import { FollowNotificationSettingsDialog } from './FollowNotificationSettingsDialog'
 
 interface FollowingSubscriptionListProps {
   /**
@@ -76,6 +78,11 @@ export function FollowingSubscriptionList({ followType }: FollowingSubscriptionL
   // History dialog state
   const [historyDialogSubscription, setHistoryDialogSubscription] =
     useState<HistoryDialogSubscription | null>(null)
+  // Notification settings dialog state
+  const [notificationSettingsSubscription, setNotificationSettingsSubscription] = useState<{
+    id: number
+    name: string
+  } | null>(null)
 
   // Load following subscriptions
   const loadSubscriptions = useCallback(
@@ -320,6 +327,20 @@ export function FollowingSubscriptionList({ followType }: FollowingSubscriptionL
                   <Button
                     variant="ghost"
                     size="sm"
+                    onClick={() =>
+                      setNotificationSettingsSubscription({
+                        id: subscription.id,
+                        name: subscription.display_name,
+                      })
+                    }
+                    className="text-text-muted hover:text-primary"
+                    title={t('notification_settings.title')}
+                  >
+                    <Settings className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
                     onClick={() => handleUnfollowClick(item)}
                     disabled={unfollowingId === subscription.id}
                     className="text-text-muted hover:text-destructive"
@@ -385,6 +406,18 @@ export function FollowingSubscriptionList({ followType }: FollowingSubscriptionL
           if (!open) setHistoryDialogSubscription(null)
         }}
       />
+
+      {/* Notification Settings Dialog */}
+      {notificationSettingsSubscription && (
+        <FollowNotificationSettingsDialog
+          subscriptionId={notificationSettingsSubscription.id}
+          subscriptionName={notificationSettingsSubscription.name}
+          open={notificationSettingsSubscription !== null}
+          onOpenChange={open => {
+            if (!open) setNotificationSettingsSubscription(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/i18n/locales/en/feed.json
+++ b/frontend/src/i18n/locales/en/feed.json
@@ -264,6 +264,23 @@
   "unfollow_confirm_message": "Are you sure you want to unfollow \"{{name}}\"?",
   "followed_at": "Followed at",
   "shared_by": "Shared by",
+  "notification_settings": {
+    "title": "Notification Settings",
+    "description": "Configure how you want to be notified when \"{{name}}\" executes",
+    "level_label": "Notification Level",
+    "level_silent": "Silent",
+    "level_silent_desc": "Execute but hide from timeline",
+    "level_default": "Default",
+    "level_default_desc": "Show in Feed timeline",
+    "level_notify": "Notify",
+    "level_notify_desc": "Send notification via Messager channels",
+    "channels_label": "Notification Channels",
+    "no_channels": "No Messager channels available",
+    "not_bound": "Not bound",
+    "bind_hint": "To use unbound channels, send a message via that channel first",
+    "save_success": "Notification settings saved",
+    "save_failed": "Failed to save notification settings"
+  },
   "feed": {
     "title": "Feed",
     "empty_title": "No activities yet",

--- a/frontend/src/i18n/locales/zh-CN/feed.json
+++ b/frontend/src/i18n/locales/zh-CN/feed.json
@@ -264,6 +264,23 @@
   "tabs": {
     "all": "全部"
   },
+  "notification_settings": {
+    "title": "通知设置",
+    "description": "配置当「{{name}}」执行时如何通知您",
+    "level_label": "通知级别",
+    "level_silent": "静默",
+    "level_silent_desc": "执行但不在时间线显示",
+    "level_default": "默认",
+    "level_default_desc": "在动态时间线中显示",
+    "level_notify": "通知",
+    "level_notify_desc": "通过 Messager 渠道发送通知",
+    "channels_label": "通知渠道",
+    "no_channels": "暂无可用的 Messager 渠道",
+    "not_bound": "未绑定",
+    "bind_hint": "要使用未绑定的渠道，请先通过该渠道发送一条消息",
+    "save_success": "通知设置已保存",
+    "save_failed": "保存通知设置失败"
+  },
   "feed": {
     "title": "动态",
     "empty_title": "还没有动态",

--- a/frontend/src/types/subscription.ts
+++ b/frontend/src/types/subscription.ts
@@ -377,3 +377,42 @@ export interface RentalCountResponse {
   subscription_id: number
   rental_count: number
 }
+
+// ========== Notification Level Types ==========
+
+// Notification level enumeration
+export type NotificationLevel = 'silent' | 'default' | 'notify'
+
+// Subscription follow config
+export interface SubscriptionFollowConfig {
+  notification_level: NotificationLevel
+  notification_channel_ids?: number[]
+}
+
+// Follow subscription request with notification settings
+export interface FollowSubscriptionRequest {
+  notification_level?: NotificationLevel
+  notification_channel_ids?: number[]
+}
+
+// Update follow settings request
+export interface UpdateFollowSettingsRequest {
+  notification_level: NotificationLevel
+  notification_channel_ids?: number[]
+}
+
+// Notification channel info
+export interface NotificationChannelInfo {
+  id: number
+  name: string
+  channel_type: string
+  is_bound: boolean
+}
+
+// Follow settings response
+export interface FollowSettingsResponse {
+  notification_level: NotificationLevel
+  notification_channel_ids: number[]
+  notification_channels: NotificationChannelInfo[]
+  available_channels: NotificationChannelInfo[]
+}


### PR DESCRIPTION
## Summary

- Add notification level feature for subscription followers
- Implement three notification levels: `silent`, `default`, and `notify`
- Create notification settings dialog in the FollowingSubscriptionList component
- Add IM channel binding detection for Messager channels (DingTalk, etc.)
- Dispatch notifications to followers when subscriptions execute

## Changes

### Backend

1. **Database Migration**
   - Add `config` column to `subscription_follows` table (JSON format)
   - Store notification_level and notification_channel_ids

2. **Models & Schemas**
   - Add `NotificationLevel` enum: `silent`, `default`, `notify`
   - Add `SubscriptionFollowConfig`, `FollowSettingsResponse`, `NotificationChannelInfo` schemas
   - Extend `SubscriptionFollow` model with config field

3. **API Endpoints**
   - `GET /subscriptions/{id}/follow/settings` - Get notification settings
   - `PUT /subscriptions/{id}/follow/settings` - Update notification settings
   - Extend `POST /subscriptions/{id}/follow` to accept notification settings

4. **Services**
   - Create `notification_service.py` for managing follow notification settings
   - Create `notification_dispatcher.py` for dispatching notifications on execution
   - Update `follow_service.py` to support notification config on follow

5. **Execution Flow**
   - Update `subscription_tasks.py` to dispatch notifications after execution
   - Update DingTalk handler to track user IM channel bindings

### Frontend

1. **Components**
   - Create `FollowNotificationSettingsDialog.tsx` for notification settings UI
   - Add settings button to `FollowingSubscriptionList.tsx`

2. **APIs & Types**
   - Add TypeScript types for notification settings
   - Add API methods for getting/updating follow settings

3. **i18n**
   - Add English and Chinese translations for notification settings

## Notification Levels

| Level | Name | Behavior |
|-------|------|----------|
| `silent` | Silent | Execute but hide from Feed timeline |
| `default` | Default | Show in Feed timeline (existing behavior) |
| `notify` | Notify | Send notification via Messager channels |

## Test Plan

- [ ] Verify notification settings dialog opens correctly
- [ ] Verify notification level selection works
- [ ] Verify channel selection shows available Messager channels
- [ ] Verify settings are saved and persisted
- [ ] Verify subscription execution dispatches notifications based on follower settings
- [ ] Verify DingTalk handler updates user IM bindings
- [ ] Verify i18n translations display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-subscription notification preferences (silent, default, notify) with selectable channels.
  * New "Notification Settings" dialog in the feed to view and update follow settings.
  * Followers receive automatic post-completion notifications honoring configured levels and channels.
  * IM channel bindings are tracked so bound channels can be used for notifications.

* **Localization**
  * New UI strings for notification settings in English and Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->