### PR TITLE
feat(image): add follow-up support for image generation

### DIFF
--- a/backend/app/services/execution/agents/base_intent_analyzer.py
+++ b/backend/app/services/execution/agents/base_intent_analyzer.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Base intent analyzer for follow-up messages.
+
+Provides shared LLM-call infrastructure for image and video intent analysis
+in multi-turn generation conversations.
+"""
+
+import json
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class BaseIntentAnalyzer:
+    """Shared LLM infrastructure for generation intent analysis."""
+
+    async def _call_llm_json(
+        self,
+        prompt: str,
+        model_config: dict,
+    ) -> Optional[dict]:
+        """Call secondary LLM and return parsed JSON result.
+
+        Args:
+            prompt: Full prompt string to send to LLM
+            model_config: LLM configuration (api_key, base_url, model_id)
+
+        Returns:
+            Parsed JSON dict from LLM, or None on failure
+        """
+        from openai import AsyncOpenAI
+
+        client = AsyncOpenAI(
+            api_key=model_config.get("api_key"),
+            base_url=model_config.get("base_url"),
+        )
+
+        try:
+            response = await client.chat.completions.create(
+                model=model_config.get("model_id", "gpt-4o-mini"),
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0,
+                response_format={"type": "json_object"},
+            )
+            return json.loads(response.choices[0].message.content)
+        except Exception as e:
+            logger.error(f"[{self.__class__.__name__}] LLM call failed: {e}")
+            return None

--- a/backend/app/services/execution/agents/base_intent_analyzer.py
+++ b/backend/app/services/execution/agents/base_intent_analyzer.py
@@ -49,5 +49,5 @@ class BaseIntentAnalyzer:
             )
             return json.loads(response.choices[0].message.content)
         except Exception as e:
-            logger.error(f"[{self.__class__.__name__}] LLM call failed: {e}")
+            logger.exception(f"[{self.__class__.__name__}] LLM call failed: {e}")
             return None

--- a/backend/app/services/execution/agents/image/image_agent.py
+++ b/backend/app/services/execution/agents/image/image_agent.py
@@ -22,7 +22,7 @@ from shared.models import EventType, ExecutionEvent, ExecutionRequest
 
 from ...emitters import ResultEmitter
 from ..base import PollingAgent
-from .intent_analyzer import ImageIntentAnalyzer
+from .intent_analyzer import ImageIntentAnalyzer, ImageIntentResult
 from .providers import get_image_provider
 
 logger = logging.getLogger(__name__)
@@ -239,7 +239,7 @@ class ImageAgent(PollingAgent):
 
         return reference_images
 
-    async def _analyze_intent(self, request: ExecutionRequest):
+    async def _analyze_intent(self, request: ExecutionRequest) -> ImageIntentResult:
         """Run ImageIntentAnalyzer for multi-turn follow-up detection.
 
         Args:

--- a/backend/app/services/execution/agents/image/image_agent.py
+++ b/backend/app/services/execution/agents/image/image_agent.py
@@ -7,12 +7,12 @@ Image generation agent.
 
 Handles image generation workflow:
 1. Parse request and extract image config
-2. Call image generation provider
-3. Upload result as attachment
-4. Emit events via emitter
+2. Analyze intent for follow-up messages (using secondary LLM)
+3. Call image generation provider (with optional reference image)
+4. Upload result as attachment
+5. Emit events via emitter
 """
 
-import asyncio
 import logging
 import time
 import uuid
@@ -22,6 +22,7 @@ from shared.models import EventType, ExecutionEvent, ExecutionRequest
 
 from ...emitters import ResultEmitter
 from ..base import PollingAgent
+from .intent_analyzer import ImageIntentAnalyzer
 from .providers import get_image_provider
 
 logger = logging.getLogger(__name__)
@@ -49,9 +50,10 @@ class ImageAgent(PollingAgent):
 
         Workflow:
         1. Emit START event
-        2. Call image generation provider
-        3. Upload result as attachment
-        4. Emit DONE event with image result
+        2. Analyze intent for follow-ups (using secondary model)
+        3. Call image generation provider (with reference image if follow-up)
+        4. Upload result as attachment
+        5. Emit DONE event with image result
         """
         from app.services.chat.storage.session import session_manager
 
@@ -110,17 +112,38 @@ class ImageAgent(PollingAgent):
                 else str(request.prompt)
             )
 
-            # Extract reference images from attachments if any
-            reference_images = self._extract_reference_images(request)
+            # Step 1: Extract reference images explicitly provided by user (highest priority)
+            user_reference_images = self._extract_reference_images(request)
+
+            # Step 2: Run intent analysis for follow-up if no explicit user reference images
+            # and there is prior task history to analyze.
+            if not user_reference_images and request.task_id:
+                intent_result = await self._analyze_intent(request)
+                final_prompt = (
+                    intent_result.merged_prompt
+                    if intent_result.is_followup
+                    else prompt
+                )
+                # Use reference image from intent analysis when user didn't specify one
+                reference_images = (
+                    [intent_result.reference_image]
+                    if intent_result.should_use_image and intent_result.reference_image
+                    else []
+                )
+            else:
+                # User explicitly provided attachments - skip intent analysis
+                final_prompt = prompt
+                reference_images = user_reference_images
 
             # Generate images
             logger.info(
                 f"[{self.name}] Generating image: task_id={task_id}, "
-                f"provider={provider.name}"
+                f"provider={provider.name}, "
+                f"reference_images={len(reference_images)}"
             )
 
             result = await provider.generate(
-                prompt=prompt,
+                prompt=final_prompt,
                 reference_images=reference_images,
             )
 
@@ -215,6 +238,36 @@ class ImageAgent(PollingAgent):
                         reference_images.append(url)
 
         return reference_images
