### PR TITLE
refactor(chat_shell): organize MCP tools by server name

### DIFF
--- a/chat_shell/chat_shell/tools/mcp/client.py
+++ b/chat_shell/chat_shell/tools/mcp/client.py
@@ -245,7 +245,7 @@ class MCPClient:
         self.task_data = task_data
         self.connections = build_connections(config, task_data) if config else {}
         self._client: MultiServerMCPClient | None = None
-        self._tools: list[BaseTool] = []
+        self._tools: dict[str, list[BaseTool]] = {}
 
     async def __aenter__(self) -> "MCPClient":
         """Async context manager entry - connect to servers."""
@@ -284,9 +284,9 @@ class MCPClient:
         # Load tools from each server individually to handle failures gracefully
         # This avoids the issue where one failing server causes all tools to fail
         add_span_event("loading_tools_started")
-        raw_tools: list[BaseTool] = []
         failed_servers: list[str] = []
         successful_servers: list[str] = []
+        total_tools = 0
 
         async def load_server_tools(
             server_name: str,
@@ -330,12 +330,15 @@ class MCPClient:
                 )
             else:
                 successful_servers.append(server_name)
-                raw_tools.extend(tools)
+                # Wrap tools with protection and store by server name
+                protected_tools = [wrap_tool_with_protection(tool) for tool in tools]
+                self._tools[server_name] = protected_tools
+                total_tools += len(protected_tools)
 
         add_span_event(
             "loading_tools_completed",
             {
-                "raw_tools_count": len(raw_tools),
+                "total_tools_count": total_tools,
                 "successful_servers": successful_servers,
                 "failed_servers": failed_servers,
             },
@@ -349,32 +352,28 @@ class MCPClient:
                 ", ".join(failed_servers),
             )
 
-        # Wrap all tools with protection mechanisms
-        add_span_event("wrapping_tools_started")
-        self._tools = [wrap_tool_with_protection(tool) for tool in raw_tools]
-        add_span_event(
-            "wrapping_tools_completed", {"protected_tools_count": len(self._tools)}
-        )
-
-        for tool in self._tools:
-            logger.debug(
-                "[MCP] Registered tool (protected): name='%s', description='%s', type='%s'",
-                getattr(tool, "name", "UNKNOWN"),
-                getattr(tool, "description", "NO_DESCRIPTION"),
-                type(tool).__name__,
-            )
+        # Log all loaded tools
+        for server_name, tools in self._tools.items():
+            for tool in tools:
+                logger.debug(
+                    "[MCP] Registered tool (protected): server='%s', name='%s', description='%s', type='%s'",
+                    server_name,
+                    getattr(tool, "name", "UNKNOWN"),
+                    getattr(tool, "description", "NO_DESCRIPTION"),
+                    type(tool).__name__,
+                )
 
         logger.debug(
             "Connected to MCP servers: %s, loaded %d protected tools",
             ", ".join(self.list_servers()),
-            len(self._tools),
+            total_tools,
         )
 
     async def disconnect(self) -> None:
         """Disconnect from all MCP servers."""
         if self._client:
             self._client = None
-            self._tools = []
+            self._tools = {}
             logger.debug("Disconnected from MCP servers")
 
     def get_tools(self, server_names: list[str] | None = None) -> list[BaseTool]:
@@ -382,6 +381,7 @@ class MCPClient:
 
         Args:
             server_names: Optional list of server names to filter tools.
+                         If None, returns all tools from all servers.
 
         Returns:
             List of LangChain BaseTool instances
@@ -390,23 +390,40 @@ class MCPClient:
             return []
 
         if server_names is None:
-            return list(self._tools)
+            # Return all tools from all servers
+            all_tools = []
+            for tools in self._tools.values():
+                all_tools.extend(tools)
+            return all_tools
 
+        # Filter tools by server names
         filtered_tools = []
-        for tool in self._tools:
-            for server_name in server_names:
-                if tool.name.startswith(f"{server_name}_") or server_name in getattr(
-                    tool, "server_name", ""
-                ):
-                    filtered_tools.append(tool)
-                    break
+        for server_name in server_names:
+            if server_name in self._tools:
+                filtered_tools.extend(self._tools[server_name])
         return filtered_tools
 
     def list_servers(self) -> list[str]:
         """List configured server names."""
         return list(self.connections.keys())
 
