### PR TITLE
fix(im-channel): use wegent-wework team for device/cloud mode

### DIFF
--- a/backend/app/services/channels/handler.py
+++ b/backend/app/services/channels/handler.py
@@ -729,6 +729,16 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
                         model_display_name = m.get("displayName") or override_model_name
                         break
 
+            # Clear conversation cache if switching mode or device
+            current_selection = await device_selection_manager.get_selection(user.id)
+            if (
+                current_selection.device_type != DeviceType.LOCAL
+                or current_selection.device_id != matched_device["device_id"]
+            ):
+                await self._delete_conversation_task_id(
+                    message_context.conversation_id, user.id
+                )
+
             await device_selection_manager.set_local_device(
                 user.id,
                 matched_device["device_id"],

--- a/backend/app/services/channels/handler.py
+++ b/backend/app/services/channels/handler.py
@@ -802,6 +802,21 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
 
         argument = argument.strip().lower()
 
+        # Check if mode is changing; if so, clear conversation cache
+        # so the next message creates a new task with the correct team
+        current_selection = await device_selection_manager.get_selection(user.id)
+        current_mode = current_selection.device_type
+        target_mode_map = {
+            "chat": DeviceType.CHAT,
+            "cloud": DeviceType.CLOUD,
+            "device": DeviceType.LOCAL,
+        }
+        target_mode = target_mode_map.get(argument)
+        if target_mode and target_mode != current_mode:
+            await self._delete_conversation_task_id(
+                message_context.conversation_id, user.id
+            )
+
         # Helper to get current model display name
         async def get_model_display() -> str:
             model_selection = await model_selection_manager.get_selection(user.id)

--- a/backend/app/services/channels/handler.py
+++ b/backend/app/services/channels/handler.py
@@ -23,6 +23,7 @@ from typing import Any, Callable, Dict, Generic, List, Optional, TypeVar
 from sqlalchemy.orm import Session
 
 from app.core.cache import cache_manager
+from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.kind import Kind
 from app.models.user import User
@@ -57,6 +58,7 @@ from app.services.channels.model_selection import (
     is_claude_provider,
     model_selection_manager,
 )
+from app.services.readers.kinds import KindType, kindReader
 
 logger = logging.getLogger(__name__)
 
@@ -384,6 +386,45 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
             self.logger.warning(
                 f"[{self._channel_type.value}Handler] Default team not found: id={team_id}"
             )
+
+        return team
+
+    def _get_task_mode_team(self, db: Session, user_id: int) -> Optional[Kind]:
+        """Get the default team for task mode (device/cloud execution).
+
+        Uses the DEFAULT_TEAM_TASK config (e.g. "wegent-wework#default") to look up
+        the team by name and namespace, matching the behavior of the PC/Web frontend.
+        Falls back to the channel's default_team_id if not configured.
+
+        Args:
+            db: Database session
+            user_id: User ID
+
+        Returns:
+            Team Kind object or None
+        """
+        config_value = settings.DEFAULT_TEAM_TASK
+        if not config_value or not config_value.strip():
+            return self._get_default_team(db, user_id)
+
+        parts = config_value.strip().split("#", 1)
+        name = parts[0].strip()
+        namespace = parts[1].strip() if len(parts) > 1 else "default"
+
+        if not name:
+            return self._get_default_team(db, user_id)
+
+        team = kindReader.get_by_name_and_namespace(
+            db, user_id, KindType.TEAM, namespace, name
+        )
+
+        if not team:
+            self.logger.warning(
+                f"[{self._channel_type.value}Handler] Task mode team not found: "
+                f"name={name}, namespace={namespace}, user_id={user_id}. "
+                f"Falling back to channel default team."
+            )
+            return self._get_default_team(db, user_id)
 
         return team
 
@@ -1284,7 +1325,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         # Use short-lived db session for database operations
         db = SessionLocal()
         try:
-            team = self._get_default_team(db, user.id)
+            team = self._get_task_mode_team(db, user.id)
             if not team:
                 await self.send_text_reply(
                     message_context, "配置错误: 未配置默认智能体"
@@ -1313,7 +1354,7 @@ class BaseChannelHandler(ABC, Generic[TMessage, TCallbackInfo]):
         # Use short-lived db session for database operations
         db = SessionLocal()
         try:
-            team = self._get_default_team(db, user.id)
+            team = self._get_task_mode_team(db, user.id)
             if not team:
                 await self.send_text_reply(
                     message_context, "配置错误: 未配置默认智能体"


### PR DESCRIPTION
## Summary
- IM channels (DingTalk etc.) were using the channel's single `default_team_id` (`wegent-chat`) for all modes (chat/device/cloud)
- Device and cloud modes now resolve the team from `DEFAULT_TEAM_TASK` config (`wegent-wework`), matching the PC/Web frontend behavior
- Chat mode remains unchanged, still using the channel's configured default team
- Switching execution mode (`/use chat/device/cloud`) or device (`/devices <id>`) now auto-starts a new conversation, preventing the old task (with wrong team) from being reused

## Test plan
- [x] Verified task 510 (DingTalk `/use device`) → `wegent-wework`
- [x] Verified task 512 (DingTalk `/use chat`) → `wegent-chat`
- [x] Verified task 508 (PC device mode) → `wegent-wework` (unchanged)
- [x] 106 channel tests passed