### PR TITLE
refactor(executor): apply strategy pattern for Local/Docker mode separation

### DIFF
--- a/executor/agents/claude_code/strategies/__init__.py
+++ b/executor/agents/claude_code/strategies/__init__.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Strategy module for Claude Code mode-specific behavior.
+
+This module provides the strategy pattern implementation for separating
+Local and Docker mode-specific logic in ClaudeCodeAgent.
+
+Usage:
+    from executor.agents.claude_code.strategies import get_mode_strategy
+
+    strategy = get_mode_strategy()
+    config_dir, env_config = strategy.save_config_files(agent_config, task_id, workspace_root)
+"""
+
+from executor.config import config
+
+from .base_strategy import ClaudeCodeModeStrategy
+from .docker_strategy import DockerClaudeCodeStrategy
+from .local_strategy import LocalClaudeCodeStrategy
+
+
+def get_mode_strategy() -> ClaudeCodeModeStrategy:
+    """Factory function to get the appropriate strategy based on executor mode.
+
+    Returns:
+        ClaudeCodeModeStrategy: LocalClaudeCodeStrategy for local mode,
+                               DockerClaudeCodeStrategy for docker/sandbox mode
+    """
+    if config.EXECUTOR_MODE == "local":
+        return LocalClaudeCodeStrategy()
+    else:
+        return DockerClaudeCodeStrategy()
+
+
+__all__ = [
+    "ClaudeCodeModeStrategy",
+    "LocalClaudeCodeStrategy",
+    "DockerClaudeCodeStrategy",
+    "get_mode_strategy",
+]

--- a/executor/agents/claude_code/strategies/base_strategy.py
+++ b/executor/agents/claude_code/strategies/base_strategy.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Abstract base strategy for mode-specific Claude Code behavior.
+
+This module defines the interface for strategies that handle mode-specific
+behavior in ClaudeCodeAgent (Local vs Docker execution modes).
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional, Tuple
+
+
+class ClaudeCodeModeStrategy(ABC):
+    """Abstract strategy for mode-specific Claude Code behavior.
+
+    This strategy pattern separates Local and Docker mode-specific logic
+    from the main ClaudeCodeAgent class, improving code clarity and testability.
+
+    Implementations:
+        - LocalClaudeCodeStrategy: For local executor running on user's machine
+        - DockerClaudeCodeStrategy: For container-based execution
+    """
+
+    @abstractmethod
+    def save_config_files(
+        self,
+        agent_config: Dict[str, Any],
+        task_id: int,
+        workspace_root: str,
+    ) -> Tuple[str, Dict[str, str]]:
+        """Save Claude config files and return configuration.
+
+        Args:
+            agent_config: Claude model configuration dict containing env settings
+            task_id: Task ID for creating task-specific directories
+            workspace_root: Root workspace directory path
+
+        Returns:
+            Tuple of (config_dir_path, env_config_dict):
+                - config_dir_path: Directory where config files are stored
+                - env_config_dict: Environment variables to pass to SDK
+        """
+        pass
+
+    @abstractmethod
+    def configure_sdk_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Configure SDK options with mode-specific settings.
+
+        Args:
+            options: Base SDK options dict
+            config_dir: Claude config directory path
+            env_config: Environment configuration dict from save_config_files
+
+        Returns:
+            Modified options dict with mode-specific settings applied
+        """
+        pass
+
+    @abstractmethod
+    def get_skills_deployment_config(
+        self,
+        config_dir: str,
+    ) -> Tuple[str, bool, bool]:
+        """Get skills deployment configuration.
+
+        Args:
+            config_dir: Claude config directory path
+
+        Returns:
+            Tuple of (skills_dir, skip_existing, clear_cache):
+                - skills_dir: Directory to deploy skills to
+                - skip_existing: Whether to skip already deployed skills
+                - clear_cache: Whether to clear skill cache before deployment
+        """
+        pass
+
+    @abstractmethod
+    def cleanup_session(
+        self,
+        task_id: int,
+        workspace_root: str,
+        delete_session_file: bool,
+    ) -> None:
+        """Cleanup session resources.
+
+        Args:
+            task_id: Task ID to cleanup
+            workspace_root: Root workspace directory path
+            delete_session_file: Whether to delete the session file
+                - True: Full cleanup (manual close) - deletes session file
+                - False: Partial cleanup (pause) - keeps session file for resume
+        """
+        pass
+
+    @abstractmethod
+    def get_session_file_path(
+        self,
+        task_id: int,
+        workspace_root: str,
+    ) -> Optional[str]:
+        """Get session file path for persistence.
+
+        Args:
+            task_id: Task ID
+            workspace_root: Root workspace directory path
+
+        Returns:
+            Path to session file, or None if session persistence is not supported
+        """
+        pass
+
+    @abstractmethod
+    def supports_session_persistence(self) -> bool:
+        """Check if this strategy supports session persistence.
+
+        Returns:
+            True if session can be persisted and resumed, False otherwise
+        """
+        pass

