### PR TITLE
feat(feed): allow selecting notification level when following subscriptions

### DIFF
--- a/backend/app/api/endpoints/adapter/subscription_follows.py
+++ b/backend/app/api/endpoints/adapter/subscription_follows.py
@@ -21,6 +21,7 @@ from app.api.dependencies import get_db
 from app.core import security
 from app.models.user import User
 from app.schemas.subscription import (
+    AcceptInvitationRequest,
     DeveloperNotificationSettingsResponse,
     DeveloperNotificationSettingsUpdateRequest,
     DiscoverSubscriptionsListResponse,
@@ -411,16 +412,27 @@ invitation_router = APIRouter()
 @invitation_router.post("/{invitation_id}/accept", status_code=status.HTTP_200_OK)
 def accept_invitation(
     invitation_id: int,
+    request: Optional[AcceptInvitationRequest] = None,
     db: Session = Depends(get_db),
     current_user: User = Depends(security.get_current_user),
 ):
     """
     Accept a subscription invitation.
+
+    Optionally specify notification settings (level and channels).
     """
+    notification_level = None
+    notification_channel_ids = None
+    if request:
+        notification_level = request.notification_level
+        notification_channel_ids = request.notification_channel_ids
+
     return subscription_follow_service.accept_invitation(
         db=db,
         invitation_id=invitation_id,
         user_id=current_user.id,
+        notification_level=notification_level,
+        notification_channel_ids=notification_channel_ids,
     )
 
 

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -780,6 +780,17 @@ class FollowSubscriptionRequest(BaseModel):
     )
 
 
+class AcceptInvitationRequest(BaseModel):
+    """Request to accept a subscription invitation with optional notification settings."""
+
+    notification_level: Optional[NotificationLevel] = Field(
+        None, description="Notification level (default: 'default')"
+    )
+    notification_channel_ids: Optional[List[int]] = Field(
+        None, description="Messager channel IDs for notify level"
+    )
+
+
 class UpdateFollowSettingsRequest(BaseModel):
     """Request to update follow notification settings."""
 

--- a/backend/app/services/subscription/follow_service.py
+++ b/backend/app/services/subscription/follow_service.py
@@ -948,6 +948,8 @@ class SubscriptionFollowService:
         *,
         invitation_id: int,
         user_id: int,
