### PR TITLE
fix(executor): use Ubuntu 22.04 for Linux builds to improve GLIBC com…

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -522,10 +522,13 @@ jobs:
 
   # ============================================================================
   # Executor Local Binary Build (Linux)
+  # Note: Using Ubuntu 22.04 for better GLIBC compatibility (GLIBC 2.35)
+  # This ensures the binary works on most Linux distributions including
+  # CentOS 7/8, RHEL, Debian 11+, Ubuntu 20.04+, etc.
   # ============================================================================
   build-executor-local-linux-amd64:
     needs: prepare-release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
@@ -561,7 +564,7 @@ jobs:
 
   build-executor-local-linux-arm64:
     needs: prepare-release
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
…patibility

Switch from ubuntu-latest (24.04, GLIBC 2.38) to ubuntu-22.04 (GLIBC 2.35) for building Linux executor binaries. This ensures compatibility with older Linux distributions including CentOS 7/8, RHEL, Debian 11+, Ubuntu 20.04+.

Fixes: GLIBC_2.38 not found error on older Linux systems