### PR TITLE
feat(tasks): add message pagination and complete export

### DIFF
--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -165,6 +165,7 @@ class TaskDetail(BaseModel):
         None  # App preview information (set by expose_service tool)
     )
     device_id: Optional[str] = None  # Device ID used for execution (for task history)
+    total_messages: int = 0  # Total number of messages for pagination
 
     class Config:
         from_attributes = True

--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -627,21 +627,12 @@ class TaskQueryMixin:
 
         # Get total message count for pagination
         from app.models.subtask import Subtask as SubtaskModel
-        from app.services.task_member_service import task_member_service
 
-        is_member = task_member_service.is_member(db, task_id, user_id)
-        if is_member:
-            total_messages = (
-                db.query(SubtaskModel).filter(SubtaskModel.task_id == task_id).count()
-            )
-        else:
-            total_messages = (
-                db.query(SubtaskModel)
-                .filter(
-                    SubtaskModel.task_id == task_id, SubtaskModel.user_id == user_id
-                )
-                .count()
-            )
+        # Note: User is guaranteed to be a member at this point since get_task_by_id
+        # already validates membership and raises 404 if not a member.
+        total_messages = (
+            db.query(SubtaskModel).filter(SubtaskModel.task_id == task_id).count()
+        )
 
         # Get related subtasks (limit to 50 for initial load, pagination supported via /subtasks API)
         subtasks = subtask_service.get_by_task(

--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -48,8 +48,7 @@ class TaskQueryMixin:
         """
         # Use raw SQL to get task IDs where user is owner OR member (using resource_members)
         # Exclude system namespace tasks (background tasks)
-        count_sql = text(
-            """
+        count_sql = text("""
             SELECT COUNT(DISTINCT k.id)
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -57,13 +56,11 @@ class TaskQueryMixin:
             AND k.is_active = true
             AND k.namespace != 'system'
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
-        """
-        )
+        """)
         total_result = db.execute(count_sql, {"user_id": user_id}).scalar()
 
         # Get task IDs sorted by created_at
-        ids_sql = text(
-            """
+        ids_sql = text("""
             SELECT DISTINCT k.id, k.created_at
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -73,8 +70,7 @@ class TaskQueryMixin:
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
             ORDER BY k.created_at DESC
             LIMIT :limit OFFSET :skip
-        """
-        )
+        """)
         task_id_rows = db.execute(
             ids_sql, {"user_id": user_id, "limit": limit + 50, "skip": skip}
         ).fetchall()
@@ -125,8 +121,7 @@ class TaskQueryMixin:
         Includes tasks owned by user AND tasks user is a member of (group chats).
         """
         # Get task IDs where user is owner OR member (using resource_members)
-        count_sql = text(
-            """
+        count_sql = text("""
             SELECT COUNT(DISTINCT k.id)
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -134,13 +129,11 @@ class TaskQueryMixin:
             AND k.is_active = true
             AND k.namespace != 'system'
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
-        """
-        )
+        """)
         total_result = db.execute(count_sql, {"user_id": user_id}).scalar()
 
         # Get task IDs sorted by created_at
-        ids_sql = text(
-            """
+        ids_sql = text("""
             SELECT DISTINCT k.id, k.created_at
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -150,8 +143,7 @@ class TaskQueryMixin:
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
             ORDER BY k.created_at DESC
             LIMIT :limit OFFSET :skip
-        """
-        )
+        """)
         task_id_rows = db.execute(
             ids_sql, {"user_id": user_id, "limit": limit + 50, "skip": skip}
         ).fetchall()
@@ -215,8 +207,7 @@ class TaskQueryMixin:
         from app.models.share_link import ResourceType
 
         # Get task IDs that are group chats (have members) using resource_members
-        member_task_ids_sql = text(
-            """
+        member_task_ids_sql = text("""
             SELECT DISTINCT tm.resource_id
             FROM resource_members tm
             INNER JOIN tasks k ON k.id = tm.resource_id AND tm.resource_type = 'Task'
@@ -225,16 +216,14 @@ class TaskQueryMixin:
             AND k.is_active = true
             AND k.namespace != 'system'
             AND (k.user_id = :user_id OR tm.user_id = :user_id)
-        """
-        )
+        """)
         member_task_ids_result = db.execute(
             member_task_ids_sql, {"user_id": user_id}
         ).fetchall()
         member_task_ids = {row[0] for row in member_task_ids_result}
 
         # Also get tasks where is_group_chat is explicitly set to true
-        explicit_group_sql = text(
-            """
+        explicit_group_sql = text("""
             SELECT DISTINCT k.id
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -243,8 +232,7 @@ class TaskQueryMixin:
             AND k.namespace != 'system'
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
             AND JSON_EXTRACT(k.json, '$.spec.is_group_chat') = true
-        """
-        )
+        """)
         explicit_group_result = db.execute(
             explicit_group_sql, {"user_id": user_id}
         ).fetchall()
@@ -303,8 +291,7 @@ class TaskQueryMixin:
         from app.models.share_link import ResourceType
 
         # Get all task IDs that are group chats (have members) using resource_members
-        member_task_ids_sql = text(
-            """
+        member_task_ids_sql = text("""
             SELECT DISTINCT tm.resource_id
             FROM resource_members tm
             INNER JOIN tasks k ON k.id = tm.resource_id AND tm.resource_type = 'Task'
@@ -312,14 +299,12 @@ class TaskQueryMixin:
             AND k.kind = 'Task'
             AND k.is_active = true
             AND k.namespace != 'system'
-        """
-        )
+        """)
         member_task_ids_result = db.execute(member_task_ids_sql).fetchall()
         member_task_ids = {row[0] for row in member_task_ids_result}
 
         # Also get task IDs where is_group_chat is explicitly set to true
-        explicit_group_sql = text(
-            """
+        explicit_group_sql = text("""
             SELECT DISTINCT k.id
             FROM tasks k
             WHERE k.kind = 'Task'
@@ -327,8 +312,7 @@ class TaskQueryMixin:
             AND k.namespace != 'system'
             AND k.user_id = :user_id
             AND JSON_EXTRACT(k.json, '$.spec.is_group_chat') = true
-        """
-        )
+        """)
         explicit_group_result = db.execute(
             explicit_group_sql, {"user_id": user_id}
         ).fetchall()
@@ -338,21 +322,18 @@ class TaskQueryMixin:
         all_group_task_ids = member_task_ids | explicit_group_ids
 
         # Get user's owned tasks (not group chats)
-        count_sql = text(
-            """
+        count_sql = text("""
             SELECT COUNT(*)
             FROM tasks k
             WHERE k.kind = 'Task'
             AND k.is_active = true
             AND k.namespace != 'system'
             AND k.user_id = :user_id
-        """
-        )
+        """)
         total_result = db.execute(count_sql, {"user_id": user_id}).scalar()
 
         # Get task IDs sorted by created_at
-        ids_sql = text(
-            """
+        ids_sql = text("""
             SELECT k.id, k.created_at
             FROM tasks k
             WHERE k.kind = 'Task'
@@ -361,8 +342,7 @@ class TaskQueryMixin:
             AND k.user_id = :user_id
             ORDER BY k.created_at DESC
             LIMIT :limit OFFSET :skip
-        """
-        )
+        """)
         task_id_rows = db.execute(
             ids_sql, {"user_id": user_id, "limit": limit + 100, "skip": skip}
         ).fetchall()
@@ -448,8 +428,7 @@ class TaskQueryMixin:
         Returns tasks with ID greater than since_id, ordered by ID descending.
         """
         # Get task IDs where user is owner OR member, with ID > since_id (using resource_members)
-        ids_sql = text(
-            """
+        ids_sql = text("""
             SELECT DISTINCT k.id, k.created_at
             FROM tasks k
             LEFT JOIN resource_members tm ON k.id = tm.resource_id AND tm.resource_type = 'Task' AND tm.user_id = :user_id AND tm.status = 'approved'
@@ -460,8 +439,7 @@ class TaskQueryMixin:
             AND (k.user_id = :user_id OR tm.id IS NOT NULL)
             ORDER BY k.id DESC
             LIMIT :limit
-        """
-        )
+        """)
         task_id_rows = db.execute(
             ids_sql, {"user_id": user_id, "since_id": since_id, "limit": limit}
         ).fetchall()
@@ -515,19 +493,16 @@ class TaskQueryMixin:
         Excludes DELETE status tasks.
         """
         # Get task IDs
-        count_sql = text(
-            """
+        count_sql = text("""
             SELECT COUNT(*) FROM tasks
             WHERE user_id = :user_id
             AND kind = 'Task'
             AND is_active = true
             AND namespace != 'system'
-        """
-        )
+        """)
         total_result = db.execute(count_sql, {"user_id": user_id}).scalar()
 
-        ids_sql = text(
-            """
+        ids_sql = text("""
             SELECT id FROM tasks
             WHERE user_id = :user_id
             AND kind = 'Task'
@@ -535,8 +510,7 @@ class TaskQueryMixin:
             AND namespace != 'system'
             ORDER BY created_at DESC
             LIMIT :limit OFFSET :skip
-        """
-        )
+        """)
         task_id_rows = db.execute(
             ids_sql, {"user_id": user_id, "limit": limit + 100, "skip": skip}
         ).fetchall()
@@ -651,9 +625,27 @@ class TaskQueryMixin:
                     )
                     team = None
 
