### PR TITLE
fix(knowledge): skip excel rag indexing tasks

### DIFF
--- a/backend/app/services/knowledge/indexing.py
+++ b/backend/app/services/knowledge/indexing.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.db.session import SessionLocal
 from app.models.kind import Kind
+from app.models.subtask_context import ContextType, SubtaskContext
 from app.schemas.rag import (
     SemanticSplitterConfig,
     SentenceSplitterConfig,
@@ -39,6 +40,8 @@ from app.schemas.rag import (
 from shared.telemetry import add_span_event
 
 logger = logging.getLogger(__name__)
+
+RAG_INDEXING_DISABLED_EXTENSIONS = frozenset({".xls", ".xlsx"})
 
 
 @dataclass
@@ -68,6 +71,37 @@ class RAGIndexingParams:
     user_name: str
     splitter_config: Optional[SplitterConfig]
     kb_index_info: KnowledgeBaseIndexInfo
+
+
+def normalize_document_extension(file_extension: Optional[str]) -> str:
+    """Normalize a document extension for indexing checks."""
+    ext = (file_extension or "").strip().lower()
+    if not ext:
+        return ""
+    if not ext.startswith("."):
+        return f".{ext}"
+    return ext
+
+
+def get_rag_indexing_skip_reason(
+    source_type: Optional[str],
+    file_extension: Optional[str],
+) -> Optional[str]:
+    """Return the reason why a document should skip RAG indexing, if any."""
+    normalized_source_type = (source_type or "").strip().lower()
+    normalized_extension = normalize_document_extension(file_extension)
+
+    if normalized_source_type == "table":
+        return (
+            "Table documents are queried in real-time and do not support RAG indexing"
+        )
+
+    if normalized_extension in RAG_INDEXING_DISABLED_EXTENSIONS:
+        return (
+            f"Excel documents ({normalized_extension}) are excluded from RAG indexing"
+        )
+
+    return None
 
 
 def is_organization_namespace(db: Session, namespace: str) -> bool:
@@ -439,6 +473,58 @@ def run_document_indexing(
         db = SessionLocal()
 
     try:
+        document = None
+        file_extension = None
+        source_type = None
+
+        if document_id is not None:
+            from app.models.knowledge import KnowledgeDocument
+
+            document = (
+                db.query(KnowledgeDocument)
+                .filter(KnowledgeDocument.id == document_id)
+                .first()
+            )
+            if document:
+                file_extension = document.file_extension
+                source_type = document.source_type
+        elif attachment_id:
+            attachment = (
+                db.query(SubtaskContext)
+                .filter(
+                    SubtaskContext.id == attachment_id,
+                    SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+                )
+                .first()
+            )
+            if attachment:
+                file_extension = attachment.file_extension
+
+        skip_reason = get_rag_indexing_skip_reason(source_type, file_extension)
+        if skip_reason:
+            logger.info(
+                f"[Indexing] Skipping: kb_id={knowledge_base_id}, "
+                f"document_id={document_id}, attachment_id={attachment_id}, "
+                f"reason={skip_reason}"
+            )
+            add_span_event(
+                "rag.indexing.skipped",
+                {
+                    "kb_id": str(knowledge_base_id),
+                    "document_id": str(document_id),
+                    "attachment_id": str(attachment_id),
+                    "reason": skip_reason,
+                },
+            )
+            return {
+                "status": "skipped",
+                "reason": skip_reason,
+                "document_id": document_id,
+                "knowledge_base_id": knowledge_base_id,
+                "indexed_count": 0,
+                "index_name": None,
+            }
+
         # Resolve KB index info (use pre-computed or fetch from DB)
         kb_info = resolve_kb_index_info(
             db=db,

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1089,6 +1089,7 @@ class KnowledgeOrchestrator:
             KnowledgeDocumentResponse
         """
         from app.schemas.knowledge import DocumentSourceType
+        from app.services.knowledge.indexing import get_rag_indexing_skip_reason
 
         # Create document
         document = KnowledgeService.create_document(
@@ -1102,9 +1103,16 @@ class KnowledgeOrchestrator:
             f"[Orchestrator] Created document {document.id} in KB {knowledge_base_id}"
         )
 
-        # Schedule indexing via Celery if enabled
-        # Skip RAG indexing for TABLE source type as table data should be queried in real-time
-        if trigger_indexing and data.source_type != DocumentSourceType.TABLE:
+        skip_reason = get_rag_indexing_skip_reason(
+            (
+                data.source_type.value
+                if data.source_type
+                else DocumentSourceType.FILE.value
+            ),
+            data.file_extension,
+        )
+
+        if trigger_indexing and not skip_reason:
             self._schedule_indexing_celery(
                 db=db,
                 knowledge_base=knowledge_base,
@@ -1112,6 +1120,11 @@ class KnowledgeOrchestrator:
                 user=user,
                 trigger_summary=trigger_summary,
                 splitter_config=splitter_config,
+            )
+        elif trigger_indexing and skip_reason:
+            logger.info(
+                f"[Orchestrator] Skipping indexing for document {document.id}: "
+                f"{skip_reason}"
             )
 
         return KnowledgeDocumentResponse.model_validate(document)
@@ -1282,7 +1295,7 @@ class KnowledgeOrchestrator:
         )
 
         # Schedule indexing via Celery
-        index_document_task.delay(
+        async_result = index_document_task.delay(
             knowledge_base_id=str(knowledge_base.id),
             attachment_id=document.attachment_id,
             retriever_name=retriever_name,
@@ -1294,6 +1307,11 @@ class KnowledgeOrchestrator:
             document_id=document.id,
             splitter_config_dict=splitter_config,
             trigger_summary=trigger_summary,
+        )
+        logger.info(
+            f"[Orchestrator] RAG indexing task enqueued: "
+            f"document_id={document.id}, attachment_id={document.attachment_id}, "
+            f"kb_id={knowledge_base.id}, celery_task_id={async_result.id}"
         )
 
     def reindex_document(
@@ -1323,9 +1341,9 @@ class KnowledgeOrchestrator:
             ValueError: If document not found, access denied, or RAG not configured
         """
         from app.models.knowledge import KnowledgeDocument
-        from app.schemas.knowledge import DocumentSourceType
         from app.services.knowledge.indexing import (
             extract_rag_config_from_knowledge_base,
+            get_rag_indexing_skip_reason,
         )
         from app.tasks.knowledge_tasks import index_document_task
 
@@ -1339,9 +1357,11 @@ class KnowledgeOrchestrator:
         if not document:
             raise ValueError("Document not found")
 
-        # TABLE documents do not support RAG indexing (real-time query instead)
-        if document.source_type == DocumentSourceType.TABLE.value:
-            raise ValueError("Table documents do not support indexing")
+        skip_reason = get_rag_indexing_skip_reason(
+            document.source_type, document.file_extension
+        )
+        if skip_reason:
+            raise ValueError(skip_reason)
 
         # Check access permission via knowledge base
         knowledge_base = KnowledgeService.get_knowledge_base(
@@ -1362,7 +1382,7 @@ class KnowledgeOrchestrator:
             )
 
         # Schedule re-indexing via Celery
-        index_document_task.delay(
+        async_result = index_document_task.delay(
             knowledge_base_id=str(document.kind_id),
             attachment_id=document.attachment_id,
             retriever_name=rag_params.retriever_name,
@@ -1377,7 +1397,9 @@ class KnowledgeOrchestrator:
         )
 
         logger.info(
-            f"[Orchestrator] Scheduled reindex via Celery for document {document.id}"
+            f"[Orchestrator] Scheduled reindex via Celery for document {document.id}: "
+            f"celery_task_id={async_result.id}, attachment_id={document.attachment_id}, "
+            f"kb_id={document.kind_id}"
         )
 
         return {

--- a/backend/app/tasks/knowledge_tasks.py
+++ b/backend/app/tasks/knowledge_tasks.py
@@ -65,9 +65,15 @@ def index_document_task(
         splitter_config_dict: Optional splitter configuration as dict
         trigger_summary: Whether to trigger document summary after indexing
     """
+    task_id = getattr(self.request, "id", "unknown")
+    retry_count = getattr(self.request, "retries", 0)
+    worker_hostname = getattr(self.request, "hostname", "unknown")
+
     logger.info(
-        f"[Celery RAG Indexing] Task started: kb_id={knowledge_base_id}, "
-        f"attachment_id={attachment_id}, document_id={document_id}"
+        f"[Celery RAG Indexing] Task started: task_id={task_id}, "
+        f"worker={worker_hostname}, retry={retry_count}/{self.max_retries}, "
+        f"kb_id={knowledge_base_id}, attachment_id={attachment_id}, "
+        f"document_id={document_id}, trigger_summary={trigger_summary}"
     )
 
     try:
@@ -88,17 +94,43 @@ def index_document_task(
             trigger_summary=trigger_summary,
         )
 
-        logger.info(
-            f"[Celery RAG Indexing] Completed for document {document_id}: {result}"
-        )
+        result_status = result.get("status")
+        if result_status == "skipped":
+            logger.info(
+                f"[Celery RAG Indexing] Task skipped: task_id={task_id}, "
+                f"document_id={document_id}, attachment_id={attachment_id}, "
+                f"reason={result.get('reason')}"
+            )
+        else:
+            logger.info(
+                f"[Celery RAG Indexing] Completed: task_id={task_id}, "
+                f"document_id={document_id}, attachment_id={attachment_id}, "
+                f"result={result}"
+            )
         return result
 
     except Exception as e:
+        retry_count = getattr(self.request, "retries", 0)
+        will_retry = retry_count < self.max_retries
         logger.error(
-            f"[Celery RAG Indexing] Error indexing document {document_id}: {e}",
+            f"[Celery RAG Indexing] Error: task_id={task_id}, "
+            f"document_id={document_id}, attachment_id={attachment_id}, "
+            f"retry={retry_count}/{self.max_retries}, will_retry={will_retry}, "
+            f"error={e}",
             exc_info=True,
         )
-        # Retry the task
+
+        if will_retry:
+            logger.warning(
+                f"[Celery RAG Indexing] Retrying task: task_id={task_id}, "
+                f"document_id={document_id}, next_retry={retry_count + 1}/{self.max_retries}"
+            )
+        else:
+            logger.error(
+                f"[Celery RAG Indexing] Retries exhausted: task_id={task_id}, "
+                f"document_id={document_id}, attachment_id={attachment_id}"
+            )
+
         raise self.retry(exc=e)
 
 

--- a/backend/tests/services/knowledge/test_orchestrator.py
+++ b/backend/tests/services/knowledge/test_orchestrator.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from app.schemas.knowledge import DocumentSourceType, KnowledgeDocumentCreate
+from app.services.knowledge.indexing import get_rag_indexing_skip_reason
 from app.services.knowledge.orchestrator import (
     KnowledgeOrchestrator,
     _build_filename,
@@ -342,3 +344,90 @@ class TestKnowledgeOrchestrator:
                     name="test",
                     source_type="invalid",
                 )
+
+    def test_create_document_from_attachment_skips_excel_indexing(
+        self, orchestrator, mock_db, mock_user
+    ):
+        """Test Excel documents are created without scheduling RAG indexing."""
+        mock_kb = MagicMock()
+        mock_kb.id = 1
+        mock_kb.json = {"spec": {}}
+
+        mock_doc = MagicMock()
+        mock_doc.id = 99
+        mock_doc.attachment_id = 123
+
+        data = KnowledgeDocumentCreate(
+            attachment_id=123,
+            name="report.xlsx",
+            file_extension="xlsx",
+            file_size=1024,
+            source_type=DocumentSourceType.FILE,
+        )
+
+        with patch(
+            "app.services.knowledge.orchestrator.KnowledgeService"
+        ) as mock_service:
+            mock_service.get_knowledge_base.return_value = mock_kb
+            mock_service.create_document.return_value = mock_doc
+
+            with patch.object(
+                orchestrator, "_schedule_indexing_celery"
+            ) as mock_schedule:
+                with patch(
+                    "app.services.knowledge.orchestrator.KnowledgeDocumentResponse"
+                ) as mock_response:
+                    mock_response.model_validate.return_value = MagicMock()
+
+                    orchestrator.create_document_from_attachment(
+                        db=mock_db,
+                        user=mock_user,
+                        knowledge_base_id=1,
+                        data=data,
+                        trigger_indexing=True,
+                        trigger_summary=False,
+                    )
+
+        mock_schedule.assert_not_called()
+
+    def test_reindex_document_raises_for_excel_document(
+        self, orchestrator, mock_db, mock_user
+    ):
+        """Test Excel documents cannot be reindexed."""
+        mock_document = MagicMock()
+        mock_document.id = 1
+        mock_document.source_type = DocumentSourceType.FILE.value
+        mock_document.file_extension = "xlsx"
+
+        with patch.object(mock_db, "query") as mock_query:
+            mock_query.return_value.filter.return_value.first.return_value = (
+                mock_document
+            )
+
+            with pytest.raises(
+                ValueError, match="Excel documents \\(.xlsx\\) are excluded"
+            ):
+                orchestrator.reindex_document(
+                    db=mock_db,
+                    user=mock_user,
+                    document_id=1,
+                )
+
+
+class TestIndexingPolicy:
+    """Tests for knowledge indexing skip policy."""
+
+    def test_excel_documents_are_skipped(self):
+        """Test Excel extensions are excluded from RAG indexing."""
+        reason = get_rag_indexing_skip_reason("file", "xlsx")
+
+        assert reason == "Excel documents (.xlsx) are excluded from RAG indexing"
+
+    def test_table_documents_are_skipped(self):
+        """Test table source types are excluded from RAG indexing."""
+        reason = get_rag_indexing_skip_reason("table", "txt")
+
+        assert (
+            reason
+            == "Table documents are queried in real-time and do not support RAG indexing"
+        )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Excel files (.xls, .xlsx) are now excluded from RAG indexing to improve system reliability.

* **Improvements**
  * Enhanced error handling and validation to prevent reindexing of unsupported file types.
  * Improved logging and monitoring for document indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->