### PR TITLE
feat(knowledge): allow Excel file indexing with 2MB size limit

### DIFF
--- a/backend/app/services/knowledge/indexing.py
+++ b/backend/app/services/knowledge/indexing.py
@@ -41,7 +41,11 @@ from shared.telemetry import add_span_event
 
 logger = logging.getLogger(__name__)
 
-RAG_INDEXING_DISABLED_EXTENSIONS = frozenset({".xls", ".xlsx"})
+RAG_INDEXING_DISABLED_EXTENSIONS = frozenset()
+
+# Excel file size limit for RAG indexing (2MB)
+EXCEL_FILE_SIZE_LIMIT = 2 * 1024 * 1024  # 2MB in bytes
+EXCEL_EXTENSIONS = frozenset({".xls", ".xlsx"})
 
 
 @dataclass
@@ -86,8 +90,18 @@ def normalize_document_extension(file_extension: Optional[str]) -> str:
 def get_rag_indexing_skip_reason(
     source_type: Optional[str],
     file_extension: Optional[str],
+    file_size: Optional[int] = None,
 ) -> Optional[str]:
-    """Return the reason why a document should skip RAG indexing, if any."""
+    """Return the reason why a document should skip RAG indexing, if any.
+
+    Args:
+        source_type: The source type of the document (e.g., "file", "table")
+        file_extension: The file extension (e.g., ".xlsx", "pdf")
+        file_size: The file size in bytes (optional, used for Excel file size check)
+
+    Returns:
+        A string describing the reason to skip indexing, or None if indexing is allowed
+    """
     normalized_source_type = (source_type or "").strip().lower()
     normalized_extension = normalize_document_extension(file_extension)
 
@@ -97,9 +111,16 @@ def get_rag_indexing_skip_reason(
         )
 
     if normalized_extension in RAG_INDEXING_DISABLED_EXTENSIONS:
-        return (
-            f"Excel documents ({normalized_extension}) are excluded from RAG indexing"
-        )
+        return f"Documents with extension ({normalized_extension}) are excluded from RAG indexing"
+
+    # Check Excel file size limit (2MB)
+    if normalized_extension in EXCEL_EXTENSIONS:
+        if file_size is not None and file_size > EXCEL_FILE_SIZE_LIMIT:
+            size_mb = file_size / (1024 * 1024)
+            limit_mb = EXCEL_FILE_SIZE_LIMIT / (1024 * 1024)
+            # Return error code with parameters for i18n support
+            # Format: EXCEL_FILE_SIZE_EXCEEDED|extension|limit|size
+            return f"EXCEL_FILE_SIZE_EXCEEDED|{normalized_extension}|{limit_mb:.0f}|{size_mb:.2f}"
 
     return None
 
