### PR TITLE
fix: backend executor-manager config url

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -352,7 +352,7 @@ class Settings(BaseSettings):
     # Chat Shell service URL (only used when CHAT_SHELL_MODE="http")
     CHAT_SHELL_URL: str = "http://localhost:8100"
     # Executor Manager service URL (for ClaudeCode, Agno, Dify shell types)
-    EXECUTOR_MANAGER_URL: str = "http://localhost:8001/executor-manager"
+    EXECUTOR_MANAGER_URL: str = "http://localhost:8001"
     # Chat Shell service authentication token (only used when CHAT_SHELL_MODE="http")
     CHAT_SHELL_TOKEN: str = ""
     # Internal service authentication token (for HTTP mode communication)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the executor manager endpoint configuration from a nested path to a base URL format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->