### PR TITLE
feat(executor): add --version CLI flag support

### DIFF
--- a/executor/hooks/rthook_version.py
+++ b/executor/hooks/rthook_version.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+PyInstaller runtime hook for handling --version flag.
+
+This hook runs before the main script and handles the --version/-v flag
+immediately to avoid any module initialization that could cause cleanup errors.
+
+The version is read from the embedded _EMBEDDED_VERSION in version.py,
+which is set during the build process.
+"""
+
+import sys
+
+# Check for version flag before any other initialization
+if "--version" in sys.argv or "-v" in sys.argv:
+    # Read version directly from the embedded value
+    # This avoids importing any modules that could cause cleanup issues
+    try:
+        # Try to import just the version module with minimal dependencies
+        from executor.version import _EMBEDDED_VERSION
+
+        version = _EMBEDDED_VERSION if _EMBEDDED_VERSION else "unknown"
+    except ImportError:
+        version = "unknown"
+
+    # Write to stdout and flush
+    sys.stdout.write(version + "\n")
+    sys.stdout.flush()
+
+    # Use os._exit to avoid any cleanup hooks
+    import os
+
+    os._exit(0)

--- a/executor/main.py
+++ b/executor/main.py
@@ -26,17 +26,13 @@ def _handle_version_flag() -> None:
     """Handle --version/-v flag before any other initialization.
 
     If the flag is present, print version and exit immediately.
-    This is done before any imports to ensure fast response.
+    This is done before any heavy imports to ensure fast response.
     """
     if "--version" in sys.argv or "-v" in sys.argv:
         from executor.version import get_version
 
         print(get_version())
         sys.exit(0)
-
-
-# Check for version flag first (before any heavy imports)
-_handle_version_flag()
 
 
 # Required for PyInstaller on macOS/Windows to prevent infinite fork
@@ -60,13 +56,16 @@ from shared.logger import setup_logger
 logger = setup_logger("task_executor")
 
 
-def main():
+def main() -> None:
     """
     Main function for running the executor.
 
     In local mode (EXECUTOR_MODE=local), starts the WebSocket-based local runner.
     In Docker mode (default), starts the FastAPI server.
     """
+    # Handle version flag first (before any heavy initialization)
+    _handle_version_flag()
+
     from executor.config import config
 
     if config.EXECUTOR_MODE == "local":

--- a/executor/main.py
+++ b/executor/main.py
@@ -12,11 +12,32 @@ Executor main entry point.
 Supports two modes:
 - Local mode (EXECUTOR_MODE=local): WebSocket-based executor for local deployment
 - Docker mode (default): FastAPI server for container deployment
+
+CLI options:
+- --version, -v: Print version and exit
 """
 
 import multiprocessing
 import os
 import sys
+
+
+def _handle_version_flag() -> None:
+    """Handle --version/-v flag before any other initialization.
+
+    If the flag is present, print version and exit immediately.
+    This is done before any imports to ensure fast response.
+    """
+    if "--version" in sys.argv or "-v" in sys.argv:
+        from executor.version import get_version
+
+        print(get_version())
+        sys.exit(0)
+
+
+# Check for version flag first (before any heavy imports)
+_handle_version_flag()
+
 
 # Required for PyInstaller on macOS/Windows to prevent infinite fork
 if getattr(sys, "frozen", False):

--- a/executor/main.py
+++ b/executor/main.py
@@ -15,6 +15,8 @@ Supports two modes:
 
 CLI options:
 - --version, -v: Print version and exit
+  Note: In PyInstaller builds, this is handled by hooks/rthook_version.py
+  to avoid module initialization issues.
 """
 
 import multiprocessing
@@ -27,14 +29,20 @@ def _handle_version_flag() -> None:
 
     If the flag is present, print version and exit immediately.
     This is done before any heavy imports to ensure fast response.
+
+    Note: In PyInstaller builds, version flag is handled earlier by the
+    runtime hook (hooks/rthook_version.py) to avoid cleanup errors.
+    This function serves as a fallback for non-frozen (development) mode.
     """
+    # Skip if already handled by PyInstaller runtime hook
+    if getattr(sys, "frozen", False):
+        return
+
     if "--version" in sys.argv or "-v" in sys.argv:
         from executor.version import get_version
 
         print(get_version(), flush=True)
-        # Use os._exit() instead of sys.exit() to avoid PyInstaller cleanup
-        # hooks that may fail when modules are not fully initialized
-        os._exit(0)
+        sys.exit(0)
 
 
 # Required for PyInstaller on macOS/Windows to prevent infinite fork

