### PR TITLE
fix(frontend): fix group knowledge base selection to select all KBs i…

### DIFF
--- a/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatContextInput.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import AddContextButton from './AddContextButton'
 import ContextSelector from './ContextSelector'
 import type { ContextItem } from '@/types/context'
@@ -32,13 +32,37 @@ export default function ChatContextInput({
 }: ChatContextInputProps) {
   const [selectorOpen, setSelectorOpen] = useState(false)
 
-  const handleSelect = (context: ContextItem) => {
-    onContextsChange([...selectedContexts, context])
-  }
+  const handleSelect = useCallback(
+    (context: ContextItem) => {
+      onContextsChange([...selectedContexts, context])
+    },
+    [selectedContexts, onContextsChange]
+  )
 
-  const handleDeselect = (id: number | string) => {
-    onContextsChange(selectedContexts.filter(ctx => ctx.id !== id))
-  }
+  const handleDeselect = useCallback(
+    (id: number | string) => {
+      onContextsChange(selectedContexts.filter(ctx => ctx.id !== id))
+    },
+    [selectedContexts, onContextsChange]
+  )
+
+  // Handle batch selection for group knowledge bases
+  // This is critical to avoid the closure problem when selecting multiple items
+  const handleSelectMultiple = useCallback(
+    (contextsToAdd: ContextItem[]) => {
+      onContextsChange([...selectedContexts, ...contextsToAdd])
+    },
+    [selectedContexts, onContextsChange]
+  )
+
+  // Handle batch deselection for group knowledge bases
+  const handleDeselectMultiple = useCallback(
+    (ids: (number | string)[]) => {
+      const idSet = new Set(ids)
+      onContextsChange(selectedContexts.filter(ctx => !idSet.has(ctx.id)))
+    },
+    [selectedContexts, onContextsChange]
+  )
 
   // If chat context feature is disabled, don't render anything
   if (!isChatContextEnabled()) {
@@ -52,6 +76,8 @@ export default function ChatContextInput({
       selectedContexts={selectedContexts}
       onSelect={handleSelect}
       onDeselect={handleDeselect}
+      onSelectMultiple={handleSelectMultiple}
+      onDeselectMultiple={handleDeselectMultiple}
       excludeKnowledgeBaseId={excludeKnowledgeBaseId}
     >
       <div>

--- a/frontend/src/features/tasks/components/chat/ContextSelector.tsx
+++ b/frontend/src/features/tasks/components/chat/ContextSelector.tsx
@@ -57,6 +57,10 @@ interface ContextSelectorProps {
   selectedContexts: ContextItem[]
   onSelect: (context: ContextItem) => void
   onDeselect: (id: number | string) => void
+  /** Batch selection callback for selecting multiple contexts at once (e.g., group selection) */
+  onSelectMultiple?: (contexts: ContextItem[]) => void
+  /** Batch deselection callback for deselecting multiple contexts at once */
+  onDeselectMultiple?: (ids: (number | string)[]) => void
   children: React.ReactNode
   /** Task ID for group chat mode - if provided, shows bound knowledge bases */
   taskId?: number
@@ -132,6 +136,8 @@ export default function ContextSelector({
   selectedContexts,
   onSelect,
   onDeselect,
+  onSelectMultiple,
+  onDeselectMultiple,
   children,
   taskId,
   isGroupChat,
@@ -299,27 +305,41 @@ export default function ContextSelector({
 
     if (isFullySelected) {
       // Deselect all knowledge bases in the group
-      kbs.forEach(kb => {
-        if (isSelected(kb.id)) {
-          onDeselect(kb.id)
-        }
-      })
+      // Use batch deselect if available to avoid closure issues
+      const idsToDeselect = kbs.filter(kb => isSelected(kb.id)).map(kb => kb.id)
+      if (onDeselectMultiple && idsToDeselect.length > 0) {
+        onDeselectMultiple(idsToDeselect)
+      } else {
+        // Fallback to individual deselect
+        kbs.forEach(kb => {
+          if (isSelected(kb.id)) {
+            onDeselect(kb.id)
+          }
+        })
+      }
     } else {
       // Select all unselected knowledge bases in the group
-      kbs.forEach(kb => {
-        if (!isSelected(kb.id)) {
-          const context: KnowledgeBaseContext = {
-            id: kb.id,
-            name: kb.name,
-            type: 'knowledge_base',
-            description: kb.description ?? undefined,
-            retriever_name: kb.retrieval_config?.retriever_name,
-            retriever_namespace: kb.retrieval_config?.retriever_namespace,
-            document_count: kb.document_count,
-          }
+      // Use batch select if available to avoid closure issues
+      const contextsToAdd: KnowledgeBaseContext[] = kbs
+        .filter(kb => !isSelected(kb.id))
+        .map(kb => ({
+          id: kb.id,
+          name: kb.name,
+          type: 'knowledge_base' as const,
+          description: kb.description ?? undefined,
+          retriever_name: kb.retrieval_config?.retriever_name,
+          retriever_namespace: kb.retrieval_config?.retriever_namespace,
+          document_count: kb.document_count,
+        }))
+
+      if (onSelectMultiple && contextsToAdd.length > 0) {
+        onSelectMultiple(contextsToAdd)
+      } else {
+        // Fallback to individual select
+        contextsToAdd.forEach(context => {
           onSelect(context)
-        }
-      })
+        })
+      }
     }
   }
 


### PR DESCRIPTION
…n group

When selecting a group knowledge base, only one KB was being selected instead of all KBs in the group. This was caused by React state closure issue where handleSelect was using a stale selectedContexts snapshot in a loop.

- Add onSelectMultiple and onDeselectMultiple callbacks to ContextSelector
- Implement batch selection in ChatContextInput to avoid closure issues
- Update handleGroupSelect to use batch callbacks when available

Fixes: group knowledge base selection now correctly selects all KBs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch selection and deselection capabilities for multiple contexts, enabling more efficient context management when toggling context groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->