### PR TITLE
feat(rag): add placeholder support for embedding custom headers

### DIFF
--- a/backend/app/api/endpoints/internal/rag.py
+++ b/backend/app/api/endpoints/internal/rag.py
@@ -38,6 +38,10 @@ class InternalRetrieveRequest(BaseModel):
         default=None,
         description="Optional list of document IDs to filter. Only chunks from these documents will be returned.",
     )
+    user_name: Optional[str] = Field(
+        default=None,
+        description="User name for placeholder replacement in embedding headers",
+    )
 
 
 class RetrieveRecord(BaseModel):
@@ -108,6 +112,7 @@ async def internal_retrieve(
             knowledge_base_id=request.knowledge_base_id,
             db=db,
             metadata_condition=metadata_condition,
+            user_name=request.user_name,
         )
 
         records = result.get("records", [])

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -880,6 +880,7 @@ def _index_document_background(
                     splitter_config=splitter_config,
                     document_id=document_id,
                     trace_context=current_trace_ctx,
+                    user_name=user_name,
                 )
             )
             logger.info(f"[RAG Indexing] index_document returned: result={result}")

--- a/backend/app/api/endpoints/rag.py
+++ b/backend/app/api/endpoints/rag.py
@@ -237,6 +237,7 @@ async def upload_document(
                 user_id=index_owner_user_id,
                 db=db,
                 splitter_config=parsed_splitter_config,
+                user_name=current_user.user_name,
             )
             return result
         finally:

--- a/backend/app/services/rag/document_service.py
+++ b/backend/app/services/rag/document_service.py
@@ -120,6 +120,7 @@ class DocumentService:
         splitter_config: Optional[SplitterConfig] = None,
         document_id: Optional[int] = None,
         trace_context: Optional[dict] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Synchronous document indexing implementation.
@@ -139,6 +140,7 @@ class DocumentService:
             splitter_config: Optional splitter configuration
             document_id: Optional document ID to use as doc_ref
             trace_context: Trace context for distributed tracing (captured via capture_trace_context())
+            user_name: User name for placeholder replacement in embedding headers (optional)
 
         Returns:
             Indexing result dict
@@ -168,6 +170,7 @@ class DocumentService:
             user_id=user_id,
             model_name=embedding_model_name,
             model_namespace=embedding_model_namespace,
+            user_name=user_name,
         )
         add_span_event(
             "rag.document_service.embedding_model.created",
@@ -257,6 +260,7 @@ class DocumentService:
         splitter_config: Optional[SplitterConfig] = None,
         document_id: Optional[int] = None,
         trace_context: Optional[dict] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Index a document into storage backend.
@@ -274,6 +278,7 @@ class DocumentService:
             trace_context: Optional trace context for distributed tracing (captured via capture_trace_context()).
                           If provided, this context will be propagated to the background thread.
                           If None, the current trace context will be captured automatically.
+            user_name: User name for placeholder replacement in embedding headers (optional)
 
         Returns:
             Indexing result dict with:
@@ -309,6 +314,7 @@ class DocumentService:
             splitter_config,
             document_id,
             trace_context=trace_ctx,
+            user_name=user_name,
         )
 
     async def delete_document(

--- a/backend/app/services/rag/retrieval_service.py
+++ b/backend/app/services/rag/retrieval_service.py
@@ -49,6 +49,7 @@ class RetrievalService:
         db: Session,
         retrieval_setting: Dict[str, Any],
         metadata_condition: Optional[Dict[str, Any]] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Synchronous retrieval implementation.
@@ -63,6 +64,7 @@ class RetrievalService:
             db: Database session
             retrieval_setting: Retrieval settings (Dify-style)
             metadata_condition: Optional metadata filtering
+            user_name: User name for placeholder replacement in embedding headers (optional)
 
         Returns:
             Retrieval result dict
@@ -73,6 +75,7 @@ class RetrievalService:
             user_id=user_id,
             model_name=embedding_model_name,
             model_namespace=embedding_model_namespace,
+            user_name=user_name,
         )
 
         # Create retriever with storage backend
@@ -105,6 +108,7 @@ class RetrievalService:
         vector_weight: Optional[float] = None,
         keyword_weight: Optional[float] = None,
         metadata_condition: Optional[Dict[str, Any]] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Retrieve relevant document chunks (Dify-compatible API).
@@ -122,6 +126,7 @@ class RetrievalService:
             vector_weight: Weight for vector search (hybrid mode only)
             keyword_weight: Weight for BM25 search (hybrid mode only)
             metadata_condition: Optional metadata filtering conditions
+            user_name: User name for placeholder replacement in embedding headers (optional)
 
         Returns:
             Dict with Dify-compatible format:
@@ -163,6 +168,7 @@ class RetrievalService:
             db,
             retrieval_setting,
             metadata_condition,
