### PR TITLE
Feat/skill mcp in claude code

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -11,6 +11,7 @@ providing complete Bot, Model, Ghost, Shell, and Skill resolution.
 """
 
 import logging
+import urllib.request
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel
@@ -207,6 +208,14 @@ class TaskRequestBuilder:
                 if name not in existing_skills:
                     bot_config[0].setdefault("skills", []).append(name)
                     existing_skills.add(name)
+
+        # For ClaudeCode executor: merge skill MCP, normalize types, filter unreachable
+        if bot_config:
+            shell_type = bot_config[0].get("shell_type", "")
+            if shell_type == "ClaudeCode":
+                self._prepare_mcp_for_claude_code(
+                    bot_config[0], resolved_skills
+                )
 
         # Build MCP servers configuration
         mcp_servers = self._build_mcp_servers(bot, team)
@@ -1283,6 +1292,186 @@ class TaskRequestBuilder:
             )
 
         return merged_servers
+
+    # =========================================================================
+    # Claude Code MCP Processing
+    # =========================================================================
+
+    def _prepare_mcp_for_claude_code(
+        self, bot_config: dict, skill_configs: list
+    ) -> None:
+        """Prepare MCP servers for Claude Code executor.
+
+        For ClaudeCode shell type, this method:
+        1. Extracts skill MCP servers and merges into bot mcp_servers
+        2. Normalizes types (streamable-http -> http) for Claude Code SDK
+        3. Filters out unreachable servers to prevent SDK initialization timeout
+
+        Modifies bot_config in-place.
+
+        Args:
+            bot_config: Single bot configuration dict (modified in-place)
+            skill_configs: List of resolved skill config dicts
+        """
+        # Step 1: Extract skill MCP servers and merge
+        skill_mcp = self._extract_skill_mcp_to_list(skill_configs)
+        if skill_mcp:
+            bot_config.setdefault("mcp_servers", []).extend(skill_mcp)
+            logger.info(
+                "[MCP-CLAUDE] Merged %d skill MCP server(s): %s",
+                len(skill_mcp),
+                [s.get("name", "?") for s in skill_mcp],
+            )
+
+        mcp_list = bot_config.get("mcp_servers", [])
+        if not mcp_list:
+            return
+
+        # Step 2: Normalize types (streamable-http -> http)
+        self._normalize_mcp_types_for_claude_code(mcp_list)
+
+        # Step 3: Filter out unreachable servers
+        bot_config["mcp_servers"] = self._filter_reachable_mcp_servers(mcp_list)
+        if not bot_config["mcp_servers"]:
+            logger.warning("[MCP-CLAUDE] All MCP servers unreachable, removed")
+
+    @staticmethod
+    def _extract_skill_mcp_to_list(skill_configs: list) -> list:
+        """Extract MCP servers from skill configs in list format.
+
+        Each skill may declare mcpServers in dict format. This converts them
+        to list format with prefixed names to avoid cross-skill conflicts.
+
+        Args:
+            skill_configs: List of resolved skill config dicts
+
+        Returns:
+            List of MCP server dicts in list format:
+            [{"name": "skillName_serverName", "type": "...", "url": "...", ...}]
+        """
+        if not skill_configs:
+            return []
+
+        result: list[dict] = []
+        for skill_config in skill_configs:
+            skill_name = skill_config.get("name", "unknown")
+            mcp_servers = skill_config.get("mcpServers")
+            if not mcp_servers or not isinstance(mcp_servers, dict):
+                continue
+
+            for server_name, server_config in mcp_servers.items():
+                if not isinstance(server_config, dict):
+                    continue
+                entry = {
+                    "name": f"{skill_name}_{server_name}",
+                    **server_config,
+                }
+                result.append(entry)
+                logger.info(
+                    "[SKILL-MCP] Extracted: %s -> type=%s, url=%s",
+                    entry["name"],
+                    server_config.get("type", "?"),
+                    server_config.get("url", "?"),
+                )
+
+        return result
+
+    @staticmethod
+    def _normalize_mcp_types_for_claude_code(mcp_servers: list) -> None:
+        """Normalize MCP server types for Claude Code SDK compatibility.
+
+        Claude Code SDK supports "http" but skill/ghost configs use
+        "streamable-http". Converts in-place.
+
+        Args:
+            mcp_servers: List of MCP server config dicts (modified in-place)
+        """
+        TYPE_MAPPING = {"streamable-http": "http"}
+
+        for server in mcp_servers:
+            if not isinstance(server, dict):
+                continue
+            original_type = server.get("type", "")
+            mapped = TYPE_MAPPING.get(original_type)
+            if mapped:
+                server["type"] = mapped
+                logger.info(
+                    "[MCP-NORMALIZE] '%s': type '%s' -> '%s'",
+                    server.get("name", "?"),
+                    original_type,
+                    mapped,
+                )
+
+    @staticmethod
+    def _check_mcp_server_reachable(server: dict) -> bool:
+        """Check if an MCP server URL is reachable with a short timeout.
+
+        Sends a HEAD request. Any HTTP response (including 4xx/5xx) means
+        the server is reachable. Only connection failures are treated as
+        unreachable.
+
+        Args:
+            server: Server config dict with 'url' and optional 'headers'
+
+        Returns:
+            True if server responded, False on connection failure
+        """
+        url = server.get("url", "")
+        if not url:
+            return False
+
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            # Add headers, skipping unresolved placeholders
+            headers = server.get("headers", server.get("auth", {}))
+            if isinstance(headers, dict):
+                for k, v in headers.items():
+                    if isinstance(v, str) and not v.startswith("${{"):
+                        req.add_header(k, v)
+            urllib.request.urlopen(req, timeout=5)
+            return True
+        except urllib.error.HTTPError:
+            # Any HTTP response means the server is reachable
+            return True
+        except Exception:
+            return False
+
+    def _filter_reachable_mcp_servers(self, mcp_servers: list) -> list:
+        """Filter out unreachable MCP servers.
+
+        Args:
+            mcp_servers: List of MCP server config dicts
+
+        Returns:
+            List containing only reachable MCP servers
+        """
+        if not mcp_servers:
+            return mcp_servers
+
+        reachable = []
+        unreachable_names: list[str] = []
+
+        for server in mcp_servers:
+            name = server.get("name", "?")
+            if self._check_mcp_server_reachable(server):
+                reachable.append(server)
+                logger.info("[MCP-CHECK] '%s' is reachable", name)
+            else:
+                unreachable_names.append(name)
+                logger.warning(
+                    "[MCP-CHECK] '%s' is NOT reachable: %s",
+                    name,
+                    server.get("url", "?"),
+                )
+
+        if unreachable_names:
+            logger.warning(
+                "[MCP-FILTER] Removed %d unreachable server(s): %s",
+                len(unreachable_names),
+                unreachable_names,
+            )
+
+        return reachable
 
     # =========================================================================
     # Helper Methods

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for Claude Code MCP processing in TaskRequestBuilder.
+
+Verifies that skill MCP extraction, type normalization, and reachability
+filtering work correctly when preparing MCP servers for Claude Code executor.
+"""
+
+from unittest.mock import patch
+
+from app.services.execution.request_builder import TaskRequestBuilder
+
+
+class TestExtractSkillMcpToList:
+    """Tests for _extract_skill_mcp_to_list static method."""
+
+    def test_empty_skill_configs(self):
+        result = TaskRequestBuilder._extract_skill_mcp_to_list([])
+        assert result == []
+
+    def test_skill_without_mcp_servers(self):
+        configs = [{"name": "code-review", "description": "Reviews code"}]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+        assert result == []
+
+    def test_single_skill_single_mcp(self):
+        configs = [
+            {
+                "name": "image-toolkit",
+                "mcpServers": {
+                    "imageFetchServer": {
+                        "type": "streamable-http",
+                        "url": "http://mcp.example.com/fetch-image",
+                        "headers": {"Authorization": "Bearer token123"},
+                    }
+                },
+            }
+        ]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "image-toolkit_imageFetchServer"
+        assert result[0]["type"] == "streamable-http"
+        assert result[0]["url"] == "http://mcp.example.com/fetch-image"
+        assert result[0]["headers"]["Authorization"] == "Bearer token123"
+
+    def test_single_skill_multiple_mcps(self):
+        configs = [
+            {
+                "name": "image-toolkit",
+                "mcpServers": {
+                    "imageFetchServer": {
+                        "type": "streamable-http",
+                        "url": "http://mcp.example.com/fetch-image",
+                    },
+                    "nanoBananaServer": {
+                        "type": "streamable-http",
+                        "url": "http://mcp.example.com/nano-banana",
+                    },
+                },
+            }
+        ]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+
+        assert len(result) == 2
+        names = [s["name"] for s in result]
+        assert "image-toolkit_imageFetchServer" in names
+        assert "image-toolkit_nanoBananaServer" in names
+
+    def test_multiple_skills_with_mcps(self):
+        configs = [
+            {
+                "name": "image-toolkit",
+                "mcpServers": {
+                    "imageServer": {
+                        "type": "streamable-http",
+                        "url": "http://mcp.example.com/image",
+                    },
+                },
+            },
+            {
+                "name": "knowledge-base",
+                "mcpServers": {
+                    "kbServer": {
+                        "type": "streamable-http",
+                        "url": "http://mcp.example.com/kb",
+                    },
+                },
+            },
+        ]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+
+        assert len(result) == 2
+        names = [s["name"] for s in result]
+        assert "image-toolkit_imageServer" in names
+        assert "knowledge-base_kbServer" in names
+
+    def test_mixed_skills_with_and_without_mcp(self):
+        configs = [
+            {"name": "no-mcp-skill", "description": "No MCP"},
+            {
+                "name": "with-mcp",
+                "mcpServers": {
+                    "server1": {
+                        "type": "streamable-http",
+                        "url": "http://example.com",
+                    },
+                },
+            },
+        ]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "with-mcp_server1"
+
+    def test_invalid_mcp_servers_type_skipped(self):
+        configs = [{"name": "bad-skill", "mcpServers": "not-a-dict"}]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+        assert result == []
+
+    def test_non_dict_server_config_skipped(self):
+        configs = [
+            {
+                "name": "bad-skill",
+                "mcpServers": {"server1": "not-a-dict"},
+            }
+        ]
+        result = TaskRequestBuilder._extract_skill_mcp_to_list(configs)
+        assert result == []
+
+
+class TestNormalizeMcpTypesForClaudeCode:
+    """Tests for _normalize_mcp_types_for_claude_code static method."""
+
+    def test_empty_list(self):
+        servers = []
+        TaskRequestBuilder._normalize_mcp_types_for_claude_code(servers)
+        assert servers == []
+
+    def test_streamable_http_converted_to_http(self):
+        servers = [
+            {"name": "s1", "type": "streamable-http", "url": "http://example.com"}
+        ]
+        TaskRequestBuilder._normalize_mcp_types_for_claude_code(servers)
+        assert servers[0]["type"] == "http"
+
+    def test_http_type_unchanged(self):
+        servers = [{"name": "s1", "type": "http", "url": "http://example.com"}]
+        TaskRequestBuilder._normalize_mcp_types_for_claude_code(servers)
+        assert servers[0]["type"] == "http"
+
+    def test_mixed_types_normalized(self):
+        servers = [
+            {"name": "s1", "type": "streamable-http", "url": "http://a.com"},
+            {"name": "s2", "type": "http", "url": "http://b.com"},
+            {"name": "s3", "type": "sse", "url": "http://c.com"},
+        ]
+        TaskRequestBuilder._normalize_mcp_types_for_claude_code(servers)
+        assert servers[0]["type"] == "http"
+        assert servers[1]["type"] == "http"
+        assert servers[2]["type"] == "sse"
+
+    def test_non_dict_item_skipped(self):
+        servers = [
+            {"name": "s1", "type": "streamable-http", "url": "http://a.com"},
+            "not-a-dict",
+        ]
+        TaskRequestBuilder._normalize_mcp_types_for_claude_code(servers)
+        assert servers[0]["type"] == "http"
+        assert servers[1] == "not-a-dict"
+
+
+class TestCheckMcpServerReachable:
+    """Tests for _check_mcp_server_reachable static method."""
+
+    def test_no_url_returns_false(self):
+        assert TaskRequestBuilder._check_mcp_server_reachable({}) is False
+
+    def test_empty_url_returns_false(self):
+        assert TaskRequestBuilder._check_mcp_server_reachable({"url": ""}) is False
+
+    @patch("app.services.execution.request_builder.urllib.request.urlopen")
+    def test_successful_response_returns_true(self, mock_urlopen):
+        server = {"url": "http://mcp.example.com/server", "type": "http"}
+        result = TaskRequestBuilder._check_mcp_server_reachable(server)
+        assert result is True
+
+    @patch(
+        "app.services.execution.request_builder.urllib.request.urlopen",
+        side_effect=Exception("Connection refused"),
+    )
+    def test_connection_error_returns_false(self, mock_urlopen):
+        server = {"url": "http://192.0.2.1:9999/unreachable", "type": "http"}
+        result = TaskRequestBuilder._check_mcp_server_reachable(server)
+        assert result is False
+
+    def test_skips_placeholder_headers(self):
+        """Headers with ${{...}} placeholders should not be sent."""
+        import urllib.request
+
+        server = {
+            "url": "http://mcp.example.com/server",
+            "headers": {
+                "mcp-proxy-wegent-user": "${{user.name}}",
+                "X-Static": "fixed-value",
+            },
+        }
+        with patch(
+            "app.services.execution.request_builder.urllib.request.urlopen"
+        ) as mock_urlopen:
+            TaskRequestBuilder._check_mcp_server_reachable(server)
+            # Verify the request was made
+            assert mock_urlopen.called
+            req = mock_urlopen.call_args[0][0]
+            # Static header should be present, placeholder should not
+            assert req.get_header("X-static") == "fixed-value"
+            assert req.get_header("Mcp-proxy-wegent-user") is None
+
+
+class TestFilterReachableMcpServers:
+    """Tests for _filter_reachable_mcp_servers."""
+
+    def test_empty_list_returns_empty(self):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        assert builder._filter_reachable_mcp_servers([]) == []
+
+    @patch.object(
+        TaskRequestBuilder,
+        "_check_mcp_server_reachable",
+        side_effect=lambda s: s.get("name") != "bad-server",
+    )
+    def test_filters_unreachable(self, mock_check):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        servers = [
+            {"name": "good-server", "type": "http", "url": "http://good.example.com"},
+            {"name": "bad-server", "type": "http", "url": "http://bad.example.com"},
+        ]
+        result = builder._filter_reachable_mcp_servers(servers)
+
+        assert len(result) == 1
+        assert result[0]["name"] == "good-server"
+
+
+class TestPrepareMcpForClaudeCode:
+    """Integration tests for _prepare_mcp_for_claude_code."""
+
+    @patch.object(
+        TaskRequestBuilder,
+        "_check_mcp_server_reachable",
+        return_value=True,
+    )
+    def test_skill_mcp_merged_and_normalized(self, mock_check):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        bot_config = {
+            "shell_type": "ClaudeCode",
+            "mcp_servers": [
+                {
+                    "name": "ghost-server",
+                    "type": "streamable-http",
+                    "url": "http://ghost.example.com/mcp",
+                },
+            ],
+        }
+        skill_configs = [
+            {
+                "name": "my-skill",
+                "mcpServers": {
+                    "skillServer": {
+                        "type": "streamable-http",
+                        "url": "http://skill.example.com/mcp",
+                    },
+                },
+            }
+        ]
+
+        builder._prepare_mcp_for_claude_code(bot_config, skill_configs)
+
+        mcp = bot_config["mcp_servers"]
+        assert len(mcp) == 2
+        names = [s["name"] for s in mcp]
+        assert "ghost-server" in names
+        assert "my-skill_skillServer" in names
+        # All types should be normalized to http
+        for s in mcp:
+            assert s["type"] == "http"
+
+    @patch.object(
+        TaskRequestBuilder,
+        "_check_mcp_server_reachable",
+        return_value=True,
+    )
+    def test_skill_mcp_only_no_ghost(self, mock_check):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        bot_config = {"shell_type": "ClaudeCode", "mcp_servers": []}
+        skill_configs = [
+            {
+                "name": "my-skill",
+                "mcpServers": {
+                    "server1": {
+                        "type": "streamable-http",
+                        "url": "http://example.com/mcp",
+                    },
+                },
+            }
+        ]
+
+        builder._prepare_mcp_for_claude_code(bot_config, skill_configs)
+
+        assert len(bot_config["mcp_servers"]) == 1
+        assert bot_config["mcp_servers"][0]["name"] == "my-skill_server1"
+        assert bot_config["mcp_servers"][0]["type"] == "http"
+
+    @patch.object(
+        TaskRequestBuilder,
+        "_check_mcp_server_reachable",
+        return_value=False,
+    )
+    def test_unreachable_servers_removed(self, mock_check):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        bot_config = {
+            "shell_type": "ClaudeCode",
+            "mcp_servers": [
+                {
+                    "name": "unreachable",
+                    "type": "http",
+                    "url": "http://192.0.2.1:9999/mcp",
+                },
+            ],
+        }
+
+        builder._prepare_mcp_for_claude_code(bot_config, [])
+
+        assert bot_config["mcp_servers"] == []
+
+    @patch.object(
+        TaskRequestBuilder,
+        "_check_mcp_server_reachable",
+        return_value=True,
+    )
+    def test_no_skill_configs_preserves_ghost(self, mock_check):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        bot_config = {
+            "shell_type": "ClaudeCode",
+            "mcp_servers": [
+                {
+                    "name": "ghost-server",
+                    "type": "http",
+                    "url": "http://ghost.example.com/mcp",
+                },
+            ],
+        }
+
+        builder._prepare_mcp_for_claude_code(bot_config, [])
+
+        assert len(bot_config["mcp_servers"]) == 1
+        assert bot_config["mcp_servers"][0]["name"] == "ghost-server"

