### PR TITLE
fix(frontend): normalize permission_level to lowercase for legacy dat…

### DIFF
--- a/frontend/src/apis/knowledge-permission.ts
+++ b/frontend/src/apis/knowledge-permission.ts
@@ -101,19 +101,21 @@ export const knowledgePermissionApi = {
     }>(`/share/KnowledgeBase/${kbId}/requests`)
 
     // Transform pending requests
+    // Normalize permission_level to lowercase to handle legacy data (e.g., VIEW -> view)
     const pending = pendingResponse.requests.map(r => ({
       id: r.id,
       user_id: r.user_id,
       username: r.user_name || '',
       email: r.user_email || '',
-      permission_level: r.requested_permission_level as 'view' | 'edit' | 'manage',
+      permission_level: r.requested_permission_level.toLowerCase() as 'view' | 'edit' | 'manage',
       requested_at: r.requested_at,
     }))
 
     // Transform approved members
+    // Normalize permission_level to lowercase to handle legacy data (e.g., VIEW -> view)
     const approved = membersResponse.members.reduce(
       (acc, m) => {
-        const level = m.permission_level as 'view' | 'edit' | 'manage'
+        const level = m.permission_level.toLowerCase() as 'view' | 'edit' | 'manage'
         if (!acc[level]) acc[level] = []
         const member: {
           id: number


### PR DESCRIPTION
…a compatibility

The database contains mixed case permission_level values (e.g., VIEW, EDIT vs view, edit). This fix normalizes all permission_level values to lowercase when processing API responses, ensuring members are correctly grouped by permission level regardless of the case stored in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent permission-level formatting across pending requests and members to prevent mismatches.
  * Improved handling of varied status labels so approvals and requests behave consistently.
* **New Features**
  * Member list deduplication to avoid duplicate entries for the same user.
  * Share-link handling improved to reuse or generate links when joining, and surface copied resource IDs after approval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->