### PR TITLE
fix(frontend): prevent repo selector auto-open when disabled

### DIFF
--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -441,6 +441,8 @@ export default function UnifiedRepositorySelector({
                               className="hidden group-hover:flex items-center justify-center h-4 w-4 rounded-full hover:bg-hover text-text-muted hover:text-text-primary transition-colors"
                               onClick={e => {
                                 e.stopPropagation()
+                                // Prevent clearing when disabled (e.g., historical conversation)
+                                if (disabled) return
                                 handleRequiresWorkspaceToggle(false)
                               }}
                             >

--- a/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
+++ b/frontend/src/features/tasks/components/selector/UnifiedRepositorySelector.tsx
@@ -274,9 +274,13 @@ export default function UnifiedRepositorySelector({
 
   // Auto-open popover when requiresWorkspace changes from false to true (e.g., team switch)
   // and no repo is currently selected
+  // NOTE: Do NOT auto-open when disabled (e.g., historical conversation page)
   useEffect(() => {
     const prevValue = prevRequiresWorkspaceRef.current
     prevRequiresWorkspaceRef.current = requiresWorkspace
+
+    // Skip auto-open when disabled (e.g., viewing historical conversation)
+    if (disabled) return
 
     // If changed from false to true and no repo selected, auto-open
     if (!prevValue && requiresWorkspace && !selectedRepo) {
@@ -284,7 +288,7 @@ export default function UnifiedRepositorySelector({
         setIsOpen(true)
       }, 100)
     }
-  }, [requiresWorkspace, selectedRepo])
+  }, [requiresWorkspace, selectedRepo, disabled])
 
   // Navigate to settings page
   const handleIntegrationClick = () => {
@@ -336,15 +340,16 @@ export default function UnifiedRepositorySelector({
       if (!checked) {
         onRepoChange(null)
         onBranchChange(null)
-      } else {
+      } else if (!disabled) {
         // When turning on workspace requirement, auto-open the popover
         // Use setTimeout to ensure the toggle animation completes first
+        // NOTE: Do NOT auto-open when disabled (defensive check)
         setTimeout(() => {
           setIsOpen(true)
         }, 100)
       }
     },
-    [onRequiresWorkspaceChange, onRepoChange, onBranchChange]
+    [onRequiresWorkspaceChange, onRepoChange, onBranchChange, disabled]
   )
 
   // Determine the display text


### PR DESCRIPTION
## Summary

- Fixed an issue where the repository selector popover would auto-open on historical conversation pages even when the selector is in disabled state
- Added `disabled` prop check to the auto-open `useEffect` that triggers when `requiresWorkspace` changes from false to true
- Added `disabled` prop check to `handleRequiresWorkspaceToggle` callback as a defensive measure

## Problem

When entering a historical programming conversation page, the `UnifiedRepositorySelector` component receives `disabled={hasMessages}` which should be `true`. However, the popover was still auto-opening due to:

1. The `useEffect` at line 275-287 that auto-opens when `requiresWorkspace` changes didn't check the `disabled` prop
2. The `handleRequiresWorkspaceToggle` callback also had a code path that could open the popover without checking `disabled`

## Solution

Added `disabled` check to both auto-open triggers:

```typescript
// useEffect for requiresWorkspace change
if (disabled) return  // Skip auto-open when disabled

// handleRequiresWorkspaceToggle callback  
} else if (!disabled) {  // Only auto-open when NOT disabled
```

## Test plan

- [ ] Navigate to a new chat page - repository selector should work normally
- [ ] Switch team that requires workspace when no repo is selected - popover should auto-open
- [ ] Navigate to a historical conversation page - repository selector should be disabled and popover should NOT auto-open
- [ ] On historical page, verify the repository/branch information is still displayed correctly (synced from task detail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended auto-opening of repository and workspace popovers when the task selector is disabled.
  * Prevented repository/branch from being cleared via the clear control while the selector is disabled.
  * Improved handling of the disabled state so controls and popovers consistently respect being disabled, reducing unexpected UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->