--- a/executor/main.py
+++ b/executor/main.py
@@ -31,8 +31,10 @@ def _handle_version_flag() -> None:
     if "--version" in sys.argv or "-v" in sys.argv:
         from executor.version import get_version
 
-        print(get_version())
-        sys.exit(0)
+        print(get_version(), flush=True)
+        # Use os._exit() instead of sys.exit() to avoid PyInstaller cleanup
+        # hooks that may fail when modules are not fully initialized
+        os._exit(0)
 
 
 # Required for PyInstaller on macOS/Windows to prevent infinite fork

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -162,6 +162,8 @@ def build_executable(target_arch: str | None = None):
             f"--specpath={executor_root}",
             # Add project root to Python path
             f"--paths={project_root}",
+            # Runtime hook for --version flag (runs before main script)
+            f"--runtime-hook={executor_root / 'hooks' / 'rthook_version.py'}",
             # Hidden imports for dependencies
             "--hidden-import=executor",
             "--hidden-import=executor.config",

--- a/executor/tests/test_version_cli.py
+++ b/executor/tests/test_version_cli.py
@@ -4,6 +4,7 @@
 
 """Tests for the --version CLI flag functionality."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -71,41 +72,43 @@ class TestVersionCLI:
 
 
 class TestHandleVersionFlag:
-    """Test _handle_version_flag function directly."""
+    """Test _handle_version_flag function directly using mocked os._exit."""
 
     def test_handle_version_flag_with_version(self) -> None:
-        """Test that _handle_version_flag exits when --version is present."""
+        """Test that _handle_version_flag calls os._exit(0) when --version is present."""
         with patch.object(sys, "argv", ["main.py", "--version"]):
-            with pytest.raises(SystemExit) as exc_info:
+            with patch.object(os, "_exit") as mock_exit:
                 from executor.main import _handle_version_flag
 
                 _handle_version_flag()
-            assert exc_info.value.code == 0
+                mock_exit.assert_called_once_with(0)
 
     def test_handle_version_flag_with_v(self) -> None:
-        """Test that _handle_version_flag exits when -v is present."""
+        """Test that _handle_version_flag calls os._exit(0) when -v is present."""
         with patch.object(sys, "argv", ["main.py", "-v"]):
-            with pytest.raises(SystemExit) as exc_info:
+            with patch.object(os, "_exit") as mock_exit:
                 from executor.main import _handle_version_flag
 
                 _handle_version_flag()
-            assert exc_info.value.code == 0
+                mock_exit.assert_called_once_with(0)
 
     def test_handle_version_flag_without_flag(self) -> None:
         """Test that _handle_version_flag does nothing without version flag."""
         with patch.object(sys, "argv", ["main.py"]):
-            from executor.main import _handle_version_flag
+            with patch.object(os, "_exit") as mock_exit:
+                from executor.main import _handle_version_flag
 
-            # Should not raise SystemExit
-            _handle_version_flag()
+                _handle_version_flag()
+                mock_exit.assert_not_called()
 
     def test_handle_version_flag_with_other_args(self) -> None:
         """Test that _handle_version_flag does nothing with other arguments."""
         with patch.object(sys, "argv", ["main.py", "--help"]):
-            from executor.main import _handle_version_flag
+            with patch.object(os, "_exit") as mock_exit:
+                from executor.main import _handle_version_flag
 
-            # Should not raise SystemExit
-            _handle_version_flag()
+                _handle_version_flag()
+                mock_exit.assert_not_called()
 
 
 class TestModuleImportSafety:
@@ -119,7 +122,7 @@ class TestModuleImportSafety:
         original_argv = sys.argv.copy()
         try:
             sys.argv = ["pytest", "-v", "test_file.py"]
-            # This import should NOT cause SystemExit
+            # This import should NOT cause os._exit or any exit
             import importlib
 
             import executor.main

--- a/executor/tests/test_version_cli.py
+++ b/executor/tests/test_version_cli.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the --version CLI flag functionality."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from executor.version import get_version
+
+
+class TestVersionCLI:
+    """Test suite for executor --version CLI flag."""
+
+    def test_version_flag_long(self):
+        """Test that --version flag prints version and exits."""
+        result = subprocess.run(
+            [sys.executable, "-m", "executor.main", "--version"],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/190858/Wegent",
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == get_version()
+
+    def test_version_flag_short(self):
+        """Test that -v flag prints version and exits."""
+        result = subprocess.run(
+            [sys.executable, "-m", "executor.main", "-v"],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/190858/Wegent",
+        )
+        assert result.returncode == 0
+        assert result.stdout.strip() == get_version()
+
+    def test_version_output_format(self):
+        """Test that version output is just the version number without prefix/suffix."""
+        result = subprocess.run(
+            [sys.executable, "-m", "executor.main", "--version"],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/190858/Wegent",
+        )
+        version_output = result.stdout.strip()
+        # Version should be a simple semver format (e.g., "1.0.0")
+        assert version_output
+        # Should not contain any prefix like "version:" or "v"
+        assert not version_output.startswith("v")
+        assert ":" not in version_output
+        assert "version" not in version_output.lower()
+
+    def test_version_matches_get_version(self):
+        """Test that CLI version output matches get_version() function."""
+        expected_version = get_version()
+        result = subprocess.run(
+            [sys.executable, "-m", "executor.main", "--version"],
+            capture_output=True,
+            text=True,
+            cwd="/workspace/190858/Wegent",
+        )
+        assert result.stdout.strip() == expected_version
+
+
+class TestHandleVersionFlag:
+    """Test _handle_version_flag function directly."""
+
+    def test_handle_version_flag_with_version(self):
+        """Test that _handle_version_flag exits when --version is present."""
+        with patch.object(sys, "argv", ["main.py", "--version"]):
+            with pytest.raises(SystemExit) as exc_info:
+                from executor.main import _handle_version_flag
+
+                _handle_version_flag()
+            assert exc_info.value.code == 0
+
+    def test_handle_version_flag_with_v(self):
+        """Test that _handle_version_flag exits when -v is present."""
+        with patch.object(sys, "argv", ["main.py", "-v"]):
+            with pytest.raises(SystemExit) as exc_info:
+                from executor.main import _handle_version_flag
+
+                _handle_version_flag()
+            assert exc_info.value.code == 0
+
+    def test_handle_version_flag_without_flag(self):
+        """Test that _handle_version_flag does nothing without version flag."""
+        with patch.object(sys, "argv", ["main.py"]):
+            from executor.main import _handle_version_flag
+
+            # Should not raise SystemExit
+            _handle_version_flag()
+
+    def test_handle_version_flag_with_other_args(self):
+        """Test that _handle_version_flag does nothing with other arguments."""
+        with patch.object(sys, "argv", ["main.py", "--help"]):
+            from executor.main import _handle_version_flag
+
+            # Should not raise SystemExit
+            _handle_version_flag()

--- a/executor/tests/test_version_cli.py
+++ b/executor/tests/test_version_cli.py
@@ -6,11 +6,15 @@
 
 import subprocess
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from executor.version import get_version
+
+# Get the project root directory dynamically
+PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 
 class TestVersionCLI:
@@ -22,7 +26,7 @@ class TestVersionCLI:
             [sys.executable, "-m", "executor.main", "--version"],
             capture_output=True,
             text=True,
-            cwd="/workspace/190858/Wegent",
+            cwd=str(PROJECT_ROOT),
         )
         assert result.returncode == 0
         assert result.stdout.strip() == get_version()
@@ -33,7 +37,7 @@ class TestVersionCLI:
             [sys.executable, "-m", "executor.main", "-v"],
             capture_output=True,
             text=True,
-            cwd="/workspace/190858/Wegent",
+            cwd=str(PROJECT_ROOT),
         )
         assert result.returncode == 0
         assert result.stdout.strip() == get_version()
@@ -44,7 +48,7 @@ class TestVersionCLI:
             [sys.executable, "-m", "executor.main", "--version"],
             capture_output=True,
             text=True,
-            cwd="/workspace/190858/Wegent",
+            cwd=str(PROJECT_ROOT),
         )
         version_output = result.stdout.strip()
         # Version should be a simple semver format (e.g., "1.0.0")
@@ -61,7 +65,7 @@ class TestVersionCLI:
             [sys.executable, "-m", "executor.main", "--version"],
             capture_output=True,
             text=True,
-            cwd="/workspace/190858/Wegent",
+            cwd=str(PROJECT_ROOT),
         )
         assert result.stdout.strip() == expected_version
 

--- a/executor/tests/test_version_cli.py
+++ b/executor/tests/test_version_cli.py
@@ -20,7 +20,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.parent
 class TestVersionCLI:
     """Test suite for executor --version CLI flag."""
 
-    def test_version_flag_long(self):
+    def test_version_flag_long(self) -> None:
         """Test that --version flag prints version and exits."""
         result = subprocess.run(
             [sys.executable, "-m", "executor.main", "--version"],
@@ -31,7 +31,7 @@ class TestVersionCLI:
         assert result.returncode == 0
         assert result.stdout.strip() == get_version()
 
-    def test_version_flag_short(self):
+    def test_version_flag_short(self) -> None:
         """Test that -v flag prints version and exits."""
         result = subprocess.run(
             [sys.executable, "-m", "executor.main", "-v"],
@@ -42,7 +42,7 @@ class TestVersionCLI:
         assert result.returncode == 0
         assert result.stdout.strip() == get_version()
 
-    def test_version_output_format(self):
+    def test_version_output_format(self) -> None:
         """Test that version output is just the version number without prefix/suffix."""
         result = subprocess.run(
             [sys.executable, "-m", "executor.main", "--version"],
@@ -58,7 +58,7 @@ class TestVersionCLI:
         assert ":" not in version_output
         assert "version" not in version_output.lower()
 
-    def test_version_matches_get_version(self):
+    def test_version_matches_get_version(self) -> None:
         """Test that CLI version output matches get_version() function."""
         expected_version = get_version()
         result = subprocess.run(
@@ -73,7 +73,7 @@ class TestVersionCLI:
 class TestHandleVersionFlag:
     """Test _handle_version_flag function directly."""
 
-    def test_handle_version_flag_with_version(self):
+    def test_handle_version_flag_with_version(self) -> None:
         """Test that _handle_version_flag exits when --version is present."""
         with patch.object(sys, "argv", ["main.py", "--version"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -82,7 +82,7 @@ class TestHandleVersionFlag:
                 _handle_version_flag()
             assert exc_info.value.code == 0
 
-    def test_handle_version_flag_with_v(self):
+    def test_handle_version_flag_with_v(self) -> None:
         """Test that _handle_version_flag exits when -v is present."""
         with patch.object(sys, "argv", ["main.py", "-v"]):
             with pytest.raises(SystemExit) as exc_info:
@@ -91,7 +91,7 @@ class TestHandleVersionFlag:
                 _handle_version_flag()
             assert exc_info.value.code == 0
 
-    def test_handle_version_flag_without_flag(self):
+    def test_handle_version_flag_without_flag(self) -> None:
         """Test that _handle_version_flag does nothing without version flag."""
         with patch.object(sys, "argv", ["main.py"]):
             from executor.main import _handle_version_flag
@@ -99,10 +99,32 @@ class TestHandleVersionFlag:
             # Should not raise SystemExit
             _handle_version_flag()
 
-    def test_handle_version_flag_with_other_args(self):
+    def test_handle_version_flag_with_other_args(self) -> None:
         """Test that _handle_version_flag does nothing with other arguments."""
         with patch.object(sys, "argv", ["main.py", "--help"]):
             from executor.main import _handle_version_flag
 
             # Should not raise SystemExit
             _handle_version_flag()
+
+
+class TestModuleImportSafety:
+    """Test that importing executor.main doesn't cause unintended side effects."""
+
+    def test_import_with_v_flag_does_not_exit(self) -> None:
+        """Test that importing executor.main with -v in sys.argv doesn't exit.
+
+        This ensures pytest -v and similar commands work correctly.
+        """
+        original_argv = sys.argv.copy()
+        try:
+            sys.argv = ["pytest", "-v", "test_file.py"]
+            # This import should NOT cause SystemExit
+            import importlib
+
+            import executor.main
+
+            importlib.reload(executor.main)
+            # If we reach here, the import didn't exit - which is correct behavior
+        finally:
+            sys.argv = original_argv


