### PR TITLE
chore(deps): update relay-server package and connection flow

### DIFF
--- a/deps/browser/relay-server/package-lock.json
+++ b/deps/browser/relay-server/package-lock.json
@@ -1,0 +1,90 @@
+{
+  "name": "@wb/wegent-cdp-relay-server",
+  "version": "0.1.5",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@wb/wegent-cdp-relay-server",
+      "version": "0.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "browser-tool": "dist/tool-cli.js",
+        "cdp-relay-server": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.10",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.8",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-22.19.8.tgz",
+      "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wb/wegent-cdp-relay-server",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Chrome DevTools Protocol relay server and browser automation tool",
   "type": "module",
   "main": "dist/index.js",

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wb/wegent-cdp-relay-server",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Chrome DevTools Protocol relay server and browser automation tool",
   "type": "module",
   "main": "dist/index.js",

--- a/deps/browser/relay-server/src/relay-server.ts
+++ b/deps/browser/relay-server/src/relay-server.ts
@@ -245,7 +245,7 @@ export async function ensureRelayServer(opts: RelayServerOptions): Promise<CdpRe
       const timer = setTimeout(() => {
         pendingExtension.delete(payload.id);
         reject(new Error(`extension request timeout: ${payload.params.method}`));
-      }, 30_000);
+      }, 10_000);
       pendingExtension.set(payload.id, { resolve, reject, timer });
     });
   };