--- a/executor/agents/claude_code/strategies/docker_strategy.py
+++ b/executor/agents/claude_code/strategies/docker_strategy.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Docker mode strategy for Claude Code execution.
+
+This strategy handles mode-specific behavior when the executor runs
+inside a Docker container (isolated environment).
+"""
+
+import json
+import os
+import random
+import string
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from shared.logger import setup_logger
+
+from .base_strategy import ClaudeCodeModeStrategy
+
+logger = setup_logger("docker_strategy")
+
+
+def _generate_claude_code_user_id() -> str:
+    """Generate a random user ID for Claude Code."""
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
+
+
+class DockerClaudeCodeStrategy(ClaudeCodeModeStrategy):
+    """Strategy for Docker container execution.
+
+    Key characteristics:
+        - Uses default ~/.claude/ directory (SDK standard location)
+        - Writes both settings.json and claude.json (container is isolated)
+        - No special environment variable overrides needed
+        - Session persistence not supported (containers are ephemeral)
+        - Skills are deployed with clear_cache=True for fresh state
+    """
+
+    def save_config_files(
+        self,
+        agent_config: Dict[str, Any],
+        task_id: int,
+        workspace_root: str,
+    ) -> Tuple[str, Dict[str, str]]:
+        """Save Claude config files to default SDK location.
+
+        In Docker mode:
+        - Config directory: ~/.claude/ (SDK default)
+        - Writes both settings.json (with sensitive config) and claude.json
+        - Container isolation means no security concern with sensitive data
+        - Returns empty env_config (SDK reads from files directly)
+
+        Args:
+            agent_config: Claude model configuration dict
+            task_id: Task ID (not used in Docker mode)
+            workspace_root: Root workspace directory (not used in Docker mode)
+
+        Returns:
+            Tuple of (config_dir_path, env_config_dict)
+        """
+        # Non-sensitive user preferences config for claude.json
+        claude_json_config = {
+            "numStartups": 2,
+            "installMethod": "unknown",
+            "autoUpdates": True,
+            "sonnet45MigrationComplete": True,
+            "userID": _generate_claude_code_user_id(),
+            "hasCompletedOnboarding": True,
+            "lastOnboardingVersion": "2.0.14",
+            "bypassPermissionsModeAccepted": True,
+            "hasOpusPlanDefault": False,
+            "lastReleaseNotesSeen": "2.0.14",
+            "isQualifiedForDataSharing": False,
+        }
+
+        # Docker mode: save to user's ~/.claude directory (SDK default location)
+        config_dir = os.path.expanduser("~/.claude")
+        claude_json_path = os.path.expanduser("~/.claude.json")
+
+        Path(config_dir).mkdir(parents=True, exist_ok=True)
+
+        # Save settings.json (Docker mode only - isolated container environment)
+        settings_path = os.path.join(config_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump(agent_config, f, indent=2)
+
+        # Save claude.json
+        with open(claude_json_path, "w") as f:
+            json.dump(claude_json_config, f, indent=2)
+
+        logger.info(f"Docker mode: Saved config files to {config_dir}")
+
+        # Return empty env_config - SDK reads from config files in Docker mode
+        return config_dir, {}
+
+    def configure_sdk_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Configure SDK options for Docker mode.
+
+        In Docker mode:
+        - No special configuration needed
+        - SDK uses default paths (~/.claude/)
+        - Returns options unchanged
+
+        Args:
+            options: Base SDK options dict
+            config_dir: Claude config directory path (not used)
+            env_config: Environment configuration dict (not used)
+
+        Returns:
+            Unchanged options dict
+        """
+        # Docker mode: no modifications needed, SDK uses default paths
+        return options
+
+    def get_skills_deployment_config(
+        self,
+        config_dir: str,
+    ) -> Tuple[str, bool, bool]:
+        """Get skills deployment configuration for Docker mode.
+
+        In Docker mode:
+        - Skills deployed to ~/.claude/skills (standard location)
+        - skip_existing=False to always deploy
+        - clear_cache=True for fresh state each container
+
+        Args:
+            config_dir: Claude config directory path (not used)
+
+        Returns:
+            Tuple of (skills_dir, skip_existing, clear_cache)
+        """
+        skills_dir = os.path.expanduser("~/.claude/skills")
+        return (skills_dir, False, True)  # skip_existing=False, clear_cache=True
+
+    def cleanup_session(
+        self,
+        task_id: int,
+        workspace_root: str,
+        delete_session_file: bool,
+    ) -> None:
+        """Cleanup session resources for Docker mode.
+
+        Docker mode does not persist sessions, so this is a no-op.
+
+        Args:
+            task_id: Task ID
+            workspace_root: Root workspace directory
+            delete_session_file: Whether to delete session file (ignored)
+        """
+        logger.debug(
+            f"Docker mode: Session persistence not supported, no cleanup needed for task {task_id}"
+        )
+
+    def get_session_file_path(
+        self,
+        task_id: int,
+        workspace_root: str,
+    ) -> Optional[str]:
+        """Get session file path for Docker mode.
+
+        Docker mode does not support session persistence.
+
+        Args:
+            task_id: Task ID
+            workspace_root: Root workspace directory
+
+        Returns:
+            None - session persistence not supported in Docker mode
+        """
+        return None
+
+    def supports_session_persistence(self) -> bool:
+        """Docker mode does not support session persistence.
+
+        Returns:
+            False - sessions are ephemeral in containers
+        """
+        return False

