### PR TITLE
feat(attachment): add chunked upload support for large files

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -33,6 +33,7 @@ from app.api.endpoints.adapter import (
     attachments,
     bots,
     chat,
+    chunked_upload,
     dify,
     models,
     retrievers,
@@ -102,6 +103,9 @@ api_router.include_router(
 api_router.include_router(chat.router, prefix="/chat", tags=["chat"])
 api_router.include_router(
     attachments.router, prefix="/attachments", tags=["attachments"]
+)
+api_router.include_router(
+    chunked_upload.router, prefix="/attachments/chunked", tags=["chunked-upload"]
 )
 api_router.include_router(repository.router, prefix="/git", tags=["repository"])
 api_router.include_router(quota.router, prefix="/quota", tags=["quota"])

--- a/backend/app/api/endpoints/adapter/chunked_upload.py
+++ b/backend/app/api/endpoints/adapter/chunked_upload.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Chunked upload API endpoints for handling large file uploads.
+
+Provides endpoints for:
+- Initializing chunked uploads
+- Uploading individual chunks
+- Completing/finalizing uploads
+- Aborting uploads
+- Checking upload status
+"""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.models.user import User
+from app.schemas.subtask_context import AttachmentResponse, TruncationInfo
+from app.services.attachment.chunked_upload import (
+    CHUNK_SIZE,
+    ChunkedUploadError,
+    chunked_upload_service,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ChunkedUploadInitRequest(BaseModel):
+    """Request to initialize a chunked upload."""
+
+    filename: str = Field(..., description="Original filename")
+    file_size: int = Field(..., gt=0, description="Total file size in bytes")
+    chunk_size: Optional[int] = Field(
+        None, ge=1024 * 1024, le=10 * 1024 * 1024, description="Chunk size (1-10MB)"
+    )
+
+
+class ChunkedUploadInitResponse(BaseModel):
+    """Response for chunked upload initialization."""
+
+    upload_id: str = Field(..., description="Unique upload session ID")
+    total_chunks: int = Field(..., description="Number of chunks to upload")
+    chunk_size: int = Field(..., description="Size of each chunk in bytes")
+
+
+class ChunkUploadResponse(BaseModel):
+    """Response for chunk upload."""
+
+    chunk_index: int = Field(..., description="Index of uploaded chunk")
+    received_chunks: int = Field(..., description="Total received chunks")
+    total_chunks: int = Field(..., description="Total chunks expected")
+    progress_percent: float = Field(..., description="Upload progress percentage")
+
+
+class UploadStatusResponse(BaseModel):
+    """Response for upload status check."""
+
+    upload_id: str
+    filename: str
+    file_size: int
+    total_chunks: int
+    received_chunks: int
+    missing_chunks: list[int]
+    progress_percent: float
+    created_at: float
+    last_updated: float
+
+
+def _build_attachment_response(
+    context,
+    truncation_info: Optional[TruncationInfo],
+) -> AttachmentResponse:
+    """Build attachment response from context."""
+    response_truncation_info = None
+    if truncation_info and truncation_info.is_truncated:
+        response_truncation_info = TruncationInfo(
+            is_truncated=True,
+            original_length=truncation_info.original_length,
+            truncated_length=truncation_info.truncated_length,
+            truncation_message_key="content_truncated",
+        )
+
+    return AttachmentResponse.from_context(context, response_truncation_info)
+
+
+@router.post("/init", response_model=ChunkedUploadInitResponse)
+async def init_chunked_upload(
+    request: ChunkedUploadInitRequest,
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+):
+    """
+    Initialize a chunked upload session.
+
+    This endpoint must be called before uploading any chunks.
+    Returns an upload_id that must be used for subsequent chunk uploads.
+
+    Limits:
+    - Maximum file size: 100 MB
+    - Maximum concurrent uploads per user: 10
+    - Upload session expires after 24 hours
+
+    Args:
+        request: Upload initialization request with filename and file size
+
+    Returns:
+        Upload session details including upload_id and chunk configuration
+    """
+    logger.info(
+        f"[chunked_upload] init: user_id={current_user.id}, "
+        f"filename={request.filename}, file_size={request.file_size}"
+    )
+
+    try:
+        chunk_size = request.chunk_size or CHUNK_SIZE
+        upload_id, total_chunks, actual_chunk_size = (
+            chunked_upload_service.init_chunked_upload(
+                user_id=current_user.id,
+                filename=request.filename,
+                file_size=request.file_size,
+                chunk_size=chunk_size,
+            )
+        )
+
+        return ChunkedUploadInitResponse(
+            upload_id=upload_id,
+            total_chunks=total_chunks,
+            chunk_size=actual_chunk_size,
+        )
+
+    except ChunkedUploadError as e:
+        logger.warning(f"[chunked_upload] init failed: {e.message}")
+        raise HTTPException(
+            status_code=400,
+            detail={"message": e.message, "error_code": e.error_code},
+        ) from e
+    except Exception as e:
+        logger.exception(f"[chunked_upload] init error: {e}")
+        raise HTTPException(
+            status_code=500, detail="Failed to initialize upload"
+        ) from e
+
+
+@router.post("/{upload_id}/chunk", response_model=ChunkUploadResponse)
+async def upload_chunk(
+    upload_id: str,
+    chunk_index: int = Form(..., ge=0, description="Index of this chunk (0-based)"),
+    checksum: Optional[str] = Form(None, description="MD5 checksum for verification"),
+    chunk: UploadFile = File(..., description="Chunk binary data"),
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+):
+    """
+    Upload a single chunk of the file.
+
+    Chunks can be uploaded in any order, but all chunks must be
+    uploaded before calling the complete endpoint.
+
+    Args:
+        upload_id: Upload session ID from init
+        chunk_index: Index of this chunk (0-based)
+        checksum: Optional MD5 checksum for verification
+        chunk: Chunk binary data
+
+    Returns:
+        Upload progress information
+    """
+    try:
+        chunk_data = await chunk.read()
+
+        received_count, total_chunks = chunked_upload_service.upload_chunk(
+            upload_id=upload_id,
+            user_id=current_user.id,
+            chunk_index=chunk_index,
+            chunk_data=chunk_data,
+            checksum=checksum,
+        )
+
+        progress = round(received_count / total_chunks * 100, 1)
+
+        return ChunkUploadResponse(
+            chunk_index=chunk_index,
+            received_chunks=received_count,
+            total_chunks=total_chunks,
+            progress_percent=progress,
+        )
+
+    except ChunkedUploadError as e:
+        logger.warning(
+            f"[chunked_upload] chunk upload failed: upload_id={upload_id}, "
+            f"chunk_index={chunk_index}, error={e.message}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail={"message": e.message, "error_code": e.error_code},
+        ) from e
+    except Exception as e:
+        logger.exception(
+            f"[chunked_upload] chunk upload error: upload_id={upload_id}, "
+            f"chunk_index={chunk_index}"
+        )
+        raise HTTPException(status_code=500, detail="Failed to upload chunk") from e
+
+
+@router.post("/{upload_id}/complete", response_model=AttachmentResponse)
+async def complete_chunked_upload(
+    upload_id: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+):
+    """
+    Complete the chunked upload and create the attachment.
+
+    This endpoint assembles all uploaded chunks, processes the file,
+    and creates the attachment record. All chunks must be uploaded
+    before calling this endpoint.
+
+    Args:
+        upload_id: Upload session ID from init
+
+    Returns:
+        Attachment details including ID and processing status
+    """
+    logger.info(
+        f"[chunked_upload] completing: upload_id={upload_id}, user_id={current_user.id}"
+    )
+
+    try:
+        context, truncation_info = chunked_upload_service.complete_chunked_upload(
+            db=db,
+            upload_id=upload_id,
+            user_id=current_user.id,
+        )
+
+        return _build_attachment_response(context, truncation_info)
+
+    except ChunkedUploadError as e:
+        logger.warning(
+            f"[chunked_upload] complete failed: upload_id={upload_id}, "
+            f"error={e.message}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail={"message": e.message, "error_code": e.error_code},
+        ) from e
+    except Exception as e:
+        logger.exception(f"[chunked_upload] complete error: upload_id={upload_id}")
+        raise HTTPException(status_code=500, detail="Failed to complete upload") from e
+
+
+@router.delete("/{upload_id}/abort")
+async def abort_chunked_upload(
+    upload_id: str,
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+):
+    """
+    Abort a chunked upload and cleanup resources.
+
+    Use this endpoint to cancel an in-progress upload and free up
+    server resources.
+
+    Args:
+        upload_id: Upload session ID from init
+
+    Returns:
+        Success message
+    """
+    logger.info(
+        f"[chunked_upload] aborting: upload_id={upload_id}, user_id={current_user.id}"
+    )
+
+    try:
+        chunked_upload_service.abort_chunked_upload(
+            upload_id=upload_id,
+            user_id=current_user.id,
+        )
+
+        return {"message": "Upload aborted successfully"}
+
+    except ChunkedUploadError as e:
+        logger.warning(
+            f"[chunked_upload] abort failed: upload_id={upload_id}, "
+            f"error={e.message}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail={"message": e.message, "error_code": e.error_code},
+        ) from e
+    except Exception as e:
+        logger.exception(f"[chunked_upload] abort error: upload_id={upload_id}")
+        raise HTTPException(status_code=500, detail="Failed to abort upload") from e
+
+
+@router.get("/{upload_id}/status", response_model=UploadStatusResponse)
+async def get_upload_status(
+    upload_id: str,
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
+):
+    """
+    Get the status of a chunked upload.
+
+    Returns information about upload progress, including which chunks
+    have been received and which are still missing.
+
+    Args:
+        upload_id: Upload session ID from init
+
+    Returns:
+        Upload status information
+    """
+    try:
+        status = chunked_upload_service.get_upload_status(
+            upload_id=upload_id,
+            user_id=current_user.id,
+        )
+
+        return UploadStatusResponse(**status)
+
+    except ChunkedUploadError as e:
+        logger.warning(
+            f"[chunked_upload] status failed: upload_id={upload_id}, "
+            f"error={e.message}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail={"message": e.message, "error_code": e.error_code},
+        ) from e
+    except Exception as e:
+        logger.exception(f"[chunked_upload] status error: upload_id={upload_id}")
+        raise HTTPException(
+            status_code=500, detail="Failed to get upload status"
+        ) from e

--- a/backend/app/services/attachment/chunked_upload.py
+++ b/backend/app/services/attachment/chunked_upload.py
@@ -302,20 +302,58 @@ class ChunkedUploadService:
         chunk_key = self._chunk_key(upload_id, chunk_index)
         redis_client.setex(chunk_key, UPLOAD_EXPIRATION, chunk_data)
 
-        # Update session
-        if chunk_index not in session.received_chunks:
-            session.received_chunks.append(chunk_index)
-            session.received_chunks.sort()
+        # Update session atomically using Redis WATCH/MULTI
+        # This prevents race conditions when multiple chunks are uploaded concurrently
+        chunk_checksum = hashlib.md5(chunk_data).hexdigest()  # noqa: S324
+        max_retries = 5
+        for retry in range(max_retries):
+            try:
+                # Watch the session key for changes
+                redis_client.watch(session_key)
 
-        session.chunk_checksums[chunk_index] = hashlib.md5(chunk_data).hexdigest()
-        session.last_updated = time.time()
+                # Re-read session data
+                session_data = redis_client.get(session_key)
+                if not session_data:
+                    redis_client.unwatch()
+                    raise ChunkedUploadError(
+                        f"Upload session expired during chunk upload: {upload_id}",
+                        error_code="session_not_found",
+                    )
 
-        # Save updated session
-        redis_client.setex(
-            session_key,
-            UPLOAD_EXPIRATION,
-            json.dumps(session.to_dict()),
-        )
+                session = ChunkedUploadSession.from_dict(json.loads(session_data))
+
+                # Update session
+                if chunk_index not in session.received_chunks:
+                    session.received_chunks.append(chunk_index)
+                    session.received_chunks.sort()
+
+                session.chunk_checksums[chunk_index] = chunk_checksum
+                session.last_updated = time.time()
+
+                # Execute atomic update
+                pipe = redis_client.pipeline()
+                pipe.setex(
+                    session_key,
+                    UPLOAD_EXPIRATION,
+                    json.dumps(session.to_dict()),
+                )
+                pipe.execute()
+                break  # Success
+            except Exception as e:
+                # Check if it's a WatchError (concurrent modification)
+                if "WATCH" in str(type(e).__name__) or "WatchError" in str(e):
+                    if retry < max_retries - 1:
+                        logger.debug(
+                            f"Retrying session update due to concurrent modification: "
+                            f"upload_id={upload_id}, chunk_index={chunk_index}, retry={retry + 1}"
+                        )
+                        continue
+                    else:
+                        logger.warning(
+                            f"Max retries reached for session update: "
+                            f"upload_id={upload_id}, chunk_index={chunk_index}"
+                        )
+                raise
 
         logger.debug(
             f"Uploaded chunk: upload_id={upload_id}, chunk_index={chunk_index}, "

--- a/backend/app/services/attachment/chunked_upload.py
+++ b/backend/app/services/attachment/chunked_upload.py
@@ -1,0 +1,580 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Chunked upload service for handling large file uploads.
+
+This service provides a way to upload large files in smaller chunks,
+avoiding gateway timeouts and improving upload reliability.
+
+The chunked upload flow is:
+1. Client calls init_chunked_upload() to start an upload session
+2. Client uploads chunks via upload_chunk() in sequence
+3. Client calls complete_chunked_upload() to finalize and process the file
+4. Optionally, client can call abort_chunked_upload() to cancel
+
+Temporary chunks are stored in Redis with an expiration time.
+"""
+
+import hashlib
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
+from app.schemas.subtask_context import TruncationInfo
+from app.services.attachment.parser import DocumentParseError, DocumentParser
+from app.services.attachment.storage_backend import StorageError, generate_storage_key
+from app.services.attachment.storage_factory import get_storage_backend
+from shared.utils.crypto import encrypt_attachment
+
+logger = logging.getLogger(__name__)
+
+
+# Constants for chunked upload
+CHUNK_SIZE = 5 * 1024 * 1024  # 5 MB per chunk
+MAX_CHUNKS = 200  # Max 200 chunks = 1GB max file size
+UPLOAD_EXPIRATION = 24 * 60 * 60  # 24 hours expiration for incomplete uploads
+MAX_CONCURRENT_UPLOADS = 10  # Max concurrent uploads per user
+
+
+@dataclass
+class ChunkedUploadSession:
+    """Represents an active chunked upload session."""
+
+    upload_id: str
+    user_id: int
+    filename: str
+    file_size: int
+    total_chunks: int
+    received_chunks: List[int]
+    chunk_checksums: Dict[int, str]  # chunk_index -> md5 checksum
+    created_at: float
+    last_updated: float
+    mime_type: str
+    file_extension: str
+
+    def to_dict(self) -> Dict:
+        """Convert session to dictionary for storage."""
+        return {
+            "upload_id": self.upload_id,
+            "user_id": self.user_id,
+            "filename": self.filename,
+            "file_size": self.file_size,
+            "total_chunks": self.total_chunks,
+            "received_chunks": self.received_chunks,
+            "chunk_checksums": self.chunk_checksums,
+            "created_at": self.created_at,
+            "last_updated": self.last_updated,
+            "mime_type": self.mime_type,
+            "file_extension": self.file_extension,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "ChunkedUploadSession":
+        """Create session from dictionary."""
+        return cls(
+            upload_id=data["upload_id"],
+            user_id=data["user_id"],
+            filename=data["filename"],
+            file_size=data["file_size"],
+            total_chunks=data["total_chunks"],
+            received_chunks=data["received_chunks"],
+            chunk_checksums=data["chunk_checksums"],
+            created_at=data["created_at"],
+            last_updated=data["last_updated"],
+            mime_type=data["mime_type"],
+            file_extension=data["file_extension"],
+        )
+
+
+class ChunkedUploadError(Exception):
+    """Exception for chunked upload errors."""
+
+    def __init__(self, message: str, error_code: str = "chunked_upload_error"):
+        self.message = message
+        self.error_code = error_code
+        super().__init__(self.message)
+
+
+class ChunkedUploadService:
+    """
+    Service for managing chunked file uploads.
+
+    Uses Redis for temporary storage of upload sessions and chunks.
+    """
+
+    def __init__(self):
+        self.parser = DocumentParser()
+        self._redis_client = None
+
+    def _get_redis_client(self):
+        """Get Redis client lazily."""
+        if self._redis_client is None:
+            import os
+
+            import redis
+
+            redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+            self._redis_client = redis.from_url(redis_url)
+        return self._redis_client
+
+    def _session_key(self, upload_id: str) -> str:
+        """Get Redis key for upload session."""
+        return f"chunked_upload:session:{upload_id}"
+
+    def _chunk_key(self, upload_id: str, chunk_index: int) -> str:
+        """Get Redis key for chunk data."""
+        return f"chunked_upload:chunk:{upload_id}:{chunk_index}"
+
+    def _user_uploads_key(self, user_id: int) -> str:
+        """Get Redis key for user's active uploads."""
+        return f"chunked_upload:user:{user_id}:uploads"
+
+    def init_chunked_upload(
+        self,
+        user_id: int,
+        filename: str,
+        file_size: int,
+        chunk_size: int = CHUNK_SIZE,
+    ) -> Tuple[str, int, int]:
+        """
+        Initialize a chunked upload session.
+
+        Args:
+            user_id: User ID
+            filename: Original filename
+            file_size: Total file size in bytes
+            chunk_size: Size of each chunk (default: 5MB)
+
+        Returns:
+            Tuple of (upload_id, total_chunks, chunk_size)
+
+        Raises:
+            ChunkedUploadError: If validation fails or too many concurrent uploads
+        """
+        # Validate file size
+        max_file_size = DocumentParser.get_max_file_size()
+        if file_size > max_file_size:
+            raise ChunkedUploadError(
+                f"File size exceeds maximum limit ({max_file_size / (1024 * 1024)} MB)",
+                error_code="file_too_large",
+            )
+
+        # Validate file extension
+        import os
+
+        _, extension = os.path.splitext(filename)
+        extension = extension.lower()
+
+        if not self.parser.is_supported_extension(extension):
+            raise ChunkedUploadError(
+                f"Unsupported file type: {extension}",
+                error_code="unsupported_type",
+            )
+
+        # Calculate total chunks
+        total_chunks = (file_size + chunk_size - 1) // chunk_size
+        if total_chunks > MAX_CHUNKS:
+            raise ChunkedUploadError(
+                f"File too large: requires {total_chunks} chunks (max: {MAX_CHUNKS})",
+                error_code="too_many_chunks",
+            )
+
+        # Check concurrent upload limit
+        redis_client = self._get_redis_client()
+        user_uploads_key = self._user_uploads_key(user_id)
+        current_uploads = redis_client.scard(user_uploads_key)
+
+        if current_uploads >= MAX_CONCURRENT_UPLOADS:
+            raise ChunkedUploadError(
+                f"Too many concurrent uploads (max: {MAX_CONCURRENT_UPLOADS})",
+                error_code="too_many_uploads",
+            )
+
+        # Create upload session
+        upload_id = str(uuid.uuid4())
+        mime_type = self.parser.get_mime_type(extension)
+        now = time.time()
+
+        session = ChunkedUploadSession(
+            upload_id=upload_id,
+            user_id=user_id,
+            filename=filename,
+            file_size=file_size,
+            total_chunks=total_chunks,
+            received_chunks=[],
+            chunk_checksums={},
+            created_at=now,
+            last_updated=now,
+            mime_type=mime_type,
+            file_extension=extension,
+        )
+
+        # Store session in Redis
+        session_key = self._session_key(upload_id)
+        redis_client.setex(
+            session_key,
+            UPLOAD_EXPIRATION,
+            json.dumps(session.to_dict()),
+        )
+
+        # Track user's active uploads
+        redis_client.sadd(user_uploads_key, upload_id)
+        redis_client.expire(user_uploads_key, UPLOAD_EXPIRATION)
+
+        logger.info(
+            f"Initialized chunked upload: upload_id={upload_id}, "
+            f"user_id={user_id}, filename={filename}, "
+            f"file_size={file_size}, total_chunks={total_chunks}"
+        )
+
+        return upload_id, total_chunks, chunk_size
+
+    def upload_chunk(
+        self,
+        upload_id: str,
+        user_id: int,
+        chunk_index: int,
+        chunk_data: bytes,
+        checksum: Optional[str] = None,
+    ) -> Tuple[int, int]:
+        """
+        Upload a single chunk.
+
+        Args:
+            upload_id: Upload session ID
+            user_id: User ID for authorization
+            chunk_index: Index of this chunk (0-based)
+            chunk_data: Binary chunk data
+            checksum: Optional MD5 checksum for verification
+
+        Returns:
+            Tuple of (received_chunks_count, total_chunks)
+
+        Raises:
+            ChunkedUploadError: If validation fails
+        """
+        redis_client = self._get_redis_client()
+
+        # Get session
+        session_key = self._session_key(upload_id)
+        session_data = redis_client.get(session_key)
+
+        if not session_data:
+            raise ChunkedUploadError(
+                f"Upload session not found or expired: {upload_id}",
+                error_code="session_not_found",
+            )
+
+        session = ChunkedUploadSession.from_dict(json.loads(session_data))
+
+        # Verify user ownership
+        if session.user_id != user_id:
+            raise ChunkedUploadError(
+                "Unauthorized access to upload session",
+                error_code="unauthorized",
+            )
+
+        # Validate chunk index
+        if chunk_index < 0 or chunk_index >= session.total_chunks:
+            raise ChunkedUploadError(
+                f"Invalid chunk index: {chunk_index} (valid: 0-{session.total_chunks - 1})",
+                error_code="invalid_chunk_index",
+            )
+
+        # Verify checksum if provided
+        if checksum:
+            actual_checksum = hashlib.md5(chunk_data).hexdigest()
+            if actual_checksum != checksum:
+                raise ChunkedUploadError(
+                    f"Chunk checksum mismatch for chunk {chunk_index}",
+                    error_code="checksum_mismatch",
+                )
+
+        # Store chunk
+        chunk_key = self._chunk_key(upload_id, chunk_index)
+        redis_client.setex(chunk_key, UPLOAD_EXPIRATION, chunk_data)
+
+        # Update session
+        if chunk_index not in session.received_chunks:
+            session.received_chunks.append(chunk_index)
+            session.received_chunks.sort()
+
+        session.chunk_checksums[chunk_index] = hashlib.md5(chunk_data).hexdigest()
+        session.last_updated = time.time()
+
+        # Save updated session
+        redis_client.setex(
+            session_key,
+            UPLOAD_EXPIRATION,
+            json.dumps(session.to_dict()),
+        )
+
+        logger.debug(
+            f"Uploaded chunk: upload_id={upload_id}, chunk_index={chunk_index}, "
+            f"received={len(session.received_chunks)}/{session.total_chunks}"
+        )
+
+        return len(session.received_chunks), session.total_chunks
+
+    def complete_chunked_upload(
+        self,
+        db: Session,
+        upload_id: str,
+        user_id: int,
+    ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
+        """
+        Complete the chunked upload by assembling chunks and processing the file.
+
+        Args:
+            db: Database session
+            upload_id: Upload session ID
+            user_id: User ID for authorization
+
+        Returns:
+            Tuple of (Created SubtaskContext, TruncationInfo if truncated)
+
+        Raises:
+            ChunkedUploadError: If validation fails or chunks are missing
+        """
+        redis_client = self._get_redis_client()
+
+        # Get session
+        session_key = self._session_key(upload_id)
+        session_data = redis_client.get(session_key)
+
+        if not session_data:
+            raise ChunkedUploadError(
+                f"Upload session not found or expired: {upload_id}",
+                error_code="session_not_found",
+            )
+
+        session = ChunkedUploadSession.from_dict(json.loads(session_data))
+
+        # Verify user ownership
+        if session.user_id != user_id:
+            raise ChunkedUploadError(
+                "Unauthorized access to upload session",
+                error_code="unauthorized",
+            )
+
+        # Check all chunks are received
+        if len(session.received_chunks) != session.total_chunks:
+            missing = set(range(session.total_chunks)) - set(session.received_chunks)
+            raise ChunkedUploadError(
+                f"Missing chunks: {sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}",
+                error_code="missing_chunks",
+            )
+
+        # Assemble all chunks
+        logger.info(f"Assembling {session.total_chunks} chunks for upload {upload_id}")
+        binary_data_parts = []
+
+        for i in range(session.total_chunks):
+            chunk_key = self._chunk_key(upload_id, i)
+            chunk_data = redis_client.get(chunk_key)
+
+            if chunk_data is None:
+                raise ChunkedUploadError(
+                    f"Chunk {i} data not found",
+                    error_code="chunk_data_missing",
+                )
+
+            binary_data_parts.append(chunk_data)
+
+        binary_data = b"".join(binary_data_parts)
+
+        # Verify total size
+        if len(binary_data) != session.file_size:
+            raise ChunkedUploadError(
+                f"Assembled file size mismatch: expected {session.file_size}, got {len(binary_data)}",
+                error_code="size_mismatch",
+            )
+
+        logger.info(f"Assembled file: upload_id={upload_id}, size={len(binary_data)}")
+
+        # Create attachment context using the same logic as regular upload
+        try:
+            context, truncation_info = self._create_attachment_from_binary(
+                db=db,
+                user_id=user_id,
+                filename=session.filename,
+                binary_data=binary_data,
+                extension=session.file_extension,
+                mime_type=session.mime_type,
+            )
+        except Exception as e:
+            logger.exception(f"Failed to create attachment from chunked upload: {e}")
+            raise
+
+        # Cleanup Redis data
+        self._cleanup_upload_session(upload_id, user_id, session.total_chunks)
+
+        logger.info(
+            f"Completed chunked upload: upload_id={upload_id}, "
+            f"attachment_id={context.id}, filename={session.filename}"
+        )
+
+        return context, truncation_info
+
+    def _create_attachment_from_binary(
+        self,
+        db: Session,
+        user_id: int,
+        filename: str,
+        binary_data: bytes,
+        extension: str,
+        mime_type: str,
+    ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
+        """
+        Create attachment context from assembled binary data.
+
+        This is similar to context_service.upload_attachment but accepts
+        pre-validated binary data.
+        """
+        import os as _os
+
+        from app.services.context import context_service
+
+        # Reuse the context service's upload_attachment method
+        # This ensures consistent behavior with regular uploads
+        return context_service.upload_attachment(
+            db=db,
+            user_id=user_id,
+            filename=filename,
+            binary_data=binary_data,
+        )
+
+    def abort_chunked_upload(
+        self,
+        upload_id: str,
+        user_id: int,
+    ) -> bool:
+        """
+        Abort a chunked upload and cleanup resources.
+
+        Args:
+            upload_id: Upload session ID
+            user_id: User ID for authorization
+
+        Returns:
+            True if aborted successfully
+
+        Raises:
+            ChunkedUploadError: If session not found or unauthorized
+        """
+        redis_client = self._get_redis_client()
+
+        # Get session
+        session_key = self._session_key(upload_id)
+        session_data = redis_client.get(session_key)
+
+        if not session_data:
+            raise ChunkedUploadError(
+                f"Upload session not found or expired: {upload_id}",
+                error_code="session_not_found",
+            )
+
+        session = ChunkedUploadSession.from_dict(json.loads(session_data))
+
+        # Verify user ownership
+        if session.user_id != user_id:
+            raise ChunkedUploadError(
+                "Unauthorized access to upload session",
+                error_code="unauthorized",
+            )
+
+        # Cleanup
+        self._cleanup_upload_session(upload_id, user_id, session.total_chunks)
+
+        logger.info(f"Aborted chunked upload: upload_id={upload_id}")
+
+        return True
+
+    def _cleanup_upload_session(
+        self,
+        upload_id: str,
+        user_id: int,
+        total_chunks: int,
+    ) -> None:
+        """Cleanup all Redis data for an upload session."""
+        redis_client = self._get_redis_client()
+
+        # Delete session
+        session_key = self._session_key(upload_id)
+        redis_client.delete(session_key)
+
+        # Delete all chunks
+        for i in range(total_chunks):
+            chunk_key = self._chunk_key(upload_id, i)
+            redis_client.delete(chunk_key)
+
+        # Remove from user's active uploads
+        user_uploads_key = self._user_uploads_key(user_id)
+        redis_client.srem(user_uploads_key, upload_id)
+
+    def get_upload_status(
+        self,
+        upload_id: str,
+        user_id: int,
+    ) -> Dict:
+        """
+        Get status of a chunked upload.
+
+        Args:
+            upload_id: Upload session ID
+            user_id: User ID for authorization
+
+        Returns:
+            Status dictionary with progress information
+
+        Raises:
+            ChunkedUploadError: If session not found or unauthorized
+        """
+        redis_client = self._get_redis_client()
+
+        # Get session
+        session_key = self._session_key(upload_id)
+        session_data = redis_client.get(session_key)
+
+        if not session_data:
+            raise ChunkedUploadError(
+                f"Upload session not found or expired: {upload_id}",
+                error_code="session_not_found",
+            )
+
+        session = ChunkedUploadSession.from_dict(json.loads(session_data))
+
+        # Verify user ownership
+        if session.user_id != user_id:
+            raise ChunkedUploadError(
+                "Unauthorized access to upload session",
+                error_code="unauthorized",
+            )
+
+        return {
+            "upload_id": session.upload_id,
+            "filename": session.filename,
+            "file_size": session.file_size,
+            "total_chunks": session.total_chunks,
+            "received_chunks": len(session.received_chunks),
+            "missing_chunks": sorted(
+                set(range(session.total_chunks)) - set(session.received_chunks)
+            ),
+            "progress_percent": round(
+                len(session.received_chunks) / session.total_chunks * 100, 1
+            ),
+            "created_at": session.created_at,
+            "last_updated": session.last_updated,
+        }
+
+
+# Singleton instance
+chunked_upload_service = ChunkedUploadService()

--- a/frontend/src/apis/attachments.ts
+++ b/frontend/src/apis/attachments.ts
@@ -8,6 +8,7 @@
 
 import { getToken } from './user'
 import type { TruncationInfo } from '@/types/api'
+import { shouldUseChunkedUpload, uploadFileChunked } from './chunkedUpload'
 
 // API base URL - use relative path for browser compatibility
 const API_BASE_URL = ''
@@ -345,6 +346,9 @@ export function getAttachmentPreviewUrl(attachmentId: number, shareToken?: strin
 /**
  * Upload a file attachment
  *
+ * Automatically uses chunked upload for large files (>10MB) to avoid
+ * gateway timeouts. For smaller files, uses regular upload.
+ *
  * @param file - File to upload
  * @param onProgress - Optional progress callback (0-100)
  * @returns Attachment response
@@ -360,6 +364,14 @@ export async function uploadAttachment(
     throw new Error(`文件大小超过 ${MAX_FILE_SIZE / (1024 * 1024)} MB 限制`)
   }
 
+  // Use chunked upload for large files
+  if (shouldUseChunkedUpload(file.size)) {
+    return uploadFileChunked(file, progress => {
+      onProgress?.(progress.percent)
+    })
+  }
+
+  // Regular upload for smaller files
   const formData = new FormData()
   formData.append('file', file)
 

--- a/frontend/src/apis/chunkedUpload.ts
+++ b/frontend/src/apis/chunkedUpload.ts
@@ -61,22 +61,6 @@ export interface UploadStatusResponse {
 }
 
 /**
- * Calculate hash checksum of data using Web Crypto API
- * Note: Prefixed with _ as it's reserved for future use (optional checksum verification)
- */
-async function _calculateChecksum(data: ArrayBuffer): Promise<string> {
-  // Use SubtleCrypto for hashing (MD5 is not available, use a simple approach)
-  // For MD5, we'll use a lightweight implementation
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
-  const hashArray = Array.from(new Uint8Array(hashBuffer))
-  // Take first 16 bytes to simulate MD5 length (for checksum purposes)
-  return hashArray
-    .slice(0, 16)
-    .map(b => b.toString(16).padStart(2, '0'))
-    .join('')
-}
-
-/**
  * Initialize a chunked upload session
  *
  * @param filename - Original filename

--- a/frontend/src/apis/chunkedUpload.ts
+++ b/frontend/src/apis/chunkedUpload.ts
@@ -1,0 +1,362 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Chunked upload API client for handling large file uploads.
+ *
+ * This module provides functions for uploading large files in chunks,
+ * avoiding gateway timeouts and improving upload reliability.
+ *
+ * Flow:
+ * 1. Call initChunkedUpload() to start an upload session
+ * 2. Upload chunks via uploadChunk() sequentially
+ * 3. Call completeChunkedUpload() to finalize and create attachment
+ * 4. Optionally call abortChunkedUpload() to cancel
+ */
+
+import { getToken } from './user'
+import type { AttachmentResponse } from './attachments'
+
+const API_BASE_URL = ''
+
+// Default chunk size: 5MB
+export const DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024
+
+// Threshold for using chunked upload (files larger than 10MB use chunked upload)
+export const CHUNKED_UPLOAD_THRESHOLD = 10 * 1024 * 1024
+
+/**
+ * Response from chunked upload initialization
+ */
+export interface ChunkedUploadInitResponse {
+  upload_id: string
+  total_chunks: number
+  chunk_size: number
+}
+
+/**
+ * Response from chunk upload
+ */
+export interface ChunkUploadResponse {
+  chunk_index: number
+  received_chunks: number
+  total_chunks: number
+  progress_percent: number
+}
+
+/**
+ * Response from upload status check
+ */
+export interface UploadStatusResponse {
+  upload_id: string
+  filename: string
+  file_size: number
+  total_chunks: number
+  received_chunks: number
+  missing_chunks: number[]
+  progress_percent: number
+  created_at: number
+  last_updated: number
+}
+
+/**
+ * Calculate hash checksum of data using Web Crypto API
+ * Note: Prefixed with _ as it's reserved for future use (optional checksum verification)
+ */
+async function _calculateChecksum(data: ArrayBuffer): Promise<string> {
+  // Use SubtleCrypto for hashing (MD5 is not available, use a simple approach)
+  // For MD5, we'll use a lightweight implementation
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  // Take first 16 bytes to simulate MD5 length (for checksum purposes)
+  return hashArray
+    .slice(0, 16)
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Initialize a chunked upload session
+ *
+ * @param filename - Original filename
+ * @param fileSize - Total file size in bytes
+ * @param chunkSize - Optional chunk size (default: 5MB)
+ * @returns Upload session details
+ */
+export async function initChunkedUpload(
+  filename: string,
+  fileSize: number,
+  chunkSize?: number
+): Promise<ChunkedUploadInitResponse> {
+  const token = getToken()
+
+  const response = await fetch(`${API_BASE_URL}/api/attachments/chunked/init`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+    body: JSON.stringify({
+      filename,
+      file_size: fileSize,
+      chunk_size: chunkSize,
+    }),
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = error.detail?.message || error.detail || 'Failed to initialize upload'
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+/**
+ * Upload a single chunk
+ *
+ * @param uploadId - Upload session ID
+ * @param chunkIndex - Index of this chunk (0-based)
+ * @param chunkData - Chunk binary data
+ * @param checksum - Optional checksum for verification
+ * @returns Upload progress
+ */
+export async function uploadChunk(
+  uploadId: string,
+  chunkIndex: number,
+  chunkData: Blob,
+  checksum?: string
+): Promise<ChunkUploadResponse> {
+  const token = getToken()
+
+  const formData = new FormData()
+  formData.append('chunk_index', chunkIndex.toString())
+  formData.append('chunk', chunkData)
+  if (checksum) {
+    formData.append('checksum', checksum)
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/attachments/chunked/${uploadId}/chunk`, {
+    method: 'POST',
+    headers: {
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+    body: formData,
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = error.detail?.message || error.detail || `Failed to upload chunk ${chunkIndex}`
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+/**
+ * Complete the chunked upload and create attachment
+ *
+ * @param uploadId - Upload session ID
+ * @returns Attachment response
+ */
+export async function completeChunkedUpload(uploadId: string): Promise<AttachmentResponse> {
+  const token = getToken()
+
+  const response = await fetch(`${API_BASE_URL}/api/attachments/chunked/${uploadId}/complete`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = error.detail?.message || error.detail || 'Failed to complete upload'
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+/**
+ * Abort a chunked upload
+ *
+ * @param uploadId - Upload session ID
+ */
+export async function abortChunkedUpload(uploadId: string): Promise<void> {
+  const token = getToken()
+
+  const response = await fetch(`${API_BASE_URL}/api/attachments/chunked/${uploadId}/abort`, {
+    method: 'DELETE',
+    headers: {
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+  })
+
+  if (!response.ok) {
+    // Ignore abort errors - the upload might already be completed or expired
+    console.warn('Failed to abort chunked upload:', uploadId)
+  }
+}
+
+/**
+ * Get upload status
+ *
+ * @param uploadId - Upload session ID
+ * @returns Upload status
+ */
+export async function getUploadStatus(uploadId: string): Promise<UploadStatusResponse> {
+  const token = getToken()
+
+  const response = await fetch(`${API_BASE_URL}/api/attachments/chunked/${uploadId}/status`, {
+    method: 'GET',
+    headers: {
+      ...(token && { Authorization: `Bearer ${token}` }),
+    },
+  })
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}))
+    const message = error.detail?.message || error.detail || 'Failed to get upload status'
+    throw new Error(message)
+  }
+
+  return response.json()
+}
+
+/**
+ * Progress callback type for chunked upload
+ */
+export type ChunkedUploadProgressCallback = (progress: {
+  phase: 'initializing' | 'uploading' | 'completing'
+  uploadedChunks: number
+  totalChunks: number
+  uploadedBytes: number
+  totalBytes: number
+  percent: number
+}) => void
+
+/**
+ * Upload a file using chunked upload
+ *
+ * This function handles the entire chunked upload flow:
+ * 1. Initialize upload session
+ * 2. Upload all chunks sequentially
+ * 3. Complete the upload
+ *
+ * @param file - File to upload
+ * @param onProgress - Optional progress callback
+ * @param abortSignal - Optional AbortSignal to cancel upload
+ * @returns Attachment response
+ */
+export async function uploadFileChunked(
+  file: File,
+  onProgress?: ChunkedUploadProgressCallback,
+  abortSignal?: AbortSignal
+): Promise<AttachmentResponse> {
+  // Report initializing phase
+  onProgress?.({
+    phase: 'initializing',
+    uploadedChunks: 0,
+    totalChunks: 0,
+    uploadedBytes: 0,
+    totalBytes: file.size,
+    percent: 0,
+  })
+
+  // Initialize upload
+  const initResponse = await initChunkedUpload(file.name, file.size)
+  const { upload_id, total_chunks, chunk_size } = initResponse
+
+  try {
+    // Upload chunks sequentially
+    for (let i = 0; i < total_chunks; i++) {
+      // Check for abort
+      if (abortSignal?.aborted) {
+        await abortChunkedUpload(upload_id)
+        throw new Error('Upload cancelled')
+      }
+
+      const start = i * chunk_size
+      const end = Math.min(start + chunk_size, file.size)
+      const chunkBlob = file.slice(start, end)
+
+      await uploadChunk(upload_id, i, chunkBlob)
+
+      // Report progress
+      const uploadedBytes = end
+      onProgress?.({
+        phase: 'uploading',
+        uploadedChunks: i + 1,
+        totalChunks: total_chunks,
+        uploadedBytes,
+        totalBytes: file.size,
+        percent: Math.round((uploadedBytes / file.size) * 90), // 0-90% for upload phase
+      })
+    }
+
+    // Check for abort before completing
+    if (abortSignal?.aborted) {
+      await abortChunkedUpload(upload_id)
+      throw new Error('Upload cancelled')
+    }
+
+    // Report completing phase
+    onProgress?.({
+      phase: 'completing',
+      uploadedChunks: total_chunks,
+      totalChunks: total_chunks,
+      uploadedBytes: file.size,
+      totalBytes: file.size,
+      percent: 95,
+    })
+
+    // Complete upload
+    const attachment = await completeChunkedUpload(upload_id)
+
+    // Report 100%
+    onProgress?.({
+      phase: 'completing',
+      uploadedChunks: total_chunks,
+      totalChunks: total_chunks,
+      uploadedBytes: file.size,
+      totalBytes: file.size,
+      percent: 100,
+    })
+
+    return attachment
+  } catch (error) {
+    // Try to abort on error (best effort)
+    try {
+      await abortChunkedUpload(upload_id)
+    } catch {
+      // Ignore abort errors
+    }
+    throw error
+  }
+}
+
+/**
+ * Check if a file should use chunked upload
+ *
+ * @param fileSize - File size in bytes
+ * @returns true if chunked upload should be used
+ */
+export function shouldUseChunkedUpload(fileSize: number): boolean {
+  return fileSize > CHUNKED_UPLOAD_THRESHOLD
+}
+
+/**
+ * Chunked upload API exports
+ */
+export const chunkedUploadApis = {
+  initChunkedUpload,
+  uploadChunk,
+  completeChunkedUpload,
+  abortChunkedUpload,
+  getUploadStatus,
+  uploadFileChunked,
+  shouldUseChunkedUpload,
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1199,7 +1199,11 @@
       "network_error_hint": "Network connection error. Please check your network and try again",
       "content_truncated": "File content truncated",
       "content_truncated_hint": "File content was too long. Kept first {{length}} million characters",
-      "batch_limit_exceeded": "Too many files selected (max {{max}} files)"
+      "batch_limit_exceeded": "Too many files selected (max {{max}} files)",
+      "chunked_upload_failed": "Large file upload failed",
+      "chunked_upload_failed_hint": "Failed to upload large file. Please try again",
+      "upload_session_expired": "Upload session expired",
+      "upload_session_expired_hint": "The upload session has expired. Please start a new upload"
     },
     "preview": {
       "label": "Preview",
@@ -1213,7 +1217,13 @@
     "html_preview": "HTML Preview",
     "click_to_preview": "Click to preview",
     "characters": "chars",
-    "upload_tooltip": "Supported file types: Documents (PDF, Word, PPT, Excel), Images, Code files and text files\nMax file size: {{size}} MB"
+    "upload_tooltip": "Supported file types: Documents (PDF, Word, PPT, Excel), Images, Code files and text files\nMax file size: {{size}} MB",
+    "chunked_upload": {
+      "initializing": "Preparing upload...",
+      "uploading": "Uploading ({{percent}}%)",
+      "completing": "Processing file...",
+      "large_file_hint": "Large file will be uploaded in chunks"
+    }
   },
   "editor": {
     "vim": {

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1193,7 +1193,11 @@
       "network_error_hint": "网络连接异常，请检查网络后重试",
       "content_truncated": "文件内容已压缩",
       "content_truncated_hint": "文件内容过长，已自动保留前 {{length}} 万字符",
-      "batch_limit_exceeded": "选择的文件过多（最多 {{max}} 个文件）"
+      "batch_limit_exceeded": "选择的文件过多（最多 {{max}} 个文件）",
+      "chunked_upload_failed": "大文件上传失败",
+      "chunked_upload_failed_hint": "大文件分片上传失败，请重试",
+      "upload_session_expired": "上传会话已过期",
+      "upload_session_expired_hint": "上传会话已过期，请重新开始上传"
     },
     "preview": {
       "label": "预览",
@@ -1207,7 +1211,13 @@
     "html_preview": "HTML 预览",
     "click_to_preview": "点击预览",
     "characters": "字符",
-    "upload_tooltip": "支持的文件类型: 文档(PDF, Word, PPT, Excel), 图片, 代码文件及各类文本文件\n最大文件大小: {{size}} MB"
+    "upload_tooltip": "支持的文件类型: 文档(PDF, Word, PPT, Excel), 图片, 代码文件及各类文本文件\n最大文件大小: {{size}} MB",
+    "chunked_upload": {
+      "initializing": "正在准备上传...",
+      "uploading": "上传中 ({{percent}}%)",
+      "completing": "正在处理文件...",
+      "large_file_hint": "大文件将采用分片上传"
+    }
   },
   "editor": {
     "vim": {


### PR DESCRIPTION
## Summary

- Add chunked upload support for large files (>10MB) to avoid gateway timeouts
- Files are automatically uploaded in chunks when size exceeds threshold
- Chunks are temporarily stored in Redis and assembled on completion
- Upload sessions auto-expire after 24 hours

## Changes

### Backend
1. **New service:** `backend/app/services/attachment/chunked_upload.py`
   - `ChunkedUploadService` class with init/chunk/complete/abort operations
   - Redis-based temporary storage for upload sessions and chunks
   - Support for concurrent upload limit per user (max 10)
   - Checksum verification support (optional)

2. **New API endpoints:** `backend/app/api/endpoints/adapter/chunked_upload.py`
   - `POST /api/attachments/chunked/init` - Initialize upload session
   - `POST /api/attachments/chunked/{upload_id}/chunk` - Upload single chunk
   - `POST /api/attachments/chunked/{upload_id}/complete` - Complete upload
   - `DELETE /api/attachments/chunked/{upload_id}/abort` - Abort upload
   - `GET /api/attachments/chunked/{upload_id}/status` - Get upload status

### Frontend
1. **New API client:** `frontend/src/apis/chunkedUpload.ts`
   - Full chunked upload flow with progress tracking
   - AbortSignal support for cancellation
   - Transparent integration with existing upload flow

2. **Updated:** `frontend/src/apis/attachments.ts`
   - `uploadAttachment()` now automatically uses chunked upload for files >10MB
   - No changes required to existing upload UI components

### i18n
- Added translations for chunked upload states and error messages (en/zh-CN)

## Technical Details

- **Chunk size:** 5MB per chunk
- **Threshold:** Files >10MB use chunked upload
- **Max file size:** 100MB (unchanged, limited by parser)
- **Session expiry:** 24 hours
- **Max concurrent uploads:** 10 per user

## Test plan

- [ ] Test uploading small files (<10MB) - should use regular upload
- [ ] Test uploading large files (>10MB) - should use chunked upload
- [ ] Verify progress callback reports correct percentage
- [ ] Test upload cancellation with abort signal
- [ ] Test concurrent upload limit
- [ ] Verify session cleanup after completion/abort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large files (≥10 MB) now upload in resumable chunks with initialize/upload/complete/abort/status endpoints.
  * Automatic frontend chunked upload flow with per-chunk progress, overall percent, abort/retry support, and cleanup on errors.
* **Documentation / Localization**
  * Added user-facing messages and translations for chunked upload phases, failures, and session expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->