--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -837,6 +837,37 @@ class ClaudeCodeAgent(Agent):
 
         # Create client with options
         if self.options:
+            # Log MCP servers being passed to SDK
+            mcp_in_opts = self.options.get("mcp_servers") or self.options.get(
+                "mcpServers"
+            )
+            if mcp_in_opts:
+                if isinstance(mcp_in_opts, dict):
+                    logger.info(
+                        "[SDK-INIT] Passing %d MCP server(s) to Claude SDK: %s",
+                        len(mcp_in_opts),
+                        list(mcp_in_opts.keys()),
+                    )
+                    for sname, scfg in mcp_in_opts.items():
+                        logger.info(
+                            "[SDK-INIT]   %s -> type=%s, url=%s",
+                            sname,
+                            scfg.get("type", "?") if isinstance(scfg, dict) else "?",
+                            scfg.get("url", "?") if isinstance(scfg, dict) else "?",
+                        )
+                elif isinstance(mcp_in_opts, str):
+                    logger.info(
+                        "[SDK-INIT] MCP servers via config file: %s", mcp_in_opts
+                    )
+                else:
+                    logger.info(
+                        "[SDK-INIT] MCP servers (type=%s): %s",
+                        type(mcp_in_opts).__name__,
+                        mcp_in_opts,
+                    )
+            else:
+                logger.info("[SDK-INIT] No MCP servers in options")
+
             code_options = ClaudeAgentOptions(**self.options)
             self.client = ClaudeSDKClient(options=code_options)
         else:

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -342,6 +342,43 @@ def _filter_reachable_mcp_servers(
     return reachable
 
 
+def _normalize_mcp_server_types(mcp_servers: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize MCP server types for Claude Code SDK compatibility.
+
+    Claude Code SDK only supports "http" type, but skill configurations
+    may use "streamable-http". This function converts unsupported types.
+
+    Args:
+        mcp_servers: Dict of MCP server configs
+
+    Returns:
+        Dict with normalized server types
+    """
+    if not mcp_servers:
+        return mcp_servers
+
+    # Claude Code SDK supported types
+    TYPE_MAPPING = {
+        "streamable-http": "http",
+    }
+
+    for name, config in mcp_servers.items():
+        if not isinstance(config, dict):
+            continue
+        original_type = config.get("type", "")
+        mapped_type = TYPE_MAPPING.get(original_type)
+        if mapped_type:
+            config["type"] = mapped_type
+            logger.info(
+                "[MCP-NORMALIZE] Server '%s': type '%s' -> '%s'",
+                name,
+                original_type,
+                mapped_type,
+            )
+
+    return mcp_servers
+
+
 def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
     """Extract and merge MCP servers from skill_configs.
 
@@ -354,7 +391,7 @@ def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
 
     Returns:
         Dict of MCP server configs in Claude Code SDK format, e.g.
-        {"skillName_serverName": {"type": "streamable-http", "url": "..."}}
+        {"skillName_serverName": {"type": "http", "url": "..."}}
     """
     from shared.utils.mcp_utils import replace_mcp_server_variables
 
@@ -531,6 +568,12 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
             logger.info(
                 f"Added wegent MCP server (HTTP) for subscription task at {wegent_mcp_url}"
             )
+
+        # Normalize MCP server types for Claude Code SDK compatibility
+        # (e.g., "streamable-http" -> "http")
+        final_mcp = bot_config.get("mcp_servers")
+        if isinstance(final_mcp, dict) and final_mcp:
+            bot_config["mcp_servers"] = _normalize_mcp_server_types(final_mcp)
 
         # Filter out unreachable MCP servers to prevent SDK initialization timeout
         final_mcp = bot_config.get("mcp_servers")

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -14,9 +14,8 @@ import json
 import os
 import random
 import string
-import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 from executor.config.config import get_wegent_mcp_url
 from shared.logger import setup_logger
@@ -274,192 +273,14 @@ def _convert_mcp_servers_list_to_dict(mcp_servers: Any) -> Dict[str, Any]:
     return {}
 
 
-def _check_mcp_server_reachable(name: str, server_config: Dict[str, Any]) -> bool:
-    """Check if an MCP server URL is reachable with a short timeout.
-
-    Args:
-        name: Server name for logging
-        server_config: Server configuration dict containing 'url'
-
-    Returns:
-        True if the server responded (any HTTP status), False on connection failure
-    """
-    url = server_config.get("url", "")
-    if not url:
-        logger.warning("[MCP-CHECK] Server '%s' has no URL configured, skipping", name)
-        return False
-
-    try:
-        req = urllib.request.Request(url, method="HEAD")
-        # Add auth headers if present so the server doesn't reject immediately
-        headers = server_config.get("headers", {})
-        for k, v in headers.items():
-            req.add_header(k, v)
-        urllib.request.urlopen(req, timeout=5)
-        logger.info("[MCP-CHECK] Server '%s' is reachable: %s", name, url)
-        return True
-    except urllib.error.HTTPError:
-        # Any HTTP response (4xx, 5xx) means the server is reachable
-        logger.info("[MCP-CHECK] Server '%s' is reachable (HTTP error): %s", name, url)
-        return True
-    except Exception as e:
-        logger.warning(
-            "[MCP-CHECK] Server '%s' is NOT reachable: %s (error: %s)", name, url, e
-        )
-        return False
-
-
-def _filter_reachable_mcp_servers(
-    mcp_servers: Dict[str, Any],
-) -> Dict[str, Any]:
-    """Filter out unreachable MCP servers to prevent SDK initialization timeout.
-
-    Args:
-        mcp_servers: Dict of MCP server configs
-
-    Returns:
-        Dict containing only reachable MCP servers
-    """
-    if not mcp_servers:
-        return mcp_servers
-
-    reachable = {}
-    unreachable_names: List[str] = []
-
-    for name, config in mcp_servers.items():
-        if _check_mcp_server_reachable(name, config):
-            reachable[name] = config
-        else:
-            unreachable_names.append(name)
-
-    if unreachable_names:
-        logger.warning(
-            "[MCP-FILTER] Removed %d unreachable MCP server(s): %s",
-            len(unreachable_names),
-            unreachable_names,
-        )
-
-    return reachable
-
-
-def _normalize_mcp_server_types(mcp_servers: Dict[str, Any]) -> Dict[str, Any]:
-    """Normalize MCP server types for Claude Code SDK compatibility.
-
-    Claude Code SDK only supports "http" type, but skill configurations
-    may use "streamable-http". This function converts unsupported types.
-
-    Args:
-        mcp_servers: Dict of MCP server configs
-
-    Returns:
-        Dict with normalized server types
-    """
-    if not mcp_servers:
-        return mcp_servers
-
-    # Claude Code SDK supported types
-    TYPE_MAPPING = {
-        "streamable-http": "http",
-    }
-
-    for name, config in mcp_servers.items():
-        if not isinstance(config, dict):
-            continue
-        original_type = config.get("type", "")
-        mapped_type = TYPE_MAPPING.get(original_type)
-        if mapped_type:
-            config["type"] = mapped_type
-            logger.info(
-                "[MCP-NORMALIZE] Server '%s': type '%s' -> '%s'",
-                name,
-                original_type,
-                mapped_type,
-            )
-
-    return mcp_servers
-
-
-def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
-    """Extract and merge MCP servers from skill_configs.
-
-    Each skill may declare mcpServers in its configuration. This function
-    collects them all, applies variable substitution, and returns a merged
-    dict keyed by prefixed server names (to avoid cross-skill conflicts).
-
-    Args:
-        task_data: The task data object containing skill_configs
-
-    Returns:
-        Dict of MCP server configs in Claude Code SDK format, e.g.
-        {"skillName_serverName": {"type": "http", "url": "..."}}
-    """
-    from shared.utils.mcp_utils import replace_mcp_server_variables
-
-    skill_configs = task_data.skill_configs
-    if not skill_configs:
-        logger.debug("[SKILL-MCP] No skill_configs present")
-        return {}
-
-    logger.info(
-        "[SKILL-MCP] Processing %d skill config(s): %s",
-        len(skill_configs),
-        [s.get("name", "?") for s in skill_configs],
-    )
-
-    merged: Dict[str, Any] = {}
-    for skill_config in skill_configs:
-        skill_name = skill_config.get("name", "unknown")
-        mcp_servers = skill_config.get("mcpServers")
-        if not mcp_servers or not isinstance(mcp_servers, dict):
-            logger.debug("[SKILL-MCP] Skill '%s' has no mcpServers", skill_name)
-            continue
-
-        logger.info(
-            "[SKILL-MCP] Skill '%s' raw mcpServers: %s",
-            skill_name,
-            json.dumps(
-                {
-                    k: {**v, "headers": "***"} if "headers" in v else v
-                    for k, v in mcp_servers.items()
-                },
-                ensure_ascii=False,
-            ),
-        )
-
-        # Replace ${{...}} placeholders with actual values from task_data
-        mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
-
-        # Prefix server names with skill name to avoid cross-skill conflicts
-        for server_name, server_config in mcp_servers.items():
-            prefixed_name = f"{skill_name}_{server_name}"
-            merged[prefixed_name] = server_config
-            logger.info(
-                "[SKILL-MCP] Registered: %s -> type=%s, url=%s",
-                prefixed_name,
-                server_config.get("type", "?"),
-                server_config.get("url", "?"),
-            )
-
-    if merged:
-        logger.info(
-            "[SKILL-MCP] Total skill MCP servers collected: %d",
-            len(merged),
-        )
-    else:
-        logger.info(
-            "[SKILL-MCP] No skill MCP servers found in %d skill(s)", len(skill_configs)
-        )
-
-    return merged
-
 
 
 def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     """Extract Claude Code options from task data.
 
     Collects all non-None configuration parameters from task_data,
-    including Ghost-level MCP servers and Skill-level MCP servers.
-    Unreachable MCP servers are filtered out to prevent initialization timeout.
+    including Ghost-level MCP servers. Skill-level MCP merging, type
+    normalization, and reachability filtering are handled by the backend.
 
     Args:
         task_data: The task data object
@@ -532,19 +353,6 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
         else:
             logger.info("[MCP] No Ghost-level MCP servers configured")
 
-        # Extract Skill-level MCP servers and merge into bot_config
-        skill_mcp_servers = _extract_skill_mcp_servers(task_data)
-        if skill_mcp_servers:
-            existing = bot_config.get("mcp_servers")
-            if isinstance(existing, dict):
-                existing.update(skill_mcp_servers)
-            else:
-                bot_config["mcp_servers"] = skill_mcp_servers
-            logger.info(
-                "[MCP] After merging skill MCP: %s",
-                list(bot_config["mcp_servers"].keys()),
-            )
-
         # Add wegent MCP server for subscription tasks
         if task_data.is_subscription:
             wegent_mcp_url = get_wegent_mcp_url()
@@ -568,31 +376,6 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
             logger.info(
                 f"Added wegent MCP server (HTTP) for subscription task at {wegent_mcp_url}"
             )
-
-        # Normalize MCP server types for Claude Code SDK compatibility
-        # (e.g., "streamable-http" -> "http")
-        final_mcp = bot_config.get("mcp_servers")
-        if isinstance(final_mcp, dict) and final_mcp:
-            bot_config["mcp_servers"] = _normalize_mcp_server_types(final_mcp)
-
-        # Filter out unreachable MCP servers to prevent SDK initialization timeout
-        final_mcp = bot_config.get("mcp_servers")
-        if isinstance(final_mcp, dict) and final_mcp:
-            logger.info(
-                "[MCP] Pre-filter: %d MCP server(s): %s",
-                len(final_mcp),
-                list(final_mcp.keys()),
-            )
-            bot_config["mcp_servers"] = _filter_reachable_mcp_servers(final_mcp)
-            logger.info(
-                "[MCP] Post-filter: %d MCP server(s): %s",
-                len(bot_config["mcp_servers"]),
-                list(bot_config["mcp_servers"].keys()),
-            )
-            # Remove empty mcp_servers to avoid passing {} to SDK
-            if not bot_config["mcp_servers"]:
-                del bot_config["mcp_servers"]
-                logger.info("[MCP] All MCP servers unreachable, removed from options")
 
         for key in valid_options:
             if key in bot_config and bot_config[key] is not None:

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -14,8 +14,9 @@ import json
 import os
 import random
 import string
+import urllib.request
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from executor.config.config import get_wegent_mcp_url
 from shared.logger import setup_logger
@@ -273,6 +274,74 @@ def _convert_mcp_servers_list_to_dict(mcp_servers: Any) -> Dict[str, Any]:
     return {}
 
 
+def _check_mcp_server_reachable(name: str, server_config: Dict[str, Any]) -> bool:
+    """Check if an MCP server URL is reachable with a short timeout.
+
+    Args:
+        name: Server name for logging
+        server_config: Server configuration dict containing 'url'
+
+    Returns:
+        True if the server responded (any HTTP status), False on connection failure
+    """
+    url = server_config.get("url", "")
+    if not url:
+        logger.warning("[MCP-CHECK] Server '%s' has no URL configured, skipping", name)
+        return False
+
+    try:
+        req = urllib.request.Request(url, method="HEAD")
+        # Add auth headers if present so the server doesn't reject immediately
+        headers = server_config.get("headers", {})
+        for k, v in headers.items():
+            req.add_header(k, v)
+        urllib.request.urlopen(req, timeout=5)
+        logger.info("[MCP-CHECK] Server '%s' is reachable: %s", name, url)
+        return True
+    except urllib.error.HTTPError:
+        # Any HTTP response (4xx, 5xx) means the server is reachable
+        logger.info("[MCP-CHECK] Server '%s' is reachable (HTTP error): %s", name, url)
+        return True
+    except Exception as e:
+        logger.warning(
+            "[MCP-CHECK] Server '%s' is NOT reachable: %s (error: %s)", name, url, e
+        )
+        return False
+
+
+def _filter_reachable_mcp_servers(
+    mcp_servers: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Filter out unreachable MCP servers to prevent SDK initialization timeout.
+
+    Args:
+        mcp_servers: Dict of MCP server configs
+
+    Returns:
+        Dict containing only reachable MCP servers
+    """
+    if not mcp_servers:
+        return mcp_servers
+
+    reachable = {}
+    unreachable_names: List[str] = []
+
+    for name, config in mcp_servers.items():
+        if _check_mcp_server_reachable(name, config):
+            reachable[name] = config
+        else:
+            unreachable_names.append(name)
+
+    if unreachable_names:
+        logger.warning(
+            "[MCP-FILTER] Removed %d unreachable MCP server(s): %s",
+            len(unreachable_names),
+            unreachable_names,
+        )
+
+    return reachable
+
+
 def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
     """Extract and merge MCP servers from skill_configs.
 
@@ -291,14 +360,34 @@ def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
 
     skill_configs = task_data.skill_configs
     if not skill_configs:
+        logger.debug("[SKILL-MCP] No skill_configs present")
         return {}
+
+    logger.info(
+        "[SKILL-MCP] Processing %d skill config(s): %s",
+        len(skill_configs),
+        [s.get("name", "?") for s in skill_configs],
+    )
 
     merged: Dict[str, Any] = {}
     for skill_config in skill_configs:
         skill_name = skill_config.get("name", "unknown")
         mcp_servers = skill_config.get("mcpServers")
         if not mcp_servers or not isinstance(mcp_servers, dict):
+            logger.debug("[SKILL-MCP] Skill '%s' has no mcpServers", skill_name)
             continue
+
+        logger.info(
+            "[SKILL-MCP] Skill '%s' raw mcpServers: %s",
+            skill_name,
+            json.dumps(
+                {
+                    k: {**v, "headers": "***"} if "headers" in v else v
+                    for k, v in mcp_servers.items()
+                },
+                ensure_ascii=False,
+            ),
+        )
 
         # Replace ${{...}} placeholders with actual values from task_data
         mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
@@ -307,19 +396,21 @@ def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
         for server_name, server_config in mcp_servers.items():
             prefixed_name = f"{skill_name}_{server_name}"
             merged[prefixed_name] = server_config
-
-        logger.info(
-            "Extracted %d MCP server(s) from skill '%s': %s",
-            len(mcp_servers),
-            skill_name,
-            list(mcp_servers.keys()),
-        )
+            logger.info(
+                "[SKILL-MCP] Registered: %s -> type=%s, url=%s",
+                prefixed_name,
+                server_config.get("type", "?"),
+                server_config.get("url", "?"),
+            )
 
     if merged:
         logger.info(
-            "Total skill MCP servers collected: %d from %d skill(s)",
+            "[SKILL-MCP] Total skill MCP servers collected: %d",
             len(merged),
-            len(skill_configs),
+        )
+    else:
+        logger.info(
+            "[SKILL-MCP] No skill MCP servers found in %d skill(s)", len(skill_configs)
         )
 
     return merged
@@ -331,6 +422,7 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
 
     Collects all non-None configuration parameters from task_data,
     including Ghost-level MCP servers and Skill-level MCP servers.
+    Unreachable MCP servers are filtered out to prevent initialization timeout.
 
     Args:
         task_data: The task data object
@@ -378,14 +470,30 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     if bot_config:
         # Create a shallow copy of bot_config to avoid modifying the original
         bot_config = bot_config.copy()
+
         # Extract Ghost-level MCP servers configuration
+        logger.info("[MCP] Extracting Ghost-level MCP servers from bot_config...")
         mcp_servers = extract_mcp_servers_config(bot_config)
         if mcp_servers:
+            logger.info(
+                "[MCP] Ghost-level raw MCP servers: %s",
+                (
+                    list(mcp_servers.keys())
+                    if isinstance(mcp_servers, dict)
+                    else type(mcp_servers).__name__
+                ),
+            )
             # Replace placeholders in MCP servers config with actual values
             mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
             # Convert list format to dict format for Claude Code SDK
             mcp_servers = _convert_mcp_servers_list_to_dict(mcp_servers)
             bot_config["mcp_servers"] = mcp_servers
+            logger.info(
+                "[MCP] Ghost-level MCP servers after processing: %s",
+                list(mcp_servers.keys()),
+            )
+        else:
+            logger.info("[MCP] No Ghost-level MCP servers configured")
 
         # Extract Skill-level MCP servers and merge into bot_config
         skill_mcp_servers = _extract_skill_mcp_servers(task_data)
@@ -395,6 +503,10 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
                 existing.update(skill_mcp_servers)
             else:
                 bot_config["mcp_servers"] = skill_mcp_servers
+            logger.info(
+                "[MCP] After merging skill MCP: %s",
+                list(bot_config["mcp_servers"].keys()),
+            )
 
         # Add wegent MCP server for subscription tasks
         if task_data.is_subscription:
@@ -420,9 +532,38 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
                 f"Added wegent MCP server (HTTP) for subscription task at {wegent_mcp_url}"
             )
 
+        # Filter out unreachable MCP servers to prevent SDK initialization timeout
+        final_mcp = bot_config.get("mcp_servers")
+        if isinstance(final_mcp, dict) and final_mcp:
+            logger.info(
+                "[MCP] Pre-filter: %d MCP server(s): %s",
+                len(final_mcp),
+                list(final_mcp.keys()),
+            )
+            bot_config["mcp_servers"] = _filter_reachable_mcp_servers(final_mcp)
+            logger.info(
+                "[MCP] Post-filter: %d MCP server(s): %s",
+                len(bot_config["mcp_servers"]),
+                list(bot_config["mcp_servers"].keys()),
+            )
+            # Remove empty mcp_servers to avoid passing {} to SDK
+            if not bot_config["mcp_servers"]:
+                del bot_config["mcp_servers"]
+                logger.info("[MCP] All MCP servers unreachable, removed from options")
+
         for key in valid_options:
             if key in bot_config and bot_config[key] is not None:
                 options[key] = bot_config[key]
+
+    # Final summary log
+    final_mcp = options.get("mcp_servers", options.get("mcpServers"))
+    if final_mcp:
+        logger.info(
+            "[MCP] Final MCP servers in options: %s",
+            list(final_mcp.keys()) if isinstance(final_mcp, dict) else final_mcp,
+        )
+    else:
+        logger.info("[MCP] No MCP servers in final options")
 
     return options
 

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -273,10 +273,64 @@ def _convert_mcp_servers_list_to_dict(mcp_servers: Any) -> Dict[str, Any]:
     return {}
 
 
+def _extract_skill_mcp_servers(task_data: ExecutionRequest) -> Dict[str, Any]:
+    """Extract and merge MCP servers from skill_configs.
+
+    Each skill may declare mcpServers in its configuration. This function
+    collects them all, applies variable substitution, and returns a merged
+    dict keyed by prefixed server names (to avoid cross-skill conflicts).
+
+    Args:
+        task_data: The task data object containing skill_configs
+
+    Returns:
+        Dict of MCP server configs in Claude Code SDK format, e.g.
+        {"skillName_serverName": {"type": "streamable-http", "url": "..."}}
+    """
+    from shared.utils.mcp_utils import replace_mcp_server_variables
+
+    skill_configs = task_data.skill_configs
+    if not skill_configs:
+        return {}
+
+    merged: Dict[str, Any] = {}
+    for skill_config in skill_configs:
+        skill_name = skill_config.get("name", "unknown")
+        mcp_servers = skill_config.get("mcpServers")
+        if not mcp_servers or not isinstance(mcp_servers, dict):
+            continue
+
+        # Replace ${{...}} placeholders with actual values from task_data
+        mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
+
+        # Prefix server names with skill name to avoid cross-skill conflicts
+        for server_name, server_config in mcp_servers.items():
+            prefixed_name = f"{skill_name}_{server_name}"
+            merged[prefixed_name] = server_config
+
+        logger.info(
+            "Extracted %d MCP server(s) from skill '%s': %s",
+            len(mcp_servers),
+            skill_name,
+            list(mcp_servers.keys()),
+        )
+
+    if merged:
+        logger.info(
+            "Total skill MCP servers collected: %d from %d skill(s)",
+            len(merged),
+            len(skill_configs),
+        )
+
+    return merged
+
+
+
 def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     """Extract Claude Code options from task data.
 
-    Collects all non-None configuration parameters from task_data.
+    Collects all non-None configuration parameters from task_data,
+    including Ghost-level MCP servers and Skill-level MCP servers.
 
     Args:
         task_data: The task data object
@@ -324,7 +378,7 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     if bot_config:
         # Create a shallow copy of bot_config to avoid modifying the original
         bot_config = bot_config.copy()
-        # Extract MCP servers configuration
+        # Extract Ghost-level MCP servers configuration
         mcp_servers = extract_mcp_servers_config(bot_config)
         if mcp_servers:
             # Replace placeholders in MCP servers config with actual values
@@ -332,6 +386,15 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
             # Convert list format to dict format for Claude Code SDK
             mcp_servers = _convert_mcp_servers_list_to_dict(mcp_servers)
             bot_config["mcp_servers"] = mcp_servers
+
+        # Extract Skill-level MCP servers and merge into bot_config
+        skill_mcp_servers = _extract_skill_mcp_servers(task_data)
+        if skill_mcp_servers:
+            existing = bot_config.get("mcp_servers")
+            if isinstance(existing, dict):
+                existing.update(skill_mcp_servers)
+            else:
+                bot_config["mcp_servers"] = skill_mcp_servers
 
         # Add wegent MCP server for subscription tasks
         if task_data.is_subscription:

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -3,422 +3,72 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Tests for Skill MCP server extraction in Claude Code executor.
+Tests for Skill MCP server handling in Claude Code executor.
 
-Verifies that MCP servers declared in skill_configs are correctly
-extracted, variable-substituted, prefix-namespaced, and merged into
-the final Claude Code SDK options alongside Ghost-level MCP servers.
+Note: Skill MCP extraction, type normalization, and reachability filtering
+have been migrated to the backend (TaskRequestBuilder). These tests verify
+the executor correctly passes through the pre-processed MCP servers from
+bot_config into Claude Code SDK options.
 """
 
-from unittest.mock import patch
-
-import pytest
-
 from executor.agents.claude_code.config_manager import (
-    _check_mcp_server_reachable,
-    _extract_skill_mcp_servers,
-    _filter_reachable_mcp_servers,
-    _normalize_mcp_server_types,
     extract_claude_options,
 )
 from shared.models.execution import ExecutionRequest
 
 
-def _mock_reachable(name, config):
-    """Mock that treats all servers as reachable."""
-    return True
+class TestExtractClaudeOptionsWithMcp:
+    """Tests for MCP handling in extract_claude_options.
 
-
-class TestExtractSkillMcpServers:
-    """Tests for _extract_skill_mcp_servers helper."""
-
-    def test_no_skill_configs(self):
-        """Returns empty dict when no skill_configs."""
-        task_data = ExecutionRequest(task_id=1, skill_configs=[])
-        result = _extract_skill_mcp_servers(task_data)
-        assert result == {}
-
-    def test_skill_without_mcp_servers(self):
-        """Returns empty dict when skills have no mcpServers."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {"name": "code-review", "description": "Reviews code"},
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-        assert result == {}
-
-    def test_single_skill_single_mcp(self):
-        """Extracts MCP from a single skill with one server."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {
-                    "name": "image-toolkit",
-                    "mcpServers": {
-                        "imageFetchServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/fetch-image",
-                            "headers": {"Authorization": "Bearer token123"},
-                        }
-                    },
-                }
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-
-        assert "image-toolkit_imageFetchServer" in result
-        server = result["image-toolkit_imageFetchServer"]
-        assert server["type"] == "streamable-http"
-        assert server["url"] == "http://mcp.example.com/fetch-image"
-        assert server["headers"]["Authorization"] == "Bearer token123"
-
-    def test_single_skill_multiple_mcps(self):
-        """Extracts multiple MCP servers from a single skill."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {
-                    "name": "image-toolkit",
-                    "mcpServers": {
-                        "imageFetchServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/fetch-image",
-                        },
-                        "nanoBananaServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/nano-banana",
-                        },
-                    },
-                }
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-
-        assert len(result) == 2
-        assert "image-toolkit_imageFetchServer" in result
-        assert "image-toolkit_nanoBananaServer" in result
-
-    def test_multiple_skills_with_mcps(self):
-        """Extracts and merges MCP servers from multiple skills."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {
-                    "name": "image-toolkit",
-                    "mcpServers": {
-                        "imageServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/image",
-                        },
-                    },
-                },
-                {
-                    "name": "knowledge-base",
-                    "mcpServers": {
-                        "kbServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/kb",
-                        },
-                    },
-                },
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-
-        assert len(result) == 2
-        assert "image-toolkit_imageServer" in result
-        assert "knowledge-base_kbServer" in result
-
-    def test_variable_substitution(self):
-        """Verifies ${{...}} placeholders are replaced with task_data values."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            user={"name": "testuser"},
-            skill_configs=[
-                {
-                    "name": "my-skill",
-                    "mcpServers": {
-                        "server1": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/api",
-                            "headers": {
-                                "mcp-proxy-wegent-user": "${{user.name}}",
-                            },
-                        },
-                    },
-                }
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-
-        server = result["my-skill_server1"]
-        assert server["headers"]["mcp-proxy-wegent-user"] == "testuser"
-
-    def test_mixed_skills_with_and_without_mcp(self):
-        """Skills without mcpServers are skipped cleanly."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {"name": "no-mcp-skill", "description": "No MCP"},
-                {
-                    "name": "with-mcp",
-                    "mcpServers": {
-                        "server1": {
-                            "type": "streamable-http",
-                            "url": "http://example.com",
-                        },
-                    },
-                },
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-
-        assert len(result) == 1
-        assert "with-mcp_server1" in result
-
-    def test_invalid_mcp_servers_type_skipped(self):
-        """Non-dict mcpServers values are skipped."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            skill_configs=[
-                {"name": "bad-skill", "mcpServers": "not-a-dict"},
-            ],
-        )
-        result = _extract_skill_mcp_servers(task_data)
-        assert result == {}
-
-
-class TestNormalizeMcpServerTypes:
-    """Tests for _normalize_mcp_server_types."""
-
-    def test_empty_dict(self):
-        assert _normalize_mcp_server_types({}) == {}
-
-    def test_none_returns_none(self):
-        assert _normalize_mcp_server_types(None) is None
-
-    def test_streamable_http_converted_to_http(self):
-        """streamable-http type is converted to http."""
-        servers = {
-            "server1": {
-                "type": "streamable-http",
-                "url": "http://example.com/mcp",
-            }
-        }
-        result = _normalize_mcp_server_types(servers)
-        assert result["server1"]["type"] == "http"
-
-    def test_http_type_unchanged(self):
-        """http type remains unchanged."""
-        servers = {
-            "server1": {
-                "type": "http",
-                "url": "http://example.com/mcp",
-            }
-        }
-        result = _normalize_mcp_server_types(servers)
-        assert result["server1"]["type"] == "http"
-
-    def test_mixed_types_normalized(self):
-        """Only streamable-http is converted, others remain unchanged."""
-        servers = {
-            "s1": {"type": "streamable-http", "url": "http://a.com"},
-            "s2": {"type": "http", "url": "http://b.com"},
-            "s3": {"type": "sse", "url": "http://c.com"},
-        }
-        result = _normalize_mcp_server_types(servers)
-        assert result["s1"]["type"] == "http"
-        assert result["s2"]["type"] == "http"
-        assert result["s3"]["type"] == "sse"
-
-    def test_non_dict_config_skipped(self):
-        """Non-dict server configs are skipped without error."""
-        servers = {
-            "good": {"type": "streamable-http", "url": "http://example.com"},
-            "bad": "not-a-dict",
-        }
-        result = _normalize_mcp_server_types(servers)
-        assert result["good"]["type"] == "http"
-        assert result["bad"] == "not-a-dict"
-
-
-class TestFilterReachableMcpServers:
-    """Tests for _filter_reachable_mcp_servers and _check_mcp_server_reachable."""
-
-    def test_empty_dict_returns_empty(self):
-        assert _filter_reachable_mcp_servers({}) == {}
-
-    def test_none_returns_none(self):
-        assert _filter_reachable_mcp_servers(None) is None
-
-    def test_no_url_returns_false(self):
-        assert _check_mcp_server_reachable("test", {}) is False
-
-    @patch(
-        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-        side_effect=lambda n, c: n != "bad-server",
-    )
-    def test_filters_unreachable(self, mock_check):
-        """Unreachable servers are removed from the result."""
-        servers = {
-            "good-server": {"type": "http", "url": "http://good.example.com"},
-            "bad-server": {"type": "http", "url": "http://bad.example.com"},
-        }
-        result = _filter_reachable_mcp_servers(servers)
-
-        assert "good-server" in result
-        assert "bad-server" not in result
-
-
-class TestExtractClaudeOptionsWithSkillMcp:
-    """Tests for skill MCP integration in extract_claude_options.
-
-    All tests mock _check_mcp_server_reachable to bypass network checks.
+    The backend now pre-processes MCP servers (skill merge, type normalization,
+    reachability filtering). The executor just needs to extract, substitute
+    variables, and convert to dict format.
     """
 