-        # Get related subtasks
+        # Get total message count for pagination
+        from app.models.subtask import Subtask as SubtaskModel
+        from app.services.task_member_service import task_member_service
+
+        is_member = task_member_service.is_member(db, task_id, user_id)
+        if is_member:
+            total_messages = (
+                db.query(SubtaskModel).filter(SubtaskModel.task_id == task_id).count()
+            )
+        else:
+            total_messages = (
+                db.query(SubtaskModel)
+                .filter(
+                    SubtaskModel.task_id == task_id, SubtaskModel.user_id == user_id
+                )
+                .count()
+            )
+
+        # Get related subtasks (limit to 50 for initial load, pagination supported via /subtasks API)
         subtasks = subtask_service.get_by_task(
-            db=db, task_id=task_id, user_id=user_id, from_latest=True
+            db=db, task_id=task_id, user_id=user_id, from_latest=True, limit=50
         )
 
         # Get all bot objects for the subtasks
@@ -670,6 +662,7 @@ class TaskQueryMixin:
         task_dict["user"] = user
         task_dict["team"] = team
         task_dict["subtasks"] = subtasks_dict
+        task_dict["total_messages"] = total_messages
 
         # Add group chat information
         self._add_group_chat_info_to_task(db, task_id, task_dict, user_id)
