### PR TITLE
fix: reduce default max_tokens from 65536 to 32768

### DIFF
--- a/backend/app/services/simple_chat/providers/base.py
+++ b/backend/app/services/simple_chat/providers/base.py
@@ -49,7 +49,7 @@ class ProviderConfig:
     model_id: str
     default_headers: dict[str, Any] = field(default_factory=dict)
     timeout: float = 300.0
-    max_tokens: int = 65536
+    max_tokens: int = 32768
 
 
 class LLMProvider(ABC):

--- a/chat_shell/chat_shell/adapters/wegent.py
+++ b/chat_shell/chat_shell/adapters/wegent.py
@@ -145,7 +145,7 @@ class WeGentToResponseAdapter:
         return {
             "model_config": model_config,
             "temperature": agent_config.get("temperature", 0.7),
-            "max_tokens": agent_config.get("max_tokens", 65536),
+            "max_tokens": agent_config.get("max_tokens", 32768),
             "input": input_config,
             "session_id": wegent_request.session_id,
             "include_history": True,
@@ -288,7 +288,7 @@ class WeGentToResponseAdapter:
             model_config=request_dict["model_config"],
             system_prompt=request_dict.get("system"),
             temperature=request_dict.get("temperature", 0.7),
-            max_tokens=request_dict.get("max_tokens", 65536),
+            max_tokens=request_dict.get("max_tokens", 32768),
             tools_config=request_dict.get("tools"),
             tool_choice=request_dict.get("tool_choice", "auto"),
             enable_deep_thinking=request_dict.get("features", {}).get(

--- a/chat_shell/chat_shell/cli/utils/config_file.py
+++ b/chat_shell/chat_shell/cli/utils/config_file.py
@@ -35,7 +35,7 @@ DEFAULT_CONFIG = {
     },
     "defaults": {
         "temperature": 0.7,
-        "max_tokens": 65536,
+        "max_tokens": 32768,
     },
 }
 

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -118,7 +118,7 @@ class LangChainModelFactory:
                 ),
                 "anthropic_api_url": cfg.get("base_url") or None,
                 "temperature": kw.get("temperature", 1.0),
-                "max_tokens": kw.get("max_tokens", 65536),
+                "max_tokens": kw.get("max_tokens", 32768),
                 "streaming": kw.get("streaming", False),
                 # Enable prompt caching for Anthropic models (90% cost reduction on cached tokens)
                 # Merge user-provided headers with the prompt-caching beta header


### PR DESCRIPTION
Adjusts the default max_tokens configuration across backend and chat_shell modules to 32768 to better align with LLM provider limits and reduce potential API errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced default maximum token limit from 65536 to 32768 across AI provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->