### PR TITLE
fix(frontend): correct scope parameter for group knowledge base creation

### DIFF
--- a/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
+++ b/frontend/src/features/knowledge/document/hooks/useEmbeddingModels.ts
@@ -22,10 +22,9 @@ export function useEmbeddingModels(
   const fetchModels = useCallback(async () => {
     try {
       setLoading(true)
-      // For organization and group scope, use 'personal' to get user's models + public models
-      // Organization and Group KBs should be able to use personal or public models
-      // Group-specific models can be added later if needed
-      const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope || 'all'
+      // For organization scope, use 'personal' to get user's models + public models
+      // For group scope, pass 'group' directly to get group's models + public models
+      const apiScope = scope === 'organization' ? 'personal' : scope || 'all'
       // Use modelApis.getUnifiedModels with scope support and filter by embedding type
       const response = await modelApis.getUnifiedModels(
         undefined, // shellType

--- a/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
+++ b/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
@@ -18,7 +18,7 @@ export function useRetrievers(
       setLoading(true)
       // For organization scope, use 'personal' to get user's retrievers + public retrievers
       // For group scope, pass 'group' directly to get group's retrievers + public retrievers
-      const apiScope = scope === 'organization' ? 'personal' : scope
+      const apiScope = scope === 'organization' ? 'personal' : scope || 'all'
       const response = await retrieverApis.getUnifiedRetrievers(apiScope, groupName)
       const data = response.data || []
       // Sort by type priority based on scope, then by name

--- a/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
+++ b/frontend/src/features/knowledge/document/hooks/useRetrievers.ts
@@ -16,10 +16,9 @@ export function useRetrievers(
   const fetchRetrievers = useCallback(async () => {
     try {
       setLoading(true)
-      // For organization and group scope, use 'personal' to get user's retrievers + public retrievers
-      // Organization and Group KBs should be able to use personal or public retrievers
-      // Group-specific retrievers can be added later if needed
-      const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope
+      // For organization scope, use 'personal' to get user's retrievers + public retrievers
+      // For group scope, pass 'group' directly to get group's retrievers + public retrievers
+      const apiScope = scope === 'organization' ? 'personal' : scope
       const response = await retrieverApis.getUnifiedRetrievers(apiScope, groupName)
       const data = response.data || []
       // Sort by type priority based on scope, then by name


### PR DESCRIPTION
## Summary

- Fix `useRetrievers.ts` to pass `'group'` scope directly to API instead of converting to `'personal'`
- Fix `useEmbeddingModels.ts` with the same correction for group scope handling
- Update comments to accurately reflect the scope mapping behavior

## Problem

When creating a knowledge base in the group knowledge page, the hooks incorrectly converted `scope='group'` to `'personal'` when calling backend APIs. This caused the UI to display personal retrievers/models instead of group resources.

## Changes

**`useRetrievers.ts`:**
```typescript
// Before (incorrect):
const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope

// After (correct):
const apiScope = scope === 'organization' ? 'personal' : scope
```

**`useEmbeddingModels.ts`:**
```typescript
// Before (incorrect):
const apiScope = scope === 'organization' || scope === 'group' ? 'personal' : scope || 'all'

// After (correct):
const apiScope = scope === 'organization' ? 'personal' : scope || 'all'
```

## Expected Behavior

- **Personal knowledge page**: Shows personal + public retrievers/models
- **Group knowledge page**: Shows group + public retrievers/models (now fixed)
- **Organization knowledge page**: Shows personal + public retrievers/models

## Test plan

- [ ] Verify personal knowledge base creation shows personal + public retrievers/models
- [ ] Verify group knowledge base creation shows group + public retrievers/models
- [ ] Verify the sorting order prioritizes scope-specific resources over public resources

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scope handling so group-scoped embedding models and retrievers now return group-specific resources instead of being treated as personal.
  * Adjusted default scope resolution so unspecified scopes fall back to a global "all" view, ensuring expected model and retriever listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->