### PR TITLE
feat(backend): add API Key authentication support for WebSocket connections

### DIFF
--- a/backend/app/services/chat/access/__init__.py
+++ b/backend/app/services/chat/access/__init__.py
@@ -5,15 +5,25 @@
 """Access control module for Chat Service.
 
 This module provides utilities for checking task access permissions
-and JWT authentication.
+and token authentication (JWT and API Key).
 """
 
-from .auth import get_token_expiry, is_token_expired, verify_jwt_token
+from .auth import (
+    get_token_expiry,
+    is_api_key,
+    is_token_expired,
+    verify_api_key_for_websocket,
+    verify_jwt_token,
+    verify_websocket_token,
+)
 from .permissions import can_access_task, can_access_task_sync, get_active_streaming
 
 __all__ = [
     "verify_jwt_token",
+    "verify_api_key_for_websocket",
+    "verify_websocket_token",
     "is_token_expired",
+    "is_api_key",
     "get_token_expiry",
     "can_access_task",
     "can_access_task_sync",

--- a/backend/app/services/chat/access/auth.py
+++ b/backend/app/services/chat/access/auth.py
@@ -2,22 +2,29 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""JWT authentication utilities for Chat Service.
+"""Authentication utilities for Chat Service.
 
-This module provides JWT token verification for WebSocket connections.
+This module provides token verification for WebSocket connections,
+supporting both JWT tokens and API Keys.
 """
 
+import hashlib
 import logging
-from typing import Optional
+from datetime import datetime
+from typing import Optional, Tuple
 
 from jose import jwt
 from jose.exceptions import ExpiredSignatureError
 
 from app.core.config import settings
 from app.db.session import SessionLocal
+from app.models.api_key import APIKey
 from app.models.user import User
 
 logger = logging.getLogger(__name__)
+
+# API Key prefix constant
+API_KEY_PREFIX = "wg-"
 
 
 def verify_jwt_token(token: str) -> Optional[User]:
@@ -91,3 +98,133 @@ def get_token_expiry(token: str) -> Optional[int]:
         return payload.get("exp")
     except Exception:
         return None
+
+
+def is_api_key(token: str) -> bool:
+    """
+    Check if the token is an API Key.
+
+    API Keys have a "wg-" prefix.
+
+    Args:
+        token: Token string
+
+    Returns:
+        True if token is an API Key, False otherwise
+    """
+    return token.startswith(API_KEY_PREFIX) if token else False
+
+
+def verify_api_key_for_websocket(api_key: str) -> Tuple[Optional[User], Optional[int]]:
+    """
+    Verify API Key and return user with optional expiry timestamp.
+
+    This function validates the API Key for WebSocket authentication.
+    It checks the key hash, active status, and expiration.
+
+    Args:
+        api_key: API Key string starting with "wg-"
+
+    Returns:
+        Tuple of (User object if valid, expiry timestamp or None for never expires)
+        Returns (None, None) if validation fails
+    """
+    if not api_key or not api_key.startswith(API_KEY_PREFIX):
+        logger.warning("API Key verification failed: invalid prefix")
+        return None, None
+
+    db = SessionLocal()
+    try:
+        # Calculate SHA256 hash of the API key
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+
+        # Query API Key record
+        api_key_record = (
+            db.query(APIKey)
+            .filter(
+                APIKey.key_hash == key_hash,
+                APIKey.is_active == True,
+            )
+            .first()
+        )
+
+        if not api_key_record:
+            logger.warning("API Key verification failed: key not found or inactive")
+            return None, None
+
+        # Check expiration
+        if api_key_record.expires_at < datetime.utcnow():
+            logger.warning(
+                f"API Key verification failed: key expired at {api_key_record.expires_at}"
+            )
+            return None, None
+
+        # Update last_used_at
+        api_key_record.last_used_at = datetime.utcnow()
+        db.commit()
+
+        # Get associated user
+        user = db.query(User).filter(User.id == api_key_record.user_id).first()
+        if not user:
+            logger.warning(
+                f"API Key verification failed: user not found for user_id={api_key_record.user_id}"
+            )
+            return None, None
+
+        if not user.is_active:
+            logger.warning(
+                f"API Key verification failed: user is inactive user_id={user.id}"
+            )
+            return None, None
+
+        # Calculate expiry timestamp
+        # For API Keys with far-future expiry (9999-12-31), treat as never expires (None)
+        expiry_timestamp = None
+        if api_key_record.expires_at.year < 9999:
+            expiry_timestamp = int(api_key_record.expires_at.timestamp())
+
+        logger.info(
+            f"API Key verification successful: user_id={user.id}, "
+            f"key_name={api_key_record.name}, expires_at={api_key_record.expires_at}"
+        )
+        return user, expiry_timestamp
+
+    except Exception as e:
+        logger.exception(f"API Key verification error: {e}")
+        return None, None
+    finally:
+        db.close()
+
+
+def verify_websocket_token(token: str) -> Tuple[Optional[User], Optional[int], str]:
+    """
+    Unified WebSocket token verification entry point.
+
+    Automatically identifies token type and calls the appropriate verification method:
+    - "wg-" prefix → API Key verification
+    - Otherwise → JWT token verification
+
+    Args:
+        token: Token string (JWT or API Key)
+
+    Returns:
+        Tuple of (User object if valid, expiry timestamp, auth_type)
+        - auth_type is "api_key" or "jwt"
+        - expiry timestamp is None for never-expiring API Keys
+        Returns (None, None, "") if validation fails
+    """
+    if not token:
+        logger.warning("WebSocket token verification failed: empty token")
+        return None, None, ""
+
+    if is_api_key(token):
+        # API Key authentication
+        user, expiry = verify_api_key_for_websocket(token)
+        return user, expiry, "api_key" if user else ""
+    else:
+        # JWT token authentication
+        user = verify_jwt_token(token)
+        if user:
+            expiry = get_token_expiry(token)
+            return user, expiry, "jwt"
+        return None, None, ""


### PR DESCRIPTION
## Summary
- Add support for API Key authentication in WebSocket connections, enabling Executor local mode to use long-lived Personal API Keys instead of short-lived JWT tokens (7 days)
- WebSocket now supports both JWT Token (for frontend) and API Key (for Executor) authentication methods
- API Keys with default expiry (9999-12-31) are treated as never-expiring

## Changes
| File | Description |
|------|-------------|
| `backend/app/services/chat/access/auth.py` | Add `verify_api_key_for_websocket()` and `verify_websocket_token()` functions |
| `backend/app/services/chat/access/__init__.py` | Export new authentication functions |
| `backend/app/api/ws/chat_namespace.py` | Modify `on_connect()` to support dual authentication; Update `_check_token_expiry()` for API Key scenario |

## Authentication Flow
```
1. Token received in auth parameter
2. Check if token starts with "wg-" prefix
   - Yes → API Key authentication
   - No → JWT Token authentication
3. For API Key:
   - Calculate SHA256 hash
   - Query api_keys table (check is_active, expires_at)
   - Update last_used_at
   - Return user with auth_type="api_key"
4. For JWT Token:
   - Decode and verify JWT
   - Return user with auth_type="jwt"
```

## Usage for Executor Local Mode
Users can now configure Executor with a Personal API Key:
```bash
WEGENT_AUTH_TOKEN=wg-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
WEGENT_BACKEND_URL=wss://your-wegent-server.com
```

## Test plan
- [ ] Test WebSocket connection with valid API Key
- [ ] Test WebSocket connection with invalid API Key (rejected)
- [ ] Test WebSocket connection with disabled API Key (rejected)
- [ ] Test WebSocket connection with expired API Key (rejected)
- [ ] Test WebSocket connection with JWT Token (regression - should still work)
- [ ] Test token expiry check for API Key (should never expire for default expiry)
- [ ] Test token expiry check for JWT Token (should expire as before)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * API Key authentication is now supported for WebSocket chat connections, offering an alternative to JWT-based authentication
  * Never-expiring API Keys are now available for permanent access
  * Improved session management with enhanced token expiration handling that accounts for both authentication types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->