### PR TITLE
feat(chat): implement tool display whitelist with database sanitization

### DIFF
--- a/backend/app/services/adapters/executor_kinds.py
+++ b/backend/app/services/adapters/executor_kinds.py
@@ -1433,6 +1433,13 @@ class ExecutorKindsService(
                 ):
                     value["thinking"] = existing_result["thinking"]
 
+                # Sanitize thinking data before storing to database
+                # This removes sensitive tool input/output from thinking steps
+                if isinstance(value, dict) and value.get("thinking"):
+                    from app.utils.thinking_sanitizer import sanitize_result_for_storage
+
+                    value = sanitize_result_for_storage(value)
+
             setattr(subtask, field, value)
 
         # Set completion time

--- a/backend/app/services/chat/storage/db.py
+++ b/backend/app/services/chat/storage/db.py
@@ -99,6 +99,7 @@ class DatabaseHandler:
     ) -> None:
         """Synchronous subtask update (runs in thread pool)."""
         from app.models.subtask import Subtask, SubtaskStatus
+        from app.utils.thinking_sanitizer import sanitize_result_for_storage
 
         try:
             with _db_session() as db:
@@ -110,7 +111,9 @@ class DatabaseHandler:
                 subtask.updated_at = datetime.now()
 
                 if result is not None:
-                    subtask.result = result
+                    # Sanitize thinking data before storing to database
+                    sanitized_result = sanitize_result_for_storage(result)
+                    subtask.result = sanitized_result
                 if error is not None:
                     subtask.error_message = error
                 if status in _TERMINAL_STATUSES:

