### PR TITLE
feat(workbench): add workspace files display and download for no-repository mode

### DIFF
--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db, with_task_telemetry
@@ -689,9 +690,6 @@ def delete_task_services(
 # ============================================================================
 # Workspace Files API - for "no repository mode" file display and download
 # ============================================================================
-
-
-from pydantic import BaseModel
 
 
 class WorkspaceFile(BaseModel):

--- a/executor/envd/api/models.py
+++ b/executor/envd/api/models.py
@@ -46,3 +46,23 @@ class ErrorResponse(BaseModel):
 
     message: str
     code: int
+
+
+class WorkspaceFile(BaseModel):
+    """Workspace file/directory information for tree display"""
+
+    name: str  # File/directory name
+    path: str  # Relative path from workspace root
+    type: str  # 'file' or 'directory'
+    size: Optional[int] = None  # File size in bytes (only for files)
+    children: Optional[list["WorkspaceFile"]] = (
+        None  # Child items (only for directories)
+    )
+
+
+class WorkspaceFilesResponse(BaseModel):
+    """Response model for workspace files listing"""
+
+    files: list[WorkspaceFile]
+    total_files: int
+    total_size: int

--- a/executor/envd/api/routes.py
+++ b/executor/envd/api/routes.py
@@ -5,17 +5,26 @@
 REST API route handlers for envd
 """
 
+import io
 import os
 import time
+import zipfile
+from pathlib import Path
 from typing import Optional
 
 import psutil
 from fastapi import FastAPI, File, Header, HTTPException, Query, Response, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 
 from shared.logger import setup_logger
 
-from .models import EntryInfo, InitRequest, MetricsResponse
+from .models import (
+    EntryInfo,
+    InitRequest,
+    MetricsResponse,
+    WorkspaceFile,
+    WorkspaceFilesResponse,
+)
 from .state import AccessTokenAlreadySetError, get_state_manager
 from .utils import resolve_path, verify_access_token, verify_signature
 
@@ -187,6 +196,276 @@ def register_rest_api(app: FastAPI):
             logger.exception(f"Error uploading file: {e}")
             raise HTTPException(status_code=500, detail=str(e))
 
+    # Directories and files to exclude from workspace file listing
+    EXCLUDED_DIRS = {
+        ".git",
+        ".svn",
+        ".hg",
+        "node_modules",
+        "vendor",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".cache",
+        ".tmp",
+        "tmp",
+        ".idea",
+        ".vscode",
+        "dist",
+        "build",
+        "target",
+        "out",
+        ".next",
+        ".nuxt",
+        "coverage",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "eggs",
+        "*.egg-info",
+        ".tox",
+        ".nox",
+    }
+
+    EXCLUDED_FILES = {
+        ".DS_Store",
+        "Thumbs.db",
+        ".gitignore",
+        ".gitattributes",
+        "*.pyc",
+        "*.pyo",
+        "*.so",
+        "*.dylib",
+        "*.dll",
+        "*.exe",
+        "*.class",
+        "*.jar",
+    }
+
+    def should_exclude(name: str, is_dir: bool) -> bool:
+        """Check if a file or directory should be excluded from listing"""
+        excluded_set = EXCLUDED_DIRS if is_dir else EXCLUDED_FILES
+
+        # Check exact match
+        if name in excluded_set:
+            return True
+
+        # Check pattern match (e.g., *.pyc)
+        for pattern in excluded_set:
+            if pattern.startswith("*") and name.endswith(pattern[1:]):
+                return True
+
+        return False
+
+    def build_file_tree(
+        root_path: Path, relative_base: str = "", max_files: int = 1000
+    ) -> tuple[list[WorkspaceFile], int, int]:
+        """
+        Recursively build a file tree from a directory.
+
+        Args:
+            root_path: The root directory path
+            relative_base: The relative path from workspace root
+            max_files: Maximum number of files to return
+
+        Returns:
+            Tuple of (file list, total file count, total size in bytes)
+        """
+        files: list[WorkspaceFile] = []
+        total_files = 0
+        total_size = 0
+
+        try:
+            entries = sorted(
+                root_path.iterdir(), key=lambda x: (not x.is_dir(), x.name.lower())
+            )
+        except PermissionError:
+            return files, total_files, total_size
+        except Exception as e:
+            logger.warning(f"Error reading directory {root_path}: {e}")
+            return files, total_files, total_size
+
+        for entry in entries:
+            if total_files >= max_files:
+                break
+
+            name = entry.name
+            is_dir = entry.is_dir()
+
+            # Skip excluded items
+            if should_exclude(name, is_dir):
+                continue
+
+            relative_path = f"{relative_base}/{name}" if relative_base else name
+
+            if is_dir:
+                # Recursively build children
+                children, child_count, child_size = build_file_tree(
+                    entry, relative_path, max_files - total_files
+                )
+                total_files += child_count
+                total_size += child_size
+
+                files.append(
+                    WorkspaceFile(
+                        name=name,
+                        path=relative_path,
+                        type="directory",
+                        size=None,
+                        children=children if children else None,
+                    )
+                )
+            else:
+                try:
+                    file_size = entry.stat().st_size
+                except Exception:
+                    file_size = 0
+
+                total_files += 1
+                total_size += file_size
+
+                files.append(
+                    WorkspaceFile(
+                        name=name,
+                        path=relative_path,
+                        type="file",
+                        size=file_size,
+                        children=None,
+                    )
+                )
+
+        return files, total_files, total_size
+
+    @app.get("/files/list", response_model=WorkspaceFilesResponse)
+    async def list_workspace_files(
+        path: Optional[str] = Query(None, description="Subdirectory to list"),
+        x_access_token: Optional[str] = Header(None),
+    ):
+        """
+        List all files in the workspace directory (recursive).
+
+        Returns a tree structure of files and directories with smart filtering
+        to exclude common temporary/build files.
+        """
+        verify_access_token(x_access_token)
+
+        try:
+            # Use default workdir or specified path
+            base_path = state_manager.default_workdir or "/workspace"
+            if path:
+                base_path = resolve_path(path, None, base_path)
+            else:
+                base_path = Path(base_path)
+
+            if not base_path.exists():
+                raise HTTPException(
+                    status_code=404, detail=f"Directory not found: {base_path}"
+                )
+
+            if not base_path.is_dir():
+                raise HTTPException(
+                    status_code=400, detail=f"Path is not a directory: {base_path}"
+                )
+
+            # Build file tree
+            files, total_files, total_size = build_file_tree(base_path)
+
+            return WorkspaceFilesResponse(
+                files=files,
+                total_files=total_files,
+                total_size=total_size,
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception(f"Error listing workspace files: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+
+    @app.get("/files/download-zip")
+    async def download_workspace_zip(
+        path: Optional[str] = Query(None, description="Subdirectory to download"),
+        x_access_token: Optional[str] = Header(None),
+    ):
+        """
+        Download all files in the workspace directory as a ZIP archive.
+
+        Smart filtering is applied to exclude temporary/build files.
+        """
+        verify_access_token(x_access_token)
+
+        try:
+            # Use default workdir or specified path
+            base_path = state_manager.default_workdir or "/workspace"
+            if path:
+                base_path = resolve_path(path, None, base_path)
+            else:
+                base_path = Path(base_path)
+
+            if not base_path.exists():
+                raise HTTPException(
+                    status_code=404, detail=f"Directory not found: {base_path}"
+                )
+
+            if not base_path.is_dir():
+                raise HTTPException(
+                    status_code=400, detail=f"Path is not a directory: {base_path}"
+                )
+
+            # Create in-memory ZIP file
+            zip_buffer = io.BytesIO()
+
+            def add_files_to_zip(
+                zipf: zipfile.ZipFile, dir_path: Path, arc_prefix: str = ""
+            ):
+                """Recursively add files to ZIP archive"""
+                try:
+                    entries = sorted(dir_path.iterdir())
+                except PermissionError:
+                    return
+                except Exception as e:
+                    logger.warning(f"Error reading directory {dir_path}: {e}")
+                    return
+
+                for entry in entries:
+                    name = entry.name
+                    is_dir = entry.is_dir()
+
+                    # Skip excluded items
+                    if should_exclude(name, is_dir):
+                        continue
+
+                    arc_name = f"{arc_prefix}/{name}" if arc_prefix else name
+
+                    if is_dir:
+                        add_files_to_zip(zipf, entry, arc_name)
+                    else:
+                        try:
+                            zipf.write(entry, arc_name)
+                        except Exception as e:
+                            logger.warning(f"Error adding file to ZIP {entry}: {e}")
+
+            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zipf:
+                add_files_to_zip(zipf, base_path)
+
+            zip_buffer.seek(0)
+
+            # Generate filename based on directory name
+            dir_name = base_path.name or "workspace"
+            filename = f"{dir_name}_files.zip"
+
+            return StreamingResponse(
+                zip_buffer,
+                media_type="application/zip",
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.exception(f"Error creating ZIP download: {e}")
+            raise HTTPException(status_code=500, detail=str(e))
+
     logger.info("Registered envd REST API routes:")
     logger.info("  GET /health")
     logger.info("  GET /metrics")
@@ -194,3 +473,5 @@ def register_rest_api(app: FastAPI):
     logger.info("  GET /envs")
     logger.info("  GET /files")
     logger.info("  POST /files")
+    logger.info("  GET /files/list")
+    logger.info("  GET /files/download-zip")

--- a/frontend/src/features/tasks/components/workbench/Workbench.tsx
+++ b/frontend/src/features/tasks/components/workbench/Workbench.tsx
@@ -26,6 +26,7 @@ import { useTheme } from '@/features/theme/ThemeProvider'
 import { useTranslation } from '@/hooks/useTranslation'
 import { taskApis, BranchDiffResponse } from '@/apis/tasks'
 import DiffViewer from '../message/DiffViewer'
+import WorkspaceFiles from './WorkspaceFiles'
 import { TaskApp } from '@/types/api'
 
 // Tool icon mapping
@@ -931,10 +932,14 @@ export default function Workbench({
                   // Files Changed Tab - with integrated diff support
                   <>
                     {!hasRepository ? (
-                      // No repository - show friendly message
-                      <div className="rounded-lg border border-border bg-surface p-8 text-center">
-                        <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
-                      </div>
+                      // No repository - show workspace files from executor container
+                      taskNumber ? (
+                        <WorkspaceFiles taskId={parseInt(taskNumber.replace('#', ''), 10)} />
+                      ) : (
+                        <div className="rounded-lg border border-border bg-surface p-8 text-center">
+                          <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
+                        </div>
+                      )
                     ) : isDiffLoading ? (
                       // Loading diff data
                       <div className="flex items-center justify-center h-64">

--- a/frontend/src/features/tasks/components/workbench/Workbench.tsx
+++ b/frontend/src/features/tasks/components/workbench/Workbench.tsx
@@ -933,13 +933,18 @@ export default function Workbench({
                   <>
                     {!hasRepository ? (
                       // No repository - show workspace files from executor container
-                      taskNumber ? (
-                        <WorkspaceFiles taskId={parseInt(taskNumber.replace('#', ''), 10)} />
-                      ) : (
-                        <div className="rounded-lg border border-border bg-surface p-8 text-center">
-                          <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
-                        </div>
-                      )
+                      (() => {
+                        const taskId = taskNumber
+                          ? parseInt(taskNumber.replace('#', ''), 10)
+                          : NaN
+                        return !Number.isNaN(taskId) ? (
+                          <WorkspaceFiles taskId={taskId} />
+                        ) : (
+                          <div className="rounded-lg border border-border bg-surface p-8 text-center">
+                            <p className="text-text-muted">{t('tasks:workbench.no_repository')}</p>
+                          </div>
+                        )
+                      })()
                     ) : isDiffLoading ? (
                       // Loading diff data
                       <div className="flex items-center justify-center h-64">

--- a/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
+++ b/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
@@ -96,11 +96,11 @@ function getFileIcon(filename: string): string {
 }
 
 function formatFileSize(bytes: number | undefined): string {
-  if (bytes === undefined || bytes === null) return ''
+  if (bytes === undefined || bytes === null || bytes < 0) return ''
   if (bytes === 0) return '0 B'
   const k = 1024
   const sizes = ['B', 'KB', 'MB', 'GB']
-  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1)
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
 }
 
@@ -117,8 +117,8 @@ function FileTreeNode({ file, level, defaultExpanded = false }: FileTreeNodeProp
   return (
     <div>
       <div
-        className={`flex items-center gap-1 py-1 px-2 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm ${
-          level === 0 ? '' : 'ml-4'
+        className={`flex items-center gap-1 py-1 px-2 rounded-md transition-colors text-sm ${
+          isDirectory ? 'cursor-pointer hover:bg-muted' : ''
         }`}
         onClick={() => isDirectory && setIsExpanded(!isExpanded)}
         style={{ paddingLeft: `${level * 16 + 8}px` }}

--- a/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
+++ b/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
@@ -1,0 +1,326 @@
+// SPDX-FileCopyrightText: 2025 WeCode, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import {
+  ChevronRightIcon,
+  DocumentIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  ArrowDownTrayIcon,
+  ExclamationTriangleIcon,
+  ArrowPathIcon,
+} from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import { taskApis, WorkspaceFile, WorkspaceFilesResponse } from '@/apis/tasks'
+import { Button } from '@/components/ui/button'
+
+interface WorkspaceFilesProps {
+  taskId: number
+}
+
+// File icon mapping by extension
+const FILE_ICONS: Record<string, string> = {
+  // Programming
+  ts: '📄',
+  tsx: '⚛️',
+  js: '📜',
+  jsx: '⚛️',
+  py: '🐍',
+  rb: '💎',
+  go: '🔷',
+  rs: '🦀',
+  java: '☕',
+  kt: '🟣',
+  swift: '🍎',
+  c: '🔧',
+  cpp: '🔧',
+  h: '📋',
+  cs: '🟢',
+  php: '🐘',
+
+  // Web
+  html: '🌐',
+  htm: '🌐',
+  css: '🎨',
+  scss: '🎨',
+  less: '🎨',
+  svg: '🖼️',
+
+  // Data
+  json: '📋',
+  yaml: '📋',
+  yml: '📋',
+  xml: '📋',
+  toml: '📋',
+  ini: '⚙️',
+  env: '🔐',
+
+  // Documentation
+  md: '📝',
+  mdx: '📝',
+  txt: '📄',
+  rst: '📝',
+
+  // Config
+  lock: '🔒',
+  config: '⚙️',
+  gitignore: '🙈',
+  dockerfile: '🐳',
+  dockerignore: '🐳',
+
+  // Images
+  png: '🖼️',
+  jpg: '🖼️',
+  jpeg: '🖼️',
+  gif: '🖼️',
+  webp: '🖼️',
+  ico: '🖼️',
+
+  // Archive
+  zip: '📦',
+  tar: '📦',
+  gz: '📦',
+  rar: '📦',
+
+  // Default
+  default: '📄',
+}
+
+function getFileIcon(filename: string): string {
+  const ext = filename.split('.').pop()?.toLowerCase() || ''
+  return FILE_ICONS[ext] || FILE_ICONS.default
+}
+
+function formatFileSize(bytes: number | undefined): string {
+  if (bytes === undefined || bytes === null) return ''
+  if (bytes === 0) return '0 B'
+  const k = 1024
+  const sizes = ['B', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i]
+}
+
+interface FileTreeNodeProps {
+  file: WorkspaceFile
+  level: number
+  defaultExpanded?: boolean
+}
+
+function FileTreeNode({ file, level, defaultExpanded = false }: FileTreeNodeProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded && level < 2)
+  const isDirectory = file.type === 'directory'
+
+  return (
+    <div>
+      <div
+        className={`flex items-center gap-1 py-1 px-2 rounded-md hover:bg-muted transition-colors cursor-pointer text-sm ${
+          level === 0 ? '' : 'ml-4'
+        }`}
+        onClick={() => isDirectory && setIsExpanded(!isExpanded)}
+        style={{ paddingLeft: `${level * 16 + 8}px` }}
+      >
+        {isDirectory ? (
+          <>
+            <ChevronRightIcon
+              className={`h-4 w-4 text-text-muted transition-transform ${
+                isExpanded ? 'rotate-90' : ''
+              }`}
+            />
+            {isExpanded ? (
+              <FolderOpenIcon className="h-4 w-4 text-primary" />
+            ) : (
+              <FolderIcon className="h-4 w-4 text-primary" />
+            )}
+          </>
+        ) : (
+          <>
+            <span className="w-4" />
+            <span className="text-sm">{getFileIcon(file.name)}</span>
+          </>
+        )}
+        <span className="flex-1 truncate text-text-primary">{file.name}</span>
+        {!isDirectory && file.size !== undefined && (
+          <span className="text-xs text-text-muted">{formatFileSize(file.size)}</span>
+        )}
+      </div>
+
+      {isDirectory && isExpanded && file.children && (
+        <div>
+          {file.children.map((child, index) => (
+            <FileTreeNode key={`${child.path}-${index}`} file={child} level={level + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function WorkspaceFiles({ taskId }: WorkspaceFilesProps) {
+  const { t } = useTranslation('tasks')
+  const [files, setFiles] = useState<WorkspaceFile[]>([])
+  const [totalFiles, setTotalFiles] = useState(0)
+  const [totalSize, setTotalSize] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isDownloading, setIsDownloading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [errorType, setErrorType] = useState<'container_stopped' | 'network' | 'unknown'>('unknown')
+
+  const loadFiles = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const response = await taskApis.getWorkspaceFiles(taskId)
+      setFiles(response.files)
+      setTotalFiles(response.total_files)
+      setTotalSize(response.total_size)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      setError(errorMessage)
+
+      // Determine error type
+      if (
+        errorMessage.includes('503') ||
+        errorMessage.toLowerCase().includes('container') ||
+        errorMessage.toLowerCase().includes('not running') ||
+        errorMessage.toLowerCase().includes('stopped')
+      ) {
+        setErrorType('container_stopped')
+      } else if (
+        errorMessage.toLowerCase().includes('network') ||
+        errorMessage.toLowerCase().includes('timeout') ||
+        errorMessage.includes('504')
+      ) {
+        setErrorType('network')
+      } else {
+        setErrorType('unknown')
+      }
+    } finally {
+      setIsLoading(false)
+    }
+  }, [taskId])
+
+  useEffect(() => {
+    loadFiles()
+  }, [loadFiles])
+
+  const handleDownload = async () => {
+    setIsDownloading(true)
+    try {
+      const blob = await taskApis.downloadWorkspaceZip(taskId)
+
+      // Create download link
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `task_${taskId}_files.zip`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      setError(errorMessage)
+    } finally {
+      setIsDownloading(false)
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <span className="ml-3 text-text-muted">{t('workbench.workspace_files.loading')}</span>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-6">
+        <div className="flex flex-col items-center text-center">
+          <ExclamationTriangleIcon className="w-10 h-10 text-amber-600 dark:text-amber-400 mb-3" />
+          <h4 className="text-base font-medium text-amber-800 dark:text-amber-200">
+            {errorType === 'container_stopped'
+              ? t('workbench.workspace_files.container_stopped_title')
+              : t('workbench.workspace_files.error_title')}
+          </h4>
+          <p className="mt-2 text-sm text-amber-700 dark:text-amber-300 max-w-md">
+            {errorType === 'container_stopped'
+              ? t('workbench.workspace_files.container_stopped')
+              : errorType === 'network'
+                ? t('workbench.workspace_files.network_error')
+                : error}
+          </p>
+          <button
+            onClick={loadFiles}
+            className="mt-4 inline-flex items-center px-4 py-2 text-sm font-medium text-amber-800 dark:text-amber-200 bg-amber-100 dark:bg-amber-800/30 hover:bg-amber-200 dark:hover:bg-amber-800/50 rounded-md transition-colors"
+          >
+            <ArrowPathIcon className="w-4 h-4 mr-2" />
+            {t('workbench.retry')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (files.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-surface p-8 text-center">
+        <DocumentIcon className="w-12 h-12 text-text-muted mx-auto mb-3" />
+        <p className="text-text-muted">{t('workbench.workspace_files.no_files')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Header with download button */}
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-text-muted">
+          {t('workbench.workspace_files.file_count', { count: totalFiles })}
+          {totalSize > 0 && ` (${formatFileSize(totalSize)})`}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleDownload}
+          disabled={isDownloading}
+          className="h-8"
+        >
+          {isDownloading ? (
+            <>
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current mr-2"></div>
+              {t('workbench.workspace_files.downloading')}
+            </>
+          ) : (
+            <>
+              <ArrowDownTrayIcon className="w-4 h-4 mr-2" />
+              {t('workbench.workspace_files.download_all')}
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* File tree */}
+      <div className="rounded-lg border border-border bg-surface overflow-hidden">
+        <div className="max-h-[500px] overflow-y-auto p-2">
+          {files.map((file, index) => (
+            <FileTreeNode key={`${file.path}-${index}`} file={file} level={0} defaultExpanded />
+          ))}
+        </div>
+      </div>
+
+      {/* Warning if too many files */}
+      {totalFiles >= 1000 && (
+        <div className="text-xs text-amber-600 dark:text-amber-400 text-center">
+          {t('workbench.workspace_files.too_many_files')}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
+++ b/frontend/src/features/tasks/components/workbench/WorkspaceFiles.tsx
@@ -15,7 +15,7 @@ import {
   ArrowPathIcon,
 } from '@heroicons/react/24/outline'
 import { useTranslation } from '@/hooks/useTranslation'
-import { taskApis, WorkspaceFile, WorkspaceFilesResponse } from '@/apis/tasks'
+import { taskApis, WorkspaceFile } from '@/apis/tasks'
 import { Button } from '@/components/ui/button'
 
 interface WorkspaceFilesProps {

--- a/frontend/src/features/tasks/components/workbench/index.ts
+++ b/frontend/src/features/tasks/components/workbench/index.ts
@@ -1,2 +1,3 @@
 export { default as Workbench } from './Workbench'
 export { default as WelcomeMessage } from './WelcomeMessage'
+export { default as WorkspaceFiles } from './WorkspaceFiles'

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -67,7 +67,20 @@
     "loading_diff_message": "Loading diff...",
     "no_changes_between_branches": "No changes found between branches",
     "execution_timeline": "Execution Timeline",
-    "no_repository": "This task is not associated with a code repository"
+    "no_repository": "This task is not associated with a code repository",
+    "workspace_files": {
+      "loading": "Loading workspace files...",
+      "error_title": "Unable to load files",
+      "container_stopped_title": "Container Not Running",
+      "container_stopped": "The execution environment has stopped. Files are only available while the executor is active.",
+      "network_error": "Network error. Please check your connection and try again.",
+      "no_files": "No files generated yet",
+      "file_count": "{{count}} files",
+      "file_count_one": "{{count}} file",
+      "download_all": "Download All",
+      "downloading": "Downloading...",
+      "too_many_files": "File list limited to 1000 items. Use \"Download All\" to get all files."
+    }
   },
   "thinking": {
     "execution_completed": "Execution Completed",

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -63,7 +63,20 @@
     "loading_diff_message": "加载中...",
     "no_changes_between_branches": "分支之间未发现变更",
     "execution_timeline": "执行时间线",
-    "no_repository": "该任务未关联代码仓库"
+    "no_repository": "该任务未关联代码仓库",
+    "workspace_files": {
+      "loading": "正在加载工作区文件...",
+      "error_title": "无法加载文件",
+      "container_stopped_title": "容器已停止",
+      "container_stopped": "任务执行环境已关闭，无法获取文件列表。文件仅在执行器运行期间可用。",
+      "network_error": "网络错误，请检查网络连接后重试。",
+      "no_files": "暂无生成的文件",
+      "file_count": "{{count}} 个文件",
+      "file_count_one": "{{count}} 个文件",
+      "download_all": "打包下载",
+      "downloading": "下载中...",
+      "too_many_files": "文件列表限制显示 1000 项，可点击「打包下载」获取全部文件。"
+    }
   },
   "thinking": {
     "execution_completed": "执行完成",


### PR DESCRIPTION
## Summary

- Add file listing and download functionality for tasks without a code repository (no-repo mode)
- In the coding conversation interface, when `hasRepository === false`, the Files Changed tab now displays workspace files from the executor container instead of showing an empty message
- Implement smart filtering to exclude common temporary/build files and directories

## Changes

### Executor (envd REST API)
- Add `GET /files/list` endpoint to list workspace files recursively as a tree structure
- Add `GET /files/download-zip` endpoint to download all files as a ZIP archive
- Implement smart filtering (excludes `.git`, `node_modules`, `__pycache__`, `.venv`, `dist`, `build`, etc.)
- Add new Pydantic models: `WorkspaceFile`, `WorkspaceFilesResponse`

### Backend (FastAPI)
- Add `GET /api/tasks/{task_id}/workspace/files` endpoint to get workspace file list
- Add `GET /api/tasks/{task_id}/workspace/download` endpoint to download workspace as ZIP
- Endpoints proxy requests to the executor container via `SandboxFileSyncer`
- Include proper access control (task membership check)
- Handle container stopped/unavailable states with appropriate error messages

### Frontend (React/TypeScript)
- Add `getWorkspaceFiles()` and `downloadWorkspaceZip()` API functions
- Create `WorkspaceFiles` component with:
  - Tree-based file listing with expand/collapse
  - File type icons based on extension
  - File size display
  - "Download All" button for ZIP download
  - Loading, error, and empty states
  - Container stopped state handling with retry button
- Update `Workbench` component to show `WorkspaceFiles` when `hasRepository === false`

### i18n
- Add English translations for workspace files feature
- Add Chinese translations for workspace files feature

## Test Plan

- [ ] Verify file listing appears when opening Files Changed tab for a no-repo task
- [ ] Verify directory tree expands/collapses correctly
- [ ] Verify file sizes are displayed correctly
- [ ] Verify Download All button downloads a ZIP file
- [ ] Verify error message appears when executor container is stopped
- [ ] Verify retry button works after container restart
- [ ] Verify translations display correctly in both EN and ZH locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace file explorer for no-repository tasks: interactive hierarchical tree with sizes, totals, and collapse/expand.
  * Download-all: download workspace as a ZIP with streaming and progress feedback.
  * Files view now appears in the Workbench Files tab when no repository is present.

* **Documentation / Localization**
  * Added English and Chinese UI strings for loading, errors, counts, and download states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->