### PR TITLE
fix(deps): reduce browser extension wait timeout from 8s to 3s

### DIFF
--- a/deps/browser/relay-server/src/tool.ts
+++ b/deps/browser/relay-server/src/tool.ts
@@ -399,7 +399,7 @@ async function tryEnsureConnected(params: BrowserToolParams): Promise<{
   }
 
   // Wait for extension to attach
-  const connected = await waitForConnection(8000);
+  const connected = await waitForConnection(3000);
 
   if (connected) {
     return { connected: true };


### PR DESCRIPTION
## Summary
- Reduce `waitForConnection` timeout from 8 seconds to 3 seconds for faster response when navigating to URLs like `chrome://extensions`

## Test plan
- [ ] Test browser tool with `navigate` action to verify faster timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced wait time for extension connection from 8 seconds to 3 seconds, enabling faster error handling and fallback responses when the extension fails to connect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->