### PR TITLE
fix(ci): update macOS runner from retired macos-13 to macos-15

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -474,7 +474,7 @@ jobs:
 
   build-executor-local-macos-amd64:
     needs: prepare-release
-    runs-on: macos-13  # Intel runner
+    runs-on: macos-15  # Intel runner (macos-13 is retired)
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The macOS-13 based runner images have been retired by GitHub. This was causing the build-executor-local-macos-amd64 job to fail, which in turn cancelled the create-release-tag job.

Reference: https://github.com/actions/runner-images/issues/13046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS build runner to a newer version to ensure continued compatibility and maintain current infrastructure standards.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->