### PR TITLE
fix(backend): address code review issues in memory client and async tests

### DIFF
--- a/backend/app/services/memory/client.py
+++ b/backend/app/services/memory/client.py
@@ -299,7 +299,10 @@ class LongTermMemoryClient:
         if not response.success:
             return MemorySearchResponse(results=[])
 
-        result = MemorySearchResponse(**response.data)
+        if not response.data:
+            result = MemorySearchResponse(results=[])
+        else:
+            result = MemorySearchResponse(**response.data)
         logger.info(
             "Found %d memories for user %s",
             len(result.results),

--- a/backend/tests/core/test_async_loop_issues.py
+++ b/backend/tests/core/test_async_loop_issues.py
@@ -57,7 +57,9 @@ class TestCrossLoopExecution:
         results = []
 
         async def async_func(value: int) -> int:
-            results.append(f"executed in loop: {asyncio.get_running_loop() is main_loop}")
+            results.append(
+                f"executed in loop: {asyncio.get_running_loop() is main_loop}"
+            )
             return value * 2
 
         # When in the same loop, should execute directly
@@ -120,8 +122,6 @@ class TestAsyncSessionManager:
         This ensures each request gets a session bound to its own loop,
         avoiding cross-loop issues.
         """
-        current_loop = asyncio.get_running_loop()
-
         with patch("aiohttp.ClientSession") as mock_session_class:
             mock_session = AsyncMock()
             mock_session.close = AsyncMock()
@@ -143,7 +143,7 @@ class TestAsyncSessionManager:
                 mock_session.close = AsyncMock()
                 mock_session_class.return_value = mock_session
 
-                async with AsyncSessionManager(timeout=60.0) as session:
+                async with AsyncSessionManager(timeout=60.0) as _:
                     pass
 
                 # Timeout should be created with correct value
@@ -214,6 +214,7 @@ class TestOriginalBugReproduction:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
+
                 async def request_1():
                     async with AsyncSessionManager(timeout=10.0) as session:
                         results.append("loop1: session created")
@@ -229,6 +230,7 @@ class TestOriginalBugReproduction:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
+
                 async def request_2():
                     # With AsyncSessionManager, this works fine
                     # because a NEW session is created in THIS loop


### PR DESCRIPTION
## Summary

- Guard against null `response.data` in `MemorySearchResponse` unpacking to prevent `TypeError`
- Remove unused `current_loop` variable in `test_session_created_in_current_loop` test function
- Replace unused `session` variable with `_` in `test_session_with_custom_timeout` to resolve Ruff F841 lint error

## Changes

1. **backend/app/services/memory/client.py** (lines 299-311):
   - Added check for `response.data` truthiness before unpacking
   - If `response.data` is None or empty, return `MemorySearchResponse(results=[])` safely
   - Preserved logging with `len(result.results)` and `user_id`

2. **backend/tests/core/test_async_loop_issues.py**:
   - Removed unused `current_loop = asyncio.get_running_loop()` assignment in `test_session_created_in_current_loop`
   - Changed `async with AsyncSessionManager(timeout=60.0) as session:` to `async with AsyncSessionManager(timeout=60.0) as _:` in `test_session_with_custom_timeout`

## Test plan

- [x] All 8 tests in `test_async_loop_issues.py` pass
- [x] Code formatted with black and isort
- [x] Ruff F841 (unused variable) warnings resolved