### PR TITLE
fix(backend): filter out share-copy records in group chat task queries

### DIFF
--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -215,6 +215,8 @@ class TaskQueryMixin:
         from app.models.share_link import ResourceType
 
         # Get task IDs that are group chats (have members) using resource_members
+        # Note: copied_resource_id = 0 filters out share-copy records (where copied_resource_id > 0)
+        # Share-copy records are created when users import shared tasks, not for group chat membership
         member_task_ids_sql = text(
             """
             SELECT DISTINCT tm.resource_id
@@ -225,6 +227,7 @@ class TaskQueryMixin:
             AND k.is_active = true
             AND k.namespace != 'system'
             AND (k.user_id = :user_id OR tm.user_id = :user_id)
+            AND tm.copied_resource_id = 0
         """
         )
         member_task_ids_result = db.execute(
@@ -303,6 +306,8 @@ class TaskQueryMixin:
         from app.models.share_link import ResourceType
 
         # Get all task IDs that are group chats (have members) using resource_members
+        # Note: copied_resource_id = 0 filters out share-copy records (where copied_resource_id > 0)
+        # Share-copy records are created when users import shared tasks, not for group chat membership
         member_task_ids_sql = text(
             """
             SELECT DISTINCT tm.resource_id
@@ -312,6 +317,7 @@ class TaskQueryMixin:
             AND k.kind = 'Task'
             AND k.is_active = true
             AND k.namespace != 'system'
+            AND tm.copied_resource_id = 0
         """
         )
         member_task_ids_result = db.execute(member_task_ids_sql).fetchall()


### PR DESCRIPTION
The resource_members table stores two types of records:
1. Group chat membership (copied_resource_id = 0)
2. Share-copy records (copied_resource_id > 0) for imported tasks

The SQL queries in get_user_group_tasks_lite() and get_user_personal_tasks_lite() were not distinguishing between these record types, causing personal tasks to incorrectly appear in the group chat list when they had been shared and imported by other users.

Added `AND tm.copied_resource_id = 0` condition to both queries to ensure only actual group chat membership records are considered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined filtering in group and personal task lists to exclude previously imported shared tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->