### PR TITLE
fix(standalone): normalize startup script line endings

### DIFF
--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -123,7 +123,7 @@ COPY backend/init_data /app/init_data
 
 # Copy startup script
 COPY docker/standalone/start.sh /app/start.sh
-RUN chmod +x /app/start.sh
+RUN sed -i 's/\r$//' /app/start.sh && chmod +x /app/start.sh
 
 # Environment variables for standalone mode
 ENV STANDALONE_MODE=true


### PR DESCRIPTION
## Summary
- normalize `docker/standalone/start.sh` line endings during image build
- prevent standalone containers built from CRLF workspaces from failing with `/app/start.sh: no such file or directory`

## Test Plan
- rebuild standalone image locally from a Windows workspace
- start container and verify `/health` succeeds

## Notes
- isolated to standalone image startup compatibility
- no runtime logic changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker container startup reliability by normalizing line endings in the startup script, preventing potential execution issues caused by carriage return characters that could interfere with script execution in containerized environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->