### PR TITLE
Optimize kb tool call limits

### DIFF
--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -218,7 +218,11 @@ async def get_knowledge_base_info(
             estimated_tokens = file_size // 4
 
             # Get KB configuration from Kind spec
-            kb_kind = db.query(Kind).filter(Kind.id == kb_id, Kind.kind == "KnowledgeBase").first()
+            kb_kind = (
+                db.query(Kind)
+                .filter(Kind.id == kb_id, Kind.kind == "KnowledgeBase")
+                .first()
+            )
 
             if kb_kind:
                 spec = kb_kind.json.get("spec", {})
@@ -230,12 +234,16 @@ async def get_knowledge_base_info(
                 if exempt_calls >= max_calls:
                     logger.warning(
                         "[internal_rag] Invalid KB config for KB %d: exempt=%d >= max=%d. Using defaults.",
-                        kb_id, exempt_calls, max_calls
+                        kb_id,
+                        exempt_calls,
+                        max_calls,
                     )
                     max_calls, exempt_calls = 10, 5
             else:
                 # KB not found, use defaults
-                logger.warning("[internal_rag] KB %d not found, using default config", kb_id)
+                logger.warning(
+                    "[internal_rag] KB %d not found, using default config", kb_id
+                )
                 max_calls, exempt_calls, kb_name = 10, 5, f"KB-{kb_id}"
 
             items.append(
@@ -274,8 +282,8 @@ async def get_knowledge_base_info(
                     document_count=0,
                     estimated_tokens=0,
                     max_calls_per_conversation=10,  # Default
-                    exempt_calls_before_check=5,    # Default
-                    name=f"KB-{kb_id}",              # Default
+                    exempt_calls_before_check=5,  # Default
+                    name=f"KB-{kb_id}",  # Default
                 )
             )
 

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 
 # API Format Enum for OpenAI-compatible models
@@ -720,6 +720,35 @@ class KnowledgeBaseSpec(BaseModel):
         None,
         description="Model reference for summary generation. Required when summaryEnabled=True",
     )
+
+    # Knowledge base tool call limit configuration
+    maxCallsPerConversation: Optional[int] = Field(
+        default=10,
+        ge=2,
+        le=50,
+        description="Maximum number of knowledge base tool calls allowed per conversation. "
+        "Default: 10. For backward compatibility, if not set, defaults to 10 in code.",
+    )
+    exemptCallsBeforeCheck: Optional[int] = Field(
+        default=5,
+        ge=1,
+        description="Number of calls that are exempt from token checking. "
+        "Must be less than maxCallsPerConversation. Default: 5.",
+    )
+
+    @model_validator(mode="after")
+    def validate_call_limits(self):
+        """Validate that exemptCallsBeforeCheck < maxCallsPerConversation"""
+        if (
+            self.exemptCallsBeforeCheck is not None
+            and self.maxCallsPerConversation is not None
+        ):
+            if self.exemptCallsBeforeCheck >= self.maxCallsPerConversation:
+                raise ValueError(
+                    f"exemptCallsBeforeCheck ({self.exemptCallsBeforeCheck}) must be less than "
+                    f"maxCallsPerConversation ({self.maxCallsPerConversation})"
+                )
+        return self
 
 
 class KnowledgeBaseStatus(Status):

--- a/backend/app/services/background_chat_executor.py
+++ b/backend/app/services/background_chat_executor.py
@@ -140,6 +140,13 @@ class BackgroundChatExecutor:
                 f"task_id={task.id}"
             )
 
+            logger.info(
+                "[BackgroundChatExecutor] Model config summary: name=%s, namespace=%s, type=%s",
+                model_config.get("model_name"),
+                model_config.get("model_namespace"),
+                model_config.get("model_type"),
+            )
+
             accumulated_content = ""
             chunk_count = 0
             async for event in self._adapter.chat(chat_request):

--- a/backend/app/services/chat/adapters/http.py
+++ b/backend/app/services/chat/adapters/http.py
@@ -166,47 +166,8 @@ class HTTPAdapter(ChatInterface):
             "is_subscription": request.is_subscription,
         }
 
-        # Fetch KB configurations for HTTP mode injection
-        # This follows the same pattern as package mode
-        if request.knowledge_base_ids:
-            kb_configs = {}
-            try:
-                from app.services.knowledge.knowledge_service import KnowledgeService
-
-                for kb_id in request.knowledge_base_ids:
-                    try:
-                        kb_kind = KnowledgeService.get_knowledge_base(
-                            request.db_session, kb_id, request.user_id
-                        )
-                        if kb_kind:
-                            spec = kb_kind.json.get("spec", {})
-                            kb_configs[kb_id] = {
-                                "maxCallsPerConversation": spec.get(
-                                    "maxCallsPerConversation", 10
-                                ),
-                                "exemptCallsBeforeCheck": spec.get(
-                                    "exemptCallsBeforeCheck", 5
-                                ),
-                                "name": spec.get("name", f"KB-{kb_id}"),
-                            }
-                    except Exception as e:
-                        logger.warning(
-                            f"[HTTP_ADAPTER] Failed to fetch config for KB {kb_id}: {e}"
-                        )
-                        # Use defaults if fetch fails
-                        kb_configs[kb_id] = {
-                            "maxCallsPerConversation": 10,
-                            "exemptCallsBeforeCheck": 5,
-                            "name": f"KB-{kb_id}",
-                        }
-            except Exception as e:
-                logger.warning(
-                    f"[HTTP_ADAPTER] Failed to fetch KB configs: {e}, using empty config"
-                )
-                kb_configs = {}
-
-            # Add kb_configs to metadata for chat_shell injection
-            metadata["kb_configs"] = kb_configs
+        # KB configs (max_calls, exempt_calls, name) are now fetched by chat_shell from Backend API
+        # No need to inject them via metadata
 
         logger.info(
             "[HTTP_ADAPTER] Building metadata: is_subscription=%s, task_id=%d, subtask_id=%d",

--- a/backend/app/services/chat/adapters/http.py
+++ b/backend/app/services/chat/adapters/http.py
@@ -166,6 +166,48 @@ class HTTPAdapter(ChatInterface):
             "is_subscription": request.is_subscription,
         }
 
