### PR TITLE
fix(backend): ensure push mode dispatch completes for subscription tasks

### DIFF
--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -1199,6 +1199,33 @@ def execute_subscription_task(
                     )
                 else:
                     # Executor type - subtask picked up by executor_manager
+                    # Push mode: dispatch task to executor_manager immediately
+                    # Note: We must await the dispatch here because the event loop
+                    # will be closed after this block, so scheduled tasks won't run.
+                    try:
+                        from app.services.task_dispatcher import task_dispatcher
+
+                        if task_dispatcher.enabled:
+                            # Use dispatch_pending_tasks directly since we're in async context
+                            success = loop.run_until_complete(
+                                task_dispatcher.dispatch_pending_tasks(
+                                    db, task_ids=[task_id], task_type="online"
+                                )
+                            )
+                            if success:
+                                logger.info(
+                                    f"[subscription_tasks] Push mode: dispatched task {task_id}"
+                                )
+                            else:
+                                logger.warning(
+                                    f"[subscription_tasks] Push mode: dispatch returned False for task {task_id}"
+                                )
+                    except Exception as e:
+                        logger.warning(
+                            f"[subscription_tasks] Push mode dispatch failed for task {task_id}: {e}",
+                            exc_info=True,
+                        )
+
                     logger.debug(
                         f"[subscription_tasks] Executor type, task {task_id} dispatched to executor_manager"
                     )


### PR DESCRIPTION
- Fix task_dispatcher.schedule_dispatch to create new event loop when no running loop exists (Celery worker context)
- Fix subscription_tasks to use synchronous dispatch_pending_tasks instead of schedule_dispatch, ensuring dispatch completes before event loop closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced task dispatch reliability with improved fallback mechanisms and error handling
  * Subscription-based tasks now execute more immediately with graceful error recovery
  * Better error reporting and logging for dispatch failures
  * Improved handling of edge cases in task execution

* **Documentation**
  * Expanded documentation covering task dispatch scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->