### PR TITLE
fix(standalone): repair in-process execution flow

### DIFF
--- a/backend/app/services/execution/inprocess_executor.py
+++ b/backend/app/services/execution/inprocess_executor.py
@@ -27,6 +27,7 @@ from shared.models import (
 )
 from shared.models.responses_api import ResponsesAPIStreamEvents
 from shared.models.responses_api_emitter import EventTransport
+from shared.status import TaskStatus
 
 from .emitters import ResultEmitter
 
@@ -311,15 +312,12 @@ class InprocessExecutor:
                 .build()
             )
 
-            # Convert request to task_data dict for AgentService
-            task_data = request.to_dict()
-
             # Get or create agent service (singleton)
             agent_service = AgentService()
 
             # Create agent with custom emitter
             # AgentService caches agents by task_id, so same task reuses the same agent
-            agent = agent_service.create_agent(task_data)
+            agent = agent_service.create_agent(request)
             if not agent:
                 raise RuntimeError(f"Failed to create agent for task {request.task_id}")
 
@@ -350,6 +348,12 @@ class InprocessExecutor:
                 f"[InprocessExecutor] Execution completed: "
                 f"task_id={request.task_id}, status={status}, error={error_message}"
             )
+
+            if status == TaskStatus.FAILED:
+                raise RuntimeError(
+                    error_message
+                    or f"In-process execution failed for task {request.task_id}"
+                )
 
             # Note: The agent's emitter will have already sent DONE/ERROR events
             # through the bridge transport, so we don't need to emit them again here
@@ -392,13 +396,16 @@ class InprocessExecutor:
         from shared.status import TaskStatus
 
         try:
-            # Pre-execute phase (sync, but fast)
+            # Mirror Agent.handle() semantics in the current event loop.
             logger.info(
                 f"Agent[{agent.get_name()}][{agent.task_id}] handle: Starting pre_execute."
             )
-            pre_status = agent.pre_execute()
-            if pre_status not in (TaskStatus.SUCCESS, TaskStatus.RUNNING):
-                return pre_status, f"Pre-execute failed with status: {pre_status}"
+            pre_status, pre_error = await agent.pre_execute()
+            if pre_status != TaskStatus.SUCCESS:
+                error_msg = f"Pre-execute failed with status: {pre_status}"
+                if pre_error:
+                    error_msg = f"{error_msg}\n{pre_error}"
+                return TaskStatus.FAILED, error_msg
 
             # Execute phase - use async method if available
             logger.info(
@@ -417,9 +424,6 @@ class InprocessExecutor:
             logger.info(
                 f"Agent[{agent.get_name()}][{agent.task_id}] handle: execute finished with result: {status}"
             )
-
-            # Post-execute phase (sync, but fast)
-            agent.post_execute()
 
             return status, None
 

--- a/backend/app/services/execution/inprocess_executor.py
+++ b/backend/app/services/execution/inprocess_executor.py
@@ -278,11 +278,17 @@ class InprocessExecutor:
         request: ExecutionRequest,
         emitter: ResultEmitter,
     ) -> None:
-        """Execute task in-process.
+        """Execute one standalone task inside the backend process.
 
         Args:
             request: Execution request
             emitter: Result emitter for event emission
+
+        Raises:
+            RuntimeError: When agent creation fails or the in-process lifecycle
+                returns a terminal failure status. The exception is re-raised
+                after emitting an error event so outer dispatcher layers can
+                keep their normal failure handling.
         """
         logger.info(
             f"[InprocessExecutor] Starting in-process execution: "
@@ -381,17 +387,19 @@ class InprocessExecutor:
         self,
         agent,
     ) -> tuple:
-        """Execute agent asynchronously in the current event loop.
+        """Run the agent lifecycle in the current event loop.
 
-        This method handles the agent lifecycle (pre_execute, execute, post_execute)
-        similar to Agent.handle(), but uses async methods to stay in the current
-        event loop.
+        This mirrors ``Agent.handle()`` for standalone mode by awaiting
+        ``pre_execute()`` and then using ``execute_async()`` when available.
+        It returns a ``FAILED`` status tuple instead of raising so ``execute()``
+        can centralize frontend error emission and dispatcher propagation.
 
         Args:
             agent: The agent instance to execute
 
         Returns:
-            Tuple of (TaskStatus, error_message)
+            Tuple of ``(TaskStatus, error_message)`` where ``error_message`` is
+            populated only for failure states.
         """
         from shared.status import TaskStatus
 

