### PR TITLE
feat(knowledge): add organization knowledge base support

### DIFF
--- a/backend/alembic/versions/z6a7b8c9d0e1_add_namespace_level.py
+++ b/backend/alembic/versions/z6a7b8c9d0e1_add_namespace_level.py
@@ -5,7 +5,7 @@
 """Add level column to namespace table
 
 Revision ID: z6a7b8c9d0e1
-Revises: y5z6a7b8c9d0
+Revises: f1e2d3c4b5a6
 Create Date: 2025-02-10
 
 This migration adds a 'level' column to the namespace table to support
@@ -16,6 +16,7 @@ Migration steps:
 2. Create index on 'level' column
 3. Set existing 'organization' namespace to level='organization'
 4. Keep 'default' namespace unchanged (level remains NULL)
+5. Fix collation for all character columns to utf8mb4_0900_ai_ci
 """
 
 from typing import Sequence, Union
@@ -26,7 +27,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "z6a7b8c9d0e1"
-down_revision: Union[str, None] = "y5z6a7b8c9d0"
+down_revision: Union[str, None] = "f1e2d3c4b5a6"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -58,7 +59,8 @@ def index_exists(table_name: str, index_name: str) -> bool:
 
 
 def upgrade() -> None:
-    """Add level column to namespace table."""
+    """Add level column to namespace table and ensure organization namespace exists."""
+    conn = op.get_bind()
 
     # Add level column if not exists
     if not column_exists("namespace", "level"):
@@ -82,15 +84,77 @@ def upgrade() -> None:
             unique=False,
         )
 
