### PR TITLE
feat(backend): add sandbox path to attachment metadata

### DIFF
--- a/backend/app/api/endpoints/adapter/attachments.py
+++ b/backend/app/api/endpoints/adapter/attachments.py
@@ -605,13 +605,15 @@ async def get_attachment_by_subtask(
 async def get_all_task_attachments(
     task_id: int,
     db: Session = Depends(get_db),
-    current_user: User = Depends(security.get_current_user),
+    current_user: User = Depends(security.get_current_user_flexible_for_executor),
 ):
     """
     Get all attachments for a task (across all subtasks).
 
     This endpoint is used by the executor to pre-download all attachments
     for a task at sandbox startup.
+
+    Supports both JWT token and API Key authentication.
 
     Args:
         task_id: Task ID
@@ -633,7 +635,7 @@ async def get_all_task_attachments(
         .filter(
             TaskMember.task_id == task_id,
             TaskMember.user_id == current_user.id,
-            TaskMember.status == MemberStatus.ACTIVE.value,
+            TaskMember.status == MemberStatus.ACTIVE,
         )
         .first()
         is not None

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -490,15 +490,12 @@ def _schedule_attachment_sync_to_sandbox(
     """
     import asyncio
 
-    from app.services.sandbox_file_syncer import (
-        get_sandbox_file_syncer,
-        sync_attachment_to_sandbox_background,
-    )
+    from app.services.sandbox_file_syncer import sync_attachment_to_sandbox_background
 
     try:
-        # Check if sandbox is healthy synchronously first (fast check)
-        # This avoids fetching binary data if sandbox is not running
-        syncer = get_sandbox_file_syncer()
+        # Import sandbox sync utilities (deferred to avoid circular imports)
+        # Health check is performed asynchronously in the background task
+        # to avoid blocking the main flow
 
         # Get attachment data from database
         attachment_contexts = (

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -251,7 +251,7 @@ def _process_attachment_context(
             image_header = (
                 f"[Image Attachment: {filename} | ID: {attachment_id} | "
                 f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-                f"Sandbox: {sandbox_path}]"
+                f"File Path(already in sandbox): {sandbox_path}]"
             )
         else:
             image_header = (

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -112,14 +112,14 @@ class ContextService:
             filename: Original filename
 
         Returns:
-            Sandbox path in format: {task_id}:executor:attachments/{subtask_id}/{filename}
+            Sandbox path in format: /home/user/{task_id}:executor:attachments/{subtask_id}/{filename}
             Returns None if task_id or subtask_id is not provided.
         """
         if task_id is None or subtask_id is None:
             return None
         # Guard against None filename and strip control characters
         safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
-        return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+        return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
     # ==================== Attachment Operations ====================
 
@@ -634,7 +634,7 @@ class ContextService:
             prefix = (
                 f"[Attachment: {filename} | ID: {attachment_id} | "
                 f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-                f"Sandbox: {sandbox_path}]\n"
+                f"File Path(already in sandbox): {sandbox_path}]\n"
             )
         else:
             prefix = (

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -117,7 +117,9 @@ class ContextService:
         """
         if task_id is None or subtask_id is None:
             return None
-        return f"{task_id}:executor:attachments/{subtask_id}/{filename}"
+        # Strip control characters to prevent metadata string corruption
+        safe_filename = filename.replace("\n", "").replace("\r", "")
+        return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
     # ==================== Attachment Operations ====================
 

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -117,8 +117,8 @@ class ContextService:
         """
         if task_id is None or subtask_id is None:
             return None
-        # Strip control characters to prevent metadata string corruption
-        safe_filename = filename.replace("\n", "").replace("\r", "")
+        # Guard against None filename and strip control characters
+        safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
         return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
     # ==================== Attachment Operations ====================

--- a/backend/app/services/sandbox_file_syncer.py
+++ b/backend/app/services/sandbox_file_syncer.py
@@ -130,25 +130,25 @@ class SandboxFileSyncer:
                 base_url = data.get("base_url")
 
                 if status in SANDBOX_HEALTHY_STATUSES and base_url:
-                    logger.debug(
+                    logger.info(
                         f"[SandboxFileSyncer] Sandbox {sandbox_id} is healthy: "
                         f"status={status}, base_url={base_url}"
                     )
                     return True, base_url
                 else:
-                    logger.debug(
+                    logger.warning(
                         f"[SandboxFileSyncer] Sandbox {sandbox_id} not healthy: "
                         f"status={status}, base_url={base_url}"
                     )
                     return False, None
 
         except httpx.TimeoutException:
-            logger.debug(
+            logger.warning(
                 f"[SandboxFileSyncer] Timeout checking sandbox {sandbox_id} status"
             )
             return False, None
         except Exception as e:
-            logger.debug(
+            logger.error(
                 f"[SandboxFileSyncer] Error checking sandbox {sandbox_id} status: {e}"
             )
             return False, None

--- a/backend/app/services/sandbox_file_syncer.py
+++ b/backend/app/services/sandbox_file_syncer.py
@@ -15,7 +15,6 @@ block the attachment upload flow.
 import asyncio
 import logging
 import os
-import re
 from typing import Optional
 
 import httpx
@@ -300,7 +299,5 @@ async def sync_attachment_to_sandbox_background(
             filename=filename,
             binary_data=binary_data,
         )
-    except Exception as e:
-        logger.exception(
-            f"[SandboxFileSyncer] Unexpected error in background sync: {e}"
-        )
+    except Exception:
+        logger.exception("[SandboxFileSyncer] Unexpected error in background sync")

--- a/backend/app/services/sandbox_file_syncer.py
+++ b/backend/app/services/sandbox_file_syncer.py
@@ -1,0 +1,306 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sandbox file syncer service for synchronizing files to running sandboxes.
+
+This service provides functionality to:
+- Check if a sandbox is running and healthy
+- Upload files to running sandboxes via the envd /files endpoint
+
+The sync is performed in the background and failures are logged but do not
+block the attachment upload flow.
+"""
+
+import asyncio
+import logging
+import os
+import re
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+EXECUTOR_MANAGER_URL = os.getenv("EXECUTOR_MANAGER_URL", "http://localhost:8001")
+SANDBOX_FILE_SYNC_TIMEOUT = float(os.getenv("SANDBOX_FILE_SYNC_TIMEOUT", "30.0"))
+SANDBOX_STATUS_CHECK_TIMEOUT = float(os.getenv("SANDBOX_STATUS_CHECK_TIMEOUT", "5.0"))
+
+# Valid sandbox statuses for file sync
+SANDBOX_HEALTHY_STATUSES = {"running"}
+
+
+def _sanitize_filename(filename: str) -> str:
+    """Sanitize filename to prevent path traversal attacks.
+
+    Args:
+        filename: Original filename
+
+    Returns:
+        Sanitized filename safe for use in file paths
+    """
+    # Get basename to remove any directory components
+    safe_name = os.path.basename(filename or "attachment")
+    # Replace path separators that might have been encoded
+    safe_name = safe_name.replace("/", "_").replace("\\", "_")
+    # Remove control characters
+    safe_name = safe_name.replace("\n", "").replace("\r", "")
+    return safe_name if safe_name else "attachment"
+
+
+def build_sandbox_attachment_path(task_id: int, subtask_id: int, filename: str) -> str:
+    """Build the sandbox path for an attachment.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        filename: Original filename
+
+    Returns:
+        Path where the attachment should be stored in sandbox
+    """
+    safe_filename = _sanitize_filename(filename)
+    return f"/home/user/attachments/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+
+
+class SandboxFileSyncer:
+    """Service for synchronizing files to running sandboxes.
+
+    This service is used to sync uploaded attachments to running sandboxes
+    so that the executor can access them without re-downloading.
+
+    Example:
+        syncer = SandboxFileSyncer()
+        await syncer.sync_attachment_to_sandbox(
+            task_id=123,
+            subtask_id=456,
+            filename="document.pdf",
+            binary_data=file_bytes,
+        )
+    """
+
+    def __init__(
+        self,
+        executor_manager_url: Optional[str] = None,
+        file_sync_timeout: Optional[float] = None,
+        status_check_timeout: Optional[float] = None,
+    ):
+        """Initialize the sandbox file syncer.
+
+        Args:
+            executor_manager_url: URL of executor_manager service
+            file_sync_timeout: Timeout for file upload in seconds
+            status_check_timeout: Timeout for sandbox status check in seconds
+        """
+        self.executor_manager_url = (
+            executor_manager_url or EXECUTOR_MANAGER_URL
+        ).rstrip("/")
+        self.file_sync_timeout = file_sync_timeout or SANDBOX_FILE_SYNC_TIMEOUT
+        self.status_check_timeout = status_check_timeout or SANDBOX_STATUS_CHECK_TIMEOUT
+
+    async def is_sandbox_healthy(self, task_id: int) -> tuple[bool, Optional[str]]:
+        """Check if the sandbox for a task is running and healthy.
+
+        Args:
+            task_id: Task ID (sandbox_id is derived from task_id)
+
+        Returns:
+            Tuple of (is_healthy, base_url or None)
+        """
+        sandbox_id = str(task_id)
+        url = f"{self.executor_manager_url}/executor-manager/sandboxes/{sandbox_id}"
+
+        try:
+            async with httpx.AsyncClient(timeout=self.status_check_timeout) as client:
+                response = await client.get(url)
+
+                if response.status_code == 404:
+                    logger.debug(f"[SandboxFileSyncer] Sandbox {sandbox_id} not found")
+                    return False, None
+
+                if response.status_code != 200:
+                    logger.warning(
+                        f"[SandboxFileSyncer] Failed to get sandbox status: "
+                        f"HTTP {response.status_code}"
+                    )
+                    return False, None
+
+                data = response.json()
+                status = data.get("status", "").lower()
+                base_url = data.get("base_url")
+
+                if status in SANDBOX_HEALTHY_STATUSES and base_url:
+                    logger.debug(
+                        f"[SandboxFileSyncer] Sandbox {sandbox_id} is healthy: "
+                        f"status={status}, base_url={base_url}"
+                    )
+                    return True, base_url
+                else:
+                    logger.debug(
+                        f"[SandboxFileSyncer] Sandbox {sandbox_id} not healthy: "
+                        f"status={status}, base_url={base_url}"
+                    )
+                    return False, None
+
+        except httpx.TimeoutException:
+            logger.debug(
+                f"[SandboxFileSyncer] Timeout checking sandbox {sandbox_id} status"
+            )
+            return False, None
+        except Exception as e:
+            logger.debug(
+                f"[SandboxFileSyncer] Error checking sandbox {sandbox_id} status: {e}"
+            )
+            return False, None
+
+    async def upload_file_to_sandbox(
+        self,
+        base_url: str,
+        remote_path: str,
+        binary_data: bytes,
+        filename: str,
+    ) -> bool:
+        """Upload a file to the sandbox via envd /files endpoint.
+
+        Args:
+            base_url: Sandbox base URL (e.g., http://localhost:8080)
+            remote_path: Path where the file should be stored in sandbox
+            binary_data: File content
+            filename: Original filename
+
+        Returns:
+            True if upload succeeded, False otherwise
+        """
+        # envd expects POST /files with path query parameter
+        url = f"{base_url}/files"
+        params = {"path": remote_path}
+
+        try:
+            async with httpx.AsyncClient(timeout=self.file_sync_timeout) as client:
+                # Send as multipart form data
+                files = {"file": (filename, binary_data)}
+                response = await client.post(url, params=params, files=files)
+
+                if response.status_code == 200:
+                    logger.info(
+                        f"[SandboxFileSyncer] Successfully uploaded file to sandbox: "
+                        f"{remote_path}"
+                    )
+                    return True
+                else:
+                    logger.warning(
+                        f"[SandboxFileSyncer] Failed to upload file to sandbox: "
+                        f"HTTP {response.status_code}, response={response.text[:200]}"
+                    )
+                    return False
+
+        except httpx.TimeoutException:
+            logger.warning(
+                f"[SandboxFileSyncer] Timeout uploading file to sandbox: {remote_path}"
+            )
+            return False
+        except Exception as e:
+            logger.warning(f"[SandboxFileSyncer] Error uploading file to sandbox: {e}")
+            return False
+
+    async def sync_attachment_to_sandbox(
+        self,
+        task_id: int,
+        subtask_id: int,
+        filename: str,
+        binary_data: bytes,
+    ) -> bool:
+        """Sync an attachment to the sandbox if it's running.
+
+        This method checks if the sandbox is healthy and uploads the file.
+        Failures are logged but do not raise exceptions.
+
+        Args:
+            task_id: Task ID
+            subtask_id: Subtask ID
+            filename: Original filename
+            binary_data: File content
+
+        Returns:
+            True if sync succeeded, False otherwise (including if sandbox not running)
+        """
+        # Check if sandbox is healthy
+        is_healthy, base_url = await self.is_sandbox_healthy(task_id)
+        if not is_healthy or not base_url:
+            logger.debug(
+                f"[SandboxFileSyncer] Skipping sync for task {task_id}: "
+                f"sandbox not healthy"
+            )
+            return False
+
+        # Build target path
+        remote_path = build_sandbox_attachment_path(task_id, subtask_id, filename)
+
+        # Upload file
+        success = await self.upload_file_to_sandbox(
+            base_url=base_url,
+            remote_path=remote_path,
+            binary_data=binary_data,
+            filename=_sanitize_filename(filename),
+        )
+
+        if success:
+            logger.info(
+                f"[SandboxFileSyncer] Synced attachment to sandbox: "
+                f"task_id={task_id}, subtask_id={subtask_id}, filename={filename}"
+            )
+        else:
+            logger.warning(
+                f"[SandboxFileSyncer] Failed to sync attachment to sandbox: "
+                f"task_id={task_id}, subtask_id={subtask_id}, filename={filename}"
+            )
+
+        return success
+
+
+# Global instance
+_sandbox_file_syncer: Optional[SandboxFileSyncer] = None
+
+
+def get_sandbox_file_syncer() -> SandboxFileSyncer:
+    """Get the global SandboxFileSyncer instance.
+
+    Returns:
+        The SandboxFileSyncer singleton
+    """
+    global _sandbox_file_syncer
+    if _sandbox_file_syncer is None:
+        _sandbox_file_syncer = SandboxFileSyncer()
+    return _sandbox_file_syncer
+
+
+async def sync_attachment_to_sandbox_background(
+    task_id: int,
+    subtask_id: int,
+    filename: str,
+    binary_data: bytes,
+) -> None:
+    """Sync attachment to sandbox in background.
+
+    This function is designed to be called from asyncio.create_task()
+    and handles all exceptions internally.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        filename: Original filename
+        binary_data: File content
+    """
+    try:
+        syncer = get_sandbox_file_syncer()
+        await syncer.sync_attachment_to_sandbox(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            filename=filename,
+            binary_data=binary_data,
+        )
+    except Exception as e:
+        logger.exception(
+            f"[SandboxFileSyncer] Unexpected error in background sync: {e}"
+        )

--- a/backend/app/services/sandbox_file_syncer.py
+++ b/backend/app/services/sandbox_file_syncer.py
@@ -60,7 +60,7 @@ def build_sandbox_attachment_path(task_id: int, subtask_id: int, filename: str) 
         Path where the attachment should be stored in sandbox
     """
     safe_filename = _sanitize_filename(filename)
-    return f"/home/user/attachments/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+    return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
 
 class SandboxFileSyncer:

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -304,11 +304,11 @@ class TestContextServiceFormatting:
 
         # Test with valid task_id and subtask_id
         path = context_service.build_sandbox_path(123, 456, "test.pdf")
-        assert path == "123:executor:attachments/456/test.pdf"
+        assert path == "/home/user/123:executor:attachments/456/test.pdf"
 
         # Test with different values
         path = context_service.build_sandbox_path(1, 2, "image.png")
-        assert path == "1:executor:attachments/2/image.png"
+        assert path == "/home/user/1:executor:attachments/2/image.png"
 
     def test_build_sandbox_path_returns_none_for_missing_ids(self):
         """Test sandbox path returns None when task_id or subtask_id is missing"""
@@ -329,15 +329,15 @@ class TestContextServiceFormatting:
 
         # Test filename with newline
         path = context_service.build_sandbox_path(123, 456, "test\n.pdf")
-        assert path == "123:executor:attachments/456/test.pdf"
+        assert path == "/home/user/123:executor:attachments/456/test.pdf"
 
         # Test filename with carriage return
         path = context_service.build_sandbox_path(123, 456, "test\r.pdf")
-        assert path == "123:executor:attachments/456/test.pdf"
+        assert path == "/home/user/123:executor:attachments/456/test.pdf"
 
         # Test filename with both
         path = context_service.build_sandbox_path(123, 456, "test\r\n.pdf")
-        assert path == "123:executor:attachments/456/test.pdf"
+        assert path == "/home/user/123:executor:attachments/456/test.pdf"
 
     def test_build_document_text_prefix_with_sandbox_path(self):
         """Test building document text prefix with sandbox path included"""
@@ -378,7 +378,10 @@ class TestContextServiceFormatting:
         assert "Type: application/pdf" in prefix
         assert "Size: 2.5 MB" in prefix
         assert "URL: /api/attachments/12345/download" in prefix
-        assert "Sandbox: 100:executor:attachments/200/test.pdf" in prefix
+        assert (
+            "File Path(already in sandbox): /home/user/100:executor:attachments/200/test.pdf"
+            in prefix
+        )
         assert "This is the extracted PDF content." in prefix
 
     def test_build_document_text_prefix(self):

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -298,6 +298,73 @@ class TestContextServiceFormatting:
         )
         assert context_service.build_attachment_url(1) == "/api/attachments/1/download"
 
+    def test_build_sandbox_path(self):
+        """Test sandbox path generation"""
+        from app.services.context import context_service
+
+        # Test with valid task_id and subtask_id
+        path = context_service.build_sandbox_path(123, 456, "test.pdf")
+        assert path == "123:executor:attachments/456/test.pdf"
+
+        # Test with different values
+        path = context_service.build_sandbox_path(1, 2, "image.png")
+        assert path == "1:executor:attachments/2/image.png"
+
+    def test_build_sandbox_path_returns_none_for_missing_ids(self):
+        """Test sandbox path returns None when task_id or subtask_id is missing"""
+        from app.services.context import context_service
+
+        # Test with None task_id
+        assert context_service.build_sandbox_path(None, 456, "test.pdf") is None
+
+        # Test with None subtask_id
+        assert context_service.build_sandbox_path(123, None, "test.pdf") is None
+
+        # Test with both None
+        assert context_service.build_sandbox_path(None, None, "test.pdf") is None
+
+    def test_build_document_text_prefix_with_sandbox_path(self):
+        """Test building document text prefix with sandbox path included"""
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.context import context_service
+
+        # Arrange
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="test.pdf",
+            status=ContextStatus.READY.value,
+            extracted_text="This is the extracted PDF content.",
+            text_length=35,
+            type_data={
+                "file_extension": ".pdf",
+                "original_filename": "test.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 2621440,  # 2.5 MB
+            },
+        )
+        context.id = 12345
+
+        # Act - with task_id and subtask_id
+        prefix = context_service.build_document_text_prefix(
+            context, task_id=100, subtask_id=200
+        )
+
+        # Assert
+        assert prefix is not None
+        assert "[Attachment: test.pdf |" in prefix
+        assert "ID: 12345" in prefix
+        assert "Type: application/pdf" in prefix
+        assert "Size: 2.5 MB" in prefix
+        assert "URL: /api/attachments/12345/download" in prefix
+        assert "Sandbox: 100:executor:attachments/200/test.pdf" in prefix
+        assert "This is the extracted PDF content." in prefix
+
     def test_build_document_text_prefix(self):
         """Test building document text prefix with attachment metadata"""
         from app.models.subtask_context import (

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -323,6 +323,22 @@ class TestContextServiceFormatting:
         # Test with both None
         assert context_service.build_sandbox_path(None, None, "test.pdf") is None
 
+    def test_build_sandbox_path_strips_control_characters(self):
+        """Test sandbox path strips control characters from filename"""
+        from app.services.context import context_service
+
+        # Test filename with newline
+        path = context_service.build_sandbox_path(123, 456, "test\n.pdf")
+        assert path == "123:executor:attachments/456/test.pdf"
+
+        # Test filename with carriage return
+        path = context_service.build_sandbox_path(123, 456, "test\r.pdf")
+        assert path == "123:executor:attachments/456/test.pdf"
+
+        # Test filename with both
+        path = context_service.build_sandbox_path(123, 456, "test\r\n.pdf")
+        assert path == "123:executor:attachments/456/test.pdf"
+
     def test_build_document_text_prefix_with_sandbox_path(self):
         """Test building document text prefix with sandbox path included"""
         from app.models.subtask_context import (

--- a/backend/tests/services/test_sandbox_file_syncer.py
+++ b/backend/tests/services/test_sandbox_file_syncer.py
@@ -59,22 +59,17 @@ class TestBuildSandboxAttachmentPath:
     def test_normal_path(self):
         """Test normal path generation."""
         path = build_sandbox_attachment_path(123, 456, "document.pdf")
-        assert (
-            path == "/home/user/attachments/123:executor:attachments/456/document.pdf"
-        )
+        assert path == "/home/user/123:executor:attachments/456/document.pdf"
 
     def test_path_with_unsafe_filename(self):
         """Test path generation with unsafe filename."""
         path = build_sandbox_attachment_path(123, 456, "../../../etc/passwd")
-        assert path == "/home/user/attachments/123:executor:attachments/456/passwd"
+        assert path == "/home/user/123:executor:attachments/456/passwd"
 
     def test_path_with_special_chars(self):
         """Test path generation with special characters in filename."""
         path = build_sandbox_attachment_path(123, 456, "file\nwith\rnewlines.pdf")
-        assert (
-            path
-            == "/home/user/attachments/123:executor:attachments/456/filewithnewlines.pdf"
-        )
+        assert path == "/home/user/123:executor:attachments/456/filewithnewlines.pdf"
 
 
 class TestSandboxFileSyncer:
@@ -209,7 +204,7 @@ class TestSandboxFileSyncer:
 
             success = await syncer.upload_file_to_sandbox(
                 base_url="http://sandbox:8080",
-                remote_path="/home/user/attachments/123:executor:attachments/456/doc.pdf",
+                remote_path="/home/user/123:executor:attachments/456/doc.pdf",
                 binary_data=b"test content",
                 filename="doc.pdf",
             )
@@ -235,7 +230,7 @@ class TestSandboxFileSyncer:
 
             success = await syncer.upload_file_to_sandbox(
                 base_url="http://sandbox:8080",
-                remote_path="/home/user/attachments/123:executor:attachments/456/doc.pdf",
+                remote_path="/home/user/123:executor:attachments/456/doc.pdf",
                 binary_data=b"test content",
                 filename="doc.pdf",
             )

--- a/backend/tests/services/test_sandbox_file_syncer.py
+++ b/backend/tests/services/test_sandbox_file_syncer.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sandbox file syncer service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.sandbox_file_syncer import (
+    SandboxFileSyncer,
+    _sanitize_filename,
+    build_sandbox_attachment_path,
+    get_sandbox_file_syncer,
+    sync_attachment_to_sandbox_background,
+)
+
+
+class TestSanitizeFilename:
+    """Tests for _sanitize_filename function."""
+
+    def test_normal_filename(self):
+        """Test normal filename is unchanged."""
+        assert _sanitize_filename("document.pdf") == "document.pdf"
+
+    def test_filename_with_path(self):
+        """Test filename with path components is sanitized."""
+        assert _sanitize_filename("/etc/passwd") == "passwd"
+        assert _sanitize_filename("../../../etc/passwd") == "passwd"
+
+    def test_filename_with_backslash(self):
+        """Test filename with backslash is sanitized."""
+        # On Linux, os.path.basename doesn't recognize Windows paths
+        # So backslashes are replaced with underscores
+        result = _sanitize_filename("C:\\Windows\\System32\\file.txt")
+        # Result should not contain backslashes
+        assert "\\" not in result
+        assert "/" not in result
+
+    def test_filename_with_control_chars(self):
+        """Test filename with control characters is sanitized."""
+        assert _sanitize_filename("file\nname.pdf") == "filename.pdf"
+        assert _sanitize_filename("file\rname.pdf") == "filename.pdf"
+
+    def test_empty_filename(self):
+        """Test empty filename returns default."""
+        assert _sanitize_filename("") == "attachment"
+        assert _sanitize_filename(None) == "attachment"
+
+    def test_only_path_separators(self):
+        """Test filename with only path separators."""
+        assert _sanitize_filename("///") == "attachment"
+
+
+class TestBuildSandboxAttachmentPath:
+    """Tests for build_sandbox_attachment_path function."""
+
+    def test_normal_path(self):
+        """Test normal path generation."""
+        path = build_sandbox_attachment_path(123, 456, "document.pdf")
+        assert (
+            path == "/home/user/attachments/123:executor:attachments/456/document.pdf"
+        )
+
+    def test_path_with_unsafe_filename(self):
+        """Test path generation with unsafe filename."""
+        path = build_sandbox_attachment_path(123, 456, "../../../etc/passwd")
+        assert path == "/home/user/attachments/123:executor:attachments/456/passwd"
+
+    def test_path_with_special_chars(self):
+        """Test path generation with special characters in filename."""
+        path = build_sandbox_attachment_path(123, 456, "file\nwith\rnewlines.pdf")
+        assert (
+            path
+            == "/home/user/attachments/123:executor:attachments/456/filewithnewlines.pdf"
+        )
+
+
+class TestSandboxFileSyncer:
+    """Tests for SandboxFileSyncer class."""
+
+    def test_init_default_values(self):
+        """Test syncer initializes with default values."""
+        syncer = SandboxFileSyncer()
+        assert syncer.executor_manager_url == "http://localhost:8001"
+        assert syncer.file_sync_timeout == 30.0
+        assert syncer.status_check_timeout == 5.0
+
+    def test_init_custom_values(self):
+        """Test syncer initializes with custom values."""
+        syncer = SandboxFileSyncer(
+            executor_manager_url="http://custom:9000",
+            file_sync_timeout=60.0,
+            status_check_timeout=10.0,
+        )
+        assert syncer.executor_manager_url == "http://custom:9000"
+        assert syncer.file_sync_timeout == 60.0
+        assert syncer.status_check_timeout == 10.0
+
+    @pytest.mark.asyncio
+    async def test_is_sandbox_healthy_running(self):
+        """Test sandbox health check returns True for running sandbox."""
+        syncer = SandboxFileSyncer()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "running",
+            "base_url": "http://sandbox:8080",
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            is_healthy, base_url = await syncer.is_sandbox_healthy(123)
+
+            assert is_healthy is True
+            assert base_url == "http://sandbox:8080"
+
+    @pytest.mark.asyncio
+    async def test_is_sandbox_healthy_not_found(self):
+        """Test sandbox health check returns False when sandbox not found."""
+        syncer = SandboxFileSyncer()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            is_healthy, base_url = await syncer.is_sandbox_healthy(123)
+
+            assert is_healthy is False
+            assert base_url is None
+
+    @pytest.mark.asyncio
+    async def test_is_sandbox_healthy_not_running(self):
+        """Test sandbox health check returns False for non-running sandbox."""
+        syncer = SandboxFileSyncer()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "status": "pending",
+            "base_url": None,
+        }
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            is_healthy, base_url = await syncer.is_sandbox_healthy(123)
+
+            assert is_healthy is False
+            assert base_url is None
+
+    @pytest.mark.asyncio
+    async def test_is_sandbox_healthy_timeout(self):
+        """Test sandbox health check returns False on timeout."""
+        import httpx
+
+        syncer = SandboxFileSyncer()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.get = AsyncMock(
+                side_effect=httpx.TimeoutException("timeout")
+            )
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            is_healthy, base_url = await syncer.is_sandbox_healthy(123)
+
+            assert is_healthy is False
+            assert base_url is None
+
+    @pytest.mark.asyncio
+    async def test_upload_file_to_sandbox_success(self):
+        """Test file upload to sandbox succeeds."""
+        syncer = SandboxFileSyncer()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            success = await syncer.upload_file_to_sandbox(
+                base_url="http://sandbox:8080",
+                remote_path="/home/user/attachments/123:executor:attachments/456/doc.pdf",
+                binary_data=b"test content",
+                filename="doc.pdf",
+            )
+
+            assert success is True
+
+    @pytest.mark.asyncio
+    async def test_upload_file_to_sandbox_failure(self):
+        """Test file upload to sandbox fails."""
+        syncer = SandboxFileSyncer()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal server error"
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client_instance = AsyncMock()
+            mock_client_instance.post = AsyncMock(return_value=mock_response)
+            mock_client.return_value.__aenter__ = AsyncMock(
+                return_value=mock_client_instance
+            )
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            success = await syncer.upload_file_to_sandbox(
+                base_url="http://sandbox:8080",
+                remote_path="/home/user/attachments/123:executor:attachments/456/doc.pdf",
+                binary_data=b"test content",
+                filename="doc.pdf",
+            )
+
+            assert success is False
+
+    @pytest.mark.asyncio
+    async def test_sync_attachment_to_sandbox_success(self):
+        """Test full sync flow succeeds."""
+        syncer = SandboxFileSyncer()
+
+        with patch.object(syncer, "is_sandbox_healthy") as mock_healthy:
+            mock_healthy.return_value = (True, "http://sandbox:8080")
+
+            with patch.object(syncer, "upload_file_to_sandbox") as mock_upload:
+                mock_upload.return_value = True
+
+                success = await syncer.sync_attachment_to_sandbox(
+                    task_id=123,
+                    subtask_id=456,
+                    filename="document.pdf",
+                    binary_data=b"test content",
+                )
+
+                assert success is True
+                mock_upload.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_attachment_to_sandbox_not_healthy(self):
+        """Test sync skipped when sandbox not healthy."""
+        syncer = SandboxFileSyncer()
+
+        with patch.object(syncer, "is_sandbox_healthy") as mock_healthy:
+            mock_healthy.return_value = (False, None)
+
+            with patch.object(syncer, "upload_file_to_sandbox") as mock_upload:
+                success = await syncer.sync_attachment_to_sandbox(
+                    task_id=123,
+                    subtask_id=456,
+                    filename="document.pdf",
+                    binary_data=b"test content",
+                )
+
+                assert success is False
+                mock_upload.assert_not_called()
+
+
+class TestGlobalSyncer:
+    """Tests for global syncer instance."""
+
+    def test_get_sandbox_file_syncer_singleton(self):
+        """Test get_sandbox_file_syncer returns same instance."""
+        # Reset global instance
+        import app.services.sandbox_file_syncer as module
+
+        module._sandbox_file_syncer = None
+
+        syncer1 = get_sandbox_file_syncer()
+        syncer2 = get_sandbox_file_syncer()
+
+        assert syncer1 is syncer2
+
+    @pytest.mark.asyncio
+    async def test_sync_attachment_to_sandbox_background(self):
+        """Test background sync function handles exceptions."""
+        with patch(
+            "app.services.sandbox_file_syncer.get_sandbox_file_syncer"
+        ) as mock_get:
+            mock_syncer = AsyncMock()
+            mock_syncer.sync_attachment_to_sandbox = AsyncMock(return_value=True)
+            mock_get.return_value = mock_syncer
+
+            await sync_attachment_to_sandbox_background(
+                task_id=123,
+                subtask_id=456,
+                filename="doc.pdf",
+                binary_data=b"content",
+            )
+
+            mock_syncer.sync_attachment_to_sandbox.assert_called_once_with(
+                task_id=123,
+                subtask_id=456,
+                filename="doc.pdf",
+                binary_data=b"content",
+            )

--- a/backend/tests/services/test_sandbox_file_syncer.py
+++ b/backend/tests/services/test_sandbox_file_syncer.py
@@ -300,7 +300,7 @@ class TestGlobalSyncer:
 
     @pytest.mark.asyncio
     async def test_sync_attachment_to_sandbox_background(self):
-        """Test background sync function handles exceptions."""
+        """Test background sync function delegates to syncer instance."""
         with patch(
             "app.services.sandbox_file_syncer.get_sandbox_file_syncer"
         ) as mock_get:

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -564,8 +564,8 @@ def _build_sandbox_path(
     """
     if task_id is None or subtask_id is None:
         return None
-    # Strip control characters to prevent metadata string corruption
-    safe_filename = filename.replace("\n", "").replace("\r", "")
+    # Guard against None filename and strip control characters
+    safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
     return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
 

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -564,7 +564,9 @@ def _build_sandbox_path(
     """
     if task_id is None or subtask_id is None:
         return None
-    return f"{task_id}:executor:attachments/{subtask_id}/{filename}"
+    # Strip control characters to prevent metadata string corruption
+    safe_filename = filename.replace("\n", "").replace("\r", "")
+    return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
 
 def _build_image_metadata_header(

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -559,14 +559,14 @@ def _build_sandbox_path(
         filename: Original filename
 
     Returns:
-        Sandbox path in format: {task_id}:executor:attachments/{subtask_id}/{filename}
+        Sandbox path in format: /home/user/{task_id}:executor:attachments/{subtask_id}/{filename}
         Returns None if task_id or subtask_id is not provided.
     """
     if task_id is None or subtask_id is None:
         return None
     # Guard against None filename and strip control characters
     safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
-    return f"{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+    return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
 
 def _build_image_metadata_header(
@@ -589,7 +589,7 @@ def _build_image_metadata_header(
         return (
             f"[Image Attachment: {filename} | ID: {attachment_id} | "
             f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-            f"Sandbox: {sandbox_path}]"
+            f"File Path in Sandbox: {sandbox_path}]"
         )
     return (
         f"[Image Attachment: {filename} | ID: {attachment_id} | "
@@ -627,7 +627,7 @@ def _build_document_text_prefix(
         return (
             f"[Attachment: {filename} | ID: {attachment_id} | "
             f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-            f"Sandbox: {sandbox_path}]\n"
+            f"File Path(already in sandbox): {sandbox_path}]\n"
             f"{context.extracted_text}\n\n"
         )
     return (

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -389,19 +389,27 @@ def _build_history_message(
         image_metadata_headers: list[str] = []
         total_attachment_text_length = 0
 
+        # Get task_id and subtask_id for building sandbox paths
+        task_id = subtask.task_id
+        subtask_id = subtask.id
+
         for attachment in attachments:
             vision_block = _build_vision_content_block(attachment)
             if vision_block:
                 vision_parts.append(vision_block)
                 # Add image metadata header for reference in text content
-                image_header = _build_image_metadata_header(attachment)
+                image_header = _build_image_metadata_header(
+                    attachment, task_id=task_id, subtask_id=subtask_id
+                )
                 image_metadata_headers.append(image_header)
                 logger.info(
                     f"[history] Loaded image attachment: id={attachment.id}, "
                     f"name={attachment.name}, mime_type={attachment.mime_type}"
                 )
             else:
-                doc_prefix = _build_document_text_prefix(attachment)
+                doc_prefix = _build_document_text_prefix(
+                    attachment, task_id=task_id, subtask_id=subtask_id
+                )
                 if doc_prefix:
                     attachment_text_parts.append(doc_prefix)
                     total_attachment_text_length += len(doc_prefix)
@@ -535,7 +543,35 @@ def _build_attachment_url(attachment_id: int) -> str:
     return f"/api/attachments/{attachment_id}/download"
 
 
-def _build_image_metadata_header(context) -> str:
+def _build_sandbox_path(
+    task_id: int | None,
+    subtask_id: int | None,
+    filename: str,
+) -> str | None:
+    """Build the sandbox file path for an attachment.
+
+    This path corresponds to where the Executor downloads attachments
+    in the sandbox environment.
+
+    Args:
+        task_id: Task ID
+        subtask_id: Subtask ID
+        filename: Original filename
+
+    Returns:
+        Sandbox path in format: {task_id}:executor:attachments/{subtask_id}/{filename}
+        Returns None if task_id or subtask_id is not provided.
+    """
+    if task_id is None or subtask_id is None:
+        return None
+    return f"{task_id}:executor:attachments/{subtask_id}/{filename}"
+
+
+def _build_image_metadata_header(
+    context,
+    task_id: int | None = None,
+    subtask_id: int | None = None,
+) -> str:
     """Build image attachment metadata header string."""
     attachment_id = context.id
     filename = context.name or "image"
@@ -544,19 +580,32 @@ def _build_image_metadata_header(context) -> str:
     formatted_size = _format_file_size(file_size)
     url = _build_attachment_url(attachment_id)
 
+    # Build sandbox path if task_id and subtask_id are provided
+    sandbox_path = _build_sandbox_path(task_id, subtask_id, filename)
+
+    if sandbox_path:
+        return (
+            f"[Image Attachment: {filename} | ID: {attachment_id} | "
+            f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
+            f"Sandbox: {sandbox_path}]"
+        )
     return (
         f"[Image Attachment: {filename} | ID: {attachment_id} | "
         f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]"
     )
 
 
-def _build_document_text_prefix(context) -> str:
+def _build_document_text_prefix(
+    context,
+    task_id: int | None = None,
+    subtask_id: int | None = None,
+) -> str:
     """Build a text prefix for a document context (without XML tags).
 
     Note: This returns raw content. The caller is responsible for wrapping
     multiple attachments in a single <attachment> XML tag.
 
-    Includes attachment metadata (id, filename, mime_type, file_size, url).
+    Includes attachment metadata (id, filename, mime_type, file_size, url, sandbox_path).
     """
     if not context.extracted_text:
         return ""
@@ -569,6 +618,16 @@ def _build_document_text_prefix(context) -> str:
     formatted_size = _format_file_size(file_size)
     url = _build_attachment_url(attachment_id)
 
+    # Build sandbox path if task_id and subtask_id are provided
+    sandbox_path = _build_sandbox_path(task_id, subtask_id, filename)
+
+    if sandbox_path:
+        return (
+            f"[Attachment: {filename} | ID: {attachment_id} | "
+            f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
+            f"Sandbox: {sandbox_path}]\n"
+            f"{context.extracted_text}\n\n"
+        )
     return (
         f"[Attachment: {filename} | ID: {attachment_id} | "
         f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]\n"

--- a/executor/executor.spec
+++ b/executor/executor.spec
@@ -58,6 +58,9 @@ hiddenimports += collect_submodules('opentelemetry.instrumentation.system_metric
 if os.path.exists(shared_path):
     hiddenimports += collect_submodules('shared')
 
+# Collect Rich Unicode data modules (fix for Unicode character handling)
+hiddenimports += collect_submodules('rich._unicode_data')
+
 # Additional hidden imports
 hiddenimports += [
     'uvicorn.logging',
@@ -74,7 +77,7 @@ hiddenimports += [
 
 # Collect package data
 for package in ['fastapi', 'uvicorn', 'pydantic', 'anthropic', 'claude_agent_sdk',
-                'agno', 'openai', 'mcp', 'sqlalchemy', 'httpx', 'starlette', 'sse_starlette']:
+                'agno', 'openai', 'mcp', 'sqlalchemy', 'httpx', 'starlette', 'sse_starlette', 'rich']:
     try:
         tmp_datas, tmp_binaries, tmp_hiddenimports = collect_all(package)
         datas += tmp_datas

--- a/executor/services/api_client.py
+++ b/executor/services/api_client.py
@@ -521,5 +521,5 @@ def fetch_task_attachments(task_id: str, auth_token: str) -> TaskAttachmentsResu
             )
 
     except Exception as e:
-        logger.error(f"[fetch_task_attachments] Error: {e}")
+        logger.exception("[fetch_task_attachments] Error")
         return TaskAttachmentsResult(attachments=[], error=str(e))

--- a/executor/services/attachment_downloader.py
+++ b/executor/services/attachment_downloader.py
@@ -85,7 +85,28 @@ class AttachmentDownloader:
         Returns:
             Full path to the attachment file
         """
-        return os.path.join(self.get_attachments_dir(), filename)
+        # Sanitize filename to prevent path traversal attacks
+        safe_filename = self._sanitize_filename(filename)
+        return os.path.join(self.get_attachments_dir(), safe_filename)
+
+    @staticmethod
+    def _sanitize_filename(filename: str) -> str:
+        """
+        Sanitize filename to prevent path traversal and metadata corruption.
+
+        Args:
+            filename: Original filename
+
+        Returns:
+            Sanitized filename safe for filesystem operations
+        """
+        # Use basename to strip any directory components
+        safe_name = os.path.basename(filename)
+        # Strip control characters (newline, carriage return)
+        safe_name = safe_name.replace("\n", "").replace("\r", "")
+        # Remove any remaining path separators
+        safe_name = safe_name.replace("/", "_").replace("\\", "_")
+        return safe_name or "document"
 
     def download_all(
         self, attachments: List[Dict[str, Any]]


### PR DESCRIPTION
## Summary

- Add sandbox file path to attachment metadata header to help AI agents locate files in the executor sandbox environment
- The sandbox path follows the executor's download directory structure: `{task_id}:executor:attachments/{subtask_id}/{filename}`
- Update attachment metadata format from `[Attachment: filename | ID: xxx | Type: xxx | Size: xxx | URL: xxx]` to include `File Path(already in sandbox): {sandbox_path}`

## Changes

### Backend (`backend/app/services/context/context_service.py`)
- Add `build_sandbox_path()` static method to generate sandbox file paths
- Modify `build_document_text_prefix()` to accept optional `task_id` and `subtask_id` parameters
- Include sandbox path in attachment metadata header when task_id and subtask_id are provided

### Backend (`backend/app/services/chat/preprocessing/contexts.py`)
- Update `_process_attachment_context()` to accept and use `task_id` and `subtask_id` parameters
- Update `_process_attachment_contexts_for_message()` to pass task_id and subtask_id
- Modify `prepare_contexts_for_chat()` to pass task_id and user_subtask_id to attachment processing
- Add sandbox path to image attachment headers as well

### Chat Shell (`chat_shell/chat_shell/history/loader.py`)
- Add `_build_sandbox_path()` helper function
- Update `_build_image_metadata_header()` to accept and use task_id and subtask_id
- Update `_build_document_text_prefix()` to include sandbox path
- Update `_build_history_message()` to pass task_id and subtask_id to attachment processing

### Tests (`backend/tests/services/test_context_service.py`)
- Add `test_build_sandbox_path()` for sandbox path generation
- Add `test_build_sandbox_path_returns_none_for_missing_ids()` for edge cases
- Add `test_build_document_text_prefix_with_sandbox_path()` for integration testing

## Example Output

**Before:**
```
[Attachment: document.pdf | ID: 123 | Type: application/pdf | Size: 2.5 MB | URL: /api/attachments/123/download]
```

**After:**
```
[Attachment: document.pdf | ID: 123 | Type: application/pdf | Size: 2.5 MB | URL: /api/attachments/123/download | Sandbox: 100:executor:attachments/200/document.pdf]
```

## Test plan

- [x] Run `test_context_service.py` tests - all 20 tests pass
- [x] Verify sandbox path format matches executor download directory structure
- [ ] E2E test: Upload attachment in chat session, verify sandbox path appears in AI context
- [ ] E2E test: Verify executor can locate file at specified sandbox path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachment metadata now includes a Sandbox path when task and subtask IDs are present; image headers and document prefixes surface this info.
  * Task/subtask IDs flow through attachment processing so chat, history, and knowledge-base prompts are sandbox-aware.
  * Attachments can be scheduled for asynchronous syncing to running sandboxes; sandboxes pre-download task attachments at startup.
  * New endpoint to list all attachments for a task across subtasks.
  * Filenames are sanitized on download.

* **Tests**
  * Added tests for sandbox path generation, filename sanitization, document-prefix integration, and sandbox sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->