### PR TITLE
fix(executor_manager): fix "argument list too long" error for large TASK_INFO

### DIFF
--- a/executor_manager/executors/docker/executor.py
+++ b/executor_manager/executors/docker/executor.py
@@ -15,6 +15,7 @@ Uses unified ExecutionRequest from shared.models.execution.
 import json
 import os
 import subprocess
+import tempfile
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -53,6 +54,10 @@ from shared.telemetry.config import get_otel_config
 from shared.utils.http_client import traced_session, traced_sync_client
 
 logger = setup_logger(__name__)
+
+# Maximum size of TASK_INFO to pass via environment variable (32KB)
+# If TASK_INFO exceeds this size, it will be written to a file and mounted as a volume
+TASK_INFO_ENV_MAX_SIZE = 32 * 1024  # 32KB
 
 
 class DockerExecutor(Executor):
@@ -645,7 +650,20 @@ class DockerExecutor(Executor):
         # Sandbox containers should wait for execute requests via API
         is_sandbox = get_metadata_field(task, "type") == "sandbox"
         if not is_sandbox:
-            cmd.extend(["-e", f"TASK_INFO={task_str}"])
+            # Check if TASK_INFO is too large to pass via environment variable
+            task_info_size = len(task_str.encode("utf-8"))
+            if task_info_size > TASK_INFO_ENV_MAX_SIZE:
+                # Write TASK_INFO to a temporary file and mount it as a volume
+                # This avoids "argument list too long" errors for large task data
+                task_info_file = self._write_task_info_to_temp_file(task_id, task_str)
+                cmd.extend(
+                    ["-v", f"{task_info_file}:/root/.wegent/.config/task_info:ro"]
+                )
+                logger.info(
+                    f"TASK_INFO too large ({task_info_size} bytes), using file mount for task {task_id}"
+                )
+            else:
+                cmd.extend(["-e", f"TASK_INFO={task_str}"])
         else:
             # For sandbox mode, pass auth_token and task_id via environment variables
             # so the container can call Backend API to fetch and download skills
@@ -714,6 +732,40 @@ class DockerExecutor(Executor):
         cmd.append(final_image)
 
         return cmd
+
+    def _write_task_info_to_temp_file(self, task_id: str, task_str: str) -> str:
+        """
+        Write TASK_INFO to a temporary file for mounting as a volume.
+
+        This is used when TASK_INFO is too large to pass via environment variable,
+        to avoid "argument list too long" errors.
+
+        The file is created in the system temp directory with a unique name
+        based on the task ID.
+
+        Args:
+            task_id: The task ID for creating a unique filename
+            task_str: The JSON-serialized task data
+
+        Returns:
+            Path to the temporary file
+        """
+        # Create a temp directory for task info files if it doesn't exist
+        temp_dir = os.path.join(tempfile.gettempdir(), "wegent_task_info")
+        os.makedirs(temp_dir, exist_ok=True)
+
+        # Create a unique filename based on task_id
+        # Use a sanitized version of task_id to ensure valid filename
+        task_id_str = str(task_id)
+        safe_task_id = "".join(c if c.isalnum() else "_" for c in task_id_str)
+        temp_file = os.path.join(temp_dir, f"{safe_task_id}_task_info.json")
+
+        # Write the task info to the file
+        with open(temp_file, "w", encoding="utf-8") as f:
+            f.write(task_str)
+
+        logger.debug(f"Wrote TASK_INFO to temporary file: {temp_file}")
+        return temp_file
 
     def _add_task_api_domain(self, cmd: List[str]) -> None:
         """Add TASK_API_DOMAIN environment variable for executor to access backend API"""

--- a/executor_manager/tests/executors/test_docker_executor.py
+++ b/executor_manager/tests/executors/test_docker_executor.py
@@ -2,13 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import subprocess
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
 
-from executor_manager.executors.docker.executor import DockerExecutor
+from executor_manager.executors.docker.executor import (
+    TASK_INFO_ENV_MAX_SIZE,
+    DockerExecutor,
+)
 from shared.status import TaskStatus
 
 
@@ -334,3 +338,104 @@ class TestDockerExecutor:
             progress=50,
             status=TaskStatus.RUNNING.value,
         )
