### PR TITLE
fix(mcp): fix variable substitution in CHAT_MCP_SERVERS configuration

### DIFF
--- a/backend/app/services/openapi/mcp.py
+++ b/backend/app/services/openapi/mcp.py
@@ -17,7 +17,9 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 
 
-async def load_server_mcp_tools(task_id: int) -> Any:
+async def load_server_mcp_tools(
+    task_id: int, task_data: dict[str, Any] | None = None
+) -> Any:
     """
     Load server-side MCP tools from CHAT_MCP_SERVERS configuration.
 
@@ -26,6 +28,7 @@ async def load_server_mcp_tools(task_id: int) -> Any:
 
     Args:
         task_id: Task ID for session management and logging
+        task_data: Optional task data for variable substitution in MCP configs
 
     Returns:
         MCPClient instance or None if no server MCP configured
@@ -54,8 +57,8 @@ async def load_server_mcp_tools(task_id: int) -> Any:
             )
             return None
 
-        # Create MCP client with server configuration
-        client = MCPClient(backend_servers)
+        # Create MCP client with server configuration and variable substitution
+        client = MCPClient(backend_servers, task_data=task_data)
         try:
             await asyncio.wait_for(client.connect(), timeout=30.0)
             logger.info(
@@ -82,7 +85,11 @@ async def load_server_mcp_tools(task_id: int) -> Any:
 
 
 async def load_bot_mcp_tools(
-    task_id: int, user_id: int, bot_name: str, bot_namespace: str = "default"
+    task_id: int,
+    user_id: int,
+    bot_name: str,
+    bot_namespace: str = "default",
+    task_data: dict[str, Any] | None = None,
 ) -> Any:
     """
     Load bot-specific MCP tools from Bot/Ghost mcpServers configuration.