+
+    async def _analyze_intent(self, request: ExecutionRequest):
+        """Run ImageIntentAnalyzer for multi-turn follow-up detection.
+
+        Args:
+            request: Execution request
+
+        Returns:
+            ImageIntentResult with merged_prompt, should_use_image, reference_image, is_followup
+        """
+        model_config = request.model_config or {}
+        secondary_model_config = model_config.get("secondary_model_config")
+        current_prompt = (
+            request.prompt
+            if isinstance(request.prompt, str)
+            else str(request.prompt)
+        )
+
+        # Build exclusion list: current assistant subtask + user subtask
+        exclude_ids = [
+            sid for sid in [request.subtask_id, request.user_subtask_id] if sid
+        ]
+
+        analyzer = ImageIntentAnalyzer()
+        return await analyzer.analyze(
+            task_id=request.task_id,
+            current_prompt=current_prompt,
+            secondary_model_config=secondary_model_config,
+            exclude_subtask_ids=exclude_ids,
+        )
 
     async def _emit_image_block(
         self,

--- a/backend/app/services/execution/agents/image/image_agent.py
+++ b/backend/app/services/execution/agents/image/image_agent.py
@@ -105,25 +105,33 @@ class ImageAgent(PollingAgent):
             protocol = model_config.get("protocol") or "seedream"
             provider = get_image_provider(protocol, model_config)
 
-            # Extract prompt
-            prompt = (
-                request.prompt
-                if isinstance(request.prompt, str)
-                else str(request.prompt)
-            )
+            # Normalize prompt.
+            # request.prompt can be either:
+            # - str
+            # - OpenAI Responses API vision content list:
+            #   [{"type":"input_text","text":"..."}, {"type":"input_image","image_url":"data:..."}]
+            prompt_text, prompt_images = self._normalize_prompt(request.prompt)
 
             # Step 1: Extract reference images explicitly provided by user (highest priority)
-            user_reference_images = self._extract_reference_images(request)
+            # Sources:
+            # 1) Attachments list (legacy)
+            # 2) Vision content blocks in request.prompt
+            user_reference_images = [
+                *self._extract_reference_images(request),
+                *prompt_images,
+            ]
+
+            prompt = prompt_text
 
             # Step 2: Run intent analysis for follow-up if no explicit user reference images
             # and there is prior task history to analyze.
+            intent_result: ImageIntentResult | None = None
             if not user_reference_images and request.task_id:
                 intent_result = await self._analyze_intent(request)
                 final_prompt = (
-                    intent_result.merged_prompt
-                    if intent_result.is_followup
-                    else prompt
+                    intent_result.merged_prompt if intent_result.is_followup else prompt
                 )
+
                 # Use reference image from intent analysis when user didn't specify one
                 reference_images = (
                     [intent_result.reference_image]
@@ -135,11 +143,38 @@ class ImageAgent(PollingAgent):
                 final_prompt = prompt
                 reference_images = user_reference_images
 
-            # Generate images
+            # Debug logs for prompt merge and provider params
+            # Note: Do NOT log full base64 strings; only log a safe preview.
+            prompt_preview = final_prompt.replace("\n", " ")
+            if len(prompt_preview) > 500:
+                prompt_preview = prompt_preview[:500] + "..."
+
+            ref_previews: list[str] = []
+            for ref in reference_images[:3]:
+                if not isinstance(ref, str):
+                    ref_previews.append(str(type(ref)))
+                    continue
+                if ref.startswith("data:"):
+                    ref_previews.append("data_url")
+                elif ref.startswith("http://") or ref.startswith("https://"):
+                    ref_previews.append(ref[:120])
+                else:
+                    ref_previews.append(f"non_url:{ref[:120]}")
+
             logger.info(
-                f"[{self.name}] Generating image: task_id={task_id}, "
-                f"provider={provider.name}, "
-                f"reference_images={len(reference_images)}"
+                "[%s] Image generation request: task_id=%s, provider=%s, "
+                "is_followup=%s, should_use_image=%s, user_ref_count=%d, ref_count=%d, "
+                "image_config=%s, prompt_preview=%s, ref_previews=%s",
+                self.name,
+                task_id,
+                provider.name,
+                getattr(intent_result, "is_followup", False),
+                getattr(intent_result, "should_use_image", False),
+                len(user_reference_images),
+                len(reference_images),
+                model_config.get("imageConfig"),
+                prompt_preview,
+                ref_previews,
             )
 
             result = await provider.generate(
@@ -225,19 +260,83 @@ class ImageAgent(PollingAgent):
             await session_manager.unregister_stream(subtask_id)
 
     def _extract_reference_images(self, request: ExecutionRequest) -> List[str]:
-        """Extract reference images from request attachments."""
-        reference_images = []
+        """Extract reference images from request.attachments (legacy input).
 
-        # Check if there are attachments in the request
+        NOTE:
+        - Newer chat flows may provide images via `request.prompt` vision blocks instead.
+          Those are handled by `_normalize_prompt()`.
+        """
+        reference_images: list[str] = []
+
         if request.attachments:
             for att in request.attachments:
-                # Check if it's an image attachment
                 if att.get("mime_type", "").startswith("image/"):
                     url = att.get("url") or att.get("content")
                     if url:
                         reference_images.append(url)
 
         return reference_images
+
+    def _normalize_prompt(
+        self,
+        prompt: str | list[dict],
+    ) -> tuple[str, list[str]]:
+        """Normalize ExecutionRequest.prompt to plain text + reference images.
+
+        Returns:
+            (prompt_text, images)
+
+        Rules:
+        - For vision content list: concatenate all input_text blocks
+        - Extract input_image.image_url as reference images
+        - If text contains our context wrapper, prefer the actual user question part
+        """
+        if isinstance(prompt, str):
+            return self._extract_user_question(prompt), []
+
+        if not isinstance(prompt, list):
+            # Defensive fallback
+            return self._extract_user_question(str(prompt)), []
+
+        text_parts: list[str] = []
+        images: list[str] = []
+
+        for block in prompt:
+            if not isinstance(block, dict):
+                continue
+
+            if block.get("type") == "input_text":
+                text = block.get("text")
+                if isinstance(text, str) and text.strip():
+                    text_parts.append(text)
+
+            if block.get("type") == "input_image":
+                image_url = block.get("image_url")
+                if isinstance(image_url, str) and image_url.strip():
+                    images.append(image_url)
+
+        combined_text = "\n".join(text_parts).strip()
+        combined_text = self._extract_user_question(combined_text)
+        return combined_text, images
+
+    def _extract_user_question(self, text: str) -> str:
+        """Extract user-visible question from a context-wrapped prompt.
+
+        The chat context preprocessor may build prompts like:
+        "<attachment>...metadata...</attachment>\n\n[User Question]:\n<message>"
+
+        Seedream applies sensitive-text filters; passing attachment metadata (URLs, paths)
+        increases false positives. Prefer only the real user question if the marker exists.
+        """
+        if not isinstance(text, str):
+            return str(text)
+
+        marker = "[User Question]:"
+        if marker in text:
+            after = text.split(marker, 1)[1]
+            return after.lstrip("\n").strip()
+
+        return text.strip()
 
     async def _analyze_intent(self, request: ExecutionRequest) -> ImageIntentResult:
         """Run ImageIntentAnalyzer for multi-turn follow-up detection.
@@ -250,11 +349,10 @@ class ImageAgent(PollingAgent):
         """
         model_config = request.model_config or {}
         secondary_model_config = model_config.get("secondary_model_config")
-        current_prompt = (
-            request.prompt
-            if isinstance(request.prompt, str)
-            else str(request.prompt)
-        )
+
+        # Use normalized prompt text to avoid leaking attachment metadata into intent analysis.
+        prompt_text, _prompt_images = self._normalize_prompt(request.prompt)
+        current_prompt = prompt_text
 
         # Build exclusion list: current assistant subtask + user subtask
         exclude_ids = [

--- a/backend/app/services/execution/agents/image/intent_analyzer.py
+++ b/backend/app/services/execution/agents/image/intent_analyzer.py
@@ -80,8 +80,21 @@ class ImageIntentAnalyzer(BaseIntentAnalyzer):
                 query = query.filter(Subtask.id.notin_(exclude_subtask_ids))
             subtasks = query.order_by(Subtask.message_id.asc()).all()
 
+            # Debug: show basic history snapshot for follow-up detection
+            # Note: keep logs minimal and avoid leaking user content.
+            logger.info(
+                "[ImageIntentAnalyzer] History loaded: task_id=%s, total_subtasks=%d, exclude_ids=%s",
+                task_id,
+                len(subtasks),
+                exclude_subtask_ids or [],
+            )
+
             if len(subtasks) < 2:
                 # Not enough history - this is the first message
+                logger.info(
+                    "[ImageIntentAnalyzer] Not enough history for follow-up: task_id=%s",
+                    task_id,
+                )
                 return ImageIntentResult(
                     merged_prompt=current_prompt,
                     should_use_image=False,
@@ -99,26 +112,89 @@ class ImageIntentAnalyzer(BaseIntentAnalyzer):
                     break
 
             if not prev_user or not prev_ai:
+                logger.info(
+                    "[ImageIntentAnalyzer] Cannot find (prev_user, prev_ai) pair: task_id=%s, prev_user=%s, prev_ai=%s",
+                    task_id,
+                    getattr(prev_user, "id", None),
+                    getattr(prev_ai, "id", None),
+                )
                 return ImageIntentResult(
                     merged_prompt=current_prompt,
                     should_use_image=False,
                     is_followup=False,
                 )
 
+            logger.info(
+                "[ImageIntentAnalyzer] Selected prev pair: task_id=%s, prev_user_id=%s(msg_id=%s), prev_ai_id=%s(msg_id=%s)",
+                task_id,
+                prev_user.id,
+                getattr(prev_user, "message_id", None),
+                prev_ai.id,
+                getattr(prev_ai, "message_id", None),
+            )
+
             prev_prompt = prev_user.prompt or ""
             prev_result = prev_ai.result or {}
+
+            # Debug: summarize previous AI result blocks
+            try:
+                blocks = (
+                    prev_result.get("blocks", [])
+                    if isinstance(prev_result, dict)
+                    else []
+                )
+                block_types = []
+                for b in blocks[:10]:
+                    if isinstance(b, dict):
+                        block_types.append(b.get("type"))
+                logger.info(
+                    "[ImageIntentAnalyzer] Prev AI result summary: task_id=%s, prev_ai_id=%s, blocks_count=%d, block_types=%s",
+                    task_id,
+                    prev_ai.id,
+                    len(blocks),
+                    block_types,
+                )
+            except Exception as e:
+                logger.debug(
+                    "[ImageIntentAnalyzer] Failed to summarize prev_ai.result: task_id=%s, err=%s",
+                    task_id,
+                    e,
+                )
 
             # Check if previous AI result contains image attachment IDs
             reference_image_url = self._extract_reference_image_url(prev_result)
             has_image = reference_image_url is not None
 
+            if has_image and reference_image_url:
+                safe_preview = (
+                    "data_url"
+                    if reference_image_url.startswith("data:")
+                    else reference_image_url[:120]
+                )
+                logger.info(
+                    "[ImageIntentAnalyzer] Resolved reference image for task=%s: %s",
+                    task_id,
+                    safe_preview,
+                )
+
             # No previous image result means this is a brand-new generation
             if not has_image:
+                logger.info(
+                    "[ImageIntentAnalyzer] No usable previous image found: task_id=%s, prev_ai_id=%s (treat as non-followup)",
+                    task_id,
+                    prev_ai.id,
+                )
                 return ImageIntentResult(
                     merged_prompt=current_prompt,
                     should_use_image=False,
                     is_followup=False,
                 )
+
+            logger.info(
+                "[ImageIntentAnalyzer] has_image=true, proceed intent analysis: task_id=%s, prev_ai_id=%s",
+                task_id,
+                prev_ai.id,
+            )
 
             # This is a follow-up (previous turn had an image result)
             # If no secondary model is configured, use simple merge with image
@@ -134,11 +210,22 @@ class ImageIntentAnalyzer(BaseIntentAnalyzer):
                 )
 
             # Use secondary LLM for intelligent intent analysis
+            logger.info(
+                "[ImageIntentAnalyzer] Calling secondary LLM for intent: task_id=%s, has_image=%s",
+                task_id,
+                has_image,
+            )
             intent = await self._analyze_with_llm(
                 prev_prompt=prev_prompt,
                 current_prompt=current_prompt,
                 has_image=has_image,
                 model_config=secondary_model_config,
+            )
+            logger.info(
+                "[ImageIntentAnalyzer] Secondary LLM result: task_id=%s, should_use_image=%s, merged_prompt_len=%d",
+                task_id,
+                intent.should_use_image,
+                len(intent.merged_prompt or ""),
             )
 
             if intent.should_use_image and has_image:
@@ -151,46 +238,117 @@ class ImageIntentAnalyzer(BaseIntentAnalyzer):
             db.close()
 
     def _extract_reference_image_url(self, prev_result: dict) -> Optional[str]:
-        """Extract a usable image URL from the previous AI subtask result.
+        """Extract a usable image reference from the previous assistant result.
 
-        Looks for image_attachment_ids inside blocks, then resolves the URL
-        via context_service.
+        Priority:
+        1) Prefer data URL built from stored `image_base64` in SubtaskContext.
+           This is the most compatible format for Seedream (avoids external URL fetch).
+        2) Fallback to relative download URL ("/api/attachments/{id}/download").
+        3) Fallback to `image_urls[0]` in the message block.
 
         Args:
             prev_result: result dict from previous assistant subtask
 
         Returns:
-            Image URL string or None
+            Image reference string (data URL or URL) or None.
         """
         from app.db.session import SessionLocal
         from app.services.context.context_service import context_service
 
         blocks = prev_result.get("blocks", [])
+        if not isinstance(blocks, list):
+            logger.debug(
+                "[ImageIntentAnalyzer] prev_result.blocks is not a list: type=%s",
+                type(blocks),
+            )
+            return None
+
+        image_blocks_found = 0
         for block in blocks:
-            if block.get("type") == "image":
-                attachment_ids = block.get("image_attachment_ids", [])
-                if attachment_ids:
-                    attachment_id = attachment_ids[0]
-                    db = SessionLocal()
-                    try:
-                        context = context_service.get_context_optional(
-                            db=db, context_id=attachment_id
-                        )
-                        if context and context.status == "ready":
-                            return context_service.build_attachment_url(attachment_id)
-                    except Exception as e:
-                        logger.warning(
-                            f"[ImageIntentAnalyzer] Failed to build attachment URL "
-                            f"for id={attachment_id}: {e}"
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "image":
+                continue
+
+            image_blocks_found += 1
+
+            attachment_ids = block.get("image_attachment_ids", [])
+            if attachment_ids:
+                attachment_id = attachment_ids[0]
+                db = SessionLocal()
+                try:
+                    context = context_service.get_context_optional(
+                        db=db, context_id=attachment_id
+                    )
+                    if not context:
+                        logger.info(
+                            "[ImageIntentAnalyzer] Attachment context not found: id=%s",
+                            attachment_id,
                         )
                         continue
-                    finally:
-                        db.close()
 
-                # Fallback: try image_urls list from block
-                image_urls = block.get("image_urls", [])
-                if image_urls:
-                    return image_urls[0]
+                    logger.info(
+                        "[ImageIntentAnalyzer] Attachment context loaded: id=%s, status=%s, mime_type=%s, has_image_base64=%s",
+                        attachment_id,
+                        getattr(context, "status", None),
+                        getattr(context, "mime_type", None),
+                        bool(getattr(context, "image_base64", None)),
+                    )
+
+                    if context.status == "ready":
+                        # Prefer embedding image as data URL.
+                        # NOTE: Do NOT log full base64 string.
+                        if getattr(context, "image_base64", None) and getattr(
+                            context, "mime_type", None
+                        ):
+                            return f"data:{context.mime_type};base64,{context.image_base64}"
+
+                        # Fallback 1: Use stored external URL if available (e.g., TOS signed URL).
+                        # This is typically more compatible for third-party providers than a relative backend URL.
+                        type_data = getattr(context, "type_data", None) or {}
+                        if isinstance(type_data, dict):
+                            image_meta = type_data.get("image_metadata") or {}
+                            if isinstance(image_meta, dict):
+                                image_url = image_meta.get("image_url")
+                                if isinstance(image_url, str) and image_url.startswith(
+                                    ("http://", "https://")
+                                ):
+                                    logger.info(
+                                        "[ImageIntentAnalyzer] Using image_metadata.image_url as reference: %s",
+                                        image_url[:120],
+                                    )
+                                    return image_url
+
+                        # Fallback 2: relative URL (caller may need to make it absolute).
+                        return context_service.build_attachment_url(attachment_id)
+
+                    logger.info(
+                        "[ImageIntentAnalyzer] Attachment context not ready for reference: id=%s, status=%s",
+                        attachment_id,
+                        getattr(context, "status", None),
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "[ImageIntentAnalyzer] Failed to resolve reference image for id=%s: %s",
+                        attachment_id,
+                        e,
+                    )
+                finally:
+                    db.close()
+
+            # Fallback: try image_urls list from block
+            image_urls = block.get("image_urls", [])
+            if image_urls:
+                return image_urls[0]
+
+        if image_blocks_found == 0:
+            logger.info(
+                "[ImageIntentAnalyzer] No image blocks found in prev_result.blocks"
+            )
+        else:
+            logger.info(
+                "[ImageIntentAnalyzer] Found image blocks but no usable reference image"
+            )
 
         return None
 

--- a/backend/app/services/execution/agents/image/intent_analyzer.py
+++ b/backend/app/services/execution/agents/image/intent_analyzer.py
@@ -183,7 +183,7 @@ class ImageIntentAnalyzer(BaseIntentAnalyzer):
                             f"[ImageIntentAnalyzer] Failed to build attachment URL "
                             f"for id={attachment_id}: {e}"
                         )
-                        return None
+                        continue
                     finally:
                         db.close()
 

--- a/backend/app/services/execution/agents/image/intent_analyzer.py
+++ b/backend/app/services/execution/agents/image/intent_analyzer.py
@@ -1,0 +1,233 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Image intent analyzer for follow-up messages.
+
+Analyzes user intent in multi-turn image generation conversations
+to merge prompts and determine whether to pass a reference image.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from ..base_intent_analyzer import BaseIntentAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ImageIntentResult:
+    """Result of image intent analysis."""
+
+    merged_prompt: str
+    should_use_image: bool
+    reference_image: Optional[str] = None
+    is_followup: bool = False
+
+
+INTENT_PROMPT = """You are an image generation intent analysis assistant. The user is in a multi-turn image generation conversation.
+
+Previous user prompt: {previous_prompt}
+Current user prompt: {current_prompt}
+Has reference image from previous turn: {has_image}
+
+Please analyze the user intent and output JSON:
+{{
+    "merged_prompt": "Merged and optimized image generation prompt",
+    "should_use_image": true/false
+}}
+
+Rules:
+- merged_prompt: Merge the two prompts into a complete, coherent image generation description. If the user is modifying the previous image, incorporate the modification clearly.
+- should_use_image: Set to true only when has_image=true AND the user's intent implies modifying or building upon the previous image (e.g., changing colors, style, elements). Set to false when the user is describing an entirely new image.
+
+Output JSON only."""
+
+
+class ImageIntentAnalyzer(BaseIntentAnalyzer):
+    """Analyzes image generation intent for follow-up messages."""
+
+    async def analyze(
+        self,
+        task_id: int,
+        current_prompt: str,
+        secondary_model_config: Optional[dict],
+        exclude_subtask_ids: Optional[list] = None,
+    ) -> ImageIntentResult:
+        """
+        Analyze intent for follow-up image generation message.
+
+        Args:
+            task_id: Task ID
+            current_prompt: Current user prompt
+            secondary_model_config: LLM config for intent analysis
+            exclude_subtask_ids: Subtask IDs to exclude from history
+
+        Returns:
+            ImageIntentResult with merged prompt and reference image info
+        """
+        from app.db.session import SessionLocal
+        from app.models.subtask import Subtask, SubtaskRole
+
+        db = SessionLocal()
+        try:
+            # Retrieve relevant subtask history
+            query = db.query(Subtask).filter(Subtask.task_id == task_id)
+            if exclude_subtask_ids:
+                query = query.filter(Subtask.id.notin_(exclude_subtask_ids))
+            subtasks = query.order_by(Subtask.message_id.asc()).all()
+
+            if len(subtasks) < 2:
+                # Not enough history - this is the first message
+                return ImageIntentResult(
+                    merged_prompt=current_prompt,
+                    should_use_image=False,
+                    is_followup=False,
+                )
+
+            # Find most recent user + AI subtask pair
+            prev_user, prev_ai = None, None
+            for st in reversed(subtasks):
+                if st.role == SubtaskRole.ASSISTANT and not prev_ai:
+                    prev_ai = st
+                elif st.role == SubtaskRole.USER and not prev_user:
+                    prev_user = st
+                if prev_user and prev_ai:
+                    break
+
+            if not prev_user or not prev_ai:
+                return ImageIntentResult(
+                    merged_prompt=current_prompt,
+                    should_use_image=False,
+                    is_followup=False,
+                )
+
+            prev_prompt = prev_user.prompt or ""
+            prev_result = prev_ai.result or {}
+
+            # Check if previous AI result contains image attachment IDs
+            reference_image_url = self._extract_reference_image_url(prev_result)
+            has_image = reference_image_url is not None
+
+            # No previous image result means this is a brand-new generation
+            if not has_image:
+                return ImageIntentResult(
+                    merged_prompt=current_prompt,
+                    should_use_image=False,
+                    is_followup=False,
+                )
+
+            # This is a follow-up (previous turn had an image result)
+            # If no secondary model is configured, use simple merge with image
+            if not secondary_model_config:
+                logger.warning(
+                    "[ImageIntentAnalyzer] No secondary model, using simple merge"
+                )
+                return ImageIntentResult(
+                    merged_prompt=f"{prev_prompt}\n\n{current_prompt}",
+                    should_use_image=True,
+                    reference_image=reference_image_url,
+                    is_followup=True,
+                )
+
+            # Use secondary LLM for intelligent intent analysis
+            intent = await self._analyze_with_llm(
+                prev_prompt=prev_prompt,
+                current_prompt=current_prompt,
+                has_image=has_image,
+                model_config=secondary_model_config,
+            )
+
+            if intent.should_use_image and has_image:
+                intent.reference_image = reference_image_url
+            intent.is_followup = True
+
+            return intent
+
+        finally:
+            db.close()
+
+    def _extract_reference_image_url(self, prev_result: dict) -> Optional[str]:
+        """Extract a usable image URL from the previous AI subtask result.
+
+        Looks for image_attachment_ids inside blocks, then resolves the URL
+        via context_service.
+
+        Args:
+            prev_result: result dict from previous assistant subtask
+
+        Returns:
+            Image URL string or None
+        """
+        from app.db.session import SessionLocal
+        from app.services.context.context_service import context_service
+
+        blocks = prev_result.get("blocks", [])
+        for block in blocks:
+            if block.get("type") == "image":
+                attachment_ids = block.get("image_attachment_ids", [])
+                if attachment_ids:
+                    attachment_id = attachment_ids[0]
+                    db = SessionLocal()
+                    try:
+                        context = context_service.get_context_optional(
+                            db=db, context_id=attachment_id
+                        )
+                        if context and context.status == "ready":
+                            return context_service.build_attachment_url(attachment_id)
+                    except Exception as e:
+                        logger.warning(
+                            f"[ImageIntentAnalyzer] Failed to build attachment URL "
+                            f"for id={attachment_id}: {e}"
+                        )
+                        return None
+                    finally:
+                        db.close()
+
+                # Fallback: try image_urls list from block
+                image_urls = block.get("image_urls", [])
+                if image_urls:
+                    return image_urls[0]
+
+        return None
+
+    async def _analyze_with_llm(
+        self,
+        prev_prompt: str,
+        current_prompt: str,
+        has_image: bool,
+        model_config: dict,
+    ) -> ImageIntentResult:
+        """Call secondary LLM to analyze user intent.
+
+        Args:
+            prev_prompt: Previous user prompt
+            current_prompt: Current user prompt
+            has_image: Whether previous response has an image
+            model_config: LLM configuration
+
+        Returns:
+            ImageIntentResult from LLM analysis
+        """
+        prompt = INTENT_PROMPT.format(
+            previous_prompt=prev_prompt,
+            current_prompt=current_prompt,
+            has_image=str(has_image).lower(),
+        )
+
+        result = await self._call_llm_json(prompt, model_config)
+
+        if result is None:
+            # Fallback on LLM failure
+            return ImageIntentResult(
+                merged_prompt=f"{prev_prompt}\n\n{current_prompt}",
+                should_use_image=has_image,
+            )
+
+        return ImageIntentResult(
+            merged_prompt=result.get("merged_prompt", current_prompt),
+            should_use_image=result.get("should_use_image", False),
+        )

--- a/backend/app/services/execution/agents/image/providers/seedream.py
+++ b/backend/app/services/execution/agents/image/providers/seedream.py
@@ -79,8 +79,11 @@ class SeedreamProvider(ImageProvider):
             "watermark": self.image_config.get("watermark", False),
         }
 
-        # Add reference images if provided
-        if reference_images:
+        # Add reference images if provided.
+        # Note: doubao-seedream-3.0-t2i does NOT support the image parameter.
+        # Other Seedream variants (5.0-lite, 4.5, 4.0, seededit-3.0-i2i) support it.
+        model_supports_reference_image = "3.0-t2i" not in self.model
+        if reference_images and model_supports_reference_image:
             if len(reference_images) == 1:
                 extra_body["image"] = reference_images[0]
             else:

--- a/backend/app/services/execution/agents/image/providers/seedream.py
+++ b/backend/app/services/execution/agents/image/providers/seedream.py
@@ -82,7 +82,9 @@ class SeedreamProvider(ImageProvider):
         # Add reference images if provided.
         # Note: doubao-seedream-3.0-t2i does NOT support the image parameter.
         # Other Seedream variants (5.0-lite, 4.5, 4.0, seededit-3.0-i2i) support it.
-        model_supports_reference_image = "3.0-t2i" not in self.model
+        model_supports_reference_image = not any(
+            tag in self.model for tag in ("3.0-t2i", "3-0-t2i")
+        )
         if reference_images and model_supports_reference_image:
             if len(reference_images) == 1:
                 extra_body["image"] = reference_images[0]

--- a/backend/app/services/execution/agents/video/intent_analyzer.py
+++ b/backend/app/services/execution/agents/video/intent_analyzer.py
@@ -173,5 +173,7 @@ class VideoIntentAnalyzer(BaseIntentAnalyzer):
         return VideoIntentResult(
             merged_prompt=result.get("merged_prompt", current_prompt),
             should_use_image=result.get("should_use_image", False),
-            image_mode=result.get("image_mode"),
+            image_mode=result.get("image_mode")
+            if result.get("image_mode") in ("first_frame", "last_frame", "reference")
+            else None,
         )

--- a/backend/app/services/execution/agents/video/intent_analyzer.py
+++ b/backend/app/services/execution/agents/video/intent_analyzer.py
@@ -173,7 +173,10 @@ class VideoIntentAnalyzer(BaseIntentAnalyzer):
         return VideoIntentResult(
             merged_prompt=result.get("merged_prompt", current_prompt),
             should_use_image=result.get("should_use_image", False),
-            image_mode=result.get("image_mode")
-            if result.get("image_mode") in ("first_frame", "last_frame", "reference")
-            else None,
+            image_mode=(
+                result.get("image_mode")
+                if result.get("image_mode")
+                in ("first_frame", "last_frame", "reference")
+                else None
+            ),
         )

--- a/backend/app/services/execution/agents/video/intent_analyzer.py
+++ b/backend/app/services/execution/agents/video/intent_analyzer.py
@@ -9,10 +9,11 @@ Analyzes user intent in multi-turn video generation conversations
 to merge prompts and determine image usage.
 """
 
-import json
 import logging
 from dataclasses import dataclass
 from typing import Literal, Optional
+
+from ..base_intent_analyzer import BaseIntentAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ Rules:
 Output JSON only."""
 
 
-class VideoIntentAnalyzer:
+class VideoIntentAnalyzer(BaseIntentAnalyzer):
     """Analyzes video generation intent for follow-up messages."""
 
     async def analyze(
@@ -154,38 +155,23 @@ class VideoIntentAnalyzer:
         Returns:
             VideoIntentResult from LLM analysis
         """
-        from openai import AsyncOpenAI
-
         prompt = INTENT_PROMPT.format(
             previous_prompt=prev_prompt,
             current_prompt=current_prompt,
             has_image=str(has_image).lower(),
         )
 
-        client = AsyncOpenAI(
-            api_key=model_config.get("api_key"),
-            base_url=model_config.get("base_url"),
-        )
+        result = await self._call_llm_json(prompt, model_config)
 
-        try:
-            response = await client.chat.completions.create(
-                model=model_config.get("model_id", "gpt-4o-mini"),
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0,
-                response_format={"type": "json_object"},
-            )
-
-            result = json.loads(response.choices[0].message.content)
-
-            return VideoIntentResult(
-                merged_prompt=result.get("merged_prompt", current_prompt),
-                should_use_image=result.get("should_use_image", False),
-                image_mode=result.get("image_mode"),
-            )
-        except Exception as e:
-            logger.error(f"[VideoIntentAnalyzer] LLM call failed: {e}")
+        if result is None:
             return VideoIntentResult(
                 merged_prompt=f"{prev_prompt}\n\n{current_prompt}",
                 should_use_image=has_image,
                 image_mode="reference" if has_image else None,
             )
+
+        return VideoIntentResult(
+            merged_prompt=result.get("merged_prompt", current_prompt),
+            should_use_image=result.get("should_use_image", False),
+            image_mode=result.get("image_mode"),
+        )

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -415,9 +415,10 @@ class TaskRequestBuilder:
             task_data=task_data,
         )
 