-    # Set existing 'organization' namespace to level='organization'
-    op.execute(
-        sa.text(
-            "UPDATE namespace SET level = 'organization' WHERE name = 'organization'"
-        )
+    # Check if 'organization' namespace exists
+    result = conn.execute(
+        sa.text("SELECT id, level FROM namespace WHERE name = 'organization'")
     )
+    row = result.fetchone()
+
+    if row is None:
+        # Create 'organization' namespace if it doesn't exist
+        # First, try to get the first admin user as the owner
+        admin_result = conn.execute(
+            sa.text("SELECT id FROM users WHERE role = 'admin' ORDER BY id LIMIT 1")
+        )
+        admin_row = admin_result.fetchone()
+
+        if admin_row is not None:
+            owner_user_id = admin_row[0]
+        else:
+            # If no admin user exists, use the first user
+            user_result = conn.execute(
+                sa.text("SELECT id FROM users ORDER BY id LIMIT 1")
+            )
+            user_row = user_result.fetchone()
+            owner_user_id = (
+                user_row[0] if user_row else 1
+            )  # Default to 1 if no users exist
+
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO namespace (name, display_name, owner_user_id, level, visibility, description, is_active, created_at, updated_at)
+                VALUES ('organization', 'Organization', :owner_user_id, 'organization', 'private', 'Organization level knowledge base', 1, NOW(), NOW())
+                """
+            ),
+            {"owner_user_id": owner_user_id},
+        )
+    elif row[1] != "organization":
+        # Update level to 'organization' if it's not already set
+        conn.execute(
+            sa.text(
+                "UPDATE namespace SET level = 'organization' WHERE name = 'organization'"
+            )
+        )
 
     # Keep 'default' namespace with NULL level (represents personal namespace)
     # No action needed as new columns default to NULL
+
+    # Fix collation for namespace table to use utf8mb4_0900_ai_ci
+    conn.execute(
+        sa.text(
+            """
+            ALTER TABLE namespace 
+            MODIFY COLUMN name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN display_name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN description TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN visibility VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN level VARCHAR(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+            """
+        )
+    )
+
+    # Fix collation for kinds table to use utf8mb4_0900_ai_ci
+    conn.execute(
+        sa.text(
+            """
+            ALTER TABLE kinds 
+            MODIFY COLUMN kind VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN name VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+            MODIFY COLUMN namespace VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci
+            """
+        )
+    )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/z6a7b8c9d0e1_add_namespace_level.py
+++ b/backend/alembic/versions/z6a7b8c9d0e1_add_namespace_level.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Add level column to namespace table
+
+Revision ID: z6a7b8c9d0e1
+Revises: y5z6a7b8c9d0
+Create Date: 2025-02-10
+
+This migration adds a 'level' column to the namespace table to support
+organization-level groups. The level can be 'group' (default) or 'organization'.
+
+Migration steps:
+1. Add 'level' column with default 'group'
+2. Create index on 'level' column
+3. Set existing 'organization' namespace to level='organization'
+4. Keep 'default' namespace unchanged (level remains NULL)
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "z6a7b8c9d0e1"
+down_revision: Union[str, None] = "y5z6a7b8c9d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def column_exists(table_name: str, column_name: str) -> bool:
+    """Check if a column exists in the table."""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_name = :table_name AND column_name = :column_name AND table_schema = DATABASE()"
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return result.scalar() > 0
+
+
+def index_exists(table_name: str, index_name: str) -> bool:
+    """Check if an index exists on the table."""
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            "SELECT COUNT(*) FROM information_schema.statistics "
+            "WHERE table_name = :table_name AND index_name = :index_name AND table_schema = DATABASE()"
+        ),
+        {"table_name": table_name, "index_name": index_name},
+    )
+    return result.scalar() > 0
+
+
+def upgrade() -> None:
+    """Add level column to namespace table."""
+
+    # Add level column if not exists
+    if not column_exists("namespace", "level"):
+        op.add_column(
+            "namespace",
+            sa.Column(
+                "level",
+                sa.String(20),
+                nullable=True,
+                server_default=sa.text("'group'"),
+                comment="Group level: 'group' (default) or 'organization' (admin only)",
+            ),
+        )
+
+    # Create index on level column if not exists
+    if not index_exists("namespace", "idx_namespace_level"):
+        op.create_index(
+            "idx_namespace_level",
+            "namespace",
+            ["level"],
+            unique=False,
+        )
+
+    # Set existing 'organization' namespace to level='organization'
+    op.execute(
+        sa.text(
+            "UPDATE namespace SET level = 'organization' WHERE name = 'organization'"
+        )
+    )
+
+    # Keep 'default' namespace with NULL level (represents personal namespace)
+    # No action needed as new columns default to NULL
+
+
+def downgrade() -> None:
+    """Remove level column from namespace table."""
+
+    # Drop index
+    if index_exists("namespace", "idx_namespace_level"):
+        op.drop_index("idx_namespace_level", table_name="namespace")
+
+    # Drop column
+    if column_exists("namespace", "level"):
+        op.drop_column("namespace", "level")

--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -40,8 +40,15 @@ def list_groups(
     Returns paginated results.
     """
     skip = (page - 1) * limit
+    # Check if user is admin to include organization groups
+    is_admin = current_user.role == "admin"
+
     groups = group_service.list_user_groups(
-        db=db, user_id=current_user.id, skip=skip, limit=limit
+        db=db,
+        user_id=current_user.id,
+        skip=skip,
+        limit=limit,
+        include_organization=is_admin,
     )
 
     # Calculate total count
@@ -50,7 +57,11 @@ def list_groups(
     else:
         # Get total count of user's groups
         all_groups = group_service.list_user_groups(
-            db=db, user_id=current_user.id, skip=0, limit=1000
+            db=db,
+            user_id=current_user.id,
+            skip=0,
+            limit=1000,
+            include_organization=is_admin,
         )
         total = len(all_groups)
 
@@ -69,7 +80,10 @@ def create_group_endpoint(
     """
     try:
         return group_service.create_group(
-            db=db, group_data=group_create, owner_user_id=current_user.id
+            db=db,
+            group_data=group_create,
+            owner_user_id=current_user.id,
+            user_role=current_user.role,
         )
     except HTTPException:
         raise
@@ -445,6 +459,7 @@ def update_group_endpoint(
             group_name=group_name,
             update_data=group_update,
             user_id=current_user.id,
+            user_role=current_user.role,
         )
     except HTTPException:
         raise

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -75,7 +75,7 @@ router = APIRouter()
 def list_knowledge_bases(
     scope: str = Query(
         default="all",
-        description="Resource scope: personal, group, or all",
+        description="Resource scope: personal, group, organization, or all",
     ),
     group_name: Optional[str] = Query(
         default=None,
@@ -89,6 +89,7 @@ def list_knowledge_bases(
 
     - **scope=personal**: Only user's own personal knowledge bases
     - **scope=group**: Knowledge bases from a specific group (requires group_name)
+    - **scope=organization**: Organization knowledge bases (visible to all, admin only for management)
     - **scope=all**: All accessible knowledge bases (personal + team)
     """
     try:
@@ -96,7 +97,7 @@ def list_knowledge_bases(
     except ValueError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid scope: {scope}. Must be one of: personal, group, all",
+            detail=f"Invalid scope: {scope}. Must be one of: personal, group, organization, all",
         )
 
     if resource_scope == ResourceScope.GROUP and not group_name:

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -512,20 +512,41 @@ def _extract_rag_config_from_knowledge_base(
     spec = (knowledge_base.json or {}).get("spec", {})
     retrieval_config = spec.get("retrievalConfig")
 
+    # Debug logging to diagnose incomplete retrieval_config issues
+    logger.info(
+        f"[RAG Config Debug] KB {knowledge_base.id}: retrievalConfig = {retrieval_config}"
+    )
+
     if not retrieval_config:
+        logger.warning(
+            f"[RAG Config Debug] KB {knowledge_base.id}: No retrievalConfig found in spec"
+        )
         return None
 
     retriever_name = retrieval_config.get("retriever_name")
     retriever_namespace = retrieval_config.get("retriever_namespace", "default")
     embedding_config = retrieval_config.get("embedding_config")
 
+    logger.info(
+        f"[RAG Config Debug] KB {knowledge_base.id}: retriever_name={retriever_name}, "
+        f"retriever_namespace={retriever_namespace}, embedding_config={embedding_config}"
+    )
+
     if not retriever_name or not embedding_config:
+        logger.warning(
+            f"[RAG Config Debug] KB {knowledge_base.id}: Missing retriever_name or embedding_config. "
+            f"retriever_name={retriever_name}, embedding_config={embedding_config}"
+        )
         return None
 
     embedding_model_name = embedding_config.get("model_name")
     embedding_model_namespace = embedding_config.get("model_namespace", "default")
 
     if not embedding_model_name:
+        logger.warning(
+            f"[RAG Config Debug] KB {knowledge_base.id}: Missing embedding model_name. "
+            f"embedding_config={embedding_config}"
+        )
         return None
 
     # Pre-compute KB index info

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -553,6 +553,10 @@ def _extract_rag_config_from_knowledge_base(
     summary_enabled = spec.get("summaryEnabled", False)
     if knowledge_base.namespace == "default":
         index_owner_user_id = current_user_id
+    elif knowledge_base.namespace == "organization":
+        # Organization KB - use current user's ID for index naming
+        # All users can access organization KBs, so we use the current user's ID
+        index_owner_user_id = current_user_id
     else:
         # Group KB - use creator's user_id for shared index
         index_owner_user_id = knowledge_base.user_id
@@ -1344,7 +1348,12 @@ async def update_document_content(
                     summary_enabled = spec.get("summaryEnabled", False)
                     if knowledge_base.namespace == "default":
                         index_owner_user_id = current_user.id
+                    elif knowledge_base.namespace == "organization":
+                        # Organization KB - use current user's ID for index naming
+                        # All users can access organization KBs, so we use the current user's ID
+                        index_owner_user_id = current_user.id
                     else:
+                        # Group KB - use creator's user_id for shared index
                         index_owner_user_id = knowledge_base.user_id
 
                     kb_index_info = KnowledgeBaseIndexInfo(

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -666,6 +666,10 @@ def _get_kb_index_info_sync(
     if kb.namespace == "default":
         # Personal knowledge base - use current user's ID
         index_owner_user_id = current_user_id
+    elif kb.namespace == "organization":
+        # Organization knowledge base - use current user's ID for index naming
+        # All users can access organization KBs, so we use the current user's ID
+        index_owner_user_id = current_user_id
     else:
         # Group knowledge base - use KB creator's user_id for index naming
         # This ensures all group members access the same index

--- a/backend/app/api/endpoints/rag.py
+++ b/backend/app/api/endpoints/rag.py
@@ -34,6 +34,7 @@ from app.schemas.rag import (
 )
 from app.services.adapters.retriever_kinds import retriever_kinds_service
 from app.services.group_permission import get_effective_role_in_group
+from app.services.knowledge.knowledge_service import _is_organization_namespace
 from app.services.rag.document_service import DocumentService
 from app.services.rag.retrieval_service import RetrievalService
 from app.services.rag.storage.factory import create_storage_backend
@@ -124,7 +125,7 @@ def get_index_owner_user_id(
                 detail="Access denied to this knowledge base",
             )
         return current_user_id
-    elif kb.namespace == "organization":
+    elif _is_organization_namespace(db, kb.namespace):
         # Organization knowledge base - accessible to all authenticated users
         # Return the knowledge base creator's user_id for index naming
         # This ensures all users access the same index

--- a/backend/app/api/endpoints/rag.py
+++ b/backend/app/api/endpoints/rag.py
@@ -124,6 +124,11 @@ def get_index_owner_user_id(
                 detail="Access denied to this knowledge base",
             )
         return current_user_id
+    elif kb.namespace == "organization":
+        # Organization knowledge base - accessible to all authenticated users
+        # Return the knowledge base creator's user_id for index naming
+        # This ensures all users access the same index
+        return kb.user_id
     else:
         # Group knowledge base - check if user has access to the group
         role = get_effective_role_in_group(db, current_user_id, kb.namespace)

--- a/backend/app/api/endpoints/web_scraper.py
+++ b/backend/app/api/endpoints/web_scraper.py
@@ -261,7 +261,12 @@ async def create_web_document(
                     summary_enabled = spec.get("summaryEnabled", False)
                     if knowledge_base.namespace == "default":
                         index_owner_user_id = current_user.id
+                    elif knowledge_base.namespace == "organization":
+                        # Organization KB - use current user's ID for index naming
+                        # All users can access organization KBs, so we use the current user's ID
+                        index_owner_user_id = current_user.id
                     else:
+                        # Group KB - use creator's user_id for shared index
                         index_owner_user_id = knowledge_base.user_id
 
                     kb_index_info = KnowledgeBaseIndexInfo(
@@ -477,7 +482,12 @@ async def refresh_web_document(
                     summary_enabled = spec.get("summaryEnabled", False)
                     if knowledge_base.namespace == "default":
                         index_owner_user_id = current_user.id
+                    elif knowledge_base.namespace == "organization":
+                        # Organization KB - use current user's ID for index naming
+                        # All users can access organization KBs, so we use the current user's ID
+                        index_owner_user_id = current_user.id
                     else:
+                        # Group KB - use creator's user_id for shared index
                         index_owner_user_id = knowledge_base.user_id
 
                     kb_index_info = KnowledgeBaseIndexInfo(

--- a/backend/app/api/endpoints/web_scraper.py
+++ b/backend/app/api/endpoints/web_scraper.py
@@ -149,6 +149,7 @@ async def create_web_document(
     from app.models.subtask_context import SubtaskContext
     from app.schemas.knowledge import DocumentSourceType, KnowledgeDocumentCreate
     from app.services.knowledge import KnowledgeService
+    from app.services.knowledge.knowledge_service import _is_organization_namespace
 
     logger.info(
         f"User {current_user.id} creating web document from URL: {request.url} "
@@ -261,7 +262,7 @@ async def create_web_document(
                     summary_enabled = spec.get("summaryEnabled", False)
                     if knowledge_base.namespace == "default":
                         index_owner_user_id = current_user.id
-                    elif knowledge_base.namespace == "organization":
+                    elif _is_organization_namespace(db, knowledge_base.namespace):
                         # Organization KB - use current user's ID for index naming
                         # All users can access organization KBs, so we use the current user's ID
                         index_owner_user_id = current_user.id
@@ -339,6 +340,7 @@ async def refresh_web_document(
     from app.models.knowledge import DocumentSourceType, KnowledgeDocument
     from app.models.subtask_context import SubtaskContext
     from app.services.knowledge import KnowledgeService
+    from app.services.knowledge.knowledge_service import _is_organization_namespace
 
     logger.info(f"User {current_user.id} refreshing web document {request.document_id}")
 
@@ -482,7 +484,7 @@ async def refresh_web_document(
                     summary_enabled = spec.get("summaryEnabled", False)
                     if knowledge_base.namespace == "default":
                         index_owner_user_id = current_user.id
-                    elif knowledge_base.namespace == "organization":
+                    elif _is_organization_namespace(db, knowledge_base.namespace):
                         # Organization KB - use current user's ID for index naming
                         # All users can access organization KBs, so we use the current user's ID
                         index_owner_user_id = current_user.id

--- a/backend/app/models/namespace.py
+++ b/backend/app/models/namespace.py
@@ -4,7 +4,7 @@
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, Text
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -33,6 +33,8 @@ class Namespace(Base):
     visibility = Column(String(20), nullable=False, default="private")
     # Group description
     description = Column(Text, nullable=False, default="")
+    # Group level: 'group' (default) or 'organization' (admin only)
+    level = Column(String(20), nullable=True, index=True, default="group")
     # Is group active
     is_active = Column(Boolean, default=True)
     created_at = Column(DateTime, default=func.now())

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -46,6 +46,7 @@ class ResourceScope(str, Enum):
 
     PERSONAL = "personal"
     GROUP = "group"
+    ORGANIZATION = "organization"
     ALL = "all"
 
 

--- a/backend/app/schemas/namespace.py
+++ b/backend/app/schemas/namespace.py
@@ -26,6 +26,13 @@ class GroupVisibility(str, Enum):
     public = "public"
 
 
+class GroupLevel(str, Enum):
+    """Group level types"""
+
+    group = "group"
+    organization = "organization"
+
+
 class GroupBase(BaseModel):
     """Base group model"""
 
@@ -74,7 +81,7 @@ class GroupBase(BaseModel):
 class GroupCreate(GroupBase):
     """Group creation model"""
 
-    pass
+    level: Optional[GroupLevel] = Field(default=GroupLevel.group, description="Group level: 'group' or 'organization' (admin only)")
 
 
 class GroupUpdate(BaseModel):
@@ -83,6 +90,7 @@ class GroupUpdate(BaseModel):
     display_name: Optional[str] = Field(None, max_length=100)
     visibility: Optional[GroupVisibility] = None
     description: Optional[str] = None
+    level: Optional[GroupLevel] = Field(default=None, description="Group level: 'group' or 'organization' (admin only)")
 
 
 class GroupResponse(GroupBase):
@@ -90,6 +98,7 @@ class GroupResponse(GroupBase):
 
     id: int
     owner_user_id: int
+    level: Optional[str] = None
     is_active: bool
     created_at: datetime
     updated_at: datetime

--- a/backend/app/services/adapters/retriever_kinds.py
+++ b/backend/app/services/adapters/retriever_kinds.py
@@ -18,6 +18,7 @@ from app.models.user import User
 from app.schemas.kind import Retriever
 from app.services.base import BaseService
 from app.services.group_permission import check_group_permission, get_user_groups
+from app.services.knowledge.knowledge_service import _is_organization_namespace
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +171,7 @@ class RetrieverKindsService(BaseService[Kind, Dict, Dict]):
         """
         # Check permissions for group resources
         # Skip permission check for organization namespace (visible to all users)
-        if namespace != "default" and namespace != "organization":
+        if namespace != "default" and not _is_organization_namespace(db, namespace):
             if not check_group_permission(
                 db, user_id, namespace, required_role="Reporter"
             ):

--- a/backend/app/services/adapters/retriever_kinds.py
+++ b/backend/app/services/adapters/retriever_kinds.py
@@ -169,7 +169,8 @@ class RetrieverKindsService(BaseService[Kind, Dict, Dict]):
             HTTPException: If retriever not found or access denied
         """
         # Check permissions for group resources
-        if namespace != "default":
+        # Skip permission check for organization namespace (visible to all users)
+        if namespace != "default" and namespace != "organization":
             if not check_group_permission(
                 db, user_id, namespace, required_role="Reporter"
             ):

--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -12,6 +12,7 @@ from app.models.namespace import Namespace
 from app.models.namespace_member import NamespaceMember
 from app.schemas.namespace import (
     GroupCreate,
+    GroupLevel,
     GroupResponse,
     GroupRole,
     GroupUpdate,
@@ -33,7 +34,7 @@ MAX_GROUP_DEPTH = 5
 
 
 def create_group(
-    db: Session, group_data: GroupCreate, owner_user_id: int
+    db: Session, group_data: GroupCreate, owner_user_id: int, user_role: str | None = None
 ) -> GroupResponse:
     """
     Create a new group and add the creator as Owner.
@@ -42,6 +43,7 @@ def create_group(
         db: Database session
         group_data: Group creation data
         owner_user_id: User ID of the group creator (becomes owner)
+        user_role: User's system role ('admin' or 'user') for organization-level check
 
     Returns:
         Created group response
@@ -49,6 +51,14 @@ def create_group(
     Raises:
         HTTPException: If group name already exists or validation fails
     """
+    # Check permission for organization-level group (admin only)
+    group_level = group_data.level.value if group_data.level else GroupLevel.group.value
+    if group_level == GroupLevel.organization.value and user_role != "admin":
+        raise HTTPException(
+            status_code=403,
+            detail="Only admin users can create organization-level groups",
+        )
+
     # Check if group name already exists
     existing = (
         db.query(Namespace)
@@ -85,7 +95,7 @@ def create_group(
 
         # Check if user has permission to create subgroups (must be at least Maintainer)
         # Use effective role to support inheritance
-        user_role = get_effective_role_in_group(db, owner_user_id, parent_name)
+        user_group_role = get_effective_role_in_group(db, owner_user_id, parent_name)
         role_hierarchy = {
             GroupRole.Owner: 0,
             GroupRole.Maintainer: 1,
@@ -94,8 +104,8 @@ def create_group(
         }
 
         if (
-            user_role is None
-            or role_hierarchy.get(user_role, 999) > role_hierarchy[GroupRole.Maintainer]
+            user_group_role is None
+            or role_hierarchy.get(user_group_role, 999) > role_hierarchy[GroupRole.Maintainer]
         ):
             raise HTTPException(
                 status_code=403,
@@ -109,6 +119,7 @@ def create_group(
         owner_user_id=owner_user_id,
         visibility=group_data.visibility.value,
         description=group_data.description,
+        level=group_level,
         is_active=True,
     )
 
@@ -158,7 +169,11 @@ def get_group(db: Session, group_name: str) -> Optional[GroupResponse]:
 
 
 def list_user_groups(
-    db: Session, user_id: int, skip: int = 0, limit: int = 100
+    db: Session,
+    user_id: int,
+    skip: int = 0,
+    limit: int = 100,
+    include_organization: bool = False,
 ) -> list[GroupResponse]:
     """
     List groups where user is a member (created or joined).
@@ -169,6 +184,7 @@ def list_user_groups(
         user_id: User ID
         skip: Number of records to skip
         limit: Maximum number of records to return
+        include_organization: Whether to include organization-level groups (admin only)
 
     Returns:
         List of GroupResponse objects with additional fields
@@ -190,13 +206,21 @@ def list_user_groups(
     group_roles = {name: role for name, role in member_data}
     group_names = list(group_roles.keys())
 
-    groups = (
-        db.query(Namespace)
-        .filter(
-            Namespace.name.in_(group_names),
-            Namespace.is_active == True,
+    # Build query for groups
+    query = db.query(Namespace).filter(
+        Namespace.name.in_(group_names),
+        Namespace.is_active == True,
+    )
+
+    # Filter out organization-level groups for non-admin users
+    if not include_organization:
+        query = query.filter(
+            (Namespace.level != GroupLevel.organization.value)
+            | (Namespace.level.is_(None))
         )
-        .order_by(Namespace.created_at.desc())
+
+    groups = (
+        query.order_by(Namespace.created_at.desc())
         .offset(skip)
         .limit(limit)
         .all()
@@ -227,7 +251,11 @@ def list_user_groups(
 
 
 def update_group(
-    db: Session, group_name: str, update_data: GroupUpdate, user_id: int
+    db: Session,
+    group_name: str,
+    update_data: GroupUpdate,
+    user_id: int,
+    user_role: str | None = None,
 ) -> GroupResponse:
     """
     Update group information.
@@ -237,6 +265,7 @@ def update_group(
         group_name: Group name
         update_data: Update data
         user_id: User ID performing the update
+        user_role: User's system role ('admin' or 'user') for organization-level check
 
     Returns:
         Updated group response
@@ -263,6 +292,19 @@ def update_group(
             detail="Only Maintainers and Owners can update group information",
         )
 
+    # Check permission for organization-level changes (admin only)
+    if update_data.level is not None:
+        new_level = update_data.level.value
+        current_level = group.level
+
+        # Check if changing to or from organization level
+        if new_level == GroupLevel.organization.value or current_level == GroupLevel.organization.value:
+            if user_role != "admin":
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only admin users can change group level to/from organization",
+                )
+
     # Update fields
     update_dict = update_data.model_dump(exclude_unset=True)
 
@@ -270,6 +312,8 @@ def update_group(
         if hasattr(group, field):
             # Handle enum conversion
             if field == "visibility" and isinstance(value, GroupVisibility):
+                setattr(group, field, value.value)
+            elif field == "level" and isinstance(value, GroupLevel):
                 setattr(group, field, value.value)
             else:
                 setattr(group, field, value)

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -1083,7 +1083,8 @@ class KnowledgeService:
                             # Get the correct user_id for index naming
                             # For group knowledge bases, use the KB creator's user_id
                             # This ensures we delete from the same index where documents were stored
-                            if kb.namespace == "default":
+                            if kb.namespace == "default" or kb.namespace == "organization":
+                                # Personal/Organization knowledge base - use current user's ID
                                 index_owner_user_id = user_id
                             else:
                                 # Group knowledge base - use KB creator's user_id

--- a/backend/app/services/knowledge/task_knowledge_base_service.py
+++ b/backend/app/services/knowledge/task_knowledge_base_service.py
@@ -19,7 +19,10 @@ from app.models.task import TaskResource
 from app.models.user import User
 from app.schemas.kind import KnowledgeBaseTaskRef
 from app.services.group_permission import get_effective_role_in_group
-from app.services.knowledge.knowledge_service import KnowledgeService
+from app.services.knowledge.knowledge_service import (
+    KnowledgeService,
+    _is_organization_namespace,
+)
 from app.services.task_member_service import task_member_service
 
 logger = logging.getLogger(__name__)
@@ -117,7 +120,7 @@ class TaskKnowledgeBaseService:
             return kb.user_id == user_id
 
         # For organization knowledge base, all authenticated users have access
-        if kb.namespace == "organization":
+        if _is_organization_namespace(db, kb.namespace):
             return True
 
         # For team knowledge base, check group membership

--- a/backend/app/services/knowledge/task_knowledge_base_service.py
+++ b/backend/app/services/knowledge/task_knowledge_base_service.py
@@ -116,6 +116,10 @@ class TaskKnowledgeBaseService:
         if kb.namespace == "default":
             return kb.user_id == user_id
 
+        # For organization knowledge base, all authenticated users have access
+        if kb.namespace == "organization":
+            return True
+
         # For team knowledge base, check group membership
         role = get_effective_role_in_group(db, user_id, kb.namespace)
         return role is not None

--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -26,6 +26,7 @@ from app.schemas.share import (
 )
 from app.schemas.share import PermissionLevel as SchemaPermissionLevel
 from app.services.group_permission import get_effective_role_in_group
+from app.services.knowledge.knowledge_service import _is_organization_namespace
 from app.services.share.base_service import UnifiedShareService
 from shared.telemetry.decorators import add_span_event, set_span_attribute, trace_sync
 
@@ -111,7 +112,7 @@ class KnowledgeShareService(UnifiedShareService):
         logger.warning(f"[_get_resource] User has NO explicit shared access")
 
         # For organization knowledge bases, all authenticated users have access
-        if kb.namespace == "organization":
+        if _is_organization_namespace(db, kb.namespace):
             logger.info(
                 f"[_get_resource] Organization KB - granting access to user_id={user_id}"
             )
@@ -247,7 +248,7 @@ class KnowledgeShareService(UnifiedShareService):
             return True, explicit_perm.permission_level, False
 
         # For organization knowledge bases, all authenticated users have VIEW access
-        if kb.namespace == "organization":
+        if _is_organization_namespace(db, kb.namespace):
             return True, PermissionLevel.VIEW.value, False
 
         # For team knowledge bases, check group permission
@@ -356,7 +357,7 @@ class KnowledgeShareService(UnifiedShareService):
 
         # Check group permission for team KB or organization KB
         group_level = None
-        if kb.namespace == "organization":
+        if _is_organization_namespace(db, kb.namespace):
             # Organization KB - all authenticated users have VIEW access
             group_level = SchemaPermissionLevel.VIEW
         elif kb.namespace != "default":

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,4 +1,4 @@
- 
+/* eslint-disable */
 /* tslint:disable */
 
 /**
@@ -74,7 +74,7 @@ addEventListener('message', async function (event) {
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId)
 
-      const remainingClients = allClients.filter(client => {
+      const remainingClients = allClients.filter((client) => {
         return client.id !== clientId
       })
 
@@ -98,7 +98,10 @@ addEventListener('fetch', function (event) {
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
     return
   }
 
@@ -121,7 +124,12 @@ addEventListener('fetch', function (event) {
 async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event)
   const requestCloneForEvents = event.request.clone()
-  const response = await getResponse(event, client, requestId, requestInterceptedAt)
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
@@ -151,7 +159,7 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : []
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
     )
   }
 
@@ -182,11 +190,11 @@ async function resolveMainClient(event) {
   })
 
   return allClients
-    .filter(client => {
+    .filter((client) => {
       // Get only those clients that are currently visible.
       return client.visibilityState === 'visible'
     })
-    .find(client => {
+    .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
       return activeClientIds.has(client.id)
@@ -215,8 +223,10 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
     // user-defined CORS policies.
     const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map(value => value.trim())
-      const filteredValues = values.filter(value => value !== 'msw/passthrough')
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
 
       if (filteredValues.length > 0) {
         headers.set('accept', filteredValues.join(', '))
@@ -253,7 +263,7 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
         ...serializedRequest,
       },
     },
-    [serializedRequest.body]
+    [serializedRequest.body],
   )
 
   switch (clientMessage.type) {
@@ -279,7 +289,7 @@ function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
 
-    channel.port1.onmessage = event => {
+    channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
         return reject(event.data.error)
       }
@@ -287,7 +297,10 @@ function sendToClient(client, message, transferrables = []) {
       resolve(event.data)
     }
 
-    client.postMessage(message, [channel.port2, ...transferrables.filter(Boolean)])
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
   })
 }
 

--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -288,6 +288,22 @@ export async function getKnowledgeConfig(): Promise<KnowledgeConfig> {
   return apiClient.get<KnowledgeConfig>('/knowledge-bases/config')
 }
 
+/**
+ * Organization namespace response
+ */
+export interface OrganizationNamespaceResponse {
+  namespace: string | null
+}
+
+/**
+ * Get the organization-level namespace name
+ * Returns the namespace name that has level='organization'
+ * This is used when creating organization knowledge bases
+ */
+export async function getOrganizationNamespace(): Promise<OrganizationNamespaceResponse> {
+  return apiClient.get<OrganizationNamespaceResponse>('/knowledge-bases/organization-namespace')
+}
+
 // ============== Chunk APIs ==============
 
 /**

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageDesktop.tsx
@@ -215,6 +215,10 @@ export function KnowledgeBaseChatPageDesktop({
     if (knowledgeBase.namespace === 'default') {
       return knowledgeBase.user_id === user.id
     }
+    // Organization knowledge base - only admin can manage
+    if (knowledgeBase.namespace === 'organization') {
+      return user.role === 'admin'
+    }
     // Group knowledge base - check group role
     // Developer or higher can edit, Maintainer or higher can delete
     const groupRole = groupRoleMap.get(knowledgeBase.namespace)

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseChatPageMobile.tsx
@@ -178,6 +178,10 @@ export function KnowledgeBaseChatPageMobile({ onKbTypeChanged }: KnowledgeBaseCh
     if (knowledgeBase.namespace === 'default') {
       return knowledgeBase.user_id === user.id
     }
+    // Organization knowledge base - only admin can manage
+    if (knowledgeBase.namespace === 'organization') {
+      return user.role === 'admin'
+    }
     // Group knowledge base - check group role
     // Developer or higher can edit, Maintainer or higher can delete
     const groupRole = groupRoleMap.get(knowledgeBase.namespace)

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseClassicPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseClassicPageDesktop.tsx
@@ -149,6 +149,10 @@ export function KnowledgeBaseClassicPageDesktop({
     if (knowledgeBase.namespace === 'default') {
       return knowledgeBase.user_id === user.id
     }
+    // Organization knowledge base - only admin can manage
+    if (knowledgeBase.namespace === 'organization') {
+      return user.role === 'admin'
+    }
     // Group knowledge base - check group role
     // Developer or higher can edit, Maintainer or higher can delete
     const groupRole = groupRoleMap.get(knowledgeBase.namespace)

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseClassicPageMobile.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/KnowledgeBaseClassicPageMobile.tsx
@@ -111,6 +111,10 @@ export function KnowledgeBaseClassicPageMobile({
     if (knowledgeBase.namespace === 'default') {
       return knowledgeBase.user_id === user.id
     }
+    // Organization knowledge base - only admin can manage
+    if (knowledgeBase.namespace === 'organization') {
+      return user.role === 'admin'
+    }
     // Group knowledge base - check group role
     // Developer or higher can edit, Maintainer or higher can delete
     const groupRole = groupRoleMap.get(knowledgeBase.namespace)

--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -32,7 +32,7 @@ interface CreateKnowledgeBaseDialogProps {
     exempt_calls_before_check: number
   }) => Promise<void>
   loading?: boolean
-  scope?: 'personal' | 'group' | 'all'
+  scope?: 'personal' | 'group' | 'organization' | 'all'
   groupName?: string
   /** Knowledge base type selected from dropdown menu (read-only in dialog) */
   kbType?: KnowledgeBaseType

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
@@ -1154,10 +1154,10 @@ function OrganizationKnowledgeContent({
             onClick={() => onSelectKb(kb)}
             onEdit={isAdmin ? () => onEditKb(kb) : undefined}
             onDelete={isAdmin ? () => onDeleteKb(kb) : undefined}
-            onShare={() => onShareKb(kb)}
+            onShare={isAdmin ? () => onShareKb(kb) : undefined}
             canEdit={isAdmin}
             canDelete={isAdmin}
-            canShare={true}
+            canShare={isAdmin}
           />
         ))}
       </div>

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
@@ -16,6 +16,7 @@ import {
   Search,
   BookOpen,
   FolderOpen,
+  Building2,
 } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { Card } from '@/components/ui/card'
@@ -37,11 +38,12 @@ import { userApis } from '@/apis/user'
 import { teamService } from '@/features/tasks/service/teamService'
 import { saveGlobalModelPreference, type ModelPreference } from '@/utils/modelPreferences'
 import { useKnowledgeBases } from '../hooks/useKnowledgeBases'
+import { useUser } from '@/features/common/UserContext'
 import type { Group } from '@/types/group'
 import type { KnowledgeBase, KnowledgeBaseType, SummaryModelRef } from '@/types/knowledge'
 import type { DefaultTeamsResponse, Team } from '@/types/api'
 
-type DocumentTabType = 'personal' | 'group' | 'external'
+type DocumentTabType = 'personal' | 'group' | 'organization' | 'external'
 
 interface DocumentTab {
   id: DocumentTabType
@@ -62,6 +64,11 @@ const tabs: DocumentTab[] = [
     icon: <Users className="w-4 h-4" />,
   },
   {
+    id: 'organization',
+    labelKey: 'knowledge:document.tabs.organization',
+    icon: <Building2 className="w-4 h-4" />,
+  },
+  {
     id: 'external',
     labelKey: 'knowledge:document.tabs.external',
     icon: <Globe className="w-4 h-4" />,
@@ -73,11 +80,13 @@ export function KnowledgeDocumentPage() {
   const { t } = useTranslation()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { user } = useUser()
 
   // Get initial tab from URL parameter
   const getInitialTab = useCallback((): DocumentTabType => {
     const tab = searchParams.get('tab')
     if (tab === 'group') return 'group'
+    if (tab === 'organization') return 'organization'
     if (tab === 'external') return 'external'
     return 'personal' // default
   }, [searchParams])
@@ -92,6 +101,7 @@ export function KnowledgeDocumentPage() {
   // Dialog states
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [createForGroup, setCreateForGroup] = useState<string | null>(null)
+  const [createForOrganization, setCreateForOrganization] = useState(false)
   const [createKbType, setCreateKbType] = useState<KnowledgeBaseType>('notebook')
   const [editingKb, setEditingKb] = useState<KnowledgeBase | null>(null)
   const [deletingKb, setDeletingKb] = useState<KnowledgeBase | null>(null)
@@ -106,6 +116,12 @@ export function KnowledgeDocumentPage() {
 
   // Personal knowledge bases
   const personalKb = useKnowledgeBases({ scope: 'personal' })
+
+  // Organization knowledge bases
+  const organizationKb = useKnowledgeBases({ scope: 'organization' })
+
+  // Check if user is admin
+  const isAdmin = user?.role === 'admin'
 
   // Load default teams config and teams list on mount
   useEffect(() => {
@@ -169,9 +185,14 @@ export function KnowledgeDocumentPage() {
     loadGroups()
   }, [])
 
-  const handleCreateKb = (groupName: string | null, kbType: KnowledgeBaseType) => {
+  const handleCreateKb = (
+    groupName: string | null,
+    kbType: KnowledgeBaseType,
+    isOrganization = false
+  ) => {
     setCreateForGroup(groupName)
     setCreateKbType(kbType)
+    setCreateForOrganization(isOrganization)
     setShowCreateDialog(true)
   }
 
@@ -182,10 +203,11 @@ export function KnowledgeDocumentPage() {
     summary_enabled?: boolean
     summary_model_ref?: Parameters<typeof personalKb.create>[0]['summary_model_ref'] | null
   }) => {
-    await personalKb.create({
+    const kbService = createForOrganization ? organizationKb : personalKb
+    await kbService.create({
       name: data.name,
       description: data.description,
-      namespace: createForGroup || 'default',
+      namespace: createForOrganization ? 'organization' : createForGroup || 'default',
       retrieval_config: data.retrieval_config,
       summary_enabled: data.summary_enabled,
       summary_model_ref: data.summary_model_ref,
@@ -199,19 +221,24 @@ export function KnowledgeDocumentPage() {
     }
 
     setShowCreateDialog(false)
-    // Refresh the appropriate list based on whether it's a group or personal knowledge base
-    if (createForGroup) {
+    // Refresh the appropriate list based on whether it's a group, organization, or personal knowledge base
+    if (createForOrganization) {
+      organizationKb.refresh()
+    } else if (createForGroup) {
       setGroupRefreshKey(prev => prev + 1)
     } else {
       personalKb.refresh()
     }
     setCreateForGroup(null)
+    setCreateForOrganization(false)
     setCreateKbType('notebook')
   }
 
   const handleUpdate = async (data: Parameters<typeof personalKb.update>[1]) => {
     if (!editingKb) return
-    await personalKb.update(editingKb.id, data)
+    // Use organizationKb service if editing organization knowledge base
+    const kbService = editingKb.namespace === 'organization' ? organizationKb : personalKb
+    await kbService.update(editingKb.id, data)
 
     // Save summary model to knowledge team's preference for notebook type
     // This allows the model selector in notebook chat page to pre-select the configured model
@@ -219,8 +246,10 @@ export function KnowledgeDocumentPage() {
       saveSummaryModelToPreference(data.summary_model_ref)
     }
 
-    // Refresh the appropriate list based on whether it's a group or personal knowledge base
-    if (editingKb.namespace !== 'default') {
+    // Refresh the appropriate list based on whether it's a group, organization, or personal knowledge base
+    if (editingKb.namespace === 'organization') {
+      organizationKb.refresh()
+    } else if (editingKb.namespace !== 'default') {
       // Group knowledge base - trigger refresh via refreshKey
       setGroupRefreshKey(prev => prev + 1)
     }
@@ -229,9 +258,13 @@ export function KnowledgeDocumentPage() {
 
   const handleDelete = async () => {
     if (!deletingKb) return
-    await personalKb.remove(deletingKb.id)
-    // Refresh the appropriate list based on whether it's a group or personal knowledge base
-    if (deletingKb.namespace !== 'default') {
+    // Use organizationKb service if deleting organization knowledge base
+    const kbService = deletingKb.namespace === 'organization' ? organizationKb : personalKb
+    await kbService.remove(deletingKb.id)
+    // Refresh the appropriate list based on whether it's a group, organization, or personal knowledge base
+    if (deletingKb.namespace === 'organization') {
+      organizationKb.refresh()
+    } else if (deletingKb.namespace !== 'default') {
       // Group knowledge base - trigger refresh via refreshKey
       setGroupRefreshKey(prev => prev + 1)
     }
@@ -328,6 +361,19 @@ export function KnowledgeDocumentPage() {
           />
         )}
 
+        {activeTab === 'organization' && (
+          <OrganizationKnowledgeContent
+            knowledgeBases={organizationKb.knowledgeBases}
+            loading={organizationKb.loading}
+            isAdmin={isAdmin}
+            onSelectKb={handleSelectKb}
+            onEditKb={setEditingKb}
+            onDeleteKb={setDeletingKb}
+            onShareKb={setSharingKb}
+            onCreateKb={kbType => handleCreateKb(null, kbType, true)}
+          />
+        )}
+
         {activeTab === 'external' && (
           <div className="flex flex-col items-center justify-center py-16 text-text-muted">
             <Globe className="w-12 h-12 mb-4 opacity-50" />
@@ -343,12 +389,13 @@ export function KnowledgeDocumentPage() {
           setShowCreateDialog(open)
           if (!open) {
             setCreateForGroup(null)
+            setCreateForOrganization(false)
             setCreateKbType('notebook')
           }
         }}
         onSubmit={handleCreate}
-        loading={personalKb.loading}
-        scope={createForGroup ? 'group' : 'personal'}
+        loading={personalKb.loading || organizationKb.loading}
+        scope={createForOrganization ? 'organization' : createForGroup ? 'group' : 'personal'}
         groupName={createForGroup || undefined}
         kbType={createKbType}
         knowledgeDefaultTeamId={knowledgeDefaultTeamId}
@@ -359,7 +406,7 @@ export function KnowledgeDocumentPage() {
         onOpenChange={open => !open && setEditingKb(null)}
         knowledgeBase={editingKb}
         onSubmit={handleUpdate}
-        loading={personalKb.loading}
+        loading={personalKb.loading || organizationKb.loading}
         knowledgeDefaultTeamId={knowledgeDefaultTeamId}
       />
 
@@ -368,7 +415,7 @@ export function KnowledgeDocumentPage() {
         onOpenChange={open => !open && setDeletingKb(null)}
         knowledgeBase={deletingKb}
         onConfirm={handleDelete}
-        loading={personalKb.loading}
+        loading={personalKb.loading || organizationKb.loading}
       />
 
       <ShareLinkDialog
@@ -920,6 +967,206 @@ function GroupKnowledgeBaseList({
               <p>{t('knowledge:document.knowledgeBase.noResults')}</p>
             </div>
           )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Organization knowledge content component
+interface OrganizationKnowledgeContentProps {
+  knowledgeBases: KnowledgeBase[]
+  loading: boolean
+  isAdmin: boolean
+  onSelectKb: (kb: KnowledgeBase) => void
+  onEditKb: (kb: KnowledgeBase) => void
+  onDeleteKb: (kb: KnowledgeBase) => void
+  onShareKb: (kb: KnowledgeBase) => void
+  onCreateKb: (kbType: KnowledgeBaseType) => void
+}
+
+function OrganizationKnowledgeContent({
+  knowledgeBases,
+  loading,
+  isAdmin,
+  onSelectKb,
+  onEditKb,
+  onDeleteKb,
+  onShareKb,
+  onCreateKb,
+}: OrganizationKnowledgeContentProps) {
+  const { t } = useTranslation()
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filteredKnowledgeBases = useMemo(() => {
+    if (!searchQuery.trim()) return knowledgeBases
+    const query = searchQuery.toLowerCase()
+    return knowledgeBases.filter(
+      kb => kb.name.toLowerCase().includes(query) || kb.description?.toLowerCase().includes(query)
+    )
+  }, [knowledgeBases, searchQuery])
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner />
+      </div>
+    )
+  }
+
+  // Empty state - different for admin vs non-admin
+  if (knowledgeBases.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16">
+        {isAdmin ? (
+          // Admin: show create button
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Card
+                padding="lg"
+                className="hover:bg-hover transition-colors cursor-pointer flex flex-col items-center justify-center w-64 h-48"
+              >
+                <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center mb-4">
+                  <Plus className="w-8 h-8 text-primary" />
+                </div>
+                <h3 className="font-medium text-base mb-2 text-text-primary">
+                  {t('knowledge:document.knowledgeBase.create')}
+                </h3>
+                <p className="text-sm text-text-muted text-center">
+                  {t('knowledge:document.knowledgeBase.createDesc')}
+                </p>
+              </Card>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" className="w-56">
+              <DropdownMenuItem
+                onClick={() => onCreateKb('notebook')}
+                className="flex items-start gap-3 py-3"
+              >
+                <BookOpen className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                <div>
+                  <div className="font-medium">
+                    {t('knowledge:document.knowledgeBase.typeNotebook')}
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    {t('knowledge:document.knowledgeBase.notebookDesc')}
+                  </div>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onCreateKb('classic')}
+                className="flex items-start gap-3 py-3"
+              >
+                <FolderOpen className="w-5 h-5 text-text-secondary mt-0.5 flex-shrink-0" />
+                <div>
+                  <div className="font-medium">
+                    {t('knowledge:document.knowledgeBase.typeClassic')}
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    {t('knowledge:document.knowledgeBase.classicDesc')}
+                  </div>
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          // Non-admin: show hint message
+          <div className="flex flex-col items-center justify-center text-text-secondary">
+            <Building2 className="w-12 h-12 mb-4 opacity-50" />
+            <p className="text-sm mb-2">{t('knowledge:document.noOrgKnowledgeBase')}</p>
+            <p className="text-xs text-text-muted">{t('knowledge:document.noOrgKnowledgeBaseHint')}</p>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center">
+      {/* Search bar */}
+      <div className="mb-4 w-full max-w-4xl">
+        <div className="relative w-full max-w-md mx-auto">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-text-muted" />
+          <input
+            type="text"
+            className="w-full h-9 pl-9 pr-3 text-sm bg-surface border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary"
+            placeholder={t('knowledge:document.knowledgeBase.search')}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="w-full max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+        {/* Add knowledge base card with dropdown - only show for admin */}
+        {!searchQuery && isAdmin && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Card
+                padding="sm"
+                className="hover:bg-hover transition-colors cursor-pointer flex flex-col items-center justify-center h-[140px]"
+              >
+                <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mb-3">
+                  <Plus className="w-6 h-6 text-primary" />
+                </div>
+                <h3 className="font-medium text-sm">
+                  {t('knowledge:document.knowledgeBase.create')}
+                </h3>
+              </Card>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="center" className="w-56">
+              <DropdownMenuItem
+                onClick={() => onCreateKb('notebook')}
+                className="flex items-start gap-3 py-3"
+              >
+                <BookOpen className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                <div>
+                  <div className="font-medium">
+                    {t('knowledge:document.knowledgeBase.typeNotebook')}
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    {t('knowledge:document.knowledgeBase.notebookDesc')}
+                  </div>
+                </div>
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onClick={() => onCreateKb('classic')}
+                className="flex items-start gap-3 py-3"
+              >
+                <FolderOpen className="w-5 h-5 text-text-secondary mt-0.5 flex-shrink-0" />
+                <div>
+                  <div className="font-medium">
+                    {t('knowledge:document.knowledgeBase.typeClassic')}
+                  </div>
+                  <div className="text-xs text-text-muted">
+                    {t('knowledge:document.knowledgeBase.classicDesc')}
+                  </div>
+                </div>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        {/* Knowledge base cards */}
+        {filteredKnowledgeBases.map(kb => (
+          <KnowledgeBaseCard
+            key={kb.id}
+            knowledgeBase={kb}
+            onClick={() => onSelectKb(kb)}
+            onEdit={isAdmin ? () => onEditKb(kb) : undefined}
+            onDelete={isAdmin ? () => onDeleteKb(kb) : undefined}
+            onShare={() => onShareKb(kb)}
+            canEdit={isAdmin}
+            canDelete={isAdmin}
+            canShare={true}
+          />
+        ))}
+      </div>
+
+      {/* No results message */}
+      {searchQuery && filteredKnowledgeBases.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-12 text-text-secondary">
+          <FileText className="w-12 h-12 mb-4 opacity-50" />
+          <p>{t('knowledge:document.knowledgeBase.noResults')}</p>
         </div>
       )}
     </div>

--- a/frontend/src/features/knowledge/document/components/RetrievalSettingsSection.tsx
+++ b/frontend/src/features/knowledge/document/components/RetrievalSettingsSection.tsx
@@ -38,7 +38,7 @@ interface RetrievalSettingsSectionProps {
   onChange: (config: Partial<RetrievalConfig>) => void
   readOnly?: boolean
   partialReadOnly?: boolean // When true, only retriever and embedding model are read-only
-  scope?: 'personal' | 'group' | 'all'
+  scope?: 'personal' | 'group' | 'organization' | 'all'
   groupName?: string
 }
 

--- a/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
+++ b/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
@@ -8,10 +8,10 @@ import { modelApis, UnifiedModel } from '@/apis/models'
 /**
  * Hook to fetch embedding models with scope support.
  *
- * @param scope - Resource scope: 'personal', 'group', or 'all'
+ * @param scope - Resource scope: 'personal', 'group', 'organization', or 'all'
  * @param groupName - Group name (required when scope is 'group')
  */
-export function useEmbeddingModels(scope?: 'personal' | 'group' | 'all', groupName?: string) {
+export function useEmbeddingModels(scope?: 'personal' | 'group' | 'organization' | 'all', groupName?: string) {
   const [models, setModels] = useState<UnifiedModel[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -19,11 +19,14 @@ export function useEmbeddingModels(scope?: 'personal' | 'group' | 'all', groupNa
   const fetchModels = useCallback(async () => {
     try {
       setLoading(true)
+      // For organization scope, use 'personal' to get user's models + public models
+      // Organization KBs should use personal or public models
+      const apiScope = scope === 'organization' ? 'personal' : (scope || 'all')
       // Use modelApis.getUnifiedModels with scope support and filter by embedding type
       const response = await modelApis.getUnifiedModels(
         undefined, // shellType
         false, // includeConfig
-        scope || 'all', // scope - default to 'all' to include personal + group + public models
+        apiScope, // scope - default to 'all' to include personal + group + public models
         groupName, // groupName
         'embedding' // modelCategoryType - filter by embedding models
       )
@@ -31,6 +34,7 @@ export function useEmbeddingModels(scope?: 'personal' | 'group' | 'all', groupNa
       // Sort by type priority based on scope, then by name
       // - Personal scope: user > public
       // - Group scope: group > public
+      // - Organization scope: user > public (same as personal)
       const typePriority: Record<string, number> =
         scope === 'group' ? { group: 0, public: 1 } : { user: 0, public: 1 }
       data.sort((a, b) => {

--- a/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
+++ b/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
@@ -11,7 +11,10 @@ import { modelApis, UnifiedModel } from '@/apis/models'
  * @param scope - Resource scope: 'personal', 'group', 'organization', or 'all'
  * @param groupName - Group name (required when scope is 'group')
  */
-export function useEmbeddingModels(scope?: 'personal' | 'group' | 'organization' | 'all', groupName?: string) {
+export function useEmbeddingModels(
+  scope?: 'personal' | 'group' | 'organization' | 'all',
+  groupName?: string
+) {
   const [models, setModels] = useState<UnifiedModel[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -19,9 +22,10 @@ export function useEmbeddingModels(scope?: 'personal' | 'group' | 'organization'
   const fetchModels = useCallback(async () => {
     try {
       setLoading(true)
-      // For organization scope, use 'personal' to get user's models + public models
-      // Organization KBs should use personal or public models
-      const apiScope = scope === 'organization' ? 'personal' : (scope || 'all')
+      // For organization and group scope, use 'personal' to get user's models + public models
+      // Organization and Group KBs should be able to use personal or public models
+      // Group-specific models can be added later if needed
+      const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope || 'all'
       // Use modelApis.getUnifiedModels with scope support and filter by embedding type
       const response = await modelApis.getUnifiedModels(
         undefined, // shellType

--- a/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
+++ b/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
@@ -5,7 +5,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { retrieverApis, type UnifiedRetriever } from '@/apis/retrievers'
 
-export function useRetrievers(scope?: 'personal' | 'group' | 'all', groupName?: string) {
+export function useRetrievers(scope?: 'personal' | 'group' | 'organization' | 'all', groupName?: string) {
   const [retrievers, setRetrievers] = useState<UnifiedRetriever[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -13,11 +13,15 @@ export function useRetrievers(scope?: 'personal' | 'group' | 'all', groupName?: 
   const fetchRetrievers = useCallback(async () => {
     try {
       setLoading(true)
-      const response = await retrieverApis.getUnifiedRetrievers(scope, groupName)
+      // For organization scope, use 'personal' to get user's retrievers + public retrievers
+      // Organization KBs should use personal or public retrievers
+      const apiScope = scope === 'organization' ? 'personal' : scope
+      const response = await retrieverApis.getUnifiedRetrievers(apiScope, groupName)
       const data = response.data || []
       // Sort by type priority based on scope, then by name
       // - Personal scope: user > public
       // - Group scope: group > public
+      // - Organization scope: user > public (same as personal)
       const typePriority: Record<string, number> =
         scope === 'group' ? { group: 0, public: 1 } : { user: 0, public: 1 }
       data.sort((a, b) => {

--- a/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
+++ b/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
@@ -5,7 +5,10 @@
 import { useEffect, useState, useCallback } from 'react'
 import { retrieverApis, type UnifiedRetriever } from '@/apis/retrievers'
 
-export function useRetrievers(scope?: 'personal' | 'group' | 'organization' | 'all', groupName?: string) {
+export function useRetrievers(
+  scope?: 'personal' | 'group' | 'organization' | 'all',
+  groupName?: string
+) {
   const [retrievers, setRetrievers] = useState<UnifiedRetriever[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<Error | null>(null)
@@ -13,9 +16,10 @@ export function useRetrievers(scope?: 'personal' | 'group' | 'organization' | 'a
   const fetchRetrievers = useCallback(async () => {
     try {
       setLoading(true)
-      // For organization scope, use 'personal' to get user's retrievers + public retrievers
-      // Organization KBs should use personal or public retrievers
-      const apiScope = scope === 'organization' ? 'personal' : scope
+      // For organization and group scope, use 'personal' to get user's retrievers + public retrievers
+      // Organization and Group KBs should be able to use personal or public retrievers
+      // Group-specific retrievers can be added later if needed
+      const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope
       const response = await retrieverApis.getUnifiedRetrievers(apiScope, groupName)
       const data = response.data || []
       // Sort by type priority based on scope, then by name

--- a/frontend/src/features/settings/components/groups/CreateGroupDialog.tsx
+++ b/frontend/src/features/settings/components/groups/CreateGroupDialog.tsx
@@ -276,9 +276,7 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
             <Label htmlFor="level">{t('groups:groups.level')}</Label>
             <Select
               value={formData.level}
-              onValueChange={(value: GroupLevel) =>
-                setFormData({ ...formData, level: value })
-              }
+              onValueChange={(value: GroupLevel) => setFormData({ ...formData, level: value })}
               disabled={isSubmitting}
             >
               <SelectTrigger id="level" data-testid="level-select">
@@ -287,12 +285,12 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
               <SelectContent>
                 <SelectItem value="group">
                   <div className="flex flex-col">
-                    <span>{t('groups:levels.group')}</span>
+                    <span>{t('groups:groups.levels.group')}</span>
                   </div>
                 </SelectItem>
                 <SelectItem value="organization">
                   <div className="flex flex-col">
-                    <span>{t('groups:levels.organization')}</span>
+                    <span>{t('groups:groups.levels.organization')}</span>
                   </div>
                 </SelectItem>
               </SelectContent>

--- a/frontend/src/features/settings/components/groups/CreateGroupDialog.tsx
+++ b/frontend/src/features/settings/components/groups/CreateGroupDialog.tsx
@@ -19,8 +19,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { createGroup, listGroups } from '@/apis/groups'
+import { useUser } from '@/features/common/UserContext'
 import { toast } from 'sonner'
-import type { GroupCreate, Group, GroupVisibility } from '@/types/group'
+import type { GroupCreate, Group, GroupVisibility, GroupLevel } from '@/types/group'
 
 interface CreateGroupDialogProps {
   isOpen: boolean
@@ -30,11 +31,15 @@ interface CreateGroupDialogProps {
 
 export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDialogProps) {
   const { t } = useTranslation()
+  const { user } = useUser()
+  const isAdmin = user?.role === 'admin'
+
   const [formData, setFormData] = useState<GroupCreate>({
     name: '',
     display_name: '',
     visibility: 'internal',
     description: '',
+    level: 'group',
   })
   const [parentGroup, setParentGroup] = useState<string>('__none__')
   const [availableGroups, setAvailableGroups] = useState<Group[]>([])
@@ -119,6 +124,7 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
         display_name: formData.display_name?.trim() || baseName,
         visibility: formData.visibility,
         description: formData.description?.trim() || undefined,
+        level: formData.level,
       }
 
       await createGroup(payload)
@@ -130,6 +136,7 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
         display_name: '',
         visibility: 'internal',
         description: '',
+        level: 'group',
       })
       setParentGroup('__none__')
       setErrors({})
@@ -152,6 +159,7 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
         display_name: '',
         visibility: 'internal',
         description: '',
+        level: 'group',
       })
       setParentGroup('__none__')
       setErrors({})
@@ -261,6 +269,40 @@ export function CreateGroupDialog({ isOpen, onClose, onSuccess }: CreateGroupDia
             {formData.visibility === 'internal' && t('groups:groupCreate.visibilityInternalHint')}
           </p>
         </div>
+
+        {/* Level - Admin Only */}
+        {isAdmin && (
+          <div>
+            <Label htmlFor="level">{t('groups:groups.level')}</Label>
+            <Select
+              value={formData.level}
+              onValueChange={(value: GroupLevel) =>
+                setFormData({ ...formData, level: value })
+              }
+              disabled={isSubmitting}
+            >
+              <SelectTrigger id="level" data-testid="level-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="group">
+                  <div className="flex flex-col">
+                    <span>{t('groups:levels.group')}</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="organization">
+                  <div className="flex flex-col">
+                    <span>{t('groups:levels.organization')}</span>
+                  </div>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-text-muted mt-1">
+              {formData.level === 'organization' && t('groups:groupCreate.levelOrganizationHint')}
+              {formData.level === 'group' && t('groups:groupCreate.levelGroupHint')}
+            </p>
+          </div>
+        )}
 
         {/* Description */}
         <div>

--- a/frontend/src/features/settings/components/groups/EditGroupDialog.tsx
+++ b/frontend/src/features/settings/components/groups/EditGroupDialog.tsx
@@ -197,12 +197,12 @@ export function EditGroupDialog({ isOpen, onClose, onSuccess, group }: EditGroup
               <SelectContent>
                 <SelectItem value="group">
                   <div className="flex flex-col">
-                    <span>{t('groups:levels.group')}</span>
+                    <span>{t('groups:groups.levels.group')}</span>
                   </div>
                 </SelectItem>
                 <SelectItem value="organization">
                   <div className="flex flex-col">
-                    <span>{t('groups:levels.organization')}</span>
+                    <span>{t('groups:groups.levels.organization')}</span>
                   </div>
                 </SelectItem>
               </SelectContent>

--- a/frontend/src/features/settings/components/groups/EditGroupDialog.tsx
+++ b/frontend/src/features/settings/components/groups/EditGroupDialog.tsx
@@ -19,8 +19,9 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { updateGroup } from '@/apis/groups'
+import { useUser } from '@/features/common/UserContext'
 import { toast } from 'sonner'
-import type { Group, GroupUpdate, GroupVisibility } from '@/types/group'
+import type { Group, GroupUpdate, GroupVisibility, GroupLevel } from '@/types/group'
 
 interface EditGroupDialogProps {
   isOpen: boolean
@@ -31,10 +32,14 @@ interface EditGroupDialogProps {
 
 export function EditGroupDialog({ isOpen, onClose, onSuccess, group }: EditGroupDialogProps) {
   const { t } = useTranslation()
+  const { user } = useUser()
+  const isAdmin = user?.role === 'admin'
+
   const [formData, setFormData] = useState<GroupUpdate>({
     display_name: '',
     visibility: 'private',
     description: '',
+    level: 'group',
   })
   const [errors, setErrors] = useState<Record<string, string>>({})
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -45,6 +50,7 @@ export function EditGroupDialog({ isOpen, onClose, onSuccess, group }: EditGroup
         display_name: group.display_name || '',
         visibility: group.visibility,
         description: group.description || '',
+        level: group.level || 'group',
       })
     }
   }, [isOpen, group])
@@ -73,6 +79,7 @@ export function EditGroupDialog({ isOpen, onClose, onSuccess, group }: EditGroup
         display_name: formData.display_name?.trim() || undefined,
         visibility: formData.visibility,
         description: formData.description?.trim() || undefined,
+        level: formData.level,
       }
 
       await updateGroup(group.name, payload)
@@ -170,6 +177,42 @@ export function EditGroupDialog({ isOpen, onClose, onSuccess, group }: EditGroup
             {formData.visibility === 'internal' && t('groups:groupCreate.visibilityInternalHint')}
           </p>
         </div>
+
+        {/* Level - Admin Only */}
+        {isAdmin && (
+          <div>
+            <Label htmlFor="level">{t('groups:groups.level')}</Label>
+            <Select
+              value={formData.level}
+              onValueChange={(value: GroupLevel) => {
+                if (value) {
+                  setFormData(prev => ({ ...prev, level: value }))
+                }
+              }}
+              disabled={isSubmitting}
+            >
+              <SelectTrigger id="level" data-testid="level-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="group">
+                  <div className="flex flex-col">
+                    <span>{t('groups:levels.group')}</span>
+                  </div>
+                </SelectItem>
+                <SelectItem value="organization">
+                  <div className="flex flex-col">
+                    <span>{t('groups:levels.organization')}</span>
+                  </div>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-text-muted mt-1">
+              {formData.level === 'organization' && t('groups:groupCreate.levelOrganizationHint')}
+              {formData.level === 'group' && t('groups:groupCreate.levelGroupHint')}
+            </p>
+          </div>
+        )}
 
         {/* Description */}
         <div>

--- a/frontend/src/features/settings/components/groups/GroupManager.tsx
+++ b/frontend/src/features/settings/components/groups/GroupManager.tsx
@@ -151,13 +151,9 @@ export function GroupManager({ onGroupsChange }: GroupManagerProps) {
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {group.level === 'organization' ? (
-                        <Badge variant="default">
-                          {t('groups:levels.organization')}
-                        </Badge>
+                        <Badge variant="default">{t('groups:groups.levels.organization')}</Badge>
                       ) : (
-                        <Badge variant="outline">
-                          {t('groups:levels.group')}
-                        </Badge>
+                        <Badge variant="secondary">{t('groups:groups.levels.group')}</Badge>
                       )}
                     </td>
                     <td className="px-4 py-3 text-sm">

--- a/frontend/src/features/settings/components/groups/GroupManager.tsx
+++ b/frontend/src/features/settings/components/groups/GroupManager.tsx
@@ -122,6 +122,9 @@ export function GroupManager({ onGroupsChange }: GroupManagerProps) {
                     {t('groups:groups.visibility')}
                   </th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-text-primary">
+                    {t('groups:groups.level')}
+                  </th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-text-primary">
                     {t('groups:groups.myRole')}
                   </th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-text-primary">
@@ -145,6 +148,17 @@ export function GroupManager({ onGroupsChange }: GroupManagerProps) {
                       <Badge variant={group.visibility === 'public' ? 'success' : 'secondary'}>
                         {t(`groups:groups.${group.visibility}`)}
                       </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {group.level === 'organization' ? (
+                        <Badge variant="default">
+                          {t('groups:levels.organization')}
+                        </Badge>
+                      ) : (
+                        <Badge variant="outline">
+                          {t('groups:levels.group')}
+                        </Badge>
+                      )}
                     </td>
                     <td className="px-4 py-3 text-sm">
                       {group.my_role ? (

--- a/frontend/src/i18n/locales/en/groups.json
+++ b/frontend/src/i18n/locales/en/groups.json
@@ -12,9 +12,14 @@
     "resources": "Resources",
     "myRole": "My Role",
     "createdAt": "Created At",
+    "level": "Level",
     "private": "Private",
     "internal": "Internal",
     "public": "Public",
+    "levels": {
+      "group": "Group",
+      "organization": "Organization"
+    },
     "roles": {
       "Owner": "Owner",
       "Maintainer": "Maintainer",
@@ -78,7 +83,9 @@
     "finalNameWillBe": "Final group name will be: {{name}}",
     "visibilityPublicHint": "Public: Agents created in this group can be called via API by anyone.",
     "visibilityInternalHint": "Internal: Resources are only visible to group members.",
-    "visibilityPrivateHint": "Private: Only visible to the creator."
+    "visibilityPrivateHint": "Private: Only visible to the creator.",
+    "levelGroupHint": "Group: Regular group for team collaboration.",
+    "levelOrganizationHint": "Organization: Company-level group visible to all users."
   },
   "groupMembers": {
     "selectUser": "Select user...",

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -32,8 +32,12 @@
     "tabs": {
       "personal": "Personal",
       "group": "Group",
+      "organization": "Organization",
       "external": "External"
     },
+    "noOrgKnowledgeBase": "No organization knowledge base",
+    "noOrgKnowledgeBaseHint": "Organization knowledge bases are managed by administrators. All members can view.",
+    "orgKnowledgeBaseReadOnly": "You have view-only access.",
     "knowledgeBase": {
       "title": "Knowledge Base",
       "create": "Create Knowledge Base",

--- a/frontend/src/i18n/locales/zh-CN/groups.json
+++ b/frontend/src/i18n/locales/zh-CN/groups.json
@@ -12,9 +12,14 @@
     "resources": "资源",
     "myRole": "我的角色",
     "createdAt": "创建时间",
+    "level": "级别",
     "private": "私有",
     "internal": "内部",
     "public": "公开",
+    "levels": {
+      "group": "群组",
+      "organization": "公司"
+    },
     "roles": {
       "Owner": "创建者",
       "Maintainer": "管理员",
@@ -78,7 +83,9 @@
     "finalNameWillBe": "最终群组名称将为：{{name}}",
     "visibilityPublicHint": "公开组：组内资源可被所有人通过 API 调用",
     "visibilityInternalHint": "内部组：组内资源仅成员可见和使用",
-    "visibilityPrivateHint": "私有组：仅创建者可见和使用"
+    "visibilityPrivateHint": "私有组：仅创建者可见和使用",
+    "levelGroupHint": "群组：普通群组，用于团队协作。",
+    "levelOrganizationHint": "公司：公司级别群组，所有用户可见。"
   },
   "groupMembers": {
     "selectUser": "选择用户...",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -32,8 +32,12 @@
     "tabs": {
       "personal": "个人知识",
       "group": "组知识",
+      "organization": "公司知识",
       "external": "外部知识库"
     },
+    "noOrgKnowledgeBase": "暂无公司知识库",
+    "noOrgKnowledgeBaseHint": "公司知识库由管理员创建和管理，所有成员可查看",
+    "orgKnowledgeBaseReadOnly": "您没有管理权限，仅可查看",
     "knowledgeBase": {
       "title": "知识库",
       "create": "创建知识库",

--- a/frontend/src/types/group.ts
+++ b/frontend/src/types/group.ts
@@ -10,6 +10,8 @@ export type GroupRole = 'Owner' | 'Maintainer' | 'Developer' | 'Reporter'
 
 export type GroupVisibility = 'private' | 'internal' | 'public'
 
+export type GroupLevel = 'group' | 'organization'
+
 export interface Group {
   id: number
   name: string
@@ -17,6 +19,7 @@ export interface Group {
   parent_name: string | null
   owner_user_id: number
   visibility: GroupVisibility
+  level?: GroupLevel | null
   description: string | null
   is_active: boolean
   member_count?: number
@@ -31,12 +34,14 @@ export interface GroupCreate {
   display_name?: string
   visibility?: GroupVisibility
   description?: string
+  level?: GroupLevel
 }
 
 export interface GroupUpdate {
   display_name?: string
   visibility?: GroupVisibility
   description?: string
+  level?: GroupLevel
 }
 
 export interface GroupMember {

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -10,7 +10,7 @@ export type DocumentStatus = 'enabled' | 'disabled'
 
 export type DocumentSourceType = 'file' | 'text' | 'table' | 'web'
 
-export type KnowledgeResourceScope = 'personal' | 'group' | 'all'
+export type KnowledgeResourceScope = 'personal' | 'organization' | 'group' | 'all'
 
 // Retrieval Config types
 export interface RetrievalConfig {


### PR DESCRIPTION
## Summary

This PR implements the Organization Knowledge Base feature, allowing administrators to create and manage company-wide knowledge bases that are visible to all users.

## Changes

### Backend
- Extended ResourceScope enum with ORGANIZATION value
- Added organization scope handling in list_knowledge_bases service method
- Added admin permission checks for organization knowledge base CRUD operations
- Updated API endpoint to support scope=organization parameter

### Frontend
- Extended KnowledgeResourceScope type to include 'organization'
- Added Organization tab in document knowledge page (positioned between Group and External)
- Created OrganizationKnowledgeContent component with differentiated views for admin/non-admin users
  - Admin view: Shows create button and management controls
  - Non-admin view: Read-only list of available knowledge bases
- Added i18n translations for organization knowledge base (English and Chinese)

### Storage Design
- Organization knowledge bases use namespace=organization in the existing kinds table
- No new database tables required

## Permission Matrix

| Function | Admin | Regular User |
|----------|-------|--------------|
| View organization KB list | ✅ | ✅ |
| Search organization KB | ✅ | ✅ |
| View KB documents | ✅ | ✅ |
| Create organization KB | ✅ | ❌ |
| Edit organization KB | ✅ | ❌ |
| Delete organization KB | ✅ | ❌ |
| Upload/Delete documents | ✅ | ❌ |

## Testing

- [ ] Admin can create organization knowledge base
- [ ] Admin can edit/delete organization knowledge base
- [ ] Non-admin can view but not modify organization knowledge bases
- [ ] Tab order: Personal → Group → Organization → External
- [ ] URL parameter tab=organization works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-scoped knowledge bases and an "Organization" tab for centralized browsing and management.
  * UI: organization KB listing, admin-only creation flows, and read-only messaging for non-admin members.

* **Bug Fixes / Behavior**
  * Management and document operations for organization KBs now require admin role; listing and indexing behaviors adjusted for organization scope.
  * Retriever/embedding listings treat organization scope appropriately for visibility and sorting.

* **Documentation**
  * Added English and Chinese localization strings for organization knowledge features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->