### PR TITLE
Load tool when skill is activated

### DIFF
--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -15,7 +15,7 @@ import asyncio
 import logging
 import time
 from collections.abc import AsyncGenerator
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
@@ -156,6 +156,78 @@ class LangGraphAgentBuilder:
 
         return prompt_modifier
 
+    def _find_load_skill_tool(self) -> Optional[Any]:
+        """Find the LoadSkillTool from registered tools.
+
+        Returns:
+            LoadSkillTool instance or None if not found
+        """
+        from ..tools.builtin import LoadSkillTool
+
+        for tool in self.tools:
+            if isinstance(tool, LoadSkillTool):
+                return tool
+        return None
+
+    def _create_model_configurator(self) -> tuple[Optional[Any], list[BaseTool]]:
+        """Create a model configurator function for dynamic tool selection.
+
+        This function is called before each model invocation to dynamically
+        select which tools are available based on loaded skills.
+
+        Returns:
+            A tuple of (callable that configures the model with tools, all tools for execution)
+            Returns (None, self.tools) if no dynamic tools
+        """
+        load_skill_tool = self._find_load_skill_tool()
+        if not load_skill_tool:
+            return None, self.tools
+
+        # Get all registered skill tools
+        all_skill_tools = load_skill_tool.get_all_registered_tools()
+        if not all_skill_tools:
+            return None, self.tools
+
+        # Create a set of skill tool names for quick lookup
+        skill_tool_names = {t.name for t in all_skill_tools}
+
+        # Separate base tools (non-skill tools) from skill tools
+        base_tools = [t for t in self.tools if t.name not in skill_tool_names]
+
+        # All tools = base tools + all skill tools (for execution)
+        # This ensures all tools are available for execution when model calls them
+        all_tools = base_tools + all_skill_tools
+
+        llm = self.llm
+
+        def configure_model(state: dict[str, Any], config: Any) -> Any:
+            """Configure the model with tools based on loaded skills.
+
+            This function dynamically selects tools based on which skills
+            have been loaded via load_skill tool.
+
+            Args:
+                state: The current agent state
+                config: Runtime configuration from LangGraph
+            """
+            # Get currently available skill tools (only for loaded skills)
+            available_skill_tools = load_skill_tool.get_available_tools()
+
+            # Combine base tools with available skill tools
+            selected_tools = base_tools + available_skill_tools
+
+            logger.debug(
+                "[configure_model] Selected %d tools: base=%d, skill=%d, loaded_skills=%s",
+                len(selected_tools),
+                len(base_tools),
+                len(available_skill_tools),
+                list(load_skill_tool.get_loaded_skills()),
+            )
+
+            return llm.bind_tools(selected_tools)
+
+        return configure_model, all_tools
+
     @trace_sync(
         span_name="agent_builder.build_agent",
         tracer_name="chat_shell.agents",
@@ -186,13 +258,34 @@ class LangGraphAgentBuilder:
             {"has_modifier": prompt_modifier is not None},
         )
 
-        # Build agent with optional prompt modifier for dynamic system prompt updates
-        self._agent = create_react_agent(
-            model=self.llm,
-            tools=self.tools,
-            checkpointer=checkpointer,
-            prompt=prompt_modifier,
+        # Create model configurator for dynamic tool selection
+        model_configurator, all_tools = self._create_model_configurator()
+        add_span_event(
+            "model_configurator_created",
+            {
+                "has_configurator": model_configurator is not None,
+                "all_tools_count": len(all_tools),
+            },
         )
+
+        # Build agent with optional prompt modifier for dynamic system prompt updates
+        # If we have a model configurator, use it for dynamic tool selection
+        # Note: all_tools includes ALL possible tools (base + all skill tools) for execution
+        # while model_configurator controls which tools the model sees at each step
+        if model_configurator:
+            self._agent = create_react_agent(
+                model=model_configurator,
+                tools=all_tools,
+                checkpointer=checkpointer,
+                prompt=prompt_modifier,
+            )
+        else:
+            self._agent = create_react_agent(
+                model=self.llm,
+                tools=all_tools,
+                checkpointer=checkpointer,
+                prompt=prompt_modifier,
+            )
         add_span_event("react_agent_created")
 
         return self._agent

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -153,6 +153,22 @@ class ChatContext:
                 len(history),
             )
 
