### PR TITLE
refactor: read config via env_reader and add auth_token

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -852,7 +852,6 @@ class ClaudeCodeAgent(Agent):
             if mcp_servers:
                 # Replace placeholders in MCP servers config with actual values from task_data
                 mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
-                logger.info(f"Detected MCP servers configuration: {mcp_servers}")
                 bot_config["mcp_servers"] = mcp_servers
 
             # Add wegent MCP server for subscription tasks (provides silent_exit tool via HTTP)

--- a/executor/config/env_reader.py
+++ b/executor/config/env_reader.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Environment variable reader with file-based fallback.
+
+This module provides a unified way to read configuration values that supports:
+1. Environment variables (os.environ)
+2. File-based configuration as fallback
+
+The reading priority is:
+1. Environment variable (os.environ)
+2. File at /root/.wegent/.config/{key}
+3. Default value
+"""
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+from shared.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# Default config directory for file-based config
+DEFAULT_CONFIG_DIR = "/root/.wegent/.config"
+
+
+def get_config_dir() -> str:
+    """Get the configuration directory path."""
+    return os.getenv("WEGENT_CONFIG_DIR", DEFAULT_CONFIG_DIR)
+
+
+def get_env(key: str, default: Optional[str] = None) -> Optional[str]:
+    """
+    Get configuration value with file-based fallback.
+
+    Priority:
+    1. Environment variable (os.environ)
+    2. File at {config_dir}/{key.lower()}
+    3. Default value
+
+    Args:
+        key: Configuration key (e.g., "TASK_INFO", "AUTH_TOKEN")
+        default: Default value if not found
+
+    Returns:
+        Configuration value or default
+    """
+    # 1. Try environment variable first
+    value = os.environ.get(key)
+    if value is not None:
+        return value
+
+    # 2. Try file-based config
+    config_dir = get_config_dir()
+    file_path = os.path.join(config_dir, key.lower())
+
+    if os.path.exists(file_path):
+        try:
+            with open(file_path, "r") as f:
+                content = f.read().strip()
+                if content:
+                    logger.debug(f"Read config '{key}' from file: {file_path}")
+                    return content
+        except Exception as e:
+            logger.warning(f"Failed to read config file {file_path}: {e}")
+
+    # 3. Return default
+    return default
+
+
+def get_env_json(
+    key: str, default: Optional[Dict[str, Any]] = None
+) -> Optional[Dict[str, Any]]:
+    """
+    Get JSON configuration value with file-based fallback.
+
+    Args:
+        key: Configuration key
+        default: Default value if not found or invalid JSON
+
+    Returns:
+        Parsed JSON dict or default
+    """
+    value = get_env(key)
+    if value is None:
+        return default
+
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Invalid JSON for config '{key}': {e}")
+        return default
+
+
+def get_task_info() -> Optional[Dict[str, Any]]:
+    """
+    Get task information from environment or file.
+
+    Returns:
+        Task info dict or None
+    """
+    return get_env_json("TASK_INFO")
+
+
+def get_auth_token() -> Optional[str]:
+    """Get authentication token."""
+    return get_env("AUTH_TOKEN")
+
+
+def get_task_id() -> Optional[str]:
+    """Get task ID."""
+    return get_env("TASK_ID")
+
+
+def get_executor_name() -> Optional[str]:
+    """Get executor name."""
+    return get_env("EXECUTOR_NAME")
+
+
+def get_callback_url() -> Optional[str]:
+    """Get callback URL."""
+    return get_env("CALLBACK_URL")
+
+
+def get_heartbeat_base_url() -> str:
+    """
+    Get executor manager heartbeat base URL.
+
+    Returns:
+        Heartbeat base URL or empty string if not configured
+    """
+    return get_env("EXECUTOR_MANAGER_HEARTBEAT_BASE_URL", "")
+
+
+def get_task_api_domain() -> str:
+    """
+    Get task API domain.
+
+    Returns:
+        Task API domain or empty string if not configured
+    """
+    return get_env("TASK_API_DOMAIN", "")

--- a/executor/services/api_client.py
+++ b/executor/services/api_client.py
@@ -37,6 +37,7 @@ from typing import List, Optional
 import requests
 
 from executor.config import config
+from executor.config.env_reader import get_task_api_domain
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,11 @@ def get_api_base_url() -> str:
     """
     if config.EXECUTOR_MODE == "local":
         return config.WEGENT_BACKEND_URL.rstrip("/")
