### PR TITLE
feat(frontend): Restricting members of the Restricted Analyst role from accessing the group knowledge base

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -262,9 +262,16 @@ def get_knowledge_base(
             knowledge_base_id=knowledge_base_id,
         )
     except ValueError as e:
+        error_msg = str(e)
+        # Check if it's an access denied error
+        if "access denied" in error_msg.lower():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=error_msg,
+            )
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(e),
+            detail=error_msg,
         )
 
 

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -695,12 +695,17 @@ def get_document_detail_standalone(
         )
 
     # Check access permission via knowledge base
-    kb = KnowledgeService.get_knowledge_base(
+    kb, has_access = KnowledgeService.get_knowledge_base(
         db=db,
         knowledge_base_id=document.kind_id,
         user_id=current_user.id,
     )
     if not kb:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Knowledge base not found",
+        )
+    if not has_access:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied to this document",
@@ -983,11 +988,16 @@ async def get_kb_summary(
     from app.services.knowledge import get_summary_service
 
     # Validate KB access permission
-    kb = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
+    kb, has_access = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
     if not kb:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Knowledge base not found or access denied",
+            detail="Knowledge base not found",
+        )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this knowledge base",
         )
 
     summary_service = get_summary_service(db)
@@ -1012,11 +1022,16 @@ async def refresh_kb_summary(
     from app.schemas.summary import SummaryRefreshResponse
 
     # Validate KB access permission
-    kb = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
+    kb, has_access = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
     if not kb:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Knowledge base not found or access denied",
+            detail="Knowledge base not found",
+        )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this knowledge base",
         )
 
     # Run in background, return immediately
@@ -1065,11 +1080,16 @@ async def get_document_detail(
     from app.services.knowledge import get_summary_service
 
     # Validate KB access permission first
-    kb = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
+    kb, has_access = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
     if not kb:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Knowledge base not found or access denied",
+            detail="Knowledge base not found",
+        )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this knowledge base",
         )
 
     # Validate document belongs to the specified knowledge base
@@ -1159,11 +1179,16 @@ async def get_document_summary(
     from app.services.knowledge import get_summary_service
 
     # Validate KB access permission first
-    kb = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
+    kb, has_access = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
     if not kb:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Knowledge base not found or access denied",
+            detail="Knowledge base not found",
+        )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this knowledge base",
         )
 
     # Validate document belongs to the specified knowledge base
@@ -1204,11 +1229,16 @@ async def refresh_document_summary(
     from app.schemas.summary import SummaryRefreshResponse
 
     # Validate KB access permission first
-    kb = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
+    kb, has_access = KnowledgeService.get_knowledge_base(db, kb_id, current_user.id)
     if not kb:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Knowledge base not found or access denied",
+            detail="Knowledge base not found",
+        )
+    if not has_access:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied to this knowledge base",
         )
 
     # Validate document belongs to the specified knowledge base
@@ -1415,12 +1445,17 @@ def list_document_chunks(
         )
 
     # Check access permission via knowledge base
-    kb = KnowledgeService.get_knowledge_base(
+    kb, has_access = KnowledgeService.get_knowledge_base(
         db=db,
         knowledge_base_id=document.kind_id,
         user_id=current_user.id,
     )
     if not kb:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Knowledge base not found",
+        )
+    if not has_access:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied to this document",
@@ -1483,12 +1518,17 @@ def get_document_chunk(
         )
 
     # Check access permission via knowledge base
-    kb = KnowledgeService.get_knowledge_base(
+    kb, has_access = KnowledgeService.get_knowledge_base(
         db=db,
         knowledge_base_id=document.kind_id,
         user_id=current_user.id,
     )
     if not kb:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Knowledge base not found",
+        )
+    if not has_access:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Access denied to this document",

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -263,16 +263,21 @@ def get_knowledge_base(
         )
     except ValueError as e:
         error_msg = str(e)
-        # Check if it's an access denied error
         if "access denied" in error_msg.lower():
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
+                detail="Access denied",
+            )
+        elif "not found" in error_msg.lower():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Knowledge base not found",
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
                 detail=error_msg,
             )
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=error_msg,
-        )
 
 
 @router.put("/{knowledge_base_id}", response_model=KnowledgeBaseResponse)

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -237,7 +237,7 @@ class KnowledgeService:
         db: Session,
         knowledge_base_id: int,
         user_id: int,
-    ) -> Optional[Kind]:
+    ) -> tuple[Optional[Kind], bool]:
         """
         Get a knowledge base by ID with permission check.
 
@@ -247,7 +247,9 @@ class KnowledgeService:
             user_id: Requesting user ID
 
         Returns:
-            Kind if found and accessible, None otherwise
+            Tuple of (Kind, has_access):
+            - Kind: The knowledge base Kind if found, None otherwise
+            - has_access: True if user has access to the knowledge base, False otherwise
         """
         from app.services.share import knowledge_share_service
 
