### PR TITLE
refactor(frontend): extract IntegrationsPage container for settings i…

### DIFF
--- a/frontend/src/app/(tasks)/settings/page.tsx
+++ b/frontend/src/app/(tasks)/settings/page.tsx
@@ -13,7 +13,7 @@ import {
   CollapsedSidebarButtons,
 } from '@/features/tasks/components/sidebar'
 import { SettingsTabNav, SettingsTabId } from '@/features/settings/components/SettingsTabNav'
-import GitHubIntegration from '@/features/settings/components/GitHubIntegration'
+import IntegrationsPage from '@/features/settings/components/IntegrationsPage'
 import NotificationSettings from '@/features/settings/components/NotificationSettings'
 import { GroupManager } from '@/features/settings/components/groups/GroupManager'
 import { ModelListWithScope } from '@/features/settings/components/ModelListWithScope'
@@ -207,7 +207,7 @@ function SettingsContent() {
           />
         )
       case 'integrations':
-        return <GitHubIntegration />
+        return <IntegrationsPage />
       case 'general':
         return <NotificationSettings />
       case 'api-keys':

--- a/frontend/src/features/settings/components/GitHubIntegration.tsx
+++ b/frontend/src/features/settings/components/GitHubIntegration.tsx
@@ -105,10 +105,10 @@ export default function GitHubIntegration() {
   return (
     <div className="space-y-3">
       <div>
-        <h2 className="text-xl font-semibold text-text-primary mb-1">
-          {t('common:integrations.title')}
-        </h2>
-        <p className="text-sm text-text-muted mb-1">{t('common:integrations.description')}</p>
+        <h3 className="text-base font-medium text-text-primary mb-1">
+          {t('common:integrations.git_title')}
+        </h3>
+        <p className="text-xs text-text-muted">{t('common:integrations.git_description')}</p>
       </div>
       <div className="bg-base border border-border rounded-md p-2 space-y-1 max-h-[70vh] overflow-y-auto custom-scrollbar w-full">
         {isLoading ? (

--- a/frontend/src/features/settings/components/IntegrationsPage.tsx
+++ b/frontend/src/features/settings/components/IntegrationsPage.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useTranslation } from '@/hooks/useTranslation'
+import GitHubIntegration from './GitHubIntegration'
+
+export default function IntegrationsPage() {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h2 className="text-xl font-semibold text-text-primary mb-1">
+          {t('common:integrations.title')}
+        </h2>
+        <p className="text-sm text-text-muted mb-1">{t('common:integrations.description')}</p>
+      </div>
+
+      {/* Git integration section */}
+      <GitHubIntegration />
+
+      {/* Future: more integration sections here */}
+    </div>
+  )
+}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -388,6 +388,8 @@
   "integrations": {
     "title": "Integrations",
     "description": "Setting external services to enhance your workflow",
+    "git_title": "Git Tokens",
+    "git_description": "Manage Git access tokens for repository operations",
     "loading": "Loading Git integrations...",
     "edit_token": "Edit Token",
     "delete": "Delete",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -388,6 +388,8 @@
   "integrations": {
     "title": "集成",
     "description": "设置外部服务以增强您的工作流程",
+    "git_title": "Git 令牌",
+    "git_description": "管理用于仓库操作的 Git 访问令牌",
     "loading": "加载 Git 集成中...",
     "edit_token": "编辑令牌",
     "delete": "删除",


### PR DESCRIPTION
…ntegrations tab

Introduce IntegrationsPage as a container component so future integration modules (Slack, Jira, etc.) can be added as sections without modifying the settings page router. GitHubIntegration now renders with a section-level heading (h3) while the page-level title is managed by IntegrationsPage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the integrations settings page with improved organization and layout for managing Git access tokens.
  * Enhanced section hierarchy and visual presentation for better integration configuration and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->