-        # Handle secondaryModelRef for video models
-        # When modelType is 'video', resolve secondary model for intent analysis
-        if model_config.get("modelType") == "video":
+        # Handle secondaryModelRef for generation models (video and image).
+        # When modelType is 'video' or 'image', resolve secondary model for intent analysis
+        # used in multi-turn follow-up generation.
+        if model_config.get("modelType") in ("video", "image"):
             secondary_model_config = self._get_secondary_model_config(
                 bot=bot,
                 user_id=user_id,
@@ -440,7 +441,8 @@ class TaskRequestBuilder:
     ) -> dict[str, Any] | None:
         """Get secondary model configuration from bot's secondaryModelRef.
 
-        Used for auxiliary tasks like intent analysis in video generation.
+        Used for auxiliary tasks like intent analysis in video/image generation
+        follow-up conversations.
 
         Args:
             bot: Bot Kind object

--- a/backend/tests/services/execution/agents/image/test_image_agent.py
+++ b/backend/tests/services/execution/agents/image/test_image_agent.py
@@ -19,6 +19,18 @@ import pytest
 from shared.models import EventType, ExecutionRequest
 
 
+def _make_no_followup_intent():
+    """Return a mock ImageIntentResult indicating no follow-up history."""
+    from app.services.execution.agents.image.intent_analyzer import ImageIntentResult
+
+    return ImageIntentResult(
+        merged_prompt="A beautiful sunset over the ocean",
+        should_use_image=False,
+        reference_image=None,
+        is_followup=False,
+    )
+
+
 class TestImageAgent:
     """Tests for ImageAgent."""
 
@@ -39,6 +51,17 @@ class TestImageAgent:
         emitter.emit_start = AsyncMock()
         emitter.emit = AsyncMock()
         return emitter
+
+    @pytest.fixture
+    def mock_intent_analyzer(self):
+        """Mock ImageIntentAnalyzer to prevent DB access in tests."""
+        with patch(
+            "app.services.execution.agents.image.image_agent.ImageIntentAnalyzer"
+        ) as mock_cls:
+            mock_instance = AsyncMock()
+            mock_instance.analyze = AsyncMock(return_value=_make_no_followup_intent())
+            mock_cls.return_value = mock_instance
+            yield mock_instance
 
     @pytest.fixture
     def sample_request(self):
@@ -64,7 +87,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_normal_flow(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test normal execution flow."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -133,7 +156,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_cancellation(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution with cancellation."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -163,7 +186,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_cancel_event_set(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution when cancel event is already set."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -189,7 +212,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_provider_error(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution with provider error."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -228,7 +251,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_no_images_generated(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution when no images are generated."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -268,7 +291,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_base64_image(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution with base64 encoded image result."""
         from app.services.execution.agents.image.image_agent import ImageAgent