+        notification_level: Optional[SchemaNotificationLevel] = None,
+        notification_channel_ids: Optional[List[int]] = None,
     ) -> dict:
         """
         Accept a subscription invitation.
@@ -956,6 +958,8 @@ class SubscriptionFollowService:
             db: Database session
             invitation_id: ID of the invitation (follow record)
             user_id: ID of the user accepting
+            notification_level: Optional notification level setting
+            notification_channel_ids: Optional Messager channel IDs for notify level
 
         Returns:
             Success message
@@ -980,13 +984,24 @@ class SubscriptionFollowService:
                 detail="Invitation not found or already responded",
             )
 
+        # Update invitation status
         follow.invitation_status = InvitationStatus.ACCEPTED.value
         follow.responded_at = datetime.now(timezone.utc).replace(tzinfo=None)
         follow.updated_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+        # Update notification config if provided
+        if notification_level is not None:
+            config = SubscriptionFollowConfig(
+                notification_level=notification_level,
+                notification_channel_ids=notification_channel_ids,
+            )
+            follow.config = config.model_dump_json()
+
         db.commit()
 
         logger.info(
             f"[SubscriptionFollow] User {user_id} accepted invitation {invitation_id}"
+            f", notification_level={notification_level}"
         )
 
         return {"message": "Invitation accepted"}

--- a/frontend/src/apis/subscription.ts
+++ b/frontend/src/apis/subscription.ts
@@ -306,8 +306,11 @@ export const subscriptionApis = {
   /**
    * Accept a subscription invitation
    */
-  async acceptInvitation(invitationId: number): Promise<{ message: string }> {
-    return apiClient.post(`/subscription-invitations/${invitationId}/accept`)
+  async acceptInvitation(
+    invitationId: number,
+    request?: { notification_level?: string; notification_channel_ids?: number[] }
+  ): Promise<{ message: string }> {
+    return apiClient.post(`/subscription-invitations/${invitationId}/accept`, request || {})
   },
 
   /**

--- a/frontend/src/features/feed/components/DiscoverFeedCard.tsx
+++ b/frontend/src/features/feed/components/DiscoverFeedCard.tsx
@@ -25,7 +25,6 @@ import {
   AlertCircle,
   VolumeX,
 } from 'lucide-react'
-import { toast } from 'sonner'
 import { useTranslation } from '@/hooks/useTranslation'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -39,6 +38,7 @@ import { useUser } from '@/features/common/UserContext'
 import { parseUTCDate } from '@/lib/utils'
 import { EnhancedMarkdown } from '@/components/common/EnhancedMarkdown'
 import { useTheme } from '@/features/theme/ThemeProvider'
+import { FollowWithNotificationDropdown } from './FollowWithNotificationDropdown'
 
 // Status configuration for execution display
 const statusConfig: Record<
@@ -93,8 +93,7 @@ interface DiscoverFeedCardProps {
   subscription: DiscoverSubscriptionResponse
   latestExecution?: BackgroundExecution
   isFollowing: boolean
-  onFollow: (subscriptionId: number) => Promise<void>
-  onUnfollow: (subscriptionId: number) => Promise<void>
+  onFollowChange?: (subscriptionId: number, isFollowing: boolean) => void
   onClick: (subscription: DiscoverSubscriptionResponse) => void
 }
 
@@ -102,8 +101,7 @@ export function DiscoverFeedCard({
   subscription,
   latestExecution,
   isFollowing: initialIsFollowing,
-  onFollow,
-  onUnfollow,
+  onFollowChange,
   onClick,
 }: DiscoverFeedCardProps) {
   const { t } = useTranslation('feed')
@@ -113,7 +111,6 @@ export function DiscoverFeedCard({
 
   const [isExpanded, setIsExpanded] = useState(false)
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing)
-  const [isFollowLoading, setIsFollowLoading] = useState(false)
   const [needsExpansion, setNeedsExpansion] = useState(false)
   const contentRef = useRef<HTMLDivElement>(null)
 
@@ -125,32 +122,18 @@ export function DiscoverFeedCard({
     }
   }, [latestExecution?.result_summary])
 
-  // Handle follow/unfollow toggle
-  const handleFollowClick = useCallback(
-    async (e: React.MouseEvent) => {
-      e.stopPropagation()
+  // Sync with prop changes
+  useEffect(() => {
+    setIsFollowing(initialIsFollowing)
+  }, [initialIsFollowing])
 
-      if (isFollowLoading) return
-
-      setIsFollowLoading(true)
-      try {
-        if (isFollowing) {
-          await onUnfollow(subscription.id)
-          setIsFollowing(false)
-          toast.success(t('unfollow_success'))
-        } else {
-          await onFollow(subscription.id)
-          setIsFollowing(true)
-          toast.success(t('follow_success'))
-        }
-      } catch (error) {
-        console.error('Failed to toggle follow:', error)
-        toast.error(isFollowing ? t('unfollow_failed') : t('follow_failed'))
-      } finally {
-        setIsFollowLoading(false)
-      }
+  // Handle follow state change from dropdown
+  const handleFollowChange = useCallback(
+    (newIsFollowing: boolean) => {
+      setIsFollowing(newIsFollowing)
+      onFollowChange?.(subscription.id, newIsFollowing)
     },
-    [isFollowing, isFollowLoading, onFollow, onUnfollow, subscription.id, t]
+    [subscription.id, onFollowChange]
   )
 
   // Handle view subscription detail
@@ -223,23 +206,12 @@ export function DiscoverFeedCard({
             </div>
             {/* Follow Button - Top Right */}
             {!isOwnSubscription && (
-              <button
-                onClick={handleFollowClick}
-                disabled={isFollowLoading}
-                className={`text-xs font-medium shrink-0 transition-colors ${
-                  isFollowing
-                    ? 'text-text-muted hover:text-destructive'
-                    : 'text-primary hover:text-primary/80'
-                }`}
-              >
-                {isFollowLoading ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : isFollowing ? (
-                  t('following')
-                ) : (
-                  <span className="flex items-center gap-0.5">+ {t('follow')}</span>
-                )}
-              </button>
+              <FollowWithNotificationDropdown
+                subscriptionId={subscription.id}
+                isFollowing={isFollowing}
+                onSuccess={handleFollowChange}
+                compact
+              />
             )}
           </div>
 

--- a/frontend/src/features/feed/components/DiscoverPageInline.tsx
+++ b/frontend/src/features/feed/components/DiscoverPageInline.tsx
@@ -162,46 +162,43 @@ export function DiscoverPageInline({ onInvitationHandled }: DiscoverPageInlinePr
     setSearch(searchInput)
   }, [searchInput])
 
-  // Handle follow
-  const handleFollow = useCallback(
-    async (subscriptionId: number) => {
-      await subscriptionApis.followSubscription(subscriptionId)
-      setFollowingIds(prev => new Set([...prev, subscriptionId]))
-      // Update followers count in list
-      setSubscriptions(prev =>
-        prev.map(sub =>
-          sub.id === subscriptionId
-            ? { ...sub, followers_count: sub.followers_count + 1, is_following: true }
-            : sub
+  // Handle follow state change
+  const handleFollowChange = useCallback(
+    (subscriptionId: number, isFollowing: boolean) => {
+      if (isFollowing) {
+        setFollowingIds(prev => new Set([...prev, subscriptionId]))
+        // Update followers count in list
+        setSubscriptions(prev =>
+          prev.map(sub =>
+            sub.id === subscriptionId
+              ? { ...sub, followers_count: sub.followers_count + 1, is_following: true }
+              : sub
+          )
         )
-      )
-      // Notify parent to refresh executions
-      onInvitationHandled?.()
+        // Notify parent to refresh executions
+        onInvitationHandled?.()
+      } else {
+        setFollowingIds(prev => {
+          const next = new Set(prev)
+          next.delete(subscriptionId)
+          return next
+        })
+        // Update followers count in list
+        setSubscriptions(prev =>
+          prev.map(sub =>
+            sub.id === subscriptionId
+              ? {
+                  ...sub,
+                  followers_count: Math.max(0, sub.followers_count - 1),
+                  is_following: false,
+                }
+              : sub
+          )
+        )
+      }
     },
     [onInvitationHandled]
   )
-
-  // Handle unfollow
-  const handleUnfollow = useCallback(async (subscriptionId: number) => {
-    await subscriptionApis.unfollowSubscription(subscriptionId)
-    setFollowingIds(prev => {
-      const next = new Set(prev)
-      next.delete(subscriptionId)
-      return next
-    })
-    // Update followers count in list
-    setSubscriptions(prev =>
-      prev.map(sub =>
-        sub.id === subscriptionId
-          ? {
-              ...sub,
-              followers_count: Math.max(0, sub.followers_count - 1),
-              is_following: false,
-            }
-          : sub
-      )
-    )
-  }, [])
 
   // Load more
   const handleLoadMore = useCallback(() => {
@@ -285,8 +282,7 @@ export function DiscoverPageInline({ onInvitationHandled }: DiscoverPageInlinePr
                       subscription={subscription}
                       latestExecution={executionHistory[subscription.id]}
                       isFollowing={followingIds.has(subscription.id)}
-                      onFollow={handleFollow}
-                      onUnfollow={handleUnfollow}
+                      onFollowChange={handleFollowChange}
                       onClick={handleCardClick}
                     />
                   ))}

--- a/frontend/src/features/feed/components/FollowWithNotificationDropdown.tsx
+++ b/frontend/src/features/feed/components/FollowWithNotificationDropdown.tsx
@@ -1,0 +1,799 @@
+'use client'
+
+// SPDX-FileCopyrightText: 2025 WeCode, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Follow with notification level dropdown component.
+ * Allows users to select notification level when following a subscription.
+ * Supports hover-to-expand behavior on desktop and click on mobile.
+ */
+import { useState, useCallback, useEffect, useRef } from 'react'
+import {
+  Bell,
+  BellOff,
+  BellRing,
+  Check,
+  ChevronLeft,
+  Loader2,
+  MessageSquare,
+  Plus,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { useTranslation } from '@/hooks/useTranslation'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { subscriptionApis } from '@/apis/subscription'
+import type { NotificationLevel, NotificationChannelInfo } from '@/types/subscription'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
+import { cn } from '@/lib/utils'
+
+type DropdownStep = 'level' | 'channels'
+
+interface FollowWithNotificationDropdownProps {
+  /** Subscription ID to follow */
+  subscriptionId: number
+  /** Whether user is already following */
+  isFollowing?: boolean
+  /** Callback when follow/unfollow succeeds */
+  onSuccess?: (isFollowing: boolean) => void
+  /** Button variant */
+  variant?: 'default' | 'ghost' | 'outline' | 'primary'
+  /** Button size */
+  size?: 'default' | 'sm' | 'lg' | 'icon'
+  /** Additional class name */
+  className?: string
+  /** Whether to show as compact text button (for discover cards) */
+  compact?: boolean
+}
+
+export function FollowWithNotificationDropdown({
+  subscriptionId,
+  isFollowing: initialIsFollowing = false,
+  onSuccess,
+  variant = 'default',
+  size = 'sm',
+  className,
+  compact = false,
+}: FollowWithNotificationDropdownProps) {
+  const { t } = useTranslation('feed')
+  const isMobile = useIsMobile()
+
+  // State
+  const [isFollowing, setIsFollowing] = useState(initialIsFollowing)
+  const [isOpen, setIsOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [step, setStep] = useState<DropdownStep>('level')
+  const [_selectedLevel, setSelectedLevel] = useState<NotificationLevel>('default')
+  const [selectedChannels, setSelectedChannels] = useState<number[]>([])
+  const [availableChannels, setAvailableChannels] = useState<NotificationChannelInfo[]>([])
+  const [channelsLoading, setChannelsLoading] = useState(false)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Sync with prop changes
+  useEffect(() => {
+    setIsFollowing(initialIsFollowing)
+  }, [initialIsFollowing])
+
+  // Load available channels
+  const loadAvailableChannels = useCallback(async () => {
+    try {
+      setChannelsLoading(true)
+      const response = await subscriptionApis.getFollowSettings(subscriptionId)
+      setAvailableChannels(response.available_channels)
+    } catch (error) {
+      console.error('Failed to load available channels:', error)
+    } finally {
+      setChannelsLoading(false)
+    }
+  }, [subscriptionId])
+
+  // Check if user has any bound channels
+  const hasBoundChannels = availableChannels.some(c => c.is_bound)
+
+  // Handle mouse enter (desktop only)
+  const handleMouseEnter = useCallback(() => {
+    if (isMobile || isFollowing) return
+
+    // Clear any pending close timeout
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+      hoverTimeoutRef.current = null
+    }
+
+    setIsOpen(true)
+    if (availableChannels.length === 0) {
+      loadAvailableChannels()
+    }
+  }, [isMobile, isFollowing, availableChannels.length, loadAvailableChannels])
+
+  // Handle mouse leave (desktop only)
+  const handleMouseLeave = useCallback(() => {
+    if (isMobile) return
+
+    // Delay close to allow moving to dropdown
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false)
+      setStep('level')
+      setSelectedChannels([])
+    }, 150)
+  }, [isMobile])
+
+  // Handle click on follow button
+  const handleButtonClick = useCallback(
+    async (e: React.MouseEvent) => {
+      e.stopPropagation()
+
+      if (isFollowing) {
+        // Unfollow
+        try {
+          setIsLoading(true)
+          await subscriptionApis.unfollowSubscription(subscriptionId)
+          setIsFollowing(false)
+          toast.success(t('unfollow_success'))
+          onSuccess?.(false)
+        } catch (error) {
+          console.error('Failed to unfollow:', error)
+          toast.error(t('unfollow_failed'))
+        } finally {
+          setIsLoading(false)
+        }
+        return
+      }
+
+      // On mobile, toggle dropdown
+      if (isMobile) {
+        setIsOpen(!isOpen)
+        if (!isOpen && availableChannels.length === 0) {
+          loadAvailableChannels()
+        }
+      }
+    },
+    [
+      isFollowing,
+      isMobile,
+      isOpen,
+      subscriptionId,
+      availableChannels.length,
+      loadAvailableChannels,
+      onSuccess,
+      t,
+    ]
+  )
+
+  // Handle level selection
+  const handleLevelSelect = useCallback(
+    async (level: NotificationLevel) => {
+      if (level === 'notify') {
+        // Move to channel selection step
+        setSelectedLevel(level)
+        setStep('channels')
+        return
+      }
+
+      // Follow with selected level
+      try {
+        setIsLoading(true)
+        await subscriptionApis.followSubscription(subscriptionId, {
+          notification_level: level,
+        })
+        setIsFollowing(true)
+        setIsOpen(false)
+        setStep('level')
+        toast.success(t('follow_success'))
+        onSuccess?.(true)
+      } catch (error) {
+        console.error('Failed to follow:', error)
+        toast.error(t('follow_failed'))
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [subscriptionId, onSuccess, t]
+  )
+
+  // Handle channel toggle
+  const handleChannelToggle = useCallback((channelId: number, checked: boolean) => {
+    setSelectedChannels(prev =>
+      checked ? [...prev, channelId] : prev.filter(id => id !== channelId)
+    )
+  }, [])
+
+  // Handle confirm follow with notify level
+  const handleConfirmNotify = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      await subscriptionApis.followSubscription(subscriptionId, {
+        notification_level: 'notify',
+        notification_channel_ids: selectedChannels,
+      })
+      setIsFollowing(true)
+      setIsOpen(false)
+      setStep('level')
+      setSelectedChannels([])
+      toast.success(t('follow_success'))
+      onSuccess?.(true)
+    } catch (error) {
+      console.error('Failed to follow:', error)
+      toast.error(t('follow_failed'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [subscriptionId, selectedChannels, onSuccess, t])
+
+  // Handle back button
+  const handleBack = useCallback(() => {
+    setStep('level')
+    setSelectedChannels([])
+  }, [])
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // Close dropdown when clicking outside (mobile)
+  useEffect(() => {
+    if (!isMobile || !isOpen) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+        setStep('level')
+        setSelectedChannels([])
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isMobile, isOpen])
+
+  // Get channel type icon
+  const getChannelIcon = (_channelType: string) => {
+    return <MessageSquare className="h-4 w-4" />
+  }
+
+  // Render compact text button (for discover cards)
+  if (compact) {
+    return (
+      <div
+        ref={containerRef}
+        className="relative"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        <button
+          onClick={handleButtonClick}
+          disabled={isLoading}
+          className={cn(
+            'text-xs font-medium shrink-0 transition-colors',
+            isFollowing
+              ? 'text-text-muted hover:text-destructive'
+              : 'text-primary hover:text-primary/80',
+            className
+          )}
+        >
+          {isLoading ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : isFollowing ? (
+            t('following')
+          ) : (
+            <span className="flex items-center gap-0.5">+ {t('follow')}</span>
+          )}
+        </button>
+
+        {/* Dropdown */}
+        {isOpen && !isFollowing && (
+          <div
+            className="absolute right-0 top-full mt-1 z-50 w-60 rounded-lg border border-border bg-surface shadow-lg"
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            {step === 'level' ? (
+              <LevelSelectionContent
+                t={t}
+                isLoading={isLoading}
+                hasBoundChannels={hasBoundChannels}
+                channelsLoading={channelsLoading}
+                onSelect={handleLevelSelect}
+              />
+            ) : (
+              <ChannelSelectionContent
+                t={t}
+                isLoading={isLoading}
+                availableChannels={availableChannels}
+                selectedChannels={selectedChannels}
+                onToggle={handleChannelToggle}
+                onBack={handleBack}
+                onConfirm={handleConfirmNotify}
+                getChannelIcon={getChannelIcon}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Render standard button
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Button
+        variant={isFollowing ? 'ghost' : variant === 'default' ? 'default' : variant}
+        size={size}
+        onClick={handleButtonClick}
+        disabled={isLoading}
+        className={cn(
+          isFollowing ? 'text-text-muted hover:text-destructive hover:bg-destructive/10' : '',
+          className
+        )}
+      >
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
+        ) : isFollowing ? (
+          <Check className="h-4 w-4 mr-1.5" />
+        ) : (
+          <Plus className="h-4 w-4 mr-1.5" />
+        )}
+        {isFollowing ? t('following') : t('follow')}
+      </Button>
+
+      {/* Dropdown */}
+      {isOpen && !isFollowing && (
+        <div
+          className="absolute right-0 top-full mt-1 z-50 w-60 rounded-lg border border-border bg-surface shadow-lg"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          {step === 'level' ? (
+            <LevelSelectionContent
+              t={t}
+              isLoading={isLoading}
+              hasBoundChannels={hasBoundChannels}
+              channelsLoading={channelsLoading}
+              onSelect={handleLevelSelect}
+            />
+          ) : (
+            <ChannelSelectionContent
+              t={t}
+              isLoading={isLoading}
+              availableChannels={availableChannels}
+              selectedChannels={selectedChannels}
+              onToggle={handleChannelToggle}
+              onBack={handleBack}
+              onConfirm={handleConfirmNotify}
+              getChannelIcon={getChannelIcon}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Level selection step content
+interface LevelSelectionContentProps {
+  t: (key: string) => string
+  isLoading: boolean
+  hasBoundChannels: boolean
+  channelsLoading: boolean
+  onSelect: (level: NotificationLevel) => void
+}
+
+function LevelSelectionContent({
+  t,
+  isLoading,
+  hasBoundChannels,
+  channelsLoading,
+  onSelect,
+}: LevelSelectionContentProps) {
+  const notifyDisabled = !hasBoundChannels && !channelsLoading
+
+  return (
+    <div className="p-2">
+      <div className="px-2 py-1.5 text-xs font-medium text-text-muted">
+        {t('follow_dropdown.select_level')}
+      </div>
+      <div className="space-y-0.5">
+        {/* Silent */}
+        <button
+          className="w-full flex items-center gap-3 px-2 py-2 rounded-md hover:bg-hover transition-colors text-left"
+          onClick={() => onSelect('silent')}
+          disabled={isLoading}
+        >
+          <BellOff className="h-4 w-4 text-text-muted shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium">{t('follow_dropdown.level_silent')}</div>
+            <div className="text-xs text-text-muted truncate">
+              {t('follow_dropdown.level_silent_desc')}
+            </div>
+          </div>
+        </button>
+
+        {/* Default */}
+        <button
+          className="w-full flex items-center gap-3 px-2 py-2 rounded-md hover:bg-hover transition-colors text-left"
+          onClick={() => onSelect('default')}
+          disabled={isLoading}
+        >
+          <Bell className="h-4 w-4 text-text-muted shrink-0" />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium flex items-center gap-1.5">
+              {t('follow_dropdown.level_default')}
+              <span className="text-[10px] text-primary bg-primary/10 px-1.5 py-0.5 rounded">
+                {t('default')}
+              </span>
+            </div>
+            <div className="text-xs text-text-muted truncate">
+              {t('follow_dropdown.level_default_desc')}
+            </div>
+          </div>
+        </button>
+
+        {/* Notify */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <button
+                className={cn(
+                  'w-full flex items-center gap-3 px-2 py-2 rounded-md transition-colors text-left',
+                  notifyDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-hover cursor-pointer'
+                )}
+                onClick={() => !notifyDisabled && onSelect('notify')}
+                disabled={isLoading || notifyDisabled}
+              >
+                <BellRing className="h-4 w-4 text-text-muted shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium">{t('follow_dropdown.level_notify')}</div>
+                  <div className="text-xs text-text-muted truncate">
+                    {t('follow_dropdown.level_notify_desc')}
+                  </div>
+                </div>
+              </button>
+            </div>
+          </TooltipTrigger>
+          {notifyDisabled && (
+            <TooltipContent side="left" className="max-w-[200px]">
+              {t('follow_dropdown.notify_disabled_hint')}
+            </TooltipContent>
+          )}
+        </Tooltip>
+      </div>
+    </div>
+  )
+}
+
+// Channel selection step content
+interface ChannelSelectionContentProps {
+  t: (key: string) => string
+  isLoading: boolean
+  availableChannels: NotificationChannelInfo[]
+  selectedChannels: number[]
+  onToggle: (channelId: number, checked: boolean) => void
+  onBack: () => void
+  onConfirm: () => void
+  getChannelIcon: (channelType: string) => React.ReactNode
+}
+
+function ChannelSelectionContent({
+  t,
+  isLoading,
+  availableChannels,
+  selectedChannels,
+  onToggle,
+  onBack,
+  onConfirm,
+  getChannelIcon,
+}: ChannelSelectionContentProps) {
+  const boundChannels = availableChannels.filter(c => c.is_bound)
+  const hasSelection = selectedChannels.length > 0
+
+  return (
+    <div className="p-2">
+      {/* Header with back button */}
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <button
+          className="p-1 rounded hover:bg-hover transition-colors"
+          onClick={onBack}
+          disabled={isLoading}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <div className="text-xs font-medium text-text-muted">
+          {t('follow_dropdown.select_channels')}
+        </div>
+      </div>
+
+      {/* Channel list */}
+      <div className="space-y-0.5 max-h-[200px] overflow-y-auto">
+        {boundChannels.length === 0 ? (
+          <div className="px-2 py-4 text-center text-xs text-text-muted">
+            {t('notification_settings.no_channels')}
+          </div>
+        ) : (
+          boundChannels.map(channel => (
+            <label
+              key={channel.id}
+              className="w-full flex items-center gap-3 px-2 py-2 rounded-md hover:bg-hover transition-colors cursor-pointer"
+            >
+              <Checkbox
+                checked={selectedChannels.includes(channel.id)}
+                onCheckedChange={checked => onToggle(channel.id, checked as boolean)}
+                disabled={isLoading}
+              />
+              {getChannelIcon(channel.channel_type)}
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium truncate">{channel.name}</div>
+                <div className="text-xs text-text-muted">{channel.channel_type}</div>
+              </div>
+            </label>
+          ))
+        )}
+      </div>
+
+      {/* Hint */}
+      <div className="px-2 py-1.5 text-xs text-text-muted">
+        {t('follow_dropdown.select_channels_hint')}
+      </div>
+
+      {/* Confirm button */}
+      <div className="px-2 pt-1 pb-1 border-t border-border mt-1">
+        <Button
+          variant="primary"
+          size="sm"
+          className="w-full"
+          onClick={onConfirm}
+          disabled={isLoading || !hasSelection}
+        >
+          {isLoading ? <Loader2 className="h-4 w-4 mr-1.5 animate-spin" /> : null}
+          {t('follow_dropdown.confirm_follow')}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+// Export for use in invitation component
+export interface AcceptWithNotificationDropdownProps {
+  /** Invitation ID */
+  invitationId: number
+  /** Subscription ID (for loading channels) */
+  subscriptionId: number
+  /** Callback when accept succeeds */
+  onSuccess?: () => void
+  /** Additional class name */
+  className?: string
+}
+
+export function AcceptWithNotificationDropdown({
+  invitationId,
+  subscriptionId,
+  onSuccess,
+  className,
+}: AcceptWithNotificationDropdownProps) {
+  const { t } = useTranslation('feed')
+  const isMobile = useIsMobile()
+
+  // State
+  const [isOpen, setIsOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [step, setStep] = useState<DropdownStep>('level')
+  const [_selectedLevel, setSelectedLevel] = useState<NotificationLevel>('default')
+  const [selectedChannels, setSelectedChannels] = useState<number[]>([])
+  const [availableChannels, setAvailableChannels] = useState<NotificationChannelInfo[]>([])
+  const [channelsLoading, setChannelsLoading] = useState(false)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Load available channels
+  const loadAvailableChannels = useCallback(async () => {
+    try {
+      setChannelsLoading(true)
+      const response = await subscriptionApis.getFollowSettings(subscriptionId)
+      setAvailableChannels(response.available_channels)
+    } catch (error) {
+      console.error('Failed to load available channels:', error)
+    } finally {
+      setChannelsLoading(false)
+    }
+  }, [subscriptionId])
+
+  // Check if user has any bound channels
+  const hasBoundChannels = availableChannels.some(c => c.is_bound)
+
+  // Handle mouse enter (desktop only)
+  const handleMouseEnter = useCallback(() => {
+    if (isMobile) return
+
+    if (hoverTimeoutRef.current) {
+      clearTimeout(hoverTimeoutRef.current)
+      hoverTimeoutRef.current = null
+    }
+
+    setIsOpen(true)
+    if (availableChannels.length === 0) {
+      loadAvailableChannels()
+    }
+  }, [isMobile, availableChannels.length, loadAvailableChannels])
+
+  // Handle mouse leave (desktop only)
+  const handleMouseLeave = useCallback(() => {
+    if (isMobile) return
+
+    hoverTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false)
+      setStep('level')
+      setSelectedChannels([])
+    }, 150)
+  }, [isMobile])
+
+  // Handle click on accept button (mobile)
+  const handleButtonClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation()
+
+      if (isMobile) {
+        setIsOpen(!isOpen)
+        if (!isOpen && availableChannels.length === 0) {
+          loadAvailableChannels()
+        }
+      }
+    },
+    [isMobile, isOpen, availableChannels.length, loadAvailableChannels]
+  )
+
+  // Handle level selection
+  const handleLevelSelect = useCallback(
+    async (level: NotificationLevel) => {
+      if (level === 'notify') {
+        setSelectedLevel(level)
+        setStep('channels')
+        return
+      }
+
+      // Accept with selected level
+      try {
+        setIsLoading(true)
+        await subscriptionApis.acceptInvitation(invitationId, {
+          notification_level: level,
+        })
+        setIsOpen(false)
+        setStep('level')
+        toast.success(t('invitation_accepted'))
+        onSuccess?.()
+      } catch (error) {
+        console.error('Failed to accept invitation:', error)
+        toast.error(t('invitation_accept_failed'))
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [invitationId, onSuccess, t]
+  )
+
+  // Handle channel toggle
+  const handleChannelToggle = useCallback((channelId: number, checked: boolean) => {
+    setSelectedChannels(prev =>
+      checked ? [...prev, channelId] : prev.filter(id => id !== channelId)
+    )
+  }, [])
+
+  // Handle confirm accept with notify level
+  const handleConfirmNotify = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      await subscriptionApis.acceptInvitation(invitationId, {
+        notification_level: 'notify',
+        notification_channel_ids: selectedChannels,
+      })
+      setIsOpen(false)
+      setStep('level')
+      setSelectedChannels([])
+      toast.success(t('invitation_accepted'))
+      onSuccess?.()
+    } catch (error) {
+      console.error('Failed to accept invitation:', error)
+      toast.error(t('invitation_accept_failed'))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [invitationId, selectedChannels, onSuccess, t])
+
+  // Handle back button
+  const handleBack = useCallback(() => {
+    setStep('level')
+    setSelectedChannels([])
+  }, [])
+
+  // Clean up timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // Close dropdown when clicking outside (mobile)
+  useEffect(() => {
+    if (!isMobile || !isOpen) return
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false)
+        setStep('level')
+        setSelectedChannels([])
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isMobile, isOpen])
+
+  // Get channel type icon
+  const getChannelIcon = (_channelType: string) => {
+    return <MessageSquare className="h-4 w-4" />
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <Button size="sm" onClick={handleButtonClick} disabled={isLoading} className={className}>
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 mr-1 animate-spin" />
+        ) : (
+          <Check className="h-4 w-4 mr-1" />
+        )}
+        {t('invitation_accept')}
+      </Button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full mt-1 z-50 w-60 rounded-lg border border-border bg-surface shadow-lg"
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          {step === 'level' ? (
+            <LevelSelectionContent
+              t={t}
+              isLoading={isLoading}
+              hasBoundChannels={hasBoundChannels}
+              channelsLoading={channelsLoading}
+              onSelect={handleLevelSelect}
+            />
+          ) : (
+            <ChannelSelectionContent
+              t={t}
+              isLoading={isLoading}
+              availableChannels={availableChannels}
+              selectedChannels={selectedChannels}
+              onToggle={handleChannelToggle}
+              onBack={handleBack}
+              onConfirm={handleConfirmNotify}
+              getChannelIcon={getChannelIcon}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/feed/components/SubscriptionDetailPage.tsx
+++ b/frontend/src/features/feed/components/SubscriptionDetailPage.tsx
@@ -13,12 +13,10 @@ import { useRouter } from 'next/navigation'
 import {
   ArrowLeft,
   CalendarClock,
-  Check,
   Clock,
   Eye,
   EyeOff,
   Loader2,
-  Plus,
   Settings,
   Share2,
   Timer,
@@ -40,6 +38,7 @@ import { paths } from '@/config/paths'
 import { useUser } from '@/features/common/UserContext'
 import { DeveloperNotificationSettingsDialog } from './DeveloperNotificationSettingsDialog'
 import { SubscriptionShareDialog } from './SubscriptionShareDialog'
+import { FollowWithNotificationDropdown } from './FollowWithNotificationDropdown'
 
 interface SubscriptionDetailPageProps {
   subscriptionId: number
@@ -64,7 +63,6 @@ export function SubscriptionDetailPage({ subscriptionId }: SubscriptionDetailPag
   const [followersLoading, setFollowersLoading] = useState(false)
   const [followersTotal, setFollowersTotal] = useState(0)
   const [isFollowing, setIsFollowing] = useState(false)
-  const [followLoading, setFollowLoading] = useState(false)
   const [shareDialogOpen, setShareDialogOpen] = useState(false)
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false)
 
@@ -114,34 +112,20 @@ export function SubscriptionDetailPage({ subscriptionId }: SubscriptionDetailPag
     }
   }, [isOwner, loadFollowers])
 
-  // Handle follow/unfollow
-  const handleFollow = useCallback(async () => {
-    if (!subscription) return
-
-    try {
-      setFollowLoading(true)
-      if (isFollowing) {
-        await subscriptionApis.unfollowSubscription(subscriptionId)
-        setIsFollowing(false)
-        setSubscription(prev =>
-          prev ? { ...prev, followers_count: Math.max(0, prev.followers_count - 1) } : null
-        )
-        toast.success(t('unfollow_success'))
-      } else {
-        await subscriptionApis.followSubscription(subscriptionId)
-        setIsFollowing(true)
-        setSubscription(prev =>
-          prev ? { ...prev, followers_count: prev.followers_count + 1 } : null
-        )
-        toast.success(t('follow_success'))
-      }
-    } catch (error) {
-      console.error('Failed to follow/unfollow:', error)
-      toast.error(isFollowing ? t('unfollow_failed') : t('follow_failed'))
-    } finally {
-      setFollowLoading(false)
-    }
-  }, [subscription, subscriptionId, isFollowing, t])
+  // Handle follow state change from dropdown
+  const handleFollowChange = useCallback((newIsFollowing: boolean) => {
+    setIsFollowing(newIsFollowing)
+    setSubscription(prev =>
+      prev
+        ? {
+            ...prev,
+            followers_count: newIsFollowing
+              ? prev.followers_count + 1
+              : Math.max(0, prev.followers_count - 1),
+          }
+        : null
+    )
+  }, [])
 
   // Get trigger label
   const getTriggerLabel = (sub: Subscription): string => {
@@ -209,26 +193,13 @@ export function SubscriptionDetailPage({ subscriptionId }: SubscriptionDetailPag
               </>
             )}
             {!isOwner && (
-              <Button
-                variant={isFollowing ? 'ghost' : 'default'}
+              <FollowWithNotificationDropdown
+                subscriptionId={subscriptionId}
+                isFollowing={isFollowing}
+                onSuccess={handleFollowChange}
+                variant="default"
                 size="sm"
-                onClick={handleFollow}
-                disabled={followLoading}
-                className={
-                  isFollowing
-                    ? 'text-text-muted hover:text-destructive hover:bg-destructive/10'
-                    : ''
-                }
-              >
-                {followLoading ? (
-                  <Loader2 className="h-4 w-4 mr-1.5 animate-spin" />
-                ) : isFollowing ? (
-                  <Check className="h-4 w-4 mr-1.5" />
-                ) : (
-                  <Plus className="h-4 w-4 mr-1.5" />
-                )}
-                {isFollowing ? t('following') : t('follow')}
-              </Button>
+              />
             )}
           </div>
         </div>

--- a/frontend/src/features/feed/components/SubscriptionInvitations.tsx
+++ b/frontend/src/features/feed/components/SubscriptionInvitations.tsx
@@ -10,7 +10,7 @@
  */
 import { useCallback, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Check, Loader2, Mail, X } from 'lucide-react'
+import { Loader2, Mail, X } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslation } from '@/hooks/useTranslation'
 import { Button } from '@/components/ui/button'
@@ -18,6 +18,7 @@ import { Badge } from '@/components/ui/badge'
 import { subscriptionApis } from '@/apis/subscription'
 import type { SubscriptionInvitationResponse } from '@/types/subscription'
 import { paths } from '@/config/paths'
+import { AcceptWithNotificationDropdown } from './FollowWithNotificationDropdown'
 
 interface SubscriptionInvitationsProps {
   onInvitationHandled?: () => void
@@ -51,24 +52,14 @@ export function SubscriptionInvitations({ onInvitationHandled }: SubscriptionInv
     loadInvitations()
   }, [loadInvitations])
 
-  // Handle accept invitation
-  const handleAccept = useCallback(
-    async (invitationId: number) => {
-      try {
-        setProcessingId(invitationId)
-        await subscriptionApis.acceptInvitation(invitationId)
-        toast.success(t('invitation_accepted'))
-        // Remove from list
-        setInvitations(prev => prev.filter(inv => inv.id !== invitationId))
-        onInvitationHandled?.()
-      } catch (error) {
-        console.error('Failed to accept invitation:', error)
-        toast.error(t('invitation_accept_failed'))
-      } finally {
-        setProcessingId(null)
-      }
+  // Handle accept invitation success
+  const handleAcceptSuccess = useCallback(
+    (invitationId: number) => {
+      // Remove from list
+      setInvitations(prev => prev.filter(inv => inv.id !== invitationId))
+      onInvitationHandled?.()
     },
-    [t, onInvitationHandled]
+    [onInvitationHandled]
   )
 
   // Handle reject invitation
@@ -162,20 +153,11 @@ export function SubscriptionInvitations({ onInvitationHandled }: SubscriptionInv
                 </>
               )}
             </Button>
-            <Button
-              size="sm"
-              onClick={() => handleAccept(invitation.id)}
-              disabled={processingId === invitation.id}
-            >
-              {processingId === invitation.id ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <>
-                  <Check className="h-4 w-4 mr-1" />
-                  {t('invitation_accept')}
-                </>
-              )}
-            </Button>
+            <AcceptWithNotificationDropdown
+              invitationId={invitation.id}
+              subscriptionId={invitation.subscription_id}
+              onSuccess={() => handleAcceptSuccess(invitation.id)}
+            />
           </div>
         </div>
       ))}

--- a/frontend/src/i18n/locales/en/feed.json
+++ b/frontend/src/i18n/locales/en/feed.json
@@ -299,6 +299,21 @@
     "save_success": "Notification settings saved",
     "save_failed": "Failed to save notification settings"
   },
+  "follow_dropdown": {
+    "select_level": "Select notification level",
+    "level_silent": "Silent",
+    "level_silent_desc": "Execute but hide from timeline",
+    "level_default": "Default",
+    "level_default_desc": "Show in Feed timeline",
+    "level_notify": "Notify",
+    "level_notify_desc": "Send notification via Messager channels",
+    "notify_disabled_hint": "Please bind a Messager channel by sending a message first",
+    "select_channels": "Select notification channels",
+    "select_channels_hint": "Select at least one bound channel",
+    "channel_not_bound": "Not bound",
+    "back": "Back",
+    "confirm_follow": "Confirm Follow"
+  },
   "developer_notification_settings": {
     "title": "Developer Notification Settings",
     "description": "Configure how you want to be notified when \"{{name}}\" executes (as the subscription owner)",

--- a/frontend/src/i18n/locales/zh-CN/feed.json
+++ b/frontend/src/i18n/locales/zh-CN/feed.json
@@ -299,6 +299,21 @@
     "save_success": "通知设置已保存",
     "save_failed": "保存通知设置失败"
   },
+  "follow_dropdown": {
+    "select_level": "选择通知级别",
+    "level_silent": "静默",
+    "level_silent_desc": "执行但不在时间线显示",
+    "level_default": "默认",
+    "level_default_desc": "在动态时间线中显示",
+    "level_notify": "通知",
+    "level_notify_desc": "通过 Messager 渠道发送通知",
+    "notify_disabled_hint": "请先通过 Messager 渠道发送一条消息进行绑定",
+    "select_channels": "选择通知渠道",
+    "select_channels_hint": "选择至少一个已绑定的渠道",
+    "channel_not_bound": "未绑定",
+    "back": "返回",
+    "confirm_follow": "确认关注"
+  },
   "developer_notification_settings": {
     "title": "开发者通知设置",
     "description": "配置当「{{name}}」执行时如何通知您（作为订阅器创建者）",

--- a/frontend/src/types/subscription.ts
+++ b/frontend/src/types/subscription.ts
@@ -413,6 +413,12 @@ export interface FollowSubscriptionRequest {
   notification_channel_ids?: number[]
 }
 
+// Accept invitation request with notification settings
+export interface AcceptInvitationRequest {
+  notification_level?: NotificationLevel
+  notification_channel_ids?: number[]
+}
+
 // Update follow settings request
 export interface UpdateFollowSettingsRequest {
   notification_level: NotificationLevel


### PR DESCRIPTION
## Summary
- Add `FollowWithNotificationDropdown` component with hover-to-expand menu for selecting notification level when following subscriptions
- Support three notification levels: Silent, Default (recommended), Notify
- When Notify level is selected, show a second step for channel selection
- Disable Notify option when user has no bound Messager channels
- Extend `acceptInvitation` API to support notification settings when accepting invitations
- Add i18n translations for the new follow dropdown UI

## Affected Entry Points
1. **Discover page cards** - Follow button on subscription cards
2. **Subscription detail page** - Follow button in the header
3. **Invitation acceptance** - Accept button now also supports notification level selection

## Interaction Design
- **Desktop**: Hover on "Follow" button to expand notification level dropdown
- **Mobile**: Click on "Follow" button to toggle dropdown
- Silent/Default options directly complete the follow action
- Notify option opens a second step for channel selection

## Test Plan
- [ ] Test hover-to-expand behavior on desktop for Discover cards
- [ ] Test hover-to-expand behavior on desktop for Detail page
- [ ] Test tap behavior on mobile devices
- [ ] Test notification level selection (Silent, Default, Notify)
- [ ] Test Notify channel selection step
- [ ] Verify Notify is disabled when no bound channels
- [ ] Test invitation acceptance with notification level selection
- [ ] Verify i18n works for both zh-CN and en locales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select notification preferences (silent, default, or notify) when accepting subscription invitations and following subscriptions.
  * New dropdown interface allows users to choose specific notification channels for receiving alerts.
  * Multi-step notification setup with level selection followed by channel configuration.
  * Added support for English and Chinese languages in the notification preference interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->