### PR TITLE
feat(chat): support dynamic skill update during Chat Shell conversation

### DIFF
--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -37,6 +37,7 @@ class ClientEvents:
 
     # Generic Skill Events
     SKILL_RESPONSE = "skill:response"  # Client -> Server: skill response
+    SKILL_UPDATE = "skill:update"  # Client -> Server: update task skills
 
 
 class ServerEvents:
@@ -226,6 +227,18 @@ class HistorySyncPayload(BaseModel):
 
     task_id: int = Field(..., description="Task ID")
     after_message_id: int = Field(..., description="Get messages after this ID")
+
+
+class SkillUpdatePayload(BaseModel):
+    """Payload for skill:update event.
+
+    Allows dynamically updating skills for an active Chat Shell task.
+    """
+
+    task_id: int = Field(..., description="Task ID to update skills for")
+    skills: List[SkillRef] = Field(
+        ..., description="New skill list with full info (name, namespace, is_public)"
+    )
 
 
 # ============================================================

--- a/executor/modes/local/events.py
+++ b/executor/modes/local/events.py
@@ -26,6 +26,12 @@ class TaskEvents:
     CLOSE_SESSION = "task:close-session"
 
 
+class SkillEvents:
+    """Skill-related events."""
+
+    SYNC = "skill:sync"  # Backend -> Executor: sync new skills to sandbox
+
+
 class ChatEvents:
     """Chat streaming events."""
 

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -31,6 +31,7 @@ import { useFloatingInput } from '../hooks/useFloatingInput'
 import { useAttachmentUpload } from '../hooks/useAttachmentUpload'
 import { useSchemeMessageActions } from '@/lib/scheme'
 import { useSkillSelector } from '../../hooks/useSkillSelector'
+import { useSkillUpdate } from '../../hooks/useSkillUpdate'
 
 /**
  * Threshold in pixels for determining when to collapse selectors.
@@ -106,6 +107,13 @@ function ChatAreaContent({
   const skillSelector = useSkillSelector({
     team: chatState.selectedTeam,
     enabled: true,
+  })
+
+  // Skill update hook - handles WebSocket synchronization for Chat Shell
+  const skillUpdate = useSkillUpdate({
+    taskId: selectedTaskDetail?.id,
+    isChatShellType: skillSelector.isChatShellType,
+    skillSelector,
   })
 
   // Compute subtask info for scroll management
@@ -650,7 +658,8 @@ function ChatAreaContent({
     teamSkillNames: skillSelector.teamSkillNames,
     preloadedSkillNames: skillSelector.preloadedSkillNames,
     selectedSkillNames: skillSelector.selectedSkillNames,
-    onToggleSkill: skillSelector.toggleSkill,
+    // Use skillUpdate.toggleSkill for Chat Shell to enable WebSocket sync on active tasks
+    onToggleSkill: skillUpdate.toggleSkill,
   }
 
   return (

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -109,10 +109,9 @@ function ChatAreaContent({
     enabled: true,
   })
 
-  // Skill update hook - handles WebSocket synchronization for Chat Shell
+  // Skill update hook - handles WebSocket synchronization for all shell types
   const skillUpdate = useSkillUpdate({
     taskId: selectedTaskDetail?.id,
-    isChatShellType: skillSelector.isChatShellType,
     skillSelector,
   })
 

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -257,9 +257,10 @@ export function ChatInputCard({
               selectedSkillNames={selectedSkillNames}
               onSkillSelect={onToggleSkill}
               isChatShell={selectedTeam?.agent_type === 'chat'}
-              // Skill selection is read-only after task creation (hasMessages) - except for Chat Shell
-              // Chat Shell supports dynamic skill update during conversation
-              skillSelectorReadOnly={hasMessages && selectedTeam?.agent_type !== 'chat'}
+              // Skill selection now supports dynamic update for all shell types
+              // Chat Shell: skills stored in task metadata, read at next response
+              // ClaudeCode/Agno (local devices): skill:sync event triggers download
+              skillSelectorReadOnly={false}
               // Pass skill button ref for fly animation
               skillButtonRef={
                 { current: getSkillButtonElement() } as React.RefObject<HTMLElement | null>

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -257,8 +257,9 @@ export function ChatInputCard({
               selectedSkillNames={selectedSkillNames}
               onSkillSelect={onToggleSkill}
               isChatShell={selectedTeam?.agent_type === 'chat'}
-              // Skill selection is read-only after task creation (hasMessages)
-              skillSelectorReadOnly={hasMessages}
+              // Skill selection is read-only after task creation (hasMessages) - except for Chat Shell
+              // Chat Shell supports dynamic skill update during conversation
+              skillSelectorReadOnly={hasMessages && selectedTeam?.agent_type !== 'chat'}
               // Pass skill button ref for fly animation
               skillButtonRef={
                 { current: getSkillButtonElement() } as React.RefObject<HTMLElement | null>

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -323,7 +323,8 @@ export function ChatInputControls({
         )}
 
         {/* Skill Selector - show when skills are available */}