@@ -896,8 +889,7 @@ class TaskQueryMixin:
             team_name = task_crd.spec.teamRef.name
             team_namespace = task_crd.spec.teamRef.namespace
             team_result = db.execute(
-                text(
-                    """
+                text("""
                     SELECT id FROM kinds
                     WHERE user_id = :user_id
                     AND kind = 'Team'
@@ -905,16 +897,14 @@ class TaskQueryMixin:
                     AND namespace = :namespace
                     AND is_active = true
                     LIMIT 1
-                """
-                ),
+                """),
                 {"user_id": user_id, "name": team_name, "namespace": team_namespace},
             ).fetchone()
 
             team_id = team_result[0] if team_result else None
             if not team_id:
                 shared_team_result = db.execute(
-                    text(
-                        """
+                    text("""
                         SELECT k.id FROM kinds k
                         INNER JOIN resource_members rm
                             ON rm.resource_id = k.id
@@ -926,8 +916,7 @@ class TaskQueryMixin:
                         AND k.namespace = :namespace
                         AND k.is_active = true
                         LIMIT 1
-                    """
-                    ),
+                    """),
                     {
                         "user_id": user_id,
                         "name": team_name,
@@ -940,8 +929,7 @@ class TaskQueryMixin:
             workspace_name = task_crd.spec.workspaceRef.name
             workspace_namespace = task_crd.spec.workspaceRef.namespace
             workspace_result = db.execute(
-                text(
-                    """
+                text("""
                     SELECT JSON_EXTRACT(json, '$.spec.repository.gitRepo') as git_repo
                     FROM tasks
                     WHERE user_id = :user_id
@@ -950,8 +938,7 @@ class TaskQueryMixin:
                     AND namespace = :namespace
                     AND is_active = true
                     LIMIT 1
-                """
-                ),
+                """),
                 {
                     "user_id": user_id,
                     "name": workspace_name,

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -225,7 +225,7 @@ export default function MessagesArea({
     loadedCount,
     totalCount,
     loadMoreMessages,
-    error: paginationError,
+    error: _paginationError,
   } = useMessagePagination({
     taskId: selectedTaskDetail?.id,
     totalMessages: selectedTaskDetail?.total_messages ?? 0,

--- a/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
+++ b/frontend/src/features/tasks/components/share/ExportSelectModal.tsx
@@ -154,7 +154,7 @@ export default function ExportSelectModal({
                 knowledgeBases.push({
                   id: ctx.id,
                   name: ctx.name,
-                  document_count: ctx.document_count,
+                  document_count: ctx.document_count ?? undefined,
                 })
               }
             }

--- a/frontend/src/features/tasks/hooks/useMessagePagination.ts
+++ b/frontend/src/features/tasks/hooks/useMessagePagination.ts
@@ -1,0 +1,272 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * useMessagePagination Hook
+ *
+ * Handles pagination for loading older messages in task chat history.
+ * Provides infinite scroll functionality with proper state management.
+ */
+
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { subtaskApis, SubtaskListResponse } from '@/apis/subtasks'
+import type { TaskDetailSubtask } from '@/types/api'
+import { taskStateManager, UnifiedMessage } from '../state'
+
+export interface UseMessagePaginationOptions {
+  /** Task ID for the messages */
+  taskId: number | null | undefined
+  /** Total messages count from task detail */
+  totalMessages: number
+  /** Team name for display */
+  teamName?: string
+  /** Whether this is a group chat */
+  isGroupChat?: boolean
+  /** Current user ID */
+  currentUserId?: number
+  /** Current user name */
+  currentUserName?: string
+}
+
+export interface UseMessagePaginationResult {
+  /** Whether more messages are available */
+  hasMoreMessages: boolean
+  /** Whether currently loading more messages */
+  isLoadingMore: boolean
+  /** Number of loaded messages */
+  loadedCount: number
+  /** Total messages count */
+  totalCount: number
+  /** Load more messages (older messages) */
+  loadMoreMessages: () => Promise<void>
+  /** Error message if loading failed */
+  error: string | null
+  /** Reset pagination state (when task changes) */
+  resetPagination: () => void
+}
+
+const PAGE_SIZE = 50
+
+/**
+ * Hook to manage message pagination for infinite scroll
+ */
+export function useMessagePagination({
+  taskId,
+  totalMessages,
+  teamName,
+  isGroupChat,
+  currentUserId,
+  currentUserName,
+}: UseMessagePaginationOptions): UseMessagePaginationResult {
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [hasLoadedAll, setHasLoadedAll] = useState(false)
+  const [loadedCount, setLoadedCount] = useState(0)
+
+  // Track the oldest message ID we've loaded
+  const oldestMessageIdRef = useRef<number | null>(null)
+  // Track last task ID to reset state when task changes
+  const lastTaskIdRef = useRef<number | null>(null)
+
+  // Reset pagination when task changes
+  useEffect(() => {
+    if (taskId !== lastTaskIdRef.current) {
+      lastTaskIdRef.current = taskId ?? null
+      setHasLoadedAll(false)
+      setError(null)
+      oldestMessageIdRef.current = null
+      setLoadedCount(0)
+    }
+  }, [taskId])
+
+  // Update loaded count when state machine updates
+  useEffect(() => {
+    if (!taskId) {
+      setLoadedCount(0)
+      return
+    }
+
+    const machine = taskStateManager.get(taskId)
+    if (machine) {
+      const updateCount = () => {
+        const state = machine.getState()
+        setLoadedCount(state.messages.size)
+
+        // Check if we've loaded all messages
+        if (state.messages.size >= totalMessages) {
+          setHasLoadedAll(true)
+        }
+      }
+
+      // Get initial count
+      updateCount()
+
+      // Subscribe to updates
+      const unsubscribe = machine.subscribe(updateCount)
+      return unsubscribe
+    }
+  }, [taskId, totalMessages])
+
+  /**
+   * Load more (older) messages
+   */
+  const loadMoreMessages = useCallback(async () => {
+    if (!taskId || isLoadingMore || hasLoadedAll) return
+
+    setIsLoadingMore(true)
+    setError(null)
+
+    try {
+      // Get current state machine to find oldest message
+      const machine = taskStateManager.get(taskId)
+      if (!machine) {
+        setError('State machine not found')
+        return
+      }
+
+      const currentState = machine.getState()
+      const currentMessages = Array.from(currentState.messages.values())
+
+      // Find the oldest messageId (lowest messageId value)
+      let oldestMessageId: number | undefined
+      for (const msg of currentMessages) {
+        if (msg.messageId !== undefined) {
+          if (oldestMessageId === undefined || msg.messageId < oldestMessageId) {
+            oldestMessageId = msg.messageId
+          }
+        }
+      }
+
+      // If no messages with messageId, we can't paginate
+      if (oldestMessageId === undefined) {
+        setHasLoadedAll(true)
+        return
+      }
+
+      // Fetch older messages using before_message_id parameter
+      const response: SubtaskListResponse = await subtaskApis.listSubtasks({
+        taskId,
+        limit: PAGE_SIZE,
+        fromLatest: false, // Get messages in ascending order
+        beforeMessageId: oldestMessageId,
+      })
+
+      if (response.items.length === 0) {
+        setHasLoadedAll(true)
+        return
+      }
+
+      // Convert subtasks to UnifiedMessage and add to state machine
+      const newMessages = convertSubtasksToMessages(response.items, {
+        teamName,
+        isGroupChat,
+        currentUserId,
+        currentUserName,
+      })
+
+      // Merge new messages into state machine
+      machine.mergeOlderMessages(newMessages)
+
+      // Check if we've loaded all messages
+      if (response.items.length < PAGE_SIZE) {
+        setHasLoadedAll(true)
+      }
+
+      // Update oldest message ID reference
+      oldestMessageIdRef.current = response.items.reduce((min, item) => {
+        return item.message_id < min ? item.message_id : min
+      }, response.items[0]?.message_id ?? Infinity)
+    } catch (err) {
+      console.error('[useMessagePagination] Failed to load more messages:', err)
+      setError(err instanceof Error ? err.message : 'Failed to load messages')
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [taskId, isLoadingMore, hasLoadedAll, teamName, isGroupChat, currentUserId, currentUserName])
+
+  /**
+   * Reset pagination state (when task changes)
+   */
+  const resetPagination = useCallback(() => {
+    setHasLoadedAll(false)
+    setError(null)
+    oldestMessageIdRef.current = null
+    setLoadedCount(0)
+  }, [])
+
+  const hasMoreMessages = !hasLoadedAll && loadedCount < totalMessages && totalMessages > 0
+
+  return {
+    hasMoreMessages,
+    isLoadingMore,
+    loadedCount,
+    totalCount: totalMessages,
+    loadMoreMessages,
+    error,
+    resetPagination,
+  }
+}
+
+/**
+ * Convert backend subtasks to UnifiedMessage format
+ */
+function convertSubtasksToMessages(
+  subtasks: TaskDetailSubtask[],
+  options: {
+    teamName?: string
+    isGroupChat?: boolean
+    currentUserId?: number
+    currentUserName?: string
+  }
+): UnifiedMessage[] {
+  const { teamName, isGroupChat, currentUserId, currentUserName } = options
+  const messages: UnifiedMessage[] = []
+
+  for (const subtask of subtasks) {
+    const isUserMessage = subtask.role === 'USER' || subtask.role?.toUpperCase() === 'USER'
+    const messageId = isUserMessage ? `user-backend-${subtask.id}` : `ai-${subtask.id}`
+
+    // Determine status
+    let status: 'pending' | 'streaming' | 'completed' | 'error' = 'completed'
+    if (subtask.status === 'RUNNING') {
+      status = 'streaming'
+    } else if (subtask.status === 'FAILED' || subtask.status === 'CANCELLED') {
+      status = 'error'
+    } else if (subtask.status === 'PENDING') {
+      status = 'pending'
+    }
+
+    // Get content
+    const content = isUserMessage
+      ? subtask.prompt || ''
+      : typeof subtask.result?.value === 'string'
+        ? subtask.result.value
+        : ''
+
+    messages.push({
+      id: messageId,
+      type: isUserMessage ? 'user' : 'ai',
+      status,
+      content,
+      timestamp: new Date(subtask.created_at).getTime(),
+      subtaskId: subtask.id,
+      messageId: subtask.message_id,
+      attachments: subtask.attachments,
+      contexts: subtask.contexts,
+      botName: !isUserMessage && subtask.bots?.[0]?.name ? subtask.bots[0].name : teamName,
+      senderUserName:
+        subtask.sender_user_name ||
+        (isUserMessage && subtask.sender_user_id === currentUserId ? currentUserName : undefined),
+      senderUserId: subtask.sender_user_id || (isUserMessage ? currentUserId : undefined),
+      shouldShowSender: isGroupChat && isUserMessage,
+      subtaskStatus: subtask.status,
+      result: subtask.result as UnifiedMessage['result'],
+      error: subtask.error_message || undefined,
+    })
+  }
+
+  return messages
+}
+
+export default useMessagePagination

--- a/frontend/src/features/tasks/hooks/useMessagePagination.ts
+++ b/frontend/src/features/tasks/hooks/useMessagePagination.ts
@@ -97,8 +97,8 @@ export function useMessagePagination({
         setLoadedCount(state.messages.size)
 
         // Check if we've loaded all messages
-        if (state.messages.size >= totalMessages) {
-          setHasLoadedAll(true)
+        if (totalMessages > 0) {
+          setHasLoadedAll(state.messages.size >= totalMessages)
         }
       }
 

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -384,6 +384,30 @@ export class TaskStateMachine {
   }
 
   /**
+   * Merge older messages into state (for pagination)
+   * Only adds messages that don't already exist
+   */
+  mergeOlderMessages(messages: UnifiedMessage[]): void {
+    if (messages.length === 0) return
+
+    const newMessages = new Map(this.state.messages)
+    let addedCount = 0
+
+    for (const msg of messages) {
+      // Only add if not already exists
+      if (!newMessages.has(msg.id)) {
+        newMessages.set(msg.id, msg)
+        addedCount++
+      }
+    }
+
+    if (addedCount > 0) {
+      this.state = { ...this.state, messages: newMessages }
+      this.notifyListeners()
+    }
+  }
+
+  /**
    * Set stopping state
    */
   setStopping(isStopping: boolean): void {

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -292,6 +292,7 @@
     "no_messages": "No messages to export",
     "select_at_least_one": "Please select at least one message",
     "selected_count": "Selected: {{count}} message(s)",
+    "total_messages": "{{count}} total",
     "select_all": "Select All",
     "deselect_all": "Deselect All",
     "cancel": "Cancel",
@@ -308,7 +309,14 @@
     "knowledge_bases": "knowledge base(s)",
     "preparing": "Preparing export...",
     "font_load_failed": "Failed to load font, please retry",
-    "retry": "Retry"
+    "retry": "Retry",
+    "loading_all_messages": "Loading all messages...",
+    "load_error_fallback": "Using currently loaded messages"
+  },
+  "pagination": {
+    "loading_more": "Loading more messages...",
+    "loaded_count": "Loaded {{loaded}} / {{total}} messages",
+    "all_loaded": "All messages loaded"
   },
   "web_search": {
     "enable": "Enable web search",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -286,7 +286,15 @@
     "knowledge_bases": "个知识库",
     "preparing": "正在准备导出...",
     "font_load_failed": "字体加载失败，请重试",
-    "retry": "重试"
+    "retry": "重试",
+    "loading_all_messages": "正在加载所有消息...",
+    "load_error_fallback": "使用当前已加载的消息",
+    "total_messages": "共 {{count}} 条"
+  },
+  "pagination": {
+    "loading_more": "正在加载更多消息...",
+    "loaded_count": "已加载 {{loaded}} / {{total}} 条消息",
+    "all_loaded": "已加载全部消息"
   },
   "web_search": {
     "enable": "启用联网搜索",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -274,6 +274,7 @@ export interface TaskDetail {
   member_count?: number // Number of active members in the group
   app?: TaskApp | null // App preview information (set by expose_service tool)
   device_id?: string | null // Device ID used for execution (for task history)
+  total_messages?: number // Total number of messages for pagination
 }
 
 /** Correction data stored in subtask.result.correction */


### PR DESCRIPTION
## Summary

- Add support for paginated message loading with infinite scroll
- Fix export functionality to include all messages instead of just loaded ones
- Add total message count display for user awareness

## Changes

### Backend
- **task.py schema**: Add `total_messages` field to `TaskDetail` response
- **queries.py**: 
  - Calculate and return total message count for pagination
  - Reduce initial subtasks limit from 100 to 50 for faster initial load

### Frontend
- **useMessagePagination.ts**: New hook for infinite scroll pagination
  - Tracks loaded count vs total count
  - Uses `before_message_id` parameter for loading older messages
  - Manages loading state and error handling
- **TaskStateMachine.ts**: Add `mergeOlderMessages()` method for adding paginated messages to state
- **MessagesArea.tsx**:
  - Implement IntersectionObserver for detecting scroll to top
  - Show "Loading more messages..." indicator when fetching
  - Display "Loaded X/Y messages" progress indicator
  - Show "All messages loaded" when complete
  - Preserve scroll position when loading older messages
- **ExportSelectModal.tsx**:
  - Fetch ALL messages from backend when modal opens (not just currently loaded)
  - Show loading state while fetching complete message list
  - Fallback to currently loaded messages if fetch fails
- **api.ts types**: Add `total_messages` field to `TaskDetail` interface
- **i18n**: Add translations for pagination UI (en/zh-CN)
  - `pagination.loading_more`
  - `pagination.loaded_count`
  - `pagination.all_loaded`
  - `export.loading_all_messages`
  - `export.load_error_fallback`
  - `export.total_messages`

## Test plan

- [ ] Verify initial load shows only first 50 messages
- [ ] Verify scrolling to top triggers loading more messages
- [ ] Verify "Loaded X/Y messages" indicator displays correctly
- [ ] Verify scroll position is preserved after loading more messages
- [ ] Verify "All messages loaded" shows when all messages are fetched
- [ ] Verify export modal loads ALL messages from backend
- [ ] Verify export with selected messages works correctly
- [ ] Verify functionality works in both desktop and mobile views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Infinite-scroll pagination for messages (scroll to top to load earlier messages) with loading indicators, loaded/total counts, and an all-loaded indicator; preserves scroll position during loads.
  * Export modal now loads the full message set on open, shows total-message counts, improved selection controls (Select All / Deselect All), and loading/error feedback.
  * Tasks now expose a total message count for pagination.

* **Localization**
  * Added English and Chinese strings for export and pagination flows (loading, counts, all-loaded).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->