+        # Fetch KB configurations for HTTP mode injection
+        # This follows the same pattern as package mode
+        if request.knowledge_base_ids:
+            kb_configs = {}
+            try:
+                from app.services.knowledge.knowledge_service import KnowledgeService
+
+                for kb_id in request.knowledge_base_ids:
+                    try:
+                        kb_kind = KnowledgeService.get_knowledge_base(
+                            request.db_session, kb_id, request.user_id
+                        )
+                        if kb_kind:
+                            spec = kb_kind.json.get("spec", {})
+                            kb_configs[kb_id] = {
+                                "maxCallsPerConversation": spec.get(
+                                    "maxCallsPerConversation", 10
+                                ),
+                                "exemptCallsBeforeCheck": spec.get(
+                                    "exemptCallsBeforeCheck", 5
+                                ),
+                                "name": spec.get("name", f"KB-{kb_id}"),
+                            }
+                    except Exception as e:
+                        logger.warning(
+                            f"[HTTP_ADAPTER] Failed to fetch config for KB {kb_id}: {e}"
+                        )
+                        # Use defaults if fetch fails
+                        kb_configs[kb_id] = {
+                            "maxCallsPerConversation": 10,
+                            "exemptCallsBeforeCheck": 5,
+                            "name": f"KB-{kb_id}",
+                        }
+            except Exception as e:
+                logger.warning(
+                    f"[HTTP_ADAPTER] Failed to fetch KB configs: {e}, using empty config"
+                )
+                kb_configs = {}
+
+            # Add kb_configs to metadata for chat_shell injection
+            metadata["kb_configs"] = kb_configs
+
         logger.info(
             "[HTTP_ADAPTER] Building metadata: is_subscription=%s, task_id=%d, subtask_id=%d",
             request.is_subscription,

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -925,43 +925,16 @@ def _prepare_kb_tools_from_contexts(
         f"{len(knowledge_base_ids)} knowledge bases: {knowledge_base_ids}"
     )
 
-    # Fetch KB configurations for injection (package mode)
-    # This follows the same pattern as context_window, injection_mode, etc.
-    kb_configs = {}
-    from app.services.knowledge.knowledge_service import KnowledgeService
-
-    for kb_id in knowledge_base_ids:
-        try:
-            kb_kind = KnowledgeService.get_knowledge_base(db, kb_id, user_id)
-            if kb_kind:
-                spec = kb_kind.json.get("spec", {})
-                kb_configs[kb_id] = {
-                    "maxCallsPerConversation": spec.get("maxCallsPerConversation", 10),
-                    "exemptCallsBeforeCheck": spec.get("exemptCallsBeforeCheck", 5),
-                    "name": spec.get("name", f"KB-{kb_id}"),
-                }
-        except Exception as e:
-            logger.warning(
-                f"[_prepare_kb_tools_from_contexts] Failed to fetch config for KB {kb_id}: {e}"
-            )
-            # Use defaults if fetch fails
-            kb_configs[kb_id] = {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 5,
-                "name": f"KB-{kb_id}",
-            }
-
     # Import KnowledgeBaseTool
     from chat_shell.tools.builtin import KnowledgeBaseTool
 
     # Create KnowledgeBaseTool with the specified knowledge bases
-    # Inject kb_configs following same pattern as context_window, injection_mode
+    # KB configs (max_calls, exempt_calls, name) are now fetched from Backend API
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         user_id=user_id,
         db_session=db,
         user_subtask_id=user_subtask_id,
-        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -12,6 +12,7 @@ from typing import Optional
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
+from app.core.exceptions import ValidationException
 from app.models.kind import Kind
 from app.models.knowledge import (
     DocumentStatus,
@@ -415,7 +416,7 @@ class KnowledgeService:
         max_calls = spec.get("maxCallsPerConversation", 10)
         exempt_calls = spec.get("exemptCallsBeforeCheck", 5)
         if exempt_calls >= max_calls:
-            raise ValueError(
+            raise ValidationException(
                 f"exemptCallsBeforeCheck ({exempt_calls}) must be less than "
                 f"maxCallsPerConversation ({max_calls})"
             )

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -404,6 +404,22 @@ class KnowledgeService:
         if "summary_model_ref" in data.model_fields_set:
             spec["summaryModelRef"] = data.summary_model_ref
 
+        # Update call limit configuration if provided
+        if data.max_calls_per_conversation is not None:
+            spec["maxCallsPerConversation"] = data.max_calls_per_conversation
+
+        if data.exempt_calls_before_check is not None:
+            spec["exemptCallsBeforeCheck"] = data.exempt_calls_before_check
+
+        # Validate call limits: exempt < max (additional backend validation)
+        max_calls = spec.get("maxCallsPerConversation", 10)
+        exempt_calls = spec.get("exemptCallsBeforeCheck", 5)
+        if exempt_calls >= max_calls:
+            raise ValueError(
+                f"exemptCallsBeforeCheck ({exempt_calls}) must be less than "
+                f"maxCallsPerConversation ({max_calls})"
+            )
+
         kb_json["spec"] = spec
         kb.json = kb_json
         # Mark JSON field as modified so SQLAlchemy detects the change

--- a/backend/app/services/knowledge/summary_service.py
+++ b/backend/app/services/knowledge/summary_service.py
@@ -229,7 +229,7 @@ class SummaryService:
 
     @staticmethod
     def _truncate_prompt_if_needed(content: Optional[str], label: str) -> str:
-        """Ensure prompt payload stays within TEXT(64KB) byte limit with headroom for system prompt."""
+        """Ensure prompt payload stays within MAX_DOCUMENT_CONTENT_LENGTH (~50KB) with headroom for system prompt."""
         if not content:
             return ""
 

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -233,6 +233,12 @@ class Metadata(BaseModel):
         True,
         description="Whether KB is explicitly selected by user (strict mode) or inherited from task (relaxed mode)",
     )
+    # Knowledge base call limit configuration (injected by Backend for both package and HTTP modes)
+    # Maps KB ID to config: {"maxCallsPerConversation": int, "exemptCallsBeforeCheck": int, "name": str}
+    kb_configs: Optional[dict[int, dict[str, Any]]] = Field(
+        None,
+        description="Knowledge base configurations (max calls, exempt calls, name) - injected by Backend",
+    )
     # Table configuration
     table_contexts: Optional[list[dict]] = Field(
         None, description="Table contexts for DataTableTool"

--- a/chat_shell/chat_shell/api/v1/schemas.py
+++ b/chat_shell/chat_shell/api/v1/schemas.py
@@ -233,12 +233,6 @@ class Metadata(BaseModel):
         True,
         description="Whether KB is explicitly selected by user (strict mode) or inherited from task (relaxed mode)",
     )
-    # Knowledge base call limit configuration (injected by Backend for both package and HTTP modes)
-    # Maps KB ID to config: {"maxCallsPerConversation": int, "exemptCallsBeforeCheck": int, "name": str}
-    kb_configs: Optional[dict[int, dict[str, Any]]] = Field(
-        None,
-        description="Knowledge base configurations (max calls, exempt calls, name) - injected by Backend",
-    )
     # Table configuration
     table_contexts: Optional[list[dict]] = Field(
         None, description="Table contexts for DataTableTool"

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -288,11 +288,7 @@ class ChatContext:
                 "skipping KB prompt enhancement"
             )
 
-        # Extract kb_configs from request metadata (injected by Backend)
-        kb_configs = (
-            self._request.metadata.get("kb_configs") if self._request.metadata else None
-        )
-
+        # KB configs (max_calls, exempt_calls, name) are now fetched by KnowledgeBaseTool from Backend API
         result = await prepare_knowledge_base_tools(
             knowledge_base_ids=self._request.knowledge_base_ids,
             user_id=self._request.user_id,
@@ -303,7 +299,6 @@ class ChatContext:
             is_user_selected=self._request.is_user_selected_kb,
             document_ids=self._request.document_ids,
             context_window=context_window,
-            kb_configs=kb_configs,
             skip_prompt_enhancement=skip_prompt_enhancement,
         )
         add_span_event("kb_tools_prepared", {"tools_count": len(result[0])})

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -288,6 +288,11 @@ class ChatContext:
                 "skipping KB prompt enhancement"
             )
 
+        # Extract kb_configs from request metadata (injected by Backend)
+        kb_configs = (
+            self._request.metadata.get("kb_configs") if self._request.metadata else None
+        )
+
         result = await prepare_knowledge_base_tools(
             knowledge_base_ids=self._request.knowledge_base_ids,
             user_id=self._request.user_id,
@@ -298,6 +303,7 @@ class ChatContext:
             is_user_selected=self._request.is_user_selected_kb,
             document_ids=self._request.document_ids,
             context_window=context_window,
+            kb_configs=kb_configs,
             skip_prompt_enhancement=skip_prompt_enhancement,
         )
         add_span_event("kb_tools_prepared", {"tools_count": len(result[0])})

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -500,6 +500,10 @@ class KnowledgeBaseTool(BaseTool):
                 # Return rejection message without incrementing call count
                 return self._format_rejection_message(rejection_reason, max_calls)
 
+            # Increment call count IMMEDIATELY after passing limit check
+            # This ensures accurate counting even if the search operation fails later
+            self._call_count += 1
+
             # Note: db_session may be None in HTTP mode (chat_shell running independently)
             # In that case, we use HTTP API to communicate with backend
 
@@ -1065,8 +1069,7 @@ class KnowledgeBaseTool(BaseTool):
         # Extract chunks used for persistence
         chunks_used = injection_result.get("chunks_used", [])
 
-        # Update call count and accumulated tokens
-        self._call_count += 1
+        # Update accumulated tokens (call count already incremented in _arun)
         injected_content = injection_result.get("injected_content", "")
         self._accumulated_tokens += self._estimate_tokens_from_content(injected_content)
 
@@ -1174,8 +1177,7 @@ class KnowledgeBaseTool(BaseTool):
         # Limit total results
         all_chunks = all_chunks[:max_results]
 
-        # Update call count and accumulated tokens
-        self._call_count += 1
+        # Update accumulated tokens (call count already incremented in _arun)
         total_content = "\n".join([chunk["content"] for chunk in all_chunks])
         self._accumulated_tokens += self._estimate_tokens_from_content(total_content)
 

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -25,7 +25,6 @@ async def prepare_knowledge_base_tools(
     is_user_selected: bool = True,
     document_ids: Optional[list[int]] = None,
     context_window: Optional[int] = None,
-    kb_configs: Optional[dict[int, dict]] = None,
     skip_prompt_enhancement: bool = False,
 ) -> tuple[list, str]:
     """
@@ -48,8 +47,6 @@ async def prepare_knowledge_base_tools(
             When set, only chunks from these specific documents will be returned.
         context_window: Optional context window size from Model CRD.
             Used by KnowledgeBaseTool for injection strategy decisions.
-        kb_configs: Optional KB call limit configurations (max calls, exempt calls, name).
-            Injected by Backend in both package mode and HTTP mode.
         skip_prompt_enhancement: If True, skip adding KB prompt instructions to system prompt.
             Used in HTTP mode when Backend has already added KB prompts to avoid duplication.
 
@@ -70,23 +67,19 @@ async def prepare_knowledge_base_tools(
 
     logger.info(
         "[knowledge_factory] Creating KnowledgeBaseTool for %d knowledge bases: %s, "
-        "is_user_selected=%s, document_ids=%s, context_window=%s, kb_configs=%s",
+        "is_user_selected=%s, document_ids=%s, context_window=%s",
         len(knowledge_base_ids),
         knowledge_base_ids,
         is_user_selected,
         document_ids,
         context_window,
-        kb_configs is not None,
     )
 
     # Import KnowledgeBaseTool
     from chat_shell.tools.builtin import KnowledgeBaseTool
 
     # Create KnowledgeBaseTool with the specified knowledge bases
-    # Pass user_subtask_id for persisting RAG results to context database
-    # Pass document_ids for filtering to specific documents
-    # Pass context_window from Model CRD for injection strategy decisions
-    # Pass kb_configs for call limit enforcement (injected by Backend)
+    # KB configs (max_calls, exempt_calls, name) are fetched from Backend API
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         document_ids=document_ids or [],
@@ -94,7 +87,6 @@ async def prepare_knowledge_base_tools(
         db_session=db,
         user_subtask_id=user_subtask_id,
         context_window=context_window,
-        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -25,6 +25,7 @@ async def prepare_knowledge_base_tools(
     is_user_selected: bool = True,
     document_ids: Optional[list[int]] = None,
     context_window: Optional[int] = None,
+    kb_configs: Optional[dict[int, dict]] = None,
     skip_prompt_enhancement: bool = False,
 ) -> tuple[list, str]:
     """
@@ -47,6 +48,8 @@ async def prepare_knowledge_base_tools(
             When set, only chunks from these specific documents will be returned.
         context_window: Optional context window size from Model CRD.
             Used by KnowledgeBaseTool for injection strategy decisions.
+        kb_configs: Optional KB call limit configurations (max calls, exempt calls, name).
+            Injected by Backend in both package mode and HTTP mode.
         skip_prompt_enhancement: If True, skip adding KB prompt instructions to system prompt.
             Used in HTTP mode when Backend has already added KB prompts to avoid duplication.
 
@@ -67,12 +70,13 @@ async def prepare_knowledge_base_tools(
 
     logger.info(
         "[knowledge_factory] Creating KnowledgeBaseTool for %d knowledge bases: %s, "
-        "is_user_selected=%s, document_ids=%s, context_window=%s",
+        "is_user_selected=%s, document_ids=%s, context_window=%s, kb_configs=%s",
         len(knowledge_base_ids),
         knowledge_base_ids,
         is_user_selected,
         document_ids,
         context_window,
+        kb_configs is not None,
     )
 
     # Import KnowledgeBaseTool
@@ -82,6 +86,7 @@ async def prepare_knowledge_base_tools(
     # Pass user_subtask_id for persisting RAG results to context database
     # Pass document_ids for filtering to specific documents
     # Pass context_window from Model CRD for injection strategy decisions
+    # Pass kb_configs for call limit enforcement (injected by Backend)
     kb_tool = KnowledgeBaseTool(
         knowledge_base_ids=knowledge_base_ids,
         document_ids=document_ids or [],
@@ -89,6 +94,7 @@ async def prepare_knowledge_base_tools(
         db_session=db,
         user_subtask_id=user_subtask_id,
         context_window=context_window,
+        kb_configs=kb_configs,
     )
     extra_tools.append(kb_tool)
 

--- a/chat_shell/tests/test_knowledge_base_call_limits.py
+++ b/chat_shell/tests/test_knowledge_base_call_limits.py
@@ -1,0 +1,193 @@
+"""Test knowledge base tool call limits with injected configuration.
+
+This test verifies that KB call limit configuration is properly injected
+and used by KnowledgeBaseTool in both package mode and HTTP mode.
+"""
+
+import pytest
+
+from chat_shell.tools.builtin import KnowledgeBaseTool
+
+
+class TestKnowledgeBaseCallLimitsInjection:
+    """Test KB call limit configuration injection."""
+
+    def test_kb_configs_injected_and_used(self):
+        """Test that injected kb_configs are used for call limits."""
+        # Arrange: Create tool with injected kb_configs
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 15,
+                "exemptCallsBeforeCheck": 7,
+                "name": "Test KB 1",
+            },
+            2: {
+                "maxCallsPerConversation": 20,
+                "exemptCallsBeforeCheck": 10,
+                "name": "Test KB 2",
+            },
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1, 2],
+            user_id=123,
+            context_window=200000,
+            kb_configs=kb_configs,
+        )
+
+        # Act: Get limits
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses first KB's config
+        assert max_calls == 15
+        assert exempt_calls == 7
+
+    def test_kb_name_from_injected_config(self):
+        """Test that KB name is extracted from injected config."""
+        # Arrange
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 10,
+                "exemptCallsBeforeCheck": 5,
+                "name": "My Custom KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        kb_name = tool._get_kb_name()
+
+        # Assert
+        assert kb_name == "My Custom KB"
+
+    def test_fallback_to_defaults_when_no_config(self):
+        """Test fallback to default limits when kb_configs is None."""
+        # Arrange: No kb_configs injected
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+            kb_configs=None,  # No config injected
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses defaults
+        assert max_calls == 10  # DEFAULT_MAX_CALLS_PER_CONVERSATION
+        assert exempt_calls == 5  # DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
+
+    def test_fallback_name_when_no_config(self):
+        """Test fallback to KB-{id} name when no config."""
+        # Arrange
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[123],
+            user_id=456,
+            kb_configs=None,
+        )
+
+        # Act
+        kb_name = tool._get_kb_name()
+
+        # Assert
+        assert kb_name == "KB-123"
+
+    def test_invalid_config_validation(self):
+        """Test that invalid config (exempt >= max) falls back to defaults."""
+        # Arrange: Invalid config
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 10,
+                "exemptCallsBeforeCheck": 15,  # Invalid: >= max
+                "name": "Invalid KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Falls back to defaults
+        assert max_calls == 10
+        assert exempt_calls == 5
+
+    def test_multiple_kbs_uses_first_config(self):
+        """Test that with multiple KBs, first KB's config is used."""
+        # Arrange
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 15,
+                "exemptCallsBeforeCheck": 7,
+                "name": "First KB",
+            },
+            2: {
+                "maxCallsPerConversation": 25,
+                "exemptCallsBeforeCheck": 12,
+                "name": "Second KB",
+            },
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1, 2],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+        kb_name = tool._get_kb_name()
+
+        # Assert: Uses first KB's config
+        assert max_calls == 15
+        assert exempt_calls == 7
+        assert kb_name == "First KB"
+
+    def test_partial_config_uses_defaults_for_missing_fields(self):
+        """Test that missing fields in config use defaults."""
+        # Arrange: Partial config (missing exemptCallsBeforeCheck)
+        kb_configs = {
+            1: {
+                "maxCallsPerConversation": 20,
+                # Missing exemptCallsBeforeCheck
+                "name": "Partial KB",
+            }
+        }
+
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            kb_configs=kb_configs,
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert: Uses provided max_calls, defaults for exempt
+        assert max_calls == 20
+        assert exempt_calls == 5  # Default
+
+    def test_empty_knowledge_base_ids_returns_defaults(self):
+        """Test that empty KB IDs returns default limits."""
+        # Arrange
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[],
+            user_id=123,
+            kb_configs={},
+        )
+
+        # Act
+        max_calls, exempt_calls = tool._get_kb_limits()
+
+        # Assert
+        assert max_calls == 10
+        assert exempt_calls == 5

