### PR TITLE
refactor(executor): separate ClaudeCodeAgent mode logic using Strateg…

### DIFF
--- a/executor/agents/claude_code/__init__.py
+++ b/executor/agents/claude_code/__init__.py
@@ -7,5 +7,17 @@
 # -*- coding: utf-8 -*-
 
 from executor.agents.claude_code.claude_code_agent import ClaudeCodeAgent
+from executor.agents.claude_code.docker_mode_strategy import DockerModeStrategy
+from executor.agents.claude_code.local_mode_strategy import LocalModeStrategy
+from executor.agents.claude_code.mode_strategy import (
+    ExecutionModeStrategy,
+    ModeStrategyFactory,
+)
 
-__all__ = ["ClaudeCodeAgent"]
+__all__ = [
+    "ClaudeCodeAgent",
+    "ExecutionModeStrategy",
+    "ModeStrategyFactory",
+    "LocalModeStrategy",
+    "DockerModeStrategy",
+]

--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -23,6 +23,10 @@ from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
 
 from executor.agents.agno.thinking_step_manager import ThinkingStepManager
 from executor.agents.base import Agent
+from executor.agents.claude_code.mode_strategy import (
+    ExecutionModeStrategy,
+    ModeStrategyFactory,
+)
 from executor.agents.claude_code.progress_state_manager import ProgressStateManager
 from executor.agents.claude_code.response_processor import process_response
 from executor.config import config
@@ -323,6 +327,9 @@ class ClaudeCodeAgent(Agent):
 
         # Callback for when client is created (used for heartbeat updates)
         self.on_client_created_callback: Optional[callable] = None
+
+        # Initialize execution mode strategy
+        self._mode_strategy: ExecutionModeStrategy = ModeStrategyFactory.create()
 
     def _set_git_env_variables(self, task_data: Dict[str, Any]) -> None:
         """
@@ -658,6 +665,7 @@ class ClaudeCodeAgent(Agent):
         """
         Save Claude config files to appropriate directory based on execution mode.
 
+        Delegates to the mode strategy which handles:
         - Docker mode: saves to ~/.claude/ (SDK reads from default location)
         - Local mode: Does NOT write settings.json (contains sensitive API keys).
           Sensitive config is passed via environment variables in _create_and_connect_client().
@@ -666,9 +674,6 @@ class ClaudeCodeAgent(Agent):
         Args:
             agent_config: The agent configuration dictionary
         """
-        # Store env config for passing to SDK via environment variables
-        self._claude_env_config = agent_config.get("env", {})
-
         # Non-sensitive user preferences config for claude.json
         claude_json_config = {
             "numStartups": 2,
@@ -684,45 +689,16 @@ class ClaudeCodeAgent(Agent):
             "isQualifiedForDataSharing": False,
         }
 
-        if config.EXECUTOR_MODE == "local":
-            # Local mode: Do NOT write settings.json (contains sensitive API keys/tokens)
-            # Sensitive config is passed via env parameter in _create_and_connect_client()
-            config_dir = os.path.join(
-                config.get_workspace_root(), str(self.task_id), ".claude"
-            )
-            claude_json_path = os.path.join(config_dir, "claude.json")
+        # Delegate to mode strategy
+        config_dir, env_config = self._mode_strategy.save_config_files(
+            task_id=self.task_id,
+            agent_config=agent_config,
+            claude_json_config=claude_json_config,
+        )
 
-            # Create directory with restricted permissions (owner only)
-            Path(config_dir).mkdir(parents=True, exist_ok=True)
-            os.chmod(config_dir, 0o700)
-
-            # Write only non-sensitive claude.json with restricted permissions
-            with open(claude_json_path, "w") as f:
-                json.dump(claude_json_config, f, indent=2)
-            os.chmod(claude_json_path, 0o600)
-
-            logger.info(
-                f"Local mode: Saved claude.json to {config_dir} "
-                "(settings.json skipped - sensitive config passed via env)"
-            )
-        else:
-            # Docker mode: save to user's ~/.claude directory (original behavior)
-            config_dir = os.path.expanduser("~/.claude")
-            claude_json_path = os.path.expanduser("~/.claude.json")
-
-            Path(config_dir).mkdir(parents=True, exist_ok=True)
-
-            # Save settings.json (Docker mode only - isolated container environment)
-            settings_path = os.path.join(config_dir, "settings.json")
-            with open(settings_path, "w") as f:
-                json.dump(agent_config, f, indent=2)
-
-            # Save claude.json
-            with open(claude_json_path, "w") as f:
-                json.dump(claude_json_config, f, indent=2)
-
-        # Store config directory for SDK configuration
+        # Store config directory and env config for SDK configuration
         self._claude_config_dir = config_dir
+        self._claude_env_config = env_config
 
     def _resolve_env_value(self, value: str) -> str:
         """Resolve a value that may be an environment variable template or encrypted.
