### PR TITLE
feat: implement Executor Local version management

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -218,4 +218,4 @@ MEMORY_TIMEOUT_SECONDS=2.0
 # This includes 2 history messages + 1 current message for better memory quality
 MEMORY_CONTEXT_MESSAGES=3
 
-EXECUTOR_LATEST_VERSION=1.1.0
+EXECUTOR_LATEST_VERSION=1.0.0

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -217,3 +217,5 @@ MEMORY_TIMEOUT_SECONDS=2.0
 # Number of recent messages to include as context when saving memory (default: 3)
 # This includes 2 history messages + 1 current message for better memory quality
 MEMORY_CONTEXT_MESSAGES=3
+
+EXECUTOR_LATEST_VERSION=1.1.0

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -611,7 +611,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
         logger.info(
             f"[Device WS] device:register user={user_id}, device_id={payload.device_id}, "
-            f"name={payload.name}"
+            f"name={payload.name}, executor_version={payload.executor_version}"
         )
 
         # Database operation: quick in, quick out
@@ -625,6 +625,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
             device_id=payload.device_id,
             socket_id=sid,
             name=payload.name,
+            executor_version=payload.executor_version,
         )
 
         # Update session with device_id
@@ -675,7 +676,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
         # Refresh Redis TTL and update running_task_ids
         await device_service.refresh_device_heartbeat(
-            user_id, payload.device_id, payload.running_task_ids
+            user_id, payload.device_id, payload.running_task_ids, payload.executor_version
         )
 
         # Database operation: quick in, quick out

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -676,7 +676,10 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
         # Refresh Redis TTL and update running_task_ids
         await device_service.refresh_device_heartbeat(
-            user_id, payload.device_id, payload.running_task_ids, payload.executor_version
+            user_id,
+            payload.device_id,
+            payload.running_task_ids,
+            payload.executor_version,
         )
 
         # Database operation: quick in, quick out

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,6 +65,9 @@ class Settings(BaseSettings):
     EXECUTOR_CANCEL_TASK_URL: str = (
         "http://localhost:8001/executor-manager/tasks/cancel"
     )
+    # Latest Executor version (manually updated when releasing new versions)
+    # This is used to show upgrade warnings in the UI
+    EXECUTOR_LATEST_VERSION: str = "1.0.0"
 
     # JWT configuration
     SECRET_KEY: str = "secret-key"

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -54,6 +54,16 @@ class DeviceInfo(BaseModel):
     running_tasks: List[DeviceRunningTask] = Field(
         default_factory=list, description="List of tasks running on this device"
     )
+    # Version information
+    executor_version: Optional[str] = Field(
+        None, description="Device's current executor version"
+    )
+    latest_version: Optional[str] = Field(
+        None, description="Latest available executor version"
+    )
+    update_available: bool = Field(
+        False, description="Whether an update is available"
+    )
 
     class Config:
         from_attributes = True
@@ -81,6 +91,11 @@ class DeviceRegisterPayload(BaseModel):
         max_length=100,
         description="Device name (self-provided)",
     )
+    executor_version: Optional[str] = Field(
+        None,
+        max_length=50,
+        description="Executor version (e.g., '1.0.0')",
+    )
 
 
 class DeviceHeartbeatPayload(BaseModel):
@@ -89,6 +104,11 @@ class DeviceHeartbeatPayload(BaseModel):
     device_id: str = Field(..., description="Device unique identifier")
     running_task_ids: List[int] = Field(
         default_factory=list, description="List of active task IDs on this device"
+    )
+    executor_version: Optional[str] = Field(
+        None,
+        max_length=50,
+        description="Executor version (e.g., '1.0.0')",
     )
 
 

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -61,9 +61,7 @@ class DeviceInfo(BaseModel):
     latest_version: Optional[str] = Field(
         None, description="Latest available executor version"
     )
-    update_available: bool = Field(
-        False, description="Whether an update is available"
-    )
+    update_available: bool = Field(False, description="Whether an update is available")
 
     class Config:
         from_attributes = True

