### PR TITLE
feat(knowledge): group personal knowledge bases by ownership

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -38,6 +38,7 @@ from app.schemas.knowledge import (
     KnowledgeDocumentListResponse,
     KnowledgeDocumentResponse,
     KnowledgeDocumentUpdate,
+    PersonalKnowledgeBaseGroup,
     ResourceScope,
 )
 from app.schemas.knowledge_qa_history import QAHistoryResponse
@@ -120,6 +121,25 @@ def get_accessible_knowledge(
     This endpoint is designed for AI chat integration.
     """
     return KnowledgeService.get_accessible_knowledge(
+        db=db,
+        user_id=current_user.id,
+    )
+
+
+@router.get("/personal/grouped", response_model=PersonalKnowledgeBaseGroup)
+@trace_sync("get_personal_knowledge_bases_grouped", "knowledge.api")
+def get_personal_knowledge_bases_grouped(
+    current_user: User = Depends(security.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Get personal knowledge bases grouped by ownership.
+
+    Returns knowledge bases in two groups:
+    - **created_by_me**: Knowledge bases created by the current user
+    - **shared_with_me**: Knowledge bases shared with the current user by others
+    """
+    return KnowledgeService.get_personal_knowledge_bases_grouped(
         db=db,
         user_id=current_user.id,
     )

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -383,6 +383,13 @@ class AccessibleKnowledgeResponse(BaseModel):
     team: list[TeamKnowledgeGroup]
 
 
+class PersonalKnowledgeBaseGroup(BaseModel):
+    """Schema for personal knowledge base group (created by me vs shared with me)."""
+
+    created_by_me: list[KnowledgeBaseResponse]
+    shared_with_me: list[KnowledgeBaseResponse]
+
+
 # ============== Table URL Validation Schemas ==============
 
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -27,6 +27,7 @@ from app.schemas.knowledge import (
     AccessibleKnowledgeResponse,
     BatchOperationResult,
     KnowledgeBaseCreate,
+    KnowledgeBaseResponse,
     KnowledgeBaseUpdate,
     KnowledgeDocumentCreate,
     KnowledgeDocumentUpdate,
@@ -1512,6 +1513,86 @@ class KnowledgeService:
                 )
 
         return AccessibleKnowledgeResponse(personal=personal, team=team_groups)
+
+    @staticmethod
+    def get_personal_knowledge_bases_grouped(
+        db: Session,
+        user_id: int,
+    ) -> dict:
+        """
+        Get personal knowledge bases grouped by ownership.
+
+        Groups knowledge bases into:
+        - created_by_me: Knowledge bases created by the current user (namespace=default)
+        - shared_with_me: Knowledge bases shared with the current user (via ResourceMember, any namespace)
+
+        Args:
+            db: Database session
+            user_id: Current user ID
+
+        Returns:
+            Dict with 'created_by_me' and 'shared_with_me' lists
+        """
+        from app.models.resource_member import MemberStatus, ResourceMember
+        from app.models.share_link import ResourceType
+
+        # Get KBs created by user (personal knowledge bases, namespace=default)
+        created_kbs = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == "KnowledgeBase",
+                Kind.is_active == True,
+                Kind.namespace == "default",
+                Kind.user_id == user_id,
+            )
+            .order_by(Kind.updated_at.desc())
+            .all()
+        )
+
+        # Get KB IDs that are shared with the user via ResourceMember
+        shared_kb_ids = (
+            db.query(ResourceMember.resource_id)
+            .filter(
+                ResourceMember.resource_type == ResourceType.KNOWLEDGE_BASE.value,
+                ResourceMember.user_id == user_id,
+                ResourceMember.status == MemberStatus.APPROVED.value,
+            )
+            .all()
+        )
+        shared_kb_ids = [p[0] for p in shared_kb_ids]
+
+        # Query shared KBs (any namespace, but not created by current user)
+        shared_kbs = []
+        if shared_kb_ids:
+            shared_kbs = (
+                db.query(Kind)
+                .filter(
+                    Kind.kind == "KnowledgeBase",
+                    Kind.is_active == True,
+                    Kind.id.in_(shared_kb_ids),
+                    Kind.user_id != user_id,  # Exclude KBs created by current user
+                )
+                .order_by(Kind.updated_at.desc())
+                .all()
+            )
+
+        # Build response lists
+        created_by_me = []
+        for kb in created_kbs:
+            document_count = KnowledgeService.get_active_document_count(db, kb.id)
+            kb_response = KnowledgeBaseResponse.from_kind(kb, document_count)
+            created_by_me.append(kb_response)
+
+        shared_with_me = []
+        for kb in shared_kbs:
+            document_count = KnowledgeService.get_active_document_count(db, kb.id)
+            kb_response = KnowledgeBaseResponse.from_kind(kb, document_count)
+            shared_with_me.append(kb_response)
+
+        return {
+            "created_by_me": created_by_me,
+            "shared_with_me": shared_with_me,
+        }
 
     @staticmethod
     def can_manage_knowledge_base(

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -818,6 +818,41 @@ class KnowledgeService:
         )
 
     @staticmethod