@@ -322,7 +345,7 @@ class TestImageAgent:
 
     @pytest.mark.asyncio
     async def test_execute_with_multiple_images(
-        self, mock_session_manager, mock_emitter, sample_request
+        self, mock_session_manager, mock_emitter, mock_intent_analyzer, sample_request
     ):
         """Test execution with multiple images generated."""
         from app.services.execution.agents.image.image_agent import ImageAgent

--- a/frontend/src/app/(tasks)/generate/GeneratePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/generate/GeneratePageDesktop.tsx
@@ -38,12 +38,26 @@ import { ChatArea } from '@/features/tasks/components/chat'
 /** Generation mode type - video or image */
 type GenerateMode = 'video' | 'image'
 
+const GENERATE_MODE_STORAGE_KEY = 'wegent_generate_last_mode'
+
+function isGenerateMode(value: unknown): value is GenerateMode {
+  return value === 'video' || value === 'image'
+}
+
 export function GeneratePageDesktop() {
   // Team state from service
   const { teams, isTeamsLoading, refreshTeams } = teamService.useTeams()
 
   // Generation mode state - video or image
-  const [generateMode, setGenerateMode] = useState<GenerateMode>('video')
+  // Priority:
+  // 1) Existing task's task_type (synced in useEffect below)
+  // 2) Last user selection from localStorage
+  // 3) Default to 'video'
+  const [generateMode, setGenerateMode] = useState<GenerateMode>(() => {
+    if (typeof window === 'undefined') return 'video'
+    const saved = localStorage.getItem(GENERATE_MODE_STORAGE_KEY)
+    return isGenerateMode(saved) ? saved : 'video'
+  })
 
   // Filter teams based on current generation mode
   // Teams with empty bind_mode support all modes
@@ -57,6 +71,14 @@ export function GeneratePageDesktop() {
   // Task context for refreshing task list
   const { refreshTasks, selectedTaskDetail, setSelectedTask, refreshSelectedTaskDetail } =
     useTaskContext()
+
+  // Sync generate mode from task detail when entering from history (taskId in URL)
+  useEffect(() => {
+    const taskType = selectedTaskDetail?.task_type
+    if (taskType === 'video' || taskType === 'image') {
+      setGenerateMode(taskType)
+    }
+  }, [selectedTaskDetail?.id, selectedTaskDetail?.task_type])
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskDetail?.title
@@ -111,6 +133,13 @@ export function GeneratePageDesktop() {
   const handleRefreshTeams = async (): Promise<Team[]> => {
     return await refreshTeams()
   }
+
+  const handleGenerateModeChange = useCallback((mode: GenerateMode) => {
+    setGenerateMode(mode)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(GENERATE_MODE_STORAGE_KEY, mode)
+    }
+  }, [])
 
   const handleToggleCollapsed = () => {
     setIsCollapsed(prev => {
@@ -172,7 +201,7 @@ export function GeneratePageDesktop() {
           showRepositorySelector={false}
           taskType={generateMode}
           onRefreshTeams={handleRefreshTeams}
-          onGenerateModeChange={setGenerateMode}
+          onGenerateModeChange={handleGenerateModeChange}
         />
       </div>
       {/* Search Dialog - rendered at page level for global shortcut support */}

--- a/frontend/src/app/(tasks)/generate/GeneratePageMobile.tsx
+++ b/frontend/src/app/(tasks)/generate/GeneratePageMobile.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useRouter } from 'next/navigation'
 import { teamService } from '@/features/tasks/service/teamService'
 import TopNavigation from '@/features/layout/TopNavigation'
@@ -34,12 +34,26 @@ import { ChatArea } from '@/features/tasks/components/chat'
 /** Generation mode type - video or image */
 type GenerateMode = 'video' | 'image'
 
+const GENERATE_MODE_STORAGE_KEY = 'wegent_generate_last_mode'
+
+function isGenerateMode(value: unknown): value is GenerateMode {
+  return value === 'video' || value === 'image'
+}
+
 export function GeneratePageMobile() {
   // Team state from service
   const { teams, isTeamsLoading, refreshTeams } = teamService.useTeams()
 
   // Generation mode state - video or image
-  const [generateMode, setGenerateMode] = useState<GenerateMode>('video')
+  // Priority:
+  // 1) Existing task's task_type (synced in useEffect below)
+  // 2) Last user selection from localStorage
+  // 3) Default to 'video'
+  const [generateMode, setGenerateMode] = useState<GenerateMode>(() => {
+    if (typeof window === 'undefined') return 'video'
+    const saved = localStorage.getItem(GENERATE_MODE_STORAGE_KEY)
+    return isGenerateMode(saved) ? saved : 'video'
+  })
 
   // Filter teams based on current generation mode
   // Teams with empty bind_mode support all modes
@@ -53,6 +67,14 @@ export function GeneratePageMobile() {
   // Task context for refreshing task list
   const { refreshTasks, selectedTaskDetail, setSelectedTask, refreshSelectedTaskDetail } =
     useTaskContext()
+
+  // Sync generate mode from task detail when entering from history (taskId in URL)
+  useEffect(() => {
+    const taskType = selectedTaskDetail?.task_type
+    if (taskType === 'video' || taskType === 'image') {
+      setGenerateMode(taskType)
+    }
+  }, [selectedTaskDetail?.id, selectedTaskDetail?.task_type])
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskDetail?.title
@@ -100,6 +122,13 @@ export function GeneratePageMobile() {
     return await refreshTeams()
   }
 
+  const handleGenerateModeChange = useCallback((mode: GenerateMode) => {
+    setGenerateMode(mode)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(GENERATE_MODE_STORAGE_KEY, mode)
+    }
+  }, [])
+
   return (
     <div className="flex smart-h-screen bg-base text-text-primary box-border">
       {/* Mobile sidebar - use TaskSidebar's built-in MobileSidebar component */}
@@ -137,7 +166,7 @@ export function GeneratePageMobile() {
           showRepositorySelector={false}
           taskType={generateMode}
           onRefreshTeams={handleRefreshTeams}
-          onGenerateModeChange={setGenerateMode}
+          onGenerateModeChange={handleGenerateModeChange}
         />
       </div>
       {/* Search Dialog - rendered at page level for global shortcut support */}

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -604,8 +604,9 @@ function ChatAreaContent({
           file_extension: detail.file_extension,
           created_at: detail.created_at,
         })
-      } catch {
-        // Silently ignore fetch errors - the system will use auto intent analysis
+      } catch (error) {
+        // Log error; system will fall back to auto intent analysis
+        console.error('Failed to use image as reference:', error)
       }
     },
     [chatState]

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -28,6 +28,7 @@ import { useTaskStateMachine } from '../../hooks/useTaskStateMachine'
 import { Button } from '@/components/ui/button'
 import { useScrollManagement } from '../hooks/useScrollManagement'
 import { useFloatingInput } from '../hooks/useFloatingInput'
+import { getAttachment } from '@/apis/attachments'
 import { useAttachmentUpload } from '../hooks/useAttachmentUpload'
 import { useSchemeMessageActions } from '@/lib/scheme'
 import { useSkillSelector } from '../../hooks/useSkillSelector'
@@ -583,10 +584,36 @@ function ChatAreaContent({
     [chatState]
   )
 
+  // Callback when user wants to use a previously generated image as reference
+  // Fetches the attachment metadata and adds it to the current input attachments
+  const handleUseAsReference = useCallback(
+    async (item: import('../message/ImageGallery').ImageItem) => {
+      if (!item.attachmentId) return
+      try {
+        const detail = await getAttachment(item.attachmentId)
+        chatState.addExistingAttachment({
+          id: detail.id,
+          filename: detail.filename,
+          file_size: detail.file_size,
+          mime_type: detail.mime_type,
+          status: detail.status,
+          text_length: detail.text_length ?? null,
+          error_message: detail.error_message ?? null,
+          error_code: detail.error_code ?? null,
+          subtask_id: detail.subtask_id ?? null,
+          file_extension: detail.file_extension,
+          created_at: detail.created_at,
+        })
+      } catch {
+        // Silently ignore fetch errors - the system will use auto intent analysis
+      }
+    },
+    [chatState]
+  )
+
   // Handle access denied state
   if (accessDenied) {
     const handleGoHome = () => {
-      clearAccessDenied()
       setSelectedTask(null)
       router.push('/chat')
     }
@@ -804,6 +831,7 @@ function ChatAreaContent({
               isPendingConfirmation={pipelineStageInfo?.is_pending_confirmation}
               onContextReselect={handleContextReselect}
               hideGroupChatOptions={taskType === 'knowledge'}
+              onUseAsReference={handleUseAsReference}
             />
           </div>
         </div>

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -97,7 +97,7 @@ function ChatAreaContent({
   const { quote, clearQuote, formatQuoteForMessage } = useQuote()
 
   // Task context
-  const { selectedTaskDetail, setSelectedTask, accessDenied, clearAccessDenied } = useTaskContext()
+  const { selectedTaskDetail, setSelectedTask, accessDenied } = useTaskContext()
 
   // Use useTaskStateMachine hook for reactive state updates (SINGLE SOURCE OF TRUTH per AGENTS.md)
   const { state: taskState } = useTaskStateMachine(selectedTaskDetail?.id)

--- a/frontend/src/features/tasks/components/chat/useChatAreaState.ts
+++ b/frontend/src/features/tasks/components/chat/useChatAreaState.ts
@@ -107,6 +107,8 @@ export interface ChatAreaState {
   attachmentState: MultiAttachmentUploadState
   handleFileSelect: (files: File | File[]) => Promise<void>
   handleAttachmentRemove: (attachmentId: number) => Promise<void>
+  /** Add an already-uploaded attachment as reference (e.g., from ImageGallery follow-up) */
+  addExistingAttachment: (attachment: import('@/types/api').Attachment) => void
   resetAttachment: () => void
   isAttachmentReadyToSend: boolean
   isUploading: boolean
@@ -254,6 +256,7 @@ export function useChatAreaState({
   const {
     state: attachmentState,
     handleFileSelect,
+    addExistingAttachment,
     handleRemove: handleAttachmentRemove,
     reset: resetAttachment,
     isReadyToSend: isAttachmentReadyToSend,
@@ -608,6 +611,7 @@ export function useChatAreaState({
     // Attachment state (multi-attachment)
     attachmentState,
     handleFileSelect,
+    addExistingAttachment,
     handleAttachmentRemove,
     resetAttachment,
     isAttachmentReadyToSend,

--- a/frontend/src/features/tasks/components/message/ImageGallery.tsx
+++ b/frontend/src/features/tasks/components/message/ImageGallery.tsx
@@ -155,7 +155,7 @@ export function ImageGallery({ images, className, onUseAsReference }: ImageGalle
               </button>
 
               {/* Use as reference button (shown only when callback provided) - 44px touch target */}
-              {onUseAsReference && (
+              {onUseAsReference && image.attachmentId && (
                 <button
                   type="button"
                   onClick={e => {

--- a/frontend/src/features/tasks/components/message/ImageGallery.tsx
+++ b/frontend/src/features/tasks/components/message/ImageGallery.tsx
@@ -17,7 +17,7 @@
 
 import React, { useState, useCallback } from 'react'
 import Image from 'next/image'
-import { Download, Maximize2, X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Download, Maximize2, X, ChevronLeft, ChevronRight, ImagePlus } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/hooks/useTranslation'
 
@@ -30,9 +30,11 @@ export interface ImageItem {
 export interface ImageGalleryProps {
   images: ImageItem[]
   className?: string
+  /** Optional callback when user wants to use an image as reference for follow-up generation */
+  onUseAsReference?: (item: ImageItem) => void
 }
 
-export function ImageGallery({ images, className }: ImageGalleryProps) {
+export function ImageGallery({ images, className, onUseAsReference }: ImageGalleryProps) {
   const { t } = useTranslation('chat')
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null)
 
@@ -151,6 +153,21 @@ export function ImageGallery({ images, className }: ImageGalleryProps) {
               >
                 <Maximize2 className="h-5 w-5 text-white" />
               </button>
+
+              {/* Use as reference button (shown only when callback provided) - 44px touch target */}
+              {onUseAsReference && (
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.stopPropagation()
+                    onUseAsReference(image)
+                  }}
+                  className="h-11 w-11 min-w-[44px] flex items-center justify-center rounded-full bg-white/20 hover:bg-white/30 transition-colors"
+                  title={t('image.use_as_reference', 'Use as reference')}
+                >
+                  <ImagePlus className="h-5 w-5 text-white" />
+                </button>
+              )}
             </div>
 
             {/* Image size badge (if available) */}

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -1652,7 +1652,8 @@ const MessageBubble = memo(
       prevProps.isPendingConfirmation === nextProps.isPendingConfirmation &&
       prevProps.isEditing === nextProps.isEditing &&
       prevProps.isLastAiMessage === nextProps.isLastAiMessage &&
-      prevProps.isRegenerating === nextProps.isRegenerating
+      prevProps.isRegenerating === nextProps.isRegenerating &&
+      prevProps.onUseAsReference === nextProps.onUseAsReference
 
     return shouldSkipRender
   }

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -185,6 +185,8 @@ export interface MessageBubbleProps {
   onRegenerate?: (msg: Message, model: Model) => void
   /** Whether regenerate is in progress */
   isRegenerating?: boolean
+  /** Callback when user wants to use a generated image as reference for follow-up generation */
+  onUseAsReference?: (item: import('./ImageGallery').ImageItem) => void
   /** Share token for public access to attachments (no login required) */
   shareToken?: string
 }
@@ -309,6 +311,7 @@ const MessageBubble = memo(
     isLastAiMessage,
     onRegenerate,
     isRegenerating,
+    onUseAsReference,
     shareToken,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
@@ -1408,6 +1411,7 @@ const MessageBubble = memo(
                         theme={theme}
                         blocks={msg.result.blocks}
                         annotations={msg.result?.annotations}
+                        onUseAsReference={onUseAsReference}
                       />
                       <SourceReferences sources={msg.sources || msg.result?.sources || []} />
                       <GeminiAnnotations annotations={msg.result?.annotations || []} />

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -75,6 +75,7 @@ interface StreamingMessageBubbleProps {
   isGroupChat?: boolean
   isPendingConfirmation?: boolean
   onContextReselect?: (context: import('@/types/api').SubtaskContextBrief) => void
+  onUseAsReference?: (item: import('./ImageGallery').ImageItem) => void
 }
 
 function StreamingMessageBubble({
@@ -90,6 +91,7 @@ function StreamingMessageBubble({
   isGroupChat,
   isPendingConfirmation,
   onContextReselect,
+  onUseAsReference,
 }: StreamingMessageBubbleProps) {
   // Use typewriter effect for streaming content
   const displayContent = useTypewriter(message.content || '')
@@ -148,6 +150,7 @@ function StreamingMessageBubble({
       isGroupChat={isGroupChat}
       isPendingConfirmation={isPendingConfirmation}
       onContextReselect={onContextReselect}
+      onUseAsReference={onUseAsReference}
     />
   )
 }
@@ -188,6 +191,8 @@ interface MessagesAreaProps {
   onContextReselect?: (context: import('@/types/api').SubtaskContextBrief) => void
   /** Hide group chat management button (e.g., in notebook mode) */
   hideGroupChatOptions?: boolean
+  /** Callback when user wants to use a generated image as reference for follow-up generation */
+  onUseAsReference?: (item: import('./ImageGallery').ImageItem) => void
 }
 
 export default function MessagesArea({
@@ -208,6 +213,7 @@ export default function MessagesArea({
   isPendingConfirmation,
   onContextReselect,
   hideGroupChatOptions = false,
+  onUseAsReference,
 }: MessagesAreaProps) {
   const { t } = useTranslation()
   const { toast } = useToast()
@@ -1138,6 +1144,7 @@ export default function MessagesArea({
                   isGroupChat={isGroupChat}
                   isPendingConfirmation={isPendingConfirmation}
                   onContextReselect={onContextReselect}
+                  onUseAsReference={onUseAsReference}
                 />
               )
             }
@@ -1168,6 +1175,7 @@ export default function MessagesArea({
                     isGroupChat={isGroupChat}
                     isPendingConfirmation={isPendingConfirmation}
                     onContextReselect={onContextReselect}
+                    onUseAsReference={onUseAsReference}
                   />
                   <div className="flex flex-col gap-2">
                     {/* Show progress indicator when correction is in progress */}
@@ -1236,6 +1244,7 @@ export default function MessagesArea({
                 isLastAiMessage={isLastAiMessage}
                 onRegenerate={!isGroupChat ? handleRegenerate : undefined}
                 isRegenerating={isRegenerating}
+                onUseAsReference={onUseAsReference}
               />
             )
           })}

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -23,6 +23,8 @@ interface MixedContentViewProps {
   theme: 'light' | 'dark'
   blocks?: MessageBlock[] // NEW: Block-based rendering support
   annotations?: GeminiAnnotation[]
+  /** Optional callback when user wants to use a generated image as reference for follow-up */
+  onUseAsReference?: (item: import('../ImageGallery').ImageItem) => void
 }
 
 /**
@@ -40,6 +42,7 @@ const MixedContentView = memo(function MixedContentView({
   theme,
   blocks,
   annotations,
+  onUseAsReference,
 }: MixedContentViewProps) {
   const { t } = useTranslation('chat')
   // Extract tools from thinking (legacy mode)
@@ -311,6 +314,7 @@ const MixedContentView = memo(function MixedContentView({
                     url,
                     attachmentId: item.imageAttachmentIds?.[i],
                   }))}
+                  onUseAsReference={onUseAsReference}
                 />
               ) : null}
             </div>

--- a/frontend/src/hooks/useMultiAttachment.ts
+++ b/frontend/src/hooks/useMultiAttachment.ts
@@ -24,6 +24,8 @@ interface UseMultiAttachmentReturn {
   state: MultiAttachmentUploadState
   /** Handle file selection and upload */
   handleFileSelect: (files: File | File[]) => Promise<void>
+  /** Add an already-uploaded attachment directly (e.g., reference image from history) */
+  addExistingAttachment: (attachment: import('@/types/api').Attachment) => void
   /** Remove specific attachment */
   handleRemove: (attachmentId: number) => Promise<void>
   /** Reset state */
@@ -203,6 +205,22 @@ export function useMultiAttachment(): UseMultiAttachmentReturn {
     [state.attachments, t]
   )
 
+  const addExistingAttachment = useCallback(
+    (attachment: import('@/types/api').Attachment) => {
+      // Skip if already in the list
+      setState(prev => {
+        if (prev.attachments.some(a => a.id === attachment.id)) {
+          return prev
+        }
+        return {
+          ...prev,
+          attachments: [...prev.attachments, attachment],
+        }
+      })
+    },
+    []
+  )
+
   const handleRemove = useCallback(
     async (attachmentId: number) => {
       const attachment = state.attachments.find(a => a.id === attachmentId)
@@ -250,6 +268,7 @@ export function useMultiAttachment(): UseMultiAttachmentReturn {
   return {
     state,
     handleFileSelect,
+    addExistingAttachment,
     handleRemove,
     reset,
     isReadyToSend,

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -587,6 +587,7 @@
     "failed": "Image generation failed",
     "download": "Download image",
     "expand": "View full size",
+    "use_as_reference": "Use as reference",
     "generated_image": "Generated image",
     "lightbox": "Image preview",
     "no_models": "No image models available"

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -565,6 +565,7 @@
     "failed": "图片生成失败",
     "download": "下载图片",
     "expand": "查看大图",
+    "use_as_reference": "用作参考图",
     "generated_image": "生成的图片",
     "lightbox": "图片预览",
     "no_models": "暂无可用的图片模型"


### PR DESCRIPTION
## Summary

- **Backend**: Extract `BaseIntentAnalyzer` shared base class; add `ImageIntentAnalyzer` for multi-turn prompt merging and reference image resolution; extend `secondaryModelRef` resolution to image models; update `ImageAgent` to run intent analysis; guard `seedream-3.0-t2i` from unsupported `image` parameter
- **Frontend**: Add `addExistingAttachment` to `useMultiAttachment`; wire `onUseAsReference` callback from `ChatArea` → `MessagesArea` → `MessageBubble` → `MixedContentView` → `ImageGallery`; show "Use as reference" hover button (`ImagePlus`) on generated image thumbnails
- **i18n**: Add `image.use_as_reference` key in both `en` and `zh-CN`

## How it works

**Auto follow-up (no user action required):**
```
User sends "改成红色背景" (no attachment)
  → ImageIntentAnalyzer detects history has image → secondary LLM merges prompts
  → seedream.generate(merged_prompt, reference_images=[prev_image_url])
```

**User-specified reference (explicit):**
```
User hovers generated image → clicks ImagePlus button
  → attachment_id added to chat input badge
  → User sends follow-up message
  → ImageAgent: user_reference_images=[url] → skips intent analysis
  → seedream.generate(prompt, reference_images=[user_url])
```

**Priority**: User-specified attachment > intent analysis auto-reference

## Test plan

- [ ] Image generation with no history: generates normally, no intent analysis triggered
- [ ] Send follow-up after image generation (no button): auto intent analysis merges prompt + carries reference image
- [ ] Click "Use as reference" button on a generated image: badge appears in input, sends with correct `attachment_id`
- [ ] `doubao-seedream-3.0-t2i` model: reference image param is skipped, no API error
- [ ] Video generation still works correctly after `VideoIntentAnalyzer` refactor
- [ ] i18n: hover button tooltip shows correct text in zh-CN and en

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Reuse generated images as references in follow-up image/video requests.
  - “Use as reference” action added across image galleries, chat UI, and message components.
  - Multi-turn intent analysis for merging follow-up prompts and optionally selecting reference images; applied to image and video generation.
  - Persistent generation mode (mobile/desktop) with local storage.

* **Localization**
  - Added "Use as reference" text in English and Chinese.

* **Tests**
  - Updated tests to mock intent analyzer for follow-up flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->