### PR TITLE
feat(executor): add client_ip to device registration

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -158,7 +158,7 @@ def _handle_device_disconnect(user_id: int, device_id: str) -> list[FailedSubtas
 
 
 def _register_device(
-    user_id: int, device_id: str, name: str
+    user_id: int, device_id: str, name: str, client_ip: Optional[str] = None
 ) -> tuple[bool, Optional[str]]:
     """
     Register or update device CRD in database.
@@ -167,6 +167,7 @@ def _register_device(
         user_id: Device owner user ID
         device_id: Device unique identifier (stored in Kind.name)
         name: Device display name
+        client_ip: Device's client IP address
 
     Returns (success, error_message).
     """
@@ -177,6 +178,7 @@ def _register_device(
                 user_id=user_id,
                 device_id=device_id,
                 name=name,
+                client_ip=client_ip,
             )
         return True, None
     except Exception as e:
@@ -479,11 +481,11 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
         logger.info(
             f"[Device WS] device:register user={user_id}, device_id={payload.device_id}, "
-            f"name={payload.name}, executor_version={payload.executor_version}"
+            f"name={payload.name}, executor_version={payload.executor_version}, client_ip={payload.client_ip}"
         )
 
         # Database operation: quick in, quick out
-        success, error = _register_device(user_id, payload.device_id, payload.name)
+        success, error = _register_device(user_id, payload.device_id, payload.name, payload.client_ip)
         if not success:
             return {"error": f"Registration failed: {error}"}
 

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -90,6 +90,10 @@ class DeviceInfo(BaseModel):
         None, description="Latest available executor version"
     )
     update_available: bool = Field(False, description="Whether an update is available")
+    # Network information
+    client_ip: Optional[str] = Field(
+        None, description="Device's client IP address"
+    )
 
     class Config:
         from_attributes = True
@@ -129,6 +133,11 @@ class DeviceRegisterPayload(BaseModel):
         None,
         max_length=50,
         description="Executor version (e.g., '1.0.0')",
+    )
+    client_ip: Optional[str] = Field(
+        None,
+        max_length=50,
+        description="Device's client IP address",
     )
 
 

--- a/backend/app/services/device/base_provider.py
+++ b/backend/app/services/device/base_provider.py
@@ -51,6 +51,7 @@ class BaseDeviceProvider(ABC):
         socket_id: Optional[str] = None,
         executor_version: Optional[str] = None,
         capabilities: Optional[List[str]] = None,
+        client_ip: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Register a device.
 
@@ -65,6 +66,7 @@ class BaseDeviceProvider(ABC):
             socket_id: WebSocket session ID (for WebSocket-connected devices)
             executor_version: Executor version string
             capabilities: List of capability tags
+            client_ip: Device's client IP address
 
         Returns:
             Dict containing device info including 'id' and 'is_default'

--- a/backend/app/services/device/local_provider.py
+++ b/backend/app/services/device/local_provider.py
@@ -70,6 +70,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
         socket_id: Optional[str] = None,
         executor_version: Optional[str] = None,
         capabilities: Optional[List[str]] = None,
+        client_ip: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Register a local device.
 
@@ -83,6 +84,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
             socket_id: WebSocket session ID
             executor_version: Executor version string
             capabilities: Device capability tags
+            client_ip: Device's client IP address
 
         Returns:
             Dict with device 'id' and 'is_default'
@@ -110,6 +112,8 @@ class LocalDeviceProvider(BaseDeviceProvider):
             device_json["spec"]["connectionMode"] = DeviceConnectionMode.WEBSOCKET.value
             if capabilities is not None:
                 device_json["spec"]["capabilities"] = capabilities
+            if client_ip is not None:
+                device_json["spec"]["clientIp"] = client_ip
             device_kind.json = device_json
             device_kind.updated_at = datetime.now()
             device_kind.is_active = True
@@ -149,6 +153,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
                     "connectionMode": DeviceConnectionMode.WEBSOCKET.value,
                     "isDefault": is_first_device,
                     "capabilities": capabilities,
+                    "clientIp": client_ip,
                 },
                 "status": {
                     "state": "Available",
@@ -277,6 +282,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
             "executor_version": executor_version,
             "latest_version": latest_version,
             "update_available": update_available,
+            "client_ip": spec.get("clientIp"),
         }
 
     async def _get_online_info(
@@ -369,6 +375,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
                     "executor_version": executor_version,
                     "latest_version": latest_version,
                     "update_available": update_available,
+                    "client_ip": spec.get("clientIp"),
                 }
             )
 

--- a/backend/app/services/device_service.py
+++ b/backend/app/services/device_service.py
@@ -253,6 +253,7 @@ class DeviceService:
         user_id: int,
         device_id: str,
         name: str,