--- a/backend/app/utils/thinking_sanitizer.py
+++ b/backend/app/utils/thinking_sanitizer.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for sanitizing thinking data before database storage.
+
+This module provides functions to remove sensitive tool input/output data from
+thinking steps before they are persisted to the database, in compliance with
+the chat_shell TOOL_DISPLAY_WHITELIST configuration.
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def sanitize_thinking_for_storage(
+    thinking: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Remove tool input/output from thinking steps before database storage.
+
+    This function ensures that sensitive tool input/output data is not persisted
+    to the database. It removes:
+    - details.input field from tool_use steps
+    - details.output field from tool_result steps
+    - details.content field from tool_result steps
+
+    Args:
+        thinking: List of thinking steps containing tool execution data
+
+    Returns:
+        Sanitized list of thinking steps with input/output removed
+    """
+    if not thinking:
+        return thinking
+
+    sanitized = []
+    for step in thinking:
+        # Deep copy the step to avoid modifying the original
+        step_copy = step.copy()
+
+        # Process details if present
+        if "details" in step_copy and isinstance(step_copy["details"], dict):
+            details = step_copy["details"].copy()
+            step_type = details.get("type")
+
+            # Remove input from tool_use steps
+            if step_type == "tool_use":
+                details.pop("input", None)
+                logger.debug(
+                    "[SANITIZE] Removed input from tool_use: tool_name=%s",
+                    details.get("tool_name", "unknown"),
+                )
+
+            # Remove output and content from tool_result steps
+            elif step_type == "tool_result":
+                details.pop("output", None)
+                details.pop("content", None)
+                logger.debug(
+                    "[SANITIZE] Removed output from tool_result: tool_name=%s",
+                    details.get("tool_name", "unknown"),
+                )
+
+            step_copy["details"] = details
+
+        sanitized.append(step_copy)
+
+    return sanitized
+
+
+def sanitize_result_for_storage(result: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize entire result object before database storage.
+
+    This function removes tool input/output from the result's thinking data
+    while preserving all other fields like value, sources, reasoning_content, etc.
+
+    Args:
+        result: Result dictionary containing value, thinking, sources, etc.
+
+    Returns:
+        Sanitized result dictionary
+    """
+    if not result or not isinstance(result, dict):
+        return result
+
+    # Deep copy the result to avoid modifying the original
+    result_copy = result.copy()
+
+    # Sanitize thinking if present
+    if "thinking" in result_copy and isinstance(result_copy["thinking"], list):
+        result_copy["thinking"] = sanitize_thinking_for_storage(result_copy["thinking"])
+        logger.info(
+            "[SANITIZE] Sanitized thinking data: removed input/output from %d steps",
+            len(result_copy["thinking"]),
+        )
+
+    return result_copy

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -124,6 +124,12 @@ class Settings(BaseSettings):
     # This is shared configuration between backend and chat_shell, uses validation_alias to read from DATA_TABLE_CONFIG (no prefix)
     DATA_TABLE_CONFIG: str = Field(default="", validation_alias="DATA_TABLE_CONFIG")
 
+    # Tool Display Configuration
+    # Comma-separated list of keywords to match tool names (uses substring matching)
+    # Empty string or "*" means all tools will display details
+    # Example: "read,write,search" will match "read_file", "write_file", "web_search", etc.
+    TOOL_DISPLAY_WHITELIST: str = "read,write,upload,command"
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -44,12 +44,24 @@ export const ToolBlock = memo(function ToolBlock({
   // Check if this is an upload tool with downloadable attachment
   const isDownloadable = tool.toolName === 'Upload' && tool.status === 'done'
 
+  // Check if both input and output are empty
+  const hasInput =
+    tool.toolUse?.details?.input &&
+    (typeof tool.toolUse.details.input === 'string'
+      ? tool.toolUse.details.input.length > 0
+      : Object.keys(tool.toolUse.details.input).length > 0)
+  const hasOutput = tool.toolResult?.details?.output || tool.toolResult?.details?.content
+  const hasContent = hasInput || hasOutput
+  const isExpandable = hasContent
+
   return (
     <div className="border border-border rounded-lg bg-surface overflow-hidden mb-2">
       {/* Header */}
       <div
-        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-fill-tert transition-colors"
-        onClick={() => setIsExpanded(!isExpanded)}
+        className={`flex items-center justify-between px-4 py-3 ${
+          isExpandable ? 'cursor-pointer hover:bg-fill-tert' : 'cursor-default'
+        } transition-colors`}
+        onClick={() => isExpandable && setIsExpanded(!isExpanded)}
       >
         <div className="flex items-center gap-2">
           <StatusIcon className={`h-4 w-4 ${statusColor}`} />
@@ -61,17 +73,21 @@ export const ToolBlock = memo(function ToolBlock({
               {t('thinking.downloadable') || 'Downloadable'}
             </span>
           )}
-          {/* Expand/collapse icon */}
-          {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-text-muted" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-text-muted" />
+          {/* Expand/collapse icon - only show if there's content to expand */}
+          {isExpandable && (
+            <>
+              {isExpanded ? (
+                <ChevronDown className="h-4 w-4 text-text-muted" />
+              ) : (
+                <ChevronRight className="h-4 w-4 text-text-muted" />
+              )}
+            </>
           )}
         </div>
       </div>
 
       {/* Content (Specialized Renderer) */}
-      {isExpanded && (
+      {isExpanded && isExpandable && (
         <div className="px-4 py-3 border-t border-border bg-base">
           <ToolRenderer tool={tool} />
         </div>


### PR DESCRIPTION
- Add TOOL_DISPLAY_WHITELIST config to chat_shell (default: read,write,upload,command)
- Implement substring matching for tool whitelist keywords
- Conditionally include tool_input/tool_output based on whitelist in streaming
- Frontend: hide expand button when both input/output are empty
- Backend: sanitize thinking data before database storage
  - Remove details.input from tool_use steps
  - Remove details.output/content from tool_result steps
- Add sanitization in executor_kinds.py and db.py storage paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable tool display whitelist to control visibility of tool input/output details.
  * Tool details in thinking steps now conditionally displayed based on tool type.

* **Bug Fixes**
  * Sensitive tool input/output data now sanitized before storage for improved privacy and security.

* **Style**
  * Enhanced tool block UI with conditional expand/collapse icons and improved visual indicators for better usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->