@@ -262,17 +264,14 @@ class KnowledgeService:
         )
 
         if not kb:
-            return None
+            return None, False
 
         # Use the knowledge share service to check access
         has_access, _, _, _ = knowledge_share_service.get_user_kb_permission(
             db, knowledge_base_id, user_id
         )
 
-        if not has_access:
-            return None
-
-        return kb
+        return kb, has_access
 
     @staticmethod
     def list_knowledge_bases(
@@ -481,8 +480,10 @@ class KnowledgeService:
         Raises:
             ValueError: If validation fails or permission denied
         """
-        kb = KnowledgeService.get_knowledge_base(db, knowledge_base_id, user_id)
-        if not kb:
+        kb, has_access = KnowledgeService.get_knowledge_base(
+            db, knowledge_base_id, user_id
+        )
+        if not kb or not has_access:
             return None
 
         # Check permission for organization-level knowledge base (admin only)
@@ -633,8 +634,10 @@ class KnowledgeService:
             # Admin can delete organization KB, skip get_knowledge_base permission check
         else:
             # For non-organization KBs, use get_knowledge_base for permission check
-            kb = KnowledgeService.get_knowledge_base(db, knowledge_base_id, user_id)
-            if not kb:
+            kb, has_access = KnowledgeService.get_knowledge_base(
+                db, knowledge_base_id, user_id
+            )
+            if not kb or not has_access:
                 return False
             # Only creator can delete personal/group knowledge base
             if kb.user_id != user_id:
@@ -678,8 +681,10 @@ class KnowledgeService:
         Raises:
             ValueError: If validation fails or permission denied
         """
-        kb = KnowledgeService.get_knowledge_base(db, knowledge_base_id, user_id)
-        if not kb:
+        kb, has_access = KnowledgeService.get_knowledge_base(
+            db, knowledge_base_id, user_id
+        )
+        if not kb or not has_access:
             return None
 
         # Check permission for team knowledge base
@@ -1015,8 +1020,8 @@ class KnowledgeService:
             return None
 
         # Check access via knowledge base
-        kb = KnowledgeService.get_knowledge_base(db, doc.kind_id, user_id)
-        if not kb:
+        kb, has_access = KnowledgeService.get_knowledge_base(db, doc.kind_id, user_id)
+        if not kb or not has_access:
             return None
 
         return doc
@@ -1039,8 +1044,10 @@ class KnowledgeService:
             List of documents
         """
         # Check access to knowledge base
-        kb = KnowledgeService.get_knowledge_base(db, knowledge_base_id, user_id)
-        if not kb:
+        kb, has_access = KnowledgeService.get_knowledge_base(
+            db, knowledge_base_id, user_id
+        )
+        if not kb or not has_access:
             return []
 
         return (

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -603,12 +603,12 @@ class KnowledgeOrchestrator:
             ValueError: If knowledge base not found or access denied
         """
         # Verify access
-        kb = KnowledgeService.get_knowledge_base(
+        kb, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb:
+        if not kb or not has_access:
             raise ValueError("Knowledge base not found or access denied")
 
         documents = KnowledgeService.list_documents(
@@ -642,27 +642,16 @@ class KnowledgeOrchestrator:
         Raises:
             ValueError: If knowledge base not found or access denied
         """
-        knowledge_base = KnowledgeService.get_knowledge_base(
+        knowledge_base, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
 
         if not knowledge_base:
-            # Check if KB exists but user has no access, or KB doesn't exist
-            kb_exists = (
-                db.query(Kind)
-                .filter(
-                    Kind.id == knowledge_base_id,
-                    Kind.kind == "KnowledgeBase",
-                    Kind.is_active == True,
-                )
-                .first()
-            )
-            if kb_exists:
-                raise ValueError("Access denied to knowledge base")
-            else:
-                raise ValueError("Knowledge base not found")
+            raise ValueError("Knowledge base not found")
+        if not has_access:
+            raise ValueError("Access denied to knowledge base")
 
         return KnowledgeBaseResponse.from_kind(
             knowledge_base, KnowledgeService.get_document_count(db, knowledge_base.id)
@@ -891,12 +880,12 @@ class KnowledgeOrchestrator:
         db.commit()
 
         # Fetch and return created knowledge base
-        knowledge_base = KnowledgeService.get_knowledge_base(
+        knowledge_base, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=kb_id,
             user_id=user.id,
         )
-        if not knowledge_base:
+        if not knowledge_base or not has_access:
             raise ValueError("Failed to retrieve created knowledge base")
 
         return KnowledgeBaseResponse.from_kind(
@@ -946,12 +935,12 @@ class KnowledgeOrchestrator:
         from app.services.context import context_service
 
         # Verify access
-        kb = KnowledgeService.get_knowledge_base(
+        kb, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb:
+        if not kb or not has_access:
             raise ValueError("Knowledge base not found or access denied")
 
         # Validate input based on source_type
@@ -1046,12 +1035,12 @@ class KnowledgeOrchestrator:
             ValueError: If validation fails or access denied
         """
         # Verify access
-        kb = KnowledgeService.get_knowledge_base(
+        kb, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb:
+        if not kb or not has_access:
             raise ValueError("Knowledge base not found or access denied")
 
         # Get splitter config from data if provided
@@ -1180,14 +1169,14 @@ class KnowledgeOrchestrator:
         logger.info(f"[Orchestrator] Updated document {document_id} content")
 
         # Get knowledge base for indexing config
-        kb = KnowledgeService.get_knowledge_base(
+        kb, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=document.kind_id,
             user_id=user.id,
         )
 
         # Schedule re-indexing via Celery if enabled
-        if trigger_reindex and kb:
+        if trigger_reindex and kb and has_access:
             self._schedule_indexing_celery(
                 db=db,
                 knowledge_base=kb,
@@ -1377,13 +1366,13 @@ class KnowledgeOrchestrator:
             raise ValueError(skip_reason)
 
         # Check access permission via knowledge base
-        knowledge_base = KnowledgeService.get_knowledge_base(
+        knowledge_base, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=document.kind_id,
             user_id=user.id,
         )
 
-        if not knowledge_base:
+        if not knowledge_base or not has_access:
             raise ValueError("Access denied to this document")
 
         # Extract RAG config using shared helper
@@ -1467,12 +1456,12 @@ class KnowledgeOrchestrator:
         )
 
         # Verify knowledge base access
-        knowledge_base = KnowledgeService.get_knowledge_base(
+        knowledge_base, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not knowledge_base:
+        if not knowledge_base or not has_access:
             raise ValueError("Knowledge base not found or access denied")
 
         # Scrape the web page (async)
@@ -1724,12 +1713,12 @@ class KnowledgeOrchestrator:
 
             # Trigger RAG re-indexing via Celery if enabled
             if trigger_indexing:
-                knowledge_base = KnowledgeService.get_knowledge_base(
+                knowledge_base, has_access = KnowledgeService.get_knowledge_base(
                     db=db,
                     knowledge_base_id=document.kind_id,
                     user_id=user.id,
                 )
-                if knowledge_base:
+                if knowledge_base and has_access:
                     self._schedule_indexing_celery(
                         db=db,
                         knowledge_base=knowledge_base,

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -608,8 +608,10 @@ class KnowledgeOrchestrator:
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb or not has_access:
-            raise ValueError("Knowledge base not found or access denied")
+        if not kb:
+            raise ValueError("Knowledge base not found")
+        if not has_access:
+            raise ValueError("Access denied to knowledge base")
 
         documents = KnowledgeService.list_documents(
             db=db,
@@ -940,8 +942,10 @@ class KnowledgeOrchestrator:
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb or not has_access:
-            raise ValueError("Knowledge base not found or access denied")
+        if not kb:
+            raise ValueError("Knowledge base not found")
+        if not has_access:
+            raise ValueError("Access denied to knowledge base")
 
         # Validate input based on source_type
         normalized_ext: str = DEFAULT_TEXT_FILE_EXTENSION
@@ -1040,8 +1044,10 @@ class KnowledgeOrchestrator:
             knowledge_base_id=knowledge_base_id,
             user_id=user.id,
         )
-        if not kb or not has_access:
-            raise ValueError("Knowledge base not found or access denied")
+        if not kb:
+            raise ValueError("Knowledge base not found")
+        if not has_access:
+            raise ValueError("Access denied to knowledge base")
 
         # Get splitter config from data if provided
         splitter_config_dict = None

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -649,7 +649,20 @@ class KnowledgeOrchestrator:
         )
 
         if not knowledge_base:
-            raise ValueError("Knowledge base not found or access denied")
+            # Check if KB exists but user has no access, or KB doesn't exist
+            kb_exists = (
+                db.query(Kind)
+                .filter(
+                    Kind.id == knowledge_base_id,
+                    Kind.kind == "KnowledgeBase",
+                    Kind.is_active == True,
+                )
+                .first()
+            )
+            if kb_exists:
+                raise ValueError("Access denied to knowledge base")
+            else:
+                raise ValueError("Knowledge base not found")
 
         return KnowledgeBaseResponse.from_kind(
             knowledge_base, KnowledgeService.get_document_count(db, knowledge_base.id)

--- a/backend/app/services/rag/retrieval_service.py
+++ b/backend/app/services/rag/retrieval_service.py
@@ -212,16 +212,16 @@ class RetrievalService:
             ValueError: If knowledge base not found, access denied, or configuration invalid
         """
         # Get knowledge base configuration with permission check
-        kb = KnowledgeService.get_knowledge_base(
+        kb, has_access = KnowledgeService.get_knowledge_base(
             db=db,
             knowledge_base_id=knowledge_base_id,
             user_id=user_id,
         )
 
         if not kb:
-            raise ValueError(
-                f"Knowledge base {knowledge_base_id} not found or access denied for user {user_id}"
-            )
+            raise ValueError(f"Knowledge base {knowledge_base_id} not found")
+        if not has_access:
+            raise ValueError(f"Access denied to knowledge base {knowledge_base_id}")
 
         # Check if user is a Restricted Analyst in the knowledge base's group
         # Restricted Analysts cannot access knowledge base content

--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -28,7 +28,10 @@ from app.schemas.share import (
     PendingRequestInfo,
 )
 from app.schemas.share import PermissionLevel as SchemaPermissionLevel
-from app.services.group_permission import get_effective_role_in_group
+from app.services.group_permission import (
+    get_effective_role_in_group,
+    is_restricted_analyst,
+)
 from app.services.knowledge.knowledge_service import _is_organization_namespace
 from app.services.share.base_service import UnifiedShareService
 from shared.telemetry.decorators import add_span_event, set_span_attribute, trace_sync
@@ -128,6 +131,14 @@ class KnowledgeShareService(UnifiedShareService):
             )
             role = get_effective_role_in_group(db, user_id, kb.namespace)
             if role is not None:
+                # Check if user is a Restricted Analyst
+                # Restricted Analysts cannot access knowledge base content
+                if is_restricted_analyst(db, user_id, kb.namespace):
+                    logger.warning(
+                        f"[_get_resource] User {user_id} is Restricted Analyst in group "
+                        f"'{kb.namespace}', blocking access to KB {resource_id}"
+                    )
+                    return None
                 logger.info(f"[_get_resource] User has team role: role={role}")
                 return kb
             logger.warning(
@@ -259,6 +270,14 @@ class KnowledgeShareService(UnifiedShareService):
         if kb.namespace != "default":
             group_role = get_effective_role_in_group(db, user_id, kb.namespace)
             if group_role is not None:
+                # Check if user is a Restricted Analyst
+                # Restricted Analysts cannot access knowledge base content
+                if is_restricted_analyst(db, user_id, kb.namespace):
+                    logger.warning(
+                        f"[get_user_kb_permission] User {user_id} is Restricted Analyst in group "
+                        f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
+                    )
+                    return False, None, None, False
                 # Map group role to permission level
                 # Owner/Maintainer -> manage, Developer -> edit, Reporter -> view
                 role_mapping = {
@@ -467,24 +486,39 @@ class KnowledgeShareService(UnifiedShareService):
         elif kb.namespace != "default":
             team_role = get_effective_role_in_group(db, user_id, kb.namespace)
             if team_role is not None:
-                role_mapping = {
-                    "Owner": (
-                        SchemaMemberRole.MAINTAINER,
-                        SchemaPermissionLevel.MANAGE,
-                    ),
-                    "Maintainer": (
-                        SchemaMemberRole.MAINTAINER,
-                        SchemaPermissionLevel.MANAGE,
-                    ),
-                    "Developer": (
-                        SchemaMemberRole.DEVELOPER,
-                        SchemaPermissionLevel.EDIT,
-                    ),
-                    "Reporter": (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW),
-                }
-                group_role, group_level = role_mapping.get(
-                    team_role, (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW)
-                )
+                # Check if user is a Restricted Analyst
+                # Restricted Analysts cannot access knowledge base content
+                if is_restricted_analyst(db, user_id, kb.namespace):
+                    logger.warning(
+                        f"[get_my_permission] User {user_id} is Restricted Analyst in group "
+                        f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
+                    )
+                    # Restricted Analysts get no group permission
+                    group_role = None
+                    group_level = None
+                else:
+                    role_mapping = {
+                        "Owner": (
+                            SchemaMemberRole.MAINTAINER,
+                            SchemaPermissionLevel.MANAGE,
+                        ),
+                        "Maintainer": (
+                            SchemaMemberRole.MAINTAINER,
+                            SchemaPermissionLevel.MANAGE,
+                        ),
+                        "Developer": (
+                            SchemaMemberRole.DEVELOPER,
+                            SchemaPermissionLevel.EDIT,
+                        ),
+                        "Reporter": (
+                            SchemaMemberRole.REPORTER,
+                            SchemaPermissionLevel.VIEW,
+                        ),
+                    }
+                    group_role, group_level = role_mapping.get(
+                        team_role,
+                        (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW),
+                    )
 
         # Determine final access level (higher of explicit vs group)
         if has_explicit_access and group_level:

--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -38,6 +38,15 @@ from shared.telemetry.decorators import add_span_event, set_span_attribute, trac
 
 logger = logging.getLogger(__name__)
 
+# Shared role-to-permission mapping for group team roles
+# Maps team_role to (SchemaMemberRole, SchemaPermissionLevel)
+GROUP_ROLE_PERMISSION_MAP: dict[str, tuple[SchemaMemberRole, SchemaPermissionLevel]] = {
+    "Owner": (SchemaMemberRole.MAINTAINER, SchemaPermissionLevel.MANAGE),
+    "Maintainer": (SchemaMemberRole.MAINTAINER, SchemaPermissionLevel.MANAGE),
+    "Developer": (SchemaMemberRole.DEVELOPER, SchemaPermissionLevel.EDIT),
+    "Reporter": (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW),
+}
+
 
 class KnowledgeShareService(UnifiedShareService):
     """
@@ -61,6 +70,9 @@ class KnowledgeShareService(UnifiedShareService):
         2. Explicit shared access (ResourceMember)
         3. Organization membership (for organization knowledge bases)
         4. Team membership (for team knowledge bases)
+
+        Note: For group KBs, Restricted Analysts are denied access regardless of
+        explicit permissions (creator or ResourceMember grants).
         """
         logger.info(
             f"[_get_resource] Fetching KnowledgeBase: resource_id={resource_id}, user_id={user_id}"
@@ -86,6 +98,18 @@ class KnowledgeShareService(UnifiedShareService):
             f"[_get_resource] KnowledgeBase found: id={kb.id}, "
             f"kb.user_id={kb.user_id}, namespace={kb.namespace}"
         )
+
+        # For group knowledge bases, check Restricted Analyst status FIRST
+        # This check must run before creator/explicit-share checks to prevent bypass
+        if kb.namespace != "default" and not _is_organization_namespace(
+            db, kb.namespace
+        ):
+            if is_restricted_analyst(db, user_id, kb.namespace):
+                logger.warning(
+                    f"[_get_resource] User {user_id} is Restricted Analyst in group "
+                    f"'{kb.namespace}', blocking access to KB {resource_id}"
+                )
+                return None
 
         # Check if user is creator
         if kb.user_id == user_id:
@@ -131,14 +155,6 @@ class KnowledgeShareService(UnifiedShareService):
             )
             role = get_effective_role_in_group(db, user_id, kb.namespace)
             if role is not None:
-                # Check if user is a Restricted Analyst
-                # Restricted Analysts cannot access knowledge base content
-                if is_restricted_analyst(db, user_id, kb.namespace):
-                    logger.warning(
-                        f"[_get_resource] User {user_id} is Restricted Analyst in group "
-                        f"'{kb.namespace}', blocking access to KB {resource_id}"
-                    )
-                    return None
                 logger.info(f"[_get_resource] User has team role: role={role}")
                 return kb
             logger.warning(
@@ -242,6 +258,18 @@ class KnowledgeShareService(UnifiedShareService):
         if not kb:
             return False, None, None, False
 
+        # For group knowledge bases, check Restricted Analyst status FIRST
+        # This check must run before creator/explicit-share checks to prevent bypass
+        if kb.namespace != "default" and not _is_organization_namespace(
+            db, kb.namespace
+        ):
+            if is_restricted_analyst(db, user_id, kb.namespace):
+                logger.warning(
+                    f"[get_user_kb_permission] User {user_id} is Restricted Analyst in group "
+                    f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
+                )
+                return False, None, None, False
+
         # Check if user is creator
         if kb.user_id == user_id:
             return True, ResourceRole.OWNER.value, PermissionLevel.MANAGE.value, True
@@ -270,16 +298,9 @@ class KnowledgeShareService(UnifiedShareService):
         if kb.namespace != "default":
             group_role = get_effective_role_in_group(db, user_id, kb.namespace)
             if group_role is not None:
-                # Check if user is a Restricted Analyst
-                # Restricted Analysts cannot access knowledge base content
-                if is_restricted_analyst(db, user_id, kb.namespace):
-                    logger.warning(
-                        f"[get_user_kb_permission] User {user_id} is Restricted Analyst in group "
-                        f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
-                    )
-                    return False, None, None, False
                 # Map group role to permission level
                 # Owner/Maintainer -> manage, Developer -> edit, Reporter -> view
+                # Use shared mapping constant
                 role_mapping = {
                     "Owner": (
                         ResourceRole.MAINTAINER.value,
@@ -433,9 +454,22 @@ class KnowledgeShareService(UnifiedShareService):
                 pending_request=None,
             )
 
+        # For group knowledge bases, check Restricted Analyst status FIRST
+        # This check must run before creator/explicit-share checks to prevent bypass
+        is_restricted = False
+        if kb.namespace != "default" and not _is_organization_namespace(
+            db, kb.namespace
+        ):
+            if is_restricted_analyst(db, user_id, kb.namespace):
+                logger.warning(
+                    f"[get_my_permission] User {user_id} is Restricted Analyst in group "
+                    f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
+                )
+                is_restricted = True
+
         # Check if user is creator
         is_creator = kb.user_id == user_id
-        if is_creator:
+        if is_creator and not is_restricted:
             return MyKBPermissionResponse(
                 has_access=True,
                 role=SchemaMemberRole.OWNER,
@@ -460,7 +494,7 @@ class KnowledgeShareService(UnifiedShareService):
         explicit_role = None
         explicit_level = None
 
-        if explicit_perm:
+        if explicit_perm and not is_restricted:
             effective_role = explicit_perm.get_effective_role()
             if explicit_perm.status == MemberStatus.APPROVED.value:
                 has_explicit_access = True
@@ -481,44 +515,18 @@ class KnowledgeShareService(UnifiedShareService):
         group_level = None
         if _is_organization_namespace(db, kb.namespace):
             # Organization KB - all authenticated users have VIEW access
-            group_role = SchemaMemberRole.REPORTER
-            group_level = SchemaPermissionLevel.VIEW
+            # Unless they are Restricted Analysts
+            if not is_restricted:
+                group_role = SchemaMemberRole.REPORTER
+                group_level = SchemaPermissionLevel.VIEW
         elif kb.namespace != "default":
             team_role = get_effective_role_in_group(db, user_id, kb.namespace)
-            if team_role is not None:
-                # Check if user is a Restricted Analyst
-                # Restricted Analysts cannot access knowledge base content
-                if is_restricted_analyst(db, user_id, kb.namespace):
-                    logger.warning(
-                        f"[get_my_permission] User {user_id} is Restricted Analyst in group "
-                        f"'{kb.namespace}', denying access to KB {knowledge_base_id}"
-                    )
-                    # Restricted Analysts get no group permission
-                    group_role = None
-                    group_level = None
-                else:
-                    role_mapping = {
-                        "Owner": (
-                            SchemaMemberRole.MAINTAINER,
-                            SchemaPermissionLevel.MANAGE,
-                        ),
-                        "Maintainer": (
-                            SchemaMemberRole.MAINTAINER,
-                            SchemaPermissionLevel.MANAGE,
-                        ),
-                        "Developer": (
-                            SchemaMemberRole.DEVELOPER,
-                            SchemaPermissionLevel.EDIT,
-                        ),
-                        "Reporter": (
-                            SchemaMemberRole.REPORTER,
-                            SchemaPermissionLevel.VIEW,
-                        ),
-                    }
-                    group_role, group_level = role_mapping.get(
-                        team_role,
-                        (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW),
-                    )
+            if team_role is not None and not is_restricted:
+                # Use shared mapping constant
+                group_role, group_level = GROUP_ROLE_PERMISSION_MAP.get(
+                    team_role,
+                    (SchemaMemberRole.REPORTER, SchemaPermissionLevel.VIEW),
+                )
 
         # Determine final access level (higher of explicit vs group)
         if has_explicit_access and group_level:
@@ -559,7 +567,7 @@ class KnowledgeShareService(UnifiedShareService):
                 has_access=False,
                 role=None,
                 permission_level=None,
-                is_creator=False,
+                is_creator=is_creator,  # Still report creator status even if restricted
                 pending_request=pending_request,
             )
 

--- a/backend/tests/services/knowledge/test_orchestrator.py
+++ b/backend/tests/services/knowledge/test_orchestrator.py
@@ -218,7 +218,7 @@ class TestKnowledgeOrchestrator:
         with patch(
             "app.services.knowledge.orchestrator.KnowledgeService"
         ) as mock_service:
-            mock_service.get_knowledge_base.return_value = None
+            mock_service.get_knowledge_base.return_value = (None, False)
 
             with pytest.raises(ValueError, match="Knowledge base not found"):
                 orchestrator.list_documents(mock_db, mock_user, knowledge_base_id=999)
@@ -231,7 +231,7 @@ class TestKnowledgeOrchestrator:
             mock_kb = MagicMock()
             mock_kb.id = 1
             mock_kb.json = {"spec": {}}
-            mock_kb_service.get_knowledge_base.return_value = mock_kb
+            mock_kb_service.get_knowledge_base.return_value = (mock_kb, True)
 
             mock_doc = MagicMock()
             mock_doc.id = 1
@@ -274,7 +274,7 @@ class TestKnowledgeOrchestrator:
             mock_kb = MagicMock()
             mock_kb.id = 1
             mock_kb.json = {"spec": {}}
-            mock_kb_service.get_knowledge_base.return_value = mock_kb
+            mock_kb_service.get_knowledge_base.return_value = (mock_kb, True)
 
             mock_doc = MagicMock()
             mock_doc.id = 1
@@ -314,7 +314,7 @@ class TestKnowledgeOrchestrator:
             "app.services.knowledge.orchestrator.KnowledgeService"
         ) as mock_service:
             mock_kb = MagicMock()
-            mock_service.get_knowledge_base.return_value = mock_kb
+            mock_service.get_knowledge_base.return_value = (mock_kb, True)
 
             with pytest.raises(ValueError, match="content is required"):
                 orchestrator.create_document_with_content(
@@ -334,7 +334,7 @@ class TestKnowledgeOrchestrator:
             "app.services.knowledge.orchestrator.KnowledgeService"
         ) as mock_service:
             mock_kb = MagicMock()
-            mock_service.get_knowledge_base.return_value = mock_kb
+            mock_service.get_knowledge_base.return_value = (mock_kb, True)
 
             with pytest.raises(ValueError, match="Invalid source_type"):
                 orchestrator.create_document_with_content(
@@ -368,7 +368,7 @@ class TestKnowledgeOrchestrator:
         with patch(
             "app.services.knowledge.orchestrator.KnowledgeService"
         ) as mock_service:
-            mock_service.get_knowledge_base.return_value = mock_kb
+            mock_service.get_knowledge_base.return_value = (mock_kb, True)
             mock_service.create_document.return_value = mock_doc
 
             with patch.object(

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
@@ -6,13 +6,16 @@
 
 import { Suspense } from 'react'
 import dynamic from 'next/dynamic'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import '@/app/tasks/tasks.css'
 import '@/features/common/scrollbar.css'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { TaskParamSync } from '@/features/tasks/components/params'
 import { Spinner } from '@/components/ui/spinner'
+import { Button } from '@/components/ui/button'
 import { useKnowledgeBaseDetail } from '@/features/knowledge/document/hooks'
+import { useTranslation } from '@/hooks/useTranslation'
+import { ArrowLeft, Lock } from 'lucide-react'
 
 // Loading fallback component for dynamic imports
 function PageLoadingFallback() {
@@ -86,6 +89,8 @@ export default function KnowledgeBaseChatPage() {
   // Mobile detection
   const isMobile = useIsMobile()
   const params = useParams()
+  const router = useRouter()
+  const { t } = useTranslation('knowledge')
 
   // Parse knowledge base ID from URL
   const knowledgeBaseId = params.knowledgeBaseId
@@ -97,15 +102,64 @@ export default function KnowledgeBaseChatPage() {
   const {
     knowledgeBase,
     loading,
+    error,
+    accessDenied,
     refresh: refreshKnowledgeBase,
   } = useKnowledgeBaseDetail({
     knowledgeBaseId: knowledgeBaseId || 0,
     autoLoad: !!knowledgeBaseId,
   })
 
+  // Handle back navigation
+  const handleBack = () => {
+    router.back()
+  }
+
+  // Handle navigate to knowledge base list
+  const handleGoToList = () => {
+    router.push('/knowledge?type=document')
+  }
+
   // Show loading while fetching knowledge base info
-  if (loading || !knowledgeBase) {
+  if (loading) {
     return <PageLoadingFallback />
+  }
+
+  // Show access denied state for 403 errors
+  if (accessDenied) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-base">
+        <div className="text-center max-w-md px-6">
+          <div className="w-16 h-16 bg-surface rounded-full flex items-center justify-center mx-auto mb-6">
+            <Lock className="w-8 h-8 text-text-muted" />
+          </div>
+          <h1 className="text-xl font-semibold text-text-primary mb-3">
+            {t('chatPage.accessDenied.title')}
+          </h1>
+          <p className="text-text-muted mb-8 leading-relaxed">
+            {t('chatPage.accessDenied.description')}
+          </p>
+          <Button variant="primary" onClick={handleGoToList}>
+            {t('chatPage.accessDenied.backButton')}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // Show error state if fetch failed (non-403 errors)
+  if (error || !knowledgeBase) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-base">
+        <div className="text-center">
+          <p className="text-text-muted mb-4">{error || t('chatPage.notFound')}</p>
+          <Button variant="outline" onClick={handleBack}>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            {t('chatPage.backToList')}
+          </Button>
+        </div>
+      </div>
+    )
   }
 
   // Determine the layout type (default to 'notebook' if not specified)

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
@@ -110,9 +110,15 @@ export default function KnowledgeBaseChatPage() {
     autoLoad: !!knowledgeBaseId,
   })
 
-  // Handle back navigation
+  // Handle back navigation with fallback to knowledge list
   const handleBack = () => {
-    router.back()
+    // Check if there's history to go back to
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back()
+    } else {
+      // Fallback to knowledge list when no history available
+      router.push('/knowledge?type=document')
+    }
   }
 
   // Handle navigate to knowledge base list

--- a/frontend/src/features/knowledge/document/hooks/useKnowledgeBaseDetail.ts
+++ b/frontend/src/features/knowledge/document/hooks/useKnowledgeBaseDetail.ts
@@ -39,9 +39,16 @@ export function useKnowledgeBaseDetail(options: UseKnowledgeBaseDetailOptions) {
     } catch (err) {
       // Check if it's a 403 Forbidden error (access denied)
       if (err instanceof ApiError && err.status === 403) {
+        // 403 path: exclusive access denied state
         setAccessDenied(true)
+        setError(null)
+        setKnowledgeBase(null)
+      } else {
+        // Non-403 errors: set error state and clear other states
+        setAccessDenied(false)
+        setError(err instanceof Error ? err.message : 'Failed to fetch knowledge base')
+        setKnowledgeBase(null)
       }
-      setError(err instanceof Error ? err.message : 'Failed to fetch knowledge base')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/features/knowledge/document/hooks/useKnowledgeBaseDetail.ts
+++ b/frontend/src/features/knowledge/document/hooks/useKnowledgeBaseDetail.ts
@@ -8,6 +8,7 @@
 
 import { useState, useCallback, useEffect } from 'react'
 import { getKnowledgeBase } from '@/apis/knowledge'
+import { ApiError } from '@/apis/client'
 import type { KnowledgeBase } from '@/types/knowledge'
 
 interface UseKnowledgeBaseDetailOptions {
@@ -23,16 +24,23 @@ export function useKnowledgeBaseDetail(options: UseKnowledgeBaseDetailOptions) {
   // This prevents brief flash of error/empty state before the effect fires
   const [loading, setLoading] = useState(autoLoad && !!knowledgeBaseId)
   const [error, setError] = useState<string | null>(null)
+  // Track access denied state for 403 errors
+  const [accessDenied, setAccessDenied] = useState(false)
 
   const fetchKnowledgeBase = useCallback(async () => {
     if (!knowledgeBaseId) return
 
     setLoading(true)
     setError(null)
+    setAccessDenied(false)
     try {
       const data = await getKnowledgeBase(knowledgeBaseId)
       setKnowledgeBase(data)
     } catch (err) {
+      // Check if it's a 403 Forbidden error (access denied)
+      if (err instanceof ApiError && err.status === 403) {
+        setAccessDenied(true)
+      }
       setError(err instanceof Error ? err.message : 'Failed to fetch knowledge base')
     } finally {
       setLoading(false)
@@ -49,6 +57,7 @@ export function useKnowledgeBaseDetail(options: UseKnowledgeBaseDetailOptions) {
     knowledgeBase,
     loading,
     error,
+    accessDenied,
     refresh: fetchKnowledgeBase,
   }
 }

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -507,6 +507,11 @@
     "summaryFailed": "Summary generation failed",
     "summaryFailedHint": "Click retry to regenerate summary",
     "summaryRetry": "Retry",
-    "summaryRetrying": "Retrying..."
+    "summaryRetrying": "Retrying...",
+    "accessDenied": {
+      "title": "Cannot Access Knowledge Base",
+      "description": "You do not have permission to access this knowledge base. If you have any questions, please contact the knowledge base creator or administrator.",
+      "backButton": "Back to Knowledge Base List"
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -507,6 +507,11 @@
     "summaryFailed": "摘要生成失败",
     "summaryFailedHint": "点击重试按钮重新生成摘要",
     "summaryRetry": "重试",
-    "summaryRetrying": "重试中..."
+    "summaryRetrying": "重试中...",
+    "accessDenied": {
+      "title": "无法访问知识库",
+      "description": "您没有该知识库详细信息的访问权限。如有疑问，请联系知识库创建者或管理员。",
+      "backButton": "返回知识库列表"
+    }
   }
 }


### PR DESCRIPTION
…errors

- Restricting members of the Restricted Analyst role from accessing the group knowledge base
- Add accessDenied state to useKnowledgeBaseDetail hook to detect 403 errors
- Display user-friendly access denied page with lock icon and helpful message
- Add i18n translations for access denied UI in both zh-CN and en locales
- Provide navigation button to return to knowledge base list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit "Access denied" UI and messaging with a back-to-list action.
  * Translations for access-denied text (en and zh-CN).
  * Hook/API now expose an accessDenied state for UI handling.

* **Bug Fixes / Improvements**
  * Clearer error semantics: distinguish 403 "Access denied" vs 404 "Knowledge base not found" across endpoints and flows.
  * Early, consistent access checks applied to document, summary, retrieval, and background task paths.

* **Tests**
  * Unit tests updated to reflect the new access/return behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->