--- a/executor/agents/claude_code/strategies/local_strategy.py
+++ b/executor/agents/claude_code/strategies/local_strategy.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Local mode strategy for Claude Code execution.
+
+This strategy handles mode-specific behavior when the executor runs
+locally on the user's machine (not in a Docker container).
+"""
+
+import json
+import os
+import random
+import string
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from shared.logger import setup_logger
+
+from .base_strategy import ClaudeCodeModeStrategy
+
+logger = setup_logger("local_strategy")
+
+
+def _generate_claude_code_user_id() -> str:
+    """Generate a random user ID for Claude Code."""
+    return "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
+
+
+class LocalClaudeCodeStrategy(ClaudeCodeModeStrategy):
+    """Strategy for local executor running on user's machine.
+
+    Key characteristics:
+        - Uses task-specific config directory to avoid polluting user's ~/.claude/
+        - Does NOT write settings.json (contains sensitive API keys)
+        - Passes sensitive config via environment variables
+        - Supports session persistence via .claude_session_id file
+        - Skills are deployed with skip_existing=True to avoid re-downloading
+    """
+
+    def save_config_files(
+        self,
+        agent_config: Dict[str, Any],
+        task_id: int,
+        workspace_root: str,
+    ) -> Tuple[str, Dict[str, str]]:
+        """Save Claude config files to task-specific directory.
+
+        In Local mode:
+        - Config directory: {workspace_root}/{task_id}/.claude/
+        - Only writes claude.json (non-sensitive user preferences)
+        - Does NOT write settings.json (contains sensitive API keys)
+        - Sensitive config is passed via environment variables
+        - Uses restricted file permissions (0o700 for dir, 0o600 for file)
+
+        Args:
+            agent_config: Claude model configuration dict
+            task_id: Task ID
+            workspace_root: Root workspace directory
+
+        Returns:
+            Tuple of (config_dir_path, env_config_dict)
+        """
+        # Extract env config for passing to SDK via environment variables
+        env_config = agent_config.get("env", {})
+
+        # Non-sensitive user preferences config for claude.json
+        claude_json_config = {
+            "numStartups": 2,
+            "installMethod": "unknown",
+            "autoUpdates": True,
+            "sonnet45MigrationComplete": True,
+            "userID": _generate_claude_code_user_id(),
+            "hasCompletedOnboarding": True,
+            "lastOnboardingVersion": "2.0.14",
+            "bypassPermissionsModeAccepted": True,
+            "hasOpusPlanDefault": False,
+            "lastReleaseNotesSeen": "2.0.14",
+            "isQualifiedForDataSharing": False,
+        }
+
+        # Local mode: task-specific config directory
+        config_dir = os.path.join(workspace_root, str(task_id), ".claude")
+        claude_json_path = os.path.join(config_dir, "claude.json")
+
+        # Create directory with restricted permissions (owner only)
+        Path(config_dir).mkdir(parents=True, exist_ok=True)
+        os.chmod(config_dir, 0o700)
+
+        # Write only non-sensitive claude.json with restricted permissions
+        with open(claude_json_path, "w") as f:
+            json.dump(claude_json_config, f, indent=2)
+        os.chmod(claude_json_path, 0o600)
+
+        logger.info(
+            f"Local mode: Saved claude.json to {config_dir} "
+            "(settings.json skipped - sensitive config passed via env)"
+        )
+
+        return config_dir, env_config
+
+    def configure_sdk_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, str],
+    ) -> Dict[str, Any]:
+        """Configure SDK options for local mode.
+
+        In Local mode:
+        - Merges env_config into options["env"]
+        - Sets CLAUDE_CONFIG_DIR to redirect SDK config reads/writes
+          to task-specific directory instead of ~/.claude/
+
+        Args:
+            options: Base SDK options dict
+            config_dir: Claude config directory path
+            env_config: Environment configuration dict
+
+        Returns:
+            Modified options dict
+        """
+        # Make a copy to avoid modifying the original
+        options = dict(options)
+
+        # Pass env config (contains ANTHROPIC_AUTH_TOKEN, ANTHROPIC_MODEL, etc.)
+        if env_config:
+            existing_env = options.get("env", {})
+            merged_env = {**existing_env, **env_config}
+            options["env"] = {k: str(v) for k, v in merged_env.items()}
+
+        # Set CLAUDE_CONFIG_DIR env var to redirect all config reads/writes
+        # This affects settings.json, claude.json, and skills locations
+        if config_dir:
+            env = options.get("env", {})
+            env["CLAUDE_CONFIG_DIR"] = config_dir
+            options["env"] = env
+
+        return options
+
+    def get_skills_deployment_config(
+        self,
+        config_dir: str,
+    ) -> Tuple[str, bool, bool]:
+        """Get skills deployment configuration for local mode.
+
+        In Local mode:
+        - Skills deployed to {config_dir}/skills (follows CLAUDE_CONFIG_DIR)
+        - skip_existing=True to avoid re-downloading existing skills
+        - clear_cache=False to preserve cached skills
+
+        Args:
+            config_dir: Claude config directory path
+
+        Returns:
+            Tuple of (skills_dir, skip_existing, clear_cache)
+        """
+        skills_dir = os.path.join(config_dir, "skills")
+        return (skills_dir, True, False)  # skip_existing=True, clear_cache=False
+
+    def cleanup_session(
+        self,
+        task_id: int,
+        workspace_root: str,
+        delete_session_file: bool,
+    ) -> None:
+        """Cleanup session resources for local mode.
+
+        Args:
+            task_id: Task ID
+            workspace_root: Root workspace directory
+            delete_session_file: Whether to delete the session file
+                - True: Full cleanup (manual close)
+                - False: Partial cleanup (pause) - keep session file for resume
+        """
+        if not delete_session_file:
+            logger.info(
+                f"Local mode: Keeping session file for task {task_id} (pause mode)"
+            )
+            return
+
+        # Delete session file for full cleanup
+        session_file = self.get_session_file_path(task_id, workspace_root)
+        if session_file and os.path.exists(session_file):
+            try:
+                os.remove(session_file)
+                logger.info(f"Deleted session file: {session_file}")
+            except Exception as e:
+                logger.warning(f"Failed to delete session file {session_file}: {e}")
+        else:
+            logger.debug(
+                f"Session file not found for task {task_id}, nothing to delete"
+            )
+
+    def get_session_file_path(
+        self,
+        task_id: int,
+        workspace_root: str,
+    ) -> Optional[str]:
+        """Get session file path for local mode.
+
+        Args:
+            task_id: Task ID
+            workspace_root: Root workspace directory
+
+        Returns:
+            Path to session file: {workspace_root}/{task_id}/.claude_session_id
+        """
+        task_dir = os.path.join(workspace_root, str(task_id))
+        return os.path.join(task_dir, ".claude_session_id")
+
+    def supports_session_persistence(self) -> bool:
+        """Local mode supports session persistence.
+
+        Returns:
+            True - sessions can be persisted and resumed
+        """
+        return True

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -260,8 +260,11 @@ class LocalRunner:
             logger.info(
                 f"[Runner] About to call cleanup_task_clients for task_id={task_id}"
             )
-            # Cleanup any lingering client for this task_id
-            cleaned = await ClaudeCodeAgent.cleanup_task_clients(task_id)
+            # Manual close: Full cleanup including session file deletion
+            # This prevents session resume after explicit close
+            cleaned = await ClaudeCodeAgent.cleanup_task_clients(
+                task_id, delete_session_file=True
+            )
             logger.info(f"[Runner] cleanup_task_clients returned: cleaned={cleaned}")
             if cleaned > 0:
                 logger.info(


### PR DESCRIPTION
## Summary

- Introduce strategy pattern to separate Local and Docker mode-specific logic in ClaudeCodeAgent
- Implement session lifecycle improvements: pause preserves session file for resume, manual close fully deletes
- Eliminate scattered `config.EXECUTOR_MODE == "local"` conditionals throughout the codebase

## Changes

### New Files
- `executor/agents/claude_code/strategies/base_strategy.py`: Abstract base class `ClaudeCodeModeStrategy`
- `executor/agents/claude_code/strategies/local_strategy.py`: `LocalClaudeCodeStrategy` implementation
- `executor/agents/claude_code/strategies/docker_strategy.py`: `DockerClaudeCodeStrategy` implementation
- `executor/agents/claude_code/strategies/__init__.py`: Factory function `get_mode_strategy()`

### Modified Files
- `executor/agents/claude_code/claude_code_agent.py`:
  - Inject mode strategy in `__init__`
  - Refactor `_save_claude_config_files()` to use strategy
  - Refactor `_create_and_connect_client()` to use strategy
  - Refactor `_download_and_deploy_skills()` to use strategy
  - Add `delete_session_file` parameter to `cleanup_task_clients()`
  - Update `cancel_run()` to clean up clients while preserving session file

- `executor/modes/local/runner.py`:
  - Update `close_task_session()` to pass `delete_session_file=True` for full cleanup

## Session Lifecycle

| Operation | Client Process | `_clients` Dict | `.claude_session_id` | Can Resume |
|-----------|---------------|-----------------|---------------------|------------|
| **Pause** | ✅ Terminates | ✅ Removed | ❌ Preserved | ✅ Yes |
| **Manual Close** | ✅ Terminates | ✅ Removed | ✅ Deleted | ❌ No |
| **Continue Chat** | New | Re-cached | Used for resume | - |

## Test plan

- [x] All 85 existing executor tests pass
- [x] Python syntax validation passes
- [ ] Manual test: Pause a task, verify session file preserved, continue chat resumes context
- [ ] Manual test: Manual close via UI, verify session file deleted, new chat is fresh session
- [ ] Verify Local mode: config files written to task-specific directory
- [ ] Verify Docker mode: config files written to ~/.claude/