### PR TITLE
ci: add Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Add Python 3.12 to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended backend test matrix to verify compatibility with Python 3.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->