### PR TITLE
feat(knowledge): add document processing pipeline for smart splitting

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -428,6 +428,15 @@ class Settings(BaseSettings):
     # When enabled, chunk content is also saved to knowledge_documents.chunks column
     CHUNK_STORAGE_ENABLED: bool = False
 
+    # Docling document conversion service configuration
+    # Docling provides advanced document conversion for Office files (DOC, DOCX, PPT, PPTX, PDF)
+    # When configured, Docling takes priority over Pandoc for document conversion
+    # If Docling is unavailable, the system falls back to Pandoc (for Office files) or LlamaIndex (for PDF)
+    DOCLING_URL: Optional[str] = (
+        None  # Docling service URL, e.g., "http://localhost:8080"
+    )
+    DOCLING_TIMEOUT: int = 120  # Request timeout in seconds for Docling API calls
+
     # Long-term memory configuration (mem0)
     # Enable/disable long-term memory feature
     MEMORY_ENABLED: bool = False

--- a/backend/app/services/rag/index/indexer.py
+++ b/backend/app/services/rag/index/indexer.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from llama_index.core import Document, SimpleDirectoryReader
+from llama_index.core.schema import TextNode
 
 from app.schemas.rag import SmartSplitterConfig, SplitterConfig
 from app.services.rag.pipeline.factory import create_pipeline, should_use_pipeline
@@ -275,7 +276,7 @@ class DocumentIndexer:
                 chunk_overlap=chunk_overlap,
             )
         except ValueError as e:
-            logger.error(f"Failed to create pipeline for {file_extension}: {e}")
+            logger.exception(f"Failed to create pipeline for {file_extension}: {e}")
             # Fall back to LlamaIndex if pipeline creation fails
             logger.warning("Falling back to LlamaIndex processing")
             return self._index_with_llamaindex(
@@ -304,7 +305,7 @@ class DocumentIndexer:
                 source_file=source_file,
             )
         except Exception as e:
-            logger.error(f"Pipeline processing failed: {e}")
+            logger.exception(f"Pipeline processing failed: {e}")
             # For Office documents, we should not fall back to LlamaIndex
             # as LlamaIndex may not handle them well
             raise
@@ -379,8 +380,6 @@ class DocumentIndexer:
 
         # For pipeline documents, we need to convert them to nodes for the storage backend
         # Create simple text nodes from documents
