### PR TITLE
fix(frontend): fix dialog footer scrolling in knowledge base dialogs

### DIFF
--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -82,8 +82,7 @@ export function CreateKnowledgeBaseDialog({
 
   // Note: Auto-selection of retriever and embedding model is handled by RetrievalSettingsSection
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = async () => {
     setError('')
     setSummaryModelError('')
 
@@ -174,12 +173,11 @@ export function CreateKnowledgeBaseDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle>{t('knowledge:document.knowledgeBase.create')}</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit} className="max-h-[80vh] overflow-y-auto">
-          <div className="space-y-4 py-4">
+        <div className="flex-1 overflow-y-auto space-y-4 py-4">
             <KnowledgeBaseForm
               typeSection={
                 <div className="space-y-2">
@@ -254,18 +252,16 @@ export function CreateKnowledgeBaseDialog({
           </div>
           <DialogFooter>
             <Button
-              type="button"
               variant="outline"
               onClick={() => handleOpenChange(false)}
               disabled={loading}
             >
               {t('common:actions.cancel')}
             </Button>
-            <Button type="submit" variant="primary" disabled={loading}>
+            <Button onClick={handleSubmit} variant="primary" disabled={loading}>
               {loading ? t('common:actions.creating') : t('common:actions.create')}
             </Button>
           </DialogFooter>
-        </form>
       </DialogContent>
     </Dialog>
   )

--- a/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
@@ -76,8 +76,7 @@ export function EditKnowledgeBaseDialog({
     setRetrievalConfig(config)
   }, [])
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
+  const handleSubmit = async () => {
     setError('')
     setSummaryModelError('')
 
@@ -154,12 +153,11 @@ export function EditKnowledgeBaseDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle>{t('knowledge:document.knowledgeBase.edit')}</DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4 py-4">
+        <div className="flex-1 overflow-y-auto space-y-4 py-4">
             <KnowledgeBaseForm
               name={name}
               description={description}
@@ -201,18 +199,16 @@ export function EditKnowledgeBaseDialog({
           </div>
           <DialogFooter>
             <Button
-              type="button"
               variant="outline"
               onClick={() => handleOpenChange(false)}
               disabled={loading}
             >
               {t('common:actions.cancel')}
             </Button>
-            <Button type="submit" variant="primary" disabled={loading}>
+            <Button onClick={handleSubmit} variant="primary" disabled={loading}>
               {loading ? t('common:actions.saving') : t('common:actions.save')}
             </Button>
           </DialogFooter>
-        </form>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
## Problem
The Create Knowledge Base and Edit Knowledge Base dialogs had incorrect scrolling behavior:
- The entire dialog (including footer buttons) scrolled together
- Footer buttons were too close to the bottom border
- Content overflow caused visible cut-off on left/right sides

## Root Cause
Both dialogs used a `<form>` element wrapping both the scrollable content area and `DialogFooter`. This caused:
1. The form element to not properly participate in the flexbox layout
2. The entire form content (including footer) to scroll as a single unit
3. Incorrect spacing for the footer buttons

## Solution
Restructured dialogs to match the working pattern used in `TeamEditDialog`:
- Removed `<form>` element wrapper
- Changed `DialogContent` to use `flex flex-col` layout
- Made content area scrollable with `flex-1 overflow-y-auto`
- Kept `DialogFooter` outside the scrollable area (fixed at bottom)
- Changed buttons to use `onClick` handlers instead of form submit

## Files Changed
- `frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx`
- `frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx`


BEFORE:
![img_v3_02va_41a28a66-f5c6-4df9-ace6-d6c99e712b4g](https://github.com/user-attachments/assets/1c7db358-f7c8-428e-a004-5d3d43d21473)

AFTER:
![img_v3_02va_d155c7e2-5b35-4a91-b90a-bb6625c74cfg](https://github.com/user-attachments/assets/db23fe7f-5c49-49bb-8b2e-2385582147d1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal submission flow for knowledge base dialogs, replacing form-based handling with explicit button-triggered submission.
  * Minor layout adjustments to dialog content structure for better scrolling behavior and constraint management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->