+            # Restore skill loading state from history (for skill retention across turns)
+            if self._load_skill_tool and history:
+                add_span_event("restoring_skill_state_from_history")
+                self._load_skill_tool.restore_from_history(history)
+                restored_skills = self._load_skill_tool.get_loaded_skills()
+                if restored_skills:
+                    add_span_event(
+                        "skill_state_restored",
+                        {"restored_skills": list(restored_skills)},
+                    )
+                    logger.info(
+                        "[CHAT_CONTEXT] Restored %d skills from history: %s",
+                        len(restored_skills),
+                        list(restored_skills),
+                    )
+
             # Build extra_tools from all sources (including builtin tools)
             add_span_event("building_extra_tools")
             extra_tools = self._build_extra_tools(kb_result, skill_tools, mcp_result)

--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -4,23 +4,27 @@
 
 """Load skill tool for on-demand skill prompt expansion.
 
-This tool implements session-level skill expansion caching:
+This tool implements session-level skill expansion caching with persistence:
 - Within a single user-AI conversation turn, a skill only needs to be expanded once
 - Subsequent calls to the same skill in the same turn return a confirmation message
-- When the AI finishes responding to the user, the expansion state is cleared
-- The next user message starts a fresh conversation turn
+- Skills remain loaded for up to 5 conversation turns (configurable via SKILL_RETENTION_TURNS)
+- After 5 turns without being used, skills are automatically unloaded
+- Skill state is restored from chat history when a new conversation turn starts
 
 In HTTP mode, skill prompts are obtained from the skill_configs passed via ChatRequest.
 """
 
 import logging
-from typing import Optional, Set
+from typing import Any, Optional, Set
 
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field, PrivateAttr
 
 logger = logging.getLogger(__name__)
+
+# Default number of turns to retain a loaded skill
+DEFAULT_SKILL_RETENTION_TURNS = 5
 
 
 class LoadSkillInput(BaseModel):
@@ -36,11 +40,17 @@ class LoadSkillTool(BaseTool):
     all skill prompts in the system prompt, skills are loaded only
     when needed, keeping the context window efficient.
 
-    Session-level caching:
+    Session-level caching with persistence:
     - Skills are cached within a single conversation turn (one user message -> AI response)
     - First call returns the full prompt, subsequent calls return a short confirmation
     - This prevents redundant prompt expansion during multi-tool-call cycles