-    @patch(
-        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-        _mock_reachable,
-    )
-    def test_skill_mcp_merged_into_options(self):
-        """Skill MCP servers appear in the final options with normalized type."""
+    def test_mcp_servers_from_bot_config_passed_through(self):
+        """Pre-processed MCP servers from bot_config appear in options."""
         task_data = ExecutionRequest(
             task_id=1,
-            bot=[{"system_prompt": "You are helpful."}],
-            skill_configs=[
+            bot=[
                 {
-                    "name": "image-toolkit",
-                    "mcpServers": {
-                        "imageServer": {
-                            "type": "streamable-http",
-                            "url": "http://mcp.example.com/image",
+                    "mcp_servers": [
+                        {
+                            "name": "ghost-server",
+                            "type": "http",
+                            "url": "http://ghost.example.com/mcp",
                         },
-                    },
+                        {
+                            "name": "my-skill_skillServer",
+                            "type": "http",
+                            "url": "http://skill.example.com/mcp",
+                        },
+                    ],
                 }
             ],
         )
         options = extract_claude_options(task_data)
 
         assert "mcp_servers" in options
-        assert "image-toolkit_imageServer" in options["mcp_servers"]
-        # streamable-http should be normalized to http
-        assert options["mcp_servers"]["image-toolkit_imageServer"]["type"] == "http"
-
-    @patch(
-        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-        _mock_reachable,
-    )
-    def test_skill_mcp_merged_with_ghost_mcp(self):
-        """Skill MCP servers merge alongside Ghost-level MCP with type normalization."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            bot=[
-                {
-                    "mcp_servers": {
-                        "ghost-server": {
-                            "type": "http",
-                            "url": "http://ghost.example.com/mcp",
-                        },
-                    },
-                }
-            ],
-            skill_configs=[
-                {
-                    "name": "my-skill",
-                    "mcpServers": {
-                        "skillServer": {
-                            "type": "streamable-http",
-                            "url": "http://skill.example.com/mcp",
-                        },
-                    },
-                }
-            ],
-        )
-        options = extract_claude_options(task_data)
-
         mcp = options["mcp_servers"]
+        # Should be converted to dict format
+        assert isinstance(mcp, dict)
         assert "ghost-server" in mcp
         assert "my-skill_skillServer" in mcp
-        # Ghost server type remains http, skill server streamable-http normalized to http
+        # Types should already be normalized by backend
         assert mcp["ghost-server"]["type"] == "http"
         assert mcp["my-skill_skillServer"]["type"] == "http"
 
-    @patch(
-        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-        _mock_reachable,
-    )
-    def test_no_skill_configs_preserves_ghost_mcp(self):
-        """When no skill_configs, Ghost MCP remains unchanged."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            bot=[
-                {
-                    "mcp_servers": {
-                        "ghost-server": {
-                            "type": "http",
-                            "url": "http://ghost.example.com/mcp",
-                        },
-                    },
-                }
-            ],
-            skill_configs=[],
-        )
-        options = extract_claude_options(task_data)
-
-        mcp = options["mcp_servers"]
-        assert "ghost-server" in mcp
-        assert len(mcp) == 1
-
-    @patch(
-        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-        _mock_reachable,
-    )
-    def test_skill_mcp_only_no_ghost_mcp(self):
-        """Skill MCP works when Ghost has no MCP servers configured."""
+    def test_no_mcp_servers(self):
+        """No mcp_servers key when bot has none configured."""
         task_data = ExecutionRequest(
             task_id=1,
             bot=[{"system_prompt": "You are helpful."}],
-            skill_configs=[
-                {
-                    "name": "my-skill",
-                    "mcpServers": {
-                        "server1": {
-                            "type": "streamable-http",
-                            "url": "http://example.com/mcp",
-                        },
-                    },
-                }
-            ],
         )
         options = extract_claude_options(task_data)