--- a/chat_shell/tests/test_knowledge_base_call_limits.py
+++ b/chat_shell/tests/test_knowledge_base_call_limits.py
@@ -1,176 +1,252 @@
-"""Test knowledge base tool call limits with injected configuration.
+"""Test knowledge base tool call limits with HTTP-fetched configuration.
 
-This test verifies that KB call limit configuration is properly injected
-and used by KnowledgeBaseTool in both package mode and HTTP mode.
+This test verifies that KB call limit configuration is properly fetched
+from Backend API and used by KnowledgeBaseTool.
 """
 
 import pytest
+from unittest.mock import AsyncMock, patch
 
 from chat_shell.tools.builtin import KnowledgeBaseTool
 
 
-class TestKnowledgeBaseCallLimitsInjection:
-    """Test KB call limit configuration injection."""
+class TestKnowledgeBaseCallLimitsHTTP:
+    """Test KB call limit configuration fetching from HTTP API."""
 
-    def test_kb_configs_injected_and_used(self):
-        """Test that injected kb_configs are used for call limits."""
-        # Arrange: Create tool with injected kb_configs
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 15,
-                "exemptCallsBeforeCheck": 7,
-                "name": "Test KB 1",
-            },
-            2: {
-                "maxCallsPerConversation": 20,
-                "exemptCallsBeforeCheck": 10,
-                "name": "Test KB 2",
-            },
-        }
-
+    @pytest.mark.asyncio
+    async def test_kb_info_fetched_and_used(self):
+        """Test that KB info is fetched from HTTP API and used for call limits."""
+        # Arrange: Create tool without any injected config
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1, 2],
             user_id=123,
             context_window=200000,
-            kb_configs=kb_configs,
         )
 
-        # Act: Get limits
-        max_calls, exempt_calls = tool._get_kb_limits()
+        # Mock HTTP response
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 600,
+                    "document_count": 5,
+                    "estimated_tokens": 150,
+                    "max_calls_per_conversation": 15,
+                    "exempt_calls_before_check": 7,
+                    "name": "Test KB 1",
+                },
+                {
+                    "id": 2,
+                    "total_file_size": 400,
+                    "document_count": 3,
+                    "estimated_tokens": 100,
+                    "max_calls_per_conversation": 20,
+                    "exempt_calls_before_check": 10,
+                    "name": "Test KB 2",
+                },
+            ],
+        }
+
+        # Mock the HTTP call
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            # Act: Fetch KB info to populate cache
+            await tool._get_kb_info()
+
+            # Get limits (should use cached data)
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses first KB's config
         assert max_calls == 15
         assert exempt_calls == 7
 
-    def test_kb_name_from_injected_config(self):
-        """Test that KB name is extracted from injected config."""
+    @pytest.mark.asyncio
+    async def test_kb_name_from_http(self):
+        """Test that KB name is extracted from HTTP response."""
         # Arrange
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 5,
-                "name": "My Custom KB",
-            }
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        kb_name = tool._get_kb_name()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 10,
+                    "exempt_calls_before_check": 5,
+                    "name": "My Custom KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            # Populate cache
+            await tool._get_kb_info()
+
+            # Act
+            kb_name = tool._get_kb_name()
 
         # Assert
         assert kb_name == "My Custom KB"
 
-    def test_fallback_to_defaults_when_no_config(self):
-        """Test fallback to default limits when kb_configs is None."""
-        # Arrange: No kb_configs injected
+    def test_fallback_to_defaults_when_no_cache(self):
+        """Test fallback to default limits when cache is not populated."""
+        # Arrange: No HTTP call made, cache is None
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
             context_window=200000,
-            kb_configs=None,  # No config injected
         )
 
-        # Act
+        # Act: Get limits without populating cache (should use defaults)
         max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses defaults
         assert max_calls == 10  # DEFAULT_MAX_CALLS_PER_CONVERSATION
         assert exempt_calls == 5  # DEFAULT_EXEMPT_CALLS_BEFORE_CHECK
 
-    def test_fallback_name_when_no_config(self):
-        """Test fallback to KB-{id} name when no config."""
+    def test_fallback_name_when_no_cache(self):
+        """Test fallback to KB-{id} name when cache is not populated."""
         # Arrange
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[123],
             user_id=456,
-            kb_configs=None,
         )
 
-        # Act
+        # Act: Get name without populating cache
         kb_name = tool._get_kb_name()
 
         # Assert
         assert kb_name == "KB-123"
 
-    def test_invalid_config_validation(self):
+    @pytest.mark.asyncio
+    async def test_invalid_config_validation(self):
         """Test that invalid config (exempt >= max) falls back to defaults."""
         # Arrange: Invalid config
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 10,
-                "exemptCallsBeforeCheck": 15,  # Invalid: >= max
-                "name": "Invalid KB",
-            }
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 10,
+                    "exempt_calls_before_check": 15,  # Invalid: >= max
+                    "name": "Invalid KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Falls back to defaults
         assert max_calls == 10
         assert exempt_calls == 5
 
-    def test_multiple_kbs_uses_first_config(self):
+    @pytest.mark.asyncio
+    async def test_multiple_kbs_uses_first_config(self):
         """Test that with multiple KBs, first KB's config is used."""
         # Arrange
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 15,
-                "exemptCallsBeforeCheck": 7,
-                "name": "First KB",
-            },
-            2: {
-                "maxCallsPerConversation": 25,
-                "exemptCallsBeforeCheck": 12,
-                "name": "Second KB",
-            },
-        }
-
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1, 2],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
-        kb_name = tool._get_kb_name()
+        mock_kb_info = {
+            "total_file_size": 1400,
+            "total_estimated_tokens": 350,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 800,
+                    "document_count": 8,
+                    "estimated_tokens": 200,
+                    "max_calls_per_conversation": 15,
+                    "exempt_calls_before_check": 7,
+                    "name": "First KB",
+                },
+                {
+                    "id": 2,
+                    "total_file_size": 600,
+                    "document_count": 6,
+                    "estimated_tokens": 150,
+                    "max_calls_per_conversation": 25,
+                    "exempt_calls_before_check": 12,
+                    "name": "Second KB",
+                },
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
+            kb_name = tool._get_kb_name()
 
         # Assert: Uses first KB's config
         assert max_calls == 15
         assert exempt_calls == 7
         assert kb_name == "First KB"
 
