### PR TITLE
feat(chat): filter regenerate model list by task type

### DIFF
--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -12,6 +12,7 @@ import type {
   GitBranch,
   Attachment,
   SubtaskContextBrief,
+  TaskType,
 } from '@/types/api'
 import {
   Bot,
@@ -199,6 +200,8 @@ export interface MessageBubbleProps {
   onReEdit?: (msg: Message) => void
   /** Share token for public access to attachments (no login required) */
   shareToken?: string
+  /** Current task type to determine which model category to show in regenerate popover */
+  taskType?: TaskType
 }
 
 // Component for rendering a paragraph with hover action button
@@ -346,6 +349,7 @@ const MessageBubble = memo(
     onUseAsReference,
     onReEdit,
     shareToken,
+    taskType,
   }: MessageBubbleProps) {
     // Use trace hook for telemetry (auto-includes user and task context)
     const { trace } = useTraceAction()
@@ -743,6 +747,7 @@ const MessageBubble = memo(
                   isLoading={isRegenerating}
                   trigger={defaultButton}
                   tooltipText={tooltipText}
+                  taskType={taskType}
                 />
               )}
               showReEdit={canShowReEdit(msg, isGroupChat, onReEdit)}
@@ -1517,6 +1522,7 @@ const MessageBubble = memo(
                               isLoading={isRegenerating}
                               trigger={defaultButton}
                               tooltipText={tooltipText}
+                              taskType={taskType}
                             />
                           )}
                           showReEdit={canShowReEdit(msg, isGroupChat, onReEdit)}

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -1704,7 +1704,8 @@ const MessageBubble = memo(
       prevProps.isLastAiMessage === nextProps.isLastAiMessage &&
       prevProps.isRegenerating === nextProps.isRegenerating &&
       prevProps.onUseAsReference === nextProps.onUseAsReference &&
-      prevProps.onReEdit === nextProps.onReEdit
+      prevProps.onReEdit === nextProps.onReEdit &&
+      prevProps.taskType === nextProps.taskType
 
     return shouldSkipRender
   }

--- a/frontend/src/features/tasks/components/message/MessagesArea.tsx
+++ b/frontend/src/features/tasks/components/message/MessagesArea.tsx
@@ -151,6 +151,7 @@ function StreamingMessageBubble({
       isPendingConfirmation={isPendingConfirmation}
       onContextReselect={onContextReselect}
       onUseAsReference={onUseAsReference}
+      taskType={selectedTaskDetail?.task_type}
     />
   )
 }
@@ -1180,6 +1181,7 @@ export default function MessagesArea({
                     onContextReselect={onContextReselect}
                     onUseAsReference={onUseAsReference}
                     onReEdit={onReEdit}
+                    taskType={selectedTaskDetail?.task_type}
                   />
                   <div className="flex flex-col gap-2">
                     {/* Show progress indicator when correction is in progress */}
@@ -1250,6 +1252,7 @@ export default function MessagesArea({
                 isRegenerating={isRegenerating}
                 onUseAsReference={onUseAsReference}
                 onReEdit={onReEdit}
+                taskType={selectedTaskDetail?.task_type}
               />
             )
           })}

--- a/frontend/src/features/tasks/components/message/RegenerateModelPopover.tsx
+++ b/frontend/src/features/tasks/components/message/RegenerateModelPopover.tsx
@@ -9,9 +9,26 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useModelSelection, type Model } from '../../hooks/useModelSelection'
-import type { Team } from '@/types/api'
+import type { Team, TaskType } from '@/types/api'
+import type { ModelCategoryType } from '@/apis/models'
 import { cn } from '@/lib/utils'
 import { Globe, User } from 'lucide-react'
+
+/**
+ * Maps task type to the corresponding model category type.
+ * This ensures the regenerate model popover shows the correct model list
+ * based on the current task type (e.g., image task shows image models).
+ */
+function getModelCategoryFromTaskType(taskType?: TaskType): ModelCategoryType {
+  switch (taskType) {
+    case 'image':
+      return 'image'
+    case 'video':
+      return 'video'
+    default:
+      return 'llm'
+  }
+}
 
 export interface RegenerateModelPopoverProps {
   open: boolean
@@ -22,6 +39,8 @@ export interface RegenerateModelPopoverProps {
   trigger: React.ReactNode
   /** Tooltip text for the trigger button */
   tooltipText?: string
+  /** Current task type to determine which model category to show */
+  taskType?: TaskType
 }
 
 /**
@@ -36,8 +55,12 @@ export function RegenerateModelPopover({
   isLoading = false,
   trigger,
   tooltipText,
+  taskType,
 }: RegenerateModelPopoverProps) {
   const { t } = useTranslation('chat')
+
+  // Determine model category based on task type
+  const modelCategoryType = getModelCategoryFromTaskType(taskType)
 
   // Use the model selection hook to get filtered models
   const {
@@ -48,6 +71,7 @@ export function RegenerateModelPopover({
     teamId: selectedTeam?.id ?? null,
     taskId: null,
     selectedTeam,
+    modelCategoryType,
   })
 
   const handleModelSelect = (model: Model) => {


### PR DESCRIPTION
## Summary
- Enhanced the "Regenerate" (再次生成) button's model selection popover to automatically display models matching the current task type
- Image generation tasks now show only image models
- Video generation tasks now show only video models
- Other tasks (chat, code, knowledge, task) continue to show only LLM models

## Background
Previously, the regenerate model popover only displayed LLM models regardless of the current task type. This was problematic for image and video generation tasks, as users needed to select corresponding model types when regenerating.

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Unit tests pass
- [ ] Manual test: Open a chat/code task, click regenerate → should show LLM models only
- [ ] Manual test: Open an image generation task, click regenerate → should show image models only
- [ ] Manual test: Open a video generation task, click regenerate → should show video models only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regenerate model popover is now task-aware, showing models filtered by the current task type (image/video/LLM).
  * Message components now receive task type context so model options reflect the message’s task.

* **Bug Fixes**
  * Message UI will re-render when task type changes so model options stay in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->