### PR TITLE
feat(frontend): disable auto-upgrade for OpenClaw devices

### DIFF
--- a/frontend/src/features/devices/components/DeviceCard.tsx
+++ b/frontend/src/features/devices/components/DeviceCard.tsx
@@ -111,8 +111,16 @@ export function DeviceCard({
                   executorVersion={device.executor_version}
                   latestVersion={device.latest_version}
                   updateAvailable={device.update_available}
-                  onUpgrade={device.update_available && device.status === 'online' && !isUpgrading ? () => onUpgrade?.(device) : undefined}
+                  onUpgrade={
+                    device.update_available &&
+                    device.status === 'online' &&
+                    !isUpgrading &&
+                    !isOpenClawDevice(device)
+                      ? () => onUpgrade?.(device)
+                      : undefined
+                  }
                   isUpgrading={isUpgrading}
+                  isOpenClaw={isOpenClawDevice(device)}
                 />
               )}
             </div>

--- a/frontend/src/features/devices/components/VersionBadge.tsx
+++ b/frontend/src/features/devices/components/VersionBadge.tsx
@@ -17,6 +17,7 @@ interface VersionBadgeProps {
   className?: string
   onUpgrade?: () => void
   isUpgrading?: boolean
+  isOpenClaw?: boolean
 }
 
 export function VersionBadge({
@@ -26,6 +27,7 @@ export function VersionBadge({
   className,
   onUpgrade,
   isUpgrading,
+  isOpenClaw,
 }: VersionBadgeProps) {
   const { t } = useTranslation('devices')
 
@@ -34,7 +36,7 @@ export function VersionBadge({
   return (
     <div className={cn('flex items-center gap-1.5', className)}>
       <span className="text-xs text-text-muted">v{executorVersion}</span>
-      {updateAvailable && !isUpgrading && (
+      {updateAvailable && !isUpgrading && !isOpenClaw && (
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -58,9 +60,7 @@ export function VersionBadge({
                 <p className="text-text-muted">
                   {t('version.latest')}: {latestVersion}
                 </p>
-                {onUpgrade && (
-                  <p className="text-xs text-primary">{t('version.clickToUpgrade')}</p>
-                )}
+                {onUpgrade && <p className="text-xs text-primary">{t('version.clickToUpgrade')}</p>}
               </div>
             </TooltipContent>
           </Tooltip>

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -137,6 +137,7 @@
     "current": "Current Version",
     "latest": "Latest Version",
     "updateAvailable": "Update Available",
-    "clickToUpgrade": "Click to upgrade"
+    "clickToUpgrade": "Click to upgrade",
+    "openclawNotSupported": "OpenClaw devices do not support auto-upgrade"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -137,6 +137,7 @@
     "current": "当前版本",
     "latest": "最新版本",
     "updateAvailable": "有新版本可用",
-    "clickToUpgrade": "点击升级"
+    "clickToUpgrade": "点击升级",
+    "openclawNotSupported": "OpenClaw 设备不支持自动升级"
   }
 }


### PR DESCRIPTION
OpenClaw devices do not support auto-upgrade functionality. Hide the upgrade badge completely for OpenClaw devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenClaw devices now display a notification that auto-upgrade is not supported and the upgrade action is blocked for these device types.
  * Added localized messaging in English and Chinese explaining the limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->