### PR TITLE
feat(deps): add CDP relay server for browser automation

### DIFF
--- a/deps/browser/relay-server/README.md
+++ b/deps/browser/relay-server/README.md
@@ -1,0 +1,96 @@
+# CDP Relay Server
+
+A standalone Chrome DevTools Protocol (CDP) relay server that bridges communication between a Chrome extension and CDP clients (like Playwright).
+
+## Architecture
+
+```
+┌─────────────────────┐
+│   Chrome Browser    │
+│  (chrome.debugger)  │
+└──────────┬──────────┘
+           │ CDP commands/events
+           ▼
+┌─────────────────────┐
+│   Chrome Extension  │
+│   (background.js)   │
+└──────────┬──────────┘
+           │ WebSocket (ws://127.0.0.1:PORT/extension)
+           ▼
+┌─────────────────────┐
+│   Relay Server      │  ← This package
+└──────────┬──────────┘
+           │ WebSocket (/cdp endpoint)
+           ▼
+┌─────────────────────┐
+│   CDP Client        │  ← Playwright, etc.
+└─────────────────────┘
+```
+
+## Quick Start
+
+### 1. Start Relay Server
+
+```bash
+cd ~/dev/git/browser/relay-server
+npm install
+npm start
+```
+
+### 2. Load Chrome Extension
+
+1. Open Chrome → `chrome://extensions`
+2. Enable "Developer mode"
+3. Click "Load unpacked"
+4. Select: `~/dev/git/browser/relay-server/chrome-extension`
+
+### 3. Attach to Tab
+
+Click the extension icon on any tab. Badge shows:
+- **ON**: Attached
+- **...**: Connecting
+- **!**: Error
+
+## Programmatic Usage
+
+```typescript
+import { ensureRelayServer, stopRelayServer, getRelayAuthHeaders } from 'cdp-relay-server';
+
+// Start the relay server
+const relay = await ensureRelayServer({
+  cdpUrl: 'http://127.0.0.1:9224'
+});
+
+console.log(`Relay server running at ${relay.baseUrl}`);
+console.log(`CDP WebSocket URL: ${relay.cdpWsUrl}`);
+console.log(`Extension connected: ${relay.extensionConnected()}`);
+
+// Get auth headers for CDP client connections
+const headers = getRelayAuthHeaders(relay.cdpWsUrl);
+
+// Stop the server
+await relay.stop();
+// or
+await stopRelayServer({ cdpUrl: 'http://127.0.0.1:18792' });
+```
+
+## Endpoints
+
+- `GET /` - Health check (returns "OK")
+- `GET /extension/status` - Extension connection status
+- `GET /json/version` - CDP version info
+- `GET /json/list` - List connected targets
+- `GET /json/activate/:targetId` - Activate a target
+- `GET /json/close/:targetId` - Close a target
+- `WS /extension` - WebSocket endpoint for Chrome extension
+- `WS /cdp` - WebSocket endpoint for CDP clients (requires auth header)
+
+## Security
+
+- Only accepts connections from loopback addresses (127.0.0.1, ::1)
+- CDP client connections require an auth token via `x-cdp-relay-token` header
+- Extension connections must have `chrome-extension://` origin
+
+## License
+
+MIT

