### PR TITLE
feat(chat-shell): add builtin filesystem tools with local/remote mode support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,7 +170,7 @@ jobs:
         working-directory: ./shared
         run: |
           python -m pip install --upgrade pip
-          pip install cryptography pytest pytest-cov
+          pip install -e ".[dev]"
 
       - name: Run shared tests
         working-directory: ./shared

--- a/backend/init_data/skills/sandbox/SKILL.md
+++ b/backend/init_data/skills/sandbox/SKILL.md
@@ -1,9 +1,9 @@
 ---
-description: "Provides read_file/write_file/exec/list_files/read_file/write_file for running process and managing filesystems in the sandbox. Ideal for code testing, file management, and command execution. The sub_claude_agent tool is available for advanced use cases. You MUST load this skill BEFORE use sandbox tools."
+description: "Provides sub_claude_agent for running Claude AI tasks, and upload_attachment/download_attachment for file transfers. The read_file/write_file/exec/list_files tools are now builtin and automatically available without loading this skill."
 displayName: "沙箱环境"
-version: "2.1.0"
+version: "3.0.0"
 author: "Wegent Team"
-tags: ["sandbox", "code-execution", "filesystem", "automation"]
+tags: ["sandbox", "code-execution", "claude-ai", "attachment"]
 bindShells: ["Chat"]
 provider:
   module: provider
@@ -23,20 +23,10 @@ config:
           model_id: "xxxxx"
           small_model: "xxxxx"
 tools:
-  - name: exec
-    provider: sandbox
   - name: sub_claude_agent
     provider: sandbox
     config:
       command_timeout: 1800
-  - name: list_files
-    provider: sandbox
-  - name: read_file
-    provider: sandbox
-  - name: write_file
-    provider: sandbox
-    config:
-      max_file_size: 10485760
   - name: upload_attachment
     provider: sandbox
     config:
@@ -47,63 +37,41 @@ tools:
 
 # Sandbox Environment
 
-Execute code, commands, and complex tasks securely in isolated Docker containers running **AlmaLinux 9.4**.
+Execute complex Claude AI tasks and manage file attachments in isolated Docker containers running **AlmaLinux 9.4**.
+
+## Important: Builtin Filesystem Tools
+
+> **Note**: The following tools are now **builtin** in Chat Shell and are automatically available without loading this skill:
+> - `read_file` - Read file contents
+> - `write_file` - Write content to files
+> - `list_files` - List directory contents
+> - `exec` - Execute shell commands
+>
+> These builtin tools support both **local mode** (direct filesystem access) and **remote mode** (E2B sandbox).
+> You only need to load this skill if you need `sub_claude_agent` or attachment operations.
 
 ## Core Capabilities
 
-The sandbox environment provides fully isolated execution spaces with:
+The sandbox skill now focuses on:
 
-1. **Command Execution** - Run shell commands, scripts, and programs
-2. **File Operations** - Read/write files, browse directories, manage filesystems
-3. **Code Execution** - Safely execute and test code
-4. **Claude AI Tasks** - Available for advanced use cases when explicitly requested by users
-5. **Attachment Upload/Download** - Upload generated files to Wegent for user download, or download user attachments for processing
+1. **Claude AI Tasks** - Run Claude AI agent for complex multi-step programming tasks
+2. **Attachment Upload** - Upload generated files to Wegent for user download
+3. **Attachment Download** - Download user attachments for processing in sandbox
 
-## When to Use
+## When to Use This Skill
 
 Use this skill when you need to:
 
-- ✅ Execute shell commands or scripts
-- ✅ Run and test code
-- ✅ Read, write, or manage files
-- ✅ Perform multi-step programming tasks
-- ✅ Git operations (clone, commit, push, etc.)
-- ✅ Require isolated environment for safety
+- ✅ Run Claude AI for complex programming tasks (`sub_claude_agent`)
+- ✅ Upload generated files for user download (`upload_attachment`)
+- ✅ Download user attachments for processing (`download_attachment`)
 
-**Note**: The `sub_claude_agent` tool should only be used when the user explicitly requests Claude AI assistance (e.g., "use Claude to generate...", "ask Claude to create...").
+**Note**: For basic file operations (read/write/list/exec), use the builtin tools directly - no need to load this skill.
 
 ## Available Tools
 
-### Command Execution
+### `sub_claude_agent`
 
-#### `exec`
-Execute shell commands in the sandbox environment.
-
-**Use Cases:**
-- Run single commands or scripts
-- Directory operations (create, delete, move)
-- Install dependencies, run tests
-- View system information
-
-**Parameters:**
-- `command` (required): Shell command to execute
-- `working_dir` (optional): Working directory path
-- `timeout` (optional): Timeout in seconds
-
-**Example:**
-```json
-{
-  "name": "exec",
-  "arguments": {
-    "command": "python script.py --arg value",
-    "working_dir": "/home/user/project"
-  }
-}
-```
-
----
-
-#### `sub_claude_agent`
 Run Claude AI to execute complex tasks in the sandbox.
 
 **⚠️ IMPORTANT**: This tool should **only be used when the user explicitly requests it**. Do not use this tool automatically or as a default option.
@@ -138,94 +106,8 @@ Run Claude AI to execute complex tasks in the sandbox.
 
 ---
 
-### File Operations
+### `upload_attachment`
 
-#### `list_files`
-List files and subdirectories in a directory.
-
-**Parameters:**
-- `path` (required): Directory path
-- `depth` (optional): Recursion depth, default 1
-
-**Returns:**
-- File metadata including name, size, permissions, modification time
-
-**Example:**
-```json
-{
-  "name": "list_files",
-  "arguments": {
-    "path": "/home/user/project",
-    "depth": 2
-  }
-}
-```
-
----
-
-#### `read_file`
-Read file contents.
-
-**Parameters:**
-- `file_path` (required): File path to read
-
-**Limits:**
-- Maximum file size: 1MB (configurable)
-
-**Example:**
-```json
-{
-  "name": "read_file",
-  "arguments": {
-    "file_path": "/home/user/config.json"
-  }
-}
-```
-
----
-
-#### `write_file`
-Write content to a file.
-
-⚠️ **IMPORTANT**: Both `file_path` AND `content` are **REQUIRED** parameters. You must always provide the content to write.
-
-**Parameters:**
-- `file_path` (REQUIRED): File path to write
-- `content` (REQUIRED): Content to write (MUST be provided, cannot be omitted)
-- `format` (optional): Content format - 'text' (default) or 'bytes' (base64-encoded)
-- `create_dirs` (optional): Auto-create parent directories (default: True)
-
-**Features:**
-- Automatically creates parent directories
-- Maximum file size: 10MB (configurable)
-
-**Example - Text file:**
-```json
-{
-  "name": "write_file",
-  "arguments": {
-    "file_path": "/home/user/output.txt",
-    "content": "Hello, Sandbox!"
-  }
-}
-```
-
-**Example - HTML file:**
-```json
-{
-  "name": "write_file",
-  "arguments": {
-    "file_path": "/home/user/index.html",
-    "content": "<!DOCTYPE html><html><head><title>Test</title></head><body><h1>Hello</h1></body></html>"
-  }
-}
-```
-
----
-
-### Attachment Operations
-
-#### `upload_attachment`
 Upload a file from sandbox to Wegent and get a download URL for users.
 
 **Use Cases:**
@@ -271,7 +153,8 @@ Document generation completed!
 
 ---
 
-#### `download_attachment`
+### `download_attachment`
+
 Download a file from Wegent attachment URL to sandbox for processing.
 
 **Use Cases:**
@@ -305,97 +188,15 @@ Download a file from Wegent attachment URL to sandbox for processing.
 
 | Task Type | Recommended Tool | Reason |
 |-----------|-----------------|--------|
-| Execute commands or scripts | `exec` | Fast execution, no overhead |
-| Create/delete directories | `exec` | Use `mkdir -p` or `rm -rf` directly |
-| Read files | `read_file` | Better error handling and size validation |
-| Write files | `write_file` | Auto directory creation, size validation |
-| Browse directories | `list_files` | Structured output with metadata |
+| Execute commands or scripts | `exec` (builtin) | Fast execution, no skill loading needed |
+| Read files | `read_file` (builtin) | Better error handling and size validation |
+| Write files | `write_file` (builtin) | Auto directory creation, size validation |
+| Browse directories | `list_files` (builtin) | Structured output with metadata |
 | Upload files for user download | `upload_attachment` | Get download URL for user-facing files |
 | Download attachments | `download_attachment` | Retrieve Wegent attachments into sandbox |
 | Complex tasks with Claude | `sub_claude_agent` | **Only when user explicitly requests** |
 
-**Important**: Always prefer `exec` for standard operations. Only use `sub_claude_agent` when the user specifically asks for Claude AI assistance.
-
----
-
-## Usage Examples
-
-### Scenario 1: Run Python Script
-
-```json
-{
-  "name": "exec",
-  "arguments": {
-    "command": "cd /home/user && python -m pip install requests && python app.py"
-  }
-}
-```
-
-### Scenario 2: Install System Packages (AlmaLinux)
-
-```json
-{
-  "name": "exec",
-  "arguments": {
-    "command": "dnf install -y gcc make && gcc --version"
-  }
-}
-```
-
-### Scenario 3: File Management
-
-```json
-// 1. List files
-{
-  "name": "list_files",
-  "arguments": {
-    "path": "/home/user"
-  }
-}
-
-// 2. Read file
-{
-  "name": "read_file",
-  "arguments": {
-    "file_path": "/home/user/data.json"
-  }
-}
-
-// 3. Write file
-{
-  "name": "write_file",
-  "arguments": {
-    "file_path": "/home/user/result.txt",
-    "content": "Processing complete: Success"
-  }
-}
-```
-
-### Scenario 4: Git Operations
-
-```json
-{
-  "name": "exec",
-  "arguments": {
-    "command": "git clone https://github.com/user/repo.git && cd repo && git checkout -b feature"
-  }
-}
-```
-
-### Scenario 5: Using Claude (Only When Explicitly Requested)
-
-**Example user request**: "Please use Claude to generate a presentation about AI"
-
-```json
-{
-  "name": "sub_claude_agent",
-  "arguments": {
-    "prompt": "Create a 5-page presentation about the history of artificial intelligence"
-  }
-}
-```
-
-**Note**: This scenario should only be used when the user explicitly asks for Claude assistance.
+**Important**: For basic filesystem operations, use the builtin tools directly. Only load this skill when you need Claude AI tasks or attachment operations.
 
 ---
 
@@ -417,10 +218,7 @@ Download a file from Wegent attachment URL to sandbox for processing.
 - Each sandbox runs in an isolated Docker container
 
 ### Resource Limits
-- **Read file limit**: 1MB (configurable)
-- **Write file limit**: 10MB (configurable)
 - **Upload file limit**: 100MB (configurable)
-- **Command timeout**: 300 seconds (5 minutes)
 - **Claude timeout**: 1800 seconds (30 minutes, minimum: 600 seconds / 10 minutes)
 - **Total task timeout**: 7200 seconds (2 hours)
 
@@ -454,12 +252,12 @@ Control Claude's available tools via the `allowed_tools` parameter:
 
 ## Best Practices
 
-1. **Clear Task Descriptions** - Provide detailed instructions and expected outcomes
-2. **Use Absolute Paths** - Avoid path ambiguity
-3. **Choose the Right Tool** - Refer to the tool selection guide
-4. **Check Return Results** - Verify the `success` field
-5. **Mind Size Limits** - File read/write operations have size constraints
-6. **Prefer exec** - Use for most tasks; only use `sub_claude_agent` when user explicitly requests Claude assistance
+1. **Use Builtin Tools First** - For read/write/exec/list, use builtin tools (no skill loading)
+2. **Load This Skill Only When Needed** - For Claude AI or attachment operations
+3. **Clear Task Descriptions** - Provide detailed instructions and expected outcomes
+4. **Use Absolute Paths** - Avoid path ambiguity
+5. **Check Return Results** - Verify the `success` field
+6. **Only Use sub_claude_agent When Requested** - Don't use it automatically
 
 ---
 
