### PR TITLE
feat(frontend): enable device selection on chat page

### DIFF
--- a/frontend/src/app/(tasks)/chat/page.tsx
+++ b/frontend/src/app/(tasks)/chat/page.tsx
@@ -9,7 +9,7 @@ import dynamic from 'next/dynamic'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { teamService } from '@/features/tasks/service/teamService'
 import OnboardingTour from '@/features/onboarding/OnboardingTour'
-import { TaskParamSync, DeviceTaskSync } from '@/features/tasks/components/params'
+import { TaskParamSync, DeviceTaskSync, DeviceParamSync } from '@/features/tasks/components/params'
 import { TeamShareHandler, TaskShareHandler } from '@/features/tasks/components/share'
 import { InviteJoinHandler } from '@/features/tasks/components/group-chat'
 import OidcTokenHandler from '@/features/login/components/OidcTokenHandler'
@@ -88,6 +88,7 @@ export default function ChatPage() {
       <Suspense>
         <TaskParamSync />
         <DeviceTaskSync />
+        <DeviceParamSync />
       </Suspense>
       <Suspense>
         <TeamShareHandler

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -215,15 +215,16 @@ export function useChatStreamHandlers({
   // Get selected device ID for executor-based tasks
   const { selectedDeviceId } = useDevices()
 
-  // Determine if we're on the devices page - only devices page should send device_id
-  // This prevents coding tasks from accidentally inheriting a device_id from a previous device task
+  // Determine if we're in device mode - devices page or chat page with device selected
+  // This prevents coding tasks from accidentally inheriting a device_id
   const isDevicesPage = pathname?.startsWith('/devices')
+  const isDeviceMode = isDevicesPage || taskType === 'task'
 
   // Determine effective device_id to send:
-  // - Only send device_id if we're on the devices page AND team is not Chat Shell
-  // - This ensures coding tasks (on /code or /chat pages) don't get routed to devices
+  // - Send device_id when in device mode (devices page or chat page with device selected) AND team is not Chat Shell
+  // - This ensures coding tasks don't get routed to devices
   const effectiveDeviceId =
-    isDevicesPage && !isChatShell(selectedTeam) ? selectedDeviceId || undefined : undefined
+    isDeviceMode && !isChatShell(selectedTeam) ? selectedDeviceId || undefined : undefined
 
   // Local state
   const [pendingTaskId, setPendingTaskId] = useState<number | null>(null)


### PR DESCRIPTION
Add DeviceParamSync to /chat page and relax the device_id guard in useChatStreamHandlers so that device mode works on both /devices/chat and /chat pages. Previously device_id was only sent when on the /devices path; now it is sent whenever taskType is 'task' (i.e. a device is selected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced device parameter synchronization in the chat interface.
  * Improved device ID handling during device mode operations to better support chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->