### PR TITLE
fix chat_shell and executor_manager port mapping error in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,6 @@ services:
     ports:
       - "${CHAT_SHELL_PORT:-8100}:8100"
     environment:
-      - PORT=${CHAT_SHELL_PORT:-8100}
       - HOST=${CHAT_SHELL_HOST:-0.0.0.0}
       - CHAT_SHELL_MODE=${CHAT_SHELL_MODE:-http}
       - CHAT_SHELL_STORAGE_TYPE=${CHAT_SHELL_STORAGE_TYPE:-remote}
@@ -206,7 +205,7 @@ services:
           echo "=== Failed to pull executor image, will use cached version ===" >&2
         fi
         echo "=== Starting executor manager ===" >&2
-        exec uvicorn main:app --host 0.0.0.0 --port $${PORT:-8001}
+        exec uvicorn main:app --host 0.0.0.0 --port 8001
     ports:
       - "${EXECUTOR_MANAGER_PORT:-8001}:8001"
     environment:
@@ -215,7 +214,6 @@ services:
       - EXECUTOR_MANAGER_EXTERNAL_URL=${EXECUTOR_MANAGER_EXTERNAL_URL:-http://executor_manager:8001}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
       - MAX_CONCURRENT_TASKS=${EXECUTOR_MAX_CONCURRENT_TASKS:-30}
-      - PORT=${EXECUTOR_MANAGER_PORT:-8001}
       - CALLBACK_HOST=${EXECUTOR_CALLBACK_HOST:-http://executor_manager:8001}
       - NETWORK=${EXECUTOR_NETWORK:-wegent-network}
       - EXECUTOR_IMAGE=${EXECUTOR_IMAGE:-ghcr.io/wecode-ai/wegent-executor:latest}


### PR DESCRIPTION
原先chat_shell和executor_manager的PORT, 会导致端口映射失败, 对话不可用
比如我的配置文件:
```
BACKEND_PORT=18000
CHAT_SHELL_PORT=18100
EXECUTOR_MANAGER_PORT=18001
WEGENT_FRONTEND_PORT=13000
```
## 项目中的docker compose文件启动后chat_shell端口映射错误:
```yaml
  chat_shell:
    image: ghcr.io/wecode-ai/wegent-chat-shell:latest
    pull_policy: ${DOCKER_PULL_POLICY:-always}
    container_name: wegent-chat-shell
    restart: always
    ports:
      - "${CHAT_SHELL_PORT:-8100}:8100"
    environment:
      - PORT=${CHAT_SHELL_PORT:-8100}
```
启动后, 由于CHAT_SHELL_PORT=18100, 所以PORT=18100
chat_shell的启动命令:
```
CMD ["sh", "-c", "exec uvicorn chat_shell.main:app --host ${HOST} --port ${PORT} --workers 1 --timeout-graceful-shutdown ${GRACEFUL_SHUTDOWN_TIMEOUT}"]
```
那么chat_shell的启动端口是18100
但是compose文件中是把容器的8100端口映射到宿主机的18100, 外部调用curl "http://localhost:18100" 时失败

## executor_manager类似的问题:
```yaml
executor_manager:
    # build:
    #   dockerfile: docker/executor_manager/Dockerfile
    image: ghcr.io/wecode-ai/wegent-executor-manager:latest
    pull_policy: ${DOCKER_PULL_POLICY:-always}
    extra_hosts:
      - "host.docker.internal:host-gateway"
    container_name: wegent-executor-manager
    restart: always
    entrypoint:
      - sh
      - -c
      - |
        echo "=== Pulling executor image: $${EXECUTOR_IMAGE} ===" >&2
        if docker pull $${EXECUTOR_IMAGE} 2>&1; then
          echo "=== Successfully pulled executor image ===" >&2
        else
          echo "=== Failed to pull executor image, will use cached version ===" >&2
        fi
        echo "=== Starting executor manager ===" >&2
        exec uvicorn main:app --host 0.0.0.0 --port $${PORT:-8001}
    ports:
      - "${EXECUTOR_MANAGER_PORT:-8001}:8001"
    environment:
      - PORT=${EXECUTOR_MANAGER_PORT:-8001}
```
启动时: EXECUTOR_MANAGER_PORT=18001, 那么PORT=18001
所以uvicorn main:app --host 0.0.0.0 --port 18001
但是端口映射的时候, 是把容器的8001端口映射到宿主机的18001
外部调用curl "http://localhost:18101" 时失败



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker service configuration to streamline port management and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->