@@ -476,10 +274,6 @@ Control Claude's available tools via the `allowed_tools` parameter:
 ### Command Timeout
 **Cause**: Task execution takes too long
 **Solution**: Increase timeout setting or split into smaller tasks
-
-### File Too Large
-**Cause**: Exceeds size limit (1MB read / 10MB write)
-**Solution**: Process in chunks or adjust configuration
 
 ### Permission Denied
 **Cause**: Insufficient file permissions

--- a/backend/init_data/skills/sandbox/provider.py
+++ b/backend/init_data/skills/sandbox/provider.py
@@ -81,15 +81,23 @@ class SandboxToolProvider(SkillToolProvider):
     def supported_tools(self) -> list[str]:
         """Return the list of tools this provider can create.
 
+        Note: read_file, write_file, list_files, exec have been moved to
+        Chat Shell builtin tools (chat_shell/tools/builtin/filesystem_tools.py).
+        These tools are now automatically available without loading the sandbox skill.
+
         Returns:
             List containing supported tool names
         """
         return [
-            "exec",
+            # Deprecated: These tools are now builtin in Chat Shell
+            # Keep them here for backward compatibility during transition
+            # They will be removed in a future version
+            "exec",  # DEPRECATED: Use builtin exec tool
+            "list_files",  # DEPRECATED: Use builtin list_files tool
+            "read_file",  # DEPRECATED: Use builtin read_file tool
+            "write_file",  # DEPRECATED: Use builtin write_file tool
+            # Active tools (sandbox-specific, not available as builtin)
             "sub_claude_agent",
-            "list_files",
-            "read_file",
-            "write_file",
             "upload_attachment",
             "download_attachment",
         ]

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -106,6 +106,22 @@ class Settings(BaseSettings):
     ENABLE_SKILLS: bool = True
     ENABLE_CHECKPOINTING: bool = False
 
+    # ========== Sandbox Mode Configuration ==========
+    # "local" - Use local filesystem operations (direct access to host filesystem)
+    # "remote" - Use remote E2B sandbox (default, backward compatible)
+    # Env: CHAT_SHELL_SANDBOX_MODE
+    SANDBOX_MODE: str = "remote"
+
+    # Local mode configuration
+    # Default working directory for local file operations
+    LOCAL_WORKSPACE_ROOT: str = "/workspace"
+    # Command execution timeout in seconds
+    LOCAL_COMMAND_TIMEOUT: int = 300
+    # Maximum command output size in bytes (64KB)
+    LOCAL_MAX_OUTPUT_SIZE: int = 65536
+    # Maximum file read size in bytes (100KB)
+    LOCAL_MAX_FILE_SIZE: int = 102400
+
     # Attachment/Context configuration
     MAX_EXTRACTED_TEXT_LENGTH: int = 100000
 

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -729,6 +729,10 @@ class ChatContext:
             self._request.subtask_id,
         )
 
+        # Add filesystem tools (read_file, write_file, list_files, exec)
+        # These are builtin tools that support both local and remote sandbox modes
+        self._add_filesystem_tools(extra_tools)
+
         # === External Tools ===
 
         # Add KB tools
@@ -746,3 +750,46 @@ class ChatContext:
             extra_tools.extend(mcp_tools)
 
         return extra_tools
+
+    def _add_filesystem_tools(self, extra_tools: list) -> None:
+        """Add filesystem tools based on SANDBOX_MODE configuration.
+
+        This method adds builtin filesystem tools (read_file, write_file, list_files, exec)
+        that support both local and remote sandbox modes.
+
+        Args:
+            extra_tools: List to append filesystem tools to
+        """
+        from chat_shell.tools.builtin import get_filesystem_tools
+
+        # Get sandbox mode from settings (default: "remote")
+        sandbox_mode = settings.SANDBOX_MODE if hasattr(settings, "SANDBOX_MODE") else "remote"
+
+        # Get local mode configuration
+        workspace_root = getattr(settings, "LOCAL_WORKSPACE_ROOT", "/workspace")
+        command_timeout = getattr(settings, "LOCAL_COMMAND_TIMEOUT", 300)
+        max_output_size = getattr(settings, "LOCAL_MAX_OUTPUT_SIZE", 65536)
+        max_file_size = getattr(settings, "LOCAL_MAX_FILE_SIZE", 102400)
+
+        # Create filesystem tools
+        fs_tools = get_filesystem_tools(
+            sandbox_mode=sandbox_mode,
+            workspace_root=workspace_root,
+            max_file_size=max_file_size,
+            max_output_size=max_output_size,
+            command_timeout=command_timeout,
+            task_id=self._request.task_id,
+            subtask_id=self._request.subtask_id,
+            user_id=self._request.user_id,
+            user_name=self._request.user_name,
+            # Note: ws_emitter, bot_config, auth_token would need to be passed
+            # if we want full sandbox functionality in remote mode
+            # For now, we'll use basic configuration
+        )
+
+        extra_tools.extend(fs_tools)
+        logger.info(
+            "[CHAT_CONTEXT] Added %d filesystem tools (mode=%s)",
+            len(fs_tools),
+            sandbox_mode,
+        )

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -763,7 +763,7 @@ class ChatContext:
         from chat_shell.tools.builtin import get_filesystem_tools
 
         # Get sandbox mode from settings (default: "remote")
-        sandbox_mode = settings.SANDBOX_MODE if hasattr(settings, "SANDBOX_MODE") else "remote"
+        sandbox_mode = getattr(settings, "SANDBOX_MODE", "remote")
 
         # Get local mode configuration
         workspace_root = getattr(settings, "LOCAL_WORKSPACE_ROOT", "/workspace")
@@ -782,9 +782,7 @@ class ChatContext:
             subtask_id=self._request.subtask_id,
             user_id=self._request.user_id,
             user_name=self._request.user_name,
-            # Note: ws_emitter, bot_config, auth_token would need to be passed
-            # if we want full sandbox functionality in remote mode
-            # For now, we'll use basic configuration
+            auth_token=getattr(self._request, "auth_token", ""),
         )
 
         extra_tools.extend(fs_tools)

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -8,6 +8,14 @@ from .create_subscription import CreateSubscriptionTool
 from .data_table import DataTableTool
 from .evaluation import SubmitEvaluationResultTool
 from .file_reader import FileListSkill, FileReaderSkill
+from .filesystem_tools import (
+    BaseFilesystemTool,
+    ExecuteCommandTool,
+    ListFilesTool,
+    ReadFileTool,
+    WriteFileTool,
+    get_filesystem_tools,
+)
 from .knowledge_base import KnowledgeBaseTool
 from .knowledge_listing import KbHeadTool, KbLsTool, KBToolCallCounter
 from .load_skill import LoadSkillTool
@@ -27,4 +35,11 @@ __all__ = [
     "SubmitEvaluationResultTool",
     "LoadSkillTool",
     "SilentExitException",  # Keep exception for backward compatibility
+    # Filesystem tools
+    "ReadFileTool",
+    "WriteFileTool",
+    "ListFilesTool",
+    "ExecuteCommandTool",
+    "BaseFilesystemTool",
+    "get_filesystem_tools",
 ]

