### PR TITLE
fix(device): prevent device selection reset on new task creation

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -681,6 +681,7 @@ class ChatNamespace(socketio.AsyncNamespace):
                 knowledge_base_id=payload.knowledge_base_id,
                 additional_skills=additional_skills_dicts,
                 pipeline_bot_ids=pipeline_bot_ids,
+                device_id=payload.device_id,
             )
 
             result = await create_chat_task(

--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -63,6 +63,8 @@ class TaskCreationParams:
     # Pipeline mode: specific bot_ids for the next stage
     # When set, only create subtask for these bots instead of all team members
     pipeline_bot_ids: Optional[List[int]] = None
+    # Device ID for local device execution (saved at task creation to avoid race condition)
+    device_id: Optional[str] = None
 
 
 def get_bot_ids_from_team(db: Session, team: Kind) -> List[int]:
@@ -301,6 +303,11 @@ def create_new_task(
             },
             "workspaceRef": {"name": workspace_name, "namespace": "default"},
             "is_group_chat": params.is_group_chat,
+            **(
+                {"device_id": params.device_id}
+                if params.device_id
+                else {}
+            ),
             **(
                 {"knowledgeBaseRefs": knowledge_base_refs}
                 if knowledge_base_refs

--- a/frontend/src/features/tasks/components/params/DeviceTaskSync.tsx
+++ b/frontend/src/features/tasks/components/params/DeviceTaskSync.tsx
@@ -33,11 +33,11 @@ export default function DeviceTaskSync() {
       return
     }
 
-    // Task has no device_id — clear device selection
+    // Task has no device_id — keep current selection as-is
+    // This handles:
+    // 1. Newly created task where device_id hasn't been saved yet (race condition)
+    // 2. Cloud executor tasks where device selection should not be affected
     if (!selectedTaskDetail.device_id) {
-      if (selectedDeviceId) {
-        setSelectedDeviceId(null)
-      }
       lastProcessedTaskIdRef.current = selectedTaskDetail.id
       return
     }


### PR DESCRIPTION
## Summary                                                                                                              - 修复设备会话串设备问题：用户选择设备B发消息后，设备选择被重置为设备A
  - 前端：DeviceTaskSync 不再因 device_id=null 清空当前设备选择                                                           - 后端：任务创建时即保存 device_id，消除竞态窗口
                                                                                                                          Fixes wecode-ai/Wegent#613

  ## Root Cause
  任务创建时 device_id 未立即持久化（由 device_router 异步写入），前端 getTaskDetail 返回 device_id=null，触发
  DeviceTaskSync 清空设备选择 → auto-select 选中第一个在线设备。

  ## Changes
  - `DeviceTaskSync.tsx`: 当任务无 device_id 时保留当前选择不变（而非清空）
  - `task_manager.py`: TaskCreationParams 新增 device_id 字段，create_new_task 写入 task spec
  - `chat_namespace.py`: 传递 payload.device_id 到 TaskCreationParams