### PR TITLE
fix(frontend): improve WebSocket connection error feedback

### DIFF
--- a/frontend/src/contexts/SocketContext.tsx
+++ b/frontend/src/contexts/SocketContext.tsx
@@ -70,6 +70,8 @@ interface SocketContextType {
   connectionError: Error | null
   /** Reconnect attempt count */
   reconnectAttempts: number
+  /** WebSocket connection URL */
+  socketUrl: string
   /** Connect to Socket.IO server */
   connect: (token: string) => void
   /** Disconnect from server */
@@ -184,6 +186,7 @@ export function SocketProvider({ children }: { children: ReactNode }) {
   const [isConnected, setIsConnected] = useState(false)
   const [connectionError, setConnectionError] = useState<Error | null>(null)
   const [reconnectAttempts, setReconnectAttempts] = useState(0)
+  const [socketUrl, setSocketUrl] = useState('')
 
   // Track current joined tasks
   const joinedTasksRef = useRef<Set<number>>(new Set())
@@ -364,6 +367,7 @@ export function SocketProvider({ children }: { children: ReactNode }) {
       // This allows RUNTIME_SOCKET_DIRECT_URL to be changed without rebuilding
       fetchRuntimeConfig().then(config => {
         const socketUrl = config.socketDirectUrl || getSocketUrl()
+        setSocketUrl(socketUrl)
         createSocketConnection(token, socketUrl)
       })
     },
@@ -850,6 +854,7 @@ export function SocketProvider({ children }: { children: ReactNode }) {
         isConnected,
         connectionError,
         reconnectAttempts,
+        socketUrl,
         connect,
         disconnect,
         joinTask,

--- a/frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx
+++ b/frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { WifiOff, Wifi, Check } from 'lucide-react'
+import { WifiOff, Wifi, Check, AlertTriangle, ChevronDown, ChevronUp } from 'lucide-react'
 import { useSocket } from '@/contexts/SocketContext'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -19,15 +19,17 @@ import { useTranslation } from '@/hooks/useTranslation'
  * - Reconnected: Briefly shown after successful reconnection (auto-hides after 3s)
  */
 export function ConnectionStatusBanner() {
-  const { isConnected, reconnectAttempts } = useSocket()
+  const { isConnected, reconnectAttempts, connectionError, socketUrl } = useSocket()
   const { t } = useTranslation('chat')
   const [showReconnected, setShowReconnected] = useState(false)
+  const [showDetails, setShowDetails] = useState(false)
   const prevConnectedRef = useRef(isConnected)
 
   useEffect(() => {
     // Detect state change from disconnected to connected
     if (isConnected && !prevConnectedRef.current) {
       setShowReconnected(true)
+      setShowDetails(false)
       const timer = setTimeout(() => setShowReconnected(false), 3000)
       return () => clearTimeout(timer)
     }
@@ -47,19 +49,99 @@ export function ConnectionStatusBanner() {
     )
   }
 
+  // Determine error type based on error message
+  const getErrorType = (error: Error | null): string | null => {
+    if (!error) return null
+    const message = error.message.toLowerCase()
+    
+    // Check for timeout
+    if (message.includes('timeout') || message.includes('timed out')) {
+      return 'timeout'
+    }
+    // Check for connection refused
+    if (message.includes('refused') || message.includes('econnrefused')) {
+      return 'refused'
+    }
+    // Default to generic error
+    return 'generic'
+  }
+
+  const errorType = getErrorType(connectionError)
+  const hasError = errorType !== null
+
+  // Extract backend URL from socket URL
+  const backendUrl = socketUrl ? socketUrl.replace('/chat', '') : 'http://localhost:8000'
+  const healthUrl = backendUrl + '/health'
+
   // Disconnected or reconnecting state
   return (
-    <div className="mx-4 mb-2 px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm flex items-center gap-2 animate-in fade-in duration-200">
-      {reconnectAttempts > 0 ? (
-        <>
+    <div className="mx-4 mb-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400 text-sm animate-in fade-in duration-200">
+      <div className="px-3 py-2 flex items-center gap-2">
+        {hasError ? (
+          <AlertTriangle className="h-4 w-4" />
+        ) : reconnectAttempts > 0 ? (
           <Wifi className="h-4 w-4 animate-pulse" />
-          <span>{t('status.reconnecting', { count: reconnectAttempts })}</span>
-        </>
-      ) : (
-        <>
+        ) : (
           <WifiOff className="h-4 w-4" />
-          <span>{t('status.disconnected')}</span>
-        </>
+        )}
+        <span className="flex-1">
+          {reconnectAttempts > 0
+            ? t('status.reconnecting', { count: reconnectAttempts })
+            : t('status.disconnected')}
+        </span>
+        {hasError && (
+          <button
+            onClick={() => setShowDetails(!showDetails)}
+            className="flex items-center gap-1 text-xs hover:underline focus:outline-none"
+            aria-expanded={showDetails}
+          >
+            {showDetails ? (
+              <>
+                <ChevronUp className="h-3 w-3" />
+                {t('status.hide_details')}
+              </>
+            ) : (
+              <>
+                <ChevronDown className="h-3 w-3" />
+                {t('status.show_details')}
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Error details section */}
+      {hasError && showDetails && (
+        <div className="px-3 pb-3 border-t border-amber-200 dark:border-amber-800/30 mt-2 pt-3">
+          <div className="font-semibold mb-2 flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4" />
+            {t('status.connection_error_title')}
+          </div>
+          
+          {/* Specific error message */}
+          <div className="mb-3 text-xs">
+            {errorType === 'timeout' && (
+              <div>{t('status.connection_error_timeout')}</div>
+            )}
+            {errorType === 'refused' && (
+              <div>{t('status.connection_error_refused')}</div>
+            )}
+            {errorType === 'generic' && (
+              <div>{t('status.connection_error_config')}</div>
+            )}
+          </div>
+
+          {/* Troubleshooting steps */}
+          <div className="text-xs space-y-1">
+            <div className="font-semibold mb-1">{t('status.troubleshoot_title')}</div>
+            <div className="space-y-1 text-amber-600 dark:text-amber-400">
+              <div>{t('status.troubleshoot_check_backend', { healthUrl })}</div>
+              <div>{t('status.troubleshoot_check_socket_url', { socketUrl })}</div>
+              <div>{t('status.troubleshoot_check_network')}</div>
+              <div>{t('status.troubleshoot_restart_services')}</div>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -46,7 +46,19 @@
     "connecting": "Connecting...",
     "disconnected": "Disconnected",
     "reconnecting": "Reconnecting... (attempt {{count}})",
-    "reconnected": "Reconnected"
+    "reconnected": "Reconnected",
+    "connection_error_title": "Connection Failed",
+    "connection_error_config": "Configuration Error: Please check if WebSocket connection address is correct",
+    "connection_error_timeout": "Connection Timeout: Please check your network connection or if backend service is running",
+    "connection_error_refused": "Connection Refused: Please confirm backend service is started",
+    "connection_error_generic": "Connection Failed: Please check your network connection or refresh the page",
+    "troubleshoot_title": "Troubleshooting",
+    "troubleshoot_check_backend": "1. Check if backend is running: Visit {{healthUrl}}",
+    "troubleshoot_check_socket_url": "2. Check WebSocket connection address configuration ({{socketUrl}})",
+    "troubleshoot_check_network": "3. Check network connection: Confirm firewall is not blocking WebSocket",
+    "troubleshoot_restart_services": "4. Restart services",
+    "show_details": "Show Details",
+    "hide_details": "Hide Details"
   },
   "messages": {
     "assistant": "AI Assistant",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -46,7 +46,19 @@
     "connecting": "连接中...",
     "disconnected": "连接断开",
     "reconnecting": "正在重连...（第 {{count}} 次尝试）",
-    "reconnected": "已重新连接"
+    "reconnected": "已重新连接",
+    "connection_error_title": "连接失败",
+    "connection_error_config": "配置错误：请检查 WebSocket 连接地址是否正确",
+    "connection_error_timeout": "连接超时：请检查网络连接或后端服务是否正常运行",
+    "connection_error_refused": "连接被拒绝：请确认后端服务已启动",
+    "connection_error_generic": "连接失败：请检查网络连接或刷新页面重试",
+    "troubleshoot_title": "故障排查",
+    "troubleshoot_check_backend": "1. 检查后端服务是否运行：访问 {{healthUrl}}",
+    "troubleshoot_check_socket_url": "2. 检查 WebSocket 连接地址配置 ({{socketUrl}})",
+    "troubleshoot_check_network": "3. 检查网络连接：确认防火墙未阻止 WebSocket 连接",
+    "troubleshoot_restart_services": "4. 重启服务",
+    "show_details": "显示详情",
+    "hide_details": "隐藏详情"
   },
   "messages": {
     "assistant": "AI 助手",


### PR DESCRIPTION
# Pull Request Title

fix(frontend): improve WebSocket connection error feedback

## Summary

Improve WebSocket connection error feedback to help users troubleshoot connection issues more easily.

## Changes

### Frontend

- **ConnectionStatusBanner**: Add expandable error details section with troubleshooting steps
- **SocketContext**: Expose `socketUrl` to context for dynamic display
- **Translations**: Add user-friendly error messages with dynamic URL placeholders

### Details

- When WebSocket connection fails, users can now click "显示详情" / "Show Details" to see:
  - Specific error type (timeout, refused, config error)
  - 4 troubleshooting steps with dynamic URLs
  - Backend health check URL (e.g., http://localhost:8000/health)
  - WebSocket connection address (e.g., ws://localhost:8000/chat)

- Error messages are simplified to be user-friendly without technical jargon
- No more references to `.env` file which only developers understand

### Files Changed

- `frontend/src/contexts/SocketContext.tsx`
- `frontend/src/features/tasks/components/input/ConnectionStatusBanner.tsx`
- `frontend/src/i18n/locales/zh-CN/chat.json`
- `frontend/src/i18n/locales/en/chat.json`

## Related Issues

Fixes the issue where WebSocket connection errors showed only "正在重连...（第 X 次尝试）" without helpful information.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced connection error display with detailed error messages (timeout, refused, or generic errors).
  * Added expandable error details section to show troubleshooting guidance.
  * Included troubleshooting steps: backend health check, socket URL verification, network diagnostics, and service restart suggestions.

* **Localization**
  * Added multi-language support for connection error and troubleshooting messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->