@@ -1260,22 +1236,13 @@ class ClaudeCodeAgent(Agent):
             os.makedirs(cwd, exist_ok=True)
             self.options["cwd"] = cwd
 
-        # In Local mode, configure SDK to use task-specific config directory
-        # to avoid modifying user's personal ~/.claude/ config
-        if config.EXECUTOR_MODE == "local" and self._claude_config_dir:
-            # Pass env config (contains ANTHROPIC_AUTH_TOKEN, ANTHROPIC_MODEL, etc.)
-            if self._claude_env_config:
-                existing_env = self.options.get("env", {})
-                merged_env = {**existing_env, **self._claude_env_config}
-                self.options["env"] = {k: str(v) for k, v in merged_env.items()}
-
-            # Set CLAUDE_CONFIG_DIR env var to redirect all config reads/writes
-            # This affects settings.json, claude.json, and skills locations
-            # Note: Keep setting_sources as ["user", "project", "local"] so SDK
-            # reads config from CLAUDE_CONFIG_DIR instead of default ~/.claude/
-            env = self.options.get("env", {})
-            env["CLAUDE_CONFIG_DIR"] = self._claude_config_dir
-            self.options["env"] = env
+        # Delegate mode-specific configuration to strategy
+        if self._claude_config_dir:
+            self.options = self._mode_strategy.configure_client_options(
+                options=self.options,
+                config_dir=self._claude_config_dir,
+                env_config=self._claude_env_config,
+            )
 
         # Check if there's a saved session ID to resume
         saved_session_id = self._load_saved_session_id(self.task_id)
