### PR TITLE
fix(backend): use TASK_SHARE_BASE_URL for knowledge base share links

### DIFF
--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -142,8 +142,8 @@ class KnowledgeShareService(UnifiedShareService):
 
     def _get_share_url_base(self) -> str:
         """Get base URL for KnowledgeBase share links."""
-        # Use token-based URL pattern consistent with Task sharing
-        base_url = getattr(settings, "FRONTEND_BASE_URL", "http://localhost:3000")
+        # Use TASK_SHARE_BASE_URL consistent with Task sharing
+        base_url = getattr(settings, "TASK_SHARE_BASE_URL", "http://localhost:3000")
         return f"{base_url}/shared/knowledge"
 
     def _on_member_approved(


### PR DESCRIPTION
The knowledge share service was using undefined FRONTEND_BASE_URL config, which caused it to fall back to the default value 'http://localhost:3000'. Changed to use TASK_SHARE_BASE_URL to be consistent with task share service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated base URL configuration for knowledge base share links to ensure correct sharing URLs are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->