### PR TITLE
fix(backend): fix share link expires_at NOT NULL constraint violation

### DIFF
--- a/backend/alembic/versions/y5z6a7b8c9d0_add_unified_share_tables.py
+++ b/backend/alembic/versions/y5z6a7b8c9d0_add_unified_share_tables.py
@@ -300,7 +300,7 @@ def migrate_data_from_old_tables() -> None:
                 """
                 INSERT INTO share_links (
                     resource_type, resource_id, share_token,
-                    require_approval, default_permission_level,
+                    require_approval, default_permission_level, expires_at,
                     created_by_user_id, is_active, created_at, updated_at
                 )
                 SELECT DISTINCT
@@ -309,6 +309,7 @@ def migrate_data_from_old_tables() -> None:
                     CONCAT('team_', team_id, '_', MD5(CONCAT(team_id, NOW()))) as share_token,
                     0 as require_approval,
                     'view' as default_permission_level,
+                    DATE_ADD(NOW(), INTERVAL 100 YEAR) as expires_at,
                     original_user_id as created_by_user_id,
                     is_active,
                     created_at,
@@ -363,7 +364,7 @@ def migrate_data_from_old_tables() -> None:
                 """
                 INSERT INTO share_links (
                     resource_type, resource_id, share_token,
-                    require_approval, default_permission_level,
+                    require_approval, default_permission_level, expires_at,
                     created_by_user_id, is_active, created_at, updated_at
                 )
                 SELECT DISTINCT
@@ -372,6 +373,7 @@ def migrate_data_from_old_tables() -> None:
                     CONCAT('task_', original_task_id, '_', MD5(CONCAT(original_task_id, NOW()))) as share_token,
                     0 as require_approval,
                     'view' as default_permission_level,
+                    DATE_ADD(NOW(), INTERVAL 100 YEAR) as expires_at,
                     original_user_id as created_by_user_id,
                     is_active,
                     created_at,
@@ -428,7 +430,7 @@ def migrate_data_from_old_tables() -> None:
                 """
                 INSERT INTO share_links (
                     resource_type, resource_id, share_token,
-                    require_approval, default_permission_level,
+                    require_approval, default_permission_level, expires_at,
                     created_by_user_id, is_active, created_at, updated_at
                 )
                 SELECT DISTINCT
@@ -437,6 +439,7 @@ def migrate_data_from_old_tables() -> None:
                     CONCAT('task_', tm.task_id, '_', MD5(CONCAT(tm.task_id, NOW()))) as share_token,
                     0 as require_approval,
                     'view' as default_permission_level,
+                    DATE_ADD(NOW(), INTERVAL 100 YEAR) as expires_at,
                     tm.invited_by as created_by_user_id,
                     CASE WHEN tm.status = 'ACTIVE' THEN 1 ELSE 0 END as is_active,
                     tm.created_at,

--- a/backend/app/services/share/base_service.py
+++ b/backend/app/services/share/base_service.py
@@ -292,7 +292,8 @@ class UnifiedShareService(ABC):
                     hours=config.expires_in_hours
                 )
             else:
-                existing_link.expires_at = None
+                # Set to far future instead of None to avoid NOT NULL constraint
+                existing_link.expires_at = datetime.utcnow() + timedelta(days=365 * 100)
             existing_link.updated_at = datetime.utcnow()
             db.commit()
             db.refresh(existing_link)
@@ -303,9 +304,11 @@ class UnifiedShareService(ABC):
         share_token = self._generate_share_token(user_id, resource_id)
 
         # Calculate expiration
-        expires_at = None
+        # Use far future instead of None to avoid NOT NULL constraint
         if config.expires_in_hours:
             expires_at = datetime.utcnow() + timedelta(hours=config.expires_in_hours)
+        else:
+            expires_at = datetime.utcnow() + timedelta(days=365 * 100)
 
         # Create new share link
         share_link = ShareLink(


### PR DESCRIPTION
- Set expires_at to 100 years in future instead of None when expires_in_hours is not specified
- This resolves IntegrityError: Column 'expires_at' cannot be null
- Database column expires_at is defined as NOT NULL DEFAULT CURRENT_TIMESTAMP
- Using far future date maintains 'never expires' semantics while satisfying constraint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved share link expiration timestamp handling to ensure proper database integrity.

* **Chores**
  * Updated share link migrations to include expiration timestamps for existing entries.
  * Added enhanced logging to share service for improved diagnostics and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->