-    def test_partial_config_uses_defaults_for_missing_fields(self):
-        """Test that missing fields in config use defaults."""
-        # Arrange: Partial config (missing exemptCallsBeforeCheck)
-        kb_configs = {
-            1: {
-                "maxCallsPerConversation": 20,
-                # Missing exemptCallsBeforeCheck
-                "name": "Partial KB",
-            }
-        }
-
+    @pytest.mark.asyncio
+    async def test_partial_config_uses_defaults_for_missing_fields(self):
+        """Test that missing fields in response use defaults."""
+        # Arrange: Partial response (missing exempt_calls_before_check)
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[1],
             user_id=123,
-            kb_configs=kb_configs,
         )
 
-        # Act
-        max_calls, exempt_calls = tool._get_kb_limits()
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "total_file_size": 1000,
+                    "document_count": 10,
+                    "estimated_tokens": 250,
+                    "max_calls_per_conversation": 20,
+                    # Missing exempt_calls_before_check
+                    "name": "Partial KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+
+            await tool._get_kb_info()
+
+            # Act
+            max_calls, exempt_calls = tool._get_kb_limits()
 
         # Assert: Uses provided max_calls, defaults for exempt
         assert max_calls == 20
@@ -182,7 +258,6 @@ class TestKnowledgeBaseCallLimitsInjection:
         tool = KnowledgeBaseTool(
             knowledge_base_ids=[],
             user_id=123,
-            kb_configs={},
         )
 
         # Act