-        {/* Skill selection is read-only after task creation (hasMessages) */}
+        {/* Skill selection is read-only after task creation (hasMessages) - except for Chat Shell */}
+        {/* Chat Shell supports dynamic skill update during conversation */}
         {availableSkills.length > 0 && onToggleSkill && (
           <SkillSelectorPopover
             ref={skillSelectorRef}
@@ -334,7 +335,7 @@ export function ChatInputControls({
             onToggleSkill={onToggleSkill}
             isChatShell={isChatShell(selectedTeam)}
             disabled={isLoading || isStreaming}
-            readOnly={hasMessages}
+            readOnly={hasMessages && !isChatShell(selectedTeam)}
           />
         )}
 

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -323,8 +323,7 @@ export function ChatInputControls({
         )}
 
         {/* Skill Selector - show when skills are available */}
-        {/* Skill selection is read-only after task creation (hasMessages) - except for Chat Shell */}
-        {/* Chat Shell supports dynamic skill update during conversation */}
+        {/* Skill selection now supports dynamic update for all shell types */}
         {availableSkills.length > 0 && onToggleSkill && (
           <SkillSelectorPopover
             ref={skillSelectorRef}
@@ -335,7 +334,7 @@ export function ChatInputControls({
             onToggleSkill={onToggleSkill}
             isChatShell={isChatShell(selectedTeam)}
             disabled={isLoading || isStreaming}
-            readOnly={hasMessages && !isChatShell(selectedTeam)}
+            readOnly={false}
           />
         )}
 

--- a/frontend/src/features/tasks/hooks/useSkillUpdate.ts
+++ b/frontend/src/features/tasks/hooks/useSkillUpdate.ts
@@ -1,0 +1,152 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useCallback, useRef, useEffect } from 'react'
+import { useSocket } from '@/contexts/SocketContext'
+import { useToast } from '@/hooks/use-toast'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { SkillRef, UseSkillSelectorReturn } from './useSkillSelector'
+
+interface UseSkillUpdateOptions {
+  /** Current task ID (undefined for new chats) */
+  taskId: number | undefined
+  /** Whether the team is Chat Shell type (supports dynamic skill update) */
+  isChatShellType: boolean
+  /** Skill selector instance */
+  skillSelector: UseSkillSelectorReturn
+}
+
+interface UseSkillUpdateReturn {
+  /** Toggle skill with automatic WebSocket update for active tasks */
+  toggleSkill: (skillName: string) => void
+  /** Add skill with automatic WebSocket update for active tasks */
+  addSkill: (skillName: string) => void
+  /** Remove skill with automatic WebSocket update for active tasks */
+  removeSkill: (skillName: string) => void
+}
+
+/**
+ * Hook for managing skill updates with WebSocket synchronization.
+ *
+ * For Chat Shell tasks, when skills are modified in an active conversation,
+ * this hook automatically emits a `skill:update` WebSocket event to sync
+ * the skill configuration with the backend.
+ *
+ * For non-Chat Shell tasks, skills are only sent when a new message is sent.
+ */
+export function useSkillUpdate({
+  taskId,
+  isChatShellType,
+  skillSelector,
+}: UseSkillUpdateOptions): UseSkillUpdateReturn {
+  const { t } = useTranslation('chat')
+  const { toast } = useToast()
+  const { updateTaskSkills, isConnected } = useSocket()
+
+  // Track previous skills to detect changes
+  const prevSkillsRef = useRef<SkillRef[]>([])
+  // Track if initial sync has been done (to avoid toast on initial load)
+  const initialSyncDoneRef = useRef(false)
+
+  /**
+   * Send skill update to backend via WebSocket
+   */
+  const sendSkillUpdate = useCallback(
+    async (skills: SkillRef[]) => {
+      if (!taskId || !isChatShellType || !isConnected) {
+        return
+      }
+
+      console.log('[useSkillUpdate] Sending skill update:', { taskId, skills })
+
+      const result = await updateTaskSkills(taskId, skills)
+
+      if (result.success) {
+        toast({
+          title: t('skill_update_success'),
+          duration: 2000,
+        })
+      } else {
+        console.error('[useSkillUpdate] Failed to update skills:', result.error)
+        toast({
+          title: t('skill_update_error'),
+          description: result.error,
+          variant: 'destructive',
+          duration: 3000,
+        })
+      }
+    },
+    [taskId, isChatShellType, isConnected, updateTaskSkills, toast, t]
+  )
+
+  // Monitor skill changes and emit update for active Chat Shell tasks
+  useEffect(() => {
+    // Skip if no task or not Chat Shell
+    if (!taskId || !isChatShellType) {
+      initialSyncDoneRef.current = false
+      prevSkillsRef.current = []
+      return
+    }
+
+    const currentSkills = skillSelector.selectedSkills
+
+    // Skip initial sync (when first loading a task)
+    if (!initialSyncDoneRef.current) {
+      initialSyncDoneRef.current = true
+      prevSkillsRef.current = currentSkills
+      return
+    }
+
+    // Check if skills actually changed
+    const prevSkillNames = new Set(prevSkillsRef.current.map(s => s.name))
+    const currentSkillNames = new Set(currentSkills.map(s => s.name))
+
+    const hasChanges =
+      prevSkillNames.size !== currentSkillNames.size ||
+      [...prevSkillNames].some(name => !currentSkillNames.has(name))
+
+    if (hasChanges) {
+      sendSkillUpdate(currentSkills)
+      prevSkillsRef.current = currentSkills
+    }
+  }, [taskId, isChatShellType, skillSelector.selectedSkills, sendSkillUpdate])
+
+  // Reset initial sync flag when task changes
+  useEffect(() => {
+    initialSyncDoneRef.current = false
+    prevSkillsRef.current = []
+  }, [taskId])
+
+  // Wrap skill operations to trigger update
+  const toggleSkill = useCallback(
+    (skillName: string) => {
+      skillSelector.toggleSkill(skillName)
+    },
+    [skillSelector]
+  )
+
+  const addSkill = useCallback(
+    (skillName: string) => {
+      skillSelector.addSkill(skillName)
+    },
+    [skillSelector]
+  )
+
+  const removeSkill = useCallback(
+    (skillName: string) => {
+      skillSelector.removeSkill(skillName)
+    },
+    [skillSelector]
+  )
+
+  return {
+    toggleSkill,
+    addSkill,
+    removeSkill,
+  }
+}
+
+export type { UseSkillUpdateReturn }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -532,5 +532,7 @@
     "proceeding_to_stage": "Proceeding to stage: {{stage}}",
     "pipeline_completed": "Pipeline completed",
     "no_task_id": "No task ID available"
-  }
+  },
+  "skill_update_success": "Skill configuration updated",
+  "skill_update_error": "Failed to update skills"
 }

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -510,5 +510,7 @@
     "proceeding_to_stage": "正在进入阶段: {{stage}}",
     "pipeline_completed": "流水线已完成",
     "no_task_id": "没有可用的任务 ID"
