### PR TITLE
feat(subscription): add DingTalk group webhook notification support

### DIFF
--- a/backend/app/api/endpoints/admin/im_channels.py
+++ b/backend/app/api/endpoints/admin/im_channels.py
@@ -46,6 +46,8 @@ SENSITIVE_CONFIG_KEYS: Set[str] = {
     "encrypt_key",
     "encoding_aes_key",
     "bot_token",
+    "webhook_url",
+    "sign_secret",
 }
 
 
@@ -231,7 +233,7 @@ async def create_im_channel(
     Create a new IM channel.
     """
     # Validate channel type
-    valid_types = ["dingtalk", "feishu", "wechat", "telegram"]
+    valid_types = ["dingtalk", "dingtalk_group", "feishu", "wechat", "telegram"]
     if channel_data.channel_type not in valid_types:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/schemas/im_channel.py
+++ b/backend/app/schemas/im_channel.py
@@ -14,14 +14,15 @@ from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, field_validator
 
 # Channel type literals
-ChannelType = Literal["dingtalk", "feishu", "wechat", "telegram"]
+ChannelType = Literal["dingtalk", "dingtalk_group", "feishu", "wechat", "telegram"]
 
 
 class MessagerSpec(BaseModel):
     """Spec for Messager CRD."""
 
     channelType: ChannelType = Field(
-        ..., description="Channel type: dingtalk, feishu, wechat, telegram"
+        ...,
+        description="Channel type: dingtalk, dingtalk_group, feishu, wechat, telegram",
     )
     isEnabled: bool = Field(default=True, description="Whether channel is enabled")
     config: Dict[str, Any] = Field(
@@ -41,7 +42,8 @@ class IMChannelCreate(BaseModel):
     )
     namespace: str = Field(default="default", description="Namespace")
     channel_type: ChannelType = Field(
-        ..., description="Channel type: dingtalk, feishu, wechat, telegram"
+        ...,
+        description="Channel type: dingtalk, dingtalk_group, feishu, wechat, telegram",
     )
     config: Dict[str, Any] = Field(
         ..., description="Channel configuration (varies by type)"
@@ -152,6 +154,23 @@ class DingTalkChannelConfig(BaseModel):
     user_mapping_config: Optional[Dict[str, Any]] = Field(
         default=None,
         description="User mapping configuration. For select_user mode: {target_user_id: int}",
+    )
+
+
+class DingTalkGroupChannelConfig(BaseModel):
+    """Configuration schema for DingTalk Group Webhook channel.
+
+    This channel type is used for sending notifications to DingTalk groups
+    via webhook. Unlike the regular DingTalk channel, it does not require
+    user binding and sends messages directly to the group.
+    """
+
+    webhook_url: str = Field(
+        ..., description="DingTalk Group Webhook URL (includes access_token)"
+    )
+    sign_secret: Optional[str] = Field(
+        None,
+        description="Optional signing secret for HMAC-SHA256 signature verification",
     )
 
 

--- a/backend/app/services/channels/dingtalk/group_sender.py
+++ b/backend/app/services/channels/dingtalk/group_sender.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2025 Weco AI, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+DingTalk Group Webhook Message Sender.
+
+This module provides functionality to send messages to DingTalk groups
+via webhook. Used for subscription notifications to group chats.
+
+Unlike the regular DingTalk robot sender (which uses OAuth2 + oToMessages API),
+this sender uses the webhook URL directly with optional HMAC-SHA256 signing.
+
+API Reference:
+- Robot webhook: POST https://oapi.dingtalk.com/robot/send?access_token=xxx
+"""
+
+import base64
+import hashlib
+import hmac
+import logging
+import time
+import urllib.parse
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# DingTalk webhook message has a 20000 character limit
+DINGTALK_MESSAGE_CHAR_LIMIT = 20000
+
+
+class DingTalkGroupWebhookSender:
+    """Sender for DingTalk group webhook messages.
+
+    This class sends messages to DingTalk groups using the webhook API.
+    Supports optional HMAC-SHA256 signing for security.
+
+    Unlike DingTalkRobotSender which sends to individual users,
+    this sender broadcasts messages to an entire group chat.
+    """
+
+    def __init__(self, webhook_url: str, sign_secret: Optional[str] = None):
+        """Initialize the sender.
+
+        Args:
+            webhook_url: DingTalk group webhook URL (includes access_token)
+            sign_secret: Optional signing secret for HMAC-SHA256 signature
+        """
+        self.webhook_url = webhook_url
+        self.sign_secret = sign_secret
+
+    def _generate_signature(self, timestamp: int) -> str:
+        """Generate HMAC-SHA256 signature for webhook request.
+
+        The signature is calculated as:
+        1. Create string_to_sign = "{timestamp}\\n{secret}"
+        2. Calculate HMAC-SHA256 using secret as key
+        3. Base64 encode the result
+        4. URL encode the base64 string
+
+        Args:
+            timestamp: Current timestamp in milliseconds
+
+        Returns:
+            URL-encoded base64 signature
+        """
+        if not self.sign_secret:
+            return ""
+
+        string_to_sign = f"{timestamp}\n{self.sign_secret}"
+        hmac_code = hmac.new(
+            self.sign_secret.encode("utf-8"),
+            string_to_sign.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).digest()
+        sign = urllib.parse.quote_plus(base64.b64encode(hmac_code).decode("utf-8"))
+        return sign
+
+    def _build_url(self) -> str:
+        """Build the webhook URL with optional signature.
+
+        If sign_secret is configured, appends timestamp and sign parameters
+        to the webhook URL for security verification.
+
+        Returns:
+            Complete webhook URL with timestamp and signature if configured
+        """
+        url = self.webhook_url
+
+        if self.sign_secret:
+            timestamp = int(time.time() * 1000)
+            sign = self._generate_signature(timestamp)
+            separator = "&" if "?" in url else "?"
+            url = f"{url}{separator}timestamp={timestamp}&sign={sign}"
+
+        return url
+
+    async def send_markdown_message(
+        self,
+        title: str,
+        text: str,
+    ) -> Dict[str, Any]:
+        """Send markdown message to DingTalk group.
+
+        Args:
+            title: Message title (shown in notification preview)
+            text: Markdown text content
+
+        Returns:
+            API response dict with success status
+        """
+        # Handle message length limit
+        original_length = len(text)
+        if original_length > DINGTALK_MESSAGE_CHAR_LIMIT:
+            truncated_notice = "\n\n---\n*内容过长已截断，请查看详情链接*"
+            max_text_len = DINGTALK_MESSAGE_CHAR_LIMIT - len(truncated_notice)
+            text = text[:max_text_len] + truncated_notice
+            logger.warning(
+                f"[DingTalkGroupWebhook] Message truncated from {original_length} "
+                f"to {DINGTALK_MESSAGE_CHAR_LIMIT} chars"
+            )
+
+        return await self._send_message(
+            msg_type="markdown",
+            content={"title": title, "text": text},
+        )
+
+    async def send_text_message(self, content: str) -> Dict[str, Any]:
+        """Send text message to DingTalk group.
+
+        Args:
+            content: Text message content
+
+        Returns:
+            API response dict with success status
+        """
+        # Handle message length limit
+        original_length = len(content)
+        if original_length > DINGTALK_MESSAGE_CHAR_LIMIT:
+            truncated_notice = "... (内容过长已截断)"
+            max_text_len = DINGTALK_MESSAGE_CHAR_LIMIT - len(truncated_notice)
+            content = content[:max_text_len] + truncated_notice
+            logger.warning(
+                f"[DingTalkGroupWebhook] Message truncated from {original_length} "
+                f"to {DINGTALK_MESSAGE_CHAR_LIMIT} chars"
+            )
+
+        return await self._send_message(
+            msg_type="text",
+            content={"content": content},
+        )
+
+    async def _send_message(
+        self,
+        msg_type: str,
+        content: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Send message to DingTalk group via webhook.
+
+        Args:
+            msg_type: Message type ("text" or "markdown")
+            content: Message content dict
+
+        Returns:
+            API response dict with success/error status
+        """
+        try:
+            url = self._build_url()
+            payload = {"msgtype": msg_type, msg_type: content}
+
+            logger.info(
+                f"[DingTalkGroupWebhook] Sending {msg_type} message, "
+                f"content_length={len(str(content))}"
+            )
+
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                # DingTalk returns errcode: 0 on success
+                if data.get("errcode") == 0:
+                    logger.info("[DingTalkGroupWebhook] Message sent successfully")
+                    return {"success": True, "result": data}
+                else:
+                    error_code = data.get("errcode", "UNKNOWN")
+                    error_msg = data.get("errmsg", "Unknown error")
+                    logger.error(
+                        f"[DingTalkGroupWebhook] API error: {error_code} - {error_msg}"
+                    )
+                    return {"success": False, "error": f"{error_code}: {error_msg}"}
+
+        except httpx.HTTPStatusError as e:
+            error_data = {}
+            try:
+                error_data = e.response.json()
+            except Exception:
+                pass
+
+            error_code = error_data.get("errcode", "HTTP_ERROR")
+            error_msg = error_data.get("errmsg", str(e))
+            logger.error(
+                f"[DingTalkGroupWebhook] HTTP error: {error_code} - {error_msg}"
+            )
+            return {"success": False, "error": f"{error_code}: {error_msg}"}
+
+        except httpx.TimeoutException:
+            logger.error("[DingTalkGroupWebhook] Request timeout")
+            return {"success": False, "error": "Request timeout"}
+
+        except Exception as e:
+            logger.error(f"[DingTalkGroupWebhook] Error: {e}")
+            return {"success": False, "error": str(e)}

--- a/backend/app/services/subscription/notification_dispatcher.py
+++ b/backend/app/services/subscription/notification_dispatcher.py
@@ -169,7 +169,7 @@ class SubscriptionNotificationDispatcher:
             db, user_id=user_id
         )
 
-        # Format the notification message
+        # Format the notification message (truncated for single-user channels)
         logger.info(
             f"[_send_messager_notifications] Formatting message with detail_url: {detail_url}"
         )
@@ -180,20 +180,18 @@ class SubscriptionNotificationDispatcher:
             detail_url=detail_url,
         )
 
+        # Format the full notification message (for group channels)
+        group_message = self._format_group_notification_message(
+            subscription_display_name=subscription_display_name,
+            status=status,
+            result_summary=result_summary,
+            detail_url=detail_url,
+        )
+
         # Send to each configured channel
         tasks = []
         for channel_id in channel_ids:
             channel_id_str = str(channel_id)
-
-            # Check if user has binding for this channel
-            if channel_id_str not in user_bindings:
-                logger.warning(
-                    f"[SubscriptionNotificationDispatcher] User {user_id} has no binding "
-                    f"for channel {channel_id}"
-                )
-                continue
-
-            binding = user_bindings[channel_id_str]
 
             # Get channel info
             channel = (
@@ -216,7 +214,26 @@ class SubscriptionNotificationDispatcher:
             channel_type = spec.get("channelType", "")
 
             # Dispatch based on channel type
-            if channel_type == "dingtalk":
+            if channel_type == "dingtalk_group":
+                # dingtalk_group sends directly to webhook, no user binding needed
+                tasks.append(
+                    self._send_dingtalk_group_notification(
+                        db=db,
+                        channel=channel,
+                        message=group_message,
+                        subscription_id=subscription_id,
+                        execution_id=execution_id,
+                    )
+                )
+            elif channel_type == "dingtalk":
+                # Check if user has binding for this channel
+                if channel_id_str not in user_bindings:
+                    logger.warning(
+                        f"[SubscriptionNotificationDispatcher] User {user_id} has no binding "
+                        f"for channel {channel_id}"
+                    )
+                    continue
+                binding = user_bindings[channel_id_str]
                 tasks.append(
                     self._send_dingtalk_notification(
                         db=db,
@@ -229,6 +246,14 @@ class SubscriptionNotificationDispatcher:
                     )
                 )
             elif channel_type == "telegram":
+                # Check if user has binding for this channel
+                if channel_id_str not in user_bindings:
+                    logger.warning(
+                        f"[SubscriptionNotificationDispatcher] User {user_id} has no binding "
+                        f"for channel {channel_id}"
+                    )
+                    continue
+                binding = user_bindings[channel_id_str]
                 tasks.append(
                     self._send_telegram_notification(
                         db=db,
@@ -421,6 +446,91 @@ class SubscriptionNotificationDispatcher:
             )
             raise
 
+    async def _send_dingtalk_group_notification(
+        self,
+        db: Session,
+        *,
+        channel: Kind,
+        message: str,
+        subscription_id: int,
+        execution_id: int,
+    ) -> None:
+        """
+        Send notification to DingTalk group via webhook.
+
+        Unlike single-chat DingTalk notifications, group notifications
+        don't require user binding - they send directly to the group webhook.
+
+        Args:
+            db: Database session
+            channel: Messager Kind
+            message: Notification message (full content)
+            subscription_id: Subscription ID
+            execution_id: Background execution ID
+        """
+        try:
+            # Get channel config
+            spec = channel.json.get("spec", {})
+            config = spec.get("config", {})
+            webhook_url_encrypted = config.get("webhook_url")
+            sign_secret_encrypted = config.get("sign_secret")
+
+            if not webhook_url_encrypted:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] Channel {channel.id} missing "
+                    f"webhook_url"
+                )
+                return
+
+            # Decrypt the sensitive fields
+            from shared.utils.crypto import decrypt_sensitive_data
+
+            webhook_url = decrypt_sensitive_data(webhook_url_encrypted)
+            sign_secret = (
+                decrypt_sensitive_data(sign_secret_encrypted)
+                if sign_secret_encrypted
+                else None
+            )
+
+            # Send message via group webhook
+            from app.services.channels.dingtalk.group_sender import (
+                DingTalkGroupWebhookSender,
+            )
+
+            sender = DingTalkGroupWebhookSender(
+                webhook_url=webhook_url,
+                sign_secret=sign_secret,
+            )
+
+            logger.info(
+                f"[_send_dingtalk_group_notification] Sending message to group, "
+                f"channel_id={channel.id}, message_length={len(message)}"
+            )
+
+            result = await sender.send_markdown_message(
+                title="订阅通知",
+                text=message,
+            )
+
+            if result.get("success"):
+                logger.info(
+                    f"[SubscriptionNotificationDispatcher] Sent DingTalk group notification "
+                    f"to channel {channel.id} (subscription={subscription_id}, "
+                    f"execution={execution_id})"
+                )
+            else:
+                logger.warning(
+                    f"[SubscriptionNotificationDispatcher] Failed to send DingTalk group "
+                    f"notification to channel {channel.id}: {result.get('error')}"
+                )
+
+        except Exception as e:
+            logger.error(
+                f"[SubscriptionNotificationDispatcher] Failed to send DingTalk group "
+                f"notification to channel {channel.id}: {e}"
+            )
+            raise
+
     def _format_notification_message(
         self,
         *,
@@ -465,6 +575,55 @@ class SubscriptionNotificationDispatcher:
 
         if detail_url:
             message_lines.extend(["", f"[查看详情]({detail_url})"])
+
+        # Join with explicit newlines for better DingTalk rendering
+        message = "\n".join(message_lines)
+
+        return message
+
+    def _format_group_notification_message(
+        self,
+        *,
+        subscription_display_name: str,
+        status: str,
+        result_summary: str,
+        detail_url: Optional[str] = None,
+    ) -> str:
+        """
+        Format the notification message for group channels (full content).
+
+        Unlike _format_notification_message which truncates to 300 chars,
+        this method sends the full result_summary for group channels.
+        The DingTalkGroupWebhookSender handles the 20000 char limit internally.
+
+        Args:
+            subscription_display_name: Display name of the subscription
+            status: Execution status
+            result_summary: Full execution result (not truncated)
+            detail_url: URL to view execution details
+
+        Returns:
+            Formatted notification message with full content
+        """
+        status_emoji = "✅" if status == "COMPLETED" else "❌"
+        status_text = "执行成功" if status == "COMPLETED" else "执行失败"
+
+        # For group notifications, send full result_summary without truncation
+        # For DingTalk markdown, use explicit line breaks with double newlines
+        message_lines = [
+            "📬 **订阅任务通知**",
+            "",
+            f"**订阅名称**: {subscription_display_name}",
+            "",
+            f"**执行状态**: {status_emoji} {status_text}",
+            "",
+            "**执行结果**:",
+            "",
+            result_summary,
+        ]
+
+        if detail_url:
+            message_lines.extend(["", "---", f"[查看详情]({detail_url})"])
 
         # Join with explicit newlines for better DingTalk rendering
         message = "\n".join(message_lines)

--- a/backend/app/services/subscription/notification_service.py
+++ b/backend/app/services/subscription/notification_service.py
@@ -553,6 +553,12 @@ class SubscriptionNotificationService:
             if not spec.get("isEnabled", True):
                 continue
 
+            channel_type = spec.get("channelType", "unknown")
+            # dingtalk_group channels don't require user binding - they send directly to webhook
+            is_bound = (
+                channel_type == "dingtalk_group" or str(channel.id) in user_bindings
+            )
+
             channel_info = NotificationChannelInfo(
                 id=channel.id,
                 name=(
@@ -560,8 +566,8 @@ class SubscriptionNotificationService:
                     if channel.json
                     else channel.name
                 ),
-                channel_type=spec.get("channelType", "unknown"),
-                is_bound=str(channel.id) in user_bindings,
+                channel_type=channel_type,
+                is_bound=is_bound,
             )
             result.append(channel_info)
 
@@ -605,6 +611,12 @@ class SubscriptionNotificationService:
         for channel in channels:
             # Get spec from json field for Messager kind
             spec = channel.json.get("spec", {}) if channel.json else {}
+            channel_type = spec.get("channelType", "unknown")
+            # dingtalk_group channels don't require user binding - they send directly to webhook
+            is_bound = (
+                channel_type == "dingtalk_group" or str(channel.id) in user_bindings
+            )
+
             channel_info = NotificationChannelInfo(
                 id=channel.id,
                 name=(
@@ -612,8 +624,8 @@ class SubscriptionNotificationService:
                     if channel.json
                     else channel.name
                 ),
-                channel_type=spec.get("channelType", "unknown"),
-                is_bound=str(channel.id) in user_bindings,
+                channel_type=channel_type,
+                is_bound=is_bound,
             )
             result.append(channel_info)
 

--- a/frontend/src/apis/admin.ts
+++ b/frontend/src/apis/admin.ts
@@ -361,7 +361,7 @@ export interface AdminPublicShellUpdate {
 }
 
 // IM Channel Types
-export type IMChannelType = 'dingtalk' | 'feishu' | 'wechat' | 'telegram'
+export type IMChannelType = 'dingtalk' | 'dingtalk_group' | 'feishu' | 'wechat' | 'telegram'
 
 export interface IMChannel {
   id: number

--- a/frontend/src/features/admin/components/IMChannelList.tsx
+++ b/frontend/src/features/admin/components/IMChannelList.tsx
@@ -95,6 +95,8 @@ const IMChannelList: React.FC = () => {
     client_id: string
     client_secret: string
     bot_token: string
+    webhook_url: string
+    sign_secret: string
     user_mapping_mode: UserMappingMode
     target_user_id: number
   }>({
@@ -106,6 +108,8 @@ const IMChannelList: React.FC = () => {
     client_id: '',
     client_secret: '',
     bot_token: '',
+    webhook_url: '',
+    sign_secret: '',
     user_mapping_mode: 'select_user',
     target_user_id: 0,
   })
@@ -253,6 +257,14 @@ const IMChannelList: React.FC = () => {
         })
         return
       }
+    } else if (formData.channel_type === 'dingtalk_group') {
+      if (!formData.webhook_url.trim()) {
+        toast({
+          variant: 'destructive',
+          title: t('admin:im_channels.errors.webhook_url_required'),
+        })
+        return
+      }
     } else {
       // DingTalk and other channels use client_id/client_secret
       if (!formData.client_id.trim() || !formData.client_secret.trim()) {
@@ -264,8 +276,8 @@ const IMChannelList: React.FC = () => {
       }
     }
 
-    // Validate: default team is required
-    if (!formData.default_team_id) {
+    // Validate: default team is required (except for dingtalk_group which is notification-only)
+    if (formData.channel_type !== 'dingtalk_group' && !formData.default_team_id) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.team_required'),
@@ -273,8 +285,12 @@ const IMChannelList: React.FC = () => {
       return
     }
 
-    // Validate: if team has no model, must select a default model
-    if (!teamHasModel(formData.default_team_id) && !formData.default_model_name) {
+    // Validate: if team has no model, must select a default model (not applicable for dingtalk_group)
+    if (
+      formData.channel_type !== 'dingtalk_group' &&
+      !teamHasModel(formData.default_team_id) &&
+      !formData.default_model_name
+    ) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.model_required_for_team'),
@@ -282,8 +298,12 @@ const IMChannelList: React.FC = () => {
       return
     }
 
-    // Validate: if select_user mode, must select a target user
-    if (formData.user_mapping_mode === 'select_user' && !formData.target_user_id) {
+    // Validate: if select_user mode, must select a target user (not applicable for dingtalk_group)
+    if (
+      formData.channel_type !== 'dingtalk_group' &&
+      formData.user_mapping_mode === 'select_user' &&
+      !formData.target_user_id
+    ) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.target_user_required'),
@@ -294,19 +314,28 @@ const IMChannelList: React.FC = () => {
     setSaving(true)
     try {
       // Build config based on channel type
-      const config: Record<string, unknown> = {
-        user_mapping_mode: formData.user_mapping_mode,
-      }
+      const config: Record<string, unknown> = {}
 
       if (formData.channel_type === 'telegram') {
         config.bot_token = formData.bot_token.trim()
+        config.user_mapping_mode = formData.user_mapping_mode
+      } else if (formData.channel_type === 'dingtalk_group') {
+        config.webhook_url = formData.webhook_url.trim()
+        if (formData.sign_secret.trim()) {
+          config.sign_secret = formData.sign_secret.trim()
+        }
       } else {
         config.client_id = formData.client_id.trim()
         config.client_secret = formData.client_secret.trim()
+        config.user_mapping_mode = formData.user_mapping_mode
       }
 
-      // Add user_mapping_config if select_user mode
-      if (formData.user_mapping_mode === 'select_user' && formData.target_user_id) {
+      // Add user_mapping_config if select_user mode (not for dingtalk_group)
+      if (
+        formData.channel_type !== 'dingtalk_group' &&
+        formData.user_mapping_mode === 'select_user' &&
+        formData.target_user_id
+      ) {
         config.user_mapping_config = {
           target_user_id: formData.target_user_id,
         }
@@ -316,8 +345,11 @@ const IMChannelList: React.FC = () => {
         name: formData.name.trim(),
         channel_type: formData.channel_type,
         is_enabled: formData.is_enabled,
-        default_team_id: formData.default_team_id,
-        default_model_name: formData.default_model_name || undefined,
+        default_team_id: formData.channel_type === 'dingtalk_group' ? 0 : formData.default_team_id,
+        default_model_name:
+          formData.channel_type === 'dingtalk_group'
+            ? undefined
+            : formData.default_model_name || undefined,
         config,
       }
       await adminApis.createIMChannel(createData)
@@ -339,8 +371,8 @@ const IMChannelList: React.FC = () => {
   const handleUpdateChannel = async () => {
     if (!selectedChannel) return
 
-    // Validate: default team is required
-    if (!formData.default_team_id) {
+    // Validate: default team is required (except for dingtalk_group which is notification-only)
+    if (selectedChannel.channel_type !== 'dingtalk_group' && !formData.default_team_id) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.team_required'),
@@ -348,8 +380,12 @@ const IMChannelList: React.FC = () => {
       return
     }
 
-    // Validate: if team has no model, must select a default model
-    if (!teamHasModel(formData.default_team_id) && !formData.default_model_name) {
+    // Validate: if team has no model, must select a default model (not applicable for dingtalk_group)
+    if (
+      selectedChannel.channel_type !== 'dingtalk_group' &&
+      !teamHasModel(formData.default_team_id) &&
+      !formData.default_model_name
+    ) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.model_required_for_team'),
@@ -357,8 +393,12 @@ const IMChannelList: React.FC = () => {
       return
     }
 
-    // Validate: if select_user mode, must select a target user
-    if (formData.user_mapping_mode === 'select_user' && !formData.target_user_id) {
+    // Validate: if select_user mode, must select a target user (not applicable for dingtalk_group)
+    if (
+      selectedChannel.channel_type !== 'dingtalk_group' &&
+      formData.user_mapping_mode === 'select_user' &&
+      !formData.target_user_id
+    ) {
       toast({
         variant: 'destructive',
         title: t('admin:im_channels.errors.target_user_required'),
@@ -383,15 +423,22 @@ const IMChannelList: React.FC = () => {
       }
 
       // Build config based on channel type
-      const newConfig: Record<string, unknown> = {
-        user_mapping_mode: formData.user_mapping_mode,
-      }
+      const newConfig: Record<string, unknown> = {}
 
       if (selectedChannel.channel_type === 'telegram') {
+        newConfig.user_mapping_mode = formData.user_mapping_mode
         if (formData.bot_token.trim()) {
           newConfig.bot_token = formData.bot_token.trim()
         }
+      } else if (selectedChannel.channel_type === 'dingtalk_group') {
+        if (formData.webhook_url.trim()) {
+          newConfig.webhook_url = formData.webhook_url.trim()
+        }
+        if (formData.sign_secret.trim()) {
+          newConfig.sign_secret = formData.sign_secret.trim()
+        }
       } else {
+        newConfig.user_mapping_mode = formData.user_mapping_mode
         if (formData.client_id.trim()) {
           newConfig.client_id = formData.client_id.trim()
         }
@@ -400,8 +447,12 @@ const IMChannelList: React.FC = () => {
         }
       }
 
-      // Add user_mapping_config if select_user mode
-      if (formData.user_mapping_mode === 'select_user' && formData.target_user_id) {
+      // Add user_mapping_config if select_user mode (not for dingtalk_group)
+      if (
+        selectedChannel.channel_type !== 'dingtalk_group' &&
+        formData.user_mapping_mode === 'select_user' &&
+        formData.target_user_id
+      ) {
         newConfig.user_mapping_config = {
           target_user_id: formData.target_user_id,
         }
@@ -488,6 +539,8 @@ const IMChannelList: React.FC = () => {
       client_id: '',
       client_secret: '',
       bot_token: '',
+      webhook_url: '',
+      sign_secret: '',
       user_mapping_mode: 'select_user',
       target_user_id: 0,
     })
@@ -512,6 +565,8 @@ const IMChannelList: React.FC = () => {
       client_id: (channel.config?.client_id as string) || '',
       client_secret: '', // Don't show existing secret
       bot_token: '', // Don't show existing bot_token
+      webhook_url: '', // Don't show existing webhook_url
+      sign_secret: '', // Don't show existing sign_secret
       user_mapping_mode: userMappingMode,
       target_user_id: targetUserId,
     })
@@ -528,6 +583,8 @@ const IMChannelList: React.FC = () => {
     switch (type) {
       case 'dingtalk':
         return t('admin:im_channels.types.dingtalk')
+      case 'dingtalk_group':
+        return t('admin:im_channels.types.dingtalk_group')
       case 'feishu':
         return t('admin:im_channels.types.feishu')
       case 'wechat':
@@ -718,6 +775,9 @@ const IMChannelList: React.FC = () => {
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="dingtalk">{t('admin:im_channels.types.dingtalk')}</SelectItem>
+                  <SelectItem value="dingtalk_group">
+                    {t('admin:im_channels.types.dingtalk_group')}
+                  </SelectItem>
                   <SelectItem value="telegram">{t('admin:im_channels.types.telegram')}</SelectItem>
                   <SelectItem value="feishu" disabled>
                     {t('admin:im_channels.types.feishu')} (
@@ -726,7 +786,7 @@ const IMChannelList: React.FC = () => {
                 </SelectContent>
               </Select>
             </div>
-            {/* Telegram uses bot_token, other channels use client_id/client_secret */}
+            {/* Telegram uses bot_token, dingtalk_group uses webhook_url, other channels use client_id/client_secret */}
             {formData.channel_type === 'telegram' ? (
               <div className="space-y-2">
                 <Label htmlFor="bot_token">{t('admin:im_channels.form.bot_token')} *</Label>
@@ -738,6 +798,32 @@ const IMChannelList: React.FC = () => {
                   placeholder={t('admin:im_channels.form.bot_token_placeholder')}
                 />
               </div>
+            ) : formData.channel_type === 'dingtalk_group' ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="webhook_url">{t('admin:im_channels.form.webhook_url')} *</Label>
+                  <Input
+                    id="webhook_url"
+                    type="text"
+                    value={formData.webhook_url}
+                    onChange={e => setFormData({ ...formData, webhook_url: e.target.value })}
+                    placeholder={t('admin:im_channels.form.webhook_url_placeholder')}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="sign_secret">{t('admin:im_channels.form.sign_secret')}</Label>
+                  <Input
+                    id="sign_secret"
+                    type="password"
+                    value={formData.sign_secret}
+                    onChange={e => setFormData({ ...formData, sign_secret: e.target.value })}
+                    placeholder={t('admin:im_channels.form.sign_secret_placeholder')}
+                  />
+                  <p className="text-xs text-text-muted">
+                    {t('admin:im_channels.form.sign_secret_description')}
+                  </p>
+                </div>
+              </>
             ) : (
               <>
                 <div className="space-y-2">
@@ -763,121 +849,128 @@ const IMChannelList: React.FC = () => {
                 </div>
               </>
             )}
-            <div className="space-y-2">
-              <Label htmlFor="default_team">{t('admin:im_channels.form.default_team')} *</Label>
-              <Select
-                value={formData.default_team_id ? formData.default_team_id.toString() : ''}
-                onValueChange={value =>
-                  setFormData({ ...formData, default_team_id: parseInt(value) })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t('admin:im_channels.form.default_team_placeholder')} />
-                </SelectTrigger>
-                <SelectContent>
-                  {teams.map(team => (
-                    <SelectItem key={team.id} value={team.id.toString()}>
-                      {team.display_name || team.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
-                <p className="text-xs text-amber-600">
-                  {t('admin:im_channels.form.team_no_model_warning')}
-                </p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="default_model">
-                {t('admin:im_channels.form.default_model')}
-                {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
-                  <span className="text-red-500 ml-1">*</span>
-                )}
-              </Label>
-              <Select
-                value={formData.default_model_name || '__none__'}
-                onValueChange={value =>
-                  setFormData({
-                    ...formData,
-                    default_model_name: value === '__none__' ? '' : value,
-                  })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={t('admin:im_channels.form.default_model_placeholder')}
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">
-                    {t('admin:im_channels.form.no_default_model')}
-                  </SelectItem>
-                  {models.map(model => (
-                    <SelectItem key={model.id} value={model.name}>
-                      {model.display_name || model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* User Mapping Mode */}
-            <div className="space-y-2">
-              <Label htmlFor="user_mapping_mode">
-                {t('admin:im_channels.form.user_mapping_mode')} *
-              </Label>
-              <Select
-                value={formData.user_mapping_mode}
-                onValueChange={value =>
-                  setFormData({ ...formData, user_mapping_mode: value as UserMappingMode })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="select_user">
-                    {t('admin:im_channels.form.user_mapping_modes.select_user')}
-                  </SelectItem>
-                  <SelectItem value="staff_id">
-                    {t('admin:im_channels.form.user_mapping_modes.staff_id')}
-                  </SelectItem>
-                  <SelectItem value="email">
-                    {t('admin:im_channels.form.user_mapping_modes.email')}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-text-muted">
-                {t('admin:im_channels.form.user_mapping_mode_description')}
-              </p>
-            </div>
-            {/* Target User (only for select_user mode) */}
-            {formData.user_mapping_mode === 'select_user' && (
-              <div className="space-y-2">
-                <Label htmlFor="target_user">{t('admin:im_channels.form.target_user')} *</Label>
-                <Select
-                  value={formData.target_user_id ? formData.target_user_id.toString() : ''}
-                  onValueChange={value =>
-                    setFormData({ ...formData, target_user_id: parseInt(value) })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue
-                      placeholder={t('admin:im_channels.form.select_user_placeholder')}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {users.map(user => (
-                      <SelectItem key={user.id} value={user.id.toString()}>
-                        {user.user_name} ({user.email || user.id})
+            {/* Default team and model selection - not shown for dingtalk_group */}
+            {formData.channel_type !== 'dingtalk_group' && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="default_team">{t('admin:im_channels.form.default_team')} *</Label>
+                  <Select
+                    value={formData.default_team_id ? formData.default_team_id.toString() : ''}
+                    onValueChange={value =>
+                      setFormData({ ...formData, default_team_id: parseInt(value) })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={t('admin:im_channels.form.default_team_placeholder')}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teams.map(team => (
+                        <SelectItem key={team.id} value={team.id.toString()}>
+                          {team.display_name || team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
+                    <p className="text-xs text-amber-600">
+                      {t('admin:im_channels.form.team_no_model_warning')}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="default_model">
+                    {t('admin:im_channels.form.default_model')}
+                    {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
+                      <span className="text-red-500 ml-1">*</span>
+                    )}
+                  </Label>
+                  <Select
+                    value={formData.default_model_name || '__none__'}
+                    onValueChange={value =>
+                      setFormData({
+                        ...formData,
+                        default_model_name: value === '__none__' ? '' : value,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={t('admin:im_channels.form.default_model_placeholder')}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">
+                        {t('admin:im_channels.form.no_default_model')}
                       </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-text-muted">
-                  {t('admin:im_channels.form.target_user_description')}
-                </p>
-              </div>
+                      {models.map(model => (
+                        <SelectItem key={model.id} value={model.name}>
+                          {model.display_name || model.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {/* User Mapping Mode */}
+                <div className="space-y-2">
+                  <Label htmlFor="user_mapping_mode">
+                    {t('admin:im_channels.form.user_mapping_mode')} *
+                  </Label>
+                  <Select
+                    value={formData.user_mapping_mode}
+                    onValueChange={value =>
+                      setFormData({ ...formData, user_mapping_mode: value as UserMappingMode })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="select_user">
+                        {t('admin:im_channels.form.user_mapping_modes.select_user')}
+                      </SelectItem>
+                      <SelectItem value="staff_id">
+                        {t('admin:im_channels.form.user_mapping_modes.staff_id')}
+                      </SelectItem>
+                      <SelectItem value="email">
+                        {t('admin:im_channels.form.user_mapping_modes.email')}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-text-muted">
+                    {t('admin:im_channels.form.user_mapping_mode_description')}
+                  </p>
+                </div>
+                {/* Target User (only for select_user mode) */}
+                {formData.user_mapping_mode === 'select_user' && (
+                  <div className="space-y-2">
+                    <Label htmlFor="target_user">{t('admin:im_channels.form.target_user')} *</Label>
+                    <Select
+                      value={formData.target_user_id ? formData.target_user_id.toString() : ''}
+                      onValueChange={value =>
+                        setFormData({ ...formData, target_user_id: parseInt(value) })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={t('admin:im_channels.form.select_user_placeholder')}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {users.map(user => (
+                          <SelectItem key={user.id} value={user.id.toString()}>
+                            {user.user_name} ({user.email || user.id})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-text-muted">
+                      {t('admin:im_channels.form.target_user_description')}
+                    </p>
+                  </div>
+                )}
+              </>
             )}
             <div className="flex items-center justify-between">
               <Label htmlFor="is_enabled">{t('admin:im_channels.form.is_enabled')}</Label>
@@ -924,7 +1017,7 @@ const IMChannelList: React.FC = () => {
                 className="bg-muted"
               />
             </div>
-            {/* Telegram uses bot_token, other channels use client_id/client_secret */}
+            {/* Telegram uses bot_token, dingtalk_group uses webhook_url, other channels use client_id/client_secret */}
             {formData.channel_type === 'telegram' ? (
               <div className="space-y-2">
                 <Label htmlFor="edit-bot_token">
@@ -941,6 +1034,42 @@ const IMChannelList: React.FC = () => {
                   placeholder={t('admin:im_channels.form.bot_token_edit_placeholder')}
                 />
               </div>
+            ) : formData.channel_type === 'dingtalk_group' ? (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-webhook_url">
+                    {t('admin:im_channels.form.webhook_url')}
+                    <span className="text-xs text-text-muted ml-2">
+                      ({t('admin:im_channels.form.leave_empty_to_keep')})
+                    </span>
+                  </Label>
+                  <Input
+                    id="edit-webhook_url"
+                    type="text"
+                    value={formData.webhook_url}
+                    onChange={e => setFormData({ ...formData, webhook_url: e.target.value })}
+                    placeholder={t('admin:im_channels.form.webhook_url_edit_placeholder')}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-sign_secret">
+                    {t('admin:im_channels.form.sign_secret')}
+                    <span className="text-xs text-text-muted ml-2">
+                      ({t('admin:im_channels.form.leave_empty_to_keep')})
+                    </span>
+                  </Label>
+                  <Input
+                    id="edit-sign_secret"
+                    type="password"
+                    value={formData.sign_secret}
+                    onChange={e => setFormData({ ...formData, sign_secret: e.target.value })}
+                    placeholder={t('admin:im_channels.form.sign_secret_edit_placeholder')}
+                  />
+                  <p className="text-xs text-text-muted">
+                    {t('admin:im_channels.form.sign_secret_description')}
+                  </p>
+                </div>
+              </>
             ) : (
               <>
                 <div className="space-y-2">
@@ -969,125 +1098,132 @@ const IMChannelList: React.FC = () => {
                 </div>
               </>
             )}
-            <div className="space-y-2">
-              <Label htmlFor="edit-default_team">
-                {t('admin:im_channels.form.default_team')} *
-              </Label>
-              <Select
-                value={formData.default_team_id ? formData.default_team_id.toString() : ''}
-                onValueChange={value =>
-                  setFormData({ ...formData, default_team_id: parseInt(value) })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t('admin:im_channels.form.default_team_placeholder')} />
-                </SelectTrigger>
-                <SelectContent>
-                  {teams.map(team => (
-                    <SelectItem key={team.id} value={team.id.toString()}>
-                      {team.display_name || team.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
-                <p className="text-xs text-amber-600">
-                  {t('admin:im_channels.form.team_no_model_warning')}
-                </p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="edit-default_model">
-                {t('admin:im_channels.form.default_model')}
-                {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
-                  <span className="text-red-500 ml-1">*</span>
-                )}
-              </Label>
-              <Select
-                value={formData.default_model_name || '__none__'}
-                onValueChange={value =>
-                  setFormData({
-                    ...formData,
-                    default_model_name: value === '__none__' ? '' : value,
-                  })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue
-                    placeholder={t('admin:im_channels.form.default_model_placeholder')}
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__none__">
-                    {t('admin:im_channels.form.no_default_model')}
-                  </SelectItem>
-                  {models.map(model => (
-                    <SelectItem key={model.id} value={model.name}>
-                      {model.display_name || model.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {/* User Mapping Mode */}
-            <div className="space-y-2">
-              <Label htmlFor="edit-user_mapping_mode">
-                {t('admin:im_channels.form.user_mapping_mode')} *
-              </Label>
-              <Select
-                value={formData.user_mapping_mode}
-                onValueChange={value =>
-                  setFormData({ ...formData, user_mapping_mode: value as UserMappingMode })
-                }
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="select_user">
-                    {t('admin:im_channels.form.user_mapping_modes.select_user')}
-                  </SelectItem>
-                  <SelectItem value="staff_id">
-                    {t('admin:im_channels.form.user_mapping_modes.staff_id')}
-                  </SelectItem>
-                  <SelectItem value="email">
-                    {t('admin:im_channels.form.user_mapping_modes.email')}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-text-muted">
-                {t('admin:im_channels.form.user_mapping_mode_description')}
-              </p>
-            </div>
-            {/* Target User (only for select_user mode) */}
-            {formData.user_mapping_mode === 'select_user' && (
-              <div className="space-y-2">
-                <Label htmlFor="edit-target_user">
-                  {t('admin:im_channels.form.target_user')} *
-                </Label>
-                <Select
-                  value={formData.target_user_id ? formData.target_user_id.toString() : ''}
-                  onValueChange={value =>
-                    setFormData({ ...formData, target_user_id: parseInt(value) })
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue
-                      placeholder={t('admin:im_channels.form.select_user_placeholder')}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {users.map(user => (
-                      <SelectItem key={user.id} value={user.id.toString()}>
-                        {user.user_name} ({user.email || user.id})
+            {/* Default team and model selection - not shown for dingtalk_group */}
+            {formData.channel_type !== 'dingtalk_group' && (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-default_team">
+                    {t('admin:im_channels.form.default_team')} *
+                  </Label>
+                  <Select
+                    value={formData.default_team_id ? formData.default_team_id.toString() : ''}
+                    onValueChange={value =>
+                      setFormData({ ...formData, default_team_id: parseInt(value) })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={t('admin:im_channels.form.default_team_placeholder')}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {teams.map(team => (
+                        <SelectItem key={team.id} value={team.id.toString()}>
+                          {team.display_name || team.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
+                    <p className="text-xs text-amber-600">
+                      {t('admin:im_channels.form.team_no_model_warning')}
+                    </p>
+                  )}
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-default_model">
+                    {t('admin:im_channels.form.default_model')}
+                    {formData.default_team_id > 0 && !teamHasModel(formData.default_team_id) && (
+                      <span className="text-red-500 ml-1">*</span>
+                    )}
+                  </Label>
+                  <Select
+                    value={formData.default_model_name || '__none__'}
+                    onValueChange={value =>
+                      setFormData({
+                        ...formData,
+                        default_model_name: value === '__none__' ? '' : value,
+                      })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue
+                        placeholder={t('admin:im_channels.form.default_model_placeholder')}
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">
+                        {t('admin:im_channels.form.no_default_model')}
                       </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-xs text-text-muted">
-                  {t('admin:im_channels.form.target_user_description')}
-                </p>
-              </div>
+                      {models.map(model => (
+                        <SelectItem key={model.id} value={model.name}>
+                          {model.display_name || model.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                {/* User Mapping Mode */}
+                <div className="space-y-2">
+                  <Label htmlFor="edit-user_mapping_mode">
+                    {t('admin:im_channels.form.user_mapping_mode')} *
+                  </Label>
+                  <Select
+                    value={formData.user_mapping_mode}
+                    onValueChange={value =>
+                      setFormData({ ...formData, user_mapping_mode: value as UserMappingMode })
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="select_user">
+                        {t('admin:im_channels.form.user_mapping_modes.select_user')}
+                      </SelectItem>
+                      <SelectItem value="staff_id">
+                        {t('admin:im_channels.form.user_mapping_modes.staff_id')}
+                      </SelectItem>
+                      <SelectItem value="email">
+                        {t('admin:im_channels.form.user_mapping_modes.email')}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-text-muted">
+                    {t('admin:im_channels.form.user_mapping_mode_description')}
+                  </p>
+                </div>
+                {/* Target User (only for select_user mode) */}
+                {formData.user_mapping_mode === 'select_user' && (
+                  <div className="space-y-2">
+                    <Label htmlFor="edit-target_user">
+                      {t('admin:im_channels.form.target_user')} *
+                    </Label>
+                    <Select
+                      value={formData.target_user_id ? formData.target_user_id.toString() : ''}
+                      onValueChange={value =>
+                        setFormData({ ...formData, target_user_id: parseInt(value) })
+                      }
+                    >
+                      <SelectTrigger>
+                        <SelectValue
+                          placeholder={t('admin:im_channels.form.select_user_placeholder')}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {users.map(user => (
+                          <SelectItem key={user.id} value={user.id.toString()}>
+                            {user.user_name} ({user.email || user.id})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <p className="text-xs text-text-muted">
+                      {t('admin:im_channels.form.target_user_description')}
+                    </p>
+                  </div>
+                )}
+              </>
             )}
             <div className="flex items-center justify-between">
               <Label htmlFor="edit-is_enabled">{t('admin:im_channels.form.is_enabled')}</Label>

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -718,6 +718,7 @@
     "restart_channel": "Restart Connection",
     "types": {
       "dingtalk": "DingTalk",
+      "dingtalk_group": "DingTalk Group Bot",
       "feishu": "Feishu",
       "telegram": "Telegram",
       "not_supported": "Not supported"
@@ -742,6 +743,13 @@
       "bot_token": "Bot Token",
       "bot_token_placeholder": "Enter Telegram Bot Token",
       "bot_token_edit_placeholder": "Enter new Bot Token (leave empty to keep existing)",
+      "webhook_url": "Webhook URL",
+      "webhook_url_placeholder": "Enter DingTalk group robot Webhook URL",
+      "webhook_url_edit_placeholder": "Enter new Webhook URL (leave empty to keep existing)",
+      "sign_secret": "Signing Secret",
+      "sign_secret_placeholder": "Enter signing secret (optional)",
+      "sign_secret_edit_placeholder": "Enter new signing secret (leave empty to keep existing)",
+      "sign_secret_description": "Optional. HMAC-SHA256 signing will be enabled if configured",
       "leave_empty_to_keep": "Leave empty to keep existing",
       "default_team": "Default Agent",
       "default_team_placeholder": "Select default agent",
@@ -784,6 +792,7 @@
       "name_required": "Channel name is required",
       "config_required": "Client ID and Client Secret are required",
       "bot_token_required": "Bot Token is required",
+      "webhook_url_required": "Webhook URL is required",
       "team_required": "A default agent must be selected",
       "model_required_for_team": "The selected agent has no model configured. You must select a default model.",
       "target_user_required": "A target user must be selected when using Specific User mode"

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -718,6 +718,7 @@
     "restart_channel": "重启连接",
     "types": {
       "dingtalk": "钉钉",
+      "dingtalk_group": "钉钉群机器人",
       "feishu": "飞书",
       "telegram": "Telegram",
       "not_supported": "暂不支持"
@@ -742,6 +743,13 @@
       "bot_token": "Bot Token",
       "bot_token_placeholder": "请输入 Telegram Bot Token",
       "bot_token_edit_placeholder": "请输入新的 Bot Token（留空保持不变）",
+      "webhook_url": "Webhook URL",
+      "webhook_url_placeholder": "请输入钉钉群机器人 Webhook URL",
+      "webhook_url_edit_placeholder": "请输入新的 Webhook URL（留空保持不变）",
+      "sign_secret": "签名密钥",
+      "sign_secret_placeholder": "请输入签名密钥（可选）",
+      "sign_secret_edit_placeholder": "请输入新的签名密钥（留空保持不变）",
+      "sign_secret_description": "可选。配置后将使用 HMAC-SHA256 签名验证",
       "leave_empty_to_keep": "留空保持不变",
       "default_team": "默认智能体",
       "default_team_placeholder": "选择默认智能体",
@@ -784,6 +792,7 @@
       "name_required": "渠道名称不能为空",
       "config_required": "Client ID 和 Client Secret 不能为空",
       "bot_token_required": "Bot Token 不能为空",
+      "webhook_url_required": "Webhook URL 不能为空",
       "team_required": "必须选择一个默认智能体",
       "model_required_for_team": "所选智能体没有配置模型，必须选择一个默认模型",
       "target_user_required": "使用指定用户模式时必须选择一个目标用户"


### PR DESCRIPTION
## Summary

- Add support for sending subscription execution results to DingTalk groups via robot webhook
- New `dingtalk_group` channel type for group chat notifications
- Unlike `dingtalk` single-chat, this sends directly to group webhook without user binding
- Supports HMAC-SHA256 signing for webhook security
- Sends full execution results (up to 20000 chars) for group notifications

## Changes

### Backend
- **Schema**: Add `dingtalk_group` to `ChannelType`, add `DingTalkGroupChannelConfig` class
- **API**: Add `webhook_url` and `sign_secret` to sensitive config keys
- **New File**: `backend/app/services/channels/dingtalk/group_sender.py` - DingTalkGroupWebhookSender class
- **Notification Service**: `dingtalk_group` channels always show as `is_bound=True`
- **Notification Dispatcher**: Add `_send_dingtalk_group_notification()` method

### Frontend
- **Types**: Add `dingtalk_group` to `IMChannelType`
- **i18n**: Add translations for new channel type (zh-CN and en)
- **IMChannelList**: Add form fields for webhook_url and sign_secret when channel type is `dingtalk_group`

## Test plan

- [x] Backend Python module imports verified
- [x] Existing DingTalk channel tests pass (37 tests)
- [x] Schema and im_channel related tests pass (27 tests)
- [x] Frontend TypeScript type check passes
- [x] Frontend ESLint check passes (no new errors)
- [ ] Manual test: Create `dingtalk_group` Messager in admin panel
- [ ] Manual test: Subscribe to a subscription and trigger execution
- [ ] Manual test: Verify DingTalk group receives notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced DingTalk Group Bot as a new notification channel type supporting webhook-based group messaging
  * Added optional HMAC-SHA256 signing support for secure webhook communications
  * Implemented automatic message truncation with notification indicators for oversized content
  * Extended admin configuration interface with webhook URL and signing secret fields for new channel setup
  * Added English and Chinese translations for the new channel type and related configuration fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->