### PR TITLE
fix(device): auto-recover Redis key when heartbeat detects expiration

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -665,8 +665,9 @@ class DeviceNamespace(socketio.AsyncNamespace):
             executor_version=payload.executor_version,
         )
 
-        # Update session with device_id
+        # Update session with device_id and device_name
         session["device_id"] = payload.device_id
+        session["device_name"] = payload.name
         session["registered"] = True
         await self.save_session(sid, session)
 
@@ -712,12 +713,29 @@ class DeviceNamespace(socketio.AsyncNamespace):
             return {"error": "Device ID mismatch"}
 
         # Refresh Redis TTL and update running_task_ids
-        await device_service.refresh_device_heartbeat(
+        success = await device_service.refresh_device_heartbeat(
             user_id,
             payload.device_id,
             payload.running_task_ids,
             payload.executor_version,
         )
+
+        if not success:
+            # Redis key expired, recreate it to recover from ghost-offline state
+            device_name = session.get("device_name", f"device-{payload.device_id[:8]}")
+            logger.warning(
+                f"[Device WS] Heartbeat recovery: recreating Redis key for "
+                f"user={user_id}, device={payload.device_id}"
+            )
+            await device_service.set_device_online(
+                user_id=user_id,
+                device_id=payload.device_id,
+                socket_id=sid,
+                name=device_name,
+                executor_version=payload.executor_version,
+            )
+            # Re-broadcast device online event
+            await self._broadcast_device_online(user_id, payload.device_id, device_name)
 
         # Database operation: quick in, quick out
         _update_device_heartbeat(user_id, payload.device_id)


### PR DESCRIPTION
When the Redis key `device:online:{user_id}:{device_id}` expires due to network jitter or Redis restart, `refresh_heartbeat()` returns False but the WebSocket connection is still alive. This causes the device to become "ghost offline" — the system thinks it's offline while it keeps sending heartbeats.

Save device_name in session during registration and check the return value of refresh_device_heartbeat(). When it returns False, recreate the Redis key via set_device_online() and re-broadcast the device:online event to restore correct state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced device session management to store both device ID and name for better tracking
* Improved resilience for device heartbeat monitoring with automatic recovery when connection state expires, ensuring devices are properly restored online with updated notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->