### PR TITLE
fix: add missing Celery Beat schedule files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,13 @@ htmlcov/
 *.sqlite3
 
 # Celery Beat schedule files
-celerybeat-schedule
-celerybeat-schedule.db
+# PersistentScheduler (default, uses shelve/dumbdbm)
+celerybeat-schedule.dat
 celerybeat-schedule.dir
+celerybeat-schedule.bak
+celerybeat-schedule
+# SQLAlchemyScheduler (uses SQLite-WAL)
+celerybeat-schedule.db
 celerybeat-schedule.pag
 celerybeat-schedule-shm
 celerybeat-schedule-wal


### PR DESCRIPTION
- Add .dat and .bak files for PersistentScheduler (shelve/dumbdbm)
- Keep existing .db, .pag, .shm, .wal files for SQLAlchemyScheduler
- Add comments to clarify which files belong to which scheduler

The original .gitignore was configured for SQLAlchemyScheduler (SQLite-WAL), but the project uses PersistentScheduler (shelve/dumbdbm) which generates .dat, .dir, and .bak files. This caused celerybeat-schedule.dat and celerybeat-schedule.bak to appear in git status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to properly manage background job scheduler tracking files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->