### PR TITLE
feat(sandbox): pass skills and auth_token for sandbox skill download

### DIFF
--- a/backend/app/services/pet/manager.py
+++ b/backend/app/services/pet/manager.py
@@ -578,6 +578,7 @@ class PetService:
         resource = pet.json.copy()
         resource["spec"] = spec
         pet.json = resource
+        flag_modified(pet, "json")
         pet.updated_at = datetime.now()
 
         db.commit()

--- a/backend/init_data/skills/document/SKILL.md
+++ b/backend/init_data/skills/document/SKILL.md
@@ -25,7 +25,7 @@ Provides **mandatory step-by-step instructions** to load Anthropic's official do
 
 This skill guides you through the process of using Anthropic's official document skills (pre-installed in Docker):
 
-1. **Read Skill Documentation**: Use `sandbox_read_file` to read the official skill instructions
+1. **Read Skill Documentation**: Use `read_file` to read the official skill instructions
 2. **Follow Instructions**: Generate documents according to the loaded skill documentation
 3. **Upload and Return URL**: Upload generated documents and provide download URLs to users
 
@@ -63,7 +63,7 @@ Get mandatory step-by-step instructions for loading a specific document skill.
 2. You **CANNOT skip any steps** - each step is required
 3. You **MUST use sandbox tools** to execute each step
 4. **DO NOT use 'claude' command** - it's not available for all models
-5. **DO NOT use 'sandbox_claude' tool** for document generation
+5. **DO NOT use 'sub_claude_agent' tool** for document generation
 6. Your existing knowledge about python-pptx/openpyxl/python-docx may be **OUTDATED**
 7. Anthropic's skills contain the **LATEST and CORRECT** instructions
 8. **IMPORTANT**: Follow the design guidelines in the skill documentation to generate **visually appealing, professional-looking documents**
@@ -80,16 +80,16 @@ Get mandatory step-by-step instructions for loading a specific document skill.
 
 **What You MUST Do:**
 
-1. **Step 1**: ⚠️ **NEVER SKIP THIS** - Execute `sandbox_read_file` to read the skill documentation
+1. **Step 1**: ⚠️ **NEVER SKIP THIS** - Execute `read_file` to read the skill documentation
 2. **Step 2**: Only AFTER reading, follow the loaded skill instructions to generate documents
    - ⚠️ Follow the design guidelines and best practices in the skill documentation
    - ⚠️ Generate visually appealing, professional-looking documents with proper styling
-   - DO NOT use 'claude' command or 'sandbox_claude' tool
-3. **Step 3**: ⚠️ **NEVER SKIP THIS** - Upload the generated document using `sandbox_upload_attachment` and return the download URL to the user
+   - DO NOT use 'claude' command or 'sub_claude_agent' tool
+3. **Step 3**: ⚠️ **NEVER SKIP THIS** - Upload the generated document using `upload_attachment` and return the download URL to the user
 
 **DO NOT** generate documents based on your existing knowledge without loading the skill first.
 **DO NOT** just tell the user the file path - they cannot access sandbox files directly.
-**DO NOT** use 'claude' command or 'sandbox_claude' tool for document generation.
+**DO NOT** use 'claude' command or 'sub_claude_agent' tool for document generation.
 
 **Example Usage:**
 
@@ -113,7 +113,7 @@ Get mandatory step-by-step instructions for loading a specific document skill.
     "⚠️ WARNING": "These steps are MANDATORY...",
     "step_1_READ_SKILL_DOCUMENTATION": {
       "description": "Read PPTX skill documentation",
-      "tool": "sandbox_read_file",
+      "tool": "read_file",
       "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pptx/SKILL.md"},
       "critical_importance": "⚠️ THIS IS THE MOST IMPORTANT STEP ⚠️"
     },
@@ -121,12 +121,12 @@ Get mandatory step-by-step instructions for loading a specific document skill.
       "description": "Follow the instructions from step 1",
       "forbidden": [
         "❌ DO NOT use 'claude' command - it's not available for all models",
-        "❌ DO NOT use 'sandbox_claude' tool for document generation"
+        "❌ DO NOT use 'sub_claude_agent' tool for document generation"
       ]
     },
     "step_3_UPLOAD_AND_RETURN_URL": {
       "description": "Upload document and return download URL to user",
-      "tool": "sandbox_upload_attachment",
+      "tool": "upload_attachment",
       "critical_importance": "⚠️ THIS STEP IS MANDATORY - users cannot access sandbox files directly ⚠️"
     }
   },
@@ -143,21 +143,21 @@ Get mandatory step-by-step instructions for loading a specific document skill.
 
 2. **Execute Step 1** - ⚠️ **MANDATORY** - Read skill documentation
    ```json
-   {"name": "sandbox_read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pptx/SKILL.md"}}
+   {"name": "read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pptx/SKILL.md"}}
    ```
 
 3. **Follow Step 2** - Use the instructions from step 1 to:
-   - Install dependencies if needed: `sandbox_command` with `pip install python-pptx`
-   - Create generation script: `sandbox_write_file` with your Python code
+   - Install dependencies if needed: `exec` with `pip install python-pptx`
+   - Create generation script: `write_file` with your Python code
    - ⚠️ Follow the design guidelines and best practices in the skill documentation
    - ⚠️ Generate visually appealing, professional-looking documents with proper styling
-   - Execute script: `sandbox_command` with `python /home/user/generate_ppt.py`
-   - Verify output: `sandbox_list_files` to check generated files
-   - ⚠️ **DO NOT use 'claude' command or 'sandbox_claude' tool**
+   - Execute script: `exec` with `python /home/user/generate_ppt.py`
+   - Verify output: `list_files` to check generated files
+   - ⚠️ **DO NOT use 'claude' command or 'sub_claude_agent' tool**
 
 4. **Execute Step 3** - ⚠️ **MANDATORY** - Upload and return download URL
    ```json
-   {"name": "sandbox_upload_attachment", "arguments": {"file_path": "/home/user/documents/ai_trends.pptx"}}
+   {"name": "upload_attachment", "arguments": {"file_path": "/home/user/documents/ai_trends.pptx"}}
    ```
 
    Then present the download link to user:
@@ -177,7 +177,7 @@ The `load_document_skill` tool operates as an **instruction provider**, NOT an e
 
 2. **Returns Instructions**: Provides structured JSON with mandatory steps:
    - Step 1: How to read the official skill documentation (Anthropic skills are pre-installed in Docker)