--- a/chat_shell/chat_shell/tools/builtin/filesystem_tools.py
+++ b/chat_shell/chat_shell/tools/builtin/filesystem_tools.py
@@ -1,0 +1,952 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in filesystem tools for Chat Shell.
+
+This module provides filesystem operation tools that can run in two modes:
+- local: Direct filesystem access using shared/utils/filesystem.py
+- remote: E2B sandbox access using existing sandbox infrastructure
+
+The mode is determined by SANDBOX_MODE configuration setting.
+"""
+
+import json
+import logging
+from typing import Any, Optional
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# Input schemas for tools
+class ReadFileInput(BaseModel):
+    """Input schema for read_file tool."""
+
+    file_path: str = Field(
+        ...,
+        description="Absolute or relative path to the file to read",
+    )
+    format: Optional[str] = Field(
+        default="text",
+        description="Format to read the file: 'text' (default) or 'bytes'",
+    )
+
+
+class WriteFileInput(BaseModel):
+    """Input schema for write_file tool."""
+
+    file_path: str = Field(
+        ...,
+        description="Absolute or relative path to the file to write",
+    )
+    content: str = Field(
+        ...,
+        description="REQUIRED: Content to write to the file. This parameter is mandatory.",
+    )
+    format: Optional[str] = Field(
+        default="text",
+        description="Format of content: 'text' (default) or 'bytes' (base64-encoded)",
+    )
+    create_dirs: Optional[bool] = Field(
+        default=True,
+        description="Create parent directories if they don't exist (default: True)",
+    )
+
+
+class ListFilesInput(BaseModel):
+    """Input schema for list_files tool."""
+
+    path: Optional[str] = Field(
+        default="/home/user",
+        description="Directory path to list (default: /home/user for remote, workspace root for local)",
+    )
+    depth: Optional[int] = Field(
+        default=1,
+        description="Depth of directory listing (default: 1). Use higher values for recursive listing.",
+    )
+
+
+class ExecuteCommandInput(BaseModel):
+    """Input schema for exec tool."""
+
+    command: str = Field(
+        ...,
+        description="The command to execute",
+    )
+    working_dir: Optional[str] = Field(
+        default=None,
+        description="Working directory for command execution",
+    )
+    timeout_seconds: Optional[int] = Field(
+        default=None,
+        description="Command timeout in seconds (overrides default)",
+    )
+
+
+class BaseFilesystemTool(BaseTool):
+    """Base class for filesystem tools with dual-mode support.
+
+    Supports both local filesystem operations and remote sandbox operations
+    based on the sandbox_mode setting.
+
+    Attributes:
+        sandbox_mode: "local" or "remote"
+        workspace_root: Base directory for local mode operations
+        max_file_size: Maximum file size for read operations
+        max_output_size: Maximum output size for command execution
+        command_timeout: Default command timeout in seconds
+        task_id: Task ID for sandbox operations
+        subtask_id: Subtask ID for sandbox operations
+        user_id: User ID for sandbox operations
+        user_name: Username for sandbox operations
+        ws_emitter: WebSocket emitter for status updates
+        bot_config: Bot configuration list
+        auth_token: API auth token
+    """
+
+    # Mode configuration
+    sandbox_mode: str = "remote"  # "local" or "remote"
+    workspace_root: str = "/workspace"
+    max_file_size: int = 102400  # 100KB
+    max_output_size: int = 65536  # 64KB
+    command_timeout: int = 300  # 5 minutes
+
+    # Sandbox dependencies (for remote mode)
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    user_name: str = ""
+    ws_emitter: Any = None
+    bot_config: list = []
+    auth_token: str = ""
+    default_shell_type: str = "ClaudeCode"
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _format_error(self, error_message: str, **kwargs) -> str:
+        """Format error response as JSON string."""
+        response = {
+            "success": False,
+            "error": error_message,
+        }
+        response.update(kwargs)
+        return json.dumps(response, ensure_ascii=False, indent=2)
+
+    def _get_sandbox_manager(self):
+        """Get sandbox manager for remote mode operations."""
+        from chat_shell.tools.sandbox import SandboxManager
+
+        return SandboxManager.get_instance(
+            task_id=self.task_id,
+            user_id=self.user_id,
+            user_name=self.user_name,
+            bot_config=self.bot_config,
+            auth_token=self.auth_token,
+        )
+
+    async def _emit_tool_status(
+        self, status: str, message: str = "", result: dict = None
+    ) -> None:
+        """Emit tool status update to frontend via WebSocket."""
+        if not self.ws_emitter:
+            return
+
+        try:
+            tool_output = {"message": message}
+            if result:
+                tool_output.update(result)
+
+            await self.ws_emitter.emit_tool_call(
+                task_id=self.task_id,
+                tool_name=self.name,
+                tool_input={},
+                tool_output=tool_output,
+                status=status,
+            )
+        except Exception as e:
+            logger.warning(f"[{self.__class__.__name__}] Failed to emit tool status: {e}")
+
+
+class ReadFileTool(BaseFilesystemTool):
+    """Tool for reading files from local filesystem or remote sandbox."""
+
+    name: str = "read_file"
+    display_name: str = "Read File"
+    description: str = """Read the contents of a file.
+
+Use this tool to read files from the filesystem.
+
+Parameters:
+- file_path (required): Path to the file (absolute or relative)
+- format (optional): Read format - 'text' (default) or 'bytes'
+
+Size Limits:
+- Text files: Maximum 100KB (102400 bytes)
+- Binary files: Maximum 32KB (32768 bytes)
+
+Returns:
+- success: Whether the file was read successfully
+- content: File contents as string (or base64 for bytes)
+- size: File size in bytes
+- path: Absolute path to the file
+- format: Format used for reading
+
+Example:
+{
+  "file_path": "/path/to/file.txt",
+  "format": "text"
+}"""
+
+    args_schema: type[BaseModel] = ReadFileInput
+
+    def _run(
+        self,
+        file_path: str,
+        format: Optional[str] = "text",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Synchronous run - not implemented."""
+        raise NotImplementedError("ReadFileTool only supports async execution")
+
+    async def _arun(
+        self,
+        file_path: str,
+        format: Optional[str] = "text",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Read file from filesystem or sandbox."""
+        logger.info(
+            f"[ReadFileTool] Reading file: {file_path}, format={format}, "
+            f"mode={self.sandbox_mode}"
+        )
+
+        if self.sandbox_mode == "local":
+            return await self._read_local(file_path, format)
+        else:
+            return await self._read_remote(file_path, format)
+
+    async def _read_local(self, file_path: str, format: str) -> str:
+        """Read file from local filesystem."""
+        from shared.utils.filesystem import read_file
+
+        result = await read_file(
+            file_path=file_path,
+            format=format,
+            max_size=self.max_file_size,
+            base_dir=self.workspace_root,
+        )
+
+        if result["success"]:
+            await self._emit_tool_status(
+                "completed",
+                f"File read successfully ({result['size']} bytes)",
+                result,
+            )
+        else:
+            await self._emit_tool_status("failed", result.get("error", "Unknown error"))
+
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+    async def _read_remote(self, file_path: str, format: str) -> str:
+        """Read file from remote sandbox using E2B SDK."""
+        import base64
+
+        try:
+            sandbox_manager = self._get_sandbox_manager()
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type=self.default_shell_type,
+                workspace_ref=None,
+            )
+
+            if error:
+                return self._format_error(
+                    f"Failed to create sandbox: {error}",
+                    content="",
+                    size=0,
+                    path="",
+                )
+
+            # Normalize path for sandbox
+            if not file_path.startswith("/"):
+                file_path = f"/home/user/{file_path}"
+
+            # Get file info
+            try:
+                file_info = await sandbox.files.get_info(file_path)
+            except Exception:
+                return self._format_error(
+                    f"File not found: {file_path}",
+                    content="",
+                    size=0,
+                    path=file_path,
+                )
+
+            # Check file type
+            if file_info.type and file_info.type.value != "file":
+                return self._format_error(
+                    f"Path is a {file_info.type.value}, not a file",
+                    content="",
+                    size=0,
+                    path=file_path,
+                )
+
+            # Check file size
+            file_size = file_info.size
+            max_size = 32768 if format == "bytes" else self.max_file_size
+            if file_size > max_size:
+                return self._format_error(
+                    f"File too large: {file_size} bytes. Maximum: {max_size} bytes.",
+                    content="",
+                    size=file_size,
+                    path=file_path,
+                )
+
+            # Read file
+            if format == "bytes":
+                content = await sandbox.files.read(file_path, format="bytes")
+                content_str = base64.b64encode(content).decode("ascii")
+            else:
+                content = await sandbox.files.read(file_path, format="text")
+                content_str = content
+
+            response = {
+                "success": True,
+                "content": content_str,
+                "size": file_size,
+                "path": file_path,
+                "format": format,
+                "modified_time": file_info.modified_time.isoformat(),
+                "sandbox_id": sandbox.sandbox_id,
+            }
+
+            await self._emit_tool_status(
+                "completed",
+                f"File read successfully ({file_size} bytes)",
+                response,
+            )
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except ImportError as e:
+            logger.error(f"[ReadFileTool] E2B SDK import error: {e}")
+            return self._format_error(
+                "E2B SDK not available. Please install e2b-code-interpreter.",
+                content="",
+                size=0,
+                path="",
+            )
+        except Exception as e:
+            logger.error(f"[ReadFileTool] Read failed: {e}", exc_info=True)
+            return self._format_error(
+                f"Failed to read file: {e}",
+                content="",
+                size=0,
+                path="",
+            )
+
+
+class WriteFileTool(BaseFilesystemTool):
+    """Tool for writing files to local filesystem or remote sandbox."""
+
+    name: str = "write_file"
+    display_name: str = "Write File"
+    description: str = """Write content to a file.
+
+Use this tool to create or overwrite files in the filesystem.
+
+IMPORTANT: Both file_path AND content are REQUIRED parameters.
+
+Parameters:
+- file_path (REQUIRED): Path to the file (absolute or relative)
+- content (REQUIRED): Content to write (text or base64-encoded bytes)
+- format (optional): Content format - 'text' (default) or 'bytes'
+- create_dirs (optional): Create parent directories if needed (default: True)
+
+Returns:
+- success: Whether the file was written successfully
+- path: Absolute path to the file
+- size: Number of bytes written
+- format: Format used for writing
+
+Example:
+{
+  "file_path": "/path/to/file.txt",
+  "content": "Hello, World!",
+  "format": "text"
+}"""
+
+    args_schema: type[BaseModel] = WriteFileInput
+
+    def _run(
+        self,
+        file_path: str,
+        content: str,
+        format: Optional[str] = "text",
+        create_dirs: Optional[bool] = True,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Synchronous run - not implemented."""
+        raise NotImplementedError("WriteFileTool only supports async execution")
+
+    async def _arun(
+        self,
+        file_path: str,
+        content: str,
+        format: Optional[str] = "text",
+        create_dirs: Optional[bool] = True,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Write file to filesystem or sandbox."""
+        # Validate content
+        if not content:
+            error_msg = (
+                "Missing required parameter 'content'. "
+                "You MUST provide content to write to the file."
+            )
+            await self._emit_tool_status("failed", error_msg)
+            return self._format_error(error_msg, path=file_path, size=0)
+
+        logger.info(
+            f"[WriteFileTool] Writing file: {file_path}, format={format}, "
+            f"mode={self.sandbox_mode}"
+        )
+
+        if self.sandbox_mode == "local":
+            return await self._write_local(file_path, content, format, create_dirs)
+        else:
+            return await self._write_remote(file_path, content, format, create_dirs)
+
+    async def _write_local(
+        self, file_path: str, content: str, format: str, create_dirs: bool
+    ) -> str:
+        """Write file to local filesystem."""
+        from shared.utils.filesystem import write_file
+
+        result = await write_file(
+            file_path=file_path,
+            content=content,
+            format=format,
+            create_dirs=create_dirs,
+            base_dir=self.workspace_root,
+        )
+
+        if result["success"]:
+            await self._emit_tool_status(
+                "completed",
+                f"File written successfully ({result['size']} bytes)",
+                result,
+            )
+        else:
+            await self._emit_tool_status("failed", result.get("error", "Unknown error"))
+
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+    async def _write_remote(
+        self, file_path: str, content: str, format: str, create_dirs: bool
+    ) -> str:
+        """Write file to remote sandbox using E2B SDK."""
+        import base64
+        import os
+
+        try:
+            sandbox_manager = self._get_sandbox_manager()
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type=self.default_shell_type,
+                workspace_ref=None,
+            )
+
+            if error:
+                return self._format_error(
+                    f"Failed to create sandbox: {error}",
+                    path="",
+                    size=0,
+                )
+
+            # Normalize path for sandbox
+            if not file_path.startswith("/"):
+                file_path = f"/home/user/{file_path}"
+
+            # Prepare content
+            if format == "bytes":
+                try:
+                    content_bytes = base64.b64decode(content)
+                except Exception as e:
+                    return self._format_error(
+                        f"Invalid base64 content: {e}",
+                        path="",
+                        size=0,
+                    )
+            else:
+                content_bytes = content.encode("utf-8")
+
+            # Create parent directories if needed
+            if create_dirs:
+                parent_dir = os.path.dirname(file_path)
+                if parent_dir and parent_dir != "/":
+                    try:
+                        await sandbox.files.make_dir(parent_dir)
+                    except Exception:
+                        pass  # Directory might already exist
+
+            # Write file
+            if format == "bytes":
+                await sandbox.files.write(file_path, content_bytes)
+            else:
+                await sandbox.files.write(file_path, content)
+
+            # Get file info
+            file_info = await sandbox.files.get_info(file_path)
+
+            response = {
+                "success": True,
+                "path": file_path,
+                "size": file_info.size,
+                "format": format,
+                "modified_time": file_info.modified_time.isoformat(),
+                "sandbox_id": sandbox.sandbox_id,
+            }
+
+            await self._emit_tool_status(
+                "completed",
+                f"File written successfully ({file_info.size} bytes)",
+                response,
+            )
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except ImportError as e:
+            logger.error(f"[WriteFileTool] E2B SDK import error: {e}")
+            return self._format_error(
+                "E2B SDK not available. Please install e2b-code-interpreter.",
+                path="",
+                size=0,
+            )
+        except Exception as e:
+            logger.error(f"[WriteFileTool] Write failed: {e}", exc_info=True)
+            return self._format_error(
+                f"Failed to write file: {e}",
+                path="",
+                size=0,
+            )
+
+
+class ListFilesTool(BaseFilesystemTool):
+    """Tool for listing files in local filesystem or remote sandbox."""
+
+    name: str = "list_files"
+    display_name: str = "List Files"
+    description: str = """List files and directories.
+
+Use this tool to explore the filesystem structure.
+
+Parameters:
+- path (optional): Directory to list (default: workspace root for local, /home/user for remote)
+- depth (optional): Depth of directory listing (default: 1)
+
+Returns:
+- success: Whether the listing was successful
+- entries: List of file/directory entries with metadata
+- total: Total number of entries
+
+Example:
+{
+  "path": "/workspace",
+  "depth": 2
+}"""
+
+    args_schema: type[BaseModel] = ListFilesInput
+
+    def _run(
+        self,
+        path: Optional[str] = None,
+        depth: Optional[int] = 1,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Synchronous run - not implemented."""
+        raise NotImplementedError("ListFilesTool only supports async execution")
+
+    async def _arun(
+        self,
+        path: Optional[str] = None,
+        depth: Optional[int] = 1,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """List files in filesystem or sandbox."""
+        # Use default path based on mode
+        if path is None:
+            path = self.workspace_root if self.sandbox_mode == "local" else "/home/user"
+
+        logger.info(
+            f"[ListFilesTool] Listing: {path}, depth={depth}, mode={self.sandbox_mode}"
+        )
+
+        if self.sandbox_mode == "local":
+            return await self._list_local(path, depth)
+        else:
+            return await self._list_remote(path, depth)
+
+    async def _list_local(self, path: str, depth: int) -> str:
+        """List files in local filesystem."""
+        from shared.utils.filesystem import list_files
+
+        result = await list_files(
+            directory=path,
+            depth=depth,
+            base_dir=self.workspace_root,
+        )
+
+        if result["success"]:
+            await self._emit_tool_status(
+                "completed",
+                f"Listed {result['total']} entries",
+                result,
+            )
+        else:
+            await self._emit_tool_status("failed", result.get("error", "Unknown error"))
+
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+    async def _list_remote(self, path: str, depth: int) -> str:
+        """List files in remote sandbox using E2B SDK."""
+        try:
+            sandbox_manager = self._get_sandbox_manager()
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type=self.default_shell_type,
+                workspace_ref=None,
+            )
+
+            if error:
+                return self._format_error(
+                    f"Failed to create sandbox: {error}",
+                    entries=[],
+                    total=0,
+                    path="",
+                )
+
+            # Normalize path for sandbox
+            if not path.startswith("/"):
+                path = f"/home/user/{path}"
+
+            # List files
+            entries = await sandbox.files.list(path=path, depth=depth)
+
+            # Convert to JSON-serializable format
+            entries_data = []
+            for entry in entries:
+                entry_dict = {
+                    "name": entry.name,
+                    "path": entry.path,
+                    "type": entry.type.value if entry.type else None,
+                    "size": entry.size,
+                    "permissions": entry.permissions,
+                    "owner": entry.owner,
+                    "group": entry.group,
+                    "modified_time": entry.modified_time.isoformat(),
+                }
+                if entry.symlink_target:
+                    entry_dict["symlink_target"] = entry.symlink_target
+                entries_data.append(entry_dict)
+
+            response = {
+                "success": True,
+                "entries": entries_data,
+                "total": len(entries_data),
+                "path": path,
+                "sandbox_id": sandbox.sandbox_id,
+            }
+
+            await self._emit_tool_status(
+                "completed",
+                f"Listed {len(entries_data)} entries",
+                response,
+            )
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except ImportError as e:
+            logger.error(f"[ListFilesTool] E2B SDK import error: {e}")
+            return self._format_error(
+                "E2B SDK not available. Please install e2b-code-interpreter.",
+                entries=[],
+                total=0,
+                path="",
+            )
+        except Exception as e:
+            logger.error(f"[ListFilesTool] List failed: {e}", exc_info=True)
+            return self._format_error(
+                f"Failed to list files: {e}",
+                entries=[],
+                total=0,
+                path="",
+            )
+
+
+class ExecuteCommandTool(BaseFilesystemTool):
+    """Tool for executing commands in local environment or remote sandbox."""
+
+    name: str = "exec"
+    display_name: str = "Execute Command"
+    description: str = """Execute a shell command.
+
+Use this tool to run shell commands in the environment.
+
+Parameters:
+- command (required): The command to execute
+- working_dir (optional): Working directory for execution
+- timeout_seconds (optional): Command timeout in seconds
+
+Returns:
+- success: Whether the command executed successfully
+- stdout: Standard output from the command
+- stderr: Standard error output
+- exit_code: Command exit code
+- execution_time: Time taken to execute
+
+Example:
+{
+  "command": "ls -la",
+  "working_dir": "/workspace"
+}"""
+
+    args_schema: type[BaseModel] = ExecuteCommandInput
+
+    def _run(
+        self,
+        command: str,
+        working_dir: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Synchronous run - not implemented."""
+        raise NotImplementedError("ExecuteCommandTool only supports async execution")
+
+    async def _arun(
+        self,
+        command: str,
+        working_dir: Optional[str] = None,
+        timeout_seconds: Optional[int] = None,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Execute command in local environment or sandbox."""
+        effective_timeout = timeout_seconds or self.command_timeout
+        effective_cwd = working_dir or self.workspace_root
+
+        logger.info(
+            f"[ExecuteCommandTool] Executing: {command[:100]}, "
+            f"mode={self.sandbox_mode}"
+        )
+
+        if self.sandbox_mode == "local":
+            return await self._exec_local(command, effective_cwd, effective_timeout)
+        else:
+            return await self._exec_remote(command, effective_cwd, effective_timeout)
+
+    async def _exec_local(self, command: str, cwd: str, timeout: int) -> str:
+        """Execute command in local environment."""
+        from shared.utils.filesystem import execute_command
+
+        result = await execute_command(
+            command=command,
+            timeout=timeout,
+            cwd=cwd,
+            max_output_size=self.max_output_size,
+        )
+
+        if result["success"]:
+            await self._emit_tool_status(
+                "completed",
+                "Command executed successfully",
+                result,
+            )
+        else:
+            await self._emit_tool_status(
+                "failed",
+                f"Command failed with exit code {result.get('exit_code', -1)}",
+                result,
+            )
+
+        return json.dumps(result, ensure_ascii=False, indent=2)
+
+    async def _exec_remote(self, command: str, cwd: str, timeout: int) -> str:
+        """Execute command in remote sandbox using E2B SDK."""
+        import re
+        import time
+
+        start_time = time.time()
+
+        # Shell operators pattern for wrapping
+        shell_operators = re.compile(
+            r"&&|\|\||"
+            r"\|(?!\|)|"
+            r";|>>|>|<<|<|"
+            r"\$\(|`"
+        )
+
+        # Wrap command if contains shell operators
+        if shell_operators.search(command):
+            escaped = command.replace("'", "'\"'\"'")
+            command = f"bash -c '{escaped}'"
+
+        try:
+            sandbox_manager = self._get_sandbox_manager()
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type=self.default_shell_type,
+                workspace_ref=None,
+            )
+
+            if error:
+                return self._format_error(
+                    f"Failed to create sandbox: {error}",
+                    stdout="",
+                    stderr=error,
+                    exit_code=-1,
+                    execution_time=time.time() - start_time,
+                )
+
+            # Execute command
+            result = await sandbox.commands.run(
+                cmd=command,
+                cwd=cwd,
+                timeout=timeout,
+            )
+
+            execution_time = time.time() - start_time
+
+            # Truncate output if needed
+            stdout = result.stdout or ""
+            stderr = result.stderr or ""
+            stdout_truncated = False
+            stderr_truncated = False
+
+            if len(stdout) > self.max_output_size:
+                stdout = stdout[: self.max_output_size]
+                stdout_truncated = True
+
+            if len(stderr) > self.max_output_size:
+                stderr = stderr[: self.max_output_size]
+                stderr_truncated = True
+
+            response = {
+                "success": result.exit_code == 0,
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": result.exit_code,
+                "execution_time": execution_time,
+                "sandbox_id": sandbox.sandbox_id,
+            }
+
+            if stdout_truncated or stderr_truncated:
+                response["truncated"] = True
+                response["truncation_info"] = {
+                    "stdout_truncated": stdout_truncated,
+                    "stderr_truncated": stderr_truncated,
+                    "max_output_size": self.max_output_size,
+                }
+
+            if result.exit_code == 0:
+                await self._emit_tool_status(
+                    "completed",
+                    "Command executed successfully",
+                    response,
+                )
+            else:
+                await self._emit_tool_status(
+                    "failed",
+                    f"Command failed with exit code {result.exit_code}",
+                    response,
+                )
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except ImportError as e:
+            logger.error(f"[ExecuteCommandTool] E2B SDK import error: {e}")
+            return self._format_error(
+                "E2B SDK not available. Please install e2b-code-interpreter.",
+                stdout="",
+                stderr="",
+                exit_code=-1,
+                execution_time=time.time() - start_time,
+            )
+        except Exception as e:
+            logger.error(f"[ExecuteCommandTool] Execution failed: {e}", exc_info=True)
+            return self._format_error(
+                f"Command execution failed: {e}",
+                stdout="",
+                stderr=str(e),
+                exit_code=-1,
+                execution_time=time.time() - start_time,
+            )
+
+
+def get_filesystem_tools(
+    sandbox_mode: str = "remote",
+    workspace_root: str = "/workspace",
+    max_file_size: int = 102400,
+    max_output_size: int = 65536,
+    command_timeout: int = 300,
+    task_id: int = 0,
+    subtask_id: int = 0,
+    user_id: int = 0,
+    user_name: str = "",
+    ws_emitter: Any = None,
+    bot_config: list = None,
+    auth_token: str = "",
+    default_shell_type: str = "ClaudeCode",
+) -> list[BaseTool]:
+    """Create filesystem tools with the specified configuration.
+
+    Args:
+        sandbox_mode: "local" or "remote" (default: "remote")
+        workspace_root: Base directory for local mode
+        max_file_size: Maximum file size for read operations
+        max_output_size: Maximum output size for command execution
+        command_timeout: Default command timeout in seconds
+        task_id: Task ID for sandbox operations
+        subtask_id: Subtask ID for sandbox operations
+        user_id: User ID for sandbox operations
+        user_name: Username for sandbox operations
+        ws_emitter: WebSocket emitter for status updates
+        bot_config: Bot configuration list
+        auth_token: API auth token
+        default_shell_type: Default shell type for sandbox
+
+    Returns:
+        List of configured filesystem tools
+    """
+    common_kwargs = {
+        "sandbox_mode": sandbox_mode,
+        "workspace_root": workspace_root,
+        "max_file_size": max_file_size,
+        "max_output_size": max_output_size,
+        "command_timeout": command_timeout,
+        "task_id": task_id,
+        "subtask_id": subtask_id,
+        "user_id": user_id,
+        "user_name": user_name,
+        "ws_emitter": ws_emitter,
+        "bot_config": bot_config or [],
+        "auth_token": auth_token,
+        "default_shell_type": default_shell_type,
+    }
+
+    return [
+        ReadFileTool(**common_kwargs),
+        WriteFileTool(**common_kwargs),
+        ListFilesTool(**common_kwargs),
+        ExecuteCommandTool(**common_kwargs),
+    ]
+
+
+__all__ = [
+    "ReadFileTool",
+    "WriteFileTool",
+    "ListFilesTool",
+    "ExecuteCommandTool",
+    "get_filesystem_tools",
+    "BaseFilesystemTool",
+]

--- a/chat_shell/chat_shell/tools/builtin/filesystem_tools.py
+++ b/chat_shell/chat_shell/tools/builtin/filesystem_tools.py
@@ -402,8 +402,8 @@ Example:
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Write file to filesystem or sandbox."""
-        # Validate content
-        if not content:
+        # Validate content - only reject None, allow empty string
+        if content is None:
             error_msg = (
                 "Missing required parameter 'content'. "
                 "You MUST provide content to write to the file."

--- a/chat_shell/tests/test_filesystem_tools.py
+++ b/chat_shell/tests/test_filesystem_tools.py
@@ -222,17 +222,34 @@ class TestWriteFileTool:
         assert test_file.exists()
 
     @pytest.mark.asyncio
-    async def test_write_empty_content_error(self, local_tool, tmp_path: Path):
-        """Test that empty content returns error."""
+    async def test_write_none_content_error(self, local_tool, tmp_path: Path):
+        """Test that None content returns error."""
         # Act
         result = await local_tool._arun(
-            file_path=str(tmp_path / "file.txt"), content=""
+            file_path=str(tmp_path / "file.txt"), content=None
         )
 
         # Assert
         result_data = json.loads(result)
         assert result_data["success"] is False
         assert "content" in result_data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_write_empty_string_succeeds(self, local_tool, tmp_path: Path):
+        """Test that empty string content succeeds."""
+        # Arrange
+        test_file = tmp_path / "empty.txt"
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(
+            file_path=str(test_file), content=""
+        )
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert test_file.read_text() == ""
 
 
 class TestListFilesTool:

--- a/chat_shell/tests/test_filesystem_tools.py
+++ b/chat_shell/tests/test_filesystem_tools.py
@@ -1,0 +1,399 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for filesystem builtin tools.
+
+This module tests:
+- ReadFileTool in local and remote modes
+- WriteFileTool in local and remote modes
+- ListFilesTool in local and remote modes
+- ExecuteCommandTool in local and remote modes
+- get_filesystem_tools factory function
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from chat_shell.tools.builtin.filesystem_tools import (
+    BaseFilesystemTool,
+    ExecuteCommandTool,
+    ListFilesTool,
+    ReadFileTool,
+    WriteFileTool,
+    get_filesystem_tools,
+)
+
+
+class TestGetFilesystemTools:
+    """Tests for get_filesystem_tools factory function."""
+
+    def test_returns_all_tools(self):
+        """Test that factory returns all filesystem tools."""
+        tools = get_filesystem_tools()
+
+        assert len(tools) == 4
+        tool_names = {t.name for t in tools}
+        assert tool_names == {"read_file", "write_file", "list_files", "exec"}
+
+    def test_configures_sandbox_mode(self):
+        """Test that sandbox_mode is configured on all tools."""
+        tools = get_filesystem_tools(sandbox_mode="local")
+
+        for tool in tools:
+            assert tool.sandbox_mode == "local"
+
+    def test_configures_workspace_root(self):
+        """Test that workspace_root is configured on all tools."""
+        tools = get_filesystem_tools(workspace_root="/custom/path")
+
+        for tool in tools:
+            assert tool.workspace_root == "/custom/path"
+
+    def test_configures_task_context(self):
+        """Test that task context is configured on all tools."""
+        tools = get_filesystem_tools(
+            task_id=123,
+            subtask_id=456,
+            user_id=789,
+            user_name="test_user",
+        )
+
+        for tool in tools:
+            assert tool.task_id == 123
+            assert tool.subtask_id == 456
+            assert tool.user_id == 789
+            assert tool.user_name == "test_user"
+
+
+class TestReadFileTool:
+    """Tests for ReadFileTool."""
+
+    @pytest.fixture
+    def local_tool(self):
+        """Create a ReadFileTool in local mode."""
+        return ReadFileTool(
+            sandbox_mode="local",
+            workspace_root="/tmp",
+            task_id=1,
+            user_id=1,
+            user_name="test",
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_local_file(self, local_tool, tmp_path: Path):
+        """Test reading a file in local mode."""
+        # Arrange
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(file_path=str(test_file))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert result_data["content"] == "hello world"
+        assert result_data["size"] == 11
+
+    @pytest.mark.asyncio
+    async def test_read_local_file_not_found(self, local_tool, tmp_path: Path):
+        """Test reading a nonexistent file in local mode."""
+        # Arrange
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(file_path=str(tmp_path / "nonexistent.txt"))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert "not found" in result_data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_read_local_binary_file(self, local_tool, tmp_path: Path):
+        """Test reading a binary file in local mode."""
+        # Arrange
+        test_file = tmp_path / "test.bin"
+        test_file.write_bytes(b"\x00\x01\x02")
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(file_path=str(test_file), format="bytes")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert result_data["format"] == "bytes"
+        # Should be base64 encoded
+        import base64
+
+        assert result_data["content"] == base64.b64encode(b"\x00\x01\x02").decode(
+            "ascii"
+        )
+
+    @pytest.mark.asyncio
+    async def test_read_remote_mode_calls_sandbox(self):
+        """Test that remote mode calls sandbox manager."""
+        # Arrange
+        tool = ReadFileTool(
+            sandbox_mode="remote",
+            task_id=1,
+            user_id=1,
+            user_name="test",
+        )
+
+        # Mock sandbox manager and sandbox
+        mock_sandbox = MagicMock()
+        mock_sandbox.sandbox_id = "test-sandbox-id"
+        mock_file_info = MagicMock()
+        mock_file_info.size = 100
+        mock_file_info.type = MagicMock()
+        mock_file_info.type.value = "file"
+        mock_file_info.modified_time = MagicMock()
+        mock_file_info.modified_time.isoformat.return_value = "2025-01-01T00:00:00"
+        mock_sandbox.files.get_info = AsyncMock(return_value=mock_file_info)
+        mock_sandbox.files.read = AsyncMock(return_value="content")
+
+        mock_manager = MagicMock()
+        mock_manager.get_or_create_sandbox = AsyncMock(
+            return_value=(mock_sandbox, None)
+        )
+
+        with patch.object(tool, "_get_sandbox_manager", return_value=mock_manager):
+            # Act
+            result = await tool._arun(file_path="/home/user/test.txt")
+
+            # Assert
+            result_data = json.loads(result)
+            assert result_data["success"] is True
+            assert result_data["sandbox_id"] == "test-sandbox-id"
+            mock_manager.get_or_create_sandbox.assert_called_once()
+
+
+class TestWriteFileTool:
+    """Tests for WriteFileTool."""
+
+    @pytest.fixture
+    def local_tool(self):
+        """Create a WriteFileTool in local mode."""
+        return WriteFileTool(
+            sandbox_mode="local",
+            workspace_root="/tmp",
+            task_id=1,
+            user_id=1,
+            user_name="test",
+        )
+
+    @pytest.mark.asyncio
+    async def test_write_local_file(self, local_tool, tmp_path: Path):
+        """Test writing a file in local mode."""
+        # Arrange
+        test_file = tmp_path / "output.txt"
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(file_path=str(test_file), content="hello world")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert test_file.read_text() == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_write_creates_directories(self, local_tool, tmp_path: Path):
+        """Test that writing creates parent directories."""
+        # Arrange
+        test_file = tmp_path / "subdir" / "nested" / "file.txt"
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(
+            file_path=str(test_file), content="content", create_dirs=True
+        )
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert test_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_write_empty_content_error(self, local_tool, tmp_path: Path):
+        """Test that empty content returns error."""
+        # Act
+        result = await local_tool._arun(
+            file_path=str(tmp_path / "file.txt"), content=""
+        )
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert "content" in result_data["error"].lower()
+
+
+class TestListFilesTool:
+    """Tests for ListFilesTool."""
+
+    @pytest.fixture
+    def local_tool(self):
+        """Create a ListFilesTool in local mode."""
+        return ListFilesTool(
+            sandbox_mode="local",
+            workspace_root="/tmp",
+            task_id=1,
+            user_id=1,
+            user_name="test",
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_local_directory(self, local_tool, tmp_path: Path):
+        """Test listing a directory in local mode."""
+        # Arrange
+        (tmp_path / "file1.txt").write_text("content1")
+        (tmp_path / "file2.txt").write_text("content2")
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(path=str(tmp_path))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert result_data["total"] == 2
+        names = [e["name"] for e in result_data["entries"]]
+        assert "file1.txt" in names
+        assert "file2.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_list_empty_directory(self, local_tool, tmp_path: Path):
+        """Test listing an empty directory."""
+        # Arrange
+        local_tool.workspace_root = str(tmp_path)
+
+        # Act
+        result = await local_tool._arun(path=str(tmp_path))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert result_data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_nonexistent_directory(self, local_tool, tmp_path: Path):
+        """Test listing a nonexistent directory."""
+        # Act
+        result = await local_tool._arun(path=str(tmp_path / "nonexistent"))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert "not found" in result_data["error"].lower()
+
+
+class TestExecuteCommandTool:
+    """Tests for ExecuteCommandTool."""
+
+    @pytest.fixture
+    def local_tool(self):
+        """Create an ExecuteCommandTool in local mode."""
+        return ExecuteCommandTool(
+            sandbox_mode="local",
+            workspace_root="/tmp",
+            command_timeout=30,
+            task_id=1,
+            user_id=1,
+            user_name="test",
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_simple_command(self, local_tool):
+        """Test executing a simple command in local mode."""
+        # Act
+        result = await local_tool._arun(command="echo hello")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert "hello" in result_data["stdout"]
+        assert result_data["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_execute_command_failure(self, local_tool):
+        """Test executing a failing command."""
+        # Act
+        result = await local_tool._arun(command="exit 1")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert result_data["exit_code"] == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_with_working_dir(self, local_tool, tmp_path: Path):
+        """Test executing with working directory."""
+        # Act
+        result = await local_tool._arun(command="pwd", working_dir=str(tmp_path))
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert str(tmp_path) in result_data["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_shell_operators(self, local_tool):
+        """Test executing commands with shell operators."""
+        # Act
+        result = await local_tool._arun(command="echo hello && echo world")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is True
+        assert "hello" in result_data["stdout"]
+        assert "world" in result_data["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_timeout(self, local_tool):
+        """Test command timeout."""
+        # Arrange
+        local_tool.command_timeout = 1
+
+        # Act
+        result = await local_tool._arun(command="sleep 10", timeout_seconds=1)
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert result_data.get("timed_out") is True or "timeout" in result_data.get(
+            "error", ""
+        ).lower()
+
+
+class TestBaseFilesystemTool:
+    """Tests for BaseFilesystemTool base class."""
+
+    def test_format_error(self):
+        """Test error formatting."""
+        # Arrange
+        tool = ReadFileTool(sandbox_mode="local", task_id=1, user_id=1, user_name="test")
+
+        # Act
+        result = tool._format_error("Test error", extra_field="extra_value")
+
+        # Assert
+        result_data = json.loads(result)
+        assert result_data["success"] is False
+        assert result_data["error"] == "Test error"
+        assert result_data["extra_field"] == "extra_value"
+
+    def test_sync_run_not_implemented(self):
+        """Test that sync _run raises NotImplementedError."""
+        # Arrange
+        tool = ReadFileTool(sandbox_mode="local", task_id=1, user_id=1, user_name="test")
+
+        # Act & Assert
+        with pytest.raises(NotImplementedError):
+            tool._run(file_path="/test.txt")

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -36,6 +36,14 @@ dependencies = [
     "opentelemetry-instrumentation-redis>=0.48b0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.1",
+    "pytest-asyncio>=1.3.0",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.1",

--- a/shared/pyproject.toml
+++ b/shared/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "cryptography>=42.0.4",
     "httpx>=0.26.0",
     "requests>=2.31.0",
+    "aiofiles>=24.1.0",
 
     # Database ORM
     "sqlalchemy>=2.0.25",

--- a/shared/tests/test_filesystem.py
+++ b/shared/tests/test_filesystem.py
@@ -382,7 +382,7 @@ class TestExecuteCommand:
 
         assert result["success"] is False
         assert result.get("timed_out") is True
-        assert "timeout" in result["error"].lower()
+        assert "timed out" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_execute_command_with_shell_operators(self):

--- a/shared/tests/test_filesystem.py
+++ b/shared/tests/test_filesystem.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for shared/utils/filesystem.py module."""
+
+import asyncio
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from shared.utils.filesystem import (
+    DEFAULT_COMMAND_TIMEOUT,
+    DEFAULT_LIST_DEPTH,
+    DEFAULT_MAX_FILE_SIZE,
+    DEFAULT_MAX_OUTPUT_SIZE,
+    execute_command,
+    get_file_info,
+    list_files,
+    normalize_path,
+    read_file,
+    write_file,
+)
+
+
+class TestNormalizePath:
+    """Tests for normalize_path function."""
+
+    def test_absolute_path(self):
+        """Test that absolute paths are returned as-is (after normalization)."""
+        result = normalize_path("/tmp/test.txt")
+        assert result == "/tmp/test.txt"
+
+    def test_relative_path_with_base_dir(self):
+        """Test that relative paths are joined with base_dir."""
+        result = normalize_path("test.txt", base_dir="/tmp")
+        assert result == "/tmp/test.txt"
+
+    def test_relative_path_without_base_dir(self):
+        """Test that relative paths are converted to absolute."""
+        result = normalize_path("test.txt")
+        assert os.path.isabs(result)
+
+    def test_home_expansion(self):
+        """Test that ~ is expanded to user home directory."""
+        result = normalize_path("~/test.txt")
+        assert not result.startswith("~")
+        assert os.path.isabs(result)
+
+    def test_path_normalization(self):
+        """Test that paths with .. are normalized."""
+        result = normalize_path("/tmp/foo/../bar/test.txt")
+        assert result == "/tmp/bar/test.txt"
+
+
+class TestGetFileInfo:
+    """Tests for get_file_info function."""
+
+    def test_file_info(self, tmp_path: Path):
+        """Test getting info for a regular file."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        info = get_file_info(str(test_file))
+
+        assert info["name"] == "test.txt"
+        assert info["type"] == "file"
+        assert info["size"] == 11
+        assert "permissions" in info
+        assert "modified_time" in info
+        assert info["is_symlink"] is False
+
+    def test_directory_info(self, tmp_path: Path):
+        """Test getting info for a directory."""
+        test_dir = tmp_path / "subdir"
+        test_dir.mkdir()
+
+        info = get_file_info(str(test_dir))
+
+        assert info["name"] == "subdir"
+        assert info["type"] == "directory"
+        assert info["is_symlink"] is False
+
+    def test_symlink_info(self, tmp_path: Path):
+        """Test getting info for a symbolic link."""
+        target = tmp_path / "target.txt"
+        target.write_text("content")
+        link = tmp_path / "link.txt"
+        link.symlink_to(target)
+
+        info = get_file_info(str(link))
+
+        assert info["name"] == "link.txt"
+        assert info["type"] == "symlink"
+        assert info["is_symlink"] is True
+        assert info["symlink_target"] == str(target)
+
+    def test_nonexistent_file(self, tmp_path: Path):
+        """Test that FileNotFoundError is raised for nonexistent files."""
+        with pytest.raises(FileNotFoundError):
+            get_file_info(str(tmp_path / "nonexistent.txt"))
+
+
+class TestReadFile:
+    """Tests for read_file function."""
+
+    @pytest.mark.asyncio
+    async def test_read_text_file(self, tmp_path: Path):
+        """Test reading a text file."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("hello world")
+
+        result = await read_file(str(test_file))
+
+        assert result["success"] is True
+        assert result["content"] == "hello world"
+        assert result["size"] == 11
+        assert result["format"] == "text"
+        assert "modified_time" in result
+
+    @pytest.mark.asyncio
+    async def test_read_binary_file(self, tmp_path: Path):
+        """Test reading a binary file as base64."""
+        test_file = tmp_path / "test.bin"
+        test_file.write_bytes(b"\x00\x01\x02\x03")
+
+        result = await read_file(str(test_file), format="bytes")
+
+        assert result["success"] is True
+        assert result["format"] == "bytes"
+        # Base64 of b"\x00\x01\x02\x03"
+        import base64
+
+        expected = base64.b64encode(b"\x00\x01\x02\x03").decode("ascii")
+        assert result["content"] == expected
+
+    @pytest.mark.asyncio
+    async def test_read_nonexistent_file(self, tmp_path: Path):
+        """Test reading a nonexistent file."""
+        result = await read_file(str(tmp_path / "nonexistent.txt"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_read_directory(self, tmp_path: Path):
+        """Test reading a directory returns error."""
+        result = await read_file(str(tmp_path))
+
+        assert result["success"] is False
+        assert "directory" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_read_file_too_large(self, tmp_path: Path):
+        """Test reading a file that exceeds max_size."""
+        test_file = tmp_path / "large.txt"
+        test_file.write_text("x" * 1000)
+
+        result = await read_file(str(test_file), max_size=100)
+
+        assert result["success"] is False
+        assert "too large" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_read_with_base_dir(self, tmp_path: Path):
+        """Test reading with relative path and base_dir."""
+        test_file = tmp_path / "test.txt"
+        test_file.write_text("content")
+
+        result = await read_file("test.txt", base_dir=str(tmp_path))
+
+        assert result["success"] is True
+        assert result["content"] == "content"
+
+
+class TestWriteFile:
+    """Tests for write_file function."""
+
+    @pytest.mark.asyncio
+    async def test_write_text_file(self, tmp_path: Path):
+        """Test writing a text file."""
+        test_file = tmp_path / "output.txt"
+
+        result = await write_file(str(test_file), "hello world")
+
+        assert result["success"] is True
+        assert result["size"] == 11
+        assert result["format"] == "text"
+        assert test_file.read_text() == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_write_binary_file(self, tmp_path: Path):
+        """Test writing a binary file from base64."""
+        test_file = tmp_path / "output.bin"
+        import base64
+
+        content = base64.b64encode(b"\x00\x01\x02\x03").decode("ascii")
+
+        result = await write_file(str(test_file), content, format="bytes")
+
+        assert result["success"] is True
+        assert result["format"] == "bytes"
+        assert test_file.read_bytes() == b"\x00\x01\x02\x03"
+
+    @pytest.mark.asyncio
+    async def test_write_creates_directories(self, tmp_path: Path):
+        """Test that write_file creates parent directories."""
+        test_file = tmp_path / "subdir" / "nested" / "file.txt"
+
+        result = await write_file(str(test_file), "content", create_dirs=True)
+
+        assert result["success"] is True
+        assert test_file.exists()
+        assert test_file.read_text() == "content"
+
+    @pytest.mark.asyncio
+    async def test_write_none_content(self, tmp_path: Path):
+        """Test writing None content returns error."""
+        test_file = tmp_path / "output.txt"
+
+        result = await write_file(str(test_file), None)
+
+        assert result["success"] is False
+        assert "cannot be None" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_write_invalid_base64(self, tmp_path: Path):
+        """Test writing invalid base64 content returns error."""
+        test_file = tmp_path / "output.bin"
+
+        result = await write_file(str(test_file), "not-valid-base64!!!", format="bytes")
+
+        assert result["success"] is False
+        assert "base64" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_write_overwrites_existing(self, tmp_path: Path):
+        """Test that write_file overwrites existing files."""
+        test_file = tmp_path / "output.txt"
+        test_file.write_text("old content")
+
+        result = await write_file(str(test_file), "new content")
+
+        assert result["success"] is True
+        assert test_file.read_text() == "new content"
+
+
+class TestListFiles:
+    """Tests for list_files function."""
+
+    @pytest.mark.asyncio
+    async def test_list_empty_directory(self, tmp_path: Path):
+        """Test listing an empty directory."""
+        result = await list_files(str(tmp_path))
+
+        assert result["success"] is True
+        assert result["entries"] == []
+        assert result["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_directory_with_files(self, tmp_path: Path):
+        """Test listing a directory with files."""
+        (tmp_path / "file1.txt").write_text("content1")
+        (tmp_path / "file2.txt").write_text("content2")
+
+        result = await list_files(str(tmp_path))
+
+        assert result["success"] is True
+        assert result["total"] == 2
+        names = [e["name"] for e in result["entries"]]
+        assert "file1.txt" in names
+        assert "file2.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_list_with_subdirectories(self, tmp_path: Path):
+        """Test listing a directory with subdirectories."""
+        (tmp_path / "subdir").mkdir()
+        (tmp_path / "file.txt").write_text("content")
+
+        result = await list_files(str(tmp_path))
+
+        assert result["success"] is True
+        assert result["total"] == 2
+        types = {e["name"]: e["type"] for e in result["entries"]}
+        assert types["subdir"] == "directory"
+        assert types["file.txt"] == "file"
+
+    @pytest.mark.asyncio
+    async def test_list_recursive(self, tmp_path: Path):
+        """Test listing with depth > 1."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (subdir / "nested.txt").write_text("content")
+        (tmp_path / "root.txt").write_text("content")
+
+        result = await list_files(str(tmp_path), depth=2)
+
+        assert result["success"] is True
+        names = [e["name"] for e in result["entries"]]
+        assert "subdir" in names
+        assert "root.txt" in names
+        assert "nested.txt" in names
+
+    @pytest.mark.asyncio
+    async def test_list_nonexistent_directory(self, tmp_path: Path):
+        """Test listing a nonexistent directory."""
+        result = await list_files(str(tmp_path / "nonexistent"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_list_file_not_directory(self, tmp_path: Path):
+        """Test listing a file (not a directory) returns error."""
+        test_file = tmp_path / "file.txt"
+        test_file.write_text("content")
+
+        result = await list_files(str(test_file))
+
+        assert result["success"] is False
+        assert "not a directory" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_list_with_pattern(self, tmp_path: Path):
+        """Test listing with pattern filter."""
+        (tmp_path / "file1.txt").write_text("content")
+        (tmp_path / "file2.py").write_text("content")
+        (tmp_path / "file3.txt").write_text("content")
+
+        result = await list_files(str(tmp_path), pattern="*.txt")
+
+        assert result["success"] is True
+        assert result["total"] == 2
+        names = [e["name"] for e in result["entries"]]
+        assert "file1.txt" in names
+        assert "file3.txt" in names
+        assert "file2.py" not in names
+
+
+class TestExecuteCommand:
+    """Tests for execute_command function."""
+
+    @pytest.mark.asyncio
+    async def test_execute_simple_command(self):
+        """Test executing a simple command."""
+        result = await execute_command("echo hello")
+
+        assert result["success"] is True
+        assert "hello" in result["stdout"]
+        assert result["exit_code"] == 0
+        assert "execution_time" in result
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_error(self):
+        """Test executing a command that fails."""
+        result = await execute_command("exit 1")
+
+        assert result["success"] is False
+        assert result["exit_code"] == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_stderr(self):
+        """Test executing a command that writes to stderr."""
+        result = await execute_command("echo error >&2")
+
+        assert "error" in result["stderr"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_cwd(self, tmp_path: Path):
+        """Test executing a command with working directory."""
+        result = await execute_command("pwd", cwd=str(tmp_path))
+
+        assert result["success"] is True
+        assert str(tmp_path) in result["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_timeout(self):
+        """Test that command times out."""
+        result = await execute_command("sleep 10", timeout=1)
+
+        assert result["success"] is False
+        assert result.get("timed_out") is True
+        assert "timeout" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_shell_operators(self):
+        """Test executing commands with shell operators."""
+        result = await execute_command("echo hello && echo world")
+
+        assert result["success"] is True
+        assert "hello" in result["stdout"]
+        assert "world" in result["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_with_pipe(self):
+        """Test executing commands with pipe."""
+        result = await execute_command("echo 'hello world' | grep hello")
+
+        assert result["success"] is True
+        assert "hello" in result["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_execute_command_output_truncation(self):
+        """Test that large output is truncated."""
+        # Generate output larger than default max
+        result = await execute_command(
+            "python3 -c \"print('x' * 100000)\"", max_output_size=1000
+        )
+
+        assert result["success"] is True
+        assert len(result["stdout"]) <= 1000
+        assert result.get("truncated") is True
+
+    @pytest.mark.asyncio
+    async def test_execute_nonexistent_command(self):
+        """Test executing a nonexistent command."""
+        result = await execute_command("nonexistent_command_12345")
+
+        assert result["success"] is False
+        assert result["exit_code"] != 0
+
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_default_constants(self):
+        """Test that default constants have reasonable values."""
+        assert DEFAULT_MAX_FILE_SIZE == 102400  # 100KB
+        assert DEFAULT_MAX_OUTPUT_SIZE == 65536  # 64KB
+        assert DEFAULT_COMMAND_TIMEOUT == 300  # 5 minutes
+        assert DEFAULT_LIST_DEPTH == 1

--- a/shared/utils/filesystem.py
+++ b/shared/utils/filesystem.py
@@ -1,0 +1,653 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Filesystem utilities for local file operations.
+
+This module provides common file system operations that can be reused
+by both executor and chat_shell modules. These utilities support:
+- Async file reading and writing
+- Directory listing with depth control
+- Command execution with timeout and output limits
+
+All functions return a unified JSON-serializable dict format:
+{"success": bool, "data": ..., "error": ...}
+"""
+
+import asyncio
+import base64
+import fnmatch
+import os
+import re
+import stat
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import aiofiles
+
+from shared.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+# Default configuration constants
+DEFAULT_MAX_FILE_SIZE = 102400  # 100KB
+DEFAULT_MAX_OUTPUT_SIZE = 65536  # 64KB
+DEFAULT_COMMAND_TIMEOUT = 300  # 5 minutes
+DEFAULT_LIST_DEPTH = 1
+
+# Shell operators that require bash -c wrapping
+SHELL_OPERATORS_PATTERN = re.compile(
+    r"&&|"  # AND operator
+    r"\|\||"  # OR operator
+    r"\|(?!\|)|"  # Pipe (but not ||)
+    r";|"  # Command separator
+    r">>|"  # Append redirect
+    r">|"  # Output redirect
+    r"<<|"  # Here document
+    r"<|"  # Input redirect
+    r"\$\(|"  # Command substitution $(...)
+    r"`"  # Backtick command substitution
+)
+
+
+def normalize_path(path: str, base_dir: Optional[str] = None) -> str:
+    """Normalize and resolve a file path.
+
+    Args:
+        path: The path to normalize (absolute or relative)
+        base_dir: Optional base directory for relative paths
+
+    Returns:
+        Absolute path with user home expansion
+    """
+    # Expand user home directory
+    expanded_path = os.path.expanduser(path)
+
+    # If path is relative and base_dir is provided, join them
+    if not os.path.isabs(expanded_path) and base_dir:
+        expanded_path = os.path.join(base_dir, expanded_path)
+
+    # Return absolute path
+    return os.path.abspath(expanded_path)
+
+
+def get_file_info(path: str) -> dict[str, Any]:
+    """Get detailed information about a file or directory.
+
+    Args:
+        path: Path to the file or directory
+
+    Returns:
+        Dictionary with file metadata:
+        - name: File/directory name
+        - path: Absolute path
+        - type: "file", "directory", or "symlink"
+        - size: Size in bytes
+        - permissions: Permission string (e.g., "-rw-r--r--")
+        - mode: Numeric mode
+        - modified_time: ISO format timestamp
+        - is_symlink: Whether it's a symbolic link
+        - symlink_target: Target path if symlink
+
+    Raises:
+        FileNotFoundError: If path doesn't exist
+        PermissionError: If access is denied
+    """
+    path_obj = Path(path)
+
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Path not found: {path}")
+
+    # Use lstat to get info about symlink itself, not target
+    stat_info = path_obj.lstat()
+
+    # Determine file type
+    if path_obj.is_symlink():
+        file_type = "symlink"
+    elif path_obj.is_dir():
+        file_type = "directory"
+    else:
+        file_type = "file"
+
+    # Build response
+    info = {
+        "name": path_obj.name,
+        "path": str(path_obj.absolute()),
+        "type": file_type,
+        "size": stat_info.st_size,
+        "permissions": stat.filemode(stat_info.st_mode),
+        "mode": stat_info.st_mode,
+        "modified_time": datetime.fromtimestamp(stat_info.st_mtime).isoformat(),
+        "is_symlink": path_obj.is_symlink(),
+    }
+
+    # Add symlink target if applicable
+    if path_obj.is_symlink():
+        try:
+            info["symlink_target"] = str(path_obj.readlink())
+        except (OSError, PermissionError):
+            info["symlink_target"] = None
+
+    return info
+
+
+async def read_file(
+    file_path: str,
+    format: str = "text",
+    max_size: int = DEFAULT_MAX_FILE_SIZE,
+    base_dir: Optional[str] = None,
+) -> dict[str, Any]:
+    """Read file contents asynchronously.
+
+    Args:
+        file_path: Path to the file to read
+        format: Read format - "text" (default) or "bytes" (returns base64)
+        max_size: Maximum file size to read in bytes
+        base_dir: Optional base directory for relative paths
+
+    Returns:
+        Dictionary with:
+        - success: Whether the operation succeeded
+        - content: File contents (text or base64-encoded for bytes)
+        - size: File size in bytes
+        - path: Absolute path to the file
+        - format: Format used for reading
+        - modified_time: Last modification time (ISO format)
+        - error: Error message if failed
+    """
+    try:
+        # Normalize path
+        abs_path = normalize_path(file_path, base_dir)
+
+        # Check if file exists
+        if not os.path.exists(abs_path):
+            return {
+                "success": False,
+                "error": f"File not found: {abs_path}",
+                "content": "",
+                "size": 0,
+                "path": abs_path,
+                "format": format,
+            }
+
+        # Check if it's a file (not directory)
+        if os.path.isdir(abs_path):
+            return {
+                "success": False,
+                "error": f"Path is a directory, not a file: {abs_path}",
+                "content": "",
+                "size": 0,
+                "path": abs_path,
+                "format": format,
+            }
+
+        # Get file info
+        stat_info = os.stat(abs_path)
+        file_size = stat_info.st_size
+        modified_time = datetime.fromtimestamp(stat_info.st_mtime).isoformat()
+
+        # Check file size
+        if file_size > max_size:
+            max_kb = max_size / 1024
+            file_kb = file_size / 1024
+            return {
+                "success": False,
+                "error": (
+                    f"File too large: {file_size} bytes ({file_kb:.1f} KB). "
+                    f"Maximum allowed: {max_size} bytes ({max_kb:.0f} KB)."
+                ),
+                "content": "",
+                "size": file_size,
+                "path": abs_path,
+                "format": format,
+            }
+
+        # Read file content
+        if format == "bytes":
+            async with aiofiles.open(abs_path, "rb") as f:
+                content_bytes = await f.read()
+            content = base64.b64encode(content_bytes).decode("ascii")
+        else:
+            async with aiofiles.open(abs_path, "r", encoding="utf-8") as f:
+                content = await f.read()
+
+        logger.debug(f"[read_file] Read {file_size} bytes from {abs_path}")
+
+        return {
+            "success": True,
+            "content": content,
+            "size": file_size,
+            "path": abs_path,
+            "format": format,
+            "modified_time": modified_time,
+        }
+
+    except PermissionError as e:
+        logger.error(f"[read_file] Permission denied: {file_path}")
+        return {
+            "success": False,
+            "error": f"Permission denied: {e}",
+            "content": "",
+            "size": 0,
+            "path": file_path,
+            "format": format,
+        }
+    except UnicodeDecodeError as e:
+        logger.error(f"[read_file] Encoding error reading {file_path}: {e}")
+        return {
+            "success": False,
+            "error": f"File encoding error. Try using format='bytes' for binary files: {e}",
+            "content": "",
+            "size": 0,
+            "path": file_path,
+            "format": format,
+        }
+    except Exception as e:
+        logger.error(f"[read_file] Error reading file {file_path}: {e}")
+        return {
+            "success": False,
+            "error": f"Failed to read file: {e}",
+            "content": "",
+            "size": 0,
+            "path": file_path,
+            "format": format,
+        }
+
+
+async def write_file(
+    file_path: str,
+    content: str,
+    format: str = "text",
+    create_dirs: bool = True,
+    base_dir: Optional[str] = None,
+) -> dict[str, Any]:
+    """Write content to a file asynchronously.
+
+    Args:
+        file_path: Path to the file to write
+        content: Content to write (text or base64-encoded for bytes format)
+        format: Content format - "text" (default) or "bytes" (content is base64)
+        create_dirs: Create parent directories if they don't exist
+        base_dir: Optional base directory for relative paths
+
+    Returns:
+        Dictionary with:
+        - success: Whether the operation succeeded
+        - path: Absolute path to the file
+        - size: Number of bytes written
+        - format: Format used for writing
+        - modified_time: File modification time after write
+        - error: Error message if failed
+    """
+    try:
+        # Normalize path
+        abs_path = normalize_path(file_path, base_dir)
+
+        # Validate content
+        if content is None:
+            return {
+                "success": False,
+                "error": "Content cannot be None. You must provide content to write.",
+                "path": abs_path,
+                "size": 0,
+                "format": format,
+            }
+
+        # Create parent directories if needed
+        if create_dirs:
+            parent_dir = os.path.dirname(abs_path)
+            if parent_dir and not os.path.exists(parent_dir):
+                os.makedirs(parent_dir, exist_ok=True)
+                logger.debug(f"[write_file] Created directory: {parent_dir}")
+
+        # Prepare content based on format
+        if format == "bytes":
+            try:
+                content_bytes = base64.b64decode(content)
+            except Exception as e:
+                return {
+                    "success": False,
+                    "error": f"Invalid base64 content: {e}",
+                    "path": abs_path,
+                    "size": 0,
+                    "format": format,
+                }
+            # Write binary file
+            async with aiofiles.open(abs_path, "wb") as f:
+                await f.write(content_bytes)
+            written_size = len(content_bytes)
+        else:
+            # Write text file
+            async with aiofiles.open(abs_path, "w", encoding="utf-8") as f:
+                await f.write(content)
+            written_size = len(content.encode("utf-8"))
+
+        # Get updated file info
+        stat_info = os.stat(abs_path)
+        modified_time = datetime.fromtimestamp(stat_info.st_mtime).isoformat()
+
+        logger.debug(f"[write_file] Wrote {written_size} bytes to {abs_path}")
+
+        return {
+            "success": True,
+            "path": abs_path,
+            "size": written_size,
+            "format": format,
+            "modified_time": modified_time,
+        }
+
+    except PermissionError as e:
+        logger.error(f"[write_file] Permission denied: {file_path}")
+        return {
+            "success": False,
+            "error": f"Permission denied: {e}",
+            "path": file_path,
+            "size": 0,
+            "format": format,
+        }
+    except Exception as e:
+        logger.error(f"[write_file] Error writing file {file_path}: {e}")
+        return {
+            "success": False,
+            "error": f"Failed to write file: {e}",
+            "path": file_path,
+            "size": 0,
+            "format": format,
+        }
+
+
+async def list_files(
+    directory: str,
+    depth: int = DEFAULT_LIST_DEPTH,
+    pattern: Optional[str] = None,
+    base_dir: Optional[str] = None,
+) -> dict[str, Any]:
+    """List files and directories asynchronously.
+
+    Args:
+        directory: Directory path to list
+        depth: Depth of recursive listing (1 = current directory only)
+        pattern: Optional glob pattern to filter results (e.g., "*.py")
+        base_dir: Optional base directory for relative paths
+
+    Returns:
+        Dictionary with:
+        - success: Whether the operation succeeded
+        - entries: List of file/directory entries with metadata
+        - total: Total number of entries
+        - path: Directory path that was listed
+        - error: Error message if failed
+    """
+    try:
+        # Normalize path
+        abs_path = normalize_path(directory, base_dir)
+
+        # Check if directory exists
+        if not os.path.exists(abs_path):
+            return {
+                "success": False,
+                "error": f"Directory not found: {abs_path}",
+                "entries": [],
+                "total": 0,
+                "path": abs_path,
+            }
+
+        # Check if it's a directory
+        if not os.path.isdir(abs_path):
+            return {
+                "success": False,
+                "error": f"Path is not a directory: {abs_path}",
+                "entries": [],
+                "total": 0,
+                "path": abs_path,
+            }
+
+        entries = []
+
+        # Walk directory tree up to specified depth
+        for root, dirs, files in os.walk(abs_path, followlinks=False):
+            # Calculate current depth
+            rel_path = os.path.relpath(root, abs_path)
+            if rel_path == ".":
+                current_depth = 0
+            else:
+                current_depth = len(rel_path.split(os.sep))
+
+            # Stop if exceeded depth
+            if current_depth >= depth:
+                dirs.clear()  # Don't descend further
+                continue
+
+            # Process directories and files at this level
+            for name in sorted(dirs) + sorted(files):
+                item_path = os.path.join(root, name)
+
+                # Apply pattern filter if specified
+                if pattern and not fnmatch.fnmatch(name, pattern):
+                    continue
+
+                try:
+                    info = get_file_info(item_path)
+                    entries.append(info)
+                except (PermissionError, FileNotFoundError) as e:
+                    logger.debug(f"[list_files] Skipping {item_path}: {e}")
+                    continue
+
+        logger.debug(f"[list_files] Listed {len(entries)} entries from {abs_path}")
+
+        return {
+            "success": True,
+            "entries": entries,
+            "total": len(entries),
+            "path": abs_path,
+        }
+
+    except PermissionError as e:
+        logger.error(f"[list_files] Permission denied: {directory}")
+        return {
+            "success": False,
+            "error": f"Permission denied: {e}",
+            "entries": [],
+            "total": 0,
+            "path": directory,
+        }
+    except Exception as e:
+        logger.error(f"[list_files] Error listing directory {directory}: {e}")
+        return {
+            "success": False,
+            "error": f"Failed to list directory: {e}",
+            "entries": [],
+            "total": 0,
+            "path": directory,
+        }
+
+
+def _wrap_shell_command(command: str) -> str:
+    """Wrap command with bash -c if it contains shell operators.
+
+    E2B SDK and subprocess execute commands directly without a shell interpreter,
+    so shell operators like &&, ||, |, ;, >, <, etc. are not recognized.
+    This method detects such operators and wraps the command with bash -c.
+
+    Args:
+        command: The original command string
+
+    Returns:
+        The command wrapped with bash -c if needed, otherwise the original command
+    """
+    # Check if command contains shell operators
+    if SHELL_OPERATORS_PATTERN.search(command):
+        # Escape single quotes in the command for bash -c
+        escaped_command = command.replace("'", "'\"'\"'")
+        wrapped = f"bash -c '{escaped_command}'"
+        logger.debug(
+            f"[_wrap_shell_command] Command contains shell operators, "
+            f"wrapping with bash -c: {wrapped[:100]}..."
+        )
+        return wrapped
+    return command
+
+
+async def execute_command(
+    command: str,
+    timeout: int = DEFAULT_COMMAND_TIMEOUT,
+    cwd: Optional[str] = None,
+    max_output_size: int = DEFAULT_MAX_OUTPUT_SIZE,
+    env: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    """Execute a shell command asynchronously.
+
+    Args:
+        command: The command to execute
+        timeout: Command timeout in seconds
+        cwd: Working directory for command execution
+        max_output_size: Maximum output size in bytes (per stream)
+        env: Optional environment variables to set
+
+    Returns:
+        Dictionary with:
+        - success: Whether the command executed successfully (exit_code == 0)
+        - stdout: Standard output (truncated if too large)
+        - stderr: Standard error (truncated if too large)
+        - exit_code: Command exit code
+        - execution_time: Time taken in seconds
+        - truncated: Whether output was truncated
+        - error: Error message if failed to execute
+    """
+    import time
+
+    start_time = time.time()
+
+    # Wrap command with bash -c if it contains shell operators
+    wrapped_command = _wrap_shell_command(command)
+
+    logger.info(
+        f"[execute_command] Executing: {command[:100]}, cwd={cwd}, timeout={timeout}s"
+    )
+
+    try:
+        # Prepare environment
+        process_env = os.environ.copy()
+        if env:
+            process_env.update(env)
+
+        # Create subprocess
+        process = await asyncio.create_subprocess_shell(
+            wrapped_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=process_env,
+        )
+
+        try:
+            # Wait for completion with timeout
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                process.communicate(), timeout=timeout
+            )
+        except asyncio.TimeoutError:
+            # Kill process on timeout
+            process.kill()
+            await process.wait()
+            execution_time = time.time() - start_time
+
+            logger.warning(f"[execute_command] Command timed out after {timeout}s")
+
+            return {
+                "success": False,
+                "error": f"Command timed out after {timeout} seconds",
+                "stdout": "",
+                "stderr": "",
+                "exit_code": -1,
+                "execution_time": execution_time,
+                "timed_out": True,
+            }
+
+        execution_time = time.time() - start_time
+
+        # Decode output
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        # Track truncation
+        stdout_truncated = False
+        stderr_truncated = False
+
+        # Truncate if needed
+        if len(stdout) > max_output_size:
+            stdout = stdout[:max_output_size]
+            stdout_truncated = True
+            logger.warning(
+                f"[execute_command] stdout truncated "
+                f"(original: {len(stdout_bytes)} bytes)"
+            )
+
+        if len(stderr) > max_output_size:
+            stderr = stderr[:max_output_size]
+            stderr_truncated = True
+            logger.warning(
+                f"[execute_command] stderr truncated "
+                f"(original: {len(stderr_bytes)} bytes)"
+            )
+
+        exit_code = process.returncode or 0
+
+        result = {
+            "success": exit_code == 0,
+            "stdout": stdout,
+            "stderr": stderr,
+            "exit_code": exit_code,
+            "execution_time": execution_time,
+        }
+
+        # Add truncation info if applicable
+        if stdout_truncated or stderr_truncated:
+            result["truncated"] = True
+            result["truncation_info"] = {
+                "stdout_truncated": stdout_truncated,
+                "stderr_truncated": stderr_truncated,
+                "max_output_size": max_output_size,
+                "message": f"Output truncated to {max_output_size} bytes per stream",
+            }
+
+        logger.info(
+            f"[execute_command] Completed: exit_code={exit_code}, "
+            f"time={execution_time:.2f}s"
+        )
+
+        return result
+
+    except FileNotFoundError as e:
+        execution_time = time.time() - start_time
+        logger.error(f"[execute_command] Command not found: {e}")
+        return {
+            "success": False,
+            "error": f"Command not found: {e}",
+            "stdout": "",
+            "stderr": str(e),
+            "exit_code": -1,
+            "execution_time": execution_time,
+        }
+    except PermissionError as e:
+        execution_time = time.time() - start_time
+        logger.error(f"[execute_command] Permission denied: {e}")
+        return {
+            "success": False,
+            "error": f"Permission denied: {e}",
+            "stdout": "",
+            "stderr": str(e),
+            "exit_code": -1,
+            "execution_time": execution_time,
+        }
+    except Exception as e:
+        execution_time = time.time() - start_time
+        logger.error(f"[execute_command] Error executing command: {e}")
+        return {
+            "success": False,
+            "error": f"Failed to execute command: {e}",
+            "stdout": "",
+            "stderr": str(e),
+            "exit_code": -1,
+            "execution_time": execution_time,
+        }


### PR DESCRIPTION
## Summary

- Extract filesystem operations from sandbox skill into Chat Shell builtin tools
- Add support for local mode (direct filesystem access) and remote mode (E2B sandbox)
- Create shared filesystem utilities in `shared/utils/filesystem.py` for reuse by executor and chat_shell
- Deprecate filesystem tools in sandbox skill (keep for backward compatibility during transition)

## Changes

### 1. Shared Module (`shared/utils/filesystem.py`)
- `read_file()` - Async file reading with text/bytes format support
- `write_file()` - Async file writing with auto directory creation
- `list_files()` - Directory listing with depth control and pattern filtering
- `execute_command()` - Command execution with timeout, output limits, and shell operator support
- Helper functions: `normalize_path()`, `get_file_info()`

### 2. Chat Shell Configuration (`chat_shell/core/config.py`)
- `SANDBOX_MODE`: "local" or "remote" (default: "remote" for backward compatibility)
- `LOCAL_WORKSPACE_ROOT`: Base directory for local operations
- `LOCAL_COMMAND_TIMEOUT`: Command timeout in seconds
- `LOCAL_MAX_OUTPUT_SIZE`: Maximum command output size
- `LOCAL_MAX_FILE_SIZE`: Maximum file read size

### 3. Builtin Filesystem Tools (`chat_shell/tools/builtin/filesystem_tools.py`)
- `ReadFileTool` - Read files from local filesystem or remote sandbox
- `WriteFileTool` - Write files to local filesystem or remote sandbox
- `ListFilesTool` - List directory contents in local or remote mode
- `ExecuteCommandTool` - Execute commands locally or in remote sandbox

### 4. Tool Registration (`chat_shell/services/context.py`)
- Auto-register filesystem tools based on `SANDBOX_MODE` configuration
- Tools are available by default without loading the sandbox skill

### 5. Sandbox Skill Update
- Updated to version 3.0.0
- Removed `exec`, `read_file`, `write_file`, `list_files` from active tools
- Kept deprecated support for backward compatibility
- Focus on `sub_claude_agent`, `upload_attachment`, `download_attachment`

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                      Chat Shell                              │
├─────────────────────────────────────────────────────────────┤
│  tools/builtin/filesystem_tools.py                          │
│  ┌─────────────────────────────────────────────────────────┐ │
│  │ ReadFileTool / WriteFileTool / ListFilesTool / ExecTool │ │
│  └─────────────────────────────────────────────────────────┘ │
│                           │                                  │
│           ┌───────────────┴───────────────┐                  │
│           │      SANDBOX_MODE check       │                  │
│           └───────────────┬───────────────┘                  │
│        ┌──────────────────┼──────────────────┐               │
│        ▼                                     ▼               │
│  ┌───────────┐                        ┌───────────┐          │
│  │   local   │                        │  remote   │          │
│  └─────┬─────┘                        └─────┬─────┘          │
│        │                                    │                │
│        ▼                                    ▼                │
│  shared/utils/                    tools/sandbox/_base.py     │
│  filesystem.py                    (E2B SDK)                  │
└────────┼────────────────────────────────────┼────────────────┘
         │                                    │
         ▼                                    ▼
┌─────────────────┐                 ┌─────────────────┐
│  Local System   │                 │  Remote Sandbox │
│  (subprocess)   │                 │  (executor_mgr) │
└─────────────────┘                 └─────────────────┘
```

## Test Plan

- [x] Unit tests for `shared/utils/filesystem.py`
- [x] Unit tests for `chat_shell/tools/builtin/filesystem_tools.py`
- [ ] Integration test: Chat Shell with `SANDBOX_MODE=local`
- [ ] Integration test: Chat Shell with `SANDBOX_MODE=remote`
- [ ] Verify backward compatibility: sandbox skill still works

## Migration Notes

1. **Backward Compatible**: `SANDBOX_MODE` defaults to "remote", existing deployments work without changes
2. **Gradual Deprecation**: Sandbox skill filesystem tools marked deprecated, will be removed in future version
3. **No Skill Loading Required**: Filesystem tools now available by default without `load_skill("sandbox")`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filesystem operations (read/write/list/exec) exposed as builtin tools; dual local/remote sandbox modes with configurable workspace, timeouts, and size limits.
  * Attachment-focused tools and a lightweight sub-agent option to drive Claude AI tasks.

* **Documentation**
  * Sandbox skill updated to v3.0.0 — emphasizes Claude AI workflows, builtin tool usage, and attachment operations; refreshed examples and best practices.

* **Tests**
  * Comprehensive tests added for filesystem utilities and builtin tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->