### PR TITLE
chore(browser): update relay package metadata and options page

### DIFF
--- a/deps/browser/relay-server/chrome-extension/options.html
+++ b/deps/browser/relay-server/chrome-extension/options.html
@@ -2,113 +2,37 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Browser Relay Settings</title>
+  <title>安装成功</title>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      padding: 16px;
+      margin: 0;
       min-width: 320px;
+      min-height: 200px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       background: #1a1a1a;
       color: #e0e0e0;
     }
-    h2 {
-      margin: 0 0 16px 0;
+    .card {
+      padding: 24px 32px;
+      border-radius: 10px;
+      background: #222;
+      border: 1px solid #333;
+      text-align: center;
+    }
+    .title {
+      margin: 0;
       font-size: 18px;
       color: #4CAF50;
-    }
-    .field {
-      margin-bottom: 16px;
-    }
-    label {
-      display: block;
-      margin-bottom: 6px;
-      font-size: 13px;
-      color: #aaa;
-    }
-    input[type="number"] {
-      width: 100%;
-      padding: 8px 12px;
-      border: 1px solid #333;
-      border-radius: 4px;
-      background: #2a2a2a;
-      color: #e0e0e0;
-      font-size: 14px;
-      box-sizing: border-box;
-    }
-    input[type="number"]:focus {
-      outline: none;
-      border-color: #4CAF50;
-    }
-    button {
-      background: #4CAF50;
-      color: white;
-      border: none;
-      padding: 10px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-size: 14px;
-      width: 100%;
-    }
-    button:hover {
-      background: #45a049;
-    }
-    .status {
-      margin-top: 12px;
-      padding: 10px;
-      border-radius: 4px;
-      font-size: 13px;
-    }
-    .status.success {
-      background: #1b3a1b;
-      color: #4CAF50;
-    }
-    .status.error {
-      background: #3a1b1b;
-      color: #f44336;
-    }
-    .help {
-      margin-top: 20px;
-      padding: 12px;
-      background: #252525;
-      border-radius: 4px;
-      font-size: 12px;
-      line-height: 1.5;
-      color: #888;
-    }
-    .help h3 {
-      margin: 0 0 8px 0;
-      font-size: 13px;
-      color: #aaa;
-    }
-    code {
-      background: #333;
-      padding: 2px 6px;
-      border-radius: 3px;
-      font-family: 'SF Mono', Monaco, monospace;
-      font-size: 11px;
+      letter-spacing: 0.5px;
     }
   </style>
 </head>
 <body>
-  <h2>Browser Relay Settings</h2>
-
-  <div class="field">
-    <label for="port">Relay Server Port</label>
-    <input type="number" id="port" min="1" max="65535" value="9224">
+  <div class="card">
+    <h1 class="title">安装成功</h1>
   </div>
-
-  <button id="save">Save Settings</button>
-
-  <div id="status" class="status" style="display: none;"></div>
-
-  <div class="help">
-    <h3>Setup Instructions</h3>
-    <p>1. Start the relay server:</p>
-    <p><code>cd ~/.claude/skills/browser && pnpm start</code></p>
-    <p>2. Click the extension icon on any tab to attach</p>
-    <p>3. The LLM can now control the attached tab</p>
-  </div>
-
-  <script src="options.js"></script>
 </body>
 </html>

--- a/deps/browser/relay-server/package-lock.json
+++ b/deps/browser/relay-server/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wb/wegent-cdp-relay-server",
+  "name": "@wegent/cdp-relay-server",
   "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@wb/wegent-cdp-relay-server",
-  "version": "0.1.8",
+  "name": "@wegent/cdp-relay-server",
+  "version": "0.1.10",
   "description": "Chrome DevTools Protocol relay server and browser automation tool",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- rename relay package to `@wegent/cdp-relay-server`
- bump package version metadata to `0.1.10` in `package.json`
- simplify extension options page to a minimal install-success screen

## Validation
- npm run typecheck (in `deps/browser/relay-server`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the browser extension options page with a new installation success confirmation message featuring a simplified, centered card layout.

* **Chores**
  * Updated package metadata including version and name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->