### PR TITLE
feat(knowledge): add index status tooltip for documents

### DIFF
--- a/backend/alembic/versions/x4y5z6a7b8c9_add_index_status_to_knowledge_documents.py
+++ b/backend/alembic/versions/x4y5z6a7b8c9_add_index_status_to_knowledge_documents.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add index_status column to knowledge_documents
+
+Revision ID: x4y5z6a7b8c9
+Revises: w3x4y5z6a7b8
+Create Date: 2025-02-04
+
+This migration adds an index_status column to track document indexing progress.
+
+The index_status column values:
+- '' (empty string): Legacy default, status determined by is_active field
+- 'indexing': Document is currently being indexed
+- 'completed': Indexing completed successfully
+- 'failed': Indexing failed
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "x4y5z6a7b8c9"
+down_revision: Union[str, None] = "w3x4y5z6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def column_exists(table_name: str, column_name: str) -> bool:
+    """Check if a column exists in a table."""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_name = :table_name AND column_name = :column_name"
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return result.scalar() > 0
+
+
+def upgrade() -> None:
+    """Add index_status column to knowledge_documents table."""
+
+    # Check if column already exists (handles case where DB was modified manually)
+    if column_exists("knowledge_documents", "index_status"):
+        return
+
+    # Add index_status column for tracking indexing progress
+    op.add_column(
+        "knowledge_documents",
+        sa.Column(
+            "index_status",
+            sa.String(20),
+            nullable=False,
+            server_default="",
+            comment="Index status: '' (legacy), 'indexing', 'completed', 'failed'",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Remove index_status column from knowledge_documents table."""
+
+    op.drop_column("knowledge_documents", "index_status")

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -92,6 +92,9 @@ class KnowledgeDocument(Base):
     chunks = Column(
         JSON, nullable=True
     )  # Chunk metadata including content and position info
+    index_status = Column(
+        String(20), nullable=False, default=""
+    )  # Index status: '' (legacy default), 'indexing', 'completed', 'failed'
     created_at = Column(DateTime, nullable=False, default=func.now())
     updated_at = Column(
         DateTime, nullable=False, default=func.now(), onupdate=func.now()

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -297,6 +297,10 @@ class KnowledgeDocumentResponse(BaseModel):
     doc_ref: Optional[str] = Field(
         None, description="RAG storage document reference ID"
     )
+    index_status: str = Field(
+        default="",
+        description="Index status: '' (legacy), 'indexing', 'completed', 'failed'",
+    )
     created_at: datetime
     updated_at: datetime
 

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -16,7 +16,7 @@ const badgeVariants = cva(
         success: 'bg-success text-white',
         error: 'bg-error text-white',
         warning: 'bg-warning text-white',
-        info: 'bg-surface text-text-primary border border-border',
+        info: 'bg-blue-500/10 text-blue-600 border border-blue-500/20',
         secondary: 'bg-muted text-text-secondary',
       },
       size: {

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -194,6 +194,32 @@ export function DocumentItem({
                 className="w-1 h-1 rounded-full flex-shrink-0 bg-green-500"
                 title={t('knowledge:document.document.indexStatus.available')}
               />
+            ) : document.index_status === 'indexing' ? (
+              <TooltipProvider>
+                <Tooltip delayDuration={200}>
+                  <TooltipTrigger asChild>
+                    <span className="w-1 h-1 rounded-full flex-shrink-0 bg-blue-500 animate-pulse cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs">
+                    <p className="text-xs">
+                      {t('knowledge:document.document.indexStatus.indexingHint')}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : document.index_status === 'failed' ? (
+              <TooltipProvider>
+                <Tooltip delayDuration={200}>
+                  <TooltipTrigger asChild>
+                    <span className="w-1 h-1 rounded-full flex-shrink-0 bg-yellow-500 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs">
+                    <p className="text-xs">
+                      {t('knowledge:document.document.indexStatus.failedHint')}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             ) : !ragConfigured ? (
               <TooltipProvider>
                 <Tooltip delayDuration={200}>
@@ -364,6 +390,42 @@ export function DocumentItem({
           <Badge variant="success" size="sm" className="whitespace-nowrap">
             {t('knowledge:document.document.indexStatus.available')}
           </Badge>
+        ) : document.index_status === 'indexing' ? (
+          <TooltipProvider>
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger asChild>
+                <span>
+                  <Badge
+                    variant="info"
+                    size="sm"
+                    className="whitespace-nowrap cursor-help animate-pulse"
+                  >
+                    {t('knowledge:document.document.indexStatus.indexing')}
+                  </Badge>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs">
+                <p className="text-xs">
+                  {t('knowledge:document.document.indexStatus.indexingHint')}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : document.index_status === 'failed' ? (
+          <TooltipProvider>
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger asChild>
+                <span>
+                  <Badge variant="warning" size="sm" className="whitespace-nowrap cursor-help">
+                    {t('knowledge:document.document.indexStatus.unavailable')}
+                  </Badge>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs">
+                <p className="text-xs">{t('knowledge:document.document.indexStatus.failedHint')}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         ) : !ragConfigured ? (
           <TooltipProvider>
             <Tooltip delayDuration={200}>

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -83,7 +83,10 @@
       "indexStatus": {
         "available": "Indexed",
         "unavailable": "Index Unavailable",
-        "unavailableHint": "AI will use other tools to browse documents (slightly less efficient than quick retrieval)"
+        "unavailableHint": "AI will use other tools to browse documents (slightly less efficient than quick retrieval)",
+        "indexing": "Indexing",
+        "indexingHint": "Building index, usually takes a few minutes. Please refresh later to check~",
+        "failedHint": "Index generation failed. AI will use other tools to browse documents"
       },
       "openLink": "Open Link",
       "columns": {

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -83,7 +83,10 @@
       "indexStatus": {
         "available": "可用",
         "unavailable": "索引不可用",
-        "unavailableHint": "AI 将使用其它工具浏览文档（效率略低于快速检索）"
+        "unavailableHint": "AI 将使用其它工具浏览文档（效率略低于快速检索）",
+        "indexing": "索引中",
+        "indexingHint": "正在建立索引，通常需要几分钟，请稍后刷新查看～",
+        "failedHint": "索引生成失败，AI 将使用其它工具浏览文档"
       },
       "openLink": "打开链接",
       "columns": {

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -152,6 +152,8 @@ export interface KnowledgeDocument {
   status: DocumentStatus
   user_id: number
   is_active: boolean
+  /** Index status: '' (legacy), 'indexing', 'completed', 'failed' */
+  index_status: string
   splitter_config?: SplitterConfig
   source_type: DocumentSourceType
   source_config: Record<string, unknown>


### PR DESCRIPTION
## Summary

- Add `index_status` field to `KnowledgeDocument` model to track indexing progress
- Values: `''` (legacy default), `'indexing'`, `'completed'`, `'failed'`
- Update frontend `DocumentItem` component with indexing status tooltip
- Show blue pulsing badge for "indexing" status with friendly hint
- Show yellow badge with tooltip for "failed" status

## Changes

### Backend
1. **Model** (`backend/app/models/knowledge.py`):
   - Add `index_status` column (VARCHAR(20), default empty string)

2. **Schema** (`backend/app/schemas/knowledge.py`):
   - Add `index_status` field to `KnowledgeDocumentResponse`

3. **Business Logic** (`backend/app/api/endpoints/knowledge.py`):
   - Set `index_status='indexing'` when starting indexing
   - Set `index_status='completed'` on success
   - Set `index_status='failed'` on failure

4. **Migration** (`backend/alembic/versions/x4y5z6a7b8c9_add_index_status_to_knowledge_documents.py`):
   - Add new column with empty string default (no data migration needed)

### Frontend
1. **Types** (`frontend/src/types/knowledge.ts`):
   - Add `index_status: string` to `KnowledgeDocument` interface

2. **i18n** (both `en` and `zh-CN`):
   - Add `indexing`, `indexingHint`, `failedHint` translations

3. **Badge** (`frontend/src/components/ui/badge.tsx`):
   - Update `info` variant to blue color for indexing state

4. **DocumentItem** (`frontend/src/features/knowledge/document/components/DocumentItem.tsx`):
   - Add status logic for both table mode and compact mode
   - Show blue pulsing badge/dot for indexing with tooltip hint
   - Show yellow badge/dot for failed with tooltip hint

## User Experience

| Status | Badge | Tooltip |
|--------|-------|---------|
| Indexed | 🟢 Green | None |
| Indexing | 🔵 Blue + pulse | "Building index, usually takes a few minutes..." |
| Failed | 🟡 Yellow | "Index generation failed. AI will use other tools..." |
| No RAG | 🟡 Yellow | "AI will use other tools to browse documents..." |

## Test plan

- [ ] Verify new documents show "Indexing" status during background processing
- [ ] Verify status changes to "Indexed" after successful indexing
- [ ] Verify status shows "Index Unavailable" with failed hint on indexing failure
- [ ] Verify legacy documents (empty index_status) display correctly based on is_active
- [ ] Verify tooltips appear on hover for both table and compact modes
- [ ] Verify i18n works for both Chinese and English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time indexing status tracking for knowledge documents with visual progress indicators
  * Documents now display distinct visual states: indexing in progress, indexing completed, or indexing failed
  * Implemented helpful tooltips to guide users during indexing operations and inform them of any failures

* **Style**
  * Updated badge component styling for improved visual consistency and clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->