### PR TITLE
fix(executor-manager): extend session hash TTL to prevent GC data loss

### DIFF
--- a/executor_manager/common/config.py
+++ b/executor_manager/common/config.py
@@ -68,6 +68,9 @@ class TimeoutConfig:
 
     # Redis TTL
     redis_ttl: int = 86400  # 24 hours
+    # Session hash TTL must be longer than redis_ttl to ensure GC can load sandbox data
+    # Formula: redis_ttl + GC_INTERVAL + buffer (default: 86400 + 3600 + 3600 = 93600)
+    session_hash_ttl: int = 93600
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Introduced session_hash_ttl (93600s) separate from redis_ttl (86400s) to ensure garbage collector can still load sandbox data even when sandboxes are marked as expired. The extended TTL accounts for GC interval (3600s) plus buffer (3600s).

Updated all Redis hash operations to use session_hash_ttl instead of redis_ttl, including session metadata, execution data, and e2b sandbox ID index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal session management configuration to improve data consistency and garbage collection handling with adjusted TTL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->