### PR TITLE
fix: restore workbench data flow from executor to frontend

### DIFF
--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -399,6 +399,7 @@ async def _create_streaming_response_unified(
         from app.services.execution.emitters import SSEResultEmitter
 
         accumulated_content = ""
+        final_result = None  # Store complete result from DONE event
 
         try:
             cancel_event = await session_manager.register_stream(assistant_subtask_id)
@@ -435,8 +436,12 @@ async def _create_streaming_response_unified(
                         logger.error(f"[OPENAPI] Error from execution: {error_msg}")
                         raise Exception(error_msg)
                     elif event.type == EventType.DONE.value:
+                        # Store complete result including workbench/thinking
+                        final_result = event.result
                         logger.info(
-                            f"[OPENAPI] Stream completed for subtask {assistant_subtask_id}"
+                            f"[OPENAPI] Stream completed for subtask {assistant_subtask_id}, "
+                            f"has_result={final_result is not None}, "
+                            f"has_workbench={final_result.get('workbench') is not None if final_result else False}"
                         )
             finally:
                 # Wait for dispatch task to complete
@@ -449,7 +454,15 @@ async def _create_streaming_response_unified(
             if not cancel_event.is_set() and not await session_manager.is_cancelled(
                 assistant_subtask_id
             ):
-                result = {"value": accumulated_content}
+                # Use final_result from DONE event (includes workbench/thinking)
+                # Fall back to accumulated_content if result is missing
+                if final_result:
+                    result = final_result
+                    # Ensure value field contains accumulated content if not present
+                    if "value" not in result or not result["value"]:
+                        result["value"] = accumulated_content
+                else:
+                    result = {"value": accumulated_content}
                 await session_manager.save_streaming_content(
                     assistant_subtask_id, accumulated_content
                 )
@@ -680,7 +693,7 @@ async def _create_sync_response_unified(
         )
 
         # Collect all content from emitter
-        accumulated_content, _ = await emitter.collect()
+        accumulated_content, final_event = await emitter.collect()
 
         # Wait for dispatch task to complete
         try:
@@ -691,7 +704,14 @@ async def _create_sync_response_unified(
         logger.info(f"[OPENAPI] Sync completed for subtask {assistant_subtask_id}")
 
         # Update subtask to completed
-        result = {"value": accumulated_content}
+        # Use final_event.result (includes workbench/thinking) if available
+        if final_event and final_event.result:
+            result = final_event.result
+            # Ensure value field contains accumulated content if not present
+            if "value" not in result or not result["value"]:
+                result["value"] = accumulated_content
+        else:
+            result = {"value": accumulated_content}
         await db_handler.update_subtask_status(
             assistant_subtask_id, "COMPLETED", result=result
         )

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -124,6 +124,8 @@ class ResponsesAPIEventParser:
                     "silent_exit_reason": response_data.get("silent_exit_reason"),
                     "loaded_skills": response_data.get("loaded_skills"),
                     "stop_reason": response_data.get("stop_reason"),
+                    "workbench": response_data.get("workbench"),
+                    "thinking": response_data.get("thinking"),
                 },
                 message_id=message_id,
             )

--- a/executor/agents/claude_code/response_processor.py
+++ b/executor/agents/claude_code/response_processor.py
@@ -938,6 +938,14 @@ async def _process_result_message(
                     )
                 )
 
+                # Get workbench and thinking data from state manager
+                workbench_data = None
+                thinking_data = None
+                if state_manager:
+                    current_state = state_manager.get_current_state()
+                    workbench_data = current_state.get("workbench")
+                    thinking_data = current_state.get("thinking")
+
                 # Send done event (response.completed) via emitter
                 await emitter.done(
                     content=content,
@@ -946,6 +954,8 @@ async def _process_result_message(
                     silent_exit_reason=(
                         silent_exit_reason if silent_exit_reason else None
                     ),
+                    workbench=workbench_data,
+                    thinking=thinking_data,
                 )
                 logger.info(f"Sent done event for task {task_id}")
             except Exception as e:
@@ -966,10 +976,20 @@ async def _process_result_message(
             # Update task status to completed
             state_manager.set_task_status(TaskStatus.COMPLETED.value)
 
+            # Get workbench and thinking data from state manager
+            workbench_data = None
+            thinking_data = None
+            if state_manager:
+                current_state = state_manager.get_current_state()
+                workbench_data = current_state.get("workbench")
+                thinking_data = current_state.get("thinking")
+
             # Send done event (response.completed) via emitter
             await emitter.done(
                 content=result_str,
                 usage=msg.usage,
+                workbench=workbench_data,
+                thinking=thinking_data,
             )
             logger.info(f"Sent done event for task {task_id}")
         return TaskStatus.COMPLETED

--- a/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
@@ -139,24 +139,24 @@ export function CodePageDesktop() {
       // Priority for workbench: streaming message > completed message with result
       const allBlocks: MessageBlock[] = []
       let latestWorkbench: WorkbenchData | null = null
+      let streamingWorkbench: WorkbenchData | null = null
+      let completedWorkbench: WorkbenchData | null = null
 
       for (const msg of taskState.messages.values()) {
-        if (msg.type === 'ai') {
-          // Collect blocks from all AI messages
-          if (msg.result) {
-            const result = msg.result as { blocks?: MessageBlock[]; workbench?: WorkbenchData }
-            if (result.blocks && Array.isArray(result.blocks)) {
-              allBlocks.push(...result.blocks)
-            }
-            // For streaming messages, always use their workbench (real-time updates)
-            if (msg.status === 'streaming' && result.workbench) {
-              latestWorkbench = result.workbench
-            } else if (!latestWorkbench && result.workbench) {
-              latestWorkbench = result.workbench
-            }
+        if (msg.type === 'ai' && msg.result) {
+          const result = msg.result as { blocks?: MessageBlock[]; workbench?: WorkbenchData }
+          if (result.blocks && Array.isArray(result.blocks)) {
+            allBlocks.push(...result.blocks)
+          }
+          if (msg.status === 'streaming' && result.workbench) {
+            streamingWorkbench = result.workbench
+          } else if (result.workbench) {
+            completedWorkbench = result.workbench
           }
         }
       }
+
+      latestWorkbench = streamingWorkbench || completedWorkbench
 
       // Return aggregated blocks and latest workbench
       if (allBlocks.length > 0 || latestWorkbench) {


### PR DESCRIPTION
- response_processor.py: pass workbench/thinking to emitter.done()
- dispatcher.py: extract workbench/thinking from RESPONSE_COMPLETED
- openapi_responses.py: use final_result instead of accumulated_content
- CodePageDesktop.tsx: fix workbench priority (streaming > completed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result capture and completion tracking for AI code execution operations.
  * Enhanced workbench data handling and display in the code interface, with prioritized streaming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->