### PR TITLE
feat(frontend): add device guide entry button on devices page

### DIFF
--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -39,6 +39,8 @@ import {
   Trash2,
   ExternalLink,
   MessageCircleQuestion,
+  Plus,
+  ChevronUp,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -161,6 +163,9 @@ export default function DevicesPage() {
   // Collapsed sidebar state
   const [isCollapsed, setIsCollapsed] = useState(false)
 
+  // Guide visibility state (for showing installation guide when devices exist)
+  const [showGuide, setShowGuide] = useState(false)
+
   // Load collapsed state from localStorage
   useEffect(() => {
     const savedCollapsed = localStorage.getItem('task-sidebar-collapsed')
@@ -253,16 +258,39 @@ export default function DevicesPage() {
                   {t('beta')}
                 </span>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={refreshDevices}
-                disabled={isLoading}
-                className="flex items-center gap-2"
-              >
-                <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
-                {t('refresh')}
-              </Button>
+              <div className="flex items-center gap-2">
+                {/* Add Device button - only show when devices exist */}
+                {sortedDevices.length > 0 && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowGuide(!showGuide)}
+                    className="flex items-center gap-2"
+                  >
+                    {showGuide ? (
+                      <>
+                        <ChevronUp className="w-4 h-4" />
+                        {t('hide_guide')}
+                      </>
+                    ) : (
+                      <>
+                        <Plus className="w-4 h-4" />
+                        {t('add_device')}
+                      </>
+                    )}
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={refreshDevices}
+                  disabled={isLoading}
+                  className="flex items-center gap-2"
+                >
+                  <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
+                  {t('refresh')}
+                </Button>
+              </div>
             </div>
 
             {/* Instructions */}
@@ -322,6 +350,17 @@ export default function DevicesPage() {
                   </div>
                 )}
               </>
+            )}
+
+            {/* Installation guide when triggered by Add Device button */}
+            {showGuide && sortedDevices.length > 0 && (
+              <div className="mb-6">
+                <LocalExecutorGuide
+                  backendUrl={backendUrl}
+                  authToken={authToken}
+                  guideUrl={guideUrl}
+                />
+              </div>
             )}
 
             {/* Device list */}

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -78,5 +78,7 @@
     "current": "Current Version",
     "latest": "Latest Version",
     "updateAvailable": "Update Available"
-  }
+  },
+  "add_device": "Add Device",
+  "hide_guide": "Hide Guide"
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -78,5 +78,7 @@
     "current": "当前版本",
     "latest": "最新版本",
     "updateAvailable": "有新版本可用"
-  }
+  },
+  "add_device": "添加设备",
+  "hide_guide": "收起指南"
 }


### PR DESCRIPTION
Add an "Add Device" button that allows users to re-open the installation guide when they already have devices connected, making it easier to add additional devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation guide toggle added to the devices page for streamlined setup assistance
  * New "Add Device" button with improved UI controls now available in device management
  * Enhanced interface with better button grouping and refresh functionality
  * Expanded localization support for new UI elements across English and Chinese

<!-- end of auto-generated comment: release notes by coderabbit.ai -->