### PR TITLE
feat(devices): add device type selection with tabbed interface

### DIFF
--- a/frontend/src/app/(tasks)/devices/page.tsx
+++ b/frontend/src/app/(tasks)/devices/page.tsx
@@ -21,59 +21,46 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContext'
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
-import { useSocket } from '@/contexts/SocketContext'
 import { paths } from '@/config/paths'
 import { useDevices } from '@/contexts/DeviceContext'
-import { getToken } from '@/apis/user'
 import { DeviceInfo } from '@/apis/devices'
-import { SlotIndicator } from '@/features/devices/components/SlotIndicator'
-import { RunningTasksList } from '@/features/devices/components/RunningTasksList'
-import { VersionBadge } from '@/features/devices/components/VersionBadge'
-import {
-  Monitor,
-  RefreshCw,
-  Loader2,
-  Play,
-  Star,
-  MoreVertical,
-  Trash2,
-  ExternalLink,
-  MessageCircleQuestion,
-  Plus,
-  ChevronUp,
-  Cloud,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown'
-import { Tooltip, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn } from '@/lib/utils'
-import { toast } from 'sonner'
+import { getToken } from '@/apis/user'
+import { Monitor, Loader2, Cloud } from 'lucide-react'
 import { getSocketUrl } from '@/lib/runtime-config'
-import { LocalExecutorGuide } from '@/features/devices/components/LocalExecutorGuide'
+import {
+  DeviceCard,
+  DevicesPageHeader,
+  DeviceSection,
+  DeviceSetupGuide,
+} from '@/features/devices/components'
+import { useDeviceHandlers } from '@/features/devices/hooks'
 
-// Device type constants matching backend DeviceType enum
-const DEVICE_TYPE = {
-  LOCAL: 'local',
-  CLOUD: 'cloud',
-} as const
+// Helper function to sort devices by priority
+function sortDevices(devices: DeviceInfo[]): DeviceInfo[] {
+  return [...devices].sort((a, b) => {
+    // Priority 1: Online devices first (online > busy > offline)
+    const statusOrder: Record<string, number> = { online: 0, busy: 1, offline: 2 }
+    const statusDiff = (statusOrder[a.status] ?? 2) - (statusOrder[b.status] ?? 2)
+    if (statusDiff !== 0) return statusDiff
+
+    // Priority 2: Default device first
+    if (a.is_default && !b.is_default) return -1
+    if (!a.is_default && b.is_default) return 1
+
+    // Priority 3: Alphabetically by name
+    return a.name.localeCompare(b.name)
+  })
+}
 
 export default function DevicesPage() {
   const { t } = useTranslation('devices')
   const router = useRouter()
   const { clearAllStreams } = useChatStreamContext()
   const { setSelectedTask } = useTaskContext()
-  const { closeTaskSession } = useSocket()
   const isMobile = useIsMobile()
 
   // Environment variables for device setup
   const guideUrl = process.env.NEXT_PUBLIC_DEVICE_GUIDE_URL || ''
-  const communityUrl = process.env.NEXT_PUBLIC_COMMUNITY_URL || ''
-  const faqUrl = process.env.NEXT_PUBLIC_FAQ_URL || ''
 
   // Generate dynamic backend URL from runtime config
   const backendUrl = useMemo(() => getSocketUrl(), [])
@@ -81,106 +68,13 @@ export default function DevicesPage() {
   // Get auth token
   const authToken = useMemo(() => getToken() || '<YOUR_AUTH_TOKEN>', [])
 
-  const {
-    devices,
-    isLoading,
-    error,
-    refreshDevices,
-    setSelectedDeviceId,
-    setDefaultDevice,
-    deleteDevice,
-  } = useDevices()
+  const { devices, isLoading, error, refreshDevices } = useDevices()
 
-  // Handle cancelling/closing a task via WebSocket
-  // For running tasks: pauses execution
-  // For completed tasks: closes session and frees device slot
-  const handleCancelTask = async (taskId: number) => {
-    try {
-      const result = await closeTaskSession(taskId)
-      if (result.success) {
-        toast.success(t('close_session_success'))
-        // Refresh devices to update slot usage
-        await refreshDevices()
-      } else {
-        toast.error(result.error || t('close_session_error'))
-      }
-    } catch (error) {
-      console.error('Failed to close task session:', error)
-      toast.error(t('close_session_error'))
-    }
-  }
+  // Device action handlers (consolidated in custom hook)
+  const handlers = useDeviceHandlers()
 
-  // Sort devices: online first, then by default status, then by name
-  const sortedDevices = useMemo(() => {
-    return [...devices].sort((a, b) => {
-      // Priority 1: Online devices first (online > busy > offline)
-      const statusOrder: Record<string, number> = { online: 0, busy: 1, offline: 2 }
-      const statusDiff = (statusOrder[a.status] ?? 2) - (statusOrder[b.status] ?? 2)
-      if (statusDiff !== 0) return statusDiff
-
-      // Priority 2: Default device first
-      if (a.is_default && !b.is_default) return -1
-      if (!a.is_default && b.is_default) return 1
-
-      // Priority 3: Alphabetically by name
-      return a.name.localeCompare(b.name)
-    })
-  }, [devices])
-
-  // Group devices by type (local vs cloud)
-  const { localDevices, cloudDevices } = useMemo(() => {
-    const local: DeviceInfo[] = []
-    const cloud: DeviceInfo[] = []
-
-    for (const device of sortedDevices) {
-      // Check device_type field, default to 'local' for backward compatibility
-      const deviceType = (device as DeviceInfo & { device_type?: string }).device_type || 'local'
-      if (deviceType === DEVICE_TYPE.LOCAL) {
-        local.push(device)
-      } else {
-        cloud.push(device)
-      }
-    }
-
-    return { localDevices: local, cloudDevices: cloud }
-  }, [sortedDevices])
-
-  // Handle starting a task with a device
-  const handleStartTask = useCallback(
-    (deviceId: string) => {
-      setSelectedDeviceId(deviceId)
-      setSelectedTask(null)
-      clearAllStreams()
-      router.push('/devices/chat')
-    },
-    [setSelectedDeviceId, setSelectedTask, clearAllStreams, router]
-  )
-
-  // Handle setting a device as default
-  const handleSetDefault = useCallback(
-    async (device: DeviceInfo) => {
-      try {
-        await setDefaultDevice(device.device_id)
-        toast.success(t('set_default_success', { name: device.name }))
-      } catch {
-        toast.error(t('set_default_error'))
-      }
-    },
-    [setDefaultDevice, t]
-  )
-
-  // Handle deleting a device
-  const handleDeleteDevice = useCallback(
-    async (device: DeviceInfo) => {
-      try {
-        await deleteDevice(device.device_id)
-        toast.success(t('delete_success', { name: device.name }))
-      } catch {
-        toast.error(t('delete_error'))
-      }
-    },
-    [deleteDevice, t]
-  )
+  // Sort and group devices
+  const sortedDevices = useMemo(() => sortDevices(devices), [devices])
 
   // Mobile sidebar state
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
@@ -188,8 +82,8 @@ export default function DevicesPage() {
   // Collapsed sidebar state
   const [isCollapsed, setIsCollapsed] = useState(false)
 
-  // Guide visibility state (for showing installation guide when devices exist)
-  const [showGuide, setShowGuide] = useState(false)
+  // Guide visibility state
+  const [showSetupGuide, setShowSetupGuide] = useState(false)
 
   // Load collapsed state from localStorage
   useEffect(() => {
@@ -217,28 +111,6 @@ export default function DevicesPage() {
     clearAllStreams()
     router.replace(paths.chat.getHref())
   }, [setSelectedTask, clearAllStreams, router])
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case 'online':
-        return 'bg-green-500'
-      case 'busy':
-        return 'bg-yellow-500'
-      default:
-        return 'bg-gray-400'
-    }
-  }
-
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'online':
-        return t('status_online')
-      case 'busy':
-        return t('status_busy')
-      default:
-        return t('status_offline')
-    }
-  }
 
   return (
     <div className="flex smart-h-screen bg-base text-text-primary box-border">
@@ -275,48 +147,12 @@ export default function DevicesPage() {
         <div className="flex-1 overflow-auto p-6">
           <div className="max-w-4xl mx-auto">
             {/* Header with refresh button */}
-            <div className="flex items-center justify-between mb-6">
-              <div className="flex items-center gap-3">
-                <Monitor className="w-6 h-6 text-primary" />
-                <h2 className="text-lg font-semibold">{t('title')}</h2>
-                <span className="px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-700 rounded-full">
-                  {t('beta')}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                {/* Add Device button - only show when devices exist */}
-                {sortedDevices.length > 0 && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowGuide(!showGuide)}
-                    className="flex items-center gap-2"
-                  >
-                    {showGuide ? (
-                      <>
-                        <ChevronUp className="w-4 h-4" />
-                        {t('hide_guide')}
-                      </>
-                    ) : (
-                      <>
-                        <Plus className="w-4 h-4" />
-                        {t('add_device')}
-                      </>
-                    )}
-                  </Button>
-                )}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={refreshDevices}
-                  disabled={isLoading}
-                  className="flex items-center gap-2"
-                >
-                  <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
-                  {t('refresh')}
-                </Button>
-              </div>
-            </div>
+            <DevicesPageHeader
+              isLoading={isLoading}
+              hasDevices={sortedDevices.length > 0}
+              onRefresh={refreshDevices}
+              onAddDevice={() => setShowSetupGuide(true)}
+            />
 
             {/* Instructions */}
             <p className="text-text-muted text-sm mb-6">{t('instructions')}</p>
@@ -335,52 +171,10 @@ export default function DevicesPage() {
               </div>
             )}
 