--- a/backend/app/services/device_service.py
+++ b/backend/app/services/device_service.py
@@ -269,15 +269,19 @@ class DeviceService:
         """
         Check if update is available using semantic version comparison.
 
+        If current version is None or empty, it means old executor without
+        version reporting, which should be considered as needing update.
+
         Args:
-            current: Current executor version (e.g., '1.0.0')
+            current: Current executor version (e.g., '1.0.0'), None for old executors
             latest: Latest available version (e.g., '1.1.0')
 
         Returns:
-            True if update is available (current < latest)
+            True if update is available (current < latest or current is None)
         """
+        # Old executor without version reporting should be considered as needing update
         if not current:
-            return False
+            return True
         try:
             return pkg_version.parse(current) < pkg_version.parse(latest)
         except Exception:

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -22,6 +22,7 @@ from typing import Any, Callable, Dict, Optional
 import socketio
 
 from executor.config import config
+from executor.version import get_version
 from shared.logger import setup_logger
 
 logger = setup_logger("websocket_client")
@@ -370,6 +371,7 @@ class WebSocketClient:
             register_data = {
                 "device_id": self.device_id,
                 "name": self.device_name,
+                "executor_version": get_version(),
             }
             logger.info(f"Sending device:register to /local-executor: {register_data}")
 
