### PR TITLE
feat(workspace): add file listing and download for no-repository mode

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -65,6 +65,8 @@ class Settings(BaseSettings):
     EXECUTOR_CANCEL_TASK_URL: str = (
         "http://localhost:8001/executor-manager/tasks/cancel"
     )
+    # Executor Manager base URL for API calls
+    EXECUTOR_MANAGER_BASE_URL: str = "http://localhost:8001"
     # Latest Executor version (manually updated when releasing new versions)
     # This is used to show upgrade warnings in the UI
     EXECUTOR_LATEST_VERSION: str = "1.0.0"

--- a/backend/app/services/workspace_files.py
+++ b/backend/app/services/workspace_files.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Workspace files service for accessing files in executor containers.
+
+This service provides access to files in the executor container's workspace
+directory for tasks without an associated git repository.
+"""
+
+import logging
+from typing import Any, Optional
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.subtask import Subtask, SubtaskRole
+from app.models.task import TaskResource
+from app.services.task_member_service import task_member_service
+
+logger = logging.getLogger(__name__)
+
+# Timeout for API calls to executor manager (seconds)
+EXECUTOR_API_TIMEOUT = 60.0
+
+
+class WorkspaceFilesService:
+    """Service for accessing workspace files in executor containers."""
+
+    def __init__(self):
+        self.executor_manager_base_url = settings.EXECUTOR_MANAGER_BASE_URL
+
+    def _get_task_executor_info(
+        self, db: Session, task_id: int, user_id: int
+    ) -> tuple[Optional[str], Optional[str]]:
+        """
+        Get executor info for a task.
+
+        Args:
+            db: Database session
+            task_id: Task ID
+            user_id: User ID for access validation
+
+        Returns:
+            Tuple of (executor_name, error_message)
+        """
+        # Check user access
+        if not task_member_service.is_member(db, task_id, user_id):
+            return None, "Task not found or access denied"
+
+        # Get task
+        task = (
+            db.query(TaskResource)
+            .filter(
+                TaskResource.id == task_id,
+                TaskResource.kind == "Task",
+                TaskResource.is_active.is_(True),
+            )
+            .first()
+        )
+
+        if not task:
+            return None, "Task not found"
+
+        # Get the latest assistant subtask with executor_name
+        subtask = (
+            db.query(Subtask)
+            .filter(
+                Subtask.task_id == task_id,
+                Subtask.role == SubtaskRole.ASSISTANT,
+                Subtask.executor_name.isnot(None),
+                Subtask.executor_name != "",
+            )
+            .order_by(Subtask.created_at.desc())
+            .first()
+        )
+
+        if not subtask or not subtask.executor_name:
+            return None, "No executor found for this task"
+
+        # Skip device-based executors (they run on user's device, not in container)
+        if subtask.executor_name.startswith("device-"):
+            return None, "This task runs on a local device, workspace files are not available"
+
+        return subtask.executor_name, None
+
+    async def get_workspace_files(
+        self, db: Session, task_id: int, user_id: int
+    ) -> dict[str, Any]:
+        """
+        Get list of files in the task's workspace directory.
+
+        Args:
+            db: Database session
+            task_id: Task ID
+            user_id: User ID for access validation
+
+        Returns:
+            Dict with files list and metadata
+        """
+        executor_name, error = self._get_task_executor_info(db, task_id, user_id)
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        # Call executor manager to get container address
+        try:
+            container_info = await self._get_container_address(executor_name)
+            if not container_info.get("status") == "success":
+                error_msg = container_info.get(
+                    "error_msg", "Container not available"
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Executor container not available: {error_msg}",
+                )
+
+            base_url = container_info.get("address")
+            if not base_url:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Could not determine container address",
+                )
+
+            # Call envd files/list endpoint
+            # The workspace path is /workspace/{task_id}/
+            workspace_path = f"/workspace/{task_id}"
+            files_response = await self._call_envd_api(
+                base_url, "files/list", {"path": workspace_path}
+            )
+
+            return {
+                "files": files_response.get("files", []),
+                "total_count": files_response.get("total_count", 0),
+                "filtered_count": files_response.get("filtered_count", 0),
+                "workspace_path": workspace_path,
+            }
+
+        except HTTPException:
+            raise
+        except httpx.ConnectError as e:
+            logger.error(f"Connection error to executor container: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Executor container is not running or unreachable",
+            )
+        except httpx.TimeoutException as e:
+            logger.error(f"Timeout connecting to executor container: {e}")
+            raise HTTPException(
+                status_code=504,
+                detail="Request to executor container timed out",
+            )
+        except Exception as e:
+            logger.error(f"Error getting workspace files: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to get workspace files: {str(e)}",
+            )
+
+    async def download_workspace_zip(
+        self, db: Session, task_id: int, user_id: int
+    ) -> tuple[bytes, str]:
+        """
+        Download workspace files as a ZIP archive.
+
+        Args:
+            db: Database session
+            task_id: Task ID
+            user_id: User ID for access validation
+
+        Returns:
+            Tuple of (zip_content_bytes, filename)
+        """
+        executor_name, error = self._get_task_executor_info(db, task_id, user_id)
+        if error:
+            raise HTTPException(status_code=404, detail=error)
+
+        try:
+            container_info = await self._get_container_address(executor_name)
+            if not container_info.get("status") == "success":
+                error_msg = container_info.get(
+                    "error_msg", "Container not available"
+                )
+                raise HTTPException(
+                    status_code=503,
+                    detail=f"Executor container not available: {error_msg}",
+                )
+
+            base_url = container_info.get("address")
+            if not base_url:
+                raise HTTPException(
+                    status_code=503,
+                    detail="Could not determine container address",
+                )
+
+            # Call envd files/download-zip endpoint
+            workspace_path = f"/workspace/{task_id}"
+            zip_content = await self._download_envd_zip(
+                base_url, workspace_path
+            )
+
+            filename = f"task_{task_id}_files.zip"
+            return zip_content, filename
+
+        except HTTPException:
+            raise
+        except httpx.ConnectError as e:
+            logger.error(f"Connection error to executor container: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Executor container is not running or unreachable",
+            )
+        except httpx.TimeoutException as e:
+            logger.error(f"Timeout connecting to executor container: {e}")
+            raise HTTPException(
+                status_code=504,
+                detail="Request to executor container timed out",
+            )
+        except Exception as e:
+            logger.error(f"Error downloading workspace ZIP: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Failed to download workspace files: {str(e)}",
+            )
+
+    async def _get_container_address(self, executor_name: str) -> dict[str, Any]:
+        """
+        Get container address from executor manager.
+
+        Args:
+            executor_name: Name of the executor container
+
+        Returns:
+            Dict with container address info
+        """
+        url = f"{self.executor_manager_base_url}/executor-manager/executor/address"
+        async with httpx.AsyncClient(timeout=EXECUTOR_API_TIMEOUT) as client:
+            response = await client.get(url, params={"executor_name": executor_name})
+
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 404:
+                return {"status": "error", "error_msg": "Container not found"}
+            else:
+                return {
+                    "status": "error",
+                    "error_msg": f"HTTP {response.status_code}: {response.text}",
+                }
+
+    async def _call_envd_api(
+        self, base_url: str, endpoint: str, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """
+        Call envd REST API endpoint.
+
+        Args:
+            base_url: Container base URL (e.g., http://localhost:49983)
+            endpoint: API endpoint path
+            params: Query parameters
+
+        Returns:
+            API response as dict
+        """
+        url = f"{base_url}/{endpoint}"
+        async with httpx.AsyncClient(timeout=EXECUTOR_API_TIMEOUT) as client:
+            response = await client.get(url, params=params)
+
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 404:
+                # Directory not found - return empty result
+                return {"files": [], "total_count": 0, "filtered_count": 0}
+            else:
+                raise HTTPException(
+                    status_code=response.status_code,
+                    detail=f"Envd API error: {response.text}",
+                )
+
+    async def _download_envd_zip(
+        self, base_url: str, workspace_path: str
+    ) -> bytes:
+        """
+        Download ZIP file from envd.
+
+        Args:
+            base_url: Container base URL
+            workspace_path: Path to workspace directory
+
+        Returns:
+            ZIP file content as bytes
+        """
+        url = f"{base_url}/files/download-zip"
+        async with httpx.AsyncClient(timeout=EXECUTOR_API_TIMEOUT * 2) as client:
+            response = await client.get(url, params={"path": workspace_path})
+
+            if response.status_code == 200:
+                return response.content
+            elif response.status_code == 404:
+                raise HTTPException(
+                    status_code=404,
+                    detail="Workspace directory not found or empty",
+                )
+            else:
+                raise HTTPException(
+                    status_code=response.status_code,
+                    detail=f"Failed to download ZIP: {response.text}",
+                )
+
+
+# Singleton instance
+workspace_files_service = WorkspaceFilesService()

--- a/executor/envd/api/models.py
+++ b/executor/envd/api/models.py
@@ -46,3 +46,21 @@ class ErrorResponse(BaseModel):
 
     message: str
     code: int
+
+
+class WorkspaceFile(BaseModel):
+    """Workspace file information with recursive structure"""
+
+    name: str  # File or directory name
+    path: str  # Relative path from workspace root
+    type: str  # 'file' or 'directory'
+    size: Optional[int] = None  # File size in bytes (only for files)
+    children: Optional[list["WorkspaceFile"]] = None  # Child items (only for directories)
+
+
+class WorkspaceFileListResponse(BaseModel):
+    """Response model for workspace file listing"""
+
+    files: list[WorkspaceFile]
+    total_count: int
+    filtered_count: int  # Count after applying filters

--- a/executor/envd/api/routes.py
+++ b/executor/envd/api/routes.py
@@ -5,19 +5,55 @@
 REST API route handlers for envd
 """
 
+import io
 import os
 import time
+import zipfile
+from pathlib import Path
 from typing import Optional
 
 import psutil
 from fastapi import FastAPI, File, Header, HTTPException, Query, Response, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 
 from shared.logger import setup_logger
 
-from .models import EntryInfo, InitRequest, MetricsResponse
+from .models import EntryInfo, InitRequest, MetricsResponse, WorkspaceFile, WorkspaceFileListResponse
 from .state import AccessTokenAlreadySetError, get_state_manager
 from .utils import resolve_path, verify_access_token, verify_signature
+
+# Directories and patterns to exclude from file listings
+EXCLUDED_DIRS = {
+    ".git",
+    ".svn",
+    ".hg",
+    "node_modules",
+    "vendor",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".cache",
+    ".tmp",
+    "tmp",
+    ".idea",
+    ".vscode",
+    "dist",
+    "build",
+    "target",
+    "out",
+    ".next",
+    ".nuxt",
+    "coverage",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".tox",
+    "eggs",
+    "*.egg-info",
+    ".eggs",
+}
+
+# Maximum number of files to list (safety limit)
+MAX_FILE_COUNT = 1000
 
 logger = setup_logger("envd_api_routes")
 
@@ -187,6 +223,212 @@ def register_rest_api(app: FastAPI):
             logger.exception(f"Error uploading file: {e}")
             raise HTTPException(status_code=500, detail=str(e))
 
+    def _should_exclude(name: str) -> bool:
+        """Check if a file or directory should be excluded from listing"""
+        if name in EXCLUDED_DIRS:
+            return True
+        # Check for pattern matches (e.g., *.egg-info)
+        for pattern in EXCLUDED_DIRS:
+            if "*" in pattern:
+                # Simple glob pattern matching
+                prefix, suffix = pattern.split("*", 1)
+                if name.startswith(prefix) and name.endswith(suffix):
+                    return True
+        return False
+
+    def _scan_directory(
+        dir_path: Path, base_path: Path, current_count: list[int]
+    ) -> tuple[list[WorkspaceFile], int]:
+        """
+        Recursively scan a directory and return file tree structure.
+
+        Args:
+            dir_path: Directory to scan
+            base_path: Base path for relative path calculation
+            current_count: Mutable counter to track total files
+
+        Returns:
+            Tuple of (files list, filtered count)
+        """
+        files = []
+        filtered_count = 0
+
+        try:
+            entries = sorted(dir_path.iterdir(), key=lambda x: (x.is_file(), x.name.lower()))
+        except PermissionError:
+            logger.warning(f"Permission denied: {dir_path}")
+            return files, filtered_count
+
+        for entry in entries:
+            # Check exclusion
+            if _should_exclude(entry.name):
+                filtered_count += 1
+                continue
+
+            # Check file count limit
+            if current_count[0] >= MAX_FILE_COUNT:
+                break
+
+            relative_path = str(entry.relative_to(base_path))
+
+            if entry.is_file():
+                current_count[0] += 1
+                try:
+                    size = entry.stat().st_size
+                except (OSError, PermissionError):
+                    size = 0
+                files.append(
+                    WorkspaceFile(
+                        name=entry.name,
+                        path=relative_path,
+                        type="file",
+                        size=size,
+                    )
+                )
+            elif entry.is_dir():
+                children, child_filtered = _scan_directory(entry, base_path, current_count)
+                filtered_count += child_filtered
+                # Only add directory if it has children or we haven't exceeded limit
+                if children or current_count[0] < MAX_FILE_COUNT:
+                    files.append(
+                        WorkspaceFile(
+                            name=entry.name,
+                            path=relative_path,
+                            type="directory",
+                            children=children if children else None,
+                        )
+                    )
+
+        return files, filtered_count
+
+    @app.get("/files/list", response_model=WorkspaceFileListResponse)
+    async def list_workspace_files(
+        path: Optional[str] = Query(None, description="Directory path to list"),
+        username: Optional[str] = Query(None),
+        x_access_token: Optional[str] = Header(None),
+    ):
+        """
+        List all files in a workspace directory recursively.
+
+        Returns a tree structure with directories and files,
+        excluding common temporary and generated directories.
+        """
+        verify_access_token(x_access_token)
+
+        try:
+            # Resolve directory path
+            dir_path = resolve_path(path, username, state_manager.default_workdir)
+
+            # Check if directory exists
+            if not dir_path.exists():
+                raise HTTPException(status_code=404, detail=f"Directory not found: {path}")
+
+            if not dir_path.is_dir():
+                raise HTTPException(
+                    status_code=400, detail=f"Path is not a directory: {path}"
+                )
+
+            # Check permissions
+            if not os.access(dir_path, os.R_OK):
+                raise HTTPException(
+                    status_code=401, detail=f"Permission denied: {path}"
+                )
+
+            # Scan directory
+            current_count = [0]  # Use list to allow mutation in nested function
+            files, filtered_count = _scan_directory(dir_path, dir_path, current_count)
+
+            return WorkspaceFileListResponse(
+                files=files,
+                total_count=current_count[0],
+                filtered_count=filtered_count,
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception(f"Error listing workspace files: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.get("/files/download-zip")
+    async def download_workspace_zip(
+        path: Optional[str] = Query(None, description="Directory path to download as ZIP"),
+        username: Optional[str] = Query(None),
+        x_access_token: Optional[str] = Header(None),
+    ):
+        """
+        Download a workspace directory as a ZIP file.
+
+        Excludes common temporary and generated directories.
+        Returns a streaming response with the ZIP file.
+        """
+        verify_access_token(x_access_token)
+
+        try:
+            # Resolve directory path
+            dir_path = resolve_path(path, username, state_manager.default_workdir)
+
+            # Check if directory exists
+            if not dir_path.exists():
+                raise HTTPException(status_code=404, detail=f"Directory not found: {path}")
+
+            if not dir_path.is_dir():
+                raise HTTPException(
+                    status_code=400, detail=f"Path is not a directory: {path}"
+                )
+
+            # Check permissions
+            if not os.access(dir_path, os.R_OK):
+                raise HTTPException(
+                    status_code=401, detail=f"Permission denied: {path}"
+                )
+
+            # Create ZIP file in memory
+            zip_buffer = io.BytesIO()
+            file_count = 0
+
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+                for root, dirs, files in os.walk(dir_path):
+                    # Filter out excluded directories (modify in-place to skip them)
+                    dirs[:] = [d for d in dirs if not _should_exclude(d)]
+
+                    for file in files:
+                        if file_count >= MAX_FILE_COUNT:
+                            break
+                        if _should_exclude(file):
+                            continue
+
+                        file_path = Path(root) / file
+                        try:
+                            # Get relative path for ZIP
+                            arcname = str(file_path.relative_to(dir_path))
+                            zip_file.write(file_path, arcname)
+                            file_count += 1
+                        except (OSError, PermissionError) as e:
+                            logger.warning(f"Could not add file to ZIP: {file_path}: {e}")
+                            continue
+
+                    if file_count >= MAX_FILE_COUNT:
+                        break
+
+            # Prepare response
+            zip_buffer.seek(0)
+            dir_name = dir_path.name or "workspace"
+
+            return StreamingResponse(
+                zip_buffer,
+                media_type="application/zip",
+                headers={
+                    "Content-Disposition": f'attachment; filename="{dir_name}_files.zip"'
+                },
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception(f"Error creating workspace ZIP: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+
     logger.info("Registered envd REST API routes:")
     logger.info("  GET /health")
     logger.info("  GET /metrics")
@@ -194,3 +436,5 @@ def register_rest_api(app: FastAPI):
     logger.info("  GET /envs")
     logger.info("  GET /files")
     logger.info("  POST /files")
+    logger.info("  GET /files/list")
+    logger.info("  GET /files/download-zip")

--- a/frontend/src/apis/tasks.ts
+++ b/frontend/src/apis/tasks.ts
@@ -222,6 +222,22 @@ export interface TaskSkillsResponse {
   preload_skills: string[]
 }
 
+// Workspace Files Types
+export interface WorkspaceFile {
+  name: string // File or directory name
+  path: string // Relative path from workspace root
+  type: 'file' | 'directory'
+  size?: number // File size in bytes (only for files)
+  children?: WorkspaceFile[] // Child items (only for directories)
+}
+
+export interface WorkspaceFilesResponse {
+  files: WorkspaceFile[]
+  total_count: number
+  filtered_count: number
+  workspace_path: string
+}
+
 // Task Services
 
 export const taskApis = {
@@ -450,6 +466,44 @@ export const taskApis = {
    */
   getTaskSkills: async (taskId: number): Promise<TaskSkillsResponse> => {
     return apiClient.get(`/tasks/${taskId}/skills`)
+  },
+
+  /**
+   * Get workspace files for a task (no-repository mode)
+   * @param taskId - Task ID
+   */
+  getWorkspaceFiles: async (taskId: number): Promise<WorkspaceFilesResponse> => {
+    return apiClient.get(`/tasks/${taskId}/workspace/files`)
+  },
+
+  /**
+   * Download workspace files as ZIP archive
+   * @param taskId - Task ID
+   */
+  downloadWorkspaceZip: async (taskId: number): Promise<Blob> => {
+    const token = getToken()
+    const response = await fetch(`/api/tasks/${taskId}/workspace/download`, {
+      method: 'GET',
+      headers: {
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      let errorMsg = errorText
+      try {
+        const json = JSON.parse(errorText)
+        if (json && typeof json.detail === 'string') {
+          errorMsg = json.detail
+        }
+      } catch {
+        // Not JSON, use original text
+      }
+      throw new Error(errorMsg)
+    }
+
+    return response.blob()
   },
 }
 

--- a/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
@@ -297,6 +297,7 @@ export function CodePageDesktop() {
               }
               taskTitle={selectedTaskDetail?.title}
               taskNumber={selectedTaskDetail ? `#${selectedTaskDetail.id}` : undefined}
+              taskId={selectedTaskDetail?.id}
               thinking={thinkingData}
               app={selectedTaskDetail?.app}
             />

--- a/frontend/src/features/tasks/components/workbench/Workbench.tsx
+++ b/frontend/src/features/tasks/components/workbench/Workbench.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { taskApis, BranchDiffResponse } from '@/apis/tasks'
 import DiffViewer from '../message/DiffViewer'
 import { TaskApp } from '@/types/api'
+import WorkspaceFileViewer from './WorkspaceFileViewer'
 
 // Tool icon mapping
 const TOOL_ICONS: Record<string, string> = {
@@ -108,6 +109,7 @@ interface WorkbenchProps {
   isLoading?: boolean
   taskTitle?: string
   taskNumber?: string
+  taskId?: number
   thinking?: Array<{
     title: string
     next_action: string
@@ -199,6 +201,7 @@ export default function Workbench({
   isLoading: _isLoading = false,
   taskTitle,
   taskNumber,
+  taskId,
   thinking,
   app,
 }: WorkbenchProps) {
@@ -931,10 +934,14 @@ export default function Workbench({
                   // Files Changed Tab - with integrated diff support
                   <>
                     {!hasRepository ? (
-                      // No repository - show friendly message
-                      <div className="rounded-lg border border-border bg-surface p-8 text-center">
-                        <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
-                      </div>
+                      // No repository - show workspace files from executor container
+                      taskId ? (
+                        <WorkspaceFileViewer taskId={taskId} />
+                      ) : (
+                        <div className="rounded-lg border border-border bg-surface p-8 text-center">
+                          <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
+                        </div>
+                      )
                     ) : isDiffLoading ? (
                       // Loading diff data
                       <div className="flex items-center justify-center h-64">

--- a/frontend/src/features/tasks/components/workbench/WorkspaceFileViewer.tsx
+++ b/frontend/src/features/tasks/components/workbench/WorkspaceFileViewer.tsx
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2025 WeCode, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  FolderIcon,
+  FolderOpenIcon,
+  DocumentIcon,
+  ArrowDownTrayIcon,
+  ArrowPathIcon,
+  ExclamationTriangleIcon,
+  ChevronRightIcon,
+} from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import { taskApis, WorkspaceFile } from '@/apis/tasks'
+
+// File extension to icon mapping
+const FILE_ICONS: Record<string, string> = {
+  // Programming languages
+  ts: '📘',
+  tsx: '📘',
+  js: '📒',
+  jsx: '📒',
+  py: '🐍',
+  java: '☕',
+  go: '🔵',
+  rs: '🦀',
+  rb: '💎',
+  php: '🐘',
+  c: '📄',
+  cpp: '📄',
+  h: '📄',
+  cs: '📄',
+  swift: '🍎',
+  kt: '🟣',
+  // Web
+  html: '🌐',
+  css: '🎨',
+  scss: '🎨',
+  less: '🎨',
+  vue: '💚',
+  svelte: '🧡',
+  // Config
+  json: '📋',
+  yaml: '📋',
+  yml: '📋',
+  toml: '📋',
+  xml: '📋',
+  env: '🔒',
+  // Documentation
+  md: '📝',
+  txt: '📄',
+  rst: '📝',
+  // Data
+  sql: '🗄️',
+  csv: '📊',
+  // Shell
+  sh: '⚙️',
+  bash: '⚙️',
+  zsh: '⚙️',
+  // Other
+  dockerfile: '🐳',
+  makefile: '🔧',
+  gitignore: '🚫',
+}
+
+function getFileIcon(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() || ''
+  const lowerName = filename.toLowerCase()
+
+  // Special filenames
+  if (lowerName === 'dockerfile') return '🐳'
+  if (lowerName === 'makefile') return '🔧'
+  if (lowerName.startsWith('.gitignore')) return '🚫'
+  if (lowerName.startsWith('.env')) return '🔒'
+
+  return FILE_ICONS[ext] || '📄'
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+interface FileTreeNodeProps {
+  file: WorkspaceFile
+  level: number
+  defaultExpanded?: boolean
+}
+
+function FileTreeNode({ file, level, defaultExpanded = false }: FileTreeNodeProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+
+  const isDirectory = file.type === 'directory'
+  const hasChildren = isDirectory && file.children && file.children.length > 0
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors ${
+          level > 0 ? 'ml-4' : ''
+        }`}
+        onClick={() => isDirectory && setIsExpanded(!isExpanded)}
+      >
+        {/* Expand/collapse chevron for directories */}
+        {isDirectory ? (
+          <ChevronRightIcon
+            className={`w-4 h-4 text-text-muted transition-transform ${
+              isExpanded ? 'rotate-90' : ''
+            }`}
+          />
+        ) : (
+          <span className="w-4" />
+        )}
+
+        {/* File/folder icon */}
+        {isDirectory ? (
+          isExpanded ? (
+            <FolderOpenIcon className="w-5 h-5 text-amber-500" />
+          ) : (
+            <FolderIcon className="w-5 h-5 text-amber-500" />
+          )
+        ) : (
+          <span className="text-sm">{getFileIcon(file.name)}</span>
+        )}
+
+        {/* File name */}
+        <span className="flex-1 text-sm text-text-primary truncate">{file.name}</span>
+
+        {/* File size for files */}
+        {!isDirectory && file.size !== undefined && (
+          <span className="text-xs text-text-muted">{formatFileSize(file.size)}</span>
+        )}
+      </div>
+
+      {/* Children (for expanded directories) */}
+      {isDirectory && isExpanded && hasChildren && (
+        <div className="border-l border-border ml-4">
+          {file.children!.map((child, index) => (
+            <FileTreeNode
+              key={`${child.path}-${index}`}
+              file={child}
+              level={level + 1}
+              defaultExpanded={level < 1}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface WorkspaceFileViewerProps {
+  taskId: number
+}
+
+export default function WorkspaceFileViewer({ taskId }: WorkspaceFileViewerProps) {
+  const { t } = useTranslation('tasks')
+  const [files, setFiles] = useState<WorkspaceFile[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isDownloading, setIsDownloading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [totalCount, setTotalCount] = useState(0)
+
+  const loadFiles = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await taskApis.getWorkspaceFiles(taskId)
+      setFiles(response.files)
+      setTotalCount(response.total_count)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      setError(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [taskId])
+
+  useEffect(() => {
+    loadFiles()
+  }, [loadFiles])
+
+  const handleDownload = async () => {
+    setIsDownloading(true)
+    try {
+      const blob = await taskApis.downloadWorkspaceZip(taskId)
+
+      // Create download link
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `task_${taskId}_files.zip`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      setError(errorMessage)
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border border-border bg-surface p-8">
+        <div className="flex items-center justify-center gap-3">
+          <div className="animate-spin rounded-full h-5 w-5 border-2 border-primary border-t-transparent" />
+          <span className="text-sm text-text-muted">{t('workbench.workspace_files.loading')}</span>
+        </div>
+      </div>
+    )
+  }
+
+  // Error state
+  if (error) {
+    const isContainerStopped =
+      error.includes('not running') ||
+      error.includes('unreachable') ||
+      error.includes('not available') ||
+      error.includes('Container not found')
+
+    return (
+      <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-6">
+        <div className="flex flex-col items-center text-center">
+          <ExclamationTriangleIcon className="w-10 h-10 text-amber-600 dark:text-amber-400 mb-3" />
+          <h4 className="text-base font-medium text-amber-800 dark:text-amber-200">
+            {isContainerStopped
+              ? t('workbench.workspace_files.container_stopped')
+              : t('workbench.workspace_files.error_title')}
+          </h4>
+          <p className="mt-2 text-sm text-amber-700 dark:text-amber-300 max-w-md">
+            {isContainerStopped
+              ? t('workbench.workspace_files.container_stopped_hint')
+              : error}
+          </p>
+          {!isContainerStopped && (
+            <button
+              onClick={loadFiles}
+              className="mt-4 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-amber-600 hover:bg-amber-700 rounded-md transition-colors"
+            >
+              <ArrowPathIcon className="w-4 h-4" />
+              {t('workbench.retry')}
+            </button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  // Empty state
+  if (files.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-surface p-8 text-center">
+        <DocumentIcon className="w-12 h-12 text-text-muted mx-auto mb-3" />
+        <p className="text-text-muted">{t('workbench.workspace_files.no_files')}</p>
+      </div>
+    )
+  }
+
+  // Files list
+  return (
+    <div className="space-y-4">
+      {/* Header with download button */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-medium text-text-primary">
+            {t('workbench.workspace_files.title')}
+          </h3>
+          <span className="text-xs text-text-muted bg-muted px-2 py-0.5 rounded-full">
+            {totalCount} {totalCount === 1 ? 'file' : 'files'}
+          </span>
+        </div>
+        <button
+          onClick={handleDownload}
+          disabled={isDownloading}
+          className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-text-primary bg-surface border border-border hover:bg-muted rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isDownloading ? (
+            <>
+              <div className="animate-spin rounded-full h-4 w-4 border-2 border-primary border-t-transparent" />
+              {t('workbench.workspace_files.downloading')}
+            </>
+          ) : (
+            <>
+              <ArrowDownTrayIcon className="w-4 h-4" />
+              {t('workbench.workspace_files.download_all')}
+            </>
+          )}
+        </button>
+      </div>
+
+      {/* File tree */}
+      <div className="rounded-lg border border-border bg-surface overflow-hidden">
+        <div className="p-2 max-h-[500px] overflow-y-auto">
+          {files.map((file, index) => (
+            <FileTreeNode
+              key={`${file.path}-${index}`}
+              file={file}
+              level={0}
+              defaultExpanded={true}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Refresh button */}
+      <div className="flex justify-end">
+        <button
+          onClick={loadFiles}
+          className="inline-flex items-center gap-1.5 px-2 py-1 text-xs text-text-muted hover:text-text-primary transition-colors"
+        >
+          <ArrowPathIcon className="w-3.5 h-3.5" />
+          {t('workbench.workspace_files.refresh')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -67,7 +67,18 @@
     "loading_diff_message": "Loading diff...",
     "no_changes_between_branches": "No changes found between branches",
     "execution_timeline": "Execution Timeline",
-    "no_repository": "This task is not associated with a code repository"
+    "no_repository": "This task is not associated with a code repository",
+    "workspace_files": {
+      "title": "Workspace Files",
+      "loading": "Loading files...",
+      "no_files": "No files generated",
+      "download_all": "Download All",
+      "downloading": "Packaging...",
+      "refresh": "Refresh",
+      "error_title": "Failed to load files",
+      "container_stopped": "Container Stopped",
+      "container_stopped_hint": "The task execution environment has been shut down. File list is no longer available. Please re-run the task if you need to access the generated files."
+    }
   },
   "thinking": {
     "execution_completed": "Execution Completed",

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -63,7 +63,18 @@
     "loading_diff_message": "加载中...",
     "no_changes_between_branches": "分支之间未发现变更",
     "execution_timeline": "执行时间线",
-    "no_repository": "该任务未关联代码仓库"
+    "no_repository": "该任务未关联代码仓库",
+    "workspace_files": {
+      "title": "工作区文件",
+      "loading": "正在加载文件列表...",
+      "no_files": "暂无生成的文件",
+      "download_all": "打包下载",
+      "downloading": "正在打包...",
+      "refresh": "刷新",
+      "error_title": "获取文件列表失败",
+      "container_stopped": "容器已停止",
+      "container_stopped_hint": "任务执行环境已关闭，无法获取文件列表。如需获取生成的文件，请重新运行任务。"
+    }
   },
   "thinking": {
     "execution_completed": "执行完成",


### PR DESCRIPTION
Implement workspace files viewing and ZIP download functionality for tasks without associated git repositories. Files are retrieved from the executor container's workspace directory.

Changes:
- Add /files/list and /files/download-zip endpoints to executor envd API
- Add /executor/address endpoint to executor manager for container discovery
- Add workspace files service and API endpoints in backend
- Add WorkspaceFileViewer component with file tree and download button
- Add i18n translations for workspace files feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace file browser: View hierarchical file structures from task workspaces when using no-repository mode, including file sizes and directory listings.
  * Download workspace files: Export all workspace files as a compressed ZIP archive.
  * Added error handling for unavailable containers with refresh functionality and multi-language support (English and Simplified Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->