+    def get_active_document_counts(
+        db: Session,
+        knowledge_base_ids: list[int],
+    ) -> dict[int, int]:
+        """
+        Get active document counts for multiple knowledge bases in a single query.
+
+        Args:
+            db: Database session
+            knowledge_base_ids: List of knowledge base IDs
+
+        Returns:
+            Dict mapping kb_id -> active document count
+        """
+        from sqlalchemy import func
+
+        if not knowledge_base_ids:
+            return {}
+
+        results = (
+            db.query(
+                KnowledgeDocument.kind_id,
+                func.count(KnowledgeDocument.id).label("count"),
+            )
+            .filter(
+                KnowledgeDocument.kind_id.in_(knowledge_base_ids),
+                KnowledgeDocument.is_active == True,
+            )
+            .group_by(KnowledgeDocument.kind_id)
+            .all()
+        )
+
+        return {kb_id: count for kb_id, count in results}
+
+    @staticmethod
     def get_active_document_text_length_stats(
         db: Session,
         knowledge_base_id: int,
@@ -1576,16 +1611,20 @@ class KnowledgeService:
                 .all()
             )
 
-        # Build response lists
+        # Batch fetch document counts for all KBs to avoid N+1 queries
+        all_kb_ids = [kb.id for kb in created_kbs] + [kb.id for kb in shared_kbs]
+        document_counts = KnowledgeService.get_active_document_counts(db, all_kb_ids)
+
+        # Build response lists using batched counts
         created_by_me = []
         for kb in created_kbs:
-            document_count = KnowledgeService.get_active_document_count(db, kb.id)
+            document_count = document_counts.get(kb.id, 0)
             kb_response = KnowledgeBaseResponse.from_kind(kb, document_count)
             created_by_me.append(kb_response)
 
         shared_with_me = []
         for kb in shared_kbs:
-            document_count = KnowledgeService.get_active_document_count(db, kb.id)
+            document_count = document_counts.get(kb.id, 0)
             kb_response = KnowledgeBaseResponse.from_kind(kb, document_count)
             shared_with_me.append(kb_response)
 

--- a/frontend/src/apis/knowledge-base.ts
+++ b/frontend/src/apis/knowledge-base.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import type { KnowledgeBasesResponse } from '@/types/api'
+import type { KnowledgeBasesResponse, PersonalKnowledgeBaseGroup } from '@/types/api'
 import type { DocumentDetailResponse, KnowledgeBaseSummaryResponse } from '@/types/knowledge'
 import client from './client'
 
