### PR TITLE
fix(frontend): sync knowledge page URL with group/kb selection

### DIFF
--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
@@ -108,13 +108,22 @@ export default function KnowledgeBaseChatPage() {
   // Restores previous group selection if available
   const handleBack = () => {
     // Check if there was a previous group selection
-    const lastGroup =
-      typeof window !== 'undefined' ? localStorage.getItem('knowledge-last-group') : null
+    let lastGroup: string | null = null
+    try {
+      lastGroup =
+        typeof window !== 'undefined' ? localStorage.getItem('knowledge-last-group') : null
+    } catch {
+      // Non-blocking: localStorage access may fail in some browsers
+    }
 
     if (lastGroup) {
       // Navigate back to the group view
       router.push(`/knowledge?type=document&group=${encodeURIComponent(lastGroup)}`)
-      localStorage.removeItem('knowledge-last-group')
+      try {
+        localStorage.removeItem('knowledge-last-group')
+      } catch {
+        // Non-blocking: cleanup failure is acceptable
+      }
     } else if (typeof window !== 'undefined' && window.history.length > 1) {
       // Try browser history
       router.back()

--- a/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/document/[knowledgeBaseId]/page.tsx
@@ -105,9 +105,18 @@ export default function KnowledgeBaseChatPage() {
   })
 
   // Handle back navigation with fallback to knowledge list
+  // Restores previous group selection if available
   const handleBack = () => {
-    // Check if there's history to go back to
-    if (typeof window !== 'undefined' && window.history.length > 1) {
+    // Check if there was a previous group selection
+    const lastGroup =
+      typeof window !== 'undefined' ? localStorage.getItem('knowledge-last-group') : null
+
+    if (lastGroup) {
+      // Navigate back to the group view
+      router.push(`/knowledge?type=document&group=${encodeURIComponent(lastGroup)}`)
+      localStorage.removeItem('knowledge-last-group')
+    } else if (typeof window !== 'undefined' && window.history.length > 1) {
+      // Try browser history
       router.back()
     } else {
       // Fallback to knowledge list when no history available

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
@@ -13,7 +13,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { FolderOpen } from 'lucide-react'
 import { userApis } from '@/apis/user'
 import { teamService } from '@/features/tasks/service/teamService'
@@ -42,6 +42,7 @@ const SIDEBAR_WIDTH = 280
 
 export function KnowledgeDocumentPageDesktop() {
   const { t } = useTranslation('knowledge')
+  const router = useRouter()
   const searchParams = useSearchParams()
 
   // Knowledge sidebar hook
@@ -187,6 +188,28 @@ export function KnowledgeDocumentPageDesktop() {
     }
   }, [searchParams, sidebar.allKnowledgeBases, sidebar.selectedKbId, sidebar.selectKb])
 
+  // Sync selected group from URL parameter
+  useEffect(() => {
+    const groupParam = searchParams.get('group')
+    if (groupParam && groupParam !== sidebar.selectedGroupId) {
+      // Check if the group exists
+      const groupExists = sidebar.groups.some(g => g.id === groupParam)
+      if (groupExists) {
+        sidebar.selectGroup(groupParam)
+      }
+    } else if (!groupParam && sidebar.selectedGroupId && sidebar.viewMode === 'group') {
+      // URL has no group param but sidebar has group selected - sync to "all" view
+      sidebar.selectAll()
+    }
+  }, [
+    searchParams,
+    sidebar.groups,
+    sidebar.selectedGroupId,
+    sidebar.viewMode,
+    sidebar.selectGroup,
+    sidebar.selectAll,
+  ])
+
   // Helper function to convert KnowledgeBaseWithGroupInfo to KnowledgeBase
   const toKnowledgeBase = useCallback(
     (kb: {
@@ -305,28 +328,44 @@ export function KnowledgeDocumentPageDesktop() {
       const fullKb = sidebar.allKnowledgeBases.find(k => k.id === kb.id)
       if (fullKb) {
         sidebar.selectKb(fullKb)
+        // Save current group selection before navigating to KB detail
+        if (sidebar.selectedGroupId) {
+          localStorage.setItem('knowledge-last-group', sidebar.selectedGroupId)
+        } else if (sidebar.viewMode === 'all' && sidebar.filterGroupId) {
+          localStorage.setItem('knowledge-last-group', sidebar.filterGroupId)
+        } else {
+          localStorage.removeItem('knowledge-last-group')
+        }
+        // Navigate to KB detail page (consistent with mobile)
+        router.push(`/knowledge/document/${fullKb.id}`)
       }
     },
-    [sidebar]
+    [sidebar, router]
   )
 
   // Handle "All" selection
   const handleSelectAll = useCallback(() => {
     sidebar.selectAll()
-  }, [sidebar])
+    // Clear group parameter from URL
+    router.replace('/knowledge?type=document')
+  }, [sidebar, router])
 
   // Handle group selection
   const handleSelectGroup = useCallback(
     (groupId: string) => {
       sidebar.selectGroup(groupId)
+      // Update URL with group parameter
+      router.replace(`/knowledge?type=document&group=${encodeURIComponent(groupId)}`)
     },
-    [sidebar]
+    [sidebar, router]
   )
 
   // Handle back from group list
   const handleBackFromGroup = useCallback(() => {
     sidebar.clearSelection()
-  }, [sidebar])
+    // Clear group parameter from URL
+    router.replace('/knowledge?type=document')
+  }, [sidebar, router])
 
   // Handle create KB from group list
   const handleCreateKbFromGroup = useCallback(
@@ -549,8 +588,10 @@ export function KnowledgeDocumentPageDesktop() {
         sidebarGroupId = `group-${groupId}`
       }
       sidebar.selectGroup(sidebarGroupId)
+      // Update URL with group parameter
+      router.replace(`/knowledge?type=document&group=${encodeURIComponent(sidebarGroupId)}`)
     },
-    [sidebar]
+    [sidebar, router]
   )
 
   // Render main content area

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
@@ -196,6 +196,9 @@ export function KnowledgeDocumentPageDesktop() {
       const groupExists = sidebar.groups.some(g => g.id === groupParam)
       if (groupExists) {
         sidebar.selectGroup(groupParam)
+      } else {
+        // Invalid group param - fall back to "all" view
+        sidebar.selectAll()
       }
     } else if (!groupParam && sidebar.selectedGroupId && sidebar.viewMode === 'group') {
       // URL has no group param but sidebar has group selected - sync to "all" view
@@ -329,12 +332,16 @@ export function KnowledgeDocumentPageDesktop() {
       if (fullKb) {
         sidebar.selectKb(fullKb)
         // Save current group selection before navigating to KB detail
-        if (sidebar.selectedGroupId) {
-          localStorage.setItem('knowledge-last-group', sidebar.selectedGroupId)
-        } else if (sidebar.viewMode === 'all' && sidebar.filterGroupId) {
-          localStorage.setItem('knowledge-last-group', sidebar.filterGroupId)
-        } else {
-          localStorage.removeItem('knowledge-last-group')
+        try {
+          if (sidebar.selectedGroupId) {
+            localStorage.setItem('knowledge-last-group', sidebar.selectedGroupId)
+          } else if (sidebar.viewMode === 'all' && sidebar.filterGroupId) {
+            localStorage.setItem('knowledge-last-group', sidebar.filterGroupId)
+          } else {
+            localStorage.removeItem('knowledge-last-group')
+          }
+        } catch {
+          // Non-blocking: navigation should still proceed even if localStorage fails
         }
         // Navigate to KB detail page (consistent with mobile)
         router.push(`/knowledge/document/${fullKb.id}`)


### PR DESCRIPTION
## Summary

- Fix issue where Knowledge page URL is not updated when selecting knowledge bases or groups
- Add `useRouter` to `KnowledgeDocumentPageDesktop.tsx` for URL navigation
- Update `handleSelectKb` to navigate to KB detail page (consistent with mobile implementation)
- Update `handleSelectGroup`, `handleSelectAll`, and `handleBackFromGroup` to update URL with group parameter
- Add `useEffect` to sync sidebar state from URL `group` parameter on page load/refresh
- Update `handleBack` in KB detail page to restore previous group selection from localStorage
- Save current group selection to localStorage before navigating to KB detail

## Test plan

- [ ] Click a knowledge base card → URL changes to `/knowledge/document/[id]`
- [ ] Click a group → URL changes to `/knowledge?type=document&group=[groupId]`
- [ ] Click "All" → URL changes to `/knowledge?type=document`
- [ ] Refresh page at `/knowledge/document/[id]` → Correctly displays the KB detail
- [ ] Refresh page at `/knowledge?type=document&group=personal` → Correctly displays personal group KB list
- [ ] Use browser back button → Returns to previous page/state
- [ ] Use browser forward button → Goes to next page/state
- [ ] Enter KB detail from group page, click back → Returns to the previously selected group
- [ ] Desktop and mobile KB selection URLs are consistent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores your last-selected knowledge group when returning from document views, reducing navigation clicks.
  * Keeps group selection synchronized with the URL so browser navigation and deep links reflect the sidebar state.
  * Back navigation now prefers returning you to the previously selected group view instead of the main knowledge list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->