### PR TITLE
feat(ci,frontend): add local executor installation guide and macOS binary builds

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -655,3 +655,4 @@ jobs:
           files: |
             ./executor-binaries/wegent-executor-macos-arm64
             ./executor-binaries/wegent-executor-macos-amd64
+            ./executor/scripts/install.sh

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -434,6 +434,81 @@ jobs:
           cache-to: type=gha,mode=max,scope=chat-shell-arm64
 
   # ============================================================================
+  # Executor Local Binary Build (macOS)
+  # ============================================================================
+  build-executor-local-macos-arm64:
+    needs: prepare-release
+    runs-on: macos-14  # Apple Silicon runner
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build
+        working-directory: executor
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor executor/dist/wegent-executor-macos-arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-macos-arm64
+          path: executor/dist/wegent-executor-macos-arm64
+          retention-days: 1
+
+  build-executor-local-macos-amd64:
+    needs: prepare-release
+    runs-on: macos-13  # Intel runner
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build
+        working-directory: executor
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor executor/dist/wegent-executor-macos-amd64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-macos-amd64
+          path: executor/dist/wegent-executor-macos-amd64
+          retention-days: 1
+
+  # ============================================================================
   # Create Multi-arch Manifests (combine amd64 + arm64 into single tag)
   # ============================================================================
   create-manifests:
@@ -504,6 +579,8 @@ jobs:
     needs:
       - prepare-release
       - create-manifests
+      - build-executor-local-macos-arm64
+      - build-executor-local-macos-amd64
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -514,6 +591,13 @@ jobs:
         with:
           ref: ${{ env.GIT_REF }}
           fetch-depth: 0
+
+      - name: Download executor binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wegent-executor-macos-*
+          path: ./executor-binaries
+          merge-multiple: true
 
       - name: Create and push tag
         shell: bash
@@ -568,3 +652,6 @@ jobs:
           body: ${{ steps.release-notes.outputs.body }}
           draft: false
           prerelease: false
+          files: |
+            ./executor-binaries/wegent-executor-macos-arm64
+            ./executor-binaries/wegent-executor-macos-amd64

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -655,4 +655,4 @@ jobs:
           files: |
             ./executor-binaries/wegent-executor-macos-arm64
             ./executor-binaries/wegent-executor-macos-amd64
-            ./executor/scripts/install.sh
+            ./executor/scripts/local_executor_install.sh