-   - Step 2: Guidelines for following the loaded instructions (includes design best practices for professional-looking documents, DO NOT use 'claude' command or 'sandbox_claude' tool)
+   - Step 2: Guidelines for following the loaded instructions (includes design best practices for professional-looking documents, DO NOT use 'claude' command or 'sub_claude_agent' tool)
    - Step 3: How to upload and return download URL to user
 
 3. **You Execute**: You must execute each step using sandbox tools
@@ -209,9 +209,9 @@ After reading the skill file in Step 1, you'll receive:
 3. **Follow Design Guidelines**: Pay attention to the design best practices in the skill documentation
 4. **Generate Professional Documents**: Ensure documents are visually appealing with proper styling, colors, and formatting
 5. **Never Skip Step 3**: Always upload documents and provide download URLs - users cannot access sandbox files
-6. **Never Use Claude Command**: DO NOT use 'claude' command or 'sandbox_claude' tool for document generation
+6. **Never Use Claude Command**: DO NOT use 'claude' command or 'sub_claude_agent' tool for document generation
 7. **Follow Steps In Order**: Execute step 1 → step 2 → step 3
-8. **Install Dependencies in Sandbox**: Use `sandbox_command` to install required Python packages if needed
+8. **Install Dependencies in Sandbox**: Use `exec` to install required Python packages if needed
 9. **Test Incrementally**: Start with simple documents, then add complexity
 10. **Save to User Directory**: Use `/home/user/documents/` or subdirectories for output files
 11. **Trust Official Documentation**: Anthropic's skills contain the latest library usage patterns and design guidelines
@@ -222,7 +222,7 @@ After reading the skill file in Step 1, you'll receive:
 - DO NOT skip reading skill documentation (Step 1)
 - DO NOT skip uploading and returning download URL (Step 3)
 - DO NOT use 'claude' command - it's not available for all models
-- DO NOT use 'sandbox_claude' tool for document generation
+- DO NOT use 'sub_claude_agent' tool for document generation
 - DO NOT generate documents based solely on your existing knowledge
 - DO NOT assume you know the correct approach without reading the instructions
 - DO NOT just tell the user the file path - they cannot access sandbox files directly
@@ -236,17 +236,17 @@ After reading the skill file in Step 1, you'll receive:
 - **Anthropic Skills Pre-installed**: Anthropic's official skills are pre-installed in Docker, no installation needed
 - **Sandbox Environment Only**: Skills are loaded from sandbox environment at `/root/.claude/plugins/marketplaces/`
 - **Manual Execution Required**: You must execute each step using sandbox tools - the tool only provides instructions
-- **Claude Command Not Universal**: 'claude' command and 'sandbox_claude' tool are not available for all AI models
+- **Claude Command Not Universal**: 'claude' command and 'sub_claude_agent' tool are not available for all AI models
 
 ## Troubleshooting
 
 ### Problem: Skill File Not Found
-- **Symptom**: `sandbox_read_file` returns error when reading SKILL.md
+- **Symptom**: `read_file` returns error when reading SKILL.md
 - **Cause**: File path incorrect or skills not properly installed in Docker image
 - **Solution**:
   - Verify file path in tool response
   - Check if Anthropic skills are included in Docker image
-  - Use `sandbox_list_files` to verify the marketplace directory exists
+  - Use `list_files` to verify the marketplace directory exists
 
 ### Problem: Tool Returns Timeout
 - **Symptom**: `load_document_skill` times out after 300 seconds
@@ -256,12 +256,12 @@ After reading the skill file in Step 1, you'll receive:
 ### Problem: LLM Skips Reading Documentation
 - **Symptom**: Documents generated incorrectly or using outdated patterns
 - **Cause**: Skipped Step 1 (reading skill documentation)
-- **Solution**: Always execute Step 1 - use `sandbox_read_file` to read the official documentation before generating documents
+- **Solution**: Always execute Step 1 - use `read_file` to read the official documentation before generating documents
 
 ### Problem: LLM Uses Claude Command
 - **Symptom**: Error "claude: command not found" or similar
-- **Cause**: Used 'claude' command or 'sandbox_claude' tool which is not available for all models
-- **Solution**: DO NOT use 'claude' command or 'sandbox_claude' tool - use Python libraries directly with `sandbox_command`
+- **Cause**: Used 'claude' command or 'sub_claude_agent' tool which is not available for all models
+- **Solution**: DO NOT use 'claude' command or 'sub_claude_agent' tool - use Python libraries directly with `exec`
 
 ## Examples
 
@@ -276,26 +276,26 @@ After reading the skill file in Step 1, you'll receive:
 {"name": "load_document_skill", "arguments": {"document_type": "pptx"}}
 
 // Step 2: Read PPTX skill (execute step 1 from response)
-{"name": "sandbox_read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pptx/SKILL.md"}}
+{"name": "read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pptx/SKILL.md"}}
 
 // Step 3: After reading, follow the loaded instructions
 // Install dependencies if needed
-{"name": "sandbox_command", "arguments": {"command": "pip install python-pptx"}}
+{"name": "exec", "arguments": {"command": "pip install python-pptx"}}
 
 // Create generation script
-{"name": "sandbox_write_file", "arguments": {
+{"name": "write_file", "arguments": {
   "file_path": "/home/user/generate_ai_trends.py",
   "content": "from pptx import Presentation\nfrom pptx.util import Inches, Pt\n\n# Create presentation\nprs = Presentation()\n\n# Title slide\ntitle_slide = prs.slides.add_slide(prs.slide_layouts[0])\ntitle = title_slide.shapes.title\ntitle.text = 'AI Trends 2025'\n\n# Save\nprs.save('/home/user/documents/ai_trends.pptx')"
 }}
 
 // Execute script
-{"name": "sandbox_command", "arguments": {"command": "python /home/user/generate_ai_trends.py"}}
+{"name": "exec", "arguments": {"command": "python /home/user/generate_ai_trends.py"}}
 
 // Verify output
-{"name": "sandbox_list_files", "arguments": {"path": "/home/user/documents"}}
+{"name": "list_files", "arguments": {"path": "/home/user/documents"}}
 
 // Step 4: Upload document and return download URL
-{"name": "sandbox_upload_attachment", "arguments": {"file_path": "/home/user/documents/ai_trends.pptx"}}
+{"name": "upload_attachment", "arguments": {"file_path": "/home/user/documents/ai_trends.pptx"}}
 // Then present download link to user:
 // Document generation completed!
 // 📄 **ai_trends.pptx**
@@ -311,14 +311,14 @@ After reading the skill file in Step 1, you'll receive:
 {"name": "load_document_skill", "arguments": {"document_type": "xlsx"}}
 
 // Step 2: Read XLSX skill documentation
-{"name": "sandbox_read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/xlsx/SKILL.md"}}
+{"name": "read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/xlsx/SKILL.md"}}
 
 // Step 3: Install dependencies if needed and generate based on loaded instructions
