### PR TITLE
fix: 修复executor因为数据上报导致卡死的问题

### DIFF
--- a/executor/agents/base.py
+++ b/executor/agents/base.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import os
+import threading
 from collections import OrderedDict
 from typing import Any, Dict, Optional, Tuple
 
@@ -27,6 +28,8 @@ class Agent:
     """
     Base Agent class that all specific agents should inherit from
     """
+
+    PROGRESS_CALLBACK_TIMEOUT_SECONDS = 10.0
 
     def get_name(self) -> str:
         """
@@ -66,6 +69,8 @@ class Agent:
 
         # Emitter is required and must be provided by caller
         self.emitter: ResponsesAPIEmitter = emitter
+        self._progress_task_lock = threading.Lock()
+        self._inflight_progress_task: Optional[asyncio.Task] = None
 
     def get_emitter(self) -> ResponsesAPIEmitter:
         """
@@ -198,19 +203,65 @@ class Agent:
                 else:
                     await self.get_emitter().in_progress()
 
-            # Run async in sync context
+            async def _send_progress_with_timeout():
+                await asyncio.wait_for(
+                    _send_progress(),
+                    timeout=self.PROGRESS_CALLBACK_TIMEOUT_SECONDS,
+                )
+
+            # In async context, schedule callback without blocking the event loop.
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                loop = asyncio.get_event_loop()
-                loop.run_until_complete(_send_progress())
+                asyncio.run(_send_progress_with_timeout())
                 return
 
-            import concurrent.futures
+            with self._progress_task_lock:
+                inflight_task = self._inflight_progress_task
+                if (
+                    not is_failed
+                    and inflight_task is not None
+                    and not inflight_task.done()
+                ):
+                    logger.info(
+                        f"Cancelling previous in-progress callback before sending newer progress: "
+                        f"task_id={self.task_id}, progress={progress}, status={status}"
+                    )
+                    inflight_task.cancel()
 
-            with concurrent.futures.ThreadPoolExecutor() as executor:
-                future = executor.submit(asyncio.run, _send_progress())
-                future.result()
+            task = loop.create_task(_send_progress_with_timeout())
+            with self._progress_task_lock:
+                self._inflight_progress_task = task
+
+            def _log_task_error(done_task: asyncio.Task) -> None:
+                with self._progress_task_lock:
+                    if self._inflight_progress_task is done_task:
+                        self._inflight_progress_task = None
+
+                try:
+                    done_task.result()
+                except asyncio.CancelledError:
+                    logger.warning(
+                        f"[CALLBACK_CANCELLED] task_id={self.task_id}, progress={progress}, "
+                        f"status={status}"
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        f"[CALLBACK_TIMEOUT] task_id={self.task_id}, progress={progress}, "
+                        f"status={status}, timeout={self.PROGRESS_CALLBACK_TIMEOUT_SECONDS}s"
+                    )
+                except Exception as task_error:
+                    logger.critical(
+                        f"[CALLBACK_FAIL] task_id={self.task_id}, progress={progress}, "
+                        f"status={status}, error={type(task_error).__name__}: {str(task_error)}"
+                    )
+
+            task.add_done_callback(_log_task_error)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"[CALLBACK_TIMEOUT] task_id={self.task_id}, progress={progress}, "
+                f"status={status}, timeout={self.PROGRESS_CALLBACK_TIMEOUT_SECONDS}s"
+            )
         except Exception as e:
             logger.critical(
                 f"[CALLBACK_FAIL] task_id={self.task_id}, progress={progress}, "

--- a/executor/tests/agents/test_base.py
+++ b/executor/tests/agents/test_base.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -91,6 +93,95 @@ class TestAgent:
 
         # Verify emitter.in_progress was called
         mock_emitter.in_progress.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_report_progress_non_blocking_in_async_context(
+        self, agent, mock_emitter
+    ):
+        """Test report_progress returns quickly when called inside an event loop."""
+
+        async def slow_in_progress():
+            await asyncio.sleep(0.2)
+            return {"status": "success"}
+
+        mock_emitter.in_progress.side_effect = slow_in_progress
+
+        start = time.perf_counter()
+        agent.report_progress(
+            progress=50,
+            status="running",
+            message="Test message",
+            result={"key": "value"},
+        )
+        elapsed = time.perf_counter() - start
+
+        # report_progress should not block the caller while callback is running.
+        assert elapsed < 0.1
+
+        await asyncio.sleep(0.25)
+        assert mock_emitter.in_progress.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_report_progress_cancels_previous_callback_when_newer_one_arrives(
+        self, agent, mock_emitter
+    ):
+        """Test in-progress callback is replaced when a newer progress update arrives."""
+
+        state = {"started": 0, "cancelled": 0, "completed": 0}
+
+        async def slow_in_progress():
+            state["started"] += 1
+            try:
+                await asyncio.sleep(0.3)
+                state["completed"] += 1
+                return {"status": "success"}
+            except asyncio.CancelledError:
+                state["cancelled"] += 1
+                raise
+
+        mock_emitter.in_progress.side_effect = slow_in_progress
+        agent.PROGRESS_CALLBACK_TIMEOUT_SECONDS = 1.0
+
+        agent.report_progress(
+            progress=10,
+            status=TaskStatus.RUNNING.value,
+            message="step-1",
+        )
+        await asyncio.sleep(0.01)
+
+        agent.report_progress(
+            progress=11,
+            status=TaskStatus.RUNNING.value,
+            message="step-2",
+        )
+        await asyncio.sleep(0.4)
+
+        assert mock_emitter.in_progress.await_count == 2
+        assert state["started"] == 2
+        assert state["cancelled"] == 1
+        assert state["completed"] == 1
+
+    @pytest.mark.asyncio
+    async def test_report_progress_timeout_clears_inflight_task(
+        self, agent, mock_emitter
+    ):
+        """Test timeout clears inflight progress task to avoid stale blocking state."""
+
+        async def hanging_in_progress():
+            await asyncio.sleep(1.0)
+            return {"status": "success"}
+
+        mock_emitter.in_progress.side_effect = hanging_in_progress
+        agent.PROGRESS_CALLBACK_TIMEOUT_SECONDS = 0.05
+
+        agent.report_progress(
+            progress=20,
+            status=TaskStatus.RUNNING.value,
+            message="step-timeout",
+        )
+
+        await asyncio.sleep(0.2)
+        assert agent._inflight_progress_task is None
 
     @pytest.mark.asyncio
     @patch("executor.agents.base.git_util.clone_repo")

--- a/executor/tests/agents/test_multimodal_prompt.py
+++ b/executor/tests/agents/test_multimodal_prompt.py
@@ -150,7 +150,7 @@ class TestCreateMultimodalQuery:
                 messages.append(msg)
             return messages
 
-        messages = asyncio.get_event_loop().run_until_complete(run())
+        messages = asyncio.run(run())
         assert len(messages) == 1
         assert messages[0]["type"] == "user"
         assert messages[0]["message"]["role"] == "user"
@@ -175,7 +175,7 @@ class TestCreateMultimodalQuery:
                 messages.append(msg)
             return messages
 
-        messages = asyncio.get_event_loop().run_until_complete(run())
+        messages = asyncio.run(run())
         assert messages[0]["message"]["content"] == content
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Progress callbacks now execute non-blocking and won't freeze the application during extended operations.
  * Progress callbacks timeout after 10 seconds if they don't complete.
  * Rapid progress updates are handled more efficiently by cancelling outdated callbacks.

* **Tests**
  * Added comprehensive tests for progress reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->