+
+    def test_write_task_info_to_temp_file(self, executor):
+        """Test writing TASK_INFO to temporary file"""
+        task_id = "test-task-123"
+        task_data = {"key": "value", "nested": {"data": "test"}}
+        task_str = json.dumps(task_data)
+
+        temp_file = executor._write_task_info_to_temp_file(task_id, task_str)
+
+        # Verify file was created
+        assert os.path.exists(temp_file)
+        assert "wegent_task_info" in temp_file
+        assert "test_task_123" in temp_file
+
+        # Verify content
+        with open(temp_file, "r") as f:
+            content = f.read()
+            assert content == task_str
+            assert json.loads(content) == task_data
+
+        # Cleanup
+        os.remove(temp_file)
+
+    def test_write_task_info_sanitizes_task_id(self, executor):
+        """Test that task_id is sanitized for filename"""
+        task_id = "test/task:with.special@chars"
+        task_str = '{"data": "test"}'
+
+        temp_file = executor._write_task_info_to_temp_file(task_id, task_str)
+
+        # Verify file was created with sanitized name
+        assert os.path.exists(temp_file)
+        assert "test_task_with_special_chars" in temp_file
+
+        # Cleanup
+        os.remove(temp_file)
+
+    @patch("executor_manager.executors.docker.utils.get_docker_used_ports")
+    @patch("executor_manager.executors.docker.executor.build_callback_url")
+    def test_prepare_docker_command_large_task_info_uses_file_mount(
+        self, mock_callback, mock_get_ports, executor
+    ):
+        """Test that large TASK_INFO uses file mount instead of env var"""
+        mock_get_ports.return_value = set()
+        mock_callback.return_value = "http://callback.url"
+
+        # Create a large task that exceeds TASK_INFO_ENV_MAX_SIZE
+        large_content = "x" * (TASK_INFO_ENV_MAX_SIZE + 1000)
+        large_task = {
+            "task_id": 123,
+            "subtask_id": 456,
+            "user": {"name": "test_user"},
+            "executor_image": "test/executor:latest",
+            "mode": "code",
+            "type": "online",
+            "large_field": large_content,
+        }
+
+        task_info = executor._extract_task_info(large_task)
+        executor_name = "test-executor"
+        executor_image = "test/executor:latest"
+
+        cmd = executor._prepare_docker_command(
+            large_task, task_info, executor_name, executor_image
+        )
+
+        # Verify file mount is used instead of environment variable
+        cmd_str = " ".join(cmd)
+        assert "/root/.wegent/.config/task_info" in cmd_str
+        assert "TASK_INFO=" not in cmd_str
+
+        # Cleanup any created temp files
+        import tempfile
+
+        temp_dir = os.path.join(tempfile.gettempdir(), "wegent_task_info")
+        if os.path.exists(temp_dir):
+            for f in os.listdir(temp_dir):
+                if f.endswith("_task_info.json"):
+                    os.remove(os.path.join(temp_dir, f))
+
+    @patch("executor_manager.executors.docker.utils.get_docker_used_ports")
+    @patch("executor_manager.executors.docker.executor.build_callback_url")
+    def test_prepare_docker_command_small_task_info_uses_env_var(
+        self, mock_callback, mock_get_ports, executor, sample_task
+    ):
+        """Test that small TASK_INFO uses environment variable"""
+        mock_get_ports.return_value = set()
+        mock_callback.return_value = "http://callback.url"
+
+        task_info = executor._extract_task_info(sample_task)
+        executor_name = "test-executor"
+        executor_image = "test/executor:latest"
+
+        cmd = executor._prepare_docker_command(
+            sample_task, task_info, executor_name, executor_image
+        )
+
+        # Verify environment variable is used for small task info
+        cmd_str = " ".join(cmd)
+        assert "TASK_INFO=" in cmd_str
+        assert "/root/.wegent/.config/task_info" not in cmd_str


### PR DESCRIPTION
…ASK_INFO

When TASK_INFO environment variable exceeds 32KB, Docker run command fails with "argument list too long" error due to Linux ARG_MAX limit.

Solution:
- Add TASK_INFO_ENV_MAX_SIZE threshold (32KB)
- When TASK_INFO exceeds threshold, write to temp file and mount as volume
- Executor reads from /root/.wegent/.config/task_info (existing fallback)
- Small TASK_INFO continues to use environment variable

Changes:
- executor.py: Add _write_task_info_to_temp_file method, modify _prepare_docker_command to use file mount for large payloads
- test_docker_executor.py: Add 4 tests for new functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker executor now intelligently handles large task information by writing to temporary files and mounting them as read-only volumes instead of passing via environment variables. Smaller task information continues using the environment variable approach for efficiency.

* **Tests**
  * Added comprehensive test coverage for the new file-based task information transmission, including filename sanitization, file cleanup, and environment variable fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->