### PR TITLE
feat: Celery queues support splitting online and preview.

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,6 +34,10 @@ REDIS_URL=redis://127.0.0.1:6379/0
 # CELERY_RESULT_BACKEND=redis://127.0.0.1:6379/0
 # If not set, will use REDIS_URL
 
+# Celery Task Default Queue (useful for separating environments)
+# Set to 'wegent_online' or 'wegent_preview' as needed
+# CELERY_TASK_DEFAULT_QUEUE=wegent_online
+
 # Celery Beat scheduler configuration
 # RedBeat (default): Uses Redis for distributed schedule storage
 # - Automatically handles multi-instance coordination

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -65,6 +65,8 @@ celery_app.conf.update(
     result_expires=3600,  # Results expire after 1 hour
     # Retry settings
     task_default_retry_delay=60,  # 1 minute default retry delay
+    # Default queue configuration
+    task_default_queue=settings.CELERY_TASK_DEFAULT_QUEUE,
     # Beat schedule for periodic tasks
     beat_schedule={
         "check-due-subscriptions": {

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -160,6 +160,9 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: Optional[str] = None  # If None/empty, uses REDIS_URL
     CELERY_RESULT_BACKEND: Optional[str] = None  # If None/empty, uses REDIS_URL
 
+    # Celery default queue name (useful for separating preview and prod environments)
+    CELERY_TASK_DEFAULT_QUEUE: str = "wegent_online"
+
     # Celery Beat scheduler configuration
     # "default" = SQLite file (single instance only)
     # "sqlalchemy" = MySQL database (multi-instance deployment)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added configurable default task queue setting that can be customized per environment via configuration variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->