--- a/deps/browser/relay-server/chrome-extension/background.js
+++ b/deps/browser/relay-server/chrome-extension/background.js
@@ -1,0 +1,409 @@
+const DEFAULT_PORT = 9224
+
+const BADGE = {
+  on: { text: 'ON', color: '#4CAF50' },
+  off: { text: '', color: '#000000' },
+  connecting: { text: '...', color: '#FF9800' },
+  error: { text: '!', color: '#F44336' },
+}
+
+/** @type {WebSocket|null} */
+let relayWs = null
+/** @type {Promise<void>|null} */
+let relayConnectPromise = null
+
+let debuggerListenersInstalled = false
+let nextSession = 1
+
+/** @type {Map<number, {state:'connecting'|'connected', sessionId?:string, targetId?:string}>} */
+const tabs = new Map()
+/** @type {Map<string, number>} */
+const tabBySession = new Map()
+/** @type {Map<string, number>} */
+const childSessionToTab = new Map()
+
+/** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
+const pending = new Map()
+
+async function getRelayPort() {
+  const stored = await chrome.storage.local.get(['relayPort'])
+  const raw = stored.relayPort
+  const n = Number.parseInt(String(raw || ''), 10)
+  if (!Number.isFinite(n) || n <= 0 || n > 65535) return DEFAULT_PORT
+  return n
+}
+
+function setBadge(tabId, kind) {
+  const cfg = BADGE[kind]
+  void chrome.action.setBadgeText({ tabId, text: cfg.text })
+  void chrome.action.setBadgeBackgroundColor({ tabId, color: cfg.color })
+  void chrome.action.setBadgeTextColor({ tabId, color: '#FFFFFF' }).catch(() => {})
+}
+
+async function ensureRelayConnection() {
+  if (relayWs && relayWs.readyState === WebSocket.OPEN) return
+  if (relayConnectPromise) return await relayConnectPromise
+
+  relayConnectPromise = (async () => {
+    const port = await getRelayPort()
+    const httpBase = `http://127.0.0.1:${port}`
+    const wsUrl = `ws://127.0.0.1:${port}/extension`
+
+    // Preflight check
+    try {
+      await fetch(`${httpBase}/`, { method: 'HEAD', signal: AbortSignal.timeout(2000) })
+    } catch (err) {
+      throw new Error(`Relay server not reachable at ${httpBase}`)
+    }
+
+    const ws = new WebSocket(wsUrl)
+    relayWs = ws
+
+    await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('WebSocket connect timeout')), 5000)
+      ws.onopen = () => { clearTimeout(t); resolve() }
+      ws.onerror = () => { clearTimeout(t); reject(new Error('WebSocket connect failed')) }
+      ws.onclose = (ev) => { clearTimeout(t); reject(new Error(`WebSocket closed (${ev.code})`)) }
+    })
+
+    ws.onmessage = (event) => void onRelayMessage(String(event.data || ''))
+    ws.onclose = () => onRelayClosed('closed')
+    ws.onerror = () => onRelayClosed('error')
+
+    if (!debuggerListenersInstalled) {
+      debuggerListenersInstalled = true
+      chrome.debugger.onEvent.addListener(onDebuggerEvent)
+      chrome.debugger.onDetach.addListener(onDebuggerDetach)
+    }
+  })()
+
+  try {
+    await relayConnectPromise
+  } finally {
+    relayConnectPromise = null
+  }
+}
+
+function onRelayClosed(reason) {
+  relayWs = null
+  for (const [id, p] of pending.entries()) {
+    pending.delete(id)
+    p.reject(new Error(`Relay disconnected (${reason})`))
+  }
+
+  for (const tabId of tabs.keys()) {
+    void chrome.debugger.detach({ tabId }).catch(() => {})
+    setBadge(tabId, 'connecting')
+  }
+  tabs.clear()
+  tabBySession.clear()
+  childSessionToTab.clear()
+}
+
+function sendToRelay(payload) {
+  const ws = relayWs
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    throw new Error('Relay not connected')
+  }
+  ws.send(JSON.stringify(payload))
+}
+
+async function onRelayMessage(text) {
+  let msg
+  try {
+    msg = JSON.parse(text)
+  } catch {
+    return
+  }
+
+  if (msg && msg.method === 'ping') {
+    try { sendToRelay({ method: 'pong' }) } catch {}
+    return
+  }
+
+  if (msg && typeof msg.id === 'number' && (msg.result !== undefined || msg.error !== undefined)) {
+    const p = pending.get(msg.id)
+    if (!p) return
+    pending.delete(msg.id)
+    if (msg.error) p.reject(new Error(String(msg.error)))
+    else p.resolve(msg.result)
+    return
+  }
+
+  if (msg && typeof msg.id === 'number' && msg.method === 'forwardCDPCommand') {
+    try {
+      const result = await handleForwardCdpCommand(msg)
+      sendToRelay({ id: msg.id, result })
+    } catch (err) {
+      sendToRelay({ id: msg.id, error: err instanceof Error ? err.message : String(err) })
+    }
+  }
+}
+
+function getTabBySessionId(sessionId) {
+  const direct = tabBySession.get(sessionId)
+  if (direct) return { tabId: direct, kind: 'main' }
+  const child = childSessionToTab.get(sessionId)
+  if (child) return { tabId: child, kind: 'child' }
+  return null
+}
+
+function getTabByTargetId(targetId) {
+  for (const [tabId, tab] of tabs.entries()) {
+    if (tab.targetId === targetId) return tabId
+  }
+  return null
+}
+
+async function attachTab(tabId, opts = {}) {
+  const debuggee = { tabId }
+  await chrome.debugger.attach(debuggee, '1.3')
+  await chrome.debugger.sendCommand(debuggee, 'Page.enable').catch(() => {})
+
+  const info = await chrome.debugger.sendCommand(debuggee, 'Target.getTargetInfo')
+  const targetInfo = info?.targetInfo
+  const targetId = String(targetInfo?.targetId || '').trim()
+  if (!targetId) {
+    throw new Error('Target.getTargetInfo returned no targetId')
+  }
+
+  const sessionId = `tab-${nextSession++}`
+  tabs.set(tabId, { state: 'connected', sessionId, targetId })
+  tabBySession.set(sessionId, tabId)
+
+  if (!opts.skipAttachedEvent) {
+    sendToRelay({
+      method: 'forwardCDPEvent',
+      params: {
+        method: 'Target.attachedToTarget',
+        params: {
+          sessionId,
+          targetInfo: { ...targetInfo, attached: true },
+          waitingForDebugger: false,
+        },
+      },
+    })
+  }
+
+  setBadge(tabId, 'on')
+  return { sessionId, targetId }
+}
+
+async function detachTab(tabId, reason) {
+  const tab = tabs.get(tabId)
+  if (tab?.sessionId && tab?.targetId) {
+    try {
+      sendToRelay({
+        method: 'forwardCDPEvent',
+        params: {
+          method: 'Target.detachedFromTarget',
+          params: { sessionId: tab.sessionId, targetId: tab.targetId, reason },
+        },
+      })
+    } catch {}
+  }
+
+  if (tab?.sessionId) tabBySession.delete(tab.sessionId)
+  tabs.delete(tabId)
+
+  for (const [childSessionId, parentTabId] of childSessionToTab.entries()) {
+    if (parentTabId === tabId) childSessionToTab.delete(childSessionId)
+  }
+
+  try { await chrome.debugger.detach({ tabId }) } catch {}
+
+  setBadge(tabId, 'off')
+}
+
+async function connectOrToggleForActiveTab() {
+  const [active] = await chrome.tabs.query({ active: true, currentWindow: true })
+  const tabId = active?.id
+  if (!tabId) return
+
+  const existing = tabs.get(tabId)
+  if (existing?.state === 'connected') {
+    await detachTab(tabId, 'toggle')
+    return
+  }
+
+  tabs.set(tabId, { state: 'connecting' })
+  setBadge(tabId, 'connecting')
+
+  try {
+    await ensureRelayConnection()
+    await attachTab(tabId)
+  } catch (err) {
+    tabs.delete(tabId)
+    setBadge(tabId, 'error')
+    console.warn('attach failed', err instanceof Error ? err.message : String(err))
+    void chrome.runtime.openOptionsPage()
+  }
+}
+
+async function handleForwardCdpCommand(msg) {
+  const method = String(msg?.params?.method || '').trim()
+  const params = msg?.params?.params || undefined
+  const sessionId = typeof msg?.params?.sessionId === 'string' ? msg.params.sessionId : undefined
+
+  const bySession = sessionId ? getTabBySessionId(sessionId) : null
+  const targetId = typeof params?.targetId === 'string' ? params.targetId : undefined
+  const tabId =
+    bySession?.tabId ||
+    (targetId ? getTabByTargetId(targetId) : null) ||
+    (() => {
+      for (const [id, tab] of tabs.entries()) {
+        if (tab.state === 'connected') return id
+      }
+      return null
+    })()
+
+  if (!tabId) throw new Error(`No attached tab for method ${method}`)
+
+  const debuggee = { tabId }
+
+  // Handle special methods
+  if (method === 'Runtime.enable') {
+    try {
+      await chrome.debugger.sendCommand(debuggee, 'Runtime.disable')
+      await new Promise((r) => setTimeout(r, 50))
+    } catch {}
+    return await chrome.debugger.sendCommand(debuggee, 'Runtime.enable', params)
+  }
+
+  if (method === 'Target.createTarget') {
+    const url = typeof params?.url === 'string' ? params.url : 'about:blank'
+    const tab = await chrome.tabs.create({ url, active: false })
+    if (!tab.id) throw new Error('Failed to create tab')
+    await new Promise((r) => setTimeout(r, 100))
+    const attached = await attachTab(tab.id)
+    return { targetId: attached.targetId }
+  }
+
+  if (method === 'Target.closeTarget') {
+    const target = typeof params?.targetId === 'string' ? params.targetId : ''
+    const toClose = target ? getTabByTargetId(target) : tabId
+    if (!toClose) return { success: false }
+    try { await chrome.tabs.remove(toClose) } catch { return { success: false } }
+    return { success: true }
+  }
+
+  if (method === 'Target.activateTarget') {
+    const target = typeof params?.targetId === 'string' ? params.targetId : ''
+    const toActivate = target ? getTabByTargetId(target) : tabId
+    if (!toActivate) return {}
+    const tab = await chrome.tabs.get(toActivate).catch(() => null)
+    if (!tab) return {}
+    if (tab.windowId) {
+      await chrome.windows.update(tab.windowId, { focused: true }).catch(() => {})
+    }
+    await chrome.tabs.update(toActivate, { active: true }).catch(() => {})
+    return {}
+  }
+
+  const tabState = tabs.get(tabId)
+  const mainSessionId = tabState?.sessionId
+  const debuggerSession =
+    sessionId && mainSessionId && sessionId !== mainSessionId
+      ? { ...debuggee, sessionId }
+      : debuggee
+
+  return await chrome.debugger.sendCommand(debuggerSession, method, params)
+}
+
+function onDebuggerEvent(source, method, params) {
+  const tabId = source.tabId
+  if (!tabId) return
+  const tab = tabs.get(tabId)
+  if (!tab?.sessionId) return
+
+  if (method === 'Target.attachedToTarget' && params?.sessionId) {
+    childSessionToTab.set(String(params.sessionId), tabId)
+  }
+
+  if (method === 'Target.detachedFromTarget' && params?.sessionId) {
+    childSessionToTab.delete(String(params.sessionId))
+  }
+
+  try {
+    sendToRelay({
+      method: 'forwardCDPEvent',
+      params: {
+        sessionId: source.sessionId || tab.sessionId,
+        method,
+        params,
+      },
+    })
+  } catch {}
+}
+
+function onDebuggerDetach(source, reason) {
+  const tabId = source.tabId
+  if (!tabId) return
+  if (!tabs.has(tabId)) return
+  void detachTab(tabId, reason)
+}
+
+chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
+
+chrome.runtime.onInstalled.addListener(() => {
+  void chrome.runtime.openOptionsPage()
+})
+
+// Auto-attach: continuously try to attach when relay is available and no tab is attached
+async function tryAutoAttach() {
+  // Check if relay server is available
+  const port = await getRelayPort()
+  const httpBase = `http://127.0.0.1:${port}`
+
+  try {
+    await fetch(`${httpBase}/`, { method: 'HEAD', signal: AbortSignal.timeout(2000) })
+  } catch {
+    // Relay not available, retry later
+    setTimeout(tryAutoAttach, 3000)
+    return
+  }
+
+  // Check if any tab is already attached
+  const hasAttachedTab = Array.from(tabs.values()).some(t => t.state === 'connected')
+  if (hasAttachedTab) {
+    // Already have an attached tab, check again later in case it gets detached
+    setTimeout(tryAutoAttach, 5000)
+    return
+  }
+
+  // Relay is available but no tab attached, get active tab
+  const [active] = await chrome.tabs.query({ active: true, currentWindow: true })
+  const tabId = active?.id
+  const url = active?.url || ''
+
+  // Skip chrome:// pages but keep retrying
+  if (!tabId || url.startsWith('chrome://') || url.startsWith('chrome-extension://') || url === '' || url === 'about:blank') {
+    setTimeout(tryAutoAttach, 2000)
+    return
+  }
+
+  // Auto-attach to current tab
+  tabs.set(tabId, { state: 'connecting' })
+  setBadge(tabId, 'connecting')
+
+  try {
+    await ensureRelayConnection()
+    await attachTab(tabId)
+    console.log('Auto-attached to tab:', tabId, url)
+  } catch (err) {
+    tabs.delete(tabId)
+    setBadge(tabId, 'off')
+    console.warn('Auto-attach failed:', err instanceof Error ? err.message : String(err))
+  }
+
+  // Keep checking
+  setTimeout(tryAutoAttach, 3000)
+}
+
+// Also try auto-attach when tab is activated
+chrome.tabs.onActivated.addListener(() => {
+  setTimeout(tryAutoAttach, 500)
+})
+
+// Start auto-attach loop on extension load
+tryAutoAttach()

--- a/deps/browser/relay-server/chrome-extension/manifest.json
+++ b/deps/browser/relay-server/chrome-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Wegent Browser Relay",
+  "version": "0.0.1",
+  "description": "Enable LLM to control browser tabs via CDP relay",
+  "permissions": ["debugger", "tabs", "activeTab", "storage"],
+  "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
+  "background": {
+    "service_worker": "background.js",
+    "type": "module"
+  },
+  "action": {
+    "default_title": "Browser Relay (click to attach/detach)"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
+  "icons": {}
+}

--- a/deps/browser/relay-server/chrome-extension/options.html
+++ b/deps/browser/relay-server/chrome-extension/options.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Browser Relay Settings</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 16px;
+      min-width: 320px;
+      background: #1a1a1a;
+      color: #e0e0e0;
+    }
+    h2 {
+      margin: 0 0 16px 0;
+      font-size: 18px;
+      color: #4CAF50;
+    }
+    .field {
+      margin-bottom: 16px;
+    }
+    label {
+      display: block;
+      margin-bottom: 6px;
+      font-size: 13px;
+      color: #aaa;
+    }
+    input[type="number"] {
+      width: 100%;
+      padding: 8px 12px;
+      border: 1px solid #333;
+      border-radius: 4px;
+      background: #2a2a2a;
+      color: #e0e0e0;
+      font-size: 14px;
+      box-sizing: border-box;
+    }
+    input[type="number"]:focus {
+      outline: none;
+      border-color: #4CAF50;
+    }
+    button {
+      background: #4CAF50;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      width: 100%;
+    }
+    button:hover {
+      background: #45a049;
+    }
+    .status {
+      margin-top: 12px;
+      padding: 10px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+    .status.success {
+      background: #1b3a1b;
+      color: #4CAF50;
+    }
+    .status.error {
+      background: #3a1b1b;
+      color: #f44336;
+    }
+    .help {
+      margin-top: 20px;
+      padding: 12px;
+      background: #252525;
+      border-radius: 4px;
+      font-size: 12px;
+      line-height: 1.5;
+      color: #888;
+    }
+    .help h3 {
+      margin: 0 0 8px 0;
+      font-size: 13px;
+      color: #aaa;
+    }
+    code {
+      background: #333;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+  <h2>Browser Relay Settings</h2>
+
+  <div class="field">
+    <label for="port">Relay Server Port</label>
+    <input type="number" id="port" min="1" max="65535" value="9224">
+  </div>
+
+  <button id="save">Save Settings</button>
+
+  <div id="status" class="status" style="display: none;"></div>
+
+  <div class="help">
+    <h3>Setup Instructions</h3>
+    <p>1. Start the relay server:</p>
+    <p><code>cd ~/.claude/skills/browser && pnpm start</code></p>
+    <p>2. Click the extension icon on any tab to attach</p>
+    <p>3. The LLM can now control the attached tab</p>
+  </div>
+
+  <script src="options.js"></script>
+</body>
+</html>

--- a/deps/browser/relay-server/chrome-extension/options.js
+++ b/deps/browser/relay-server/chrome-extension/options.js
@@ -1,0 +1,32 @@
+const portInput = document.getElementById('port')
+const saveBtn = document.getElementById('save')
+const statusEl = document.getElementById('status')
+
+async function loadSettings() {
+  const stored = await chrome.storage.local.get(['relayPort'])
+  if (stored.relayPort) {
+    portInput.value = stored.relayPort
+  }
+}
+
+function showStatus(message, isError = false) {
+  statusEl.textContent = message
+  statusEl.className = 'status ' + (isError ? 'error' : 'success')
+  statusEl.style.display = 'block'
+  setTimeout(() => {
+    statusEl.style.display = 'none'
+  }, 3000)
+}
+
+saveBtn.addEventListener('click', async () => {
+  const port = parseInt(portInput.value, 10)
+  if (!port || port < 1 || port > 65535) {
+    showStatus('Invalid port number', true)
+    return
+  }
+
+  await chrome.storage.local.set({ relayPort: port })
+  showStatus('Settings saved!')
+})
+
+loadSettings()

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@wb/wegent-cdp-relay-server",
+  "version": "0.1.5",
+  "description": "Chrome DevTools Protocol relay server and browser automation tool",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "cdp-relay-server": "dist/cli.js",
+    "browser-tool": "dist/tool-cli.js"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./tool": {
+      "import": "./dist/tool.js",
+      "types": "./dist/tool.d.ts"
+    },
+    "./client": {
+      "import": "./dist/browser-client.js",
+      "types": "./dist/browser-client.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "chrome-extension"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "start": "node dist/cli.js",
+    "tool": "node dist/tool-cli.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.10",
+    "typescript": "^5.5.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT"
+}

--- a/deps/browser/relay-server/src/actions.ts
+++ b/deps/browser/relay-server/src/actions.ts
@@ -1,0 +1,609 @@
+/**
+ * Browser Actions
+ *
+ * Execute browser actions like click, type, hover, etc.
+ */
+
+import { createBrowserClient, type BrowserClient } from "./browser-client.js";
+import { getStoredRefs, parseRef } from "./snapshot.js";
+
+export type ActRequest =
+  | { kind: "click"; ref: string; doubleClick?: boolean; button?: string; modifiers?: string[] }
+  | { kind: "type"; ref: string; text: string; submit?: boolean; slowly?: boolean }
+  | { kind: "press"; key: string }
+  | { kind: "hover"; ref: string }
+  | { kind: "drag"; startRef: string; endRef: string }
+  | { kind: "select"; ref: string; values: string[] }
+  | { kind: "fill"; fields: Array<{ ref: string; value: string }> }
+  | { kind: "scroll"; ref?: string; direction?: "up" | "down" | "left" | "right"; amount?: number }
+  | { kind: "wait"; timeMs?: number; text?: string; textGone?: string; selector?: string }
+  | { kind: "resize"; width: number; height: number };
+
+export type ActResult = {
+  ok: boolean;
+  error?: string;
+};
+
+/**
+ * Find element by ref using stored accessibility refs
+ */
+async function findElementByRef(
+  client: BrowserClient,
+  ref: string
+): Promise<{ nodeId: number; x: number; y: number; width: number; height: number }> {
+  const parsed = parseRef(ref);
+  if (!parsed) {
+    throw new Error(`Invalid ref: ${ref}`);
+  }
+
+  const refInfo = getStoredRefs()[parsed];
+  if (!refInfo) {
+    throw new Error(`Ref not found: ${parsed}. Run snapshot first to get element refs.`);
+  }
+
+  // Build selector from role and name (for debugging reference)
+  const { role, name, nth } = refInfo;
+  const _selector =
+    name
+      ? `[role="${role}"][aria-label="${name}"], [role="${role}"]:has-text("${name}")`
+      : `[role="${role}"]`;
+  void _selector; // Used for debugging
+
+  // Use DOM to find element and get bounding box
+  const expression = `(() => {
+    const role = ${JSON.stringify(role)};
+    const name = ${JSON.stringify(name)};
+    const nth = ${JSON.stringify(nth ?? 0)};
+
+    // Find all matching elements
+    const allElements = document.querySelectorAll('[role="' + role + '"]');
+    let matches = [];
+
+    for (const el of allElements) {
+      const label = el.getAttribute('aria-label') || el.textContent?.trim() || '';
+      if (!name || label.includes(name)) {
+        matches.push(el);
+      }
+    }
+
+    // Also try by tag name for common roles
+    const tagMap = {
+      button: 'button',
+      link: 'a',
+      textbox: 'input[type="text"], input[type="email"], input[type="password"], input:not([type]), textarea',
+      checkbox: 'input[type="checkbox"]',
+      radio: 'input[type="radio"]',
+      combobox: 'select',
+      searchbox: 'input[type="search"]',
+    };
+
+    if (tagMap[role] && matches.length === 0) {
+      const tagElements = document.querySelectorAll(tagMap[role]);
+      for (const el of tagElements) {
+        const label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || el.textContent?.trim() || '';
+        if (!name || label.includes(name)) {
+          matches.push(el);
+        }
+      }
+    }
+
+    if (matches.length === 0) {
+      return { error: 'Element not found for role=' + role + (name ? ' name=' + name : '') };
+    }
+
+    const el = matches[nth] || matches[0];
+    const rect = el.getBoundingClientRect();
+
+    return {
+      x: rect.x + rect.width / 2,
+      y: rect.y + rect.height / 2,
+      width: rect.width,
+      height: rect.height,
+      tag: el.tagName.toLowerCase(),
+    };
+  })()`;
+
+  await client.send("Runtime.enable", {});
+  const result = (await client.send("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  })) as { result?: { value?: { error?: string; x?: number; y?: number; width?: number; height?: number } } };
+
+  const value = result?.result?.value;
+  if (!value || value.error) {
+    throw new Error(value?.error ?? "Element not found");
+  }
+
+  return {
+    nodeId: 0,
+    x: value.x ?? 0,
+    y: value.y ?? 0,
+    width: value.width ?? 0,
+    height: value.height ?? 0,
+  };
+}
+
+/**
+ * Click on element
+ */
+export async function click(
+  ref: string,
+  opts?: { doubleClick?: boolean; button?: string; modifiers?: string[] }
+): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    const el = await findElementByRef(client, ref);
+
+    const button = opts?.button ?? "left";
+    const clickCount = opts?.doubleClick ? 2 : 1;
+
+    // Mouse down
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: el.x,
+      y: el.y,
+      button,
+      clickCount,
+    });
+
+    // Mouse up
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: el.x,
+      y: el.y,
+      button,
+      clickCount,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Type text into element
+ */
+export async function type(
+  ref: string,
+  text: string,
+  opts?: { submit?: boolean; slowly?: boolean }
+): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    // First click to focus
+    const el = await findElementByRef(client, ref);
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: el.x,
+      y: el.y,
+      button: "left",
+      clickCount: 1,
+    });
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: el.x,
+      y: el.y,
+      button: "left",
+      clickCount: 1,
+    });
+
+    // Clear existing text
+    await client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "a", modifiers: 2 }); // Ctrl+A
+    await client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "a", modifiers: 2 });
+
+    // Type text
+    if (opts?.slowly) {
+      for (const char of text) {
+        await client.send("Input.insertText", { text: char });
+        await new Promise((r) => setTimeout(r, 50));
+      }
+    } else {
+      await client.send("Input.insertText", { text });
+    }
+
+    // Submit if requested
+    if (opts?.submit) {
+      await client.send("Input.dispatchKeyEvent", {
+        type: "keyDown",
+        key: "Enter",
+        code: "Enter",
+        windowsVirtualKeyCode: 13,
+        nativeVirtualKeyCode: 13,
+      });
+      await client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Enter" });
+    }
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Press a keyboard key
+ */
+export async function press(key: string): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    // Map common key names
+    const keyMap: Record<string, { code: string; keyCode: number }> = {
+      Enter: { code: "Enter", keyCode: 13 },
+      Tab: { code: "Tab", keyCode: 9 },
+      Escape: { code: "Escape", keyCode: 27 },
+      Backspace: { code: "Backspace", keyCode: 8 },
+      Delete: { code: "Delete", keyCode: 46 },
+      ArrowUp: { code: "ArrowUp", keyCode: 38 },
+      ArrowDown: { code: "ArrowDown", keyCode: 40 },
+      ArrowLeft: { code: "ArrowLeft", keyCode: 37 },
+      ArrowRight: { code: "ArrowRight", keyCode: 39 },
+      Space: { code: "Space", keyCode: 32 },
+    };
+
+    const keyInfo = keyMap[key] ?? { code: `Key${key.toUpperCase()}`, keyCode: key.charCodeAt(0) };
+
+    await client.send("Input.dispatchKeyEvent", {
+      type: "keyDown",
+      key,
+      code: keyInfo.code,
+      windowsVirtualKeyCode: keyInfo.keyCode,
+      nativeVirtualKeyCode: keyInfo.keyCode,
+    });
+
+    await client.send("Input.dispatchKeyEvent", {
+      type: "keyUp",
+      key,
+      code: keyInfo.code,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Hover over element
+ */
+export async function hover(ref: string): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    const el = await findElementByRef(client, ref);
+
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: el.x,
+      y: el.y,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Drag from one element to another
+ */
+export async function drag(startRef: string, endRef: string): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    const startEl = await findElementByRef(client, startRef);
+    const endEl = await findElementByRef(client, endRef);
+
+    // Mouse down on start
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x: startEl.x,
+      y: startEl.y,
+      button: "left",
+    });
+
+    // Move to end
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseMoved",
+      x: endEl.x,
+      y: endEl.y,
+    });
+
+    // Mouse up on end
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x: endEl.x,
+      y: endEl.y,
+      button: "left",
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Select options in a dropdown
+ */
+export async function select(ref: string, values: string[]): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    // Click to open dropdown
+    await click(ref);
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Select each option by clicking
+    for (const value of values) {
+      const expression = `(() => {
+        const options = document.querySelectorAll('option, [role="option"]');
+        for (const opt of options) {
+          if (opt.textContent?.includes(${JSON.stringify(value)}) || opt.value === ${JSON.stringify(value)}) {
+            const rect = opt.getBoundingClientRect();
+            return { x: rect.x + rect.width/2, y: rect.y + rect.height/2 };
+          }
+        }
+        return { error: 'Option not found: ${value}' };
+      })()`;
+
+      await client.send("Runtime.enable", {});
+      const result = (await client.send("Runtime.evaluate", {
+        expression,
+        returnByValue: true,
+      })) as { result?: { value?: { x?: number; y?: number; error?: string } } };
+
+      if (result?.result?.value?.error) {
+        throw new Error(result.result.value.error);
+      }
+
+      const { x, y } = result?.result?.value ?? {};
+      if (x !== undefined && y !== undefined) {
+        await client.send("Input.dispatchMouseEvent", {
+          type: "mousePressed",
+          x,
+          y,
+          button: "left",
+          clickCount: 1,
+        });
+        await client.send("Input.dispatchMouseEvent", {
+          type: "mouseReleased",
+          x,
+          y,
+          button: "left",
+        });
+      }
+    }
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Fill multiple form fields
+ */
+export async function fill(fields: Array<{ ref: string; value: string }>): Promise<ActResult> {
+  for (const field of fields) {
+    const result = await type(field.ref, field.value);
+    if (!result.ok) {
+      return result;
+    }
+  }
+  return { ok: true };
+}
+
+/**
+ * Scroll the page or element
+ */
+export async function scroll(opts?: {
+  ref?: string;
+  direction?: "up" | "down" | "left" | "right";
+  amount?: number;
+}): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    const direction = opts?.direction ?? "down";
+    const amount = opts?.amount ?? 300;
+
+    let x = 0,
+      y = 0;
+    if (opts?.ref) {
+      const el = await findElementByRef(client, opts.ref);
+      x = el.x;
+      y = el.y;
+    } else {
+      // Scroll at center of viewport
+      const result = (await client.send("Runtime.evaluate", {
+        expression: "JSON.stringify({ x: window.innerWidth/2, y: window.innerHeight/2 })",
+        returnByValue: true,
+      })) as { result?: { value?: string } };
+      const pos = JSON.parse(result?.result?.value ?? "{}");
+      x = pos.x ?? 400;
+      y = pos.y ?? 300;
+    }
+
+    let deltaX = 0,
+      deltaY = 0;
+    switch (direction) {
+      case "up":
+        deltaY = -amount;
+        break;
+      case "down":
+        deltaY = amount;
+        break;
+      case "left":
+        deltaX = -amount;
+        break;
+      case "right":
+        deltaX = amount;
+        break;
+    }
+
+    await client.send("Input.dispatchMouseEvent", {
+      type: "mouseWheel",
+      x,
+      y,
+      deltaX,
+      deltaY,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Wait for condition
+ */
+export async function wait(opts: {
+  timeMs?: number;
+  text?: string;
+  textGone?: string;
+  selector?: string;
+}): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    // Simple time wait
+    if (opts.timeMs) {
+      await new Promise((r) => setTimeout(r, opts.timeMs));
+      return { ok: true };
+    }
+
+    // Wait for text to appear
+    if (opts.text) {
+      const maxWait = 10000;
+      const start = Date.now();
+      while (Date.now() - start < maxWait) {
+        const result = (await client.send("Runtime.evaluate", {
+          expression: `document.body.innerText.includes(${JSON.stringify(opts.text)})`,
+          returnByValue: true,
+        })) as { result?: { value?: boolean } };
+        if (result?.result?.value) {
+          return { ok: true };
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      return { ok: false, error: `Text not found after ${maxWait}ms: ${opts.text}` };
+    }
+
+    // Wait for text to disappear
+    if (opts.textGone) {
+      const maxWait = 10000;
+      const start = Date.now();
+      while (Date.now() - start < maxWait) {
+        const result = (await client.send("Runtime.evaluate", {
+          expression: `!document.body.innerText.includes(${JSON.stringify(opts.textGone)})`,
+          returnByValue: true,
+        })) as { result?: { value?: boolean } };
+        if (result?.result?.value) {
+          return { ok: true };
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      return { ok: false, error: `Text still present after ${maxWait}ms: ${opts.textGone}` };
+    }
+
+    // Wait for selector
+    if (opts.selector) {
+      const maxWait = 10000;
+      const start = Date.now();
+      while (Date.now() - start < maxWait) {
+        const result = (await client.send("Runtime.evaluate", {
+          expression: `!!document.querySelector(${JSON.stringify(opts.selector)})`,
+          returnByValue: true,
+        })) as { result?: { value?: boolean } };
+        if (result?.result?.value) {
+          return { ok: true };
+        }
+        await new Promise((r) => setTimeout(r, 200));
+      }
+      return { ok: false, error: `Selector not found after ${maxWait}ms: ${opts.selector}` };
+    }
+
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Resize browser viewport
+ */
+export async function resize(width: number, height: number): Promise<ActResult> {
+  const client = await createBrowserClient();
+  try {
+    await client.send("Emulation.setDeviceMetricsOverride", {
+      width: Math.max(1, Math.floor(width)),
+      height: Math.max(1, Math.floor(height)),
+      deviceScaleFactor: 1,
+      mobile: false,
+    });
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Execute action from request object
+ */
+export async function executeAction(request: ActRequest): Promise<ActResult> {
+  switch (request.kind) {
+    case "click":
+      return click(request.ref, {
+        doubleClick: request.doubleClick,
+        button: request.button,
+        modifiers: request.modifiers,
+      });
+    case "type":
+      return type(request.ref, request.text, {
+        submit: request.submit,
+        slowly: request.slowly,
+      });
+    case "press":
+      return press(request.key);
+    case "hover":
+      return hover(request.ref);
+    case "drag":
+      return drag(request.startRef, request.endRef);
+    case "select":
+      return select(request.ref, request.values);
+    case "fill":
+      return fill(request.fields);
+    case "scroll":
+      return scroll({
+        ref: request.ref,
+        direction: request.direction,
+        amount: request.amount,
+      });
+    case "wait":
+      return wait({
+        timeMs: request.timeMs,
+        text: request.text,
+        textGone: request.textGone,
+        selector: request.selector,
+      });
+    case "resize":
+      return resize(request.width, request.height);
+    default:
+      return { ok: false, error: `Unknown action kind: ${(request as ActRequest).kind}` };
+  }
+}

--- a/deps/browser/relay-server/src/browser-client.ts
+++ b/deps/browser/relay-server/src/browser-client.ts
@@ -1,0 +1,330 @@
+/**
+ * Browser Client
+ *
+ * Connects to externally running CDP relay server
+ */
+
+import WebSocket, { type RawData } from "ws";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const DEFAULT_RELAY_PORT = 9224;
+const DEFAULT_BROWSER_PREFIX = path.join(os.homedir(), ".wegent-executor", "browser");
+
+function getBrowserPrefix(): string {
+  return process.env.BROWSER_PREFIX || DEFAULT_BROWSER_PREFIX;
+}
+
+function getTokenFilePath(): string {
+  return path.join(getBrowserPrefix(), ".token");
+}
+
+type CdpResponse = {
+  id: number;
+  result?: unknown;
+  error?: { message?: string };
+};
+
+type Pending = {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+};
+
+type TargetInfo = {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+};
+
+function rawDataToString(data: RawData): string {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf-8");
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf-8");
+  if (Array.isArray(data)) return Buffer.concat(data).toString("utf-8");
+  return String(data);
+}
+
+function getRelayPort(): number {
+  const envPort = process.env.BROWSER_RELAY_PORT;
+  if (envPort) {
+    const port = parseInt(envPort, 10);
+    if (!isNaN(port) && port > 0 && port < 65536) return port;
+  }
+  return DEFAULT_RELAY_PORT;
+}
+
+function getAuthToken(): string | null {
+  const tokenFile = getTokenFilePath();
+  try {
+    if (fs.existsSync(tokenFile)) {
+      return fs.readFileSync(tokenFile, "utf-8").trim();
+    }
+  } catch {}
+  return null;
+}
+
+export type RelayStatus = {
+  relayRunning: boolean;
+  extensionConnected: boolean;
+  targets: Array<{ targetId: string; title: string; url: string }>;
+};
+
+/**
+ * Check relay server status via HTTP
+ */
+export async function getStatus(): Promise<RelayStatus> {
+  const port = getRelayPort();
+  const token = getAuthToken();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    // Check if server is running
+    const rootRes = await fetch(baseUrl, { method: "HEAD" });
+    if (!rootRes.ok) {
+      return { relayRunning: false, extensionConnected: false, targets: [] };
+    }
+
+    // Check extension status
+    const statusRes = await fetch(`${baseUrl}/extension/status`);
+    const statusData = (await statusRes.json()) as { connected?: boolean };
+    const extensionConnected = statusData?.connected ?? false;
+
+    // Get targets list
+    let targets: Array<{ targetId: string; title: string; url: string }> = [];
+    if (extensionConnected && token) {
+      const listRes = await fetch(`${baseUrl}/json/list`, {
+        headers: { "x-cdp-relay-token": token },
+      });
+      if (listRes.ok) {
+        const list = (await listRes.json()) as TargetInfo[];
+        targets = list.map((t) => ({
+          targetId: t.id,
+          title: t.title,
+          url: t.url,
+        }));
+      }
+    }
+
+    return { relayRunning: true, extensionConnected, targets };
+  } catch {
+    return { relayRunning: false, extensionConnected: false, targets: [] };
+  }
+}
+
+export type BrowserClient = {
+  send: (method: string, params?: Record<string, unknown>) => Promise<unknown>;
+  close: () => void;
+};
+
+export async function createBrowserClient(): Promise<BrowserClient> {
+  const port = getRelayPort();
+  const token = getAuthToken();
+
+  if (!token) {
+    throw new Error("No auth token found. Is relay server running?");
+  }
+
+  // Check status first
+  const status = await getStatus();
+  if (!status.relayRunning) {
+    throw new Error("Relay server not running. Start it with: cd ~/dev/git/browser/relay-server && npm start");
+  }
+  if (!status.extensionConnected) {
+    throw new Error("Browser extension not connected. Click extension icon on a tab to attach.");
+  }
+
+  const wsUrl = `ws://127.0.0.1:${port}/cdp`;
+  const ws = new WebSocket(wsUrl, {
+    headers: { "x-cdp-relay-token": token },
+    handshakeTimeout: 5000,
+  });
+
+  let nextId = 1;
+  const pending = new Map<number, Pending>();
+
+  await new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", (err) => reject(err));
+  });
+
+  ws.on("message", (data) => {
+    try {
+      const parsed = JSON.parse(rawDataToString(data)) as CdpResponse;
+      if (typeof parsed.id !== "number") return;
+      const p = pending.get(parsed.id);
+      if (!p) return;
+      pending.delete(parsed.id);
+      if (parsed.error?.message) {
+        p.reject(new Error(parsed.error.message));
+      } else {
+        p.resolve(parsed.result);
+      }
+    } catch {}
+  });
+
+  ws.on("close", () => {
+    for (const [, p] of pending) {
+      p.reject(new Error("Connection closed"));
+    }
+    pending.clear();
+  });
+
+  const send = (method: string, params?: Record<string, unknown>): Promise<unknown> => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("Connection not open"));
+    }
+    const id = nextId++;
+    ws.send(JSON.stringify({ id, method, params }));
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+    });
+  };
+
+  return {
+    send,
+    close: () => ws.close(),
+  };
+}
+
+// High-level browser operations
+
+export async function listTabs(): Promise<
+  Array<{ targetId: string; title: string; url: string }>
+> {
+  const status = await getStatus();
+  return status.targets;
+}
+
+export async function openTab(url: string): Promise<{ targetId: string }> {
+  const client = await createBrowserClient();
+  try {
+    const result = (await client.send("Target.createTarget", { url })) as { targetId: string };
+    return { targetId: result.targetId };
+  } finally {
+    client.close();
+  }
+}
+
+export async function closeTab(targetId: string): Promise<{ success: boolean }> {
+  const client = await createBrowserClient();
+  try {
+    const result = (await client.send("Target.closeTarget", { targetId })) as { success: boolean };
+    return { success: result.success };
+  } finally {
+    client.close();
+  }
+}
+
+export async function focusTab(targetId: string): Promise<void> {
+  const client = await createBrowserClient();
+  try {
+    await client.send("Target.activateTarget", { targetId });
+  } finally {
+    client.close();
+  }
+}
+
+export async function navigate(url: string, _targetId?: string): Promise<{ url: string }> {
+  const client = await createBrowserClient();
+  try {
+    await client.send("Page.enable", {});
+    await client.send("Page.navigate", { url });
+    // Wait a bit for navigation
+    await new Promise((r) => setTimeout(r, 500));
+    return { url };
+  } finally {
+    client.close();
+  }
+}
+
+export async function screenshot(opts?: {
+  fullPage?: boolean;
+  format?: "png" | "jpeg";
+  quality?: number;
+}): Promise<Buffer> {
+  const client = await createBrowserClient();
+  try {
+    await client.send("Page.enable", {});
+
+    let clip: { x: number; y: number; width: number; height: number; scale: number } | undefined;
+    if (opts?.fullPage) {
+      const metrics = (await client.send("Page.getLayoutMetrics")) as {
+        cssContentSize?: { width?: number; height?: number };
+        contentSize?: { width?: number; height?: number };
+      };
+      const size = metrics?.cssContentSize ?? metrics?.contentSize;
+      const width = Number(size?.width ?? 0);
+      const height = Number(size?.height ?? 0);
+      if (width > 0 && height > 0) {
+        clip = { x: 0, y: 0, width, height, scale: 1 };
+      }
+    }
+
+    const format = opts?.format ?? "png";
+    const quality =
+      format === "jpeg" ? Math.max(0, Math.min(100, Math.round(opts?.quality ?? 85))) : undefined;
+
+    const result = (await client.send("Page.captureScreenshot", {
+      format,
+      ...(quality !== undefined ? { quality } : {}),
+      fromSurface: true,
+      captureBeyondViewport: true,
+      ...(clip ? { clip } : {}),
+    })) as { data?: string };
+
+    if (!result?.data) {
+      throw new Error("Screenshot failed: missing data");
+    }
+    return Buffer.from(result.data, "base64");
+  } finally {
+    client.close();
+  }
+}
+
+export async function evaluate(expression: string): Promise<{
+  result: unknown;
+  error?: string;
+}> {
+  const client = await createBrowserClient();
+  try {
+    await client.send("Runtime.enable", {});
+    const result = (await client.send("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+      userGesture: true,
+    })) as {
+      result?: { value?: unknown; type?: string };
+      exceptionDetails?: { text?: string; exception?: { description?: string } };
+    };
+
+    if (result.exceptionDetails) {
+      return {
+        result: undefined,
+        error:
+          result.exceptionDetails.exception?.description ??
+          result.exceptionDetails.text ??
+          "Evaluation failed",
+      };
+    }
+    return { result: result.result?.value };
+  } finally {
+    client.close();
+  }
+}
+
+export async function getPageInfo(): Promise<{
+  url: string;
+  title: string;
+}> {
+  const result = await evaluate(
+    `JSON.stringify({ url: location.href, title: document.title })`
+  );
+  if (result.error) {
+    throw new Error(result.error);
+  }
+  return JSON.parse(result.result as string);
+}