-    return os.getenv("TASK_API_DOMAIN", "http://wegent-backend:8000").rstrip("/")
+
+    task_api_domain = get_task_api_domain()
+    if task_api_domain:
+        return task_api_domain.rstrip("/")
+    return "http://wegent-backend:8000"
 
 
 class ApiClient:

--- a/executor/tasks/task_processor.py
+++ b/executor/tasks/task_processor.py
@@ -6,7 +6,6 @@
 
 # -*- coding: utf-8 -*-
 
-import json
 import os
 from typing import Any, Dict, Optional, Tuple
 
@@ -28,19 +27,21 @@ logger = setup_logger("task_processor")
 
 def read_task_data() -> Dict[str, Any]:
     """
-    Read task data from environment variable
+    Read task data from environment variable or file.
 
     Returns:
         dict: Task data
 
     Raises:
-        SystemExit: If TASK_INFO environment variable is not set
+        SystemExit: If TASK_INFO is not found
     """
-    task_data = os.getenv("TASK_INFO")
+    from executor.config.env_reader import get_task_info
+
+    task_data = get_task_info()
     if task_data is None:
-        logger.error("TASK_INFO environment variable is not set")
+        logger.error("TASK_INFO not found")
         os._exit(1)
-    return json.loads(task_data)
+    return task_data
 
 
 def execute_task(agent: Agent) -> Tuple[TaskStatus, Optional[str]]:

--- a/executor/tests/config/__init__.py
+++ b/executor/tests/config/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/executor/tests/config/test_env_reader.py
+++ b/executor/tests/config/test_env_reader.py
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for env_reader module.
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+import pytest
+
+from executor.config.env_reader import (
+    get_env,
+    get_env_json,
+    get_task_info,
+)
+
+
+class TestGetEnv:
+    """Tests for get_env function."""
+
+    def test_returns_env_var_when_set(self):
+        """Should return environment variable value when set."""
+        with patch.dict(os.environ, {"TEST_KEY": "env_value"}):
+            result = get_env("TEST_KEY")
+            assert result == "env_value"
+
+    def test_returns_file_content_when_env_not_set(self):
+        """Should return file content when env var not set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create config file
+            file_path = os.path.join(tmpdir, "test_key")
+            with open(file_path, "w") as f:
+                f.write("file_value")
+
+            # Clear env var and set config dir
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}, clear=False):
+                # Remove the env var if it exists
+                env_copy = os.environ.copy()
+                env_copy.pop("TEST_KEY", None)
+                with patch.dict(os.environ, env_copy, clear=True):
+                    with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}):
+                        result = get_env("TEST_KEY")
+                        assert result == "file_value"
+
+    def test_returns_default_when_neither_exists(self):
+        """Should return default when neither env var nor file exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}, clear=True):
+                result = get_env("NONEXISTENT_KEY", "default_value")
+                assert result == "default_value"
+
+    def test_env_var_takes_precedence_over_file(self):
+        """Environment variable should take precedence over file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create config file
+            file_path = os.path.join(tmpdir, "test_key")
+            with open(file_path, "w") as f:
+                f.write("file_value")
+
+            with patch.dict(
+                os.environ, {"TEST_KEY": "env_value", "WEGENT_CONFIG_DIR": tmpdir}
+            ):
+                result = get_env("TEST_KEY")
+                assert result == "env_value"
+
+    def test_strips_whitespace_from_file_content(self):
+        """Should strip whitespace from file content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = os.path.join(tmpdir, "test_key")
+            with open(file_path, "w") as f:
+                f.write("  value_with_spaces  \n")
+
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}, clear=True):
+                result = get_env("TEST_KEY")
+                assert result == "value_with_spaces"
+
+
+class TestGetEnvJson:
+    """Tests for get_env_json function."""
+
+    def test_parses_valid_json_from_env(self):
+        """Should parse valid JSON from environment variable."""
+        json_data = {"key": "value", "number": 123}
+        with patch.dict(os.environ, {"JSON_KEY": json.dumps(json_data)}):
+            result = get_env_json("JSON_KEY")
+            assert result == json_data
+
+    def test_returns_default_for_invalid_json(self):
+        """Should return default for invalid JSON."""
+        with patch.dict(os.environ, {"INVALID_JSON": "not valid json"}):
+            result = get_env_json("INVALID_JSON", {"default": True})
+            assert result == {"default": True}
+
+    def test_returns_default_when_not_found(self):
+        """Should return default when key not found."""
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": "/nonexistent"}):
+                result = get_env_json("MISSING_KEY", {"default": True})
+                assert result == {"default": True}
+
+
+class TestGetTaskInfo:
+    """Tests for get_task_info function."""
+
+    def test_returns_task_info_from_env(self):
+        """Should return task info from TASK_INFO env var."""
+        task_data = {"task_id": 123, "subtask_id": 456}
+        with patch.dict(os.environ, {"TASK_INFO": json.dumps(task_data)}):
+            result = get_task_info()
+            assert result == task_data
+
+    def test_returns_task_info_from_file(self):
+        """Should return task info from file when env var not set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            task_data = {"task_id": 789, "subtask_id": 101}
+            file_path = os.path.join(tmpdir, "task_info")
+            with open(file_path, "w") as f:
+                f.write(json.dumps(task_data))
+
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}, clear=True):
+                result = get_task_info()
+                assert result == task_data
+
+    def test_returns_none_when_not_found(self):
+        """Should return None when task info not found."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(os.environ, {"WEGENT_CONFIG_DIR": tmpdir}, clear=True):
+                result = get_task_info()
+                assert result is None