+        client_ip: Optional[str] = None,
     ) -> Kind:
         """Create or update a Device CRD record.
 
@@ -264,6 +265,7 @@ class DeviceService:
             user_id: Device owner user ID
             device_id: Device unique identifier (stored in Kind.name)
             name: Device display name (stored in spec.displayName)
+            client_ip: Device's client IP address (stored in spec.clientIp)
 
         Returns:
             Kind model instance for the device
@@ -291,6 +293,9 @@ class DeviceService:
                 device_json["spec"]["deviceType"] = DeviceType.LOCAL.value
             if "connectionMode" not in device_json["spec"]:
                 device_json["spec"]["connectionMode"] = "websocket"
+            # Update client IP if provided
+            if client_ip is not None:
+                device_json["spec"]["clientIp"] = client_ip
             device_kind.json = device_json
             device_kind.updated_at = datetime.now()
             device_kind.is_active = True
@@ -328,6 +333,7 @@ class DeviceService:
                     "connectionMode": "websocket",
                     "isDefault": is_first_device,
                     "capabilities": None,
+                    "clientIp": client_ip,
                 },
                 "status": {
                     "state": "Available",

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -326,7 +326,7 @@ class WebSocketClient:
                 if ip and ip != '127.0.0.1':
                     return ip
         except Exception:
-            pass
+            logger.debug("Failed to detect IP via UDP socket", exc_info=True)
 
         try:
             # Method 2: Get hostname resolution
@@ -334,10 +334,10 @@ class WebSocketClient:
             if ip and ip != '127.0.0.1':
                 return ip
         except Exception:
-            pass
+            logger.debug("Failed to detect IP via hostname resolution", exc_info=True)
 
         try:
-            # Method 3: Try to get IP from network interfaces (Linux/Mac)
+            # Method 3: Try to get IP from network interfaces (Linux only)
             result = subprocess.run(
                 ['hostname', '-I'],
                 capture_output=True,
@@ -350,7 +350,7 @@ class WebSocketClient:
                     if ip and not ip.startswith('127.'):
                         return ip
         except Exception:
-            pass
+            logger.debug("Failed to detect IP via hostname -I", exc_info=True)
 
         # Fallback to localhost
         return '127.0.0.1'

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -34,6 +34,7 @@ import hashlib
 import os
 import platform
 import re
+import socket
 import subprocess
 import uuid
 from pathlib import Path
@@ -303,6 +304,57 @@ class WebSocketClient:
         """Get device name from system."""
         return f"{platform.system()} - {platform.node()}"
 
+    def _get_client_ip(self) -> str:
+        """Get the local IP address of the default route interface.
+
+        This method attempts to determine the IP address of the interface
+        used for the default route (internet connection). Falls back to
+        127.0.0.1 if detection fails.
+
+        Returns:
+            Local IP address string.
+        """
+        try:
+            # Method 1: Try to connect to a public DNS server to determine
+            # which interface would be used for internet traffic
+            # This doesn't actually send any data, just sets up the socket
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                s.settimeout(2)
+                # Google's public DNS server (8.8.8.8)
+                s.connect(('8.8.8.8', 80))
+                ip = s.getsockname()[0]
+                if ip and ip != '127.0.0.1':
+                    return ip
+        except Exception:
+            pass
+
+        try:
+            # Method 2: Get hostname resolution
+            ip = socket.gethostbyname(socket.gethostname())
+            if ip and ip != '127.0.0.1':
+                return ip
+        except Exception:
+            pass
+
+        try:
+            # Method 3: Try to get IP from network interfaces (Linux/Mac)
+            result = subprocess.run(
+                ['hostname', '-I'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0:
+                ips = result.stdout.strip().split()
+                for ip in ips:
+                    if ip and not ip.startswith('127.'):
+                        return ip
+        except Exception:
+            pass
+
+        # Fallback to localhost
+        return '127.0.0.1'
+
     def _setup_internal_handlers(self) -> None:
         """Setup internal event handlers for connection lifecycle."""
 
@@ -424,6 +476,7 @@ class WebSocketClient:
                 "device_id": self.device_id,
                 "name": self.device_name,
                 "executor_version": get_version(),
+                "client_ip": self._get_client_ip(),
             }
             logger.info(f"Sending device:register to /local-executor: {register_data}")
 


### PR DESCRIPTION
## Summary

Add client_ip field to executor local registration to properly capture the executor's actual IP address instead of 127.0.0.1.

## Changes

### Executor Side
- **websocket_client.py**: 
  - Added `_get_client_ip()` method that detects the local IP address using the default route interface
  - Uses multiple fallback methods: UDP socket to 8.8.8.8, hostname resolution, and subprocess
  - Includes `client_ip` in the device registration payload

### Backend Side
- **device.py (schemas)**:
  - Added `client_ip: Optional[str]` field to `DeviceRegisterPayload`
  - Added `client_ip: Optional[str]` field to `DeviceInfo`

- **base_provider.py**:
  - Added `client_ip: Optional[str]` parameter to `register()` abstract method

- **local_provider.py**:
  - Updated `register()` to accept and store `client_ip` in the Device CRD's `spec.clientIp` field
  - Updated `get_status()` and `list_devices()` to include `client_ip` in responses

- **device_service.py**:
  - Updated `upsert_device_crd()` to accept and store `client_ip`

- **device_namespace.py**:
  - Updated `_register_device()` to pass `client_ip` to device service
  - Updated `on_device_register()` to extract `client_ip` from payload

## Implementation Details

The IP detection uses the following priority:
1. UDP socket connection to 8.8.8.8 (determines default route interface)
2. Hostname resolution via `socket.gethostbyname()`
3. Fallback to `127.0.0.1` if all methods fail

The `client_ip` is stored in the Device CRD's JSON `spec.clientIp` field and is included in device status responses but not displayed in the UI.

## Test Plan

- [ ] Verify executor detects correct local IP address
- [ ] Verify executor sends client_ip in registration payload
- [ ] Verify backend stores client_ip in Device CRD
- [ ] Verify client_ip is returned in device list/status APIs
- [ ] Verify backward compatibility (executors without client_ip still work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Devices now automatically detect and report their client IP address during registration.
  * Client IP is included in registration payloads and stored in device profiles for each device.
  * Device status queries and device listings now display client IP information to aid network identification.
  * Local clients attempt multiple strategies to determine their reachable IP before reporting it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->