### PR TITLE
refactor(backend): migrate namespace_members to resource_members

### DIFF
--- a/backend/alembic/versions/a7b8c9d0e1f2_add_role_to_resource_members.py
+++ b/backend/alembic/versions/a7b8c9d0e1f2_add_role_to_resource_members.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Add role column to resource_members table.
+"""Add role column to resource_members table and migrate namespace_members.
 
 This migration:
 1. Adds role column to resource_members table
 2. Migrates existing permission_level data to role
 3. Updates permission_level comment to indicate deprecation
+4. Migrates namespace_members data to resource_members with resource_type='Namespace'
 
 Revision ID: a7b8c9d0e1f2
 Revises: z6a7b8c9d0e1
@@ -17,6 +18,15 @@ Migration rules:
 - permission_level = 'view'/'VIEW' -> role = 'Reporter'
 - permission_level = 'edit'/'EDIT' -> role = 'Developer'
 - permission_level = 'manage'/'MANAGE' -> role = 'Maintainer'
+
+Namespace members migration:
+- namespace_members.group_name -> resource_members.resource_id (via namespace.id)
+- namespace_members.user_id -> resource_members.user_id
+- namespace_members.role -> resource_members.role
+- namespace_members.invited_by_user_id -> resource_members.invited_by_user_id
+- namespace_members.is_active=True -> resource_members.status='approved'
+- resource_members.resource_type = 'Namespace'
+- resource_members.permission_level derived from role
 """
 from typing import Sequence, Union
 
@@ -64,6 +74,78 @@ def upgrade() -> None:
                 comment="Member role: Owner, Maintainer, Developer, Reporter",
             ),
         )
+
+    # 2. Migrate namespace_members to resource_members
+    # This migrates group membership data to the unified resource_members table
+    if table_exists(conn, "namespace_members") and table_exists(conn, "resource_members"):
+        # Get all namespace members with their namespace IDs
+        # Use INSERT IGNORE (MySQL) or INSERT OR IGNORE (SQLite) to avoid duplicates
+        dialect = conn.dialect.name
+
+        if dialect == "mysql":
+            # MySQL: Use INSERT IGNORE with JOIN to get namespace IDs
+            op.execute(
+                """
+                INSERT IGNORE INTO resource_members
+                (resource_type, resource_id, user_id, role, permission_level, status,
+                 invited_by_user_id, share_link_id, reviewed_by_user_id, reviewed_at,
+                 copied_resource_id, requested_at, created_at, updated_at)
+                SELECT
+                    'Namespace' as resource_type,
+                    n.id as resource_id,
+                    nm.user_id,
+                    nm.role,
+                    CASE nm.role
+                        WHEN 'Owner' THEN 'manage'
+                        WHEN 'Maintainer' THEN 'manage'
+                        WHEN 'Developer' THEN 'edit'
+                        ELSE 'view'
+                    END as permission_level,
+                    CASE WHEN nm.is_active = 1 THEN 'approved' ELSE 'rejected' END as status,
+                    nm.invited_by_user_id,
+                    0 as share_link_id,
+                    0 as reviewed_by_user_id,
+                    '1970-01-01 00:00:00' as reviewed_at,
+                    0 as copied_resource_id,
+                    nm.created_at as requested_at,
+                    nm.created_at,
+                    nm.updated_at
+                FROM namespace_members nm
+                JOIN namespace n ON nm.group_name = n.name
+                """
+            )
+        else:
+            # SQLite: Use INSERT OR IGNORE with JOIN to get namespace IDs
+            op.execute(
+                """
+                INSERT OR IGNORE INTO resource_members
+                (resource_type, resource_id, user_id, role, permission_level, status,
+                 invited_by_user_id, share_link_id, reviewed_by_user_id, reviewed_at,
+                 copied_resource_id, requested_at, created_at, updated_at)
+                SELECT
+                    'Namespace' as resource_type,
+                    n.id as resource_id,
+                    nm.user_id,
+                    nm.role,
+                    CASE nm.role
+                        WHEN 'Owner' THEN 'manage'
+                        WHEN 'Maintainer' THEN 'manage'
+                        WHEN 'Developer' THEN 'edit'
+                        ELSE 'view'
+                    END as permission_level,
+                    CASE WHEN nm.is_active = 1 THEN 'approved' ELSE 'rejected' END as status,
+                    nm.invited_by_user_id,
+                    0 as share_link_id,
+                    0 as reviewed_by_user_id,
+                    '1970-01-01 00:00:00' as reviewed_at,
+                    0 as copied_resource_id,
+                    nm.created_at as requested_at,
+                    nm.created_at,
+                    nm.updated_at
+                FROM namespace_members nm
+                JOIN namespace n ON nm.group_name = n.name
+                """
+            )
 
     # 2. Migrate data from permission_level to role
     # Only run if table and columns exist

