### PR TITLE
feat(executor): add KB retrieval MCP server for executor knowledge ba…

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -69,7 +69,11 @@ async def lifespan(app: FastAPI):
     # ==================== MCP SERVER LIFESPAN ====================
     # MCP servers need their session_manager.run() to be called within the lifespan
     # This is required for the streamable HTTP transport to work properly
-    from app.mcp_server.server import knowledge_mcp_server, system_mcp_server
+    from app.mcp_server.server import (
+        kb_retrieval_mcp_server,
+        knowledge_mcp_server,
+        system_mcp_server,
+    )
 
     # ==================== STARTUP ====================
     # Try to get Redis client for distributed locking
@@ -302,7 +306,9 @@ async def lifespan(app: FastAPI):
         logger.info("✓ System MCP server session manager started")
         async with knowledge_mcp_server.session_manager.run():
             logger.info("✓ Knowledge MCP server session manager started")
-            yield
+            async with kb_retrieval_mcp_server.session_manager.run():
+                logger.info("✓ KB Retrieval MCP server session manager started")
+                yield
 
     # ==================== SHUTDOWN ====================
     logger.info("=" * 60)

--- a/backend/app/mcp_server/server.py
+++ b/backend/app/mcp_server/server.py
@@ -4,16 +4,18 @@
 
 """Wegent Backend MCP Server.
 
-This module provides a unified MCP Server for Wegent Backend with two endpoints:
+This module provides a unified MCP Server for Wegent Backend with three endpoints:
 - /mcp/system - System-level tools (silent_exit) automatically injected into all tasks
-- /mcp/knowledge - Knowledge MCP module root
+- /mcp/knowledge - Knowledge MCP module root (CRUD management tools)
   - /mcp/knowledge/sse - Knowledge MCP streamable HTTP transport endpoint
+- /mcp/kb-retrieval - Knowledge base retrieval tools (search/read, for executor agents)
+  - /mcp/kb-retrieval/sse - KB retrieval MCP streamable HTTP transport endpoint
 New MCP servers should follow /mcp/<name>/sse for streamable HTTP transport.
 
 The MCP Server uses FastMCP with HTTP Streamable transport and integrates
 with the existing FastAPI application.
 
-The knowledge MCP server uses a decorator-based auto-registration system:
+The knowledge and kb-retrieval MCP servers use a decorator-based auto-registration system:
 - FastAPI endpoints marked with @mcp_tool decorator are automatically registered
 - Parameters and response schemas are extracted from endpoint signatures
 - This eliminates code duplication between REST API and MCP implementations
@@ -51,6 +53,8 @@ SYSTEM_MCP_MOUNT_PATH = "/mcp/system"
 SYSTEM_MCP_TRANSPORT_PATH = "/"
 KNOWLEDGE_MCP_MOUNT_PATH = "/mcp/knowledge"
 KNOWLEDGE_MCP_TRANSPORT_PATH = "/sse"
+KB_RETRIEVAL_MCP_MOUNT_PATH = "/mcp/kb-retrieval"
+KB_RETRIEVAL_MCP_TRANSPORT_PATH = "/sse"
 
 
 @dataclass(frozen=True)
@@ -220,6 +224,54 @@ def ensure_knowledge_tools_registered() -> None:
     _register_knowledge_tools()
 
 
+# ============== KB Retrieval MCP Server ==============
+# Provides knowledge base retrieval tools (search, list docs, read docs)
+# Automatically injected into executor tasks when knowledge bases are selected
+# Uses decorator-based auto-registration from @mcp_tool decorated endpoints
+
+kb_retrieval_mcp_server = FastMCP(
+    "wegent-kb-retrieval-mcp",
+    stateless_http=True,
+    json_response=True,
+    streamable_http_path="/",
+    transport_security=_build_transport_security_settings(),
+)
+
+# Store for KB retrieval MCP request context (used by McpAppSpec)
+_kb_retrieval_request_token_info: contextvars.ContextVar[Optional[TaskTokenInfo]] = (
+    contextvars.ContextVar("_kb_retrieval_request_token_info", default=None)
+)
+
+# Flag to track if tools have been registered
+_kb_retrieval_tools_registered = False
+
+
+def _register_kb_retrieval_tools() -> None:
+    """Register KB retrieval tools from @mcp_tool decorated endpoints.
+
+    This function imports the kb_retrieval tools module to trigger decorator
+    registration, then registers all collected tools to the KB retrieval MCP server.
+    """
+    global _kb_retrieval_tools_registered
+    if _kb_retrieval_tools_registered:
+        return
+
+    from app.mcp_server.tool_registry import register_tools_to_server
+    from app.mcp_server.tools import (  # noqa: F401 side-effect: triggers @mcp_tool registration
+        kb_retrieval,
+    )
+
+    count = register_tools_to_server(kb_retrieval_mcp_server, "kb_retrieval")
+    logger.info(f"[MCP:KBRetrieval] Registered {count} tools from decorated endpoints")
+
+    _kb_retrieval_tools_registered = True
+
+
+def ensure_kb_retrieval_tools_registered() -> None:
+    """Ensure KB retrieval MCP tools are registered."""
+    _register_kb_retrieval_tools()
+
+
 # ============== Starlette App Factory ==============
 
 _SYSTEM_MCP_SPEC = McpAppSpec(
@@ -244,7 +296,18 @@ _KNOWLEDGE_MCP_SPEC = McpAppSpec(
     include_root_metadata=True,
 )
 
-MCP_APP_SPECS = (_SYSTEM_MCP_SPEC, _KNOWLEDGE_MCP_SPEC)
+_KB_RETRIEVAL_MCP_SPEC = McpAppSpec(
+    name="kb_retrieval",
+    service_name="wegent-kb-retrieval-mcp",
+    mount_path=KB_RETRIEVAL_MCP_MOUNT_PATH,
+    transport_path=KB_RETRIEVAL_MCP_TRANSPORT_PATH,
+    server=kb_retrieval_mcp_server,
+    token_context=_kb_retrieval_request_token_info,
+    log_prefix="KBRetrieval",
+    include_root_metadata=True,
+)
+
+MCP_APP_SPECS = (_SYSTEM_MCP_SPEC, _KNOWLEDGE_MCP_SPEC, _KB_RETRIEVAL_MCP_SPEC)
 
 
 def _build_root_metadata(spec: McpAppSpec) -> Dict[str, Any]:
@@ -260,9 +323,11 @@ def _build_root_metadata(spec: McpAppSpec) -> Dict[str, Any]:
 
 def _build_mcp_app(spec: McpAppSpec) -> Starlette:
     """Create a Starlette app for a streamable-http MCP server."""
-    # Ensure knowledge tools are registered before creating the app
+    # Ensure tools are registered before creating the app
     if spec.name == "knowledge":
         ensure_knowledge_tools_registered()
+    elif spec.name == "kb_retrieval":
+        ensure_kb_retrieval_tools_registered()
 
     async def health_check(request: Request) -> JSONResponse:
         return JSONResponse({"status": "healthy", "service": spec.service_name})
@@ -292,12 +357,12 @@ def _build_mcp_app(spec: McpAppSpec) -> Starlette:
                     token_info.subtask_id,
                     token_info.user_name,
                 )
-                # Set MCPRequestContext for decorator-based tools (knowledge server)
-                if spec.name == "knowledge":
+                # Set MCPRequestContext for decorator-based tools (knowledge and kb_retrieval servers)
+                if spec.name in ("knowledge", "kb_retrieval"):
                     mcp_ctx = MCPRequestContext(
                         token_info=token_info,
                         tool_name="",  # Will be set by tool invocation
-                        server_name="knowledge",
+                        server_name=spec.name,
                     )
                     mcp_ctx_token = set_mcp_context(mcp_ctx)
             else:
@@ -379,6 +444,10 @@ def create_mcp_router() -> APIRouter:
     async def knowledge_health():
         return {"status": "healthy", "service": "wegent-knowledge-mcp"}
 
+    @router.get("/mcp/kb-retrieval/health")
+    async def kb_retrieval_health():
+        return {"status": "healthy", "service": "wegent-kb-retrieval-mcp"}
+
     return router, system_app, knowledge_app
 
 
@@ -438,6 +507,27 @@ def get_mcp_knowledge_config(backend_url: str, auth_token: str) -> Dict[str, Any
         url=f"{backend_url}{KNOWLEDGE_MCP_MOUNT_PATH}{KNOWLEDGE_MCP_TRANSPORT_PATH}",
         auth_token=auth_token,
         timeout=300,  # 5 minutes for document operations
+    )
+
+
+def get_mcp_kb_retrieval_config(backend_url: str, auth_token: str) -> Dict[str, Any]:
+    """Get KB retrieval MCP server configuration for executor injection.
+
+    This configuration is injected into executor agents (ClaudeCode, Agno) when
+    knowledge bases are selected for a task, providing search/read tools.
+
+    Args:
+        backend_url: Backend URL (e.g., "http://localhost:8000")
+        auth_token: Authentication token for MCP server
+
+    Returns:
+        MCP server configuration dictionary
+    """
+    return _build_streamable_http_config(
+        name="wegent-kb-retrieval",
+        url=f"{backend_url}{KB_RETRIEVAL_MCP_MOUNT_PATH}{KB_RETRIEVAL_MCP_TRANSPORT_PATH}",
+        auth_token=auth_token,
+        timeout=300,  # 5 minutes for retrieval operations
     )
 
 

--- a/backend/app/mcp_server/tools/__init__.py
+++ b/backend/app/mcp_server/tools/__init__.py
@@ -8,9 +8,13 @@ Contains tools for:
 - System MCP (silent_exit)
 - Knowledge MCP (list_knowledge_bases, list_documents, create_knowledge_base,
   create_document, update_document_content)
+- KB Retrieval MCP (knowledge_base_search, kb_ls, kb_head)
 
 Knowledge MCP tools are implemented independently using the KnowledgeOrchestrator
 service layer, with Celery-based async task scheduling for indexing and summary.
+
+KB Retrieval MCP tools provide read-only access to knowledge base content,
+equivalent to chat_shell's LangChain tools but exposed via MCP for executor agents.
 
 Tools are declared using @mcp_tool decorator which provides:
 - Automatic parameter schema extraction
@@ -25,12 +29,14 @@ from .decorator import (
     get_registered_mcp_tools,
     mcp_tool,
 )
+from .kb_retrieval import KB_RETRIEVAL_MCP_TOOLS
 from .knowledge import KNOWLEDGE_MCP_TOOLS
 from .silent_exit import silent_exit
 
 __all__ = [
     "silent_exit",
     "KNOWLEDGE_MCP_TOOLS",
+    "KB_RETRIEVAL_MCP_TOOLS",
     "mcp_tool",
     "get_registered_mcp_tools",
     "build_mcp_tools_dict",

--- a/backend/app/mcp_server/tools/kb_retrieval.py
+++ b/backend/app/mcp_server/tools/kb_retrieval.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+MCP tools for Knowledge Base retrieval operations.
+
+This module provides read-only MCP tools for querying knowledge bases,
+equivalent to the LangChain tools used by chat_shell but exposed via MCP
+for use by executor agents (ClaudeCode, Agno).
+
+Tools:
+- knowledge_base_search: RAG vector/hybrid search
+- kb_ls: List documents in a knowledge base
+- kb_head: Read document content with offset/limit pagination
+
+These tools are registered with server="kb_retrieval" and use the
+@mcp_tool decorator for automatic registration.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from app.db.session import SessionLocal
+from app.mcp_server.auth import TaskTokenInfo
+from app.mcp_server.tools.decorator import build_mcp_tools_dict, mcp_tool
+
+logger = logging.getLogger(__name__)
+
+# Constants for document reading pagination
+DEFAULT_READ_DOC_LIMIT = 50_000  # Default characters to return
+MAX_READ_DOC_LIMIT = 500_000  # Maximum characters allowed per request
+
+
+@mcp_tool(
+    name="knowledge_base_search",
+    description=(
+        "Search a knowledge base using RAG (vector/hybrid) retrieval. "
+        "Returns the most relevant text chunks matching the query. "
+        "Use this tool when you need to find specific information in the knowledge base."
+    ),
+    server="kb_retrieval",
+    param_descriptions={
+        "query": "Search query text describing the information you need",
+        "kb_id": "Knowledge base ID to search in",
+        "max_results": "Maximum number of results to return (default: 5)",
+    },
+)
+def knowledge_base_search(
+    token_info: TaskTokenInfo,
+    query: str,
+    kb_id: int,
+    max_results: int = 5,
+) -> Dict[str, Any]:
+    """
+    Search a knowledge base using RAG retrieval.
+
+    Args:
+        token_info: Task token information (auto-injected)
+        query: Search query text
+        kb_id: Knowledge base ID
+        max_results: Maximum results to return
+
+    Returns:
+        Dict with search results containing content, score, and title
+    """
+    db = SessionLocal()
+    try:
+        from app.services.rag.retrieval_service import RetrievalService
+
+        retrieval_service = RetrievalService()
+
+        # Run async retrieval in event loop
+        result = asyncio.get_event_loop().run_until_complete(
+            retrieval_service.retrieve_from_knowledge_base_internal(
+                query=query,
+                knowledge_base_id=kb_id,
+                db=db,
+                user_name=token_info.user_name,
+            )
+        )
+
+        records = result.get("records", [])
+        total_before_limit = len(records)
+        records = records[:max_results]
+
+        total_content_chars = sum(len(r.get("content", "")) for r in records)
+
+        logger.info(
+            "[MCP:KBRetrieval] knowledge_base_search: kb_id=%d, query='%s', "
+            "results=%d/%d, content_size=%d chars",
+            kb_id,
+            query[:50],
+            len(records),
+            total_before_limit,
+            total_content_chars,
+        )
+
+        return {
+            "results": [
+                {
+                    "content": r.get("content", ""),
+                    "score": r.get("score", 0.0),
+                    "title": r.get("title", "Unknown"),
+                }
+                for r in records
+            ],
+            "total": len(records),
+            "query": query,
+        }
+
+    except Exception as e:
+        logger.error(
+            "[MCP:KBRetrieval] knowledge_base_search error: %s", e, exc_info=True
+        )
+        return {"error": str(e), "results": [], "total": 0}
+
+    finally:
+        db.close()
+
+
+@mcp_tool(
+    name="kb_ls",
+    description=(
+        "List all documents in a knowledge base with metadata and summaries. "
+        "Returns document names, sizes, types, and short summaries. "
+        "Use this to explore what content is available before reading specific documents."
+    ),
+    server="kb_retrieval",
+    param_descriptions={
+        "kb_id": "Knowledge base ID to list documents from",
+    },
+)
+def kb_ls(
+    token_info: TaskTokenInfo,
+    kb_id: int,
+) -> Dict[str, Any]:
+    """
+    List all documents in a knowledge base.
+
+    Args:
+        token_info: Task token information (auto-injected)
+        kb_id: Knowledge base ID
+
+    Returns:
+        Dict with document list including names, sizes, and summaries
+    """
+    db = SessionLocal()
+    try:
+        from app.models.knowledge import KnowledgeDocument
+
+        # Query documents directly (permission validated at task level)
+        documents = (
+            db.query(KnowledgeDocument)
+            .filter(KnowledgeDocument.kind_id == kb_id)
+            .order_by(KnowledgeDocument.created_at.desc())
+            .all()
+        )
+
+        doc_items: List[Dict[str, Any]] = []
+        for doc in documents:
+            short_summary = None
+            if doc.summary and isinstance(doc.summary, dict):
+                short_summary = doc.summary.get("short_summary")
+
+            doc_items.append(
+                {
+                    "id": doc.id,
+                    "name": doc.name,
+                    "file_extension": doc.file_extension or "",
+                    "file_size": doc.file_size or 0,
+                    "short_summary": short_summary,
+                    "is_active": doc.is_active,
+                }
+            )
+
+        logger.info(
+            "[MCP:KBRetrieval] kb_ls: kb_id=%d, documents=%d",
+            kb_id,
+            len(doc_items),
+        )
+
+        return {
+            "documents": doc_items,
+            "total": len(doc_items),
+        }
+
+    except Exception as e:
+        logger.error("[MCP:KBRetrieval] kb_ls error: %s", e, exc_info=True)
+        return {"error": str(e), "documents": [], "total": 0}
+
+    finally:
+        db.close()
+
+
+@mcp_tool(
+    name="kb_head",
+    description=(
+        "Read document content from a knowledge base with offset/limit pagination. "
+        "Similar to 'head' command. Returns partial content starting from offset position. "
+        "Use has_more flag to check if more content exists. "
+        "Use this to read specific documents identified by kb_ls."
+    ),
+    server="kb_retrieval",
+    param_descriptions={
+        "document_id": "Document ID to read (from kb_ls results)",
+        "offset": "Start position in characters (default: 0)",
+        "limit": "Maximum characters to return (default: 50000, max: 500000)",
+    },
+)
+def kb_head(
+    token_info: TaskTokenInfo,
+    document_id: int,
+    offset: int = 0,
+    limit: int = DEFAULT_READ_DOC_LIMIT,
+) -> Dict[str, Any]:
+    """
+    Read document content with offset/limit pagination.
+
+    Args:
+        token_info: Task token information (auto-injected)
+        document_id: Document ID to read
+        offset: Start position in characters
+        limit: Maximum characters to return
+
+    Returns:
+        Dict with document content, pagination info, and has_more flag
+    """
+    db = SessionLocal()
+    try:
+        from app.models.knowledge import KnowledgeDocument
+        from app.services.context import context_service
+
+        # Clamp limit to max
+        limit = min(limit, MAX_READ_DOC_LIMIT)
+
+        # Get document
+        document = (
+            db.query(KnowledgeDocument)
+            .filter(KnowledgeDocument.id == document_id)
+            .first()
+        )
+
+        if not document:
+            return {"error": f"Document {document_id} not found"}
+
+        # Read content from attachment
+        content = ""
+        total_length = 0
+        actual_start = 0
+
+        if document.attachment_id:
+            attachment = context_service.get_context_optional(
+                db=db,
+                context_id=document.attachment_id,
+            )
+            if attachment and attachment.extracted_text:
+                full_content = attachment.extracted_text
+                total_length = len(full_content)
+
+                # Apply offset and limit, clamp start to total_length
+                actual_start = min(offset, total_length)
+                end = min(actual_start + limit, total_length)
+                content = full_content[actual_start:end]
+
+        returned_length = len(content)
+        has_more = (actual_start + returned_length) < total_length
+
+        logger.info(
+            "[MCP:KBRetrieval] kb_head: doc_id=%d, offset=%d, returned=%d/%d, has_more=%s",
+            document_id,
+            actual_start,
+            returned_length,
+            total_length,
+            has_more,
+        )
+
+        return {
+            "document_id": document.id,
+            "name": document.name,
+            "content": content,
+            "total_length": total_length,
+            "offset": actual_start,
+            "returned_length": returned_length,
+            "has_more": has_more,
+            "kb_id": document.kind_id,
+        }
+
+    except Exception as e:
+        logger.error("[MCP:KBRetrieval] kb_head error: %s", e, exc_info=True)
+        return {"error": str(e)}
+
+    finally:
+        db.close()
+
+
+# Build tool registry from decorated functions
+KB_RETRIEVAL_MCP_TOOLS = build_mcp_tools_dict(server="kb_retrieval")

--- a/backend/tests/mcp_server/test_kb_retrieval_tools.py
+++ b/backend/tests/mcp_server/test_kb_retrieval_tools.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for KB Retrieval MCP tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.mcp_server.auth import TaskTokenInfo
+
+
+@pytest.fixture
+def token_info():
+    """Create a test token info."""
+    return TaskTokenInfo(
+        task_id=100,
+        subtask_id=200,
+        user_id=1,
+        user_name="testuser",
+    )
+
+
+class TestKnowledgeBaseSearchTool:
+    """Tests for knowledge_base_search MCP tool."""
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_search_returns_results(self, mock_session_local, token_info):
+        """Test successful RAG search returns formatted results."""
+        from app.mcp_server.tools.kb_retrieval import knowledge_base_search
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        # Mock RetrievalService
+        mock_service = MagicMock()
+        mock_retrieval_result = {
+            "records": [
+                {"content": "Result 1 content", "score": 0.95, "title": "doc1.md"},
+                {"content": "Result 2 content", "score": 0.85, "title": "doc2.md"},
+            ]
+        }
+
+        with (
+            patch(
+                "app.services.rag.retrieval_service.RetrievalService",
+                return_value=mock_service,
+            ),
+            patch("app.mcp_server.tools.kb_retrieval.asyncio") as mock_asyncio,
+        ):
+            mock_asyncio.get_event_loop.return_value.run_until_complete.return_value = (
+                mock_retrieval_result
+            )
+
+            result = knowledge_base_search(
+                token_info=token_info,
+                query="test query",
+                kb_id=10,
+                max_results=5,
+            )
+
+        assert result["total"] == 2
+        assert len(result["results"]) == 2
+        assert result["results"][0]["content"] == "Result 1 content"
+        assert result["results"][0]["score"] == 0.95
+        assert result["results"][0]["title"] == "doc1.md"
+        assert result["query"] == "test query"
+        mock_db.close.assert_called_once()
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_search_limits_results(self, mock_session_local, token_info):
+        """Test that max_results limits the number of returned results."""
+        from app.mcp_server.tools.kb_retrieval import knowledge_base_search
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        with patch("app.mcp_server.tools.kb_retrieval.asyncio") as mock_asyncio:
+            mock_asyncio.get_event_loop.return_value.run_until_complete.return_value = {
+                "records": [
+                    {
+                        "content": f"Result {i}",
+                        "score": 0.9 - i * 0.1,
+                        "title": f"doc{i}.md",
+                    }
+                    for i in range(10)
+                ]
+            }
+
+            result = knowledge_base_search(
+                token_info=token_info,
+                query="test",
+                kb_id=10,
+                max_results=3,
+            )
+
+        assert result["total"] == 3
+        assert len(result["results"]) == 3
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_search_handles_error(self, mock_session_local, token_info):
+        """Test that errors are caught and returned as error dict."""
+        from app.mcp_server.tools.kb_retrieval import knowledge_base_search
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        with patch("app.mcp_server.tools.kb_retrieval.asyncio") as mock_asyncio:
+            mock_asyncio.get_event_loop.return_value.run_until_complete.side_effect = (
+                ValueError("KB not found")
+            )
+
+            result = knowledge_base_search(
+                token_info=token_info,
+                query="test",
+                kb_id=999,
+            )
+
+        assert "error" in result
+        assert "KB not found" in result["error"]
+        mock_db.close.assert_called_once()
+
+
+class TestKbLsTool:
+    """Tests for kb_ls MCP tool."""
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_ls_returns_documents(self, mock_session_local, token_info):
+        """Test listing documents from a knowledge base."""
+        from app.mcp_server.tools.kb_retrieval import kb_ls
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        # Mock document query results
+        mock_doc1 = MagicMock()
+        mock_doc1.id = 1
+        mock_doc1.name = "readme.md"
+        mock_doc1.file_extension = "md"
+        mock_doc1.file_size = 1024
+        mock_doc1.summary = {"short_summary": "Project readme"}
+        mock_doc1.is_active = True
+
+        mock_doc2 = MagicMock()
+        mock_doc2.id = 2
+        mock_doc2.name = "api.pdf"
+        mock_doc2.file_extension = "pdf"
+        mock_doc2.file_size = 2048
+        mock_doc2.summary = None
+        mock_doc2.is_active = True
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.order_by.return_value.all.return_value = [
+            mock_doc1,
+            mock_doc2,
+        ]
+        mock_db.query.return_value = mock_query
+
+        result = kb_ls(token_info=token_info, kb_id=10)
+
+        assert result["total"] == 2
+        assert len(result["documents"]) == 2
+        assert result["documents"][0]["name"] == "readme.md"
+        assert result["documents"][0]["short_summary"] == "Project readme"
+        assert result["documents"][1]["short_summary"] is None
+        mock_db.close.assert_called_once()
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_ls_empty_kb(self, mock_session_local, token_info):
+        """Test listing documents from an empty knowledge base."""
+        from app.mcp_server.tools.kb_retrieval import kb_ls
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.order_by.return_value.all.return_value = []
+        mock_db.query.return_value = mock_query
+
+        result = kb_ls(token_info=token_info, kb_id=10)
+
+        assert result["total"] == 0
+        assert result["documents"] == []
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_ls_handles_error(self, mock_session_local, token_info):
+        """Test that errors return error dict."""
+        from app.mcp_server.tools.kb_retrieval import kb_ls
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+        mock_db.query.side_effect = Exception("DB error")
+
+        result = kb_ls(token_info=token_info, kb_id=10)
+
+        assert "error" in result
+        assert "DB error" in result["error"]
+
+
+class TestKbHeadTool:
+    """Tests for kb_head MCP tool."""
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_head_returns_content(self, mock_session_local, token_info):
+        """Test reading document content."""
+        from app.mcp_server.tools.kb_retrieval import kb_head
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        # Mock document
+        mock_doc = MagicMock()
+        mock_doc.id = 1
+        mock_doc.name = "readme.md"
+        mock_doc.attachment_id = 100
+        mock_doc.kind_id = 10
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_doc
+        mock_db.query.return_value = mock_query
+
+        # Mock attachment content
+        mock_attachment = MagicMock()
+        mock_attachment.extracted_text = "Hello world! This is test content."
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.get_context_optional.return_value = mock_attachment
+
+        with patch("app.services.context.context_service", mock_ctx_svc):
+            result = kb_head(token_info=token_info, document_id=1)
+
+        assert result["document_id"] == 1
+        assert result["name"] == "readme.md"
+        assert result["content"] == "Hello world! This is test content."
+        assert result["total_length"] == 34
+        assert result["offset"] == 0
+        assert result["has_more"] is False
+        mock_db.close.assert_called_once()
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_head_with_offset_and_limit(self, mock_session_local, token_info):
+        """Test reading content with offset and limit pagination."""
+        from app.mcp_server.tools.kb_retrieval import kb_head
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_doc = MagicMock()
+        mock_doc.id = 1
+        mock_doc.name = "large.md"
+        mock_doc.attachment_id = 100
+        mock_doc.kind_id = 10
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_doc
+        mock_db.query.return_value = mock_query
+
+        full_content = "A" * 100  # 100 character content
+        mock_attachment = MagicMock()
+        mock_attachment.extracted_text = full_content
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.get_context_optional.return_value = mock_attachment
+
+        with patch("app.services.context.context_service", mock_ctx_svc):
+            result = kb_head(token_info=token_info, document_id=1, offset=10, limit=20)
+
+        assert result["offset"] == 10
+        assert result["returned_length"] == 20
+        assert result["total_length"] == 100
+        assert result["has_more"] is True
+        assert result["content"] == "A" * 20
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_head_document_not_found(self, mock_session_local, token_info):
+        """Test reading a non-existent document."""
+        from app.mcp_server.tools.kb_retrieval import kb_head
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = None
+        mock_db.query.return_value = mock_query
+
+        result = kb_head(token_info=token_info, document_id=999)
+
+        assert "error" in result
+        assert "not found" in result["error"]
+
+    @patch("app.mcp_server.tools.kb_retrieval.SessionLocal")
+    def test_head_clamps_limit_to_max(self, mock_session_local, token_info):
+        """Test that limit is clamped to MAX_READ_DOC_LIMIT."""
+        from app.mcp_server.tools.kb_retrieval import MAX_READ_DOC_LIMIT, kb_head
+
+        mock_db = MagicMock()
+        mock_session_local.return_value = mock_db
+
+        mock_doc = MagicMock()
+        mock_doc.id = 1
+        mock_doc.name = "doc.md"
+        mock_doc.attachment_id = 100
+        mock_doc.kind_id = 10
+
+        mock_query = MagicMock()
+        mock_query.filter.return_value.first.return_value = mock_doc
+        mock_db.query.return_value = mock_query
+
+        # Content smaller than max limit
+        content = "X" * 1000
+        mock_attachment = MagicMock()
+        mock_attachment.extracted_text = content
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.get_context_optional.return_value = mock_attachment
+
+        with patch("app.services.context.context_service", mock_ctx_svc):
+            # Request limit larger than MAX_READ_DOC_LIMIT
+            result = kb_head(
+                token_info=token_info,
+                document_id=1,
+                limit=MAX_READ_DOC_LIMIT + 100000,
+            )
+
+        # Should still return all content since content < max limit
+        assert result["returned_length"] == 1000
+
+
+class TestKbRetrievalToolRegistration:
+    """Tests for KB retrieval tool registration."""
+
+    def test_tools_are_registered(self):
+        """Test that all 3 KB retrieval tools are registered."""
+        from app.mcp_server.tools.kb_retrieval import KB_RETRIEVAL_MCP_TOOLS
+
+        assert "knowledge_base_search" in KB_RETRIEVAL_MCP_TOOLS
+        assert "kb_ls" in KB_RETRIEVAL_MCP_TOOLS
+        assert "kb_head" in KB_RETRIEVAL_MCP_TOOLS
+
+    def test_tools_have_correct_server(self):
+        """Test that tools are registered with correct server name."""
+        from app.mcp_server.tools.decorator import get_registered_mcp_tools
+
+        kb_tools = get_registered_mcp_tools(server="kb_retrieval")
+        tool_names = set(kb_tools.keys())
+        assert "knowledge_base_search" in tool_names
+        assert "kb_ls" in tool_names
+        assert "kb_head" in tool_names

--- a/executor/agents/agno/agno_agent.py
+++ b/executor/agents/agno/agno_agent.py
@@ -351,7 +351,6 @@ class AgnoAgent(Agent):
 
         return TaskStatus.SUCCESS
 
-
     def execute(self) -> TaskStatus:
         """
         Execute the Agno Agent task
