### PR TITLE
feat: add preserve executor functionality for tasks

### DIFF
--- a/backend/app/api/endpoints/adapter/subscriptions.py
+++ b/backend/app/api/endpoints/adapter/subscriptions.py
@@ -8,6 +8,7 @@ API endpoints for Subscription (订阅) module.
 This module provides REST API endpoints for managing Subscription configurations
 and their background executions.
 """
+
 import hashlib
 import hmac
 import logging

--- a/backend/app/api/endpoints/kind/__init__.py
+++ b/backend/app/api/endpoints/kind/__init__.py
@@ -5,6 +5,7 @@
 """
 Kubernetes-style API endpoints
 """
+
 from fastapi import APIRouter
 
 from app.api.endpoints.kind.batch import router as batch_router

--- a/backend/app/api/endpoints/kind/batch.py
+++ b/backend/app/api/endpoints/kind/batch.py
@@ -5,6 +5,7 @@
 """
 Batch operation API endpoints
 """
+
 from typing import Any, Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException, status

--- a/backend/app/api/endpoints/kind/common.py
+++ b/backend/app/api/endpoints/kind/common.py
@@ -5,6 +5,7 @@
 """
 Common helper functions and constants for kind API endpoints to reduce code duplication
 """
+
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException, status

--- a/backend/app/api/endpoints/kind/kinds.py
+++ b/backend/app/api/endpoints/kind/kinds.py
@@ -5,6 +5,7 @@
 """
 Unified Kind API endpoints for all Kubernetes-style CRD operations
 """
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Path, status

--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -5,6 +5,7 @@
 """
 Skills API endpoints for managing Claude Code Skills
 """
+
 import io
 import zipfile
 from typing import Any, Dict, List, Optional

--- a/backend/app/api/endpoints/projects.py
+++ b/backend/app/api/endpoints/projects.py
@@ -7,6 +7,7 @@ Project API endpoints for managing projects and project-task associations.
 
 Projects are containers for organizing tasks. Each task can belong to one project.
 """
+
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, status
 from sqlalchemy.orm import Session
 

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -5,6 +5,7 @@
 """
 API router module, providing a global API router instance
 """
+
 from fastapi import APIRouter
 
 # Create a global API router instance

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -8,6 +8,7 @@ Project model for organizing tasks into projects.
 Projects are containers for tasks, allowing users to categorize and organize
 their tasks. Each task can belong to one project (one-to-many relationship).
 """
+
 from datetime import datetime
 
 from sqlalchemy import (

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -8,6 +8,7 @@ Database model for Subscription (订阅).
 Subscription is a CRD resource stored in the kinds table.
 BackgroundExecution stores execution records in the background_executions table.
 """