+            user_name,
         )
 
     async def retrieve_from_knowledge_base(
@@ -230,6 +236,7 @@ class RetrievalService:
         knowledge_base_id: int,
         db: Session,
         metadata_condition: Optional[Dict[str, Any]] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Internal method to retrieve from knowledge base without user permission check.
@@ -246,6 +253,7 @@ class RetrievalService:
             knowledge_base_id: Knowledge base ID
             db: Database session
             metadata_condition: Optional metadata filtering conditions
+            user_name: User name for placeholder replacement in embedding headers
 
         Returns:
             Dict with retrieval results in Dify-compatible format
@@ -274,6 +282,7 @@ class RetrievalService:
             kb=kb,
             db=db,
             metadata_condition=metadata_condition,
+            user_name=user_name,
         )
 
     async def _retrieve_from_kb_internal(
@@ -282,6 +291,7 @@ class RetrievalService:
         kb,  # Kind instance
         db: Session,
         metadata_condition: Optional[Dict[str, Any]] = None,
+        user_name: Optional[str] = None,
     ) -> Dict:
         """
         Internal helper method to perform retrieval from a knowledge base.
@@ -291,6 +301,7 @@ class RetrievalService:
             kb: Knowledge base Kind instance
             db: Database session
             metadata_condition: Optional metadata filtering conditions
+            user_name: User name for placeholder replacement in embedding headers (optional)
 
         Returns:
             Dict with retrieval results
@@ -400,6 +411,7 @@ class RetrievalService:
             user_id=embedding_owner_user_id,
             model_name=embedding_model_name,
             model_namespace=embedding_model_namespace,
+            user_name=user_name,
         )
 
         # Create retriever with storage backend

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -322,6 +322,7 @@ class ChatContext:
             model_id=model_id,
             context_window=context_window,
             skip_prompt_enhancement=skip_prompt_enhancement,
+            user_name=self._request.user_name,
         )
         add_span_event("kb_tools_prepared", {"tools_count": len(result[0])})
         return result

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -981,7 +981,7 @@ class KnowledgeBaseTool(BaseTool):
                     }
                     if self.document_ids:
                         payload["document_ids"] = self.document_ids
-                    if self.user_name:
+                    if self.user_name is not None:
                         payload["user_name"] = self.user_name
 
                     response = await client.post(

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -74,6 +74,9 @@ class KnowledgeBaseTool(BaseTool):
     # User ID for access control
     user_id: int = 0
 
+    # User name for embedding API custom headers (placeholder replacement)
+    user_name: Optional[str] = None
+
     # Database session (will be set when tool is created)
     # Accepts both sync Session (backend) and AsyncSession (chat_shell HTTP mode)
     # In HTTP mode, db_session is not used - retrieval goes through HTTP API
@@ -906,6 +909,7 @@ class KnowledgeBaseTool(BaseTool):
                             knowledge_base_id=kb_id,
                             db=self.db_session,
                             metadata_condition=metadata_condition,
+                            user_name=self.user_name,
                         )
                     )
 
@@ -977,6 +981,8 @@ class KnowledgeBaseTool(BaseTool):
                     }
                     if self.document_ids:
                         payload["document_ids"] = self.document_ids
+                    if self.user_name:
+                        payload["user_name"] = self.user_name
 
                     response = await client.post(
                         f"{backend_url}/api/internal/rag/retrieve",

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -29,6 +29,7 @@ async def prepare_knowledge_base_tools(
     model_id: Optional[str] = None,
     context_window: Optional[int] = None,
     skip_prompt_enhancement: bool = False,
+    user_name: Optional[str] = None,
 ) -> tuple[list, str]:
     """
     Prepare knowledge base tools and enhanced system prompt.
@@ -54,6 +55,7 @@ async def prepare_knowledge_base_tools(
             Used by KnowledgeBaseTool for injection strategy decisions.
         skip_prompt_enhancement: If True, skip adding KB prompt instructions to system prompt.
             Used in HTTP mode when Backend has already added KB prompts to avoid duplication.
+        user_name: Optional user name for embedding API custom headers (placeholder replacement).
 
     Returns:
         Tuple of (extra_tools list, enhanced_system_prompt string)
@@ -98,6 +100,7 @@ async def prepare_knowledge_base_tools(
         knowledge_base_ids=knowledge_base_ids,
         document_ids=document_ids or [],
         user_id=user_id,
+        user_name=user_name,
         db_session=db,
         user_subtask_id=user_subtask_id,
         model_id=model_id or KnowledgeBaseTool.model_id,


### PR DESCRIPTION
## Summary

Add support for `${user.name}` placeholder replacement in embedding model custom headers configuration. This allows dynamic header values based on the current user's name when making embedding API calls.

### Changes

- **backend/app/services/rag/embedding/factory.py**:
  - Add `_process_custom_headers_placeholders()` function to handle placeholder replacement
  - Add `user_name` parameter to `create_embedding_model_from_crd()`
  - Process custom headers placeholders before creating `CustomEmbedding` instance

- **backend/app/services/rag/document_service.py**:
  - Add `user_name` parameter to `_index_document_sync()` and `index_document()`
  - Pass `user_name` through the embedding model creation chain

- **backend/app/services/rag/retrieval_service.py**:
  - Add `user_name` parameter to `_retrieve_sync()`, `retrieve()`, and `_retrieve_from_kb_internal()`
  - For internal KB retrieval, automatically resolve KB owner's `user_name` from the database

### Usage Example

Configure custom headers in the Model CRD with placeholders:
```json
{
  "custom_headers": {
    "wecode_user": "${user.name}",
    "X-Custom-Header": "static-value"
  }
}
```

At runtime, `${user.name}` will be replaced with the actual user's name when making embedding API calls.

## Test plan

- [ ] Run backend unit tests: `cd backend && uv run pytest tests/services/ -v`
- [ ] Verify placeholder replacement works with custom headers containing `${user.name}`
- [ ] Verify headers without placeholders remain unchanged
- [ ] Verify backward compatibility when `user_name` is not provided (defaults to empty string)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-name support across document indexing, retrieval APIs, background tasks, and KB tools to enable per-user embedding behavior.
  * Custom embedding headers support placeholders that can be replaced with the user name (falls back to KB owner when absent).
  * User-name context is propagated end-to-end through indexing, retrieval, KB preparation, and HTTP retrieval paths as an optional field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->