--- a/executor_manager/services/sandbox/execution_runner.py
+++ b/executor_manager/services/sandbox/execution_runner.py
@@ -97,6 +97,13 @@ class ExecutionRunner(metaclass=SingletonMeta):
             "timeout": timeout,
         }
 
+        # Add auth_token for skill downloads in sandbox (from sandbox or execution metadata)
+        auth_token = sandbox.metadata.get("auth_token") or execution.metadata.get(
+            "auth_token"
+        )
+        if auth_token:
+            task_data["auth_token"] = auth_token
+
         return task_data
 
     async def send_execution_request(

--- a/executor_manager/services/sandbox/manager.py
+++ b/executor_manager/services/sandbox/manager.py
@@ -184,6 +184,15 @@ class SandboxManager(metaclass=SingletonMeta):
         # Build task data for executor
         task_data = self._build_sandbox_task(sandbox)
 
+        # Log task data for debugging auth_token transmission
+        logger.info(
+            f"[SandboxManager] Creating sandbox container with task_data: "
+            f"task_id={task_data.get('task_id')}, "
+            f"type={task_data.get('type')}, "
+            f"auth_token={'present' if task_data.get('auth_token') else 'missing'}, "
+            f"metadata_keys={list(sandbox.metadata.keys())}"
+        )
+
         # Get executor and create container
         executor = ExecutorDispatcher.get_executor(EXECUTOR_DISPATCHER_MODE)
 
@@ -433,7 +442,7 @@ class SandboxManager(metaclass=SingletonMeta):
             if result.get("status") == "not_found":
                 logger.info(
                     f"[SandboxManager] Pod not found by name '{sandbox.container_name}', "
-                    f"trying to delete by task_id label: {sandbox_id}"
+                    f"trying to delete by task_id: {sandbox_id}"
                 )
                 result = executor.delete_executor_by_task_id(sandbox_id)
 
@@ -929,7 +938,8 @@ class SandboxManager(metaclass=SingletonMeta):
             try:
                 executor = ExecutorDispatcher.get_executor(EXECUTOR_DISPATCHER_MODE)
                 result = executor.delete_executor(sandbox.container_name)
-                if result.get("status") != "success":
+
+                if result.get("status") not in ("success", "not_found"):
                     logger.warning(
                         f"[SandboxManager] Failed to delete container: {result.get('error_msg')}"
                     )

--- a/executor_manager/services/sandbox/repository.py
+++ b/executor_manager/services/sandbox/repository.py
@@ -19,6 +19,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 import redis
+import redis.asyncio as aioredis
 
 from executor_manager.common.config import get_config
 from executor_manager.common.redis_factory import RedisClientFactory
@@ -37,6 +38,7 @@ logger = setup_logger(__name__)
 SESSION_HASH_PREFIX = "wegent-sandbox-session:"
 SANDBOX_FIELD_NAME = "__sandbox__"
 ACTIVE_SANDBOXES_ZSET = "wegent-sandbox:active"
+E2B_SANDBOX_ID_INDEX_PREFIX = "wegent-sandbox-e2b-index:"
 
 
 class SandboxRepository(metaclass=SingletonMeta):
@@ -50,6 +52,7 @@ class SandboxRepository(metaclass=SingletonMeta):
         """Initialize the repository."""
         self._config = get_config()
         self._redis_client: Optional[redis.Redis] = None
+        self._async_redis_client: Optional[aioredis.Redis] = None
 
     @property
     def redis_client(self) -> Optional[redis.Redis]:
@@ -57,6 +60,12 @@ class SandboxRepository(metaclass=SingletonMeta):
         if self._redis_client is None:
             self._redis_client = RedisClientFactory.get_sync_client()
         return self._redis_client
+
+    async def _get_async_client(self) -> Optional[aioredis.Redis]:
+        """Lazy-load async Redis client."""
+        if self._async_redis_client is None:
+            self._async_redis_client = await RedisClientFactory.get_async_client()
+        return self._async_redis_client
 
     # =========================================================================
     # Sandbox Operations
@@ -105,6 +114,11 @@ class SandboxRepository(metaclass=SingletonMeta):
 
             # Update active sandboxes ZSet with current timestamp
             self.redis_client.zadd(ACTIVE_SANDBOXES_ZSET, {str(task_id): time.time()})
+
+            # Save e2b_sandbox_id index for O(1) lookup
+            e2b_sandbox_id = sandbox.metadata.get("e2b_sandbox_id")
+            if e2b_sandbox_id:
+                self._save_e2b_index(e2b_sandbox_id, str(task_id))
 
             return True
         except Exception as e:
@@ -185,6 +199,13 @@ class SandboxRepository(metaclass=SingletonMeta):
 
         try:
             task_id = int(sandbox_id)
+
+            # Load sandbox first to get e2b_sandbox_id for index cleanup
+            sandbox = self.load_sandbox(sandbox_id)
+            if sandbox:
+                e2b_sandbox_id = sandbox.metadata.get("e2b_sandbox_id")
+                if e2b_sandbox_id:
+                    self._delete_e2b_index(e2b_sandbox_id)
 
             # Remove from active sandboxes ZSet
             self.redis_client.zrem(ACTIVE_SANDBOXES_ZSET, str(task_id))
@@ -442,7 +463,11 @@ class SandboxRepository(metaclass=SingletonMeta):
     # =========================================================================
 
     def save_executor_binding(
-        self, task_id: int, executor_name: str, ttl: Optional[int] = None
+        self,
+        task_id: int,
+        executor_name: str,
+        ttl: Optional[int] = None,
+        **extra_fields,
     ) -> bool:
         """Save executor binding for task continuity.
 
@@ -450,6 +475,7 @@ class SandboxRepository(metaclass=SingletonMeta):
             task_id: Task ID
             executor_name: Executor container name
             ttl: TTL in seconds (defaults to config value)
+            **extra_fields: Additional fields to store
 
         Returns:
             True if successful, False otherwise
@@ -463,6 +489,7 @@ class SandboxRepository(metaclass=SingletonMeta):
                 "executor_name": executor_name,
                 "task_id": task_id,
                 "created_at": time.time(),
+                **extra_fields,  # Merge any additional fields
             }
 
             if ttl is None:
@@ -471,7 +498,8 @@ class SandboxRepository(metaclass=SingletonMeta):
             self.redis_client.setex(binding_key, ttl, json.dumps(binding_value))
             logger.info(
                 f"[SandboxRepository] Stored executor binding: "
-                f"task_id={task_id} -> executor={executor_name}, ttl={ttl}s"
+                f"task_id={task_id} -> executor={executor_name}, "
+                f"extra={list(extra_fields.keys())}, ttl={ttl}s"
             )
             return True
         except Exception as e:
@@ -487,6 +515,18 @@ class SandboxRepository(metaclass=SingletonMeta):
         Returns:
             Executor name if found, None otherwise
         """
+        binding = self.load_executor_binding_full(task_id)
+        return binding.get("executor_name") if binding else None
+
+    def load_executor_binding_full(self, task_id: int) -> Optional[Dict[str, Any]]:
+        """Load full executor binding info for task continuity.
+
+        Args:
+            task_id: Task ID
+
+        Returns:
+            Binding dict with executor_name, sandbox_claim_name, etc. if found
+        """
         if self.redis_client is None:
             return None
 
@@ -495,11 +535,86 @@ class SandboxRepository(metaclass=SingletonMeta):
             binding_json = self.redis_client.get(binding_key)
 
             if binding_json:
-                binding = json.loads(binding_json)
-                return binding.get("executor_name")
+                return json.loads(binding_json)
             return None
         except Exception as e:
             logger.warning(f"[SandboxRepository] Failed to load executor binding: {e}")
+            return None
+
+    # =========================================================================
+    # E2B Sandbox ID Index Operations
+    # =========================================================================
+
+    def _save_e2b_index(self, e2b_sandbox_id: str, sandbox_id: str) -> bool:
+        """Save e2b_sandbox_id -> sandbox_id index for O(1) lookup.
+
+        Args:
+            e2b_sandbox_id: E2B format sandbox UUID
+            sandbox_id: Internal sandbox ID (task_id as string)
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if self.redis_client is None:
+            return False
+
+        try:
+            index_key = f"{E2B_SANDBOX_ID_INDEX_PREFIX}{e2b_sandbox_id}"
+            self.redis_client.setex(
+                index_key, self._config.timeout.redis_ttl, sandbox_id
+            )
+            logger.debug(
+                f"[SandboxRepository] Saved e2b index: {e2b_sandbox_id} -> {sandbox_id}"
+            )
+            return True
+        except Exception as e:
+            logger.error(f"[SandboxRepository] Failed to save e2b index: {e}")
+            return False
+
+    def _delete_e2b_index(self, e2b_sandbox_id: str) -> bool:
+        """Delete e2b_sandbox_id index.
+
+        Args:
+            e2b_sandbox_id: E2B format sandbox UUID
+
+        Returns:
+            True if successful, False otherwise
+        """
+        if self.redis_client is None:
+            return False
+
+        try:
+            index_key = f"{E2B_SANDBOX_ID_INDEX_PREFIX}{e2b_sandbox_id}"
+            self.redis_client.delete(index_key)
+            logger.debug(f"[SandboxRepository] Deleted e2b index: {e2b_sandbox_id}")
+            return True
+        except Exception as e:
+            logger.error(f"[SandboxRepository] Failed to delete e2b index: {e}")
+            return False
+
+    def lookup_sandbox_id_by_e2b_id(self, e2b_sandbox_id: str) -> Optional[str]:
+        """Lookup sandbox_id by e2b_sandbox_id using index (O(1) lookup).
+
+        Args:
+            e2b_sandbox_id: E2B format sandbox UUID
+
+        Returns:
+            sandbox_id if found, None otherwise
+        """
+        if self.redis_client is None:
+            return None
+
+        try:
+            index_key = f"{E2B_SANDBOX_ID_INDEX_PREFIX}{e2b_sandbox_id}"
+            sandbox_id = self.redis_client.get(index_key)
+            if sandbox_id:
+                logger.debug(
+                    f"[SandboxRepository] E2B index lookup hit: {e2b_sandbox_id} -> {sandbox_id}"
+                )
+                return sandbox_id
+            return None
+        except Exception as e:
+            logger.error(f"[SandboxRepository] Failed to lookup e2b index: {e}")
             return None
 
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional preload mode to pre-download sandbox skills and attachments on first request for faster warm starts
  * File-based configuration fallback for environment values

* **Improvements**
  * E2B sandbox ID tracking and O(1) lookup for improved sandbox management
  * Auth token propagation into sandbox task payloads
  * Heartbeat service now supports dynamic enable/disable and runtime config refresh

* **Bug Fixes**
  * Sandbox initialization failures are logged and no longer block requests

* **Tests**
  * Added comprehensive tests for configuration reader behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->