### PR TITLE
feat(executor): add Linux support for executor local binary

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -521,6 +521,81 @@ jobs:
           retention-days: 1
 
   # ============================================================================
+  # Executor Local Binary Build (Linux)
+  # ============================================================================
+  build-executor-local-linux-amd64:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build
+        working-directory: executor
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor executor/dist/wegent-executor-linux-amd64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-linux-amd64
+          path: executor/dist/wegent-executor-linux-amd64
+          retention-days: 1
+
+  build-executor-local-linux-arm64:
+    needs: prepare-release
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build
+        working-directory: executor
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor executor/dist/wegent-executor-linux-arm64
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-linux-arm64
+          path: executor/dist/wegent-executor-linux-arm64
+          retention-days: 1
+
+  # ============================================================================
   # Create Multi-arch Manifests (combine amd64 + arm64 into single tag)
   # ============================================================================
   create-manifests:
@@ -593,6 +668,8 @@ jobs:
       - create-manifests
       - build-executor-local-macos-arm64
       - build-executor-local-macos-amd64
+      - build-executor-local-linux-amd64
+      - build-executor-local-linux-arm64
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -607,7 +684,7 @@ jobs:
       - name: Download executor binaries
         uses: actions/download-artifact@v4
         with:
-          pattern: wegent-executor-macos-*
+          pattern: wegent-executor-*
           path: ./executor-binaries
           merge-multiple: true
 
@@ -667,4 +744,6 @@ jobs:
           files: |
             ./executor-binaries/wegent-executor-macos-arm64
             ./executor-binaries/wegent-executor-macos-amd64
+            ./executor-binaries/wegent-executor-linux-amd64
+            ./executor-binaries/wegent-executor-linux-arm64
             ./executor/scripts/local_executor_install.sh

--- a/executor/scripts/local_executor_install.sh
+++ b/executor/scripts/local_executor_install.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Wegent Executor Installation Script
-# This script downloads and installs the wegent-executor binary for macOS.
+# This script downloads and installs the wegent-executor binary for macOS and Linux.
 #
 # Usage:
 #   curl -fsSL https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.sh | bash
@@ -92,7 +92,11 @@ check_nodejs() {
         echo ""
         print_info "Please install Node.js first:"
         echo "  - Visit: https://nodejs.org/"
-        echo "  - Or use Homebrew: brew install node"
+        if [[ "$OS" == "macos" ]]; then
+            echo "  - Or use Homebrew: brew install node"
+        elif [[ "$OS" == "linux" ]]; then
+            echo "  - Or use your package manager: apt install nodejs / dnf install nodejs"
+        fi
         echo "  - Or use nvm: nvm install ${MIN_NODE_VERSION}"
         echo ""
         exit 1
@@ -110,7 +114,11 @@ check_nodejs() {
         echo ""
         print_info "Please upgrade Node.js:"
         echo "  - Visit: https://nodejs.org/"
-        echo "  - Or use Homebrew: brew upgrade node"
+        if [[ "$OS" == "macos" ]]; then
+            echo "  - Or use Homebrew: brew upgrade node"
+        elif [[ "$OS" == "linux" ]]; then
+            echo "  - Or use your package manager to upgrade nodejs"
+        fi
         echo "  - Or use nvm: nvm install ${MIN_NODE_VERSION}"
         echo ""
         exit 1
@@ -252,8 +260,7 @@ detect_platform() {
             OS="macos"
             ;;
         Linux)
-            print_error "Linux is not yet supported. Please use Docker deployment."
-            exit 1
+            OS="linux"
             ;;
         *)
             print_error "Unsupported operating system: $os"
@@ -390,9 +397,12 @@ print_usage_instructions() {
     echo ""
     echo "Add this line to your ~/.zshrc or ~/.bashrc to make it permanent."
     echo ""
-    print_warning "First run may require allowing the binary in:"
-    print_warning "System Settings > Privacy & Security"
-    echo ""
+    # Platform-specific notes
+    if [[ "$OS" == "macos" ]]; then
+        print_warning "First run may require allowing the binary in:"
+        print_warning "System Settings > Privacy & Security"
+        echo ""
+    fi
 }
 
 # Main function


### PR DESCRIPTION
## Summary

- Add Linux build jobs (amd64 and arm64) to the CI release workflow
- Enable Linux platform detection in the installation script
- Add Linux-specific package manager hints (apt/dnf) for Node.js installation
- Include Linux binaries (`wegent-executor-linux-amd64`, `wegent-executor-linux-arm64`) in GitHub releases
- Remove macOS-specific Gatekeeper warning for Linux users

## Changes

### CI Workflow (`.github/workflows/publish-image.yml`)
- Added `build-executor-local-linux-amd64` job using `ubuntu-latest` runner
- Added `build-executor-local-linux-arm64` job using `ubuntu-24.04-arm` runner
- Updated `create-release-tag` job dependencies to include Linux builds
- Updated artifact download pattern from `wegent-executor-macos-*` to `wegent-executor-*`
- Added Linux binaries to GitHub Release files list

### Installation Script (`executor/scripts/local_executor_install.sh`)
- Changed `detect_platform()` to accept Linux instead of rejecting it
- Added platform-specific Node.js installation hints for Linux (apt/dnf)
- Made Gatekeeper warning conditional (macOS only)
- Updated script header comment to mention Linux support

## Test plan

- [ ] Verify CI workflow syntax is valid
- [ ] Verify Linux amd64 build job succeeds on release
- [ ] Verify Linux arm64 build job succeeds on release
- [ ] Verify all 4 executor binaries are attached to GitHub Release
- [ ] Test installation script on Linux system

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux (amd64 and arm64) support for executor builds and releases
  * Installation script now provides platform-specific setup guidance for Linux and macOS users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->