-    - Cache is automatically fresh for each new tool instance (new conversation turn)
+    - Skills remain loaded for up to 5 conversation turns (configurable)
+    - Skill state is restored from chat history at the start of each turn
+
+    Dynamic tool loading:
+    - Skill tools are registered with this tool via register_skill_tools()
+    - When a skill is loaded, its tools become available for the model to use
+    - The get_available_tools() method returns all tools for loaded skills
     """
 
     name: str = "load_skill"
@@ -59,6 +69,8 @@ class LoadSkillTool(BaseTool):
     skill_names: list[str]  # Available skill names for this session
     # Skill metadata from ChatRequest (skill_configs)
     skill_metadata: dict[str, dict] = {}  # skill_name -> {description, prompt, ...}
+    # Number of turns to retain a loaded skill (default: 5)
+    skill_retention_turns: int = DEFAULT_SKILL_RETENTION_TURNS
 
     # Private instance attribute for session-level cache (not shared between instances)
     # This tracks which skills have been expanded in the current conversation turn
@@ -70,12 +82,26 @@ class LoadSkillTool(BaseTool):
     # Cache for skill display names (skill_name -> displayName)
     _skill_display_names: dict[str, str] = PrivateAttr(default_factory=dict)
 
+    # Store skill tools for dynamic tool selection
+    # skill_name -> list of tools
+    _skill_tools: dict[str, list] = PrivateAttr(default_factory=dict)
+
+    # Track remaining turns for each loaded skill
+    # skill_name -> remaining_turns (decremented each turn, skill unloaded when 0)
+    _skill_remaining_turns: dict[str, int] = PrivateAttr(default_factory=dict)
+
+    # Flag to indicate if state was restored from history
+    _state_restored: bool = PrivateAttr(default=False)
+
     def __init__(self, **data):
         """Initialize with a fresh expanded_skills cache."""
         super().__init__(**data)
         self._expanded_skills = set()
         self._loaded_skill_prompts = {}
         self._skill_display_names = {}
+        self._skill_tools = {}
+        self._skill_remaining_turns = {}
+        self._state_restored = False
 
     def _run(
         self,
@@ -91,6 +117,8 @@ class LoadSkillTool(BaseTool):
 
         # Check if skill was already expanded in this turn
         if skill_name in self._expanded_skills:
+            # Reset the remaining turns counter since skill is being used again
+            self._skill_remaining_turns[skill_name] = self.skill_retention_turns
             return (
                 f"Skill '{skill_name}' is already active in this conversation turn. "
                 f"The skill instructions have been added to the system prompt."
@@ -107,10 +135,19 @@ class LoadSkillTool(BaseTool):
         self._expanded_skills.add(skill_name)
         self._loaded_skill_prompts[skill_name] = prompt
 
+        # Set the remaining turns counter for this skill
+        self._skill_remaining_turns[skill_name] = self.skill_retention_turns
+
         # Cache the display name for friendly UI display
         display_name = skill_info.get("displayName")
         if display_name:
             self._skill_display_names[skill_name] = display_name
+
+        logger.info(
+            "[LoadSkillTool] Loaded skill '%s' with %d turns retention",
+            skill_name,
+            self.skill_retention_turns,
+        )
 
         # Return a confirmation message (the actual prompt will be injected into system prompt)
         return f"Skill '{skill_name}' has been loaded. The instructions have been added to the system prompt. Please follow them strictly."
@@ -239,3 +276,247 @@ class LoadSkillTool(BaseTool):
     def get_combined_skill_prompt(self) -> str:
         """Alias for get_prompt_modification for backward compatibility."""
         return self.get_prompt_modification()
+
+    def register_skill_tools(self, skill_name: str, tools: list) -> None:
+        """Register tools for a skill.
+
+        This method is called by prepare_skill_tools to register all tools
+        for a skill. These tools will become available when the skill is loaded.
+
+        Args:
+            skill_name: The name of the skill
+            tools: List of tool instances for this skill
+        """
+        self._skill_tools[skill_name] = tools
+        logger.debug(
+            "[LoadSkillTool] Registered %d tools for skill '%s': %s",
+            len(tools),
+            skill_name,
+            [t.name for t in tools],
+        )
+
+    def get_skill_tools(self, skill_name: str) -> list:
+        """Get tools for a specific skill.
+
+        Args:
+            skill_name: The name of the skill
+
+        Returns:
+            List of tool instances for the skill, or empty list if not found
+        """
+        return self._skill_tools.get(skill_name, [])
+
+    def get_available_tools(self) -> list:
+        """Get all tools for loaded/expanded skills.
+
+        This method returns tools only for skills that have been loaded
+        (either preloaded or loaded via load_skill tool).
+
+        Returns:
+            List of tool instances for all loaded skills
+        """
+        available_tools = []
+        for skill_name in self._expanded_skills:
+            skill_tools = self._skill_tools.get(skill_name, [])
+            available_tools.extend(skill_tools)
+        return available_tools
+
+    def get_all_registered_tools(self) -> list:
+        """Get all registered tools regardless of skill load status.
+
+        This method returns all tools that have been registered,
+        regardless of whether their skills have been loaded.
+        Used by LangGraphAgentBuilder to know all possible tools.
+
+        Returns:
+            List of all registered tool instances
+        """
+        all_tools = []
+        for tools in self._skill_tools.values():
+            all_tools.extend(tools)
+        return all_tools
+
+    def is_skill_loaded(self, skill_name: str) -> bool:
+        """Check if a skill has been loaded.
+
+        Args:
+            skill_name: The name of the skill
+
+        Returns:
+            True if the skill has been loaded, False otherwise
+        """
+        return skill_name in self._expanded_skills
+
+    def get_loaded_skills(self) -> set[str]:
+        """Get the set of loaded skill names.
+
+        Returns:
+            Set of skill names that have been loaded
+        """
+        return self._expanded_skills.copy()
+
+    def get_skill_remaining_turns(self, skill_name: str) -> int:
+        """Get the remaining turns for a loaded skill.
+
+        Args:
+            skill_name: The name of the skill
+
+        Returns:
+            Remaining turns, or 0 if skill is not loaded
+        """
+        return self._skill_remaining_turns.get(skill_name, 0)
+
+    def restore_from_history(self, history: list[dict[str, Any]]) -> None:
+        """Restore skill loading state from chat history.
+
+        This method analyzes the chat history to find load_skill tool calls
+        and restores the skill loading state. It counts the number of conversation
+        turns since each skill was loaded and only restores skills that are still
+        within the retention window.
+
+        A conversation turn is defined as a user message followed by an assistant response.
+        The method counts turns backwards from the most recent message.
+
+        Args:
+            history: List of message dictionaries with 'role' and 'content' keys.
+                    May also contain 'tool_calls' for assistant messages.
+        """
+        if self._state_restored:
+            logger.debug(
+                "[LoadSkillTool] State already restored, skipping restore_from_history"
+            )
+            return
+
+        if not history:
+            logger.debug("[LoadSkillTool] No history to restore from")
+            self._state_restored = True
+            return
+
+        # Find all load_skill tool calls and their positions (turn index)
+        # We need to count turns from the end of history
+        skill_load_turns: dict[str, int] = {}  # skill_name -> turns_ago
+
+        # Count conversation turns (user-assistant pairs) from the end
+        current_turn = 0
+        i = len(history) - 1
+
+        while i >= 0:
+            msg = history[i]
+            role = msg.get("role", "")
+
+            if role == "assistant":
+                # Check for load_skill tool calls in this assistant message
+                content = msg.get("content", "")
+
+                # Look for load_skill tool call patterns in the content
+                # The tool result is typically in the format:
+                # "Skill 'skill_name' has been loaded..."
+                loaded_skills = self._extract_loaded_skills_from_content(content)
+                for skill_name in loaded_skills:
+                    # Only record the most recent load (closest to current turn)
+                    if skill_name not in skill_load_turns:
+                        skill_load_turns[skill_name] = current_turn
+                        logger.debug(
+                            "[LoadSkillTool] Found skill '%s' loaded %d turns ago",
+                            skill_name,
+                            current_turn,
+                        )
+
+                # Move to the previous message
+                i -= 1
+
+                # If the previous message is a user message, we've completed a turn
+                if i >= 0 and history[i].get("role") == "user":
+                    current_turn += 1
+                    i -= 1
+            else:
+                # Skip non-assistant messages when not paired
+                i -= 1
+
+        # Restore skills that are still within the retention window
+        restored_count = 0
+        for skill_name, turns_ago in skill_load_turns.items():
+            remaining_turns = self.skill_retention_turns - turns_ago
+
+            if remaining_turns > 0 and skill_name in self.skill_names:
+                # Restore this skill
+                skill_info = self.skill_metadata.get(skill_name, {})
+                prompt = skill_info.get("prompt", "")
+
+                if prompt:
+                    self._expanded_skills.add(skill_name)
+                    self._loaded_skill_prompts[skill_name] = prompt
+                    self._skill_remaining_turns[skill_name] = remaining_turns
+
+                    # Cache display name
+                    display_name = skill_info.get("displayName")
+                    if display_name:
+                        self._skill_display_names[skill_name] = display_name
+
+                    restored_count += 1
+                    logger.info(
+                        "[LoadSkillTool] Restored skill '%s' from history "
+                        "(loaded %d turns ago, %d turns remaining)",
+                        skill_name,
+                        turns_ago,
+                        remaining_turns,
+                    )
+            elif remaining_turns <= 0:
+                logger.debug(
+                    "[LoadSkillTool] Skill '%s' expired (loaded %d turns ago, "
+                    "retention=%d turns)",
+                    skill_name,
+                    turns_ago,
+                    self.skill_retention_turns,
+                )
+
+        self._state_restored = True
+        logger.info(
+            "[LoadSkillTool] Restored %d skills from history (retention=%d turns)",
+            restored_count,
+            self.skill_retention_turns,
+        )
+
+    def _extract_loaded_skills_from_content(self, content: str) -> list[str]:
+        """Extract skill names from assistant message content.
+
+        This method looks for patterns indicating that a skill was loaded,
+        such as the load_skill tool result message.
+
+        Args:
+            content: The assistant message content
+
+        Returns:
+            List of skill names that were loaded in this message
+        """
+        import re
+
+        loaded_skills = []
+
+        if not content or not isinstance(content, str):
+            return loaded_skills
+
+        # Pattern 1: Match the load_skill tool result message
+        # "Skill 'skill_name' has been loaded..."
+        pattern1 = r"Skill '([^']+)' has been loaded"
+        matches = re.findall(pattern1, content)
+        loaded_skills.extend(matches)
+
+        # Pattern 2: Match the "already active" message (skill was loaded earlier in same turn)
+        # "Skill 'skill_name' is already active..."
+        pattern2 = r"Skill '([^']+)' is already active"
+        matches = re.findall(pattern2, content)
+        loaded_skills.extend(matches)
+
+        # Filter to only include skills that are available in this session
+        valid_skills = [s for s in loaded_skills if s in self.skill_names]
+
+        return valid_skills
+
+    def is_state_restored(self) -> bool:
+        """Check if state has been restored from history.
+
+        Returns:
+            True if restore_from_history has been called, False otherwise
+        """
+        return self._state_restored

--- a/chat_shell/tests/test_dynamic_skill_tools.py
+++ b/chat_shell/tests/test_dynamic_skill_tools.py
@@ -1,0 +1,610 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dynamic skill tool loading functionality.
+
+This module tests the ability to dynamically load skill tools when
+a skill is loaded via the load_skill tool.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from chat_shell.tools.builtin.load_skill import LoadSkillTool
+
+
+class TestLoadSkillToolDynamicTools:
+    """Test cases for LoadSkillTool dynamic tool management."""
+
+    def test_register_skill_tools(self):
+        """Test that skill tools can be registered."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Create mock tools
+        mock_tool_a1 = MagicMock()
+        mock_tool_a1.name = "tool_a1"
+        mock_tool_a2 = MagicMock()
+        mock_tool_a2.name = "tool_a2"
+        mock_tool_b1 = MagicMock()
+        mock_tool_b1.name = "tool_b1"
+
+        # Register tools for skills
+        tool.register_skill_tools("skill_a", [mock_tool_a1, mock_tool_a2])
+        tool.register_skill_tools("skill_b", [mock_tool_b1])
+
+        # Verify tools are registered
+        assert tool.get_skill_tools("skill_a") == [mock_tool_a1, mock_tool_a2]
+        assert tool.get_skill_tools("skill_b") == [mock_tool_b1]
+        assert tool.get_skill_tools("nonexistent") == []
+
+    def test_get_available_tools_empty_when_no_skills_loaded(self):
+        """Test that get_available_tools returns empty when no skills are loaded."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        # Register tools but don't load the skill
+        mock_tool = MagicMock()
+        mock_tool.name = "tool_a"
+        tool.register_skill_tools("skill_a", [mock_tool])
+
+        # No skills loaded, so no tools available
+        assert tool.get_available_tools() == []
+
+    def test_get_available_tools_returns_tools_for_loaded_skills(self):
+        """Test that get_available_tools returns tools for loaded skills."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Register tools
+        mock_tool_a = MagicMock()
+        mock_tool_a.name = "tool_a"
+        mock_tool_b = MagicMock()
+        mock_tool_b.name = "tool_b"
+        tool.register_skill_tools("skill_a", [mock_tool_a])
+        tool.register_skill_tools("skill_b", [mock_tool_b])
+
+        # Load only skill_a
+        tool._run("skill_a")
+
+        # Only skill_a's tools should be available
+        available = tool.get_available_tools()
+        assert mock_tool_a in available
+        assert mock_tool_b not in available
+
+    def test_get_available_tools_updates_after_loading_more_skills(self):
+        """Test that get_available_tools updates when more skills are loaded."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Register tools
+        mock_tool_a = MagicMock()
+        mock_tool_a.name = "tool_a"
+        mock_tool_b = MagicMock()
+        mock_tool_b.name = "tool_b"
+        tool.register_skill_tools("skill_a", [mock_tool_a])
+        tool.register_skill_tools("skill_b", [mock_tool_b])
+
+        # Initially no tools available
+        assert tool.get_available_tools() == []
+
+        # Load skill_a
+        tool._run("skill_a")
+        available = tool.get_available_tools()
+        assert len(available) == 1
+        assert mock_tool_a in available
+
+        # Load skill_b
+        tool._run("skill_b")
+        available = tool.get_available_tools()
+        assert len(available) == 2
+        assert mock_tool_a in available
+        assert mock_tool_b in available
+
+    def test_get_all_registered_tools(self):
+        """Test that get_all_registered_tools returns all tools regardless of load status."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Register tools
+        mock_tool_a = MagicMock()
+        mock_tool_a.name = "tool_a"
+        mock_tool_b = MagicMock()
+        mock_tool_b.name = "tool_b"
+        tool.register_skill_tools("skill_a", [mock_tool_a])
+        tool.register_skill_tools("skill_b", [mock_tool_b])
+
+        # All tools should be returned regardless of load status
+        all_tools = tool.get_all_registered_tools()
+        assert len(all_tools) == 2
+        assert mock_tool_a in all_tools
+        assert mock_tool_b in all_tools
+
+    def test_is_skill_loaded(self):
+        """Test is_skill_loaded method."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Initially no skills loaded
+        assert not tool.is_skill_loaded("skill_a")
+        assert not tool.is_skill_loaded("skill_b")
+
+        # Load skill_a
+        tool._run("skill_a")
+        assert tool.is_skill_loaded("skill_a")
+        assert not tool.is_skill_loaded("skill_b")
+
+    def test_get_loaded_skills(self):
+        """Test get_loaded_skills method."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Initially empty
+        assert tool.get_loaded_skills() == set()
+
+        # Load skills
+        tool._run("skill_a")
+        assert tool.get_loaded_skills() == {"skill_a"}
+
+        tool._run("skill_b")
+        assert tool.get_loaded_skills() == {"skill_a", "skill_b"}
+
+    def test_preload_skill_prompt_makes_tools_available(self):
+        """Test that preloading a skill makes its tools available."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        # Register tools
+        mock_tool = MagicMock()
+        mock_tool.name = "tool_a"
+        tool.register_skill_tools("skill_a", [mock_tool])
+
+        # Preload the skill
+        tool.preload_skill_prompt("skill_a", {"prompt": "Skill A prompt"})
+
+        # Tools should now be available
+        available = tool.get_available_tools()
+        assert mock_tool in available
+
+    def test_clear_expanded_skills_clears_available_tools(self):
+        """Test that clearing expanded skills also clears available tools."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        # Register and load skill
+        mock_tool = MagicMock()
+        mock_tool.name = "tool_a"
+        tool.register_skill_tools("skill_a", [mock_tool])
+        tool._run("skill_a")
+
+        # Tools should be available
+        assert len(tool.get_available_tools()) == 1
+
+        # Clear expanded skills
+        tool.clear_expanded_skills()
+
+        # Tools should no longer be available (but still registered)
+        assert tool.get_available_tools() == []
+        assert len(tool.get_all_registered_tools()) == 1
+
+
+class TestDynamicToolSelectionIntegration:
+    """Integration tests for dynamic tool selection with LangGraphAgentBuilder."""
+
+    def test_model_configurator_selects_tools_based_on_loaded_skills(self):
+        """Test that model configurator correctly selects tools based on loaded skills."""
+        from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+        from chat_shell.tools.base import ToolRegistry
+
+        # Create a LoadSkillTool with registered tools
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+        )
+
+        # Register mock tools
+        mock_tool_a = MagicMock()
+        mock_tool_a.name = "tool_a"
+        mock_tool_b = MagicMock()
+        mock_tool_b.name = "tool_b"
+        load_skill_tool.register_skill_tools("skill_a", [mock_tool_a])
+        load_skill_tool.register_skill_tools("skill_b", [mock_tool_b])
+
+        # Create a mock LLM
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(return_value=mock_llm)
+
+        # Create tool registry with load_skill_tool
+        tool_registry = ToolRegistry()
+        tool_registry.register(load_skill_tool)
+
+        # Create builder with load_skill_tool
+        builder = LangGraphAgentBuilder(
+            llm=mock_llm,
+            tool_registry=tool_registry,
+        )
+
+        # Find the load_skill_tool
+        found_tool = builder._find_load_skill_tool()
+        assert found_tool is load_skill_tool
+
+        # Create model configurator
+        configurator, all_tools = builder._create_model_configurator()
+
+        # Verify all_tools includes all skill tools for execution
+        all_tool_names = [t.name for t in all_tools]
+        assert "load_skill" in all_tool_names
+        assert "tool_a" in all_tool_names
+        assert "tool_b" in all_tool_names
+
+        # Initially no skills loaded - only base tools
+        # configure_model takes (state, config) as per LangGraph's callable signature
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        tool_names = [t.name for t in call_args]
+        assert "load_skill" in tool_names
+        assert "tool_a" not in tool_names
+        assert "tool_b" not in tool_names
+
+        # Load skill_a
+        load_skill_tool._run("skill_a")
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        tool_names = [t.name for t in call_args]
+        assert "load_skill" in tool_names
+        assert "tool_a" in tool_names
+        assert "tool_b" not in tool_names
+
+        # Load skill_b
+        load_skill_tool._run("skill_b")
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        tool_names = [t.name for t in call_args]
+        assert "load_skill" in tool_names
+        assert "tool_a" in tool_names
+        assert "tool_b" in tool_names
+
+    def test_no_model_configurator_when_no_load_skill_tool(self):
+        """Test that no model configurator is created when there's no LoadSkillTool."""
+        from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+        from chat_shell.tools.base import ToolRegistry
+
+        # Create a mock LLM
+        mock_llm = MagicMock()
+
+        # Create builder without load_skill_tool
+        mock_tool = MagicMock()
+        mock_tool.name = "some_tool"
+        tool_registry = ToolRegistry()
+        tool_registry.register(mock_tool)
+
+        builder = LangGraphAgentBuilder(
+            llm=mock_llm,
+            tool_registry=tool_registry,
+        )
+
+        # Should not find load_skill_tool
+        found_tool = builder._find_load_skill_tool()
+        assert found_tool is None
+
+        # Model configurator should return (None, self.tools)
+        configurator, all_tools = builder._create_model_configurator()
+        assert configurator is None
+        # all_tools should be the same as builder.tools
+        assert all_tools == builder.tools
+
+
+class TestSkillRetentionAcrossTurns:
+    """Test cases for skill retention across conversation turns."""
+
+    def test_skill_remaining_turns_set_on_load(self):
+        """Test that remaining turns is set when a skill is loaded."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+            skill_retention_turns=5,
+        )
+
+        # Load the skill
+        tool._run("skill_a")
+
+        # Check remaining turns is set
+        assert tool.get_skill_remaining_turns("skill_a") == 5
+
+    def test_skill_remaining_turns_reset_on_reload(self):
+        """Test that remaining turns is reset when skill is loaded again."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+            skill_retention_turns=5,
+        )
+
+        # Load the skill
+        tool._run("skill_a")
+        assert tool.get_skill_remaining_turns("skill_a") == 5
+
+        # Manually decrease remaining turns (simulating turns passing)
+        tool._skill_remaining_turns["skill_a"] = 2
+
+        # Load the skill again (should reset to 5)
+        tool._run("skill_a")
+        assert tool.get_skill_remaining_turns("skill_a") == 5
+
+    def test_restore_from_history_empty_history(self):
+        """Test restore_from_history with empty history."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        # Restore from empty history
+        tool.restore_from_history([])
+
+        # No skills should be loaded
+        assert tool.get_loaded_skills() == set()
+        assert tool.is_state_restored()
+
+    def test_restore_from_history_with_loaded_skill(self):
+        """Test restore_from_history restores skill loaded in recent history."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+            skill_retention_turns=5,
+        )
+
+        # Simulate history with a skill loaded 2 turns ago
+        history = [
+            {"role": "user", "content": "Load skill_a"},
+            {
+                "role": "assistant",
+                "content": "Skill 'skill_a' has been loaded. The instructions have been added to the system prompt.",
+            },
+            {"role": "user", "content": "Do something"},
+            {"role": "assistant", "content": "Done!"},
+            {"role": "user", "content": "Do more"},
+            {"role": "assistant", "content": "Done again!"},
+        ]
+
+        # Restore from history
+        tool.restore_from_history(history)
+
+        # Skill should be restored with remaining turns
+        assert tool.is_skill_loaded("skill_a")
+        # Loaded 2 turns ago, so 5 - 2 = 3 remaining
+        assert tool.get_skill_remaining_turns("skill_a") == 3
+        assert tool.is_state_restored()
+
+    def test_restore_from_history_skill_expired(self):
+        """Test restore_from_history does not restore expired skills."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+            skill_retention_turns=2,  # Only retain for 2 turns
+        )
+
+        # Simulate history with a skill loaded 3 turns ago (expired)
+        history = [
+            {"role": "user", "content": "Load skill_a"},
+            {"role": "assistant", "content": "Skill 'skill_a' has been loaded."},
+            {"role": "user", "content": "Turn 1"},
+            {"role": "assistant", "content": "Response 1"},
+            {"role": "user", "content": "Turn 2"},
+            {"role": "assistant", "content": "Response 2"},
+            {"role": "user", "content": "Turn 3"},
+            {"role": "assistant", "content": "Response 3"},
+        ]
+
+        # Restore from history
+        tool.restore_from_history(history)
+
+        # Skill should NOT be restored (expired after 2 turns)
+        assert not tool.is_skill_loaded("skill_a")
+        assert tool.is_state_restored()
+
+    def test_restore_from_history_multiple_skills(self):
+        """Test restore_from_history with multiple skills loaded at different times."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+            },
+            skill_retention_turns=5,
+        )
+
+        # Simulate history with skill_a loaded 3 turns ago, skill_b loaded 1 turn ago
+        history = [
+            {"role": "user", "content": "Load skill_a"},
+            {"role": "assistant", "content": "Skill 'skill_a' has been loaded."},
+            {"role": "user", "content": "Turn 1"},
+            {"role": "assistant", "content": "Response 1"},
+            {"role": "user", "content": "Load skill_b"},
+            {"role": "assistant", "content": "Skill 'skill_b' has been loaded."},
+            {"role": "user", "content": "Turn 2"},
+            {"role": "assistant", "content": "Response 2"},
+        ]
+
+        # Restore from history
+        tool.restore_from_history(history)
+
+        # Both skills should be restored
+        assert tool.is_skill_loaded("skill_a")
+        assert tool.is_skill_loaded("skill_b")
+
+        # skill_a: loaded 3 turns ago, 5 - 3 = 2 remaining
+        assert tool.get_skill_remaining_turns("skill_a") == 2
+        # skill_b: loaded 1 turn ago, 5 - 1 = 4 remaining
+        assert tool.get_skill_remaining_turns("skill_b") == 4
+
+    def test_restore_from_history_only_restores_once(self):
+        """Test that restore_from_history only runs once."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        history = [
+            {"role": "user", "content": "Load skill_a"},
+            {"role": "assistant", "content": "Skill 'skill_a' has been loaded."},
+        ]
+
+        # First restore
+        tool.restore_from_history(history)
+        assert tool.is_skill_loaded("skill_a")
+
+        # Clear the skill manually
+        tool._expanded_skills.clear()
+        tool._loaded_skill_prompts.clear()
+
+        # Second restore should not run (already restored)
+        tool.restore_from_history(history)
+        assert not tool.is_skill_loaded("skill_a")  # Still cleared
+
+    def test_extract_loaded_skills_from_content(self):
+        """Test _extract_loaded_skills_from_content method."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a", "skill_b", "skill_c"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+                "skill_b": {"description": "Skill B", "prompt": "Skill B prompt"},
+                "skill_c": {"description": "Skill C", "prompt": "Skill C prompt"},
+            },
+        )
+
+        # Test "has been loaded" pattern
+        content1 = "Skill 'skill_a' has been loaded. The instructions have been added."
+        assert tool._extract_loaded_skills_from_content(content1) == ["skill_a"]
+
+        # Test "is already active" pattern
+        content2 = "Skill 'skill_b' is already active in this conversation turn."
+        assert tool._extract_loaded_skills_from_content(content2) == ["skill_b"]
+
+        # Test multiple skills in one message
+        content3 = (
+            "Skill 'skill_a' has been loaded. Later, Skill 'skill_b' has been loaded."
+        )
+        result = tool._extract_loaded_skills_from_content(content3)
+        assert "skill_a" in result
+        assert "skill_b" in result
+
+        # Test unknown skill (not in skill_names)
+        content4 = "Skill 'unknown_skill' has been loaded."
+        assert tool._extract_loaded_skills_from_content(content4) == []
+
+        # Test empty content
+        assert tool._extract_loaded_skills_from_content("") == []
+        assert tool._extract_loaded_skills_from_content(None) == []
+
+    def test_custom_retention_turns(self):
+        """Test that custom retention turns value is respected."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+            skill_retention_turns=10,  # Custom value
+        )
+
+        # Load the skill
+        tool._run("skill_a")
+
+        # Check remaining turns uses custom value
+        assert tool.get_skill_remaining_turns("skill_a") == 10
+
+    def test_default_retention_turns(self):
+        """Test that default retention turns is 5."""
+        from chat_shell.tools.builtin.load_skill import DEFAULT_SKILL_RETENTION_TURNS
+
+        assert DEFAULT_SKILL_RETENTION_TURNS == 5
+
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        # Load the skill
+        tool._run("skill_a")
+
+        # Check remaining turns uses default value
+        assert tool.get_skill_remaining_turns("skill_a") == 5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now persist across multiple conversation turns with configurable retention window
  * Previously loaded skills are automatically restored from chat history
  * Tools are dynamically managed based on currently active skills

* **Tests**
  * Added comprehensive test coverage for dynamic skill tool loading and management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->