### PR TITLE
fix(executor): merge user-selected skills into bot_config for download

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -199,6 +199,15 @@ class TaskRequestBuilder:
             force_override=force_override,
         )
 
+        # Merge user-selected skills into bot_config so Executor downloads them
+        if bot_config and resolved_skills:
+            all_skill_names = [s["name"] for s in resolved_skills]
+            existing_skills = set(bot_config[0].get("skills", []))
+            for name in all_skill_names:
+                if name not in existing_skills:
+                    bot_config[0].setdefault("skills", []).append(name)
+                    existing_skills.add(name)
+
         # Build MCP servers configuration
         mcp_servers = self._build_mcp_servers(bot, team)
 


### PR DESCRIPTION
bot_config["skills"] only contained Ghost-level skills, causing the Executor's download_and_deploy_skills() to skip user-selected personal skills. Merge all resolved skills into bot_config before constructing the ExecutionRequest so the Executor downloads them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-selected skills are now properly integrated into bot configurations during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->