+    def get_tools_by_server(self) -> dict[str, list[BaseTool]]:
+        """Get tools organized by server name.
+
+        Returns:
+            Dict mapping server_name to list of tools
+        """
+        return dict(self._tools)
+
+    def get_tools_count_by_server(self) -> dict[str, int]:
+        """Get tool counts per server.
+
+        Returns:
+            Dict mapping server_name to tool count
+        """
+        return {server_name: len(tools) for server_name, tools in self._tools.items()}
+
     @property
     def is_connected(self) -> bool:
-        """Check if client has loaded tools."""
+        """Check if client has loaded tools from any server."""
         return len(self._tools) > 0

--- a/chat_shell/chat_shell/tools/mcp/client.py
+++ b/chat_shell/chat_shell/tools/mcp/client.py
@@ -407,7 +407,7 @@ class MCPClient:
         """List configured server names."""
         return list(self.connections.keys())
 
-    def get_tools_by_server(self) -> dict[str, list[BaseTool]]:
+    def get_tools_with_server(self) -> dict[str, list[BaseTool]]:
         """Get tools organized by server name.
 
         Returns:
@@ -415,7 +415,7 @@ class MCPClient:
         """
         return dict(self._tools)
 
-    def get_tools_count_by_server(self) -> dict[str, int]:
+    def get_tools_count_with_server(self) -> dict[str, int]:
         """Get tool counts per server.
 
         Returns:

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -393,17 +393,23 @@ async def prepare_skill_tools(
 
     # Load MCP tools from all skills if any MCP servers are configured
     if skill_mcp_configs:
-        mcp_tools, skill_mcp_clients = await _load_skill_mcp_tools(
+        mcp_tools_by_server, skill_mcp_clients = await _load_skill_mcp_tools(
             skill_mcp_configs, task_id, task_data
         )
         mcp_clients.extend(skill_mcp_clients)
 
+        # Calculate total tools count
+        total_mcp_tools = sum(len(tools) for tools in mcp_tools_by_server.values())
+
+        logger.info(
+            "[skill_factory] Loaded %d MCP tools from %d servers",
+            total_mcp_tools,
+            len(mcp_tools_by_server),
+        )
+
         # Register MCP tools under their owning skills so they are only exposed
         # after the corresponding skill is loaded.
-        if load_skill_tool is not None and mcp_tools:
-            prefixed_server_names = sorted(
-                skill_mcp_server_owner.keys(), key=len, reverse=True
-            )
+        if load_skill_tool is not None and mcp_tools_by_server:
 
             def _dedupe_by_tool_name(items: list[Any]) -> list[Any]:
                 merged: list[Any] = []
@@ -420,27 +426,27 @@ async def prepare_skill_tools(
             unassigned: list[Any] = []
             tools_by_skill: dict[str, list[Any]] = {}
 
-            for tool in mcp_tools:
-                owner_skill: str | None = None
-
-                server_name = getattr(tool, "server_name", None)
-                if (
-                    isinstance(server_name, str)
-                    and server_name in skill_mcp_server_owner
-                ):
-                    owner_skill = skill_mcp_server_owner[server_name]
-                else:
-                    tool_name = getattr(tool, "name", "")
-                    if isinstance(tool_name, str) and tool_name:
-                        for prefixed in prefixed_server_names:
-                            if tool_name.startswith(f"{prefixed}_"):
-                                owner_skill = skill_mcp_server_owner[prefixed]
-                                break
+            # Process tools by server - since server names are prefixed with skill name,
+            # we can directly map them to skills
+            for server_name, server_tools in mcp_tools_by_server.items():
+                # server_name format: "{skill_name}_{original_server_name}"
+                owner_skill = skill_mcp_server_owner.get(server_name)
 
                 if owner_skill:
-                    tools_by_skill.setdefault(owner_skill, []).append(tool)
+                    tools_by_skill.setdefault(owner_skill, []).extend(server_tools)
+                    logger.debug(
+                        "[skill_factory] Mapped %d tools from server '%s' to skill '%s'",
+                        len(server_tools),
+                        server_name,
+                        owner_skill,
+                    )
                 else:
-                    unassigned.append(tool)
+                    # This shouldn't happen since we control the server naming
+                    logger.warning(
+                        "[skill_factory] Server '%s' not found in skill_mcp_server_owner mapping",
+                        server_name,
+                    )
+                    unassigned.extend(server_tools)
 
             for skill_name, skill_tools in tools_by_skill.items():
                 existing = load_skill_tool.get_skill_tools(skill_name)
@@ -461,10 +467,11 @@ async def prepare_skill_tools(
                 )
                 # Fallback: expose unassigned tools directly so functionality isn't lost.
                 tools.extend(unassigned)
-        elif load_skill_tool is None and mcp_tools:
+        elif load_skill_tool is None and mcp_tools_by_server:
             # Without LoadSkillTool we can't apply skill gating; keep previous behavior
             # and expose MCP tools directly.
-            tools.extend(mcp_tools)
+            for server_tools in mcp_tools_by_server.values():
+                tools.extend(server_tools)
 
     # Log summary of all skills loaded
     if tools:
@@ -482,12 +489,12 @@ async def _load_skill_mcp_tools(
     mcp_configs: dict[str, dict[str, Any]],
     task_id: int,
     task_data: dict[str, Any] | None = None,
-) -> tuple[list[Any], list[Any]]:
+) -> tuple[dict[str, list[Any]], list[Any]]:
     """
     Load MCP tools from skill-level MCP server configurations.
 
     This function connects to MCP servers specified in skill configurations
