### PR TITLE
fix(chat): fix kb_meta_prompt missing for task-level KB sessions + refactor context result type

### DIFF
--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -826,7 +826,7 @@ async def prepare_contexts_for_chat(
         user_id: User ID for access control
         message: Original user message
         base_system_prompt: Base system prompt to enhance
-        task_id: Optional task ID for fetching historical KB meta
+        task_id: Optional task ID for resolving task-level bound KBs (group chat)
         context_window: Optional model context window size from Model spec.
             Used for selected_documents injection threshold calculation.
             If None, uses default value (128000).
@@ -837,29 +837,7 @@ async def prepare_contexts_for_chat(
     from .tables import parse_table_url
 
     # Get all contexts for this subtask
-    contexts = context_service.get_by_subtask(db, user_subtask_id)
-
-    if not contexts:
-        logger.info(
-            f"[prepare_contexts_for_chat] No subtask contexts for subtask={user_subtask_id}, "
-            f"checking task-level bound KBs for task_id={task_id}"
-        )
-        # Even without subtask contexts, check for task-level bound knowledge bases
-        # This is important for group chat where KBs are bound to the task, not subtask
-        kb_result = _prepare_kb_tools_from_contexts(
-            kb_contexts=[],  # No subtask-level KB contexts
-            user_id=user_id,
-            db=db,
-            base_system_prompt=base_system_prompt,
-            task_id=task_id,
-            user_subtask_id=user_subtask_id,
-        )
-        return ChatContextsResult(
-            final_message=message,
-            has_table_context=False,
-            table_contexts=[],
-            kb=kb_result,
-        )
+    contexts = context_service.get_by_subtask(db, user_subtask_id) or []
 
     # Separate contexts by type
     attachment_contexts = [
@@ -1118,13 +1096,10 @@ def _prepare_kb_tools_from_contexts(
                     document_ids.extend(doc_ids)
 
     if not knowledge_base_ids:
-        # Even without current knowledge bases, check for historical KB meta
-        if task_id:
-            kb_meta_prompt = _build_historical_kb_meta_prompt(db, task_id)
         return KnowledgeBaseToolsResult(
             extra_tools=extra_tools,
             enhanced_system_prompt=enhanced_system_prompt,
-            kb_meta_prompt=kb_meta_prompt,
+            kb_meta_prompt="",
             knowledge_base_ids=[],
             is_user_selected_kb=False,
             document_ids=[],
@@ -1148,9 +1123,9 @@ def _prepare_kb_tools_from_contexts(
     )
     extra_tools.append(kb_tool)
 
-    # Get historical knowledge base meta info if available
-    if task_id:
-        kb_meta_prompt = _build_historical_kb_meta_prompt(db, task_id)
+    # Build KB meta prompt for dynamic_context injection.
+    # This is based on the resolved KB IDs of the CURRENT request (no DB scanning by task).
+    kb_meta_prompt = _build_kb_meta_prompt(db, knowledge_base_ids)
 
     # Choose prompt template based on whether KB is user-selected or inherited from task.
     # Keep KB prompt templates fully static (no kb_meta_list placeholder).
@@ -1219,27 +1194,91 @@ def _get_bound_knowledge_base_ids(db: Session, task_id: int) -> List[int]:
         return []
 
 
-def _build_historical_kb_meta_prompt(
-    db: Session,
-    task_id: int,
-) -> str:
-    """Build knowledge base meta information from historical contexts.
+def _build_kb_meta_prompt(db: Session, knowledge_base_ids: List[int]) -> str:
+    """Build KB meta prompt for dynamic_context injection.
 
-    NOTE:
-    - Backend MUST NOT depend on chat_shell. The KB meta prompt builder lives in Backend.
+    IMPORTANT:
+    - The formatter lives in `kb_meta.py` and MUST NOT query DB.
+    - This function assembles KB meta from resolved KB IDs of the current request.
+
+    Args:
+        db: Database session
+        knowledge_base_ids: Resolved KB IDs for the current request
 
     Returns:
-        Formatted prompt string with KB meta info, or empty string.
+        Formatted prompt string, or empty string.
     """
+
+    if not knowledge_base_ids:
+        return ""
 
     try:
         from app.services.chat.preprocessing.kb_meta import (
-            build_kb_meta_prompt_for_task,
+            format_kb_meta_prompt,
+            select_kb_summary_text,
+        )
+        from app.services.knowledge.task_knowledge_base_service import (
+            task_knowledge_base_service,
         )
 
-        return build_kb_meta_prompt_for_task(db, task_id)
+        kb_map = task_knowledge_base_service.get_knowledge_bases_by_ids(
+            db, knowledge_base_ids
+        )
+
+        kb_meta_list: list[dict[str, Any]] = []
+        for kb_id in knowledge_base_ids:
+            kb_kind = kb_map.get(kb_id)
+            if not kb_kind:
+                kb_meta_list.append(
+                    {
+                        "kb_id": kb_id,
+                        "kb_name": "Unknown",
+                        "summary_text": "",
+                        "topics": [],
+                    }
+                )
+                continue
+
+            kb_spec = kb_kind.json.get("spec", {}) if kb_kind.json else {}
+            kb_name = kb_spec.get("name") or "Unknown"
+
+            summary_text = ""
+            topics: list[str] = []
+            try:
+                summary_data = kb_spec.get("summary", {})
+                if (
+                    kb_spec.get("summaryEnabled")
+                    and summary_data.get("status") == "completed"
+                ):
+                    summary_text = select_kb_summary_text(
+                        summary_data, len(knowledge_base_ids)
+                    )
+                    topics = summary_data.get("topics", []) or []
+            except Exception as e:
+                logger.warning(
+                    "[kb_meta] Failed to extract summary for KB %s: %s",
+                    kb_id,
+                    e,
+                    exc_info=True,
+                )
+
+            kb_meta_list.append(
+                {
+                    "kb_id": kb_id,
+                    "kb_name": kb_name,
+                    "summary_text": summary_text,
+                    "topics": topics,
+                }
+            )
+
+        return format_kb_meta_prompt(kb_meta_list)
     except Exception as e:
-        logger.warning(f"Failed to build KB meta prompt for task {task_id}: {e}")
+        logger.warning(
+            "Failed to build KB meta prompt for knowledge_base_ids=%s: %s",
+            knowledge_base_ids,
+            e,
+            exc_info=True,
+        )
         return ""
 
 

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 from app.models.knowledge import KnowledgeDocument
 from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
 from app.services.context import context_service
-from shared.models.knowledge import KnowledgeBaseToolsResult
+from shared.models.knowledge import ChatContextsResult, KnowledgeBaseToolsResult
 from shared.prompts import KB_PROMPT_RELAXED, KB_PROMPT_STRICT
 
 logger = logging.getLogger(__name__)
@@ -808,7 +808,7 @@ async def prepare_contexts_for_chat(
     base_system_prompt: str,
     task_id: Optional[int] = None,
     context_window: Optional[int] = None,
-) -> Tuple[str, str, List[BaseTool], bool, List[dict]]:
+) -> ChatContextsResult:
     """
     Unified context processing based on user_subtask_id.
 
@@ -832,7 +832,7 @@ async def prepare_contexts_for_chat(
             If None, uses default value (128000).
 
     Returns:
-        Tuple of (final_message, enhanced_system_prompt, extra_tools, has_table_context, table_contexts)
+        ChatContextsResult with processed message, table info, and KB results.
     """
     from .tables import parse_table_url
 
@@ -854,12 +854,11 @@ async def prepare_contexts_for_chat(
             task_id=task_id,
             user_subtask_id=user_subtask_id,
         )
-        return (
-            message,
-            kb_result.enhanced_system_prompt,
-            kb_result.extra_tools,
-            False,
-            [],
+        return ChatContextsResult(
+            final_message=message,
+            has_table_context=False,
+            table_contexts=[],
+            kb=kb_result,
         )
 
     # Separate contexts by type
@@ -911,6 +910,7 @@ async def prepare_contexts_for_chat(
 
     extra_tools = kb_result.extra_tools
     enhanced_system_prompt = kb_result.enhanced_system_prompt
+    kb_meta_prompt = kb_result.kb_meta_prompt
 
     # 3. Process table contexts - create DataTableTool and build dynamic prompt
     parsed_tables = []
@@ -988,12 +988,23 @@ async def prepare_contexts_for_chat(
         )
 
     has_table_context = len(table_contexts) > 0
-    return (
-        final_message,
-        enhanced_system_prompt,
-        extra_tools,
-        has_table_context,
-        parsed_tables,
+
+    # Rebuild KnowledgeBaseToolsResult with potentially mutated enhanced_system_prompt
+    # and extra_tools (table prompt and selected_documents processing may have modified
+    # them after kb_result was computed).
+    final_kb = KnowledgeBaseToolsResult(
+        extra_tools=extra_tools,
+        enhanced_system_prompt=enhanced_system_prompt,
+        kb_meta_prompt=kb_meta_prompt,
+        knowledge_base_ids=kb_result.knowledge_base_ids,
+        is_user_selected_kb=kb_result.is_user_selected_kb,
+        document_ids=kb_result.document_ids,
+    )
+    return ChatContextsResult(
+        final_message=final_message,
+        has_table_context=has_table_context,
+        table_contexts=parsed_tables,
+        kb=final_kb,
     )
 
 
@@ -1064,6 +1075,8 @@ def _prepare_kb_tools_from_contexts(
     NOTE:
     - Knowledge base metadata (kb_meta_prompt) is returned separately and should be injected
       via the `dynamic_context` mechanism to keep system prompts static for better caching.
+    - knowledge_base_ids, is_user_selected_kb, and document_ids are returned so callers
+      can populate ExecutionRequest fields without extra DB queries.
     """
 
     extra_tools: List[BaseTool] = []
@@ -1095,6 +1108,15 @@ def _prepare_kb_tools_from_contexts(
     else:
         knowledge_base_ids = []
 
+    # Extract document_ids from subtask KB contexts (no extra DB query needed).
+    document_ids: List[int] = []
+    if is_user_selected_kb:
+        for c in kb_contexts:
+            if c.type_data and isinstance(c.type_data, dict):
+                doc_ids = c.type_data.get("document_ids", [])
+                if doc_ids:
+                    document_ids.extend(doc_ids)
+
     if not knowledge_base_ids:
         # Even without current knowledge bases, check for historical KB meta
         if task_id:
@@ -1103,6 +1125,9 @@ def _prepare_kb_tools_from_contexts(
             extra_tools=extra_tools,
             enhanced_system_prompt=enhanced_system_prompt,
             kb_meta_prompt=kb_meta_prompt,
+            knowledge_base_ids=[],
+            is_user_selected_kb=False,
+            document_ids=[],
         )
 
     logger.info(
@@ -1150,6 +1175,9 @@ def _prepare_kb_tools_from_contexts(
         extra_tools=extra_tools,
         enhanced_system_prompt=enhanced_system_prompt,
         kb_meta_prompt=kb_meta_prompt,
+        knowledge_base_ids=knowledge_base_ids,
+        is_user_selected_kb=is_user_selected_kb,
+        document_ids=document_ids,
     )
 
 

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -965,7 +965,9 @@ async def prepare_contexts_for_chat(
             process_selected_documents_contexts(**kwargs)
         )
 
-    has_table_context = len(table_contexts) > 0
+    # Derive flag from parsed_tables (not raw table_contexts) to stay consistent
+    # with the returned table payload — if parsing fails, the flag stays False.
+    has_table_context = len(parsed_tables) > 0
 
     # Rebuild KnowledgeBaseToolsResult with potentially mutated enhanced_system_prompt
     # and extra_tools (table prompt and selected_documents processing may have modified
@@ -1087,13 +1089,28 @@ def _prepare_kb_tools_from_contexts(
         knowledge_base_ids = []
 
     # Extract document_ids from subtask KB contexts (no extra DB query needed).
+    # Normalize to int, skip invalid values, and deduplicate while preserving order.
     document_ids: List[int] = []
     if is_user_selected_kb:
+        seen_doc_ids: set[int] = set()
         for c in kb_contexts:
             if c.type_data and isinstance(c.type_data, dict):
-                doc_ids = c.type_data.get("document_ids", [])
-                if doc_ids:
-                    document_ids.extend(doc_ids)
+                raw_doc_ids = c.type_data.get("document_ids", [])
+                if isinstance(raw_doc_ids, list):
+                    for doc_id in raw_doc_ids:
+                        try:
+                            normalized = int(doc_id)
+                        except (TypeError, ValueError):
+                            logger.warning(
+                                "[_prepare_kb_tools_from_contexts] Ignore invalid "
+                                "document_id=%s in context_id=%s",
+                                doc_id,
+                                getattr(c, "id", None),
+                            )
+                            continue
+                        if normalized not in seen_doc_ids:
+                            seen_doc_ids.add(normalized)
+                            document_ids.append(normalized)
 
     if not knowledge_base_ids:
         return KnowledgeBaseToolsResult(
@@ -1240,7 +1257,8 @@ def _build_kb_meta_prompt(db: Session, knowledge_base_ids: List[int]) -> str:
                 continue
 
             kb_spec = kb_kind.json.get("spec", {}) if kb_kind.json else {}
-            kb_name = kb_spec.get("name") or "Unknown"
+            # Prefer spec-level name, then model-level Kind.name, then "Unknown".
+            kb_name = kb_spec.get("name") or getattr(kb_kind, "name", None) or "Unknown"
 
             summary_text = ""
             topics: list[str] = []

--- a/backend/app/services/chat/preprocessing/kb_meta.py
+++ b/backend/app/services/chat/preprocessing/kb_meta.py
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Knowledge base meta prompt builder (Backend-only).
+"""Knowledge base meta prompt formatter (Backend-only).
 
-This module builds the knowledge base meta prompt that used to be generated in
-`chat_shell.history.loader` (package-mode helper).
+This module formats the knowledge base metadata prompt that is injected via Chat Shell's
+`dynamic_context` mechanism as a **human message** (not system prompt).
 
 Design goals:
-- Backend is the single source of truth for KB meta prompt generation.
-- Avoid reverse dependency: Backend MUST NOT import chat_shell.
-- The generated prompt is intended to be injected via Chat Shell's
-  `dynamic_context` mechanism as a **human message** (not system prompt) to
-  improve prompt caching.
+- Keep this module PURE: it MUST NOT query the database.
+- Callers (e.g. chat preprocessing) should assemble the KB meta list based on the
+  current request's resolved KB IDs and priority rules, then call `format_kb_meta_prompt`.
+
+All comments must be written in English.
 """
 
 from __future__ import annotations
@@ -20,16 +20,21 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from sqlalchemy.orm import Session
-
 logger = logging.getLogger(__name__)
 
 
-def _get_summary_text(summary_data: dict[str, Any], kb_count: int) -> str:
-    """Return a summary text according to KB count.
+def select_kb_summary_text(summary_data: dict[str, Any], kb_count: int) -> str:
+    """Select summary text based on KB count.
 
-    - For 1-2 KBs: use long_summary.
-    - For 3+ KBs: use short_summary to save tokens.
+    - For 1-2 KBs: prefer long_summary.
+    - For 3+ KBs: prefer short_summary to save tokens.
+
+    Args:
+        summary_data: The `spec.summary` object from a KnowledgeBase Kind.
+        kb_count: Total KB count in the current meta list.
+
+    Returns:
+        Summary text or empty string.
     """
 
     use_short = kb_count >= 3
@@ -46,133 +51,45 @@ def _get_summary_text(summary_data: dict[str, Any], kb_count: int) -> str:
     return summary_text or ""
 
 
-def get_knowledge_base_meta_for_task(db: Session, task_id: int) -> list[dict[str, Any]]:
-    """Get ordered KB meta list for a task.
+def format_kb_meta_prompt(kb_meta_list: list[dict[str, Any]]) -> str:
+    """Format KB meta list into a dynamic_context prompt string.
 
-    Returns items containing:
-    - kb_id: Kind.id
-    - kb_name: display name (spec.name) fallback to context name
-    - kb_kind: Kind object (for summary/topics extraction) or None
+    Expected item keys:
+    - kb_id: int | str
+    - kb_name: str
+    - summary_text: optional str
+    - topics: optional list[str]
 
-    Order is preserved by first occurrence in historical contexts.
+    Args:
+        kb_meta_list: Pre-assembled KB meta list.
+
+    Returns:
+        A single string for dynamic_context injection, or empty string.
     """
 
-    from app.models.subtask import Subtask
-    from app.models.subtask_context import ContextType, SubtaskContext
-    from app.services.knowledge.task_knowledge_base_service import (
-        task_knowledge_base_service,
-    )
-
-    # Get all subtask IDs for this task.
-    subtask_ids = [
-        row[0] for row in db.query(Subtask.id).filter(Subtask.task_id == task_id).all()
-    ]
-
-    if not subtask_ids:
-        return []
-
-    contexts = (
-        db.query(SubtaskContext)
-        .filter(
-            SubtaskContext.subtask_id.in_(subtask_ids),
-            SubtaskContext.context_type == ContextType.KNOWLEDGE_BASE.value,
-        )
-        .all()
-    )
-
-    kb_ids: list[int] = []
-    seen_kb_ids: set[int] = set()
-    kb_name_map: dict[int, str] = {}
-
-    for ctx in contexts:
-        kb_id = ctx.knowledge_id
-        if kb_id and kb_id not in seen_kb_ids:
-            seen_kb_ids.add(kb_id)
-            kb_ids.append(kb_id)
-            kb_name_map[kb_id] = ctx.name or "Unknown"
-
-    if not kb_ids:
-        return []
-
-    # Batch fetch KB Kind objects (avoid N+1).
-    kb_map = task_knowledge_base_service.get_knowledge_bases_by_ids(db, kb_ids)
-
-    meta_list: list[dict[str, Any]] = []
-    for kb_id in kb_ids:
-        kb_kind = kb_map.get(kb_id)
-        if kb_kind:
-            kb_spec = kb_kind.json.get("spec", {}) if kb_kind.json else {}
-            meta_list.append(
-                {
-                    "kb_id": kb_id,
-                    "kb_name": kb_spec.get("name", kb_name_map.get(kb_id, "Unknown")),
-                    "kb_kind": kb_kind,
-                }
-            )
-        else:
-            meta_list.append(
-                {
-                    "kb_id": kb_id,
-                    "kb_name": kb_name_map.get(kb_id, "Unknown"),
-                    "kb_kind": None,
-                }
-            )
-
-    return meta_list
-
-
-def build_kb_meta_prompt_for_task(db: Session, task_id: int) -> str:
-    """Build KB meta prompt string for the given task.
-
-    The output is meant for **dynamic_context injection** (human message).
-    """
-
-    kb_meta_list = get_knowledge_base_meta_for_task(db, task_id)
     if not kb_meta_list:
         return ""
 
-    kb_count = len(kb_meta_list)
     kb_lines: list[str] = []
 
     for kb_meta in kb_meta_list:
         kb_name = kb_meta.get("kb_name", "Unknown")
         kb_id = kb_meta.get("kb_id", "N/A")
-        kb_kind = kb_meta.get("kb_kind")
-
         kb_lines.append(f"- KB Name: {kb_name}, KB ID: {kb_id}")
 
-        if not kb_kind:
-            continue
+        summary_text = kb_meta.get("summary_text") or ""
+        topics = kb_meta.get("topics") or []
 
-        try:
-            kb_spec = kb_kind.json.get("spec", {}) if kb_kind.json else {}
-            summary_data = kb_spec.get("summary", {})
-
-            if (
-                kb_spec.get("summaryEnabled")
-                and summary_data.get("status") == "completed"
-            ):
-                summary_text = _get_summary_text(summary_data, kb_count)
-                topics = summary_data.get("topics", [])
-
-                if summary_text:
-                    kb_lines.append(f"  - Summary: {summary_text}")
-                if topics:
-                    kb_lines.append(f"  - Topics: {', '.join(topics)}")
-        except Exception as e:
-            logger.warning(
-                "[kb_meta] Failed to extract summary for KB %s: %s",
-                kb_id,
-                e,
-                exc_info=True,
-            )
+        if summary_text:
+            kb_lines.append(f"  - Summary: {summary_text}")
+        if topics:
+            kb_lines.append(f"  - Topics: {', '.join(topics)}")
 
     kb_list_str = "\n".join(kb_lines)
 
     return (
-        "Available Knowledge Bases (from conversation context):\n"
+        "Available Knowledge Bases:\n"
         f"{kb_list_str}\n\n"
-        "Note: The knowledge base content has been pre-filled from history. "
-        "If the provided information is insufficient, you can use the knowledge_base_search "
-        "tool to retrieve more relevant content."
+        "Note: This metadata is provided for intent routing (e.g., answering which KBs are selected). "
+        "Use the knowledge_base_search tool to retrieve document evidence when needed."
     )

--- a/backend/app/services/chat/preprocessing/kb_meta.py
+++ b/backend/app/services/chat/preprocessing/kb_meta.py
@@ -22,6 +22,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Threshold above which short summaries are preferred over long summaries to
+# reduce token usage when many KBs are included in the meta prompt.
+SHORT_SUMMARY_THRESHOLD = 3
+
 
 def select_kb_summary_text(summary_data: dict[str, Any], kb_count: int) -> str:
     """Select summary text based on KB count.
@@ -37,7 +41,7 @@ def select_kb_summary_text(summary_data: dict[str, Any], kb_count: int) -> str:
         Summary text or empty string.
     """
 
-    use_short = kb_count >= 3
+    use_short = kb_count >= SHORT_SUMMARY_THRESHOLD
 
     if use_short:
         summary_text = summary_data.get("short_summary") or summary_data.get(

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -277,13 +277,6 @@ async def build_execution_request(
         # Process contexts (attachments, knowledge bases, etc.)
         if user_subtask_id:
             request = await _process_contexts(db, request, user_subtask_id, user.id)
-        elif request.task_id:
-            # When user_subtask_id is absent (e.g. group chat messages routed directly
-            # from task-level KB binding), we still need to inject kb_meta_prompt so
-            # that the Chat Shell can present KB metadata to the LLM via
-            # dynamic_context injection.  Attachment / table context processing is
-            # intentionally skipped because there is no per-message subtask context.
-            await _build_kb_meta_prompt(db, request, populate_kb_ids=True)
 
         return request
 
@@ -347,61 +340,3 @@ async def _process_contexts(
     )
 
     return request
-
-
-async def _build_kb_meta_prompt(
-    db: "Session",
-    request: "ExecutionRequest",
-    populate_kb_ids: bool = False,
-) -> None:
-    """Build kb_meta_prompt and optionally populate knowledge_base_ids.
-
-    Only called when ``user_subtask_id`` is absent (e.g. group chat where the KB
-    is bound at the task level, not per-message).  In that case ``prepare_contexts_for_chat``
-    is not invoked, so this function handles both responsibilities:
-    - Fills ``request.kb_meta_prompt`` for dynamic_context injection in Chat Shell.
-    - When ``populate_kb_ids=True``, also fills ``request.knowledge_base_ids`` from
-      task-level bound KBs so Chat Shell can create KnowledgeBaseTool for RAG retrieval.
-
-    Attachment / table context processing is intentionally skipped because those
-    are per-message, subtask-scoped operations.
-
-    Args:
-        db: Database session
-        request: ExecutionRequest to mutate in-place
-        populate_kb_ids: When True, also populate knowledge_base_ids from task-level
-            bound KBs (used when there is no user_subtask_id).
-    """
-    import asyncio
-
-    from app.services.chat.preprocessing.kb_meta import build_kb_meta_prompt_for_task
-
-    if not request.task_id:
-        return
-
-    if populate_kb_ids:
-        # Populate task-level bound knowledge base IDs so Chat Shell can create
-        # KnowledgeBaseTool for RAG retrieval (only needed when no user_subtask_id).
-        from app.services.chat.preprocessing.contexts import (
-            _get_bound_knowledge_base_ids,
-        )
-
-        knowledge_base_ids = _get_bound_knowledge_base_ids(db, request.task_id)
-        if knowledge_base_ids:
-            request.knowledge_base_ids = knowledge_base_ids
-            request.is_user_selected_kb = False
-
-    # Build KB meta prompt for dynamic_context injection.
-    request.kb_meta_prompt = ""
-    try:
-        request.kb_meta_prompt = await asyncio.to_thread(
-            build_kb_meta_prompt_for_task, db, request.task_id
-        )
-    except Exception as e:
-        logger.warning(
-            "[ai_trigger_unified] Failed to build kb_meta_prompt "
-            "(task_id=%s, populate_kb_ids=%s): error=%s",
-            request.task_id,
-            populate_kb_ids,
-            e,
-        )

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -277,6 +277,13 @@ async def build_execution_request(
         # Process contexts (attachments, knowledge bases, etc.)
         if user_subtask_id:
             request = await _process_contexts(db, request, user_subtask_id, user.id)
+        elif request.task_id:
+            # When user_subtask_id is absent (e.g. group chat messages routed directly
+            # from task-level KB binding), we still need to inject kb_meta_prompt so
+            # that the Chat Shell can present KB metadata to the LLM via
+            # dynamic_context injection.  Attachment / table context processing is
+            # intentionally skipped because there is no per-message subtask context.
+            await _build_kb_meta_prompt(db, request, populate_kb_ids=True)
 
         return request
 
@@ -302,23 +309,12 @@ async def _process_contexts(
         Enhanced ExecutionRequest with context information
     """
     from app.services.chat.preprocessing import prepare_contexts_for_chat
-    from app.services.chat.preprocessing.contexts import (
-        _get_bound_knowledge_base_ids,
-        get_document_ids_from_subtask,
-        get_knowledge_base_ids_from_subtask,
-    )
 
     # Get context_window from model_config for selected_documents injection threshold
     model_context_window = request.model_config.get("context_window")
 
     # Process contexts (attachments, knowledge bases, etc.)
-    (
-        final_message,
-        enhanced_system_prompt,
-        extra_tools,
-        has_table_context,
-        table_contexts,
-    ) = await prepare_contexts_for_chat(
+    ctx = await prepare_contexts_for_chat(
         db=db,
         user_subtask_id=user_subtask_id,
         user_id=user_id,
@@ -328,55 +324,84 @@ async def _process_contexts(
         context_window=model_context_window,
     )
 
-    # Update request with processed contexts
-    request.prompt = final_message
-    request.system_prompt = enhanced_system_prompt
-    request.table_contexts = table_contexts
-
-    # Build KB meta prompt for dynamic_context injection in chat_shell.
-    # Keeping system prompts static improves prompt caching.
-    request.kb_meta_prompt = ""
-    if request.task_id:
-        try:
-            import asyncio
-
-            from app.services.chat.preprocessing.kb_meta import (
-                build_kb_meta_prompt_for_task,
-            )
-
-            # Use asyncio.to_thread to avoid blocking the event loop
-            request.kb_meta_prompt = await asyncio.to_thread(
-                build_kb_meta_prompt_for_task, db, request.task_id
-            )
-        except Exception as e:
-            logger.warning(
-                "[ai_trigger_unified] Failed to build kb_meta_prompt: task_id=%s, error=%s",
-                request.task_id,
-                e,
-            )
-
-    # Get knowledge base IDs
-    knowledge_base_ids = get_knowledge_base_ids_from_subtask(db, user_subtask_id)
-    is_user_selected_kb = bool(knowledge_base_ids)
-
-    if knowledge_base_ids:
-        document_ids = get_document_ids_from_subtask(db, user_subtask_id)
-        request.knowledge_base_ids = knowledge_base_ids
-        request.document_ids = document_ids
-        request.is_user_selected_kb = is_user_selected_kb
-    elif request.task_id:
-        # Fall back to task-level bound knowledge bases
-        knowledge_base_ids = _get_bound_knowledge_base_ids(db, request.task_id)
-        if knowledge_base_ids:
-            request.knowledge_base_ids = knowledge_base_ids
-            request.is_user_selected_kb = False
+    # Update request with all processed context results.
+    # knowledge_base_ids / is_user_selected_kb / document_ids / kb_meta_prompt are
+    # computed inside _prepare_kb_tools_from_contexts and surfaced here - no extra
+    # DB queries needed.
+    request.prompt = ctx.final_message
+    request.system_prompt = ctx.kb.enhanced_system_prompt
+    request.table_contexts = ctx.table_contexts
+    request.kb_meta_prompt = ctx.kb.kb_meta_prompt
+    if ctx.kb.knowledge_base_ids:
+        request.knowledge_base_ids = ctx.kb.knowledge_base_ids
+        request.is_user_selected_kb = ctx.kb.is_user_selected_kb
+        if ctx.kb.document_ids:
+            request.document_ids = ctx.kb.document_ids
 
     logger.info(
         "[ai_trigger_unified] Context processing completed: "
         "user_subtask_id=%d, knowledge_base_ids=%s, table_contexts_count=%d",
         user_subtask_id,
         request.knowledge_base_ids,
-        len(table_contexts),
+        len(ctx.table_contexts),
     )
 
     return request
+
+
+async def _build_kb_meta_prompt(
+    db: "Session",
+    request: "ExecutionRequest",
+    populate_kb_ids: bool = False,
+) -> None:
+    """Build kb_meta_prompt and optionally populate knowledge_base_ids.
+
+    Only called when ``user_subtask_id`` is absent (e.g. group chat where the KB
+    is bound at the task level, not per-message).  In that case ``prepare_contexts_for_chat``
+    is not invoked, so this function handles both responsibilities:
+    - Fills ``request.kb_meta_prompt`` for dynamic_context injection in Chat Shell.
+    - When ``populate_kb_ids=True``, also fills ``request.knowledge_base_ids`` from
+      task-level bound KBs so Chat Shell can create KnowledgeBaseTool for RAG retrieval.
+
+    Attachment / table context processing is intentionally skipped because those
+    are per-message, subtask-scoped operations.
+
+    Args:
+        db: Database session
+        request: ExecutionRequest to mutate in-place
+        populate_kb_ids: When True, also populate knowledge_base_ids from task-level
+            bound KBs (used when there is no user_subtask_id).
+    """
+    import asyncio
+
+    from app.services.chat.preprocessing.kb_meta import build_kb_meta_prompt_for_task
+
+    if not request.task_id:
+        return
+
+    if populate_kb_ids:
+        # Populate task-level bound knowledge base IDs so Chat Shell can create
+        # KnowledgeBaseTool for RAG retrieval (only needed when no user_subtask_id).
+        from app.services.chat.preprocessing.contexts import (
+            _get_bound_knowledge_base_ids,
+        )
+
+        knowledge_base_ids = _get_bound_knowledge_base_ids(db, request.task_id)
+        if knowledge_base_ids:
+            request.knowledge_base_ids = knowledge_base_ids
+            request.is_user_selected_kb = False
+
+    # Build KB meta prompt for dynamic_context injection.
+    request.kb_meta_prompt = ""
+    try:
+        request.kb_meta_prompt = await asyncio.to_thread(
+            build_kb_meta_prompt_for_task, db, request.task_id
+        )
+    except Exception as e:
+        logger.warning(
+            "[ai_trigger_unified] Failed to build kb_meta_prompt "
+            "(task_id=%s, populate_kb_ids=%s): error=%s",
+            request.task_id,
+            populate_kb_ids,
+            e,
+        )

--- a/backend/app/services/group_permission.py
+++ b/backend/app/services/group_permission.py
@@ -7,12 +7,12 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 from app.models.namespace import Namespace
+from app.schemas.namespace import GroupRole
 from app.services.group_member_helper import (
     NAMESPACE_RESOURCE_TYPE,
     get_user_groups_with_roles,
     get_user_role_in_group,
 )
-from app.schemas.namespace import GroupRole
 
 
 def get_user_role_in_group(
@@ -29,7 +29,9 @@ def get_user_role_in_group(
     Returns:
         GroupRole if user is a member, None otherwise
     """
-    from app.services.group_member_helper import get_user_role_in_group as helper_get_role
+    from app.services.group_member_helper import (
+        get_user_role_in_group as helper_get_role,
+    )
 
     role_str = helper_get_role(db, user_id, group_name)
     if role_str:

--- a/backend/tests/services/chat/test_trigger_unified.py
+++ b/backend/tests/services/chat/test_trigger_unified.py
@@ -77,95 +77,27 @@ class TestBuildExecutionRequestUserSubtaskId:
                 with patch.object(
                     trigger_unified, "_process_contexts", new=AsyncMock()
                 ) as mock_process_contexts:
-                    with patch.object(
-                        trigger_unified,
-                        "_build_kb_meta_prompt",
-                        new=AsyncMock(),
-                    ) as mock_build_kb_meta_prompt:
-                        task = MagicMock()
-                        task.id = 1
-                        task.json = {}
+                    task = MagicMock()
+                    task.id = 1
+                    task.json = {}
 
-                        assistant_subtask = MagicMock()
-                        assistant_subtask.id = 2
+                    assistant_subtask = MagicMock()
+                    assistant_subtask.id = 2
 
-                        team = MagicMock()
-                        user = MagicMock()
-                        user.id = 7
+                    team = MagicMock()
+                    user = MagicMock()
+                    user.id = 7
 
-                        result = await trigger_unified.build_execution_request(
-                            task=task,
-                            assistant_subtask=assistant_subtask,
-                            team=team,
-                            user=user,
-                            message="hello",
-                            payload=None,
-                            user_subtask_id=None,
-                        )
+                    result = await trigger_unified.build_execution_request(
+                        task=task,
+                        assistant_subtask=assistant_subtask,
+                        team=team,
+                        user=user,
+                        message="hello",
+                        payload=None,
+                        user_subtask_id=None,
+                    )
 
-                        assert result.user_subtask_id is None
-                        mock_builder.build.assert_called_once()
-                        mock_process_contexts.assert_not_awaited()
-                        # kb_meta_prompt should still be built even without user_subtask_id
-                        mock_build_kb_meta_prompt.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_builds_kb_meta_prompt_when_user_subtask_id_is_none_and_task_id_exists(
-        self,
-    ):
-        """When user_subtask_id is None but task_id exists, kb_meta_prompt and
-        knowledge_base_ids should both be populated.
-
-        This covers the group chat case where KB is bound at the task level.
-        """
-        from app.services.chat.trigger import unified as trigger_unified
-
-        mock_db = MagicMock()
-
-        request_from_builder = ExecutionRequest(task_id=99, subtask_id=2)
-        mock_builder = MagicMock()
-        mock_builder.build.return_value = request_from_builder
-
-        with patch.object(trigger_unified, "SessionLocal", return_value=mock_db):
-            with patch(
-                "app.services.execution.TaskRequestBuilder", return_value=mock_builder
-            ):
-                with patch.object(
-                    trigger_unified, "_process_contexts", new=AsyncMock()
-                ):
-                    with patch(
-                        "app.services.chat.preprocessing.kb_meta.build_kb_meta_prompt_for_task",
-                        return_value="KB meta for task 99",
-                    ):
-                        with patch(
-                            "app.services.chat.preprocessing.contexts._get_bound_knowledge_base_ids",
-                            return_value=[10, 20],
-                        ):
-                            task = MagicMock()
-                            task.id = 99
-                            task.json = {}
-
-                            assistant_subtask = MagicMock()
-                            assistant_subtask.id = 2
-
-                            team = MagicMock()
-                            user = MagicMock()
-                            user.id = 7
-
-                            result = await trigger_unified.build_execution_request(
-                                task=task,
-                                assistant_subtask=assistant_subtask,
-                                team=team,
-                                user=user,
-                                message="hello",
-                                payload=None,
-                                user_subtask_id=None,
-                            )
-
-                            assert result.user_subtask_id is None
-                            # kb_meta_prompt should be populated via _build_kb_meta_prompt
-                            assert result.kb_meta_prompt == "KB meta for task 99"
-                            # knowledge_base_ids must also be set so Chat Shell
-                            # creates KnowledgeBaseTool for RAG retrieval
-                            assert result.knowledge_base_ids == [10, 20]
-                            assert result.is_user_selected_kb is False
+                    assert result.user_subtask_id is None
+                    mock_builder.build.assert_called_once()
+                    mock_process_contexts.assert_not_awaited()

--- a/backend/tests/services/chat/test_trigger_unified.py
+++ b/backend/tests/services/chat/test_trigger_unified.py
@@ -77,27 +77,95 @@ class TestBuildExecutionRequestUserSubtaskId:
                 with patch.object(
                     trigger_unified, "_process_contexts", new=AsyncMock()
                 ) as mock_process_contexts:
-                    task = MagicMock()
-                    task.id = 1
-                    task.json = {}
+                    with patch.object(
+                        trigger_unified,
+                        "_build_kb_meta_prompt",
+                        new=AsyncMock(),
+                    ) as mock_build_kb_meta_prompt:
+                        task = MagicMock()
+                        task.id = 1
+                        task.json = {}
 
-                    assistant_subtask = MagicMock()
-                    assistant_subtask.id = 2
+                        assistant_subtask = MagicMock()
+                        assistant_subtask.id = 2
 
-                    team = MagicMock()
-                    user = MagicMock()
-                    user.id = 7
+                        team = MagicMock()
+                        user = MagicMock()
+                        user.id = 7
 
-                    result = await trigger_unified.build_execution_request(
-                        task=task,
-                        assistant_subtask=assistant_subtask,
-                        team=team,
-                        user=user,
-                        message="hello",
-                        payload=None,
-                        user_subtask_id=None,
-                    )
+                        result = await trigger_unified.build_execution_request(
+                            task=task,
+                            assistant_subtask=assistant_subtask,
+                            team=team,
+                            user=user,
+                            message="hello",
+                            payload=None,
+                            user_subtask_id=None,
+                        )
 
-                    assert result.user_subtask_id is None
-                    mock_builder.build.assert_called_once()
-                    mock_process_contexts.assert_not_awaited()
+                        assert result.user_subtask_id is None
+                        mock_builder.build.assert_called_once()
+                        mock_process_contexts.assert_not_awaited()
+                        # kb_meta_prompt should still be built even without user_subtask_id
+                        mock_build_kb_meta_prompt.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_builds_kb_meta_prompt_when_user_subtask_id_is_none_and_task_id_exists(
+        self,
+    ):
+        """When user_subtask_id is None but task_id exists, kb_meta_prompt and
+        knowledge_base_ids should both be populated.
+
+        This covers the group chat case where KB is bound at the task level.
+        """
+        from app.services.chat.trigger import unified as trigger_unified
+
+        mock_db = MagicMock()
+
+        request_from_builder = ExecutionRequest(task_id=99, subtask_id=2)
+        mock_builder = MagicMock()
+        mock_builder.build.return_value = request_from_builder
+
+        with patch.object(trigger_unified, "SessionLocal", return_value=mock_db):
+            with patch(
+                "app.services.execution.TaskRequestBuilder", return_value=mock_builder
+            ):
+                with patch.object(
+                    trigger_unified, "_process_contexts", new=AsyncMock()
+                ):
+                    with patch(
+                        "app.services.chat.preprocessing.kb_meta.build_kb_meta_prompt_for_task",
+                        return_value="KB meta for task 99",
+                    ):
+                        with patch(
+                            "app.services.chat.preprocessing.contexts._get_bound_knowledge_base_ids",
+                            return_value=[10, 20],
+                        ):
+                            task = MagicMock()
+                            task.id = 99
+                            task.json = {}
+
+                            assistant_subtask = MagicMock()
+                            assistant_subtask.id = 2
+
+                            team = MagicMock()
+                            user = MagicMock()
+                            user.id = 7
+
+                            result = await trigger_unified.build_execution_request(
+                                task=task,
+                                assistant_subtask=assistant_subtask,
+                                team=team,
+                                user=user,
+                                message="hello",
+                                payload=None,
+                                user_subtask_id=None,
+                            )
+
+                            assert result.user_subtask_id is None
+                            # kb_meta_prompt should be populated via _build_kb_meta_prompt
+                            assert result.kb_meta_prompt == "KB meta for task 99"
+                            # knowledge_base_ids must also be set so Chat Shell
+                            # creates KnowledgeBaseTool for RAG retrieval
+                            assert result.knowledge_base_ids == [10, 20]
+                            assert result.is_user_selected_kb is False

--- a/backend/tests/services/test_task_knowledge_base_sync.py
+++ b/backend/tests/services/test_task_knowledge_base_sync.py
@@ -2,14 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Tests for subtask knowledge base sync to task level functionality.
+"""Tests for subtask knowledge base sync to task level functionality.
 
 This module tests the following features:
 1. sync_subtask_kb_to_task method in TaskKnowledgeBaseService
 2. Knowledge base priority logic (subtask > task level)
 3. Deduplication and limit enforcement
 4. ID-based lookup and automatic migration from name-only refs
+
+NOTE:
+- KB meta prompt formatting is tested separately in chat preprocessing.
 """
 
 from unittest.mock import MagicMock, Mock, patch
@@ -292,23 +294,19 @@ class TestKBPriorityLogic:
         ) as mock_get_bound:
             mock_get_bound.return_value = []  # No task-level KBs
 
-            with patch(
-                "app.services.chat.preprocessing.contexts._build_historical_kb_meta_prompt"
-            ) as mock_history:
-                mock_history.return_value = ""
+            kb_result = _prepare_kb_tools_from_contexts(
+                kb_contexts=[],  # No subtask KB
+                user_id=1,
+                db=mock_db,
+                base_system_prompt="Base prompt",
+                task_id=100,
+                user_subtask_id=1,
+            )
 
-                kb_result = _prepare_kb_tools_from_contexts(
-                    kb_contexts=[],  # No subtask KB
-                    user_id=1,
-                    db=mock_db,
-                    base_system_prompt="Base prompt",
-                    task_id=100,
-                    user_subtask_id=1,
-                )
-
-                # Should return empty tools
-                assert kb_result.extra_tools == []
-                assert kb_result.enhanced_system_prompt == "Base prompt"
+            # Should return empty tools
+            assert kb_result.extra_tools == []
+            assert kb_result.enhanced_system_prompt == "Base prompt"
+            assert kb_result.kb_meta_prompt == ""
 
 
 @pytest.mark.unit

--- a/backend/tests/services/test_task_knowledge_base_sync.py
+++ b/backend/tests/services/test_task_knowledge_base_sync.py
@@ -307,6 +307,10 @@ class TestKBPriorityLogic:
             assert kb_result.extra_tools == []
             assert kb_result.enhanced_system_prompt == "Base prompt"
             assert kb_result.kb_meta_prompt == ""
+            # New KB fields must also default to empty/False
+            assert kb_result.knowledge_base_ids == []
+            assert kb_result.is_user_selected_kb is False
+            assert kb_result.document_ids == []
 
 
 @pytest.mark.unit

--- a/shared/models/knowledge.py
+++ b/shared/models/knowledge.py
@@ -13,7 +13,7 @@ All comments must be written in English.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Union
 
 
 @dataclass(frozen=True)
@@ -23,3 +23,40 @@ class KnowledgeBaseToolsResult:
     extra_tools: list[Any]
     enhanced_system_prompt: str
     kb_meta_prompt: str
+    # KB IDs resolved for this request (subtask-level takes priority over task-level).
+    # Populated so callers can fill ExecutionRequest.knowledge_base_ids without a
+    # second DB query.
+    knowledge_base_ids: list[int] = None  # type: ignore[assignment]
+    is_user_selected_kb: bool = False
+    document_ids: list[int] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        # Use object.__setattr__ because the dataclass is frozen.
+        if self.knowledge_base_ids is None:
+            object.__setattr__(self, "knowledge_base_ids", [])
+        if self.document_ids is None:
+            object.__setattr__(self, "document_ids", [])
+
+
+@dataclass(frozen=True)
+class ChatContextsResult:
+    """Result container for prepare_contexts_for_chat — backend-only.
+
+    Groups the three orthogonal dimensions of context processing:
+    - final_message: user message after attachment injection
+    - has_table_context / table_contexts: parsed table info for chat_shell
+    - kb: all knowledge-base related results (tools, prompts, IDs)
+
+    ``kb`` nests ``KnowledgeBaseToolsResult`` to avoid duplicating its six
+    fields here.  Callers access KB fields via ``result.kb.knowledge_base_ids``,
+    ``result.kb.kb_meta_prompt``, etc.
+    """
+
+    # Processed user message (may be str or OpenAI Responses API vision list).
+    final_message: Union[str, list]
+    # Whether any table contexts were found for this subtask.
+    has_table_context: bool
+    # Parsed table descriptors forwarded to chat_shell for DataTableTool creation.
+    table_contexts: list[dict]
+    # All knowledge-base related results (tools, prompts, resolved IDs).
+    kb: KnowledgeBaseToolsResult

--- a/shared/models/knowledge.py
+++ b/shared/models/knowledge.py
@@ -53,10 +53,10 @@ class ChatContextsResult:
     """
 
     # Processed user message (may be str or OpenAI Responses API vision list).
-    final_message: Union[str, list]
+    final_message: Union[str, list[dict[str, Any]]]
     # Whether any table contexts were found for this subtask.
     has_table_context: bool
     # Parsed table descriptors forwarded to chat_shell for DataTableTool creation.
-    table_contexts: list[dict]
+    table_contexts: list[dict[str, Any]]
     # All knowledge-base related results (tools, prompts, resolved IDs).
     kb: KnowledgeBaseToolsResult


### PR DESCRIPTION
## Summary

- **Refactor**: Replaced the 9-element tuple returned by \`prepare_contexts_for_chat\` with the new \`ChatContextsResult\` dataclass (added to \`shared/models/knowledge.py\`). The dataclass nests \`KnowledgeBaseToolsResult\` as the \`kb\` field, grouping all KB-related results without duplicating the existing 6 fields.
- **DB query elimination**: \`knowledge_base_ids\`, \`is_user_selected_kb\`, and \`document_ids\` are now surfaced from \`_prepare_kb_tools_from_contexts\` through \`KnowledgeBaseToolsResult\` — no redundant DB queries after \`prepare_contexts_for_chat\` returns.
- **Dead code removal**: Removed the \`elif request.task_id\` branch and \`_build_kb_meta_prompt\` helper from \`build_execution_request\` — every chat message is expected to carry a \`user_subtask_id\`, so this fallback path should not exist.

## Changed files

| File | Change |
|------|--------|
| \`shared/models/knowledge.py\` | Add \`ChatContextsResult\` dataclass (nests \`KnowledgeBaseToolsResult\`) |
| \`backend/app/services/chat/preprocessing/contexts.py\` | \`prepare_contexts_for_chat\` returns \`ChatContextsResult\`; both return sites updated |
| \`backend/app/services/chat/trigger/unified.py\` | Remove \`_build_kb_meta_prompt\` helper and dead \`elif\` branch; \`_process_contexts\` uses \`ctx.kb.*\` attributes |
| \`backend/tests/services/chat/test_trigger_unified.py\` | Remove tests for deleted branch; keep 2 core tests |

## Test plan

- [x] \`tests/services/chat/test_trigger_unified.py\` — 2 tests pass
- [x] \`tests/services/test_task_knowledge_base_sync.py\` — 24 tests pass
- [x] Full suite: 26/26 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced knowledge base tracking capabilities with support for identifying selected knowledge bases and their associated documents.
  * Improved chat context data organization through a unified structured container.

* **Refactor**
  * Streamlined knowledge base metadata handling and formatting.
  * Optimized knowledge base context processing for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->