### PR TITLE
fix(frontend): resolve nested button hydration error in CollapsibleSection

### DIFF
--- a/frontend/src/features/knowledge/document/components/KnowledgeSidebar/CollapsibleSection.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeSidebar/CollapsibleSection.tsx
@@ -49,39 +49,42 @@ export function CollapsibleSection({
   return (
     <div className={cn('border-b border-border', className)} data-testid={testId}>
       {/* Header */}
-      <button
-        onClick={onToggle}
-        className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium 
+      <div
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm font-medium
                    text-text-secondary hover:bg-muted transition-colors"
         data-testid={testId ? `${testId}-header` : undefined}
       >
-        {/* Expand/collapse icon */}
-        <span className="flex-shrink-0 w-4 h-4 flex items-center justify-center">
-          {isExpanded ? (
-            <ChevronDown className="w-3.5 h-3.5" />
-          ) : (
-            <ChevronRight className="w-3.5 h-3.5" />
-          )}
-        </span>
-
-        {/* Section icon */}
-        {icon && <span className="flex-shrink-0">{icon}</span>}
-
-        {/* Title */}
-        <span className="flex-1 text-left truncate">{title}</span>
-
-        {/* Count badge */}
-        {count !== undefined && count > 0 && (
-          <span className="flex-shrink-0 text-xs text-text-muted tabular-nums">{count}</span>
-        )}
-
-        {/* Action button */}
-        {action && (
-          <span className="flex-shrink-0" onClick={e => e.stopPropagation()}>
-            {action}
+        {/* Clickable area for expand/collapse */}
+        <button
+          type="button"
+          onClick={onToggle}
+          className="flex-1 flex items-center gap-2 min-w-0 text-left"
+          aria-expanded={isExpanded}
+        >
+          {/* Expand/collapse icon */}
+          <span className="flex-shrink-0 w-4 h-4 flex items-center justify-center">
+            {isExpanded ? (
+              <ChevronDown className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5" />
+            )}
           </span>
-        )}
-      </button>
+
+          {/* Section icon */}
+          {icon && <span className="flex-shrink-0">{icon}</span>}
+
+          {/* Title */}
+          <span className="flex-1 text-left truncate">{title}</span>
+
+          {/* Count badge */}
+          {count !== undefined && count > 0 && (
+            <span className="flex-shrink-0 text-xs text-text-muted tabular-nums">{count}</span>
+          )}
+        </button>
+
+        {/* Action button - outside the toggle button to avoid nesting */}
+        {action && <span className="flex-shrink-0">{action}</span>}
+      </div>
 
       {/* Content */}
       {isExpanded && <div className="pb-2">{children}</div>}

--- a/frontend/src/features/knowledge/document/components/KnowledgeSidebar/NavigationSection.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeSidebar/NavigationSection.tsx
@@ -428,15 +428,22 @@ export function NavigationSection({
         isExpanded={isGroupsExpanded}
         onToggleExpand={() => setIsGroupsExpanded(!isGroupsExpanded)}
         actionButton={
-          <button
-            type="button"
+          <span
+            role="button"
+            tabIndex={0}
             onClick={handleGroupsSettingsClick}
-            className="p-1 hover:bg-muted rounded transition-colors"
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                handleGroupsSettingsClick()
+              }
+            }}
+            className="p-1 hover:bg-muted rounded transition-colors cursor-pointer"
             title={t('document.sidebar.groupSettings', '组设置')}
             data-testid="nav-groups-settings"
           >
             <Settings className="w-3.5 h-3.5 text-text-muted hover:text-text-primary" />
-          </button>
+          </span>
         }
       >
         {/* Sub-groups tree - hierarchical structure */}

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -61,6 +61,7 @@
     },
     "sidebar": {
       "searchPlaceholder": "Search knowledge bases...",
+      "typeToSearch": "Type to search knowledge bases",
       "favorites": "Favorites",
       "recent": "Recent",
       "groups": "Groups",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -61,6 +61,7 @@
     },
     "sidebar": {
       "searchPlaceholder": "搜索知识库...",
+      "typeToSearch": "输入关键词搜索知识库",
       "favorites": "收藏",
       "recent": "最近",
       "groups": "分组",


### PR DESCRIPTION
## Summary

- Fix HTML nesting error: `<button>` cannot be a descendant of `<button>` in `CollapsibleSection` component
- Restructure the header layout to separate the toggle button from the action slot
- Maintain all existing functionality and visual appearance

## Changes

1. **CollapsibleSection.tsx**:
   - Changed outer header element from `<button>` to `<div>` to serve as a flex container
   - Created an inner `<button>` for the expand/collapse functionality (chevron icon, section icon, title, count)
   - Moved the `action` slot outside the toggle button to prevent button nesting
   - Added `aria-expanded` attribute for better accessibility
   - Removed `stopPropagation` handler since action is now outside the toggle area

## Root Cause

The `CollapsibleSection` component wrapped the entire header in a `<button>` element, and the `action` prop (which could contain another button, like the "Clear" button in `RecentSection`) was rendered inside it. This violated HTML semantics and caused React hydration errors.

## Test plan

- [ ] Verify the collapsible section still expands/collapses when clicking the header area
- [ ] Verify the action button (clear recent) works correctly and doesn't trigger expand/collapse
- [ ] Verify no hydration errors in the console
- [ ] Verify visual appearance is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked collapsible sidebar headers to improve semantics, focus handling, and clickable area; moved auxiliary actions out of the main toggle to prevent accidental activation.
  * Converted a settings control to a focusable, keyboard-activatable element and added keyboard handlers for Enter/Space.

* **New Features**
  * Added localized helper text: "Type to search knowledge bases" (en) and corresponding Chinese translation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->