@@ -425,6 +427,7 @@ class WebSocketClient:
             heartbeat_data = {
                 "device_id": self.device_id,
                 "running_task_ids": running_task_ids,
+                "executor_version": get_version(),
             }
             logger.info(
                 f"Sending device:heartbeat to /local-executor: {heartbeat_data}"

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -26,6 +26,7 @@ Output:
 import argparse
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -64,6 +65,66 @@ def clean_build_artifacts():
             file_path.unlink()
 
 
+def get_version_from_pyproject() -> str:
+    """Read version from pyproject.toml.
+
+    Returns:
+        Version string (e.g., "1.0.0")
+    """
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore
+
+    pyproject_path = get_executor_root() / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    return data.get("project", {}).get("version", "unknown")
+
+
+def embed_version_in_source(version: str) -> str | None:
+    """Embed version into version.py for PyInstaller builds.
+
+    Args:
+        version: Version string to embed
+
+    Returns:
+        Original content of version.py for restoration, or None if failed
+    """
+    version_py = get_executor_root() / "version.py"
+
+    # Read original content
+    original_content = version_py.read_text()
+
+    # Replace _EMBEDDED_VERSION = None with the actual version
+    modified_content = re.sub(
+        r"_EMBEDDED_VERSION:\s*Optional\[str\]\s*=\s*None",
+        f'_EMBEDDED_VERSION: Optional[str] = "{version}"',
+        original_content,
+    )
+
+    if modified_content == original_content:
+        print("Warning: Could not find _EMBEDDED_VERSION placeholder in version.py")
+        return None
+
+    # Write modified content
+    version_py.write_text(modified_content)
+    print(f"Embedded version {version} into version.py")
+
+    return original_content
+
+
+def restore_version_source(original_content: str) -> None:
+    """Restore version.py to its original content.
+
+    Args:
+        original_content: Original content to restore
+    """
+    version_py = get_executor_root() / "version.py"
+    version_py.write_text(original_content)
+    print("Restored version.py to original content")
+
+
 def build_executable(target_arch: str | None = None):
     """Build the executable using PyInstaller.
 
@@ -74,178 +135,189 @@ def build_executable(target_arch: str | None = None):
     project_root = get_project_root()
     executor_root = get_executor_root()
 
-    # Change to project root for correct imports
-    os.chdir(project_root)
+    # Get version and embed it into source
+    version = get_version_from_pyproject()
+    print(f"Building version: {version}")
+    original_version_content = embed_version_in_source(version)
 
-    # Determine output name based on platform
-    if platform.system() == "Windows":
-        output_name = "wegent-executor.exe"
-    else:
-        output_name = "wegent-executor"
+    try:
+        # Change to project root for correct imports
+        os.chdir(project_root)
 
-    # PyInstaller command
-    cmd = [
-        sys.executable,
-        "-m",
-        "PyInstaller",
-        "--onefile",
-        "--name=wegent-executor",
-        f"--distpath={executor_root / 'dist'}",
-        f"--workpath={executor_root / 'build'}",
-        f"--specpath={executor_root}",
-        # Add project root to Python path
-        f"--paths={project_root}",
-        # Hidden imports for dependencies
-        "--hidden-import=executor",
-        "--hidden-import=executor.config",
-        "--hidden-import=executor.modes",
-        "--hidden-import=executor.modes.local",
-        "--hidden-import=executor.modes.local.runner",
-        "--hidden-import=executor.agents",
-        "--hidden-import=executor.agents.claude_code",
-        "--hidden-import=shared",
-        "--hidden-import=shared.logger",
-        "--hidden-import=shared.status",
-        # Socket.IO and related
-        "--hidden-import=socketio",
-        "--hidden-import=socketio.asyncio_client",
-        "--hidden-import=engineio",
-        "--hidden-import=engineio.async_client",
-        "--hidden-import=engineio.async_drivers.aiohttp",
-        # aiohttp and related (for Socket.IO transport)
-        "--hidden-import=aiohttp",
-        "--hidden-import=aiohttp.web",
-        "--hidden-import=aiohttp.client",
-        "--hidden-import=aiohttp.connector",
-        "--hidden-import=aiohttp.http",
-        "--hidden-import=aiohttp.http_parser",
-        "--hidden-import=aiohttp.http_writer",
-        "--hidden-import=aiohttp.streams",
-        "--hidden-import=aiohttp.payload",
-        "--hidden-import=aiohttp.resolver",
-        "--hidden-import=aiohttp.cookiejar",
-        "--hidden-import=aiohttp.tracing",
-        "--hidden-import=aiohttp.client_exceptions",
-        "--hidden-import=aiohttp.client_reqrep",
-        "--hidden-import=aiohttp.client_ws",
-        "--hidden-import=aiohttp.formdata",
-        "--hidden-import=aiohttp.helpers",
-        "--hidden-import=aiohttp.multipart",
-        "--hidden-import=aiohttp.web_app",
-        "--hidden-import=aiohttp.web_exceptions",
-        "--hidden-import=aiohttp.web_middlewares",
-        "--hidden-import=aiohttp.web_protocol",
-        "--hidden-import=aiohttp.web_request",
-        "--hidden-import=aiohttp.web_response",
-        "--hidden-import=aiohttp.web_routedef",
-        "--hidden-import=aiohttp.web_runner",
-        "--hidden-import=aiohttp.web_server",
-        "--hidden-import=aiohttp.web_urldispatcher",
-        "--hidden-import=aiohttp.web_ws",
-        "--hidden-import=aiohttp.abc",
-        "--hidden-import=aiohttp.base_protocol",
-        "--hidden-import=aiohttp.client_proto",
-        "--hidden-import=aiohttp.locks",
-        "--hidden-import=aiohttp.log",
-        "--hidden-import=aiohttp.typedefs",
-        "--hidden-import=aiohttp._helpers",
-        "--hidden-import=aiohttp._http_parser",
-        "--hidden-import=aiohttp._http_writer",
-        "--hidden-import=aiohttp._websocket",
-        # aiohttp dependencies
-        "--hidden-import=aiohappyeyeballs",
-        "--hidden-import=multidict",
-        "--hidden-import=yarl",
-        "--hidden-import=frozenlist",
-        "--hidden-import=propcache",
-        "--hidden-import=async_timeout",
-        "--hidden-import=aiosignal",
-        "--hidden-import=attrs",
-        # Async libraries
-        "--hidden-import=asyncio",
-        "--hidden-import=anyio",
-        "--hidden-import=anyio._backends",
-        "--hidden-import=anyio._backends._asyncio",
-        # Claude Code SDK
-        "--hidden-import=claude_code_sdk",
-        # MCP dependencies (required by claude_agent_sdk -> mcp)
-        "--hidden-import=starlette",
-        "--hidden-import=starlette.applications",
-        "--hidden-import=starlette.responses",
-        "--hidden-import=starlette.routing",
-        "--hidden-import=starlette.middleware",
-        "--hidden-import=starlette.requests",
-        "--hidden-import=starlette.websockets",
-        "--hidden-import=starlette.staticfiles",
-        "--hidden-import=starlette.templating",
-        "--hidden-import=starlette.background",
-        "--hidden-import=starlette.concurrency",
-        "--hidden-import=starlette.config",
-        "--hidden-import=starlette.convertors",
-        "--hidden-import=starlette.datastructures",
-        "--hidden-import=starlette.endpoints",
-        "--hidden-import=starlette.exceptions",
-        "--hidden-import=starlette.formparsers",
-        "--hidden-import=starlette.middleware.authentication",
-        "--hidden-import=starlette.middleware.base",
-        "--hidden-import=starlette.middleware.cors",
-        "--hidden-import=starlette.middleware.errors",
-        "--hidden-import=starlette.middleware.gzip",
-        "--hidden-import=starlette.middleware.httpsredirect",
-        "--hidden-import=starlette.middleware.sessions",
-        "--hidden-import=starlette.middleware.trustedhost",
-        "--hidden-import=starlette.middleware.wsgi",
-        "--hidden-import=starlette.schemas",
-        "--hidden-import=starlette.status",
-        "--hidden-import=starlette.testclient",
-        "--hidden-import=starlette.types",
-        "--hidden-import=sse_starlette",
-        "--hidden-import=sse_starlette.sse",
-        # SSL certificates (needed for HTTPS connections)
-        "--collect-data=certifi",
-        # Exclude packages not needed in local mode
-        "--exclude-module=uvicorn",
-        "--exclude-module=fastapi",
-        "--exclude-module=docker",
-        "--exclude-module=kubernetes",
-        "--exclude-module=torch",
-        "--exclude-module=tensorflow",
-        "--exclude-module=numpy",
-        "--exclude-module=pandas",
-        "--exclude-module=scipy",
-        "--exclude-module=matplotlib",
-        "--exclude-module=PIL",
-        "--exclude-module=cv2",
-        # Entry point
-        str(executor_root / "main.py"),
-    ]
+        # Determine output name based on platform
+        if platform.system() == "Windows":
+            output_name = "wegent-executor.exe"
+        else:
+            output_name = "wegent-executor"
 
-    # Add target architecture for cross-compilation on macOS
-    if target_arch and platform.system() == "Darwin":
-        cmd.insert(-1, f"--target-arch={target_arch}")
-        print(f"Cross-compiling for architecture: {target_arch}")
+        # PyInstaller command
+        cmd = [
+            sys.executable,
+            "-m",
+            "PyInstaller",
+            "--onefile",
+            "--name=wegent-executor",
+            f"--distpath={executor_root / 'dist'}",
+            f"--workpath={executor_root / 'build'}",
+            f"--specpath={executor_root}",
+            # Add project root to Python path
+            f"--paths={project_root}",
+            # Hidden imports for dependencies
+            "--hidden-import=executor",
+            "--hidden-import=executor.config",
+            "--hidden-import=executor.modes",
+            "--hidden-import=executor.modes.local",
+            "--hidden-import=executor.modes.local.runner",
+            "--hidden-import=executor.agents",
+            "--hidden-import=executor.agents.claude_code",
+            "--hidden-import=shared",
+            "--hidden-import=shared.logger",
+            "--hidden-import=shared.status",
+            # Socket.IO and related
+            "--hidden-import=socketio",
+            "--hidden-import=socketio.asyncio_client",
+            "--hidden-import=engineio",
+            "--hidden-import=engineio.async_client",
+            "--hidden-import=engineio.async_drivers.aiohttp",
+            # aiohttp and related (for Socket.IO transport)
+            "--hidden-import=aiohttp",
+            "--hidden-import=aiohttp.web",
+            "--hidden-import=aiohttp.client",
+            "--hidden-import=aiohttp.connector",
+            "--hidden-import=aiohttp.http",
+            "--hidden-import=aiohttp.http_parser",
+            "--hidden-import=aiohttp.http_writer",
+            "--hidden-import=aiohttp.streams",
+            "--hidden-import=aiohttp.payload",
+            "--hidden-import=aiohttp.resolver",
+            "--hidden-import=aiohttp.cookiejar",
+            "--hidden-import=aiohttp.tracing",
+            "--hidden-import=aiohttp.client_exceptions",
+            "--hidden-import=aiohttp.client_reqrep",
+            "--hidden-import=aiohttp.client_ws",
+            "--hidden-import=aiohttp.formdata",
+            "--hidden-import=aiohttp.helpers",
+            "--hidden-import=aiohttp.multipart",
+            "--hidden-import=aiohttp.web_app",
+            "--hidden-import=aiohttp.web_exceptions",
+            "--hidden-import=aiohttp.web_middlewares",
+            "--hidden-import=aiohttp.web_protocol",
+            "--hidden-import=aiohttp.web_request",
+            "--hidden-import=aiohttp.web_response",
+            "--hidden-import=aiohttp.web_routedef",
+            "--hidden-import=aiohttp.web_runner",
+            "--hidden-import=aiohttp.web_server",
+            "--hidden-import=aiohttp.web_urldispatcher",
+            "--hidden-import=aiohttp.web_ws",
+            "--hidden-import=aiohttp.abc",
+            "--hidden-import=aiohttp.base_protocol",
+            "--hidden-import=aiohttp.client_proto",
+            "--hidden-import=aiohttp.locks",
+            "--hidden-import=aiohttp.log",
+            "--hidden-import=aiohttp.typedefs",
+            "--hidden-import=aiohttp._helpers",
+            "--hidden-import=aiohttp._http_parser",
+            "--hidden-import=aiohttp._http_writer",
+            "--hidden-import=aiohttp._websocket",
+            # aiohttp dependencies
+            "--hidden-import=aiohappyeyeballs",
+            "--hidden-import=multidict",
+            "--hidden-import=yarl",
+            "--hidden-import=frozenlist",
+            "--hidden-import=propcache",
+            "--hidden-import=async_timeout",
+            "--hidden-import=aiosignal",
+            "--hidden-import=attrs",
+            # Async libraries
+            "--hidden-import=asyncio",
+            "--hidden-import=anyio",
+            "--hidden-import=anyio._backends",
+            "--hidden-import=anyio._backends._asyncio",
+            # Claude Code SDK
+            "--hidden-import=claude_code_sdk",
+            # MCP dependencies (required by claude_agent_sdk -> mcp)
+            "--hidden-import=starlette",
+            "--hidden-import=starlette.applications",
+            "--hidden-import=starlette.responses",
+            "--hidden-import=starlette.routing",
+            "--hidden-import=starlette.middleware",
+            "--hidden-import=starlette.requests",
+            "--hidden-import=starlette.websockets",
+            "--hidden-import=starlette.staticfiles",
+            "--hidden-import=starlette.templating",
+            "--hidden-import=starlette.background",
+            "--hidden-import=starlette.concurrency",
+            "--hidden-import=starlette.config",
+            "--hidden-import=starlette.convertors",
+            "--hidden-import=starlette.datastructures",
+            "--hidden-import=starlette.endpoints",
+            "--hidden-import=starlette.exceptions",
+            "--hidden-import=starlette.formparsers",
+            "--hidden-import=starlette.middleware.authentication",
+            "--hidden-import=starlette.middleware.base",
+            "--hidden-import=starlette.middleware.cors",
+            "--hidden-import=starlette.middleware.errors",
+            "--hidden-import=starlette.middleware.gzip",
+            "--hidden-import=starlette.middleware.httpsredirect",
+            "--hidden-import=starlette.middleware.sessions",
+            "--hidden-import=starlette.middleware.trustedhost",
+            "--hidden-import=starlette.middleware.wsgi",
+            "--hidden-import=starlette.schemas",
+            "--hidden-import=starlette.status",
+            "--hidden-import=starlette.testclient",
+            "--hidden-import=starlette.types",
+            "--hidden-import=sse_starlette",
+            "--hidden-import=sse_starlette.sse",
+            # SSL certificates (needed for HTTPS connections)
+            "--collect-data=certifi",
+            # Exclude packages not needed in local mode
+            "--exclude-module=uvicorn",
+            "--exclude-module=fastapi",
+            "--exclude-module=docker",
+            "--exclude-module=kubernetes",
+            "--exclude-module=torch",
+            "--exclude-module=tensorflow",
+            "--exclude-module=numpy",
+            "--exclude-module=pandas",
+            "--exclude-module=scipy",
+            "--exclude-module=matplotlib",
+            "--exclude-module=PIL",
+            "--exclude-module=cv2",
+            # Entry point
+            str(executor_root / "main.py"),
+        ]
 
-    print("Building executable...")
-    print(f"Command: {' '.join(cmd[:10])}...")  # Print first few args
+        # Add target architecture for cross-compilation on macOS
+        if target_arch and platform.system() == "Darwin":
+            cmd.insert(-1, f"--target-arch={target_arch}")
+            print(f"Cross-compiling for architecture: {target_arch}")
 
-    result = subprocess.run(cmd, capture_output=False)
+        print("Building executable...")
+        print(f"Command: {' '.join(cmd[:10])}...")  # Print first few args
 
-    if result.returncode != 0:
-        print(f"Build failed with return code {result.returncode}")
-        sys.exit(1)
+        result = subprocess.run(cmd, capture_output=False)
 
-    # Check output
-    output_path = executor_root / "dist" / output_name
-    if output_path.exists():
-        size_mb = output_path.stat().st_size / (1024 * 1024)
-        print(f"\nBuild successful!")
-        print(f"Output: {output_path}")
-        print(f"Size: {size_mb:.1f} MB")
-        if target_arch:
-            print(f"Target architecture: {target_arch}")
-    else:
-        print(f"Error: Output file not found at {output_path}")
-        sys.exit(1)
+        if result.returncode != 0:
+            print(f"Build failed with return code {result.returncode}")
+            sys.exit(1)
+
+        # Check output
+        output_path = executor_root / "dist" / output_name
+        if output_path.exists():
+            size_mb = output_path.stat().st_size / (1024 * 1024)
+            print(f"\nBuild successful!")
+            print(f"Output: {output_path}")
+            print(f"Size: {size_mb:.1f} MB")
+            print(f"Version: {version}")
+            if target_arch:
+                print(f"Target architecture: {target_arch}")
+        else:
+            print(f"Error: Output file not found at {output_path}")
+            sys.exit(1)
+    finally:
+        # Always restore version.py to its original content
+        if original_version_content:
+            restore_version_source(original_version_content)
 
 
 def main():

--- a/executor/version.py
+++ b/executor/version.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Version utilities - reads version from pyproject.toml."""
+"""Version utilities - reads version from pyproject.toml or embedded value."""
 
 import importlib.metadata
 from pathlib import Path
@@ -11,9 +11,18 @@ from typing import Optional
 # Cache the version to avoid repeated file reads
 _version_cache: Optional[str] = None
 
+# Embedded version for PyInstaller builds (set by build script)
+# This will be replaced during the build process
+_EMBEDDED_VERSION: Optional[str] = None
+
 
 def get_version() -> str:
-    """Get executor version from package metadata.
+    """Get executor version.
+
+    Priority:
+    1. Embedded version (for PyInstaller builds)
+    2. Package metadata (for installed packages)
+    3. pyproject.toml (for development)
 
     Returns:
         Version string (e.g., "1.0.0")
@@ -23,13 +32,21 @@ def get_version() -> str:
     if _version_cache is not None:
         return _version_cache
 
+    # Priority 1: Embedded version (for PyInstaller builds)
+    if _EMBEDDED_VERSION is not None:
+        _version_cache = _EMBEDDED_VERSION
+        return _version_cache
+
+    # Priority 2: Package metadata (for installed packages)
     try:
         _version_cache = importlib.metadata.version("wegent-executor")
         return _version_cache
     except importlib.metadata.PackageNotFoundError:
-        # Fallback for development mode
-        _version_cache = _read_from_pyproject()
-        return _version_cache
+        pass
+
+    # Priority 3: pyproject.toml (for development)
+    _version_cache = _read_from_pyproject()
+    return _version_cache
 
 
 def _read_from_pyproject() -> str:

--- a/executor/version.py
+++ b/executor/version.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Version utilities - reads version from pyproject.toml."""
+
+import importlib.metadata
+from pathlib import Path
+from typing import Optional
+
+# Cache the version to avoid repeated file reads
+_version_cache: Optional[str] = None
+
+
+def get_version() -> str:
+    """Get executor version from package metadata.
+
+    Returns:
+        Version string (e.g., "1.0.0")
+    """
+    global _version_cache
+
+    if _version_cache is not None:
+        return _version_cache
+
+    try:
+        _version_cache = importlib.metadata.version("wegent-executor")
+        return _version_cache
+    except importlib.metadata.PackageNotFoundError:
+        # Fallback for development mode
+        _version_cache = _read_from_pyproject()
+        return _version_cache
+
+
+def _read_from_pyproject() -> str:
+    """Read version directly from pyproject.toml (dev fallback).
+
+    Returns:
+        Version string from pyproject.toml, or "unknown" if not found
+    """
+    try:
+        import tomllib
+    except ImportError:
+        # Python < 3.11 fallback
+        try:
+            import tomli as tomllib  # type: ignore
+        except ImportError:
+            return "unknown"
+
+    # Try multiple possible locations for pyproject.toml
+    possible_paths = [
+        Path(__file__).parent / "pyproject.toml",
+        Path(__file__).parent.parent / "pyproject.toml",
+    ]
+
+    for pyproject_path in possible_paths:
+        if pyproject_path.exists():
+            try:
+                with open(pyproject_path, "rb") as f:
+                    data = tomllib.load(f)
+                return data.get("project", {}).get("version", "unknown")
+            except Exception:
+                continue
+
+    return "unknown"

--- a/frontend/src/apis/devices.ts
+++ b/frontend/src/apis/devices.ts
@@ -32,6 +32,10 @@ export interface DeviceInfo {
   slot_used: number
   slot_max: number
   running_tasks: DeviceRunningTask[]
+  // Version information
+  executor_version: string | null
+  latest_version: string | null
+  update_available: boolean
 }
 
 export interface DeviceListResponse {

--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -28,6 +28,7 @@ import { getToken } from '@/apis/user'
 import { DeviceInfo } from '@/apis/devices'
 import { SlotIndicator } from '@/features/devices/components/SlotIndicator'
 import { RunningTasksList } from '@/features/devices/components/RunningTasksList'
+import { VersionBadge } from '@/features/devices/components/VersionBadge'
 import {
   Monitor,
   RefreshCw,
@@ -498,7 +499,16 @@ export default function DevicesPage() {
                               </span>
                             )}
                           </div>
-                          <p className="text-sm text-text-muted">{device.device_id}</p>
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm text-text-muted">{device.device_id}</p>
+                            {device.status !== 'offline' && (
+                              <VersionBadge
+                                executorVersion={device.executor_version}
+                                latestVersion={device.latest_version}
+                                updateAvailable={device.update_available}
+                              />
+                            )}
+                          </div>
                           {/* Slot indicator - only show for online devices */}
                           {device.status !== 'offline' && (
                             <div className="mt-1">

--- a/frontend/src/contexts/DeviceContext.tsx
+++ b/frontend/src/contexts/DeviceContext.tsx
@@ -154,6 +154,9 @@ export function DeviceProvider({ children }: DeviceProviderProps) {
             slot_used: 0,
             slot_max: 5,
             running_tasks: [],
+            executor_version: null,
+            latest_version: null,
+            update_available: false,
           },
         ]
       })

--- a/frontend/src/features/devices/components/VersionBadge.tsx
+++ b/frontend/src/features/devices/components/VersionBadge.tsx
@@ -27,9 +27,6 @@ export function VersionBadge({
 
   if (!executorVersion) return null
 
-  // Environment variable for upgrade guide URL
-  const upgradeGuideUrl = process.env.NEXT_PUBLIC_UPGRADE_GUIDE_URL || ''
-
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       <span className="text-xs text-text-muted">v{executorVersion}</span>
@@ -53,16 +50,6 @@ export function VersionBadge({
                 <p className="text-text-muted">
                   {t('version.latest')}: {latestVersion}
                 </p>
-                {upgradeGuideUrl && (
-                  <a
-                    href={upgradeGuideUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-primary hover:underline mt-1"
-                  >
-                    {t('version.upgradeGuide')}
-                  </a>
-                )}
               </div>
             </TooltipContent>
           </Tooltip>

--- a/frontend/src/features/devices/components/VersionBadge.tsx
+++ b/frontend/src/features/devices/components/VersionBadge.tsx
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { ArrowUpCircle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Badge } from '@/components/ui/badge'
+import { useTranslation } from '@/hooks/useTranslation'
+
+interface VersionBadgeProps {
+  executorVersion: string | null
+  latestVersion: string | null
+  updateAvailable: boolean
+  className?: string
+}
+
+export function VersionBadge({
+  executorVersion,
+  latestVersion,
+  updateAvailable,
+  className,
+}: VersionBadgeProps) {
+  const { t } = useTranslation('devices')
+
+  if (!executorVersion) return null
+
+  // Environment variable for upgrade guide URL
+  const upgradeGuideUrl = process.env.NEXT_PUBLIC_UPGRADE_GUIDE_URL || ''
+
+  return (
+    <div className={cn('flex items-center gap-1.5', className)}>
+      <span className="text-xs text-text-muted">v{executorVersion}</span>
+      {updateAvailable && (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Badge
+                variant="outline"
+                className="cursor-pointer border-amber-400 text-amber-600 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-600 dark:text-amber-400 px-1.5 py-0"
+              >
+                <ArrowUpCircle className="h-3 w-3" />
+              </Badge>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" className="max-w-xs">
+              <div className="space-y-1.5 text-sm">
+                <p className="font-medium">{t('version.updateAvailable')}</p>
+                <p className="text-text-muted">
+                  {t('version.current')}: {executorVersion}
+                </p>
+                <p className="text-text-muted">
+                  {t('version.latest')}: {latestVersion}
+                </p>
+                {upgradeGuideUrl && (
+                  <a
+                    href={upgradeGuideUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-primary hover:underline mt-1"
+                  >
+                    {t('version.upgradeGuide')}
+                  </a>
+                )}
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/devices/components/VersionBadge.tsx
+++ b/frontend/src/features/devices/components/VersionBadge.tsx
@@ -35,7 +35,7 @@ export function VersionBadge({
           <Tooltip>
             <TooltipTrigger asChild>
               <Badge
-                variant="outline"
+                variant="info"
                 className="cursor-pointer border-amber-400 text-amber-600 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-600 dark:text-amber-400 px-1.5 py-0"
               >
                 <ArrowUpCircle className="h-3 w-3" />

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -77,7 +77,6 @@
   "version": {
     "current": "Current Version",
     "latest": "Latest Version",
-    "updateAvailable": "Update Available",
-    "upgradeGuide": "View Upgrade Guide"
+    "updateAvailable": "Update Available"
   }
 }

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -73,5 +73,11 @@
   "security_warning": "Security notice: Do not share the command above, it contains your authentication credentials",
   "gatekeeper_hint": "First run may require allowing it in System Settings > Privacy & Security",
   "token_expiry_hint": "The auth token expires in 7 days. Re-run the startup command to refresh it",
-  "copy_success": "Copied to clipboard"
+  "copy_success": "Copied to clipboard",
+  "version": {
+    "current": "Current Version",
+    "latest": "Latest Version",
+    "updateAvailable": "Update Available",
+    "upgradeGuide": "View Upgrade Guide"
+  }
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -73,5 +73,11 @@
   "security_warning": "安全提示：请勿分享上述命令，它包含您的认证信息",
   "gatekeeper_hint": "首次运行可能需要在「系统设置 > 隐私与安全性」中允许运行",
   "token_expiry_hint": "认证 Token 有效期为 7 天，过期后可重新执行上述启动命令刷新",
-  "copy_success": "已复制到剪贴板"
+  "copy_success": "已复制到剪贴板",
+  "version": {
+    "current": "当前版本",
+    "latest": "最新版本",
+    "updateAvailable": "有新版本可用",
+    "upgradeGuide": "查看升级指南"
+  }
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -77,7 +77,6 @@
   "version": {
     "current": "当前版本",
     "latest": "最新版本",
-    "updateAvailable": "有新版本可用",
-    "upgradeGuide": "查看升级指南"
+    "updateAvailable": "有新版本可用"
   }
 }


### PR DESCRIPTION
## Summary
- Add version tracking for Executor Local mode with version read from `executor/pyproject.toml`
- Display version badge in AI Devices page with update warning when newer version available
- Store executor version in Redis during register/heartbeat events
- Add version comparison logic in backend using semantic versioning

## Test plan
- [ ] Verify version is correctly read from pyproject.toml in executor
- [ ] Verify device registration includes executor_version in payload
- [ ] Verify device heartbeat includes executor_version in payload
- [ ] Verify Redis stores executor_version correctly
- [ ] Verify API returns executor_version, latest_version, update_available fields
- [ ] Verify VersionBadge displays current version on online devices
- [ ] Verify warning badge appears when update_available is true
- [ ] Verify tooltip shows version details and upgrade guide link
- [ ] Verify i18n translations work for both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device list now shows executor version, latest version, and update-available status.
  * Version badge displays current vs. latest and offers an optional upgrade-guide link.
  * Version info updates in real time as devices report status.
  * Added translations for version-related UI text (en, zh-CN).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->