+        assert "mcp_servers" not in options
 
-        assert "mcp_servers" in options
-        assert "my-skill_server1" in options["mcp_servers"]
-
-    def test_unreachable_mcp_servers_removed_from_options(self):
-        """MCP servers that fail reachability check are excluded from options."""
-        task_data = ExecutionRequest(
-            task_id=1,
-            bot=[
-                {
-                    "mcp_servers": {
-                        "unreachable-ghost": {
-                            "type": "http",
-                            "url": "http://192.0.2.1:9999/unreachable",
-                        },
-                    },
-                }
-            ],
-            skill_configs=[],
-        )
-
-        with patch(
-            "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
-            return_value=False,
-        ):
-            options = extract_claude_options(task_data)
-
-        # Unreachable servers should have been filtered out
+    def test_empty_bot_list(self):
+        """Empty bot list should not crash."""
+        task_data = ExecutionRequest(task_id=1, bot=[])
+        options = extract_claude_options(task_data)
         assert "mcp_servers" not in options

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for Skill MCP server extraction in Claude Code executor.
+
+Verifies that MCP servers declared in skill_configs are correctly
+extracted, variable-substituted, prefix-namespaced, and merged into
+the final Claude Code SDK options alongside Ghost-level MCP servers.
+"""
+
+import pytest
+
+from executor.agents.claude_code.config_manager import (
+    _extract_skill_mcp_servers,
+    extract_claude_options,
+)
+from shared.models.execution import ExecutionRequest
+
+
+class TestExtractSkillMcpServers:
+    """Tests for _extract_skill_mcp_servers helper."""
+
+    def test_no_skill_configs(self):
+        """Returns empty dict when no skill_configs."""
+        task_data = ExecutionRequest(task_id=1, skill_configs=[])
+        result = _extract_skill_mcp_servers(task_data)
+        assert result == {}
+
+    def test_skill_without_mcp_servers(self):
+        """Returns empty dict when skills have no mcpServers."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {"name": "code-review", "description": "Reviews code"},
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+        assert result == {}
+
+    def test_single_skill_single_mcp(self):
+        """Extracts MCP from a single skill with one server."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {
+                    "name": "image-toolkit",
+                    "mcpServers": {
+                        "imageFetchServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/fetch-image",
+                            "headers": {"Authorization": "Bearer token123"},
+                        }
+                    },
+                }
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+
+        assert "image-toolkit_imageFetchServer" in result
+        server = result["image-toolkit_imageFetchServer"]
+        assert server["type"] == "streamable-http"
+        assert server["url"] == "http://mcp.example.com/fetch-image"
+        assert server["headers"]["Authorization"] == "Bearer token123"
+
+    def test_single_skill_multiple_mcps(self):
+        """Extracts multiple MCP servers from a single skill."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {
+                    "name": "image-toolkit",
+                    "mcpServers": {
+                        "imageFetchServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/fetch-image",
+                        },
+                        "nanoBananaServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/nano-banana",
+                        },
+                    },
+                }
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+
+        assert len(result) == 2
+        assert "image-toolkit_imageFetchServer" in result
+        assert "image-toolkit_nanoBananaServer" in result
+
+    def test_multiple_skills_with_mcps(self):
+        """Extracts and merges MCP servers from multiple skills."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {
+                    "name": "image-toolkit",
+                    "mcpServers": {
+                        "imageServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/image",
+                        },
+                    },
+                },
+                {
+                    "name": "knowledge-base",
+                    "mcpServers": {
+                        "kbServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/kb",
+                        },
+                    },
+                },
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+
+        assert len(result) == 2
+        assert "image-toolkit_imageServer" in result
+        assert "knowledge-base_kbServer" in result
+
+    def test_variable_substitution(self):
+        """Verifies ${{...}} placeholders are replaced with task_data values."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            user={"name": "testuser"},
+            skill_configs=[
+                {
+                    "name": "my-skill",
+                    "mcpServers": {
+                        "server1": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/api",
+                            "headers": {
+                                "mcp-proxy-wegent-user": "${{user.name}}",
+                            },
+                        },
+                    },
+                }
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+
+        server = result["my-skill_server1"]
+        assert server["headers"]["mcp-proxy-wegent-user"] == "testuser"
+
+    def test_mixed_skills_with_and_without_mcp(self):
+        """Skills without mcpServers are skipped cleanly."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {"name": "no-mcp-skill", "description": "No MCP"},
+                {
+                    "name": "with-mcp",
+                    "mcpServers": {
+                        "server1": {
+                            "type": "streamable-http",
+                            "url": "http://example.com",
+                        },
+                    },
+                },
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+
+        assert len(result) == 1
+        assert "with-mcp_server1" in result
+
+    def test_invalid_mcp_servers_type_skipped(self):
+        """Non-dict mcpServers values are skipped."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            skill_configs=[
+                {"name": "bad-skill", "mcpServers": "not-a-dict"},
+            ],
+        )
+        result = _extract_skill_mcp_servers(task_data)
+        assert result == {}
+
+
+class TestExtractClaudeOptionsWithSkillMcp:
+    """Tests for skill MCP integration in extract_claude_options."""
+
+    def test_skill_mcp_merged_into_options(self):
+        """Skill MCP servers appear in the final options mcp_servers dict."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[{"system_prompt": "You are helpful."}],
+            skill_configs=[
+                {
+                    "name": "image-toolkit",
+                    "mcpServers": {
+                        "imageServer": {
+                            "type": "streamable-http",
+                            "url": "http://mcp.example.com/image",
+                        },
+                    },
+                }
+            ],
+        )
+        options = extract_claude_options(task_data)
+
+        assert "mcp_servers" in options
+        assert "image-toolkit_imageServer" in options["mcp_servers"]
+
+    def test_skill_mcp_merged_with_ghost_mcp(self):
+        """Skill MCP servers merge alongside existing Ghost-level MCP servers."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[
+                {
+                    "mcp_servers": {
+                        "ghost-server": {
+                            "type": "http",
+                            "url": "http://ghost.example.com/mcp",
+                        },
+                    },
+                }
+            ],
+            skill_configs=[
+                {
+                    "name": "my-skill",
+                    "mcpServers": {
+                        "skillServer": {
+                            "type": "streamable-http",
+                            "url": "http://skill.example.com/mcp",
+                        },
+                    },
+                }
+            ],
+        )
+        options = extract_claude_options(task_data)
+
+        mcp = options["mcp_servers"]
+        # Both Ghost and Skill MCP servers should be present
+        assert "ghost-server" in mcp
+        assert "my-skill_skillServer" in mcp
+
+    def test_no_skill_configs_preserves_ghost_mcp(self):
+        """When no skill_configs, Ghost MCP remains unchanged."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[
+                {
+                    "mcp_servers": {
+                        "ghost-server": {
+                            "type": "http",
+                            "url": "http://ghost.example.com/mcp",
+                        },
+                    },
+                }
+            ],
+            skill_configs=[],
+        )
+        options = extract_claude_options(task_data)
+
+        mcp = options["mcp_servers"]
+        assert "ghost-server" in mcp
+        assert len(mcp) == 1
+
+    def test_skill_mcp_only_no_ghost_mcp(self):
+        """Skill MCP works when Ghost has no MCP servers configured."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[{"system_prompt": "You are helpful."}],
+            skill_configs=[
+                {
+                    "name": "my-skill",
+                    "mcpServers": {
+                        "server1": {
+                            "type": "streamable-http",
+                            "url": "http://example.com/mcp",
+                        },
+                    },
+                }
+            ],
+        )
+        options = extract_claude_options(task_data)
+
+        assert "mcp_servers" in options
+        assert "my-skill_server1" in options["mcp_servers"]

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -10,13 +10,22 @@ extracted, variable-substituted, prefix-namespaced, and merged into
 the final Claude Code SDK options alongside Ghost-level MCP servers.
 """
 
+from unittest.mock import patch
+
 import pytest
 
 from executor.agents.claude_code.config_manager import (
+    _check_mcp_server_reachable,
     _extract_skill_mcp_servers,
+    _filter_reachable_mcp_servers,
     extract_claude_options,
 )
 from shared.models.execution import ExecutionRequest
+
+
+def _mock_reachable(name, config):
+    """Mock that treats all servers as reachable."""
+    return True
 
 
 class TestExtractSkillMcpServers:
@@ -180,9 +189,44 @@ class TestExtractSkillMcpServers:
         assert result == {}
 
 
-class TestExtractClaudeOptionsWithSkillMcp:
-    """Tests for skill MCP integration in extract_claude_options."""
+class TestFilterReachableMcpServers:
+    """Tests for _filter_reachable_mcp_servers and _check_mcp_server_reachable."""
 
+    def test_empty_dict_returns_empty(self):
+        assert _filter_reachable_mcp_servers({}) == {}
+
+    def test_none_returns_none(self):
+        assert _filter_reachable_mcp_servers(None) is None
+
+    def test_no_url_returns_false(self):
+        assert _check_mcp_server_reachable("test", {}) is False
+
+    @patch(
+        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+        side_effect=lambda n, c: n != "bad-server",
+    )
+    def test_filters_unreachable(self, mock_check):
+        """Unreachable servers are removed from the result."""
+        servers = {
+            "good-server": {"type": "http", "url": "http://good.example.com"},
+            "bad-server": {"type": "http", "url": "http://bad.example.com"},
+        }
+        result = _filter_reachable_mcp_servers(servers)
+
+        assert "good-server" in result
+        assert "bad-server" not in result
+
+
+class TestExtractClaudeOptionsWithSkillMcp:
+    """Tests for skill MCP integration in extract_claude_options.
+
+    All tests mock _check_mcp_server_reachable to bypass network checks.
+    """
+
+    @patch(
+        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+        _mock_reachable,
+    )
     def test_skill_mcp_merged_into_options(self):
         """Skill MCP servers appear in the final options mcp_servers dict."""
         task_data = ExecutionRequest(
@@ -205,6 +249,10 @@ class TestExtractClaudeOptionsWithSkillMcp:
         assert "mcp_servers" in options
         assert "image-toolkit_imageServer" in options["mcp_servers"]
 
+    @patch(
+        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+        _mock_reachable,
+    )
     def test_skill_mcp_merged_with_ghost_mcp(self):
         """Skill MCP servers merge alongside existing Ghost-level MCP servers."""
         task_data = ExecutionRequest(
@@ -234,10 +282,13 @@ class TestExtractClaudeOptionsWithSkillMcp:
         options = extract_claude_options(task_data)
 
         mcp = options["mcp_servers"]
-        # Both Ghost and Skill MCP servers should be present
         assert "ghost-server" in mcp
         assert "my-skill_skillServer" in mcp
 
+    @patch(
+        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+        _mock_reachable,
+    )
     def test_no_skill_configs_preserves_ghost_mcp(self):
         """When no skill_configs, Ghost MCP remains unchanged."""
         task_data = ExecutionRequest(
@@ -260,6 +311,10 @@ class TestExtractClaudeOptionsWithSkillMcp:
         assert "ghost-server" in mcp
         assert len(mcp) == 1
 
+    @patch(
+        "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+        _mock_reachable,
+    )
     def test_skill_mcp_only_no_ghost_mcp(self):
         """Skill MCP works when Ghost has no MCP servers configured."""
         task_data = ExecutionRequest(
@@ -281,3 +336,29 @@ class TestExtractClaudeOptionsWithSkillMcp:
 
         assert "mcp_servers" in options
         assert "my-skill_server1" in options["mcp_servers"]
+
+    def test_unreachable_mcp_servers_removed_from_options(self):
+        """MCP servers that fail reachability check are excluded from options."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[
+                {
+                    "mcp_servers": {
+                        "unreachable-ghost": {
+                            "type": "http",
+                            "url": "http://192.0.2.1:9999/unreachable",
+                        },
+                    },
+                }
+            ],
+            skill_configs=[],
+        )
+
+        with patch(
+            "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
+            return_value=False,
+        ):
+            options = extract_claude_options(task_data)
+
+        # Unreachable servers should have been filtered out
+        assert "mcp_servers" not in options

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -18,6 +18,7 @@ from executor.agents.claude_code.config_manager import (
     _check_mcp_server_reachable,
     _extract_skill_mcp_servers,
     _filter_reachable_mcp_servers,
+    _normalize_mcp_server_types,
     extract_claude_options,
 )
 from shared.models.execution import ExecutionRequest