-  }
+  },
+  "skill_update_success": "技能配置已更新",
+  "skill_update_error": "更新技能失败"
 }

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -18,6 +18,7 @@ export const ClientEvents = {
   TASK_JOIN: 'task:join',
   TASK_LEAVE: 'task:leave',
   HISTORY_SYNC: 'history:sync',
+  SKILL_UPDATE: 'skill:update',
 } as const
 
 // ============================================================
@@ -161,6 +162,15 @@ export interface TaskLeavePayload {
 export interface HistorySyncPayload {
   task_id: number
   after_message_id: number
+}
+
+export interface SkillUpdatePayload {
+  task_id: number
+  skills: Array<{
+    name: string
+    namespace: string
+    is_public: boolean
+  }>
 }
 
 // ============================================================
@@ -551,6 +561,11 @@ export interface HistorySyncAck {
 }
 
 export interface GenericAck {
+  success: boolean
+  error?: string
+}
+
+export interface SkillUpdateAck {
   success: boolean
   error?: string
 }


### PR DESCRIPTION
Enable users to modify skill configuration during an active Chat Shell conversation. This adds WebSocket event handling for real-time skill synchronization and allows the skill selector to remain editable for Chat Shell type tasks.

Changes:
- Add skill:update WebSocket event (frontend -> backend)
- Add useSkillUpdate hook to manage skill changes with WebSocket sync
- Update SkillSelectorPopover to stay editable for Chat Shell tasks
- Store updated skills in Task metadata for persistence
- Read skills from task metadata in trigger/core.py for AI responses
- Add i18n translations for skill update toast messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat Shell now supports dynamic skill updates during active sessions with real-time synchronization to local executors.
  * New client action to update task skills with user-facing success/error toasts.

* **Improvements**
  * Skill selector remains editable during conversations for on-the-fly configuration.
  * Added English and Chinese translations for skill update status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->