### PR TITLE
feat(frontend): add expand/collapse toggle for chat input area

### DIFF
--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -717,7 +717,7 @@ export default function ChatInput({
       {/* Scrollable container that includes both badge and editable content */}
       <div className="relative">
         <div
-          className="w-full custom-scrollbar transition-[max-height] duration-300 ease-in-out"
+          className="w-full custom-scrollbar transition-all duration-300 ease-in-out"
           style={{
             minHeight,
             maxHeight,
@@ -751,7 +751,7 @@ export default function ChatInput({
                     onCompositionEnd={handleCompositionEnd}
                     onFocus={handleFocus}
                     data-testid="message-input"
-                    className={`w-full pt-1 pb-2 bg-transparent text-text-primary text-base leading-[26px] focus:outline-none ${isInputDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`w-full pt-1 pb-2 bg-transparent text-text-primary text-base leading-[26px] focus:outline-none transition-all duration-300 ease-in-out ${isInputDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
                     style={{
                       minHeight,
                       whiteSpace: 'pre-wrap',

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -758,7 +758,7 @@ export default function ChatInput({
                       // only inserts <br> tags (not new <div> blocks), so text-indent
                       // correctly affects only the first line and subsequent lines start from left edge
                       textIndent: badge ? `${badgeWidth}px` : 0,
-                      // Add padding at bottom right to prevent text overlapping with expand button
+                      // Add padding at top right to prevent text overlapping with expand button
                       paddingRight: onExpandToggle && !isMobile ? '2rem' : undefined,
                     }}
                     suppressContentEditableWarning
@@ -772,7 +772,7 @@ export default function ChatInput({
           </div>
         </div>
 
-        {/* Expand/Collapse button - positioned outside scroll container for fixed position */}
+        {/* Expand/Collapse button - positioned at top-right corner */}
         {onExpandToggle && !isMobile && (
           <TooltipProvider>
             <Tooltip>
@@ -780,7 +780,7 @@ export default function ChatInput({
                 <button
                   type="button"
                   onClick={onExpandToggle}
-                  className="absolute bottom-1 right-0 p-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-secondary transition-colors z-10"
+                  className="absolute top-1 right-0 p-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-secondary transition-colors z-10"
                   aria-label={isExpanded ? t('chat:input.collapse') : t('chat:input.expand')}
                 >
                   {isExpanded ? (

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -636,9 +636,10 @@ export default function ChatInput({
   // Text area should be ~60-70px minimum (about 2-3 lines with 26px line-height)
   const minHeight = isMobile ? '3.5rem' : '4rem'
   // When expanded, double the max height for easier editing of large text
+  // Only apply expansion on desktop - mobile has no toggle button to collapse
   const baseMaxHeight = isMobile ? '9rem' : '10rem'
   const expandedMaxHeight = isMobile ? '18rem' : '20rem'
-  const maxHeight = isExpanded ? expandedMaxHeight : baseMaxHeight
+  const maxHeight = !isMobile && isExpanded ? expandedMaxHeight : baseMaxHeight
 
   // Get tooltip text based on send key preference and platform
   const tooltipText = useMemo(() => {

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { useUser } from '@/features/common/UserContext'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Maximize2, Minimize2 } from 'lucide-react'
 import type { ChatTipItem, Team, TaskType } from '@/types/api'
 import type { UnifiedSkill } from '@/apis/skills'
 import MentionAutocomplete from '../chat/MentionAutocomplete'
@@ -50,6 +51,12 @@ interface ChatInputProps {
   skillSelectorReadOnly?: boolean
   /** Ref to the skill button element for fly animation target */
   skillButtonRef?: React.RefObject<HTMLElement | null>
+
+  // Expand/collapse control for input height
+  /** Whether the input is currently expanded (2x height) */
+  isExpanded?: boolean
+  /** Callback when expand/collapse button is clicked */
+  onExpandToggle?: () => void
 }
 
 export default function ChatInput({
@@ -76,6 +83,8 @@ export default function ChatInput({
   isChatShell = false,
   skillSelectorReadOnly = false,
   skillButtonRef,
+  isExpanded = false,
+  onExpandToggle,
 }: ChatInputProps) {
   const { t, i18n } = useTranslation()
 
@@ -626,7 +635,10 @@ export default function ChatInput({
   // Figma design shows input card ~140px total, text area takes most of it
   // Text area should be ~60-70px minimum (about 2-3 lines with 26px line-height)
   const minHeight = isMobile ? '3.5rem' : '4rem'
-  const maxHeight = isMobile ? '9rem' : '10rem'
+  // When expanded, double the max height for easier editing of large text
+  const baseMaxHeight = isMobile ? '9rem' : '10rem'
+  const expandedMaxHeight = isMobile ? '18rem' : '20rem'
+  const maxHeight = isExpanded ? expandedMaxHeight : baseMaxHeight
 
   // Get tooltip text based on send key preference and platform
   const tooltipText = useMemo(() => {
@@ -699,61 +711,90 @@ export default function ChatInput({
         }
       />
       {/* Scrollable container that includes both badge and editable content */}
-      <div
-        className="w-full custom-scrollbar"
-        style={{
-          minHeight,
-          maxHeight,
-          overflowY: 'auto',
-        }}
-      >
-        {/* Inner content wrapper with badge and text */}
-        <div className="relative">
-          {/* Badge - positioned absolutely so it doesn't affect text flow */}
-          {badge && (
-            <span
-              ref={badgeRef}
-              className="absolute left-0 top-0.5 pointer-events-auto z-10"
-              style={{ userSelect: 'none' }}
-            >
-              {badge}
-            </span>
-          )}
+      <div className="relative">
+        <div
+          className="w-full custom-scrollbar transition-[max-height] duration-300 ease-in-out"
+          style={{
+            minHeight,
+            maxHeight,
+            overflowY: 'auto',
+          }}
+        >
+          {/* Inner content wrapper with badge and text */}
+          <div className="relative">
+            {/* Badge - positioned absolutely so it doesn't affect text flow */}
+            {badge && (
+              <span
+                ref={badgeRef}
+                className="absolute left-0 top-0.5 pointer-events-auto z-10"
+                style={{ userSelect: 'none' }}
+              >
+                {badge}
+              </span>
+            )}
 
-          {/* Editable content area - wrapped in Tooltip for send shortcut hint */}
+            {/* Editable content area - wrapped in Tooltip for send shortcut hint */}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    ref={editableRef}
+                    contentEditable={!isInputDisabled}
+                    onInput={handleInput}
+                    onKeyDown={handleKeyDown}
+                    onPaste={handlePaste}
+                    onCompositionStart={handleCompositionStart}
+                    onCompositionEnd={handleCompositionEnd}
+                    onFocus={handleFocus}
+                    data-testid="message-input"
+                    className={`w-full pt-1 pb-2 bg-transparent text-text-primary text-base leading-[26px] focus:outline-none ${isInputDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    style={{
+                      minHeight,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      // Use text-indent for first line only to leave space for badge
+                      // By using insertLineBreak in keydown handler, we ensure Shift+Enter
+                      // only inserts <br> tags (not new <div> blocks), so text-indent
+                      // correctly affects only the first line and subsequent lines start from left edge
+                      textIndent: badge ? `${badgeWidth}px` : 0,
+                      // Add padding at bottom right to prevent text overlapping with expand button
+                      paddingRight: onExpandToggle && !isMobile ? '2rem' : undefined,
+                    }}
+                    suppressContentEditableWarning
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  <p>{tooltipText}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </div>
+
+        {/* Expand/Collapse button - positioned outside scroll container for fixed position */}
+        {onExpandToggle && !isMobile && (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <div
-                  ref={editableRef}
-                  contentEditable={!isInputDisabled}
-                  onInput={handleInput}
-                  onKeyDown={handleKeyDown}
-                  onPaste={handlePaste}
-                  onCompositionStart={handleCompositionStart}
-                  onCompositionEnd={handleCompositionEnd}
-                  onFocus={handleFocus}
-                  data-testid="message-input"
-                  className={`w-full pt-1 pb-2 bg-transparent text-text-primary text-base leading-[26px] focus:outline-none ${isInputDisabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  style={{
-                    minHeight,
-                    whiteSpace: 'pre-wrap',
-                    wordBreak: 'break-word',
-                    // Use text-indent for first line only to leave space for badge
-                    // By using insertLineBreak in keydown handler, we ensure Shift+Enter
-                    // only inserts <br> tags (not new <div> blocks), so text-indent
-                    // correctly affects only the first line and subsequent lines start from left edge
-                    textIndent: badge ? `${badgeWidth}px` : 0,
-                  }}
-                  suppressContentEditableWarning
-                />
+                <button
+                  type="button"
+                  onClick={onExpandToggle}
+                  className="absolute bottom-1 right-0 p-1 rounded hover:bg-surface-hover text-text-muted hover:text-text-secondary transition-colors z-10"
+                  aria-label={isExpanded ? t('chat:input.collapse') : t('chat:input.expand')}
+                >
+                  {isExpanded ? (
+                    <Minimize2 className="h-4 w-4" />
+                  ) : (
+                    <Maximize2 className="h-4 w-4" />
+                  )}
+                </button>
               </TooltipTrigger>
               <TooltipContent side="top" className="text-xs">
-                <p>{tooltipText}</p>
+                <p>{isExpanded ? t('chat:input.collapse') : t('chat:input.expand')}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
-        </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -634,7 +634,10 @@ export default function ChatInput({
   // Calculate min height based on device
   // Figma design shows input card ~140px total, text area takes most of it
   // Text area should be ~60-70px minimum (about 2-3 lines with 26px line-height)
-  const minHeight = isMobile ? '3.5rem' : '4rem'
+  const baseMinHeight = isMobile ? '3.5rem' : '4rem'
+  // When expanded, increase min height to show the expanded state visually
+  const expandedMinHeight = isMobile ? '9rem' : '10rem'
+  const minHeight = !isMobile && isExpanded ? expandedMinHeight : baseMinHeight
   // When expanded, double the max height for easier editing of large text
   // Only apply expansion on desktop - mobile has no toggle button to collapse
   const baseMaxHeight = isMobile ? '9rem' : '10rem'

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React, { useRef } from 'react'
+import React, { useRef, useState, useCallback } from 'react'
 import { Upload, Sparkles } from 'lucide-react'
 import ChatInput from './ChatInput'
 import InputBadgeDisplay from './InputBadgeDisplay'
@@ -184,6 +184,14 @@ export function ChatInputCard({
 }: ChatInputCardProps) {
   const { t } = useTranslation('chat')
 
+  // State for expanded input mode (2x height for easier large text editing)
+  const [isInputExpanded, setIsInputExpanded] = useState(false)
+
+  // Toggle expand/collapse state
+  const handleExpandToggle = useCallback(() => {
+    setIsInputExpanded(prev => !prev)
+  }, [])
+
   // Ref for skill button to enable fly animation from autocomplete
   const skillSelectorRef = useRef<SkillSelectorPopoverRef>(null)
 
@@ -288,6 +296,9 @@ export function ChatInputCard({
               skillButtonRef={
                 { current: getSkillButtonElement() } as React.RefObject<HTMLElement | null>
               }
+              // Expand/collapse props for input height toggle
+              isExpanded={isInputExpanded}
+              onExpandToggle={handleExpandToggle}
             />
           </div>
         )}

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -5,7 +5,9 @@
     "empty": "No messages yet. Start a conversation!"
   },
   "input": {
-    "no_team_placeholder": "Please select or create an agent first"
+    "no_team_placeholder": "Please select or create an agent first",
+    "expand": "Expand input area",
+    "collapse": "Collapse input area"
   },
   "actions": {
     "send": "Send",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -5,7 +5,9 @@
     "empty": "还没有消息。开始对话吧！"
   },
   "input": {
-    "no_team_placeholder": "请先选择或创建智能体"
+    "no_team_placeholder": "请先选择或创建智能体",
+    "expand": "展开输入框",
+    "collapse": "收起输入框"
   },
   "actions": {
     "send": "发送",


### PR DESCRIPTION
Add expandable input area feature to make editing large text content easier:

- Add expand/collapse button in the input box (desktop only)
- Double the max height when expanded (160px -> 320px)
- Smooth CSS transition animation for height changes
- Add i18n translations for expand/collapse tooltips (en/zh-CN)

The expand button uses Maximize2/Minimize2 icons from lucide-react. State is managed locally (resets on page refresh as per requirements).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat input gains an explicit expand/collapse toggle that enlarges the input area (increases min/max height, up to ~2x on non-mobile) and moves the control outside the scrollable content.
  * Component supports external expand state and a toggle callback for controlled behavior.
  * Tooltip and localized labels now reflect the current action ("Expand"/"Collapse") in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->