-        from llama_index.core.schema import TextNode
-
         nodes = []
         for doc in documents:
             node = TextNode(

--- a/backend/app/services/rag/pipeline/__init__.py
+++ b/backend/app/services/rag/pipeline/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Document processing pipeline module.
+
+This module provides a pipeline architecture for processing documents
+through read -> convert -> split stages. Different pipeline implementations
+support various document formats and conversion methods (LlamaIndex, Pandoc, Docling).
+"""
+
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+from app.services.rag.pipeline.docling import DoclingPipeline
+from app.services.rag.pipeline.factory import create_pipeline, should_use_pipeline
+from app.services.rag.pipeline.llamaindex import LlamaIndexPipeline
+from app.services.rag.pipeline.pandoc import PandocPipeline
+
+__all__ = [
+    "BaseDocumentPipeline",
+    "LlamaIndexPipeline",
+    "PandocPipeline",
+    "DoclingPipeline",
+    "create_pipeline",
+    "should_use_pipeline",
+]

--- a/backend/app/services/rag/pipeline/base.py
+++ b/backend/app/services/rag/pipeline/base.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Base abstract class for document processing pipelines.
+
+A document pipeline consists of three stages:
+1. Read: Load raw binary data from file
+2. Convert: Transform content to Markdown (if applicable)
+3. Split: Chunk the content into Document nodes
+
+Different implementations handle different file types and conversion methods.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import List
+
+from llama_index.core import Document
+
+logger = logging.getLogger(__name__)
+
+
+class BaseDocumentPipeline(ABC):
+    """
+    Abstract base class for document processing pipelines.
+
+    Subclasses implement specific strategies for reading, converting,
+    and splitting different document types (e.g., LlamaIndex for general files,
+    Pandoc for Office documents, Docling for advanced document conversion).
+
+    Attributes:
+        chunk_size: Maximum chunk size in characters (default: 1024)
+        chunk_overlap: Number of characters to overlap between chunks (default: 50)
+    """
+
+    DEFAULT_CHUNK_SIZE = 1024
+    DEFAULT_CHUNK_OVERLAP = 50
+
+    def __init__(
+        self,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+    ):
+        """
+        Initialize the document pipeline.
+
+        Args:
+            chunk_size: Maximum chunk size in characters
+            chunk_overlap: Number of characters to overlap between chunks
+        """
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+
+    @abstractmethod
+    def read(self, binary_data: bytes, file_extension: str) -> bytes:
+        """
+        Read and prepare raw file content.
+
+        This stage may perform initial processing of the binary data,
+        such as decompression or format validation.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension (e.g., '.docx', '.pdf')
+
+        Returns:
+            Processed binary data ready for conversion
+
+        Raises:
+            ValueError: If file format is not supported
+            IOError: If file cannot be read
+        """
+        pass
+
+    @abstractmethod
+    def convert(self, content: bytes, file_extension: str) -> str:
+        """
+        Convert file content to Markdown or plain text.
+
+        This stage transforms the raw content into a text format
+        suitable for splitting. Some pipelines (like LlamaIndex)
+        may not perform actual conversion.
+
+        Args:
+            content: Binary content from read stage
+            file_extension: File extension for format detection
+
+        Returns:
+            Text content (Markdown or plain text)
+
+        Raises:
+            RuntimeError: If conversion fails
+        """
+        pass
+
+    @abstractmethod
+    def split(self, text_content: str) -> List[Document]:
+        """
+        Split text content into Document chunks.
+
+        This stage breaks the text into smaller pieces suitable
+        for embedding and retrieval.
+
+        Args:
+            text_content: Text content from convert stage
+
+        Returns:
+            List of LlamaIndex Document objects
+
+        Raises:
+            ValueError: If text content is empty
+        """
+        pass
+
+    def process(
+        self, binary_data: bytes, file_extension: str, source_file: str = ""
+    ) -> List[Document]:
+        """
+        Execute the full document processing pipeline.
+
+        This method orchestrates the read -> convert -> split flow,
+        providing consistent error handling and logging.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension (e.g., '.docx', '.pdf')
+            source_file: Original filename for metadata (optional)
+
+        Returns:
+            List of LlamaIndex Document objects with metadata
+
+        Raises:
+            Exception: If any pipeline stage fails
+        """
+        logger.info(
+            f"Processing document: extension={file_extension}, "
+            f"size={len(binary_data)} bytes, pipeline={self.__class__.__name__}"
+        )
+
+        # Stage 1: Read
+        content = self.read(binary_data, file_extension)
+        logger.debug(f"Read stage completed: {len(content)} bytes")
+
+        # Stage 2: Convert
+        text_content = self.convert(content, file_extension)
+        logger.debug(f"Convert stage completed: {len(text_content)} characters")
+
+        # Stage 3: Split
+        documents = self.split(text_content)
+        logger.info(f"Split stage completed: {len(documents)} documents created")
+
+        # Add source file metadata to all documents
+        if source_file:
+            for doc in documents:
+                if doc.metadata is None:
+                    doc.metadata = {}
+                doc.metadata["source_file"] = source_file
+                doc.metadata["pipeline"] = self.__class__.__name__
+
+        return documents
+
+    @classmethod
+    def get_supported_extensions(cls) -> set:
+        """
+        Get the set of file extensions supported by this pipeline.
+
+        Subclasses should override this method to declare their
+        supported file types.
+
+        Returns:
+            Set of supported file extensions (e.g., {'.pdf', '.docx'})
+        """
+        return set()
+
+    @classmethod
+    def supports_extension(cls, file_extension: str) -> bool:
+        """
+        Check if this pipeline supports the given file extension.
+
+        Args:
+            file_extension: File extension to check
+
+        Returns:
+            True if the extension is supported
+        """
+        return file_extension.lower() in cls.get_supported_extensions()

--- a/backend/app/services/rag/pipeline/docling.py
+++ b/backend/app/services/rag/pipeline/docling.py
@@ -1,0 +1,325 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Docling document processing pipeline.
+
+This pipeline uses the Docling API service to convert documents
+(DOC, DOCX, PPT, PPTX, PDF) to Markdown with advanced layout
+understanding and structure preservation.
+"""
+
+import logging
+from typing import List, Optional
+
+import httpx
+from llama_index.core import Document
+from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
+
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+
+logger = logging.getLogger(__name__)
+
+
+class DoclingServiceError(Exception):
+    """Raised when Docling API service call fails."""
+
+    pass
+
+
+class DoclingPipeline(BaseDocumentPipeline):
+    """
+    Document pipeline using Docling API for advanced document conversion.
+
+    Docling provides superior document understanding with:
+    - Advanced layout analysis
+    - Table extraction
+    - Figure detection
+    - Structure preservation
+
+    The service converts documents to Markdown format with OCR disabled
+    (as per requirements) for faster processing.
+
+    Suitable for:
+    - DOC/DOCX files (Word documents)
+    - PPT/PPTX files (PowerPoint presentations)
+    - PDF files (when Docling is configured)
+
+    Configuration:
+    - DOCLING_URL: Docling service endpoint
+    - DOCLING_TIMEOUT: Request timeout in seconds (default: 120)
+    """
+
+    # File extensions handled by this pipeline
+    SUPPORTED_EXTENSIONS = {".doc", ".docx", ".ppt", ".pptx", ".pdf"}
+
+    # Content type mapping for file upload
+    CONTENT_TYPE_MAP = {
+        ".doc": "application/msword",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".ppt": "application/vnd.ms-powerpoint",
+        ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ".pdf": "application/pdf",
+    }
+
+    def __init__(
+        self,
+        docling_url: str,
+        chunk_size: int = BaseDocumentPipeline.DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = BaseDocumentPipeline.DEFAULT_CHUNK_OVERLAP,
+        timeout: int = 120,
+    ):
+        """
+        Initialize Docling pipeline.
+
+        Args:
+            docling_url: Docling service URL endpoint
+            chunk_size: Maximum chunk size in characters
+            chunk_overlap: Number of characters to overlap between chunks
+            timeout: HTTP request timeout in seconds
+
+        Raises:
+            ValueError: If docling_url is empty
+        """
+        super().__init__(chunk_size, chunk_overlap)
+
+        if not docling_url:
+            raise ValueError("Docling URL is required")
+
+        self.docling_url = docling_url.rstrip("/")
+        self.timeout = timeout
+
+    @classmethod
+    def get_supported_extensions(cls) -> set:
+        """Get supported file extensions."""
+        return cls.SUPPORTED_EXTENSIONS
+
+    @classmethod
+    def is_service_available(cls, docling_url: str, timeout: int = 10) -> bool:
+        """
+        Check if Docling service is available.
+
+        Args:
+            docling_url: Docling service URL
+            timeout: Connection timeout in seconds
+
+        Returns:
+            True if service is reachable
+        """
+        if not docling_url:
+            return False
+
+        try:
+            # Try to reach the service health endpoint
+            with httpx.Client(timeout=timeout) as client:
+                # Try common health check endpoints
+                for endpoint in ["/health", "/api/health", "/"]:
+                    try:
+                        response = client.get(f"{docling_url.rstrip('/')}{endpoint}")
+                        if response.status_code < 500:
+                            return True
+                    except Exception:
+                        continue
+                return False
+        except Exception as e:
+            logger.debug(f"Docling service health check failed: {e}")
+            return False
+
+    def read(self, binary_data: bytes, file_extension: str) -> bytes:
+        """
+        Pass through binary data.
+
+        Docling conversion happens in the convert stage.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension
+
+        Returns:
+            Unchanged binary data
+        """
+        return binary_data
+
+    def convert(self, content: bytes, file_extension: str) -> str:
+        """
+        Convert document to Markdown using Docling API.
+
+        Sends the document to Docling service for conversion with
+        OCR disabled for faster processing.
+
+        API Request:
+        - Method: POST
+        - Content: multipart/form-data with file
+        - Parameters: output_format=markdown, ocr_enabled=false
+
+        API Response:
+        ```json
+        {
+            "document": {
+                "md_content": "Markdown content here..."
+            }
+        }
+        ```
+
+        Args:
+            content: Binary file content
+            file_extension: File extension for MIME type detection
+
+        Returns:
+            Markdown text content
+
+        Raises:
+            DoclingServiceError: If API call fails
+        """
+        ext = file_extension.lower()
+        content_type = self.CONTENT_TYPE_MAP.get(ext, "application/octet-stream")
+
+        # Prepare file for upload
+        filename = f"document{ext}"
+        files = {"file": (filename, content, content_type)}
+
+        # Request parameters - disable OCR for faster processing
+        params = {
+            "output_format": "markdown",
+            "ocr_enabled": "false",
+        }
+
+        try:
+            logger.info(
+                f"Calling Docling API: url={self.docling_url}, "
+                f"file_size={len(content)}, extension={ext}"
+            )
+
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.post(
+                    f"{self.docling_url}/convert",
+                    files=files,
+                    params=params,
+                )
+
+                if response.status_code != 200:
+                    error_detail = (
+                        response.text[:500] if response.text else "No details"
+                    )
+                    raise DoclingServiceError(
+                        f"Docling API returned status {response.status_code}: {error_detail}"
+                    )
+
+                result = response.json()
+
+                # Extract Markdown content from response
+                md_content = self._extract_markdown(result)
+
+                if not md_content:
+                    raise DoclingServiceError(
+                        "Docling API returned empty Markdown content"
+                    )
+
+                logger.info(
+                    f"Docling conversion successful: {len(content)} bytes -> "
+                    f"{len(md_content)} characters"
+                )
+
+                return md_content
+
+        except httpx.TimeoutException:
+            raise DoclingServiceError(
+                f"Docling API request timed out after {self.timeout} seconds"
+            )
+        except httpx.ConnectError as e:
+            raise DoclingServiceError(
+                f"Failed to connect to Docling service at {self.docling_url}: {e}"
+            )
+        except httpx.HTTPError as e:
+            raise DoclingServiceError(f"HTTP error during Docling conversion: {e}")
+
+    def _extract_markdown(self, response: dict) -> Optional[str]:
+        """
+        Extract Markdown content from Docling API response.
+
+        Handles various response formats that Docling might return.
+
+        Args:
+            response: JSON response from Docling API
+
+        Returns:
+            Markdown content string or None
+        """
+        # Primary format: {"document": {"md_content": "..."}}
+        if isinstance(response, dict):
+            document = response.get("document", {})
+            if isinstance(document, dict):
+                md_content = document.get("md_content")
+                if md_content:
+                    return md_content
+
+            # Alternative format: {"md_content": "..."}
+            md_content = response.get("md_content")
+            if md_content:
+                return md_content
+
+            # Another alternative: {"content": "..."}
+            content = response.get("content")
+            if content:
+                return content
+
+            # Direct markdown in response: {"markdown": "..."}
+            markdown = response.get("markdown")
+            if markdown:
+                return markdown
+
+        return None
+
+    def split(self, text_content: str) -> List[Document]:
+        """
+        Split Markdown content into Document chunks.
+
+        Uses a two-pass splitting strategy optimized for Markdown:
+        1. First pass: Split by Markdown structure (headers)
+        2. Second pass: Apply sentence splitting for large sections
+
+        Args:
+            text_content: Markdown text content
+
+        Returns:
+            List of Document objects
+        """
+        if not text_content.strip():
+            logger.warning("Empty text content received for splitting")
+            return []
+
+        # Create initial Document
+        doc = Document(text=text_content)
+
+        # First pass: Split by Markdown structure (headers)
+        markdown_parser = MarkdownNodeParser()
+        nodes = markdown_parser.get_nodes_from_documents([doc])
+
+        # Second pass: Apply sentence splitting to large nodes
+        sentence_splitter = SentenceSplitter(
+            chunk_size=self.chunk_size,
+            chunk_overlap=self.chunk_overlap,
+        )
+
+        # Convert nodes back to documents for second pass
+        intermediate_docs = [
+            Document(
+                text=node.text,
+                metadata=node.metadata if hasattr(node, "metadata") else {},
+            )
+            for node in nodes
+        ]
+
+        final_nodes = sentence_splitter.get_nodes_from_documents(intermediate_docs)
+
+        logger.info(f"Docling split created {len(final_nodes)} chunks")
+
+        # Convert nodes to Documents
+        return [
+            Document(
+                text=node.text,
+                metadata=node.metadata if hasattr(node, "metadata") else {},
+            )
+            for node in final_nodes
+        ]

--- a/backend/app/services/rag/pipeline/factory.py
+++ b/backend/app/services/rag/pipeline/factory.py
@@ -25,7 +25,7 @@ from typing import Optional
 
 from app.core.config import settings
 from app.services.rag.pipeline.base import BaseDocumentPipeline
-from app.services.rag.pipeline.docling import DoclingPipeline, DoclingServiceError
+from app.services.rag.pipeline.docling import DoclingPipeline
 from app.services.rag.pipeline.llamaindex import LlamaIndexPipeline
 from app.services.rag.pipeline.pandoc import (
     PandocNotFoundError,
@@ -231,7 +231,7 @@ def _try_create_docling_pipeline(
         return None
 
     docling_url = settings.DOCLING_URL
-    docling_timeout = getattr(settings, "DOCLING_TIMEOUT", 120)
+    docling_timeout = settings.DOCLING_TIMEOUT
 
     # Check if service is available
     if not DoclingPipeline.is_service_available(docling_url):

--- a/backend/app/services/rag/pipeline/factory.py
+++ b/backend/app/services/rag/pipeline/factory.py
@@ -1,0 +1,342 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Factory for creating document processing pipelines.
+
+This factory determines the appropriate pipeline based on file type
+and available services (Docling, Pandoc, LlamaIndex), with automatic
+fallback when services are unavailable.
+
+Pipeline Selection Strategy:
+1. DOC/DOCX/PPT/PPTX:
+   - If Docling is configured and available -> DoclingPipeline
+   - Else -> PandocPipeline (with Pandoc availability check)
+2. PDF:
+   - If Docling is configured and available -> DoclingPipeline
+   - Else -> LlamaIndexPipeline (default)
+3. Other files (TXT, MD, etc.):
+   -> LlamaIndexPipeline
+"""
+
+import logging
+from typing import Optional
+
+from app.core.config import settings
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+from app.services.rag.pipeline.docling import DoclingPipeline, DoclingServiceError
+from app.services.rag.pipeline.llamaindex import LlamaIndexPipeline
+from app.services.rag.pipeline.pandoc import (
+    PandocNotFoundError,
+    PandocPipeline,
+)
+
+logger = logging.getLogger(__name__)
+
+# File extensions that require conversion (not natively supported by LlamaIndex well)
+OFFICE_EXTENSIONS = {".doc", ".docx", ".ppt", ".pptx"}
+
+# PDF can benefit from Docling but LlamaIndex handles it well too
+PDF_EXTENSIONS = {".pdf"}
+
+# Extensions that LlamaIndex handles natively
+LLAMAINDEX_EXTENSIONS = {".txt", ".md", ".json", ".csv"}
+
+
+def should_use_pipeline(file_extension: str) -> bool:
+    """
+    Check if the given file extension should use the new pipeline architecture.
+
+    The pipeline architecture is used for:
+    - Office documents (DOC, DOCX, PPT, PPTX) - always use pipeline
+    - PDF files when Docling is configured
+
+    Args:
+        file_extension: File extension to check (e.g., '.docx')
+
+    Returns:
+        True if pipeline should be used for this file type
+    """
+    ext = file_extension.lower()
+
+    # Office documents always use pipeline (Docling or Pandoc)
+    if ext in OFFICE_EXTENSIONS:
+        return True
+
+    # PDF uses pipeline only if Docling is configured
+    if ext in PDF_EXTENSIONS and _is_docling_configured():
+        return True
+
+    return False
+
+
+def create_pipeline(
+    file_extension: str,
+    chunk_size: int = BaseDocumentPipeline.DEFAULT_CHUNK_SIZE,
+    chunk_overlap: int = BaseDocumentPipeline.DEFAULT_CHUNK_OVERLAP,
+) -> BaseDocumentPipeline:
+    """
+    Create the appropriate document pipeline for the given file type.
+
+    Pipeline selection logic:
+    1. DOC/DOCX/PPT/PPTX:
+       - Try Docling first (if configured)
+       - Fall back to Pandoc
+    2. PDF:
+       - Try Docling (if configured)
+       - Fall back to LlamaIndex
+    3. Other files:
+       - Use LlamaIndex
+
+    Args:
+        file_extension: File extension (e.g., '.docx', '.pdf')
+        chunk_size: Maximum chunk size in characters
+        chunk_overlap: Number of characters to overlap between chunks
+
+    Returns:
+        Appropriate pipeline instance
+
+    Raises:
+        ValueError: If no suitable pipeline can be created
+    """
+    ext = file_extension.lower()
+
+    logger.info(f"Creating pipeline for extension: {ext}")
+
+    # Handle Office documents (DOC, DOCX, PPT, PPTX)
+    if ext in OFFICE_EXTENSIONS:
+        return _create_office_pipeline(ext, chunk_size, chunk_overlap)
+
+    # Handle PDF files
+    if ext in PDF_EXTENSIONS:
+        return _create_pdf_pipeline(ext, chunk_size, chunk_overlap)
+
+    # Default to LlamaIndex for other file types
+    return LlamaIndexPipeline(
+        file_extension=ext,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+
+def _create_office_pipeline(
+    file_extension: str,
+    chunk_size: int,
+    chunk_overlap: int,
+) -> BaseDocumentPipeline:
+    """
+    Create pipeline for Office documents.
+
+    Priority:
+    1. DoclingPipeline (if configured and available)
+    2. PandocPipeline (if Pandoc is installed)
+
+    Args:
+        file_extension: File extension
+        chunk_size: Maximum chunk size
+        chunk_overlap: Overlap between chunks
+
+    Returns:
+        Pipeline instance
+
+    Raises:
+        ValueError: If neither Docling nor Pandoc is available
+    """
+    # Try Docling first
+    docling_pipeline = _try_create_docling_pipeline(chunk_size, chunk_overlap)
+    if docling_pipeline:
+        logger.info(f"Using DoclingPipeline for {file_extension}")
+        return docling_pipeline
+
+    # Fall back to Pandoc
+    pandoc_pipeline = _try_create_pandoc_pipeline(chunk_size, chunk_overlap)
+    if pandoc_pipeline:
+        logger.info(f"Using PandocPipeline for {file_extension}")
+        return pandoc_pipeline
+
+    # No suitable pipeline available
+    raise ValueError(
+        f"Cannot process {file_extension} files: "
+        "Docling is not configured and Pandoc is not installed. "
+        "Please configure DOCLING_URL or install Pandoc."
+    )
+
+
+def _create_pdf_pipeline(
+    file_extension: str,
+    chunk_size: int,
+    chunk_overlap: int,
+) -> BaseDocumentPipeline:
+    """
+    Create pipeline for PDF files.
+
+    Priority:
+    1. DoclingPipeline (if configured and available)
+    2. LlamaIndexPipeline (default fallback)
+
+    Args:
+        file_extension: File extension
+        chunk_size: Maximum chunk size
+        chunk_overlap: Overlap between chunks
+
+    Returns:
+        Pipeline instance
+    """
+    # Try Docling first
+    docling_pipeline = _try_create_docling_pipeline(chunk_size, chunk_overlap)
+    if docling_pipeline:
+        logger.info(f"Using DoclingPipeline for {file_extension}")
+        return docling_pipeline
+
+    # Fall back to LlamaIndex
+    logger.info(f"Using LlamaIndexPipeline for {file_extension}")
+    return LlamaIndexPipeline(
+        file_extension=file_extension,
+        chunk_size=chunk_size,
+        chunk_overlap=chunk_overlap,
+    )
+
+
+def _is_docling_configured() -> bool:
+    """
+    Check if Docling is configured in settings.
+
+    Returns:
+        True if DOCLING_URL is set
+    """
+    docling_url = getattr(settings, "DOCLING_URL", None)
+    return bool(docling_url and docling_url.strip())
+
+
+def _try_create_docling_pipeline(
+    chunk_size: int,
+    chunk_overlap: int,
+) -> Optional[DoclingPipeline]:
+    """
+    Try to create a DoclingPipeline.
+
+    Checks if Docling is configured and the service is available.
+    Returns None if Docling cannot be used.
+
+    Args:
+        chunk_size: Maximum chunk size
+        chunk_overlap: Overlap between chunks
+
+    Returns:
+        DoclingPipeline instance or None
+    """
+    if not _is_docling_configured():
+        logger.debug("Docling not configured (DOCLING_URL not set)")
+        return None
+
+    docling_url = settings.DOCLING_URL
+    docling_timeout = getattr(settings, "DOCLING_TIMEOUT", 120)
+
+    # Check if service is available
+    if not DoclingPipeline.is_service_available(docling_url):
+        logger.warning(
+            f"Docling service at {docling_url} is not available, "
+            "falling back to alternative pipeline"
+        )
+        return None
+
+    try:
+        return DoclingPipeline(
+            docling_url=docling_url,
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+            timeout=docling_timeout,
+        )
+    except Exception as e:
+        logger.warning(f"Failed to create DoclingPipeline: {e}")
+        return None
+
+
+def _try_create_pandoc_pipeline(
+    chunk_size: int,
+    chunk_overlap: int,
+) -> Optional[PandocPipeline]:
+    """
+    Try to create a PandocPipeline.
+
+    Checks if Pandoc is installed on the system.
+    Returns None if Pandoc is not available.
+
+    Args:
+        chunk_size: Maximum chunk size
+        chunk_overlap: Overlap between chunks
+
+    Returns:
+        PandocPipeline instance or None
+    """
+    if not PandocPipeline.is_pandoc_available():
+        logger.debug("Pandoc is not installed")
+        return None
+
+    try:
+        return PandocPipeline(
+            chunk_size=chunk_size,
+            chunk_overlap=chunk_overlap,
+        )
+    except PandocNotFoundError as e:
+        logger.warning(f"Pandoc not available: {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"Failed to create PandocPipeline: {e}")
+        return None
+
+
+def get_pipeline_info(file_extension: str) -> dict:
+    """
+    Get information about which pipeline would be used for a file type.
+
+    Useful for debugging and API responses.
+
+    Args:
+        file_extension: File extension to check
+
+    Returns:
+        Dictionary with pipeline selection details
+    """
+    ext = file_extension.lower()
+
+    info = {
+        "file_extension": ext,
+        "docling_configured": _is_docling_configured(),
+        "docling_url": (
+            getattr(settings, "DOCLING_URL", None) if _is_docling_configured() else None
+        ),
+        "pandoc_available": PandocPipeline.is_pandoc_available(),
+        "requires_pipeline": should_use_pipeline(ext),
+        "recommended_pipeline": None,
+    }
+
+    if ext in OFFICE_EXTENSIONS:
+        if _is_docling_configured():
+            docling_url = settings.DOCLING_URL
+            if DoclingPipeline.is_service_available(docling_url):
+                info["recommended_pipeline"] = "DoclingPipeline"
+            elif PandocPipeline.is_pandoc_available():
+                info["recommended_pipeline"] = "PandocPipeline (Docling unavailable)"
+        elif PandocPipeline.is_pandoc_available():
+            info["recommended_pipeline"] = "PandocPipeline"
+        else:
+            info["recommended_pipeline"] = "None (install Pandoc or configure Docling)"
+
+    elif ext in PDF_EXTENSIONS:
+        if _is_docling_configured():
+            docling_url = settings.DOCLING_URL
+            if DoclingPipeline.is_service_available(docling_url):
+                info["recommended_pipeline"] = "DoclingPipeline"
+            else:
+                info["recommended_pipeline"] = (
+                    "LlamaIndexPipeline (Docling unavailable)"
+                )
+        else:
+            info["recommended_pipeline"] = "LlamaIndexPipeline"
+
+    else:
+        info["recommended_pipeline"] = "LlamaIndexPipeline"
+
+    return info

--- a/backend/app/services/rag/pipeline/llamaindex.py
+++ b/backend/app/services/rag/pipeline/llamaindex.py
@@ -1,0 +1,248 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+LlamaIndex document processing pipeline.
+
+This pipeline uses LlamaIndex's SimpleDirectoryReader for document parsing
+and the existing splitter infrastructure for chunking. It serves as the
+default pipeline for file types that don't require special conversion.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import List
+
+from llama_index.core import Document, SimpleDirectoryReader
+from llama_index.core.node_parser import SentenceSplitter
+
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+from app.services.rag.splitter.smart import SmartSplitter
+
+logger = logging.getLogger(__name__)
+
+
+class LlamaIndexPipeline(BaseDocumentPipeline):
+    """
+    Document pipeline using LlamaIndex's built-in parsing capabilities.
+
+    This pipeline leverages SimpleDirectoryReader to parse various document
+    formats (PDF, TXT, MD, etc.) and uses SmartSplitter or SentenceSplitter
+    for chunking based on file type.
+
+    Suitable for:
+    - PDF files (when Docling is not configured)
+    - TXT files
+    - Markdown files
+    - Other formats supported by LlamaIndex
+    """
+
+    # File extensions handled by this pipeline
+    SUPPORTED_EXTENSIONS = {".pdf", ".txt", ".md", ".json", ".csv"}
+
+    def __init__(
+        self,
+        file_extension: str,
+        chunk_size: int = BaseDocumentPipeline.DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = BaseDocumentPipeline.DEFAULT_CHUNK_OVERLAP,
+    ):
+        """
+        Initialize LlamaIndex pipeline.
+
+        Args:
+            file_extension: File extension for splitter strategy selection
+            chunk_size: Maximum chunk size in characters
+            chunk_overlap: Number of characters to overlap between chunks
+        """
+        super().__init__(chunk_size, chunk_overlap)
+        self.file_extension = file_extension.lower()
+
+    @classmethod
+    def get_supported_extensions(cls) -> set:
+        """Get supported file extensions."""
+        return cls.SUPPORTED_EXTENSIONS
+
+    def read(self, binary_data: bytes, file_extension: str) -> bytes:
+        """
+        Pass through binary data for LlamaIndex processing.
+
+        LlamaIndex's SimpleDirectoryReader handles file reading internally,
+        so this stage simply returns the binary data unchanged.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension
+
+        Returns:
+            Unchanged binary data
+        """
+        return binary_data
+
+    def convert(self, content: bytes, file_extension: str) -> str:
+        """
+        Convert binary content to text using LlamaIndex.
+
+        This method writes the binary data to a temporary file and uses
+        SimpleDirectoryReader to extract text content.
+
+        Args:
+            content: Binary file content
+            file_extension: File extension for format detection
+
+        Returns:
+            Extracted text content
+        """
+        # Write to temporary file for SimpleDirectoryReader
+        with tempfile.NamedTemporaryFile(
+            suffix=file_extension, delete=False
+        ) as tmp_file:
+            tmp_file.write(content)
+            tmp_file_path = tmp_file.name
+
+        try:
+            # Use LlamaIndex to parse the document
+            documents = SimpleDirectoryReader(input_files=[tmp_file_path]).load_data()
+
+            # Combine all document texts
+            text_parts = []
+            for doc in documents:
+                if doc.text:
+                    text_parts.append(doc.text)
+
+            return "\n\n".join(text_parts)
+
+        finally:
+            # Clean up temporary file
+            try:
+                Path(tmp_file_path).unlink()
+            except Exception as e:
+                logger.warning(f"Failed to delete temporary file {tmp_file_path}: {e}")
+
+    def split(self, text_content: str) -> List[Document]:
+        """
+        Split text content into Document chunks.
+
+        Uses SmartSplitter for appropriate chunking based on file type,
+        or SentenceSplitter as fallback.
+
+        Args:
+            text_content: Text content to split
+
+        Returns:
+            List of Document objects
+        """
+        if not text_content.strip():
+            logger.warning("Empty text content received for splitting")
+            return []
+
+        # Create a Document from the text content
+        doc = Document(text=text_content)
+
+        # Use SmartSplitter if file type is supported
+        if SmartSplitter.supports_smart_split(self.file_extension):
+            splitter = SmartSplitter(
+                file_extension=self.file_extension,
+                chunk_size=self.chunk_size,
+                chunk_overlap=self.chunk_overlap,
+            )
+            nodes = splitter.split_documents([doc])
+        else:
+            # Fallback to sentence splitting
+            sentence_splitter = SentenceSplitter(
+                chunk_size=self.chunk_size,
+                chunk_overlap=self.chunk_overlap,
+            )
+            nodes = sentence_splitter.get_nodes_from_documents([doc])
+
+        # Convert nodes back to Documents
+        return [
+            Document(
+                text=node.text,
+                metadata=node.metadata if hasattr(node, "metadata") else {},
+            )
+            for node in nodes
+        ]
+
+    def process(
+        self, binary_data: bytes, file_extension: str, source_file: str = ""
+    ) -> List[Document]:
+        """
+        Process document using optimized LlamaIndex flow.
+
+        This overrides the base process method to provide a more efficient
+        flow that avoids unnecessary text extraction when we can directly
+        use SimpleDirectoryReader's document output.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension
+            source_file: Original filename for metadata
+
+        Returns:
+            List of Document objects
+        """
+        logger.info(
+            f"Processing document with LlamaIndexPipeline: "
+            f"extension={file_extension}, size={len(binary_data)} bytes"
+        )
+
+        # Write to temporary file
+        with tempfile.NamedTemporaryFile(
+            suffix=file_extension, delete=False
+        ) as tmp_file:
+            tmp_file.write(binary_data)
+            tmp_file_path = tmp_file.name
+
+        try:
+            # Parse document with LlamaIndex
+            documents = SimpleDirectoryReader(input_files=[tmp_file_path]).load_data()
+
+            # Update metadata
+            if source_file:
+                filename_without_ext = Path(source_file).stem
+                for doc in documents:
+                    if doc.metadata is None:
+                        doc.metadata = {}
+                    doc.metadata["filename"] = filename_without_ext
+                    doc.metadata["source_file"] = source_file
+                    doc.metadata["pipeline"] = self.__class__.__name__
+
+            # Split documents
+            if SmartSplitter.supports_smart_split(file_extension):
+                splitter = SmartSplitter(
+                    file_extension=file_extension,
+                    chunk_size=self.chunk_size,
+                    chunk_overlap=self.chunk_overlap,
+                )
+                nodes = splitter.split_documents(documents)
+            else:
+                sentence_splitter = SentenceSplitter(
+                    chunk_size=self.chunk_size,
+                    chunk_overlap=self.chunk_overlap,
+                )
+                nodes = sentence_splitter.get_nodes_from_documents(documents)
+
+            logger.info(f"LlamaIndexPipeline created {len(nodes)} chunks")
+
+            # Convert nodes to Documents
+            result_docs = []
+            for node in nodes:
+                doc = Document(
+                    text=node.text,
+                    metadata=node.metadata if hasattr(node, "metadata") else {},
+                )
+                if source_file and "source_file" not in doc.metadata:
+                    doc.metadata["source_file"] = source_file
+                    doc.metadata["pipeline"] = self.__class__.__name__
+                result_docs.append(doc)
+
+            return result_docs
+
+        finally:
+            # Clean up
+            try:
+                Path(tmp_file_path).unlink()
+            except Exception as e:
+                logger.warning(f"Failed to delete temporary file {tmp_file_path}: {e}")

--- a/backend/app/services/rag/pipeline/pandoc.py
+++ b/backend/app/services/rag/pipeline/pandoc.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Pandoc document processing pipeline.
+
+This pipeline uses Pandoc (via subprocess) to convert Office documents
+(DOC, DOCX, PPT, PPTX) to Markdown, then uses the existing splitter
+infrastructure for Markdown-aware chunking.
+"""
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from llama_index.core import Document
+from llama_index.core.node_parser import MarkdownNodeParser, SentenceSplitter
+
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+
+logger = logging.getLogger(__name__)
+
+
+class PandocNotFoundError(Exception):
+    """Raised when Pandoc is not installed or not found in PATH."""
+
+    pass
+
+
+class PandocConversionError(Exception):
+    """Raised when Pandoc conversion fails."""
+
+    pass
+
+
+class PandocPipeline(BaseDocumentPipeline):
+    """
+    Document pipeline using Pandoc for Office document conversion.
+
+    This pipeline converts DOC, DOCX, PPT, and PPTX files to Markdown
+    using Pandoc's command-line interface, then applies Markdown-aware
+    splitting for optimal chunking.
+
+    Prerequisites:
+    - Pandoc must be installed and available in PATH
+    - For PPT/PPTX, Pandoc 2.x or higher is recommended
+
+    Suitable for:
+    - DOC/DOCX files (Word documents)
+    - PPT/PPTX files (PowerPoint presentations)
+    """
+
+    # File extensions handled by this pipeline
+    SUPPORTED_EXTENSIONS = {".doc", ".docx", ".ppt", ".pptx"}
+
+    # Pandoc input format mapping
+    INPUT_FORMAT_MAP = {
+        ".doc": "doc",
+        ".docx": "docx",
+        ".ppt": "pptx",  # Pandoc uses pptx for both
+        ".pptx": "pptx",
+    }
+
+    def __init__(
+        self,
+        chunk_size: int = BaseDocumentPipeline.DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = BaseDocumentPipeline.DEFAULT_CHUNK_OVERLAP,
+    ):
+        """
+        Initialize Pandoc pipeline.
+
+        Args:
+            chunk_size: Maximum chunk size in characters
+            chunk_overlap: Number of characters to overlap between chunks
+
+        Raises:
+            PandocNotFoundError: If Pandoc is not installed
+        """
+        super().__init__(chunk_size, chunk_overlap)
+        self._verify_pandoc_installed()
+
+    @classmethod
+    def get_supported_extensions(cls) -> set:
+        """Get supported file extensions."""
+        return cls.SUPPORTED_EXTENSIONS
+
+    @classmethod
+    def is_pandoc_available(cls) -> bool:
+        """
+        Check if Pandoc is available on the system.
+
+        Returns:
+            True if Pandoc is installed and accessible
+        """
+        return shutil.which("pandoc") is not None
+
+    def _verify_pandoc_installed(self) -> None:
+        """
+        Verify that Pandoc is installed and accessible.
+
+        Raises:
+            PandocNotFoundError: If Pandoc is not found
+        """
+        if not self.is_pandoc_available():
+            raise PandocNotFoundError(
+                "Pandoc is not installed or not found in PATH. "
+                "Please install Pandoc: https://pandoc.org/installing.html"
+            )
+
+    def _get_pandoc_version(self) -> Optional[str]:
+        """
+        Get the installed Pandoc version.
+
+        Returns:
+            Version string or None if unable to determine
+        """
+        try:
+            result = subprocess.run(
+                ["pandoc", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                # First line contains version info
+                first_line = result.stdout.split("\n")[0]
+                return first_line
+        except Exception as e:
+            logger.warning(f"Failed to get Pandoc version: {e}")
+        return None
+
+    def read(self, binary_data: bytes, file_extension: str) -> bytes:
+        """
+        Pass through binary data.
+
+        Pandoc conversion happens in the convert stage.
+
+        Args:
+            binary_data: Raw binary file content
+            file_extension: File extension
+
+        Returns:
+            Unchanged binary data
+        """
+        return binary_data
+
+    def convert(self, content: bytes, file_extension: str) -> str:
+        """
+        Convert Office document to Markdown using Pandoc.
+
+        This method writes the binary data to a temporary file,
+        invokes Pandoc to convert it to Markdown, and returns
+        the converted text.
+
+        Args:
+            content: Binary file content
+            file_extension: File extension for format detection
+
+        Returns:
+            Markdown text content
+
+        Raises:
+            PandocConversionError: If conversion fails
+        """
+        ext = file_extension.lower()
+        input_format = self.INPUT_FORMAT_MAP.get(ext)
+
+        if not input_format:
+            raise PandocConversionError(
+                f"Unsupported file extension for Pandoc: {file_extension}"
+            )
+
+        # Create temporary files for input and output
+        with tempfile.NamedTemporaryFile(
+            suffix=file_extension, delete=False
+        ) as input_file:
+            input_file.write(content)
+            input_path = input_file.name
+
+        output_path = input_path + ".md"
+
+        try:
+            # Build Pandoc command
+            cmd = [
+                "pandoc",
+                "-f",
+                input_format,
+                "-t",
+                "markdown",
+                input_path,
+                "-o",
+                output_path,
+                "--wrap=none",  # Disable line wrapping for better splitting
+            ]
+
+            logger.debug(f"Running Pandoc command: {' '.join(cmd)}")
+
+            # Execute Pandoc
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=120,  # 2 minute timeout
+            )
+
+            if result.returncode != 0:
+                error_msg = result.stderr or result.stdout or "Unknown error"
+                raise PandocConversionError(
+                    f"Pandoc conversion failed (exit code {result.returncode}): {error_msg}"
+                )
+
+            # Read converted Markdown
+            markdown_content = Path(output_path).read_text(encoding="utf-8")
+            logger.info(
+                f"Pandoc conversion successful: {len(content)} bytes -> "
+                f"{len(markdown_content)} characters"
+            )
+
+            return markdown_content
+
+        except subprocess.TimeoutExpired:
+            raise PandocConversionError("Pandoc conversion timed out after 120 seconds")
+        except FileNotFoundError:
+            raise PandocConversionError(f"Pandoc output file not found: {output_path}")
+        finally:
+            # Clean up temporary files
+            for path in [input_path, output_path]:
+                try:
+                    Path(path).unlink(missing_ok=True)
+                except Exception as e:
+                    logger.warning(f"Failed to delete temporary file {path}: {e}")
+
+    def split(self, text_content: str) -> List[Document]:
+        """
+        Split Markdown content into Document chunks.
+
+        Uses a two-pass splitting strategy optimized for Markdown:
+        1. First pass: Split by Markdown structure (headers)
+        2. Second pass: Apply sentence splitting for large sections
+
+        Args:
+            text_content: Markdown text content
+
+        Returns:
+            List of Document objects
+        """
+        if not text_content.strip():
+            logger.warning("Empty text content received for splitting")
+            return []
+
+        # Create initial Document
+        doc = Document(text=text_content)
+
+        # First pass: Split by Markdown structure (headers)
+        markdown_parser = MarkdownNodeParser()
+        nodes = markdown_parser.get_nodes_from_documents([doc])
+
+        # Second pass: Apply sentence splitting to large nodes
+        sentence_splitter = SentenceSplitter(
+            chunk_size=self.chunk_size,
+            chunk_overlap=self.chunk_overlap,
+        )
+
+        # Convert nodes back to documents for second pass
+        intermediate_docs = [
+            Document(
+                text=node.text,
+                metadata=node.metadata if hasattr(node, "metadata") else {},
+            )
+            for node in nodes
+        ]
+
+        final_nodes = sentence_splitter.get_nodes_from_documents(intermediate_docs)
+
+        logger.info(f"Pandoc split created {len(final_nodes)} chunks")
+
+        # Convert nodes to Documents
+        return [
+            Document(
+                text=node.text,
+                metadata=node.metadata if hasattr(node, "metadata") else {},
+            )
+            for node in final_nodes
+        ]

--- a/backend/app/services/rag/splitter/smart.py
+++ b/backend/app/services/rag/splitter/smart.py
@@ -9,7 +9,7 @@ based on file type.
 Supported file types and their strategies:
 - .md: Markdown structure splitting + sentence splitting
 - .txt: Sentence-based splitting
-- .pdf, .doc, .docx: Recursive character splitting (via LangChain)
+- .pdf, .doc, .docx, .ppt, .pptx: Recursive character splitting (via LangChain)
 """
 
 from typing import List

--- a/backend/app/services/rag/splitter/smart.py
+++ b/backend/app/services/rag/splitter/smart.py
@@ -33,13 +33,17 @@ class SmartSplitter:
     - Markdown (.md): First splits by markdown structure (headers), then
       applies sentence splitting for large sections
     - Text (.txt): Uses sentence-based splitting
-    - PDF/DOC/DOCX: Uses recursive character splitting via LangChain
+    - PDF/DOC/DOCX/PPT/PPTX: Uses recursive character splitting via LangChain
 
     All strategies use unified chunk_size=1024 and chunk_overlap=50.
+
+    Note: For Office documents (DOC, DOCX, PPT, PPTX), the DocumentIndexer
+    may use the pipeline architecture (Docling or Pandoc) to convert them
+    to Markdown first, which provides better structure preservation.
     """
 
     # File extensions that support smart splitting
-    SMART_EXTENSIONS = {".pdf", ".txt", ".doc", ".docx", ".md"}
+    SMART_EXTENSIONS = {".pdf", ".txt", ".doc", ".docx", ".ppt", ".pptx", ".md"}
 
     # Default configuration
     DEFAULT_CHUNK_SIZE = 1024
@@ -94,7 +98,7 @@ class SmartSplitter:
         elif self.file_extension == ".txt":
             return self._split_text(documents)
         else:
-            # PDF, DOC, DOCX use recursive character splitting
+            # PDF, DOC, DOCX, PPT, PPTX use recursive character splitting
             return self._split_recursive(documents)
 
     def _split_markdown(self, documents: List[Document]) -> List[BaseNode]:

--- a/backend/tests/services/rag/pipeline/__init__.py
+++ b/backend/tests/services/rag/pipeline/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/backend/tests/services/rag/pipeline/test_pipeline.py
+++ b/backend/tests/services/rag/pipeline/test_pipeline.py
@@ -1,0 +1,446 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for document processing pipeline components.
+"""
+
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from llama_index.core import Document
+
+from app.services.rag.pipeline.base import BaseDocumentPipeline
+from app.services.rag.pipeline.docling import (
+    DoclingPipeline,
+    DoclingServiceError,
+)
+from app.services.rag.pipeline.factory import (
+    OFFICE_EXTENSIONS,
+    PDF_EXTENSIONS,
+    create_pipeline,
+    get_pipeline_info,
+    should_use_pipeline,
+)
+from app.services.rag.pipeline.llamaindex import LlamaIndexPipeline
+from app.services.rag.pipeline.pandoc import (
+    PandocConversionError,
+    PandocNotFoundError,
+    PandocPipeline,
+)
+
+
+class TestBaseDocumentPipeline:
+    """Tests for the abstract base class."""
+
+    def test_base_class_cannot_be_instantiated(self):
+        """Test that BaseDocumentPipeline cannot be instantiated directly."""
+        with pytest.raises(TypeError):
+            BaseDocumentPipeline()
+
+    def test_default_chunk_size_and_overlap(self):
+        """Test default chunk size and overlap values."""
+        assert BaseDocumentPipeline.DEFAULT_CHUNK_SIZE == 1024
+        assert BaseDocumentPipeline.DEFAULT_CHUNK_OVERLAP == 50
+
+
+class TestLlamaIndexPipeline:
+    """Tests for LlamaIndexPipeline."""
+
+    def test_init_with_defaults(self):
+        """Test initialization with default values."""
+        pipeline = LlamaIndexPipeline(file_extension=".pdf")
+        assert pipeline.file_extension == ".pdf"
+        assert pipeline.chunk_size == 1024
+        assert pipeline.chunk_overlap == 50
+
+    def test_init_with_custom_values(self):
+        """Test initialization with custom values."""
+        pipeline = LlamaIndexPipeline(
+            file_extension=".txt",
+            chunk_size=512,
+            chunk_overlap=100,
+        )
+        assert pipeline.file_extension == ".txt"
+        assert pipeline.chunk_size == 512
+        assert pipeline.chunk_overlap == 100
+
+    def test_supported_extensions(self):
+        """Test supported extensions class method."""
+        extensions = LlamaIndexPipeline.get_supported_extensions()
+        assert ".pdf" in extensions
+        assert ".txt" in extensions
+        assert ".md" in extensions
+
+    def test_read_passes_through_binary_data(self):
+        """Test that read() returns binary data unchanged."""
+        pipeline = LlamaIndexPipeline(file_extension=".txt")
+        data = b"Hello, World!"
+        result = pipeline.read(data, ".txt")
+        assert result == data
+
+    def test_split_empty_content(self):
+        """Test split() with empty content."""
+        pipeline = LlamaIndexPipeline(file_extension=".txt")
+        result = pipeline.split("")
+        assert result == []
+
+    def test_split_whitespace_only(self):
+        """Test split() with whitespace-only content."""
+        pipeline = LlamaIndexPipeline(file_extension=".txt")
+        result = pipeline.split("   \n\n   ")
+        assert result == []
+
+
+class TestPandocPipeline:
+    """Tests for PandocPipeline."""
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_is_pandoc_available_true(self, mock_which):
+        """Test Pandoc availability check when Pandoc is installed."""
+        mock_which.return_value = "/usr/bin/pandoc"
+        assert PandocPipeline.is_pandoc_available() is True
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_is_pandoc_available_false(self, mock_which):
+        """Test Pandoc availability check when Pandoc is not installed."""
+        mock_which.return_value = None
+        assert PandocPipeline.is_pandoc_available() is False
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_init_raises_when_pandoc_not_found(self, mock_which):
+        """Test that initialization raises error when Pandoc is not found."""
+        mock_which.return_value = None
+        with pytest.raises(PandocNotFoundError):
+            PandocPipeline()
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_supported_extensions(self, mock_which):
+        """Test supported extensions."""
+        mock_which.return_value = "/usr/bin/pandoc"
+        extensions = PandocPipeline.get_supported_extensions()
+        assert ".doc" in extensions
+        assert ".docx" in extensions
+        assert ".ppt" in extensions
+        assert ".pptx" in extensions
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_read_passes_through_binary_data(self, mock_which):
+        """Test that read() returns binary data unchanged."""
+        mock_which.return_value = "/usr/bin/pandoc"
+        pipeline = PandocPipeline()
+        data = b"Test document content"
+        result = pipeline.read(data, ".docx")
+        assert result == data
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_convert_unsupported_format(self, mock_which):
+        """Test convert() with unsupported file format."""
+        mock_which.return_value = "/usr/bin/pandoc"
+        pipeline = PandocPipeline()
+        with pytest.raises(PandocConversionError):
+            pipeline.convert(b"data", ".xyz")
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_split_empty_content(self, mock_which):
+        """Test split() with empty content."""
+        mock_which.return_value = "/usr/bin/pandoc"
+        pipeline = PandocPipeline()
+        result = pipeline.split("")
+        assert result == []
+
+
+class TestDoclingPipeline:
+    """Tests for DoclingPipeline."""
+
+    def test_init_with_valid_url(self):
+        """Test initialization with valid URL."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        assert pipeline.docling_url == "http://localhost:8080"
+        assert pipeline.timeout == 120
+
+    def test_init_with_custom_timeout(self):
+        """Test initialization with custom timeout."""
+        pipeline = DoclingPipeline(
+            docling_url="http://localhost:8080",
+            timeout=60,
+        )
+        assert pipeline.timeout == 60
+
+    def test_init_raises_for_empty_url(self):
+        """Test that initialization raises error for empty URL."""
+        with pytest.raises(ValueError):
+            DoclingPipeline(docling_url="")
+
+    def test_init_raises_for_none_url(self):
+        """Test that initialization raises error for None URL."""
+        with pytest.raises(ValueError):
+            DoclingPipeline(docling_url=None)
+
+    def test_supported_extensions(self):
+        """Test supported extensions."""
+        extensions = DoclingPipeline.get_supported_extensions()
+        assert ".doc" in extensions
+        assert ".docx" in extensions
+        assert ".ppt" in extensions
+        assert ".pptx" in extensions
+        assert ".pdf" in extensions
+
+    def test_read_passes_through_binary_data(self):
+        """Test that read() returns binary data unchanged."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        data = b"Test document content"
+        result = pipeline.read(data, ".docx")
+        assert result == data
+
+    def test_extract_markdown_primary_format(self):
+        """Test _extract_markdown with primary response format."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        response = {"document": {"md_content": "# Hello World"}}
+        result = pipeline._extract_markdown(response)
+        assert result == "# Hello World"
+
+    def test_extract_markdown_alternative_format(self):
+        """Test _extract_markdown with alternative response format."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        response = {"md_content": "# Hello World"}
+        result = pipeline._extract_markdown(response)
+        assert result == "# Hello World"
+
+    def test_extract_markdown_content_format(self):
+        """Test _extract_markdown with content key."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        response = {"content": "# Hello World"}
+        result = pipeline._extract_markdown(response)
+        assert result == "# Hello World"
+
+    def test_extract_markdown_none_for_empty_response(self):
+        """Test _extract_markdown returns None for empty response."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        response = {}
+        result = pipeline._extract_markdown(response)
+        assert result is None
+
+    def test_split_empty_content(self):
+        """Test split() with empty content."""
+        pipeline = DoclingPipeline(docling_url="http://localhost:8080")
+        result = pipeline.split("")
+        assert result == []
+
+    @patch("app.services.rag.pipeline.docling.httpx.Client")
+    def test_is_service_available_true(self, mock_client_class):
+        """Test service availability check when service is running."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_client = Mock()
+        mock_client.get.return_value = mock_response
+        mock_client.__enter__ = Mock(return_value=mock_client)
+        mock_client.__exit__ = Mock(return_value=False)
+        mock_client_class.return_value = mock_client
+
+        result = DoclingPipeline.is_service_available("http://localhost:8080")
+        assert result is True
+
+    def test_is_service_available_false_for_empty_url(self):
+        """Test service availability check for empty URL."""
+        result = DoclingPipeline.is_service_available("")
+        assert result is False
+
+
+class TestPipelineFactory:
+    """Tests for pipeline factory functions."""
+
+    def test_should_use_pipeline_for_office_documents(self):
+        """Test that Office documents should use pipeline."""
+        assert should_use_pipeline(".doc") is True
+        assert should_use_pipeline(".docx") is True
+        assert should_use_pipeline(".ppt") is True
+        assert should_use_pipeline(".pptx") is True
+
+    def test_should_use_pipeline_for_pdf_without_docling(self):
+        """Test that PDF without Docling should not use pipeline."""
+        with patch(
+            "app.services.rag.pipeline.factory._is_docling_configured",
+            return_value=False,
+        ):
+            assert should_use_pipeline(".pdf") is False
+
+    def test_should_use_pipeline_for_pdf_with_docling(self):
+        """Test that PDF with Docling should use pipeline."""
+        with patch(
+            "app.services.rag.pipeline.factory._is_docling_configured",
+            return_value=True,
+        ):
+            assert should_use_pipeline(".pdf") is True
+
+    def test_should_use_pipeline_for_other_files(self):
+        """Test that other file types should not use pipeline."""
+        assert should_use_pipeline(".txt") is False
+        assert should_use_pipeline(".md") is False
+        assert should_use_pipeline(".json") is False
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    @patch(
+        "app.services.rag.pipeline.pandoc.PandocPipeline.is_pandoc_available",
+        return_value=True,
+    )
+    @patch(
+        "app.services.rag.pipeline.pandoc.shutil.which", return_value="/usr/bin/pandoc"
+    )
+    def test_create_pipeline_for_docx_with_pandoc(
+        self, mock_which, mock_pandoc, mock_docling
+    ):
+        """Test creating pipeline for DOCX when only Pandoc is available."""
+        pipeline = create_pipeline(".docx")
+        assert isinstance(pipeline, PandocPipeline)
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    def test_create_pipeline_for_txt(self, mock_docling):
+        """Test creating pipeline for TXT file."""
+        pipeline = create_pipeline(".txt")
+        assert isinstance(pipeline, LlamaIndexPipeline)
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    def test_create_pipeline_for_md(self, mock_docling):
+        """Test creating pipeline for Markdown file."""
+        pipeline = create_pipeline(".md")
+        assert isinstance(pipeline, LlamaIndexPipeline)
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    def test_create_pipeline_for_pdf_without_docling(self, mock_docling):
+        """Test creating pipeline for PDF without Docling."""
+        pipeline = create_pipeline(".pdf")
+        assert isinstance(pipeline, LlamaIndexPipeline)
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    @patch(
+        "app.services.rag.pipeline.pandoc.PandocPipeline.is_pandoc_available",
+        return_value=False,
+    )
+    def test_create_pipeline_raises_for_office_without_converters(
+        self, mock_pandoc, mock_docling
+    ):
+        """Test that creating pipeline for Office docs without converters raises."""
+        with pytest.raises(ValueError) as exc_info:
+            create_pipeline(".docx")
+        assert "Docling is not configured and Pandoc is not installed" in str(
+            exc_info.value
+        )
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    @patch(
+        "app.services.rag.pipeline.pandoc.PandocPipeline.is_pandoc_available",
+        return_value=True,
+    )
+    @patch(
+        "app.services.rag.pipeline.pandoc.shutil.which", return_value="/usr/bin/pandoc"
+    )
+    def test_get_pipeline_info_for_docx(self, mock_which, mock_pandoc, mock_docling):
+        """Test getting pipeline info for DOCX file."""
+        info = get_pipeline_info(".docx")
+        assert info["file_extension"] == ".docx"
+        assert info["requires_pipeline"] is True
+        assert "PandocPipeline" in info["recommended_pipeline"]
+
+    @patch(
+        "app.services.rag.pipeline.factory._is_docling_configured", return_value=False
+    )
+    def test_get_pipeline_info_for_txt(self, mock_docling):
+        """Test getting pipeline info for TXT file."""
+        info = get_pipeline_info(".txt")
+        assert info["file_extension"] == ".txt"
+        assert info["requires_pipeline"] is False
+        assert info["recommended_pipeline"] == "LlamaIndexPipeline"
+
+
+class TestPipelineIntegration:
+    """Integration tests for pipeline components."""
+
+    def test_llamaindex_pipeline_split_text_document(self):
+        """Test LlamaIndex pipeline splitting text content."""
+        pipeline = LlamaIndexPipeline(
+            file_extension=".txt",
+            chunk_size=100,
+            chunk_overlap=10,
+        )
+
+        # Create a text content
+        content = "This is a test document. " * 50  # About 1300 characters
+
+        # Split the content
+        documents = pipeline.split(content)
+
+        # Should create multiple chunks
+        assert len(documents) > 1
+        for doc in documents:
+            assert isinstance(doc, Document)
+            # Chunks may exceed target size due to sentence boundaries
+            # Just verify we have valid documents
+            assert len(doc.text) > 0
+
+    def test_docling_pipeline_split_markdown(self):
+        """Test Docling pipeline splitting markdown content."""
+        pipeline = DoclingPipeline(
+            docling_url="http://localhost:8080",
+            chunk_size=100,
+            chunk_overlap=10,
+        )
+
+        markdown_content = """# Header 1
+
+This is the first section with some content.
+
+## Header 2
+
+This is the second section with more content.
+
+### Header 3
+
+And this is a subsection with even more text to split.
+"""
+
+        documents = pipeline.split(markdown_content)
+
+        # Should create multiple chunks based on markdown structure
+        assert len(documents) >= 1
+        for doc in documents:
+            assert isinstance(doc, Document)
+
+    @patch("app.services.rag.pipeline.pandoc.shutil.which")
+    def test_pandoc_pipeline_split_markdown(self, mock_which):
+        """Test Pandoc pipeline splitting markdown content."""
+        mock_which.return_value = "/usr/bin/pandoc"
+
+        pipeline = PandocPipeline(
+            chunk_size=100,
+            chunk_overlap=10,
+        )
+
+        markdown_content = """# Header 1
+
+This is the first section with some content.
+
+## Header 2
+
+This is the second section with more content.
+"""
+
+        documents = pipeline.split(markdown_content)
+
+        # Should create chunks
+        assert len(documents) >= 1
+        for doc in documents:
+            assert isinstance(doc, Document)


### PR DESCRIPTION
## Summary

- Add a pipeline-based document processing architecture for smart splitting in knowledge base document upload
- When using Smart splitter with Office documents (DOC, DOCX, PPT, PPTX), the system now converts them to Markdown first using Docling or Pandoc for better structure preservation
- Implement automatic fallback mechanism: Docling -> Pandoc -> LlamaIndex

## Key Changes

### New Pipeline Architecture

Created `backend/app/services/rag/pipeline/` module with:

1. **BaseDocumentPipeline** - Abstract base class with three stages:
   - `read()` - Load raw binary data
   - `convert()` - Transform to Markdown (if applicable)
   - `split()` - Chunk into Document nodes

2. **LlamaIndexPipeline** - Default pipeline for PDF, TXT, MD files using SimpleDirectoryReader

3. **PandocPipeline** - Converts Office documents via subprocess:
   - Supports DOC, DOCX, PPT, PPTX
   - Uses `pandoc -f {format} -t markdown` command
   - Falls back when Docling is unavailable

4. **DoclingPipeline** - Advanced conversion via HTTP API:
   - Supports DOC, DOCX, PPT, PPTX, PDF
   - Calls Docling service with OCR disabled
   - Response format: `{"document": {"md_content": "..."}}`

### Pipeline Selection Strategy

| File Type | Priority 1 (Docling configured) | Priority 2 (Fallback) | Default |
|-----------|--------------------------------|----------------------|---------|
| DOC/DOCX  | DoclingPipeline | PandocPipeline | - |
| PPT/PPTX  | DoclingPipeline | PandocPipeline | - |
| PDF       | DoclingPipeline | - | LlamaIndexPipeline |
| TXT/MD/etc | - | - | LlamaIndexPipeline |

### Configuration

Added to `backend/app/core/config.py`:
```python
DOCLING_URL: Optional[str] = None  # e.g., "http://localhost:8080"
DOCLING_TIMEOUT: int = 120         # Request timeout in seconds
```

### Other Changes

- Updated `DocumentIndexer.index_from_binary()` to use pipeline architecture when SmartSplitter is configured
- Updated `SmartSplitter.SMART_EXTENSIONS` to include `.ppt` and `.pptx`
- Added 42 unit tests for pipeline components

## Test plan

- [x] All 42 pipeline unit tests pass
- [ ] Test DOC/DOCX upload with Pandoc installed
- [ ] Test PPT/PPTX upload with Pandoc installed
- [ ] Test PDF upload (default LlamaIndex flow)
- [ ] Test with Docling service configured (optional)
- [ ] Verify fallback works when Docling is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic pipeline processing for Office documents with configurable pipeline selection (Docling, Pandoc, LlamaIndex).
  * Docling integration with configurable service URL and request timeout.

* **Improvements**
  * Added Pandoc- and LlamaIndex-based pipelines for robust conversion and splitting.
  * Enhanced chunking behavior and expanded Office support to include .ppt/.pptx.

* **Tests**
  * Comprehensive pipeline unit and integration tests covering converters, selection logic, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->