### PR TITLE
feat(security): add mandatory password change step to admin setup wizard

### DIFF
--- a/backend/app/api/endpoints/admin/system_config.py
+++ b/backend/app/api/endpoints/admin/system_config.py
@@ -235,10 +235,9 @@ async def mark_admin_setup_complete(
         AdminSetupCompleteResponse: Contains success status and message
     """
     # Verify admin password has been changed from default
-    from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+    from app.services.admin_utils import is_admin_password_default
 
-    admin_user = db.query(User).filter(User.user_name == "admin").first()
-    if admin_user and admin_user.password_hash == DEFAULT_ADMIN_Password_HASH:
+    if is_admin_password_default(db):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Please change the default password before completing setup",

--- a/backend/app/api/endpoints/admin/system_config.py
+++ b/backend/app/api/endpoints/admin/system_config.py
@@ -4,7 +4,7 @@
 
 """Admin system configuration endpoints."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
@@ -229,9 +229,21 @@ async def mark_admin_setup_complete(
     Mark admin setup wizard as completed.
     This will prevent the wizard from showing on subsequent admin logins.
 
+    Requires that the admin password has been changed from default.
+
     Returns:
         AdminSetupCompleteResponse: Contains success status and message
     """
+    # Verify admin password has been changed from default
+    from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+
+    admin_user = db.query(User).filter(User.user_name == "admin").first()
+    if admin_user and admin_user.password_hash == DEFAULT_ADMIN_Password_HASH:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Please change the default password before completing setup",
+        )
+
     config = (
         db.query(SystemConfig)
         .filter(SystemConfig.config_key == ADMIN_SETUP_CONFIG_KEY)

--- a/backend/app/api/endpoints/health.py
+++ b/backend/app/api/endpoints/health.py
@@ -36,15 +36,9 @@ def health_check(db: Session = Depends(get_db)):
         user_count = result.scalar()
 
         # Check if admin password has been changed from default
-        from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
-        from app.models.user import User
+        from app.services.admin_utils import is_admin_password_default
 
-        admin_password_changed = True
-        admin_user = db.query(User).filter(User.user_name == "admin").first()
-        if admin_user:
-            admin_password_changed = (
-                admin_user.password_hash != DEFAULT_ADMIN_Password_HASH
-            )
+        admin_password_changed = not is_admin_password_default(db)
 
         return {
             "status": "healthy",

--- a/backend/app/api/endpoints/health.py
+++ b/backend/app/api/endpoints/health.py
@@ -35,12 +35,24 @@ def health_check(db: Session = Depends(get_db)):
         result = db.execute(text("SELECT COUNT(*) FROM users"))
         user_count = result.scalar()
 
+        # Check if admin password has been changed from default
+        from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+        from app.models.user import User
+
+        admin_password_changed = True
+        admin_user = db.query(User).filter(User.user_name == "admin").first()
+        if admin_user:
+            admin_password_changed = (
+                admin_user.password_hash != DEFAULT_ADMIN_Password_HASH
+            )
+
         return {
             "status": "healthy",
             "database": "connected",
             "users_initialized": user_count > 0,
             "user_count": user_count,
             "shutting_down": shutdown_manager.is_shutting_down,
+            "admin_password_changed": admin_password_changed,
         }
     except Exception as e:
         return {"status": "unhealthy", "database": "error", "error": str(e)}

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -93,6 +93,16 @@ async def change_password(
             detail="Passwords do not match",
         )
 
+    # Prevent admin from "changing" to the same default password
+    if current_user.user_name == "admin":
+        from app.core.yaml_init import DEFAULT_ADMIN_Password
+
+        if request.new_password == DEFAULT_ADMIN_Password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="New password cannot be the same as the default password",
+            )
+
     # Hash and update the password
     current_user.password_hash = security.get_password_hash(request.new_password)
     db.commit()

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -345,15 +345,9 @@ async def get_welcome_config(
             admin_setup_completed = False
 
         # Check if admin password has been changed from default
-        from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+        from app.services.admin_utils import is_admin_password_default
 
-        admin_user = db.query(User).filter(User.user_name == "admin").first()
-        if admin_user:
-            admin_password_changed = (
-                admin_user.password_hash != DEFAULT_ADMIN_Password_HASH
-            )
-        else:
-            admin_password_changed = True
+        admin_password_changed = not is_admin_password_default(db)
 
     if not config:
         # Return default configuration

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -20,7 +20,7 @@ from app.schemas.admin import (
     QuickAccessTeam,
     WelcomeConfigResponse,
 )
-from app.schemas.user import UserCreate, UserInDB, UserUpdate
+from app.schemas.user import ChangePasswordRequest, UserCreate, UserInDB, UserUpdate
 from app.services.kind import kind_service
 from app.services.user import user_service
 
@@ -78,6 +78,26 @@ async def update_current_user_endpoint(
         return user
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.put("/me/password", response_model=UserInDB)
+async def change_password(
+    request: ChangePasswordRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+):
+    """Change current user's password"""
+    if request.new_password != request.confirm_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Passwords do not match",
+        )
+
+    # Hash and update the password
+    current_user.password_hash = security.get_password_hash(request.new_password)
+    db.commit()
+    db.refresh(current_user)
+    return current_user
 
 
 @router.delete("/me/git-token/{git_domain:path}", response_model=UserInDB)
@@ -312,6 +332,7 @@ async def get_welcome_config(
 
     # Check admin setup status for admin users
     admin_setup_completed = None
+    admin_password_changed = None
     if current_user.role == "admin":
         setup_config = (
             db.query(SystemConfig)
@@ -323,6 +344,17 @@ async def get_welcome_config(
         else:
             admin_setup_completed = False
 
+        # Check if admin password has been changed from default
+        from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+
+        admin_user = db.query(User).filter(User.user_name == "admin").first()
+        if admin_user:
+            admin_password_changed = (
+                admin_user.password_hash != DEFAULT_ADMIN_Password_HASH
+            )
+        else:
+            admin_password_changed = True
+
     if not config:
         # Return default configuration
         return WelcomeConfigResponse(
@@ -331,6 +363,7 @@ async def get_welcome_config(
             ],
             tips=[ChatTipItem(**tip) for tip in DEFAULT_SLOGAN_TIPS_CONFIG["tips"]],
             admin_setup_completed=admin_setup_completed,
+            admin_password_changed=admin_password_changed,
         )
 
     config_value = config.config_value or {}
@@ -344,6 +377,7 @@ async def get_welcome_config(
             for tip in config_value.get("tips", DEFAULT_SLOGAN_TIPS_CONFIG["tips"])
         ],
         admin_setup_completed=admin_setup_completed,
+        admin_password_changed=admin_password_changed,
     )
 
 

--- a/backend/app/core/yaml_init.py
+++ b/backend/app/core/yaml_init.py
@@ -23,6 +23,11 @@ from app.services.k_batch import batch_service
 
 logger = logging.getLogger(__name__)
 
+# Default admin password hash for "Wegent2025!" - used to detect if admin has changed default password
+DEFAULT_ADMIN_Password_HASH = (
+    "$2b$12$5jQMrJGO8NMXmF90f/xnKeLtM/Deh912k4GRPx.q3nTGOg1e1IJzW"
+)
+
 
 def load_yaml_documents(file_path: Path) -> List[Dict[str, Any]]:
     """
@@ -64,7 +69,7 @@ def ensure_default_user(db: Session) -> tuple[int, bool]:
         # Default admin user (admin/Wegent2025!)
         admin_user = User(
             user_name="admin",
-            password_hash="$2b$12$5jQMrJGO8NMXmF90f/xnKeLtM/Deh912k4GRPx.q3nTGOg1e1IJzW",
+            password_hash=DEFAULT_ADMIN_Password_HASH,
             email="admin@example.com",
             git_info=[],
             is_active=True,

--- a/backend/app/core/yaml_init.py
+++ b/backend/app/core/yaml_init.py
@@ -23,7 +23,10 @@ from app.services.k_batch import batch_service
 
 logger = logging.getLogger(__name__)
 
-# Default admin password hash for "Wegent2025!" - used to detect if admin has changed default password
+# Default admin password plaintext - used to verify if admin still uses default credentials
+DEFAULT_ADMIN_Password = "Wegent2025!"
+
+# Default admin password hash for "Wegent2025!" - used for initial user creation
 DEFAULT_ADMIN_Password_HASH = (
     "$2b$12$5jQMrJGO8NMXmF90f/xnKeLtM/Deh912k4GRPx.q3nTGOg1e1IJzW"
 )

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -242,6 +242,10 @@ class WelcomeConfigResponse(BaseModel):
         default=None,
         description="Whether admin setup wizard has been completed (only returned for admin users)",
     )
+    admin_password_changed: Optional[bool] = Field(
+        default=None,
+        description="Whether admin password has been changed from default (only returned for admin users)",
+    )
 
 
 # Public Retriever Management Schemas

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -6,7 +6,7 @@ import json
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 
 class MCPProviderKeys(BaseModel):
@@ -167,3 +167,10 @@ class CLIPollResponse(BaseModel):
     access_token: Optional[str] = None
     username: Optional[str] = None
     error: Optional[str] = None
+
+
+class ChangePasswordRequest(BaseModel):
+    """Password change request model"""
+
+    new_password: str = Field(..., min_length=6)
+    confirm_password: str = Field(..., min_length=6)

--- a/backend/app/services/admin_utils.py
+++ b/backend/app/services/admin_utils.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility functions for admin user operations."""
+
+from sqlalchemy.orm import Session
+
+from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+from app.models.user import User
+
+
+def is_admin_password_default(db: Session) -> bool:
+    """
+    Check if the admin user's password is still the default value.
+
+    Queries the admin user from the database and compares the password hash
+    with the known default admin password hash.
+
+    Args:
+        db: Database session
+
+    Returns:
+        True if the admin password is still the default, False if changed
+        or if the admin user does not exist.
+    """
+    admin_user = db.query(User).filter(User.user_name == "admin").first()
+    if not admin_user:
+        return False
+    return admin_user.password_hash == DEFAULT_ADMIN_Password_HASH

--- a/backend/app/services/admin_utils.py
+++ b/backend/app/services/admin_utils.py
@@ -6,7 +6,8 @@
 
 from sqlalchemy.orm import Session
 
-from app.core.yaml_init import DEFAULT_ADMIN_Password_HASH
+from app.core.security import verify_password
+from app.core.yaml_init import DEFAULT_ADMIN_Password
 from app.models.user import User
 
 
@@ -14,8 +15,9 @@ def is_admin_password_default(db: Session) -> bool:
     """
     Check if the admin user's password is still the default value.
 
-    Queries the admin user from the database and compares the password hash
-    with the known default admin password hash.
+    Uses bcrypt verification to compare the known default plaintext password
+    against the stored hash. This correctly handles re-hashed passwords
+    (same plaintext with different salt) unlike direct hash comparison.
 
     Args:
         db: Database session
@@ -27,4 +29,4 @@ def is_admin_password_default(db: Session) -> bool:
     admin_user = db.query(User).filter(User.user_name == "admin").first()
     if not admin_user:
         return False
-    return admin_user.password_hash == DEFAULT_ADMIN_Password_HASH
+    return verify_password(DEFAULT_ADMIN_Password, admin_user.password_hash)

--- a/frontend/e2e/config/test-users.ts
+++ b/frontend/e2e/config/test-users.ts
@@ -10,11 +10,22 @@ export interface TestUser {
 }
 
 /**
+ * Default admin password (before change) - used only for initial login in global-setup
+ */
+export const DEFAULT_ADMIN_Password = 'Wegent2025!'
+
+/**
+ * E2E admin password (after change) - used for all API calls after setup
+ */
+export const E2E_ADMIN_Password = 'WegentE2E2025!'
+
+/**
  * Default admin user for E2E tests
+ * Note: password is the E2E password (changed during global-setup), not the default
  */
 export const ADMIN_USER: TestUser = {
   username: 'admin',
-  password: 'Wegent2025!',
+  password: E2E_ADMIN_Password,
   role: 'admin',
   description: 'Default admin user with full access',
 }

--- a/frontend/e2e/tests/admin/admin-public-models.spec.ts
+++ b/frontend/e2e/tests/admin/admin-public-models.spec.ts
@@ -16,6 +16,12 @@ test.describe('Admin - Public Model Management', () => {
     await apiClient.login(ADMIN_USER.username, ADMIN_USER.password)
 
     // Mark admin setup as complete via API to prevent GlobalAdminSetupWizard from showing
+    // First change password (required before setup can be completed)
+    await apiClient
+      .changeAdminPassword(ADMIN_USER.password, ADMIN_USER.password)
+      .catch(() => {
+        // Ignore errors - password may already be changed
+      })
     await apiClient.markAdminSetupComplete().catch(() => {
       // Ignore errors - setup may already be complete
     })

--- a/frontend/e2e/tests/admin/admin-public-models.spec.ts
+++ b/frontend/e2e/tests/admin/admin-public-models.spec.ts
@@ -17,14 +17,22 @@ test.describe('Admin - Public Model Management', () => {
 
     // Mark admin setup as complete via API to prevent GlobalAdminSetupWizard from showing
     // First change password (required before setup can be completed)
-    await apiClient
+    const passwordResult = await apiClient
       .changeAdminPassword(ADMIN_USER.password, ADMIN_USER.password)
-      .catch(() => {
-        // Ignore errors - password may already be changed
+      .catch((error: Error) => {
+        console.log(`password change request failed (may already be changed): ${error.message}`)
+        return null
       })
-    await apiClient.markAdminSetupComplete().catch(() => {
-      // Ignore errors - setup may already be complete
+    if (passwordResult && passwordResult.status >= 400) {
+      console.log(`password change API returned ${passwordResult.status} - may already be changed`)
+    }
+    const setupResult = await apiClient.markAdminSetupComplete().catch((error: Error) => {
+      console.log(`Setup complete request failed (may already be complete): ${error.message}`)
+      return null
     })
+    if (setupResult && setupResult.status >= 400) {
+      console.log(`Setup complete API returned ${setupResult.status} - may already be complete`)
+    }
 
     // Navigate directly to admin page (already authenticated via global setup storageState)
     await adminPage.navigateToTab('public-models')

--- a/frontend/e2e/tests/admin/admin-users.spec.ts
+++ b/frontend/e2e/tests/admin/admin-users.spec.ts
@@ -17,6 +17,12 @@ test.describe('Admin - User Management', () => {
     await apiClient.login(ADMIN_USER.username, ADMIN_USER.password)
 
     // Mark admin setup as complete via API to prevent GlobalAdminSetupWizard from showing
+    // First change password (required before setup can be completed)
+    await apiClient
+      .changeAdminPassword(ADMIN_USER.password, ADMIN_USER.password)
+      .catch(() => {
+        // Ignore errors - password may already be changed
+      })
     await apiClient.markAdminSetupComplete().catch(() => {
       // Ignore errors - setup may already be complete
     })

--- a/frontend/e2e/tests/admin/admin-users.spec.ts
+++ b/frontend/e2e/tests/admin/admin-users.spec.ts
@@ -18,14 +18,22 @@ test.describe('Admin - User Management', () => {
 
     // Mark admin setup as complete via API to prevent GlobalAdminSetupWizard from showing
     // First change password (required before setup can be completed)
-    await apiClient
+    const passwordResult = await apiClient
       .changeAdminPassword(ADMIN_USER.password, ADMIN_USER.password)
-      .catch(() => {
-        // Ignore errors - password may already be changed
+      .catch((error: Error) => {
+        console.log(`password change request failed (may already be changed): ${error.message}`)
+        return null
       })
-    await apiClient.markAdminSetupComplete().catch(() => {
-      // Ignore errors - setup may already be complete
+    if (passwordResult && passwordResult.status >= 400) {
+      console.log(`password change API returned ${passwordResult.status} - may already be changed`)
+    }
+    const setupResult = await apiClient.markAdminSetupComplete().catch((error: Error) => {
+      console.log(`Setup complete request failed (may already be complete): ${error.message}`)
+      return null
     })
+    if (setupResult && setupResult.status >= 400) {
+      console.log(`Setup complete API returned ${setupResult.status} - may already be complete`)
+    }
 
     // Navigate directly to admin page (already authenticated via global setup storageState)
     await adminPage.navigateToTab('users')

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { TEST_USER } from '../utils/auth'
+import { ADMIN_USER } from '../config/test-users'
 
 test.describe('Authentication', () => {
   test.use({ storageState: { cookies: [], origins: [] } })
@@ -24,11 +24,11 @@ test.describe('Authentication', () => {
     await page
       .locator('input[name="user_name"], input[name="username"], input[type="text"]')
       .first()
-      .fill(TEST_USER.username)
+      .fill(ADMIN_USER.username)
     await page
       .locator('input[name="password"], input[type="password"]')
       .first()
-      .fill(TEST_USER.password)
+      .fill(ADMIN_USER.password)
 
     // Submit form
     await page.locator('button[type="submit"]').click()
@@ -93,8 +93,8 @@ test.describe('Logout', () => {
       .first()
     const passwordInput = page.locator('input[name="password"], input[type="password"]').first()
 
-    await usernameInput.fill(TEST_USER.username)
-    await passwordInput.fill(TEST_USER.password)
+    await usernameInput.fill(ADMIN_USER.username)
+    await passwordInput.fill(ADMIN_USER.password)
     await page.locator('button[type="submit"]').click()
 
     // Wait for login to complete

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -32,6 +32,26 @@ setup('authenticate', async ({ page, request }) => {
     // Get auth token from localStorage
     const token = await page.evaluate(() => localStorage.getItem('auth_token'))
     if (token) {
+      // First, change the admin password via API to satisfy the password change requirement
+      // We change it to the same value - bcrypt will generate a different hash due to random salt,
+      // so admin_password_changed will become true while keeping the same login credentials
+      const passwordResponse = await page.request.put(`${apiBaseUrl}/api/users/me/password`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        data: {
+          new_password: TEST_USER.password,
+          confirm_password: TEST_USER.password,
+        },
+      })
+      if (passwordResponse.ok()) {
+        console.log('Admin password changed successfully (same credentials, different hash)')
+      } else {
+        console.warn(`Failed to change admin password: ${passwordResponse.status()}`)
+      }
+
+      // Now mark setup as complete
       const response = await page.request.post(`${apiBaseUrl}/api/admin/setup-complete`, {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -54,16 +74,32 @@ setup('authenticate', async ({ page, request }) => {
 
   console.log('Authentication successful, storage state saved')
 
-  // Mark admin setup as complete to prevent GlobalAdminSetupWizard from showing
-  // This is done via API to ensure it's completed before any tests run
+  // Double-check: Mark admin setup as complete using request context
+  // This is a backup in case the first attempt failed
   try {
-    // Get auth token from localStorage
     const authToken = await page.evaluate(() => {
       return localStorage.getItem('auth_token')
     })
 
     if (authToken) {
       const baseURL = process.env.E2E_API_URL || 'http://localhost:8000'
+
+      // Ensure password is changed first (idempotent - safe to call again)
+      await request
+        .put(`${baseURL}/api/users/me/password`, {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+            'Content-Type': 'application/json',
+          },
+          data: {
+            new_password: TEST_USER.password,
+            confirm_password: TEST_USER.password,
+          },
+        })
+        .catch(() => {
+          // Ignore - may already be done
+        })
+
       const response = await request.post(`${baseURL}/api/admin/setup-complete`, {
         headers: {
           Authorization: `Bearer ${authToken}`,

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -48,7 +48,9 @@ setup('authenticate', async ({ page, request }) => {
       if (passwordResponse.ok()) {
         console.log('Admin password changed successfully (same credentials, different hash)')
       } else {
-        console.warn(`Failed to change admin password: ${passwordResponse.status()}`)
+        throw new Error(
+          `Failed to change admin password: ${passwordResponse.status()} - ${await passwordResponse.text()}`
+        )
       }
 
       // Now mark setup as complete
@@ -61,12 +63,13 @@ setup('authenticate', async ({ page, request }) => {
       if (response.ok()) {
         console.log('Admin setup marked as complete')
       } else {
-        console.warn(`Failed to mark admin setup as complete: ${response.status()}`)
+        throw new Error(
+          `Failed to mark admin setup as complete: ${response.status()} - ${await response.text()}`
+        )
       }
     }
   } catch (error) {
-    console.warn('Warning: Could not mark admin setup as complete:', error)
-    // Continue anyway - this is not critical for all tests
+    throw new Error(`Admin setup failed during global-setup: ${error}`)
   }
 
   // Save storage state (cookies, localStorage)

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -1,5 +1,6 @@
 import { test as setup, expect } from '@playwright/test'
 import { login, TEST_USER } from '../utils/auth'
+import { E2E_ADMIN_Password } from '../config/test-users'
 import * as path from 'path'
 import { promises as fsPromises } from 'fs'
 
@@ -33,20 +34,19 @@ setup('authenticate', async ({ page, request }) => {
     const token = await page.evaluate(() => localStorage.getItem('auth_token'))
     if (token) {
       // First, change the admin password via API to satisfy the password change requirement
-      // We change it to the same value - bcrypt will generate a different hash due to random salt,
-      // so admin_password_changed will become true while keeping the same login credentials
+      // This changes the password from the default to a dedicated E2E password
       const passwordResponse = await page.request.put(`${apiBaseUrl}/api/users/me/password`, {
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
         data: {
-          new_password: TEST_USER.password,
-          confirm_password: TEST_USER.password,
+          new_password: E2E_ADMIN_Password,
+          confirm_password: E2E_ADMIN_Password,
         },
       })
       if (passwordResponse.ok()) {
-        console.log('Admin password changed successfully (same credentials, different hash)')
+        console.log('Admin password changed successfully to E2E password')
       } else {
         throw new Error(
           `Failed to change admin password: ${passwordResponse.status()} - ${await passwordResponse.text()}`
@@ -95,12 +95,12 @@ setup('authenticate', async ({ page, request }) => {
             'Content-Type': 'application/json',
           },
           data: {
-            new_password: TEST_USER.password,
-            confirm_password: TEST_USER.password,
+            new_password: E2E_ADMIN_Password,
+            confirm_password: E2E_ADMIN_Password,
           },
         })
         .catch(() => {
-          // Ignore - may already be done
+          // Ignore - may already be done or password is already different from default
         })
 
       const response = await request.post(`${baseURL}/api/admin/setup-complete`, {

--- a/frontend/e2e/utils/api-client.ts
+++ b/frontend/e2e/utils/api-client.ts
@@ -498,8 +498,7 @@ export class ApiClient {
 
   /**
    * Change admin password (required before marking setup as complete)
-   * In E2E tests, we change to the same password - bcrypt generates a different hash
-   * which satisfies the password change requirement while keeping the same credentials
+   * Changes the admin password from the default to a new value
    */
   async changeAdminPassword(
     newPassword: string,

--- a/frontend/e2e/utils/api-client.ts
+++ b/frontend/e2e/utils/api-client.ts
@@ -497,8 +497,24 @@ export class ApiClient {
   }
 
   /**
+   * Change admin password (required before marking setup as complete)
+   * In E2E tests, we change to the same password - bcrypt generates a different hash
+   * which satisfies the password change requirement while keeping the same credentials
+   */
+  async changeAdminPassword(
+    newPassword: string,
+    confirmPassword: string
+  ): Promise<ApiResponse> {
+    return this.call('PUT', '/api/users/me/password', {
+      new_password: newPassword,
+      confirm_password: confirmPassword,
+    })
+  }
+
+  /**
    * Mark admin setup as complete (admin only)
    * This is used to dismiss the GlobalAdminSetupWizard in E2E tests
+   * Note: Requires admin password to have been changed from default first
    */
   async markAdminSetupComplete(): Promise<ApiResponse> {
     return this.call('POST', '/api/admin/setup-complete')

--- a/frontend/e2e/utils/auth.ts
+++ b/frontend/e2e/utils/auth.ts
@@ -1,11 +1,13 @@
 import { Page } from '@playwright/test'
+import { DEFAULT_ADMIN_Password } from '../config/test-users'
 
 /**
  * Test credentials for E2E testing
+ * Uses default admin password for initial login (before password change in global-setup)
  */
 export const TEST_USER = {
   username: 'admin',
-  password: 'Wegent2025!',
+  password: DEFAULT_ADMIN_Password,
 }
 
 /**

--- a/frontend/e2e/utils/cleanup.ts
+++ b/frontend/e2e/utils/cleanup.ts
@@ -1,5 +1,6 @@
 import { APIRequestContext } from '@playwright/test'
 import { ApiClient, createApiClient } from './api-client'
+import { ADMIN_USER } from '../config/test-users'
 
 /**
  * Test resource types that need cleanup
@@ -29,7 +30,7 @@ export class CleanupManager {
   /**
    * Initialize with API client
    */
-  async initialize(username: string = 'admin', password: string = 'Wegent2025!'): Promise<void> {
+  async initialize(username: string = ADMIN_USER.username, password: string = ADMIN_USER.password): Promise<void> {
     if (!this.request) {
       throw new Error('APIRequestContext is required for cleanup')
     }

--- a/frontend/e2e/utils/helpers.ts
+++ b/frontend/e2e/utils/helpers.ts
@@ -1,6 +1,7 @@
 import { Page } from '@playwright/test'
 import { ApiClient, createApiClient } from './api-client'
 import { APIRequestContext } from '@playwright/test'
+import { ADMIN_USER } from '../config/test-users'
 
 /**
  * Smart wait utilities that replace hardcoded waitForTimeout calls
@@ -366,8 +367,8 @@ export function truncate(str: string, maxLength: number): string {
  */
 export async function createAuthenticatedApiClient(
   request: APIRequestContext,
-  username: string = 'admin',
-  password: string = 'Wegent2025!'
+  username: string = ADMIN_USER.username,
+  password: string = ADMIN_USER.password
 ): Promise<ApiClient> {
   const apiClient = createApiClient(request)
   await apiClient.login(username, password)

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
-    /* API tests - no browser needed, no setup dependency */
+    /* API tests - no browser needed, depends on setup for password change */
     {
       name: 'api',
       testMatch: /api\/.*\.spec\.ts/,
@@ -83,6 +83,7 @@ export default defineConfig({
         // API tests don't need a browser
         baseURL: process.env.E2E_API_URL || 'http://localhost:8000',
       },
+      dependencies: ['setup'],
     },
     /* Performance tests */
     {

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -190,6 +190,13 @@ export const userApis = {
     return apiClient.get('/users/features')
   },
 
+  /**
+   * Change current user's password
+   */
+  async changePassword(data: { new_password: string; confirm_password: string }): Promise<User> {
+    return apiClient.put('/users/me/password', data)
+  },
+
   isAuthenticated(): boolean {
     return isAuthenticated()
   },

--- a/frontend/src/features/admin/components/GlobalAdminSetupWizard.tsx
+++ b/frontend/src/features/admin/components/GlobalAdminSetupWizard.tsx
@@ -32,10 +32,11 @@ import { adminApis } from '@/apis/admin'
 import { userApis } from '@/apis/user'
 import { useUser } from '@/features/common/UserContext'
 import { useSetupWizard } from '../contexts/SetupWizardContext'
+import SetupPasswordStep from './SetupPasswordStep'
 import SetupModelStep from './SetupModelStep'
 import SetupSkillStep from './SetupSkillStep'
 
-const TOTAL_STEPS = 2
+const TOTAL_STEPS = 3
 
 /**
  * Global Admin Setup Wizard component that shows on any page when:
@@ -44,6 +45,11 @@ const TOTAL_STEPS = 2
  *
  * This component should be placed in the root layout to ensure it shows
  * regardless of which page the admin first lands on.
+ *
+ * Setup steps:
+ * - Step 1: Change default password (mandatory, cannot be skipped)
+ * - Step 2: Configure public models (can be skipped)
+ * - Step 3: Configure public skills (can be skipped)
  *
  * Setup status is fetched from the welcome-config API to avoid extra API calls.
  */
@@ -58,6 +64,7 @@ const GlobalAdminSetupWizard: React.FC = () => {
   const [currentStep, setCurrentStep] = useState(1)
   const [isSkipDialogOpen, setIsSkipDialogOpen] = useState(false)
   const [completing, setCompleting] = useState(false)
+  const [passwordChanged, setPasswordChanged] = useState(false)
 
   // Sync open state with context so other components can know when wizard is open
   useEffect(() => {
@@ -84,6 +91,16 @@ const GlobalAdminSetupWizard: React.FC = () => {
         // admin_setup_completed is only returned for admin users
         if (response.admin_setup_completed === false) {
           setOpen(true)
+
+          // Check if password has already been changed
+          if (response.admin_password_changed === true) {
+            setPasswordChanged(true)
+            // Skip password step, start from step 2
+            setCurrentStep(2)
+          } else {
+            setPasswordChanged(false)
+            setCurrentStep(1)
+          }
         }
       } catch (error) {
         console.error('Failed to check setup status:', error)
@@ -104,10 +121,12 @@ const GlobalAdminSetupWizard: React.FC = () => {
   }, [currentStep])
 
   const handlePrevious = useCallback(() => {
-    if (currentStep > 1) {
+    // Don't go back to password step if already changed
+    const minStep = passwordChanged ? 2 : 1
+    if (currentStep > minStep) {
       setCurrentStep(prev => prev - 1)
     }
-  }, [currentStep])
+  }, [currentStep, passwordChanged])
 
   const handleComplete = useCallback(async () => {
     setCompleting(true)
@@ -150,6 +169,15 @@ const GlobalAdminSetupWizard: React.FC = () => {
     }
   }, [toast, t])
 
+  const handlePasswordChanged = useCallback(() => {
+    setPasswordChanged(true)
+    // Automatically move to next step after password change
+    setCurrentStep(2)
+  }, [])
+
+  // Whether the current step allows skipping/closing
+  const canSkipOrClose = passwordChanged || currentStep > 1
+
   // Don't render anything while checking status or if not admin
   if (loading || userLoading || !user || user.role !== 'admin') {
     return null
@@ -175,8 +203,10 @@ const GlobalAdminSetupWizard: React.FC = () => {
   const renderStepContent = () => {
     switch (currentStep) {
       case 1:
-        return <SetupModelStep />
+        return <SetupPasswordStep onPasswordChanged={handlePasswordChanged} />
       case 2:
+        return <SetupModelStep />
+      case 3:
         return <SetupSkillStep />
       default:
         return null
@@ -189,7 +219,10 @@ const GlobalAdminSetupWizard: React.FC = () => {
         open={open}
         onOpenChange={nextOpen => {
           if (!nextOpen && !completing) {
-            setIsSkipDialogOpen(true)
+            if (canSkipOrClose) {
+              setIsSkipDialogOpen(true)
+            }
+            // If password not changed, don't allow closing
           }
         }}
       >
@@ -222,18 +255,22 @@ const GlobalAdminSetupWizard: React.FC = () => {
               <Button
                 variant="ghost"
                 onClick={() => setIsSkipDialogOpen(true)}
-                disabled={completing}
+                disabled={completing || !canSkipOrClose}
               >
                 {t('setup_wizard.skip')}
               </Button>
               <div className="flex gap-2">
-                {currentStep > 1 && (
+                {currentStep > 1 && (passwordChanged ? currentStep > 2 : true) && (
                   <Button variant="outline" onClick={handlePrevious} disabled={completing}>
                     {t('setup_wizard.previous')}
                   </Button>
                 )}
                 {currentStep < TOTAL_STEPS ? (
-                  <Button variant="primary" onClick={handleNext} disabled={completing}>
+                  <Button
+                    variant="primary"
+                    onClick={handleNext}
+                    disabled={completing || (currentStep === 1 && !passwordChanged)}
+                  >
                     {t('setup_wizard.next')}
                   </Button>
                 ) : (

--- a/frontend/src/features/admin/components/SetupPasswordStep.tsx
+++ b/frontend/src/features/admin/components/SetupPasswordStep.tsx
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import React, { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { EyeIcon, EyeSlashIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
+import { Loader2 } from 'lucide-react'
+import { useToast } from '@/hooks/use-toast'
+import { useTranslation } from '@/hooks/useTranslation'
+import { userApis } from '@/apis/user'
+
+interface SetupPasswordStepProps {
+  onPasswordChanged: () => void
+}
+
+/**
+ * Setup wizard step for changing the default admin password.
+ * This step is mandatory and cannot be skipped.
+ */
+const SetupPasswordStep: React.FC<SetupPasswordStepProps> = ({ onPasswordChanged }) => {
+  const { t } = useTranslation('admin')
+  const { toast } = useToast()
+
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [showNewPassword, setShowNewPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async () => {
+    setError(null)
+
+    // Validate password length
+    if (newPassword.length < 6) {
+      setError(t('setup_wizard.password_step.password_min_length'))
+      return
+    }
+
+    // Validate password match
+    if (newPassword !== confirmPassword) {
+      setError(t('setup_wizard.password_step.password_mismatch'))
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await userApis.changePassword({
+        new_password: newPassword,
+        confirm_password: confirmPassword,
+      })
+      toast({
+        title: t('setup_wizard.password_step.change_password_success'),
+      })
+      onPasswordChanged()
+    } catch (err) {
+      console.error('Failed to change password:', err)
+      setError(err instanceof Error ? err.message : t('setup_wizard.errors.complete_failed'))
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Security notice */}
+      <div className="flex items-start gap-3 p-4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-lg">
+        <ShieldCheckIcon className="w-6 h-6 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5" />
+        <div>
+          <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+            {t('setup_wizard.password_step.title')}
+          </h3>
+          <p className="text-sm text-amber-700 dark:text-amber-300 mt-1">
+            {t('setup_wizard.password_step.description')}
+          </p>
+        </div>
+      </div>
+
+      {/* Password form */}
+      <div className="space-y-4">
+        {/* New password */}
+        <div>
+          <label
+            htmlFor="new_password"
+            className="block text-sm font-medium text-text-secondary mb-1"
+          >
+            {t('setup_wizard.password_step.new_password')}
+          </label>
+          <div className="relative">
+            <Input
+              id="new_password"
+              type={showNewPassword ? 'text' : 'password'}
+              value={newPassword}
+              onChange={e => setNewPassword(e.target.value)}
+              placeholder={t('setup_wizard.password_step.new_password')}
+              className="pr-10"
+              disabled={isSubmitting}
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 pr-3 flex items-center"
+              onClick={() => setShowNewPassword(!showNewPassword)}
+            >
+              {showNewPassword ? (
+                <EyeIcon className="h-5 w-5 text-text-muted hover:text-text-secondary" />
+              ) : (
+                <EyeSlashIcon className="h-5 w-5 text-text-muted hover:text-text-secondary" />
+              )}
+            </button>
+          </div>
+          <p className="text-xs text-text-muted mt-1">
+            {t('setup_wizard.password_step.password_min_length')}
+          </p>
+        </div>
+
+        {/* Confirm password */}
+        <div>
+          <label
+            htmlFor="confirm_password"
+            className="block text-sm font-medium text-text-secondary mb-1"
+          >
+            {t('setup_wizard.password_step.confirm_password')}
+          </label>
+          <div className="relative">
+            <Input
+              id="confirm_password"
+              type={showConfirmPassword ? 'text' : 'password'}
+              value={confirmPassword}
+              onChange={e => setConfirmPassword(e.target.value)}
+              placeholder={t('setup_wizard.password_step.confirm_password')}
+              className="pr-10"
+              disabled={isSubmitting}
+            />
+            <button
+              type="button"
+              className="absolute inset-y-0 right-0 pr-3 flex items-center"
+              onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            >
+              {showConfirmPassword ? (
+                <EyeIcon className="h-5 w-5 text-text-muted hover:text-text-secondary" />
+              ) : (
+                <EyeSlashIcon className="h-5 w-5 text-text-muted hover:text-text-secondary" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Error message */}
+        {error && <div className="text-sm text-red-600 dark:text-red-400">{error}</div>}
+
+        {/* Submit button */}
+        <Button
+          variant="primary"
+          onClick={handleSubmit}
+          disabled={isSubmitting || !newPassword || !confirmPassword}
+          className="w-full"
+        >
+          {isSubmitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              {t('common.loading')}
+            </>
+          ) : (
+            t('setup_wizard.password_step.change_password_button')
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default SetupPasswordStep

--- a/frontend/src/features/login/components/LoginForm.tsx
+++ b/frontend/src/features/login/components/LoginForm.tsx
@@ -16,19 +16,20 @@ import LanguageSwitcher from '@/components/LanguageSwitcher'
 import { ThemeToggle } from '@/features/theme/ThemeToggle'
 import { POST_LOGIN_REDIRECT_KEY, sanitizeRedirectPath } from '@/features/login/constants'
 import Image from 'next/image'
-import { getRuntimeConfigSync } from '@/lib/runtime-config'
+import { getRuntimeConfigSync, getApiBaseUrl } from '@/lib/runtime-config'
 
 export default function LoginForm() {
   const { t } = useTranslation()
   const router = useRouter()
   const searchParams = useSearchParams()
   const [formData, setFormData] = useState({
-    user_name: 'admin',
-    password: 'Wegent2025!',
+    user_name: '',
+    password: '',
   })
   const [showPassword, setShowPassword] = useState(false)
   // Used antd message.error for unified error prompt, no need for local error state
   const [isLoading, setIsLoading] = useState(false)
+  const [showDefaultCredentials, setShowDefaultCredentials] = useState(false)
 
   // Get login mode configuration from runtime config
   const runtimeConfig = getRuntimeConfigSync()
@@ -41,6 +42,31 @@ export default function LoginForm() {
   const loginPath = paths.auth.login.getHref()
   const defaultRedirect = paths.chat.getHref()
   const [redirectPath, setRedirectPath] = useState(defaultRedirect)
+
+  // Check if admin password has been changed to determine whether to show default credentials
+  useEffect(() => {
+    const checkAdminPasswordStatus = async () => {
+      try {
+        const baseUrl = getApiBaseUrl()
+        const response = await fetch(`${baseUrl}/health`)
+        if (response.ok) {
+          const data = await response.json()
+          if (data.admin_password_changed === false) {
+            // Admin still uses default password - show default credentials
+            setShowDefaultCredentials(true)
+            setFormData({
+              user_name: 'admin',
+              password: 'Wegent2025!',
+            })
+          }
+        }
+      } catch {
+        // Health check failed, keep form empty
+      }
+    }
+
+    checkAdminPasswordStatus()
+  }, [])
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -206,10 +232,12 @@ export default function LoginForm() {
             </Button>
           </div>
 
-          {/* Show test account info */}
-          <div className="mt-6 text-center text-xs text-text-muted">
-            {t('common:login.test_account')}
-          </div>
+          {/* Show test account info only when admin password hasn't been changed */}
+          {showDefaultCredentials && (
+            <div className="mt-6 text-center text-xs text-text-muted">
+              {t('common:login.test_account')}
+            </div>
+          )}
         </form>
       )}
 

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -641,6 +641,16 @@
     "skip_confirm_message": "You can configure public models and skills later in the administration panel. Are you sure you want to skip the setup wizard?",
     "skip_confirm_yes": "Yes, skip",
     "skip_confirm_no": "Continue setup",
+    "password_step": {
+      "title": "Change Password",
+      "description": "For account security, please change the default password before continuing",
+      "new_password": "New Password",
+      "confirm_password": "Confirm Password",
+      "password_min_length": "Password must be at least 6 characters",
+      "password_mismatch": "Passwords do not match",
+      "change_password_success": "Password changed successfully",
+      "change_password_button": "Change Password"
+    },
     "model_step": {
       "title": "Configure Public Models",
       "description": "Set up AI models that will be available to all users. You can add multiple models.",

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -641,6 +641,16 @@
     "skip_confirm_message": "您可以稍后在管理面板中配置公共模型和技能。确定要跳过设置向导吗？",
     "skip_confirm_yes": "是的，跳过",
     "skip_confirm_no": "继续设置",
+    "password_step": {
+      "title": "修改密码",
+      "description": "为了账户安全，请修改默认密码后再继续",
+      "new_password": "新密码",
+      "confirm_password": "确认密码",
+      "password_min_length": "密码长度至少为 6 位",
+      "password_mismatch": "两次输入的密码不一致",
+      "change_password_success": "密码修改成功",
+      "change_password_button": "确认修改"
+    },
     "model_step": {
       "title": "配置公共模型",
       "description": "设置所有用户可用的 AI 模型。您可以添加多个模型。",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -595,6 +595,8 @@ export interface WelcomeConfigResponse {
   tips: ChatTipItem[]
   /** Whether admin setup wizard has been completed (only returned for admin users) */
   admin_setup_completed?: boolean | null
+  /** Whether admin password has been changed from default (only returned for admin users) */
+  admin_password_changed?: boolean | null
 }
 
 // Default Teams Configuration Types


### PR DESCRIPTION
## Summary

- Add password change as mandatory first step in admin setup wizard (Step 1: Change Password → Step 2: Configure Models → Step 3: Configure Skills)
- Admin cannot skip or close the wizard until default password is changed
- Login page conditionally hides default credentials when admin password has been changed
- Backend enforces password change before allowing setup completion

## Changes

### Backend
1. **`backend/app/core/yaml_init.py`**: Extract default admin password hash as `DEFAULT_ADMIN_Password_HASH` constant
2. **`backend/app/schemas/user.py`**: Add `ChangePasswordRequest` schema with validation
3. **`backend/app/api/endpoints/users.py`**: Add `PUT /api/users/me/password` endpoint for password change
4. **`backend/app/api/endpoints/users.py`**: Add `admin_password_changed` to welcome-config response
5. **`backend/app/schemas/admin.py`**: Add `admin_password_changed` field to `WelcomeConfigResponse`
6. **`backend/app/api/endpoints/health.py`**: Add `admin_password_changed` to health check (unauthenticated)
7. **`backend/app/api/endpoints/admin/system_config.py`**: Block setup completion if password still default

### Frontend
8. **`frontend/src/types/api.ts`**: Add `admin_password_changed` to `WelcomeConfigResponse`
9. **`frontend/src/apis/user.ts`**: Add `changePassword()` API method
10. **`frontend/src/features/admin/components/SetupPasswordStep.tsx`**: New password change step component
11. **`frontend/src/features/admin/components/GlobalAdminSetupWizard.tsx`**: 3-step wizard with mandatory password step
12. **`frontend/src/features/login/components/LoginForm.tsx`**: Conditional default credentials based on health API
13. **`frontend/src/i18n/locales/{en,zh-CN}/admin.json`**: Add translations for password step

## Test plan

- [ ] Fresh install: Login page shows default credentials (admin/Wegent2025!)
- [ ] Fresh install: Admin login triggers setup wizard starting at password change step
- [ ] Password step: Cannot click "Next" or "Skip" until password is changed
- [ ] Password step: Cannot close dialog (ESC, overlay click, X button)
- [ ] Password step: Validates min length (6 chars) and match
- [ ] Password step: After successful change, auto-advances to step 2
- [ ] After password change: Login page no longer shows default credentials
- [ ] After password change: Skip/close wizard works for remaining steps
- [ ] Backend: `POST /setup-complete` returns 400 if password is still default
- [ ] OIDC users: Not affected by password change flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can change their password via a new profile endpoint and UI step.
  * Admin setup wizard adds a mandatory change-password step (auto-skips if already changed).
  * Health and welcome responses now indicate whether the admin password was changed.
  * Login UI can surface default credentials when appropriate.
* **Bug Fixes**
  * Prevents completing admin setup while admin password remains the default.
* **Tests**
  * E2E flows updated to perform an idempotent admin password change before completing setup.
* **Localization**
  * Added UI text for the new password step in English and Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->