### PR TITLE
fix(executor): fix Claude client process check path

### DIFF
--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -611,12 +611,14 @@ class ClaudeCodeAgent(Agent):
                         process = cached_client._transport._process
 
                     if process is not None:
-                        poll_result = process.poll()
-                        if poll_result is not None:
+                        # For asyncio.subprocess.Process, check returncode instead of poll()
+                        # returncode is None if process is still running, contains exit code if terminated
+                        returncode = getattr(process, "returncode", None)
+                        if returncode is not None:
                             # Process has terminated, remove from cache
                             logger.warning(
                                 f"Cached client process terminated for session_id: {self.session_id}, "
-                                f"exit_code={poll_result}, creating new client"
+                                f"exit_code={returncode}, creating new client"
                             )
                             SessionManager.remove_client(self.session_id)
                             # Proceed to create new client


### PR DESCRIPTION
The cached client validity check was looking for `_process` directly on the client object, but Claude SDK stores the process at `client._transport._process`. This caused the check to always fail and fall through to the else branch which assumed the client was valid.

This fix:
- Corrects the path to `client._transport._process`
- When process info is unavailable, removes client from cache instead of assuming it's valid (safer behavior)
- Adds more detailed logging including exit_code and process_pid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by detecting and recovering from stale or terminated agent connections, ensuring new connections are created when needed.
  * Fixed cancellation handling so user-initiated cancels are honored promptly and no longer masked by residual-retry states.

* **Improvements**
  * Preserves cancellation state across cleanup to prevent unwanted retries until a task restarts.
  * Enhanced termination behavior and logging for better observability during async execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->