--- a/executor/scripts/install.sh
+++ b/executor/scripts/install.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Wegent Executor Installation Script
+# This script downloads and installs the wegent-executor binary for macOS.
+#
+# Usage:
+#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/latest/download/install.sh | bash
+#
+# Or with a specific version:
+#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/download/v1.0.0/install.sh | bash -s -- --version v1.0.0
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+GITHUB_REPO="wecode-ai/Wegent"
+INSTALL_DIR="${HOME}/.wegent-executor/bin"
+BINARY_NAME="wegent-executor"
+VERSION=""
+
+# Print colored message
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Detect OS and architecture
+detect_platform() {
+    local os
+    local arch
+
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Darwin)
+            OS="macos"
+            ;;
+        Linux)
+            print_error "Linux is not yet supported. Please use Docker deployment."
+            exit 1
+            ;;
+        *)
+            print_error "Unsupported operating system: $os"
+            exit 1
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64)
+            ARCH="amd64"
+            ;;
+        arm64|aarch64)
+            ARCH="arm64"
+            ;;
+        *)
+            print_error "Unsupported architecture: $arch"
+            exit 1
+            ;;
+    esac
+
+    PLATFORM="${OS}-${ARCH}"
+    print_info "Detected platform: ${PLATFORM}"
+}
+
+# Parse command line arguments
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --version|-v)
+                VERSION="$2"
+                shift 2
+                ;;
+            --help|-h)
+                echo "Wegent Executor Installation Script"
+                echo ""
+                echo "Usage:"
+                echo "  curl -fsSL <url>/install.sh | bash"
+                echo "  curl -fsSL <url>/install.sh | bash -s -- --version v1.0.0"
+                echo ""
+                echo "Options:"
+                echo "  --version, -v    Specify version to install (e.g., v1.0.0)"
+                echo "  --help, -h       Show this help message"
+                exit 0
+                ;;
+            *)
+                print_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+}
+
+# Get download URL
+get_download_url() {
+    local base_url="https://github.com/${GITHUB_REPO}/releases"
+
+    if [[ -n "$VERSION" ]]; then
+        DOWNLOAD_URL="${base_url}/download/${VERSION}/${BINARY_NAME}-${PLATFORM}"
+    else
+        DOWNLOAD_URL="${base_url}/latest/download/${BINARY_NAME}-${PLATFORM}"
+    fi
+
+    print_info "Download URL: ${DOWNLOAD_URL}"
+}
+
+# Create installation directory
+create_install_dir() {
+    if [[ ! -d "$INSTALL_DIR" ]]; then
+        print_info "Creating installation directory: ${INSTALL_DIR}"
+        mkdir -p "$INSTALL_DIR"
+    fi
+}
+
+# Download binary
+download_binary() {
+    local tmp_file
+    tmp_file="$(mktemp)"
+
+    print_info "Downloading ${BINARY_NAME}..."
+
+    if command -v curl &> /dev/null; then
+        if ! curl -fsSL -o "$tmp_file" "$DOWNLOAD_URL"; then
+            print_error "Failed to download ${BINARY_NAME}"
+            rm -f "$tmp_file"
+            exit 1
+        fi
+    elif command -v wget &> /dev/null; then
+        if ! wget -q -O "$tmp_file" "$DOWNLOAD_URL"; then
+            print_error "Failed to download ${BINARY_NAME}"
+            rm -f "$tmp_file"
+            exit 1
+        fi
+    else
+        print_error "Neither curl nor wget found. Please install one of them."
+        exit 1
+    fi
+
+    # Move to installation directory
+    mv "$tmp_file" "${INSTALL_DIR}/${BINARY_NAME}"
+
+    # Set executable permission
+    chmod 755 "${INSTALL_DIR}/${BINARY_NAME}"
+
+    print_success "Downloaded ${BINARY_NAME} to ${INSTALL_DIR}/${BINARY_NAME}"
+}
+
+# Verify installation
+verify_installation() {
+    if [[ -x "${INSTALL_DIR}/${BINARY_NAME}" ]]; then
+        print_success "Installation verified successfully"
+    else
+        print_error "Installation verification failed"
+        exit 1
+    fi
+}
+
+# Print usage instructions
+print_usage_instructions() {
+    echo ""
+    echo "======================================"
+    echo -e "${GREEN}Installation Complete!${NC}"
+    echo "======================================"
+    echo ""
+    echo "To run wegent-executor, use the following command:"
+    echo ""
+    echo -e "${YELLOW}EXECUTOR_MODE=local \\\\${NC}"
+    echo -e "${YELLOW}WEGENT_BACKEND_URL=<your-backend-url> \\\\${NC}"
+    echo -e "${YELLOW}WEGENT_AUTH_TOKEN=<your-auth-token> \\\\${NC}"
+    echo -e "${YELLOW}${INSTALL_DIR}/${BINARY_NAME}${NC}"
+    echo ""
+    echo "Or add the binary to your PATH:"
+    echo ""
+    echo -e "${BLUE}export PATH=\"\$PATH:${INSTALL_DIR}\"${NC}"
+    echo ""
+    echo "Add this line to your ~/.zshrc or ~/.bashrc to make it permanent."
+    echo ""
+    print_warning "First run may require allowing the binary in:"
+    print_warning "System Settings > Privacy & Security"
+    echo ""
+}
+
+# Main function
+main() {
+    echo ""
+    echo "======================================"
+    echo "  Wegent Executor Installation Script"
+    echo "======================================"
+    echo ""
+
+    parse_args "$@"
+    detect_platform
+    get_download_url
+    create_install_dir
+    download_binary
+    verify_installation
+    print_usage_instructions
+}
+
+main "$@"

--- a/executor/scripts/local_executor_install.sh
+++ b/executor/scripts/local_executor_install.sh
@@ -7,10 +7,10 @@
 # This script downloads and installs the wegent-executor binary for macOS.
 #
 # Usage:
-#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.sh | bash
 #
 # Or with a specific version:
-#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/download/v1.0.0/install.sh | bash -s -- --version v1.0.0
+#   curl -fsSL https://github.com/wecode-ai/Wegent/releases/download/v1.0.0/local_executor_install.sh | bash -s -- --version v1.0.0
 
 set -euo pipefail
 