@@ -189,6 +190,60 @@ class TestExtractSkillMcpServers:
         assert result == {}
 
 
+class TestNormalizeMcpServerTypes:
+    """Tests for _normalize_mcp_server_types."""
+
+    def test_empty_dict(self):
+        assert _normalize_mcp_server_types({}) == {}
+
+    def test_none_returns_none(self):
+        assert _normalize_mcp_server_types(None) is None
+
+    def test_streamable_http_converted_to_http(self):
+        """streamable-http type is converted to http."""
+        servers = {
+            "server1": {
+                "type": "streamable-http",
+                "url": "http://example.com/mcp",
+            }
+        }
+        result = _normalize_mcp_server_types(servers)
+        assert result["server1"]["type"] == "http"
+
+    def test_http_type_unchanged(self):
+        """http type remains unchanged."""
+        servers = {
+            "server1": {
+                "type": "http",
+                "url": "http://example.com/mcp",
+            }
+        }
+        result = _normalize_mcp_server_types(servers)
+        assert result["server1"]["type"] == "http"
+
+    def test_mixed_types_normalized(self):
+        """Only streamable-http is converted, others remain unchanged."""
+        servers = {
+            "s1": {"type": "streamable-http", "url": "http://a.com"},
+            "s2": {"type": "http", "url": "http://b.com"},
+            "s3": {"type": "sse", "url": "http://c.com"},
+        }
+        result = _normalize_mcp_server_types(servers)
+        assert result["s1"]["type"] == "http"
+        assert result["s2"]["type"] == "http"
+        assert result["s3"]["type"] == "sse"
+
+    def test_non_dict_config_skipped(self):
+        """Non-dict server configs are skipped without error."""
+        servers = {
+            "good": {"type": "streamable-http", "url": "http://example.com"},
+            "bad": "not-a-dict",
+        }
+        result = _normalize_mcp_server_types(servers)
+        assert result["good"]["type"] == "http"
+        assert result["bad"] == "not-a-dict"
+
+
 class TestFilterReachableMcpServers:
     """Tests for _filter_reachable_mcp_servers and _check_mcp_server_reachable."""
 
