### PR TITLE
fix(frontend): use execCommand for paste to preserve undo stack

### DIFF
--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -589,6 +589,19 @@ export default function ChatInput({
             range.setEndAfter(textNode)
             selection.removeAllRanges()
             selection.addRange(range)
+          } else {
+            // Last-resort fallback: append text directly when no selection exists
+            // (e.g., embedded browser contexts or Shadow DOM scenarios)
+            editableRef.current.appendChild(document.createTextNode(pastedText))
+            // Move cursor to end
+            const newSelection = window.getSelection()
+            if (newSelection) {
+              const range = document.createRange()
+              range.selectNodeContents(editableRef.current)
+              range.collapse(false)
+              newSelection.removeAllRanges()
+              newSelection.addRange(range)
+            }
           }
         }
 

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -565,39 +565,16 @@ export default function ChatInput({
 
       // Handle text insertion if there is text content
       if (hasText && editableRef.current) {
-        // Get current selection
-        let selection = window.getSelection()
-
-        // Fallback: if no selection exists (edge case), focus the input and create a selection at the end
-        if (!selection || selection.rangeCount === 0) {
+        // Ensure the input is focused before using execCommand
+        if (document.activeElement !== editableRef.current) {
           editableRef.current.focus()
-          selection = window.getSelection()
-
-          // If still no selection after focus, create one at the end of the input
-          if (selection) {
-            const range = document.createRange()
-            range.selectNodeContents(editableRef.current)
-            range.collapse(false) // Collapse to end
-            selection.removeAllRanges()
-            selection.addRange(range)
-          }
         }
 
-        // Proceed with text insertion if we have a valid selection
-        if (selection && selection.rangeCount > 0) {
-          const range = selection.getRangeAt(0)
-          range.deleteContents()
-
-          // Insert plain text node
-          const textNode = document.createTextNode(pastedText)
-          range.insertNode(textNode)
-
-          // Move cursor to end of inserted text
-          range.setStartAfter(textNode)
-          range.setEndAfter(textNode)
-          selection.removeAllRanges()
-          selection.addRange(range)
-        }
+        // Use execCommand to insert text - this preserves the browser's undo stack
+        // so Cmd+Z correctly undoes the paste instead of previous input
+        // Note: execCommand is deprecated but still the best way to maintain undo compatibility
+        // in contentEditable elements across all major browsers
+        document.execCommand('insertText', false, pastedText)
 
         // Update message state - use getTextWithNewlines to preserve newlines
         const newText = getTextWithNewlines(editableRef.current)


### PR DESCRIPTION
## Summary

- Fix Cmd+Z (undo) behavior after pasting content in chat input
- Replace manual DOM manipulation with `document.execCommand('insertText')` to preserve browser's undo stack
- Previously, pasting content then pressing Cmd+Z would undo the typed content instead of the pasted content

## Problem

In `ChatInput.tsx`'s `handlePaste` function, the code used `e.preventDefault()` + manual DOM operations (`document.createTextNode` + `range.insertNode`) to handle text paste. This caused the browser's undo stack to not record the paste operation.

## Solution

Use `document.execCommand('insertText', false, pastedText)` which is properly recorded in the browser's undo stack, allowing Cmd+Z to correctly undo the paste operation.

## Test plan

- [ ] Type some text in the chat input
- [ ] Paste some content (Cmd+V / Ctrl+V)
- [ ] Press Cmd+Z / Ctrl+Z to undo
- [ ] Verify the pasted content is undone (not the typed content)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved paste handling in the chat input for more reliable and consistent pastes.
  * Ensures paste operations preserve the browser undo stack so Undo behaves as expected.
  * Adds focus checks to avoid misplaced insertions and simplifies internal paste flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->