@@ -519,7 +519,11 @@ export async function ensureRelayServer(opts: RelayServerOptions): Promise<CdpRe
         return;
       }
       if (!extensionWs) {
-        rejectUpgrade(socket, 503, "Extension not connected");
+        rejectUpgrade(
+          socket,
+          409,
+          "EXTENSION_NOT_CONNECTED: Chrome extension is not connected to any tab"
+        );
         return;
       }
       wssCdp.handleUpgrade(req, socket, head, (ws) => {

--- a/deps/browser/relay-server/src/snapshot.ts
+++ b/deps/browser/relay-server/src/snapshot.ts
@@ -4,7 +4,7 @@
  * Generate AI-readable page structure for element interaction
  */
 
-import { createBrowserClient } from "./browser-client.js";
+import { createBrowserClient, type BrowserClient } from "./browser-client.js";
 
 export type RoleRef = {
   role: string;
@@ -246,8 +246,10 @@ export async function getSnapshot(opts?: {
   compact?: boolean;
   maxDepth?: number;
   limit?: number;
+  client?: BrowserClient;
 }): Promise<SnapshotResult> {
-  const client = await createBrowserClient();
+  const client = opts?.client ?? (await createBrowserClient());
+  const ownsClient = !opts?.client;
   try {
     const limit = Math.max(1, Math.min(2000, opts?.limit ?? 500));
 
@@ -262,7 +264,9 @@ export async function getSnapshot(opts?: {
       maxDepth: opts?.maxDepth,
     });
   } finally {
-    client.close();
+    if (ownsClient) {
+      client.close();
+    }
   }
 }
 
@@ -272,8 +276,10 @@ export async function getSnapshot(opts?: {
 export async function getDomSnapshot(opts?: {
   limit?: number;
   maxTextChars?: number;
+  client?: BrowserClient;
 }): Promise<{ nodes: DomNode[] }> {
-  const client = await createBrowserClient();
+  const client = opts?.client ?? (await createBrowserClient());
+  const ownsClient = !opts?.client;
   try {
     const limit = Math.max(1, Math.min(5000, opts?.limit ?? 800));
     const maxText = Math.max(0, Math.min(5000, opts?.maxTextChars ?? 220));
@@ -330,7 +336,9 @@ export async function getDomSnapshot(opts?: {
 
     return { nodes: result?.result?.value?.nodes ?? [] };
   } finally {
-    client.close();
+    if (ownsClient) {
+      client.close();
+    }
   }
 }
 

--- a/deps/browser/relay-server/src/tool.ts
+++ b/deps/browser/relay-server/src/tool.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  createBrowserClient,
+  type BrowserClient,
   getStatus,
   listTabs,
   openTab,
@@ -282,6 +284,10 @@ Workflow:
         type: "boolean",
         description: "For screenshot: capture full page",
       },
+      ensure: {
+        type: "boolean",
+        description: "For status: ensure browser profile is launched and try to attach extension",
+      },
       request: {
         type: "object",
         description: "For act: action request object",
@@ -333,6 +339,7 @@ export type BrowserToolParams = {
   interactive?: boolean;
   compact?: boolean;
   fullPage?: boolean;
+  ensure?: boolean;
   request?: ActRequest;
   expression?: string;
 };
@@ -343,74 +350,82 @@ export type BrowserToolResult = {
   data?: unknown;
 };
 
+function isConnectionErrorMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("no auth token found") ||
+    lower.includes("relay server not running") ||
+    lower.includes("browser extension not connected") ||
+    lower.includes("connection not open") ||
+    lower.includes("econnrefused") ||
+    lower.includes("fetch failed") ||
+    lower.includes("socket hang up") ||
+    lower.includes("websocket") ||
+    lower.includes("unexpected server response: 503") ||
+    lower.includes("unexpected server response: 409")
+  );
+}
+
+async function tryEnsureConnected(params: BrowserToolParams): Promise<{
+  connected: boolean;
+  error?: string;
+}> {
+  const status = await getStatus();
+
+  if (!status.relayRunning) {
+    return {
+      connected: false,
+      error: "Relay server not running. Start it with: cdp-relay-server",
+    };
+  }
+
+  if (status.extensionConnected) {
+    return { connected: true };
+  }
+
+  const chromeRunning = isChromeRunningWithProfile();
+  const targetUrl = (params.action === "open" || params.action === "navigate") ? params.url : undefined;
+
+  if (!chromeRunning) {
+    // Chrome not running - launch with user's URL first
+    const launchResult = launchBrowserWithInstructions(targetUrl);
+    if (!launchResult.launched) {
+      return { connected: false, error: launchResult.message };
+    }
+  } else if (targetUrl) {
+    // Chrome is running but extension not connected - open the target page first
+    // Extension may auto-attach to the new tab
+    openUrlInChrome(targetUrl);
+  }
+
+  // Wait for extension to attach
+  const connected = await waitForConnection(8000);
+
+  if (connected) {
+    return { connected: true };
+  }
+
+  // Attach failed - extension probably not installed, now open extensions page
+  const extResult = openExtensionsPage();
+  return {
+    connected: false,
+    error: `Extension not connected. ${extResult.message}`,
+  };
+}
+
 /**
  * Execute browser tool
  */
 export async function executeBrowserTool(params: BrowserToolParams): Promise<BrowserToolResult> {
-  try {
-    // For status action, just return status without auto-launching
-    if (params.action === "status") {
-      const status = await getStatus();
-      return {
-        ok: true,
-        data: {
-          relayRunning: status.relayRunning,
-          extensionConnected: status.extensionConnected,
-          attachedTabs: status.targets.length,
-          targets: status.targets,
-        },
-      };
-    }
-
-    // For all other actions, check if extension is connected
-    const status = await getStatus();
-
-    if (!status.relayRunning) {
-      return {
-        ok: false,
-        error: "Relay server not running. Start it with: cdp-relay-server",
-      };
-    }
-
-    if (!status.extensionConnected) {
-      const chromeRunning = isChromeRunningWithProfile();
-
-      // Get target URL from params if available
-      const targetUrl = (params.action === "open" || params.action === "navigate") ? params.url : undefined;
-
-      if (!chromeRunning) {
-        // Chrome not running - launch with user's URL first
-        const launchResult = launchBrowserWithInstructions(targetUrl);
-        if (!launchResult.launched) {
-          return { ok: false, error: launchResult.message };
-        }
-      } else if (targetUrl) {
-        // Chrome is running but extension not connected - open the target page first
-        // Extension may auto-attach to the new tab
-        openUrlInChrome(targetUrl);
+  const runAction = async (): Promise<BrowserToolResult> => {
+    const runWithClient = async <T>(fn: (client: BrowserClient) => Promise<T>): Promise<T> => {
+      const client = await createBrowserClient({ skipStatusCheck: true });
+      try {
+        return await fn(client);
+      } finally {
+        client.close();
       }
-
-      // Wait for extension to attach
-      const connected = await waitForConnection(8000);
-
-      if (connected) {
-        // Connected! For open/navigate actions with URL, page is already open
-        if (targetUrl && (params.action === "open" || params.action === "navigate")) {
-          // Already opened the target URL during launch, return success
-          const tabs = await listTabs();
-          const tab = tabs.find(t => t.url.includes(new URL(targetUrl).hostname));
-          return { ok: true, data: { targetId: tab?.targetId, url: targetUrl, launchedWithUrl: true } };
-        }
-        // Connected and not open/navigate, continue to switch/case below
-      } else {
-        // Attach failed - extension probably not installed, now open extensions page
-        const extResult = openExtensionsPage();
-        return {
-          ok: false,
-          error: `Extension not connected. ${extResult.message}`,
-        };
-      }
-    }
+    };
 
     switch (params.action) {
 
@@ -433,10 +448,14 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         );
         if (tempTab) {
           // Reuse temp tab by navigating instead of opening new tab
-          await navigate(params.url, tempTab.targetId);
+          await runWithClient(async (client) => {
+            await navigate(params.url!, tempTab.targetId, { client });
+          });
           return { ok: true, data: { targetId: tempTab.targetId, reused: true } };
         }
-        const result = await openTab(params.url);
+        const result = await runWithClient(async (client) => {
+          return await openTab(params.url!, { client });
+        });
         return { ok: true, data: result };
       }
 
@@ -444,7 +463,9 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         if (!params.targetId) {
           return { ok: false, error: "targetId is required for close action" };
         }
-        const result = await closeTab(params.targetId);
+        const result = await runWithClient(async (client) => {
+          return await closeTab(params.targetId!, { client });
+        });
         return { ok: true, data: result };
       }
 
@@ -452,7 +473,9 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         if (!params.targetId) {
           return { ok: false, error: "targetId is required for focus action" };
         }
-        await focusTab(params.targetId);
+        await runWithClient(async (client) => {
+          await focusTab(params.targetId!, { client });
+        });
         return { ok: true, data: { focused: params.targetId } };
       }
 
@@ -460,14 +483,19 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         if (!params.url) {
           return { ok: false, error: "url is required for navigate action" };
         }
-        const result = await navigate(params.url);
+        const result = await runWithClient(async (client) => {
+          return await navigate(params.url!, undefined, { client });
+        });
         return { ok: true, data: result };
       }
 
       case "snapshot": {
-        const result = await getSnapshot({
-          interactive: params.interactive,
-          compact: params.compact,
+        const result = await runWithClient(async (client) => {
+          return await getSnapshot({
+            interactive: params.interactive,
+            compact: params.compact,
+            client,
+          });
         });
         // Store refs for subsequent actions
         storeRefs(result.refs);
@@ -481,7 +509,9 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
       }
 
       case "screenshot": {
-        const buffer = await screenshot({ fullPage: params.fullPage });
+        const buffer = await runWithClient(async (client) => {
+          return await screenshot({ fullPage: params.fullPage, client });
+        });
         // Save to temp file
         const tmpDir = path.join(os.tmpdir(), "browser-skill");
         if (!fs.existsSync(tmpDir)) {
@@ -502,7 +532,9 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         if (!params.request) {
           return { ok: false, error: "request is required for act action" };
         }
-        const result = await executeAction(params.request);
+        const result = await runWithClient(async (client) => {
+          return await executeAction(params.request!, { client });
+        });
         return { ok: result.ok, error: result.error, data: result.ok ? { acted: params.request.kind } : undefined };
       }
 
@@ -510,7 +542,9 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
         if (!params.expression) {
           return { ok: false, error: "expression is required for evaluate action" };
         }
-        const result = await evaluate(params.expression);
+        const result = await runWithClient(async (client) => {
+          return await evaluate(params.expression!, { client });
+        });
         return {
           ok: !result.error,
           error: result.error,
@@ -521,10 +555,83 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
       default:
         return { ok: false, error: `Unknown action: ${params.action}` };
     }
+  };
+
+  // For status action, just return status without auto-launching
+  if (params.action === "status") {
+    try {
+      let launched = false;
+      let launchMessage: string | undefined;
+      let waitedForAttach = false;
+
+      if (params.ensure) {
+        const ensureUrl = typeof params.url === "string" ? params.url : undefined;
+        const running = isChromeRunningWithProfile();
+        if (!running) {
+          const launchResult = launchBrowserWithInstructions(ensureUrl);
+          launched = launchResult.launched;
+          launchMessage = launchResult.message;
+        } else if (ensureUrl) {
+          openUrlInChrome(ensureUrl);
+        }
+        waitedForAttach = true;
+        await waitForConnection(5000);
+      }
+
+      const status = await getStatus();
+      return {
+        ok: true,
+        data: {
+          relayRunning: status.relayRunning,
+          extensionConnected: status.extensionConnected,
+          attachedTabs: status.targets.length,
+          targets: status.targets,
+          ...(params.ensure
+            ? {
+                ensure: {
+                  requested: true,
+                  launched,
+                  launchMessage,
+                  waitedForAttach,
+                },
+              }
+            : {}),
+        },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  try {
+    return await runAction();
   } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    };
+    const firstError = err instanceof Error ? err.message : String(err);
+    if (!isConnectionErrorMessage(firstError)) {
+      return {
+        ok: false,
+        error: firstError,
+      };
+    }
+
+    const ensure = await tryEnsureConnected(params);
+    if (!ensure.connected) {
+      return {
+        ok: false,
+        error: ensure.error ?? firstError,
+      };
+    }
+
+    try {
+      return await runAction();
+    } catch (retryErr) {
+      return {
+        ok: false,
+        error: retryErr instanceof Error ? retryErr.message : String(retryErr),
+      };
+    }
   }
 }

--- a/skills/browser/SKILL.md
+++ b/skills/browser/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: browser
+description: Fast, reliable browser automation via CDP relay. Use for real page interaction and extraction with minimal calls.
+---
+
+# Browser Control Skill
+
+## Hard Rules
+
+1. Start with the intended action directly (`navigate`/`open`/`act`/`evaluate`). Do not run `status` as a pre-check.
+2. Keep calls minimal: target `<= 8` per task (hard cap `12`, unless user explicitly asks for deep exploration).
+3. Prefer `evaluate` for extraction. Combine data into one comprehensive extraction when possible (avoid repeated partial extraction).
+4. `snapshot` is for refs/structure only. Budget: at most `1 initial + 1 final` per page.
+5. If `Ref not found`: do not retry stale ref. Take one fresh `snapshot`, retry once, then stop if still failing.
+6. `act.wait` is strict: do not use `timeMs` by default. Use condition waits (`text`/`selector`/state). Use fixed-time waits only when user explicitly asks or no condition is possible.
+7. `screenshot` is strict: default `0`. Use only if user explicitly requests it or visual evidence is strictly necessary after text/DOM extraction. Max `1` screenshot per task unless user asks for more.
+8. Keep tab context stable: once `targetId` is known, pass it in subsequent actions when supported.
+
+## Execution Order
+
+1. Direct action first (`navigate`/`open` or immediate `act`/`evaluate`).
+2. Use `snapshot` only if refs are needed for interaction.
+3. Execute interactions with minimal `act` calls (merge related input when possible).
+4. Use one final verification step only if needed (`evaluate` preferred; `snapshot` optional).
+
+## Connection Handling
+
+Connection recovery is built into the tool. On connection failure, let the tool auto-attach/launch/retry once. If still disconnected, stop and instruct the user to install/connect the extension.
+
+## Minimal CLI Usage
+
+```bash
+~/.wegent-executor/bin/browser-tool '<json>'
+```
+
+## Quick Examples
+
+```bash
+# Navigate directly
+~/.wegent-executor/bin/browser-tool '{"action":"navigate","url":"https://example.com"}'
+
+# Snapshot only when refs are needed
+~/.wegent-executor/bin/browser-tool '{"action":"snapshot","interactive":true}'
+
+# Act on ref
+~/.wegent-executor/bin/browser-tool '{"action":"act","request":{"kind":"click","ref":"e1"}}'
+
+# Comprehensive extraction in one evaluate
+~/.wegent-executor/bin/browser-tool '{"action":"evaluate","expression":"(() => ({title:document.title,url:location.href}))()"}'
+```

--- a/skills/knowledge/SKILL.md
+++ b/skills/knowledge/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: knowledge
+description: Manage knowledge bases and documents in Wegent. Create, list, delete knowledge bases. Add documents from files, text, or web URLs. Query and manage document status.
+---
+
+# Knowledge Base Management
+
+Manage knowledge bases and documents in Wegent.
+
+## Authentication
+
+Token is automatically read from:
+1. `WEGENT_API_TOKEN` environment variable
+2. `~/.wecode-cli/config.json` → `.auth.token`
+
+API base URL can be set via `WEGENT_API_BASE` (default: `https://wegent.intra.weibo.com/api`).
+
+## Tool Usage
+
+```bash
+scripts/knowledge-tool '{"action": "<action>", ...params}'
+```
+
+Or via stdin (recommended for long content):
+```bash
+echo '{"action": "<action>", ...}' | scripts/knowledge-tool
+```
+
+## Available Actions
+
+| Action | Description | Required Params |
+|--------|-------------|-----------------|
+| `list-kb` | List knowledge bases | `scope?`, `groupName?` |
+| `get-kb` | Get KB details | `kbId` |
+| `create-kb` | Create new KB | `name`, `description?`, `namespace?` |
+| `delete-kb` | Delete KB | `kbId` |
+| `list-documents` | List documents in KB | `kbId` |
+| `get-document` | Get document details | `documentId`, `includeContent?`, `includeSummary?` |
+| `add-web-document` | Add web page | `kbId`, `url`, `name?` |
+| `add-text-document` | Add text content | `kbId`, `name`, `content` or `contentFile`, `sourceUrl?` |
+| `upload-file` | Upload file | `kbId`, `file`, `name?` |
+| `toggle-document` | Enable/disable doc | `documentId`, `enable` or `disable` |
+| `delete-document` | Delete document | `documentId` |
+
+## Examples
+
+### Knowledge Base Operations
+
+```bash
+# List all knowledge bases
+scripts/knowledge-tool '{"action": "list-kb"}'
+
+# List personal knowledge bases only
+scripts/knowledge-tool '{"action": "list-kb", "scope": "personal"}'
+
+# Create a new knowledge base
+scripts/knowledge-tool '{"action": "create-kb", "name": "My Notes", "description": "Personal notes"}'
+
+# Get knowledge base details
+scripts/knowledge-tool '{"action": "get-kb", "kbId": 123}'
+
+# Delete knowledge base
+scripts/knowledge-tool '{"action": "delete-kb", "kbId": 123}'
+```
+
+### Document Operations
+
+```bash
+# List documents in a knowledge base
+scripts/knowledge-tool '{"action": "list-documents", "kbId": 123}'
+
+# Add a web page
+scripts/knowledge-tool '{"action": "add-web-document", "kbId": 123, "url": "https://example.com/doc"}'
+
+# Add text content from file (recommended for long content)
+scripts/knowledge-tool '{"action": "add-text-document", "kbId": 123, "name": "API Docs", "contentFile": "/tmp/content.txt"}'
+
+# Add text content directly (short content only)
+scripts/knowledge-tool '{"action": "add-text-document", "kbId": 123, "name": "Note", "content": "Short note"}'
+
+# Upload a file (PDF, Word, etc.)
+scripts/knowledge-tool '{"action": "upload-file", "kbId": 123, "file": "/path/to/document.pdf"}'
+
+# Get document details
+scripts/knowledge-tool '{"action": "get-document", "documentId": 456}'
+
+# Enable a document
+scripts/knowledge-tool '{"action": "toggle-document", "documentId": 456, "enable": true}'
+
+# Disable a document
+scripts/knowledge-tool '{"action": "toggle-document", "documentId": 456, "disable": true}'
+
+# Delete a document
+scripts/knowledge-tool '{"action": "delete-document", "documentId": 456}'
+```
+
+## Supported File Types
+
+- **Documents**: PDF, Word (.docx), PowerPoint (.pptx), Excel (.xlsx)
+- **Text**: TXT, Markdown (.md)
+- **Images**: PNG, JPG, JPEG, GIF, WebP
+- **Max file size**: 100MB
+
+## Error Handling
+
+All responses are JSON. On error:
+```json
+{"ok": false, "error": "Error message"}
+```

--- a/skills/knowledge/scripts/knowledge-tool
+++ b/skills/knowledge/scripts/knowledge-tool
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+/**
+ * Knowledge Base Management Tool
+ *
+ * Usage:
+ *   knowledge-tool '{"action": "list-kb"}'
+ *   echo '{"action": "add-text-document", ...}' | knowledge-tool
+ */
+
+const fs = require('fs');
+const path = require('path');
+const https = require('https');
+const http = require('http');
+
+// === Configuration ===
+
+const DEFAULT_API_BASE = 'http://127.0.0.1:8000/api';
+
+function getApiBase() {
+  return process.env.WEGENT_API_BASE || DEFAULT_API_BASE;
+}
+
+function getApiToken() {
+  // 1. Environment variable
+  if (process.env.WEGENT_API_TOKEN) {
+    return process.env.WEGENT_API_TOKEN;
+  }
+
+  // 2. Config file: ~/.wecode-cli/config.json
+  const configPath = path.join(process.env.HOME, '.wecode-cli', 'config.json');
+  try {
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (config.auth?.token) {
+        return config.auth.token;
+      }
+    }
+  } catch (e) {
+    // Ignore config read errors
+  }
+
+  return null;
+}
+
+// === HTTP Utilities ===
+
+function request(method, urlPath, options = {}) {
+  return new Promise((resolve, reject) => {
+    const apiBase = getApiBase();
+    // Properly join base URL with path (apiBase may end with /api)
+    const fullUrl = apiBase.replace(/\/$/, '') + urlPath;
+    const url = new URL(fullUrl);
+
+    // Add query params
+    if (options.params) {
+      Object.entries(options.params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          url.searchParams.append(key, value);
+        }
+      });
+    }
+
+    const isHttps = url.protocol === 'https:';
+    const lib = isHttps ? https : http;
+
+    const headers = {
+      'User-Agent': 'knowledge-tool/1.0',
+    };
+
+    const token = getApiToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    let body = null;
+
+    if (options.json) {
+      headers['Content-Type'] = 'application/json';
+      body = JSON.stringify(options.json);
+    } else if (options.formData) {
+      // Multipart form data
+      const boundary = '----KnowledgeToolBoundary' + Date.now().toString(16);
+      headers['Content-Type'] = `multipart/form-data; boundary=${boundary}`;
+      body = buildMultipartBody(options.formData, boundary);
+    }
+
+    const reqOptions = {
+      method,
+      hostname: url.hostname,
+      port: url.port || (isHttps ? 443 : 80),
+      path: url.pathname + url.search,
+      headers,
+    };
+
+    const req = lib.request(reqOptions, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        if (res.statusCode >= 400) {
+          let errorMsg = `HTTP ${res.statusCode}`;
+          try {
+            const parsed = JSON.parse(data);
+            errorMsg = parsed.message || parsed.error || errorMsg;
+          } catch (e) {
+            errorMsg = data || errorMsg;
+          }
+          reject(new Error(errorMsg));
+        } else {
+          try {
+            resolve(JSON.parse(data));
+          } catch (e) {
+            resolve(data);
+          }
+        }
+      });
+    });
+
+    req.on('error', reject);
+
+    if (body) {
+      req.write(body);
+    }
+
+    req.end();
+  });
+}
+
+function buildMultipartBody(formData, boundary) {
+  const parts = [];
+
+  for (const [key, value] of Object.entries(formData)) {
+    if (value.filename) {
+      // File field
+      parts.push(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="${key}"; filename="${value.filename}"\r\n` +
+        `Content-Type: ${value.contentType || 'application/octet-stream'}\r\n\r\n`
+      );
+      parts.push(value.content);
+      parts.push('\r\n');
+    } else {
+      // Regular field
+      parts.push(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="${key}"\r\n\r\n` +
+        `${value}\r\n`
+      );
+    }
+  }
+
+  parts.push(`--${boundary}--\r\n`);
+
+  return Buffer.concat(parts.map(p => Buffer.isBuffer(p) ? p : Buffer.from(p)));
+}
+
+// === Actions ===
+
+async function listKb(params = {}) {
+  const queryParams = { scope: params.scope || 'all' };
+  if (params.groupName) {
+    queryParams.group_name = params.groupName;
+  }
+  return request('GET', '/knowledge-bases', { params: queryParams });
+}
+
+async function getKb(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  return request('GET', `/knowledge-bases/${params.kbId}`);
+}
+
+async function createKb(params) {
+  if (!params.name) throw new Error('name is required');
+  return request('POST', '/knowledge-bases', {
+    json: {
+      name: params.name,
+      description: params.description || '',
+      namespace: params.namespace || 'default',
+    }
+  });
+}
+
+async function deleteKb(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  await request('DELETE', `/knowledge-bases/${params.kbId}`);
+  return { ok: true, message: `Knowledge base ${params.kbId} deleted` };
+}
+
+async function listDocuments(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  return request('GET', `/knowledge-bases/${params.kbId}/documents`);
+}
+
+async function getDocument(params) {
+  if (!params.documentId) throw new Error('documentId is required');
+  const queryParams = {
+    include_content: params.includeContent !== false ? 'true' : 'false',
+    include_summary: params.includeSummary !== false ? 'true' : 'false',
+  };
+  return request('GET', `/knowledge-documents/${params.documentId}/detail`, { params: queryParams });
+}
+
+async function deleteDocument(params) {
+  if (!params.documentId) throw new Error('documentId is required');
+  await request('DELETE', `/knowledge-documents/${params.documentId}`);
+  return { ok: true, message: `Document ${params.documentId} deleted` };
+}
+
+async function addWebDocument(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  if (!params.url) throw new Error('url is required');
+
+  const payload = {
+    url: params.url,
+    knowledge_base_id: params.kbId,
+  };
+  if (params.name) {
+    payload.name = params.name;
+  }
+
+  return request('POST', '/web-scraper/create-document', { json: payload });
+}
+
+async function addTextDocument(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  if (!params.name) throw new Error('name is required');
+
+  let content;
+  if (params.contentFile) {
+    content = fs.readFileSync(params.contentFile, 'utf-8');
+  } else if (params.content) {
+    content = params.content;
+  } else {
+    throw new Error('content or contentFile is required');
+  }
+
+  // Step 1: Upload as attachment
+  const fileName = params.name.endsWith('.txt') ? params.name : `${params.name}.txt`;
+  const uploadResult = await request('POST', '/attachments/upload', {
+    formData: {
+      file: {
+        filename: fileName,
+        content: Buffer.from(content, 'utf-8'),
+        contentType: 'text/plain',
+      }
+    }
+  });
+
+  // Step 2: Create document
+  const docResult = await request('POST', `/knowledge-bases/${params.kbId}/documents`, {
+    json: {
+      attachment_id: uploadResult.id,
+      name: fileName,
+      file_extension: 'txt',
+      file_size: Buffer.byteLength(content, 'utf-8'),
+      source_type: 'text',
+      source_url: params.sourceUrl || undefined,
+    }
+  });
+
+  return docResult;
+}
+
+async function uploadFile(params) {
+  if (!params.kbId) throw new Error('kbId is required');
+  if (!params.file) throw new Error('file is required');
+
+  const filePath = params.file;
+  const fileName = params.name || path.basename(filePath);
+  const fileExt = path.extname(fileName).slice(1).toLowerCase();
+  const fileContent = fs.readFileSync(filePath);
+  const fileSize = fileContent.length;
+
+  // Guess MIME type
+  const mimeTypes = {
+    pdf: 'application/pdf',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    txt: 'text/plain',
+    md: 'text/markdown',
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+  };
+  const contentType = mimeTypes[fileExt] || 'application/octet-stream';
+
+  // Step 1: Upload as attachment
+  const uploadResult = await request('POST', '/attachments/upload', {
+    formData: {
+      file: {
+        filename: fileName,
+        content: fileContent,
+        contentType,
+      }
+    }
+  });
+
+  // Step 2: Create document
+  const docResult = await request('POST', `/knowledge-bases/${params.kbId}/documents`, {
+    json: {
+      attachment_id: uploadResult.id,
+      name: fileName,
+      file_extension: fileExt,
+      file_size: fileSize,
+      source_type: 'file',
+    }
+  });
+
+  return docResult;
+}
+
+async function toggleDocument(params) {
+  if (!params.documentId) throw new Error('documentId is required');
+  if (params.enable === undefined && params.disable === undefined) {
+    throw new Error('enable or disable is required');
+  }
+
+  const isActive = params.enable === true;
+  return request('PATCH', `/knowledge-documents/${params.documentId}`, {
+    json: { is_active: isActive }
+  });
+}
+
+// === Action Router ===
+
+const actions = {
+  'list-kb': listKb,
+  'get-kb': getKb,
+  'create-kb': createKb,
+  'delete-kb': deleteKb,
+  'list-documents': listDocuments,
+  'get-document': getDocument,
+  'delete-document': deleteDocument,
+  'add-web-document': addWebDocument,
+  'add-text-document': addTextDocument,
+  'upload-file': uploadFile,
+  'toggle-document': toggleDocument,
+};
+
+// === Main ===
+
+async function main() {
+  let input;
+
+  // Try to read from argument first
+  if (process.argv[2]) {
+    input = process.argv[2];
+  } else {
+    // Read from stdin
+    input = fs.readFileSync(0, 'utf-8').trim();
+  }
+
+  if (!input) {
+    console.error(JSON.stringify({ ok: false, error: 'No input provided' }));
+    process.exit(1);
+  }
+
+  let params;
+  try {
+    params = JSON.parse(input);
+  } catch (e) {
+    console.error(JSON.stringify({ ok: false, error: `Invalid JSON: ${e.message}` }));
+    process.exit(1);
+  }
+
+  const { action, ...actionParams } = params;
+
+  if (!action) {
+    console.error(JSON.stringify({ ok: false, error: 'action is required' }));
+    process.exit(1);
+  }
+
+  const handler = actions[action];
+  if (!handler) {
+    console.error(JSON.stringify({
+      ok: false,
+      error: `Unknown action: ${action}`,
+      availableActions: Object.keys(actions)
+    }));
+    process.exit(1);
+  }
+
+  try {
+    const result = await handler(actionParams);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (e) {
+    console.error(JSON.stringify({ ok: false, error: e.message }));
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- bump relay-server package version from 0.1.5 to 0.1.7
- update browser launch default URL to about:blank
- improve extension connection flow for open/navigate actions
- add relay-server lockfile

## Scope
- only changes under deps/browser/relay-server
- excludes skills updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.8

* **Improvements**
  * More reliable browser connection and recovery, with explicit blank default landing page and faster error responses
  * Actions and browser operations now reuse connections to avoid unnecessary launches and improve performance

* **New Features**
  * Added Browser Control and Knowledge Skill documentation
  * New knowledge-management CLI tool for listing, creating, uploading, and managing knowledge items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->