-    and returns the tools provided by those servers.
+    and returns the tools provided by those servers organized by server name.
 
     Args:
         mcp_configs: Merged MCP server configurations from all skills
@@ -495,12 +502,14 @@ async def _load_skill_mcp_tools(
         task_data: Optional task data for variable substitution
 
     Returns:
-        Tuple of (mcp_tools, mcp_clients)
+        Tuple of (mcp_tools_by_server, mcp_clients) where:
+        - mcp_tools_by_server: Dict mapping server_name to list of tools
+        - mcp_clients: List of MCPClient instances
     """
     from chat_shell.tools.mcp import MCPClient
 
     if not mcp_configs:
-        return [], []
+        return {}, []
 
     logger.info(
         "[skill_factory] Loading MCP tools from %d skill MCP server(s): %s",
@@ -508,7 +517,7 @@ async def _load_skill_mcp_tools(
         list(mcp_configs.keys()),
     )
 
-    mcp_tools: list[Any] = []
+    mcp_tools_by_server: dict[str, list[Any]] = {}
     mcp_clients: list[Any] = []
     client: Any = None
 
@@ -519,14 +528,26 @@ async def _load_skill_mcp_tools(
         try:
             await asyncio.wait_for(client.connect(), timeout=30.0)
             if client.is_connected:
-                tools = client.get_tools()
-                mcp_tools.extend(tools)
+                # Get tools organized by server name
+                mcp_tools_by_server = client.get_tools_by_server()
                 mcp_clients.append(client)
+
+                # Calculate total tools count for logging
+                total_tools = sum(len(tools) for tools in mcp_tools_by_server.values())
                 logger.info(
-                    "[skill_factory] Loaded %d MCP tools from skill servers for task %d",
-                    len(tools),
+                    "[skill_factory] Loaded %d MCP tools from %d skill servers for task %d",
+                    total_tools,
+                    len(mcp_tools_by_server),
                     task_id,
                 )
+
+                # Log tool count per server
+                for server_name, tools in mcp_tools_by_server.items():
+                    logger.debug(
+                        "[skill_factory] Server '%s': %d tools",
+                        server_name,
+                        len(tools),
+                    )
             else:
                 # Connection succeeded but client not ready, clean up
                 logger.warning(
@@ -557,7 +578,7 @@ async def _load_skill_mcp_tools(
         if client is not None:
             await _safe_disconnect_client(client, task_id)
 
-    return mcp_tools, mcp_clients
+    return mcp_tools_by_server, mcp_clients
 
 
 async def _safe_disconnect_client(client: Any, task_id: int) -> None:

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -393,23 +393,23 @@ async def prepare_skill_tools(
 
     # Load MCP tools from all skills if any MCP servers are configured
     if skill_mcp_configs:
-        mcp_tools_by_server, skill_mcp_clients = await _load_skill_mcp_tools(
+        mcp_tools_with_server, skill_mcp_clients = await _load_skill_mcp_tools(
             skill_mcp_configs, task_id, task_data
         )
         mcp_clients.extend(skill_mcp_clients)
 
         # Calculate total tools count
-        total_mcp_tools = sum(len(tools) for tools in mcp_tools_by_server.values())
+        total_mcp_tools = sum(len(tools) for tools in mcp_tools_with_server.values())
 
         logger.info(
             "[skill_factory] Loaded %d MCP tools from %d servers",
             total_mcp_tools,
-            len(mcp_tools_by_server),
+            len(mcp_tools_with_server),
         )
 
         # Register MCP tools under their owning skills so they are only exposed
         # after the corresponding skill is loaded.
-        if load_skill_tool is not None and mcp_tools_by_server:
+        if load_skill_tool is not None and mcp_tools_with_server:
 
             def _dedupe_by_tool_name(items: list[Any]) -> list[Any]:
                 merged: list[Any] = []
@@ -428,7 +428,7 @@ async def prepare_skill_tools(
 
             # Process tools by server - since server names are prefixed with skill name,
             # we can directly map them to skills
-            for server_name, server_tools in mcp_tools_by_server.items():
+            for server_name, server_tools in mcp_tools_with_server.items():
                 # server_name format: "{skill_name}_{original_server_name}"
                 owner_skill = skill_mcp_server_owner.get(server_name)
 
@@ -467,10 +467,10 @@ async def prepare_skill_tools(
                 )
                 # Fallback: expose unassigned tools directly so functionality isn't lost.
                 tools.extend(unassigned)
-        elif load_skill_tool is None and mcp_tools_by_server:
+        elif load_skill_tool is None and mcp_tools_with_server:
             # Without LoadSkillTool we can't apply skill gating; keep previous behavior
             # and expose MCP tools directly.
-            for server_tools in mcp_tools_by_server.values():
+            for server_tools in mcp_tools_with_server.values():
                 tools.extend(server_tools)
 
     # Log summary of all skills loaded
@@ -502,8 +502,8 @@ async def _load_skill_mcp_tools(
         task_data: Optional task data for variable substitution
 
     Returns:
-        Tuple of (mcp_tools_by_server, mcp_clients) where:
-        - mcp_tools_by_server: Dict mapping server_name to list of tools
+        Tuple of (mcp_tools_with_server, mcp_clients) where:
+        - mcp_tools_with_server: Dict mapping server_name to list of tools
         - mcp_clients: List of MCPClient instances
     """
     from chat_shell.tools.mcp import MCPClient
@@ -517,7 +517,7 @@ async def _load_skill_mcp_tools(
         list(mcp_configs.keys()),
     )
 
-    mcp_tools_by_server: dict[str, list[Any]] = {}
+    mcp_tools_with_server: dict[str, list[Any]] = {}
     mcp_clients: list[Any] = []
     client: Any = None
 
@@ -529,20 +529,20 @@ async def _load_skill_mcp_tools(
             await asyncio.wait_for(client.connect(), timeout=30.0)
             if client.is_connected:
                 # Get tools organized by server name
-                mcp_tools_by_server = client.get_tools_by_server()
+                mcp_tools_with_server = client.get_tools_with_server()
                 mcp_clients.append(client)
 
                 # Calculate total tools count for logging
-                total_tools = sum(len(tools) for tools in mcp_tools_by_server.values())
+                total_tools = sum(len(tools) for tools in mcp_tools_with_server.values())
                 logger.info(
                     "[skill_factory] Loaded %d MCP tools from %d skill servers for task %d",
                     total_tools,
-                    len(mcp_tools_by_server),
+                    len(mcp_tools_with_server),
                     task_id,
                 )
 
                 # Log tool count per server
-                for server_name, tools in mcp_tools_by_server.items():
+                for server_name, tools in mcp_tools_with_server.items():
                     logger.debug(
                         "[skill_factory] Server '%s': %d tools",
                         server_name,
@@ -578,7 +578,7 @@ async def _load_skill_mcp_tools(
         if client is not None:
             await _safe_disconnect_client(client, task_id)
 
-    return mcp_tools_by_server, mcp_clients
+    return mcp_tools_with_server, mcp_clients
 
 
 async def _safe_disconnect_client(client: Any, task_id: int) -> None:

--- a/chat_shell/tests/test_skill_mcp_loader.py
+++ b/chat_shell/tests/test_skill_mcp_loader.py
@@ -24,8 +24,8 @@ class TestLoadSkillMcpTools:
     @pytest.mark.asyncio
     async def test_empty_mcp_configs_returns_empty(self):
         """Test that empty MCP configs returns empty dict and list."""
-        tools_by_server, clients = await _load_skill_mcp_tools({}, task_id=1)
-        assert tools_by_server == {}
+        tools_with_server, clients = await _load_skill_mcp_tools({}, task_id=1)
+        assert tools_with_server == {}
         assert clients == []
 
     @pytest.mark.asyncio
@@ -42,7 +42,7 @@ class TestLoadSkillMcpTools:
         mock_tool = MagicMock(name="test_tool")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools_by_server.return_value = {
+        mock_client.get_tools_with_server.return_value = {
             "test_skill_server1": [mock_tool]
         }
 
@@ -50,15 +50,15 @@ class TestLoadSkillMcpTools:
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client
         ) as mock_mcp_class:
             mock_client.connect = AsyncMock()
-            tools_by_server, clients = await _load_skill_mcp_tools(
+            tools_with_server, clients = await _load_skill_mcp_tools(
                 mcp_configs, task_id=1
             )
 
             mock_mcp_class.assert_called_once_with(mcp_configs, task_data=None)
             mock_client.connect.assert_called_once()
-            assert len(tools_by_server) == 1
-            assert "test_skill_server1" in tools_by_server
-            assert len(tools_by_server["test_skill_server1"]) == 1
+            assert len(tools_with_server) == 1
+            assert "test_skill_server1" in tools_with_server
+            assert len(tools_with_server["test_skill_server1"]) == 1
             assert len(clients) == 1
             assert clients[0] == mock_client
 
@@ -78,11 +78,11 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools_by_server, clients = await _load_skill_mcp_tools(
+            tools_with_server, clients = await _load_skill_mcp_tools(
                 mcp_configs, task_id=1
             )
 
-            assert tools_by_server == {}
+            assert tools_with_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
@@ -104,11 +104,11 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools_by_server, clients = await _load_skill_mcp_tools(
+            tools_with_server, clients = await _load_skill_mcp_tools(
                 mcp_configs, task_id=1
             )
 
-            assert tools_by_server == {}
+            assert tools_with_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
@@ -128,11 +128,11 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools_by_server, clients = await _load_skill_mcp_tools(
+            tools_with_server, clients = await _load_skill_mcp_tools(
                 mcp_configs, task_id=1
             )
 
-            assert tools_by_server == {}
+            assert tools_with_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
@@ -161,7 +161,7 @@ class TestPrepareSkillToolsWithMcp:
         mock_tool = MagicMock(name="mcp_tool")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools_by_server.return_value = {
+        mock_client.get_tools_with_server.return_value = {
             "test_skill_server1": [mock_tool]
         }
 
@@ -255,7 +255,7 @@ class TestPrepareSkillToolsWithMcp:
         mock_mcp_tool.name = "test_skill_server1_list_kbs"
         mock_mcp_tool.server_name = "test_skill_server1"
 
-        mock_client.get_tools_by_server.return_value = {
+        mock_client.get_tools_with_server.return_value = {
             "test_skill_server1": [mock_mcp_tool]
         }
 
@@ -339,7 +339,7 @@ class TestPrepareSkillToolsWithMcp:
         tool_b = MagicMock(name="tool_b")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools_by_server.return_value = {
+        mock_client.get_tools_with_server.return_value = {
             "skill_a_server_a": [tool_a],
             "skill_b_server_b": [tool_b],
         }
@@ -392,7 +392,7 @@ class TestPrepareSkillToolsWithMcp:
         tool_a = MagicMock(name="tool_a")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools_by_server.return_value = {"skill_a_server_a": [tool_a]}
+        mock_client.get_tools_with_server.return_value = {"skill_a_server_a": [tool_a]}
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client

--- a/chat_shell/tests/test_skill_mcp_loader.py
+++ b/chat_shell/tests/test_skill_mcp_loader.py
@@ -23,9 +23,9 @@ class TestLoadSkillMcpTools:
 
     @pytest.mark.asyncio
     async def test_empty_mcp_configs_returns_empty(self):
-        """Test that empty MCP configs returns empty lists."""
-        tools, clients = await _load_skill_mcp_tools({}, task_id=1)
-        assert tools == []
+        """Test that empty MCP configs returns empty dict and list."""
+        tools_by_server, clients = await _load_skill_mcp_tools({}, task_id=1)
+        assert tools_by_server == {}
         assert clients == []
 
     @pytest.mark.asyncio
@@ -39,25 +39,32 @@ class TestLoadSkillMcpTools:
             }
         }
 
+        mock_tool = MagicMock(name="test_tool")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools.return_value = [MagicMock(name="test_tool")]
+        mock_client.get_tools_by_server.return_value = {
+            "test_skill_server1": [mock_tool]
+        }
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client
         ) as mock_mcp_class:
             mock_client.connect = AsyncMock()
-            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+            tools_by_server, clients = await _load_skill_mcp_tools(
+                mcp_configs, task_id=1
+            )
 
             mock_mcp_class.assert_called_once_with(mcp_configs, task_data=None)
             mock_client.connect.assert_called_once()
-            assert len(tools) == 1
+            assert len(tools_by_server) == 1
+            assert "test_skill_server1" in tools_by_server
+            assert len(tools_by_server["test_skill_server1"]) == 1
             assert len(clients) == 1
             assert clients[0] == mock_client
 
     @pytest.mark.asyncio
     async def test_mcp_connection_failure_returns_empty(self):
-        """Test that connection failure returns empty lists gracefully."""
+        """Test that connection failure returns empty dict and list gracefully."""
         mcp_configs = {
             "test_skill_server1": {
                 "type": "stdio",
@@ -71,16 +78,18 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+            tools_by_server, clients = await _load_skill_mcp_tools(
+                mcp_configs, task_id=1
+            )
 
-            assert tools == []
+            assert tools_by_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_mcp_connection_timeout_returns_empty(self):
-        """Test that connection timeout returns empty lists gracefully."""
+        """Test that connection timeout returns empty dict and list gracefully."""
         import asyncio
 
         mcp_configs = {
@@ -95,9 +104,11 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+            tools_by_server, clients = await _load_skill_mcp_tools(
+                mcp_configs, task_id=1
+            )
 
-            assert tools == []
+            assert tools_by_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
@@ -117,9 +128,11 @@ class TestLoadSkillMcpTools:
         mock_client.disconnect = AsyncMock()
 
         with patch("chat_shell.tools.mcp.MCPClient", return_value=mock_client):
-            tools, clients = await _load_skill_mcp_tools(mcp_configs, task_id=1)
+            tools_by_server, clients = await _load_skill_mcp_tools(
+                mcp_configs, task_id=1
+            )
 
-            assert tools == []
+            assert tools_by_server == {}
             assert clients == []
             # Verify disconnect was called for cleanup
             mock_client.disconnect.assert_called_once()
@@ -145,9 +158,12 @@ class TestPrepareSkillToolsWithMcp:
             }
         ]
 
+        mock_tool = MagicMock(name="mcp_tool")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools.return_value = [MagicMock(name="mcp_tool")]
+        mock_client.get_tools_by_server.return_value = {
+            "test_skill_server1": [mock_tool]
+        }
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client
@@ -239,7 +255,9 @@ class TestPrepareSkillToolsWithMcp:
         mock_mcp_tool.name = "test_skill_server1_list_kbs"
         mock_mcp_tool.server_name = "test_skill_server1"
 
-        mock_client.get_tools.return_value = [mock_mcp_tool]
+        mock_client.get_tools_by_server.return_value = {
+            "test_skill_server1": [mock_mcp_tool]
+        }
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client
@@ -317,12 +335,14 @@ class TestPrepareSkillToolsWithMcp:
             },
         ]
 
+        tool_a = MagicMock(name="tool_a")
+        tool_b = MagicMock(name="tool_b")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools.return_value = [
-            MagicMock(name="tool_a"),
-            MagicMock(name="tool_b"),
-        ]
+        mock_client.get_tools_by_server.return_value = {
+            "skill_a_server_a": [tool_a],
+            "skill_b_server_b": [tool_b],
+        }
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client
@@ -369,9 +389,10 @@ class TestPrepareSkillToolsWithMcp:
             },
         ]
 
+        tool_a = MagicMock(name="tool_a")
         mock_client = MagicMock()
         mock_client.is_connected = True
-        mock_client.get_tools.return_value = [MagicMock(name="tool_a")]
+        mock_client.get_tools_by_server.return_value = {"skill_a_server_a": [tool_a]}
 
         with patch(
             "chat_shell.tools.mcp.MCPClient", return_value=mock_client


### PR DESCRIPTION
Change MCP client to store tools in a dict keyed by server name instead of a flat list. This improves tool organization and enables efficient filtering by server.

Key changes:
- MCPClient._tools: list[BaseTool] -> dict[str, list[BaseTool]]
- Add get_tools_by_server() and get_tools_count_by_server() methods
- Simplify get_tools() filtering logic using server name keys
- Update skill_factory to use dict-based tool structure
- Fix all tests to work with new dict-based API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * MCP tools are now organized per source server, improving structure and tracking.
  * Tools can be queried and inspected by server, with aggregated and per-server counts and connection status updated.
  * Loading and disconnect behavior refined to reflect server-scoped tool management.

* **Chores**
  * Tests and loading flows updated to align with the new per-server tool model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->