--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
 from app.core.security import get_current_user
-from app.models.namespace_member import NamespaceMember
+from app.models.namespace import Namespace
+from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.user import User
 from app.schemas.namespace import (
     GroupCreate,
@@ -120,12 +121,14 @@ def list_members(
             detail="You are not a member of this group",
         )
 
-    # Get all active members with user information
+    # Get all approved members with user information using ResourceMember
     members = (
-        db.query(NamespaceMember)
+        db.query(ResourceMember)
+        .join(Namespace, Namespace.id == ResourceMember.resource_id)
         .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.is_active == True,
+            ResourceMember.resource_type == "Namespace",
+            Namespace.name == group_name,
+            ResourceMember.status == MemberStatus.APPROVED.value,
         )
         .all()
     )
@@ -135,11 +138,11 @@ def list_members(
     for m in members:
         member_dict = {
             "id": m.id,
-            "group_name": m.group_name,
+            "group_name": group_name,
             "user_id": m.user_id,
             "role": m.role,
             "invited_by_user_id": m.invited_by_user_id,
-            "is_active": m.is_active,
+            "is_active": True,  # ResourceMember uses status instead
             "created_at": m.created_at,
             "updated_at": m.updated_at,
         }

--- a/backend/app/models/namespace.py
+++ b/backend/app/models/namespace.py
@@ -41,11 +41,12 @@ class Namespace(Base):
     updated_at = Column(DateTime, default=func.now(), onupdate=func.now())
 
     # Relationships
+    # Note: Namespace members are now stored in resource_members table
+    # This relationship is kept for backward compatibility but delegates to ResourceMember
     members = relationship(
-        "NamespaceMember",
-        back_populates="namespace",
+        "ResourceMember",
+        primaryjoin="and_(Namespace.id == foreign(ResourceMember.resource_id), ResourceMember.resource_type == 'Namespace')",
         cascade="all, delete-orphan",
-        primaryjoin="Namespace.name == foreign(NamespaceMember.group_name)",
     )
 
     __table_args__ = (

--- a/backend/app/models/namespace_member.py
+++ b/backend/app/models/namespace_member.py
@@ -13,9 +13,15 @@ from app.db.base import Base
 
 class NamespaceMember(Base):
     """
-    Group membership model.
+    Group membership model - DEPRECATED.
 
-    Stores user membership in groups with role-based permissions.
+    This model is deprecated and will be removed in a future version.
+    All group membership data has been migrated to resource_members table
+    with resource_type='Namespace'.
+
+    Use ResourceMember model with resource_type='Namespace' for new code.
+    This class is kept for backward compatibility during the transition period.
+
     Roles: Owner, Maintainer, Developer, Reporter
     """
 

--- a/backend/app/models/resource_member.py
+++ b/backend/app/models/resource_member.py
@@ -6,9 +6,9 @@
 Resource member model for unified resource sharing.
 
 Stores user access permissions to shared resources.
-Supports Team, Task, and KnowledgeBase resource types.
+Supports Team, Task, KnowledgeBase, and Namespace resource types.
 
-This model replaces the legacy SharedTeam, SharedTask, and TaskMember models
+This model replaces the legacy SharedTeam, SharedTask, TaskMember, and NamespaceMember models
 to provide a unified access control system for all shareable resources.
 """
 
@@ -87,7 +87,7 @@ class ResourceMember(Base):
     resource_type = Column(
         String(50),
         nullable=False,
-        comment="Resource type: Team, Task, KnowledgeBase",
+        comment="Resource type: Team, Task, KnowledgeBase, Namespace",
     )
     resource_id = Column(
         Integer,

--- a/backend/app/services/adapters/retriever_kinds.py
+++ b/backend/app/services/adapters/retriever_kinds.py
@@ -14,7 +14,6 @@ from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
 from app.models.namespace import Namespace
-from app.models.namespace_member import NamespaceMember
 from app.models.user import User
 from app.schemas.kind import Retriever
 from app.services.base import BaseService

--- a/backend/app/services/group_member_helper.py
+++ b/backend/app/services/group_member_helper.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Group membership helper using ResourceMember model.
+
+This module provides helper functions for group membership operations
+using the unified resource_members table with resource_type='Namespace'.
+
+This replaces the direct usage of NamespaceMember model.
+"""
+
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.namespace import Namespace
+from app.models.resource_member import MemberStatus, ResourceMember
+from app.schemas.namespace import GroupRole
+
+
+# Resource type for namespace/group memberships
+NAMESPACE_RESOURCE_TYPE = "Namespace"
+
+
+def get_namespace_id_by_name(db: Session, group_name: str) -> Optional[int]:
+    """Get namespace ID by name."""
+    namespace = (
+        db.query(Namespace)
+        .filter(Namespace.name == group_name, Namespace.is_active == True)
+        .first()
+    )
+    return namespace.id if namespace else None
+
+
+def get_group_member(
+    db: Session, group_name: str, user_id: int
+) -> Optional[ResourceMember]:
+    """
+    Get group membership record for a user.
+
+    Args:
+        db: Database session
+        group_name: Group name
+        user_id: User ID
+
+    Returns:
+        ResourceMember if found, None otherwise
+    """
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if not namespace_id:
+        return None
+
+    return (
+        db.query(ResourceMember)
+        .filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.resource_id == namespace_id,
+            ResourceMember.user_id == user_id,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+        )
+        .first()
+    )
+
+
+def get_user_role_in_group(
+    db: Session, user_id: int, group_name: str
+) -> Optional[GroupRole]:
+    """
+    Get user's role in a specific group.
+
+    Args:
+        db: Database session
+        user_id: User ID
+        group_name: Group name
+
+    Returns:
+        GroupRole if user is a member, None otherwise
+    """
+    member = get_group_member(db, group_name, user_id)
+    if member and member.role:
+        try:
+            return GroupRole(member.role)
+        except ValueError:
+            return None
+    return None
+
+
+def is_group_member(db: Session, group_name: str, user_id: int) -> bool:
+    """
+    Check if user is a member of a group.
+
+    Args:
+        db: Database session
+        group_name: Group name
+        user_id: User ID
+
+    Returns:
+        True if user is a member, False otherwise
+    """
+    return get_group_member(db, group_name, user_id) is not None
+
+
+def get_group_members(db: Session, group_name: str) -> list[ResourceMember]:
+    """
+    Get all approved members of a group.
+
+    Args:
+        db: Database session
+        group_name: Group name
+
+    Returns:
+        List of ResourceMember records
+    """
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if not namespace_id:
+        return []
+
+    return (
+        db.query(ResourceMember)
+        .filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.resource_id == namespace_id,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+        )
+        .all()
+    )
+
+
+def get_group_member_count(db: Session, group_name: str) -> int:
+    """
+    Get the number of approved members in a group.
+
+    Args:
+        db: Database session
+        group_name: Group name
+
+    Returns:
+        Number of approved members
+    """
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if not namespace_id:
+        return 0
+
+    return (
+        db.query(ResourceMember)
+        .filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.resource_id == namespace_id,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+        )
+        .count()
+    )
+
+
+def get_user_groups_with_roles(
+    db: Session, user_id: int
+) -> list[tuple[str, str]]:
+    """
+    Get all group names and roles for a user.
+
+    Args:
+        db: Database session
+        user_id: User ID
+
+    Returns:
+        List of tuples (group_name, role)
+    """
+    # Get all approved memberships for user
+    memberships = (
+        db.query(ResourceMember)
+        .filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.user_id == user_id,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+        )
+        .all()
+    )
+
+    # Get namespace names for each membership
+    result = []
+    namespace_ids = [m.resource_id for m in memberships]
+    if namespace_ids:
+        namespaces = (
+            db.query(Namespace)
+            .filter(Namespace.id.in_(namespace_ids), Namespace.is_active == True)
+            .all()
+        )
+        namespace_map = {n.id: n.name for n in namespaces}
+
+        for membership in memberships:
+            group_name = namespace_map.get(membership.resource_id)
+            if group_name:
+                result.append((group_name, membership.role))
+
+    return result
+
+
+def create_group_member(
+    db: Session,
+    group_name: str,
+    user_id: int,
+    role: str,
+    invited_by_user_id: int,
+) -> Optional[ResourceMember]:
+    """
+    Create a new group membership.
+
+    Args:
+        db: Database session
+        group_name: Group name
+        user_id: User ID
+        role: Role to assign
+        invited_by_user_id: User ID of the inviter
+
+    Returns:
+        Created ResourceMember or None if group not found
+    """
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if not namespace_id:
+        return None
+
+    # Map role to permission level
+    role_to_permission = {
+        GroupRole.OWNER.value: "manage",
+        GroupRole.MAINTAINER.value: "manage",
+        GroupRole.DEVELOPER.value: "edit",
+        GroupRole.REPORTER.value: "view",
+    }
+    permission_level = role_to_permission.get(role, "view")
+
+    member = ResourceMember(
+        resource_type=NAMESPACE_RESOURCE_TYPE,
+        resource_id=namespace_id,
+        user_id=user_id,
+        role=role,
+        permission_level=permission_level,
+        status=MemberStatus.APPROVED.value,
+        invited_by_user_id=invited_by_user_id,
+        share_link_id=0,
+        reviewed_by_user_id=0,
+        reviewed_at__epoch=True,  # Will be set to epoch time
+        copied_resource_id=0,
+    )
+
+    db.add(member)
+    db.flush()
+
+    return member
+
+
+def delete_group_member(
+    db: Session, group_name: str, user_id: int
+) -> bool:
+    """
+    Delete a group membership.
+
+    Args:
+        db: Database session
+        group_name: Group name
+        user_id: User ID
+
+    Returns:
+        True if deleted, False if not found
+    """
+    member = get_group_member(db, group_name, user_id)
+    if member:
+        db.delete(member)
+        db.flush()
+        return True
+    return False
+
+
+def count_group_members_by_role(db: Session, group_name: str, role: str) -> int:
+    """
+    Count members with a specific role in a group.
+
+    Args:
+        db: Database session
+        group_name: Group name
+        role: Role to count
+
+    Returns:
+        Number of members with the role
+    """
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if not namespace_id:
+        return 0
+
+    return (
+        db.query(ResourceMember)
+        .filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.resource_id == namespace_id,
+            ResourceMember.role == role,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+        )
+        .count()
+    )

