### PR TITLE
fix(frontend): fix shared task page crash when using ChatStreamContext

### DIFF
--- a/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
+++ b/frontend/src/features/tasks/components/message/FinalPromptMessage.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import { createSmartMarkdownComponents } from '@/components/common/SmartUrlRenderer'
 import { Copy, Check, Plus, Star, RefreshCw, Edit3, X, Save } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -14,7 +14,7 @@ import { useTheme } from '@/features/theme/ThemeProvider'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/hooks/use-toast'
-import { useChatStreamContext } from '../../contexts/chatStreamContext'
+import { ChatStreamContext } from '../../contexts/chatStreamContext'
 import { Textarea } from '@/components/ui/textarea'
 
 interface FinalPromptMessageProps {
@@ -31,6 +31,11 @@ interface FinalPromptMessageProps {
    */
   isPendingConfirmation?: boolean
   onStageConfirmed?: () => void
+  /**
+   * Read-only mode for shared task page (no authentication required).
+   * When true, only shows the copy prompt button and hides actions requiring auth.
+   */
+  readOnly?: boolean
 }
 
 export default function FinalPromptMessage({
@@ -41,12 +46,16 @@ export default function FinalPromptMessage({
   taskId = null,
   isPendingConfirmation = false,
   onStageConfirmed,
+  readOnly = false,
 }: FinalPromptMessageProps) {
   const { t } = useTranslation('chat')
   const { toast } = useToast()
   const { theme } = useTheme()
   const router = useRouter()
-  const { sendMessage } = useChatStreamContext()
+  // Use useContext directly to avoid throwing error when outside ChatStreamProvider
+  // This supports read-only mode in shared task page
+  const chatStreamContext = useContext(ChatStreamContext)
+  const sendMessage = chatStreamContext?.sendMessage ?? null
   const [copied, setCopied] = useState(false)
   const [isEditing, setIsEditing] = useState(false)
   const [editedPrompt, setEditedPrompt] = useState(data.final_prompt)
@@ -55,7 +64,8 @@ export default function FinalPromptMessage({
   const [hasConfirmed, setHasConfirmed] = useState(false)
 
   // Single source of truth: isPendingConfirmation from pipeline_stage_info.is_pending_confirmation
-  const showPipelineActions = isPendingConfirmation
+  // In readOnly mode (shared task page), never show pipeline actions
+  const showPipelineActions = !readOnly && isPendingConfirmation && sendMessage !== null
 
   const handleCopy = async () => {
     try {
@@ -123,7 +133,7 @@ export default function FinalPromptMessage({
       return
     }
 
-    if (!taskId || !selectedTeam) {
+    if (!taskId || !selectedTeam || !sendMessage) {
       toast({
         variant: 'destructive',
         title: t('pipeline.no_task_id'),
@@ -248,33 +258,40 @@ export default function FinalPromptMessage({
           {copied ? t('clarification.copied') : t('clarification.copy_prompt')}
         </Button>
 
-        {showPipelineActions ? (
-          <Button
-            variant="default"
-            onClick={handleContinueToNextStage}
-            disabled={isConfirming || hasConfirmed}
-            className="bg-primary hover:bg-primary/90"
-          >
-            {isConfirming || hasConfirmed ? (
-              <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+        {/* Hide auth-required actions in readOnly mode (shared task page) */}
+        {!readOnly && (
+          <>
+            {showPipelineActions ? (
+              <Button
+                variant="default"
+                onClick={handleContinueToNextStage}
+                disabled={isConfirming || hasConfirmed}
+                className="bg-primary hover:bg-primary/90"
+              >
+                {isConfirming || hasConfirmed ? (
+                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <Check className="w-4 h-4 mr-2" />
+                )}
+                {hasConfirmed ? t('pipeline.stage_confirming') : t('pipeline.confirm_stage')}
+              </Button>
             ) : (
-              <Check className="w-4 h-4 mr-2" />
+              <Button variant="secondary" onClick={handleCreateTask}>
+                <Plus className="w-4 h-4 mr-2" />
+                {t('clarification.create_task')}
+              </Button>
             )}
-            {hasConfirmed ? t('pipeline.stage_confirming') : t('pipeline.confirm_stage')}
-          </Button>
-        ) : (
-          <Button variant="secondary" onClick={handleCreateTask}>
-            <Plus className="w-4 h-4 mr-2" />
-            {t('clarification.create_task')}
-          </Button>
+          </>
         )}
       </div>
 
       {/* Hint */}
       <div className="text-xs text-text-tertiary italic">
-        {showPipelineActions
-          ? t('pipeline.confirmation_hint')
-          : t('clarification.final_prompt_hint')}
+        {readOnly
+          ? t('clarification.readonly_hint') || t('clarification.final_prompt_hint')
+          : showPipelineActions
+            ? t('pipeline.confirmation_hint')
+            : t('clarification.final_prompt_hint')}
       </div>
     </div>
   )

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -1207,6 +1207,7 @@ const MessageBubble = memo(
               taskId={selectedTaskDetail?.id}
               isPendingConfirmation={isPendingConfirmation}
               onStageConfirmed={onPipelineStageConfirmed}
+              readOnly={!!shareToken}
             />
           )
         }

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -277,6 +277,7 @@
     "copy_prompt": "Copy Prompt",
     "create_task": "Create New Task with This Prompt",
     "final_prompt_hint": "This is the refined requirement based on your answers. You can copy it or create a new code task directly.",
+    "readonly_hint": "This is a shared task. You can copy the prompt to use it in your own chat.",
     "answers_submitted": "Answers submitted",
     "waiting_response": "Waiting for response...",
     "my_answers": "My Answers",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -255,6 +255,7 @@
     "copy_prompt": "复制提示词",
     "create_task": "使用此提示词创建新任务",
     "final_prompt_hint": "这是基于您的回答精炼出的需求。您可以复制它或直接创建新的代码任务。",
+    "readonly_hint": "这是一个分享的任务。您可以复制提示词在自己的对话中使用。",
     "answers_submitted": "已提交",
     "waiting_response": "等待响应中...",
     "my_answers": "我的回答",


### PR DESCRIPTION
## Summary

Fix the shared task page (`/shared/task?token=xxx`) crashing with error: `useChatStreamContext must be used within a ChatStreamProvider`

**Root cause:**
- The `FinalPromptMessage` component directly called `useChatStreamContext()` hook
- The shared task page is not wrapped with `ChatStreamProvider` since it's a public read-only page
- When rendering AI messages containing "Final Prompt" format, the page crashed

**Changes:**
- Add `readOnly` prop to `FinalPromptMessage` component to support shared task page scenarios
- Replace `useChatStreamContext()` with `useContext(ChatStreamContext)` to avoid throwing error when outside ChatStreamProvider
- Hide auth-required actions (create task, confirm stage, edit) in readOnly mode
- Keep copy prompt functionality available in readOnly mode
- Pass `readOnly={!!shareToken}` from `MessageBubble` to `FinalPromptMessage`

## Test plan

- [ ] Access shared task page `/shared/task?token=xxx` - should load without errors
- [ ] Messages containing "Final Prompt" format should render correctly with copy button only
- [ ] Copy prompt functionality should work in shared task page
- [ ] Normal authenticated chat pages should continue to work with full functionality
- [ ] Pipeline mode confirmation should still work when not in readOnly mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only mode for shared tasks: hides edit/continue/create actions, preserves copy.
  * UI now shows read-only–specific hint text when viewing shared tasks.
  * Localization added for the read-only hint in English and Chinese so messaging appears appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->