### PR TITLE
fix(backend,frontend): fix personal tasks pagination missing history records

### DIFF
--- a/backend/app/services/adapters/task_kinds/queries.py
+++ b/backend/app/services/adapters/task_kinds/queries.py
@@ -370,7 +370,7 @@ class TaskQueryMixin:
         """
         )
         task_id_rows = db.execute(
-            ids_sql, {"user_id": user_id, "limit": limit + 100, "skip": skip}
+            ids_sql, {"user_id": user_id, "limit": limit + 200, "skip": skip}
         ).fetchall()
         task_ids = [row[0] for row in task_id_rows]
 

--- a/frontend/src/features/tasks/contexts/taskContext.tsx
+++ b/frontend/src/features/tasks/contexts/taskContext.tsx
@@ -174,7 +174,7 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
       const lastPageItems = results[results.length - 1]?.items || []
       return {
         items: allItems,
-        hasMore: lastPageItems.length === limit,
+        hasMore: lastPageItems.length > 0,
         pages: pagesArr,
         error: false,
       }


### PR DESCRIPTION
- Backend: increase SQL fetch buffer from limit+100 to limit+200 to account for subscription/group/DELETE tasks filtered in Python layer
- Frontend: change personal tasks hasMore from exact equality check (items.length === limit) to presence check (items.length > 0) so users can always load more even when Python filtering reduces the returned count below the page limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced task loading efficiency by expanding the candidate task pool queried from the database.
  * Refined pagination logic for personal tasks to better determine when additional pages are available, improving the task loading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->