### PR TITLE
feat: support custom history count

### DIFF
--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -487,12 +487,16 @@ async def _create_subscription_task(
     reuse_task_id = None
     if ctx.preserve_history and ctx.bound_task_id > 0:
         # Check if the bound task still exists and is valid
+        # Note: Subscription tasks have is_active=STATE_SUBSCRIPTION (2), not STATE_ACTIVE (1)
+        # We need to check for both states to properly reuse the bound task
         bound_task = (
             db.query(TaskResource)
             .filter(
                 TaskResource.id == ctx.bound_task_id,
                 TaskResource.kind == "Task",
-                TaskResource.is_active == TaskResource.STATE_ACTIVE,
+                TaskResource.is_active.in_(
+                    [TaskResource.STATE_ACTIVE, TaskResource.STATE_SUBSCRIPTION]
+                ),
             )
             .first()
         )

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -270,6 +270,14 @@ class ChatContext:
             limit=history_limit,
         )
         add_span_event("chat_history_loaded", {"message_count": len(history)})
+
+        # Log detailed history content for debugging preserve_history feature
+        logger.info(
+            "[CHAT_CONTEXT] <<< History loaded: task_id=%d, count=%d, history_limit=%s",
+            self._request.task_id,
+            len(history),
+            history_limit,
+        )
         return history
 
     @trace_async(

--- a/frontend/src/features/feed/components/SubscriptionForm.tsx
+++ b/frontend/src/features/feed/components/SubscriptionForm.tsx
@@ -299,6 +299,7 @@ export function SubscriptionForm({
     normalizeExecutionTarget(initialData?.executionTarget)
   )
   const [preserveHistory, setPreserveHistory] = useState(initialData?.preserveHistory ?? false)
+  const [historyMessageCount, setHistoryMessageCount] = useState(10)
   const [visibility, setVisibility] = useState<SubscriptionVisibility>(
     initialData?.visibility || 'private'
   )
@@ -566,6 +567,7 @@ export function SubscriptionForm({
       setEnabled(subscription.enabled)
       setExecutionTarget(normalizeExecutionTarget(subscription.execution_target))
       setPreserveHistory(subscription.preserve_history || false)
+      setHistoryMessageCount(subscription.history_message_count || 10)
       setVisibility(subscription.visibility || 'private')
       setMarketWhitelistUsers(
         (subscription.market_whitelist_user_ids || []).map(userId => ({
@@ -610,6 +612,7 @@ export function SubscriptionForm({
       setEnabled(initialData?.enabled ?? true)
       setExecutionTarget(normalizeExecutionTarget(initialData?.executionTarget))
       setPreserveHistory(initialData?.preserveHistory ?? false)
+      setHistoryMessageCount(10)
       setVisibility(initialData?.visibility || 'private')
       setMarketWhitelistUsers([])
       setSelectedRepo(null)
@@ -709,6 +712,7 @@ export function SubscriptionForm({
           enabled,
           execution_target: executionTarget,
           preserve_history: preserveHistory,
+          history_message_count: preserveHistory ? historyMessageCount : undefined,
           ...(isRental
             ? {}
             : {
@@ -766,6 +770,7 @@ export function SubscriptionForm({
           enabled,
           execution_target: executionTarget,
           preserve_history: preserveHistory,
+          history_message_count: preserveHistory ? historyMessageCount : undefined,
           visibility,
           market_whitelist_user_ids: marketWhitelistUserIds,
           ...(selectedRepo && {
@@ -816,6 +821,7 @@ export function SubscriptionForm({
     executionTarget,
     hasSelectableDevices,
     preserveHistory,
+    historyMessageCount,
     visibility,
     marketWhitelistUsers,
     selectedRepo,
@@ -886,6 +892,8 @@ export function SubscriptionForm({
               setKnowledgeBaseRefs={setKnowledgeBaseRefs}
               preserveHistory={preserveHistory}
               setPreserveHistory={setPreserveHistory}
+              historyMessageCount={historyMessageCount}
+              setHistoryMessageCount={setHistoryMessageCount}
               executionTarget={executionTarget}
               setExecutionTarget={setExecutionTarget}
               availableDevices={availableDevices}

--- a/frontend/src/features/feed/components/subscription-form/SendAreaSection.tsx
+++ b/frontend/src/features/feed/components/subscription-form/SendAreaSection.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -91,6 +92,8 @@ export function SendAreaSection({
   setKnowledgeBaseRefs,
   preserveHistory,
   setPreserveHistory,
+  historyMessageCount,
+  setHistoryMessageCount,
   isRental,
 }: SendAreaSectionProps) {
   const { t } = useTranslation('feed')
@@ -556,12 +559,35 @@ export function SendAreaSection({
       {modelRequired && <p className="text-xs text-destructive">{t('model_required_hint')}</p>}
 
       {/* Preserve History */}
-      <div className="flex items-center justify-between pt-2 border-t border-border/30">
-        <div className="space-y-0.5">
-          <Label className="text-sm font-medium">{t('preserve_history')}</Label>
-          <p className="text-xs text-text-muted">{t('preserve_history_hint')}</p>
+      <div className="space-y-3 pt-2 border-t border-border/30">
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label className="text-sm font-medium">{t('preserve_history')}</Label>
+            <p className="text-xs text-text-muted">{t('preserve_history_hint')}</p>
+          </div>
+          <Switch checked={preserveHistory} onCheckedChange={setPreserveHistory} />
         </div>
-        <Switch checked={preserveHistory} onCheckedChange={setPreserveHistory} />
+
+        {/* History Message Count - only show when preserve history is enabled */}
+        {preserveHistory && (
+          <div className="flex items-center gap-3 pl-4 border-l-2 border-primary/30">
+            <Label className="text-sm text-text-muted whitespace-nowrap">
+              {t('history_message_count')}
+            </Label>
+            <Input
+              type="number"
+              min={1}
+              max={50}
+              value={historyMessageCount}
+              onChange={e => {
+                const value = parseInt(e.target.value) || 10
+                setHistoryMessageCount(Math.min(50, Math.max(1, value)))
+              }}
+              className="w-20 h-8 text-center"
+            />
+            <span className="text-xs text-text-muted">{t('history_message_count_hint')}</span>
+          </div>
+        )}
       </div>
     </CollapsibleSection>
   )

--- a/frontend/src/features/feed/components/subscription-form/types.ts
+++ b/frontend/src/features/feed/components/subscription-form/types.ts
@@ -62,6 +62,9 @@ export interface SendAreaSectionProps {
   // Preserve History
   preserveHistory: boolean
   setPreserveHistory: (value: boolean) => void
+  // History Message Count
+  historyMessageCount: number
+  setHistoryMessageCount: (value: number) => void
   // Rental flag
   isRental: boolean
 }

--- a/frontend/src/i18n/locales/en/feed.json
+++ b/frontend/src/i18n/locales/en/feed.json
@@ -66,6 +66,8 @@
   "enable_subscription": "Enable Subscription",
   "preserve_history": "Preserve History",
   "preserve_history_hint": "When enabled, AI can see previous execution history to track changes",
+  "history_message_count": "Messages to keep",
+  "history_message_count_hint": "(1-50)",
   "enabled_success": "Subscription enabled",
   "disabled_success": "Subscription disabled",
   "toggle_failed": "Failed to toggle subscription",

--- a/frontend/src/i18n/locales/zh-CN/feed.json
+++ b/frontend/src/i18n/locales/zh-CN/feed.json
@@ -66,6 +66,8 @@
   "enable_subscription": "启用订阅器",
   "preserve_history": "保留对话历史",
   "preserve_history_hint": "开启后，AI 可以看到之前执行的历史记录，便于追踪变化",
+  "history_message_count": "保留消息数",
+  "history_message_count_hint": "条（1-50）",
   "enabled_success": "订阅器已启用",
   "disabled_success": "订阅器已禁用",
   "toggle_failed": "切换状态失败",

--- a/frontend/src/types/subscription.ts
+++ b/frontend/src/types/subscription.ts
@@ -125,6 +125,7 @@ export interface Subscription {
   execution_target?: SubscriptionExecutionTarget
   // History preservation settings
   preserve_history?: boolean // Whether to preserve conversation history across executions
+  history_message_count?: number // Number of history messages to preserve (1-50, default 10)
   bound_task_id?: number // Task ID bound to this subscription for history preservation
   webhook_url?: string
   webhook_secret?: string // HMAC signing secret for webhook verification
@@ -184,6 +185,7 @@ export interface SubscriptionCreateRequest {
   execution_target?: SubscriptionExecutionTarget
   // History preservation settings
   preserve_history?: boolean // Whether to preserve conversation history across executions
+  history_message_count?: number // Number of history messages to preserve (1-50, default 10)
   // Knowledge base references
   knowledge_base_refs?: SubscriptionKnowledgeBaseRef[]
   // Skill references
@@ -219,6 +221,7 @@ export interface SubscriptionUpdateRequest {
   execution_target?: SubscriptionExecutionTarget
   // History preservation settings
   preserve_history?: boolean // Whether to preserve conversation history across executions
+  history_message_count?: number // Number of history messages to preserve (1-50, default 10)
   // Knowledge base references
   knowledge_base_refs?: SubscriptionKnowledgeBaseRef[]
   // Skill references


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable message history retention limit in subscription settings, allowing users to specify 1-50 messages to preserve.
  * New History Message Count control in the subscription form when history preservation is enabled.

* **Localization**
  * Added English and Chinese translations for the new message history configuration interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->