### PR TITLE
feat(frontend): improve knowledge base document index status tooltip

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -1062,7 +1062,7 @@ async def reindex_document(
         )
 
     # Check if knowledge base has RAG configured
-    spec = knowledge_base.json.get("spec", {})
+    spec = (knowledge_base.json or {}).get("spec", {})
     retrieval_config = spec.get("retrievalConfig")
 
     if not retrieval_config:

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -45,6 +45,7 @@ from app.schemas.rag import (
     SentenceSplitterConfig,
     SplitterConfig,
 )
+from app.models.kind import Kind
 from app.services.adapters.retriever_kinds import retriever_kinds_service
 from app.services.knowledge import (
     KnowledgeBaseQAService,
@@ -490,8 +491,9 @@ class RAGIndexingParams:
     kb_index_info: KnowledgeBaseIndexInfo
 
 
+@trace_sync("extract_rag_config", "knowledge.api")
 def _extract_rag_config_from_knowledge_base(
-    knowledge_base, current_user_id: int
+    knowledge_base: Kind, current_user_id: int
 ) -> Optional[RAGIndexingParams]:
     """
     Extract RAG indexing configuration from a knowledge base.
@@ -500,7 +502,7 @@ def _extract_rag_config_from_knowledge_base(
     Otherwise returns a dict with all configuration values needed for indexing.
 
     Args:
-        knowledge_base: The knowledge base object
+        knowledge_base: The knowledge base Kind object
         current_user_id: The current user's ID for determining index owner
 
     Returns:
@@ -554,6 +556,7 @@ def _extract_rag_config_from_knowledge_base(
     )
 
 
+@trace_sync("schedule_rag_indexing", "knowledge.api")
 def _schedule_rag_indexing(
     background_tasks: BackgroundTasks,
     params: RAGIndexingParams,

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -1048,6 +1048,13 @@ async def reindex_document(
             detail="Document not found",
         )
 
+    # TABLE documents do not support RAG indexing (real-time query instead)
+    if document.source_type == DocumentSourceType.TABLE.value:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Table documents do not support indexing",
+        )
+
     # Check access permission via knowledge base
     knowledge_base = KnowledgeService.get_knowledge_base(
         db=db,

--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -125,6 +125,24 @@ export async function deleteDocument(documentId: number): Promise<void> {
   return apiClient.delete(`/knowledge-documents/${documentId}`)
 }
 
+/**
+ * Response for document reindex
+ */
+export interface DocumentReindexResponse {
+  success: boolean
+  document_id: number
+  message: string
+}
+
+/**
+ * Trigger re-indexing for a document
+ * @param documentId The document ID to reindex
+ * @returns Success message indicating reindex has started
+ */
+export async function reindexDocument(documentId: number): Promise<DocumentReindexResponse> {
+  return apiClient.post<DocumentReindexResponse>(`/knowledge-documents/${documentId}/reindex`)
+}
+
 // ============== Batch Document Operations ==============
 
 /**

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -208,10 +208,18 @@ export function DocumentItem({
                 </Tooltip>
               </TooltipProvider>
             ) : (
-              <span
-                className="w-1 h-1 rounded-full flex-shrink-0 bg-yellow-500"
-                title={t('knowledge:document.document.indexStatus.unavailable')}
-              />
+              <TooltipProvider>
+                <Tooltip delayDuration={200}>
+                  <TooltipTrigger asChild>
+                    <span className="w-1 h-1 rounded-full flex-shrink-0 bg-yellow-500 cursor-help" />
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs">
+                    <p className="text-xs">
+                      {t('knowledge:document.document.indexStatus.indexingHint')}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </div>
         </div>
@@ -382,9 +390,22 @@ export function DocumentItem({
             </Tooltip>
           </TooltipProvider>
         ) : (
-          <Badge variant="warning" size="sm" className="whitespace-nowrap">
-            {t('knowledge:document.document.indexStatus.unavailable')}
-          </Badge>
+          <TooltipProvider>
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger asChild>
+                <span>
+                  <Badge variant="warning" size="sm" className="whitespace-nowrap cursor-help">
+                    {t('knowledge:document.document.indexStatus.indexing')}
+                  </Badge>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top" className="max-w-xs">
+                <p className="text-xs">
+                  {t('knowledge:document.document.indexStatus.indexingHint')}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
       </div>
 

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -302,7 +302,7 @@ export function DocumentItem({
   // Normal mode: Table row layout
   return (
     <div
-      className={`flex items-center gap-4 px-4 py-3 bg-base hover:bg-surface transition-colors group ${showBorder ? 'border-b border-border' : ''} ${onViewDetail ? 'cursor-pointer' : ''}`}
+      className={`flex items-center gap-4 px-4 py-3 bg-base hover:bg-surface transition-colors group min-w-[800px] ${showBorder ? 'border-b border-border' : ''} ${onViewDetail ? 'cursor-pointer' : ''}`}
       onClick={handleRowClick}
     >
       {/* Checkbox for batch selection */}

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -13,6 +13,7 @@ import {
   MoreVertical,
   Globe,
   CloudDownload,
+  RefreshCw,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -31,6 +32,7 @@ interface DocumentItemProps {
   onEdit?: (doc: KnowledgeDocument) => void
   onDelete?: (doc: KnowledgeDocument) => void
   onRefresh?: (doc: KnowledgeDocument) => void
+  onReindex?: (doc: KnowledgeDocument) => void
   onViewDetail?: (doc: KnowledgeDocument) => void
   canManage?: boolean
   showBorder?: boolean
@@ -40,6 +42,8 @@ interface DocumentItemProps {
   compact?: boolean
   /** Whether the document is currently being refreshed */
   isRefreshing?: boolean
+  /** Whether the document is currently being reindexed */
+  isReindexing?: boolean
   /** Whether the knowledge base has RAG configured (retriever + embedding model) */
   ragConfigured?: boolean
 }
@@ -49,6 +53,7 @@ export function DocumentItem({
   onEdit,
   onDelete,
   onRefresh,
+  onReindex,
   onViewDetail,
   canManage = true,
   showBorder = true,
@@ -56,6 +61,7 @@ export function DocumentItem({
   onSelect,
   compact = false,
   isRefreshing = false,
+  isReindexing = false,
   ragConfigured = true,
 }: DocumentItemProps) {
   const { t } = useTranslation()
@@ -99,6 +105,11 @@ export function DocumentItem({
   const handleRefresh = (e: React.MouseEvent) => {
     e.stopPropagation()
     onRefresh?.(document)
+  }
+
+  const handleReindex = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onReindex?.(document)
   }
 
   const handleOpenLink = (e: React.MouseEvent) => {
@@ -265,6 +276,16 @@ export function DocumentItem({
                         : t('knowledge:document.upload.web.refetch')}
                     </DropdownMenuItem>
                   )}
+                  {ragConfigured && !document.is_active && !isTable && onReindex && (
+                    <DropdownMenuItem onClick={handleReindex} disabled={isReindexing}>
+                      <RefreshCw
+                        className={`w-3.5 h-3.5 mr-2 ${isReindexing ? 'animate-spin' : ''}`}
+                      />
+                      {isReindexing
+                        ? t('knowledge:document.document.reindexing')
+                        : t('knowledge:document.document.reindex')}
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuItem danger onClick={handleDelete}>
                     <Trash2 className="w-3.5 h-3.5 mr-2" />
                     {t('common:actions.delete')}
@@ -395,7 +416,7 @@ export function DocumentItem({
               <TooltipTrigger asChild>
                 <span>
                   <Badge variant="warning" size="sm" className="whitespace-nowrap cursor-help">
-                    {t('knowledge:document.document.indexStatus.indexing')}
+                    {t('knowledge:document.document.indexStatus.unavailable')}
                   </Badge>
                 </span>
               </TooltipTrigger>
@@ -429,6 +450,25 @@ export function DocumentItem({
               }
             >
               <CloudDownload className={`w-4 h-4 ${isRefreshing ? 'animate-pulse' : ''}`} />
+            </button>
+          )}
+          {/* Reindex button - only when RAG configured and document not indexed */}
+          {ragConfigured && !document.is_active && !isTable && onReindex && (
+            <button
+              className={`p-1.5 rounded-md transition-colors ${
+                isReindexing
+                  ? 'text-primary cursor-not-allowed'
+                  : 'text-text-muted hover:text-primary hover:bg-primary/10'
+              }`}
+              onClick={handleReindex}
+              disabled={isReindexing}
+              title={
+                isReindexing
+                  ? t('knowledge:document.document.reindexing')
+                  : t('knowledge:document.document.reindex')
+              }
+            >
+              <RefreshCw className={`w-4 h-4 ${isReindexing ? 'animate-spin' : ''}`} />
             </button>
           )}
           {/* Delete button */}

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -13,7 +13,7 @@ import {
   MoreVertical,
   Globe,
   CloudDownload,
-  RefreshCw,
+  RotateCcw,
 } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -278,7 +278,7 @@ export function DocumentItem({
                   )}
                   {ragConfigured && !document.is_active && !isTable && onReindex && (
                     <DropdownMenuItem onClick={handleReindex} disabled={isReindexing}>
-                      <RefreshCw
+                      <RotateCcw
                         className={`w-3.5 h-3.5 mr-2 ${isReindexing ? 'animate-spin' : ''}`}
                       />
                       {isReindexing
@@ -468,7 +468,7 @@ export function DocumentItem({
                   : t('knowledge:document.document.reindex')
               }
             >
-              <RefreshCw className={`w-4 h-4 ${isReindexing ? 'animate-spin' : ''}`} />
+              <RotateCcw className={`w-4 h-4 ${isReindexing ? 'animate-spin' : ''}`} />
             </button>
           )}
           {/* Delete button */}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -95,6 +95,8 @@ export function DocumentList({
   const [initialSelectionDone, setInitialSelectionDone] = useState(false)
   // Track which document is being refreshed
   const [refreshingDocId, setRefreshingDocId] = useState<number | null>(null)
+  // Track which document is being reindexed
+  const [reindexingDocId, setReindexingDocId] = useState<number | null>(null)
   // Track if summary is being retried
   const [isSummaryRetrying, setIsSummaryRetrying] = useState(false)
 
@@ -353,6 +355,39 @@ export function DocumentList({
       // Error will be shown via toast in the API layer
     } finally {
       setRefreshingDocId(null)
+    }
+  }
+
+  // Handle document reindex
+  const handleReindexDocument = async (doc: KnowledgeDocument) => {
+    setReindexingDocId(doc.id)
+    try {
+      const { reindexDocument } = await import('@/apis/knowledge')
+      const result = await reindexDocument(doc.id)
+
+      if (!result.success) {
+        throw new Error(t('document.document.reindexFailed'))
+      }
+
+      toast({
+        description: t('document.document.reindexSuccess'),
+      })
+
+      // Refresh document list after a short delay to allow backend to start processing
+      setTimeout(() => {
+        if (isMountedRef.current) {
+          refresh()
+        }
+      }, 2000)
+    } catch {
+      toast({
+        variant: 'destructive',
+        description: t('document.document.reindexFailed'),
+      })
+    } finally {
+      if (isMountedRef.current) {
+        setReindexingDocId(null)
+      }
     }
   }
 
@@ -628,7 +663,9 @@ export function DocumentList({
                   onEdit={setEditingDoc}
                   onDelete={setDeletingDoc}
                   onRefresh={handleRefreshWebDocument}
+                  onReindex={handleReindexDocument}
                   isRefreshing={refreshingDocId === doc.id}
+                  isReindexing={reindexingDocId === doc.id}
                   canManage={canManage}
                   showBorder={false}
                   selected={selectedIds.has(doc.id)}
@@ -700,7 +737,9 @@ export function DocumentList({
                   onEdit={setEditingDoc}
                   onDelete={setDeletingDoc}
                   onRefresh={handleRefreshWebDocument}
+                  onReindex={handleReindexDocument}
                   isRefreshing={refreshingDocId === doc.id}
+                  isReindexing={reindexingDocId === doc.id}
                   canManage={canManage}
                   showBorder={index < filteredAndSortedDocuments.length - 1}
                   selected={selectedIds.has(doc.id)}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -677,9 +677,9 @@ export function DocumentList({
             </div>
           ) : (
             /* Normal mode: Table layout */
-            <div className="border border-border rounded-lg overflow-hidden">
+            <div className="border border-border rounded-lg overflow-x-auto">
               {/* Table header */}
-              <div className="flex items-center gap-4 px-4 py-2.5 bg-surface text-xs text-text-muted font-medium">
+              <div className="flex items-center gap-4 px-4 py-2.5 bg-surface text-xs text-text-muted font-medium min-w-[800px]">
                 {/* Checkbox for select all */}
                 {canManage && (
                   <div className="flex-shrink-0">

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -83,7 +83,9 @@
       "indexStatus": {
         "available": "Indexed",
         "unavailable": "Index Unavailable",
-        "unavailableHint": "AI will use other tools to browse documents (slightly less efficient than quick retrieval)"
+        "unavailableHint": "AI will use other tools to browse documents (slightly less efficient than quick retrieval)",
+        "indexing": "Indexing",
+        "indexingHint": "Index is being generated. Refresh the page later to check the latest status."
       },
       "openLink": "Open Link",
       "columns": {

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -87,6 +87,10 @@
         "indexing": "Indexing",
         "indexingHint": "Index is being generated. Refresh the page later to check the latest status."
       },
+      "reindex": "Reindex",
+      "reindexing": "Reindexing...",
+      "reindexSuccess": "Reindex started",
+      "reindexFailed": "Failed to start reindex",
       "openLink": "Open Link",
       "columns": {
         "name": "Name",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -83,7 +83,9 @@
       "indexStatus": {
         "available": "可用",
         "unavailable": "索引不可用",
-        "unavailableHint": "AI 将使用其它工具浏览文档（效率略低于快速检索）"
+        "unavailableHint": "AI 将使用其它工具浏览文档（效率略低于快速检索）",
+        "indexing": "索引中",
+        "indexingHint": "索引正在生成中，稍后刷新页面查看最新状态"
       },
       "openLink": "打开链接",
       "columns": {

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -87,6 +87,10 @@
         "indexing": "索引中",
         "indexingHint": "索引正在生成中，稍后刷新页面查看最新状态"
       },
+      "reindex": "重新索引",
+      "reindexing": "索引中...",
+      "reindexSuccess": "已开始重新索引",
+      "reindexFailed": "启动重新索引失败",
       "openLink": "打开链接",
       "columns": {
         "name": "名称",


### PR DESCRIPTION
## Summary

- Improve the tooltip hints for document index status in knowledge base
- Add reindex button for documents when RAG is configured but not yet indexed
- Keep Badge text as "Index Unavailable" but tooltip differentiates between two scenarios:
  - Without RAG: "AI will use other tools to browse documents (slightly less efficient)"
  - With RAG: "Index is being generated. Refresh the page later to check the latest status."
- Add POST `/knowledge-documents/{document_id}/reindex` API endpoint to trigger re-indexing
- Refactor RAG indexing logic into reusable helper functions
- **Fix: Add horizontal scroll for document table in narrow viewport**

## Changes

### Frontend
1. **DocumentItem.tsx**:
   - Add RefreshCw icon import
   - Add `onReindex` callback prop and `isReindexing` state prop
   - Compact mode: Add reindex option in dropdown menu when `ragConfigured && !is_active && !isTable`
   - Table mode: Add reindex button next to refresh/delete buttons with same conditions
   - Keep Badge text as "unavailable" but show different tooltip based on RAG config
   - **Add `min-w-[800px]` to table row to ensure proper scrolling**

2. **DocumentList.tsx**:
   - Add `reindexingDocId` state to track which document is being reindexed
   - Add `handleReindexDocument` function to call reindex API
   - Pass `onReindex` and `isReindexing` props to DocumentItem components
   - **Change table container from `overflow-hidden` to `overflow-x-auto`**
   - **Add `min-w-[800px]` to table header for horizontal scrolling support**

3. **knowledge.ts** (API):
   - Add `DocumentReindexResponse` interface
   - Add `reindexDocument` function to call POST `/knowledge-documents/{document_id}/reindex`

4. **i18n translations** (en/zh-CN):
   - Add `indexing`: "Indexing" / "索引中"
   - Add `indexingHint`: "Index is being generated. Refresh the page later..." / "索引正在生成中，稍后刷新页面查看最新状态"
   - Add `reindex`: "Reindex" / "重新索引"
   - Add `reindexing`: "Reindexing..." / "索引中..."
   - Add `reindexSuccess`: "Reindex started" / "已开始重新索引"
   - Add `reindexFailed`: "Failed to start reindex" / "启动重新索引失败"

### Backend
1. **knowledge.py** (API endpoints):
   - Add `RAGIndexingParams` dataclass to encapsulate indexing parameters
   - Add `_extract_rag_config_from_knowledge_base()` helper to extract RAG config
   - Add `_schedule_rag_indexing()` helper to handle background task scheduling
   - Add `POST /knowledge-documents/{document_id}/reindex` endpoint
   - Refactor `create_document` to use shared helpers (reduces code duplication)
   - Add defensive null check for `knowledge_base.json`
   - Block reindex for TABLE documents (they use real-time queries)

## Test plan

- [ ] Upload a new file to knowledge base with RAG configured
- [ ] Verify the status shows "Index Unavailable" with "Indexing in progress" tooltip
- [ ] Verify reindex button appears for documents with unavailable index status
- [ ] Click reindex button and verify toast shows "Reindex started"
- [ ] Verify after background task completes, status changes to "Indexed"
- [ ] Verify knowledge base without RAG shows "Index Unavailable" with "AI will use other tools" tooltip
- [ ] Verify TABLE documents do not show reindex button
- [ ] Verify all i18n translations work in both English and Chinese
- [ ] **Verify document table is horizontally scrollable on narrow viewports**
- [ ] **Verify action buttons are accessible when scrolling horizontally**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added document reindexing capability with dedicated UI controls in both compact and normal layouts.
  * Enhanced indexing status display with visual indicators and tooltips for better progress feedback.
  * Background reindexing with success and error notifications to users.

* **Localization**
  * Added internationalization strings for reindexing workflow in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->