### PR TITLE
feat(backend): add unified share system for Team, Task and KnowledgeBase

### DIFF
--- a/backend/alembic/versions/y5z6a7b8c9d0_add_unified_share_tables.py
+++ b/backend/alembic/versions/y5z6a7b8c9d0_add_unified_share_tables.py
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add unified share tables (share_links and resource_members)
+
+Revision ID: y5z6a7b8c9d0
+Revises: x4y5z6a7b8c9
+Create Date: 2025-02-02
+
+This migration adds two unified tables for resource sharing:
+1. share_links - Store share link configurations and tokens
+2. resource_members - Store user access permissions to shared resources
+
+These tables replace the following fragmented tables:
+- knowledge_base_permissions
+- shared_teams
+- shared_tasks
+- task_members
+
+Supported resource types: Team, Task, KnowledgeBase
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "y5z6a7b8c9d0"
+down_revision: Union[str, None] = "x4y5z6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def table_exists(table_name: str) -> bool:
+    """Check if a table exists in the database."""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.tables "
+            "WHERE table_name = :table_name AND table_schema = DATABASE()"
+        ),
+        {"table_name": table_name},
+    )
+    return result.scalar() > 0
+
+
+def upgrade() -> None:
+    """Create share_links and resource_members tables."""
+
+    # Create share_links table
+    if not table_exists("share_links"):
+        op.create_table(
+            "share_links",
+            sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+            # Resource identification (polymorphic association)
+            sa.Column(
+                "resource_type",
+                sa.String(50),
+                nullable=False,
+                comment="Resource type: Team, Task, KnowledgeBase",
+            ),
+            sa.Column(
+                "resource_id",
+                sa.Integer(),
+                nullable=False,
+                comment="Resource ID (kinds.id or tasks.id)",
+            ),
+            # Share link info
+            sa.Column(
+                "share_token",
+                sa.String(512),
+                nullable=False,
+                comment="AES encrypted share token",
+            ),
+            # Share configuration
+            sa.Column(
+                "require_approval",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+                comment="Whether joining requires approval",
+            ),
+            sa.Column(
+                "default_permission_level",
+                sa.String(20),
+                nullable=False,
+                server_default="view",
+                comment="Default permission level: view, edit, manage",
+            ),
+            # Expiration
+            sa.Column(
+                "expires_at",
+                sa.DateTime(),
+                nullable=True,
+                comment="Expiration time (NULL = never expires)",
+            ),
+            # Creator info
+            sa.Column(
+                "created_by_user_id",
+                sa.Integer(),
+                nullable=False,
+                comment="User who created the share link",
+            ),
+            # Status
+            sa.Column(
+                "is_active",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("1"),
+                comment="Whether the link is active",
+            ),
+            # Timestamps
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+                onupdate=sa.func.now(),
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            mysql_engine="InnoDB",
+            mysql_charset="utf8mb4",
+            mysql_collate="utf8mb4_unicode_ci",
+            comment="Share link configurations for resources",
+        )
+
+        # Create indexes for share_links
+        op.create_index(
+            "ix_share_links_id", "share_links", ["id"], unique=False
+        )
+        op.create_index(
+            "ix_share_links_resource",
+            "share_links",
+            ["resource_type", "resource_id"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_share_links_token", "share_links", ["share_token"], unique=True
+        )
+        op.create_index(
+            "ix_share_links_creator",
+            "share_links",
+            ["created_by_user_id"],
+            unique=False,
+        )
+        op.create_index(
+            "uq_share_links_active_resource",
+            "share_links",
+            ["resource_type", "resource_id", "is_active"],
+            unique=False,
+        )
+
+    # Create resource_members table
+    if not table_exists("resource_members"):
+        op.create_table(
+            "resource_members",
+            sa.Column("id", sa.Integer(), nullable=False, autoincrement=True),
+            # Resource identification (polymorphic association)
+            sa.Column(
+                "resource_type",
+                sa.String(50),
+                nullable=False,
+                comment="Resource type: Team, Task, KnowledgeBase",
+            ),
+            sa.Column(
+                "resource_id",
+                sa.Integer(),
+                nullable=False,
+                comment="Resource ID",
+            ),
+            # Member info
+            sa.Column(
+                "user_id",
+                sa.Integer(),
+                nullable=False,
+                comment="Member user ID",
+            ),
+            # Permission level
+            sa.Column(
+                "permission_level",
+                sa.String(20),
+                nullable=False,
+                server_default="view",
+                comment="Permission level: view, edit, manage",
+            ),
+            # Status
+            sa.Column(
+                "status",
+                sa.String(20),
+                nullable=False,
+                server_default="pending",
+                comment="Status: pending, approved, rejected",
+            ),
+            # Source info
+            sa.Column(
+                "invited_by_user_id",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+                comment="Inviter user ID (0 = via link)",
+            ),
+            sa.Column(
+                "share_link_id",
+                sa.Integer(),
+                nullable=True,
+                comment="Associated share link ID (when joined via link)",
+            ),
+            # Review info
+            sa.Column(
+                "reviewed_by_user_id",
+                sa.Integer(),
+                nullable=True,
+                comment="Reviewer user ID",
+            ),
+            sa.Column(
+                "reviewed_at",
+                sa.DateTime(),
+                nullable=True,
+                comment="Review timestamp",
+            ),
+            # Task-specific field (only for Task type)
+            sa.Column(
+                "copied_resource_id",
+                sa.Integer(),
+                nullable=True,
+                comment="Copied resource ID (for Task copy behavior)",
+            ),
+            # Timestamps
+            sa.Column(
+                "requested_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+                comment="Request timestamp",
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(),
+                nullable=False,
+                server_default=sa.func.now(),
+                onupdate=sa.func.now(),
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "resource_type",
+                "resource_id",
+                "user_id",
+                name="uq_resource_members",
+            ),
+            mysql_engine="InnoDB",
+            mysql_charset="utf8mb4",
+            mysql_collate="utf8mb4_unicode_ci",
+            comment="Resource member permissions and access control",
+        )
+
+        # Create indexes for resource_members
+        op.create_index(
+            "ix_resource_members_id", "resource_members", ["id"], unique=False
+        )
+        op.create_index(
+            "ix_resource_members_resource",
+            "resource_members",
+            ["resource_type", "resource_id"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_resource_members_user",
+            "resource_members",
+            ["user_id"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_resource_members_status",
+            "resource_members",
+            ["status"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_resource_members_resource_status",
+            "resource_members",
+            ["resource_type", "resource_id", "status"],
+            unique=False,
+        )
+        op.create_index(
+            "ix_resource_members_share_link",
+            "resource_members",
+            ["share_link_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Drop share_links and resource_members tables."""
+
+    # Drop resource_members indexes and table
+    if table_exists("resource_members"):
+        op.drop_index("ix_resource_members_share_link", table_name="resource_members")
+        op.drop_index(
+            "ix_resource_members_resource_status", table_name="resource_members"
+        )
+        op.drop_index("ix_resource_members_status", table_name="resource_members")
+        op.drop_index("ix_resource_members_user", table_name="resource_members")
+        op.drop_index("ix_resource_members_resource", table_name="resource_members")
+        op.drop_index("ix_resource_members_id", table_name="resource_members")
+        op.drop_table("resource_members")
+
+    # Drop share_links indexes and table
+    if table_exists("share_links"):
+        op.drop_index("uq_share_links_active_resource", table_name="share_links")
+        op.drop_index("ix_share_links_creator", table_name="share_links")
+        op.drop_index("ix_share_links_token", table_name="share_links")
+        op.drop_index("ix_share_links_resource", table_name="share_links")
+        op.drop_index("ix_share_links_id", table_name="share_links")
+        op.drop_table("share_links")

--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -18,6 +18,7 @@ from app.api.endpoints import (
     quota,
     rag,
     repository,
+    share,
     subtasks,
     tables,
     users,
@@ -135,6 +136,8 @@ api_router.include_router(
     prefix="/knowledge-bases",
     tags=["knowledge-permission"],
 )
+# Unified share endpoints (Team, Task, KnowledgeBase)
+api_router.include_router(share.router, prefix="/share", tags=["share"])
 api_router.include_router(tables.router, prefix="/tables", tags=["tables"])
 api_router.include_router(rag.router, prefix="/rag", tags=["rag"])
 api_router.include_router(utils.router, prefix="/utils", tags=["utils"])

--- a/backend/app/api/endpoints/share.py
+++ b/backend/app/api/endpoints/share.py
@@ -1,0 +1,432 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unified share API endpoints.
+
+Provides REST API for managing share links and resource members.
+Supports Team, Task, and KnowledgeBase resource types.
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.models.user import User
+from app.schemas.share import (
+    JoinByLinkRequest,
+    JoinByLinkResponse,
+    MemberListResponse,
+    PendingRequestListResponse,
+    PermissionLevel,
+    ResourceMemberCreate,
+    ResourceMemberResponse,
+    ResourceMemberUpdate,
+    ResourceType,
+    ReviewRequestBody,
+    ReviewRequestResponse,
+    ShareInfoResponse,
+    ShareLinkConfig,
+    ShareLinkCreate,
+    ShareLinkResponse,
+    ShareLinkUpdate,
+)
+from app.services.share import (
+    knowledge_share_service,
+    task_share_service,
+    team_share_service,
+)
+from app.services.share.base_service import UnifiedShareService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _get_share_service(resource_type: str) -> UnifiedShareService:
+    """Get the appropriate share service for a resource type."""
+    resource_type_upper = resource_type.upper()
+    if resource_type_upper == "TEAM" or resource_type == "Team":
+        return team_share_service
+    elif resource_type_upper == "TASK" or resource_type == "Task":
+        return task_share_service
+    elif (
+        resource_type_upper == "KNOWLEDGEBASE"
+        or resource_type_upper == "KNOWLEDGE_BASE"
+        or resource_type == "KnowledgeBase"
+    ):
+        return knowledge_share_service
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid resource type: {resource_type}. "
+            "Supported types: Team, Task, KnowledgeBase",
+        )
+
+
+# =============================================================================
+# Share Link Endpoints
+# =============================================================================
+
+
+@router.post(
+    "/{resource_type}/{resource_id}/link",
+    response_model=ShareLinkResponse,
+    summary="Create or update share link",
+)
+def create_share_link(
+    resource_type: str,
+    resource_id: int,
+    body: ShareLinkCreate = ShareLinkCreate(),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Create or update a share link for a resource.
+
+    Only the resource owner can create share links.
+    If a share link already exists, it will be updated with the new configuration.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    - **body**: Share link configuration (require_approval, default_permission_level, expires_in_hours)
+    """
+    service = _get_share_service(resource_type)
+    return service.create_share_link(
+        db=db,
+        resource_id=resource_id,
+        user_id=current_user.id,
+        config=body.config,
+    )
+
+
+@router.get(
+    "/{resource_type}/{resource_id}/link",
+    response_model=Optional[ShareLinkResponse],
+    summary="Get share link",
+)
+def get_share_link(
+    resource_type: str,
+    resource_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get the active share link for a resource.
+
+    Returns None if no active share link exists.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    """
+    service = _get_share_service(resource_type)
+    return service.get_share_link(
+        db=db,
+        resource_id=resource_id,
+        user_id=current_user.id,
+    )
+
+
+@router.delete(
+    "/{resource_type}/{resource_id}/link",
+    summary="Delete share link",
+)
+def delete_share_link(
+    resource_type: str,
+    resource_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Deactivate the share link for a resource.
+
+    Only the resource owner can delete share links.
+    Existing members will retain their access.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    """
+    service = _get_share_service(resource_type)
+    service.delete_share_link(
+        db=db,
+        resource_id=resource_id,
+        user_id=current_user.id,
+    )
+    return {"message": "Share link deleted successfully"}
+
+
+# =============================================================================
+# Public Share Info (no auth required)
+# =============================================================================
+
+
+@router.get(
+    "/info",
+    response_model=ShareInfoResponse,
+    summary="Get share info (public)",
+)
+def get_share_info(
+    share_token: str,
+    db: Session = Depends(get_db),
+):
+    """
+    Get public information about a share link.
+
+    No authentication required - used for share link preview.
+
+    - **share_token**: Share token from URL
+    """
+    # Try each service to decode the token
+    for service in [team_share_service, task_share_service, knowledge_share_service]:
+        try:
+            return service.get_share_info(db=db, share_token=share_token)
+        except HTTPException as e:
+            if e.status_code == 400 and "Invalid resource type" in str(e.detail):
+                continue
+            elif e.status_code == 400 and "Invalid share token" in str(e.detail):
+                continue
+            raise
+
+    raise HTTPException(status_code=400, detail="Invalid share token")
+
+
+# =============================================================================
+# Join Endpoints
+# =============================================================================
+
+
+@router.post(
+    "/join",
+    response_model=JoinByLinkResponse,
+    summary="Join via share link",
+)
+def join_by_link(
+    body: JoinByLinkRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Request to join a shared resource via share link.
+
+    If the share link requires approval, a pending request will be created.
+    Otherwise, access is granted immediately.
+
+    - **share_token**: Share token from URL
+    - **requested_permission_level**: Optional requested permission level
+    """
+    # Try each service to find the matching one
+    for service in [team_share_service, task_share_service, knowledge_share_service]:
+        try:
+            return service.join_by_link(
+                db=db,
+                share_token=body.share_token,
+                user_id=current_user.id,
+                requested_permission_level=body.requested_permission_level,
+            )
+        except HTTPException as e:
+            if e.status_code == 400 and "Invalid resource type" in str(e.detail):
+                continue
+            elif e.status_code == 400 and "Invalid share token" in str(e.detail):
+                continue
+            raise
+
+    raise HTTPException(status_code=400, detail="Invalid share token")
+
+
+# =============================================================================
+# Member Management Endpoints
+# =============================================================================
+
+
+@router.get(
+    "/{resource_type}/{resource_id}/members",
+    response_model=MemberListResponse,
+    summary="Get members",
+)
+def get_members(
+    resource_type: str,
+    resource_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get all approved members of a resource.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    """
+    service = _get_share_service(resource_type)
+    return service.get_members(
+        db=db,
+        resource_id=resource_id,
+        user_id=current_user.id,
+    )
+
+
+@router.post(
+    "/{resource_type}/{resource_id}/members",
+    response_model=ResourceMemberResponse,
+    summary="Add member",
+)
+def add_member(
+    resource_type: str,
+    resource_id: int,
+    body: ResourceMemberCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Directly add a member to a resource.
+
+    Requires owner or manage permission.
+    The member is added with approved status immediately.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    - **body**: Member info (user_id, permission_level)
+    """
+    service = _get_share_service(resource_type)
+    return service.add_member(
+        db=db,
+        resource_id=resource_id,
+        current_user_id=current_user.id,
+        target_user_id=body.user_id,
+        permission_level=body.permission_level,
+    )
+
+
+@router.put(
+    "/{resource_type}/{resource_id}/members/{member_id}",
+    response_model=ResourceMemberResponse,
+    summary="Update member",
+)
+def update_member(
+    resource_type: str,
+    resource_id: int,
+    member_id: int,
+    body: ResourceMemberUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Update a member's permission level.
+
+    Requires owner or manage permission.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    - **member_id**: Member record ID
+    - **body**: Update info (permission_level)
+    """
+    if not body.permission_level:
+        raise HTTPException(status_code=400, detail="permission_level is required")
+
+    service = _get_share_service(resource_type)
+    return service.update_member(
+        db=db,
+        resource_id=resource_id,
+        member_id=member_id,
+        current_user_id=current_user.id,
+        permission_level=body.permission_level,
+    )
+
+
+@router.delete(
+    "/{resource_type}/{resource_id}/members/{member_id}",
+    summary="Remove member",
+)
+def remove_member(
+    resource_type: str,
+    resource_id: int,
+    member_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Remove a member from a resource.
+
+    Requires owner or manage permission.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    - **member_id**: Member record ID
+    """
+    service = _get_share_service(resource_type)
+    service.remove_member(
+        db=db,
+        resource_id=resource_id,
+        member_id=member_id,
+        current_user_id=current_user.id,
+    )
+    return {"message": "Member removed successfully"}
+
+
+# =============================================================================
+# Approval Endpoints
+# =============================================================================
+
+
+@router.get(
+    "/{resource_type}/{resource_id}/requests",
+    response_model=PendingRequestListResponse,
+    summary="Get pending requests",
+)
+def get_pending_requests(
+    resource_type: str,
+    resource_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Get pending approval requests for a resource.
+
+    Requires owner or manage permission.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    """
+    service = _get_share_service(resource_type)
+    return service.get_pending_requests(
+        db=db,
+        resource_id=resource_id,
+        user_id=current_user.id,
+    )
+
+
+@router.post(
+    "/{resource_type}/{resource_id}/requests/{request_id}/review",
+    response_model=ReviewRequestResponse,
+    summary="Review request",
+)
+def review_request(
+    resource_type: str,
+    resource_id: int,
+    request_id: int,
+    body: ReviewRequestBody,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """
+    Approve or reject a pending request.
+
+    Requires owner or manage permission.
+
+    - **resource_type**: Resource type (Team, Task, KnowledgeBase)
+    - **resource_id**: Resource ID
+    - **request_id**: Pending request (member) ID
+    - **body**: Review decision (approved, optional permission_level)
+    """
+    service = _get_share_service(resource_type)
+    return service.review_request(
+        db=db,
+        resource_id=resource_id,
+        request_id=request_id,
+        reviewer_id=current_user.id,
+        approved=body.approved,
+        permission_level=body.permission_level,
+    )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ Models package
 Note: Import order matters for SQLAlchemy relationship resolution.
 Models with relationships should be imported after their related models.
 """
+
 from app.models.api_key import APIKey
 from app.models.kind import Kind
 from app.models.knowledge import KnowledgeDocument
@@ -15,6 +16,8 @@ from app.models.knowledge_permission import KnowledgeBasePermission
 from app.models.namespace import Namespace
 from app.models.namespace_member import NamespaceMember
 from app.models.project import Project
+from app.models.resource_member import MemberStatus, ResourceMember
+from app.models.share_link import PermissionLevel, ResourceType, ShareLink
 from app.models.shared_task import SharedTask
 from app.models.shared_team import SharedTeam
 from app.models.skill_binary import SkillBinary
@@ -52,4 +55,10 @@ __all__ = [
     "Project",
     "SubscriptionFollow",
     "SubscriptionShareNamespace",
+    # Unified share system
+    "ShareLink",
+    "ResourceMember",
+    "ResourceType",
+    "PermissionLevel",
+    "MemberStatus",
 ]

--- a/backend/app/models/resource_member.py
+++ b/backend/app/models/resource_member.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Resource member model for unified resource sharing.
+
+Stores user access permissions to shared resources.
+Supports Team, Task, and KnowledgeBase resource types.
+"""
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class MemberStatus(str, PyEnum):
+    """Status of a resource member."""
+
+    PENDING = "pending"  # Awaiting approval
+    APPROVED = "approved"  # Access granted
+    REJECTED = "rejected"  # Access denied
+
+
+class ResourceMember(Base):
+    """
+    Resource member model for access control.
+
+    Stores user permissions for shared resources including:
+    - Target resource (type + id)
+    - Member user ID
+    - Permission level (view/edit/manage)
+    - Approval status (pending/approved/rejected)
+    - Invitation/review information
+    - Task-specific copied resource ID
+
+    Note: resource_id references kinds.id (for Team/KnowledgeBase) or tasks.id (for Task)
+    but without FK constraint. Referential integrity is managed at the application layer.
+    """
+
+    __tablename__ = "resource_members"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+
+    # Resource identification (polymorphic association)
+    resource_type = Column(
+        String(50),
+        nullable=False,
+        comment="Resource type: Team, Task, KnowledgeBase",
+    )
+    resource_id = Column(
+        Integer,
+        nullable=False,
+        comment="Resource ID",
+    )
+
+    # Member info
+    user_id = Column(
+        Integer,
+        nullable=False,
+        index=True,
+        comment="Member user ID",
+    )
+
+    # Permission level
+    permission_level = Column(
+        String(20),
+        nullable=False,
+        default="view",
+        comment="Permission level: view, edit, manage",
+    )
+
+    # Status
+    status = Column(
+        String(20),
+        nullable=False,
+        default=MemberStatus.PENDING.value,
+        comment="Status: pending, approved, rejected",
+    )
+
+    # Source info
+    invited_by_user_id = Column(
+        Integer,
+        nullable=False,
+        default=0,
+        comment="Inviter user ID (0 = via link)",
+    )
+    share_link_id = Column(
+        Integer,
+        nullable=True,
+        index=True,
+        comment="Associated share link ID (when joined via link)",
+    )
+
+    # Review info
+    reviewed_by_user_id = Column(
+        Integer,
+        nullable=True,
+        comment="Reviewer user ID",
+    )
+    reviewed_at = Column(
+        DateTime,
+        nullable=True,
+        comment="Review timestamp",
+    )
+
+    # Task-specific field (only for Task type)
+    copied_resource_id = Column(
+        Integer,
+        nullable=True,
+        comment="Copied resource ID (for Task copy behavior)",
+    )
+
+    # Timestamps
+    requested_at = Column(
+        DateTime,
+        nullable=False,
+        default=func.now(),
+        comment="Request timestamp",
+    )
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "resource_type", "resource_id", "user_id", name="uq_resource_members"
+        ),
+        Index("ix_resource_members_resource", "resource_type", "resource_id"),
+        Index("ix_resource_members_status", "status"),
+        Index(
+            "ix_resource_members_resource_status",
+            "resource_type",
+            "resource_id",
+            "status",
+        ),
+        {
+            "sqlite_autoincrement": True,
+            "mysql_engine": "InnoDB",
+            "mysql_charset": "utf8mb4",
+            "mysql_collate": "utf8mb4_unicode_ci",
+            "comment": "Resource member permissions and access control",
+        },
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ResourceMember(id={self.id}, resource_type={self.resource_type}, "
+            f"resource_id={self.resource_id}, user_id={self.user_id}, "
+            f"status={self.status})>"
+        )
+
+    @property
+    def is_approved(self) -> bool:
+        """Check if the member has approved access."""
+        return self.status == MemberStatus.APPROVED.value
+
+    @property
+    def is_pending(self) -> bool:
+        """Check if the member is awaiting approval."""
+        return self.status == MemberStatus.PENDING.value

--- a/backend/app/models/share_link.py
+++ b/backend/app/models/share_link.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Share link model for unified resource sharing.
+
+Stores share link configurations and tokens for shared resources.
+Supports Team, Task, and KnowledgeBase resource types.
+"""
+
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class ResourceType(str, PyEnum):
+    """Supported resource types for sharing."""
+
+    TEAM = "Team"
+    TASK = "Task"
+    KNOWLEDGE_BASE = "KnowledgeBase"
+
+
+class PermissionLevel(str, PyEnum):
+    """Permission levels for resource access."""
+
+    VIEW = "view"  # Can view resource content
+    EDIT = "edit"  # Can modify resource content
+    MANAGE = "manage"  # Can manage other users' permissions
+
+
+class ShareLink(Base):
+    """
+    Share link model for resource sharing.
+
+    Stores share link configurations including:
+    - Target resource (type + id)
+    - Encrypted share token
+    - Approval requirements
+    - Default permission level
+    - Expiration settings
+
+    Note: resource_id references kinds.id (for Team/KnowledgeBase) or tasks.id (for Task)
+    but without FK constraint. Referential integrity is managed at the application layer.
+    """
+
+    __tablename__ = "share_links"
+
+    id = Column(Integer, primary_key=True, index=True, autoincrement=True)
+
+    # Resource identification (polymorphic association)
+    resource_type = Column(
+        String(50),
+        nullable=False,
+        comment="Resource type: Team, Task, KnowledgeBase",
+    )
+    resource_id = Column(
+        Integer,
+        nullable=False,
+        comment="Resource ID (kinds.id or tasks.id)",
+    )
+
+    # Share link info
+    share_token = Column(
+        String(512),
+        nullable=False,
+        unique=True,
+        comment="AES encrypted share token",
+    )
+
+    # Share configuration
+    require_approval = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        comment="Whether joining requires approval",
+    )
+    default_permission_level = Column(
+        String(20),
+        nullable=False,
+        default=PermissionLevel.VIEW.value,
+        comment="Default permission level: view, edit, manage",
+    )
+
+    # Expiration
+    expires_at = Column(
+        DateTime,
+        nullable=True,
+        comment="Expiration time (NULL = never expires)",
+    )
+
+    # Creator info
+    created_by_user_id = Column(
+        Integer,
+        nullable=False,
+        comment="User who created the share link",
+    )
+
+    # Status
+    is_active = Column(
+        Boolean,
+        nullable=False,
+        default=True,
+        comment="Whether the link is active",
+    )
+
+    # Timestamps
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    updated_at = Column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_share_links_resource", "resource_type", "resource_id"),
+        Index(
+            "uq_share_links_active_resource",
+            "resource_type",
+            "resource_id",
+            "is_active",
+        ),
+        {
+            "sqlite_autoincrement": True,
+            "mysql_engine": "InnoDB",
+            "mysql_charset": "utf8mb4",
+            "mysql_collate": "utf8mb4_unicode_ci",
+            "comment": "Share link configurations for resources",
+        },
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ShareLink(id={self.id}, resource_type={self.resource_type}, "
+            f"resource_id={self.resource_id}, is_active={self.is_active})>"
+        )
+
+    @property
+    def is_expired(self) -> bool:
+        """Check if the share link has expired."""
+        if self.expires_at is None:
+            return False
+        return datetime.utcnow() > self.expires_at

--- a/backend/app/schemas/knowledge_permission.py
+++ b/backend/app/schemas/knowledge_permission.py
@@ -46,7 +46,9 @@ class PermissionApplyResponse(BaseModel):
 
     id: int = Field(..., description="Permission record ID")
     knowledge_base_id: int = Field(..., description="Knowledge base ID")
-    permission_level: PermissionLevel = Field(..., description="Requested permission level")
+    permission_level: PermissionLevel = Field(
+        ..., description="Requested permission level"
+    )
     status: PermissionStatus = Field(..., description="Request status")
     requested_at: datetime = Field(..., description="Request timestamp")
     message: str = Field(..., description="Response message")
@@ -77,7 +79,9 @@ class PermissionReviewResponse(BaseModel):
 
     id: int = Field(..., description="Permission record ID")
     user_id: int = Field(..., description="User ID")
-    permission_level: PermissionLevel = Field(..., description="Granted/requested permission level")
+    permission_level: PermissionLevel = Field(
+        ..., description="Granted/requested permission level"
+    )
     status: PermissionStatus = Field(..., description="New status after review")
     reviewed_at: datetime = Field(..., description="Review timestamp")
     message: str = Field(..., description="Response message")
@@ -89,7 +93,7 @@ class PermissionReviewResponse(BaseModel):
 class PermissionAddRequest(BaseModel):
     """Schema for directly adding user permission (without request)."""
 
-    user_id: int = Field(..., description="User ID to add permission for")
+    user_name: str = Field(..., description="Username to add permission for")
     permission_level: PermissionLevel = Field(
         default=PermissionLevel.VIEW,
         description="Permission level to grant",
@@ -125,16 +129,24 @@ class PendingPermissionInfo(BaseModel):
     user_id: int = Field(..., description="User ID")
     username: str = Field(..., description="Username")
     email: Optional[str] = Field(None, description="User email")
-    permission_level: PermissionLevel = Field(..., description="Requested permission level")
+    permission_level: PermissionLevel = Field(
+        ..., description="Requested permission level"
+    )
     requested_at: datetime = Field(..., description="Request timestamp")
 
 
 class ApprovedPermissionsByLevel(BaseModel):
     """Schema for approved permissions grouped by level."""
 
-    view: List[PermissionUserInfo] = Field(default_factory=list, description="Users with view permission")
-    edit: List[PermissionUserInfo] = Field(default_factory=list, description="Users with edit permission")
-    manage: List[PermissionUserInfo] = Field(default_factory=list, description="Users with manage permission")
+    view: List[PermissionUserInfo] = Field(
+        default_factory=list, description="Users with view permission"
+    )
+    edit: List[PermissionUserInfo] = Field(
+        default_factory=list, description="Users with edit permission"
+    )
+    manage: List[PermissionUserInfo] = Field(
+        default_factory=list, description="Users with manage permission"
+    )
 
 
 class PermissionListResponse(BaseModel):
@@ -157,7 +169,9 @@ class PendingRequestInfo(BaseModel):
     """Schema for current user's pending request info."""
 
     id: int = Field(..., description="Permission record ID")
-    permission_level: PermissionLevel = Field(..., description="Requested permission level")
+    permission_level: PermissionLevel = Field(
+        ..., description="Requested permission level"
+    )
     requested_at: datetime = Field(..., description="Request timestamp")
 
 

--- a/backend/app/schemas/share.py
+++ b/backend/app/schemas/share.py
@@ -1,0 +1,302 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pydantic schemas for unified resource sharing.
+
+Provides request/response schemas for share links and resource members.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ResourceType(str, Enum):
+    """Supported resource types for sharing."""
+
+    TEAM = "Team"
+    TASK = "Task"
+    KNOWLEDGE_BASE = "KnowledgeBase"
+
+
+class PermissionLevel(str, Enum):
+    """Permission levels for resource access."""
+
+    VIEW = "view"
+    EDIT = "edit"
+    MANAGE = "manage"
+
+
+class MemberStatus(str, Enum):
+    """Status of a resource member."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+# =============================================================================
+# Share Link Schemas
+# =============================================================================
+
+
+class ShareLinkConfig(BaseModel):
+    """Configuration for creating a share link."""
+
+    require_approval: bool = Field(
+        default=True, description="Whether joining requires approval"
+    )
+    default_permission_level: PermissionLevel = Field(
+        default=PermissionLevel.VIEW, description="Default permission level for joiners"
+    )
+    expires_in_hours: Optional[int] = Field(
+        default=None,
+        description="Hours until link expires (None = never expires)",
+        ge=1,
+    )
+
+
+class ShareLinkCreate(BaseModel):
+    """Request body for creating a share link."""
+
+    config: ShareLinkConfig = Field(
+        default_factory=ShareLinkConfig, description="Share link configuration"
+    )
+
+
+class ShareLinkUpdate(BaseModel):
+    """Request body for updating a share link."""
+
+    require_approval: Optional[bool] = Field(
+        default=None, description="Whether joining requires approval"
+    )
+    default_permission_level: Optional[PermissionLevel] = Field(
+        default=None, description="Default permission level for joiners"
+    )
+    expires_in_hours: Optional[int] = Field(
+        default=None, description="Hours until link expires (None = never expires)"
+    )
+    is_active: Optional[bool] = Field(
+        default=None, description="Whether the link is active"
+    )
+
+
+class ShareLinkResponse(BaseModel):
+    """Response containing share link information."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    resource_type: str
+    resource_id: int
+    share_url: str = Field(description="Full share URL")
+    share_token: str = Field(description="Share token for joining")
+    require_approval: bool
+    default_permission_level: str
+    expires_at: Optional[datetime] = None
+    is_active: bool
+    created_by_user_id: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class ShareLinkInDB(BaseModel):
+    """Share link model from database."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    resource_type: str
+    resource_id: int
+    share_token: str
+    require_approval: bool
+    default_permission_level: str
+    expires_at: Optional[datetime] = None
+    created_by_user_id: int
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+# =============================================================================
+# Resource Member Schemas
+# =============================================================================
+
+
+class ResourceMemberCreate(BaseModel):
+    """Request body for adding a member directly."""
+
+    user_id: int = Field(description="User ID to add as member")
+    permission_level: PermissionLevel = Field(
+        default=PermissionLevel.VIEW, description="Permission level"
+    )
+
+
+class ResourceMemberUpdate(BaseModel):
+    """Request body for updating member permissions."""
+
+    permission_level: Optional[PermissionLevel] = Field(
+        default=None, description="New permission level"
+    )
+
+
+class ResourceMemberResponse(BaseModel):
+    """Response containing resource member information."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    resource_type: str
+    resource_id: int
+    user_id: int
+    user_name: Optional[str] = None  # Populated from user lookup
+    permission_level: str
+    status: str
+    invited_by_user_id: int
+    invited_by_user_name: Optional[str] = None  # Populated from user lookup
+    reviewed_by_user_id: Optional[int] = None
+    reviewed_by_user_name: Optional[str] = None  # Populated from user lookup
+    reviewed_at: Optional[datetime] = None
+    copied_resource_id: Optional[int] = None  # For Task type
+    requested_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class ResourceMemberInDB(BaseModel):
+    """Resource member model from database."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    resource_type: str
+    resource_id: int
+    user_id: int
+    permission_level: str
+    status: str
+    invited_by_user_id: int
+    share_link_id: Optional[int] = None
+    reviewed_by_user_id: Optional[int] = None
+    reviewed_at: Optional[datetime] = None
+    copied_resource_id: Optional[int] = None
+    requested_at: datetime
+    created_at: datetime
+    updated_at: datetime
+
+
+class MemberListResponse(BaseModel):
+    """Response containing list of resource members."""
+
+    members: List[ResourceMemberResponse]
+    total: int
+
+
+# =============================================================================
+# Join Request Schemas
+# =============================================================================
+
+
+class JoinByLinkRequest(BaseModel):
+    """Request body for joining via share link."""
+
+    share_token: str = Field(description="Share token from URL")
+    requested_permission_level: Optional[PermissionLevel] = Field(
+        default=None, description="Requested permission level (optional)"
+    )
+
+
+class JoinByLinkResponse(BaseModel):
+    """Response for join request."""
+
+    message: str
+    status: MemberStatus = Field(description="Current status (pending/approved)")
+    member_id: int = Field(description="Created member record ID")
+    resource_type: str
+    resource_id: int
+    copied_resource_id: Optional[int] = None  # For Task type when auto-approved
+
+
+# =============================================================================
+# Approval Request Schemas
+# =============================================================================
+
+
+class PendingRequestResponse(BaseModel):
+    """Response containing pending approval request."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    user_id: int
+    user_name: Optional[str] = None
+    requested_permission_level: str
+    requested_at: datetime
+
+
+class PendingRequestListResponse(BaseModel):
+    """Response containing list of pending requests."""
+
+    requests: List[PendingRequestResponse]
+    total: int
+
+
+class ReviewRequestBody(BaseModel):
+    """Request body for reviewing a join request."""
+
+    approved: bool = Field(description="Whether to approve the request")
+    permission_level: Optional[PermissionLevel] = Field(
+        default=None,
+        description="Permission level to grant (only for approval, defaults to requested level)",
+    )
+
+
+class ReviewRequestResponse(BaseModel):
+    """Response for review action."""
+
+    message: str
+    member_id: int
+    new_status: MemberStatus
+    permission_level: Optional[str] = None
+
+
+# =============================================================================
+# Public Info Schemas (for share link preview)
+# =============================================================================
+
+
+class ShareInfoResponse(BaseModel):
+    """Public response for share link preview (no auth required)."""
+
+    resource_type: str
+    resource_id: int
+    resource_name: str = Field(description="Name of the shared resource")
+    owner_user_id: int
+    owner_user_name: str = Field(description="Name of resource owner")
+    require_approval: bool
+    default_permission_level: str
+    is_expired: bool = False
+
+
+# =============================================================================
+# Permission Check Schemas
+# =============================================================================
+
+
+class PermissionCheckRequest(BaseModel):
+    """Request for checking user permission."""
+
+    resource_type: ResourceType
+    resource_id: int
+    user_id: int
+    required_level: PermissionLevel
+
+
+class PermissionCheckResponse(BaseModel):
+    """Response for permission check."""
+
+    has_permission: bool
+    actual_permission_level: Optional[str] = None

--- a/backend/app/services/share/__init__.py
+++ b/backend/app/services/share/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Share services package for unified resource sharing.
+
+Provides base share service and resource-specific implementations.
+"""
+
+from app.services.share.base_service import UnifiedShareService
+from app.services.share.knowledge_share_service import (
+    KnowledgeShareService,
+    knowledge_share_service,
+)
+from app.services.share.task_share_service import TaskShareService, task_share_service
+from app.services.share.team_share_service import TeamShareService, team_share_service
+
+__all__ = [
+    "UnifiedShareService",
+    "TeamShareService",
+    "team_share_service",
+    "TaskShareService",
+    "task_share_service",
+    "KnowledgeShareService",
+    "knowledge_share_service",
+]

--- a/backend/app/services/share/base_service.py
+++ b/backend/app/services/share/base_service.py
@@ -1,0 +1,997 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Base service for unified resource sharing.
+
+Provides common functionality for share links and resource members management.
+Resource-specific services should extend this base class.
+"""
+
+import base64
+import logging
+import urllib.parse
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Tuple
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.resource_member import MemberStatus, ResourceMember
+from app.models.share_link import PermissionLevel, ResourceType, ShareLink
+from app.models.user import User
+from app.schemas.share import (
+    JoinByLinkResponse,
+    MemberListResponse,
+)
+from app.schemas.share import MemberStatus as SchemaMemberStatus
+from app.schemas.share import (
+    PendingRequestListResponse,
+    PendingRequestResponse,
+)
+from app.schemas.share import PermissionLevel as SchemaPermissionLevel
+from app.schemas.share import (
+    ResourceMemberResponse,
+    ReviewRequestResponse,
+    ShareInfoResponse,
+    ShareLinkConfig,
+    ShareLinkResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UnifiedShareService(ABC):
+    """
+    Base class for unified resource sharing.
+
+    Provides common functionality:
+    - AES token encryption/decryption
+    - Share link CRUD operations
+    - Resource member CRUD operations
+    - Permission checking
+
+    Subclasses must implement:
+    - _get_resource(): Fetch and validate the resource
+    - _get_resource_name(): Get resource display name
+    - _get_resource_owner_id(): Get resource owner user ID
+    - _get_share_url_base(): Get base URL for share links
+    - _on_member_approved(): Hook called when member is approved
+    """
+
+    # Permission hierarchy for comparison
+    PERMISSION_HIERARCHY: Dict[str, int] = {
+        PermissionLevel.VIEW.value: 1,
+        PermissionLevel.EDIT.value: 2,
+        PermissionLevel.MANAGE.value: 3,
+    }
+
+    def __init__(self, resource_type: ResourceType):
+        """Initialize the share service for a specific resource type."""
+        self.resource_type = resource_type
+        self.aes_key = settings.SHARE_TOKEN_AES_KEY.encode("utf-8")
+        self.aes_iv = settings.SHARE_TOKEN_AES_IV.encode("utf-8")
+
+    # =========================================================================
+    # Abstract methods (must be implemented by subclasses)
+    # =========================================================================
+
+    @abstractmethod
+    def _get_resource(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[object]:
+        """
+        Fetch and validate the resource exists and user has access.
+
+        Args:
+            db: Database session
+            resource_id: Resource ID
+            user_id: Current user ID (for ownership check)
+
+        Returns:
+            Resource object if found and accessible, None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def _get_resource_name(self, resource: object) -> str:
+        """Get display name for the resource."""
+        pass
+
+    @abstractmethod
+    def _get_resource_owner_id(self, resource: object) -> int:
+        """Get owner user ID for the resource."""
+        pass
+
+    @abstractmethod
+    def _get_share_url_base(self) -> str:
+        """Get base URL for share links."""
+        pass
+
+    @abstractmethod
+    def _on_member_approved(
+        self, db: Session, member: ResourceMember, resource: object
+    ) -> Optional[int]:
+        """
+        Hook called when a member is approved.
+
+        For Task resources, this should implement copy logic.
+        For other resources, this can be a no-op.
+
+        Args:
+            db: Database session
+            member: The approved member record
+            resource: The resource being shared
+
+        Returns:
+            Copied resource ID (for Task type) or None
+        """
+        pass
+
+    # =========================================================================
+    # AES Encryption/Decryption
+    # =========================================================================
+
+    def _aes_encrypt(self, data: str) -> str:
+        """Encrypt data using AES-256-CBC."""
+        cipher = Cipher(
+            algorithms.AES(self.aes_key),
+            modes.CBC(self.aes_iv),
+            backend=default_backend(),
+        )
+        encryptor = cipher.encryptor()
+
+        padder = padding.PKCS7(128).padder()
+        padded_data = padder.update(data.encode("utf-8")) + padder.finalize()
+
+        encrypted_bytes = encryptor.update(padded_data) + encryptor.finalize()
+        return base64.b64encode(encrypted_bytes).decode("utf-8")
+
+    def _aes_decrypt(self, encrypted_data: str) -> Optional[str]:
+        """Decrypt data using AES-256-CBC."""
+        try:
+            encrypted_bytes = base64.b64decode(encrypted_data.encode("utf-8"))
+
+            cipher = Cipher(
+                algorithms.AES(self.aes_key),
+                modes.CBC(self.aes_iv),
+                backend=default_backend(),
+            )
+            decryptor = cipher.decryptor()
+
+            decrypted_padded_bytes = (
+                decryptor.update(encrypted_bytes) + decryptor.finalize()
+            )
+
+            unpadder = padding.PKCS7(128).unpadder()
+            decrypted_bytes = (
+                unpadder.update(decrypted_padded_bytes) + unpadder.finalize()
+            )
+
+            return decrypted_bytes.decode("utf-8")
+        except Exception:
+            return None
+
+    def _generate_share_token(self, user_id: int, resource_id: int) -> str:
+        """Generate encrypted share token."""
+        # Format: "resource_type#user_id#resource_id"
+        share_data = f"{self.resource_type.value}#{user_id}#{resource_id}"
+        token = self._aes_encrypt(share_data)
+        return urllib.parse.quote(token)
+
+    def _decode_share_token(self, share_token: str) -> Optional[Tuple[str, int, int]]:
+        """
+        Decode share token to get resource info.
+
+        Returns:
+            Tuple of (resource_type, user_id, resource_id) or None if invalid
+        """
+        try:
+            decoded_token = urllib.parse.unquote(share_token)
+            share_data_str = self._aes_decrypt(decoded_token)
+            if not share_data_str:
+                return None
+
+            parts = share_data_str.split("#")
+            if len(parts) != 3:
+                return None
+
+            resource_type = parts[0]
+            user_id = int(parts[1])
+            resource_id = int(parts[2])
+
+            return (resource_type, user_id, resource_id)
+        except Exception:
+            return None
+
+    def _generate_share_url(self, share_token: str) -> str:
+        """Generate full share URL."""
+        base_url = self._get_share_url_base()
+        return f"{base_url}?share_token={share_token}"
+
+    # =========================================================================
+    # Share Link Operations
+    # =========================================================================
+
+    def create_share_link(
+        self,
+        db: Session,
+        resource_id: int,
+        user_id: int,
+        config: ShareLinkConfig,
+    ) -> ShareLinkResponse:
+        """Create or update a share link for a resource."""
+        # Validate resource exists and user is owner
+        resource = self._get_resource(db, resource_id, user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        if owner_id != user_id:
+            raise HTTPException(
+                status_code=403, detail="Only resource owner can create share link"
+            )
+
+        # Check for existing active share link
+        existing_link = (
+            db.query(ShareLink)
+            .filter(
+                ShareLink.resource_type == self.resource_type.value,
+                ShareLink.resource_id == resource_id,
+                ShareLink.is_active == True,
+            )
+            .first()
+        )
+
+        if existing_link:
+            # Update existing link
+            existing_link.require_approval = config.require_approval
+            existing_link.default_permission_level = (
+                config.default_permission_level.value
+            )
+            if config.expires_in_hours:
+                existing_link.expires_at = datetime.utcnow() + timedelta(
+                    hours=config.expires_in_hours
+                )
+            else:
+                existing_link.expires_at = None
+            existing_link.updated_at = datetime.utcnow()
+            db.commit()
+            db.refresh(existing_link)
+
+            return self._share_link_to_response(existing_link)
+
+        # Generate new share token
+        share_token = self._generate_share_token(user_id, resource_id)
+
+        # Calculate expiration
+        expires_at = None
+        if config.expires_in_hours:
+            expires_at = datetime.utcnow() + timedelta(hours=config.expires_in_hours)
+
+        # Create new share link
+        share_link = ShareLink(
+            resource_type=self.resource_type.value,
+            resource_id=resource_id,
+            share_token=share_token,
+            require_approval=config.require_approval,
+            default_permission_level=config.default_permission_level.value,
+            expires_at=expires_at,
+            created_by_user_id=user_id,
+            is_active=True,
+        )
+
+        db.add(share_link)
+        db.commit()
+        db.refresh(share_link)
+
+        return self._share_link_to_response(share_link)
+
+    def get_share_link(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[ShareLinkResponse]:
+        """Get active share link for a resource."""
+        # Validate resource access
+        resource = self._get_resource(db, resource_id, user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        share_link = (
+            db.query(ShareLink)
+            .filter(
+                ShareLink.resource_type == self.resource_type.value,
+                ShareLink.resource_id == resource_id,
+                ShareLink.is_active == True,
+            )
+            .first()
+        )
+
+        if not share_link:
+            return None
+
+        return self._share_link_to_response(share_link)
+
+    def delete_share_link(self, db: Session, resource_id: int, user_id: int) -> bool:
+        """Deactivate share link for a resource."""
+        # Validate resource and ownership
+        resource = self._get_resource(db, resource_id, user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        if owner_id != user_id:
+            raise HTTPException(
+                status_code=403, detail="Only resource owner can delete share link"
+            )
+
+        share_link = (
+            db.query(ShareLink)
+            .filter(
+                ShareLink.resource_type == self.resource_type.value,
+                ShareLink.resource_id == resource_id,
+                ShareLink.is_active == True,
+            )
+            .first()
+        )
+
+        if not share_link:
+            raise HTTPException(status_code=404, detail="Share link not found")
+
+        share_link.is_active = False
+        share_link.updated_at = datetime.utcnow()
+        db.commit()
+
+        return True
+
+    def _share_link_to_response(self, share_link: ShareLink) -> ShareLinkResponse:
+        """Convert ShareLink model to response schema."""
+        return ShareLinkResponse(
+            id=share_link.id,
+            resource_type=share_link.resource_type,
+            resource_id=share_link.resource_id,
+            share_url=self._generate_share_url(share_link.share_token),
+            share_token=share_link.share_token,
+            require_approval=share_link.require_approval,
+            default_permission_level=share_link.default_permission_level,
+            expires_at=share_link.expires_at,
+            is_active=share_link.is_active,
+            created_by_user_id=share_link.created_by_user_id,
+            created_at=share_link.created_at,
+            updated_at=share_link.updated_at,
+        )
+
+    # =========================================================================
+    # Public Info (for share link preview)
+    # =========================================================================
+
+    def get_share_info(self, db: Session, share_token: str) -> ShareInfoResponse:
+        """Get public info about a share link (no auth required)."""
+        # Decode token
+        token_info = self._decode_share_token(share_token)
+        if not token_info:
+            raise HTTPException(status_code=400, detail="Invalid share token")
+
+        resource_type, owner_id, resource_id = token_info
+
+        # Validate resource type matches
+        if resource_type != self.resource_type.value:
+            raise HTTPException(status_code=400, detail="Invalid resource type")
+
+        # Find share link
+        share_link = (
+            db.query(ShareLink)
+            .filter(
+                ShareLink.resource_type == self.resource_type.value,
+                ShareLink.resource_id == resource_id,
+                ShareLink.share_token == share_token,
+                ShareLink.is_active == True,
+            )
+            .first()
+        )
+
+        if not share_link:
+            raise HTTPException(
+                status_code=404, detail="Share link not found or inactive"
+            )
+
+        # Check expiration
+        is_expired = False
+        if share_link.expires_at and datetime.utcnow() > share_link.expires_at:
+            is_expired = True
+
+        # Get resource (without user validation)
+        resource = self._get_resource(db, resource_id, owner_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        # Get owner info
+        owner = (
+            db.query(User).filter(User.id == owner_id, User.is_active == True).first()
+        )
+        owner_name = owner.user_name if owner else f"User_{owner_id}"
+
+        return ShareInfoResponse(
+            resource_type=self.resource_type.value,
+            resource_id=resource_id,
+            resource_name=self._get_resource_name(resource),
+            owner_user_id=owner_id,
+            owner_user_name=owner_name,
+            require_approval=share_link.require_approval,
+            default_permission_level=share_link.default_permission_level,
+            is_expired=is_expired,
+        )
+
+    # =========================================================================
+    # Join Operations
+    # =========================================================================
+
+    def join_by_link(
+        self,
+        db: Session,
+        share_token: str,
+        user_id: int,
+        requested_permission_level: Optional[SchemaPermissionLevel] = None,
+    ) -> JoinByLinkResponse:
+        """Handle join request via share link."""
+        # Decode token
+        token_info = self._decode_share_token(share_token)
+        if not token_info:
+            raise HTTPException(status_code=400, detail="Invalid share token")
+
+        resource_type, owner_id, resource_id = token_info
+
+        # Validate resource type
+        if resource_type != self.resource_type.value:
+            raise HTTPException(status_code=400, detail="Invalid resource type")
+
+        # Cannot join own resource
+        if owner_id == user_id:
+            raise HTTPException(status_code=400, detail="Cannot join your own resource")
+
+        # Find share link
+        share_link = (
+            db.query(ShareLink)
+            .filter(
+                ShareLink.resource_type == self.resource_type.value,
+                ShareLink.resource_id == resource_id,
+                ShareLink.share_token == share_token,
+                ShareLink.is_active == True,
+            )
+            .first()
+        )
+
+        if not share_link:
+            raise HTTPException(
+                status_code=404, detail="Share link not found or inactive"
+            )
+
+        # Check expiration
+        if share_link.expires_at and datetime.utcnow() > share_link.expires_at:
+            raise HTTPException(status_code=400, detail="Share link has expired")
+
+        # Get resource
+        resource = self._get_resource(db, resource_id, owner_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        # Check for existing member record
+        existing_member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.user_id == user_id,
+            )
+            .first()
+        )
+
+        if existing_member:
+            if existing_member.status == MemberStatus.APPROVED.value:
+                raise HTTPException(
+                    status_code=400, detail="Already have access to this resource"
+                )
+            elif existing_member.status == MemberStatus.PENDING.value:
+                raise HTTPException(
+                    status_code=400, detail="Request already pending approval"
+                )
+            # If rejected, allow re-request by updating the record
+            existing_member.status = (
+                MemberStatus.PENDING.value
+                if share_link.require_approval
+                else MemberStatus.APPROVED.value
+            )
+            existing_member.permission_level = (
+                requested_permission_level.value
+                if requested_permission_level
+                else share_link.default_permission_level
+            )
+            existing_member.share_link_id = share_link.id
+            existing_member.requested_at = datetime.utcnow()
+            existing_member.reviewed_at = None
+            existing_member.reviewed_by_user_id = None
+            existing_member.updated_at = datetime.utcnow()
+
+            member = existing_member
+        else:
+            # Determine initial status
+            initial_status = (
+                MemberStatus.PENDING.value
+                if share_link.require_approval
+                else MemberStatus.APPROVED.value
+            )
+
+            # Determine permission level
+            permission_level = (
+                requested_permission_level.value
+                if requested_permission_level
+                else share_link.default_permission_level
+            )
+
+            # Create member record
+            member = ResourceMember(
+                resource_type=self.resource_type.value,
+                resource_id=resource_id,
+                user_id=user_id,
+                permission_level=permission_level,
+                status=initial_status,
+                invited_by_user_id=0,  # Via link
+                share_link_id=share_link.id,
+            )
+
+            db.add(member)
+
+        db.commit()
+        db.refresh(member)
+
+        # If auto-approved, call the approval hook
+        copied_resource_id = None
+        if member.status == MemberStatus.APPROVED.value:
+            copied_resource_id = self._on_member_approved(db, member, resource)
+            if copied_resource_id:
+                member.copied_resource_id = copied_resource_id
+                db.commit()
+
+        return JoinByLinkResponse(
+            message=(
+                "Request submitted for approval"
+                if member.status == MemberStatus.PENDING.value
+                else "Successfully joined"
+            ),
+            status=SchemaMemberStatus(member.status),
+            member_id=member.id,
+            resource_type=self.resource_type.value,
+            resource_id=resource_id,
+            copied_resource_id=copied_resource_id,
+        )
+
+    # =========================================================================
+    # Member Operations
+    # =========================================================================
+
+    def get_members(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> MemberListResponse:
+        """Get all members of a resource."""
+        # Validate resource access
+        resource = self._get_resource(db, resource_id, user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        members = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
+            .all()
+        )
+
+        # Populate user names
+        user_ids = set()
+        for m in members:
+            user_ids.add(m.user_id)
+            if m.invited_by_user_id:
+                user_ids.add(m.invited_by_user_id)
+            if m.reviewed_by_user_id:
+                user_ids.add(m.reviewed_by_user_id)
+
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        user_map = {u.id: u.user_name for u in users}
+
+        member_responses = [self._member_to_response(m, user_map) for m in members]
+
+        return MemberListResponse(members=member_responses, total=len(member_responses))
+
+    def add_member(
+        self,
+        db: Session,
+        resource_id: int,
+        current_user_id: int,
+        target_user_id: int,
+        permission_level: SchemaPermissionLevel,
+    ) -> ResourceMemberResponse:
+        """Directly add a member to a resource."""
+        # Validate resource and ownership/manage permission
+        resource = self._get_resource(db, resource_id, current_user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        has_manage = self.check_permission(
+            db, resource_id, current_user_id, SchemaPermissionLevel.MANAGE
+        )
+
+        if owner_id != current_user_id and not has_manage:
+            raise HTTPException(status_code=403, detail="No permission to add members")
+
+        # Cannot add self
+        if target_user_id == current_user_id:
+            raise HTTPException(status_code=400, detail="Cannot add yourself")
+
+        # Check target user exists
+        target_user = (
+            db.query(User)
+            .filter(User.id == target_user_id, User.is_active == True)
+            .first()
+        )
+        if not target_user:
+            raise HTTPException(status_code=404, detail="Target user not found")
+
+        # Check for existing member
+        existing = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.user_id == target_user_id,
+            )
+            .first()
+        )
+
+        if existing:
+            if existing.status == MemberStatus.APPROVED.value:
+                raise HTTPException(status_code=400, detail="User already has access")
+            # Update existing record
+            existing.permission_level = permission_level.value
+            existing.status = MemberStatus.APPROVED.value
+            existing.invited_by_user_id = current_user_id
+            existing.reviewed_by_user_id = current_user_id
+            existing.reviewed_at = datetime.utcnow()
+            existing.updated_at = datetime.utcnow()
+            member = existing
+        else:
+            # Create new member with approved status
+            member = ResourceMember(
+                resource_type=self.resource_type.value,
+                resource_id=resource_id,
+                user_id=target_user_id,
+                permission_level=permission_level.value,
+                status=MemberStatus.APPROVED.value,
+                invited_by_user_id=current_user_id,
+                reviewed_by_user_id=current_user_id,
+                reviewed_at=datetime.utcnow(),
+            )
+            db.add(member)
+
+        db.commit()
+        db.refresh(member)
+
+        # Call approval hook
+        copied_resource_id = self._on_member_approved(db, member, resource)
+        if copied_resource_id:
+            member.copied_resource_id = copied_resource_id
+            db.commit()
+
+        # Get user names for response
+        users = (
+            db.query(User).filter(User.id.in_([target_user_id, current_user_id])).all()
+        )
+        user_map = {u.id: u.user_name for u in users}
+
+        return self._member_to_response(member, user_map)
+
+    def update_member(
+        self,
+        db: Session,
+        resource_id: int,
+        member_id: int,
+        current_user_id: int,
+        permission_level: SchemaPermissionLevel,
+    ) -> ResourceMemberResponse:
+        """Update a member's permission level."""
+        # Validate resource and ownership/manage permission
+        resource = self._get_resource(db, resource_id, current_user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        has_manage = self.check_permission(
+            db, resource_id, current_user_id, SchemaPermissionLevel.MANAGE
+        )
+
+        if owner_id != current_user_id and not has_manage:
+            raise HTTPException(
+                status_code=403, detail="No permission to update members"
+            )
+
+        # Find member
+        member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.id == member_id,
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+            )
+            .first()
+        )
+
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+
+        # Update permission
+        member.permission_level = permission_level.value
+        member.updated_at = datetime.utcnow()
+        db.commit()
+        db.refresh(member)
+
+        # Get user names
+        user_ids = {member.user_id}
+        if member.invited_by_user_id:
+            user_ids.add(member.invited_by_user_id)
+        if member.reviewed_by_user_id:
+            user_ids.add(member.reviewed_by_user_id)
+
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        user_map = {u.id: u.user_name for u in users}
+
+        return self._member_to_response(member, user_map)
+
+    def remove_member(
+        self,
+        db: Session,
+        resource_id: int,
+        member_id: int,
+        current_user_id: int,
+    ) -> bool:
+        """Remove a member from a resource."""
+        # Validate resource and ownership/manage permission
+        resource = self._get_resource(db, resource_id, current_user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        has_manage = self.check_permission(
+            db, resource_id, current_user_id, SchemaPermissionLevel.MANAGE
+        )
+
+        if owner_id != current_user_id and not has_manage:
+            raise HTTPException(
+                status_code=403, detail="No permission to remove members"
+            )
+
+        # Find member
+        member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.id == member_id,
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+            )
+            .first()
+        )
+
+        if not member:
+            raise HTTPException(status_code=404, detail="Member not found")
+
+        # Delete member record
+        db.delete(member)
+        db.commit()
+
+        return True
+
+    def _member_to_response(
+        self, member: ResourceMember, user_map: Dict[int, str]
+    ) -> ResourceMemberResponse:
+        """Convert ResourceMember model to response schema."""
+        return ResourceMemberResponse(
+            id=member.id,
+            resource_type=member.resource_type,
+            resource_id=member.resource_id,
+            user_id=member.user_id,
+            user_name=user_map.get(member.user_id),
+            permission_level=member.permission_level,
+            status=member.status,
+            invited_by_user_id=member.invited_by_user_id,
+            invited_by_user_name=user_map.get(member.invited_by_user_id),
+            reviewed_by_user_id=member.reviewed_by_user_id,
+            reviewed_by_user_name=(
+                user_map.get(member.reviewed_by_user_id)
+                if member.reviewed_by_user_id
+                else None
+            ),
+            reviewed_at=member.reviewed_at,
+            copied_resource_id=member.copied_resource_id,
+            requested_at=member.requested_at,
+            created_at=member.created_at,
+            updated_at=member.updated_at,
+        )
+
+    # =========================================================================
+    # Approval Operations
+    # =========================================================================
+
+    def get_pending_requests(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> PendingRequestListResponse:
+        """Get pending approval requests for a resource."""
+        # Validate resource and ownership/manage permission
+        resource = self._get_resource(db, resource_id, user_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        has_manage = self.check_permission(
+            db, resource_id, user_id, SchemaPermissionLevel.MANAGE
+        )
+
+        if owner_id != user_id and not has_manage:
+            raise HTTPException(
+                status_code=403, detail="No permission to view pending requests"
+            )
+
+        # Get pending members
+        pending_members = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.status == MemberStatus.PENDING.value,
+            )
+            .all()
+        )
+
+        # Get user names
+        user_ids = {m.user_id for m in pending_members}
+        users = db.query(User).filter(User.id.in_(user_ids)).all()
+        user_map = {u.id: u.user_name for u in users}
+
+        requests = [
+            PendingRequestResponse(
+                id=m.id,
+                user_id=m.user_id,
+                user_name=user_map.get(m.user_id),
+                requested_permission_level=m.permission_level,
+                requested_at=m.requested_at,
+            )
+            for m in pending_members
+        ]
+
+        return PendingRequestListResponse(requests=requests, total=len(requests))
+
+    def review_request(
+        self,
+        db: Session,
+        resource_id: int,
+        request_id: int,
+        reviewer_id: int,
+        approved: bool,
+        permission_level: Optional[SchemaPermissionLevel] = None,
+    ) -> ReviewRequestResponse:
+        """Review (approve/reject) a pending request."""
+        # Validate resource and ownership/manage permission
+        resource = self._get_resource(db, resource_id, reviewer_id)
+        if not resource:
+            raise HTTPException(status_code=404, detail="Resource not found")
+
+        owner_id = self._get_resource_owner_id(resource)
+        has_manage = self.check_permission(
+            db, resource_id, reviewer_id, SchemaPermissionLevel.MANAGE
+        )
+
+        if owner_id != reviewer_id and not has_manage:
+            raise HTTPException(
+                status_code=403, detail="No permission to review requests"
+            )
+
+        # Find pending member
+        member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.id == request_id,
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.status == MemberStatus.PENDING.value,
+            )
+            .first()
+        )
+
+        if not member:
+            raise HTTPException(status_code=404, detail="Pending request not found")
+
+        # Update status
+        if approved:
+            member.status = MemberStatus.APPROVED.value
+            if permission_level:
+                member.permission_level = permission_level.value
+        else:
+            member.status = MemberStatus.REJECTED.value
+
+        member.reviewed_by_user_id = reviewer_id
+        member.reviewed_at = datetime.utcnow()
+        member.updated_at = datetime.utcnow()
+
+        db.commit()
+        db.refresh(member)
+
+        # If approved, call the approval hook
+        if approved:
+            copied_resource_id = self._on_member_approved(db, member, resource)
+            if copied_resource_id:
+                member.copied_resource_id = copied_resource_id
+                db.commit()
+
+        return ReviewRequestResponse(
+            message="Request approved" if approved else "Request rejected",
+            member_id=member.id,
+            new_status=SchemaMemberStatus(member.status),
+            permission_level=member.permission_level if approved else None,
+        )
+
+    # =========================================================================
+    # Permission Checking
+    # =========================================================================
+
+    def check_permission(
+        self,
+        db: Session,
+        resource_id: int,
+        user_id: int,
+        required_level: SchemaPermissionLevel,
+    ) -> bool:
+        """
+        Check if user has required permission level.
+
+        Permission hierarchy: manage > edit > view
+        """
+        member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.user_id == user_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
+            .first()
+        )
+
+        if not member:
+            return False
+
+        actual_level = self.PERMISSION_HIERARCHY.get(member.permission_level, 0)
+        required = self.PERMISSION_HIERARCHY.get(required_level.value, 0)
+
+        return actual_level >= required
+
+    def get_user_permission_level(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[str]:
+        """Get user's permission level for a resource."""
+        member = (
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == self.resource_type.value,
+                ResourceMember.resource_id == resource_id,
+                ResourceMember.user_id == user_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
+            .first()
+        )
+
+        return member.permission_level if member else None

--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Knowledge Base share service for unified resource sharing.
+
+Provides KnowledgeBase-specific implementation of the UnifiedShareService.
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.kind import Kind
+from app.models.resource_member import ResourceMember
+from app.models.share_link import ResourceType
+from app.services.share.base_service import UnifiedShareService
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeShareService(UnifiedShareService):
+    """
+    KnowledgeBase-specific share service.
+
+    Knowledge bases are shared directly without copying.
+    Members get access based on their permission level.
+    """
+
+    def __init__(self):
+        super().__init__(ResourceType.KNOWLEDGE_BASE)
+
+    def _get_resource(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[Kind]:
+        """
+        Fetch KnowledgeBase resource.
+
+        For Knowledge Bases, we check if the resource exists and belongs to the user
+        OR if the user has been shared access.
+        """
+        kb = (
+            db.query(Kind)
+            .filter(
+                Kind.id == resource_id,
+                Kind.kind == "KnowledgeBase",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if kb and kb.user_id == user_id:
+            return kb
+
+        # Check if user has shared access
+        if kb:
+            from app.models.resource_member import MemberStatus, ResourceMember
+
+            member = (
+                db.query(ResourceMember)
+                .filter(
+                    ResourceMember.resource_type == ResourceType.KNOWLEDGE_BASE.value,
+                    ResourceMember.resource_id == resource_id,
+                    ResourceMember.user_id == user_id,
+                    ResourceMember.status == MemberStatus.APPROVED.value,
+                )
+                .first()
+            )
+            if member:
+                return kb
+
+        return kb  # Return KB even if not accessible (for share info)
+
+    def _get_resource_name(self, resource: Kind) -> str:
+        """Get KnowledgeBase display name."""
+        return resource.name
+
+    def _get_resource_owner_id(self, resource: Kind) -> int:
+        """Get KnowledgeBase owner user ID."""
+        return resource.user_id
+
+    def _get_share_url_base(self) -> str:
+        """Get base URL for KnowledgeBase share links."""
+        # Construct URL for knowledge base sharing
+        base_url = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:3000")
+        return f"{base_url}/knowledge/share"
+
+    def _on_member_approved(
+        self, db: Session, member: ResourceMember, resource: Kind
+    ) -> Optional[int]:
+        """
+        Hook called when a KnowledgeBase member is approved.
+
+        For Knowledge Bases, we don't copy anything - members get direct access
+        based on their permission level.
+        """
+        # No copy needed for Knowledge Bases
+        logger.info(
+            f"KnowledgeBase member approved: user={member.user_id}, "
+            f"kb={resource.id}, permission={member.permission_level}"
+        )
+        return None
+
+
+# Singleton instance
+knowledge_share_service = KnowledgeShareService()

--- a/backend/app/services/share/task_share_service.py
+++ b/backend/app/services/share/task_share_service.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Task share service for unified resource sharing.
+
+Provides Task-specific implementation of the UnifiedShareService.
+Tasks have special copy behavior when shared.
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.resource_member import ResourceMember
+from app.models.share_link import ResourceType
+from app.models.task import TaskResource
+from app.services.share.base_service import UnifiedShareService
+
+logger = logging.getLogger(__name__)
+
+
+class TaskShareService(UnifiedShareService):
+    """
+    Task-specific share service.
+
+    Tasks are copied when shared - each member gets their own copy.
+    This preserves the original task and allows independent editing.
+    """
+
+    def __init__(self):
+        super().__init__(ResourceType.TASK)
+
+    def _get_resource(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[TaskResource]:
+        """
+        Fetch Task resource.
+
+        For Tasks, we check if the resource exists and user has access
+        (owner or group chat member).
+        """
+        from app.services.task_member_service import task_member_service
+
+        task = (
+            db.query(TaskResource)
+            .filter(
+                TaskResource.id == resource_id,
+                TaskResource.kind == "Task",
+                TaskResource.is_active == True,
+            )
+            .first()
+        )
+
+        if task:
+            # Check if user is owner or group chat member
+            if task.user_id == user_id or task_member_service.is_member(
+                db, resource_id, user_id
+            ):
+                return task
+
+        return task  # Return task even if not accessible (for share info)
+
+    def _get_resource_name(self, resource: TaskResource) -> str:
+        """Get Task display name."""
+        return resource.name or "Untitled Task"
+
+    def _get_resource_owner_id(self, resource: TaskResource) -> int:
+        """Get Task owner user ID."""
+        return resource.user_id
+
+    def _get_share_url_base(self) -> str:
+        """Get base URL for Task share links."""
+        # Use TASK_SHARE_BASE_URL from settings
+        base_url = getattr(settings, "TASK_SHARE_BASE_URL", "http://localhost:3000")
+        return f"{base_url}/shared/task"
+
+    def _on_member_approved(
+        self, db: Session, member: ResourceMember, resource: TaskResource
+    ) -> Optional[int]:
+        """
+        Hook called when a Task member is approved.
+
+        For Tasks, we copy the task and all its subtasks to the new user.
+        This is the core Task-specific behavior.
+        """
+        try:
+            # Import here to avoid circular imports
+            from app.services.shared_task import shared_task_service
+
+            # Get task details
+            task_share_info = self._get_task_share_info(db, resource)
+            if not task_share_info:
+                logger.warning(
+                    f"Could not get share info for task {resource.id}, " "skipping copy"
+                )
+                return None
+
+            # For now, we delegate to the existing shared_task_service copy logic
+            # This ensures backward compatibility during migration
+            # TODO: Extract copy logic to this service after migration is complete
+
+            logger.info(
+                f"Task member approved: user={member.user_id}, "
+                f"task={resource.id}, requires copy logic"
+            )
+
+            # Note: The actual copy logic is complex and involves:
+            # 1. Creating a new task for the user
+            # 2. Copying all subtasks and their contexts
+            # 3. Handling workspace associations
+            # For gradual migration, we keep this as a placeholder
+            # The existing SharedTask table and service will handle actual copies
+            # until full migration is complete
+
+            return None  # Return None until copy logic is fully migrated
+
+        except Exception as e:
+            logger.error(f"Error in Task _on_member_approved: {e}")
+            return None
+
+    def _get_task_share_info(self, db: Session, task: TaskResource) -> Optional[dict]:
+        """Extract share-relevant info from a task."""
+        try:
+            from app.schemas.kind import Task as TaskSchema
+            from app.schemas.kind import Workspace
+
+            task_crd = TaskSchema.model_validate(task.json)
+            workspace_ref = task_crd.spec.workspaceRef
+
+            info = {
+                "task_id": task.id,
+                "task_name": task.name,
+                "user_id": task.user_id,
+                "workspace_ref": workspace_ref,
+            }
+
+            # Get workspace details if available
+            if workspace_ref:
+                workspace = (
+                    db.query(TaskResource)
+                    .filter(
+                        TaskResource.name == workspace_ref,
+                        TaskResource.user_id == task.user_id,
+                        TaskResource.kind == "Workspace",
+                        TaskResource.is_active == True,
+                    )
+                    .first()
+                )
+
+                if workspace:
+                    ws_crd = Workspace.model_validate(workspace.json)
+                    repo = ws_crd.spec.repository
+                    info["git_repo_id"] = repo.gitRepoId
+                    info["git_repo"] = repo.gitRepo
+                    info["git_domain"] = repo.gitDomain
+                    info["branch_name"] = repo.branchName
+                    info["git_url"] = repo.gitUrl
+
+            return info
+
+        except Exception as e:
+            logger.warning(f"Error getting task share info: {e}")
+            return None
+
+
+# Singleton instance
+task_share_service = TaskShareService()

--- a/backend/app/services/share/team_share_service.py
+++ b/backend/app/services/share/team_share_service.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Team share service for unified resource sharing.
+
+Provides Team-specific implementation of the UnifiedShareService.
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.kind import Kind
+from app.models.resource_member import ResourceMember
+from app.models.share_link import ResourceType
+from app.services.share.base_service import UnifiedShareService
+
+logger = logging.getLogger(__name__)
+
+
+class TeamShareService(UnifiedShareService):
+    """
+    Team-specific share service.
+
+    Teams are joined directly without copying.
+    """
+
+    def __init__(self):
+        super().__init__(ResourceType.TEAM)
+
+    def _get_resource(
+        self, db: Session, resource_id: int, user_id: int
+    ) -> Optional[Kind]:
+        """
+        Fetch Team resource.
+
+        For Teams, we check if the resource exists and belongs to the user
+        OR if the user has been shared access to the team.
+        """
+        # First try to find team owned by user
+        team = (
+            db.query(Kind)
+            .filter(
+                Kind.id == resource_id,
+                Kind.kind == "Team",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if team and team.user_id == user_id:
+            return team
+
+        # Check if user has shared access
+        if team:
+            from app.models.resource_member import MemberStatus, ResourceMember
+
+            member = (
+                db.query(ResourceMember)
+                .filter(
+                    ResourceMember.resource_type == ResourceType.TEAM.value,
+                    ResourceMember.resource_id == resource_id,
+                    ResourceMember.user_id == user_id,
+                    ResourceMember.status == MemberStatus.APPROVED.value,
+                )
+                .first()
+            )
+            if member:
+                return team
+
+        return team  # Return team even if not owned (for share info)
+
+    def _get_resource_name(self, resource: Kind) -> str:
+        """Get Team display name."""
+        return resource.name
+
+    def _get_resource_owner_id(self, resource: Kind) -> int:
+        """Get Team owner user ID."""
+        return resource.user_id
+
+    def _get_share_url_base(self) -> str:
+        """Get base URL for Team share links."""
+        # Use TEAM_SHARE_BASE_URL from settings or construct default
+        return getattr(settings, "TEAM_SHARE_BASE_URL", "http://localhost:3000/chat")
+
+    def _on_member_approved(
+        self, db: Session, member: ResourceMember, resource: Kind
+    ) -> Optional[int]:
+        """
+        Hook called when a Team member is approved.
+
+        For Teams, we don't copy anything - members just get direct access.
+        """
+        # No copy needed for Teams
+        return None
+
+
+# Singleton instance
+team_share_service = TeamShareService()

--- a/frontend/empty-module.js
+++ b/frontend/empty-module.js
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Empty module for Turbopack browser fallback
+// Used to replace Node.js-only modules (fs, path) in browser context
+module.exports = {}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "TURBOPACK=1 next dev --turbopack",
     "build": "NODE_OPTIONS='--max-old-space-size=2048'  next build",
     "start": "next start",
     "lint": "next lint",

--- a/frontend/src/features/knowledge/permission/components/AddUserDialog.tsx
+++ b/frontend/src/features/knowledge/permission/components/AddUserDialog.tsx
@@ -35,14 +35,9 @@ interface AddUserDialogProps {
   onSuccess?: () => void
 }
 
-export function AddUserDialog({
-  open,
-  onOpenChange,
-  kbId,
-  onSuccess,
-}: AddUserDialogProps) {
+export function AddUserDialog({ open, onOpenChange, kbId, onSuccess }: AddUserDialogProps) {
   const { t } = useTranslation('knowledge')
-  const [userId, setUserId] = useState('')
+  const [userName, setUserName] = useState('')
   const [permissionLevel, setPermissionLevel] = useState<PermissionLevel>('view')
   const [localError, setLocalError] = useState<string | null>(null)
 
@@ -52,18 +47,18 @@ export function AddUserDialog({
     e.preventDefault()
     setLocalError(null)
 
-    const parsedUserId = parseInt(userId, 10)
-    if (isNaN(parsedUserId) || parsedUserId <= 0) {
-      setLocalError(t('document.permission.invalidUserId'))
+    const trimmedUserName = userName.trim()
+    if (!trimmedUserName) {
+      setLocalError(t('document.permission.invalidUserName'))
       return
     }
 
     try {
-      await addPermission(parsedUserId, permissionLevel)
+      await addPermission(trimmedUserName, permissionLevel)
       onSuccess?.()
       onOpenChange(false)
       // Reset form
-      setUserId('')
+      setUserName('')
       setPermissionLevel('view')
     } catch (_err) {
       // Error is displayed from the hook
@@ -71,7 +66,7 @@ export function AddUserDialog({
   }
 
   const handleClose = () => {
-    setUserId('')
+    setUserName('')
     setPermissionLevel('view')
     setLocalError(null)
     onOpenChange(false)
@@ -90,16 +85,15 @@ export function AddUserDialog({
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
-            {/* User ID Input */}
+            {/* User Name Input */}
             <div className="space-y-2">
-              <Label htmlFor="userId">{t('document.permission.userId')}</Label>
+              <Label htmlFor="userName">{t('document.permission.userName')}</Label>
               <Input
-                id="userId"
-                type="number"
-                min="1"
-                placeholder={t('document.permission.enterUserId')}
-                value={userId}
-                onChange={e => setUserId(e.target.value)}
+                id="userName"
+                type="text"
+                placeholder={t('document.permission.enterUserName')}
+                value={userName}
+                onChange={e => setUserName(e.target.value)}
                 required
               />
             </div>

--- a/frontend/src/features/knowledge/permission/hooks/useKnowledgePermissions.ts
+++ b/frontend/src/features/knowledge/permission/hooks/useKnowledgePermissions.ts
@@ -42,11 +42,8 @@ interface UseKnowledgePermissionsReturn {
     action: ReviewAction,
     level?: PermissionLevel
   ) => Promise<PermissionReviewResponse>
-  addPermission: (userId: number, level: PermissionLevel) => Promise<PermissionResponse>
-  updatePermission: (
-    permissionId: number,
-    level: PermissionLevel
-  ) => Promise<PermissionResponse>
+  addPermission: (userName: string, level: PermissionLevel) => Promise<PermissionResponse>
+  updatePermission: (permissionId: number, level: PermissionLevel) => Promise<PermissionResponse>
   deletePermission: (permissionId: number) => Promise<void>
   clearError: () => void
 }
@@ -140,11 +137,7 @@ export function useKnowledgePermissions({
           action,
           permission_level: level,
         }
-        const result = await knowledgePermissionApi.reviewPermission(
-          kbId,
-          permissionId,
-          request
-        )
+        const result = await knowledgePermissionApi.reviewPermission(kbId, permissionId, request)
         // Refresh permissions after review
         await fetchPermissions()
         return result
@@ -160,12 +153,12 @@ export function useKnowledgePermissions({
   )
 
   const addPermission = useCallback(
-    async (userId: number, level: PermissionLevel): Promise<PermissionResponse> => {
+    async (userName: string, level: PermissionLevel): Promise<PermissionResponse> => {
       setLoading(true)
       setError(null)
       try {
         const request: PermissionAddRequest = {
-          user_id: userId,
+          user_name: userName,
           permission_level: level,
         }
         const result = await knowledgePermissionApi.addPermission(kbId, request)

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -287,9 +287,9 @@
       "requesting": "Requesting",
       "noEmail": "No email",
       "confirmRemove": "Are you sure you want to remove this user's access permission?",
-      "userId": "User ID",
-      "enterUserId": "Enter user ID",
-      "invalidUserId": "Please enter a valid user ID",
+      "userName": "Username",
+      "enterUserName": "Enter username",
+      "invalidUserName": "Please enter a valid username",
       "invalidShareLink": "Invalid share link"
     },
     "advancedSettings": {

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -287,9 +287,9 @@
       "requesting": "申请权限",
       "noEmail": "无邮箱",
       "confirmRemove": "确定要移除该用户的访问权限吗？",
-      "userId": "用户ID",
-      "enterUserId": "请输入用户ID",
-      "invalidUserId": "请输入有效的用户ID",
+      "userName": "用户名",
+      "enterUserName": "请输入用户名",
+      "invalidUserName": "请输入有效的用户名",
       "invalidShareLink": "无效的分享链接"
     },
     "advancedSettings": {

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -356,7 +356,7 @@ export interface PermissionReviewResponse {
 
 // Permission Add/Update types
 export interface PermissionAddRequest {
-  user_id: number
+  user_name: string
   permission_level: PermissionLevel
 }
 


### PR DESCRIPTION
## Summary

Add a unified sharing system to replace fragmented sharing tables (`shared_teams`, `shared_tasks`, `task_members`, `knowledge_base_permissions`). This provides a consistent API for sharing resources with configurable approval workflows and permission levels.

### Key Changes

**New Database Tables:**
- `share_links` - Store share link configurations and tokens
- `resource_members` - Store user access permissions with approval workflow

**Key Features:**
- Support for **Team**, **Task**, and **KnowledgeBase** resource types
- Configurable approval requirements (auto-approve or require review)
- Three-level permissions: **view**, **edit**, **manage**
- Token-based share links with optional expiration
- Gradual migration strategy (old tables preserved for backward compatibility)

**New Files:**
- `backend/alembic/versions/y5z6a7b8c9d0_add_unified_share_tables.py` - DB migration
- `backend/app/models/share_link.py` - ShareLink model
- `backend/app/models/resource_member.py` - ResourceMember model
- `backend/app/schemas/share.py` - Pydantic schemas
- `backend/app/services/share/` - Service layer with base class and resource-specific implementations
- `backend/app/api/endpoints/share.py` - REST API endpoints

**New API Endpoints (`/api/share/`):**
| Method | Path | Description |
|--------|------|-------------|
| POST | `/{resource_type}/{resource_id}/link` | Create share link |
| GET | `/{resource_type}/{resource_id}/link` | Get share link |
| DELETE | `/{resource_type}/{resource_id}/link` | Delete share link |
| GET | `/info?share_token=...` | Get share info (public) |
| POST | `/join` | Join via share link |
| GET | `/{resource_type}/{resource_id}/members` | List members |
| POST | `/{resource_type}/{resource_id}/members` | Add member |
| PUT | `/{resource_type}/{resource_id}/members/{id}` | Update member |
| DELETE | `/{resource_type}/{resource_id}/members/{id}` | Remove member |
| GET | `/{resource_type}/{resource_id}/requests` | List pending requests |
| POST | `/{resource_type}/{resource_id}/requests/{id}/review` | Review request |

## Test plan

- [x] All 559 backend unit tests pass
- [x] Model imports work correctly
- [x] Service layer imports work correctly
- [x] API router loads without errors
- [ ] Integration tests for new API endpoints
- [ ] Frontend integration with new share API