@@ -228,7 +283,7 @@ class TestExtractClaudeOptionsWithSkillMcp:
         _mock_reachable,
     )
     def test_skill_mcp_merged_into_options(self):
-        """Skill MCP servers appear in the final options mcp_servers dict."""
+        """Skill MCP servers appear in the final options with normalized type."""
         task_data = ExecutionRequest(
             task_id=1,
             bot=[{"system_prompt": "You are helpful."}],
@@ -248,13 +303,15 @@ class TestExtractClaudeOptionsWithSkillMcp:
 
         assert "mcp_servers" in options
         assert "image-toolkit_imageServer" in options["mcp_servers"]
+        # streamable-http should be normalized to http
+        assert options["mcp_servers"]["image-toolkit_imageServer"]["type"] == "http"
 
     @patch(
         "executor.agents.claude_code.config_manager._check_mcp_server_reachable",
         _mock_reachable,
     )
     def test_skill_mcp_merged_with_ghost_mcp(self):
-        """Skill MCP servers merge alongside existing Ghost-level MCP servers."""
+        """Skill MCP servers merge alongside Ghost-level MCP with type normalization."""
         task_data = ExecutionRequest(
             task_id=1,
             bot=[
@@ -284,6 +341,9 @@ class TestExtractClaudeOptionsWithSkillMcp:
         mcp = options["mcp_servers"]
         assert "ghost-server" in mcp
         assert "my-skill_skillServer" in mcp
+        # Ghost server type remains http, skill server streamable-http normalized to http
+        assert mcp["ghost-server"]["type"] == "http"
+        assert mcp["my-skill_skillServer"]["type"] == "http"
 
     @patch(
         "executor.agents.claude_code.config_manager._check_mcp_server_reachable",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill-level MCP servers are merged into bot configuration so resolved skill endpoints are available at runtime.
  * MCP types normalized (e.g., streamable-http → http) and unreachable MCP servers automatically removed.

* **Chores**
  * Added runtime logging that surfaces Ghost/global and skill-level MCP selections and final options.

* **Tests**
  * Added comprehensive tests for MCP extraction, normalization, reachability filtering, merging, and end-to-end handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->