@@ -95,6 +102,7 @@ async def load_bot_mcp_tools(
         user_id: User ID for resource lookup
         bot_name: Bot name to query Ghost MCP configuration
         bot_namespace: Bot namespace for Ghost query
+        task_data: Optional task data for variable substitution in MCP configs
 
     Returns:
         MCPClient instance or None if no bot MCP configured
@@ -132,8 +140,8 @@ async def load_bot_mcp_tools(
             )
             return None
 
-        # Create MCP client with bot configuration
-        client = MCPClient(bot_servers)
+        # Create MCP client with bot configuration and variable substitution
+        client = MCPClient(bot_servers, task_data=task_data)
         try:
             await asyncio.wait_for(client.connect(), timeout=30.0)
             logger.info(
@@ -220,7 +228,9 @@ def _get_bot_mcp_servers_sync(
         db.close()
 
 
-async def load_custom_mcp_tools(task_id: int, mcp_servers: Dict[str, Any]) -> Any:
+async def load_custom_mcp_tools(
+    task_id: int, mcp_servers: Dict[str, Any], task_data: dict[str, Any] | None = None
+) -> Any:
     """
     Load custom MCP tools from user-provided configurations via API.
 
@@ -275,8 +285,8 @@ async def load_custom_mcp_tools(task_id: int, mcp_servers: Dict[str, Any]) -> An
             )
             return None
 
-        # Create MCP client with custom configuration
-        client = MCPClient(servers_config)
+        # Create MCP client with custom configuration and variable substitution
+        client = MCPClient(servers_config, task_data=task_data)
         try:
             await asyncio.wait_for(client.connect(), timeout=30.0)
             logger.info(

--- a/chat_shell/chat_shell/tools/mcp/loader.py
+++ b/chat_shell/chat_shell/tools/mcp/loader.py
@@ -16,6 +16,7 @@ from typing import Any
 import httpx
 
 from chat_shell.core.config import settings
+from shared.utils.mcp_utils import replace_mcp_server_variables
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,17 @@ async def load_mcp_tools(
             try:
                 config_data = json.loads(mcp_servers_config)
                 backend_servers = config_data.get("mcpServers", config_data)
+
+                # Apply variable substitution to backend MCP servers
+                # This replaces placeholders like ${{user.name}} with actual values
+                if task_data:
+                    backend_servers = replace_mcp_server_variables(
+                        backend_servers, task_data
+                    )
+                    logger.debug(
+                        "[MCP] Applied variable substitution to backend MCP servers"
+                    )
+
                 logger.info(
                     "[MCP] Loaded %d backend MCP servers from CHAT_MCP_SERVERS: %s",
                     len(backend_servers),

--- a/chat_shell/tests/tools/test_mcp_loader.py
+++ b/chat_shell/tests/tools/test_mcp_loader.py
@@ -1,0 +1,230 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for MCP loader variable substitution functionality.
+
+This module tests that the MCP loader correctly applies variable substitution
+to CHAT_MCP_SERVERS configuration using task_data.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from chat_shell.tools.mcp.loader import load_mcp_tools
+
+
+class TestMcpLoaderVariableSubstitution:
+    """Test cases for MCP loader variable substitution."""
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_tools_applies_variable_substitution_to_backend_servers(self):
+        """Test that load_mcp_tools applies variable substitution to CHAT_MCP_SERVERS.
+
+        This is a regression test for the issue where placeholders like ${{user.name}}
+        in CHAT_MCP_SERVERS were not being replaced.
+        """
+        # Mock CHAT_MCP_SERVERS with placeholders
+        mcp_servers_config = {
+            "test-server": {
+                "type": "streamable-http",
+                "url": "https://api.example.com/${{user.name}}/mcp",
+                "headers": {"X-User": "${{user.name}}"},
+            }
+        }
+
+        task_data = {
+            "user": {
+                "name": "zhangsan",
+                "id": 123,
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="test_tool")]
+
+        with (
+            patch(
+                "chat_shell.tools.mcp.loader.settings.CHAT_MCP_SERVERS",
+                json.dumps({"mcpServers": mcp_servers_config}),
+            ),
+            patch(
+                "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+            ) as mock_mcp_class,
+        ):
+            mock_client.connect = MagicMock()
+
+            result = await load_mcp_tools(
+                task_id=1, bot_name="", bot_namespace="default", task_data=task_data
+            )
+
+            # Verify MCPClient was created with substituted variables
+            mock_mcp_class.assert_called_once()
+            call_args = mock_mcp_class.call_args
+            config_passed = call_args[0][0]
+
+            # Verify placeholders were replaced
+            assert config_passed["test-server"]["url"] == "https://api.example.com/zhangsan/mcp"
+            assert config_passed["test-server"]["headers"]["X-User"] == "zhangsan"
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_tools_no_substitution_when_no_task_data(self):
+        """Test that placeholders are preserved when task_data is None."""
+        mcp_servers_config = {
+            "test-server": {
+                "type": "streamable-http",
+                "url": "https://api.example.com/${{user.name}}/mcp",
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="test_tool")]
+
+        with (
+            patch(
+                "chat_shell.tools.mcp.loader.settings.CHAT_MCP_SERVERS",
+                json.dumps({"mcpServers": mcp_servers_config}),
+            ),
+            patch(
+                "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+            ) as mock_mcp_class,
+        ):
+            mock_client.connect = MagicMock()
+
+            # Call without task_data
+            result = await load_mcp_tools(
+                task_id=1, bot_name="", bot_namespace="default", task_data=None
+            )
+
+            # Verify MCPClient was created with original config (placeholders preserved)
+            mock_mcp_class.assert_called_once()
+            call_args = mock_mcp_class.call_args
+            config_passed = call_args[0][0]
+
+            # Verify placeholders were NOT replaced
+            assert config_passed["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_tools_substitutes_nested_user_fields(self):
+        """Test substitution of nested user fields like ${{user.git_login}}."""
+        mcp_servers_config = {
+            "github-server": {
+                "type": "streamable-http",
+                "url": "https://github.com/${{user.git_login}}/mcp",
+                "headers": {
+                    "Authorization": "Bearer ${{user.git_token}}",
+                    "X-Email": "${{user.git_email}}",
+                },
+            }
+        }
+
+        task_data = {
+            "user": {
+                "name": "zhangsan",
+                "git_login": "zhangsan_git",
+                "git_token": "ghp_123456",
+                "git_email": "zhangsan@example.com",
+            }
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="github_tool")]
+
+        with (
+            patch(
+                "chat_shell.tools.mcp.loader.settings.CHAT_MCP_SERVERS",
+                json.dumps({"mcpServers": mcp_servers_config}),
+            ),
+            patch(
+                "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+            ) as mock_mcp_class,
+        ):
+            mock_client.connect = MagicMock()
+
+            result = await load_mcp_tools(
+                task_id=1, bot_name="", bot_namespace="default", task_data=task_data
+            )
+
+            call_args = mock_mcp_class.call_args
+            config_passed = call_args[0][0]
+
+            # Verify all nested user fields were replaced
+            assert config_passed["github-server"]["url"] == "https://github.com/zhangsan_git/mcp"
+            assert config_passed["github-server"]["headers"]["Authorization"] == "Bearer ghp_123456"
+            assert config_passed["github-server"]["headers"]["X-Email"] == "zhangsan@example.com"
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_tools_substitutes_multiple_variables(self):
+        """Test substitution of multiple different variables in config."""
+        mcp_servers_config = {
+            "multi-server": {
+                "type": "streamable-http",
+                "url": "${{backend_url}}/user/${{user.name}}/repo/${{git_repo}}",
+                "headers": {"Authorization": "Bearer ${{task_token}}"},
+            }
+        }
+
+        task_data = {
+            "backend_url": "http://localhost:8000",
+            "user": {"name": "zhangsan"},
+            "git_repo": "myrepo",
+            "task_token": "token-abc-123",
+        }
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = [MagicMock(name="multi_tool")]
+
+        with (
+            patch(
+                "chat_shell.tools.mcp.loader.settings.CHAT_MCP_SERVERS",
+                json.dumps({"mcpServers": mcp_servers_config}),
+            ),
+            patch(
+                "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+            ) as mock_mcp_class,
+        ):
+            mock_client.connect = MagicMock()
+
+            result = await load_mcp_tools(
+                task_id=1, bot_name="", bot_namespace="default", task_data=task_data
+            )
+
+            call_args = mock_mcp_class.call_args
+            config_passed = call_args[0][0]
+
+            # Verify all variables were replaced
+            assert config_passed["multi-server"]["url"] == "http://localhost:8000/user/zhangsan/repo/myrepo"
+            assert config_passed["multi-server"]["headers"]["Authorization"] == "Bearer token-abc-123"
+
+    @pytest.mark.asyncio
+    async def test_load_mcp_handles_empty_chat_mcp_servers(self):
+        """Test that load_mcp_tools handles empty CHAT_MCP_SERVERS gracefully."""
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.get_tools.return_value = []
+
+        with (
+            patch(
+                "chat_shell.tools.mcp.loader.settings.CHAT_MCP_SERVERS",
+                "{}",
+            ),
+            patch(
+                "chat_shell.tools.mcp.MCPClient", return_value=mock_client
+            ) as mock_mcp_class,
+        ):
+            mock_client.connect = MagicMock()
+
+            result = await load_mcp_tools(
+                task_id=1, bot_name="", bot_namespace="default", task_data={"user": {"name": "test"}}
+            )
+
+            # Should return None when no MCP servers are configured
+            assert result is None
+            # MCPClient should NOT be called when there are no servers
+            mock_mcp_class.assert_not_called()

--- a/chat_shell/tests/tools/test_mcp_loader.py
+++ b/chat_shell/tests/tools/test_mcp_loader.py
@@ -20,7 +20,7 @@ class TestMcpLoaderVariableSubstitution:
     """Test cases for MCP loader variable substitution."""
 
     @pytest.mark.asyncio
-    async def test_load_mcp_tools_applies_variable_substitution_to_backend_servers(self):
+    async def test_load_mcp_tools_applies_variable_substitution_to_backend_servers(self) -> None:
         """Test that load_mcp_tools applies variable substitution to CHAT_MCP_SERVERS.
 
         This is a regression test for the issue where placeholders like ${{user.name}}
@@ -71,7 +71,7 @@ class TestMcpLoaderVariableSubstitution:
             assert config_passed["test-server"]["headers"]["X-User"] == "zhangsan"
 
     @pytest.mark.asyncio
-    async def test_load_mcp_tools_no_substitution_when_no_task_data(self):
+    async def test_load_mcp_tools_no_substitution_when_no_task_data(self) -> None:
         """Test that placeholders are preserved when task_data is None."""
         mcp_servers_config = {
             "test-server": {
@@ -109,7 +109,7 @@ class TestMcpLoaderVariableSubstitution:
             assert config_passed["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
 
     @pytest.mark.asyncio
-    async def test_load_mcp_tools_substitutes_nested_user_fields(self):
+    async def test_load_mcp_tools_substitutes_nested_user_fields(self) -> None:
         """Test substitution of nested user fields like ${{user.git_login}}."""
         mcp_servers_config = {
             "github-server": {
@@ -159,7 +159,7 @@ class TestMcpLoaderVariableSubstitution:
             assert config_passed["github-server"]["headers"]["X-Email"] == "zhangsan@example.com"
 
     @pytest.mark.asyncio
-    async def test_load_mcp_tools_substitutes_multiple_variables(self):
+    async def test_load_mcp_tools_substitutes_multiple_variables(self) -> None:
         """Test substitution of multiple different variables in config."""
         mcp_servers_config = {
             "multi-server": {
@@ -203,7 +203,7 @@ class TestMcpLoaderVariableSubstitution:
             assert config_passed["multi-server"]["headers"]["Authorization"] == "Bearer token-abc-123"
 
     @pytest.mark.asyncio
-    async def test_load_mcp_handles_empty_chat_mcp_servers(self):
+    async def test_load_mcp_handles_empty_chat_mcp_servers(self) -> None:
         """Test that load_mcp_tools handles empty CHAT_MCP_SERVERS gracefully."""
         mock_client = MagicMock()
         mock_client.is_connected = True

--- a/shared/tests/utils/test_mcp_utils.py
+++ b/shared/tests/utils/test_mcp_utils.py
@@ -38,7 +38,7 @@ def test_replace_mcp_server_variables_preserves_unknown_placeholders():
     assert replaced["s"]["url"] == "http://${{unknown}}/x"
 
 
-def test_replace_mcp_server_variables_with_user_name_placeholder():
+def test_replace_mcp_server_variables_with_user_name_placeholder() -> None:
     """Test that ${{user.name}} placeholders are correctly replaced.
 
     This is a regression test for the issue where CHAT_MCP_SERVERS environment
@@ -64,7 +64,7 @@ def test_replace_mcp_server_variables_with_user_name_placeholder():
     assert replaced["custom-server"]["headers"]["X-User"] == "zhangsan"
 
 
-def test_replace_mcp_server_variables_with_nested_user_fields():
+def test_replace_mcp_server_variables_with_nested_user_fields() -> None:
     """Test replacement of nested user fields like ${{user.git_login}}."""
     mcp_servers = {
         "github-server": {
@@ -92,7 +92,7 @@ def test_replace_mcp_server_variables_with_nested_user_fields():
     assert replaced["github-server"]["headers"]["X-Git-Email"] == "zhangsan@example.com"
 
 
-def test_replace_mcp_server_variables_with_multiple_placeholders_in_string():
+def test_replace_mcp_server_variables_with_multiple_placeholders_in_string() -> None:
     """Test replacement of multiple placeholders in a single string."""
     mcp_servers = {
         "multi-server": {
@@ -111,7 +111,7 @@ def test_replace_mcp_server_variables_with_multiple_placeholders_in_string():
     assert replaced["multi-server"]["url"] == "http://localhost:8000/user/zhangsan/repo/myrepo"
 
 
-def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_none():
+def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_none() -> None:
     """Test that original config is returned when task_data is None."""
     mcp_servers = {
         "test-server": {
@@ -125,7 +125,7 @@ def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_none()
     assert replaced["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
 
 
-def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_empty():
+def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_empty() -> None:
     """Test that original config is returned when task_data is empty dict."""
     mcp_servers = {
         "test-server": {
@@ -139,7 +139,7 @@ def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_empty(
     assert replaced["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
 
 
-def test_replace_mcp_server_variables_handles_list_values():
+def test_replace_mcp_server_variables_handles_list_values() -> None:
     """Test that variables in list values are also replaced."""
     mcp_servers = {
         "list-server": {

--- a/shared/tests/utils/test_mcp_utils.py
+++ b/shared/tests/utils/test_mcp_utils.py
@@ -36,3 +36,123 @@ def test_replace_mcp_server_variables_preserves_unknown_placeholders():
     replaced = replace_mcp_server_variables(mcp_servers, task_data)
 
     assert replaced["s"]["url"] == "http://${{unknown}}/x"
+
+
+def test_replace_mcp_server_variables_with_user_name_placeholder():
+    """Test that ${{user.name}} placeholders are correctly replaced.
+
+    This is a regression test for the issue where CHAT_MCP_SERVERS environment
+    variable with placeholders like ${{user.name}} was not being substituted.
+    """
+    mcp_servers = {
+        "custom-server": {
+            "type": "streamable-http",
+            "url": "https://api.example.com/${{user.name}}/mcp",
+            "headers": {"X-User": "${{user.name}}"},
+        }
+    }
+    task_data = {
+        "user": {
+            "name": "zhangsan",
+            "id": 123,
+        }
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, task_data)
+
+    assert replaced["custom-server"]["url"] == "https://api.example.com/zhangsan/mcp"
+    assert replaced["custom-server"]["headers"]["X-User"] == "zhangsan"
+
+
+def test_replace_mcp_server_variables_with_nested_user_fields():
+    """Test replacement of nested user fields like ${{user.git_login}}."""
+    mcp_servers = {
+        "github-server": {
+            "type": "streamable-http",
+            "url": "https://github.com/${{user.git_login}}/mcp",
+            "headers": {
+                "Authorization": "Bearer ${{user.git_token}}",
+                "X-Git-Email": "${{user.git_email}}",
+            },
+        }
+    }
+    task_data = {
+        "user": {
+            "name": "zhangsan",
+            "git_login": "zhangsan_git",
+            "git_token": "ghp_123456",
+            "git_email": "zhangsan@example.com",
+        }
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, task_data)
+
+    assert replaced["github-server"]["url"] == "https://github.com/zhangsan_git/mcp"
+    assert replaced["github-server"]["headers"]["Authorization"] == "Bearer ghp_123456"
+    assert replaced["github-server"]["headers"]["X-Git-Email"] == "zhangsan@example.com"
+
+
+def test_replace_mcp_server_variables_with_multiple_placeholders_in_string():
+    """Test replacement of multiple placeholders in a single string."""
+    mcp_servers = {
+        "multi-server": {
+            "type": "streamable-http",
+            "url": "${{backend_url}}/user/${{user.name}}/repo/${{git_repo}}",
+        }
+    }
+    task_data = {
+        "backend_url": "http://localhost:8000",
+        "user": {"name": "zhangsan"},
+        "git_repo": "myrepo",
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, task_data)
+
+    assert replaced["multi-server"]["url"] == "http://localhost:8000/user/zhangsan/repo/myrepo"
+
+
+def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_none():
+    """Test that original config is returned when task_data is None."""
+    mcp_servers = {
+        "test-server": {
+            "url": "https://api.example.com/${{user.name}}/mcp",
+        }
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, None)
+
+    # Should return the original unchanged
+    assert replaced["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
+
+
+def test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_empty():
+    """Test that original config is returned when task_data is empty dict."""
+    mcp_servers = {
+        "test-server": {
+            "url": "https://api.example.com/${{user.name}}/mcp",
+        }
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, {})
+
+    # Should return the original unchanged
+    assert replaced["test-server"]["url"] == "https://api.example.com/${{user.name}}/mcp"
+
+
+def test_replace_mcp_server_variables_handles_list_values():
+    """Test that variables in list values are also replaced."""
+    mcp_servers = {
+        "list-server": {
+            "type": "stdio",
+            "command": "echo",
+            "args": ["${{user.name}}", "${{backend_url}}"],
+        }
+    }
+    task_data = {
+        "user": {"name": "zhangsan"},
+        "backend_url": "http://localhost:8000",
+    }
+
+    replaced = replace_mcp_server_variables(mcp_servers, task_data)
+
+    assert replaced["list-server"]["args"] == ["zhangsan", "http://localhost:8000"]


### PR DESCRIPTION
## Summary

This PR fixes the issue where placeholders like `${{user.name}}` in `CHAT_MCP_SERVERS` environment variable were not being replaced with actual values at runtime.

## Problem Description

When configuring MCP servers via the `CHAT_MCP_SERVERS` environment variable with placeholders like:
```json
{
  "mcpServers": {
    "custom-server": {
      "url": "https://api.example.com/${{user.name}}/mcp",
      "headers": {"X-User": "${{user.name}}"}
    }
  }
}
```

The placeholders were not being substituted with actual user data, causing MCP server connections to fail.

## Root Cause Analysis

1. **chat_shell/tools/mcp/loader.py**: Loaded `CHAT_MCP_SERVERS` configuration but did not apply variable substitution before passing to `MCPClient`

2. **backend/app/services/openapi/mcp.py**: The functions `load_server_mcp_tools()`, `load_bot_mcp_tools()`, and `load_custom_mcp_tools()` did not accept or pass `task_data` parameter to `MCPClient` for variable substitution

## Changes Made

### 1. chat_shell/tools/mcp/loader.py
- Import `replace_mcp_server_variables` from `shared.utils.mcp_utils`
- Apply variable substitution to `backend_servers` when `task_data` is provided
- Added debug logging for variable substitution

### 2. backend/app/services/openapi/mcp.py
- `load_server_mcp_tools()`: Added `task_data` parameter
- `load_bot_mcp_tools()`: Added `task_data` parameter  
- `load_custom_mcp_tools()`: Added `task_data` parameter
- All functions now pass `task_data` to `MCPClient` for variable substitution

## Test Plan

- [x] Run shared MCP utils tests: `uv run pytest tests/utils/test_mcp_utils.py -v`
- [x] Run chat_shell MCP loader tests: `uv run pytest tests/tools/test_mcp_loader.py -v`
- [x] Run skill MCP loader tests: `uv run pytest tests/test_skill_mcp_loader.py -v`
- [x] All existing tests pass

## New Test Cases

### shared/tests/utils/test_mcp_utils.py
- `test_replace_mcp_server_variables_with_user_name_placeholder`
- `test_replace_mcp_server_variables_with_nested_user_fields`
- `test_replace_mcp_server_variables_with_multiple_placeholders_in_string`
- `test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_none`
- `test_replace_mcp_server_variables_returns_unchanged_when_task_data_is_empty`
- `test_replace_mcp_server_variables_handles_list_values`

### chat_shell/tests/tools/test_mcp_loader.py (new file)
- `test_load_mcp_tools_applies_variable_substitution_to_backend_servers`
- `test_load_mcp_tools_no_substitution_when_no_task_data`
- `test_load_mcp_tools_substitutes_nested_user_fields`
- `test_load_mcp_tools_substitutes_multiple_variables`
- `test_load_mcp_handles_empty_chat_mcp_servers`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP configurations support dynamic variable substitution (e.g., ${{user.name}}, ${{user.git_login}}, ${{user.git_email}}) when task data is supplied; substitutions apply across URLs, headers, lists, and multiple servers, and unknown placeholders are preserved.
* **Tests**
  * Added comprehensive unit tests covering substitution, nested fields, multiple variables, absence of task data, multi-server scenarios, and empty configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->