-{"name": "sandbox_command", "arguments": {"command": "pip install openpyxl"}}
+{"name": "exec", "arguments": {"command": "pip install openpyxl"}}
 // ... create script and execute ...
 
 // Step 4: Upload and return download URL
-{"name": "sandbox_upload_attachment", "arguments": {"file_path": "/home/user/documents/financial_report.xlsx"}}
+{"name": "upload_attachment", "arguments": {"file_path": "/home/user/documents/financial_report.xlsx"}}
 ```
 
 ### Example 3: Generate Word Document
@@ -330,14 +330,14 @@ After reading the skill file in Step 1, you'll receive:
 {"name": "load_document_skill", "arguments": {"document_type": "docx"}}
 
 // Step 2: Read DOCX skill documentation
-{"name": "sandbox_read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/docx/SKILL.md"}}
+{"name": "read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/docx/SKILL.md"}}
 
 // Step 3: Install dependencies if needed and generate based on loaded instructions
-{"name": "sandbox_command", "arguments": {"command": "pip install python-docx"}}
+{"name": "exec", "arguments": {"command": "pip install python-docx"}}
 // ... create script and execute ...
 
 // Step 4: Upload and return download URL
-{"name": "sandbox_upload_attachment", "arguments": {"file_path": "/home/user/documents/api_docs.docx"}}
+{"name": "upload_attachment", "arguments": {"file_path": "/home/user/documents/api_docs.docx"}}
 ```
 
 ### Example 4: Generate PDF Document
@@ -349,21 +349,21 @@ After reading the skill file in Step 1, you'll receive:
 {"name": "load_document_skill", "arguments": {"document_type": "pdf"}}
 
 // Step 2: Read PDF skill documentation
-{"name": "sandbox_read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pdf/SKILL.md"}}
+{"name": "read_file", "arguments": {"file_path": "/root/.claude/plugins/marketplaces/anthropic-agent-skills/skills/pdf/SKILL.md"}}
 
 // Step 3: Install dependencies if needed and generate based on loaded instructions
-{"name": "sandbox_command", "arguments": {"command": "pip install reportlab"}}
+{"name": "exec", "arguments": {"command": "pip install reportlab"}}
 // ... create script and execute ...
 
 // Step 4: Upload and return download URL