--- a/backend/app/services/group_permission.py
+++ b/backend/app/services/group_permission.py
@@ -7,7 +7,11 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from app.models.namespace import Namespace
-from app.models.namespace_member import NamespaceMember
+from app.services.group_member_helper import (
+    NAMESPACE_RESOURCE_TYPE,
+    get_user_groups_with_roles,
+    get_user_role_in_group,
+)
 from app.schemas.namespace import GroupRole
 
 
@@ -25,19 +29,14 @@ def get_user_role_in_group(
     Returns:
         GroupRole if user is a member, None otherwise
     """
-    member = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
+    from app.services.group_member_helper import get_user_role_in_group as helper_get_role
 
-    if member:
-        return GroupRole(member.role)
-
+    role_str = helper_get_role(db, user_id, group_name)
+    if role_str:
+        try:
+            return GroupRole(role_str)
+        except ValueError:
+            return None
     return None
 
 
@@ -95,17 +94,11 @@ def get_user_groups(db: Session, user_id: int) -> list[str]:
     # Get all active groups
     all_groups = db.query(Namespace).filter(Namespace.is_active == True).all()
 
-    # Get user's direct memberships
-    direct_memberships = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .all()
-    )
+    # Get user's direct memberships with roles
+    direct_memberships = get_user_groups_with_roles(db, user_id)
 
-    direct_group_names = {m.group_name for m in direct_memberships}
+    # Create a mapping of group_name -> role
+    direct_group_names = {name for name, _ in direct_memberships}
     accessible_groups = set(direct_group_names)
 
     # Check permission inheritance for all groups

--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
 from app.models.namespace import Namespace
-from app.models.namespace_member import NamespaceMember
+from app.models.resource_member import MemberStatus, ResourceMember
 from app.schemas.namespace import (
     GroupCreate,
     GroupLevel,
@@ -22,6 +22,17 @@ from app.schemas.namespace_member import (
     GroupMemberCreate,
     GroupMemberResponse,
     GroupMemberUpdate,
+)
+from app.services.group_member_helper import (
+    NAMESPACE_RESOURCE_TYPE,
+    count_group_members_by_role,
+    create_group_member,
+    delete_group_member,
+    get_group_member,
+    get_group_member_count,
+    get_group_members,
+    get_namespace_id_by_name,
+    get_user_groups_with_roles,
 )
 from app.services.group_permission import (
     check_group_permission,
@@ -130,13 +141,18 @@ def create_group(
     db.add(new_group)
     db.flush()  # Flush to get the group ID
 
-    # Add creator as Owner member
-    owner_member = NamespaceMember(
-        group_name=group_data.name,
+    # Add creator as Owner member using ResourceMember
+    owner_member = ResourceMember(
+        resource_type=NAMESPACE_RESOURCE_TYPE,
+        resource_id=new_group.id,
         user_id=owner_user_id,
         role=GroupRole.Owner.value,
+        permission_level="manage",
+        status=MemberStatus.APPROVED.value,
         invited_by_user_id=owner_user_id,  # Self-invited
-        is_active=True,
+        share_link_id=0,
+        reviewed_by_user_id=0,
+        copied_resource_id=0,
     )
 
     db.add(owner_member)
@@ -194,14 +210,7 @@ def list_user_groups(
         List of GroupResponse objects with additional fields
     """
     # Get all groups where user is an active member with their role
-    member_data = (
-        db.query(NamespaceMember.group_name, NamespaceMember.role)
-        .filter(
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .all()
-    )
+    member_data = get_user_groups_with_roles(db, user_id)
 
     if not member_data:
         return []
@@ -228,15 +237,7 @@ def list_user_groups(
     # Get member counts for all groups
     member_counts = {}
     for group_name in group_names:
-        count = (
-            db.query(NamespaceMember)
-            .filter(
-                NamespaceMember.group_name == group_name,
-                NamespaceMember.is_active == True,
-            )
-            .count()
-        )
-        member_counts[group_name] = count
+        member_counts[group_name] = get_group_member_count(db, group_name)
 
     # Build response with additional fields
     result = []
@@ -396,8 +397,13 @@ def delete_group(db: Session, group_name: str, user_id: int) -> None:
             detail="Cannot delete group with existing resources. Move or delete resources first.",
         )
 
-    # Hard delete all members
-    db.query(NamespaceMember).filter(NamespaceMember.group_name == group_name).delete()
+    # Hard delete all members from resource_members
+    namespace_id = get_namespace_id_by_name(db, group_name)
+    if namespace_id:
+        db.query(ResourceMember).filter(
+            ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+            ResourceMember.resource_id == namespace_id,
+        ).delete()
 
     # Hard delete group
     db.delete(group)
@@ -451,36 +457,41 @@ def add_member(
         )
 
     # Check if user is already a member
-    existing = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
-
+    existing = get_group_member(db, group_name, user_id)
     if existing:
         raise HTTPException(
             status_code=400,
             detail="User is already a member of this group",
         )
 
-    # Create member
-    new_member = NamespaceMember(
+    # Create member using ResourceMember
+    new_member = create_group_member(
+        db=db,
         group_name=group_name,
         user_id=user_id,
         role=role.value,
         invited_by_user_id=invited_by_user_id,
-        is_active=True,
     )
 
-    db.add(new_member)
+    if not new_member:
+        raise HTTPException(status_code=404, detail="Group not found")
+
     db.commit()
     db.refresh(new_member)
 
-    return GroupMemberResponse.model_validate(new_member)
+    # Build response with group_name field for backward compatibility
+    response_data = {
+        "id": new_member.id,
+        "group_name": group_name,
+        "user_id": new_member.user_id,
+        "role": new_member.role,
+        "invited_by_user_id": new_member.invited_by_user_id,
+        "is_active": new_member.status == MemberStatus.APPROVED.value,
+        "created_at": new_member.created_at,
+        "updated_at": new_member.updated_at,
+    }
+
+    return GroupMemberResponse(**response_data)
 
 
 def remove_member(
@@ -501,15 +512,7 @@ def remove_member(
         HTTPException: If member not found or insufficient permissions
     """
     # Check member exists
-    member = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
+    member = get_group_member(db, group_name, user_id)
 
     if not member:
         raise HTTPException(status_code=404, detail="Member not found")
@@ -556,15 +559,7 @@ def remove_member(
 
     # Prevent removing the last owner
     if target_role == GroupRole.Owner:
-        owner_count = (
-            db.query(NamespaceMember)
-            .filter(
-                NamespaceMember.group_name == group_name,
-                NamespaceMember.role == GroupRole.Owner.value,
-                NamespaceMember.is_active == True,
-            )
-            .count()
-        )
+        owner_count = count_group_members_by_role(db, group_name, GroupRole.Owner.value)
 
         if owner_count <= 1:
             raise HTTPException(
@@ -604,15 +599,7 @@ def update_member_role(
         HTTPException: If member not found or insufficient permissions
     """
     # Check member exists
-    member = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
+    member = get_group_member(db, group_name, user_id)
 
     if not member:
         raise HTTPException(status_code=404, detail="Member not found")
@@ -642,15 +629,7 @@ def update_member_role(
 
     # Prevent downgrading the last owner
     if current_role == GroupRole.Owner and new_role != GroupRole.Owner:
-        owner_count = (
-            db.query(NamespaceMember)
-            .filter(
-                NamespaceMember.group_name == group_name,
-                NamespaceMember.role == GroupRole.Owner.value,
-                NamespaceMember.is_active == True,
-            )
-            .count()
-        )
+        owner_count = count_group_members_by_role(db, group_name, GroupRole.Owner.value)
 
         if owner_count <= 1:
             raise HTTPException(
@@ -658,12 +637,32 @@ def update_member_role(
                 detail="Cannot change role of the last owner. Add another owner first.",
             )
 
-    # Update role
+    # Update role and permission_level
     member.role = new_role.value
+    role_to_permission = {
+        GroupRole.OWNER.value: "manage",
+        GroupRole.MAINTAINER.value: "manage",
+        GroupRole.DEVELOPER.value: "edit",
+        GroupRole.REPORTER.value: "view",
+    }
+    member.permission_level = role_to_permission.get(new_role.value, "view")
+
     db.commit()
     db.refresh(member)
 
-    return GroupMemberResponse.model_validate(member)
+    # Build response with group_name field for backward compatibility
+    response_data = {
+        "id": member.id,
+        "group_name": group_name,
+        "user_id": member.user_id,
+        "role": member.role,
+        "invited_by_user_id": member.invited_by_user_id,
+        "is_active": member.status == MemberStatus.APPROVED.value,
+        "created_at": member.created_at,
+        "updated_at": member.updated_at,
+    }
+
+    return GroupMemberResponse(**response_data)
 
 
 def transfer_ownership(
@@ -716,25 +715,8 @@ def transfer_ownership(
         )
 
     # Get member records
-    current_owner_member = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == current_owner_user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
-
-    new_owner_member = (
-        db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.user_id == new_owner_user_id,
-            NamespaceMember.is_active == True,
-        )
-        .first()
-    )
+    current_owner_member = get_group_member(db, group_name, current_owner_user_id)
+    new_owner_member = get_group_member(db, group_name, new_owner_user_id)
 
     # Update group owner
     group.owner_user_id = new_owner_user_id
@@ -742,9 +724,11 @@ def transfer_ownership(
     # Update member roles
     if current_owner_member:
         current_owner_member.role = GroupRole.Maintainer.value
+        current_owner_member.permission_level = "manage"
 
     if new_owner_member:
         new_owner_member.role = GroupRole.Owner.value
+        new_owner_member.permission_level = "manage"
 
     db.commit()
     db.refresh(group)
@@ -797,26 +781,24 @@ def invite_all_users(
     all_users = db.query(User).filter(User.is_active == True).all()
 
     # Get existing members
-    existing_member_ids = {
-        m.user_id
-        for m in db.query(NamespaceMember)
-        .filter(
-            NamespaceMember.group_name == group_name,
-            NamespaceMember.is_active == True,
-        )
-        .all()
-    }
+    existing_members = get_group_members(db, group_name)
+    existing_member_ids = {m.user_id for m in existing_members}
 
     # Create new members
     new_members = []
     for user in all_users:
         if user.id not in existing_member_ids:
-            new_member = NamespaceMember(
-                group_name=group_name,
+            new_member = ResourceMember(
+                resource_type=NAMESPACE_RESOURCE_TYPE,
+                resource_id=group.id,
                 user_id=user.id,
                 role=GroupRole.Reporter.value,
+                permission_level="view",
+                status=MemberStatus.APPROVED.value,
                 invited_by_user_id=invited_by_user_id,
-                is_active=True,
+                share_link_id=0,
+                reviewed_by_user_id=0,
+                copied_resource_id=0,
             )
             db.add(new_member)
             new_members.append(new_member)
@@ -826,7 +808,22 @@ def invite_all_users(
         for member in new_members:
             db.refresh(member)
 
-    return [GroupMemberResponse.model_validate(m) for m in new_members]
+    # Build responses
+    result = []
+    for member in new_members:
+        response_data = {
+            "id": member.id,
+            "group_name": group_name,
+            "user_id": member.user_id,
+            "role": member.role,
+            "invited_by_user_id": member.invited_by_user_id,
+            "is_active": member.status == MemberStatus.APPROVED.value,
+            "created_at": member.created_at,
+            "updated_at": member.updated_at,
+        }
+        result.append(GroupMemberResponse(**response_data))
+
+    return result
 
 
 def _transfer_resources_to_owner(

--- a/backend/app/services/readers/group_members.py
+++ b/backend/app/services/readers/group_members.py
@@ -5,7 +5,8 @@
 """
 GroupMember reader - read-only queries with optional extension.
 
-Note: The underlying table is 'namespace_members', but we use 'group_members' in code for clarity.
+Note: The underlying table is now 'resource_members' with resource_type='Namespace'.
+This reader provides backward compatibility for code using group membership queries.
 
 Usage:
     from app.services.readers.group_members import groupMemberReader
@@ -23,7 +24,13 @@ from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
-from app.models.namespace_member import NamespaceMember
+from app.models.namespace import Namespace
+from app.models.resource_member import MemberStatus, ResourceMember
+from app.services.group_member_helper import (
+    NAMESPACE_RESOURCE_TYPE,
+    get_group_member,
+    get_namespace_id_by_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +56,7 @@ class IGroupMemberReader(ABC):
     @abstractmethod
     def get_by_group_and_user(
         self, db: Session, group_name: str, user_id: int
-    ) -> Optional[NamespaceMember]:
+    ) -> Optional[ResourceMember]:
         """Get GroupMember record by group_name and user_id."""
         pass
 
@@ -70,19 +77,10 @@ class IGroupMemberReader(ABC):
 
 
 class GroupMemberReader(IGroupMemberReader):
-    """GroupMember reader with direct database queries."""
+    """GroupMember reader with direct database queries using ResourceMember."""
 
     def is_member(self, db: Session, group_name: str, user_id: int) -> bool:
-        return (
-            db.query(NamespaceMember)
-            .filter(
-                NamespaceMember.group_name == group_name,
-                NamespaceMember.user_id == user_id,
-                NamespaceMember.is_active == True,
-            )
-            .first()
-            is not None
-        )
+        return get_group_member(db, group_name, user_id) is not None
 
     def get_role(self, db: Session, group_name: str, user_id: int) -> Optional[str]:
         member = self.get_by_group_and_user(db, group_name, user_id)
@@ -90,27 +88,33 @@ class GroupMemberReader(IGroupMemberReader):
 
     def get_by_group_and_user(
         self, db: Session, group_name: str, user_id: int
-    ) -> Optional[NamespaceMember]:
-        return (
-            db.query(NamespaceMember)
-            .filter(
-                NamespaceMember.group_name == group_name,
-                NamespaceMember.user_id == user_id,
-                NamespaceMember.is_active == True,
-            )
-            .first()
-        )
+    ) -> Optional[ResourceMember]:
+        return get_group_member(db, group_name, user_id)
 
     def get_user_groups(self, db: Session, user_id: int) -> List[str]:
-        results = (
-            db.query(NamespaceMember.group_name)
+        # Get all approved memberships for user
+        memberships = (
+            db.query(ResourceMember)
             .filter(
-                NamespaceMember.user_id == user_id,
-                NamespaceMember.is_active == True,
+                ResourceMember.resource_type == NAMESPACE_RESOURCE_TYPE,
+                ResourceMember.user_id == user_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
             )
             .all()
         )
-        return [r[0] for r in results]
+
+        # Get namespace names for each membership
+        namespace_ids = [m.resource_id for m in memberships]
+        if not namespace_ids:
+            return []
+
+        namespaces = (
+            db.query(Namespace)
+            .filter(Namespace.id.in_(namespace_ids), Namespace.is_active == True)
+            .all()
+        )
+
+        return [n.name for n in namespaces]
 
     def on_change(self, group_name: str, user_id: int) -> None:
         pass

--- a/backend/app/services/subscription/follow_service.py
+++ b/backend/app/services/subscription/follow_service.py
@@ -19,11 +19,11 @@ from sqlalchemy.orm import Session
 
 from app.models.kind import Kind
 from app.models.namespace import Namespace
-from app.models.namespace_member import NamespaceMember
+from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.subscription_follow import (
     FollowType,
     InvitationStatus,
-    NotificationLevel,
+    NotificationStatus,
     SubscriptionFollow,
     SubscriptionShareNamespace,
 )
@@ -592,10 +592,14 @@ class SubscriptionFollowService:
             )
             db.add(share)
 
-        # Get namespace members
+        # Get namespace members using ResourceMember
         members = (
-            db.query(NamespaceMember)
-            .filter(NamespaceMember.namespace_id == namespace_id)
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == "Namespace",
+                ResourceMember.resource_id == namespace_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
             .all()
         )
 
@@ -761,10 +765,14 @@ class SubscriptionFollowService:
         if share:
             db.delete(share)
 
-        # Get namespace members and delete their pending invitations
+        # Get namespace members using ResourceMember and delete their pending invitations
         members = (
-            db.query(NamespaceMember)
-            .filter(NamespaceMember.namespace_id == namespace_id)
+            db.query(ResourceMember)
+            .filter(
+                ResourceMember.resource_type == "Namespace",
+                ResourceMember.resource_id == namespace_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
             .all()
         )
 


### PR DESCRIPTION
Migrate group membership data from namespace_members table to resource_members table with resource_type='Namespace'. This unifies all resource membership management under a single table structure.

Changes:
- Update migration a7b8c9d0e1f2 to migrate namespace_members data
- Add group_member_helper.py with ResourceMember-based group operations
- Update group_permission.py to use ResourceMember
- Update group_service.py to use ResourceMember
- Update group_members.py reader to use ResourceMember
- Fix follow_service.py bug (namespace_id didn't exist) and migrate to ResourceMember
- Update groups.py API endpoint to use ResourceMember
- Remove unused NamespaceMember import from retriever_kinds.py
- Update Namespace model relationship to use ResourceMember
- Mark NamespaceMember as deprecated in docstring

The NamespaceMember model is kept for backward compatibility during transition.