@@ -538,6 +537,16 @@ class AgnoAgent(Agent):
 
             # Prepare prompt
             prompt = self.prompt
+
+            # Inject knowledge base meta prompt if available
+            kb_meta_prompt = self.task_data.kb_meta_prompt
+            if kb_meta_prompt:
+                prompt = f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>\n\n{prompt}"
+                logger.info(
+                    "Injected kb_meta_prompt into prompt (%d chars)",
+                    len(kb_meta_prompt),
+                )
+
             if self.options.get("cwd"):
                 prompt = (
                     prompt + "\nCurrent working directory: " + self.options.get("cwd")

--- a/executor/agents/agno/agno_agent.py
+++ b/executor/agents/agno/agno_agent.py
@@ -538,15 +538,6 @@ class AgnoAgent(Agent):
             # Prepare prompt
             prompt = self.prompt
 
-            # Inject knowledge base meta prompt if available
-            kb_meta_prompt = self.task_data.kb_meta_prompt
-            if kb_meta_prompt:
-                prompt = f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>\n\n{prompt}"
-                logger.info(
-                    "Injected kb_meta_prompt into prompt (%d chars)",
-                    len(kb_meta_prompt),
-                )
-
             if self.options.get("cwd"):
                 prompt = (
                     prompt + "\nCurrent working directory: " + self.options.get("cwd")

--- a/executor/agents/agno/member_builder.py
+++ b/executor/agents/agno/member_builder.py
@@ -76,15 +76,6 @@ class MemberBuilder:
                         f"Added system MCP tools for subscription task (member: {member_config.get('name', 'Unnamed')})"
                     )
 
-            # Add KB retrieval MCP server when knowledge bases are selected
-            kb_mcp_tools = await self._setup_kb_retrieval_mcp_tools(task_data)
-            if kb_mcp_tools:
-                all_tools.extend(kb_mcp_tools)
-                logger.info(
-                    f"Added KB retrieval MCP tools for {len(task_data.knowledge_base_ids)} knowledge bases "
-                    f"(member: {member_config.get('name', 'Unnamed')})"
-                )
-
             # Prepare data sources for placeholder replacement
             data_sources = {
                 "agent_config": agent_config,
@@ -163,14 +154,6 @@ class MemberBuilder:
                     logger.info(
                         "Added system MCP tools for subscription task (default member)"
                     )
-
-            # Add KB retrieval MCP server when knowledge bases are selected
-            kb_mcp_tools = await self._setup_kb_retrieval_mcp_tools(task_data)
-            if kb_mcp_tools:
-                all_tools.extend(kb_mcp_tools)
-                logger.info(
-                    f"Added KB retrieval MCP tools for {len(task_data.knowledge_base_ids)} knowledge bases (default member)"
-                )
 
             # Prepare data sources for placeholder replacement
             data_sources = {
@@ -365,89 +348,6 @@ class MemberBuilder:
             # Log full traceback for debugging
             logger.error(
                 f"Failed to setup system MCP tools: {type(e).__name__}: {str(e)}\n"
-                f"Traceback: {traceback.format_exc()}"
-            )
-            return None
-
-    async def _setup_kb_retrieval_mcp_tools(
-        self, task_data: ExecutionRequest
-    ) -> Optional[List[Any]]:
-        """
-        Setup KB retrieval MCP tools when knowledge bases are selected.
-
-        The KB retrieval MCP server provides search/read tools for knowledge bases.
-        It is hosted by Backend and injected when knowledge_base_ids are present.
-
-        Args:
-            task_data: Task data containing knowledge_base_ids, backend_url, auth_token
-
-        Returns:
-            List of MCPTools if successful, None otherwise
-        """
-        import asyncio
-        import traceback
-
-        try:
-            if not task_data.knowledge_base_ids:
-                return None
-
-            if not task_data.backend_url or not task_data.auth_token:
-                logger.warning(
-                    "KB retrieval MCP requires backend_url and auth_token, skipping"
-                )
-                return None
-
-            kb_mcp_url = f"{task_data.backend_url}/mcp/kb-retrieval/sse"
-            kb_mcp_config = {
-                "type": "streamable-http",
-                "url": kb_mcp_url,
-                "headers": {
-                    "Authorization": f"Bearer {task_data.auth_token}",
-                },
-                "timeout": 300,
-            }
-
-            logger.info(
-                f"Attempting to connect to KB retrieval MCP server at {kb_mcp_url} "
-                f"for {len(task_data.knowledge_base_ids)} knowledge bases"
-            )
-
-            mcp_tools = self.mcp_manager._create_streamable_http_tools(kb_mcp_config)
-
-            if mcp_tools:
-                # Retry connection with exponential backoff
-                max_retries = 3
-                retry_delay = 0.5
-
-                for attempt in range(max_retries):
-                    try:
-                        await mcp_tools.connect()
-                        self.mcp_manager.connected_tools.append(mcp_tools)
-                        logger.info(
-                            f"Connected to KB retrieval MCP server (attempt {attempt + 1})"
-                        )
-                        return [mcp_tools]
-                    except Exception as connect_error:
-                        if attempt < max_retries - 1:
-                            logger.warning(
-                                f"Failed to connect to KB retrieval MCP server (attempt {attempt + 1}/{max_retries}): "
-                                f"{type(connect_error).__name__}: {str(connect_error)}"
-                            )
-                            await asyncio.sleep(retry_delay)
-                            retry_delay *= 2
-                        else:
-                            logger.error(
-                                f"Failed to connect to KB retrieval MCP server after {max_retries} attempts: "
-                                f"{type(connect_error).__name__}: {str(connect_error)}\n"
-                                f"Traceback: {traceback.format_exc()}"
-                            )
-                            raise
-
-            return None
-
-        except Exception as e:
-            logger.error(
-                f"Failed to setup KB retrieval MCP tools: {type(e).__name__}: {str(e)}\n"
                 f"Traceback: {traceback.format_exc()}"
             )
             return None

--- a/executor/agents/agno/member_builder.py
+++ b/executor/agents/agno/member_builder.py
@@ -76,6 +76,15 @@ class MemberBuilder:
                         f"Added system MCP tools for subscription task (member: {member_config.get('name', 'Unnamed')})"
                     )
 
+            # Add KB retrieval MCP server when knowledge bases are selected
+            kb_mcp_tools = await self._setup_kb_retrieval_mcp_tools(task_data)
+            if kb_mcp_tools:
+                all_tools.extend(kb_mcp_tools)
+                logger.info(
+                    f"Added KB retrieval MCP tools for {len(task_data.knowledge_base_ids)} knowledge bases "
+                    f"(member: {member_config.get('name', 'Unnamed')})"
+                )
+
             # Prepare data sources for placeholder replacement
             data_sources = {
                 "agent_config": agent_config,
@@ -154,6 +163,14 @@ class MemberBuilder:
                     logger.info(
                         "Added system MCP tools for subscription task (default member)"
                     )
+
+            # Add KB retrieval MCP server when knowledge bases are selected
+            kb_mcp_tools = await self._setup_kb_retrieval_mcp_tools(task_data)
+            if kb_mcp_tools:
+                all_tools.extend(kb_mcp_tools)
+                logger.info(
+                    f"Added KB retrieval MCP tools for {len(task_data.knowledge_base_ids)} knowledge bases (default member)"
+                )
 
             # Prepare data sources for placeholder replacement
             data_sources = {
@@ -348,6 +365,89 @@ class MemberBuilder:
             # Log full traceback for debugging
             logger.error(
                 f"Failed to setup system MCP tools: {type(e).__name__}: {str(e)}\n"
+                f"Traceback: {traceback.format_exc()}"
+            )
+            return None
+
+    async def _setup_kb_retrieval_mcp_tools(
+        self, task_data: ExecutionRequest
+    ) -> Optional[List[Any]]:
+        """
+        Setup KB retrieval MCP tools when knowledge bases are selected.
+
+        The KB retrieval MCP server provides search/read tools for knowledge bases.
+        It is hosted by Backend and injected when knowledge_base_ids are present.
+
+        Args:
+            task_data: Task data containing knowledge_base_ids, backend_url, auth_token
+
+        Returns:
+            List of MCPTools if successful, None otherwise
+        """
+        import asyncio
+        import traceback
+
+        try:
+            if not task_data.knowledge_base_ids:
+                return None
+
+            if not task_data.backend_url or not task_data.auth_token:
+                logger.warning(
+                    "KB retrieval MCP requires backend_url and auth_token, skipping"
+                )
+                return None
+
+            kb_mcp_url = f"{task_data.backend_url}/mcp/kb-retrieval/sse"
+            kb_mcp_config = {
+                "type": "streamable-http",
+                "url": kb_mcp_url,
+                "headers": {
+                    "Authorization": f"Bearer {task_data.auth_token}",
+                },
+                "timeout": 300,
+            }
+
+            logger.info(
+                f"Attempting to connect to KB retrieval MCP server at {kb_mcp_url} "
+                f"for {len(task_data.knowledge_base_ids)} knowledge bases"
+            )
+
+            mcp_tools = self.mcp_manager._create_streamable_http_tools(kb_mcp_config)
+
+            if mcp_tools:
+                # Retry connection with exponential backoff
+                max_retries = 3
+                retry_delay = 0.5
+
+                for attempt in range(max_retries):
+                    try:
+                        await mcp_tools.connect()
+                        self.mcp_manager.connected_tools.append(mcp_tools)
+                        logger.info(
+                            f"Connected to KB retrieval MCP server (attempt {attempt + 1})"
+                        )
+                        return [mcp_tools]
+                    except Exception as connect_error:
+                        if attempt < max_retries - 1:
+                            logger.warning(
+                                f"Failed to connect to KB retrieval MCP server (attempt {attempt + 1}/{max_retries}): "
+                                f"{type(connect_error).__name__}: {str(connect_error)}"
+                            )
+                            await asyncio.sleep(retry_delay)
+                            retry_delay *= 2
+                        else:
+                            logger.error(
+                                f"Failed to connect to KB retrieval MCP server after {max_retries} attempts: "
+                                f"{type(connect_error).__name__}: {str(connect_error)}\n"
+                                f"Traceback: {traceback.format_exc()}"
+                            )
+                            raise
+
+            return None
+
+        except Exception as e:
+            logger.error(
+                f"Failed to setup KB retrieval MCP tools: {type(e).__name__}: {str(e)}\n"
                 f"Traceback: {traceback.format_exc()}"
             )
             return None

--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -454,7 +454,6 @@ class ClaudeCodeAgent(Agent):
             )
             return TaskStatus.FAILED
 
-
     def execute(self) -> TaskStatus:
         """
         Execute the Claude Code Agent task
@@ -663,6 +662,23 @@ class ClaudeCodeAgent(Agent):
             # Prepare prompt with skill emphasis if user selected skills
             prompt = self.prompt
             user_selected_skills = self.task_data.user_selected_skills
+
+            # Inject knowledge base meta prompt if available
+            kb_meta_prompt = self.task_data.kb_meta_prompt
+            if kb_meta_prompt:
+                if is_vision_prompt(prompt):
+                    prompt = append_text_to_vision_prompt(
+                        prompt,
+                        f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>",
+                        prepend=True,
+                    )
+                else:
+                    prompt = f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>\n\n{prompt}"
+                logger.info(
+                    "Injected kb_meta_prompt into prompt (%d chars)",
+                    len(kb_meta_prompt),
+                )
+
             if is_vision_prompt(prompt):
                 # Vision content: append text to the text block in the list
                 if user_selected_skills:
@@ -676,9 +692,7 @@ class ClaudeCodeAgent(Agent):
                         f"Added skill emphasis for {len(user_selected_skills)} user-selected skills: {user_selected_skills}"
                     )
                 if self.options.get("cwd"):
-                    cwd_text = "\nCurrent working directory: " + self.options.get(
-                        "cwd"
-                    )
+                    cwd_text = "\nCurrent working directory: " + self.options.get("cwd")
                     git_url = self.task_data.git_url
                     if git_url:
                         cwd_text += "\n project url:" + git_url
@@ -738,9 +752,7 @@ class ClaudeCodeAgent(Agent):
 
             # Use session_id to send messages, ensuring messages are in the same session
             # Use the current updated prompt for each execution, even with the same session ID
-            prompt_length = (
-                len(prompt) if isinstance(prompt, str) else len(str(prompt))
-            )
+            prompt_length = len(prompt) if isinstance(prompt, str) else len(str(prompt))
             logger.info(
                 f"Sending query with prompt (length: {prompt_length}) for session_id: {self.session_id}"
             )
@@ -933,16 +945,12 @@ class ClaudeCodeAgent(Agent):
             )
 
             # Terminate the CC process
-            await SessionManager._terminate_client_process(
-                self.client, self.session_id
-            )
+            await SessionManager._terminate_client_process(self.client, self.session_id)
 
             # Remove all in-memory tracking (client cache + session_id_map)
             # but preserve the on-disk .claude_session_id file for resume
             internal_key = getattr(self, "_internal_session_key", None)
-            SessionManager.cleanup_session_tracking(
-                self.session_id, internal_key
-            )
+            SessionManager.cleanup_session_tracking(self.session_id, internal_key)
 
             # Clear local client reference
             self.client = None
@@ -957,9 +965,7 @@ class ClaudeCodeAgent(Agent):
                         if asyncio.iscoroutine(result):
                             await result
                 except Exception as e:
-                    logger.warning(
-                        f"Error in heartbeat callback after auto-close: {e}"
-                    )
+                    logger.warning(f"Error in heartbeat callback after auto-close: {e}")
 
             logger.info(
                 f"Auto-closed CC session: session_id={self.session_id}, "

--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -663,21 +663,24 @@ class ClaudeCodeAgent(Agent):
             prompt = self.prompt
             user_selected_skills = self.task_data.user_selected_skills
 
-            # Inject knowledge base meta prompt if available
-            kb_meta_prompt = self.task_data.kb_meta_prompt
-            if kb_meta_prompt:
-                if is_vision_prompt(prompt):
-                    prompt = append_text_to_vision_prompt(
-                        prompt,
-                        f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>",
-                        prepend=True,
+            # Inject knowledge base meta prompt if available (local mode only)
+            from executor.config import config as executor_config
+
+            if executor_config.EXECUTOR_MODE == "local":
+                kb_meta_prompt = self.task_data.kb_meta_prompt
+                if kb_meta_prompt:
+                    if is_vision_prompt(prompt):
+                        prompt = append_text_to_vision_prompt(
+                            prompt,
+                            f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>",
+                            prepend=True,
+                        )
+                    else:
+                        prompt = f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>\n\n{prompt}"
+                    logger.info(
+                        "Injected kb_meta_prompt into prompt (%d chars)",
+                        len(kb_meta_prompt),
                     )
-                else:
-                    prompt = f"<knowledge_base_context>\n{kb_meta_prompt}\n</knowledge_base_context>\n\n{prompt}"
-                logger.info(
-                    "Injected kb_meta_prompt into prompt (%d chars)",
-                    len(kb_meta_prompt),
-                )
 
             if is_vision_prompt(prompt):
                 # Vision content: append text to the text block in the list

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -272,6 +272,7 @@ def _convert_mcp_servers_list_to_dict(mcp_servers: Any) -> Dict[str, Any]:
     )
     return {}
 
+
 def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     """Extract Claude Code options from task data.
 
@@ -354,6 +355,32 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
                 bot_config["mcp_servers"] = mcp_servers
             logger.info(
                 f"Added wegent MCP server (HTTP) for subscription task at {wegent_mcp_url}"
+            )
+
+        # Add KB retrieval MCP server when knowledge bases are selected
+        if task_data.knowledge_base_ids:
+            kb_mcp_url = f"{task_data.backend_url}/mcp/kb-retrieval/sse"
+            kb_retrieval_mcp = {
+                "wegent-kb-retrieval": {
+                    "type": "streamable-http",
+                    "url": kb_mcp_url,
+                    "headers": {
+                        "Authorization": f"Bearer {task_data.auth_token}",
+                    },
+                    "timeout": 300,
+                }
+            }
+            if "mcp_servers" not in bot_config or bot_config["mcp_servers"] is None:
+                bot_config["mcp_servers"] = {}
+            mcp_servers = bot_config["mcp_servers"]
+            if isinstance(mcp_servers, dict):
+                mcp_servers.update(kb_retrieval_mcp)
+            elif isinstance(mcp_servers, list):
+                mcp_servers = _convert_mcp_servers_list_to_dict(mcp_servers)
+                mcp_servers.update(kb_retrieval_mcp)
+                bot_config["mcp_servers"] = mcp_servers
+            logger.info(
+                f"Added KB retrieval MCP server for {len(task_data.knowledge_base_ids)} knowledge bases at {kb_mcp_url}"
             )
 
         for key in valid_options:

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -17,6 +17,7 @@ import string
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from executor.config import config as executor_config
 from executor.config.config import get_wegent_mcp_url
 from shared.logger import setup_logger
 from shared.models.execution import ExecutionRequest
@@ -357,8 +358,8 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
                 f"Added wegent MCP server (HTTP) for subscription task at {wegent_mcp_url}"
             )
 
-        # Add KB retrieval MCP server when knowledge bases are selected
-        if task_data.knowledge_base_ids:
+        # Add KB retrieval MCP server when knowledge bases are selected (local mode only)
+        if task_data.knowledge_base_ids and executor_config.EXECUTOR_MODE == "local":
             kb_mcp_url = f"{task_data.backend_url}/mcp/kb-retrieval/sse"
             kb_retrieval_mcp = {
                 "wegent-kb-retrieval": {

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -362,7 +362,7 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
             kb_mcp_url = f"{task_data.backend_url}/mcp/kb-retrieval/sse"
             kb_retrieval_mcp = {
                 "wegent-kb-retrieval": {
-                    "type": "streamable-http",
+                    "type": "http",
                     "url": kb_mcp_url,
                     "headers": {
                         "Authorization": f"Bearer {task_data.auth_token}",

--- a/executor/tests/agents/test_kb_mcp_injection.py
+++ b/executor/tests/agents/test_kb_mcp_injection.py
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for KB retrieval MCP injection in ClaudeCode and Agno executors."""
+"""Tests for KB retrieval MCP injection in ClaudeCode executor (local mode only)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -26,10 +26,12 @@ def _create_task_data(**overrides) -> ExecutionRequest:
 
 
 class TestClaudeCodeKBMCPInjection:
-    """Tests for KB MCP injection in ClaudeCode config_manager."""
+    """Tests for KB MCP injection in ClaudeCode config_manager (local mode only)."""
 
-    def test_kb_mcp_injected_when_knowledge_bases_present(self):
-        """Test that KB retrieval MCP server is added when knowledge_base_ids exist."""
+    @patch("executor.agents.claude_code.config_manager.executor_config")
+    def test_kb_mcp_injected_in_local_mode(self, mock_config):
+        """Test that KB retrieval MCP server is added in local mode."""
+        mock_config.EXECUTOR_MODE = "local"
         from executor.agents.claude_code.config_manager import extract_claude_options
 
         task_data = _create_task_data(
@@ -46,8 +48,25 @@ class TestClaudeCodeKBMCPInjection:
         assert "Bearer test-token-123" in kb_config["headers"]["Authorization"]
         assert kb_config["timeout"] == 300
 
-    def test_kb_mcp_not_injected_when_no_knowledge_bases(self):
+    @patch("executor.agents.claude_code.config_manager.executor_config")
+    def test_kb_mcp_not_injected_in_docker_mode(self, mock_config):
+        """Test that KB retrieval MCP server is NOT added in docker mode."""
+        mock_config.EXECUTOR_MODE = "docker"
+        from executor.agents.claude_code.config_manager import extract_claude_options
+
+        task_data = _create_task_data(
+            knowledge_base_ids=[1, 2, 3],
+        )
+
+        options = extract_claude_options(task_data)
+
+        mcp_servers = options.get("mcp_servers", {})
+        assert "wegent-kb-retrieval" not in mcp_servers
+
+    @patch("executor.agents.claude_code.config_manager.executor_config")
+    def test_kb_mcp_not_injected_when_no_knowledge_bases(self, mock_config):
         """Test that KB retrieval MCP is not added when no knowledge bases."""
+        mock_config.EXECUTOR_MODE = "local"
         from executor.agents.claude_code.config_manager import extract_claude_options
 
         task_data = _create_task_data(
@@ -59,8 +78,10 @@ class TestClaudeCodeKBMCPInjection:
         mcp_servers = options.get("mcp_servers", {})
         assert "wegent-kb-retrieval" not in mcp_servers
 
-    def test_kb_mcp_not_injected_when_empty_knowledge_bases(self):
+    @patch("executor.agents.claude_code.config_manager.executor_config")
+    def test_kb_mcp_not_injected_when_empty_knowledge_bases(self, mock_config):
         """Test that KB retrieval MCP is not added when knowledge_base_ids is empty."""
+        mock_config.EXECUTOR_MODE = "local"
         from executor.agents.claude_code.config_manager import extract_claude_options
 
         task_data = _create_task_data(
@@ -72,8 +93,10 @@ class TestClaudeCodeKBMCPInjection:
         mcp_servers = options.get("mcp_servers", {})
         assert "wegent-kb-retrieval" not in mcp_servers
 
-    def test_kb_mcp_merged_with_existing_mcp_servers(self):
+    @patch("executor.agents.claude_code.config_manager.executor_config")
+    def test_kb_mcp_merged_with_existing_mcp_servers(self, mock_config):
         """Test that KB MCP is merged with user-configured MCP servers."""
+        mock_config.EXECUTOR_MODE = "local"
         from executor.agents.claude_code.config_manager import extract_claude_options
 
         task_data = _create_task_data(
@@ -97,78 +120,3 @@ class TestClaudeCodeKBMCPInjection:
         # Both user MCP and KB retrieval MCP should be present
         assert "user-mcp" in mcp_servers
         assert "wegent-kb-retrieval" in mcp_servers
-
-
-class TestAgnoKBMCPInjection:
-    """Tests for KB MCP injection in Agno member_builder."""
-
-    @pytest.fixture
-    def member_builder(self):
-        """Create a MemberBuilder with mocked dependencies."""
-        with patch("executor.agents.agno.member_builder.SqliteDb"):
-            from executor.agents.agno.member_builder import MemberBuilder
-
-            mock_db = MagicMock()
-            mock_config_manager = MagicMock()
-            mock_config_manager.executor_env = {}
-            mock_config_manager.build_default_headers_with_placeholders.return_value = (
-                {}
-            )
-            builder = MemberBuilder(
-                db=mock_db,
-                config_manager=mock_config_manager,
-            )
-            return builder
-
-    @pytest.mark.anyio
-    async def test_kb_mcp_tools_setup_when_kb_present(self, member_builder):
-        """Test that _setup_kb_retrieval_mcp_tools connects when KBs are present."""
-        task_data = _create_task_data(
-            knowledge_base_ids=[1, 2],
-        )
-
-        mock_mcp_tools = MagicMock()
-        mock_mcp_tools.connect = MagicMock(return_value=None)
-        # Make connect a proper coroutine
-        import asyncio
-
-        async def mock_connect():
-            pass
-
-        mock_mcp_tools.connect = mock_connect
-
-        member_builder.mcp_manager._create_streamable_http_tools = MagicMock(
-            return_value=mock_mcp_tools
-        )
-
-        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
-
-        assert result is not None
-        assert len(result) == 1
-        # Verify the MCP config was created with correct URL
-        call_args = member_builder.mcp_manager._create_streamable_http_tools.call_args[
-            0
-        ][0]
-        assert call_args["url"] == "http://localhost:8000/mcp/kb-retrieval/sse"
-        assert "Bearer test-token-123" in call_args["headers"]["Authorization"]
-
-    @pytest.mark.anyio
-    async def test_kb_mcp_tools_returns_none_when_no_kb(self, member_builder):
-        """Test that _setup_kb_retrieval_mcp_tools returns None when no KBs."""
-        task_data = _create_task_data(knowledge_base_ids=None)
-
-        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
-
-        assert result is None
-
-    @pytest.mark.anyio
-    async def test_kb_mcp_tools_returns_none_when_no_backend_url(self, member_builder):
-        """Test that KB MCP returns None when backend_url is missing."""
-        task_data = _create_task_data(
-            knowledge_base_ids=[1],
-            backend_url="",
-        )
-
-        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
-
-        assert result is None

--- a/executor/tests/agents/test_kb_mcp_injection.py
+++ b/executor/tests/agents/test_kb_mcp_injection.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for KB retrieval MCP injection in ClaudeCode and Agno executors."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.models.execution import ExecutionRequest
+
+
+def _create_task_data(**overrides) -> ExecutionRequest:
+    """Create a minimal ExecutionRequest for testing."""
+    defaults = {
+        "task_id": 1,
+        "subtask_id": 10,
+        "prompt": "Test prompt",
+        "bot": [{"name": "test-bot"}],
+        "backend_url": "http://localhost:8000",
+        "auth_token": "test-token-123",
+    }
+    defaults.update(overrides)
+    return ExecutionRequest(**defaults)
+
+
+class TestClaudeCodeKBMCPInjection:
+    """Tests for KB MCP injection in ClaudeCode config_manager."""
+
+    def test_kb_mcp_injected_when_knowledge_bases_present(self):
+        """Test that KB retrieval MCP server is added when knowledge_base_ids exist."""
+        from executor.agents.claude_code.config_manager import extract_claude_options
+
+        task_data = _create_task_data(
+            knowledge_base_ids=[1, 2, 3],
+        )
+
+        options = extract_claude_options(task_data)
+
+        mcp_servers = options.get("mcp_servers", {})
+        assert "wegent-kb-retrieval" in mcp_servers
+        kb_config = mcp_servers["wegent-kb-retrieval"]
+        assert kb_config["type"] == "streamable-http"
+        assert "/mcp/kb-retrieval/sse" in kb_config["url"]
+        assert "Bearer test-token-123" in kb_config["headers"]["Authorization"]
+        assert kb_config["timeout"] == 300
+
+    def test_kb_mcp_not_injected_when_no_knowledge_bases(self):
+        """Test that KB retrieval MCP is not added when no knowledge bases."""
+        from executor.agents.claude_code.config_manager import extract_claude_options
+
+        task_data = _create_task_data(
+            knowledge_base_ids=None,
+        )
+
+        options = extract_claude_options(task_data)
+
+        mcp_servers = options.get("mcp_servers", {})
+        assert "wegent-kb-retrieval" not in mcp_servers
+
+    def test_kb_mcp_not_injected_when_empty_knowledge_bases(self):
+        """Test that KB retrieval MCP is not added when knowledge_base_ids is empty."""
+        from executor.agents.claude_code.config_manager import extract_claude_options
+
+        task_data = _create_task_data(
+            knowledge_base_ids=[],
+        )
+
+        options = extract_claude_options(task_data)
+
+        mcp_servers = options.get("mcp_servers", {})
+        assert "wegent-kb-retrieval" not in mcp_servers
+
+    def test_kb_mcp_merged_with_existing_mcp_servers(self):
+        """Test that KB MCP is merged with user-configured MCP servers."""
+        from executor.agents.claude_code.config_manager import extract_claude_options
+
+        task_data = _create_task_data(
+            knowledge_base_ids=[1],
+            bot=[
+                {
+                    "name": "test-bot",
+                    "mcp_servers": {
+                        "user-mcp": {
+                            "type": "streamable-http",
+                            "url": "http://user-mcp.example.com",
+                        }
+                    },
+                }
+            ],
+        )
+
+        options = extract_claude_options(task_data)
+
+        mcp_servers = options.get("mcp_servers", {})
+        # Both user MCP and KB retrieval MCP should be present
+        assert "user-mcp" in mcp_servers
+        assert "wegent-kb-retrieval" in mcp_servers
+
+
+class TestAgnoKBMCPInjection:
+    """Tests for KB MCP injection in Agno member_builder."""
+
+    @pytest.fixture
+    def member_builder(self):
+        """Create a MemberBuilder with mocked dependencies."""
+        with patch("executor.agents.agno.member_builder.SqliteDb"):
+            from executor.agents.agno.member_builder import MemberBuilder
+
+            mock_db = MagicMock()
+            mock_config_manager = MagicMock()
+            mock_config_manager.executor_env = {}
+            mock_config_manager.build_default_headers_with_placeholders.return_value = (
+                {}
+            )
+            builder = MemberBuilder(
+                db=mock_db,
+                config_manager=mock_config_manager,
+            )
+            return builder
+
+    @pytest.mark.anyio
+    async def test_kb_mcp_tools_setup_when_kb_present(self, member_builder):
+        """Test that _setup_kb_retrieval_mcp_tools connects when KBs are present."""
+        task_data = _create_task_data(
+            knowledge_base_ids=[1, 2],
+        )
+
+        mock_mcp_tools = MagicMock()
+        mock_mcp_tools.connect = MagicMock(return_value=None)
+        # Make connect a proper coroutine
+        import asyncio
+
+        async def mock_connect():
+            pass
+
+        mock_mcp_tools.connect = mock_connect
+
+        member_builder.mcp_manager._create_streamable_http_tools = MagicMock(
+            return_value=mock_mcp_tools
+        )
+
+        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
+
+        assert result is not None
+        assert len(result) == 1
+        # Verify the MCP config was created with correct URL
+        call_args = member_builder.mcp_manager._create_streamable_http_tools.call_args[
+            0
+        ][0]
+        assert call_args["url"] == "http://localhost:8000/mcp/kb-retrieval/sse"
+        assert "Bearer test-token-123" in call_args["headers"]["Authorization"]
+
+    @pytest.mark.anyio
+    async def test_kb_mcp_tools_returns_none_when_no_kb(self, member_builder):
+        """Test that _setup_kb_retrieval_mcp_tools returns None when no KBs."""
+        task_data = _create_task_data(knowledge_base_ids=None)
+
+        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_kb_mcp_tools_returns_none_when_no_backend_url(self, member_builder):
+        """Test that KB MCP returns None when backend_url is missing."""
+        task_data = _create_task_data(
+            knowledge_base_ids=[1],
+            backend_url="",
+        )
+
+        result = await member_builder._setup_kb_retrieval_mcp_tools(task_data)
+
+        assert result is None

--- a/executor/tests/agents/test_kb_mcp_injection.py
+++ b/executor/tests/agents/test_kb_mcp_injection.py
@@ -41,7 +41,7 @@ class TestClaudeCodeKBMCPInjection:
         mcp_servers = options.get("mcp_servers", {})
         assert "wegent-kb-retrieval" in mcp_servers
         kb_config = mcp_servers["wegent-kb-retrieval"]
-        assert kb_config["type"] == "streamable-http"
+        assert kb_config["type"] == "http"
         assert "/mcp/kb-retrieval/sse" in kb_config["url"]
         assert "Bearer test-token-123" in kb_config["headers"]["Authorization"]
         assert kb_config["timeout"] == 300

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -26,7 +26,7 @@ import type {
 } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
-import { isChatShell, isClaudeCode } from '../../service/messageService'
+import { isChatShell } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { MobileChatInputControls } from './MobileChatInputControls'
@@ -317,6 +317,7 @@ export function ChatInputControls({
   if (isMobile) {
     return (
       <MobileChatInputControls
+        taskType={taskType}
         selectedTeam={selectedTeam}
         selectedModel={selectedModel}
         setSelectedModel={setSelectedModel}
@@ -457,8 +458,8 @@ export function ChatInputControls({
         {/* Non-generation mode controls (chat, code, etc.) */}
         {!isGenerationMode && (
           <>
-            {/* Context Selection - available for non-code shell types */}
-            {!isClaudeCode(selectedTeam) && (
+            {/* Context Selection - hidden for code page (taskType === 'code') */}
+            {taskType !== 'code' && (
               <ChatContextInput
                 selectedContexts={selectedContexts}
                 onContextsChange={setSelectedContexts}

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -457,14 +457,12 @@ export function ChatInputControls({
         {/* Non-generation mode controls (chat, code, etc.) */}
         {!isGenerationMode && (
           <>
-            {/* Context Selection - only show for chat shell */}
-            {isChatShell(selectedTeam) && (
-              <ChatContextInput
-                selectedContexts={selectedContexts}
-                onContextsChange={setSelectedContexts}
-                excludeKnowledgeBaseId={knowledgeBaseId}
-              />
-            )}
+            {/* Context Selection - available for all shell types (KB retrieval supported via MCP) */}
+            <ChatContextInput
+              selectedContexts={selectedContexts}
+              onContextsChange={setSelectedContexts}
+              excludeKnowledgeBaseId={knowledgeBaseId}
+            />
 
             {/* File Upload Button - show for shells that support attachments (Chat, ClaudeCode) */}
             {supportsAttachments(selectedTeam) && (

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -26,7 +26,7 @@ import type {
 } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
-import { isChatShell } from '../../service/messageService'
+import { isChatShell, isClaudeCode } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { MobileChatInputControls } from './MobileChatInputControls'
@@ -457,12 +457,14 @@ export function ChatInputControls({
         {/* Non-generation mode controls (chat, code, etc.) */}
         {!isGenerationMode && (
           <>
-            {/* Context Selection - available for all shell types (KB retrieval supported via MCP) */}
-            <ChatContextInput
-              selectedContexts={selectedContexts}
-              onContextsChange={setSelectedContexts}
-              excludeKnowledgeBaseId={knowledgeBaseId}
-            />
+            {/* Context Selection - available for non-code shell types */}
+            {!isClaudeCode(selectedTeam) && (
+              <ChatContextInput
+                selectedContexts={selectedContexts}
+                onContextsChange={setSelectedContexts}
+                excludeKnowledgeBaseId={knowledgeBaseId}
+              />
+            )}
 
             {/* File Upload Button - show for shells that support attachments (Chat, ClaudeCode) */}
             {supportsAttachments(selectedTeam) && (

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -27,7 +27,7 @@ import {
 import type { Team, GitRepoInfo, GitBranch as GitBranchType, TaskDetail } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
-import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
+import { isChatShell, isClaudeCode, teamRequiresWorkspace } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import SkillSelectorPopover from '../selector/SkillSelectorPopover'
 
@@ -225,12 +225,14 @@ export function MobileChatInputControls({
         {supportsAttachments(selectedTeam) && (
           <AttachmentButton onFileSelect={onFileSelect} disabled={isLoading || isStreaming} />
         )}
-        {/* Context (Knowledge base) - available for all shell types (KB retrieval supported via MCP) */}
-        <ChatContextInput
-          selectedContexts={selectedContexts}
-          onContextsChange={setSelectedContexts}
-          excludeKnowledgeBaseId={knowledgeBaseId}
-        />
+        {/* Context (Knowledge base) - available for non-code shell types */}
+        {!isClaudeCode(selectedTeam) && (
+          <ChatContextInput
+            selectedContexts={selectedContexts}
+            onContextsChange={setSelectedContexts}
+            excludeKnowledgeBaseId={knowledgeBaseId}
+          />
+        )}
 
         {/* Skill Selector - show when skills are available */}
         {/* Skill selection is read-only after task creation (hasMessages) */}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -225,14 +225,12 @@ export function MobileChatInputControls({
         {supportsAttachments(selectedTeam) && (
           <AttachmentButton onFileSelect={onFileSelect} disabled={isLoading || isStreaming} />
         )}
-        {/* Context (Knowledge base) */}
-        {isChatShell(selectedTeam) && (
-          <ChatContextInput
-            selectedContexts={selectedContexts}
-            onContextsChange={setSelectedContexts}
-            excludeKnowledgeBaseId={knowledgeBaseId}
-          />
-        )}
+        {/* Context (Knowledge base) - available for all shell types (KB retrieval supported via MCP) */}
+        <ChatContextInput
+          selectedContexts={selectedContexts}
+          onContextsChange={setSelectedContexts}
+          excludeKnowledgeBaseId={knowledgeBaseId}
+        />
 
         {/* Skill Selector - show when skills are available */}
         {/* Skill selection is read-only after task creation (hasMessages) */}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -24,14 +24,16 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from '@/components/ui/dropdown'
-import type { Team, GitRepoInfo, GitBranch as GitBranchType, TaskDetail } from '@/types/api'
+import type { Team, GitRepoInfo, GitBranch as GitBranchType, TaskDetail, TaskType } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
-import { isChatShell, isClaudeCode, teamRequiresWorkspace } from '../../service/messageService'
+import { isChatShell, teamRequiresWorkspace } from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import SkillSelectorPopover from '../selector/SkillSelectorPopover'
 
 export interface MobileChatInputControlsProps {
+  // Task type
+  taskType?: TaskType
   // Team and Model
   selectedTeam: Team | null
   selectedModel: Model | null
@@ -103,6 +105,7 @@ export interface MobileChatInputControlsProps {
  * Optimized layout for mobile devices with dropdown menu
  */
 export function MobileChatInputControls({
+  taskType,
   selectedTeam,
   selectedModel,
   setSelectedModel,
@@ -225,8 +228,8 @@ export function MobileChatInputControls({
         {supportsAttachments(selectedTeam) && (
           <AttachmentButton onFileSelect={onFileSelect} disabled={isLoading || isStreaming} />
         )}
-        {/* Context (Knowledge base) - available for non-code shell types */}
-        {!isClaudeCode(selectedTeam) && (
+        {/* Context (Knowledge base) - hidden for code page (taskType === 'code') */}
+        {taskType !== 'code' && (
           <ChatContextInput
             selectedContexts={selectedContexts}
             onContextsChange={setSelectedContexts}


### PR DESCRIPTION
…se support

Add a new KB retrieval MCP server in Backend that exposes knowledge_base_search, kb_ls, and kb_head tools via streamable-http transport. Automatically inject this MCP server into ClaudeCode and Agno executor agents when knowledge bases are selected, along with kb_meta_prompt context injection. This bridges the gap between chat_shell's LangChain-based KB tools and executor's MCP-based tooling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added KB retrieval capabilities: search, document listing, and paginated content reading.
  - Exposed a dedicated KB-retrieval MCP endpoint with health checks and runtime mounting.
  - Injects KB-retrieval MCP configuration into local-mode executors so agents can access KBs.

* **Frontend**
  - Context input now hidden for code tasks (mobile and desktop paths updated).

* **Tests**
  - Added comprehensive unit tests for KB retrieval tools and MCP injection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->