### PR TITLE
feat(frontend): add tool detail panel with clickable tool blocks

### DIFF
--- a/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
+import { ToolDetailProvider } from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
 
 /**
  * Desktop-specific implementation of Chat Page
@@ -39,6 +40,14 @@ import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
  * @see ChatPageMobile.tsx for mobile implementation
  */
 export function ChatPageDesktop() {
+  return (
+    <ToolDetailProvider>
+      <ChatPageDesktopContent />
+    </ToolDetailProvider>
+  )
+}
+
+function ChatPageDesktopContent() {
   const { t } = useTranslation()
 
   // Team state from service

--- a/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
@@ -21,6 +21,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
+import { ToolDetailProvider } from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
 
 /**
  * Mobile-specific implementation of Chat Page
@@ -34,6 +35,14 @@ import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
  * @see ChatPageDesktop.tsx for desktop implementation
  */
 export function ChatPageMobile() {
+  return (
+    <ToolDetailProvider>
+      <ChatPageMobileContent />
+    </ToolDetailProvider>
+  )
+}
+
+function ChatPageMobileContent() {
   const { t } = useTranslation()
 
   // Team state from service

--- a/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
@@ -26,6 +26,8 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { calculateOpenLinks } from '@/utils/openLinks'
 import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
+import { useIsToolDetailOpen, ToolDetailProvider } from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
+import { ToolDetailPanel } from '@/features/tasks/components/message/thinking/components/ToolDetailPanel'
 import { Workbench } from '@/features/tasks/components'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { paths } from '@/config/paths'
@@ -42,6 +44,14 @@ import { paths } from '@/config/paths'
  * @see CodePageMobile.tsx for mobile implementation
  */
 export function CodePageDesktop() {
+  return (
+    <ToolDetailProvider>
+      <CodePageDesktopContent />
+    </ToolDetailProvider>
+  )
+}
+
+function CodePageDesktopContent() {
   // Get search params to check for taskId
   const searchParams = useSearchParams()
   const taskId = searchParams.get('taskId')
@@ -93,6 +103,9 @@ export function CodePageDesktop() {
 
   // Workbench state - default to true when taskId exists
   const [isWorkbenchOpen, setIsWorkbenchOpen] = useState(true)
+
+  // Check if tool detail panel is open
+  const isToolDetailOpen = useIsToolDetailOpen()
 
   // Search dialog state (controlled from page level for global shortcut support)
   const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false)
@@ -261,8 +274,8 @@ export function CodePageDesktop() {
             />
           </div>
 
-          {/* Workbench component - only show if there's a taskId */}
-          {hasTaskId && (
+          {/* Workbench component - only show if there's a taskId AND tool detail is not open */}
+          {hasTaskId && !isToolDetailOpen && (
             <Workbench
               isOpen={isWorkbenchOpen}
               onClose={() => setIsWorkbenchOpen(false)}
@@ -282,6 +295,9 @@ export function CodePageDesktop() {
               taskStatus={selectedTaskDetail?.status}
             />
           )}
+
+          {/* Tool Detail Panel - show when a tool is selected */}
+          {isToolDetailOpen && <ToolDetailPanel />}
         </div>
       </div>
       {/* Search Dialog - rendered at page level for global shortcut support */}

--- a/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
@@ -26,7 +26,10 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { calculateOpenLinks } from '@/utils/openLinks'
 import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
-import { useIsToolDetailOpen, ToolDetailProvider } from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
+import {
+  useIsToolDetailOpen,
+  ToolDetailProvider,
+} from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
 import { ToolDetailPanel } from '@/features/tasks/components/message/thinking/components/ToolDetailPanel'
 import { Workbench } from '@/features/tasks/components'
 import { ChatArea } from '@/features/tasks/components/chat'

--- a/frontend/src/app/(tasks)/code/CodePageMobile.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageMobile.tsx
@@ -17,6 +17,7 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
 import { ChatArea } from '@/features/tasks/components/chat'
+import { ToolDetailProvider } from '@/features/tasks/components/message/thinking/contexts/ToolDetailContext'
 
 /**
  * Mobile-specific implementation of Code Page
@@ -32,6 +33,14 @@ import { ChatArea } from '@/features/tasks/components/chat'
  * @see CodePageDesktop.tsx for desktop implementation
  */
 export function CodePageMobile() {
+  return (
+    <ToolDetailProvider>
+      <CodePageMobileContent />
+    </ToolDetailProvider>
+  )
+}
+
+function CodePageMobileContent() {
   // Get search params to check for taskId
   const searchParams = useSearchParams()
   const _hasTaskId = !!searchParams.get('taskId')

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -218,33 +218,66 @@ const MixedContentView = memo(function MixedContentView({
 
   return (
     <div className="space-y-3">
-      {mixedItems.map((item, index) => {
-        // Null check after filter
-        if (!item) {
-          return null
-        }
+      {(() => {
+        type MixedItem =
+          | { type: 'content'; content: string; blockId?: string }
+          | { type: 'tool'; tool: ToolPair; blockId?: string }
+        const groups: Array<{ type: 'content' | 'tools'; items: MixedItem[] }> = []
+        let currentGroup: { type: 'content' | 'tools'; items: MixedItem[] } | null = null
 
-        if (item.type === 'content') {
-          // Skip empty content or non-string content
-          if (!item.content || typeof item.content !== 'string' || !item.content.trim()) {
-            return null
+        mixedItems.forEach(item => {
+          if (!item) return
+
+          if (item.type === 'tool') {
+            // If current group is tools, add to it; otherwise create new tools group
+            if (currentGroup?.type === 'tools') {
+              currentGroup.items.push(item)
+            } else {
+              currentGroup = { type: 'tools', items: [item] }
+              groups.push(currentGroup)
+            }
+          } else if (item.type === 'content') {
+            // Content always creates a new group
+            currentGroup = { type: 'content', items: [item] }
+            groups.push(currentGroup)
           }
-          const key = 'blockId' in item ? item.blockId : `content-${index}`
-          const textContent =
-            annotations && annotations.length > 0
-              ? processCitePatterns(item.content, annotations)
-              : item.content
-          return (
-            <div key={key} className="text-sm">
-              <EnhancedMarkdown source={textContent} theme={theme} />
-            </div>
-          )
-        } else if (item.type === 'tool') {
-          const key = 'blockId' in item ? item.blockId : `tool-${item.tool.toolUseId}`
-          return <ToolBlock key={key} tool={item.tool} defaultExpanded={false} />
-        }
-        return null
-      })}
+        })
+
+        return groups.flatMap((group, groupIndex) => {
+          if (group.type === 'content') {
+            // Render content items
+            return group.items.map((item, index) => {
+              if (item.type !== 'content') return null
+              // Skip empty content or non-string content
+              if (!item.content || typeof item.content !== 'string' || !item.content.trim()) {
+                return null
+              }
+              const key = 'blockId' in item ? item.blockId : `content-${groupIndex}-${index}`
+              const textContent =
+                annotations && annotations.length > 0
+                  ? processCitePatterns(item.content, annotations)
+                  : item.content
+              return (
+                <div key={key} className="text-sm">
+                  <EnhancedMarkdown source={textContent} theme={theme} />
+                </div>
+              )
+            })
+          } else if (group.type === 'tools') {
+            // Render all consecutive tools in a single container with flex wrap
+            return (
+              <div key={`tools-${groupIndex}`} className="flex flex-wrap gap-2 -mt-1">
+                {group.items.map(item => {
+                  if (item.type !== 'tool') return null
+                  const key = 'blockId' in item ? item.blockId : `tool-${item.tool.toolUseId}`
+                  return <ToolBlock key={key} tool={item.tool} defaultExpanded={false} />
+                })}
+              </div>
+            )
+          }
+          return null
+        })
+      })()}
 
       {/* Show "Processing..." indicator when task is running and last block is complete */}
       {shouldShowProcessing && (

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -230,9 +230,10 @@ const MixedContentView = memo(function MixedContentView({
             return null
           }
           const key = 'blockId' in item ? item.blockId : `content-${index}`
-          const textContent = annotations && annotations.length > 0
-            ? processCitePatterns(item.content, annotations)
-            : item.content
+          const textContent =
+            annotations && annotations.length > 0
+              ? processCitePatterns(item.content, annotations)
+              : item.content
           return (
             <div key={key} className="text-sm">
               <EnhancedMarkdown source={textContent} theme={theme} />

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -4,19 +4,11 @@
 
 'use client'
 
-import { memo, useState, useMemo } from 'react'
-import { ChevronDown, ChevronRight, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
+import { memo, useMemo } from 'react'
+import { ChevronRight, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolBlockProps, ToolStatus, ToolRendererProps } from '../types'
-import { GenericToolRenderer } from './tools/GenericToolRenderer'
-import { BashToolRenderer } from './tools/BashToolRenderer'
-import { ReadToolRenderer } from './tools/ReadToolRenderer'
-import { EditToolRenderer } from './tools/EditToolRenderer'
-import { WriteToolRenderer } from './tools/WriteToolRenderer'
-import { GrepToolRenderer } from './tools/GrepToolRenderer'
-import { GlobToolRenderer } from './tools/GlobToolRenderer'
-import { TodoWriteToolRenderer } from './tools/TodoWriteToolRenderer'
-import { UploadToolRenderer } from './tools/UploadToolRenderer'
+import { useToolDetail } from '../contexts/ToolDetailContext'
 
 /**
  * Get a short preview of the tool input for display in the header
@@ -122,15 +114,15 @@ function truncateText(text: string, maxLength: number): string {
 /**
  * ToolBlock Component
  *
- * Displays a single tool execution as a collapsible block.
- * Routes to specialized renderers based on tool name.
+ * Displays a single tool execution as a clickable block.
+ * Click to display details in the shared detail panel below.
  */
 export const ToolBlock = memo(function ToolBlock({
   tool,
-  defaultExpanded = false,
+  defaultExpanded: _defaultExpanded = false,
 }: ToolBlockProps) {
   const { t } = useTranslation('chat')
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded)
+  const { selectedTool, setSelectedTool } = useToolDetail()
 
   // Get status icon component
   const StatusIcon = getStatusIcon(tool.status)
@@ -141,9 +133,6 @@ export const ToolBlock = memo(function ToolBlock({
 
   // Get tool input preview for header display
   const inputPreview = useMemo(() => getToolInputPreview(tool), [tool])
-
-  // Get specialized renderer
-  const ToolRenderer = getToolRenderer(tool.toolName)
 
   // Check if this is an upload tool with downloadable attachment
   const isDownloadable = tool.toolName === 'Upload' && tool.status === 'done'
@@ -158,52 +147,39 @@ export const ToolBlock = memo(function ToolBlock({
   const hasContent = hasInput || hasOutput
   const isExpandable = hasContent
 
-  return (
-    <div className="border border-border rounded-lg bg-surface overflow-hidden mb-2">
-      {/* Header */}
-      <div
-        className={`flex items-center justify-between px-4 py-3 ${
-          isExpandable ? 'cursor-pointer hover:bg-fill-tert' : 'cursor-default'
-        } transition-colors`}
-        onClick={() => isExpandable && setIsExpanded(!isExpanded)}
-      >
-        <div className="flex items-center gap-2 min-w-0 flex-1">
-          <StatusIcon className={`h-4 w-4 flex-shrink-0 ${statusColor}`} />
-          <span className="text-sm font-medium text-text-primary flex-shrink-0">
-            {toolDisplayName}
-          </span>
-          {/* Input preview - shown inline after tool name */}
-          {inputPreview && (
-            <code className="text-xs text-text-muted bg-fill-tert px-1.5 py-0.5 rounded font-mono truncate max-w-[300px]">
-              {inputPreview}
-            </code>
-          )}
-        </div>
-        <div className="flex items-center gap-2 flex-shrink-0">
-          {isDownloadable && (
-            <span className="text-xs text-primary bg-primary/10 px-2 py-0.5 rounded">
-              {t('thinking.downloadable') || 'Downloadable'}
-            </span>
-          )}
-          {/* Expand/collapse icon - only show if there's content to expand */}
-          {isExpandable && (
-            <>
-              {isExpanded ? (
-                <ChevronDown className="h-4 w-4 text-text-muted" />
-              ) : (
-                <ChevronRight className="h-4 w-4 text-text-muted" />
-              )}
-            </>
-          )}
-        </div>
-      </div>
+  // Check if this tool is currently selected
+  const isSelected = selectedTool?.toolUseId === tool.toolUseId
 
-      {/* Content (Specialized Renderer) */}
-      {isExpanded && isExpandable && (
-        <div className="px-4 py-3 border-t border-border bg-base">
-          <ToolRenderer tool={tool} />
-        </div>
-      )}
+  // Handle click - select this tool for detail display
+  const handleClick = () => {
+    if (isExpandable) {
+      // Toggle selection: if already selected, deselect; otherwise select
+      setSelectedTool(isSelected ? null : tool)
+    }
+  }
+
+  return (
+    <div
+      className={`flex items-center gap-2 px-3 py-2 rounded-md mb-1 transition-colors ${
+        isSelected
+          ? 'bg-primary/10 border-2 border-primary'
+          : 'bg-fill-tert border-2 border-transparent hover:bg-fill-secondary'
+      } ${isExpandable ? 'cursor-pointer' : 'cursor-default'}`}
+      onClick={handleClick}
+    >
+      <StatusIcon className={`h-4 w-4 flex-shrink-0 ${statusColor}`} />
+      <span className="text-sm text-text-secondary flex-shrink-0">{toolDisplayName}</span>
+      {/* Input preview - shown inline after tool name */}
+      {inputPreview && <span className="text-sm text-text-secondary truncate">{inputPreview}</span>}
+      <div className="flex items-center gap-2 flex-shrink-0 ml-auto">
+        {isDownloadable && (
+          <span className="text-xs text-primary bg-primary/10 px-2 py-0.5 rounded">
+            {t('thinking.downloadable') || 'Downloadable'}
+          </span>
+        )}
+        {/* Show chevron if there's content to expand */}
+        {isExpandable && <ChevronRight className="h-3.5 w-3.5 text-text-muted" />}
+      </div>
     </div>
   )
 })
@@ -274,35 +250,6 @@ function getToolDisplayName(tool: ToolRendererProps['tool'], t: (key: string) =>
   }
 
   return toolName || 'Unknown Tool'
-}
-
-/**
- * Get specialized renderer for tool type
- * Returns component that renders tool input/output
- */
-function getToolRenderer(
-  toolName: string
-): React.ComponentType<{ tool: ToolRendererProps['tool'] }> {
-  switch (toolName) {
-    case 'Bash':
-      return BashToolRenderer
-    case 'Read':
-      return ReadToolRenderer
-    case 'Edit':
-      return EditToolRenderer
-    case 'Write':
-      return WriteToolRenderer
-    case 'Grep':
-      return GrepToolRenderer
-    case 'Glob':
-      return GlobToolRenderer
-    case 'TodoWrite':
-      return TodoWriteToolRenderer
-    case 'Upload':
-      return UploadToolRenderer
-    default:
-      return GenericToolRenderer
-  }
 }
 
 export default ToolBlock

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -100,6 +100,12 @@ export const ToolBlock = memo(function ToolBlock({
   const hasContent = hasInput || hasOutput
   const isExpandable = hasContent
 
+  // Check if tool is loading based on status
+  const isLoading =
+    tool.status === 'pending' ||
+    tool.status === 'streaming' ||
+    tool.status === 'invoking'
+
   // Check if this tool is currently selected
   const isSelected = selectedTool?.toolUseId === tool.toolUseId
 
@@ -118,7 +124,9 @@ export const ToolBlock = memo(function ToolBlock({
         isSelected
           ? 'bg-hover text-text-primary'
           : 'bg-muted text-text-secondary hover:bg-hover'
-      } ${isExpandable ? 'cursor-pointer' : 'cursor-default'}`}
+      } ${isExpandable ? 'cursor-pointer' : 'cursor-default'} ${
+        isLoading ? 'animate-pulse' : ''
+      }`}
       onClick={handleClick}
       disabled={!isExpandable}
     >

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -4,219 +4,38 @@
 
 'use client'
 
-import { memo, useMemo } from 'react'
-import { ChevronRight, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
+import { memo } from 'react'
+import {
+  BookOpenIcon,
+  CommandLineIcon,
+  PencilSquareIcon,
+  DocumentPlusIcon,
+  MagnifyingGlassIcon,
+  FolderIcon,
+} from '@heroicons/react/24/outline'
 import { useTranslation } from '@/hooks/useTranslation'
-import type { ToolBlockProps, ToolStatus, ToolRendererProps } from '../types'
+import type { ToolBlockProps, ToolRendererProps } from '../types'
 import { useToolDetail } from '../contexts/ToolDetailContext'
 
 /**
- * Get a short preview of the tool input for display in the header
- * Returns a truncated string suitable for inline display
+ * Get icon for tool based on tool name
  */
-function getToolInputPreview(
-  tool: ToolRendererProps['tool'],
-  maxLength: number = 60
-): string | null {
-  const input = tool.toolUse?.details?.input as Record<string, unknown> | string | undefined
-  if (!input) return null
-
-  const toolName = tool.toolName
-
-  // Handle different tool types
+function getToolIcon(toolName: string): React.ComponentType<{ className?: string }> {
   switch (toolName) {
-    case 'Bash': {
-      const command = typeof input === 'object' ? (input.command as string) : input
-      if (command) {
-        return truncateText(command, maxLength)
-      }
-      break
-    }
-    case 'Read': {
-      const filePath = typeof input === 'object' ? (input.file_path as string) : input
-      if (filePath) {
-        return truncateText(filePath, maxLength)
-      }
-      break
-    }
-    case 'Write': {
-      const filePath = typeof input === 'object' ? (input.file_path as string) : input
-      if (filePath) {
-        return truncateText(filePath, maxLength)
-      }
-      break
-    }
-    case 'Edit': {
-      const filePath = typeof input === 'object' ? (input.file_path as string) : input
-      if (filePath) {
-        return truncateText(filePath, maxLength)
-      }
-      break
-    }
-    case 'Grep': {
-      const pattern = typeof input === 'object' ? (input.pattern as string) : input
-      if (pattern) {
-        return truncateText(`"${pattern}"`, maxLength)
-      }
-      break
-    }
-    case 'Glob': {
-      const pattern = typeof input === 'object' ? (input.pattern as string) : input
-      if (pattern) {
-        return truncateText(pattern, maxLength)
-      }
-      break
-    }
-    case 'knowledge_base_search':
-    case 'web_search': {
-      const query = typeof input === 'object' ? (input.query as string) : input
-      if (query) {
-        return truncateText(`"${query}"`, maxLength)
-      }
-      break
-    }
-    default: {
-      // For generic tools, try to extract a meaningful preview
-      if (typeof input === 'string') {
-        return truncateText(input, maxLength)
-      }
-      // Try common field names
-      if (typeof input === 'object') {
-        const preview =
-          (input.command as string) ||
-          (input.query as string) ||
-          (input.file_path as string) ||
-          (input.path as string) ||
-          (input.content as string) ||
-          (input.text as string)
-        if (preview && typeof preview === 'string') {
-          return truncateText(preview, maxLength)
-        }
-      }
-    }
-  }
-
-  return null
-}
-
-/**
- * Truncate text to a maximum length, adding ellipsis if needed
- */
-function truncateText(text: string, maxLength: number): string {
-  // Remove newlines and extra whitespace for inline display
-  const cleaned = text.replace(/\s+/g, ' ').trim()
-  if (cleaned.length <= maxLength) {
-    return cleaned
-  }
-  return cleaned.substring(0, maxLength - 3) + '...'
-}
-
-/**
- * ToolBlock Component
- *
- * Displays a single tool execution as a clickable block.
- * Click to display details in the shared detail panel below.
- */
-export const ToolBlock = memo(function ToolBlock({
-  tool,
-  defaultExpanded: _defaultExpanded = false,
-}: ToolBlockProps) {
-  const { t } = useTranslation('chat')
-  const { selectedTool, setSelectedTool } = useToolDetail()
-
-  // Get status icon component
-  const StatusIcon = getStatusIcon(tool.status)
-  const statusColor = getStatusColor(tool.status)
-
-  // Get tool display name
-  const toolDisplayName = getToolDisplayName(tool, t)
-
-  // Get tool input preview for header display
-  const inputPreview = useMemo(() => getToolInputPreview(tool), [tool])
-
-  // Check if this is an upload tool with downloadable attachment
-  const isDownloadable = tool.toolName === 'Upload' && tool.status === 'done'
-
-  // Check if both input and output are empty
-  const hasInput =
-    tool.toolUse?.details?.input &&
-    (typeof tool.toolUse.details.input === 'string'
-      ? tool.toolUse.details.input.length > 0
-      : Object.keys(tool.toolUse.details.input).length > 0)
-  const hasOutput = tool.toolResult?.details?.output || tool.toolResult?.details?.content
-  const hasContent = hasInput || hasOutput
-  const isExpandable = hasContent
-
-  // Check if this tool is currently selected
-  const isSelected = selectedTool?.toolUseId === tool.toolUseId
-
-  // Handle click - select this tool for detail display
-  const handleClick = () => {
-    if (isExpandable) {
-      // Toggle selection: if already selected, deselect; otherwise select
-      setSelectedTool(isSelected ? null : tool)
-    }
-  }
-
-  return (
-    <div
-      className={`flex items-center gap-2 px-3 py-2 rounded-md mb-1 transition-colors ${
-        isSelected
-          ? 'bg-primary/10 border-2 border-primary'
-          : 'bg-fill-tert border-2 border-transparent hover:bg-fill-secondary'
-      } ${isExpandable ? 'cursor-pointer' : 'cursor-default'}`}
-      onClick={handleClick}
-    >
-      <StatusIcon className={`h-4 w-4 flex-shrink-0 ${statusColor}`} />
-      <span className="text-sm text-text-secondary flex-shrink-0">{toolDisplayName}</span>
-      {/* Input preview - shown inline after tool name */}
-      {inputPreview && <span className="text-sm text-text-secondary truncate">{inputPreview}</span>}
-      <div className="flex items-center gap-2 flex-shrink-0 ml-auto">
-        {isDownloadable && (
-          <span className="text-xs text-primary bg-primary/10 px-2 py-0.5 rounded">
-            {t('thinking.downloadable') || 'Downloadable'}
-          </span>
-        )}
-        {/* Show chevron if there's content to expand */}
-        {isExpandable && <ChevronRight className="h-3.5 w-3.5 text-text-muted" />}
-      </div>
-    </div>
-  )
-})
-
-/**
- * Get status icon component based on tool status
- */
-function getStatusIcon(status: ToolStatus) {
-  switch (status) {
-    case 'done':
-      return CheckCircle2
-    case 'error':
-      return AlertCircle // Changed from XCircle to AlertCircle for softer warning style
-    case 'invoking':
-    case 'streaming':
-    case 'pending':
-      return Loader2
+    case 'Bash':
+      return CommandLineIcon
+    case 'Read':
+      return BookOpenIcon
+    case 'Edit':
+      return PencilSquareIcon
+    case 'Write':
+      return DocumentPlusIcon
+    case 'Grep':
+      return MagnifyingGlassIcon
+    case 'Glob':
+      return FolderIcon
     default:
-      return Loader2
-  }
-}
-
-/**
- * Get status color classes
- */
-function getStatusColor(status: ToolStatus): string {
-  switch (status) {
-    case 'done':
-      return 'text-primary'
-    case 'error':
-      return 'text-yellow-600' // Changed from text-red-500 to yellow for softer warning
-    case 'invoking':
-    case 'streaming':
-    case 'pending':
-      return 'text-primary animate-spin'
-    default:
-      return 'text-text-muted'
+      return BookOpenIcon
   }
 }
 
@@ -251,5 +70,62 @@ function getToolDisplayName(tool: ToolRendererProps['tool'], t: (key: string) =>
 
   return toolName || 'Unknown Tool'
 }
+
+/**
+ * ToolBlock Component
+ *
+ * Displays a single tool execution as a simple clickable pill/tag.
+ * Click to display details in the shared detail panel.
+ */
+export const ToolBlock = memo(function ToolBlock({
+  tool,
+  defaultExpanded: _defaultExpanded = false,
+}: ToolBlockProps) {
+  const { t } = useTranslation('chat')
+  const { selectedTool, setSelectedTool } = useToolDetail()
+
+  // Get tool icon
+  const ToolIcon = getToolIcon(tool.toolName)
+
+  // Get tool display name using previous logic
+  const toolDisplayName = getToolDisplayName(tool, t)
+
+  // Check if both input and output are empty
+  const hasInput =
+    tool.toolUse?.details?.input &&
+    (typeof tool.toolUse.details.input === 'string'
+      ? tool.toolUse.details.input.length > 0
+      : Object.keys(tool.toolUse.details.input).length > 0)
+  const hasOutput = tool.toolResult?.details?.output || tool.toolResult?.details?.content
+  const hasContent = hasInput || hasOutput
+  const isExpandable = hasContent
+
+  // Check if this tool is currently selected
+  const isSelected = selectedTool?.toolUseId === tool.toolUseId
+
+  // Handle click - select this tool for detail display
+  const handleClick = () => {
+    if (isExpandable) {
+      // Toggle selection: if already selected, deselect; otherwise select
+      setSelectedTool(isSelected ? null : tool)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm transition-colors ${
+        isSelected
+          ? 'bg-hover text-text-primary'
+          : 'bg-muted text-text-secondary hover:bg-hover'
+      } ${isExpandable ? 'cursor-pointer' : 'cursor-default'}`}
+      onClick={handleClick}
+      disabled={!isExpandable}
+    >
+      <ToolIcon className="h-4 w-4" />
+      <span className="font-normal">{toolDisplayName}</span>
+    </button>
+  )
+})
 
 export default ToolBlock

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
@@ -66,10 +66,12 @@ export const ToolBlockGroup = memo(function ToolBlockGroup({
 
       {/* Tools List */}
       {isExpanded && (
-        <div className="p-3 space-y-2 bg-base">
-          {group.tools.map(tool => (
-            <ToolBlock key={tool.toolUseId} tool={tool} defaultExpanded={false} />
-          ))}
+        <div className="p-3 bg-base">
+          <div className="space-y-2">
+            {group.tools.map(tool => (
+              <ToolBlock key={tool.toolUseId} tool={tool} defaultExpanded={false} />
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlockGroup.tsx
@@ -64,10 +64,10 @@ export const ToolBlockGroup = memo(function ToolBlockGroup({
         )}
       </div>
 
-      {/* Tools List */}
+      {/* Tools List - inline display */}
       {isExpanded && (
-        <div className="p-3 bg-base">
-          <div className="space-y-2">
+        <div className="px-4 py-3 bg-base">
+          <div className="flex flex-wrap gap-2">
             {group.tools.map(tool => (
               <ToolBlock key={tool.toolUseId} tool={tool} defaultExpanded={false} />
             ))}

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolDetailPanel.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolDetailPanel.tsx
@@ -5,9 +5,17 @@
 'use client'
 
 import { memo, useMemo } from 'react'
-import { XMarkIcon } from '@heroicons/react/24/outline'
+import {
+  XMarkIcon,
+  BookOpenIcon,
+  CommandLineIcon,
+  PencilSquareIcon,
+  DocumentPlusIcon,
+  MagnifyingGlassIcon,
+  FolderIcon,
+} from '@heroicons/react/24/outline'
 import { useTranslation } from '@/hooks/useTranslation'
-import type { ToolStatus, ToolRendererProps } from '../types'
+import type { ToolRendererProps } from '../types'
 import { useToolDetail, ToolDetailPanelContentProvider } from '../contexts/ToolDetailContext'
 import { GenericToolRenderer } from './tools/GenericToolRenderer'
 import { BashToolRenderer } from './tools/BashToolRenderer'
@@ -20,21 +28,24 @@ import { TodoWriteToolRenderer } from './tools/TodoWriteToolRenderer'
 import { UploadToolRenderer } from './tools/UploadToolRenderer'
 
 /**
- * Get status icon component based on tool status
+ * Get icon for tool based on tool name
  */
-function getStatusIcon(status: ToolStatus) {
-  // Return icon emoji instead of Lucide component for consistency with Workbench
-  switch (status) {
-    case 'done':
-      return '✅'
-    case 'error':
-      return '⚠️'
-    case 'invoking':
-    case 'streaming':
-    case 'pending':
-      return '⏳'
+function getToolIcon(toolName: string): React.ComponentType<{ className?: string }> {
+  switch (toolName) {
+    case 'Bash':
+      return CommandLineIcon
+    case 'Read':
+      return BookOpenIcon
+    case 'Edit':
+      return PencilSquareIcon
+    case 'Write':
+      return DocumentPlusIcon
+    case 'Grep':
+      return MagnifyingGlassIcon
+    case 'Glob':
+      return FolderIcon
     default:
-      return '🔧'
+      return BookOpenIcon
   }
 }
 
@@ -176,8 +187,8 @@ export const ToolDetailPanel = memo(function ToolDetailPanel() {
   // Get tool display name
   const toolDisplayName = getToolDisplayName(selectedTool, t)
 
-  // Get status icon (emoji)
-  const statusIcon = getStatusIcon(selectedTool.status)
+  // Get tool icon component
+  const ToolIcon = getToolIcon(selectedTool.toolName)
 
   // Get specialized renderer
   const ToolRenderer = getToolRenderer(selectedTool.toolName)
@@ -193,9 +204,9 @@ export const ToolDetailPanel = memo(function ToolDetailPanel() {
         <nav className="border-b border-border bg-surface">
           <div className="mx-auto px-2 sm:px-3 lg:px-4">
             <div className="flex h-12 justify-between items-center">
-              {/* Title with status icon */}
+              {/* Title with tool icon */}
               <div className="flex items-center gap-2 min-w-0">
-                <span className="text-lg">{statusIcon}</span>
+                <ToolIcon className="h-5 w-5 text-text-secondary" />
                 <h3 className="text-sm font-medium text-text-primary truncate">{toolDisplayName}</h3>
               </div>
               {/* Close button - matches Workbench style */}

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolDetailPanel.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolDetailPanel.tsx
@@ -1,0 +1,238 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { memo, useMemo } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { ToolStatus, ToolRendererProps } from '../types'
+import { useToolDetail, ToolDetailPanelContentProvider } from '../contexts/ToolDetailContext'
+import { GenericToolRenderer } from './tools/GenericToolRenderer'
+import { BashToolRenderer } from './tools/BashToolRenderer'
+import { ReadToolRenderer } from './tools/ReadToolRenderer'
+import { EditToolRenderer } from './tools/EditToolRenderer'
+import { WriteToolRenderer } from './tools/WriteToolRenderer'
+import { GrepToolRenderer } from './tools/GrepToolRenderer'
+import { GlobToolRenderer } from './tools/GlobToolRenderer'
+import { TodoWriteToolRenderer } from './tools/TodoWriteToolRenderer'
+import { UploadToolRenderer } from './tools/UploadToolRenderer'
+
+/**
+ * Get status icon component based on tool status
+ */
+function getStatusIcon(status: ToolStatus) {
+  // Return icon emoji instead of Lucide component for consistency with Workbench
+  switch (status) {
+    case 'done':
+      return '✅'
+    case 'error':
+      return '⚠️'
+    case 'invoking':
+    case 'streaming':
+    case 'pending':
+      return '⏳'
+    default:
+      return '🔧'
+  }
+}
+
+/**
+ * Get friendly display name for tool
+ */
+function getToolDisplayName(tool: ToolRendererProps['tool'], t: (key: string) => string): string {
+  const toolName = tool.toolName
+
+  const displayNames: Record<string, string> = {
+    Bash: t('thinking.tools.bash') || 'Execute Command',
+    Read: t('thinking.tools.read') || 'Read File',
+    Edit: t('thinking.tools.edit') || 'Edit File',
+    Write: t('thinking.tools.write') || 'Write File',
+    Grep: t('thinking.tools.grep') || 'Search Code',
+    Glob: t('thinking.tools.glob') || 'Find Files',
+    TodoWrite: t('thinking.tools.todo') || 'Update Tasks',
+    knowledge_base_search: t('thinking.tools.kb_search') || 'Search Knowledge Base',
+    web_search: t('thinking.tools.web_search') || 'Web Search',
+  }
+
+  if (displayNames[toolName]) {
+    return displayNames[toolName]
+  }
+
+  if (tool.displayName) {
+    return tool.displayName
+  }
+
+  return toolName || 'Unknown Tool'
+}
+
+/**
+ * Get specialized renderer for tool type
+ */
+function getToolRenderer(
+  toolName: string
+): React.ComponentType<{ tool: ToolRendererProps['tool'] }> {
+  switch (toolName) {
+    case 'Bash':
+      return BashToolRenderer
+    case 'Read':
+      return ReadToolRenderer
+    case 'Edit':
+      return EditToolRenderer
+    case 'Write':
+      return WriteToolRenderer
+    case 'Grep':
+      return GrepToolRenderer
+    case 'Glob':
+      return GlobToolRenderer
+    case 'TodoWrite':
+      return TodoWriteToolRenderer
+    case 'Upload':
+      return UploadToolRenderer
+    default:
+      return GenericToolRenderer
+  }
+}
+
+/**
+ * Get tool input preview for display
+ */
+function getToolInputPreview(tool: ToolRendererProps['tool'], maxLength: number = 80): string | null {
+  const input = tool.toolUse?.details?.input as Record<string, unknown> | string | undefined
+  if (!input) return null
+
+  const toolName = tool.toolName
+
+  const truncate = (text: string) => {
+    const cleaned = text.replace(/\s+/g, ' ').trim()
+    return cleaned.length <= maxLength ? cleaned : cleaned.substring(0, maxLength - 3) + '...'
+  }
+
+  switch (toolName) {
+    case 'Bash': {
+      const command = typeof input === 'object' ? (input.command as string) : input
+      return command ? truncate(command) : null
+    }
+    case 'Read':
+    case 'Write':
+    case 'Edit': {
+      const filePath = typeof input === 'object' ? (input.file_path as string) : input
+      return filePath ? truncate(filePath) : null
+    }
+    case 'Grep':
+    case 'Glob': {
+      const pattern = typeof input === 'object' ? (input.pattern as string) : input
+      return pattern ? truncate(`"${pattern}"`) : null
+    }
+    case 'knowledge_base_search':
+    case 'web_search': {
+      const query = typeof input === 'object' ? (input.query as string) : input
+      return query ? truncate(`"${query}"`) : null
+    }
+    default: {
+      if (typeof input === 'string') {
+        return truncate(input)
+      }
+      if (typeof input === 'object') {
+        const preview =
+          (input.command as string) ||
+          (input.query as string) ||
+          (input.file_path as string) ||
+          (input.path as string) ||
+          (input.content as string) ||
+          (input.text as string)
+        if (preview && typeof preview === 'string') {
+          return truncate(preview)
+        }
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * ToolDetailPanel Component
+ *
+ * Displays detailed information for the currently selected tool.
+ * Appears below the tool blocks when a tool is selected.
+ */
+export const ToolDetailPanel = memo(function ToolDetailPanel() {
+  const { t } = useTranslation('chat')
+  const { selectedTool, setSelectedTool } = useToolDetail()
+
+  // Get tool input preview (must be before early return to follow Hooks rules)
+  const inputPreview = useMemo(
+    () => (selectedTool ? getToolInputPreview(selectedTool) : null),
+    [selectedTool]
+  )
+
+  // Early return for no selection
+  if (!selectedTool) {
+    return null
+  }
+
+  // Get tool display name
+  const toolDisplayName = getToolDisplayName(selectedTool, t)
+
+  // Get status icon (emoji)
+  const statusIcon = getStatusIcon(selectedTool.status)
+
+  // Get specialized renderer
+  const ToolRenderer = getToolRenderer(selectedTool.toolName)
+
+  return (
+    // Right panel - matches Workbench layout exactly
+    <div
+      className="transition-all duration-300 ease-in-out bg-surface overflow-hidden"
+      style={{ width: '40%' }}
+    >
+      <div className="h-full flex flex-col border border-border rounded-lg overflow-hidden">
+        {/* Header - matches Workbench navigation header style */}
+        <nav className="border-b border-border bg-surface">
+          <div className="mx-auto px-2 sm:px-3 lg:px-4">
+            <div className="flex h-12 justify-between items-center">
+              {/* Title with status icon */}
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-lg">{statusIcon}</span>
+                <h3 className="text-sm font-medium text-text-primary truncate">{toolDisplayName}</h3>
+              </div>
+              {/* Close button - matches Workbench style */}
+              <button
+                onClick={() => setSelectedTool(null)}
+                className="relative rounded-full p-1 text-text-muted hover:text-text-primary focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary"
+              >
+                <span className="sr-only">Close tool detail</span>
+                <XMarkIcon aria-hidden="true" className="size-6" />
+              </button>
+            </div>
+          </div>
+        </nav>
+
+        {/* Content - matches Workbench content style */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-7xl px-2 pt-4 pb-2 sm:px-3 lg:px-4">
+            {/* Input preview */}
+            {inputPreview && (
+              <div className="mb-4 rounded-lg border border-border bg-surface p-4">
+                <h4 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-2">
+                  Input
+                </h4>
+                <code className="text-xs text-text-primary bg-muted px-2 py-1 rounded font-mono break-all block">
+                  {inputPreview}
+                </code>
+              </div>
+            )}
+            {/* Tool content - wrapped in provider to enable auto-expand */}
+            <ToolDetailPanelContentProvider>
+              <ToolRenderer tool={selectedTool} />
+            </ToolDetailPanelContentProvider>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+})
+
+export default ToolDetailPanel

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/BashToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/BashToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Bash tool renderer
@@ -15,7 +16,15 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function BashToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isOutputExpanded, setIsOutputExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isOutputExpanded, setIsOutputExpanded] = useState(isInDetailPanel)
+
+  // Auto-expand when in detail panel
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsOutputExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   const command = input?.command as string | undefined
@@ -60,7 +69,7 @@ export function BashToolRenderer({ tool }: ToolRendererProps) {
                 ? t('thinking.tool_error') || 'Error'
                 : t('thinking.tool_output') || 'Output'}
             </div>
-            {isOutputCollapsible && (
+            {isOutputCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsOutputExpanded(!isOutputExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -77,10 +86,12 @@ export function BashToolRenderer({ tool }: ToolRendererProps) {
                 ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
                 : 'text-text-tertiary bg-fill-tert'
             }`}
-            style={{ maxHeight: isOutputExpanded ? 'none' : '300px' }}
+            style={{ maxHeight: isOutputExpanded || isInDetailPanel ? 'none' : '300px' }}
           >
             {displayOutput}
-            {isOutputCollapsible && !isOutputExpanded && <span className="text-blue-400">...</span>}
+            {isOutputCollapsible && !isOutputExpanded && !isInDetailPanel && (
+              <span className="text-blue-400">...</span>
+            )}
           </pre>
         </div>
       )}

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/EditToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/EditToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Edit tool renderer
@@ -15,8 +16,16 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function EditToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isOldExpanded, setIsOldExpanded] = useState(false)
-  const [isNewExpanded, setIsNewExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isOldExpanded, setIsOldExpanded] = useState(isInDetailPanel)
+  const [isNewExpanded, setIsNewExpanded] = useState(isInDetailPanel)
+
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsOldExpanded(true)
+      setIsNewExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   const filePath = input?.file_path as string | undefined
@@ -61,7 +70,7 @@ export function EditToolRenderer({ tool }: ToolRendererProps) {
         <div>
           <div className="flex items-center justify-between mb-1">
             <div className="text-xs font-medium text-red-600">Old String</div>
-            {isOldCollapsible && (
+            {isOldCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsOldExpanded(!isOldExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -84,7 +93,7 @@ export function EditToolRenderer({ tool }: ToolRendererProps) {
         <div>
           <div className="flex items-center justify-between mb-1">
             <div className="text-xs font-medium text-green-600">New String</div>
-            {isNewCollapsible && (
+            {isNewCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsNewExpanded(!isNewExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/GlobToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/GlobToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Glob tool renderer
@@ -15,7 +16,14 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function GlobToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isResultsExpanded, setIsResultsExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isResultsExpanded, setIsResultsExpanded] = useState(isInDetailPanel)
+
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsResultsExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   const pattern = input?.pattern as string | undefined
@@ -95,7 +103,7 @@ export function GlobToolRenderer({ tool }: ToolRendererProps) {
                   ? `Files (${fileCount})`
                   : 'Files'}
             </div>
-            {isResultsCollapsible && (
+            {isResultsCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsResultsExpanded(!isResultsExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -112,10 +120,10 @@ export function GlobToolRenderer({ tool }: ToolRendererProps) {
                 ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
                 : 'text-text-tertiary bg-fill-tert'
             }`}
-            style={{ maxHeight: isResultsExpanded ? 'none' : '300px' }}
+            style={{ maxHeight: isResultsExpanded || isInDetailPanel ? 'none' : '300px' }}
           >
             {displayResults}
-            {isResultsCollapsible && !isResultsExpanded && (
+            {isResultsCollapsible && !isResultsExpanded && !isInDetailPanel && (
               <span className="text-blue-400">...</span>
             )}
           </pre>

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/GrepToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/GrepToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Grep tool renderer
@@ -15,7 +16,14 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function GrepToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isResultsExpanded, setIsResultsExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isResultsExpanded, setIsResultsExpanded] = useState(isInDetailPanel)
+
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsResultsExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   const pattern = input?.pattern as string | undefined
@@ -62,7 +70,7 @@ export function GrepToolRenderer({ tool }: ToolRendererProps) {
             >
               {isError ? t('thinking.tool_error') || 'Error' : 'Search Results'}
             </div>
-            {isResultsCollapsible && (
+            {isResultsCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsResultsExpanded(!isResultsExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -79,10 +87,10 @@ export function GrepToolRenderer({ tool }: ToolRendererProps) {
                 ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
                 : 'text-text-tertiary bg-fill-tert'
             }`}
-            style={{ maxHeight: isResultsExpanded ? 'none' : '400px' }}
+            style={{ maxHeight: isResultsExpanded || isInDetailPanel ? 'none' : '400px' }}
           >
             {displayResults}
-            {isResultsCollapsible && !isResultsExpanded && (
+            {isResultsCollapsible && !isResultsExpanded && !isInDetailPanel && (
               <span className="text-blue-400">...</span>
             )}
           </pre>

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/ReadToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/ReadToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Read tool renderer
@@ -15,7 +16,15 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function ReadToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isContentExpanded, setIsContentExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isContentExpanded, setIsContentExpanded] = useState(isInDetailPanel)
+
+  // Auto-expand when in detail panel
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsContentExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   let filePath = input?.file_path as string | undefined
@@ -81,7 +90,7 @@ export function ReadToolRenderer({ tool }: ToolRendererProps) {
             >
               {isError ? t('thinking.tool_error') || 'Error' : 'File Content'}
             </div>
-            {isContentCollapsible && (
+            {isContentCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsContentExpanded(!isContentExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -98,10 +107,10 @@ export function ReadToolRenderer({ tool }: ToolRendererProps) {
                 ? 'text-yellow-700 bg-yellow-50 border border-yellow-200'
                 : 'text-text-tertiary bg-fill-tert'
             }`}
-            style={{ maxHeight: isContentExpanded ? 'none' : '400px' }}
+            style={{ maxHeight: isContentExpanded || isInDetailPanel ? 'none' : '400px' }}
           >
             {displayContent}
-            {isContentCollapsible && !isContentExpanded && (
+            {isContentCollapsible && !isContentExpanded && !isInDetailPanel && (
               <span className="text-blue-400">...</span>
             )}
           </pre>

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ToolRendererProps } from '../../types'
 import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
+import { useIsInDetailPanel } from '../../contexts/ToolDetailContext'
 
 /**
  * Write tool renderer
@@ -15,7 +16,14 @@ import { shouldCollapse, getContentPreview } from '../../utils/thinkingUtils'
  */
 export function WriteToolRenderer({ tool }: ToolRendererProps) {
   const { t } = useTranslation('chat')
-  const [isContentExpanded, setIsContentExpanded] = useState(false)
+  const isInDetailPanel = useIsInDetailPanel()
+  const [isContentExpanded, setIsContentExpanded] = useState(isInDetailPanel)
+
+  useEffect(() => {
+    if (isInDetailPanel) {
+      setIsContentExpanded(true)
+    }
+  }, [isInDetailPanel])
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   let filePath = input?.file_path as string | undefined
@@ -68,7 +76,7 @@ export function WriteToolRenderer({ tool }: ToolRendererProps) {
         <div>
           <div className="flex items-center justify-between mb-1">
             <div className="text-xs font-medium text-text-secondary">Content</div>
-            {isContentCollapsible && (
+            {isContentCollapsible && !isInDetailPanel && (
               <button
                 onClick={() => setIsContentExpanded(!isContentExpanded)}
                 className="text-xs text-blue-400 hover:text-blue-500 hover:font-semibold transition-colors"
@@ -81,10 +89,10 @@ export function WriteToolRenderer({ tool }: ToolRendererProps) {
           </div>
           <pre
             className="text-xs text-text-tertiary bg-fill-tert p-2 rounded overflow-x-auto whitespace-pre-wrap break-words font-mono"
-            style={{ maxHeight: isContentExpanded ? 'none' : '400px' }}
+            style={{ maxHeight: isContentExpanded || isInDetailPanel ? 'none' : '400px' }}
           >
             {displayContent}
-            {isContentCollapsible && !isContentExpanded && (
+            {isContentCollapsible && !isContentExpanded && !isInDetailPanel && (
               <span className="text-blue-400">...</span>
             )}
           </pre>

--- a/frontend/src/features/tasks/components/message/thinking/contexts/ToolDetailContext.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/contexts/ToolDetailContext.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { createContext, useContext, useState, useCallback } from 'react'
+import type { ToolRendererProps } from '../types'
+
+interface ToolDetailContextValue {
+  selectedTool: ToolRendererProps['tool'] | null
+  setSelectedTool: (tool: ToolRendererProps['tool'] | null) => void
+  isToolDetailOpen: boolean
+  isInDetailPanel: boolean // New: indicates if renderer is in detail panel
+}
+
+const ToolDetailContext = createContext<ToolDetailContextValue | undefined>(undefined)
+
+export function ToolDetailProvider({ children }: { children: React.ReactNode }) {
+  const [selectedTool, setSelectedToolState] = useState<ToolRendererProps['tool'] | null>(null)
+
+  const setSelectedTool = useCallback((tool: ToolRendererProps['tool'] | null) => {
+    setSelectedToolState(tool)
+  }, [])
+
+  const isToolDetailOpen = selectedTool !== null
+  const isInDetailPanel = false // Default context is not in detail panel
+
+  return (
+    <ToolDetailContext.Provider
+      value={{ selectedTool, setSelectedTool, isToolDetailOpen, isInDetailPanel }}
+    >
+      {children}
+    </ToolDetailContext.Provider>
+  )
+}
+
+/**
+ * Provider for tool renderers inside detail panel - marks content as always expanded
+ */
+export function ToolDetailPanelContentProvider({ children }: { children: React.ReactNode }) {
+  const parentContext = useContext(ToolDetailContext)
+  if (!parentContext) {
+    throw new Error('ToolDetailPanelContentProvider must be used within ToolDetailProvider')
+  }
+
+  return (
+    <ToolDetailContext.Provider value={{ ...parentContext, isInDetailPanel: true }}>
+      {children}
+    </ToolDetailContext.Provider>
+  )
+}
+
+export function useToolDetail() {
+  const context = useContext(ToolDetailContext)
+  if (!context) {
+    throw new Error('useToolDetail must be used within ToolDetailProvider')
+  }
+  return context
+}
+
+/**
+ * Hook to check if tool detail is open (for use outside of provider to control other panels)
+ * Returns false if used outside provider (graceful degradation)
+ */
+export function useIsToolDetailOpen(): boolean {
+  const context = useContext(ToolDetailContext)
+  return context?.isToolDetailOpen ?? false
+}
+
+/**
+ * Hook to check if renderer is inside detail panel (for auto-expand behavior)
+ * Returns false if used outside provider (graceful degradation)
+ */
+export function useIsInDetailPanel(): boolean {
+  const context = useContext(ToolDetailContext)
+  return context?.isInDetailPanel ?? false
+}


### PR DESCRIPTION
Refactored tool display system to show detailed tool information in a dedicated panel:
- Added ToolDetailPanel component that appears on the right side (matches Workbench layout)
- Converted ToolBlock from collapsible to clickable with selection state
- Added ToolDetailContext to manage selected tool state and auto-expand behavior
- Tool renderers now auto-expand content when displayed in detail panel
- Detail panel replaces Workbench when open to maintain clean layout
- Updated CodePageDesktop to integrate ToolDetailProvider and panel display

Technical changes:
- New: ToolDetailPanel.tsx - shared panel component for tool details
- New: ToolDetailContext.tsx - context for tool selection state
- Modified: ToolBlock.tsx - simplified to clickable blocks with selection UI
- Modified: All tool renderers - added auto-expand support via useIsInDetailPanel hook
- Modified: CodePageDesktop.tsx - added provider and conditional panel display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated Tool Detail panel to view a selected tool with expanded info and full rendering.
  * Selectable tool pills to open/close the detail panel across desktop and mobile.

* **Improvements**
  * Tool renderers auto-expand and simplify controls when shown in the detail panel.
  * Tools list now uses an inline, wrapped layout for compact display.
  * Page layouts adapt (hide/reshuffle workbench) when the detail panel is open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->