### PR TITLE
refactor(executor): simplify local mode logging

### DIFF
--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -89,10 +89,7 @@ class LocalModeStrategy(ExecutionModeStrategy):
             json.dump(claude_json_config, f, indent=2)
         os.chmod(claude_json_path, 0o600)
 
-        logger.info(
-            f"Local mode: Saved claude.json to {config_dir} "
-            "(settings.json skipped - sensitive config passed via env)"
-        )
+        logger.debug(f"Local mode: Saved claude.json to {config_dir}")
 
         # Return env config to be passed via environment variables
         env_config = agent_config.get("env", {})


### PR DESCRIPTION
Reduce verbose logging in ClaudeCodeAgent for cleaner output:
- Remove redundant debug/info log pairs in cleanup code
- Downgrade routine operations to debug level (client reuse, session)
- Simplify cleanup logs by removing per-step debug statements
- Keep important state changes at info level (termination, cleanup count)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity in agent components to reduce noise while preserving important events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->