--- a/backend/tests/services/execution/test_inprocess_executor.py
+++ b/backend/tests/services/execution/test_inprocess_executor.py
@@ -12,6 +12,7 @@ from shared.status import TaskStatus
 
 @pytest.mark.asyncio
 async def test_execute_passes_execution_request_to_agent_service() -> None:
+    """Pass an ExecutionRequest object directly to AgentService."""
     request = ExecutionRequest(task_id=1, subtask_id=2, message_id=3)
     emitter = AsyncMock()
     executor = InprocessExecutor()
@@ -47,6 +48,7 @@ async def test_execute_passes_execution_request_to_agent_service() -> None:
 
 @pytest.mark.asyncio
 async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_execute() -> None:
+    """Await async lifecycle hooks without requiring post_execute()."""
     executor = InprocessExecutor()
     agent = SimpleNamespace(
         task_id=3,
@@ -65,6 +67,7 @@ async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_exe
 
 @pytest.mark.asyncio
 async def test_execute_agent_async_returns_failed_when_pre_execute_fails() -> None:
+    """Return FAILED when pre_execute reports a failure status."""
     executor = InprocessExecutor()
     agent = SimpleNamespace(
         task_id=4,
@@ -85,6 +88,7 @@ async def test_execute_agent_async_returns_failed_when_pre_execute_fails() -> No
 
 @pytest.mark.asyncio
 async def test_execute_raises_and_emits_error_when_agent_lifecycle_returns_failed() -> None:
+    """Raise and emit an error when the agent lifecycle returns FAILED."""
     request = ExecutionRequest(task_id=10, subtask_id=11, message_id=12)
     emitter = AsyncMock()
     executor = InprocessExecutor()

--- a/backend/tests/services/execution/test_inprocess_executor.py
+++ b/backend/tests/services/execution/test_inprocess_executor.py
@@ -11,7 +11,7 @@ from shared.status import TaskStatus
 
 
 @pytest.mark.asyncio
-async def test_execute_passes_execution_request_to_agent_service():
+async def test_execute_passes_execution_request_to_agent_service() -> None:
     request = ExecutionRequest(task_id=1, subtask_id=2, message_id=3)
     emitter = AsyncMock()
     executor = InprocessExecutor()
@@ -46,7 +46,7 @@ async def test_execute_passes_execution_request_to_agent_service():
 
 
 @pytest.mark.asyncio
-async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_execute():
+async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_execute() -> None:
     executor = InprocessExecutor()
     agent = SimpleNamespace(
         task_id=3,
@@ -64,7 +64,27 @@ async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_exe
 
 
 @pytest.mark.asyncio
-async def test_execute_raises_and_emits_error_when_agent_lifecycle_returns_failed():
+async def test_execute_agent_async_returns_failed_when_pre_execute_fails() -> None:
+    executor = InprocessExecutor()
+    agent = SimpleNamespace(
+        task_id=4,
+        get_name=lambda: "fake-agent",
+        pre_execute=AsyncMock(return_value=(TaskStatus.FAILED, "boom")),
+        execute_async=AsyncMock(),
+    )
+
+    status, error = await executor._execute_agent_async(agent)
+
+    assert status == TaskStatus.FAILED
+    assert error is not None
+    assert "Pre-execute failed" in error
+    assert "boom" in error
+    agent.pre_execute.assert_awaited_once()
+    agent.execute_async.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_and_emits_error_when_agent_lifecycle_returns_failed() -> None:
     request = ExecutionRequest(task_id=10, subtask_id=11, message_id=12)
     emitter = AsyncMock()
     executor = InprocessExecutor()

--- a/backend/tests/services/execution/test_inprocess_executor.py
+++ b/backend/tests/services/execution/test_inprocess_executor.py
@@ -1,0 +1,97 @@
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.execution.inprocess_executor import InprocessExecutor
+from shared.models.execution import ExecutionRequest
+from shared.status import TaskStatus
+
+
+@pytest.mark.asyncio
+async def test_execute_passes_execution_request_to_agent_service():
+    request = ExecutionRequest(task_id=1, subtask_id=2, message_id=3)
+    emitter = AsyncMock()
+    executor = InprocessExecutor()
+
+    agent = MagicMock()
+    agent.get_name.return_value = "fake-agent"
+
+    agent_service = MagicMock()
+    agent_service.create_agent.return_value = agent
+    fake_module = types.ModuleType("executor.services.agent_service")
+    fake_module.AgentService = MagicMock(return_value=agent_service)
+
+    with (
+        patch.dict(sys.modules, {"executor.services.agent_service": fake_module}),
+        patch.object(
+            executor,
+            "_execute_agent_async",
+            new=AsyncMock(return_value=(TaskStatus.SUCCESS, None)),
+        ) as mock_execute_agent,
+        patch.object(
+            executor,
+            "_cleanup_task_clients",
+            new=AsyncMock(),
+        ) as mock_cleanup,
+    ):
+        await executor.execute(request, emitter)
+
+    agent_service.create_agent.assert_called_once()
+    assert agent_service.create_agent.call_args.args[0] is request
+    mock_execute_agent.assert_awaited_once_with(agent)
+    mock_cleanup.assert_awaited_once_with(request.task_id)
+
+
+@pytest.mark.asyncio
+async def test_execute_agent_async_awaits_pre_execute_and_skips_missing_post_execute():
+    executor = InprocessExecutor()
+    agent = SimpleNamespace(
+        task_id=3,
+        get_name=lambda: "fake-agent",
+        pre_execute=AsyncMock(return_value=(TaskStatus.SUCCESS, None)),
+        execute_async=AsyncMock(return_value=TaskStatus.COMPLETED),
+    )
+
+    status, error = await executor._execute_agent_async(agent)
+
+    assert status == TaskStatus.COMPLETED
+    assert error is None
+    agent.pre_execute.assert_awaited_once()
+    agent.execute_async.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_execute_raises_and_emits_error_when_agent_lifecycle_returns_failed():
+    request = ExecutionRequest(task_id=10, subtask_id=11, message_id=12)
+    emitter = AsyncMock()
+    executor = InprocessExecutor()
+
+    agent = MagicMock()
+    agent.get_name.return_value = "fake-agent"
+
+    agent_service = MagicMock()
+    agent_service.create_agent.return_value = agent
+    fake_module = types.ModuleType("executor.services.agent_service")
+    fake_module.AgentService = MagicMock(return_value=agent_service)
+
+    with (
+        patch.dict(sys.modules, {"executor.services.agent_service": fake_module}),
+        patch.object(
+            executor,
+            "_execute_agent_async",
+            new=AsyncMock(return_value=(TaskStatus.FAILED, "pre-execute failed")),
+        ),
+        patch.object(
+            executor,
+            "_cleanup_task_clients",
+            new=AsyncMock(),
+        ) as mock_cleanup,
+        pytest.raises(RuntimeError, match="pre-execute failed"),
+    ):
+        await executor.execute(request, emitter)
+
+    emitter.emit_error.assert_awaited_once()
+    mock_cleanup.assert_not_awaited()


### PR DESCRIPTION
## Summary
- pass `ExecutionRequest` directly to `AgentService` in standalone in-process execution
- await async `pre_execute()` and align in-process lifecycle behavior with agent contracts
- propagate standalone pre-execution failures through backend error emission and add regression coverage

## Test Plan
- `uv run --project backend pytest backend/tests/services/execution/test_inprocess_executor.py -q`
- `uv run --project backend pytest backend/tests/services/execution -q`

## Notes
- focuses only on standalone in-process execution and its backend regression tests
- no docs changes because behavior is an internal execution-path fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Execution failures are now surfaced immediately: failed agent lifecycles emit clearer failure messages and are raised at the top level, with improved logging and reliable stop/cleanup behavior.
  * Unified asynchronous lifecycle avoids missed post-execution steps and ensures failures halt processing consistently.

* **Tests**
  * Added comprehensive tests covering execution lifecycle, pre-execute failures, error emission, and correct handling of execution requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->