-            {/* Empty state with installation guide */}
-            {!isLoading && devices.length === 0 && (
-              <>
-                <LocalExecutorGuide
-                  backendUrl={backendUrl}
-                  authToken={authToken}
-                  guideUrl={guideUrl}
-                />
-
-                {/* Help section */}
-                {(communityUrl || faqUrl) && (
-                  <div className="flex justify-center">
-                    <div className="flex items-center gap-4 text-sm text-text-muted">
-                      <span>{t('need_help')}</span>
-                      {communityUrl && (
-                        <a
-                          href={communityUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
-                        >
-                          <MessageCircleQuestion className="w-4 h-4" />
-                          {t('join_community')}
-                        </a>
-                      )}
-                      {faqUrl && (
-                        <a
-                          href={faqUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1.5 text-text-secondary hover:text-primary transition-colors"
-                        >
-                          <ExternalLink className="w-4 h-4" />
-                          {t('view_faq')}
-                        </a>
-                      )}
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-
-            {/* Installation guide when triggered by Add Device button */}
-            {showGuide && sortedDevices.length > 0 && (
+            {/* Device setup guide - shown when no devices or when user clicks Add Device */}
+            {(devices.length === 0 || showSetupGuide) && !isLoading && (
               <div className="mb-6">
-                <LocalExecutorGuide
+                <DeviceSetupGuide
                   backendUrl={backendUrl}
                   authToken={authToken}
                   guideUrl={guideUrl}
@@ -388,201 +182,51 @@ export default function DevicesPage() {
               </div>
             )}
 
-            {/* Local Devices Section */}
+            {/* Device sections */}
             {sortedDevices.length > 0 && (
               <div className="space-y-6">
                 {/* Local Devices */}
-                <div>
-                  <div className="flex items-center gap-2 mb-4">
-                    <Monitor className="w-5 h-5 text-text-secondary" />
-                    <h3 className="text-sm font-medium text-text-secondary">
-                      {t('local_devices_section')}
-                    </h3>
-                    <span className="text-xs text-text-muted">({localDevices.length})</span>
-                  </div>
-                  {localDevices.length > 0 ? (
-                    <div className="grid gap-4">
-                      {localDevices.map(device => (
-                        <DeviceCard
-                          key={device.device_id}
-                          device={device}
-                          onStartTask={handleStartTask}
-                          onSetDefault={handleSetDefault}
-                          onDelete={handleDeleteDevice}
-                          onCancelTask={handleCancelTask}
-                          getStatusColor={getStatusColor}
-                          getStatusText={getStatusText}
-                          t={t}
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="text-sm text-text-muted py-4 text-center border border-dashed border-border rounded-lg">
-                      {t('no_local_devices')}
-                    </div>
+                <DeviceSection
+                  title={t('local_devices_section')}
+                  icon={Monitor}
+                  devices={sortedDevices}
+                  type="local"
+                  emptyMessage={t('no_local_devices')}
+                >
+                  {device => (
+                    <DeviceCard
+                      device={device}
+                      onStartTask={handlers.handleStartTask}
+                      onSetDefault={handlers.handleSetDefault}
+                      onDelete={handlers.handleDeleteDevice}
+                      onCancelTask={handlers.handleCancelTask}
+                    />
                   )}
-                </div>
+                </DeviceSection>
 
-                {/* Cloud Devices Section (placeholder for future) */}
-                <div>
-                  <div className="flex items-center gap-2 mb-4">
-                    <Cloud className="w-5 h-5 text-text-secondary" />
-                    <h3 className="text-sm font-medium text-text-secondary">
-                      {t('cloud_devices_section')}
-                    </h3>
-                    <span className="text-xs text-text-muted">({cloudDevices.length})</span>
-                  </div>
-                  {cloudDevices.length > 0 ? (
-                    <div className="grid gap-4">
-                      {cloudDevices.map(device => (
-                        <DeviceCard
-                          key={device.device_id}
-                          device={device}
-                          onStartTask={handleStartTask}
-                          onSetDefault={handleSetDefault}
-                          onDelete={handleDeleteDevice}
-                          onCancelTask={handleCancelTask}
-                          getStatusColor={getStatusColor}
-                          getStatusText={getStatusText}
-                          t={t}
-                        />
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="text-sm text-text-muted py-4 text-center border border-dashed border-border rounded-lg">
-                      {t('cloud_devices_coming_soon')}
-                    </div>
+                {/* Cloud Devices */}
+                <DeviceSection
+                  title={t('cloud_devices_section')}
+                  icon={Cloud}
+                  devices={sortedDevices}
+                  type="cloud"
+                  emptyMessage={t('cloud_devices_coming_soon')}
+                >
+                  {device => (
+                    <DeviceCard
+                      device={device}
+                      onStartTask={handlers.handleStartTask}
+                      onSetDefault={handlers.handleSetDefault}
+                      onDelete={handlers.handleDeleteDevice}
+                      onCancelTask={handlers.handleCancelTask}
+                    />
                   )}
-                </div>
+                </DeviceSection>
               </div>
             )}
           </div>
         </div>
       </div>
-    </div>
-  )
-}
-
-// Device card component extracted for reuse
-interface DeviceCardProps {
-  device: DeviceInfo
-  onStartTask: (deviceId: string) => void
-  onSetDefault: (device: DeviceInfo) => void
-  onDelete: (device: DeviceInfo) => void
-  onCancelTask: (taskId: number) => Promise<void>
-  getStatusColor: (status: string) => string
-  getStatusText: (status: string) => string
-  t: (key: string, params?: Record<string, unknown>) => string
-}
-
-function DeviceCard({
-  device,
-  onStartTask,
-  onSetDefault,
-  onDelete,
-  onCancelTask,
-  getStatusColor,
-  getStatusText,
-  t,
-}: DeviceCardProps) {
-  return (
-    <div
-      className={cn(
-        'bg-surface border rounded-lg p-4',
-        device.is_default ? 'border-primary' : 'border-border'
-      )}
-    >
-      {/* Device info row */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
-            <Monitor className="w-5 h-5 text-primary" />
-          </div>
-          <div>
-            <div className="flex items-center gap-2">
-              <h4 className="font-medium text-text-primary">{device.name}</h4>
-              {device.is_default && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary rounded-full">
-                  <Star className="w-3 h-3 fill-current" />
-                  {t('default_device')}
-                </span>
-              )}
-            </div>
-            <div className="flex items-center gap-2">
-              <p className="text-sm text-text-muted">{device.device_id}</p>
-              {device.status !== 'offline' && (
-                <VersionBadge
-                  executorVersion={device.executor_version}
-                  latestVersion={device.latest_version}
-                  updateAvailable={device.update_available}
-                />
-              )}
-            </div>
-            {/* Slot indicator - only show for online devices */}
-            {device.status !== 'offline' && (
-              <div className="mt-1">
-                <SlotIndicator
-                  used={device.slot_used}
-                  max={device.slot_max}
-                  runningTasks={device.running_tasks}
-                />
-              </div>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2">
-            <span className={cn('w-2 h-2 rounded-full', getStatusColor(device.status))} />
-            <span className="text-sm text-text-secondary">{getStatusText(device.status)}</span>
-          </div>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <Button
-                    variant="default"
-                    size="sm"
-                    onClick={() => onStartTask(device.device_id)}
-                    disabled={device.status !== 'online'}
-                    className="flex items-center gap-2"
-                  >
-                    <Play className="w-4 h-4" />
-                    {t('start_task')}
-                  </Button>
-                </div>
-              </TooltipTrigger>
-            </Tooltip>
-          </TooltipProvider>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
-                <MoreVertical className="w-4 h-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {!device.is_default && (
-                <DropdownMenuItem onClick={() => onSetDefault(device)}>
-                  <Star className="w-4 h-4 mr-2" />
-                  {t('set_as_default')}
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem danger onClick={() => onDelete(device)}>
-                <Trash2 className="w-4 h-4 mr-2" />
-                {t('delete_device')}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-
-      {/* Running tasks list */}
-      {device.running_tasks.length > 0 && (
-        <RunningTasksList
-          tasks={device.running_tasks}
-          deviceName={device.name}
-          onCancelTask={onCancelTask}
-        />
-      )}
     </div>
   )
 }

--- a/frontend/src/features/devices/components/DeviceCard.tsx
+++ b/frontend/src/features/devices/components/DeviceCard.tsx
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device card component.
+ * Displays device information, status, actions, and running tasks.
+ */
+
+'use client'
+
+import { Monitor, Play, Star, MoreVertical, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown'
+import { Tooltip, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { DeviceInfo } from '@/apis/devices'
+import { SlotIndicator } from './SlotIndicator'
+import { RunningTasksList } from './RunningTasksList'
+import { VersionBadge } from './VersionBadge'
+import { getStatusColor } from '../utils/device-status'
+import { useTranslation } from '@/hooks/useTranslation'
+
+export interface DeviceCardProps {
+  device: DeviceInfo
+  onStartTask: (deviceId: string) => void
+  onSetDefault: (device: DeviceInfo) => void
+  onDelete: (device: DeviceInfo) => void
+  onCancelTask: (taskId: number) => Promise<void>
+}
+
+/**
+ * Device card displaying device info, status, and actions.
+ *
+ * Features:
+ * - Device name, ID, status indicator
+ * - Version badge (when online)
+ * - Slot indicator (when online)
+ * - Start Task button (enabled only when online)
+ * - Dropdown menu: Set as Default, Delete Device
+ * - Running tasks list (expandable)
+ */
+export function DeviceCard({
+  device,
+  onStartTask,
+  onSetDefault,
+  onDelete,
+  onCancelTask,
+}: DeviceCardProps) {
+  const { t } = useTranslation('devices')
+
+  /**
+   * Get localized status text.
+   * Helper function that uses i18n, kept local to component.
+   */
+  const getStatusText = (status: string) => {
+    switch (status) {
+      case 'online':
+        return t('status_online')
+      case 'busy':
+        return t('status_busy')
+      default:
+        return t('status_offline')
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'bg-surface border rounded-lg p-4',
+        device.is_default ? 'border-primary' : 'border-border'
+      )}
+    >
+      {/* Device info row */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">
+            <Monitor className="w-5 h-5 text-primary" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h4 className="font-medium text-text-primary">{device.name}</h4>
+              {device.is_default && (
+                <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium bg-primary/10 text-primary rounded-full">
+                  <Star className="w-3 h-3 fill-current" />
+                  {t('default_device')}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-sm text-text-muted">{device.device_id}</p>
+              {device.status !== 'offline' && (
+                <VersionBadge
+                  executorVersion={device.executor_version}
+                  latestVersion={device.latest_version}
+                  updateAvailable={device.update_available}
+                />
+              )}
+            </div>
+            {/* Slot indicator - only show for online devices */}
+            {device.status !== 'offline' && (
+              <div className="mt-1">
+                <SlotIndicator
+                  used={device.slot_used}
+                  max={device.slot_max}
+                  runningTasks={device.running_tasks}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <span className={cn('w-2 h-2 rounded-full', getStatusColor(device.status))} />
+            <span className="text-sm text-text-secondary">{getStatusText(device.status)}</span>
+          </div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div>
+                  <Button
+                    variant="default"
+                    size="sm"
+                    onClick={() => onStartTask(device.device_id)}
+                    disabled={device.status !== 'online'}
+                    className="flex items-center gap-2"
+                  >
+                    <Play className="w-4 h-4" />
+                    {t('start_task')}
+                  </Button>
+                </div>
+              </TooltipTrigger>
+            </Tooltip>
+          </TooltipProvider>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                <MoreVertical className="w-4 h-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {!device.is_default && (
+                <DropdownMenuItem onClick={() => onSetDefault(device)}>
+                  <Star className="w-4 h-4 mr-2" />
+                  {t('set_as_default')}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem danger onClick={() => onDelete(device)}>
+                <Trash2 className="w-4 h-4 mr-2" />
+                {t('delete_device')}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Running tasks list */}
+      {device.running_tasks.length > 0 && (
+        <RunningTasksList
+          tasks={device.running_tasks}
+          deviceName={device.name}
+          onCancelTask={onCancelTask}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/devices/components/DeviceSection.tsx
+++ b/frontend/src/features/devices/components/DeviceSection.tsx
@@ -11,7 +11,6 @@
 
 import { LucideIcon } from 'lucide-react'
 import { DeviceInfo } from '@/apis/devices'
-import { useTranslation } from '@/hooks/useTranslation'
 
 export interface DeviceSectionProps {
   title: string
@@ -52,8 +51,6 @@ export function DeviceSection({
   type,
   children,
 }: DeviceSectionProps) {
-  const { t } = useTranslation('devices')
-
   // Filter devices by type if specified
   const filteredDevices = type
     ? devices.filter(device => (device.device_type || 'local') === type)

--- a/frontend/src/features/devices/components/DeviceSection.tsx
+++ b/frontend/src/features/devices/components/DeviceSection.tsx
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device section component.
+ * Reusable section for displaying local or cloud devices with header and grid.
+ */
+
+'use client'
+
+import { LucideIcon } from 'lucide-react'
+import { DeviceInfo } from '@/apis/devices'
+import { useTranslation } from '@/hooks/useTranslation'
+
+export interface DeviceSectionProps {
+  title: string
+  icon: LucideIcon
+  devices: DeviceInfo[]
+  emptyMessage: string
+  type?: 'local' | 'cloud'
+  children: (device: DeviceInfo) => React.ReactNode
+}
+
+/**
+ * Reusable device section with header and grid layout.
+ *
+ * Features:
+ * - Section header with icon, title, and device count
+ * - Device grid using render prop pattern
+ * - Optional type filtering (local/cloud)
+ * - Empty state placeholder when no devices
+ *
+ * Usage:
+ * ```tsx
+ * <DeviceSection
+ *   title="Local Devices"
+ *   icon={Monitor}
+ *   devices={allDevices}
+ *   type="local"
+ *   emptyMessage="No local devices"
+ * >
+ *   {device => <DeviceCard device={device} ... />}
+ * </DeviceSection>
+ * ```
+ */
+export function DeviceSection({
+  title,
+  icon: Icon,
+  devices,
+  emptyMessage,
+  type,
+  children,
+}: DeviceSectionProps) {
+  const { t } = useTranslation('devices')
+
+  // Filter devices by type if specified
+  const filteredDevices = type
+    ? devices.filter(device => (device.device_type || 'local') === type)
+    : devices
+
+  return (
+    <div>
+      {/* Section header */}
+      <div className="flex items-center gap-2 mb-4">
+        <Icon className="w-5 h-5 text-text-secondary" />
+        <h3 className="text-sm font-medium text-text-secondary">{title}</h3>
+        <span className="text-xs text-text-muted">({filteredDevices.length})</span>
+      </div>
+
+      {/* Device grid or empty placeholder */}
+      {filteredDevices.length > 0 ? (
+        <div className="grid gap-4">
+          {filteredDevices.map(device => (
+            <div key={device.device_id}>{children(device)}</div>
+          ))}
+        </div>
+      ) : (
+        <div className="text-sm text-text-muted py-4 text-center border border-dashed border-border rounded-lg">
+          {emptyMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/devices/components/DeviceSetupGuide.tsx
+++ b/frontend/src/features/devices/components/DeviceSetupGuide.tsx
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device setup guide with device type selection.
+ * Allows users to choose between local and cloud devices, then shows appropriate setup instructions.
+ */
+
+'use client'
+
+import { useState } from 'react'
+import { Monitor, Cloud } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { useTranslation } from '@/hooks/useTranslation'
+import { LocalExecutorGuide } from './LocalExecutorGuide'
+
+export interface DeviceSetupGuideProps {
+  backendUrl: string
+  authToken: string
+  guideUrl?: string
+}
+
+type DeviceType = 'local' | 'cloud'
+
+/**
+ * Device setup guide with tabbed interface for device type selection.
+ *
+ * Features:
+ * - Tab selection between Local and Cloud devices
+ * - Local device shows full installation guide
+ * - Cloud device shows "coming soon" message
+ */
+export function DeviceSetupGuide({ backendUrl, authToken, guideUrl }: DeviceSetupGuideProps) {
+  const { t } = useTranslation('devices')
+  const [deviceType, setDeviceType] = useState<DeviceType>('local')
+
+  return (
+    <div className="bg-surface border border-border rounded-lg overflow-hidden">
+      {/* Device Type Tabs */}
+      <div className="flex gap-2 px-6 pt-4 border-b border-border">
+        <button
+          type="button"
+          onClick={() => setDeviceType('local')}
+          className={cn(
+            'flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors relative',
+            deviceType === 'local'
+              ? 'text-primary'
+              : 'text-text-muted hover:text-text-secondary'
+          )}
+        >
+          <Monitor className="w-4 h-4" />
+          {t('local_device')}
+          <span className="px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-700 rounded-full">
+            {t('recommended')}
+          </span>
+          {deviceType === 'local' && (
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setDeviceType('cloud')}
+          className={cn(
+            'flex items-center gap-2 px-4 py-3 text-sm font-medium transition-colors relative',
+            deviceType === 'cloud'
+              ? 'text-primary'
+              : 'text-text-muted hover:text-text-secondary'
+          )}
+        >
+          <Cloud className="w-4 h-4" />
+          {t('cloud_device')}
+          {deviceType === 'cloud' && (
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+          )}
+        </button>
+      </div>
+
+      {/* Content Area */}
+      <div className="p-6">
+        {deviceType === 'local' ? (
+          <LocalExecutorGuide backendUrl={backendUrl} authToken={authToken} guideUrl={guideUrl} />
+        ) : (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <Cloud className="w-12 h-12 text-text-muted mb-4" />
+            <h3 className="text-lg font-semibold mb-2">{t('cloud_coming_soon_title')}</h3>
+            <p className="text-sm text-text-muted max-w-md">
+              {t('cloud_coming_soon_description')}
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/devices/components/DevicesPageHeader.tsx
+++ b/frontend/src/features/devices/components/DevicesPageHeader.tsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Devices page header component.
+ * Displays page title, beta badge, and action buttons (Add Device, Refresh).
+ */
+
+'use client'
+
+import { Monitor, RefreshCw, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { useTranslation } from '@/hooks/useTranslation'
+
+export interface DevicesPageHeaderProps {
+  isLoading: boolean
+  hasDevices: boolean
+  onRefresh: () => void
+  onAddDevice: () => void
+}
+
+/**
+ * Devices page header with title and action buttons.
+ *
+ * Features:
+ * - Title with Monitor icon and beta badge
+ * - Add Device button (only shown when devices exist)
+ * - Refresh button with loading spinner
+ */
+export function DevicesPageHeader({
+  isLoading,
+  hasDevices,
+  onRefresh,
+  onAddDevice,
+}: DevicesPageHeaderProps) {
+  const { t } = useTranslation('devices')
+
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center gap-3">
+        <Monitor className="w-6 h-6 text-primary" />
+        <h2 className="text-lg font-semibold">{t('title')}</h2>
+        <span className="px-2 py-0.5 text-xs font-medium bg-amber-100 text-amber-700 rounded-full">
+          {t('beta')}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        {/* Add Device button - only show when devices exist */}
+        {hasDevices && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onAddDevice}
+            className="flex items-center gap-2"
+          >
+            <Plus className="w-4 h-4" />
+            {t('add_device')}
+          </Button>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRefresh}
+          disabled={isLoading}
+          className="flex items-center gap-2"
+        >
+          <RefreshCw className={cn('w-4 h-4', isLoading && 'animate-spin')} />
+          {t('refresh')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/devices/components/LocalExecutorGuide.tsx
+++ b/frontend/src/features/devices/components/LocalExecutorGuide.tsx
@@ -293,9 +293,9 @@ export function LocalExecutorGuide({ backendUrl, authToken, guideUrl }: LocalExe
   const activeApiKeys = apiKeys.filter(key => key.is_active)
 
   return (
-    <div className="flex flex-col items-center justify-center py-8">
+    <div className="flex flex-col items-center justify-center">
       {/* Main card */}
-      <div className="w-full max-w-2xl bg-surface border border-border rounded-xl p-6 shadow-sm">
+      <div className="w-full max-w-2xl">
         {/* Header */}
         <div className="flex items-center gap-3 mb-6">
           <div className="w-10 h-10 bg-primary/10 rounded-lg flex items-center justify-center">

--- a/frontend/src/features/devices/components/index.ts
+++ b/frontend/src/features/devices/components/index.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device components barrel export.
+ */
+
+export * from './DeviceCard'
+export * from './DevicesPageHeader'
+export * from './DeviceSection'
+export * from './DeviceSetupGuide'
+export * from './LocalExecutorGuide'
+export * from './RunningTasksList'
+export * from './SlotIndicator'
+export * from './VersionBadge'

--- a/frontend/src/features/devices/hooks/index.ts
+++ b/frontend/src/features/devices/hooks/index.ts
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device hooks barrel export.
+ */
+
+export * from './useDeviceHandlers'

--- a/frontend/src/features/devices/hooks/useDeviceHandlers.ts
+++ b/frontend/src/features/devices/hooks/useDeviceHandlers.ts
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Custom hook for device action handlers.
+ * Consolidates all device-related actions (start task, set default, delete, cancel task)
+ * to reduce prop drilling and centralize context dependencies.
+ */
+
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContext'
+import { useTaskContext } from '@/features/tasks/contexts/taskContext'
+import { useSocket } from '@/contexts/SocketContext'
+import { useDevices } from '@/contexts/DeviceContext'
+import { DeviceInfo } from '@/apis/devices'
+import { useTranslation } from '@/hooks/useTranslation'
+
+/**
+ * Device action handlers.
+ */
+export interface DeviceHandlers {
+  handleStartTask: (deviceId: string) => void
+  handleSetDefault: (device: DeviceInfo) => Promise<void>
+  handleDeleteDevice: (device: DeviceInfo) => Promise<void>
+  handleCancelTask: (taskId: number) => Promise<void>
+}
+
+/**
+ * Hook that provides all device action handlers.
+ *
+ * Usage:
+ * ```tsx
+ * const handlers = useDeviceHandlers()
+ * <DeviceCard onStartTask={handlers.handleStartTask} ... />
+ * ```
+ *
+ * @returns Object containing all device action handlers
+ */
+export function useDeviceHandlers(): DeviceHandlers {
+  const { t } = useTranslation('devices')
+  const router = useRouter()
+  const { clearAllStreams } = useChatStreamContext()
+  const { setSelectedTask } = useTaskContext()
+  const { closeTaskSession } = useSocket()
+  const { setSelectedDeviceId, setDefaultDevice, deleteDevice, refreshDevices } = useDevices()
+
+  /**
+   * Handle starting a task with a device.
+   * Clears current task state and navigates to device chat page.
+   *
+   * @param deviceId - Device unique identifier
+   */
+  const handleStartTask = useCallback(
+    (deviceId: string) => {
+      setSelectedDeviceId(deviceId)
+      setSelectedTask(null)
+      clearAllStreams()
+      router.push('/devices/chat')
+    },
+    [setSelectedDeviceId, setSelectedTask, clearAllStreams, router]
+  )
+
+  /**
+   * Handle setting a device as default.
+   * Shows success/error toast notification.
+   *
+   * @param device - Device to set as default
+   */
+  const handleSetDefault = useCallback(
+    async (device: DeviceInfo) => {
+      try {
+        await setDefaultDevice(device.device_id)
+        toast.success(t('set_default_success', { name: device.name }))
+      } catch {
+        toast.error(t('set_default_error'))
+      }
+    },
+    [setDefaultDevice, t]
+  )
+
+  /**
+   * Handle deleting a device.
+   * Shows success/error toast notification.
+   *
+   * @param device - Device to delete
+   */
+  const handleDeleteDevice = useCallback(
+    async (device: DeviceInfo) => {
+      try {
+        await deleteDevice(device.device_id)
+        toast.success(t('delete_success', { name: device.name }))
+      } catch {
+        toast.error(t('delete_error'))
+      }
+    },
+    [deleteDevice, t]
+  )
+
+  /**
+   * Handle cancelling/closing a task via WebSocket.
+   * - For running tasks: pauses execution
+   * - For completed tasks: closes session and frees device slot
+   *
+   * @param taskId - Task ID to cancel/close
+   */
+  const handleCancelTask = useCallback(
+    async (taskId: number) => {
+      try {
+        const result = await closeTaskSession(taskId)
+        if (result.success) {
+          toast.success(t('close_session_success'))
+          // Refresh devices to update slot usage
+          await refreshDevices()
+        } else {
+          toast.error(result.error || t('close_session_error'))
+        }
+      } catch (error) {
+        console.error('Failed to close task session:', error)
+        toast.error(t('close_session_error'))
+      }
+    },
+    [closeTaskSession, refreshDevices, t]
+  )
+
+  return {
+    handleStartTask,
+    handleSetDefault,
+    handleDeleteDevice,
+    handleCancelTask,
+  }
+}

--- a/frontend/src/features/devices/utils/device-status.ts
+++ b/frontend/src/features/devices/utils/device-status.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Device status utility functions.
+ * Provides pure functions for mapping device status to UI styles.
+ */
+
+import { DeviceStatus } from '@/apis/devices'
+
+/**
+ * Get Tailwind CSS color class for device status indicator.
+ *
+ * @param status - Device status (online, busy, offline)
+ * @returns Tailwind background color class (e.g., 'bg-green-500')
+ */
+export function getStatusColor(status: DeviceStatus | string): string {
+  switch (status) {
+    case 'online':
+      return 'bg-green-500'
+    case 'busy':
+      return 'bg-yellow-500'
+    default:
+      return 'bg-gray-400'
+  }
+}

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -105,5 +105,16 @@
   "local_devices_section": "Local Devices",
   "cloud_devices_section": "Cloud Devices",
   "no_local_devices": "No local devices connected. Add a device using the guide above.",
-  "cloud_devices_coming_soon": "Cloud device support coming soon."
+  "cloud_devices_coming_soon": "Cloud device support coming soon.",
+  "select_device_type": "Select Device Type",
+  "select_device_type_description": "Choose the type of device you want to add",
+  "local_device": "Local Device",
+  "local_device_description": "Run Executor on your own machine for full control and privacy",
+  "cloud_device": "Cloud Device",
+  "cloud_device_description": "Use Wegent's managed cloud infrastructure (no setup required)",
+  "recommended": "Recommended",
+  "continue": "Continue",
+  "cloud_coming_soon_title": "Cloud Devices Coming Soon",
+  "cloud_coming_soon_description": "Cloud device support is under active development. Stay tuned for updates!",
+  "got_it": "Got it"
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -105,5 +105,16 @@
   "local_devices_section": "本地设备",
   "cloud_devices_section": "云端设备",
   "no_local_devices": "暂无本地设备连接。请使用上方指南添加设备。",
-  "cloud_devices_coming_soon": "云端设备支持即将推出。"
+  "cloud_devices_coming_soon": "云端设备支持即将推出。",
+  "select_device_type": "选择设备类型",
+  "select_device_type_description": "选择您想要添加的设备类型",
+  "local_device": "本地设备",
+  "local_device_description": "在您自己的机器上运行 Executor，完全掌控和隐私保护",
+  "cloud_device": "云端设备",
+  "cloud_device_description": "使用 Wegent 托管的云端基础设施（无需安装配置）",
+  "recommended": "推荐",
+  "continue": "继续",
+  "cloud_coming_soon_title": "云端设备即将推出",
+  "cloud_coming_soon_description": "云端设备支持正在积极开发中，敬请期待！",
+  "got_it": "知道了"
 }


### PR DESCRIPTION
Add integrated device type selection directly in the devices page, allowing users to choose between local and cloud devices using a tabbed interface.

Changes:
- Add DeviceSetupGuide component with tabbed interface (local/cloud)
- Refactor devices page to use new setup guide
- Update DevicesPageHeader to simplify "Add Device" button
- Remove LocalExecutorGuide's internal border and padding
- Add translations for device type selection
- Extract device handlers to custom hook (useDeviceHandlers)
- Add device status utility functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed device setup guide with local and cloud options.
  * New device cards with actions (start, set default, delete, cancel) and running-task indicators.
  * Device sections with counts and empty-state visuals; Add Device and Refresh header controls.
  * Devices sorted by online → default → name.

* **Refactor**
  * Page reorganized into reusable components and centralized handlers for a cleaner UI and flow.

* **Localization**
  * Added English and Chinese device UI strings for setup and cloud messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->