### PR TITLE
fix(executor): stabilize local startup in packaged binary

### DIFF
--- a/executor/modes/local/events.py
+++ b/executor/modes/local/events.py
@@ -5,14 +5,9 @@
 """
 Event type definitions for local executor mode.
 
-Uses OpenAI Responses API event types from shared.models.responses_api.
-This ensures consistency across all execution modes (SSE, callback, device).
-
-Socket.IO event names are now based on OpenAI Responses API event types.
+Keep this module dependency-light because it is imported during local-mode
+bootstrap in the PyInstaller binary.
 """
-
-# Re-export OpenAI Responses API event types from shared module
-from shared.models.responses_api import ResponsesAPIStreamEvents
 
 
 class DeviceEvents:
@@ -35,35 +30,31 @@ class TaskEvents:
 
 
 class ChatEvents:
-    """Chat streaming events using OpenAI Responses API event types.
-
-    These event names are used as Socket.IO event names and match
-    the OpenAI Responses API event types for consistency.
-    """
+    """Chat streaming events (Socket.IO event names)."""
 
     # Wegent-specific incoming events
     MESSAGE = "chat:message"
 
     # Lifecycle events
-    START = ResponsesAPIStreamEvents.RESPONSE_CREATED.value
-    IN_PROGRESS = ResponsesAPIStreamEvents.RESPONSE_IN_PROGRESS.value
-    DONE = ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value
-    INCOMPLETE = ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value
-    ERROR = ResponsesAPIStreamEvents.ERROR.value
+    START = "response.created"
+    IN_PROGRESS = "response.in_progress"
+    DONE = "response.completed"
+    INCOMPLETE = "response.incomplete"
+    ERROR = "error"
 
     # Content streaming events
-    CHUNK = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value
-    TEXT_DONE = ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE.value
+    CHUNK = "response.output_text.delta"
+    TEXT_DONE = "response.output_text.done"
 
     # Tool events
-    TOOL_START = ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value
-    TOOL_DONE = ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value
+    TOOL_START = "response.function_call_arguments.delta"
+    TOOL_DONE = "response.function_call_arguments.done"
 
     # Reasoning events
-    THINKING = ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value
+    THINKING = "response.reasoning_summary_part.added"
 
     # Output item events
-    OUTPUT_ITEM_ADDED = ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value
-    OUTPUT_ITEM_DONE = ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value
-    CONTENT_PART_ADDED = ResponsesAPIStreamEvents.CONTENT_PART_ADDED.value
-    CONTENT_PART_DONE = ResponsesAPIStreamEvents.CONTENT_PART_DONE.value
+    OUTPUT_ITEM_ADDED = "response.output_item.added"
+    OUTPUT_ITEM_DONE = "response.output_item.done"
+    CONTENT_PART_ADDED = "response.content_part.added"
+    CONTENT_PART_DONE = "response.content_part.done"

--- a/executor/modes/local/events.py
+++ b/executor/modes/local/events.py
@@ -5,9 +5,14 @@
 """
 Event type definitions for local executor mode.
 
-Keep this module dependency-light because it is imported during local-mode
-bootstrap in the PyInstaller binary.
+Uses OpenAI Responses API event types from shared.models.responses_api.
+This ensures consistency across all execution modes (SSE, callback, device).
+
+Socket.IO event names are now based on OpenAI Responses API event types.
 """
+
+# Re-export OpenAI Responses API event types from shared module
+from shared.models.responses_api import ResponsesAPIStreamEvents
 
 
 class DeviceEvents:
@@ -30,31 +35,35 @@ class TaskEvents:
 
 
 class ChatEvents:
-    """Chat streaming events (Socket.IO event names)."""
+    """Chat streaming events using OpenAI Responses API event types.
+
+    These event names are used as Socket.IO event names and match
+    the OpenAI Responses API event types for consistency.
+    """
 
     # Wegent-specific incoming events
     MESSAGE = "chat:message"
 
     # Lifecycle events
-    START = "response.created"
-    IN_PROGRESS = "response.in_progress"
-    DONE = "response.completed"
-    INCOMPLETE = "response.incomplete"
-    ERROR = "error"
+    START = ResponsesAPIStreamEvents.RESPONSE_CREATED.value
+    IN_PROGRESS = ResponsesAPIStreamEvents.RESPONSE_IN_PROGRESS.value
+    DONE = ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value
+    INCOMPLETE = ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value
+    ERROR = ResponsesAPIStreamEvents.ERROR.value
 
     # Content streaming events
-    CHUNK = "response.output_text.delta"
-    TEXT_DONE = "response.output_text.done"
+    CHUNK = ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value
+    TEXT_DONE = ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE.value
 
     # Tool events
-    TOOL_START = "response.function_call_arguments.delta"
-    TOOL_DONE = "response.function_call_arguments.done"
+    TOOL_START = ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value
+    TOOL_DONE = ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value
 
     # Reasoning events
-    THINKING = "response.reasoning_summary_part.added"
+    THINKING = ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value
 
     # Output item events
-    OUTPUT_ITEM_ADDED = "response.output_item.added"
-    OUTPUT_ITEM_DONE = "response.output_item.done"
-    CONTENT_PART_ADDED = "response.content_part.added"
-    CONTENT_PART_DONE = "response.content_part.done"
+    OUTPUT_ITEM_ADDED = ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value
+    OUTPUT_ITEM_DONE = ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value
+    CONTENT_PART_ADDED = ResponsesAPIStreamEvents.CONTENT_PART_ADDED.value
+    CONTENT_PART_DONE = ResponsesAPIStreamEvents.CONTENT_PART_DONE.value

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -417,8 +417,13 @@ def build_executable(
             "--hidden-import=starlette.types",
             "--hidden-import=sse_starlette",
             "--hidden-import=sse_starlette.sse",
+            # Tokenizer plugin used by litellm/tiktoken at runtime
+            "--hidden-import=tiktoken_ext.openai_public",
             # SSL certificates (needed for HTTPS connections)
             "--collect-data=certifi",
+            "--collect-data=litellm",
+            "--collect-data=tiktoken",
+            "--collect-data=tiktoken_ext",
         ]
 
         # Add Claude CLI binary only for Windows (avoids asyncio + .cmd issue)


### PR DESCRIPTION
## Summary
- avoid heavy startup import path in local-mode events module
- include litellm/tiktoken runtime assets in PyInstaller build
- fix startup crash caused by missing tokenizer plugins/resources in packaged executor

## Scope
- only executor startup related changes
- files changed:
  - executor/modes/local/events.py
  - executor/scripts/build_local.py

## Verification
- rebuilt executor binary with scripts/build_local.py
- startup no longer fails with tiktoken cl100k_base / missing tokenizer resource errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal event handling with standardized socket event naming.

* **Chores**
  * Updated build configuration to ensure proper bundling of tokenization and model runtime dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->