--- a/deps/browser/relay-server/src/cli.ts
+++ b/deps/browser/relay-server/src/cli.ts
@@ -1,0 +1,316 @@
+#!/usr/bin/env node
+import { ensureRelayServer } from "./relay-server.js";
+import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, openSync, lstatSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { homedir, platform } from "node:os";
+import { spawn, type ChildProcess } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_PORT = 9224;
+const DEFAULT_BROWSER_PREFIX = join(homedir(), ".wegent-executor", "browser");
+
+function getBrowserPrefix(): string {
+  return process.env.BROWSER_PREFIX || DEFAULT_BROWSER_PREFIX;
+}
+
+function getTokenFilePath(): string {
+  return join(getBrowserPrefix(), ".token");
+}
+
+function getPidFilePath(): string {
+  return join(getBrowserPrefix(), "relay.pid");
+}
+
+function getLogFilePath(): string {
+  return join(getBrowserPrefix(), "relay.log");
+}
+
+function readPid(): number | null {
+  const pidFile = getPidFilePath();
+  if (!existsSync(pidFile)) {
+    return null;
+  }
+  try {
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+function isProcessRunning(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stopDaemon(): boolean {
+  const pid = readPid();
+  if (!pid) {
+    console.log("No PID file found. Server may not be running.");
+    return false;
+  }
+  if (!isProcessRunning(pid)) {
+    console.log(`Process ${pid} not running. Cleaning up PID file.`);
+    try { unlinkSync(getPidFilePath()); } catch {}
+    return false;
+  }
+  try {
+    process.kill(pid, "SIGTERM");
+    console.log(`Stopped relay server (PID: ${pid})`);
+    // Wait a moment then clean up
+    setTimeout(() => {
+      try { unlinkSync(getPidFilePath()); } catch {}
+    }, 500);
+    return true;
+  } catch (err) {
+    console.error(`Failed to stop process ${pid}:`, err);
+    return false;
+  }
+}
+
+function startDaemon(): void {
+  const pid = readPid();
+  if (pid && isProcessRunning(pid)) {
+    console.log(`Relay server already running (PID: ${pid})`);
+    process.exit(0);
+  }
+
+  const browserPrefix = getBrowserPrefix();
+  mkdirSync(browserPrefix, { recursive: true });
+
+  const logFile = getLogFilePath();
+  const out = openSync(logFile, "a");
+  const err = openSync(logFile, "a");
+
+  const args = process.argv.slice(2).filter(arg => !["--daemon", "--restart", "--stop"].includes(arg));
+  const child = spawn(process.execPath, [fileURLToPath(import.meta.url), ...args], {
+    detached: true,
+    stdio: ["ignore", out, err],
+    env: { ...process.env, __DAEMON_CHILD__: "1" },
+  });
+
+  writeFileSync(getPidFilePath(), String(child.pid));
+  console.log(`Relay server started in background (PID: ${child.pid})`);
+  console.log(`  Log file: ${logFile}`);
+  console.log(`  PID file: ${getPidFilePath()}`);
+
+  child.unref();
+  process.exit(0);
+}
+
+function getExtensionPath(): string {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  // In dist/, go up one level to find chrome-extension/
+  const extPath = resolve(__dirname, "..", "chrome-extension");
+  if (existsSync(extPath)) {
+    return extPath;
+  }
+  // Fallback for running from src/
+  return resolve(__dirname, "..", "..", "chrome-extension");
+}
+
+function getChromePath(): string | null {
+  const paths: string[] = [];
+
+  if (platform() === "darwin") {
+    paths.push(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    );
+  } else if (platform() === "win32") {
+    const programFiles = process.env["ProgramFiles"] || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    paths.push(
+      join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe")
+    );
+  } else {
+    // Linux
+    paths.push(
+      "/usr/bin/google-chrome",
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser"
+    );
+  }
+
+  for (const p of paths) {
+    if (existsSync(p)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+function isExtensionInstalled(userDataDir: string): boolean {
+  // Check if extension was previously installed by looking for our marker file
+  const markerFile = join(userDataDir, ".extension-installed");
+  return existsSync(markerFile);
+}
+
+function markExtensionInstalled(userDataDir: string): void {
+  const markerFile = join(userDataDir, ".extension-installed");
+  mkdirSync(userDataDir, { recursive: true });
+  writeFileSync(markerFile, new Date().toISOString());
+}
+
+function isChromeRunningWithProfile(): boolean {
+  const userDataDir = join(getBrowserPrefix(), "chrome-profile");
+  const lockFile = join(userDataDir, "SingletonLock");
+  try {
+    const stats = lstatSync(lockFile);
+    return stats.isSymbolicLink() || stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function launchChrome(extensionPath: string): ChildProcess | null {
+  // Don't launch if Chrome is already running with our profile
+  if (isChromeRunningWithProfile()) {
+    console.log("Chrome is already running with this profile.");
+    return null;
+  }
+
+  const chromePath = process.env.CHROME_PATH || getChromePath();
+  if (!chromePath) {
+    console.warn("Chrome not found. Please set CHROME_PATH environment variable.");
+    return null;
+  }
+
+  const userDataDir = join(getBrowserPrefix(), "chrome-profile");
+  const firstRun = !isExtensionInstalled(userDataDir);
+
+  const args = [
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    "https://weibo.com",  // Open a page for attach
+  ];
+
+  console.log(`Launching Chrome...`);
+  console.log(`  Chrome: ${chromePath}`);
+  console.log(`  Profile: ${userDataDir}`);
+
+  if (firstRun) {
+    console.log(`\n*** FIRST RUN: Please install the extension manually ***`);
+    console.log(`  1. Enable "Developer mode" (top right)`);
+    console.log(`  2. Click "Load unpacked"`);
+    console.log(`  3. Select: ${extensionPath}`);
+    console.log(`  4. Extension will auto-attach after install\n`);
+    markExtensionInstalled(userDataDir);
+  }
+
+  const child = spawn(chromePath, args, {
+    detached: true,
+    stdio: "ignore",
+  });
+
+  child.unref();
+
+  // On macOS, use osascript to open chrome://extensions after Chrome starts
+  if (firstRun && platform() === "darwin") {
+    spawn("osascript", ["-e", `
+      delay 2
+      tell application "Google Chrome"
+        activate
+        open location "chrome://extensions/"
+        delay 0.5
+        set active tab index of front window to (count of tabs of front window)
+      end tell
+    `], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
+  }
+
+  return child;
+}
+
+async function main() {
+  // Handle daemon commands
+  const args = process.argv.slice(2);
+
+  if (args.includes("--stop")) {
+    stopDaemon();
+    process.exit(0);
+  }
+
+  if (args.includes("--restart")) {
+    stopDaemon();
+    // Wait for process to stop
+    await new Promise(r => setTimeout(r, 1000));
+    startDaemon();
+    return;
+  }
+
+  if (args.includes("--daemon") && !process.env.__DAEMON_CHILD__) {
+    startDaemon();
+    return;
+  }
+
+  const port = parseInt(process.env.PORT || String(DEFAULT_PORT), 10);
+  const host = process.env.HOST || "127.0.0.1";
+  const cdpUrl = `http://${host}:${port}`;
+  const launchBrowser = args.includes("--launch") || process.env.LAUNCH_BROWSER === "1";
+
+  console.log(`Starting CDP relay server...`);
+
+  const relay = await ensureRelayServer({ cdpUrl });
+
+  // Write auth token for skill to use
+  const tokenFile = getTokenFilePath();
+  try {
+    mkdirSync(dirname(tokenFile), { recursive: true });
+    writeFileSync(tokenFile, relay.authToken, "utf-8");
+    console.log(`Auth token written to: ${tokenFile}`);
+  } catch (err) {
+    console.warn(`Warning: Could not write token file: ${err}`);
+  }
+
+  console.log(`\nCDP Relay Server running:`);
+  console.log(`  Base URL:    ${relay.baseUrl}`);
+  console.log(`  CDP WS URL:  ${relay.cdpWsUrl}`);
+  console.log(`  Extension:   ws://${host}:${port}/extension`);
+
+  if (launchBrowser) {
+    const extensionPath = getExtensionPath();
+    if (existsSync(extensionPath)) {
+      launchChrome(extensionPath);
+    } else {
+      console.warn(`Extension not found at: ${extensionPath}`);
+    }
+  }
+
+  console.log(`\nWaiting for Chrome extension to connect...`);
+
+  // Keep process alive
+  process.on("SIGINT", async () => {
+    console.log("\nShutting down...");
+    await relay.stop();
+    process.exit(0);
+  });
+
+  process.on("SIGTERM", async () => {
+    await relay.stop();
+    process.exit(0);
+  });
+
+  // Status check interval
+  setInterval(() => {
+    const connected = relay.extensionConnected();
+    if (connected) {
+      console.log(`[${new Date().toISOString()}] Extension: connected`);
+    }
+  }, 30000);
+}
+
+main().catch((err) => {
+  console.error("Failed to start:", err);
+  process.exit(1);
+});

--- a/deps/browser/relay-server/src/index.ts
+++ b/deps/browser/relay-server/src/index.ts
@@ -1,0 +1,10 @@
+// CDP Relay Server
+// A standalone Chrome DevTools Protocol relay server for browser extension communication
+
+export {
+  ensureRelayServer,
+  stopRelayServer,
+  getRelayAuthHeaders,
+  type CdpRelayServer,
+  type RelayServerOptions,
+} from "./relay-server.js";

--- a/deps/browser/relay-server/src/relay-server.ts
+++ b/deps/browser/relay-server/src/relay-server.ts
@@ -1,0 +1,794 @@
+import type { IncomingMessage } from "node:http";
+import type { AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
+import { randomBytes } from "node:crypto";
+import { createServer } from "node:http";
+import WebSocket, { WebSocketServer } from "ws";
+import { rawDataToString } from "./ws-utils.js";
+
+type CdpCommand = {
+  id: number;
+  method: string;
+  params?: unknown;
+  sessionId?: string;
+};
+
+type CdpResponse = {
+  id: number;
+  result?: unknown;
+  error?: { message: string };
+  sessionId?: string;
+};
+
+type CdpEvent = {
+  method: string;
+  params?: unknown;
+  sessionId?: string;
+};
+
+type ExtensionForwardCommandMessage = {
+  id: number;
+  method: "forwardCDPCommand";
+  params: { method: string; params?: unknown; sessionId?: string };
+};
+
+type ExtensionResponseMessage = {
+  id: number;
+  result?: unknown;
+  error?: string;
+};
+
+type ExtensionForwardEventMessage = {
+  method: "forwardCDPEvent";
+  params: { method: string; params?: unknown; sessionId?: string };
+};
+
+type ExtensionPingMessage = { method: "ping" };
+type ExtensionPongMessage = { method: "pong" };
+
+type ExtensionMessage =
+  | ExtensionResponseMessage
+  | ExtensionForwardEventMessage
+  | ExtensionPongMessage;
+
+type TargetInfo = {
+  targetId: string;
+  type?: string;
+  title?: string;
+  url?: string;
+  attached?: boolean;
+};
+
+type AttachedToTargetEvent = {
+  sessionId: string;
+  targetInfo: TargetInfo;
+  waitingForDebugger?: boolean;
+};
+
+type DetachedFromTargetEvent = {
+  sessionId: string;
+  targetId?: string;
+};
+
+type ConnectedTarget = {
+  sessionId: string;
+  targetId: string;
+  targetInfo: TargetInfo;
+};
+
+const RELAY_AUTH_HEADER = "x-cdp-relay-token";
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+  return value;
+}
+
+function getHeader(req: IncomingMessage, name: string): string | undefined {
+  return headerValue(req.headers[name.toLowerCase()]);
+}
+
+export type CdpRelayServer = {
+  host: string;
+  port: number;
+  baseUrl: string;
+  cdpWsUrl: string;
+  authToken: string;
+  extensionConnected: () => boolean;
+  stop: () => Promise<void>;
+};
+
+function isLoopbackHost(host: string) {
+  const h = host.trim().toLowerCase();
+  return (
+    h === "localhost" ||
+    h === "127.0.0.1" ||
+    h === "0.0.0.0" ||
+    h === "[::1]" ||
+    h === "::1" ||
+    h === "[::]" ||
+    h === "::"
+  );
+}
+
+function isLoopbackAddress(ip: string | undefined): boolean {
+  if (!ip) {
+    return false;
+  }
+  if (ip === "127.0.0.1") {
+    return true;
+  }
+  if (ip.startsWith("127.")) {
+    return true;
+  }
+  if (ip === "::1") {
+    return true;
+  }
+  if (ip.startsWith("::ffff:127.")) {
+    return true;
+  }
+  return false;
+}
+
+function parseBaseUrl(raw: string): {
+  host: string;
+  port: number;
+  baseUrl: string;
+} {
+  const parsed = new URL(raw.trim().replace(/\/$/, ""));
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(`relay cdpUrl must be http(s), got ${parsed.protocol}`);
+  }
+  const host = parsed.hostname;
+  const port =
+    parsed.port?.trim() !== "" ? Number(parsed.port) : parsed.protocol === "https:" ? 443 : 80;
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`relay cdpUrl has invalid port: ${parsed.port || "(empty)"}`);
+  }
+  return { host, port, baseUrl: parsed.toString().replace(/\/$/, "") };
+}
+
+function text(res: Duplex, status: number, bodyText: string) {
+  const body = Buffer.from(bodyText);
+  res.write(
+    `HTTP/1.1 ${status} ${status === 200 ? "OK" : "ERR"}\r\n` +
+      "Content-Type: text/plain; charset=utf-8\r\n" +
+      `Content-Length: ${body.length}\r\n` +
+      "Connection: close\r\n" +
+      "\r\n",
+  );
+  res.write(body);
+  res.end();
+}
+
+function rejectUpgrade(socket: Duplex, status: number, bodyText: string) {
+  text(socket, status, bodyText);
+  try {
+    socket.destroy();
+  } catch {
+    // ignore
+  }
+}
+
+const serversByPort = new Map<number, CdpRelayServer>();
+const relayAuthByPort = new Map<number, string>();
+
+function relayAuthTokenForUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!isLoopbackHost(parsed.hostname)) {
+      return null;
+    }
+    const port =
+      parsed.port?.trim() !== ""
+        ? Number(parsed.port)
+        : parsed.protocol === "https:" || parsed.protocol === "wss:"
+          ? 443
+          : 80;
+    if (!Number.isFinite(port)) {
+      return null;
+    }
+    return relayAuthByPort.get(port) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function getRelayAuthHeaders(url: string): Record<string, string> {
+  const token = relayAuthTokenForUrl(url);
+  if (!token) {
+    return {};
+  }
+  return { [RELAY_AUTH_HEADER]: token };
+}
+
+export type RelayServerOptions = {
+  cdpUrl: string;
+};
+
+export async function ensureRelayServer(opts: RelayServerOptions): Promise<CdpRelayServer> {
+  const info = parseBaseUrl(opts.cdpUrl);
+  if (!isLoopbackHost(info.host)) {
+    throw new Error(`relay requires loopback cdpUrl host (got ${info.host})`);
+  }
+
+  const existing = serversByPort.get(info.port);
+  if (existing) {
+    return existing;
+  }
+
+  let extensionWs: WebSocket | null = null;
+  const cdpClients = new Set<WebSocket>();
+  const connectedTargets = new Map<string, ConnectedTarget>();
+
+  const pendingExtension = new Map<
+    number,
+    {
+      resolve: (v: unknown) => void;
+      reject: (e: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  let nextExtensionId = 1;
+
+  const sendToExtension = async (payload: ExtensionForwardCommandMessage): Promise<unknown> => {
+    const ws = extensionWs;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      throw new Error("Chrome extension not connected");
+    }
+    ws.send(JSON.stringify(payload));
+    return await new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pendingExtension.delete(payload.id);
+        reject(new Error(`extension request timeout: ${payload.params.method}`));
+      }, 30_000);
+      pendingExtension.set(payload.id, { resolve, reject, timer });
+    });
+  };
+
+  const broadcastToCdpClients = (evt: CdpEvent) => {
+    const msg = JSON.stringify(evt);
+    for (const ws of cdpClients) {
+      if (ws.readyState !== WebSocket.OPEN) {
+        continue;
+      }
+      ws.send(msg);
+    }
+  };
+
+  const sendResponseToCdp = (ws: WebSocket, res: CdpResponse) => {
+    if (ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    ws.send(JSON.stringify(res));
+  };
+
+  const ensureTargetEventsForClient = (ws: WebSocket, mode: "autoAttach" | "discover") => {
+    for (const target of connectedTargets.values()) {
+      if (mode === "autoAttach") {
+        ws.send(
+          JSON.stringify({
+            method: "Target.attachedToTarget",
+            params: {
+              sessionId: target.sessionId,
+              targetInfo: { ...target.targetInfo, attached: true },
+              waitingForDebugger: false,
+            },
+          } satisfies CdpEvent),
+        );
+      } else {
+        ws.send(
+          JSON.stringify({
+            method: "Target.targetCreated",
+            params: { targetInfo: { ...target.targetInfo, attached: true } },
+          } satisfies CdpEvent),
+        );
+      }
+    }
+  };
+
+  const routeCdpCommand = async (cmd: CdpCommand): Promise<unknown> => {
+    switch (cmd.method) {
+      case "Browser.getVersion":
+        return {
+          protocolVersion: "1.3",
+          product: "Chrome/CDP-Extension-Relay",
+          revision: "0",
+          userAgent: "CDP-Extension-Relay",
+          jsVersion: "V8",
+        };
+      case "Browser.setDownloadBehavior":
+        return {};
+      case "Target.setAutoAttach":
+      case "Target.setDiscoverTargets":
+        return {};
+      case "Target.getTargets":
+        return {
+          targetInfos: Array.from(connectedTargets.values()).map((t) => ({
+            ...t.targetInfo,
+            attached: true,
+          })),
+        };
+      case "Target.getTargetInfo": {
+        const params = (cmd.params ?? {}) as { targetId?: string };
+        const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+        if (targetId) {
+          for (const t of connectedTargets.values()) {
+            if (t.targetId === targetId) {
+              return { targetInfo: t.targetInfo };
+            }
+          }
+        }
+        if (cmd.sessionId && connectedTargets.has(cmd.sessionId)) {
+          const t = connectedTargets.get(cmd.sessionId);
+          if (t) {
+            return { targetInfo: t.targetInfo };
+          }
+        }
+        const first = Array.from(connectedTargets.values())[0];
+        return { targetInfo: first?.targetInfo };
+      }
+      case "Target.attachToTarget": {
+        const params = (cmd.params ?? {}) as { targetId?: string };
+        const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+        if (!targetId) {
+          throw new Error("targetId required");
+        }
+        for (const t of connectedTargets.values()) {
+          if (t.targetId === targetId) {
+            return { sessionId: t.sessionId };
+          }
+        }
+        throw new Error("target not found");
+      }
+      default: {
+        const id = nextExtensionId++;
+        return await sendToExtension({
+          id,
+          method: "forwardCDPCommand",
+          params: {
+            method: cmd.method,
+            sessionId: cmd.sessionId,
+            params: cmd.params,
+          },
+        });
+      }
+    }
+  };
+
+  const relayAuthToken = randomBytes(32).toString("base64url");
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? "/", info.baseUrl);
+    const path = url.pathname;
+
+    if (path.startsWith("/json")) {
+      const token = getHeader(req, RELAY_AUTH_HEADER);
+      if (!token || token !== relayAuthToken) {
+        res.writeHead(401);
+        res.end("Unauthorized");
+        return;
+      }
+    }
+
+    if (req.method === "HEAD" && path === "/") {
+      res.writeHead(200);
+      res.end();
+      return;
+    }
+
+    if (path === "/") {
+      res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("OK");
+      return;
+    }
+
+    if (path === "/extension/status") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ connected: Boolean(extensionWs) }));
+      return;
+    }
+
+    const hostHeader = req.headers.host?.trim() || `${info.host}:${info.port}`;
+    const wsHost = `ws://${hostHeader}`;
+    const cdpWsUrl = `${wsHost}/cdp`;
+
+    if (
+      (path === "/json/version" || path === "/json/version/") &&
+      (req.method === "GET" || req.method === "PUT")
+    ) {
+      const payload: Record<string, unknown> = {
+        Browser: "CDP/extension-relay",
+        "Protocol-Version": "1.3",
+      };
+      // Only advertise the WS URL if a real extension is connected.
+      if (extensionWs) {
+        payload.webSocketDebuggerUrl = cdpWsUrl;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(payload));
+      return;
+    }
+
+    const listPaths = new Set(["/json", "/json/", "/json/list", "/json/list/"]);
+    if (listPaths.has(path) && (req.method === "GET" || req.method === "PUT")) {
+      const list = Array.from(connectedTargets.values()).map((t) => ({
+        id: t.targetId,
+        type: t.targetInfo.type ?? "page",
+        title: t.targetInfo.title ?? "",
+        description: t.targetInfo.title ?? "",
+        url: t.targetInfo.url ?? "",
+        webSocketDebuggerUrl: cdpWsUrl,
+        devtoolsFrontendUrl: `/devtools/inspector.html?ws=${cdpWsUrl.replace("ws://", "")}`,
+      }));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(list));
+      return;
+    }
+
+    const activateMatch = path.match(/^\/json\/activate\/(.+)$/);
+    if (activateMatch && (req.method === "GET" || req.method === "PUT")) {
+      const targetId = decodeURIComponent(activateMatch[1] ?? "").trim();
+      if (!targetId) {
+        res.writeHead(400);
+        res.end("targetId required");
+        return;
+      }
+      void (async () => {
+        try {
+          await sendToExtension({
+            id: nextExtensionId++,
+            method: "forwardCDPCommand",
+            params: { method: "Target.activateTarget", params: { targetId } },
+          });
+        } catch {
+          // ignore
+        }
+      })();
+      res.writeHead(200);
+      res.end("OK");
+      return;
+    }
+
+    const closeMatch = path.match(/^\/json\/close\/(.+)$/);
+    if (closeMatch && (req.method === "GET" || req.method === "PUT")) {
+      const targetId = decodeURIComponent(closeMatch[1] ?? "").trim();
+      if (!targetId) {
+        res.writeHead(400);
+        res.end("targetId required");
+        return;
+      }
+      void (async () => {
+        try {
+          await sendToExtension({
+            id: nextExtensionId++,
+            method: "forwardCDPCommand",
+            params: { method: "Target.closeTarget", params: { targetId } },
+          });
+        } catch {
+          // ignore
+        }
+      })();
+      res.writeHead(200);
+      res.end("OK");
+      return;
+    }
+
+    res.writeHead(404);
+    res.end("not found");
+  });
+
+  const wssExtension = new WebSocketServer({ noServer: true });
+  const wssCdp = new WebSocketServer({ noServer: true });
+
+  server.on("upgrade", (req, socket, head) => {
+    const url = new URL(req.url ?? "/", info.baseUrl);
+    const pathname = url.pathname;
+    const remote = req.socket.remoteAddress;
+
+    if (!isLoopbackAddress(remote)) {
+      rejectUpgrade(socket, 403, "Forbidden");
+      return;
+    }
+
+    const origin = headerValue(req.headers.origin);
+    if (origin && !origin.startsWith("chrome-extension://")) {
+      rejectUpgrade(socket, 403, "Forbidden: invalid origin");
+      return;
+    }
+
+    if (pathname === "/extension") {
+      if (extensionWs) {
+        rejectUpgrade(socket, 409, "Extension already connected");
+        return;
+      }
+      wssExtension.handleUpgrade(req, socket, head, (ws) => {
+        wssExtension.emit("connection", ws, req);
+      });
+      return;
+    }
+
+    if (pathname === "/cdp") {
+      const token = getHeader(req, RELAY_AUTH_HEADER);
+      if (!token || token !== relayAuthToken) {
+        rejectUpgrade(socket, 401, "Unauthorized");
+        return;
+      }
+      if (!extensionWs) {
+        rejectUpgrade(socket, 503, "Extension not connected");
+        return;
+      }
+      wssCdp.handleUpgrade(req, socket, head, (ws) => {
+        wssCdp.emit("connection", ws, req);
+      });
+      return;
+    }
+
+    rejectUpgrade(socket, 404, "Not Found");
+  });
+
+  wssExtension.on("connection", (ws) => {
+    extensionWs = ws;
+
+    const ping = setInterval(() => {
+      if (ws.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      ws.send(JSON.stringify({ method: "ping" } satisfies ExtensionPingMessage));
+    }, 5000);
+
+    ws.on("message", (data) => {
+      let parsed: ExtensionMessage | null = null;
+      try {
+        parsed = JSON.parse(rawDataToString(data)) as ExtensionMessage;
+      } catch {
+        return;
+      }
+
+      if (parsed && typeof parsed === "object" && "id" in parsed && typeof parsed.id === "number") {
+        const pending = pendingExtension.get(parsed.id);
+        if (!pending) {
+          return;
+        }
+        pendingExtension.delete(parsed.id);
+        clearTimeout(pending.timer);
+        if ("error" in parsed && typeof parsed.error === "string" && parsed.error.trim()) {
+          pending.reject(new Error(parsed.error));
+        } else {
+          pending.resolve(parsed.result);
+        }
+        return;
+      }
+
+      if (parsed && typeof parsed === "object" && "method" in parsed) {
+        if ((parsed as ExtensionPongMessage).method === "pong") {
+          return;
+        }
+        if ((parsed as ExtensionForwardEventMessage).method !== "forwardCDPEvent") {
+          return;
+        }
+        const evt = parsed as ExtensionForwardEventMessage;
+        const method = evt.params?.method;
+        const params = evt.params?.params;
+        const sessionId = evt.params?.sessionId;
+        if (!method || typeof method !== "string") {
+          return;
+        }
+
+        if (method === "Target.attachedToTarget") {
+          const attached = (params ?? {}) as AttachedToTargetEvent;
+          const targetType = attached?.targetInfo?.type ?? "page";
+          if (targetType !== "page") {
+            return;
+          }
+          if (attached?.sessionId && attached?.targetInfo?.targetId) {
+            const prev = connectedTargets.get(attached.sessionId);
+            const nextTargetId = attached.targetInfo.targetId;
+            const prevTargetId = prev?.targetId;
+            const changedTarget = Boolean(prev && prevTargetId && prevTargetId !== nextTargetId);
+            connectedTargets.set(attached.sessionId, {
+              sessionId: attached.sessionId,
+              targetId: nextTargetId,
+              targetInfo: attached.targetInfo,
+            });
+            if (changedTarget && prevTargetId) {
+              broadcastToCdpClients({
+                method: "Target.detachedFromTarget",
+                params: { sessionId: attached.sessionId, targetId: prevTargetId },
+                sessionId: attached.sessionId,
+              });
+            }
+            if (!prev || changedTarget) {
+              broadcastToCdpClients({ method, params, sessionId });
+            }
+            return;
+          }
+        }
+
+        if (method === "Target.detachedFromTarget") {
+          const detached = (params ?? {}) as DetachedFromTargetEvent;
+          if (detached?.sessionId) {
+            connectedTargets.delete(detached.sessionId);
+          }
+          broadcastToCdpClients({ method, params, sessionId });
+          return;
+        }
+
+        // Keep cached tab metadata fresh for /json/list.
+        // After navigation, Chrome updates URL/title via Target.targetInfoChanged.
+        if (method === "Target.targetInfoChanged") {
+          const changed = (params ?? {}) as { targetInfo?: { targetId?: string; type?: string } };
+          const targetInfo = changed?.targetInfo;
+          const targetId = targetInfo?.targetId;
+          if (targetId && (targetInfo?.type ?? "page") === "page") {
+            for (const [sid, target] of connectedTargets) {
+              if (target.targetId !== targetId) {
+                continue;
+              }
+              connectedTargets.set(sid, {
+                ...target,
+                targetInfo: { ...target.targetInfo, ...(targetInfo as object) },
+              });
+            }
+          }
+        }
+
+        broadcastToCdpClients({ method, params, sessionId });
+      }
+    });
+
+    ws.on("close", () => {
+      clearInterval(ping);
+      extensionWs = null;
+      for (const [, pending] of pendingExtension) {
+        clearTimeout(pending.timer);
+        pending.reject(new Error("extension disconnected"));
+      }
+      pendingExtension.clear();
+      connectedTargets.clear();
+
+      for (const client of cdpClients) {
+        try {
+          client.close(1011, "extension disconnected");
+        } catch {
+          // ignore
+        }
+      }
+      cdpClients.clear();
+    });
+  });
+
+  wssCdp.on("connection", (ws) => {
+    cdpClients.add(ws);
+
+    ws.on("message", async (data) => {
+      let cmd: CdpCommand | null = null;
+      try {
+        cmd = JSON.parse(rawDataToString(data)) as CdpCommand;
+      } catch {
+        return;
+      }
+      if (!cmd || typeof cmd !== "object") {
+        return;
+      }
+      if (typeof cmd.id !== "number" || typeof cmd.method !== "string") {
+        return;
+      }
+
+      if (!extensionWs) {
+        sendResponseToCdp(ws, {
+          id: cmd.id,
+          sessionId: cmd.sessionId,
+          error: { message: "Extension not connected" },
+        });
+        return;
+      }
+
+      try {
+        const result = await routeCdpCommand(cmd);
+
+        if (cmd.method === "Target.setAutoAttach" && !cmd.sessionId) {
+          ensureTargetEventsForClient(ws, "autoAttach");
+        }
+        if (cmd.method === "Target.setDiscoverTargets") {
+          const discover = (cmd.params ?? {}) as { discover?: boolean };
+          if (discover.discover === true) {
+            ensureTargetEventsForClient(ws, "discover");
+          }
+        }
+        if (cmd.method === "Target.attachToTarget") {
+          const params = (cmd.params ?? {}) as { targetId?: string };
+          const targetId = typeof params.targetId === "string" ? params.targetId : undefined;
+          if (targetId) {
+            const target = Array.from(connectedTargets.values()).find(
+              (t) => t.targetId === targetId,
+            );
+            if (target) {
+              ws.send(
+                JSON.stringify({
+                  method: "Target.attachedToTarget",
+                  params: {
+                    sessionId: target.sessionId,
+                    targetInfo: { ...target.targetInfo, attached: true },
+                    waitingForDebugger: false,
+                  },
+                } satisfies CdpEvent),
+              );
+            }
+          }
+        }
+
+        sendResponseToCdp(ws, { id: cmd.id, sessionId: cmd.sessionId, result });
+      } catch (err) {
+        sendResponseToCdp(ws, {
+          id: cmd.id,
+          sessionId: cmd.sessionId,
+          error: { message: err instanceof Error ? err.message : String(err) },
+        });
+      }
+    });
+
+    ws.on("close", () => {
+      cdpClients.delete(ws);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(info.port, info.host, () => resolve());
+    server.once("error", reject);
+  });
+
+  const addr = server.address() as AddressInfo | null;
+  const port = addr?.port ?? info.port;
+  const host = info.host;
+  const baseUrl = `${new URL(info.baseUrl).protocol}//${host}:${port}`;
+
+  const relay: CdpRelayServer = {
+    host,
+    port,
+    baseUrl,
+    cdpWsUrl: `ws://${host}:${port}/cdp`,
+    authToken: relayAuthToken,
+    extensionConnected: () => Boolean(extensionWs),
+    stop: async () => {
+      serversByPort.delete(port);
+      relayAuthByPort.delete(port);
+      try {
+        extensionWs?.close(1001, "server stopping");
+      } catch {
+        // ignore
+      }
+      for (const ws of cdpClients) {
+        try {
+          ws.close(1001, "server stopping");
+        } catch {
+          // ignore
+        }
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      wssExtension.close();
+      wssCdp.close();
+    },
+  };
+
+  relayAuthByPort.set(port, relayAuthToken);
+  serversByPort.set(port, relay);
+  return relay;
+}
+
+export async function stopRelayServer(opts: { cdpUrl: string }): Promise<boolean> {
+  const info = parseBaseUrl(opts.cdpUrl);
+  const existing = serversByPort.get(info.port);
+  if (!existing) {
+    return false;
+  }
+  await existing.stop();
+  relayAuthByPort.delete(info.port);
+  return true;
+}

--- a/deps/browser/relay-server/src/snapshot.ts
+++ b/deps/browser/relay-server/src/snapshot.ts
@@ -1,0 +1,379 @@
+/**
+ * Page Snapshot
+ *
+ * Generate AI-readable page structure for element interaction
+ */
+
+import { createBrowserClient } from "./browser-client.js";
+
+export type RoleRef = {
+  role: string;
+  name?: string;
+  nth?: number;
+};
+
+export type RoleRefMap = Record<string, RoleRef>;
+
+export type SnapshotResult = {
+  snapshot: string;
+  refs: RoleRefMap;
+  stats: {
+    lines: number;
+    chars: number;
+    refs: number;
+    interactive: number;
+  };
+};
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "checkbox",
+  "radio",
+  "combobox",
+  "listbox",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "searchbox",
+  "slider",
+  "spinbutton",
+  "switch",
+  "tab",
+  "treeitem",
+]);
+
+const CONTENT_ROLES = new Set([
+  "heading",
+  "cell",
+  "gridcell",
+  "columnheader",
+  "rowheader",
+  "listitem",
+  "article",
+  "region",
+  "main",
+  "navigation",
+]);
+
+const STRUCTURAL_ROLES = new Set([
+  "generic",
+  "group",
+  "list",
+  "table",
+  "row",
+  "rowgroup",
+  "grid",
+  "treegrid",
+  "menu",
+  "menubar",
+  "toolbar",
+  "tablist",
+  "tree",
+  "directory",
+  "document",
+  "application",
+  "presentation",
+  "none",
+]);
+
+type RawAXNode = {
+  nodeId?: string;
+  role?: { value?: string };
+  name?: { value?: string };
+  value?: { value?: string };
+  description?: { value?: string };
+  childIds?: string[];
+  backendDOMNodeId?: number;
+};
+
+function axValue(v: unknown): string {
+  if (!v || typeof v !== "object") return "";
+  const value = (v as { value?: unknown }).value;
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return "";
+}
+
+export type AriaNode = {
+  ref: string;
+  role: string;
+  name: string;
+  value?: string;
+  description?: string;
+  depth: number;
+  backendDOMNodeId?: number;
+};
+
+function formatAriaNodes(nodes: RawAXNode[], limit: number): AriaNode[] {
+  const byId = new Map<string, RawAXNode>();
+  for (const n of nodes) {
+    if (n.nodeId) byId.set(n.nodeId, n);
+  }
+
+  // Find root node
+  const referenced = new Set<string>();
+  for (const n of nodes) {
+    for (const c of n.childIds ?? []) referenced.add(c);
+  }
+  const root = nodes.find((n) => n.nodeId && !referenced.has(n.nodeId)) ?? nodes[0];
+  if (!root?.nodeId) return [];
+
+  const out: AriaNode[] = [];
+  const stack: Array<{ id: string; depth: number }> = [{ id: root.nodeId, depth: 0 }];
+
+  while (stack.length && out.length < limit) {
+    const popped = stack.pop();
+    if (!popped) break;
+    const { id, depth } = popped;
+    const n = byId.get(id);
+    if (!n) continue;
+
+    const role = axValue(n.role);
+    const name = axValue(n.name);
+    const value = axValue(n.value);
+    const description = axValue(n.description);
+    const ref = `e${out.length + 1}`;
+
+    out.push({
+      ref,
+      role: role || "unknown",
+      name: name || "",
+      ...(value ? { value } : {}),
+      ...(description ? { description } : {}),
+      ...(typeof n.backendDOMNodeId === "number" ? { backendDOMNodeId: n.backendDOMNodeId } : {}),
+      depth,
+    });
+
+    const children = (n.childIds ?? []).filter((c) => byId.has(c));
+    for (let i = children.length - 1; i >= 0; i--) {
+      const child = children[i];
+      if (child) stack.push({ id: child, depth: depth + 1 });
+    }
+  }
+
+  return out;
+}
+
+function buildSnapshotText(
+  nodes: AriaNode[],
+  opts: { interactive?: boolean; compact?: boolean; maxDepth?: number }
+): SnapshotResult {
+  const refs: RoleRefMap = {};
+  const lines: string[] = [];
+  const roleNameCounts = new Map<string, number>();
+  const refsByKey = new Map<string, string[]>();
+
+  const getKey = (role: string, name?: string) => `${role}:${name ?? ""}`;
+
+  for (const node of nodes) {
+    if (opts.maxDepth !== undefined && node.depth > opts.maxDepth) continue;
+
+    const role = node.role.toLowerCase();
+    const isInteractive = INTERACTIVE_ROLES.has(role);
+    const isContent = CONTENT_ROLES.has(role);
+    const isStructural = STRUCTURAL_ROLES.has(role);
+
+    if (opts.interactive && !isInteractive) continue;
+    if (opts.compact && isStructural && !node.name) continue;
+
+    const shouldHaveRef = isInteractive || (isContent && node.name);
+    const indent = "  ".repeat(node.depth);
+
+    if (shouldHaveRef) {
+      const key = getKey(role, node.name);
+      const count = roleNameCounts.get(key) ?? 0;
+      roleNameCounts.set(key, count + 1);
+
+      const existingRefs = refsByKey.get(key) ?? [];
+      existingRefs.push(node.ref);
+      refsByKey.set(key, existingRefs);
+
+      refs[node.ref] = {
+        role,
+        ...(node.name ? { name: node.name } : {}),
+        nth: count,
+      };
+
+      let line = `${indent}- ${node.role}`;
+      if (node.name) line += ` "${node.name}"`;
+      line += ` [ref=${node.ref}]`;
+      if (count > 0) line += ` [nth=${count}]`;
+      if (node.value) line += `: ${node.value}`;
+      lines.push(line);
+    } else {
+      let line = `${indent}- ${node.role}`;
+      if (node.name) line += ` "${node.name}"`;
+      if (node.value) line += `: ${node.value}`;
+      lines.push(line);
+    }
+  }
+
+  // Remove nth from non-duplicates
+  const duplicates = new Set<string>();
+  for (const [key, refList] of refsByKey) {
+    if (refList.length > 1) duplicates.add(key);
+  }
+  for (const [ref, data] of Object.entries(refs)) {
+    const key = getKey(data.role, data.name);
+    if (!duplicates.has(key)) {
+      delete refs[ref]?.nth;
+    }
+  }
+
+  const snapshot = lines.length ? lines.join("\n") : "(empty page)";
+  const interactiveCount = Object.values(refs).filter((r) => INTERACTIVE_ROLES.has(r.role)).length;
+
+  return {
+    snapshot,
+    refs,
+    stats: {
+      lines: lines.length,
+      chars: snapshot.length,
+      refs: Object.keys(refs).length,
+      interactive: interactiveCount,
+    },
+  };
+}
+
+/**
+ * Get page snapshot using Accessibility tree (via CDP)
+ */
+export async function getSnapshot(opts?: {
+  interactive?: boolean;
+  compact?: boolean;
+  maxDepth?: number;
+  limit?: number;
+}): Promise<SnapshotResult> {
+  const client = await createBrowserClient();
+  try {
+    const limit = Math.max(1, Math.min(2000, opts?.limit ?? 500));
+
+    await client.send("Accessibility.enable", {});
+    const res = (await client.send("Accessibility.getFullAXTree", {})) as { nodes?: RawAXNode[] };
+    const rawNodes = Array.isArray(res?.nodes) ? res.nodes : [];
+    const nodes = formatAriaNodes(rawNodes, limit);
+
+    return buildSnapshotText(nodes, {
+      interactive: opts?.interactive,
+      compact: opts?.compact,
+      maxDepth: opts?.maxDepth,
+    });
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Get DOM snapshot (alternative to Accessibility tree)
+ */
+export async function getDomSnapshot(opts?: {
+  limit?: number;
+  maxTextChars?: number;
+}): Promise<{ nodes: DomNode[] }> {
+  const client = await createBrowserClient();
+  try {
+    const limit = Math.max(1, Math.min(5000, opts?.limit ?? 800));
+    const maxText = Math.max(0, Math.min(5000, opts?.maxTextChars ?? 220));
+
+    await client.send("Runtime.enable", {});
+    const result = (await client.send("Runtime.evaluate", {
+      expression: `(() => {
+        const maxNodes = ${limit};
+        const maxText = ${maxText};
+        const nodes = [];
+        const root = document.documentElement;
+        if (!root) return { nodes };
+        const stack = [{ el: root, depth: 0, parentRef: null }];
+        while (stack.length && nodes.length < maxNodes) {
+          const cur = stack.pop();
+          const el = cur.el;
+          if (!el || el.nodeType !== 1) continue;
+          const ref = "n" + String(nodes.length + 1);
+          const tag = (el.tagName || "").toLowerCase();
+          const id = el.id ? String(el.id) : undefined;
+          const className = el.className ? String(el.className).slice(0, 300) : undefined;
+          const role = el.getAttribute && el.getAttribute("role") ? String(el.getAttribute("role")) : undefined;
+          const name = el.getAttribute && el.getAttribute("aria-label") ? String(el.getAttribute("aria-label")) : undefined;
+          let text = "";
+          try { text = String(el.innerText || "").trim(); } catch {}
+          if (maxText && text.length > maxText) text = text.slice(0, maxText) + "...";
+          const href = el.href ? String(el.href) : undefined;
+          const type = el.type ? String(el.type) : undefined;
+          const value = el.value !== undefined ? String(el.value).slice(0, 500) : undefined;
+          nodes.push({
+            ref,
+            parentRef: cur.parentRef,
+            depth: cur.depth,
+            tag,
+            ...(id ? { id } : {}),
+            ...(className ? { className } : {}),
+            ...(role ? { role } : {}),
+            ...(name ? { name } : {}),
+            ...(text ? { text } : {}),
+            ...(href ? { href } : {}),
+            ...(type ? { type } : {}),
+            ...(value ? { value } : {}),
+          });
+          const children = el.children ? Array.from(el.children) : [];
+          for (let i = children.length - 1; i >= 0; i--) {
+            stack.push({ el: children[i], depth: cur.depth + 1, parentRef: ref });
+          }
+        }
+        return { nodes };
+      })()`,
+      awaitPromise: true,
+      returnByValue: true,
+    })) as { result?: { value?: { nodes?: DomNode[] } } };
+
+    return { nodes: result?.result?.value?.nodes ?? [] };
+  } finally {
+    client.close();
+  }
+}
+
+export type DomNode = {
+  ref: string;
+  parentRef: string | null;
+  depth: number;
+  tag: string;
+  id?: string;
+  className?: string;
+  role?: string;
+  name?: string;
+  text?: string;
+  href?: string;
+  type?: string;
+  value?: string;
+};
+
+// Store refs for action resolution
+let currentRefs: RoleRefMap = {};
+
+export function storeRefs(refs: RoleRefMap): void {
+  currentRefs = refs;
+}
+
+export function getStoredRefs(): RoleRefMap {
+  return currentRefs;
+}
+
+export function getRefInfo(ref: string): RoleRef | undefined {
+  return currentRefs[ref];
+}
+
+/**
+ * Parse ref string (supports "e1", "@e1", "ref=e1")
+ */
+export function parseRef(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.startsWith("@")
+    ? trimmed.slice(1)
+    : trimmed.startsWith("ref=")
+      ? trimmed.slice(4)
+      : trimmed;
+  return /^e\d+$/.test(normalized) ? normalized : null;
+}

--- a/deps/browser/relay-server/src/tool-cli.ts
+++ b/deps/browser/relay-server/src/tool-cli.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Browser Tool CLI
+ *
+ * Command-line interface for browser automation
+ */
+
+import { executeBrowserTool } from "./tool.js";
+
+async function main() {
+  const input = process.argv[2];
+
+  if (!input || input === "--help" || input === "-h") {
+    console.log(`Browser Tool CLI
+
+Usage:
+  browser-tool '<json>'     Execute browser action
+  browser-tool --help       Show this help
+
+Examples:
+  browser-tool '{"action":"status"}'
+  browser-tool '{"action":"navigate","url":"https://example.com"}'
+  browser-tool '{"action":"snapshot","interactive":true}'
+  browser-tool '{"action":"act","request":{"kind":"click","ref":"e1"}}'
+
+Actions:
+  status     - Check relay server and extension status
+  tabs       - List attached browser tabs
+  open       - Open new tab (requires url)
+  close      - Close tab (requires targetId)
+  focus      - Focus tab (requires targetId)
+  navigate   - Navigate to URL (requires url)
+  snapshot   - Get page structure with element refs
+  screenshot - Capture page screenshot
+  act        - Perform browser action (requires request)
+  evaluate   - Execute JavaScript (requires expression)
+`);
+    process.exit(0);
+  }
+
+  try {
+    const params = JSON.parse(input);
+    const result = await executeBrowserTool(params);
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(result.ok ? 0 : 1);
+  } catch (err) {
+    console.error(JSON.stringify({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }, null, 2));
+    process.exit(1);
+  }
+}
+
+main();

--- a/deps/browser/relay-server/src/tool.ts
+++ b/deps/browser/relay-server/src/tool.ts
@@ -1,0 +1,511 @@
+/**
+ * Browser Tool
+ *
+ * LLM tool interface for browser control
+ */
+
+import {
+  getStatus,
+  listTabs,
+  openTab,
+  closeTab,
+  focusTab,
+  navigate,
+  screenshot,
+  evaluate,
+} from "./browser-client.js";
+import { getSnapshot, storeRefs } from "./snapshot.js";
+import { executeAction, type ActRequest } from "./actions.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const DEFAULT_BROWSER_PREFIX = path.join(os.homedir(), ".wegent-executor", "browser");
+
+function getBrowserPrefix(): string {
+  return process.env.BROWSER_PREFIX || DEFAULT_BROWSER_PREFIX;
+}
+
+function getExtensionPath(): string {
+  // Check multiple possible locations
+  const possiblePaths = [
+    // Installed via npm
+    path.resolve(__dirname, "..", "chrome-extension"),
+    // Development
+    path.resolve(__dirname, "..", "..", "chrome-extension"),
+    // Global install
+    path.join(os.homedir(), ".wegent-executor", "lib", "node_modules", "cdp-relay-server", "chrome-extension"),
+  ];
+
+  for (const p of possiblePaths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return possiblePaths[0]; // Default to first option
+}
+
+function getChromePath(): string | null {
+  const platform = os.platform();
+  const paths: string[] = [];
+
+  if (platform === "darwin") {
+    paths.push(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      "/Applications/Chromium.app/Contents/MacOS/Chromium"
+    );
+  } else if (platform === "win32") {
+    const programFiles = process.env["ProgramFiles"] || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    paths.push(
+      path.join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      path.join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe")
+    );
+  } else {
+    paths.push(
+      "/usr/bin/google-chrome",
+      "/usr/bin/google-chrome-stable",
+      "/usr/bin/chromium",
+      "/usr/bin/chromium-browser"
+    );
+  }
+
+  for (const p of paths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return null;
+}
+
+function isChromeRunningWithProfile(): boolean {
+  const userDataDir = path.join(getBrowserPrefix(), "chrome-profile");
+  const lockFile = path.join(userDataDir, "SingletonLock");
+  // On macOS/Linux, SingletonLock is a symlink when Chrome is running
+  // On Windows, it's a file
+  try {
+    const stats = fs.lstatSync(lockFile);
+    return stats.isSymbolicLink() || stats.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function launchBrowserWithInstructions(url?: string): { launched: boolean; message: string } {
+  // Don't launch if Chrome is already running with our profile
+  if (isChromeRunningWithProfile()) {
+    return {
+      launched: false,
+      message: "Chrome is already running. Please click the extension icon on a tab to attach.",
+    };
+  }
+
+  const chromePath = process.env.CHROME_PATH || getChromePath();
+  if (!chromePath) {
+    return {
+      launched: false,
+      message: "Chrome not found. Please install Chrome or set CHROME_PATH environment variable.",
+    };
+  }
+
+  const userDataDir = path.join(getBrowserPrefix(), "chrome-profile");
+  const targetUrl = url || "https://weibo.com";
+
+  const args = [
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    targetUrl,
+  ];
+
+  try {
+    const child = spawn(chromePath, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+
+    return {
+      launched: true,
+      message: "Browser launched",
+    };
+  } catch (err) {
+    return {
+      launched: false,
+      message: `Failed to launch browser: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function openExtensionsPage(): { opened: boolean; message: string } {
+  const extensionPath = getExtensionPath();
+
+  // On macOS, use osascript to open chrome://extensions
+  if (os.platform() === "darwin") {
+    try {
+      spawn("osascript", ["-e", `
+        tell application "Google Chrome"
+          activate
+          open location "chrome://extensions/"
+          delay 0.5
+          set active tab index of front window to (count of tabs of front window)
+        end tell
+      `], {
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+
+      return {
+        opened: true,
+        message: `Opening chrome://extensions. Please install the extension:
+1. Enable "Developer mode" (top right toggle)
+2. Click "Load unpacked"
+3. Select folder: ${extensionPath}
+4. Click extension icon on a tab to attach`,
+      };
+    } catch (err) {
+      return {
+        opened: false,
+        message: `Failed to open extensions page: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  // For other platforms, return instructions
+  return {
+    opened: false,
+    message: `Please install the extension manually:
+1. Go to chrome://extensions
+2. Enable "Developer mode" (top right toggle)
+3. Click "Load unpacked"
+4. Select folder: ${extensionPath}
+5. Click extension icon on a tab to attach`,
+  };
+}
+
+async function waitForConnection(maxWaitMs: number = 5000): Promise<boolean> {
+  const startTime = Date.now();
+  while (Date.now() - startTime < maxWaitMs) {
+    const status = await getStatus();
+    if (status.extensionConnected) {
+      return true;
+    }
+    await new Promise(r => setTimeout(r, 500));
+  }
+  return false;
+}
+
+// Tool Schema for LLM
+export const browserToolSchema = {
+  name: "browser",
+  description: `Control browser to interact with web pages. Requires relay server running and Chrome extension attached to a tab.
+
+Actions:
+- status: Check if browser relay is running and extension is connected
+- tabs: List attached browser tabs
+- open: Open a new tab with URL
+- close: Close a tab
+- focus: Focus/activate a tab
+- navigate: Navigate current tab to URL
+- snapshot: Get page structure with element refs for interaction
+- screenshot: Capture page screenshot
+- act: Perform browser action (click, type, hover, etc.)
+- evaluate: Execute JavaScript (use with caution)
+
+Workflow:
+1. Check status to ensure extension is connected
+2. Use snapshot to see page structure and get element refs
+3. Use act with refs to interact (click, type, etc.)
+4. Use snapshot again to see results`,
+  parameters: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: [
+          "status",
+          "tabs",
+          "open",
+          "close",
+          "focus",
+          "navigate",
+          "snapshot",
+          "screenshot",
+          "act",
+          "evaluate",
+        ],
+        description: "Action to perform",
+      },
+      url: {
+        type: "string",
+        description: "URL for open/navigate actions",
+      },
+      targetId: {
+        type: "string",
+        description: "Tab targetId for close/focus actions",
+      },
+      interactive: {
+        type: "boolean",
+        description: "For snapshot: only show interactive elements",
+      },
+      compact: {
+        type: "boolean",
+        description: "For snapshot: compact output",
+      },
+      fullPage: {
+        type: "boolean",
+        description: "For screenshot: capture full page",
+      },
+      request: {
+        type: "object",
+        description: "For act: action request object",
+        properties: {
+          kind: {
+            type: "string",
+            enum: ["click", "type", "press", "hover", "drag", "select", "fill", "scroll", "wait", "resize"],
+          },
+          ref: { type: "string", description: "Element ref from snapshot (e.g., e1, e2)" },
+          text: { type: "string", description: "Text for type action" },
+          key: { type: "string", description: "Key for press action" },
+          submit: { type: "boolean", description: "Press Enter after typing" },
+          doubleClick: { type: "boolean", description: "Double click" },
+          startRef: { type: "string", description: "Start ref for drag" },
+          endRef: { type: "string", description: "End ref for drag" },
+          values: { type: "array", items: { type: "string" }, description: "Values for select" },
+          fields: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                ref: { type: "string" },
+                value: { type: "string" },
+              },
+            },
+            description: "Fields for fill",
+          },
+          direction: { type: "string", enum: ["up", "down", "left", "right"] },
+          amount: { type: "number" },
+          timeMs: { type: "number" },
+          selector: { type: "string" },
+          width: { type: "number" },
+          height: { type: "number" },
+        },
+      },
+      expression: {
+        type: "string",
+        description: "JavaScript expression for evaluate action",
+      },
+    },
+    required: ["action"],
+  },
+};
+
+export type BrowserToolParams = {
+  action: string;
+  url?: string;
+  targetId?: string;
+  interactive?: boolean;
+  compact?: boolean;
+  fullPage?: boolean;
+  request?: ActRequest;
+  expression?: string;
+};
+
+export type BrowserToolResult = {
+  ok: boolean;
+  error?: string;
+  data?: unknown;
+};
+
+/**
+ * Execute browser tool
+ */
+export async function executeBrowserTool(params: BrowserToolParams): Promise<BrowserToolResult> {
+  try {
+    // For status action, just return status without auto-launching
+    if (params.action === "status") {
+      const status = await getStatus();
+      return {
+        ok: true,
+        data: {
+          relayRunning: status.relayRunning,
+          extensionConnected: status.extensionConnected,
+          attachedTabs: status.targets.length,
+          targets: status.targets,
+        },
+      };
+    }
+
+    // For all other actions, check if extension is connected
+    const status = await getStatus();
+
+    if (!status.relayRunning) {
+      return {
+        ok: false,
+        error: "Relay server not running. Start it with: cdp-relay-server",
+      };
+    }
+
+    if (!status.extensionConnected) {
+      const chromeRunning = isChromeRunningWithProfile();
+
+      if (chromeRunning) {
+        // Chrome is running but extension not connected
+        // Just open extensions page, don't launch another browser
+        const extResult = openExtensionsPage();
+        return {
+          ok: false,
+          error: `Extension not connected. ${extResult.message}`,
+        };
+      }
+
+      // Chrome not running - launch with user's URL if available, otherwise default
+      const targetUrl = (params.action === "open" || params.action === "navigate") ? params.url : undefined;
+      const launchResult = launchBrowserWithInstructions(targetUrl);
+      if (!launchResult.launched) {
+        return { ok: false, error: launchResult.message };
+      }
+
+      // Wait for extension to attach
+      const connected = await waitForConnection(8000);
+
+      if (!connected) {
+        // Attach failed - extension probably not installed, open extensions page
+        const extResult = openExtensionsPage();
+        return {
+          ok: false,
+          error: `Extension not connected. ${extResult.message}`,
+        };
+      }
+
+      // Connected! For open/navigate actions with URL, page is already open
+      if (targetUrl && (params.action === "open" || params.action === "navigate")) {
+        // Already opened the target URL during launch, return success
+        const tabs = await listTabs();
+        const tab = tabs.find(t => t.url.includes(new URL(targetUrl).hostname));
+        return { ok: true, data: { targetId: tab?.targetId, url: targetUrl, launchedWithUrl: true } };
+      }
+    }
+
+    switch (params.action) {
+
+      case "tabs": {
+        const tabs = await listTabs();
+        return { ok: true, data: { tabs } };
+      }
+
+      case "open": {
+        if (!params.url) {
+          return { ok: false, error: "url is required for open action" };
+        }
+        // Check if there's a temporary tab (weibo.com or chrome://extensions) to reuse
+        const tabs = await listTabs();
+        const tempTab = tabs.find(t =>
+          t.url.includes("weibo.com") ||
+          t.url.startsWith("chrome://extensions") ||
+          t.url === "chrome://newtab/" ||
+          t.url === "about:blank"
+        );
+        if (tempTab) {
+          // Reuse temp tab by navigating instead of opening new tab
+          await navigate(params.url, tempTab.targetId);
+          return { ok: true, data: { targetId: tempTab.targetId, reused: true } };
+        }
+        const result = await openTab(params.url);
+        return { ok: true, data: result };
+      }
+
+      case "close": {
+        if (!params.targetId) {
+          return { ok: false, error: "targetId is required for close action" };
+        }
+        const result = await closeTab(params.targetId);
+        return { ok: true, data: result };
+      }
+
+      case "focus": {
+        if (!params.targetId) {
+          return { ok: false, error: "targetId is required for focus action" };
+        }
+        await focusTab(params.targetId);
+        return { ok: true, data: { focused: params.targetId } };
+      }
+
+      case "navigate": {
+        if (!params.url) {
+          return { ok: false, error: "url is required for navigate action" };
+        }
+        const result = await navigate(params.url);
+        return { ok: true, data: result };
+      }
+
+      case "snapshot": {
+        const result = await getSnapshot({
+          interactive: params.interactive,
+          compact: params.compact,
+        });
+        // Store refs for subsequent actions
+        storeRefs(result.refs);
+        return {
+          ok: true,
+          data: {
+            snapshot: result.snapshot,
+            stats: result.stats,
+          },
+        };
+      }
+
+      case "screenshot": {
+        const buffer = await screenshot({ fullPage: params.fullPage });
+        // Save to temp file
+        const tmpDir = path.join(os.tmpdir(), "browser-skill");
+        if (!fs.existsSync(tmpDir)) {
+          fs.mkdirSync(tmpDir, { recursive: true });
+        }
+        const filePath = path.join(tmpDir, `screenshot-${Date.now()}.png`);
+        fs.writeFileSync(filePath, buffer);
+        return {
+          ok: true,
+          data: {
+            path: filePath,
+            size: buffer.length,
+          },
+        };
+      }
+
+      case "act": {
+        if (!params.request) {
+          return { ok: false, error: "request is required for act action" };
+        }
+        const result = await executeAction(params.request);
+        return { ok: result.ok, error: result.error, data: result.ok ? { acted: params.request.kind } : undefined };
+      }
+
+      case "evaluate": {
+        if (!params.expression) {
+          return { ok: false, error: "expression is required for evaluate action" };
+        }
+        const result = await evaluate(params.expression);
+        return {
+          ok: !result.error,
+          error: result.error,
+          data: result.result,
+        };
+      }
+
+      default:
+        return { ok: false, error: `Unknown action: ${params.action}` };
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/deps/browser/relay-server/src/ws-utils.ts
+++ b/deps/browser/relay-server/src/ws-utils.ts
@@ -1,0 +1,21 @@
+import type WebSocket from "ws";
+import { Buffer } from "node:buffer";
+
+export function rawDataToString(
+  data: WebSocket.RawData,
+  encoding: BufferEncoding = "utf8",
+): string {
+  if (typeof data === "string") {
+    return data;
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString(encoding);
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString(encoding);
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data).toString(encoding);
+  }
+  return Buffer.from(String(data)).toString(encoding);
+}

--- a/deps/browser/relay-server/tsconfig.json
+++ b/deps/browser/relay-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Add `@wb/wegent-cdp-relay-server` package under `deps/browser/relay-server`
- Provides CDP relay server bridging Chrome extension and CDP clients (like Playwright)
- Includes Chrome extension for debugger attachment via `chrome.debugger` API
- WebSocket-based communication for real-time CDP command/event relay

## Test plan
- [ ] Install dependencies with `npm install` in `deps/browser/relay-server`
- [ ] Build with `npm run build`
- [ ] Load Chrome extension and verify connection to relay server
- [ ] Test CDP client connection via WebSocket endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Browser CDP Relay Server enables remote browser control via Chrome extension.
  * Browser automation actions: click, type, press, hover, drag, select, fill, scroll, wait, and resize.
  * Screenshot and page snapshot generation with accessibility tree support.
  * Chrome extension settings UI for relay port configuration.
  * CLI tools for relay daemon management and browser interactions.

* **Documentation**
  * Added comprehensive README with architecture, quick start, and usage examples.

* **Chores**
  * Added package configuration and TypeScript build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->