### PR TITLE
feat(frontend): extract LocalExecutorGuide component for devices page

### DIFF
--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -37,12 +37,8 @@ import {
   Star,
   MoreVertical,
   Trash2,
-  Copy,
-  Check,
   ExternalLink,
-  Terminal,
   MessageCircleQuestion,
-  AlertTriangle,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -55,84 +51,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { cn } from '@/lib/utils'
 import { toast } from 'sonner'
 import { getSocketUrl } from '@/lib/runtime-config'
-
-// Install script URL
-const INSTALL_SCRIPT_URL =
-  'https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.sh'
-
-// Component for copy button with state
-function CopyButton({
-  text,
-  className,
-  onCopySuccess,
-}: {
-  text: string
-  className?: string
-  onCopySuccess?: () => void
-}) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(text)
-      setCopied(true)
-      onCopySuccess?.()
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      toast.error('Failed to copy')
-    }
-  }
-
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      onClick={handleCopy}
-      className={cn(
-        'shrink-0 text-gray-400 hover:text-white hover:bg-gray-800 h-8 px-3',
-        className
-      )}
-    >
-      {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
-    </Button>
-  )
-}
-
-// Component for displaying a command step
-function CommandStep({
-  stepNumber,
-  title,
-  description,
-  command,
-}: {
-  stepNumber: number
-  title: string
-  description: string
-  command: string
-}) {
-  const stepCircles = ['①', '②', '③', '④', '⑤']
-
-  return (
-    <div className="mb-6">
-      <div className="flex items-start gap-3 mb-3">
-        <span className="text-xl text-primary font-medium">{stepCircles[stepNumber - 1]}</span>
-        <div>
-          <h4 className="font-medium text-text-primary">{title}</h4>
-          <p className="text-sm text-text-muted">{description}</p>
-        </div>
-      </div>
-      <div className="bg-gray-900 rounded-lg px-5 py-4 ml-8">
-        <div className="flex items-start gap-3">
-          <span className="text-gray-500 select-none pt-0.5">$</span>
-          <div className="flex-1 overflow-x-auto">
-            <code className="text-sm font-mono whitespace-pre text-green-400">{command}</code>
-          </div>
-          <CopyButton text={command} />
-        </div>
-      </div>
-    </div>
-  )
-}
+import { LocalExecutorGuide } from '@/features/devices/components/LocalExecutorGuide'
 
 export default function DevicesPage() {
   const { t } = useTranslation('devices')
@@ -152,16 +71,6 @@ export default function DevicesPage() {
 
   // Get auth token
   const authToken = useMemo(() => getToken() || '<YOUR_AUTH_TOKEN>', [])
-
-  // Generate one-liner install command
-  const installCommand = useMemo(() => `curl -fsSL ${INSTALL_SCRIPT_URL} | bash`, [])
-
-  // Generate run command
-  const runCommand = useMemo(
-    () =>
-      `EXECUTOR_MODE=local \\\nWEGENT_BACKEND_URL=${backendUrl} \\\nWEGENT_AUTH_TOKEN=${authToken} \\\n~/.wegent-executor/bin/wegent-executor`,
-    [backendUrl, authToken]
-  )
 
   const {
     devices,
@@ -373,103 +282,46 @@ export default function DevicesPage() {
               </div>
             )}
 
-            {/* Empty state with simplified two-step installation guide */}
+            {/* Empty state with installation guide */}
             {!isLoading && devices.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-8">
-                {/* Main card */}
-                <div className="w-full max-w-2xl bg-surface border border-border rounded-xl p-6 shadow-sm">
-                  {/* Header */}
-                  <div className="flex items-center gap-3 mb-6">
-                    <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
-                      <Terminal className="w-5 h-5 text-primary" />
-                    </div>
-                    <div>
-                      <h3 className="text-lg font-semibold text-text-primary">
-                        {t('local_executor_title')}
-                      </h3>
-                      <p className="text-sm text-text-muted">{t('local_executor_description')}</p>
-                    </div>
-                  </div>
-
-                  {/* Step 1: Install */}
-                  <CommandStep
-                    stepNumber={1}
-                    title={t('step_install')}
-                    description={t('step_install_desc')}
-                    command={installCommand}
-                  />
-
-                  {/* Step 2: Run */}
-                  <CommandStep
-                    stepNumber={2}
-                    title={t('step_run')}
-                    description={t('step_run_desc')}
-                    command={runCommand}
-                  />
-
-                  {/* Security warning */}
-                  <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg mb-4">
-                    <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
-                    <p className="text-sm text-amber-700">{t('security_warning')}</p>
-                  </div>
-
-                  {/* Gatekeeper hint */}
-                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg mb-3">
-                    <span className="text-blue-600 shrink-0">💡</span>
-                    <p className="text-sm text-blue-700">{t('gatekeeper_hint')}</p>
-                  </div>
-
-                  {/* Token expiry hint */}
-                  <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
-                    <span className="text-blue-600 shrink-0">🔄</span>
-                    <p className="text-sm text-blue-700">{t('token_expiry_hint')}</p>
-                  </div>
-
-                  {/* Guide link */}
-                  {guideUrl && (
-                    <div className="mt-4 flex justify-center">
-                      <a
-                        href={guideUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                        {t('view_guide')}
-                      </a>
-                    </div>
-                  )}
-                </div>
+              <>
+                <LocalExecutorGuide
+                  backendUrl={backendUrl}
+                  authToken={authToken}
+                  guideUrl={guideUrl}
+                />
 
                 {/* Help section */}
                 {(communityUrl || faqUrl) && (
-                  <div className="mt-6 flex items-center gap-4 text-sm text-text-muted">
-                    <span>{t('need_help')}</span>
-                    {communityUrl && (
-                      <a
-                        href={communityUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
-                      >
-                        <MessageCircleQuestion className="w-4 h-4" />
-                        {t('join_community')}
-                      </a>
-                    )}
-                    {faqUrl && (
-                      <a
-                        href={faqUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                        {t('view_faq')}
-                      </a>
-                    )}
+                  <div className="flex justify-center">
+                    <div className="flex items-center gap-4 text-sm text-text-muted">
+                      <span>{t('need_help')}</span>
+                      {communityUrl && (
+                        <a
+                          href={communityUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
+                        >
+                          <MessageCircleQuestion className="w-4 h-4" />
+                          {t('join_community')}
+                        </a>
+                      )}
+                      {faqUrl && (
+                        <a
+                          href={faqUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                          {t('view_faq')}
+                        </a>
+                      )}
+                    </div>
                   </div>
                 )}
-              </div>
+              </>
             )}
 
             {/* Device list */}

--- a/frontend/src/features/devices/components/LocalExecutorGuide.tsx
+++ b/frontend/src/features/devices/components/LocalExecutorGuide.tsx
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import { Button } from '@/components/ui/button'
+import { Terminal, Copy, Check, ExternalLink, AlertTriangle } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { toast } from 'sonner'
+
+// Install script URL from GitHub
+const INSTALL_SCRIPT_URL =
+  'https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.sh'
+
+export interface LocalExecutorGuideProps {
+  backendUrl: string
+  authToken: string
+  guideUrl?: string
+}
+
+// Component for copy button with state
+function CopyButton({
+  text,
+  className,
+  onCopySuccess,
+}: {
+  text: string
+  className?: string
+  onCopySuccess?: () => void
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      onCopySuccess?.()
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      toast.error('Failed to copy')
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className={cn(
+        'shrink-0 text-gray-400 hover:text-white hover:bg-gray-800 h-8 px-3',
+        className
+      )}
+    >
+      {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+    </Button>
+  )
+}
+
+// Component for displaying a command step
+function CommandStep({
+  stepNumber,
+  title,
+  description,
+  command,
+}: {
+  stepNumber: number
+  title: string
+  description: string
+  command: string
+}) {
+  const stepCircles = ['①', '②', '③', '④', '⑤']
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-start gap-3 mb-3">
+        <span className="text-xl text-primary font-medium">{stepCircles[stepNumber - 1]}</span>
+        <div>
+          <h4 className="font-medium text-text-primary">{title}</h4>
+          <p className="text-sm text-text-muted">{description}</p>
+        </div>
+      </div>
+      <div className="bg-gray-900 rounded-lg px-5 py-4 ml-8">
+        <div className="flex items-start gap-3">
+          <span className="text-gray-500 select-none pt-0.5">$</span>
+          <div className="flex-1 overflow-x-auto">
+            <code className="text-sm font-mono whitespace-pre text-green-400">{command}</code>
+          </div>
+          <CopyButton text={command} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * External network version of Local Executor Guide
+ * Shows 2 steps: Install from GitHub -> Run with environment variables
+ */
+export function LocalExecutorGuide({ backendUrl, authToken, guideUrl }: LocalExecutorGuideProps) {
+  const { t } = useTranslation('devices')
+
+  // Step 1: Install from GitHub
+  const installCommand = useMemo(() => `curl -fsSL ${INSTALL_SCRIPT_URL} | bash`, [])
+
+  // Step 2: Run with environment variables
+  const runCommand = useMemo(
+    () =>
+      `EXECUTOR_MODE=local \\\nWEGENT_BACKEND_URL=${backendUrl} \\\nWEGENT_AUTH_TOKEN=${authToken} \\\n~/.wegent-executor/bin/wegent-executor`,
+    [backendUrl, authToken]
+  )
+
+  return (
+    <div className="flex flex-col items-center justify-center py-8">
+      {/* Main card */}
+      <div className="w-full max-w-2xl bg-surface border border-border rounded-xl p-6 shadow-sm">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6">
+          <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
+            <Terminal className="w-5 h-5 text-primary" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-text-primary">{t('local_executor_title')}</h3>
+            <p className="text-sm text-text-muted">{t('local_executor_description')}</p>
+          </div>
+        </div>
+
+        {/* Step 1: Install */}
+        <CommandStep
+          stepNumber={1}
+          title={t('step_install')}
+          description={t('step_install_desc')}
+          command={installCommand}
+        />
+
+        {/* Step 2: Run */}
+        <CommandStep
+          stepNumber={2}
+          title={t('step_run')}
+          description={t('step_run_desc')}
+          command={runCommand}
+        />
+
+        {/* Security warning */}
+        <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg mb-4">
+          <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+          <p className="text-sm text-amber-700">{t('security_warning')}</p>
+        </div>
+
+        {/* Gatekeeper hint */}
+        <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg mb-3">
+          <span className="text-blue-600 shrink-0">💡</span>
+          <p className="text-sm text-blue-700">{t('gatekeeper_hint')}</p>
+        </div>
+
+        {/* Token expiry hint */}
+        <div className="flex items-start gap-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+          <span className="text-blue-600 shrink-0">🔄</span>
+          <p className="text-sm text-blue-700">{t('token_expiry_hint')}</p>
+        </div>
+
+        {/* Guide link */}
+        {guideUrl && (
+          <div className="mt-4 flex justify-center">
+            <a
+              href={guideUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 text-sm text-primary hover:underline"
+            >
+              <ExternalLink className="w-4 h-4" />
+              {t('view_guide')}
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- Extract LocalExecutorGuide as reusable component
- Shows 2 steps: curl install from GitHub, run with env vars
- Clean up unused imports in devices page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned local executor setup guide with step-by-step installation instructions
  * Added security warnings and token expiry guidance
  * Enhanced copy-to-clipboard functionality for setup commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->