### PR TITLE
fix: 再次修复code类型的订阅任务无法执行的问题

### DIFF
--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -1199,36 +1199,22 @@ def execute_subscription_task(
                     )
                 else:
                     # Executor type - subtask picked up by executor_manager
-                    # Push mode: dispatch task to executor_manager immediately
-                    # Note: We must await the dispatch here because the event loop
-                    # will be closed after this block, so scheduled tasks won't run.
+                    # Note: schedule_dispatch is already called inside create_task_or_append
+                    # after db.commit(). However, we call it again here as a safety measure
+                    # in case the first call failed silently.
                     try:
                         from app.services.task_dispatcher import task_dispatcher
 
                         if task_dispatcher.enabled:
-                            # Use dispatch_pending_tasks directly since we're in async context
-                            success = loop.run_until_complete(
-                                task_dispatcher.dispatch_pending_tasks(
-                                    db, task_ids=[task_id], task_type="online"
-                                )
+                            task_dispatcher.schedule_dispatch(task_id)
+                            logger.info(
+                                f"[subscription_tasks] Push mode: scheduled dispatch for task {task_id}"
                             )
-                            if success:
-                                logger.info(
-                                    f"[subscription_tasks] Push mode: dispatched task {task_id}"
-                                )
-                            else:
-                                logger.warning(
-                                    f"[subscription_tasks] Push mode: dispatch returned False for task {task_id}"
-                                )
                     except Exception as e:
                         logger.warning(
                             f"[subscription_tasks] Push mode dispatch failed for task {task_id}: {e}",
                             exc_info=True,
                         )
-
-                    logger.debug(
-                        f"[subscription_tasks] Executor type, task {task_id} dispatched to executor_manager"
-                    )
 
                 # Update execution status to COMPLETED for Chat Shell type
                 # For Executor type, status will be updated by executor when done


### PR DESCRIPTION
In Celery worker processes, WebSocket/Socket.IO operations fail because:
1. ws_emitter is not initialized (different process from FastAPI)
2. Redis connections are bound to different event loops

Changes:
- EventBus.publish(): Skip event publishing when ws_emitter is None
- executor_kinds.py: Early return in WS emit methods when not in FastAPI
- task_dispatcher.py: Wait for pending async tasks before closing loop
- subscription_tasks.py: Simplify dispatch logic using schedule_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of WebSocket event handling during background task execution, with graceful handling when the WebSocket context is unavailable.
  * Enhanced task completion synchronization to ensure all pending asynchronous operations finish properly before cleanup and shutdown.
  * Refined event propagation logic to prevent unnecessary processing in certain execution contexts, reducing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->