### PR TITLE
fix(backend): fix langchain embeddings error

### DIFF
--- a/backend/app/api/endpoints/adapter/models.py
+++ b/backend/app/api/endpoints/adapter/models.py
@@ -572,6 +572,7 @@ def _test_embedding_connection(
             api_key=api_key,
             base_url=base_url or "https://api.openai.com/v1",
             default_headers=custom_headers if custom_headers else None,
+            check_embedding_ctx_length=False,
         )
         embeddings.embed_query("test")
         return {


### PR DESCRIPTION
while adding openai embeddings model, it gives 400 error. langchain OpenAIEmbeddings will convert text to token ids by default.
change the check_embedding_ctx_length can work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated embedding validation configuration handling during connection testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->