-{"name": "sandbox_upload_attachment", "arguments": {"file_path": "/home/user/documents/research_report.pdf"}}
+{"name": "upload_attachment", "arguments": {"file_path": "/home/user/documents/research_report.pdf"}}
 ```
 
 ## Integration with Other Skills
 
 This skill has a hard dependency on:
 
-- **Sandbox Skill**: Required for all operations - provides `sandbox_list_files`, `sandbox_command`, `sandbox_read_file`, `sandbox_write_file`, and `sandbox_upload_attachment` tools
+- **Sandbox Skill**: Required for all operations - provides `list_files`, `exec`, `read_file`, `write_file`, and `upload_attachment` tools
 
 The sandbox skill is automatically loaded before this skill due to the `dependencies` declaration.
 
@@ -449,13 +449,13 @@ This skill follows the **instruction-only pattern**:
 
 **Mandatory Workflow**:
 1. Call `load_document_skill` to get instructions
-2. **⚠️ NEVER SKIP**: Execute `sandbox_read_file` to read skill documentation (pre-installed in Docker)
-3. Follow the loaded instructions to generate documents (DO NOT use 'claude' command or 'sandbox_claude' tool)
-4. **⚠️ NEVER SKIP**: Execute `sandbox_upload_attachment` to upload document and return download URL
+2. **⚠️ NEVER SKIP**: Execute `read_file` to read skill documentation (pre-installed in Docker)
+3. Follow the loaded instructions to generate documents (DO NOT use 'claude' command or 'sub_claude_agent' tool)
+4. **⚠️ NEVER SKIP**: Execute `upload_attachment` to upload document and return download URL
 
 **Remember**:
 - Always read the official skill documentation before generating documents. Your existing knowledge may be outdated.
 - Always follow the design guidelines and best practices in the skill documentation.
 - Always generate visually appealing, professional-looking documents with proper styling.
 - Always upload documents and provide download URLs. Users cannot access sandbox files directly.
-- DO NOT use 'claude' command or 'sandbox_claude' tool for document generation.
+- DO NOT use 'claude' command or 'sub_claude_agent' tool for document generation.

--- a/backend/init_data/skills/document/document_tool.py
+++ b/backend/init_data/skills/document/document_tool.py
@@ -60,9 +60,9 @@ What you receive:
 - Validation criteria for each step
 
 What you MUST do:
-1. Execute step 1 using sandbox_list_files (check marketplace)
-2. Execute step 2 using sandbox_command (install if needed)
-3. Execute step 3 using sandbox_read_file (read skill documentation)
+1. Execute step 1 using list_files (check marketplace)
+2. Execute step 2 using exec (install if needed)
+3. Execute step 3 using read_file (read skill documentation)
 4. Only AFTER step 3, follow the loaded skill instructions
 
 DO NOT generate documents based on your existing knowledge without loading the skill first.
@@ -155,7 +155,7 @@ Example:
                         "DO NOT proceed to generate documents without reading this file.\n"
                         "The content field will contain Anthropic's official skill documentation."
                     ),
-                    "tool": "sandbox_read_file",
+                    "tool": "read_file",
                     "arguments": {"file_path": skill_path},
                     "expected_outcome": "success=true and content field contains the skill documentation",
                     "validation": "Verify content is not empty and contains skill instructions",
@@ -206,13 +206,13 @@ Example:
                         "Check if dependencies are already installed (most common ones are pre-installed)",
                         "Only install additional dependencies if explicitly required by the documentation",
                         "Follow the code patterns and examples in the documentation",
-                        "Use sandbox_write_file to create Python scripts",
-                        "Use sandbox_command to execute generation scripts",
-                        "Use sandbox_list_files to verify output files",
+                        "Use write_file to create Python scripts",
+                        "Use exec to execute generation scripts",
+                        "Use list_files to verify output files",
                     ],
                     "forbidden": [
                         "❌ DO NOT use 'claude' command - it's not available for all models",
-                        "❌ DO NOT use 'sandbox_claude' tool for document generation",
+                        "❌ DO NOT use 'sub_claude_agent' tool for document generation",
                         "❌ DO NOT skip reading the documentation and generate based on your knowledge",
                         "❌ DO NOT use outdated patterns not specified in the documentation",
                         "❌ DO NOT assume you know the correct approach without reading",
@@ -221,7 +221,7 @@ Example:
                 "step_3_UPLOAD_AND_RETURN_URL": {
                     "description": "Upload the generated document and return download URL to user",
                     "mandatory": True,
-                    "tool": "sandbox_upload_attachment",
+                    "tool": "upload_attachment",
                     "arguments_template": {
                         "file_path": "/home/user/documents/{generated_file_path}",
                     },
@@ -254,7 +254,7 @@ Example:
                 f"🔴 MANDATORY INSTRUCTIONS FOR {document_type.upper()} GENERATION 🔴\n\n"
                 f"You MUST execute these steps IN ORDER:\n\n"
                 f"1️⃣ STEP 1: ⚠️ READ SKILL DOCUMENTATION ⚠️ (NEVER SKIP THIS)\n"
-                f"   → Call: sandbox_read_file(file_path='{skill_path}')\n"
+                f"   → Call: read_file(file_path='{skill_path}')\n"
                 f"   → Read the 'content' field - this contains Anthropic's LATEST instructions\n"
                 f"   → This is MANDATORY - your knowledge may be outdated\n\n"
                 f"2️⃣ STEP 2: Follow the loaded instructions\n"
@@ -264,10 +264,10 @@ Example:
                 f"   → Most common dependencies are already pre-installed (python-pptx, openpyxl, pandas, python-docx, reportlab, pandoc, docx, LibreOffice, Chromium, etc.)\n"
                 f"   → Only install additional dependencies if explicitly required\n"
                 f"   → ⚠️ DO NOT use 'claude' command - it's not available for all models\n"
-                f"   → ⚠️ DO NOT use 'sandbox_claude' tool for document generation\n"
+                f"   → ⚠️ DO NOT use 'sub_claude_agent' tool for document generation\n"
                 f"   → Generate the document following the loaded instructions\n\n"
                 f"3️⃣ STEP 3: ⚠️ UPLOAD AND RETURN URL ⚠️ (MANDATORY)\n"
-                f"   → Call: sandbox_upload_attachment(file_path='{{generated_file_path}}')\n"
+                f"   → Call: upload_attachment(file_path='{{generated_file_path}}')\n"
                 f"   → Get the 'download_url' from response\n"
                 f"   → ⚠️ CRITICAL: Put the download link on its own line with no other text\n"
                 f"   → ✅ Correct format: 'Document generated!\\n\\n[Click to Download]({{download_url}})'\n"
@@ -275,7 +275,7 @@ Example:
                 f"   → Frontend will automatically render the link as an interactive card\n\n"
                 f"⚠️ DO NOT generate {document_type.upper()} files before completing step 1!\n"
                 f"⚠️ DO NOT skip step 3 - users cannot access sandbox files directly!\n"
-                f"⚠️ DO NOT use 'claude' command or 'sandbox_claude' tool for document generation!\n"
+                f"⚠️ DO NOT use 'claude' command or 'sub_claude_agent' tool for document generation!\n"
                 f"⚠️ Your existing knowledge may be OUTDATED - trust the loaded documentation!"
             ),
         }

--- a/backend/init_data/skills/sandbox/SKILL.md
+++ b/backend/init_data/skills/sandbox/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: "Provides isolated sandbox execution environments (AlmaLinux 9.4) for safely executing commands, running code, and managing filesystems. Ideal for code testing, file management, and command execution. The sandbox_claude tool is available for advanced use cases but should only be used when explicitly requested by the user."
+description: "Provides read_file/write_file/exec/list_files/read_file/write_file for running process and managing filesystems in the sandbox. Ideal for code testing, file management, and command execution. The sub_claude_agent tool is available for advanced use cases. You MUST load this skill BEFORE use sandbox tools."
 displayName: "沙箱环境"
 version: "2.1.0"
 author: "Wegent Team"
@@ -23,25 +23,25 @@ config:
           model_id: "xxxxx"
           small_model: "xxxxx"
 tools:
-  - name: sandbox_command
+  - name: exec
     provider: sandbox
-  - name: sandbox_claude
+  - name: sub_claude_agent
     provider: sandbox
     config:
       command_timeout: 1800
-  - name: sandbox_list_files
+  - name: list_files
     provider: sandbox
-  - name: sandbox_read_file
+  - name: read_file
     provider: sandbox
-  - name: sandbox_write_file
+  - name: write_file
     provider: sandbox
     config:
       max_file_size: 10485760
-  - name: sandbox_upload_attachment
+  - name: upload_attachment
     provider: sandbox
     config:
       max_file_size: 104857600
-  - name: sandbox_download_attachment
+  - name: download_attachment
     provider: sandbox
 ---
 
@@ -70,13 +70,13 @@ Use this skill when you need to:
 - ✅ Git operations (clone, commit, push, etc.)
 - ✅ Require isolated environment for safety
 
-**Note**: The `sandbox_claude` tool should only be used when the user explicitly requests Claude AI assistance (e.g., "use Claude to generate...", "ask Claude to create...").
+**Note**: The `sub_claude_agent` tool should only be used when the user explicitly requests Claude AI assistance (e.g., "use Claude to generate...", "ask Claude to create...").
 
 ## Available Tools
 
 ### Command Execution
 
-#### `sandbox_command`
+#### `exec`
 Execute shell commands in the sandbox environment.
 
 **Use Cases:**
@@ -93,7 +93,7 @@ Execute shell commands in the sandbox environment.
 **Example:**
 ```json
 {
-  "name": "sandbox_command",
+  "name": "exec",
   "arguments": {
     "command": "python script.py --arg value",
     "working_dir": "/home/user/project"
@@ -103,7 +103,7 @@ Execute shell commands in the sandbox environment.
 
 ---
 
-#### `sandbox_claude`
+#### `sub_claude_agent`
 Run Claude AI to execute complex tasks in the sandbox.
 
 **⚠️ IMPORTANT**: This tool should **only be used when the user explicitly requests it**. Do not use this tool automatically or as a default option.
@@ -128,7 +128,7 @@ Run Claude AI to execute complex tasks in the sandbox.
 **Example:**
 ```json
 {
-  "name": "sandbox_claude",
+  "name": "sub_claude_agent",
   "arguments": {
     "prompt": "Create a 5-page presentation about the history of artificial intelligence",
     "allowed_tools": "Edit,Write,Bash(*),skills,Read"
@@ -140,7 +140,7 @@ Run Claude AI to execute complex tasks in the sandbox.
 
 ### File Operations
 
-#### `sandbox_list_files`
+#### `list_files`
 List files and subdirectories in a directory.
 
 **Parameters:**
@@ -153,7 +153,7 @@ List files and subdirectories in a directory.
 **Example:**
 ```json
 {
-  "name": "sandbox_list_files",
+  "name": "list_files",
   "arguments": {
     "path": "/home/user/project",
     "depth": 2
@@ -163,7 +163,7 @@ List files and subdirectories in a directory.
 
 ---
 
-#### `sandbox_read_file`
+#### `read_file`
 Read file contents.
 
 **Parameters:**
@@ -175,7 +175,7 @@ Read file contents.
 **Example:**
 ```json
 {
-  "name": "sandbox_read_file",
+  "name": "read_file",
   "arguments": {
     "file_path": "/home/user/config.json"
   }
@@ -184,7 +184,7 @@ Read file contents.
 
 ---
 
-#### `sandbox_write_file`
+#### `write_file`
 Write content to a file.
 
 ⚠️ **IMPORTANT**: Both `file_path` AND `content` are **REQUIRED** parameters. You must always provide the content to write.
@@ -202,7 +202,7 @@ Write content to a file.
 **Example - Text file:**
 ```json
 {
-  "name": "sandbox_write_file",
+  "name": "write_file",
   "arguments": {
     "file_path": "/home/user/output.txt",
     "content": "Hello, Sandbox!"
@@ -213,7 +213,7 @@ Write content to a file.
 **Example - HTML file:**
 ```json
 {
-  "name": "sandbox_write_file",
+  "name": "write_file",
   "arguments": {
     "file_path": "/home/user/index.html",
     "content": "<!DOCTYPE html><html><head><title>Test</title></head><body><h1>Hello</h1></body></html>"
@@ -225,7 +225,7 @@ Write content to a file.
 
 ### Attachment Operations
 
-#### `sandbox_upload_attachment`
+#### `upload_attachment`
 Upload a file from sandbox to Wegent and get a download URL for users.
 
 **Use Cases:**
@@ -251,7 +251,7 @@ Upload a file from sandbox to Wegent and get a download URL for users.
 **Example:**
 ```json
 {
-  "name": "sandbox_upload_attachment",
+  "name": "upload_attachment",
   "arguments": {
     "file_path": "/home/user/documents/report.pdf"
   }
@@ -270,7 +270,7 @@ Document generation completed!
 
 ---
 
-#### `sandbox_download_attachment`
+#### `download_attachment`
 Download a file from Wegent attachment URL to sandbox for processing.
 
 **Use Cases:**
@@ -290,7 +290,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 **Example:**
 ```json
 {
-  "name": "sandbox_download_attachment",
+  "name": "download_attachment",
   "arguments": {
     "attachment_url": "/api/attachments/123/download",
     "save_path": "/home/user/downloads/document.pdf"
@@ -304,16 +304,16 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 | Task Type | Recommended Tool | Reason |
 |-----------|-----------------|--------|
-| Execute commands or scripts | `sandbox_command` | Fast execution, no overhead |
-| Create/delete directories | `sandbox_command` | Use `mkdir -p` or `rm -rf` directly |
-| Read files | `sandbox_read_file` | Better error handling and size validation |
-| Write files | `sandbox_write_file` | Auto directory creation, size validation |
-| Browse directories | `sandbox_list_files` | Structured output with metadata |
-| Upload files for user download | `sandbox_upload_attachment` | Get download URL for user-facing files |
-| Download attachments | `sandbox_download_attachment` | Retrieve Wegent attachments into sandbox |
-| Complex tasks with Claude | `sandbox_claude` | **Only when user explicitly requests** |
+| Execute commands or scripts | `exec` | Fast execution, no overhead |
+| Create/delete directories | `exec` | Use `mkdir -p` or `rm -rf` directly |
+| Read files | `read_file` | Better error handling and size validation |
+| Write files | `write_file` | Auto directory creation, size validation |
+| Browse directories | `list_files` | Structured output with metadata |
+| Upload files for user download | `upload_attachment` | Get download URL for user-facing files |
+| Download attachments | `download_attachment` | Retrieve Wegent attachments into sandbox |
+| Complex tasks with Claude | `sub_claude_agent` | **Only when user explicitly requests** |
 
-**Important**: Always prefer `sandbox_command` for standard operations. Only use `sandbox_claude` when the user specifically asks for Claude AI assistance.
+**Important**: Always prefer `exec` for standard operations. Only use `sub_claude_agent` when the user specifically asks for Claude AI assistance.
 
 ---
 
@@ -323,7 +323,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 ```json
 {
-  "name": "sandbox_command",
+  "name": "exec",
   "arguments": {
     "command": "cd /home/user && python -m pip install requests && python app.py"
   }
@@ -334,7 +334,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 ```json
 {
-  "name": "sandbox_command",
+  "name": "exec",
   "arguments": {
     "command": "dnf install -y gcc make && gcc --version"
   }
@@ -346,7 +346,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 ```json
 // 1. List files
 {
-  "name": "sandbox_list_files",
+  "name": "list_files",
   "arguments": {
     "path": "/home/user"
   }
@@ -354,7 +354,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 // 2. Read file
 {
-  "name": "sandbox_read_file",
+  "name": "read_file",
   "arguments": {
     "file_path": "/home/user/data.json"
   }
@@ -362,7 +362,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 // 3. Write file
 {
-  "name": "sandbox_write_file",
+  "name": "write_file",
   "arguments": {
     "file_path": "/home/user/result.txt",
     "content": "Processing complete: Success"
@@ -374,7 +374,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 ```json
 {
-  "name": "sandbox_command",
+  "name": "exec",
   "arguments": {
     "command": "git clone https://github.com/user/repo.git && cd repo && git checkout -b feature"
   }
@@ -387,7 +387,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 ```json
 {
-  "name": "sandbox_claude",
+  "name": "sub_claude_agent",
   "arguments": {
     "prompt": "Create a 5-page presentation about the history of artificial intelligence"
   }
@@ -458,7 +458,7 @@ Control Claude's available tools via the `allowed_tools` parameter:
 3. **Choose the Right Tool** - Refer to the tool selection guide
 4. **Check Return Results** - Verify the `success` field
 5. **Mind Size Limits** - File read/write operations have size constraints
-6. **Prefer sandbox_command** - Use for most tasks; only use `sandbox_claude` when user explicitly requests Claude assistance
+6. **Prefer exec** - Use for most tasks; only use `sub_claude_agent` when user explicitly requests Claude assistance
 
 ---
 
@@ -470,7 +470,7 @@ Control Claude's available tools via the `allowed_tools` parameter:
 
 ### File Not Found
 **Cause**: Incorrect path or file doesn't exist
-**Solution**: Use absolute paths, verify with `sandbox_list_files` first
+**Solution**: Use absolute paths, verify with `list_files` first
 
 ### Command Timeout
 **Cause**: Task execution takes too long

--- a/backend/init_data/skills/sandbox/SKILL.md
+++ b/backend/init_data/skills/sandbox/SKILL.md
@@ -232,6 +232,7 @@ Upload a file from sandbox to Wegent and get a download URL for users.
 - Upload generated documents (PDF, Word, etc.) for user download
 - Share files created in the sandbox with users
 - Export results from sandbox to Wegent storage
+- User can not access file directly, you MUST use upload_attachment tool for sending file to user.
 
 **Parameters:**
 - `file_path` (required): Path to the file in sandbox to upload

--- a/backend/init_data/skills/sandbox/claude_tool.py
+++ b/backend/init_data/skills/sandbox/claude_tool.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxClaudeInput(BaseModel):
-    """Input schema for sandbox_claude tool."""
+    """Input schema for sub_claude_agent tool."""
 
     prompt: str = Field(
         ...,
@@ -71,12 +71,12 @@ class SandboxClaudeTool(BaseSandboxTool):
     streaming output to frontend via WebSocket.
     """
 
-    name: str = "sandbox_claude"
+    name: str = "sub_claude_agent"
     display_name: str = "执行 Claude 命令"
     description: str = """Execute a Claude command in an isolated sandbox environment.
 
 ⚠️ ONLY use when user EXPLICITLY requests Claude by name (e.g., "use Claude to...", "let Claude help me...").
-DO NOT use for normal sandbox operations - use sandbox_command, sandbox_read_file, etc. instead.
+DO NOT use for normal sandbox operations - use exec, read_file, etc. instead.
 
 Parameters:
 - prompt (required): Task prompt for Claude

--- a/backend/init_data/skills/sandbox/command_tool.py
+++ b/backend/init_data/skills/sandbox/command_tool.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxCommandInput(BaseModel):
-    """Input schema for sandbox_command tool."""
+    """Input schema for exec tool."""
 
     command: str = Field(
         ...,
@@ -61,7 +61,7 @@ class SandboxCommandTool(BaseSandboxTool):
     sandbox environment using the E2B SDK.
     """
 
-    name: str = "sandbox_command"
+    name: str = "exec"
     display_name: str = "执行命令"
     description: str = """Execute a command in an isolated sandbox environment.
 

--- a/backend/init_data/skills/sandbox/download_attachment_tool.py
+++ b/backend/init_data/skills/sandbox/download_attachment_tool.py
@@ -24,7 +24,7 @@ DEFAULT_API_BASE_URL = "http://backend:8000"
 
 
 class SandboxDownloadAttachmentInput(BaseModel):
-    """Input schema for sandbox_download_attachment tool."""
+    """Input schema for download_attachment tool."""
 
     attachment_url: str = Field(
         ...,
@@ -64,7 +64,7 @@ class SandboxDownloadAttachmentTool(BaseSandboxTool):
     sandbox environment via the /api/attachments/{id}/download endpoint.
     """
 
-    name: str = "sandbox_download_attachment"
+    name: str = "download_attachment"
     display_name: str = "下载文件"
     description: str = """Download a file from Wegent attachment URL to sandbox.
 

--- a/backend/init_data/skills/sandbox/list_files_tool.py
+++ b/backend/init_data/skills/sandbox/list_files_tool.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxListFilesInput(BaseModel):
-    """Input schema for sandbox_list_files tool."""
+    """Input schema for list_files tool."""
 
     path: Optional[str] = Field(
         default="/home/user",
@@ -56,7 +56,7 @@ class SandboxListFilesTool(BaseSandboxTool):
     using the native E2B filesystem API.
     """
 
-    name: str = "sandbox_list_files"
+    name: str = "list_files"
     display_name: str = "列出文件"
     description: str = """List files and directories in the sandbox environment.
 

--- a/backend/init_data/skills/sandbox/provider.py
+++ b/backend/init_data/skills/sandbox/provider.py
@@ -63,6 +63,7 @@ class SandboxToolProvider(SkillToolProvider):
             "user_id": context.user_id,
             "user_name": context.user_name,
             "bot_config": config.get("bot_config", []),
+            "auth_token": context.auth_token,  # Pass auth_token for skill download in sandbox
             "default_shell_type": config.get("default_shell_type", "ClaudeCode"),
             "timeout": config.get("timeout", 7200),
         }

--- a/backend/init_data/skills/sandbox/provider.py
+++ b/backend/init_data/skills/sandbox/provider.py
@@ -32,13 +32,13 @@ class SandboxToolProvider(SkillToolProvider):
 
     Example SKILL.md configuration:
         tools:
-          - name: sandbox_command
+          - name: exec
             provider: sandbox
-          - name: sandbox_claude
+          - name: sub_claude_agent
             provider: sandbox
             config:
               command_timeout: 1800
-          - name: sandbox_list_files
+          - name: list_files
             provider: sandbox
     """
 
@@ -84,13 +84,13 @@ class SandboxToolProvider(SkillToolProvider):
             List containing supported tool names
         """
         return [
-            "sandbox_command",
-            "sandbox_claude",
-            "sandbox_list_files",
-            "sandbox_read_file",
-            "sandbox_write_file",
-            "sandbox_upload_attachment",
-            "sandbox_download_attachment",
+            "exec",
+            "sub_claude_agent",
+            "list_files",
+            "read_file",
+            "write_file",
+            "upload_attachment",
+            "download_attachment",
         ]
 
     def create_tool(
@@ -128,7 +128,7 @@ class SandboxToolProvider(SkillToolProvider):
         base_params = self._prepare_base_params(context, tool_config)
         config = tool_config or {}
 
-        if tool_name == "sandbox_command":
+        if tool_name == "exec":
             from .command_tool import SandboxCommandTool
 
             tool_instance = SandboxCommandTool(
@@ -136,7 +136,7 @@ class SandboxToolProvider(SkillToolProvider):
                 default_command_timeout=config.get("command_timeout", 300),
             )
 
-        elif tool_name == "sandbox_claude":
+        elif tool_name == "sub_claude_agent":
             from .claude_tool import SandboxClaudeTool
 
             tool_instance = SandboxClaudeTool(
@@ -144,12 +144,12 @@ class SandboxToolProvider(SkillToolProvider):
                 default_command_timeout=config.get("command_timeout", 1800),
             )
 
-        elif tool_name == "sandbox_list_files":
+        elif tool_name == "list_files":
             from .list_files_tool import SandboxListFilesTool
 
             tool_instance = SandboxListFilesTool(**base_params)
 
-        elif tool_name == "sandbox_read_file":
+        elif tool_name == "read_file":
             from .read_file_tool import SandboxReadFileTool
 
             tool_instance = SandboxReadFileTool(
@@ -157,7 +157,7 @@ class SandboxToolProvider(SkillToolProvider):
                 max_size=config.get("max_file_size", 1048576),  # 1MB default
             )
 
-        elif tool_name == "sandbox_write_file":
+        elif tool_name == "write_file":
             from .write_file_tool import SandboxWriteFileTool
 
             tool_instance = SandboxWriteFileTool(
@@ -165,7 +165,7 @@ class SandboxToolProvider(SkillToolProvider):
                 max_size=config.get("max_file_size", 10485760),  # 10MB default
             )
 
-        elif tool_name == "sandbox_upload_attachment":
+        elif tool_name == "upload_attachment":
             from .upload_attachment_tool import SandboxUploadAttachmentTool
 
             tool_instance = SandboxUploadAttachmentTool(
@@ -175,7 +175,7 @@ class SandboxToolProvider(SkillToolProvider):
                 api_base_url=config.get("api_base_url", ""),
             )
 
-        elif tool_name == "sandbox_download_attachment":
+        elif tool_name == "download_attachment":
             from .download_attachment_tool import SandboxDownloadAttachmentTool
 
             tool_instance = SandboxDownloadAttachmentTool(

--- a/backend/init_data/skills/sandbox/read_file_tool.py
+++ b/backend/init_data/skills/sandbox/read_file_tool.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxReadFileInput(BaseModel):
-    """Input schema for sandbox_read_file tool."""
+    """Input schema for read_file tool."""
 
     file_path: str = Field(
         ...,
@@ -57,7 +57,7 @@ class SandboxReadFileTool(BaseSandboxTool):
     using E2B SDK's file operations.
     """
 
-    name: str = "sandbox_read_file"
+    name: str = "read_file"
     display_name: str = "读取文件"
     description: str = """Read the contents of a file from the sandbox environment.
 

--- a/backend/init_data/skills/sandbox/upload_attachment_tool.py
+++ b/backend/init_data/skills/sandbox/upload_attachment_tool.py
@@ -27,7 +27,7 @@ MAX_UPLOAD_SIZE = 100 * 1024 * 1024
 
 
 class SandboxUploadAttachmentInput(BaseModel):
-    """Input schema for sandbox_upload_attachment tool."""
+    """Input schema for upload_attachment tool."""
 
     file_path: str = Field(
         ...,
@@ -63,7 +63,7 @@ class SandboxUploadAttachmentTool(BaseSandboxTool):
     attachment storage via the /api/attachments/upload endpoint.
     """
 
-    name: str = "sandbox_upload_attachment"
+    name: str = "upload_attachment"
     display_name: str = "上传文件"
     description: str = """Upload a file from sandbox to Wegent and get a download URL.
 

--- a/backend/init_data/skills/sandbox/write_file_tool.py
+++ b/backend/init_data/skills/sandbox/write_file_tool.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 class SandboxWriteFileInput(BaseModel):
-    """Input schema for sandbox_write_file tool."""
+    """Input schema for write_file tool."""
 
     file_path: str = Field(
         ...,
@@ -65,7 +65,7 @@ class SandboxWriteFileTool(BaseSandboxTool):
     using E2B SDK's file operations.
     """
 
-    name: str = "sandbox_write_file"
+    name: str = "write_file"
     display_name: str = "写入文件"
     description: str = """Write content to a file in the sandbox environment.
 

--- a/executor_manager/services/sandbox/manager.py
+++ b/executor_manager/services/sandbox/manager.py
@@ -286,6 +286,16 @@ class SandboxManager(metaclass=SingletonMeta):
         task_id = sandbox.metadata.get("task_id", 0)
         subtask_id = sandbox.metadata.get("subtask_id", 0)
 
+        # Extract skills from bot_config for skill download in executor
+        # bot_config can be a list or a dict
+        skills = []
+        if isinstance(bot_config, list) and len(bot_config) > 0:
+            # bot_config is a list of bot configurations
+            skills = bot_config[0].get("skills", [])
+        elif isinstance(bot_config, dict):
+            # bot_config is a single bot configuration
+            skills = bot_config.get("skills", [])
+
         # Build minimal task structure for sandbox
         # The container will wait for execution requests
         task = {
@@ -305,7 +315,7 @@ class SandboxManager(metaclass=SingletonMeta):
                     "agent_config": bot_config,
                     "system_prompt": "",
                     "mcp_servers": {},
-                    "skills": [],
+                    "skills": skills,  # Pass skills for download in executor
                     "role": "",
                 }
             ],
@@ -329,6 +339,11 @@ class SandboxManager(metaclass=SingletonMeta):
                 ),
             },
         }
+
+        # Add auth_token from metadata for skill download authentication
+        auth_token = sandbox.metadata.get("auth_token")
+        if auth_token:
+            task["auth_token"] = auth_token
 
         # Add workspace info if provided
         workspace_ref = sandbox.metadata.get("workspace_ref")

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -12,6 +12,7 @@ import { QuickAccessCards } from './QuickAccessCards'
 import { SloganDisplay } from './SloganDisplay'
 import { ChatInputCard } from '../input/ChatInputCard'
 import PipelineStageIndicator from './PipelineStageIndicator'
+import { ScrollToBottomIndicator } from './ScrollToBottomIndicator'
 import type { PipelineStageInfo } from '@/apis/tasks'
 import { useChatAreaState } from './useChatAreaState'
 import { useChatStreamHandlers } from './useChatStreamHandlers'
@@ -276,6 +277,7 @@ function ChatAreaContent({
   const {
     scrollContainerRef,
     isUserNearBottomRef,
+    showScrollIndicator,
     scrollToBottom,
     handleMessagesContentChange: _baseHandleMessagesContentChange,
   } = useScrollManagement({
@@ -743,7 +745,22 @@ function ChatAreaContent({
               width: floatingMetrics.width,
             }}
           >
-            <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-4">
+            {/* Bottom gradient fade effect - text fades as it approaches the input */}
+            <div
+              className="absolute top-0 left-0 right-0 h-12 -translate-y-full pointer-events-none"
+              style={{
+                background:
+                  'linear-gradient(to top, rgb(var(--color-bg-base)) 0%, rgb(var(--color-bg-base) / 0.8) 40%, rgb(var(--color-bg-base) / 0) 100%)',
+              }}
+            />
+            {/* Scroll to bottom indicator */}
+            <div className="absolute -top-2 left-1/2 -translate-x-1/2 -translate-y-full pointer-events-auto">
+              <ScrollToBottomIndicator
+                visible={showScrollIndicator}
+                onClick={() => scrollToBottom(true)}
+              />
+            </div>
+            <div className="w-full max-w-4xl mx-auto px-4 sm:px-6 py-4 bg-base">
               <ChatInputCard {...inputCardProps} />
             </div>
           </div>

--- a/frontend/src/features/tasks/components/chat/ScrollToBottomIndicator.tsx
+++ b/frontend/src/features/tasks/components/chat/ScrollToBottomIndicator.tsx
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React from 'react'
+import { ChevronDown } from 'lucide-react'
+
+interface ScrollToBottomIndicatorProps {
+  /**
+   * Whether the indicator should be visible.
+   * When true, shows the indicator with animation.
+   */
+  visible: boolean
+
+  /**
+   * Callback function when the indicator is clicked.
+   * Should scroll to the bottom of the message list.
+   */
+  onClick: () => void
+}
+
+/**
+ * ScrollToBottomIndicator Component
+ *
+ * A small circular button that appears when the user scrolls up in the chat.
+ * Clicking it scrolls the message list to the bottom (most recent messages).
+ *
+ * Design inspired by Doubao chat interface:
+ * - Circular button with downward chevron icon
+ * - Appears above the input area with smooth fade animation
+ * - Provides visual feedback on hover
+ */
+export function ScrollToBottomIndicator({ visible, onClick }: ScrollToBottomIndicatorProps) {
+  if (!visible) return null
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="
+        flex items-center justify-center
+        w-8 h-8 rounded-full
+        bg-surface border border-border
+        shadow-sm
+        text-text-secondary hover:text-text-primary
+        hover:bg-base hover:border-border-hover
+        transition-all duration-200
+        cursor-pointer
+        animate-in fade-in slide-in-from-bottom-2 duration-200
+      "
+      aria-label="Scroll to bottom"
+    >
+      <ChevronDown className="w-4 h-4" />
+    </button>
+  )
+}
+
+export default ScrollToBottomIndicator

--- a/frontend/src/features/tasks/components/hooks/useScrollManagement.ts
+++ b/frontend/src/features/tasks/components/hooks/useScrollManagement.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { useRef, useCallback, useEffect } from 'react'
+import { useRef, useCallback, useEffect, useState } from 'react'
 
 /**
  * Threshold in pixels for determining if user is near the bottom of the scroll container.
@@ -55,6 +55,12 @@ export interface UseScrollManagementReturn {
   isUserNearBottomRef: React.RefObject<boolean>
 
   /**
+   * Whether to show the scroll-to-bottom indicator button.
+   * True when user has scrolled up and is not near the bottom.
+   */
+  showScrollIndicator: boolean
+
+  /**
    * Function to scroll to the bottom of the container.
    * @param force - If true, scrolls regardless of user position.
    */
@@ -88,6 +94,8 @@ export function useScrollManagement({
 }: UseScrollManagementOptions): UseScrollManagementReturn {
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const isUserNearBottomRef = useRef<boolean>(true)
+  // State for showing/hiding the scroll-to-bottom indicator
+  const [showScrollIndicator, setShowScrollIndicator] = useState(false)
 
   /**
    * Scrolls the container to the bottom.
@@ -106,6 +114,7 @@ export function useScrollManagement({
           container.scrollTop = container.scrollHeight
           if (force) {
             isUserNearBottomRef.current = true
+            setShowScrollIndicator(false)
           }
         }
       })
@@ -127,6 +136,7 @@ export function useScrollManagement({
    *
    * This replaces the original useEffect at lines 400-414 in ChatArea.tsx.
    * Updates isUserNearBottomRef based on scroll position.
+   * Also updates showScrollIndicator state for UI display.
    */
   useEffect(() => {
     const container = scrollContainerRef.current
@@ -135,7 +145,10 @@ export function useScrollManagement({
     const handleScroll = () => {
       const distanceFromBottom =
         container.scrollHeight - container.scrollTop - container.clientHeight
-      isUserNearBottomRef.current = distanceFromBottom <= AUTO_SCROLL_THRESHOLD
+      const isNearBottom = distanceFromBottom <= AUTO_SCROLL_THRESHOLD
+      isUserNearBottomRef.current = isNearBottom
+      // Show indicator when user has scrolled up (not near bottom)
+      setShowScrollIndicator(!isNearBottom && hasMessages)
     }
 
     container.addEventListener('scroll', handleScroll)
@@ -177,6 +190,7 @@ export function useScrollManagement({
   return {
     scrollContainerRef,
     isUserNearBottomRef,
+    showScrollIndicator,
     scrollToBottom,
     handleMessagesContentChange,
   }


### PR DESCRIPTION
## Summary

- Extract skills list from bot_config in `executor_manager` and pass it to executor container
- Pass auth_token through sandbox metadata for skill download authentication
- Update `BaseSandboxTool` in backend skills to include auth_token when creating SandboxManager
- Update `SandboxToolProvider` to pass auth_token from context to base params

## Changes

1. **executor_manager/services/sandbox/manager.py**:
   - Modified `_build_sandbox_task()` to extract skills from bot_config (handles both list and dict formats)
   - Added skills to `task["bot"][0]["skills"]` so executor can download them
   - Added auth_token from sandbox metadata to task data for authentication

2. **backend/init_data/skills/sandbox/_base.py**:
   - Added `auth_token` parameter to `SandboxManager.__init__()` and `get_instance()`
   - Updated `get_or_create_sandbox()` to pass auth_token in E2B SDK metadata
   - Added `auth_token` attribute to `BaseSandboxTool` class
   - Updated `_get_sandbox_manager()` to pass auth_token to SandboxManager

3. **backend/init_data/skills/sandbox/provider.py**:
   - Added auth_token to `_prepare_base_params()` for all sandbox tools

## Test plan

- [x] All existing sandbox manager tests pass (44 tests)
- [ ] Create sandbox via chat_shell with configured skills
- [ ] Verify skills are downloaded to `~/.claude/skills/` in sandbox container
- [ ] Verify auth_token is correctly passed for skill download API calls