@@ -1973,9 +1940,9 @@ class ClaudeCodeAgent(Agent):
         """
         Download Skills from Backend API and deploy to skills directory.
 
-        - Docker mode: deploys to ~/.claude/skills/
-        - Local mode: deploys to task config directory (same as CLAUDE_CONFIG_DIR)
-          to avoid modifying user's personal skills
+        Delegates to the mode strategy which handles:
+        - Docker mode: deploys to ~/.claude/skills/, clears cache
+        - Local mode: deploys to task config directory, preserves cache
 
         Uses shared SkillDownloader from api_client module.
 
@@ -1993,13 +1960,10 @@ class ClaudeCodeAgent(Agent):
 
             logger.info(f"Found {len(skills)} skills to deploy: {skills}")
 
-            # Determine skills directory based on mode
-            if config.EXECUTOR_MODE == "local" and hasattr(self, "_claude_config_dir"):
-                # Local mode: use task config directory (follows CLAUDE_CONFIG_DIR)
-                skills_dir = os.path.join(self._claude_config_dir, "skills")
-            else:
-                # Docker mode: use default ~/.claude/skills
-                skills_dir = os.path.expanduser("~/.claude/skills")
+            # Get skills directory from strategy
+            skills_dir = self._mode_strategy.get_skills_directory(
+                config_dir=getattr(self, "_claude_config_dir", None)
+            )
 
             # Get auth token
             auth_token = self.task_data.get("auth_token")
@@ -2017,12 +1981,12 @@ class ClaudeCodeAgent(Agent):
                 skills_dir=skills_dir,
             )
 
-            # In Local mode, skip existing skills; in Docker mode, clear cache based on config
-            is_local_mode = config.EXECUTOR_MODE == "local"
+            # Get deployment options from strategy
+            deployment_options = self._mode_strategy.get_skills_deployment_options()
             result = downloader.download_and_deploy(
                 skills=skills,
-                clear_cache=not is_local_mode,  # Clear cache only in Docker mode
-                skip_existing=is_local_mode,  # Skip existing only in Local mode
+                clear_cache=deployment_options["clear_cache"],
+                skip_existing=deployment_options["skip_existing"],
             )
 
             logger.info(

--- a/executor/agents/claude_code/docker_mode_strategy.py
+++ b/executor/agents/claude_code/docker_mode_strategy.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Docker Mode Strategy for ClaudeCodeAgent.
+
+This strategy handles execution in isolated Docker container environments:
+- Full configuration files (settings.json, claude.json) are written
+- Uses default ~/.claude/ directory (isolated per container)
+- Fresh skills deployment for each container
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from executor.agents.claude_code.mode_strategy import ExecutionModeStrategy
+from shared.logger import setup_logger
+
+logger = setup_logger("docker_mode_strategy")
+
+
+class DockerModeStrategy(ExecutionModeStrategy):
+    """Strategy for Docker container execution mode.
+
+    Container-isolated implementation that:
+    - Writes full settings.json (container is isolated)
+    - Uses default ~/.claude/ directory
+    - Clears skills cache for fresh deployment each run
+    """
+
+    def get_config_directory(self, task_id: int) -> str:
+        """Get the default Claude configuration directory.
+
+        In Docker mode, we use the default ~/.claude/ directory since
+        each container is isolated.
+
+        Args:
+            task_id: The task ID (unused in Docker mode)
+
+        Returns:
+            Path to ~/.claude/ directory
+        """
+        return os.path.expanduser("~/.claude")
+
+    def save_config_files(
+        self,
+        task_id: int,
+        agent_config: Dict[str, Any],
+        claude_json_config: Dict[str, Any],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Save all configuration files (including settings.json).
+
+        In Docker mode, it's safe to write settings.json because each
+        container is isolated. The SDK reads settings from ~/.claude/settings.json.
+
+        Args:
+            task_id: The task ID (unused in Docker mode)
+            agent_config: Agent configuration containing env settings
+            claude_json_config: Non-sensitive user preferences
+
+        Returns:
+            Tuple of (config_dir, empty_dict):
+            - config_dir: Path where config files were saved (~/.claude/)
+            - empty_dict: Empty dict (env config written to settings.json)
+        """
+        config_dir = self.get_config_directory(task_id)
+        claude_json_path = os.path.expanduser("~/.claude.json")
+
+        # Create config directory
+        Path(config_dir).mkdir(parents=True, exist_ok=True)
+
+        # Save settings.json (Docker mode only - isolated container environment)
+        settings_path = os.path.join(config_dir, "settings.json")
+        with open(settings_path, "w") as f:
+            json.dump(agent_config, f, indent=2)
+
+        # Save claude.json to ~/.claude.json
+        with open(claude_json_path, "w") as f:
+            json.dump(claude_json_config, f, indent=2)
+
+        logger.info(f"Docker mode: Saved config files to {config_dir}")
+
+        # Return empty env_config since settings are written to file
+        return config_dir, {}
+
+    def configure_client_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Configure SDK client with default behavior.
+
+        In Docker mode, the SDK reads configuration from settings.json
+        in the default location, so no special configuration is needed.
+
+        Args:
+            options: Existing client options
+            config_dir: Config directory (unused - SDK uses default)
+            env_config: Environment config (unused - written to settings.json)
+
+        Returns:
+            Options unchanged (default SDK behavior)
+        """
+        # Docker mode uses default SDK behavior - no modifications needed
+        return options
+
+    def get_skills_directory(self, config_dir: str = None) -> str:
+        """Get the default skills directory.
+
+        In Docker mode, skills are stored in the default ~/.claude/skills
+        directory.
+
+        Args:
+            config_dir: Unused in Docker mode
+
+        Returns:
+            Path to ~/.claude/skills directory
+        """
+        return os.path.expanduser("~/.claude/skills")
+
+    def get_skills_deployment_options(self) -> Dict[str, bool]:
+        """Get deployment options for Docker mode.
+
+        In Docker mode:
+        - clear_cache=True: Start fresh for each container
+        - skip_existing=False: Re-deploy all skills
+
+        Returns:
+            Dictionary with clear_cache=True, skip_existing=False
+        """
+        return {
+            "clear_cache": True,
+            "skip_existing": False,
+        }

--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Local Mode Strategy for ClaudeCodeAgent.
+
+This strategy handles execution in local (non-Docker) environments with
+enhanced security measures:
+- Sensitive data (API keys, tokens) are NOT written to disk
+- Sensitive config is passed via environment variables to the SDK
+- Config files use restricted permissions (0700 for dirs, 0600 for files)
+- Task-specific directories isolate different tasks
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+from executor.agents.claude_code.mode_strategy import ExecutionModeStrategy
+from executor.config import config
+from shared.logger import setup_logger
+
+logger = setup_logger("local_mode_strategy")
+
+
+class LocalModeStrategy(ExecutionModeStrategy):
+    """Strategy for local (non-Docker) execution mode.
+
+    Security-focused implementation that:
+    - Does NOT write settings.json (contains sensitive API keys)
+    - Passes sensitive config via environment variables
+    - Uses task-specific config directories
+    - Applies restrictive file permissions
+    - Preserves skills cache between tasks
+    """
+
+    def get_config_directory(self, task_id: int) -> str:
+        """Get task-specific configuration directory.
+
+        In local mode, each task has its own .claude directory to
+        isolate configurations and prevent cross-task interference.
+
+        Args:
+            task_id: The task ID
+
+        Returns:
+            Path to task-specific .claude directory
+        """
+        workspace_root = config.get_workspace_root()
+        return os.path.join(workspace_root, str(task_id), ".claude")
+
+    def save_config_files(
+        self,
+        task_id: int,
+        agent_config: Dict[str, Any],
+        claude_json_config: Dict[str, Any],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Save only non-sensitive configuration files.
+
+        SECURITY: Does NOT write settings.json because it contains
+        sensitive data (ANTHROPIC_AUTH_TOKEN, etc.). Instead, sensitive
+        configuration is returned to be passed via environment variables.
+
+        Args:
+            task_id: The task ID
+            agent_config: Agent configuration containing env settings
+            claude_json_config: Non-sensitive user preferences
+
+        Returns:
+            Tuple of (config_dir, env_config):
+            - config_dir: Path where claude.json was saved
+            - env_config: Sensitive config to pass via env vars
+        """
+        config_dir = self.get_config_directory(task_id)
+        claude_json_path = os.path.join(config_dir, "claude.json")
+
+        # Create directory with restricted permissions (owner only: rwx)
+        Path(config_dir).mkdir(parents=True, exist_ok=True)
+        os.chmod(config_dir, 0o700)
+
+        # Write only non-sensitive claude.json with restricted permissions
+        with open(claude_json_path, "w") as f:
+            json.dump(claude_json_config, f, indent=2)
+        os.chmod(claude_json_path, 0o600)
+
+        logger.info(
+            f"Local mode: Saved claude.json to {config_dir} "
+            "(settings.json skipped - sensitive config passed via env)"
+        )
+
+        # Return env config to be passed via environment variables
+        env_config = agent_config.get("env", {})
+        return config_dir, env_config
+
+    def configure_client_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Configure SDK client with environment variables for sensitive data.
+
+        In local mode, sensitive configuration (API keys, tokens) is passed
+        via the SDK's env parameter rather than being read from settings.json.
+        The CLAUDE_CONFIG_DIR env var redirects all config reads/writes to
+        the task-specific directory.
+
+        Args:
+            options: Existing client options
+            config_dir: Task-specific config directory
+            env_config: Sensitive configuration (ANTHROPIC_AUTH_TOKEN, etc.)
+
+        Returns:
+            Updated options with env configuration
+        """
+        updated_options = options.copy()
+
+        # Merge env config (contains ANTHROPIC_AUTH_TOKEN, ANTHROPIC_MODEL, etc.)
+        if env_config:
+            existing_env = updated_options.get("env", {})
+            merged_env = {**existing_env, **env_config}
+            # Ensure all values are strings (required by SDK)
+            updated_options["env"] = {k: str(v) for k, v in merged_env.items()}
+
+        # Set CLAUDE_CONFIG_DIR to redirect all config reads/writes
+        # This affects settings.json, claude.json, and skills locations
+        env = updated_options.get("env", {})
+        env["CLAUDE_CONFIG_DIR"] = config_dir
+        updated_options["env"] = env
+
+        logger.debug(f"Local mode: Configured CLAUDE_CONFIG_DIR={config_dir}")
+        return updated_options
+
+    def get_skills_directory(self, config_dir: str = None) -> str:
+        """Get task-specific skills directory.
+
+        In local mode, skills are stored in the task's config directory
+        to avoid modifying the user's personal ~/.claude/skills.
+
+        Args:
+            config_dir: Task-specific config directory
+
+        Returns:
+            Path to skills directory within config_dir
+        """
+        if config_dir:
+            return os.path.join(config_dir, "skills")
+        # Fallback to default location if config_dir not provided
+        return os.path.expanduser("~/.claude/skills")
+
+    def get_skills_deployment_options(self) -> Dict[str, bool]:
+        """Get deployment options optimized for local mode.
+
+        In local mode:
+        - clear_cache=False: Preserve existing skills for faster startup
+        - skip_existing=True: Only deploy new/updated skills
+
+        Returns:
+            Dictionary with clear_cache=False, skip_existing=True
+        """
+        return {
+            "clear_cache": False,
+            "skip_existing": True,
+        }

--- a/executor/agents/claude_code/mode_strategy.py
+++ b/executor/agents/claude_code/mode_strategy.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- coding: utf-8 -*-
+
+"""
+Execution Mode Strategy Pattern for ClaudeCodeAgent.
+
+This module provides an abstract base class and factory for creating mode-specific
+strategies that handle differences between Local and Docker execution modes.
+
+The Strategy Pattern allows ClaudeCodeAgent to delegate mode-specific behavior
+to specialized strategy implementations, improving code organization and testability.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Tuple
+
+from executor.config import config
+from shared.logger import setup_logger
+
+logger = setup_logger("mode_strategy")
+
+
+class ExecutionModeStrategy(ABC):
+    """Abstract base class for execution mode strategies.
+
+    Each strategy encapsulates the mode-specific behavior for:
+    - Config file management (claude.json, settings.json)
+    - Client option configuration
+    - Skills deployment options
+    """
+
+    @abstractmethod
+    def get_config_directory(self, task_id: int) -> str:
+        """Get the configuration directory path for this mode.
+
+        Args:
+            task_id: The task ID for task-specific directories
+
+        Returns:
+            Path to the configuration directory
+        """
+        pass
+
+    @abstractmethod
+    def save_config_files(
+        self,
+        task_id: int,
+        agent_config: Dict[str, Any],
+        claude_json_config: Dict[str, Any],
+    ) -> Tuple[str, Dict[str, Any]]:
+        """Save Claude configuration files to appropriate locations.
+
+        Args:
+            task_id: The task ID for task-specific directories
+            agent_config: Agent configuration containing env settings
+            claude_json_config: Non-sensitive user preferences for claude.json
+
+        Returns:
+            Tuple of (config_dir_path, env_config_dict)
+            - config_dir_path: Path where config files were saved
+            - env_config_dict: Environment config to pass to SDK (may be empty)
+        """
+        pass
+
+    @abstractmethod
+    def configure_client_options(
+        self,
+        options: Dict[str, Any],
+        config_dir: str,
+        env_config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Configure SDK client options based on mode-specific requirements.
+
+        Args:
+            options: Existing client options dictionary
+            config_dir: Path to configuration directory
+            env_config: Environment configuration (sensitive data)
+
+        Returns:
+            Updated options dictionary with mode-specific configurations
+        """
+        pass
+
+    @abstractmethod
+    def get_skills_directory(self, config_dir: str = None) -> str:
+        """Get the skills directory path for this mode.
+
+        Args:
+            config_dir: Optional config directory for task-specific skills
+
+        Returns:
+            Path to the skills directory
+        """
+        pass
+
+    @abstractmethod
+    def get_skills_deployment_options(self) -> Dict[str, bool]:
+        """Get mode-specific options for skills deployment.
+
+        Returns:
+            Dictionary with deployment options:
+            - clear_cache: Whether to clear the skills cache before deployment
+            - skip_existing: Whether to skip skills that already exist
+        """
+        pass
+
+
+class ModeStrategyFactory:
+    """Factory for creating execution mode strategies.
+
+    This factory creates the appropriate strategy based on the configured
+    execution mode (local vs docker).
+    """
+
+    @classmethod
+    def create(cls, mode: str = None) -> ExecutionModeStrategy:
+        """Create an execution mode strategy.
+
+        Args:
+            mode: Execution mode ("local" or None/other for docker).
+                  If not specified, uses config.EXECUTOR_MODE.
+
+        Returns:
+            ExecutionModeStrategy instance for the specified mode
+        """
+        if mode is None:
+            mode = config.EXECUTOR_MODE
+
+        if mode == "local":
+            from executor.agents.claude_code.local_mode_strategy import (
+                LocalModeStrategy,
+            )
+
+            logger.debug("Creating LocalModeStrategy for local execution mode")
+            return LocalModeStrategy()
+        else:
+            from executor.agents.claude_code.docker_mode_strategy import (
+                DockerModeStrategy,
+            )
+
+            logger.debug("Creating DockerModeStrategy for docker execution mode")
+            return DockerModeStrategy()

--- a/executor/tests/agents/test_mode_strategy.py
+++ b/executor/tests/agents/test_mode_strategy.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for Execution Mode Strategy Pattern.
+
+This module tests the strategy pattern implementation for ClaudeCodeAgent,
+including LocalModeStrategy, DockerModeStrategy, and ModeStrategyFactory.
+"""
+
+import json
+import os
+import stat
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from executor.agents.claude_code.docker_mode_strategy import DockerModeStrategy
+from executor.agents.claude_code.local_mode_strategy import LocalModeStrategy
+from executor.agents.claude_code.mode_strategy import (
+    ExecutionModeStrategy,
+    ModeStrategyFactory,
+)
+
+
+class TestModeStrategyFactory:
+    """Tests for ModeStrategyFactory."""
+
+    def test_create_local_strategy_with_explicit_mode(self):
+        """Test factory creates LocalModeStrategy for 'local' mode."""
+        strategy = ModeStrategyFactory.create(mode="local")
+        assert isinstance(strategy, LocalModeStrategy)
+
+    def test_create_docker_strategy_with_explicit_mode(self):
+        """Test factory creates DockerModeStrategy for 'docker' mode."""
+        strategy = ModeStrategyFactory.create(mode="docker")
+        assert isinstance(strategy, DockerModeStrategy)
+
+    def test_create_docker_strategy_for_empty_mode(self):
+        """Test factory creates DockerModeStrategy for empty mode string."""
+        strategy = ModeStrategyFactory.create(mode="")
+        assert isinstance(strategy, DockerModeStrategy)
+
+    def test_create_docker_strategy_for_none_mode(self):
+        """Test factory creates DockerModeStrategy when mode is None."""
+        with patch("executor.config.config.EXECUTOR_MODE", ""):
+            strategy = ModeStrategyFactory.create(mode=None)
+            assert isinstance(strategy, DockerModeStrategy)
+
+    def test_create_local_strategy_from_config(self):
+        """Test factory reads mode from config when mode param is None."""
+        with patch("executor.config.config.EXECUTOR_MODE", "local"):
+            strategy = ModeStrategyFactory.create()
+            assert isinstance(strategy, LocalModeStrategy)
+
+    def test_create_docker_strategy_from_config(self):
+        """Test factory reads mode from config when mode param is None."""
+        with patch("executor.config.config.EXECUTOR_MODE", "docker"):
+            strategy = ModeStrategyFactory.create()
+            assert isinstance(strategy, DockerModeStrategy)
+
+
+class TestLocalModeStrategy:
+    """Tests for LocalModeStrategy."""
+
+    @pytest.fixture
+    def strategy(self):
+        """Create LocalModeStrategy instance."""
+        return LocalModeStrategy()
+
+    @pytest.fixture
+    def temp_workspace(self):
+        """Create temporary workspace directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @pytest.fixture
+    def agent_config(self):
+        """Sample agent config with sensitive data."""
+        return {
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "sk-ant-api-secret-test-key",
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                "ANTHROPIC_MODEL": "claude-3-5-sonnet-20241022",
+            },
+            "model": "claude-3-5-sonnet-20241022",
+        }
+
+    @pytest.fixture
+    def claude_json_config(self):
+        """Sample non-sensitive claude.json config."""
+        return {
+            "numStartups": 2,
+            "hasCompletedOnboarding": True,
+            "userID": "test-user-id",
+        }
+
+    def test_get_config_directory(self, strategy, temp_workspace):
+        """Test task-specific config directory path."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            config_dir = strategy.get_config_directory(task_id=12345)
+            expected = os.path.join(temp_workspace, "12345", ".claude")
+            assert config_dir == expected
+
+    def test_save_config_files_does_not_write_settings_json(
+        self, strategy, temp_workspace, agent_config, claude_json_config
+    ):
+        """Test that settings.json is NOT created (security)."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            config_dir, _ = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            settings_path = os.path.join(config_dir, "settings.json")
+            assert not os.path.exists(settings_path), "settings.json should NOT exist"
+
+    def test_save_config_files_writes_claude_json(
+        self, strategy, temp_workspace, agent_config, claude_json_config
+    ):
+        """Test that claude.json is created with correct content."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            config_dir, _ = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            claude_json_path = os.path.join(config_dir, "claude.json")
+            assert os.path.exists(claude_json_path)
+
+            with open(claude_json_path) as f:
+                saved_config = json.load(f)
+
+            assert saved_config == claude_json_config
+
+    def test_save_config_files_returns_env_config(
+        self, strategy, temp_workspace, agent_config, claude_json_config
+    ):
+        """Test that env config is returned for SDK env parameter."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            _, env_config = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            assert env_config == agent_config["env"]
+            assert "ANTHROPIC_AUTH_TOKEN" in env_config
+
+    def test_save_config_files_directory_permissions(
+        self, strategy, temp_workspace, agent_config, claude_json_config
+    ):
+        """Test that .claude directory has 0700 permissions."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            config_dir, _ = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            dir_mode = stat.S_IMODE(os.stat(config_dir).st_mode)
+            assert dir_mode == 0o700, f"Expected 0700, got {oct(dir_mode)}"
+
+    def test_save_config_files_file_permissions(
+        self, strategy, temp_workspace, agent_config, claude_json_config
+    ):
+        """Test that claude.json has 0600 permissions."""
+        with patch(
+            "executor.config.config.get_workspace_root", return_value=temp_workspace
+        ):
+            config_dir, _ = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            claude_json_path = os.path.join(config_dir, "claude.json")
+            file_mode = stat.S_IMODE(os.stat(claude_json_path).st_mode)
+            assert file_mode == 0o600, f"Expected 0600, got {oct(file_mode)}"
+
+    def test_configure_client_options_merges_env(self, strategy):
+        """Test that env config is merged into options."""
+        options = {"cwd": "/workspace", "env": {"EXISTING_VAR": "value"}}
+        env_config = {
+            "ANTHROPIC_AUTH_TOKEN": "test-token",
+            "ANTHROPIC_MODEL": "claude-model",
+        }
+        config_dir = "/workspace/12345/.claude"
+
+        result = strategy.configure_client_options(options, config_dir, env_config)
+
+        assert "EXISTING_VAR" in result["env"]
+        assert "ANTHROPIC_AUTH_TOKEN" in result["env"]
+        assert "ANTHROPIC_MODEL" in result["env"]
+        assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
+
+    def test_configure_client_options_sets_claude_config_dir(self, strategy):
+        """Test that CLAUDE_CONFIG_DIR is set correctly."""
+        options = {"cwd": "/workspace"}
+        config_dir = "/workspace/12345/.claude"
+
+        result = strategy.configure_client_options(options, config_dir, {})
+
+        assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
+
+    def test_get_skills_directory_with_config_dir(self, strategy):
+        """Test skills directory within task config dir."""
+        config_dir = "/workspace/12345/.claude"
+        skills_dir = strategy.get_skills_directory(config_dir)
+        assert skills_dir == "/workspace/12345/.claude/skills"
+
+    def test_get_skills_directory_fallback(self, strategy):
+        """Test skills directory fallback when config_dir is None."""
+        skills_dir = strategy.get_skills_directory(None)
+        expected = os.path.expanduser("~/.claude/skills")
+        assert skills_dir == expected
+
+    def test_get_skills_deployment_options(self, strategy):
+        """Test local mode deployment options."""
+        options = strategy.get_skills_deployment_options()
+        assert options["clear_cache"] is False
+        assert options["skip_existing"] is True
+
+
+class TestDockerModeStrategy:
+    """Tests for DockerModeStrategy."""
+
+    @pytest.fixture
+    def strategy(self):
+        """Create DockerModeStrategy instance."""
+        return DockerModeStrategy()
+
+    @pytest.fixture
+    def temp_home(self):
+        """Create temporary home directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    @pytest.fixture
+    def agent_config(self):
+        """Sample agent config with sensitive data."""
+        return {
+            "env": {
+                "ANTHROPIC_AUTH_TOKEN": "sk-ant-api-test-key",
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+            },
+            "model": "claude-3-5-sonnet-20241022",
+        }
+
+    @pytest.fixture
+    def claude_json_config(self):
+        """Sample non-sensitive claude.json config."""
+        return {
+            "numStartups": 2,
+            "hasCompletedOnboarding": True,
+            "userID": "test-user-id",
+        }
+
+    def test_get_config_directory(self, strategy, temp_home):
+        """Test default ~/.claude directory path."""
+        with patch("os.path.expanduser", return_value=f"{temp_home}/.claude"):
+            config_dir = strategy.get_config_directory(task_id=12345)
+            assert config_dir == f"{temp_home}/.claude"
+
+    def test_save_config_files_writes_settings_json(
+        self, strategy, temp_home, agent_config, claude_json_config
+    ):
+        """Test that settings.json IS created in Docker mode."""
+        with patch(
+            "os.path.expanduser", side_effect=lambda p: p.replace("~", temp_home)
+        ):
+            config_dir, _ = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            settings_path = os.path.join(config_dir, "settings.json")
+            assert os.path.exists(settings_path), "settings.json should exist"
+
+            with open(settings_path) as f:
+                saved_config = json.load(f)
+
+            assert saved_config == agent_config
+
+    def test_save_config_files_writes_claude_json(
+        self, strategy, temp_home, agent_config, claude_json_config
+    ):
+        """Test that claude.json is created at ~/.claude.json."""
+        with patch(
+            "os.path.expanduser", side_effect=lambda p: p.replace("~", temp_home)
+        ):
+            strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            claude_json_path = os.path.join(temp_home, ".claude.json")
+            assert os.path.exists(claude_json_path)
+
+            with open(claude_json_path) as f:
+                saved_config = json.load(f)
+
+            assert saved_config == claude_json_config
+
+    def test_save_config_files_returns_empty_env_config(
+        self, strategy, temp_home, agent_config, claude_json_config
+    ):
+        """Test that empty env config is returned (config is in settings.json)."""
+        with patch(
+            "os.path.expanduser", side_effect=lambda p: p.replace("~", temp_home)
+        ):
+            _, env_config = strategy.save_config_files(
+                task_id=12345,
+                agent_config=agent_config,
+                claude_json_config=claude_json_config,
+            )
+
+            assert env_config == {}
+
+    def test_configure_client_options_unchanged(self, strategy):
+        """Test that options are returned unchanged in Docker mode."""
+        original_options = {
+            "cwd": "/workspace",
+            "env": {"SOME_VAR": "value"},
+            "max_turns": 10,
+        }
+
+        result = strategy.configure_client_options(
+            options=original_options.copy(), config_dir="/irrelevant", env_config={}
+        )
+
+        assert result == original_options
+
+    def test_get_skills_directory(self, strategy, temp_home):
+        """Test default ~/.claude/skills directory."""
+        with patch(
+            "os.path.expanduser", side_effect=lambda p: p.replace("~", temp_home)
+        ):
+            skills_dir = strategy.get_skills_directory()
+            assert skills_dir == f"{temp_home}/.claude/skills"
+
+    def test_get_skills_deployment_options(self, strategy):
+        """Test Docker mode deployment options."""
+        options = strategy.get_skills_deployment_options()
+        assert options["clear_cache"] is True
+        assert options["skip_existing"] is False
+
+
+class TestStrategyIntegration:
+    """Integration tests for strategy pattern with ClaudeCodeAgent."""
+
+    @pytest.fixture
+    def task_data(self):
+        """Sample task data."""
+        return {
+            "task_id": 12345,
+            "subtask_id": 67890,
+            "bot": [
+                {
+                    "agent_config": {
+                        "env": {
+                            "ANTHROPIC_AUTH_TOKEN": "sk-ant-api-test",
+                            "model": "claude-model",
+                        }
+                    }
+                }
+            ],
+        }
+
+    def test_agent_initializes_local_strategy(self, task_data):
+        """Test ClaudeCodeAgent initializes LocalModeStrategy in local mode."""
+        with patch("executor.config.config.EXECUTOR_MODE", "local"):
+            from executor.agents.claude_code.claude_code_agent import ClaudeCodeAgent
+
+            agent = ClaudeCodeAgent(task_data)
+            assert isinstance(agent._mode_strategy, LocalModeStrategy)
+
+    def test_agent_initializes_docker_strategy(self, task_data):
+        """Test ClaudeCodeAgent initializes DockerModeStrategy in docker mode."""
+        with patch("executor.config.config.EXECUTOR_MODE", ""):
+            from executor.agents.claude_code.claude_code_agent import ClaudeCodeAgent
+
+            agent = ClaudeCodeAgent(task_data)
+            assert isinstance(agent._mode_strategy, DockerModeStrategy)


### PR DESCRIPTION
…y Pattern

- Add ExecutionModeStrategy ABC and ModeStrategyFactory for mode-specific behavior
- Implement LocalModeStrategy with security-focused config handling:
  - Does NOT write settings.json (sensitive data)
  - Passes config via environment variables
  - Uses restrictive file permissions (0700/0600)
  - Preserves skills cache between tasks
- Implement DockerModeStrategy for container environments:
  - Writes full config files (isolated container)
  - Clears skills cache for fresh deployment
- Refactor ClaudeCodeAgent to delegate to strategy:
  - _save_claude_config_files()
  - _create_and_connect_client()
  - _download_and_deploy_skills()
- Remove all inline config.EXECUTOR_MODE checks
- Add comprehensive unit tests (26 tests, 100% coverage on new code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured execution mode handling for improved separation between Docker and local execution environments.

* **New Features**
  * Enhanced local execution with task-scoped configuration isolation and restricted file permissions for improved security.
  * Local mode now handles sensitive configuration data via environment variables instead of files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->