### PR TITLE
fix(share): use ROLE_TO_PERMISSION mapping for default_permission_level

### DIFF
--- a/backend/app/services/share/base_service.py
+++ b/backend/app/services/share/base_service.py
@@ -335,8 +335,9 @@ class UnifiedShareService(ABC):
                 f"[create_share_link] UPDATING existing link: id={existing_link.id}"
             )
             existing_link.require_approval = config.require_approval
-            existing_link.default_permission_level = (
-                config.default_permission_level.value
+            # Map default_role to permission_level for backward compatibility
+            existing_link.default_permission_level = self.ROLE_TO_PERMISSION.get(
+                config.default_role.value, PermissionLevel.VIEW.value
             )
             if config.expires_in_hours:
                 existing_link.expires_at = datetime.utcnow() + timedelta(
@@ -385,12 +386,16 @@ class UnifiedShareService(ABC):
         logger.info(
             f"[create_share_link] Creating new ShareLink record with token: {share_token[:50]}..."
         )
+        # Map default_role to permission_level for backward compatibility
+        default_permission_level = self.ROLE_TO_PERMISSION.get(
+            config.default_role.value, PermissionLevel.VIEW.value
+        )
         share_link = ShareLink(
             resource_type=self.resource_type.value,
             resource_id=resource_id,
             share_token=share_token,
             require_approval=config.require_approval,
-            default_permission_level=config.default_permission_level.value,
+            default_permission_level=default_permission_level,
             expires_at=expires_at,
             created_by_user_id=user_id,
             is_active=True,


### PR DESCRIPTION
The ShareLinkConfig schema only has 'default_role' field, but the code was trying to access non-existent 'default_permission_level' field.

Fixed by using the existing ROLE_TO_PERMISSION mapping to derive permission_level from default_role for backward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent default permission behavior for shared links during creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->