### PR TITLE
feat(executor): add version parameter support and optimize env var handling

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -527,7 +527,7 @@ jobs:
         working-directory: executor
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
 
       - name: Rename binary with platform suffix
         run: |
@@ -575,7 +575,7 @@ jobs:
         run: |
           # Use x86_64 Python and uv to install dependencies and build
           arch -x86_64 /usr/local/bin/python3.11 -m uv sync --group build
-          arch -x86_64 /usr/local/bin/python3.11 -m uv run python scripts/build_local.py
+          arch -x86_64 /usr/local/bin/python3.11 -m uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
 
       - name: Rename binary with platform suffix
         run: |
@@ -617,7 +617,7 @@ jobs:
         working-directory: executor
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
 
       - name: Rename binary with platform suffix
         run: |
@@ -653,7 +653,7 @@ jobs:
         working-directory: executor
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
 
       - name: Rename binary with platform suffix
         run: |
@@ -694,7 +694,7 @@ jobs:
         shell: pwsh
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
 
       - name: Rename binary with platform suffix
         shell: pwsh

--- a/executor/config/device_config.py
+++ b/executor/config/device_config.py
@@ -259,13 +259,23 @@ def _apply_env_overrides(config: DeviceConfig) -> tuple[DeviceConfig, bool]:
     # Device overrides
     if os.environ.get("DEVICE_ID"):
         env_value = os.environ["DEVICE_ID"]
-        if not config.device_id:
+        if config.device_id != env_value:
+            log_msg = (
+                f"DEVICE_ID override: '{config.device_id}' -> '{env_value}' "
+                f"(will be saved to config)"
+            )
+            logger.info(log_msg)
             should_save = True
         config.device_id = env_value
 
     if os.environ.get("DEVICE_NAME"):
         env_value = os.environ["DEVICE_NAME"]
-        if not config.device_name:
+        if config.device_name != env_value:
+            log_msg = (
+                f"DEVICE_NAME override: '{config.device_name}' -> '{env_value}' "
+                f"(will be saved to config)"
+            )
+            logger.info(log_msg)
             should_save = True
         config.device_name = env_value
 

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -271,7 +271,9 @@ def _download_claude_binary_from_pypi(target_platform: str) -> tuple[str, str] |
 
 
 def build_executable(
-    target_arch: str | None = None, target_platform: str | None = None
+    target_arch: str | None = None,
+    target_platform: str | None = None,
+    version: str | None = None,
 ):
     """Build the executable using PyInstaller.
 
@@ -280,6 +282,7 @@ def build_executable(
                      If None, builds for the native architecture.
         target_platform: Target platform for cross-compilation (e.g., 'Windows', 'Darwin', 'Linux').
                         If None, builds for the current platform.
+        version: Version string to embed in the binary. If None, reads from pyproject.toml.
     """
     project_root = get_project_root()
     executor_root = get_executor_root()
@@ -288,7 +291,8 @@ def build_executable(
     effective_platform = target_platform or platform.system()
 
     # Get version and embed it into source
-    version = get_version_from_pyproject()
+    if version is None:
+        version = get_version_from_pyproject()
     print(f"Building version: {version}")
     if target_platform:
         print(f"Target platform: {target_platform}")
@@ -541,6 +545,10 @@ def main():
         help="Target platform for bundling platform-specific binaries. "
         "Use 'Windows' when building for Windows from macOS/Linux to include claude.exe.",
     )
+    parser.add_argument(
+        "--version",
+        help="Override version number (defaults to pyproject.toml version)",
+    )
     args = parser.parse_args()
 
     print("=" * 60)
@@ -558,7 +566,11 @@ def main():
     clean_build_artifacts()
 
     # Build executable
-    build_executable(target_arch=args.target_arch, target_platform=args.target_platform)
+    build_executable(
+        target_arch=args.target_arch,
+        target_platform=args.target_platform,
+        version=args.version,
+    )
 
     print()
     print("=" * 60)


### PR DESCRIPTION
  1. feat: Add version parameter to build functions and update CLI args (4884330)

  - Updated .github/workflows/publish-image.yml to support version-based builds
  - Modified executor/scripts/build_local.py to accept and handle version parameters
  - Improved CLI argument parsing for build scripts

  2. refactor: Optimize environment variable override logic (b8c51e3)

  - Refactored executor/config/device_config.py for better environment variable handling
  - Improved the override mechanism with cleaner logic (+12 lines, -2 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build script now supports a `--version` command-line option to embed version information directly into compiled binaries. This enables custom versioning for all platform builds.

* **Improvements**
  * Device configuration now automatically saves environment variable overrides for device identification whenever values differ from current settings. Enhanced logging provides visibility into configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->