+
 from datetime import datetime
 
 from sqlalchemy import (

--- a/backend/app/models/subscription_follow.py
+++ b/backend/app/models/subscription_follow.py
@@ -9,6 +9,7 @@ These models support the subscription visibility and follow feature:
 - SubscriptionFollow: Track user-subscription follow relationships
 - SubscriptionShareNamespace: Track namespace-level subscription sharing
 """
+
 from datetime import datetime
 from enum import Enum
 

--- a/backend/app/models/task.py
+++ b/backend/app/models/task.py
@@ -8,6 +8,7 @@ Task model for storing Task and Workspace CRD resources.
 This table is separated from the kinds table for better query performance
 and data management efficiency.
 """
+
 from datetime import datetime
 
 from sqlalchemy import (

--- a/backend/app/repository/gerrit_provider.py
+++ b/backend/app/repository/gerrit_provider.py
@@ -5,6 +5,7 @@
 """
 Gerrit repository provider implementation
 """
+
 import asyncio
 import base64
 import hashlib

--- a/backend/app/repository/gitea_provider.py
+++ b/backend/app/repository/gitea_provider.py
@@ -5,6 +5,7 @@
 """
 Gitea repository provider implementation
 """
+
 import asyncio
 import logging
 from functools import lru_cache

--- a/backend/app/repository/gitee_provider.py
+++ b/backend/app/repository/gitee_provider.py
@@ -5,6 +5,7 @@
 """
 Gitee repository provider implementation
 """
+
 import asyncio
 import logging
 from functools import lru_cache

--- a/backend/app/repository/github_provider.py
+++ b/backend/app/repository/github_provider.py
@@ -5,6 +5,7 @@
 """
 GitHub repository provider implementation
 """
+
 import asyncio
 import logging
 from functools import lru_cache

--- a/backend/app/repository/gitlab_provider.py
+++ b/backend/app/repository/gitlab_provider.py
@@ -5,6 +5,7 @@
 """
 GitLab repository provider implementation
 """
+
 import asyncio
 import logging
 from typing import Any, Dict, List, Optional

--- a/backend/app/repository/interfaces/repository_provider.py
+++ b/backend/app/repository/interfaces/repository_provider.py
@@ -5,6 +5,7 @@
 """
 Repository provider interface, defining methods related to code repositories
 """
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -5,6 +5,7 @@
 """
 Kubernetes-style API schemas for cloud-native agent management
 """
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional

--- a/backend/app/schemas/namespace.py
+++ b/backend/app/schemas/namespace.py
@@ -81,7 +81,10 @@ class GroupBase(BaseModel):
 class GroupCreate(GroupBase):
     """Group creation model"""
 
-    level: Optional[GroupLevel] = Field(default=GroupLevel.group, description="Group level: 'group' or 'organization' (admin only)")
+    level: Optional[GroupLevel] = Field(
+        default=GroupLevel.group,
+        description="Group level: 'group' or 'organization' (admin only)",
+    )
 
 
 class GroupUpdate(BaseModel):
@@ -90,7 +93,9 @@ class GroupUpdate(BaseModel):
     display_name: Optional[str] = Field(None, max_length=100)
     visibility: Optional[GroupVisibility] = None
     description: Optional[str] = None
-    level: Optional[GroupLevel] = Field(default=None, description="Group level: 'group' or 'organization' (admin only)")
+    level: Optional[GroupLevel] = Field(
+        default=None, description="Group level: 'group' or 'organization' (admin only)"
+    )
 
 
 class GroupResponse(GroupBase):

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -7,6 +7,7 @@ Project schemas for API request/response validation.
 
 Projects are containers for organizing tasks. Each task can belong to one project.
 """
+
 from datetime import datetime
 from typing import Optional
 

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -8,6 +8,7 @@ Subscription (订阅) CRD schemas for automated task execution.
 Subscription is a CRD resource that defines scheduled or event-triggered
 task executions. It replaces the previous Flow concept.
 """
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -131,6 +131,9 @@ class TaskInDB(TaskBase):
     updated_at: datetime
     completed_at: Optional[datetime] = None
     is_group_chat: bool = False  # Whether this is a group chat task
+    preserve_executor: bool = (
+        False  # Whether to preserve executor pod after task completion
+    )
 
     class Config:
         from_attributes = True
@@ -165,6 +168,9 @@ class TaskDetail(BaseModel):
         None  # App preview information (set by expose_service tool)
     )
     device_id: Optional[str] = None  # Device ID used for execution (for task history)
+    preserve_executor: bool = (
+        False  # Whether to preserve executor pod after task completion
+    )
 
     class Config:
         from_attributes = True

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -151,6 +151,7 @@ class TaskDetail(BaseModel):
     branch_name: str
     prompt: str
     status: TaskStatus = TaskStatus.PENDING
+    task_type: str = "chat"  # Task type: 'chat', 'code', 'knowledge', 'task'
     progress: int = 0
     result: Optional[dict[str, Any]] = None
     error_message: Optional[str] = None

--- a/backend/app/services/adapters/public_retriever.py
+++ b/backend/app/services/adapters/public_retriever.py
@@ -6,6 +6,7 @@
 Public Retriever service for managing system-level retriever configurations.
 Public retrievers are stored in the kinds table with user_id=0.
 """
+
 import logging
 from typing import Any, Dict, List, Optional
 

--- a/backend/app/services/adapters/public_skill.py
+++ b/backend/app/services/adapters/public_skill.py
@@ -5,6 +5,7 @@
 """
 Public Skill service for managing system-level Skills (user_id=0)
 """
+
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException

--- a/backend/app/services/adapters/retriever_kinds.py
+++ b/backend/app/services/adapters/retriever_kinds.py
@@ -5,6 +5,7 @@
 """
 Retriever service for managing RAG retrieval configurations
 """
+
 import logging
 from typing import Any, Dict, List, Optional
 

--- a/backend/app/services/adapters/skill_kinds.py
+++ b/backend/app/services/adapters/skill_kinds.py
@@ -5,6 +5,7 @@
 """
 Skill adapter service for managing Skills using kinds table
 """
+
 from typing import Any, Dict, List, Optional
 
 from fastapi import HTTPException

--- a/backend/app/services/adapters/task_kinds/converters.py
+++ b/backend/app/services/adapters/task_kinds/converters.py
@@ -110,6 +110,12 @@ def convert_to_task_dict(task: Kind, db: Session, user_id: int) -> Dict[str, Any
 
     model_id = task_crd.metadata.labels and task_crd.metadata.labels.get("modelId")
 
+    # Extract preserve_executor flag from task labels
+    preserve_executor = (
+        task_crd.metadata.labels
+        and task_crd.metadata.labels.get("preserveExecutor") == "true"
+    )
+
     # Extract is_group_chat from task spec
     is_group_chat = (
         task_crd.spec.is_group_chat
@@ -166,6 +172,7 @@ def convert_to_task_dict(task: Kind, db: Session, user_id: int) -> Dict[str, Any
         "is_group_chat": is_group_chat,
         "app": app_data,
         "device_id": device_id,
+        "preserve_executor": preserve_executor,
     }
 
 
@@ -196,6 +203,12 @@ def convert_to_task_dict_optimized(
     # Extract device_id from task spec
     device_id = task_crd.spec.device_id if hasattr(task_crd.spec, "device_id") else None
 
+    # Extract preserve_executor flag from task labels
+    preserve_executor = (
+        task_crd.metadata.labels
+        and task_crd.metadata.labels.get("preserveExecutor") == "true"
+    )
+
     return {
         "id": task.id,
         "type": type_value,
@@ -224,6 +237,7 @@ def convert_to_task_dict_optimized(
             else None
         ),
         "device_id": device_id,
+        "preserve_executor": preserve_executor,
     }
 
 

--- a/backend/app/services/adapters/task_kinds/operations.py
+++ b/backend/app/services/adapters/task_kinds/operations.py
@@ -1291,17 +1291,16 @@ class TaskOperationsMixin:
         if task_crd.metadata.labels is None:
             task_crd.metadata.labels = {}
 
-        # Set or remove the preserveExecutor label
+        # Set the preserveExecutor label (use "true"/"false" for consistency with autoDeleteExecutor)
         if preserve:
             task_crd.metadata.labels["preserveExecutor"] = "true"
             logger.info(
                 f"[set_preserve_executor] User {user_id} set preserveExecutor=true for task {task_id}"
             )
         else:
-            if "preserveExecutor" in task_crd.metadata.labels:
-                del task_crd.metadata.labels["preserveExecutor"]
+            task_crd.metadata.labels["preserveExecutor"] = "false"
             logger.info(
-                f"[set_preserve_executor] User {user_id} removed preserveExecutor for task {task_id}"
+                f"[set_preserve_executor] User {user_id} set preserveExecutor=false for task {task_id}"
             )
 
         # Save changes

--- a/backend/app/services/adapters/task_kinds/operations.py
+++ b/backend/app/services/adapters/task_kinds/operations.py
@@ -1242,3 +1242,82 @@ class TaskOperationsMixin:
                     )
             except Exception as e:
                 logger.warning("[delete_task] Failed to schedule close-session: %s", e)
+
+    def set_preserve_executor(
+        self, db: Session, *, task_id: int, user_id: int, preserve: bool
+    ) -> Dict[str, Any]:
+        """
+        Set or cancel the preserve executor flag for a task.
+
+        When preserve=True, the executor pod for this task will not be cleaned up
+        by the cleanup_stale_executors job even after the task is completed.
+
+        Args:
+            db: Database session
+            task_id: Task ID
+            user_id: User ID requesting the change
+            preserve: True to preserve executor, False to allow normal cleanup
+
+        Returns:
+            Dict with task_id and preserve_executor status
+
+        Raises:
+            HTTPException: If task not found or user doesn't have permission
+        """
+        from app.services.task_member_service import task_member_service
+
+        # Check if user is a member of this task (owner or group member)
+        if not task_member_service.is_member(db, task_id, user_id):
+            raise HTTPException(
+                status_code=404, detail="Task not found or no permission"
+            )
+
+        task = (
+            db.query(TaskResource)
+            .filter(
+                TaskResource.id == task_id,
+                TaskResource.kind == "Task",
+                TaskResource.is_active.is_(True),
+            )
+            .first()
+        )
+
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+
+        task_crd = Task.model_validate(task.json)
+
+        # Initialize labels if not exists
+        if task_crd.metadata.labels is None:
+            task_crd.metadata.labels = {}
+
+        # Set or remove the preserveExecutor label
+        if preserve:
+            task_crd.metadata.labels["preserveExecutor"] = "true"
+            logger.info(
+                f"[set_preserve_executor] User {user_id} set preserveExecutor=true for task {task_id}"
+            )
+        else:
+            if "preserveExecutor" in task_crd.metadata.labels:
+                del task_crd.metadata.labels["preserveExecutor"]
+            logger.info(
+                f"[set_preserve_executor] User {user_id} removed preserveExecutor for task {task_id}"
+            )
+
+        # Save changes
+        task.json = task_crd.model_dump(mode="json", exclude_none=True)
+        task.updated_at = datetime.now()
+        flag_modified(task, "json")
+
+        db.commit()
+        db.refresh(task)
+
+        return {
+            "task_id": task_id,
+            "preserve_executor": preserve,
+            "message": (
+                "Executor will be preserved for this task"
+                if preserve
+                else "Executor cleanup enabled for this task"
+            ),
+        }

--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -34,7 +34,10 @@ MAX_GROUP_DEPTH = 5
 
 
 def create_group(
-    db: Session, group_data: GroupCreate, owner_user_id: int, user_role: str | None = None
+    db: Session,
+    group_data: GroupCreate,
+    owner_user_id: int,
+    user_role: str | None = None,
 ) -> GroupResponse:
     """
     Create a new group and add the creator as Owner.
@@ -105,7 +108,8 @@ def create_group(
 
         if (
             user_group_role is None
-            or role_hierarchy.get(user_group_role, 999) > role_hierarchy[GroupRole.Maintainer]
+            or role_hierarchy.get(user_group_role, 999)
+            > role_hierarchy[GroupRole.Maintainer]
         ):
             raise HTTPException(
                 status_code=403,
@@ -219,12 +223,7 @@ def list_user_groups(
             | (Namespace.level.is_(None))
         )
 
-    groups = (
-        query.order_by(Namespace.created_at.desc())
-        .offset(skip)
-        .limit(limit)
-        .all()
-    )
+    groups = query.order_by(Namespace.created_at.desc()).offset(skip).limit(limit).all()
 
     # Get member counts for all groups
     member_counts = {}
@@ -298,7 +297,10 @@ def update_group(
         current_level = group.level
 
         # Check if changing to or from organization level
-        if new_level == GroupLevel.organization.value or current_level == GroupLevel.organization.value:
+        if (
+            new_level == GroupLevel.organization.value
+            or current_level == GroupLevel.organization.value
+        ):
             if user_role != "admin":
                 raise HTTPException(
                     status_code=403,

--- a/backend/app/services/k_batch.py
+++ b/backend/app/services/k_batch.py
@@ -5,6 +5,7 @@
 """
 Batch operation service for Kubernetes-style API
 """
+
 import logging
 from pathlib import Path
 from typing import Any, Dict, List

--- a/backend/app/services/kind.py
+++ b/backend/app/services/kind.py
@@ -5,6 +5,7 @@
 """
 Unified Kind service for all Kubernetes-style CRD operations
 """
+
 from typing import Any, Dict, List, Optional, Union
 
 from app.core.exceptions import NotFoundException

--- a/backend/app/services/kind_base.py
+++ b/backend/app/services/kind_base.py
@@ -5,6 +5,7 @@
 """
 Base service for all Kubernetes-style CRD operations
 """
+
 import json
 import logging
 from abc import ABC, abstractmethod

--- a/backend/app/services/kind_factory.py
+++ b/backend/app/services/kind_factory.py
@@ -5,6 +5,7 @@
 """
 Factory for creating Kind services
 """
+
 from typing import Dict, Type
 
 from app.services.kind_base import KindBaseService

--- a/backend/app/services/kind_impl.py
+++ b/backend/app/services/kind_impl.py
@@ -5,6 +5,7 @@
 """
 Implementation of specific Kind services
 """
+
 import logging
 from typing import Any, Dict
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -424,6 +424,7 @@ class KnowledgeService:
 
             if conditions:
                 from sqlalchemy import or_
+
                 query = query.filter(or_(*conditions))
 
             all_kbs = query.all()
@@ -1149,9 +1150,8 @@ class KnowledgeService:
                             # Get the correct user_id for index naming
                             # For group knowledge bases, use the KB creator's user_id
                             # This ensures we delete from the same index where documents were stored
-                            if (
-                                kb.namespace == "default"
-                                or _is_organization_namespace(db, kb.namespace)
+                            if kb.namespace == "default" or _is_organization_namespace(
+                                db, kb.namespace
                             ):
                                 # Personal/Organization knowledge base - use current user's ID
                                 index_owner_user_id = user_id

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -7,6 +7,7 @@ Project service for managing projects and project-task associations.
 
 Projects are containers for organizing tasks. Each task can belong to one project.
 """
+
 from typing import Optional
 
 from fastapi import HTTPException

--- a/backend/app/services/repository.py
+++ b/backend/app/services/repository.py
@@ -5,6 +5,7 @@
 """
 Repository aggregation service for handling multiple repository providers
 """
+
 import asyncio
 import logging
 from typing import Any, Dict, List

--- a/backend/app/services/skill_service.py
+++ b/backend/app/services/skill_service.py
@@ -5,6 +5,7 @@
 """
 Skill service for managing Claude Code Skills
 """
+
 import hashlib
 import io
 import re

--- a/backend/tests/services/test_preserve_executor.py
+++ b/backend/tests/services/test_preserve_executor.py
@@ -1,0 +1,455 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for preserve executor functionality.
+
+This module tests:
+1. cleanup_stale_executors skips tasks with preserveExecutor=true
+2. set_preserve_executor API functionality
+3. Permission control for preserve executor operations
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
+from app.models.task import TaskResource
+from app.schemas.kind import Task
+from app.services.adapters.executor_job import JobService
+from app.services.adapters.task_kinds import TaskKindsService
+
+
+@pytest.mark.unit
+class TestCleanupStaleExecutorsWithPreserveFlag:
+    """Test cleanup_stale_executors skips tasks with preserveExecutor label"""
+
+    @pytest.fixture
+    def job_service(self):
+        """Create JobService instance"""
+        from app.models.kind import Kind
+
+        return JobService(Kind)
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session"""
+        return Mock(spec=Session)
+
+    def _create_mock_task_resource(
+        self, task_id: int, user_id: int, preserve_executor: bool = False
+    ):
+        """Helper to create a mock TaskResource with optional preserveExecutor label"""
+        task = Mock(spec=TaskResource)
+        task.id = task_id
+        task.user_id = user_id
+        task.kind = "Task"
+        task.is_active = True
+
+        labels = {"taskType": "chat"}
+        if preserve_executor:
+            labels["preserveExecutor"] = "true"
+
+        task.json = {
+            "kind": "Task",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {
+                "name": f"task-{task_id}",
+                "namespace": "default",
+                "labels": labels,
+            },
+            "spec": {
+                "title": "Test Task",
+                "prompt": "Test prompt",
+                "teamRef": {"name": "test-team", "namespace": "default"},
+                "workspaceRef": {"name": "workspace-1", "namespace": "default"},
+            },
+            "status": {
+                "status": "COMPLETED",
+                "progress": 100,
+                "createdAt": datetime.now().isoformat(),
+                "updatedAt": datetime.now().isoformat(),
+            },
+        }
+        return task
+
+    def _create_mock_subtask(
+        self,
+        subtask_id: int,
+        task_id: int,
+        executor_name: str = "executor-1",
+        executor_namespace: str = "default",
+    ):
+        """Helper to create a mock Subtask"""
+        subtask = Mock(spec=Subtask)
+        subtask.id = subtask_id
+        subtask.task_id = task_id
+        subtask.executor_name = executor_name
+        subtask.executor_namespace = executor_namespace
+        subtask.executor_deleted_at = False
+        subtask.status = SubtaskStatus.COMPLETED
+        subtask.updated_at = datetime.now() - timedelta(hours=48)
+        return subtask
+
+    def test_skips_task_with_preserve_executor_true(self, job_service, mock_db):
+        """Test that tasks with preserveExecutor=true are skipped during cleanup"""
+        # Create a mock subtask linked to a task with preserveExecutor=true
+        mock_subtask = self._create_mock_subtask(1, 100)
+        mock_task = self._create_mock_task_resource(100, 1, preserve_executor=True)
+
+        # Setup mock query chain for subtasks
+        mock_subtask_query = MagicMock()
+        mock_subtask_query.join.return_value = mock_subtask_query
+        mock_subtask_query.filter.return_value = mock_subtask_query
+        mock_subtask_query.all.return_value = [mock_subtask]
+
+        # Setup mock query chain for task lookup
+        mock_task_query = MagicMock()
+        mock_task_query.filter.return_value = mock_task_query
+        mock_task_query.first.return_value = mock_task
+
+        def query_side_effect(model):
+            if model == Subtask:
+                return mock_subtask_query
+            elif model == TaskResource:
+                return mock_task_query
+            return MagicMock()
+
+        mock_db.query.side_effect = query_side_effect
+
+        # Mock the delete executor function
+        with patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as mock_executor_service:
+            with patch("app.services.adapters.executor_job.settings") as mock_settings:
+                mock_settings.CHAT_TASK_EXECUTOR_DELETE_AFTER_HOURS = 24
+                mock_settings.CODE_TASK_EXECUTOR_DELETE_AFTER_HOURS = 48
+
+                job_service.cleanup_stale_executors(mock_db)
+
+                # Verify delete_executor_task_sync was NOT called
+                mock_executor_service.delete_executor_task_sync.assert_not_called()
+
+    def test_cleans_up_task_without_preserve_flag(self, job_service, mock_db):
+        """Test that tasks without preserveExecutor label are cleaned up normally"""
+        # Create a mock subtask linked to a task WITHOUT preserveExecutor
+        mock_subtask = self._create_mock_subtask(1, 100)
+        mock_task = self._create_mock_task_resource(100, 1, preserve_executor=False)
+
+        # Setup mock query chain for subtasks
+        mock_subtask_query = MagicMock()
+        mock_subtask_query.join.return_value = mock_subtask_query
+        mock_subtask_query.filter.return_value = mock_subtask_query
+        mock_subtask_query.all.return_value = [mock_subtask]
+        mock_subtask_query.update.return_value = 1
+
+        # Setup mock query chain for task lookup
+        mock_task_query = MagicMock()
+        mock_task_query.filter.return_value = mock_task_query
+        mock_task_query.first.return_value = mock_task
+
+        def query_side_effect(model):
+            if model == Subtask:
+                return mock_subtask_query
+            elif model == TaskResource:
+                return mock_task_query
+            return MagicMock()
+
+        mock_db.query.side_effect = query_side_effect
+
+        # Mock the delete executor function to succeed
+        with patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as mock_executor_service:
+            with patch("app.services.adapters.executor_job.settings") as mock_settings:
+                mock_settings.CHAT_TASK_EXECUTOR_DELETE_AFTER_HOURS = 24
+                mock_settings.CODE_TASK_EXECUTOR_DELETE_AFTER_HOURS = 48
+                mock_executor_service.delete_executor_task_sync.return_value = True
+
+                job_service.cleanup_stale_executors(mock_db)
+
+                # Verify delete_executor_task_sync WAS called
+                mock_executor_service.delete_executor_task_sync.assert_called_once_with(
+                    "executor-1", "default"
+                )
+
+    def test_skips_task_with_preserve_executor_false(self, job_service, mock_db):
+        """Test that tasks with preserveExecutor=false are cleaned up normally"""
+        # Create a mock subtask linked to a task with preserveExecutor=false
+        mock_subtask = self._create_mock_subtask(1, 100)
+        mock_task = self._create_mock_task_resource(100, 1, preserve_executor=False)
+        # Explicitly set preserveExecutor to "false"
+        mock_task.json["metadata"]["labels"]["preserveExecutor"] = "false"
+
+        # Setup mock query chain for subtasks
+        mock_subtask_query = MagicMock()
+        mock_subtask_query.join.return_value = mock_subtask_query
+        mock_subtask_query.filter.return_value = mock_subtask_query
+        mock_subtask_query.all.return_value = [mock_subtask]
+        mock_subtask_query.update.return_value = 1
+
+        # Setup mock query chain for task lookup
+        mock_task_query = MagicMock()
+        mock_task_query.filter.return_value = mock_task_query
+        mock_task_query.first.return_value = mock_task
+
+        def query_side_effect(model):
+            if model == Subtask:
+                return mock_subtask_query
+            elif model == TaskResource:
+                return mock_task_query
+            return MagicMock()
+
+        mock_db.query.side_effect = query_side_effect
+
+        # Mock the delete executor function to succeed
+        with patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as mock_executor_service:
+            with patch("app.services.adapters.executor_job.settings") as mock_settings:
+                mock_settings.CHAT_TASK_EXECUTOR_DELETE_AFTER_HOURS = 24
+                mock_settings.CODE_TASK_EXECUTOR_DELETE_AFTER_HOURS = 48
+                mock_executor_service.delete_executor_task_sync.return_value = True
+
+                job_service.cleanup_stale_executors(mock_db)
+
+                # Verify delete_executor_task_sync WAS called (preserveExecutor=false means cleanup)
+                mock_executor_service.delete_executor_task_sync.assert_called_once_with(
+                    "executor-1", "default"
+                )
+
+
+@pytest.mark.unit
+class TestSetPreserveExecutorAPI:
+    """Test set_preserve_executor API functionality"""
+
+    @pytest.fixture
+    def task_service(self):
+        """Create TaskKindsService instance"""
+        return TaskKindsService(TaskResource)
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session"""
+        return Mock(spec=Session)
+
+    def _create_mock_task(
+        self, task_id: int, user_id: int, preserve_executor: bool = False
+    ):
+        """Helper to create a mock TaskResource"""
+        task = Mock(spec=TaskResource)
+        task.id = task_id
+        task.user_id = user_id
+        task.kind = "Task"
+        task.is_active = True
+
+        labels = {"taskType": "chat"}
+        if preserve_executor:
+            labels["preserveExecutor"] = "true"
+
+        task.json = {
+            "kind": "Task",
+            "apiVersion": "agent.wecode.io/v1",
+            "metadata": {
+                "name": f"task-{task_id}",
+                "namespace": "default",
+                "labels": labels,
+            },
+            "spec": {
+                "title": "Test Task",
+                "prompt": "Test prompt",
+                "teamRef": {"name": "test-team", "namespace": "default"},
+                "workspaceRef": {"name": "workspace-1", "namespace": "default"},
+            },
+            "status": {
+                "status": "COMPLETED",
+                "progress": 100,
+                "createdAt": datetime.now().isoformat(),
+                "updatedAt": datetime.now().isoformat(),
+            },
+        }
+        return task
+
+    def test_set_preserve_executor_true(self, task_service, mock_db):
+        """Test setting preserveExecutor to true"""
+        mock_task = self._create_mock_task(123, 1, preserve_executor=False)
+
+        # Setup mock query chain
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_task
+
+        # Mock task_member_service (imported inside the function)
+        with patch(
+            "app.services.task_member_service.task_member_service"
+        ) as mock_member_service:
+            mock_member_service.is_member.return_value = True
+
+            # Mock flag_modified to avoid SQLAlchemy internals
+            with patch(
+                "app.services.adapters.task_kinds.operations.flag_modified"
+            ) as mock_flag_modified:
+                result = task_service.set_preserve_executor(
+                    mock_db, task_id=123, user_id=1, preserve=True
+                )
+
+                assert result["task_id"] == 123
+                assert result["preserve_executor"] is True
+                assert "preserved" in result["message"].lower()
+
+                # Verify the task json was updated
+                assert (
+                    mock_task.json["metadata"]["labels"]["preserveExecutor"] == "true"
+                )
+                mock_db.commit.assert_called_once()
+                mock_flag_modified.assert_called_once()
+
+    def test_set_preserve_executor_false(self, task_service, mock_db):
+        """Test setting preserveExecutor to false"""
+        mock_task = self._create_mock_task(123, 1, preserve_executor=True)
+
+        # Setup mock query chain
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_task
+
+        # Mock task_member_service (imported inside the function)
+        with patch(
+            "app.services.task_member_service.task_member_service"
+        ) as mock_member_service:
+            mock_member_service.is_member.return_value = True
+
+            # Mock flag_modified to avoid SQLAlchemy internals
+            with patch(
+                "app.services.adapters.task_kinds.operations.flag_modified"
+            ) as mock_flag_modified:
+                result = task_service.set_preserve_executor(
+                    mock_db, task_id=123, user_id=1, preserve=False
+                )
+
+                assert result["task_id"] == 123
+                assert result["preserve_executor"] is False
+                assert "cleanup" in result["message"].lower()
+
+                # Verify the task json was updated to "false" (not deleted)
+                assert (
+                    mock_task.json["metadata"]["labels"]["preserveExecutor"] == "false"
+                )
+                mock_db.commit.assert_called_once()
+                mock_flag_modified.assert_called_once()
+
+    def test_non_member_cannot_set_preserve_executor(self, task_service, mock_db):
+        """Test that non-members cannot set preserve executor flag"""
+        mock_task = self._create_mock_task(123, 1, preserve_executor=False)
+
+        # Setup mock query chain
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_task
+
+        # Mock task_member_service (imported inside the function)
+        with patch(
+            "app.services.task_member_service.task_member_service"
+        ) as mock_member_service:
+            mock_member_service.is_member.return_value = False
+
+            with pytest.raises(HTTPException) as exc_info:
+                task_service.set_preserve_executor(
+                    mock_db, task_id=123, user_id=999, preserve=True
+                )
+
+            assert exc_info.value.status_code == 404
+            assert (
+                "not found" in exc_info.value.detail.lower()
+                or "permission" in exc_info.value.detail.lower()
+            )
+
+    def test_task_not_found_raises_404(self, task_service, mock_db):
+        """Test that non-existent task raises 404"""
+        # Setup mock query chain to return None
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        # Mock task_member_service (imported inside the function)
+        with patch(
+            "app.services.task_member_service.task_member_service"
+        ) as mock_member_service:
+            mock_member_service.is_member.return_value = False
+
+            with pytest.raises(HTTPException) as exc_info:
+                task_service.set_preserve_executor(
+                    mock_db, task_id=999, user_id=1, preserve=True
+                )
+
+            assert exc_info.value.status_code == 404
+
+    def test_group_member_can_set_preserve_executor(self, task_service, mock_db):
+        """Test that group chat members can set preserve executor flag"""
+        mock_task = self._create_mock_task(123, 1, preserve_executor=False)
+
+        # Setup mock query chain
+        mock_query = MagicMock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = mock_task
+
+        # Mock task_member_service (imported inside the function)
+        with patch(
+            "app.services.task_member_service.task_member_service"
+        ) as mock_member_service:
+            # User 2 is a group member, not the owner (user_id=1)
+            mock_member_service.is_member.return_value = True
+
+            # Mock flag_modified to avoid SQLAlchemy internals
+            with patch(
+                "app.services.adapters.task_kinds.operations.flag_modified"
+            ) as mock_flag_modified:
+                result = task_service.set_preserve_executor(
+                    mock_db, task_id=123, user_id=2, preserve=True
+                )
+
+                assert result["task_id"] == 123
+                assert result["preserve_executor"] is True
+                mock_member_service.is_member.assert_called_once_with(mock_db, 123, 2)
+                mock_flag_modified.assert_called_once()
+
+
+@pytest.mark.unit
+class TestPreserveExecutorLabelConsistency:
+    """Test that preserveExecutor label is handled consistently"""
+
+    def test_preserve_executor_uses_string_values(self):
+        """Test that preserveExecutor uses 'true'/'false' string values like autoDeleteExecutor"""
+        task_json = {
+            "metadata": {
+                "labels": {
+                    "autoDeleteExecutor": "false",  # Existing pattern uses strings
+                    "preserveExecutor": "true",  # Should follow same pattern
+                }
+            }
+        }
+
+        # Both should use string values for consistency
+        assert task_json["metadata"]["labels"]["autoDeleteExecutor"] == "false"
+        assert task_json["metadata"]["labels"]["preserveExecutor"] == "true"
+
+    def test_preserve_executor_false_is_explicit(self):
+        """Test that setting preserve=False results in 'false' string, not key deletion"""
+        # This ensures the behavior matches autoDeleteExecutor pattern
+        labels = {"preserveExecutor": "true"}
+
+        # When disabling, should set to "false" not delete
+        labels["preserveExecutor"] = "false"
+
+        assert "preserveExecutor" in labels
+        assert labels["preserveExecutor"] == "false"

--- a/frontend/src/apis/tasks.ts
+++ b/frontend/src/apis/tasks.ts
@@ -451,6 +451,28 @@ export const taskApis = {
   getTaskSkills: async (taskId: number): Promise<TaskSkillsResponse> => {
     return apiClient.get(`/tasks/${taskId}/skills`)
   },
+
+  /**
+   * Set preserve executor flag for a task
+   * When set, the executor pod will not be cleaned up after task completion
+   * @param taskId - Task ID
+   */
+  setPreserveExecutor: async (
+    taskId: number
+  ): Promise<{ task_id: number; preserve_executor: boolean; message: string }> => {
+    return apiClient.post(`/tasks/${taskId}/preserve-executor`, {})
+  },
+
+  /**
+   * Cancel preserve executor flag for a task
+   * When cancelled, the executor pod will be cleaned up normally
+   * @param taskId - Task ID
+   */
+  cancelPreserveExecutor: async (
+    taskId: number
+  ): Promise<{ task_id: number; preserve_executor: boolean; message: string }> => {
+    return apiClient.delete(`/tasks/${taskId}/preserve-executor`)
+  },
 }
 
 /**

--- a/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
+++ b/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React, { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { Shield, ShieldCheck } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -33,7 +33,7 @@ export function PreserveExecutorToggle({
   const [localPreserveState, setLocalPreserveState] = useState(preserveExecutor)
 
   // Sync local state with prop when it changes
-  React.useEffect(() => {
+  useEffect(() => {
     setLocalPreserveState(preserveExecutor)
   }, [preserveExecutor])
 

--- a/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
+++ b/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
@@ -4,150 +4,45 @@
 
 'use client'
 
-import { useState, useCallback, useEffect } from 'react'
-import { Shield, ShieldCheck } from 'lucide-react'
-import { Button } from '@/components/ui/button'
+import { ShieldCheck } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
-import { useToast } from '@/hooks/use-toast'
-import { taskApis } from '@/apis/tasks'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
-interface PreserveExecutorToggleProps {
-  taskId: number
+interface PreserveExecutorIndicatorProps {
   preserveExecutor: boolean
-  onToggle?: (preserve: boolean) => void
-  variant?: 'button' | 'icon'
-  size?: 'sm' | 'default'
 }
 
-export function PreserveExecutorToggle({
-  taskId,
-  preserveExecutor,
-  onToggle,
-  variant = 'button',
-  size = 'sm',
-}: PreserveExecutorToggleProps) {
+/**
+ * Read-only indicator showing whether executor is preserved for code tasks.
+ * Only displays when preserve_executor is true.
+ */
+export function PreserveExecutorIndicator({ preserveExecutor }: PreserveExecutorIndicatorProps) {
   const { t } = useTranslation()
-  const { toast } = useToast()
-  const [isLoading, setIsLoading] = useState(false)
-  const [localPreserveState, setLocalPreserveState] = useState(preserveExecutor)
 
-  // Sync local state with prop when it changes
-  useEffect(() => {
-    setLocalPreserveState(preserveExecutor)
-  }, [preserveExecutor])
-
-  const handleToggle = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const newPreserveState = !localPreserveState
-      if (newPreserveState) {
-        // Set preserve executor
-        await taskApis.setPreserveExecutor(taskId)
-        toast({
-          title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
-          description:
-            t('tasks:preserve_executor.enabled_desc') ||
-            "This task's executor pod will not be cleaned up after completion.",
-        })
-      } else {
-        // Cancel preserve executor
-        await taskApis.cancelPreserveExecutor(taskId)
-        toast({
-          title: t('tasks:preserve_executor.disabled_title') || 'Executor Cleanup Enabled',
-          description:
-            t('tasks:preserve_executor.disabled_desc') ||
-            "This task's executor pod will be cleaned up normally.",
-        })
-      }
-      setLocalPreserveState(newPreserveState)
-      onToggle?.(newPreserveState)
-    } catch (error) {
-      console.error('Failed to toggle preserve executor:', error)
-      toast({
-        variant: 'destructive',
-        title: t('tasks:preserve_executor.error_title') || 'Failed to Update',
-        description:
-          (error as Error)?.message ||
-          t('tasks:preserve_executor.error_desc') ||
-          'Could not update executor preservation setting.',
-      })
-    } finally {
-      setIsLoading(false)
-    }
-  }, [taskId, localPreserveState, onToggle, t, toast])
-
-  const isPreserved = localPreserveState
-
-  if (variant === 'icon') {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant={isPreserved ? 'default' : 'outline'}
-              size="icon"
-              onClick={handleToggle}
-              disabled={isLoading}
-              className={
-                isPreserved
-                  ? 'bg-primary text-white hover:bg-primary/90 h-8 w-8 rounded-[7px]'
-                  : 'h-8 w-8 rounded-[7px]'
-              }
-            >
-              {isPreserved ? <ShieldCheck className="h-4 w-4" /> : <Shield className="h-4 w-4" />}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">
-            <p>
-              {isPreserved
-                ? t('tasks:preserve_executor.tooltip_preserved') || 'Executor preserved'
-                : t('tasks:preserve_executor.tooltip_not_preserved') || 'Preserve executor'}
-            </p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    )
+  // Only show indicator when executor is preserved
+  if (!preserveExecutor) {
+    return null
   }
 
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button
-            variant={isPreserved ? 'default' : 'outline'}
-            size={size}
-            onClick={handleToggle}
-            disabled={isLoading}
-            className={
-              isPreserved
-                ? 'bg-primary text-white hover:bg-primary/90 flex items-center gap-1 h-8 pl-2 pr-3 rounded-[7px] text-sm'
-                : 'flex items-center gap-1 h-8 pl-2 pr-3 rounded-[7px] text-sm'
-            }
-          >
-            {isPreserved ? (
-              <>
-                <ShieldCheck className="h-3.5 w-3.5" />
-                {t('tasks:preserve_executor.preserved') || 'Preserved'}
-              </>
-            ) : (
-              <>
-                <Shield className="h-3.5 w-3.5" />
-                {t('tasks:preserve_executor.preserve') || 'Preserve'}
-              </>
-            )}
-          </Button>
+          <div className="flex items-center gap-1 h-8 px-2 rounded-[7px] text-sm bg-primary/10 text-primary border border-primary/20">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            <span>{t('tasks:preserve_executor.preserved') || 'Preserved'}</span>
+          </div>
         </TooltipTrigger>
         <TooltipContent side="bottom">
           <p>
-            {isPreserved
-              ? t('tasks:preserve_executor.tooltip_preserved') ||
-                'Executor is preserved and will not be cleaned up'
-              : t('tasks:preserve_executor.tooltip_not_preserved') ||
-                'Click to preserve executor from cleanup'}
+            {t('tasks:preserve_executor.tooltip_preserved') ||
+              'Executor is preserved and will not be cleaned up'}
           </p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
   )
 }
+
+// Keep backward compatibility with old name
+export { PreserveExecutorIndicator as PreserveExecutorToggle }

--- a/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
+++ b/frontend/src/features/tasks/components/PreserveExecutorToggle.tsx
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState, useCallback } from 'react'
+import { Shield, ShieldCheck } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from '@/hooks/useTranslation'
+import { useToast } from '@/hooks/use-toast'
+import { taskApis } from '@/apis/tasks'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+
+interface PreserveExecutorToggleProps {
+  taskId: number
+  preserveExecutor: boolean
+  onToggle?: (preserve: boolean) => void
+  variant?: 'button' | 'icon'
+  size?: 'sm' | 'default'
+}
+
+export function PreserveExecutorToggle({
+  taskId,
+  preserveExecutor,
+  onToggle,
+  variant = 'button',
+  size = 'sm',
+}: PreserveExecutorToggleProps) {
+  const { t } = useTranslation()
+  const { toast } = useToast()
+  const [isLoading, setIsLoading] = useState(false)
+  const [localPreserveState, setLocalPreserveState] = useState(preserveExecutor)
+
+  // Sync local state with prop when it changes
+  React.useEffect(() => {
+    setLocalPreserveState(preserveExecutor)
+  }, [preserveExecutor])
+
+  const handleToggle = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const newPreserveState = !localPreserveState
+      if (newPreserveState) {
+        // Set preserve executor
+        await taskApis.setPreserveExecutor(taskId)
+        toast({
+          title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
+          description:
+            t('tasks:preserve_executor.enabled_desc') ||
+            "This task's executor pod will not be cleaned up after completion.",
+        })
+      } else {
+        // Cancel preserve executor
+        await taskApis.cancelPreserveExecutor(taskId)
+        toast({
+          title: t('tasks:preserve_executor.disabled_title') || 'Executor Cleanup Enabled',
+          description:
+            t('tasks:preserve_executor.disabled_desc') ||
+            "This task's executor pod will be cleaned up normally.",
+        })
+      }
+      setLocalPreserveState(newPreserveState)
+      onToggle?.(newPreserveState)
+    } catch (error) {
+      console.error('Failed to toggle preserve executor:', error)
+      toast({
+        variant: 'destructive',
+        title: t('tasks:preserve_executor.error_title') || 'Failed to Update',
+        description:
+          (error as Error)?.message ||
+          t('tasks:preserve_executor.error_desc') ||
+          'Could not update executor preservation setting.',
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [taskId, localPreserveState, onToggle, t, toast])
+
+  const isPreserved = localPreserveState
+
+  if (variant === 'icon') {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant={isPreserved ? 'default' : 'outline'}
+              size="icon"
+              onClick={handleToggle}
+              disabled={isLoading}
+              className={
+                isPreserved
+                  ? 'bg-primary text-white hover:bg-primary/90 h-8 w-8 rounded-[7px]'
+                  : 'h-8 w-8 rounded-[7px]'
+              }
+            >
+              {isPreserved ? <ShieldCheck className="h-4 w-4" /> : <Shield className="h-4 w-4" />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            <p>
+              {isPreserved
+                ? t('tasks:preserve_executor.tooltip_preserved') || 'Executor preserved'
+                : t('tasks:preserve_executor.tooltip_not_preserved') || 'Preserve executor'}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant={isPreserved ? 'default' : 'outline'}
+            size={size}
+            onClick={handleToggle}
+            disabled={isLoading}
+            className={
+              isPreserved
+                ? 'bg-primary text-white hover:bg-primary/90 flex items-center gap-1 h-8 pl-2 pr-3 rounded-[7px] text-sm'
+                : 'flex items-center gap-1 h-8 pl-2 pr-3 rounded-[7px] text-sm'
+            }
+          >
+            {isPreserved ? (
+              <>
+                <ShieldCheck className="h-3.5 w-3.5" />
+                {t('tasks:preserve_executor.preserved') || 'Preserved'}
+              </>
+            ) : (
+              <>
+                <Shield className="h-3.5 w-3.5" />
+                {t('tasks:preserve_executor.preserve') || 'Preserve'}
+              </>
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          <p>
+            {isPreserved
+              ? t('tasks:preserve_executor.tooltip_preserved') ||
+                'Executor is preserved and will not be cleaned up'
+              : t('tasks:preserve_executor.tooltip_not_preserved') ||
+                'Click to preserve executor from cleanup'}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -913,7 +913,6 @@ export default function MessagesArea({
                     try {
                       if (selectedTaskDetail.preserve_executor) {
                         await taskApis.cancelPreserveExecutor(selectedTaskDetail.id)
-                        selectedTaskDetail.preserve_executor = false
                         toast({
                           title:
                             t('tasks:preserve_executor.disabled_title') ||
@@ -924,7 +923,6 @@ export default function MessagesArea({
                         })
                       } else {
                         await taskApis.setPreserveExecutor(selectedTaskDetail.id)
-                        selectedTaskDetail.preserve_executor = true
                         toast({
                           title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
                           description:
@@ -932,6 +930,8 @@ export default function MessagesArea({
                             'Executor will not be cleaned up.',
                         })
                       }
+                      // Refresh task detail to get updated state from backend
+                      refreshSelectedTaskDetail(false)
                     } catch (error) {
                       toast({
                         variant: 'destructive',
@@ -1005,11 +1005,9 @@ export default function MessagesArea({
             <PreserveExecutorToggle
               taskId={selectedTaskDetail.id}
               preserveExecutor={selectedTaskDetail.preserve_executor || false}
-              onToggle={preserve => {
-                // Update local state to reflect the change
-                if (selectedTaskDetail) {
-                  selectedTaskDetail.preserve_executor = preserve
-                }
+              onToggle={() => {
+                // Refresh task detail to get updated preserve_executor state from backend
+                refreshSelectedTaskDetail(false)
               }}
             />
           )}
@@ -1062,6 +1060,8 @@ export default function MessagesArea({
     selectedTaskDetail?.id,
     selectedTaskDetail?.is_group_chat,
     selectedTaskDetail?.team?.agent_type,
+    selectedTaskDetail?.status,
+    selectedTaskDetail?.preserve_executor,
     messages.length,
     isSharing,
     isMobile,
@@ -1070,6 +1070,7 @@ export default function MessagesArea({
     handleExportDocx,
     t,
     hideGroupChatOptions,
+    refreshSelectedTaskDetail,
   ])
 
   // Pass share button to parent for rendering in TopNavigation

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -905,56 +905,54 @@ export default function MessagesArea({
               <FileText className="h-4 w-4" />
               <span>{t('chat:export.export_docx') || 'Export DOCX'}</span>
             </DropdownMenuItem>
-            {/* Preserve Executor Toggle - only show for completed/failed/cancelled tasks */}
-            {selectedTaskDetail?.id &&
-              ['COMPLETED', 'FAILED', 'CANCELLED'].includes(selectedTaskDetail?.status || '') && (
-                <DropdownMenuItem
-                  onClick={async () => {
-                    try {
-                      if (selectedTaskDetail.preserve_executor) {
-                        await taskApis.cancelPreserveExecutor(selectedTaskDetail.id)
-                        toast({
-                          title:
-                            t('tasks:preserve_executor.disabled_title') ||
-                            'Executor Cleanup Enabled',
-                          description:
-                            t('tasks:preserve_executor.disabled_desc') ||
-                            'Executor will be cleaned up normally.',
-                        })
-                      } else {
-                        await taskApis.setPreserveExecutor(selectedTaskDetail.id)
-                        toast({
-                          title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
-                          description:
-                            t('tasks:preserve_executor.enabled_desc') ||
-                            'Executor will not be cleaned up.',
-                        })
-                      }
-                      // Refresh task detail to get updated state from backend
-                      refreshSelectedTaskDetail(false)
-                    } catch (error) {
+            {/* Preserve Executor Toggle - show for all task statuses */}
+            {selectedTaskDetail?.id && (
+              <DropdownMenuItem
+                onClick={async () => {
+                  try {
+                    if (selectedTaskDetail.preserve_executor) {
+                      await taskApis.cancelPreserveExecutor(selectedTaskDetail.id)
                       toast({
-                        variant: 'destructive',
-                        title: t('tasks:preserve_executor.error_title') || 'Failed to Update',
-                        description: (error as Error)?.message || 'Could not update setting.',
+                        title:
+                          t('tasks:preserve_executor.disabled_title') || 'Executor Cleanup Enabled',
+                        description:
+                          t('tasks:preserve_executor.disabled_desc') ||
+                          'Executor will be cleaned up normally.',
+                      })
+                    } else {
+                      await taskApis.setPreserveExecutor(selectedTaskDetail.id)
+                      toast({
+                        title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
+                        description:
+                          t('tasks:preserve_executor.enabled_desc') ||
+                          'Executor will not be cleaned up.',
                       })
                     }
-                  }}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
-                  {selectedTaskDetail.preserve_executor ? (
-                    <>
-                      <ShieldCheck className="h-4 w-4 text-primary" />
-                      <span>{t('tasks:preserve_executor.preserved') || 'Executor Preserved'}</span>
-                    </>
-                  ) : (
-                    <>
-                      <Shield className="h-4 w-4" />
-                      <span>{t('tasks:preserve_executor.preserve') || 'Preserve Executor'}</span>
-                    </>
-                  )}
-                </DropdownMenuItem>
-              )}
+                    // Refresh task detail to get updated state from backend
+                    refreshSelectedTaskDetail(false)
+                  } catch (error) {
+                    toast({
+                      variant: 'destructive',
+                      title: t('tasks:preserve_executor.error_title') || 'Failed to Update',
+                      description: (error as Error)?.message || 'Could not update setting.',
+                    })
+                  }
+                }}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                {selectedTaskDetail.preserve_executor ? (
+                  <>
+                    <ShieldCheck className="h-4 w-4 text-primary" />
+                    <span>{t('tasks:preserve_executor.preserved') || 'Executor Preserved'}</span>
+                  </>
+                ) : (
+                  <>
+                    <Shield className="h-4 w-4" />
+                    <span>{t('tasks:preserve_executor.preserve') || 'Preserve Executor'}</span>
+                  </>
+                )}
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={() => {
                 const feedbackUrl = getRuntimeConfigSync().feedbackUrl
@@ -999,18 +997,17 @@ export default function MessagesArea({
           </Button>
         )}
 
-        {/* Preserve Executor Toggle - only show for completed/failed/cancelled tasks */}
-        {selectedTaskDetail?.id &&
-          ['COMPLETED', 'FAILED', 'CANCELLED'].includes(selectedTaskDetail?.status || '') && (
-            <PreserveExecutorToggle
-              taskId={selectedTaskDetail.id}
-              preserveExecutor={selectedTaskDetail.preserve_executor || false}
-              onToggle={() => {
-                // Refresh task detail to get updated preserve_executor state from backend
-                refreshSelectedTaskDetail(false)
-              }}
-            />
-          )}
+        {/* Preserve Executor Toggle - show for all task statuses */}
+        {selectedTaskDetail?.id && (
+          <PreserveExecutorToggle
+            taskId={selectedTaskDetail.id}
+            preserveExecutor={selectedTaskDetail.preserve_executor || false}
+            onToggle={() => {
+              // Refresh task detail to get updated preserve_executor state from backend
+              refreshSelectedTaskDetail(false)
+            }}
+          />
+        )}
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -15,8 +15,6 @@ import {
   MessageSquare,
   Users,
   MoreHorizontal,
-  Shield,
-  ShieldCheck,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -905,54 +903,6 @@ export default function MessagesArea({
               <FileText className="h-4 w-4" />
               <span>{t('chat:export.export_docx') || 'Export DOCX'}</span>
             </DropdownMenuItem>
-            {/* Preserve Executor Toggle - show for all task statuses */}
-            {selectedTaskDetail?.id && (
-              <DropdownMenuItem
-                onClick={async () => {
-                  try {
-                    if (selectedTaskDetail.preserve_executor) {
-                      await taskApis.cancelPreserveExecutor(selectedTaskDetail.id)
-                      toast({
-                        title:
-                          t('tasks:preserve_executor.disabled_title') || 'Executor Cleanup Enabled',
-                        description:
-                          t('tasks:preserve_executor.disabled_desc') ||
-                          'Executor will be cleaned up normally.',
-                      })
-                    } else {
-                      await taskApis.setPreserveExecutor(selectedTaskDetail.id)
-                      toast({
-                        title: t('tasks:preserve_executor.enabled_title') || 'Executor Preserved',
-                        description:
-                          t('tasks:preserve_executor.enabled_desc') ||
-                          'Executor will not be cleaned up.',
-                      })
-                    }
-                    // Refresh task detail to get updated state from backend
-                    refreshSelectedTaskDetail(false)
-                  } catch (error) {
-                    toast({
-                      variant: 'destructive',
-                      title: t('tasks:preserve_executor.error_title') || 'Failed to Update',
-                      description: (error as Error)?.message || 'Could not update setting.',
-                    })
-                  }
-                }}
-                className="flex items-center gap-2 cursor-pointer"
-              >
-                {selectedTaskDetail.preserve_executor ? (
-                  <>
-                    <ShieldCheck className="h-4 w-4 text-primary" />
-                    <span>{t('tasks:preserve_executor.preserved') || 'Executor Preserved'}</span>
-                  </>
-                ) : (
-                  <>
-                    <Shield className="h-4 w-4" />
-                    <span>{t('tasks:preserve_executor.preserve') || 'Preserve Executor'}</span>
-                  </>
-                )}
-              </DropdownMenuItem>
-            )}
             <DropdownMenuItem
               onClick={() => {
                 const feedbackUrl = getRuntimeConfigSync().feedbackUrl
@@ -997,15 +947,10 @@ export default function MessagesArea({
           </Button>
         )}
 
-        {/* Preserve Executor Toggle - show for all task statuses */}
-        {selectedTaskDetail?.id && (
+        {/* Preserve Executor Indicator - only show for code tasks when preserved */}
+        {selectedTaskDetail?.task_type === 'code' && (
           <PreserveExecutorToggle
-            taskId={selectedTaskDetail.id}
             preserveExecutor={selectedTaskDetail.preserve_executor || false}
-            onToggle={() => {
-              // Refresh task detail to get updated preserve_executor state from backend
-              refreshSelectedTaskDetail(false)
-            }}
           />
         )}
 
@@ -1059,6 +1004,7 @@ export default function MessagesArea({
     selectedTaskDetail?.team?.agent_type,
     selectedTaskDetail?.status,
     selectedTaskDetail?.preserve_executor,
+    selectedTaskDetail?.task_type,
     messages.length,
     isSharing,
     isMobile,
@@ -1067,7 +1013,6 @@ export default function MessagesArea({
     handleExportDocx,
     t,
     hideGroupChatOptions,
-    refreshSelectedTaskDetail,
   ])
 
   // Pass share button to parent for rendering in TopNavigation

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -921,6 +921,13 @@ export default function MessagesArea({
     // Desktop: Show all buttons inline
     return (
       <div className="flex items-center gap-2">
+        {/* Preserve Executor Indicator - only show for code tasks when preserved */}
+        {selectedTaskDetail?.task_type === 'code' && (
+          <PreserveExecutorToggle
+            preserveExecutor={selectedTaskDetail.preserve_executor || false}
+          />
+        )}
+
         {showMembersButton && (
           <Button
             variant="outline"
@@ -945,13 +952,6 @@ export default function MessagesArea({
             <Share2 className="h-3.5 w-3.5" />
             {isSharing ? t('shared-task:sharing') : t('shared-task:share_link')}
           </Button>
-        )}
-
-        {/* Preserve Executor Indicator - only show for code tasks when preserved */}
-        {selectedTaskDetail?.task_type === 'code' && (
-          <PreserveExecutorToggle
-            preserveExecutor={selectedTaskDetail.preserve_executor || false}
-          />
         )}
 
         <DropdownMenu>

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -101,5 +101,17 @@
     "analyzing": "Analyzing in depth",
     "generating_response": "Please wait, generating response",
     "longer_than_usual": "Response is taking longer than usual"
+  },
+  "preserve_executor": {
+    "preserve": "Preserve",
+    "preserved": "Preserved",
+    "enabled_title": "Executor Preserved",
+    "enabled_desc": "This task's executor pod will not be cleaned up after completion.",
+    "disabled_title": "Executor Cleanup Enabled",
+    "disabled_desc": "This task's executor pod will be cleaned up normally.",
+    "error_title": "Failed to Update",
+    "error_desc": "Could not update executor preservation setting.",
+    "tooltip_preserved": "Executor is preserved and will not be cleaned up",
+    "tooltip_not_preserved": "Click to preserve executor from cleanup"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -97,5 +97,17 @@
     "analyzing": "正在深入分析",
     "generating_response": "请稍候，正在生成回复",
     "longer_than_usual": "响应时间较长，请耐心等待"
+  },
+  "preserve_executor": {
+    "preserve": "保留环境",
+    "preserved": "已保留",
+    "enabled_title": "已保留执行环境",
+    "enabled_desc": "此任务的执行环境将在任务完成后保留，不会被清理。",
+    "disabled_title": "已启用环境清理",
+    "disabled_desc": "此任务的执行环境将按正常规则清理。",
+    "error_title": "更新失败",
+    "error_desc": "无法更新执行环境保留设置。",
+    "tooltip_preserved": "执行环境已保留，不会被清理",
+    "tooltip_not_preserved": "点击保留执行环境，防止被清理"
   }
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -274,6 +274,7 @@ export interface TaskDetail {
   member_count?: number // Number of active members in the group
   app?: TaskApp | null // App preview information (set by expose_service tool)
   device_id?: string | null // Device ID used for execution (for task history)
+  preserve_executor?: boolean // Whether to preserve executor pod after task completion
 }
 
 /** Correction data stored in subtask.result.correction */


### PR DESCRIPTION
## Summary

This PR adds the ability to preserve executor pods for specific tasks, preventing them from being cleaned up by the `cleanup_stale_executors` job even after task completion.

## Changes

### Backend
- **Modified `cleanup_stale_executors` job** (`backend/app/services/adapters/executor_job.py`):
  - Added check for `preserveExecutor` label in task metadata
  - Tasks with `preserveExecutor="true"` are skipped from cleanup
  - Logs skipped executors for audit purposes

- **Added service method** (`backend/app/services/adapters/task_kinds/operations.py`):
  - Added `set_preserve_executor()` method to set/cancel preserve flag
  - Validates user permissions using `task_member_service.is_member()`
  - Updates task CRD metadata.labels and persists to database

- **Added API endpoints** (`backend/app/api/endpoints/adapter/tasks.py`):
  - `POST /tasks/{task_id}/preserve-executor` - Set preserve flag
  - `DELETE /tasks/{task_id}/preserve-executor` - Cancel preserve flag

- **Updated schemas** (`backend/app/schemas/task.py`):
  - Added `preserve_executor` field to `TaskInDB` and `TaskDetail` schemas

- **Updated converters** (`backend/app/services/adapters/task_kinds/converters.py`):
  - `convert_to_task_dict()` and `convert_to_task_dict_optimized()` now include `preserve_executor` field

### Frontend
- **Added API methods** (`frontend/src/apis/tasks.ts`):
  - `setPreserveExecutor(taskId)` - Set preserve flag
  - `cancelPreserveExecutor(taskId)` - Cancel preserve flag

- **Added component** (`frontend/src/features/tasks/components/PreserveExecutorToggle.tsx`):
  - Reusable toggle component with button and icon variants
  - Shows toast notifications on success/error
  - Includes tooltip explanations

- **Updated MessagesArea** (`frontend/src/features/tasks/components/message/MessagesArea.tsx`):
  - Added preserve executor toggle to desktop header (for completed/failed/cancelled tasks)
  - Added preserve executor option to mobile dropdown menu

- **Added i18n translations**:
  - English (`frontend/src/i18n/locales/en/tasks.json`)
  - Chinese (`frontend/src/i18n/locales/zh-CN/tasks.json`)

- **Updated types** (`frontend/src/types/api.ts`):
  - Added `preserve_executor` field to `TaskDetail` interface

## How It Works

1. When a task is completed, failed, or cancelled, the user can click the "Preserve" button in the task header
2. This sets the `preserveExecutor: "true"` label in the task's metadata.labels
3. The `cleanup_stale_executors` job checks for this label and skips tasks that have it set
4. The executor pod remains running even after the task is complete
5. Users can cancel preservation at any time by clicking the button again

## Test Plan

- [ ] Verify `cleanup_stale_executors` skips tasks with `preserveExecutor="true"`
- [ ] Verify API endpoints correctly set/cancel preserve flag
- [ ] Verify permission checks work (only task members can modify)
- [ ] Verify frontend toggle appears only for completed/failed/cancelled tasks
- [ ] Verify toggle updates UI and shows toast notifications
- [ ] Verify translations work in both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - UI: Read-only indicator showing when a task’s execution environment will be preserved; task details expose a preserve flag.
- **API**
  - New user-facing actions to enable/disable preserving a task’s executor from the UI.
- **Localization**
  - Added English and Chinese translations for preserve-preserved states, tooltips, and messages.
- **Tests**
  - Added comprehensive tests validating preserve behavior and cleanup handling.
- **Style**
  - Minor formatting/readability edits with no behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->