--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -162,10 +162,7 @@ export default function DevicesPage() {
   const authToken = useMemo(() => getToken() || '<YOUR_AUTH_TOKEN>', [])
 
   // Generate one-liner install command
-  const installCommand = useMemo(
-    () => `curl -fsSL ${INSTALL_SCRIPT_URL} | bash`,
-    []
-  )
+  const installCommand = useMemo(() => `curl -fsSL ${INSTALL_SCRIPT_URL} | bash`, [])
 
   // Generate run command
   const runCommand = useMemo(
@@ -406,9 +403,15 @@ export default function DevicesPage() {
                   </div>
 
                   {/* Gatekeeper hint */}
-                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg mb-3">
                     <span className="text-blue-600 shrink-0">💡</span>
                     <p className="text-sm text-blue-700">{t('gatekeeper_hint')}</p>
+                  </div>
+
+                  {/* Token expiry hint */}
+                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                    <span className="text-blue-600 shrink-0">🔄</span>
+                    <p className="text-sm text-blue-700">{t('token_expiry_hint')}</p>
                   </div>
 
                   {/* Guide link */}

--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -52,7 +52,7 @@ import { toast } from 'sonner'
 
 // Install script URL
 const INSTALL_SCRIPT_URL =
-  'https://github.com/wecode-ai/Wegent/releases/latest/download/install.sh'
+  'https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.sh'
 
 // Helper function to get backend URL dynamically
 const getBackendUrl = (): string => {

--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import {
@@ -23,6 +23,7 @@ import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContex
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { paths } from '@/config/paths'
 import { useDevices } from '@/contexts/DeviceContext'
+import { getToken } from '@/apis/user'
 import { DeviceInfo } from '@/apis/devices'
 import {
   Monitor,
@@ -37,6 +38,7 @@ import {
   ExternalLink,
   Terminal,
   MessageCircleQuestion,
+  AlertTriangle,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -48,6 +50,138 @@ import {
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 
+type MacArch = 'arm64' | 'amd64'
+
+// Helper function to get backend URL dynamically
+const getBackendUrl = (): string => {
+  if (typeof window !== 'undefined') {
+    // Check runtime config from Next.js
+    const runtimeUrl = process.env.NEXT_PUBLIC_SOCKET_DIRECT_URL
+    if (runtimeUrl) return runtimeUrl
+
+    // Derive from current origin - replace frontend port with backend port
+    const origin = window.location.origin
+    return origin.replace(':3000', ':8000')
+  }
+
+  return 'http://localhost:8000'
+}
+
+// Component for copy button with state
+function CopyButton({
+  text,
+  className,
+  onCopySuccess,
+}: {
+  text: string
+  className?: string
+  onCopySuccess?: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      onCopySuccess?.()
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className={cn(
+        'shrink-0 text-gray-400 hover:text-white hover:bg-gray-800 h-8 px-3',
+        className
+      )}
+    >
+      {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+    </Button>
+  )
+}
+
+// Component for displaying a command step
+function CommandStep({
+  stepNumber,
+  title,
+  description,
+  command,
+  children,
+}: {
+  stepNumber: number
+  title: string
+  description: string
+  command: string
+  children?: React.ReactNode
+}) {
+  const stepCircles = ['①', '②', '③', '④', '⑤']
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-start gap-3 mb-3">
+        <span className="text-xl text-primary font-medium">{stepCircles[stepNumber - 1]}</span>
+        <div>
+          <h4 className="font-medium text-text-primary">{title}</h4>
+          <p className="text-sm text-text-muted">{description}</p>
+        </div>
+      </div>
+      {children}
+      <div className="bg-gray-900 rounded-lg px-5 py-4 ml-8">
+        <div className="flex items-start gap-3">
+          <span className="text-gray-500 select-none pt-0.5">$</span>
+          <div className="flex-1 overflow-x-auto">
+            <code className="text-sm font-mono whitespace-pre text-green-400">{command}</code>
+          </div>
+          <CopyButton text={command} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Component for architecture selection tabs
+function ArchSelector({
+  arch,
+  onChange,
+  t,
+}: {
+  arch: MacArch
+  onChange: (arch: MacArch) => void
+  t: (key: string) => string
+}) {
+  return (
+    <div className="flex gap-2 ml-8 mb-2">
+      <button
+        onClick={() => onChange('arm64')}
+        className={cn(
+          'px-3 py-1.5 text-sm rounded-md transition-colors',
+          arch === 'arm64'
+            ? 'bg-primary text-white'
+            : 'bg-gray-100 text-text-secondary hover:bg-gray-200'
+        )}
+      >
+        {t('arch_apple_silicon')}
+      </button>
+      <button
+        onClick={() => onChange('amd64')}
+        className={cn(
+          'px-3 py-1.5 text-sm rounded-md transition-colors',
+          arch === 'amd64'
+            ? 'bg-primary text-white'
+            : 'bg-gray-100 text-text-secondary hover:bg-gray-200'
+        )}
+      >
+        {t('arch_intel')}
+      </button>
+    </div>
+  )
+}
+
 export default function DevicesPage() {
   const { t } = useTranslation('devices')
   const router = useRouter()
@@ -56,24 +190,39 @@ export default function DevicesPage() {
   const isMobile = useIsMobile()
 
   // Environment variables for device setup
-  const installCommand = process.env.NEXT_PUBLIC_DEVICE_INSTALL_COMMAND || ''
   const guideUrl = process.env.NEXT_PUBLIC_DEVICE_GUIDE_URL || ''
   const communityUrl = process.env.NEXT_PUBLIC_COMMUNITY_URL || ''
   const faqUrl = process.env.NEXT_PUBLIC_FAQ_URL || ''
 
-  // Copy state for install command
-  const [copied, setCopied] = useState(false)
+  // Architecture selection state
+  const [arch, setArch] = useState<MacArch>('arm64')
 
-  const handleCopyCommand = async () => {
-    if (!installCommand) return
-    try {
-      await navigator.clipboard.writeText(installCommand)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      toast.error('Failed to copy')
-    }
-  }
+  // Generate dynamic download URL based on architecture
+  const downloadUrl = useMemo(
+    () =>
+      `https://github.com/wecode-ai/Wegent/releases/latest/download/wegent-executor-macos-${arch}`,
+    [arch]
+  )
+
+  // Generate dynamic backend URL
+  const backendUrl = useMemo(() => getBackendUrl(), [])
+
+  // Get auth token
+  const authToken = useMemo(() => getToken() || '<YOUR_AUTH_TOKEN>', [])
+
+  // Generate commands
+  const downloadCommand = useMemo(
+    () => `curl -L -o wegent-executor ${downloadUrl}`,
+    [downloadUrl]
+  )
+
+  const permissionCommand = 'chmod +x wegent-executor'
+
+  const runCommand = useMemo(
+    () =>
+      `EXECUTOR_MODE=local \\\nWEGENT_BACKEND_URL=${backendUrl} \\\nWEGENT_AUTH_TOKEN=${authToken} \\\n./wegent-executor`,
+    [backendUrl, authToken]
+  )
 
   const {
     devices,
@@ -103,32 +252,41 @@ export default function DevicesPage() {
   }, [devices])
 
   // Handle starting a task with a device
-  const handleStartTask = (deviceId: string) => {
-    setSelectedDeviceId(deviceId)
-    setSelectedTask(null)
-    clearAllStreams()
-    router.push('/devices/chat')
-  }
+  const handleStartTask = useCallback(
+    (deviceId: string) => {
+      setSelectedDeviceId(deviceId)
+      setSelectedTask(null)
+      clearAllStreams()
+      router.push('/devices/chat')
+    },
+    [setSelectedDeviceId, setSelectedTask, clearAllStreams, router]
+  )
 
   // Handle setting a device as default
-  const handleSetDefault = async (device: DeviceInfo) => {
-    try {
-      await setDefaultDevice(device.device_id)
-      toast.success(t('set_default_success', { name: device.name }))
-    } catch {
-      toast.error(t('set_default_error'))
-    }
-  }
+  const handleSetDefault = useCallback(
+    async (device: DeviceInfo) => {
+      try {
+        await setDefaultDevice(device.device_id)
+        toast.success(t('set_default_success', { name: device.name }))
+      } catch {
+        toast.error(t('set_default_error'))
+      }
+    },
+    [setDefaultDevice, t]
+  )
 
   // Handle deleting a device
-  const handleDeleteDevice = async (device: DeviceInfo) => {
-    try {
-      await deleteDevice(device.device_id)
-      toast.success(t('delete_success', { name: device.name }))
-    } catch {
-      toast.error(t('delete_error'))
-    }
-  }
+  const handleDeleteDevice = useCallback(
+    async (device: DeviceInfo) => {
+      try {
+        await deleteDevice(device.device_id)
+        toast.success(t('delete_success', { name: device.name }))
+      } catch {
+        toast.error(t('delete_error'))
+      }
+    },
+    [deleteDevice, t]
+  )
 
   // Mobile sidebar state
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
@@ -148,20 +306,20 @@ export default function DevicesPage() {
     saveLastTab('devices')
   }, [])
 
-  const handleToggleCollapsed = () => {
+  const handleToggleCollapsed = useCallback(() => {
     setIsCollapsed(prev => {
       const newValue = !prev
       localStorage.setItem('task-sidebar-collapsed', String(newValue))
       return newValue
     })
-  }
+  }, [])
 
   // Handle new task from collapsed sidebar button
-  const handleNewTask = () => {
+  const handleNewTask = useCallback(() => {
     setSelectedTask(null)
     clearAllStreams()
     router.replace(paths.chat.getHref())
-  }
+  }, [setSelectedTask, clearAllStreams, router])
 
   const getStatusColor = (status: string) => {
     switch (status) {
@@ -257,52 +415,61 @@ export default function DevicesPage() {
               </div>
             )}
 
-            {/* Empty state */}
+            {/* Empty state with multi-step installation guide */}
             {!isLoading && devices.length === 0 && (
               <div className="flex flex-col items-center justify-center py-8">
                 {/* Main card */}
                 <div className="w-full max-w-2xl bg-surface border border-border rounded-xl p-6 shadow-sm">
                   {/* Header */}
-                  <div className="flex items-center gap-3 mb-2">
+                  <div className="flex items-center gap-3 mb-6">
                     <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
                       <Terminal className="w-5 h-5 text-primary" />
                     </div>
                     <div>
                       <h3 className="text-lg font-semibold text-text-primary">
-                        {t('one_step_title')}
+                        {t('local_executor_title')}
                       </h3>
-                      <p className="text-sm text-text-muted">{t('one_step_description')}</p>
+                      <p className="text-sm text-text-muted">{t('local_executor_description')}</p>
                     </div>
                   </div>
 
-                  {/* Command box */}
-                  {installCommand && (
-                    <>
-                      {/* Command box with dark theme */}
-                      <div className="bg-gray-900 rounded-lg px-5 py-4 mt-5">
-                        <div className="flex items-center gap-3">
-                          <span className="text-gray-500 select-none">$</span>
-                          <div className="flex-1 overflow-x-auto">
-                            <code className="text-sm font-mono whitespace-nowrap text-green-400">
-                              {installCommand}
-                            </code>
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={handleCopyCommand}
-                            className="shrink-0 text-gray-400 hover:text-white hover:bg-gray-800 h-8 px-3"
-                          >
-                            {copied ? (
-                              <Check className="w-4 h-4 text-green-400" />
-                            ) : (
-                              <Copy className="w-4 h-4" />
-                            )}
-                          </Button>
-                        </div>
-                      </div>
-                    </>
-                  )}
+                  {/* Step 1: Download */}
+                  <CommandStep
+                    stepNumber={1}
+                    title={t('step_download')}
+                    description={t('step_download_desc')}
+                    command={downloadCommand}
+                  >
+                    <ArchSelector arch={arch} onChange={setArch} t={t} />
+                  </CommandStep>
+
+                  {/* Step 2: Set permission */}
+                  <CommandStep
+                    stepNumber={2}
+                    title={t('step_permission')}
+                    description={t('step_permission_desc')}
+                    command={permissionCommand}
+                  />
+
+                  {/* Step 3: Run */}
+                  <CommandStep
+                    stepNumber={3}
+                    title={t('step_run')}
+                    description={t('step_run_desc')}
+                    command={runCommand}
+                  />
+
+                  {/* Security warning */}
+                  <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg mb-4">
+                    <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+                    <p className="text-sm text-amber-700">{t('security_warning')}</p>
+                  </div>
+
+                  {/* Gatekeeper hint */}
+                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                    <span className="text-blue-600 shrink-0">💡</span>
+                    <p className="text-sm text-blue-700">{t('gatekeeper_hint')}</p>
+                  </div>
 
                   {/* Guide link */}
                   {guideUrl && (

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -59,5 +59,6 @@
   "arch_intel": "Intel",
   "security_warning": "Security notice: Do not share the command above, it contains your authentication credentials",
   "gatekeeper_hint": "First run may require allowing it in System Settings > Privacy & Security",
+  "token_expiry_hint": "The auth token expires in 7 days. Re-run the startup command to refresh it",
   "copy_success": "Copied to clipboard"
 }

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -44,5 +44,18 @@
   "set_default_success": "{{name}} has been set as the default device",
   "set_default_error": "Failed to set default device",
   "delete_success": "{{name}} has been deleted",
-  "delete_error": "Failed to delete device"
+  "delete_error": "Failed to delete device",
+  "local_executor_title": "Run Local Executor",
+  "local_executor_description": "Run Executor on your Mac to execute AI tasks",
+  "step_download": "Download wegent-executor",
+  "step_download_desc": "Download the executable for your Mac from GitHub",
+  "step_permission": "Set executable permission",
+  "step_permission_desc": "Grant execution permission to the file",
+  "step_run": "Run",
+  "step_run_desc": "Start Executor with the following command",
+  "arch_apple_silicon": "Apple Silicon (M1/M2/M3)",
+  "arch_intel": "Intel",
+  "security_warning": "Security notice: Do not share the command above, it contains your authentication credentials",
+  "gatekeeper_hint": "First run may require allowing it in System Settings > Privacy & Security",
+  "copy_success": "Copied to clipboard"
 }

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -47,6 +47,8 @@
   "delete_error": "Failed to delete device",
   "local_executor_title": "Run Local Executor",
   "local_executor_description": "Run Executor on your Mac to execute AI tasks",
+  "step_install": "Install wegent-executor",
+  "step_install_desc": "Run the one-liner install script, automatically downloads and installs to ~/.wegent-executor/bin/",
   "step_download": "Download wegent-executor",
   "step_download_desc": "Download the executable for your Mac from GitHub",
   "step_permission": "Set executable permission",

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -59,5 +59,6 @@
   "arch_intel": "Intel",
   "security_warning": "安全提示：请勿分享上述命令，它包含您的认证信息",
   "gatekeeper_hint": "首次运行可能需要在「系统设置 > 隐私与安全性」中允许运行",
+  "token_expiry_hint": "认证 Token 有效期为 7 天，过期后可重新执行上述启动命令刷新",
   "copy_success": "已复制到剪贴板"
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -47,6 +47,8 @@
   "delete_error": "删除设备失败",
   "local_executor_title": "运行本地 Executor",
   "local_executor_description": "在您的 Mac 上运行 Executor 以执行 AI 任务",
+  "step_install": "安装 wegent-executor",
+  "step_install_desc": "运行一键安装脚本，自动下载并安装到 ~/.wegent-executor/bin/",
   "step_download": "下载 wegent-executor",
   "step_download_desc": "从 GitHub 下载适用于您 Mac 的可执行文件",
   "step_permission": "设置可执行权限",

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -44,5 +44,18 @@
   "set_default_success": "{{name}} 已设为默认设备",
   "set_default_error": "设置默认设备失败",
   "delete_success": "{{name}} 已删除",
-  "delete_error": "删除设备失败"
+  "delete_error": "删除设备失败",
+  "local_executor_title": "运行本地 Executor",
+  "local_executor_description": "在您的 Mac 上运行 Executor 以执行 AI 任务",
+  "step_download": "下载 wegent-executor",
+  "step_download_desc": "从 GitHub 下载适用于您 Mac 的可执行文件",
+  "step_permission": "设置可执行权限",
+  "step_permission_desc": "授予文件执行权限",
+  "step_run": "运行",
+  "step_run_desc": "使用以下命令启动 Executor",
+  "arch_apple_silicon": "Apple Silicon (M1/M2/M3)",
+  "arch_intel": "Intel",
+  "security_warning": "安全提示：请勿分享上述命令，它包含您的认证信息",
+  "gatekeeper_hint": "首次运行可能需要在「系统设置 > 隐私与安全性」中允许运行",
+  "copy_success": "已复制到剪贴板"
 }


### PR DESCRIPTION
## Summary

- Add GitHub Actions jobs to build macOS binaries (arm64 for Apple Silicon, amd64 for Intel)
- Upload executor binaries as GitHub Release assets
- Implement multi-step installation guide UI on devices empty state page
- Add architecture selection toggle (Apple Silicon / Intel)
- Generate dynamic commands with backend URL and auth token
- Add security warning for credential exposure
- Add Gatekeeper hint for first-time runs
- Add i18n translations for installation steps (zh-CN and en)

## Test plan

- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Verify macOS binaries are uploaded to GitHub Releases
- [ ] Verify devices page shows installation guide when no devices connected
- [ ] Verify architecture selection updates download URL
- [ ] Verify copy buttons work correctly
- [ ] Verify i18n translations are displayed correctly in both languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Step-by-step Local Executor setup in the Devices UI with separate Install and Run command steps and copyable commands.
  * macOS Local Executor install script added for simplified installation.
  * Dynamic backend URL and token-aware run command shown in setup.
  * Expanded localization for Local Executor (English and Chinese).

* **Chores**
  * Build/release flow updated to produce and attach macOS executor binaries and the install script to releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->