### PR TITLE
feat(frontend): restrict knowledge base upload to exclude image files

### DIFF
--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -113,7 +113,7 @@
       "namePlaceholder": "Enter document name",
       "updateFailed": "Failed to update document",
       "dropzone": "Drop files here or click to browse",
-      "supportedTypes": "PDF, Word, PPT, Excel, TXT, MD, Images (Max {{maxSize}}MB)",
+      "supportedTypes": "PDF, Word, PPT, Excel, TXT, MD (Max {{maxSize}}MB)",
       "uploading": "Uploading...",
       "uploadSuccess": "File uploaded successfully",
       "batch": {
@@ -194,6 +194,7 @@
       "textRequired": "Please enter text content",
       "insert": "Insert",
       "clickToRename": "Click to rename",
+      "unsupportedFileType": "Image files are not supported yet. Support will be added in future versions.",
       "addTable": "Add Data Table",
       "tableHint": "Enter the table link and name to add it to your knowledge base.",
       "tableUrlHint": "Please enter a valid table URL. Ensure the link is accessible and you have read permission. Currently supports DingTalk tables.",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -113,7 +113,7 @@
       "namePlaceholder": "输入文档名称",
       "updateFailed": "更新文档失败",
       "dropzone": "拖拽文件到此处或点击浏览",
-      "supportedTypes": "支持 PDF、Word、PPT、Excel、TXT、MD、图片（最大 {{maxSize}}MB）",
+      "supportedTypes": "支持 PDF、Word、PPT、Excel、TXT、MD 文件（最大 {{maxSize}}MB）",
       "uploading": "上传中...",
       "uploadSuccess": "文件上传成功",
       "batch": {
@@ -194,6 +194,7 @@
       "textRequired": "请输入文本内容",
       "insert": "插入",
       "clickToRename": "点击修改文件名",
+      "unsupportedFileType": "暂不支持图片文件，后续版本将支持",
       "addTable": "添加数据表",
       "tableHint": "输入数据表的链接和名称，即可将其添加到知识库。",
       "tableUrlHint": "请输入有效的多维表URL，确保链接可访问且有读取权限。目前支持钉钉多维表。",


### PR DESCRIPTION
## Summary

- Remove image files (.jpg, .jpeg, .png, .gif, .bmp, .webp) from knowledge base document upload
- Add file type validation with friendly error message for unsupported image files (via drag-and-drop)
- Update supported file types hint in both zh-CN and en locales
- Image files are temporarily disabled as the current RAG flow cannot properly process them

## Changes

1. **DocumentUpload.tsx**:
   - Updated `accept` attribute to `.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.csv,.txt,.md` (removed image extensions)
   - Added `KB_UNSUPPORTED_EXTENSIONS` constant for image file types
   - Added `isKBUnsupportedExtension()` helper function
   - Modified `handleFilesAdded()` to filter out image files and show friendly error

2. **i18n locales**:
   - Updated `document.document.supportedTypes` to remove "Images" mention
   - Added `document.upload.unsupportedFileType` key for validation error message

## Test plan

- [ ] Verify the file selector no longer allows image files (.jpg, .jpeg, .png, .gif, .bmp, .webp)
- [ ] Verify the supported file types hint shows "PDF, Word, PPT, Excel, TXT, MD (Max 100MB)"
- [ ] Verify drag-and-drop of image files shows friendly error message
- [ ] Verify PDF, Word, PPT, Excel, CSV, TXT, MD files can still be uploaded normally
- [ ] Verify chat attachments are not affected (can still upload images)
- [ ] Verify existing image documents in knowledge base remain accessible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to reject image file uploads with a user-friendly error message
  * File type restrictions now clearly support only PDF, Word, PowerPoint, Excel, TXT, and MD formats
  * Improved upload feedback for unsupported file types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->