### PR TITLE
fix(frontend): use ring-inset for inputs to prevent clipping and unify component usage

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -14,7 +14,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm text-text-primary ring-offset-base file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -14,7 +14,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -16,8 +16,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           chatStyle
-            ? 'flex min-h-[60px] w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 resize-none shadow-sm'
-            : 'flex min-h-[80px] w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
+            ? 'flex min-h-[60px] w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm text-text-primary ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 resize-none shadow-sm'
+            : 'flex min-h-[80px] w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm text-text-primary ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -16,8 +16,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         className={cn(
           chatStyle
-            ? 'flex min-h-[60px] w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 resize-none shadow-sm'
-            : 'flex min-h-[80px] w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
+            ? 'flex min-h-[60px] w-full rounded-2xl border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary focus-visible:border-primary disabled:cursor-not-allowed disabled:opacity-50 resize-none shadow-sm'
+            : 'flex min-h-[80px] w-full rounded-lg border border-border bg-surface px-4 py-3 text-sm ring-offset-base placeholder:text-text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         ref={ref}

--- a/frontend/src/features/knowledge/SearchBox.tsx
+++ b/frontend/src/features/knowledge/SearchBox.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { SearchIcon } from './SearchIcon'
+import { Input } from '@/components/ui/input'
 
 interface SearchBoxProps {
   value: string
@@ -37,12 +38,12 @@ export function SearchBox({
 
   return (
     <div className={`relative ${className}`}>
-      <input
+      <Input
         type="text"
         placeholder={placeholder}
         value={value}
         onChange={e => onChange(e.target.value)}
-        className={`w-full ${sizeClasses[size]} bg-surface border border-border rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40`}
+        className={`${sizeClasses[size]} focus-visible:ring-primary/40`}
       />
       <SearchIcon
         className={`absolute ${iconSizeClasses[size]} top-1/2 transform -translate-y-1/2 text-text-muted`}

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useState } from 'react'
 import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useUser } from '@/features/common/UserContext'
 import { paths } from '@/config/paths'
@@ -127,7 +128,7 @@ export default function LoginForm() {
               {t('common:login.username')}
             </label>
             <div className="mt-1">
-              <input
+              <Input
                 id="user_name"
                 name="user_name"
                 type="text"
@@ -135,7 +136,7 @@ export default function LoginForm() {
                 required
                 value={formData.user_name}
                 onChange={handleInputChange}
-                className="appearance-none block w-full px-3 py-2 border border-border rounded-md shadow-sm bg-base text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent sm:text-sm"
+                className="shadow-sm"
                 placeholder={t('common:login.enter_username')}
               />
             </div>
@@ -146,7 +147,7 @@ export default function LoginForm() {
               {t('common:login.password')}
             </label>
             <div className="mt-1 relative">
-              <input
+              <Input
                 id="password"
                 name="password"
                 type={showPassword ? 'text' : 'password'}
@@ -154,7 +155,7 @@ export default function LoginForm() {
                 required
                 value={formData.password}
                 onChange={handleInputChange}
-                className="appearance-none block w-full px-3 py-2 pr-10 border border-border rounded-md shadow-sm bg-base text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent sm:text-sm"
+                className="pr-10 shadow-sm"
                 placeholder={t('common:login.enter_password')}
               />
               <button

--- a/frontend/src/features/settings/components/BotEdit.tsx
+++ b/frontend/src/features/settings/components/BotEdit.tsx
@@ -12,6 +12,8 @@ import React, {
 } from 'react'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Loader2, XIcon, SettingsIcon, Edit, Wand2 } from 'lucide-react'
 import {
   Select,
@@ -960,13 +962,12 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
                   {t('common:bot.name')} <span className="text-red-400">*</span>
                 </label>
               </div>
-              <input
-                type="text"
+              <Input
                 value={botName}
                 onChange={e => setBotName(e.target.value)}
                 placeholder={t('common:bot.name_placeholder')}
                 disabled={readOnly}
-                className={`w-full h-10 px-4 bg-base border border-border rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary text-base ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+                className={`text-base ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
               />
             </div>
 
@@ -1161,7 +1162,6 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
                   </div>
                 )}
 
-                {/* Protocol selector - only show in advanced mode */}
                 {isCustomModel && (
                   <div className="mb-3">
                     <label className="block text-sm font-medium text-text-primary mb-1">
@@ -1201,7 +1201,7 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
                 )}
 
                 {isCustomModel ? (
-                  <textarea
+                  <Textarea
                     value={agentConfig}
                     onChange={e => {
                       if (readOnly) return
@@ -1235,7 +1235,7 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
 }`
                           : ''
                     }
-                    className={`w-full px-4 py-2 bg-base rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 font-mono text-base h-[150px] custom-scrollbar ${agentConfigError ? 'border border-red-400 focus:ring-red-300 focus:border-red-400' : 'border border-border focus:ring-primary/40 focus:border-primary'} ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+                    className={`font-mono text-base h-[150px] custom-scrollbar ${agentConfigError ? 'border-red-400 focus-visible:ring-red-300' : ''} ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
                   />
                 ) : (
                   <Select
@@ -1531,7 +1531,7 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
             </div>
 
             {/* textarea occupies all space in the second row */}
-            <textarea
+            <Textarea
               value={prompt}
               onChange={e => {
                 if (readOnly) return
@@ -1539,7 +1539,7 @@ const BotEditInner: React.ForwardRefRenderFunction<BotEditRef, BotEditProps> = (
               }}
               disabled={readOnly}
               placeholder={t('common:bot.prompt_placeholder')}
-              className={`w-full h-full px-4 py-2 bg-base border border-border rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary text-base resize-y custom-scrollbar min-h-[200px] flex-grow ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+              className={`text-base resize-y custom-scrollbar min-h-[200px] flex-grow ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
             />
           </div>
         )}

--- a/frontend/src/features/settings/components/DifyBotConfig.tsx
+++ b/frontend/src/features/settings/components/DifyBotConfig.tsx
@@ -7,6 +7,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { apiClient } from '@/apis/client'
 import { InformationCircleIcon, CheckCircleIcon } from '@heroicons/react/24/outline'
@@ -204,7 +205,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
               {t('common:bot.dify_api_key') || 'Dify API Key'}{' '}
               <span className="text-red-400">*</span>
             </Label>
-            <input
+            <Input
               id="dify-api-key"
               type="password"
               value={difyApiKey}
@@ -214,7 +215,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
               }}
               disabled={readOnly}
               placeholder="app-xxxxxxxxxxxxxxxxxxxxxxxx"
-              className={`w-full px-4 py-2 bg-base rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent text-base font-mono ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+              className={`text-base font-mono ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
             />
             <p className="text-xs text-text-muted mt-1">
               {t('common:bot.dify_api_key_hint') ||
@@ -228,7 +229,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
               {t('common:bot.dify_base_url') || 'Dify Base URL'}{' '}
               <span className="text-red-400">*</span>
             </Label>
-            <input
+            <Input
               id="dify-base-url"
               type="url"
               value={difyBaseUrl}
@@ -238,7 +239,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
               }}
               disabled={readOnly}
               placeholder="https://api.dify.ai"
-              className={`w-full px-4 py-2 bg-base rounded-md text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-transparent text-base font-mono ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+              className={`text-base font-mono ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
             />
             <p className="text-xs text-text-muted mt-1">
               {t('common:bot.dify_base_url_hint') ||
@@ -353,7 +354,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
                                 ))}
                               </select>
                             ) : field.type === 'text-input' || field.type === 'paragraph' ? (
-                              <textarea
+                              <Textarea
                                 id={`param-${field.variable}`}
                                 value={difyParams[field.variable] || ''}
                                 onChange={e => {
@@ -366,10 +367,10 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
                                 disabled={readOnly}
                                 placeholder={field.label?.en || field.label?.['en-US'] || ''}
                                 rows={field.type === 'paragraph' ? 4 : 2}
-                                className={`w-full px-3 py-2 bg-base rounded-md text-text-primary placeholder:text-text-muted border border-border focus:outline-none focus:ring-2 focus:ring-primary/40 text-sm resize-none ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+                                className={`text-sm resize-none ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
                               />
                             ) : (
-                              <input
+                              <Input
                                 id={`param-${field.variable}`}
                                 type="text"
                                 value={difyParams[field.variable] || ''}
@@ -382,7 +383,7 @@ const DifyBotConfig: React.FC<DifyBotConfigProps> = ({
                                 }}
                                 disabled={readOnly}
                                 placeholder={field.label?.en || field.label?.['en-US'] || ''}
-                                className={`w-full px-3 py-2 bg-base rounded-md text-text-primary placeholder:text-text-muted border border-border focus:outline-none focus:ring-2 focus:ring-primary/40 text-sm ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
+                                className={`text-sm ${readOnly ? 'cursor-not-allowed opacity-70' : ''}`}
                               />
                             )}
                           </div>

--- a/frontend/src/features/settings/components/SingleMcpServerEditModal.tsx
+++ b/frontend/src/features/settings/components/SingleMcpServerEditModal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -238,7 +239,7 @@ const SingleMcpServerEditModal: React.FC<SingleMcpServerEditModalProps> = ({
               <Label className="text-sm font-medium text-text-primary">
                 {t('common:bot.mcp_headers', 'Headers')} ({t('common:bot.optional', 'optional')})
               </Label>
-              <textarea
+              <Textarea
                 value={headers}
                 onChange={e => setHeaders(e.target.value)}
                 placeholder={t(
@@ -246,7 +247,7 @@ const SingleMcpServerEditModal: React.FC<SingleMcpServerEditModalProps> = ({
                   '{ "Authorization": "Bearer token" }'
                 )}
                 rows={3}
-                className="w-full px-3 py-2 bg-base border border-border rounded-md text-sm font-mono text-text-primary placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-primary/40 focus:border-primary resize-y"
+                className="text-sm font-mono resize-y"
               />
               <p className="text-xs text-text-muted">
                 {t('common:bot.mcp_headers_hint', 'JSON format')}


### PR DESCRIPTION
## 🐛 Bug Fix & Refactor

### Root Cause
Across the application (most notably in the "Create Agent" dialog), input fields and textareas exhibited a visual bug where the focus ring appeared "cut off" at the edges. 

This occurred because the default Tailwind `ring` utility expands **outwards** (similar to a box-shadow). When these elements were placed inside containers with `overflow: hidden` or tight padding/borders, the outer part of the focus ring was clipped by the parent container, resulting in an incomplete and unpolished look.

### Solution
Instead of manually patching individual instances with ad-hoc styles, this PR solves the issue using a "first principles" approach:

1.  **Updated Base Components**: Modified the shared `Input` and `Textarea` components in `src/components/ui/` to universally apply `focus-visible:ring-inset`. This forces the focus ring to be drawn **inside** the element's border, ensuring it is never clipped by surrounding containers, regardless of layout context.
    
2.  **Refactored Component Usage**: Replaced raw HTML `<input>` and `<textarea>` tags (which were using duplicated, inconsistent Tailwind classes) with the standardized `Input` and `Textarea` components in key affected areas:
    *   `BotEdit.tsx` (Agent configuration form)
    *   `LoginForm.tsx`
    *   `DifyBotConfig.tsx`
    *   `SearchBox.tsx`
    *   `SingleMcpServerEditModal.tsx`

### Benefits
*   **Visual Integrity**: Solves the clipping issue globally; the focus state is now fully visible in all contexts.
*   **Code Quality**: Significantly reduces code duplication by removing long, repetitive Tailwind class strings.
*   **Maintainability**: Future styling updates for inputs now only need to be applied in the base UI components.

BEFORE:
<img width="234" height="218" alt="image" src="https://github.com/user-attachments/assets/dfc00641-44b1-4ddc-8eae-b06b32a99c4d" />
<img width="346" height="332" alt="image" src="https://github.com/user-attachments/assets/fa42330e-6aaa-4dfc-837e-e14d69fd8a1a" />

AFTER:
<img width="334" height="172" alt="image" src="https://github.com/user-attachments/assets/1cd6490b-afba-482e-84aa-5c9dddf0a555" />
<img width="348" height="336" alt="image" src="https://github.com/user-attachments/assets/541a1979-b055-4096-8186-aa808d2880af" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized focus ring and text color styling for inputs and textareas across the app.
  * Replaced native form controls with shared UI input components to harmonize visuals.
  * Simplified input/textarea styling in login, search, settings, and configuration screens while preserving existing behaviors and bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->