### PR DESCRIPTION
## Summary

- Add `--version` and `-v` CLI flags to the executor binary entry point
- Print version number only and exit immediately with code 0
- Process version flag before any other initialization for fast response
- Leverage existing `get_version()` function from `executor/version.py`
- Add comprehensive unit tests for version CLI functionality

## Changes

**Files Modified:**
- `executor/main.py` - Add `_handle_version_flag()` function to handle version CLI flag

**Files Added:**
- `executor/tests/test_version_cli.py` - Unit tests for version CLI functionality

## Usage

```bash
# Binary mode
./wegent-executor --version
# Output: 1.0.0

./wegent-executor -v
# Output: 1.0.0

# Development mode
python -m executor.main --version
# Output: 1.0.0
```

## Test plan

- [x] Verify `--version` flag prints version and exits with code 0
- [x] Verify `-v` flag prints version and exits with code 0
- [x] Verify version output is just the version number (no prefix/suffix)
- [x] Verify version output matches `get_version()` function
- [x] Verify no SystemExit when running without version flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add --version / -v flags to print the executor version and exit early (before heavy initialization).

* **Packaging**
  * Ensure the version flag is handled for frozen/distributed builds so it prints and exits before app startup.

* **Documentation**
  * Document the CLI version flag and packaging note for frozen builds.

* **Tests**
  * Add tests confirming exact output, exit code, and correct behavior in both normal and frozen runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->