### PR TITLE
fix(executor): improve pre-execute error reporting and skip self-URL …

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -1528,6 +1528,12 @@ class TaskRequestBuilder:
         if not url:
             return False
 
+        # URLs pointing to our own backend are always reachable.
+        # Checking them with a synchronous HTTP request would deadlock
+        # (single-worker uvicorn can't serve the request while blocked).
+        if "${{backend_url}}" in url:
+            return True
+
         try:
             # Use GET instead of HEAD because some servers (especially SSE endpoints)
             # don't support HEAD method and will timeout

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -452,10 +452,11 @@ class LocalRunner:
             return
 
         # Pre-execute
-        pre_status = await agent.pre_execute()
+        pre_status, pre_error = await agent.pre_execute()
         if pre_status != TaskStatus.SUCCESS:
-            logger.error(f"Agent pre-execution failed: {pre_status}")
-            await ws_emitter.error("Agent pre-execution failed", "pre_execute_error")
+            error_msg = pre_error or "Agent pre-execution failed"
+            logger.error(f"Agent pre-execution failed: {error_msg}")
+            await ws_emitter.error(error_msg, "pre_execute_error")
             return
 
         # Execute the task (Claude client will be created inside, triggering heartbeat callback)


### PR DESCRIPTION
…reachability check

Skip HTTP reachability check for backend's own URL to prevent deadlock in single-worker uvicorn. Return specific error messages from pre_execute failures instead of generic messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in task pre-execution to capture and report detailed error messages.
  * Improved reliability by preventing potential deadlocks when MCP servers reference the backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->