--- a/chat_shell/tests/test_knowledge_base_call_limits.py
+++ b/chat_shell/tests/test_knowledge_base_call_limits.py
@@ -266,3 +266,284 @@ class TestKnowledgeBaseCallLimitsHTTP:
         # Assert
         assert max_calls == 10
         assert exempt_calls == 5
+
+
+class TestCallCountIncrementTiming:
+    """Test that call count increments correctly during consecutive calls.
+
+    These tests verify the fix for the bug where multiple consecutive calls
+    were not correctly incrementing _call_count, causing all calls in the
+    exempt period to show "Call 1/N".
+    """
+
+    @pytest.mark.asyncio
+    async def test_call_count_increments_after_check_passes(self):
+        """Test that _call_count increments immediately after _check_call_limits passes."""
+        # Arrange: Create tool with known limits
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+        )
+
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "max_calls_per_conversation": 5,
+                    "exempt_calls_before_check": 2,
+                    "name": "Test KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+            await tool._get_kb_info()
+
+            # Initial state
+            assert tool._call_count == 0
+
+            # First check - should allow and show Call 1/5
+            should_allow, rejection_reason, warning_level = tool._check_call_limits("query1")
+            assert should_allow is True
+            assert rejection_reason is None
+            assert tool._call_count == 0  # Not incremented yet (check only, no increment)
+
+            # Simulate what _arun does: increment after check passes
+            tool._call_count += 1
+            assert tool._call_count == 1
+
+            # Second check - should allow and show Call 2/5
+            should_allow, rejection_reason, warning_level = tool._check_call_limits("query2")
+            assert should_allow is True
+            assert tool._call_count == 1  # Still 1 (check only)
+
+            tool._call_count += 1
+            assert tool._call_count == 2
+
+            # Third check - should allow with warning (check period) and show Call 3/5
+            should_allow, rejection_reason, warning_level = tool._check_call_limits("query3")
+            assert should_allow is True
+            assert warning_level == "normal"  # Now in check period
+            assert tool._call_count == 2  # Still 2 (check only)
+
+            tool._call_count += 1
+            assert tool._call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_max_calls_rejection_after_limit_reached(self):
+        """Test that calls are rejected after max_calls is reached."""
+        # Arrange: Create tool with max_calls=2
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+        )
+
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "max_calls_per_conversation": 2,
+                    "exempt_calls_before_check": 1,
+                    "name": "Test KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+            await tool._get_kb_info()
+
+            # Call 1: Should allow (exempt period)
+            should_allow, rejection_reason, _ = tool._check_call_limits("query1")
+            assert should_allow is True
+            assert rejection_reason is None
+            tool._call_count += 1  # Simulate _arun behavior
+
+            # Call 2: Should allow (check period, but within limit)
+            should_allow, rejection_reason, warning_level = tool._check_call_limits("query2")
+            assert should_allow is True
+            assert rejection_reason is None
+            assert warning_level == "normal"  # In check period
+            tool._call_count += 1  # Simulate _arun behavior
+
+            # Call 3: Should be REJECTED (exceeds max_calls=2)
+            should_allow, rejection_reason, _ = tool._check_call_limits("query3")
+            assert should_allow is False
+            assert rejection_reason == "max_calls_exceeded"
+            # Call count should NOT increment for rejected calls
+            assert tool._call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_consecutive_calls_correct_counting(self):
+        """Test that consecutive calls are counted correctly even in exempt period.
+
+        This test specifically verifies the fix for the bug where multiple calls
+        in the exempt period all showed "Call 1/N" instead of 1/N, 2/N, 3/N...
+        """
+        # Arrange: max=5, exempt=3
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+        )
+
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "max_calls_per_conversation": 5,
+                    "exempt_calls_before_check": 3,
+                    "name": "Test KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+            await tool._get_kb_info()
+
+            call_results = []
+
+            # Simulate 6 consecutive calls
+            for i in range(6):
+                should_allow, rejection_reason, warning_level = tool._check_call_limits(f"query{i+1}")
+
+                if should_allow:
+                    tool._call_count += 1  # Simulate _arun behavior
+
+                call_results.append({
+                    "call_number": i + 1,
+                    "should_allow": should_allow,
+                    "rejection_reason": rejection_reason,
+                    "warning_level": warning_level,
+                    "call_count_after": tool._call_count,
+                })
+
+            # Verify results:
+            # Calls 1-3: exempt period, allowed, no warning
+            assert call_results[0]["should_allow"] is True
+            assert call_results[0]["warning_level"] is None
+            assert call_results[0]["call_count_after"] == 1
+
+            assert call_results[1]["should_allow"] is True
+            assert call_results[1]["warning_level"] is None
+            assert call_results[1]["call_count_after"] == 2
+
+            assert call_results[2]["should_allow"] is True
+            assert call_results[2]["warning_level"] is None
+            assert call_results[2]["call_count_after"] == 3
+
+            # Calls 4-5: check period, allowed with warning
+            assert call_results[3]["should_allow"] is True
+            assert call_results[3]["warning_level"] == "normal"
+            assert call_results[3]["call_count_after"] == 4
+
+            assert call_results[4]["should_allow"] is True
+            assert call_results[4]["warning_level"] == "normal"
+            assert call_results[4]["call_count_after"] == 5
+
+            # Call 6: rejected (exceeds max_calls=5)
+            assert call_results[5]["should_allow"] is False
+            assert call_results[5]["rejection_reason"] == "max_calls_exceeded"
+            assert call_results[5]["call_count_after"] == 5  # Not incremented
+
+    @pytest.mark.asyncio
+    async def test_rejection_message_shows_correct_count(self):
+        """Test that rejection message shows the correct call count."""
+        # Arrange: max=2
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+        )
+
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "max_calls_per_conversation": 2,
+                    "exempt_calls_before_check": 1,
+                    "name": "Test KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+            await tool._get_kb_info()
+
+            # Make 2 successful calls
+            for i in range(2):
+                should_allow, _, _ = tool._check_call_limits(f"query{i+1}")
+                if should_allow:
+                    tool._call_count += 1
+
+            # Third call should be rejected
+            rejection_msg = tool._format_rejection_message("max_calls_exceeded", 2)
+
+            import json
+            msg_data = json.loads(rejection_msg)
+
+            assert msg_data["status"] == "rejected"
+            assert msg_data["reason"] == "max_calls_exceeded"
+            assert msg_data["call_count"] == 2  # Shows the actual successful calls
+            assert msg_data["max_calls"] == 2
+            assert "2 successful calls" in msg_data["message"]
+
+    @pytest.mark.asyncio
+    async def test_call_statistics_header_shows_correct_call_number(self):
+        """Test that _build_call_statistics_header shows the correct call number.
+
+        This verifies that after incrementing _call_count in _arun,
+        the header correctly shows the current call number.
+        """
+        # Arrange
+        tool = KnowledgeBaseTool(
+            knowledge_base_ids=[1],
+            user_id=123,
+            context_window=200000,
+        )
+
+        mock_kb_info = {
+            "total_file_size": 1000,
+            "total_estimated_tokens": 250,
+            "items": [
+                {
+                    "id": 1,
+                    "max_calls_per_conversation": 5,
+                    "exempt_calls_before_check": 2,
+                    "name": "Test KB",
+                }
+            ],
+        }
+
+        with patch.object(tool, "_get_kb_info_via_http", new_callable=AsyncMock) as mock_http:
+            mock_http.return_value = mock_kb_info
+            await tool._get_kb_info()
+
+            # Simulate first call
+            tool._call_count = 1  # As if _arun already incremented it
+            header1 = tool._build_call_statistics_header(None, 10)
+            assert "Call 1/5" in header1
+
+            # Simulate second call
+            tool._call_count = 2
+            header2 = tool._build_call_statistics_header(None, 15)
+            assert "Call 2/5" in header2
+
+            # Simulate third call (in check period)
+            tool._call_count = 3
+            header3 = tool._build_call_statistics_header("normal", 20)
+            assert "Call 3/5" in header3
+            assert "check period" in header3

