### PR TITLE
feat: increase default MCP tool timeout from 60 to 180 seconds

### DIFF
--- a/chat_shell/chat_shell/tools/mcp/client.py
+++ b/chat_shell/chat_shell/tools/mcp/client.py
@@ -43,8 +43,8 @@ logger = logging.getLogger(__name__)
 # Type alias for connection types
 Connection = SSEConnection | StdioConnection | StreamableHttpConnection
 
-# Default timeout for MCP tool execution (60 seconds)
-DEFAULT_TOOL_TIMEOUT = 60.0
+# Default timeout for MCP tool execution (180 seconds)
+DEFAULT_TOOL_TIMEOUT = 180.0
 
 
 def wrap_tool_with_protection(


### PR DESCRIPTION
increase default MCP tool timeout from 60 to 180 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended tool execution timeout to allow longer completion times, reducing timeout errors and improving overall reliability during long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->