### PR TITLE
fix(frontend): add iOS 16 Safari compatibility fixes

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// iOS 16 Safari polyfills - must be imported first
+import '@/lib/polyfills'
+
 import type { Metadata } from 'next'
 import './globals.css'
 import '@/styles/markdown.css'
@@ -20,6 +23,7 @@ import SchemeURLDialogBridgeClient from '@/components/SchemeURLDialogBridgeClien
 import { Toaster } from '@/components/ui/toaster'
 import { Toaster as SonnerToaster } from 'sonner'
 import { TooltipProvider } from '@/components/ui/tooltip'
+import { CSSLoadFixer } from '@/components/CSSLoadFixer'
 
 export const metadata: Metadata = {
   title: 'Wegent AI',
@@ -45,6 +49,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeScript />
       </head>
       <body className="font-sans antialiased bg-base text-text-primary" suppressHydrationWarning>
+        <CSSLoadFixer />
         <ServiceWorkerRegistration />
         <TelemetryInit />
         <SchemeURLInit />

--- a/frontend/src/components/CSSLoadFixer.tsx
+++ b/frontend/src/components/CSSLoadFixer.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useEffect } from 'react'
+
+/**
+ * Fixes a Next.js 15 bug where CSS files are incorrectly loaded as <script> tags
+ * on iOS Safari. This component runs early to convert them back to <link> tags.
+ *
+ * @see https://github.com/vercel/next.js/issues (CSS in build-manifest.json bug)
+ */
+export function CSSLoadFixer() {
+  useEffect(() => {
+    // Find all script tags that incorrectly reference CSS files
+    document.querySelectorAll('script[src$=".css"]').forEach(script => {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = (script as HTMLScriptElement).src
+      script.parentNode?.replaceChild(link, script)
+    })
+  }, [])
+
+  return null
+}

--- a/frontend/src/lib/polyfills.ts
+++ b/frontend/src/lib/polyfills.ts
@@ -1,0 +1,72 @@
+/**
+ * Polyfills for iOS 16 Safari compatibility
+ *
+ * iOS 16 Safari lacks support for some ES2022+ features that modern
+ * npm packages may use. This file provides polyfills for those features.
+ */
+
+// Type declarations for polyfills
+declare global {
+  interface ObjectConstructor {
+    hasOwn?(obj: object, prop: PropertyKey): boolean
+  }
+}
+
+if (typeof window !== 'undefined') {
+  // Object.hasOwn polyfill (ES2022)
+  // Used by many modern libraries for property checking
+  if (!Object.hasOwn) {
+    ;(Object as ObjectConstructor).hasOwn = function (obj: object, prop: PropertyKey): boolean {
+      return Object.prototype.hasOwnProperty.call(obj, prop)
+    }
+  }
+
+  // Array.prototype.at polyfill (ES2022)
+  // Provides negative indexing support for arrays
+  if (!Array.prototype.at) {
+    Array.prototype.at = function <T>(this: T[], n: number): T | undefined {
+      n = Math.trunc(n) || 0
+      if (n < 0) n += this.length
+      if (n < 0 || n >= this.length) return undefined
+      return this[n]
+    }
+  }
+
+  // String.prototype.at polyfill (ES2022)
+  // Provides negative indexing support for strings
+  if (!String.prototype.at) {
+    String.prototype.at = function (n: number): string | undefined {
+      n = Math.trunc(n) || 0
+      if (n < 0) n += this.length
+      if (n < 0 || n >= this.length) return undefined
+      return this.charAt(n)
+    }
+  }
+
+  // TypedArray.prototype.at polyfill (ES2022)
+  // For consistency with Array.prototype.at
+  const typedArrayTypes = [
+    Int8Array,
+    Uint8Array,
+    Uint8ClampedArray,
+    Int16Array,
+    Uint16Array,
+    Int32Array,
+    Uint32Array,
+    Float32Array,
+    Float64Array,
+  ]
+
+  typedArrayTypes.forEach(TypedArrayConstructor => {
+    if (!TypedArrayConstructor.prototype.at) {
+      TypedArrayConstructor.prototype.at = function (n: number) {
+        n = Math.trunc(n) || 0
+        if (n < 0) n += this.length
+        if (n < 0 || n >= this.length) return undefined
+        return this[n]
+      }
+    }
+  })
+}
+
+export {}


### PR DESCRIPTION
iOS 16 Safari has two issues with the current build:
1. CSS files incorrectly loaded as <script> tags (Next.js 15 bug)
2. Modern JS syntax (ES2022+) not supported by older Safari

This fix adds:
- CSSLoadFixer component to convert CSS script tags back to link tags
- ES2022 polyfills (Object.hasOwn, Array/String.prototype.at)
- transpilePackages config for mermaid, framer-motion, codemirror, katex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS loading issues on iOS 16 Safari
  * Added polyfills for modern JavaScript features (Object.hasOwn, Array/String.prototype.at methods) to improve compatibility with iOS 16 Safari
  * Improved application bundling and chunk loading performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->