--- a/chat_shell/tests/test_knowledge_injection_strategy.py
+++ b/chat_shell/tests/test_knowledge_injection_strategy.py
@@ -292,11 +292,22 @@ class TestKnowledgeBaseTool:
 
         # Mock HTTP methods to simulate HTTP mode
         with patch.object(
-            tool, "_get_kb_size_info_via_http", new_callable=AsyncMock
-        ) as mock_kb_size:
-            mock_kb_size.return_value = {
+            tool, "_get_kb_info_via_http", new_callable=AsyncMock
+        ) as mock_kb_info:
+            mock_kb_info.return_value = {
                 "total_file_size": 1000,
                 "total_estimated_tokens": 250,
+                "items": [
+                    {
+                        "id": 1,
+                        "total_file_size": 1000,
+                        "document_count": 10,
+                        "estimated_tokens": 250,
+                        "max_calls_per_conversation": 10,
+                        "exempt_calls_before_check": 5,
+                        "name": "Test KB",
+                    }
+                ],
             }
 
             with patch.object(

--- a/chat_shell/tests/test_knowledge_injection_strategy_clean.py
+++ b/chat_shell/tests/test_knowledge_injection_strategy_clean.py
@@ -268,11 +268,22 @@ class TestKnowledgeBaseToolClean:
 
         # Mock HTTP methods to simulate HTTP mode
         with patch.object(
-            tool, "_get_kb_size_info_via_http", new_callable=AsyncMock
-        ) as mock_kb_size:
-            mock_kb_size.return_value = {
+            tool, "_get_kb_info_via_http", new_callable=AsyncMock
+        ) as mock_kb_info:
+            mock_kb_info.return_value = {
                 "total_file_size": 1000,
                 "total_estimated_tokens": 250,
+                "items": [
+                    {
+                        "id": 1,
+                        "total_file_size": 1000,
+                        "document_count": 10,
+                        "estimated_tokens": 250,
+                        "max_calls_per_conversation": 10,
+                        "exempt_calls_before_check": 5,
+                        "name": "Test KB",
+                    }
+                ],
             }
 
             with patch.object(

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseForm.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseForm.tsx
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { ReactNode } from 'react'
+import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Switch } from '@/components/ui/switch'
+import { Slider } from '@/components/ui/slider'
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { KnowledgeResourceScope, RetrievalConfig, SummaryModelRef } from '@/types/knowledge'
+import { RetrievalSettingsSection } from './RetrievalSettingsSection'
+import { SummaryModelSelector } from './SummaryModelSelector'
+
+interface KnowledgeBaseFormProps {
+  typeSection?: ReactNode
+  name: string
+  description: string
+  onNameChange: (value: string) => void
+  onDescriptionChange: (value: string) => void
+  summaryEnabled: boolean
+  onSummaryEnabledChange: (value: boolean) => void
+  summaryModelRef: SummaryModelRef | null
+  summaryModelError?: string
+  onSummaryModelChange: (value: SummaryModelRef | null) => void
+  knowledgeDefaultTeamId?: number | null
+  callLimits: {
+    maxCalls: number
+    exemptCalls: number
+  }
+  onCallLimitsChange: (limits: { maxCalls: number; exemptCalls: number }) => void
+  advancedVariant: 'accordion' | 'collapsible'
+  advancedOpen: boolean
+  onAdvancedOpenChange: (open: boolean) => void
+  advancedDescription?: string
+  showRetrievalSection: boolean
+  retrievalConfig: Partial<RetrievalConfig>
+  onRetrievalConfigChange: (config: Partial<RetrievalConfig>) => void
+  retrievalScope?: KnowledgeResourceScope
+  retrievalGroupName?: string
+  retrievalReadOnly?: boolean
+  retrievalPartialReadOnly?: boolean
+}
+
+export function KnowledgeBaseForm({
+  typeSection,
+  name,
+  description,
+  onNameChange,
+  onDescriptionChange,
+  summaryEnabled,
+  onSummaryEnabledChange,
+  summaryModelRef,
+  summaryModelError,
+  onSummaryModelChange,
+  knowledgeDefaultTeamId,
+  callLimits,
+  onCallLimitsChange,
+  advancedVariant,
+  advancedOpen,
+  onAdvancedOpenChange,
+  advancedDescription,
+  showRetrievalSection,
+  retrievalConfig,
+  onRetrievalConfigChange,
+  retrievalScope,
+  retrievalGroupName,
+  retrievalReadOnly,
+  retrievalPartialReadOnly,
+}: KnowledgeBaseFormProps) {
+  const { t } = useTranslation()
+
+  const handleMaxCallsChange = (value: number) => {
+    const adjustedExempt = Math.min(callLimits.exemptCalls, Math.max(value - 1, 1))
+    onCallLimitsChange({ maxCalls: value, exemptCalls: adjustedExempt })
+  }
+
+  const handleExemptCallsChange = (value: number) => {
+    onCallLimitsChange({ maxCalls: callLimits.maxCalls, exemptCalls: value })
+  }
+
+  const advancedContent = (
+    <div className="space-y-4 pt-2">
+      {advancedDescription && <p className="text-xs text-text-muted">{advancedDescription}</p>}
+
+      <div className="space-y-4">
+        <div className="space-y-0.5">
+          <Label className="text-sm font-medium">{t('knowledge:document.callLimits.title')}</Label>
+          <p className="text-xs text-text-muted">
+            {t('knowledge:document.callLimits.description')}
+          </p>
+        </div>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="knowledge-max-calls">
+                {t('knowledge:document.callLimits.maxCalls')}
+              </Label>
+              <span className="text-sm text-text-secondary">{callLimits.maxCalls}</span>
+            </div>
+            <Slider
+              id="knowledge-max-calls"
+              value={[callLimits.maxCalls]}
+              onValueChange={values => handleMaxCallsChange(values[0])}
+              min={2}
+              max={50}
+              step={1}
+            />
+            <p className="text-xs text-text-muted">
+              {t('knowledge:document.callLimits.maxCallsHint')}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="knowledge-exempt-calls">
+                {t('knowledge:document.callLimits.exemptCalls')}
+              </Label>
+              <span className="text-sm text-text-secondary">{callLimits.exemptCalls}</span>
+            </div>
+            <Slider
+              id="knowledge-exempt-calls"
+              value={[callLimits.exemptCalls]}
+              onValueChange={values => handleExemptCallsChange(values[0])}
+              min={1}
+              max={Math.max(1, callLimits.maxCalls - 1)}
+              step={1}
+            />
+            <p className="text-xs text-text-muted">
+              {t('knowledge:document.callLimits.exemptCallsHint')}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {showRetrievalSection && (
+        <RetrievalSettingsSection
+          config={retrievalConfig}
+          onChange={onRetrievalConfigChange}
+          scope={retrievalScope}
+          groupName={retrievalGroupName}
+          readOnly={retrievalReadOnly}
+          partialReadOnly={retrievalPartialReadOnly}
+        />
+      )}
+    </div>
+  )
+
+  return (
+    <div className="space-y-4">
+      {typeSection}
+
+      <div className="space-y-2">
+        <Label htmlFor="knowledge-name">{t('knowledge:document.knowledgeBase.name')}</Label>
+        <Input
+          id="knowledge-name"
+          value={name}
+          onChange={e => onNameChange(e.target.value)}
+          placeholder={t('knowledge:document.knowledgeBase.namePlaceholder')}
+          maxLength={100}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="knowledge-description">
+          {t('knowledge:document.knowledgeBase.description')}
+        </Label>
+        <Textarea
+          id="knowledge-description"
+          value={description}
+          onChange={e => onDescriptionChange(e.target.value)}
+          placeholder={t('knowledge:document.knowledgeBase.descriptionPlaceholder')}
+          maxLength={500}
+          rows={3}
+        />
+      </div>
+
+      <div className="space-y-3 border-b border-border pb-4">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="knowledge-summary-enabled">
+              {t('knowledge:document.summary.enableLabel')}
+            </Label>
+            <p className="text-xs text-text-muted">
+              {t('knowledge:document.summary.enableDescription')}
+            </p>
+          </div>
+          <Switch
+            id="knowledge-summary-enabled"
+            checked={summaryEnabled}
+            onCheckedChange={checked => onSummaryEnabledChange(checked)}
+          />
+        </div>
+        {summaryEnabled && (
+          <div className="space-y-2 pt-2">
+            <Label>{t('knowledge:document.summary.selectModel')}</Label>
+            <SummaryModelSelector
+              value={summaryModelRef}
+              onChange={onSummaryModelChange}
+              error={summaryModelError}
+              knowledgeDefaultTeamId={knowledgeDefaultTeamId}
+            />
+          </div>
+        )}
+      </div>
+
+      {advancedVariant === 'accordion' ? (
+        <Accordion
+          type="single"
+          collapsible
+          className="border-none"
+          value={advancedOpen ? 'advanced' : undefined}
+          onValueChange={value => onAdvancedOpenChange(value === 'advanced')}
+        >
+          <AccordionItem value="advanced" className="border-none">
+            <AccordionTrigger className="text-sm font-medium hover:no-underline">
+              {t('knowledge:document.advancedSettings.title')}
+            </AccordionTrigger>
+            <AccordionContent forceMount className={!advancedOpen ? 'hidden' : ''}>
+              {advancedContent}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      ) : (
+        <div className="pt-2">
+          <button
+            type="button"
+            onClick={() => onAdvancedOpenChange(!advancedOpen)}
+            className="flex items-center gap-2 text-sm font-medium text-text-primary hover:text-primary transition-colors"
+          >
+            {advancedOpen ? (
+              <ChevronDown className="w-4 h-4" />
+            ) : (
+              <ChevronRight className="w-4 h-4" />
+            )}
+            {t('knowledge:document.advancedSettings.title')}
+          </button>
+          {advancedOpen && (
+            <div className="mt-4 p-4 bg-bg-muted rounded-lg border border-border space-y-6">
+              {advancedContent}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -315,6 +315,15 @@
       "modelPlaceholder": "Search models...",
       "noModel": "No model selected"
     },
+    "callLimits": {
+      "title": "Call Limits",
+      "description": "Limit the number of knowledge base tool calls per conversation to control token usage",
+      "maxCalls": "Maximum Calls",
+      "maxCallsHint": "Maximum number of knowledge base tool calls allowed per conversation (2-50)",
+      "exemptCalls": "Exempt Calls",
+      "exemptCallsHint": "Number of calls exempt from token checking (must be less than maximum calls)",
+      "validationError": "Exempt calls must be less than maximum calls"
+    },
     "retrievalTest": {
       "button": "Retrieval Test",
       "title": "Retrieval Test",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -315,6 +315,15 @@
       "modelPlaceholder": "搜索模型...",
       "noModel": "未选择模型"
     },
+    "callLimits": {
+      "title": "调用次数限制",
+      "description": "限制每次对话中知识库工具的调用次数，以控制 token 使用量",
+      "maxCalls": "最大调用次数",
+      "maxCallsHint": "每次对话允许的最大知识库工具调用次数 (2-50)",
+      "exemptCalls": "豁免检查次数",
+      "exemptCallsHint": "豁免 token 检查的调用次数 (必须小于最大调用次数)",
+      "validationError": "豁免次数必须小于最大调用次数"
+    },
     "retrievalTest": {
       "button": "召回测试",
       "title": "召回测试",

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -91,6 +91,10 @@ export interface KnowledgeBase {
   summary?: KnowledgeBaseSummary | null
   /** Knowledge base display type: 'notebook' (three-column with chat) or 'classic' (document list only) */
   kb_type?: KnowledgeBaseType
+  /** Maximum number of knowledge base tool calls allowed per conversation */
+  max_calls_per_conversation: number
+  /** Number of calls exempt from token checking (must be < max_calls_per_conversation) */
+  exempt_calls_before_check: number
   created_at: string
   updated_at: string
 }
@@ -104,6 +108,10 @@ export interface KnowledgeBaseCreate {
   summary_model_ref?: SummaryModelRef | null
   /** Knowledge base display type: 'notebook' (three-column with chat) or 'classic' (document list only) */
   kb_type?: KnowledgeBaseType
+  /** Maximum number of knowledge base tool calls allowed per conversation */
+  max_calls_per_conversation?: number
+  /** Number of calls exempt from token checking (must be < max_calls_per_conversation) */
+  exempt_calls_before_check?: number
 }
 
 export interface RetrievalConfigUpdate {
@@ -122,6 +130,10 @@ export interface KnowledgeBaseUpdate {
   retrieval_config?: RetrievalConfigUpdate
   summary_enabled?: boolean
   summary_model_ref?: SummaryModelRef | null
+  /** Maximum number of knowledge base tool calls allowed per conversation */
+  max_calls_per_conversation?: number
+  /** Number of calls exempt from token checking (must be < max_calls_per_conversation) */
+  exempt_calls_before_check?: number
 }
 
 export interface KnowledgeBaseListResponse {


### PR DESCRIPTION
## Summary

Optimize knowledge base tool call limit mechanism by switching from dependency injection to HTTP API-based configuration fetching. This improves cohesion, enables caching, and simplifies the codebase.

## Changes

### Backend
1. **Extended `/api/internal/rag/kb-size` endpoint** with configuration fields:
   - `max_calls_per_conversation` (default: 10)
   - `exempt_calls_before_check` (default: 5)
   - `name` (for logging)

2. **Updated `KnowledgeBase` schema** to include call limit fields with validation

3. **Removed injection code** (~40 lines) from:
   - `backend/app/services/chat/preprocessing/contexts.py`
   - `backend/app/services/chat/adapters/http.py`
   - `chat_shell/chat_shell/api/v1/schemas.py`
   - `chat_shell/chat_shell/tools/knowledge_factory.py`
   - `chat_shell/chat_shell/services/context.py`

### Chat Shell (chat_shell)
1. **Refactored `KnowledgeBaseTool`** to fetch its own configuration:
   - Removed `kb_configs` field (dependency injection)
   - Added `_kb_info_cache` for caching HTTP responses
   - Removed dead code (package mode with wrong import path)
   - Added `_get_kb_info_sync()` helper (reduced 48 lines of duplication)
   - Added `_kb_name_cache` for optimized logging (reduced O(n) to O(1))

2. **Updated tests** to mock `_get_kb_info_via_http()` instead of injection

### Frontend
1. **Added TypeScript types** for call limit fields
2. **Added i18n translations** (English and Chinese)
3. **Added UI controls** in `EditKnowledgeBaseDialog`:
   - Slider for max_calls_per_conversation (2-50 range)
   - Slider for exempt_calls_before_check (1 to max-1 range)
   - Real-time value display
   - Validation with error messages

## Key Benefits

- **More cohesive**: All KB info fetching in one place (`_get_kb_info()`)
- **Cacheable**: Fetch once per conversation, reuse for limits/name/size
- **Simpler**: Removed ~90 lines of injection code across backend and chat_shell
- **Better extensibility**: Easy to add new fields to KB info response
- **No cross-module dependency**: HTTP API only, no backend imports needed
- **User-friendly**: Frontend UI for configuring call limits

## Testing

- All 177 Python tests passing
- Test coverage maintained at 40-60%
- Manual testing: Frontend UI works correctly with validation

## Migration Notes

- Existing knowledge bases will use default values (10, 5) if not configured
- Frontend UI allows users to customize these values per knowledge base
- No breaking changes to existing KB tool behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-conversation call limits for knowledge bases (max & exempt calls) with UI controls, validation, and clearer rejection/warning messages.
  * Token-based usage warnings and rejection thresholds surfaced in results with call-statistics headers.

* **Improvements**
  * Unified knowledge base form for create/edit flows; defaults and graceful fallbacks applied.
  * Safer prompt handling for document/KB summaries to avoid oversized inputs.
  * Localized strings for call-limit UI.

* **Tests**
  * Expanded coverage for call-limit fetching, defaults, validation, caching, and rejection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->