### PR TITLE
fix(start.sh): ensure frontend uses WSL node instead of Windows node

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -310,6 +310,14 @@ show_uv_install_instructions() {
     exit 1
 }
 
+# Detect if running in WSL
+is_wsl() {
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
 # Check if docker is installed
 check_docker_installed() {
     if command -v docker &> /dev/null; then
@@ -1133,8 +1141,23 @@ start_services() {
     export RUNTIME_INTERNAL_API_URL=http://localhost:$BACKEND_PORT
     export RUNTIME_SOCKET_DIRECT_URL=$WEGENT_SOCKET_URL
 
+    # Build the frontend startup command
+    # In WSL, use full path to node to ensure we use the correct nvm-installed version
+    # instead of potentially using Windows node or a different version
+    local frontend_cmd="PORT=$WEGENT_FRONTEND_PORT npm run dev"
+    
+    if is_wsl; then
+        # Get the full path to node from the current shell (which has nvm loaded)
+        local node_path=$(command -v node)
+        if [ -n "$node_path" ]; then
+            # Set PATH to use the nvm node directory
+            local node_dir=$(dirname "$node_path")
+            frontend_cmd="PATH=$node_dir:\$PATH $frontend_cmd"
+        fi
+    fi
+
     # Start frontend in background
-    nohup bash -c "PORT=$WEGENT_FRONTEND_PORT npm run dev" > "$PID_DIR/frontend.log" 2>&1 &
+    nohup bash -c "$frontend_cmd" > "$PID_DIR/frontend.log" 2>&1 &
     local frontend_pid=$!
     echo $frontend_pid > "$PID_DIR/frontend.pid"
 


### PR DESCRIPTION
## Problem

When running `start.sh` in WSL (Windows Subsystem for Linux), the frontend service was incorrectly using Windows-installed Node.js instead of nvm-managed Node.js in WSL. This caused several issues:

1. The start script couldn't properly track the frontend service status
2. Port conflicts between WSL and Windows processes
3. Inconsistent behavior between services (backend/chat_shell/executor_manager ran in WSL, but frontend ran in Windows)

The root cause was that when using `nvm use 22`, `node` and `npm` become shell functions/aliases. The `nohup bash -c "npm run dev"` command spawned a new shell that didn't inherit the nvm environment, causing it to fall back to Windows Node.js (if available) or fail completely.

## Solution

Added WSL detection and environment handling to ensure the frontend uses the correct nvm-installed Node.js:

1. **Added `is_wsl()` function** - Detects WSL environment by checking `/proc/version`
2. **Fixed frontend startup for WSL** - When running in WSL:
   - Gets the full path to `node` using `command -v node` from the current shell (which has nvm loaded)
   - Prepends the nvm node directory to PATH in the new shell
   - This ensures the correct nvm-installed Node.js is used instead of Windows Node.js

## Changes

- `start.sh`: Added `is_wsl()` function and WSL-aware frontend startup logic

## Benefits

- All services now consistently run in WSL when using the WSL environment
- Service status tracking works correctly for the frontend
- No more port conflicts between WSL and Windows processes
- Works with any node version manager (nvm, n, fnm, etc.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced startup process for Windows Subsystem for Linux (WSL) environments to properly resolve Node.js and npm dependencies, ensuring reliable frontend service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->