@@ -23,6 +23,17 @@ export const knowledgeBaseApi = {
     const url = `/knowledge-bases${queryString ? `?${queryString}` : ''}`
 
     const response = await client.get<KnowledgeBasesResponse>(url)
+    return response
+  },
+
+  /**
+   * Get personal knowledge bases grouped by ownership
+   * Returns { created_by_me: KnowledgeBase[], shared_with_me: KnowledgeBase[] }
+   */
+  getPersonalGrouped: async (): Promise<PersonalKnowledgeBaseGroup> => {
+    const response = await client.get<PersonalKnowledgeBaseGroup>(
+      '/knowledge-bases/personal/grouped'
+    )
     return response
   },
 

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
@@ -380,6 +380,15 @@ export function KnowledgeDocumentPage() {
             onDeleteKb={setDeletingKb}
             onShareKb={setSharingKb}
             onCreateKb={kbType => handleCreateKb(null, kbType)}
+            onRefreshRef={ref => {
+              // Store the child component's refresh function
+              if (ref) {
+                // Wrap the sync refresh to match the expected Promise<void> return type
+                personalKb.refresh = async () => {
+                  await ref()
+                }
+              }
+            }}
           />
         )}
 
@@ -536,6 +545,7 @@ interface PersonalKnowledgeContentProps {
   onDeleteKb: (kb: KnowledgeBase) => void
   onShareKb: (kb: KnowledgeBase) => void
   onCreateKb: (kbType: KnowledgeBaseType) => void
+  onRefreshRef?: (refresh: (() => void) | null) => void
 }
 
 function PersonalKnowledgeContent({
@@ -544,9 +554,18 @@ function PersonalKnowledgeContent({
   onDeleteKb,
   onShareKb,
   onCreateKb,
+  onRefreshRef,
 }: PersonalKnowledgeContentProps) {
   const { t } = useTranslation()
-  const { data, loading, refresh: _refresh } = usePersonalKnowledgeBasesGrouped()
+  const { data, loading, refresh } = usePersonalKnowledgeBasesGrouped()
+
+  // Expose refresh function to parent via callback ref
+  useEffect(() => {
+    onRefreshRef?.(refresh)
+    return () => {
+      onRefreshRef?.(null)
+    }
+  }, [refresh, onRefreshRef])
   const [searchQuery, setSearchQuery] = useState('')
 
   const createdByMe = data?.created_by_me || []

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPage.tsx
@@ -18,6 +18,8 @@ import {
   FolderOpen,
   Building2,
   Settings,
+  UserCircle,
+  Share2,
 } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { Card } from '@/components/ui/card'
@@ -42,6 +44,7 @@ import { saveGlobalModelPreference, type ModelPreference } from '@/utils/modelPr
 import { useKnowledgeBases } from '../hooks/useKnowledgeBases'
 import { useUser } from '@/features/common/UserContext'
 import { getOrganizationNamespace } from '@/apis/knowledge'
+import { knowledgeBaseApi } from '@/apis/knowledge-base'
 import type { Group } from '@/types/group'
 import type { KnowledgeBase, KnowledgeBaseType, SummaryModelRef } from '@/types/knowledge'
 import type { DefaultTeamsResponse, Team } from '@/types/api'
@@ -372,8 +375,6 @@ export function KnowledgeDocumentPage() {
       <div>
         {activeTab === 'personal' && (
           <PersonalKnowledgeContent
-            knowledgeBases={personalKb.knowledgeBases}
-            loading={personalKb.loading}
             onSelectKb={handleSelectKb}
             onEditKb={setEditingKb}
             onDeleteKb={setDeletingKb}
@@ -489,10 +490,47 @@ export function KnowledgeDocumentPage() {
   )
 }
 
+// Hook for fetching grouped personal knowledge bases
+function usePersonalKnowledgeBasesGrouped() {
+  const [data, setData] = useState<{
+    created_by_me: KnowledgeBase[]
+    shared_with_me: KnowledgeBase[]
+  } | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await knowledgeBaseApi.getPersonalGrouped()
+      setData(response)
+    } catch (err) {
+      console.error('Failed to fetch personal knowledge bases:', err)
+      setError('Failed to load knowledge bases')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const refresh = useCallback(() => {
+    fetchData()
+  }, [fetchData])
+
+  return {
+    data,
+    loading,
+    error,
+    refresh,
+  }
+}
+
 // Personal knowledge content component
 interface PersonalKnowledgeContentProps {
-  knowledgeBases: KnowledgeBase[]
-  loading: boolean
   onSelectKb: (kb: KnowledgeBase) => void
   onEditKb: (kb: KnowledgeBase) => void
   onDeleteKb: (kb: KnowledgeBase) => void
@@ -501,8 +539,6 @@ interface PersonalKnowledgeContentProps {
 }
 
 function PersonalKnowledgeContent({
-  knowledgeBases,
-  loading,
   onSelectKb,
   onEditKb,
   onDeleteKb,
@@ -510,15 +546,28 @@ function PersonalKnowledgeContent({
   onCreateKb,
 }: PersonalKnowledgeContentProps) {
   const { t } = useTranslation()
+  const { data, loading, refresh: _refresh } = usePersonalKnowledgeBasesGrouped()
   const [searchQuery, setSearchQuery] = useState('')
 
-  const filteredKnowledgeBases = useMemo(() => {
-    if (!searchQuery.trim()) return knowledgeBases
+  const createdByMe = data?.created_by_me || []
+  const sharedWithMe = data?.shared_with_me || []
+
+  // Filter knowledge bases based on search query
+  const filteredCreatedByMe = useMemo(() => {
+    if (!searchQuery.trim()) return createdByMe
     const query = searchQuery.toLowerCase()
-    return knowledgeBases.filter(
+    return createdByMe.filter(
       kb => kb.name.toLowerCase().includes(query) || kb.description?.toLowerCase().includes(query)
     )
-  }, [knowledgeBases, searchQuery])
+  }, [createdByMe, searchQuery])
+
+  const filteredSharedWithMe = useMemo(() => {
+    if (!searchQuery.trim()) return sharedWithMe
+    const query = searchQuery.toLowerCase()
+    return sharedWithMe.filter(
+      kb => kb.name.toLowerCase().includes(query) || kb.description?.toLowerCase().includes(query)
+    )
+  }, [sharedWithMe, searchQuery])
 
   if (loading) {
     return (
@@ -528,7 +577,10 @@ function PersonalKnowledgeContent({
     )
   }
 
-  if (knowledgeBases.length === 0) {
+  const totalKbs = createdByMe.length + sharedWithMe.length
+
+  // Empty state - no knowledge bases at all
+  if (totalKbs === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16">
         <DropdownMenu>
@@ -599,77 +651,122 @@ function PersonalKnowledgeContent({
         </div>
       </div>
 
-      <div className="w-full max-w-4xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {/* Add knowledge base card with dropdown */}
-        {!searchQuery && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Card
-                padding="sm"
-                className="hover:bg-hover transition-colors cursor-pointer flex flex-col items-center justify-center h-[140px]"
-              >
-                <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mb-3">
-                  <Plus className="w-6 h-6 text-primary" />
-                </div>
-                <h3 className="font-medium text-sm">
-                  {t('knowledge:document.knowledgeBase.create')}
-                </h3>
-              </Card>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-56">
-              <DropdownMenuItem
-                onClick={() => onCreateKb('notebook')}
-                className="flex items-start gap-3 py-3"
-              >
-                <BookOpen className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
-                <div>
-                  <div className="font-medium">
-                    {t('knowledge:document.knowledgeBase.typeNotebook')}
-                  </div>
-                  <div className="text-xs text-text-muted">
-                    {t('knowledge:document.knowledgeBase.notebookDesc')}
-                  </div>
-                </div>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() => onCreateKb('classic')}
-                className="flex items-start gap-3 py-3"
-              >
-                <FolderOpen className="w-5 h-5 text-text-secondary mt-0.5 flex-shrink-0" />
-                <div>
-                  <div className="font-medium">
-                    {t('knowledge:document.knowledgeBase.typeClassic')}
-                  </div>
-                  <div className="text-xs text-text-muted">
-                    {t('knowledge:document.knowledgeBase.classicDesc')}
-                  </div>
-                </div>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+      <div className="w-full max-w-4xl space-y-6">
+        {/* Created by Me Section */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <UserCircle className="w-4 h-4 text-primary" />
+            <h3 className="text-sm font-medium text-text-primary">
+              {t('knowledge:document.personalGroups.createdByMe')}
+              <span className="ml-2 text-xs text-text-muted">({createdByMe.length})</span>
+            </h3>
+          </div>
 
-        {/* Knowledge base cards */}
-        {filteredKnowledgeBases.map(kb => (
-          <KnowledgeBaseCard
-            key={kb.id}
-            knowledgeBase={kb}
-            onClick={() => onSelectKb(kb)}
-            onEdit={() => onEditKb(kb)}
-            onDelete={() => onDeleteKb(kb)}
-            onShare={() => onShareKb(kb)}
-            canShare={true}
-          />
-        ))}
-      </div>
+          {filteredCreatedByMe.length === 0 && searchQuery ? (
+            <div className="text-sm text-text-muted py-4">
+              {t('knowledge:document.knowledgeBase.noResults')}
+            </div>
+          ) : filteredCreatedByMe.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-8 text-text-muted">
+              <p className="text-sm">{t('knowledge:document.personalGroups.noCreated')}</p>
+              <p className="text-xs mt-1">{t('knowledge:document.personalGroups.createdDesc')}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {/* Add knowledge base card - only show in created by me section when no search */}
+              {!searchQuery && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Card
+                      padding="sm"
+                      className="hover:bg-hover transition-colors cursor-pointer flex flex-col items-center justify-center h-[140px]"
+                    >
+                      <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center mb-3">
+                        <Plus className="w-6 h-6 text-primary" />
+                      </div>
+                      <h3 className="font-medium text-sm">
+                        {t('knowledge:document.knowledgeBase.create')}
+                      </h3>
+                    </Card>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="center" className="w-56">
+                    <DropdownMenuItem
+                      onClick={() => onCreateKb('notebook')}
+                      className="flex items-start gap-3 py-3"
+                    >
+                      <BookOpen className="w-5 h-5 text-primary mt-0.5 flex-shrink-0" />
+                      <div>
+                        <div className="font-medium">
+                          {t('knowledge:document.knowledgeBase.typeNotebook')}
+                        </div>
+                        <div className="text-xs text-text-muted">
+                          {t('knowledge:document.knowledgeBase.notebookDesc')}
+                        </div>
+                      </div>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={() => onCreateKb('classic')}
+                      className="flex items-start gap-3 py-3"
+                    >
+                      <FolderOpen className="w-5 h-5 text-text-secondary mt-0.5 flex-shrink-0" />
+                      <div>
+                        <div className="font-medium">
+                          {t('knowledge:document.knowledgeBase.typeClassic')}
+                        </div>
+                        <div className="text-xs text-text-muted">
+                          {t('knowledge:document.knowledgeBase.classicDesc')}
+                        </div>
+                      </div>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
 
-      {/* No results message */}
-      {searchQuery && filteredKnowledgeBases.length === 0 && (
-        <div className="flex flex-col items-center justify-center py-12 text-text-secondary">
-          <FileText className="w-12 h-12 mb-4 opacity-50" />
-          <p>{t('knowledge:document.knowledgeBase.noResults')}</p>
+              {filteredCreatedByMe.map(kb => (
+                <KnowledgeBaseCard
+                  key={kb.id}
+                  knowledgeBase={kb}
+                  onClick={() => onSelectKb(kb)}
+                  onEdit={() => onEditKb(kb)}
+                  onDelete={() => onDeleteKb(kb)}
+                  onShare={() => onShareKb(kb)}
+                  canShare={true}
+                />
+              ))}
+            </div>
+          )}
         </div>
-      )}
+
+        {/* Shared with Me Section */}
+        {sharedWithMe.length > 0 && (
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <Share2 className="w-4 h-4 text-text-secondary" />
+              <h3 className="text-sm font-medium text-text-primary">
+                {t('knowledge:document.personalGroups.sharedWithMe')}
+                <span className="ml-2 text-xs text-text-muted">({sharedWithMe.length})</span>
+              </h3>
+            </div>
+
+            {filteredSharedWithMe.length === 0 && searchQuery ? (
+              <div className="text-sm text-text-muted py-4">
+                {t('knowledge:document.knowledgeBase.noResults')}
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                {filteredSharedWithMe.map(kb => (
+                  <KnowledgeBaseCard
+                    key={kb.id}
+                    knowledgeBase={kb}
+                    onClick={() => onSelectKb(kb)}
+                    canShare={false}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -36,6 +36,14 @@
       "organization": "Organization",
       "external": "External"
     },
+    "personalGroups": {
+      "createdByMe": "Created by Me",
+      "sharedWithMe": "Shared with Me",
+      "noCreated": "You haven't created any knowledge bases yet",
+      "noShared": "No knowledge bases have been shared with you",
+      "createdDesc": "Click the button above to create your first knowledge base",
+      "sharedDesc": "Knowledge bases shared by other users will appear here"
+    },
     "noOrgKnowledgeBase": "No organization knowledge base",
     "noOrgKnowledgeBaseHint": "Organization knowledge bases are managed by administrators. All members can view.",
     "orgKnowledgeBaseReadOnly": "You have view-only access.",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -36,6 +36,14 @@
       "organization": "公司知识",
       "external": "外部知识库"
     },
+    "personalGroups": {
+      "createdByMe": "我创建的",
+      "sharedWithMe": "分享给我的",
+      "noCreated": "您还没有创建任何知识库",
+      "noShared": "暂没有分享给您的知识库",
+      "createdDesc": "点击上方按钮创建您的第一个知识库",
+      "sharedDesc": "当其他用户分享知识库给您时，将显示在这里"
+    },
     "noOrgKnowledgeBase": "暂无公司知识库",
     "noOrgKnowledgeBaseHint": "公司知识库由管理员创建和管理，所有成员可查看",
     "orgKnowledgeBaseReadOnly": "您没有管理权限，仅可查看",

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -634,6 +634,7 @@ export interface KnowledgeBaseRef {
 export type {
   KnowledgeBase,
   KnowledgeBaseListResponse as KnowledgeBasesResponse,
+  PersonalKnowledgeBaseGroup,
 } from './knowledge'
 
 // Project Types

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -567,3 +567,9 @@ export interface JoinByLinkResponse {
   resource_id: number
   copied_resource_id?: number
 }
+
+// Personal Knowledge Base Group (for grouped display)
+export interface PersonalKnowledgeBaseGroup {
+  created_by_me: KnowledgeBase[]
+  shared_with_me: KnowledgeBase[]
+}


### PR DESCRIPTION
Add new API endpoint to return knowledge bases grouped into:
- created_by_me: Knowledge bases created by the current user
- shared_with_me: Knowledge bases shared with the user by others

Changes:
- Backend: Add PersonalKnowledgeBaseGroup schema and get_personal_knowledge_bases_grouped service method
- Backend: Add GET /knowledge-bases/personal/grouped endpoint
- Frontend: Add usePersonalKnowledgeBasesGrouped hook and update PersonalKnowledgeContent component
- Frontend: Display knowledge bases in two sections with search support
- i18n: Add translation keys for personal knowledge base groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal knowledge bases are now grouped into "Created by Me" and "Shared with Me" with per-section filtering and a refresh action.
  * Improved empty states and separate no-results handling for each group.

* **Internationalization**
  * Added localized labels and descriptions for grouped knowledge base sections in English and Simplified Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->