### PR TITLE
fix(backend): correct group chat filter logic for sidebar display

### DIFF
--- a/backend/app/services/adapters/task_kinds/helpers.py
+++ b/backend/app/services/adapters/task_kinds/helpers.py
@@ -364,7 +364,7 @@ def get_tasks_related_data_batch(
         }
 
     # Add is_group_chat to result
-    _add_group_chat_info(db, tasks, result)
+    _add_group_chat_info(db, tasks, result, user_id)
 
     return result
 
@@ -480,13 +480,21 @@ def _batch_query_teams(db: Session, team_refs: set, user_id: int) -> Dict[str, K
 
 
 def _add_group_chat_info(
-    db: Session, tasks: List[Kind], result: Dict[str, Dict[str, Any]]
+    db: Session, tasks: List[Kind], result: Dict[str, Dict[str, Any]], user_id: int
 ) -> None:
-    """Add is_group_chat info to result dict using ResourceMember."""
+    """Add is_group_chat info to result dict using ResourceMember.
+
+    Args:
+        db: Database session
+        tasks: List of Task Kind objects
+        result: Result dictionary to update
+        user_id: Current user ID to check membership for
+    """
     from app.models.resource_member import MemberStatus, ResourceMember
     from app.models.share_link import ResourceType
 
     task_ids = [t.id for t in tasks]
+    # Only count current user's membership, not all members
     member_count_results = (
         db.query(
             ResourceMember.resource_id, func.count(ResourceMember.id).label("count")
@@ -495,6 +503,7 @@ def _add_group_chat_info(
             ResourceMember.resource_type == ResourceType.TASK,
             ResourceMember.resource_id.in_(task_ids),
             ResourceMember.status == MemberStatus.APPROVED,
+            ResourceMember.user_id == user_id,  # Only count current user's membership
         )
         .group_by(ResourceMember.resource_id)
         .all()
@@ -528,7 +537,7 @@ def build_lite_task_list(
     Args:
         db: Database session
         tasks: List of TaskResource objects
-        user_id: User ID for looking up related data
+        user_id: User ID for looking up related data and determining group chat membership
 
     Returns:
         List of task dictionaries with essential fields
@@ -536,7 +545,9 @@ def build_lite_task_list(
     if not tasks:
         return []
 
-    # Get task member counts in batch for is_group_chat detection using ResourceMember
+    # Get tasks where the CURRENT USER is a member for is_group_chat detection
+    # Important: We only mark a task as group chat if the current user is a member,
+    # not based on whether the task has any members at all.
     from app.models.resource_member import MemberStatus, ResourceMember
     from app.models.share_link import ResourceType
 
@@ -551,6 +562,7 @@ def build_lite_task_list(
                 ResourceMember.resource_type == ResourceType.TASK,
                 ResourceMember.resource_id.in_(task_ids_for_members),
                 ResourceMember.status == MemberStatus.APPROVED,
+                ResourceMember.user_id == user_id,  # Only count current user's membership
             )
             .group_by(ResourceMember.resource_id)
             .all()

--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -176,7 +176,9 @@ class TaskQueryMixin:
 
         total = total_result if total_result else 0
 
-        # Get task member counts in batch for is_group_chat detection using ResourceMember
+        # Get tasks where the CURRENT USER is a member for is_group_chat detection
+        # Important: We only mark a task as group chat if the current user is a member,
+        # not based on whether the task has any members at all.
         from app.models.resource_member import MemberStatus, ResourceMember
         from app.models.share_link import ResourceType
 
@@ -192,6 +194,7 @@ class TaskQueryMixin:
                     ResourceMember.resource_type == ResourceType.TASK,
                     ResourceMember.resource_id.in_(task_ids_for_members),
                     ResourceMember.status == MemberStatus.APPROVED,
+                    ResourceMember.user_id == user_id,  # Only count current user's membership
                 )
                 .group_by(ResourceMember.resource_id)
                 .all()
@@ -214,17 +217,19 @@ class TaskQueryMixin:
         from app.models.resource_member import MemberStatus, ResourceMember
         from app.models.share_link import ResourceType
 
-        # Get task IDs that are group chats (have members) using resource_members
+        # Get task IDs where the CURRENT USER is a member (group chats user participates in)
+        # Important: We only consider tasks where the current user is explicitly a member,
+        # not just any task that has any member.
         member_task_ids_sql = text(
             """
             SELECT DISTINCT tm.resource_id
             FROM resource_members tm
             INNER JOIN tasks k ON k.id = tm.resource_id AND tm.resource_type = 'Task'
             WHERE tm.status = 'approved'
+            AND tm.user_id = :user_id
             AND k.kind = 'Task'
             AND k.is_active = true
             AND k.namespace != 'system'
-            AND (k.user_id = :user_id OR tm.user_id = :user_id)
         """
         )
         member_task_ids_result = db.execute(
@@ -302,19 +307,24 @@ class TaskQueryMixin:
         from app.models.resource_member import MemberStatus, ResourceMember
         from app.models.share_link import ResourceType
 
-        # Get all task IDs that are group chats (have members) using resource_members
+        # Get task IDs where the CURRENT USER is a member (group chats user participates in)
+        # Important: Only exclude tasks where the current user is explicitly a member,
+        # not just any task that has any member.
         member_task_ids_sql = text(
             """
             SELECT DISTINCT tm.resource_id
             FROM resource_members tm
             INNER JOIN tasks k ON k.id = tm.resource_id AND tm.resource_type = 'Task'
             WHERE tm.status = 'approved'
+            AND tm.user_id = :user_id
             AND k.kind = 'Task'
             AND k.is_active = true
             AND k.namespace != 'system'
         """
         )
-        member_task_ids_result = db.execute(member_task_ids_sql).fetchall()
+        member_task_ids_result = db.execute(
+            member_task_ids_sql, {"user_id": user_id}
+        ).fetchall()
         member_task_ids = {row[0] for row in member_task_ids_result}
 
         # Also get task IDs where is_group_chat is explicitly set to true
@@ -479,7 +489,8 @@ class TaskQueryMixin:
         # Restore the original order
         filtered_tasks = [id_to_task[tid] for tid in task_ids if tid in id_to_task]
 
-        # Get task member counts using ResourceMember
+        # Get tasks where the CURRENT USER is a member for is_group_chat detection
+        # Important: We only mark a task as group chat if the current user is a member
         from app.models.resource_member import MemberStatus, ResourceMember
         from app.models.share_link import ResourceType
 
@@ -495,6 +506,7 @@ class TaskQueryMixin:
                     ResourceMember.resource_type == ResourceType.TASK,
                     ResourceMember.resource_id.in_(task_ids_for_members),
                     ResourceMember.status == MemberStatus.APPROVED,
+                    ResourceMember.user_id == user_id,  # Only count current user's membership
                 )
                 .group_by(ResourceMember.resource_id)
                 .all()

--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -310,6 +310,8 @@ class TaskQueryMixin:
         # Get task IDs where the CURRENT USER is a member (group chats user participates in)
         # Important: Only exclude tasks where the current user is explicitly a member,
         # not just any task that has any member.
+        # Note: We query ALL member tasks (not just owned) because we need to exclude
+        # tasks where the user is a member but not the owner from personal tasks list.
         member_task_ids_sql = text(
             """
             SELECT DISTINCT tm.resource_id
@@ -326,6 +328,26 @@ class TaskQueryMixin:
             member_task_ids_sql, {"user_id": user_id}
         ).fetchall()
         member_task_ids = {row[0] for row in member_task_ids_result}
+
+        # Get owned tasks where user is a member (for accurate total calculation)
+        # These are the tasks the user owns AND is a member of (group chats they created)
+        owned_member_task_ids_sql = text(
+            """
+            SELECT DISTINCT tm.resource_id
+            FROM resource_members tm
+            INNER JOIN tasks k ON k.id = tm.resource_id AND tm.resource_type = 'Task'
+            WHERE tm.status = 'approved'
+            AND tm.user_id = :user_id
+            AND k.user_id = :user_id
+            AND k.kind = 'Task'
+            AND k.is_active = true
+            AND k.namespace != 'system'
+        """
+        )
+        owned_member_task_ids_result = db.execute(
+            owned_member_task_ids_sql, {"user_id": user_id}
+        ).fetchall()
+        owned_member_task_ids = {row[0] for row in owned_member_task_ids_result}
 
         # Also get task IDs where is_group_chat is explicitly set to true
         explicit_group_sql = text(
@@ -344,8 +366,13 @@ class TaskQueryMixin:
         ).fetchall()
         explicit_group_ids = {row[0] for row in explicit_group_result}
 
-        # Combine all group task IDs to exclude
+        # Combine all group task IDs to exclude from personal tasks
+        # This includes: tasks where user is member (owned or not) + explicitly marked group chats
         all_group_task_ids = member_task_ids | explicit_group_ids
+
+        # Calculate owned group task IDs for accurate total calculation
+        # Only count owned tasks as group chats (owned + member OR owned + explicit group chat)
+        owned_group_task_ids = owned_member_task_ids | explicit_group_ids
 
         # Get user's owned tasks (not group chats)
         count_sql = text(
@@ -399,8 +426,10 @@ class TaskQueryMixin:
         # Build lightweight result
         result = build_lite_task_list(db, ordered_tasks, user_id)
 
-        # Recalculate total
-        total = total_result - len(all_group_task_ids) if total_result else 0
+        # Recalculate total using owned_group_task_ids (not all_group_task_ids)
+        # This ensures we only subtract group chats that the user owns,
+        # not group chats that the user was invited to
+        total = total_result - len(owned_group_task_ids) if total_result else 0
         if total < 0:
             total = len(ordered_tasks)
 


### PR DESCRIPTION
## Summary

- Fix group chat filter logic that incorrectly showed non-group-chat tasks in the group chat sidebar
- The bug occurred when a task had members (via `resource_members` table), but the current user was the task owner, not a member
- Now correctly checks if the **current user** is a member, rather than checking if the task has **any** members

## Root Cause

The previous implementation used this SQL condition:
```sql
WHERE tm.status = 'approved'
AND (k.user_id = :user_id OR tm.user_id = :user_id)
```

This returned tasks where either:
1. The user owns the task AND the task has any approved member
2. The user is a member of the task

The correct logic should only consider case 2 - tasks where the current user is explicitly a member.

## Changes

1. **`get_user_group_tasks_lite`**: Fixed to only return tasks where `tm.user_id = :user_id`
2. **`get_user_personal_tasks_lite`**: Fixed to exclude only tasks where the current user is a member
3. **`get_user_tasks_lite`, `get_new_tasks_since_id`**: Fixed member_counts query to filter by user_id
4. **`build_lite_task_list`**: Fixed member_counts query to filter by user_id
5. **`_add_group_chat_info`**: Added user_id parameter and filter

## Test Plan

- [x] All 89 task-related tests pass
- [ ] Manual verification: Create a task, share it with another user, verify it doesn't appear in group chat sidebar for the owner
- [ ] Manual verification: When invited to a group chat, verify it appears in the group chat sidebar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group chat detection and member counts now respect the current user's membership. Task lists, lite views, totals, and pagination more accurately include/exclude group tasks based on whether the signed-in user is a member, improving task organization and counts across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->