### PR TITLE
fix(browser): improve relay interactions and browser skill guidance

### DIFF
--- a/deps/browser/relay-server/package-lock.json
+++ b/deps/browser/relay-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wegent/cdp-relay-server",
-  "version": "0.1.5",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@wb/wegent-cdp-relay-server",
-      "version": "0.1.5",
+      "name": "@wegent/cdp-relay-server",
+      "version": "0.1.11",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wegent/cdp-relay-server",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Chrome DevTools Protocol relay server and browser automation tool",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- improve relay browser interactions with P1 capabilities
  - add act support for scrollIntoView, close, evaluate
  - enhance act.wait with url, loadState, fn, timeoutMs
  - add element screenshot support via ref/element and type (png/jpeg)
- refine browser skill prompt for user-task completion reliability
  - prioritize success over hard call-count limits
  - clarify wait strategy, recovery, screenshot policy, and recommended flow
  - improve cross-platform CLI guidance with <BROWSER_TOOL_CMD>

## Files Changed
- deps/browser/relay-server/src/actions.ts
- deps/browser/relay-server/src/tool.ts
- backend/init_data/skills/browser/SKILL.md

## Validation
- npm run typecheck
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Element-targeted screenshot functionality supporting PNG and JPEG formats
  * New browser actions: scrollIntoView, close, and evaluate

* **Improvements**
  * Enhanced browser auto-attach and retry mechanisms with intelligent delay presets
  * Expanded wait conditions supporting URL matching and custom function evaluation
  * Improved stale reference handling and automatic recovery behavior for greater reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->