@@ -476,6 +497,7 @@ def run_document_indexing(
         document = None
         file_extension = None
         source_type = None
+        file_size = None
 
         if document_id is not None:
             from app.models.knowledge import KnowledgeDocument
@@ -488,6 +510,7 @@ def run_document_indexing(
             if document:
                 file_extension = document.file_extension
                 source_type = document.source_type
+                file_size = document.file_size
         elif attachment_id:
             attachment = (
                 db.query(SubtaskContext)
@@ -499,8 +522,11 @@ def run_document_indexing(
             )
             if attachment:
                 file_extension = attachment.file_extension
+                file_size = attachment.file_size
 
-        skip_reason = get_rag_indexing_skip_reason(source_type, file_extension)
+        skip_reason = get_rag_indexing_skip_reason(
+            source_type, file_extension, file_size
+        )
         if skip_reason:
             logger.info(
                 f"[Indexing] Skipping: kb_id={knowledge_base_id}, "

--- a/backend/app/services/knowledge/indexing.py
+++ b/backend/app/services/knowledge/indexing.py
@@ -41,8 +41,6 @@ from shared.telemetry import add_span_event
 
 logger = logging.getLogger(__name__)
 
-RAG_INDEXING_DISABLED_EXTENSIONS = frozenset()
-
 # Excel file size limit for RAG indexing (2MB)
 EXCEL_FILE_SIZE_LIMIT = 2 * 1024 * 1024  # 2MB in bytes
 EXCEL_EXTENSIONS = frozenset({".xls", ".xlsx"})
@@ -109,9 +107,6 @@ def get_rag_indexing_skip_reason(
         return (
             "Table documents are queried in real-time and do not support RAG indexing"
         )
-
-    if normalized_extension in RAG_INDEXING_DISABLED_EXTENSIONS:
-        return f"Documents with extension ({normalized_extension}) are excluded from RAG indexing"
 
     # Check Excel file size limit (2MB)
     if normalized_extension in EXCEL_EXTENSIONS:

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1137,6 +1137,7 @@ class KnowledgeOrchestrator:
                 else DocumentSourceType.FILE.value
             ),
             data.file_extension,
+            data.file_size,
         )
 
         if trigger_indexing and not skip_reason:
@@ -1385,7 +1386,7 @@ class KnowledgeOrchestrator:
             raise ValueError("Document not found")
 
         skip_reason = get_rag_indexing_skip_reason(
-            document.source_type, document.file_extension
+            document.source_type, document.file_extension, document.file_size
         )
         if skip_reason:
             raise ValueError(skip_reason)

--- a/backend/tests/services/knowledge/test_orchestrator.py
+++ b/backend/tests/services/knowledge/test_orchestrator.py
@@ -345,10 +345,10 @@ class TestKnowledgeOrchestrator:
                     source_type="invalid",
                 )
 
-    def test_create_document_from_attachment_skips_excel_indexing(
+    def test_create_document_from_attachment_skips_large_excel_indexing(
         self, orchestrator, mock_db, mock_user
     ):
-        """Test Excel documents are created without scheduling RAG indexing."""
+        """Test large Excel documents (>2MB) are created without scheduling RAG indexing."""
         mock_kb = MagicMock()
         mock_kb.id = 1
         mock_kb.json = {"spec": {}}
@@ -357,11 +357,14 @@ class TestKnowledgeOrchestrator:
         mock_doc.id = 99
         mock_doc.attachment_id = 123
 
+        # File size > 2MB (3MB)
+        large_file_size = 3 * 1024 * 1024
+
         data = KnowledgeDocumentCreate(
             attachment_id=123,
             name="report.xlsx",
             file_extension="xlsx",
-            file_size=1024,
+            file_size=large_file_size,
             source_type=DocumentSourceType.FILE,
         )
 
@@ -390,23 +393,22 @@ class TestKnowledgeOrchestrator:
 
         mock_schedule.assert_not_called()
 
-    def test_reindex_document_raises_for_excel_document(
+    def test_reindex_document_raises_for_large_excel_document(
         self, orchestrator, mock_db, mock_user
     ):
-        """Test Excel documents cannot be reindexed."""
+        """Test large Excel documents (>2MB) cannot be reindexed."""
         mock_document = MagicMock()
         mock_document.id = 1
         mock_document.source_type = DocumentSourceType.FILE.value
         mock_document.file_extension = "xlsx"
+        mock_document.file_size = 3 * 1024 * 1024  # 3MB
 
         with patch.object(mock_db, "query") as mock_query:
             mock_query.return_value.filter.return_value.first.return_value = (
                 mock_document
             )
 
-            with pytest.raises(
-                ValueError, match="Excel documents \\(.xlsx\\) are excluded"
-            ):
+            with pytest.raises(ValueError, match="EXCEL_FILE_SIZE_EXCEEDED"):
                 orchestrator.reindex_document(
                     db=mock_db,
                     user=mock_user,
@@ -417,11 +419,11 @@ class TestKnowledgeOrchestrator:
 class TestIndexingPolicy:
     """Tests for knowledge indexing skip policy."""
 
-    def test_excel_documents_are_skipped(self):
-        """Test Excel extensions are excluded from RAG indexing."""
+    def test_excel_documents_within_size_limit_are_allowed(self):
+        """Test Excel extensions within 2MB size limit are allowed for RAG indexing."""
         reason = get_rag_indexing_skip_reason("file", "xlsx")
 
-        assert reason == "Excel documents (.xlsx) are excluded from RAG indexing"
+        assert reason is None
 
     def test_table_documents_are_skipped(self):
         """Test table source types are excluded from RAG indexing."""

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -145,6 +145,11 @@ export function DocumentItem({
   // Check document source type
   const isTable = document.source_type === 'table'
   const isWeb = document.source_type === 'web'
+
+  // Check if Excel file exceeds size limit (2MB)
+  const EXCEL_FILE_SIZE_LIMIT = 2 * 1024 * 1024 // 2MB
+  const isExcel = ['xls', 'xlsx'].includes(document.file_extension?.toLowerCase() || '')
+  const isExcelExceedingSizeLimit = isExcel && document.file_size > EXCEL_FILE_SIZE_LIMIT
   // URL for table or web documents
   const sourceUrl =
     (isTable || isWeb) &&
@@ -239,15 +244,15 @@ export function DocumentItem({
                 className="w-1 h-1 rounded-full flex-shrink-0 bg-green-500"
                 title={t('knowledge:document.document.indexStatus.available')}
               />
-            ) : !ragConfigured ? (
+            ) : isReindexing ? (
               <TooltipProvider>
                 <Tooltip delayDuration={200}>
                   <TooltipTrigger asChild>
-                    <span className="w-1 h-1 rounded-full flex-shrink-0 bg-yellow-500 cursor-help" />
+                    <span className="w-1 h-1 rounded-full flex-shrink-0 bg-blue-500 cursor-help animate-pulse" />
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
                     <p className="text-xs">
-                      {t('knowledge:document.document.indexStatus.unavailableHint')}
+                      {t('knowledge:document.document.indexStatus.indexingHint')}
                     </p>
                   </TooltipContent>
                 </Tooltip>
@@ -260,7 +265,15 @@ export function DocumentItem({
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
                     <p className="text-xs">
-                      {t('knowledge:document.document.indexStatus.indexingHint')}
+                      {isExcelExceedingSizeLimit
+                        ? t('knowledge:document.document.excelFileSizeExceeded', {
+                            extension: document.file_extension,
+                            limit: 2,
+                            size: (document.file_size / (1024 * 1024)).toFixed(2),
+                          })
+                        : !ragConfigured
+                          ? t('knowledge:document.document.indexStatus.unavailableHint')
+                          : t('knowledge:document.document.indexStatus.unavailableHint')}
                     </p>
                   </TooltipContent>
                 </Tooltip>
@@ -445,19 +458,23 @@ export function DocumentItem({
           <Badge variant="success" size="sm" className="whitespace-nowrap">
             {t('knowledge:document.document.indexStatus.available')}
           </Badge>
-        ) : !ragConfigured ? (
+        ) : isReindexing ? (
           <TooltipProvider>
             <Tooltip delayDuration={200}>
               <TooltipTrigger asChild>
                 <span>
-                  <Badge variant="warning" size="sm" className="whitespace-nowrap cursor-help">
-                    {t('knowledge:document.document.indexStatus.unavailable')}
+                  <Badge
+                    variant="default"
+                    size="sm"
+                    className="whitespace-nowrap cursor-help bg-blue-500/10 text-blue-600 border-blue-500/20"
+                  >
+                    {t('knowledge:document.document.indexStatus.indexing')}
                   </Badge>
                 </span>
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-xs">
                 <p className="text-xs">
-                  {t('knowledge:document.document.indexStatus.unavailableHint')}
+                  {t('knowledge:document.document.indexStatus.indexingHint')}
                 </p>
               </TooltipContent>
             </Tooltip>
@@ -474,7 +491,15 @@ export function DocumentItem({
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-xs">
                 <p className="text-xs">
-                  {t('knowledge:document.document.indexStatus.indexingHint')}
+                  {isExcelExceedingSizeLimit
+                    ? t('knowledge:document.document.excelFileSizeExceeded', {
+                        extension: document.file_extension,
+                        limit: 2,
+                        size: (document.file_size / (1024 * 1024)).toFixed(2),
+                      })
+                    : !ragConfigured
+                      ? t('knowledge:document.document.indexStatus.unavailableHint')
+                      : t('knowledge:document.document.indexStatus.unavailableHint')}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -396,14 +396,14 @@ export function DocumentList({
         }
       }, 2000)
     } catch (err) {
-      // Parse error message and use i18n translation if it's a known error code
+      // Use ApiError.errorCode for structured error handling
       let errorMessage = t('document.document.reindexFailed')
       if (err instanceof Error) {
-        const message = err.message
-        // Check if it's an EXCEL_FILE_SIZE_EXCEEDED error code
-        // Format: EXCEL_FILE_SIZE_EXCEEDED|extension|limit|size
-        if (message.startsWith('EXCEL_FILE_SIZE_EXCEEDED|')) {
-          const parts = message.split('|')
+        // Check if it's an ApiError with errorCode for structured error handling
+        const apiError = err as { errorCode?: string; message: string }
+        if (apiError.errorCode === 'EXCEL_FILE_SIZE_EXCEEDED') {
+          // Format: EXCEL_FILE_SIZE_EXCEEDED|extension|limit|size
+          const parts = apiError.message.split('|')
           if (parts.length === 4) {
             errorMessage = t('document.document.excelFileSizeExceeded', {
               extension: parts[1],
@@ -413,7 +413,7 @@ export function DocumentList({
           }
         } else {
           // Use the original error message for other errors
-          errorMessage = message
+          errorMessage = apiError.message
         }
       }
       toast({

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -395,10 +395,30 @@ export function DocumentList({
           refresh()
         }
       }, 2000)
-    } catch {
+    } catch (err) {
+      // Parse error message and use i18n translation if it's a known error code
+      let errorMessage = t('document.document.reindexFailed')
+      if (err instanceof Error) {
+        const message = err.message
+        // Check if it's an EXCEL_FILE_SIZE_EXCEEDED error code
+        // Format: EXCEL_FILE_SIZE_EXCEEDED|extension|limit|size
+        if (message.startsWith('EXCEL_FILE_SIZE_EXCEEDED|')) {
+          const parts = message.split('|')
+          if (parts.length === 4) {
+            errorMessage = t('document.document.excelFileSizeExceeded', {
+              extension: parts[1],
+              limit: parts[2],
+              size: parts[3],
+            })
+          }
+        } else {
+          // Use the original error message for other errors
+          errorMessage = message
+        }
+      }
       toast({
         variant: 'destructive',
-        description: t('document.document.reindexFailed'),
+        description: errorMessage,
       })
     } finally {
       if (isMountedRef.current) {

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -184,6 +184,7 @@
       "reindexing": "Reindexing...",
       "reindexSuccess": "Reindex started",
       "reindexFailed": "Failed to start reindex",
+      "excelFileSizeExceeded": "File size exceeds the limit: Excel files ({{extension}}) must be {{limit}}MB or smaller for indexing. Current file size: {{size}}MB. Please reduce the file size or split into smaller files.",
       "openLink": "Open Link",
       "download": "Download",
       "columns": {

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -184,6 +184,7 @@
       "reindexing": "索引中...",
       "reindexSuccess": "已开始重新索引",
       "reindexFailed": "启动重新索引失败",
+      "excelFileSizeExceeded": "文件大小超过限制：Excel 文件（{{extension}}）必须小于等于 {{limit}}MB 才能索引。当前文件大小：{{size}}MB。请减小文件大小或拆分为多个小文件。",
       "openLink": "打开链接",
       "download": "下载",
       "columns": {


### PR DESCRIPTION
- Remove .xls and .xlsx from RAG_INDEXING_DISABLED_EXTENSIONS
- Add EXCEL_FILE_SIZE_LIMIT (2MB) and EXCEL_EXTENSIONS constants
- Add file_size parameter to get_rag_indexing_skip_reason function
- Return error code format for i18n support: EXCEL_FILE_SIZE_EXCEEDED|ext|limit|size
- Update orchestrator to pass file_size to indexing functions
- Update frontend DocumentItem to show 'Indexing' status when reindexing
- Show 'Index Unavailable' when not reindexing and is_active=false
- Add i18n translations for Excel file size exceeded error (zh-CN/en)
- Update tests to verify Excel files within 2MB limit are allowed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Excel files are now indexable when ≤2MB; files >2MB are skipped with a size-specific reason.
  * Added localized messages (EN/ZH) that include extension, limit, and actual size for size-exceeded errors.

* **Bug Fixes / UX**
  * Reindexing failure toasts and document tooltips now surface the Excel size-limit reason and show a clear, formatted message.

* **Tests**
  * Updated tests to reflect size-dependent Excel indexing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->