### PR TITLE
ci: add workflow to sync docs to wegent-docs repository

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,26 @@
+name: Sync Documentation to Docs Repository
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  trigger-docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs repository sync
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_REPO_TOKEN }}
+          repository: wecode-ai/wegent-docs
+          event-type: docs-updated
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+
+      - name: Log sync trigger
+        run: |
+          echo "Documentation sync triggered for commit ${{ github.sha }}"
+          echo "Changes in docs/ directory detected and sync dispatched to wegent-docs repository"


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically sync documentation to the `wegent-docs` repository
- Triggers on changes to `docs/` directory on main branch
- Supports manual trigger via `workflow_dispatch`

## How it works

1. When `docs/` directory changes on main branch, this workflow triggers
2. Sends a `repository_dispatch` event to `wecode-ai/wegent-docs` repository
3. The `wegent-docs` repository's `sync-docs.yml` workflow receives the event and syncs:
   - `docs/en/` → `wegent-docs/docs/`
   - `docs/zh/` → `wegent-docs/i18n/zh/docusaurus-plugin-content-docs/current/`
4. Documentation website auto-deploys to GitHub Pages

## Configuration Required

After merging, add the following repository secret:

- **Secret name**: `DOCS_REPO_TOKEN`
- **Secret value**: A PAT with `repo` scope (to trigger workflows in `wegent-docs` repository)

## Test plan

- [ ] Verify workflow file syntax is valid
- [ ] After adding `DOCS_REPO_TOKEN` secret, manually trigger the workflow via GitHub Actions UI
- [ ] Confirm `wegent-docs` repository receives the dispatch event and syncs documentation
- [ ] Verify https://wecode-ai.github.io/wegent-docs/ updates with latest docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated documentation synchronization workflow implemented to keep documentation repositories in sync when documentation is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->