### PR TITLE
fix: route himalaya chat commands to device backend

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -56,6 +56,7 @@ from app.api.endpoints.internal import bots_router as internal_bots_router
 from app.api.endpoints.internal import (
     callback_router,
     chat_storage_router,
+    devices_router as internal_devices_router,
     services_router,
     skills_router,
     subscriptions_router,
@@ -175,6 +176,9 @@ if not settings.STANDALONE_MODE:
 
 api_router.include_router(skills_router, prefix="/internal", tags=["internal-skills"])
 api_router.include_router(tables_router, prefix="/internal", tags=["internal-tables"])
+api_router.include_router(
+    internal_devices_router, prefix="/internal", tags=["internal-devices"]
+)
 api_router.include_router(
     internal_bots_router, prefix="/internal", tags=["internal-bots"]
 )

--- a/backend/app/api/endpoints/devices.py
+++ b/backend/app/api/endpoints/devices.py
@@ -61,6 +61,42 @@ class DeviceUpgradeResponse(BaseModel):
     message: str = Field(..., description="Human-readable status message")
 
 
+class DeviceSandboxExecRequest(BaseModel):
+    """Request model for executing a command on a user device."""
+
+    command: str = Field(..., min_length=1, description="Command to execute")
+    working_dir: str = Field(
+        default="/home/user",
+        description="Working directory for command execution",
+    )
+    timeout_seconds: int = Field(
+        default=300,
+        ge=1,
+        le=1800,
+        description="Command timeout in seconds",
+    )
+    required_capability: Optional[str] = Field(
+        default=None,
+        description="Optional device capability required for routing",
+    )
+    device_id: Optional[str] = Field(
+        default=None,
+        description="Optional explicit device ID override",
+    )
+
+
+class DeviceSandboxExecResponse(BaseModel):
+    """Response model for a device-backed command execution."""
+
+    success: bool = Field(..., description="Whether the command succeeded")
+    stdout: str = Field(default="", description="Standard output")
+    stderr: str = Field(default="", description="Standard error")
+    exit_code: int = Field(..., description="Process exit code")
+    execution_time: float = Field(..., description="Execution time in seconds")
+    device_id: str = Field(..., description="Device that executed the command")
+    backend: str = Field(default="device", description="Execution backend identifier")
+
+
 @router.get("", response_model=DeviceListResponse)
 async def get_all_devices(
     db: Session = Depends(get_db),
@@ -160,6 +196,47 @@ async def delete_device(
             detail=f"Device '{device_id}' not found",
         )
     return {"message": f"Device '{device_id}' deleted"}
+
+
+@router.post("/sandbox/exec", response_model=DeviceSandboxExecResponse)
+async def execute_device_sandbox_command(
+    request: DeviceSandboxExecRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+) -> DeviceSandboxExecResponse:
+    """
+    Execute a command on an online user device through the existing device channel.
+
+    The backend selects a compatible online device, forwards the command over
+    `/local-executor`, and returns the device's execution result.
+    """
+    from app.services.device_sandbox_service import (
+        DeviceSandboxError,
+        device_sandbox_service,
+    )
+
+    try:
+        result = await device_sandbox_service.execute_command(
+            db=db,
+            user_id=current_user.id,
+            command=request.command,
+            working_dir=request.working_dir,
+            timeout_seconds=request.timeout_seconds,
+            required_capability=request.required_capability,
+            device_id=request.device_id,
+        )
+    except DeviceSandboxError as exc:
+        logger.warning(
+            "[Device Sandbox] Command rejected: user_id=%s, error=%s",
+            current_user.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return DeviceSandboxExecResponse(**result)
 
 
 @router.post("/{device_id}/upgrade", response_model=DeviceUpgradeResponse)

--- a/backend/app/api/endpoints/internal/__init__.py
+++ b/backend/app/api/endpoints/internal/__init__.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from .bots import router as bots_router
 from .callback import router as callback_router
 from .chat_storage import router as chat_storage_router
+from .devices import router as devices_router
 from .services import router as services_router
 from .skills import router as skills_router
 from .subscriptions import router as subscriptions_router
@@ -23,6 +24,7 @@ __all__ = [
     "bots_router",
     "callback_router",
     "chat_storage_router",
+    "devices_router",
     "services_router",
     "skills_router",
     "subscriptions_router",

--- a/backend/app/api/endpoints/internal/devices.py
+++ b/backend/app/api/endpoints/internal/devices.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal device APIs for service-to-service communication."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.api.endpoints.devices import DeviceSandboxExecResponse
+
+router = APIRouter(prefix="/devices", tags=["internal-devices"])
+
+
+class InternalDeviceSandboxExecRequest(BaseModel):
+    """Internal request model for device-backed command execution."""
+
+    user_id: int = Field(..., ge=1, description="Owner user ID")
+    command: str = Field(..., min_length=1, description="Command to execute")
+    working_dir: str = Field(
+        default="/home/user",
+        description="Working directory for command execution",
+    )
+    timeout_seconds: int = Field(
+        default=300,
+        ge=1,
+        le=1800,
+        description="Command timeout in seconds",
+    )
+    required_capability: str | None = Field(
+        default=None,
+        description="Optional device capability required for routing",
+    )
+    device_id: str | None = Field(
+        default=None,
+        description="Optional explicit device ID override",
+    )
+
+
+@router.post("/sandbox/exec", response_model=DeviceSandboxExecResponse)
+async def execute_device_sandbox_command_internal(
+    request: InternalDeviceSandboxExecRequest,
+    db: Session = Depends(get_db),
+) -> DeviceSandboxExecResponse:
+    """Execute a command on a user's device for internal trusted services."""
+    from app.services.device_sandbox_service import (
+        DeviceSandboxError,
+        device_sandbox_service,
+    )
+
+    try:
+        result = await device_sandbox_service.execute_command(
+            db=db,
+            user_id=request.user_id,
+            command=request.command,
+            working_dir=request.working_dir,
+            timeout_seconds=request.timeout_seconds,
+            required_capability=request.required_capability,
+            device_id=request.device_id,
+        )
+    except DeviceSandboxError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    return DeviceSandboxExecResponse(**result)

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -165,6 +165,7 @@ def _register_device(
     client_ip: Optional[str] = None,
     device_type: Optional[str] = None,
     bind_shell: Optional[str] = None,
+    capabilities: Optional[list[str]] = None,
 ) -> tuple[bool, Optional[str]]:
     """
     Register or update device CRD in database.
@@ -189,6 +190,7 @@ def _register_device(
                 client_ip=client_ip,
                 device_type=device_type,
                 bind_shell=bind_shell,
+                capabilities=capabilities,
             )
         return True, None
     except Exception as e:
@@ -759,6 +761,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
                 payload.client_ip,
                 payload.device_type.value,
                 payload.bind_shell.value,
+                payload.capabilities,
             )
             if not success:
                 return {"error": f"Registration failed: {error}"}

--- a/backend/app/services/device_sandbox_service.py
+++ b/backend/app/services/device_sandbox_service.py
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-backed sandbox execution helpers."""
+
+import logging
+import time
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from app.core.socketio import get_sio
+from app.schemas.device import DeviceType
+from app.services.device_service import device_service
+
+logger = logging.getLogger(__name__)
+
+
+class DeviceSandboxError(RuntimeError):
+    """Raised when a device-backed sandbox command cannot be executed."""
+
+
+class DeviceSandboxService:
+    """Service for forwarding sandbox commands to an online user device."""
+
+    async def execute_command(
+        self,
+        db: Session,
+        user_id: int,
+        command: str,
+        working_dir: str = "/home/user",
+        timeout_seconds: int = 300,
+        required_capability: Optional[str] = None,
+        device_id: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Execute a command on a user's online device via Socket.IO."""
+        target_device = await self._select_target_device(
+            db=db,
+            user_id=user_id,
+            required_capability=required_capability,
+            device_id=device_id,
+        )
+        if target_device is None:
+            raise DeviceSandboxError("No compatible online device is available")
+
+        target_device_id = target_device["device_id"]
+        online_info = await device_service.get_device_online_info(
+            user_id, target_device_id
+        )
+        if not online_info:
+            raise DeviceSandboxError(f"Device '{target_device_id}' is offline")
+
+        socket_id = online_info.get("socket_id")
+        if not socket_id:
+            raise DeviceSandboxError(
+                f"Device '{target_device_id}' does not have an active socket session"
+            )
+
+        sio = get_sio()
+        started_at = time.monotonic()
+
+        logger.info(
+            "[DeviceSandboxService] Forwarding command to device: user_id=%s, "
+            "device_id=%s, working_dir=%s, timeout=%ss, required_capability=%s",
+            user_id,
+            target_device_id,
+            working_dir,
+            timeout_seconds,
+            required_capability,
+        )
+
+        try:
+            response = await sio.call(
+                "sandbox:exec",
+                {
+                    "command": command,
+                    "working_dir": working_dir,
+                    "timeout_seconds": timeout_seconds,
+                },
+                to=socket_id,
+                namespace="/local-executor",
+                timeout=max(timeout_seconds + 5, 30),
+            )
+        except Exception as exc:
+            logger.error(
+                "[DeviceSandboxService] Device command dispatch failed: user_id=%s, "
+                "device_id=%s, error=%s",
+                user_id,
+                target_device_id,
+                exc,
+            )
+            raise DeviceSandboxError(f"Device command dispatch failed: {exc}") from exc
+
+        if not isinstance(response, dict):
+            raise DeviceSandboxError("Device returned an invalid sandbox response")
+
+        execution_time = response.get("execution_time")
+        if not isinstance(execution_time, (int, float)):
+            execution_time = time.monotonic() - started_at
+
+        exit_code = response.get("exit_code", -1)
+        if not isinstance(exit_code, int):
+            try:
+                exit_code = int(exit_code)
+            except (TypeError, ValueError):
+                exit_code = -1
+
+        logger.info(
+            "[DeviceSandboxService] Device command completed: user_id=%s, device_id=%s, "
+            "socket_id=%s, success=%s, exit_code=%s, execution_time=%.2fs, "
+            "stdout_len=%s, stderr_len=%s",
+            user_id,
+            target_device_id,
+            socket_id,
+            bool(response.get("success", exit_code == 0)),
+            exit_code,
+            execution_time,
+            len(response.get("stdout", "") or ""),
+            len(response.get("stderr", "") or ""),
+        )
+
+        return {
+            "success": bool(response.get("success", exit_code == 0)),
+            "stdout": response.get("stdout", "") or "",
+            "stderr": response.get("stderr", "") or "",
+            "exit_code": exit_code,
+            "execution_time": execution_time,
+            "device_id": target_device_id,
+            "backend": "device",
+        }
+
+    async def _select_target_device(
+        self,
+        db: Session,
+        user_id: int,
+        required_capability: Optional[str],
+        device_id: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Pick an online device for sandbox execution."""
+        online_devices = await device_service.get_online_devices(db, user_id)
+        if not online_devices:
+            return None
+
+        compatible_devices = [
+            device
+            for device in online_devices
+            if self._matches_device(
+                device=device,
+                required_capability=required_capability,
+                device_id=device_id,
+            )
+        ]
+        if not compatible_devices:
+            return None
+
+        def priority(device: dict[str, Any]) -> int:
+            device_type = device.get("device_type")
+            is_default = bool(device.get("is_default"))
+            if is_default and device_type == DeviceType.CLOUD.value:
+                return 0
+            if is_default:
+                return 1
+            if device_type == DeviceType.CLOUD.value:
+                return 2
+            return 3
+
+        compatible_devices.sort(key=priority)
+        selected_device = compatible_devices[0]
+        logger.info(
+            "[DeviceSandboxService] Selected device: user_id=%s, device_id=%s, "
+            "device_name=%s, device_type=%s, is_default=%s, required_capability=%s, "
+            "requested_device_id=%s, capabilities=%s, compatible_candidates=%s",
+            user_id,
+            selected_device.get("device_id"),
+            selected_device.get("device_name"),
+            selected_device.get("device_type"),
+            selected_device.get("is_default"),
+            required_capability,
+            device_id,
+            selected_device.get("capabilities") or [],
+            [
+                {
+                    "device_id": device.get("device_id"),
+                    "device_name": device.get("device_name"),
+                    "device_type": device.get("device_type"),
+                    "is_default": device.get("is_default"),
+                }
+                for device in compatible_devices
+            ],
+        )
+        return selected_device
+
+    def _matches_device(
+        self,
+        device: dict[str, Any],
+        required_capability: Optional[str],
+        device_id: Optional[str],
+    ) -> bool:
+        """Check whether a device satisfies routing constraints."""
+        if device_id and device.get("device_id") != device_id:
+            return False
+
+        if not required_capability:
+            return True
+
+        capabilities = device.get("capabilities") or []
+        return required_capability in capabilities
+
+
+device_sandbox_service = DeviceSandboxService()

--- a/backend/app/services/device_service.py
+++ b/backend/app/services/device_service.py
@@ -270,6 +270,7 @@ class DeviceService:
         client_ip: Optional[str] = None,
         device_type: Optional[str] = None,
         bind_shell: Optional[str] = None,
+        capabilities: Optional[List[str]] = None,
     ) -> Kind:
         """Create or update a Device CRD record.
 
@@ -287,6 +288,7 @@ class DeviceService:
             bind_shell: Shell runtime binding ('claudecode' or 'openclaw').
                         If None, defaults to 'claudecode' for new devices or
                         preserves existing value.
+            capabilities: Optional capability tags persisted in spec.capabilities.
 
         Returns:
             Kind model instance for the device
@@ -320,6 +322,8 @@ class DeviceService:
             # Update client IP if provided
             if client_ip is not None:
                 device_json["spec"]["clientIp"] = client_ip
+            if capabilities is not None:
+                device_json["spec"]["capabilities"] = capabilities
             # Update bind_shell if provided, otherwise preserve existing value
             if bind_shell is not None:
                 device_json["spec"]["bindShell"] = bind_shell
@@ -374,7 +378,7 @@ class DeviceService:
                     "connectionMode": "websocket",
                     "bindShell": resolved_bind_shell,
                     "isDefault": is_first_device,
-                    "capabilities": None,
+                    "capabilities": capabilities,
                     "clientIp": client_ip,
                 },
                 "status": {

--- a/backend/init_data/skills/sandbox/command_tool.py
+++ b/backend/init_data/skills/sandbox/command_tool.py
@@ -163,6 +163,7 @@ Example:
         """
         start_time = time.time()
         effective_timeout = timeout_seconds or self.default_command_timeout
+        raw_command = command
 
         # Wrap command with bash -c if it contains shell operators
         # This ensures operators like &&, ||, |, ;, >, < are properly interpreted
@@ -193,6 +194,31 @@ Example:
         try:
             # Get sandbox manager from base class
             sandbox_manager = self._get_sandbox_manager()
+
+            if sandbox_manager.should_use_device_backend_for_command(raw_command):
+                logger.info(
+                    "[SandboxCommandTool] Routing command to device backend: %s",
+                    raw_command[:100],
+                )
+                response = await sandbox_manager.execute_command_via_device(
+                    command=raw_command,
+                    working_dir=working_dir,
+                    timeout_seconds=effective_timeout,
+                    required_capability="himalaya_mail",
+                )
+
+                if response.get("success"):
+                    await self._emit_tool_status(
+                        "completed", "Command executed successfully", response
+                    )
+                else:
+                    await self._emit_tool_status(
+                        "failed",
+                        f"Command failed with exit code {response.get('exit_code', -1)}",
+                        response,
+                    )
+
+                return json.dumps(response, ensure_ascii=False, indent=2)
 
             # Get or create sandbox
             logger.info(f"[SandboxCommandTool] Getting or creating sandbox...")

--- a/backend/tests/services/test_device_sandbox_service.py
+++ b/backend/tests/services/test_device_sandbox_service.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for device-backed sandbox execution."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.device_sandbox_service import (
+    DeviceSandboxError,
+    device_sandbox_service,
+)
+
+
+class TestDeviceSandboxService:
+    """Tests for DeviceSandboxService."""
+
+    @pytest.mark.asyncio
+    async def test_execute_command_prefers_default_cloud_device(self):
+        """Default cloud devices should be preferred over other online devices."""
+        online_devices = [
+            {
+                "device_id": "local-device",
+                "device_type": "local",
+                "is_default": True,
+                "capabilities": ["himalaya_mail"],
+            },
+            {
+                "device_id": "cloud-device",
+                "device_type": "cloud",
+                "is_default": True,
+                "capabilities": ["himalaya_mail"],
+            },
+        ]
+        mock_sio = MagicMock()
+        mock_sio.call = AsyncMock(
+            return_value={
+                "success": True,
+                "stdout": "ok",
+                "stderr": "",
+                "exit_code": 0,
+                "execution_time": 0.12,
+            }
+        )
+
+        with (
+            patch(
+                "app.services.device_sandbox_service.device_service.get_online_devices",
+                AsyncMock(return_value=online_devices),
+            ),
+            patch(
+                "app.services.device_sandbox_service.device_service.get_device_online_info",
+                AsyncMock(return_value={"socket_id": "socket-1"}),
+            ) as mock_online_info,
+            patch(
+                "app.services.device_sandbox_service.get_sio",
+                return_value=mock_sio,
+            ),
+        ):
+            result = await device_sandbox_service.execute_command(
+                db=MagicMock(),
+                user_id=1,
+                command="himalaya --help",
+                required_capability="himalaya_mail",
+            )
+
+        assert result["success"] is True
+        assert result["device_id"] == "cloud-device"
+        mock_online_info.assert_awaited_once_with(1, "cloud-device")
+        mock_sio.call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_execute_command_raises_when_no_compatible_device(self):
+        """An explicit error should be raised when no online device matches."""
+        with patch(
+            "app.services.device_sandbox_service.device_service.get_online_devices",
+            AsyncMock(return_value=[]),
+        ):
+            with pytest.raises(DeviceSandboxError, match="No compatible online device"):
+                await device_sandbox_service.execute_command(
+                    db=MagicMock(),
+                    user_id=1,
+                    command="himalaya --help",
+                    required_capability="himalaya_mail",
+                )

--- a/chat_shell/chat_shell/skills/registry.py
+++ b/chat_shell/chat_shell/skills/registry.py
@@ -9,6 +9,7 @@ registration and lookup of tool providers, as well as dynamic
 loading of providers from skill packages.
 """
 
+import importlib.machinery
 import importlib.util
 import logging
 import threading
@@ -20,6 +21,24 @@ from .context import SkillToolContext
 from .provider import SkillToolProvider
 
 logger = logging.getLogger(__name__)
+
+
+def _module_execution_priority(module_name: str) -> tuple[int, str]:
+    """Return execution priority for dynamically loaded skill modules.
+
+    Skill packages are loaded from ZIP bytes without a real filesystem-backed
+    importer. Modules that depend on shared package state, such as ``_base.py``,
+    must execute before tool modules that import them. ``__init__.py`` is
+    executed last because it commonly re-exports submodules.
+    """
+
+    if module_name == "_base":
+        return (0, module_name)
+    if module_name == "provider":
+        return (1, module_name)
+    if module_name == "__init__":
+        return (3, module_name)
+    return (2, module_name)
 
 
 class SkillToolRegistry:
@@ -288,21 +307,37 @@ class SkillToolRegistry:
                     )
                     return None
 
-                # Create the package module if it doesn't exist
+                # Create the package module if it doesn't exist.
+                # The explicit package spec makes relative imports work reliably
+                # for dynamically executed modules from in-memory ZIP content.
                 if package_name not in sys.modules:
                     package_module = types.ModuleType(package_name)
+                    package_spec = importlib.machinery.ModuleSpec(
+                        package_name,
+                        loader=None,
+                        is_package=True,
+                    )
+                    package_spec.submodule_search_locations = []
                     package_module.__path__ = []
                     package_module.__package__ = package_name
+                    package_module.__spec__ = package_spec
                     sys.modules[package_name] = package_module
 
-                # Load all Python modules in the skill package
+                module_sources: dict[str, str] = {}
+
+                # Pre-register all module objects before execution so intra-package
+                # imports resolve consistently during module initialization.
                 for py_mod_name, file_path in python_files.items():
                     full_module_name = f"{package_name}.{py_mod_name}"
 
                     if full_module_name in sys.modules:
+                        module_sources[py_mod_name] = zip_file.read(file_path).decode(
+                            "utf-8"
+                        )
                         continue
 
                     module_code = zip_file.read(file_path).decode("utf-8")
+                    module_sources[py_mod_name] = module_code
 
                     spec = importlib.util.spec_from_loader(
                         full_module_name,
@@ -320,8 +355,24 @@ class SkillToolRegistry:
                     module.__package__ = package_name
                     sys.modules[full_module_name] = module
 
+                # Execute modules in dependency-aware order. This avoids cases like
+                # command_tool importing ._base before _base.py has been executed.
+                for py_mod_name in sorted(
+                    python_files.keys(), key=_module_execution_priority
+                ):
+                    full_module_name = f"{package_name}.{py_mod_name}"
+                    module = sys.modules.get(full_module_name)
+                    if module is None:
+                        continue
+
+                    if getattr(module, "__skill_loaded__", False):
+                        continue
+
+                    module_code = module_sources[py_mod_name]
+
                     try:
                         exec(module_code, module.__dict__)
+                        module.__skill_loaded__ = True
                     except Exception as e:
                         logger.error(
                             f"[SkillToolRegistry] Failed to execute module "

--- a/chat_shell/chat_shell/tools/sandbox/_base.py
+++ b/chat_shell/chat_shell/tools/sandbox/_base.py
@@ -18,13 +18,21 @@ E2B SDK behavior.
 import asyncio
 import logging
 import os
+import re
 from typing import Any, Optional
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
 # Default configuration
 DEFAULT_EXECUTOR_MANAGER_URL = "http://localhost:8001"
+DEFAULT_BACKEND_API_URL = "http://localhost:8000"
 DEFAULT_SANDBOX_TIMEOUT = 1800  # 30 minutes
+DEVICE_EXEC_ENDPOINT = "/api/internal/devices/sandbox/exec"
+HIMALAYA_COMMAND_PATTERN = re.compile(
+    r"(^|\s)(himalaya|command\s+-v\s+himalaya|which\s+himalaya)(\s|$)"
+)
 
 # E2B SDK patching - must be done before any e2b imports
 # Setup environment variables first
@@ -369,6 +377,66 @@ class SandboxManager:
             None (sandboxes are not cached)
         """
         return None
+
+    def should_use_device_backend_for_command(self, command: str) -> bool:
+        """Return True when a command should prefer the device-backed executor."""
+        return bool(HIMALAYA_COMMAND_PATTERN.search(command))
+
+    async def execute_command_via_device(
+        self,
+        command: str,
+        working_dir: Optional[str] = "/home/user",
+        timeout_seconds: int = 300,
+        required_capability: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Execute a command through the backend's device sandbox bridge."""
+        backend_url = _get_backend_api_url()
+        headers = {"Content-Type": "application/json"}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
+        payload = {
+            "user_id": self.user_id,
+            "command": command,
+            "working_dir": working_dir or "/home/user",
+            "timeout_seconds": timeout_seconds,
+            "required_capability": required_capability,
+        }
+
+        logger.info(
+            "[SandboxManager] Executing command via device backend: backend_url=%s, "
+            "working_dir=%s, timeout=%ss, required_capability=%s",
+            backend_url,
+            payload["working_dir"],
+            timeout_seconds,
+            required_capability,
+        )
+
+        async with httpx.AsyncClient(timeout=max(timeout_seconds + 10, 60)) as client:
+            response = await client.post(
+                f"{backend_url}{DEVICE_EXEC_ENDPOINT}",
+                json=payload,
+                headers=headers,
+            )
+            response.raise_for_status()
+            return response.json()
+
+
+def _get_backend_api_url() -> str:
+    """Resolve backend API base URL for chat_shell-side HTTP calls."""
+    explicit_url = os.getenv("BACKEND_API_URL")
+    if explicit_url:
+        return explicit_url.rstrip("/")
+
+    remote_storage_url = os.getenv("CHAT_SHELL_REMOTE_STORAGE_URL", "").rstrip("/")
+    if remote_storage_url:
+        if remote_storage_url.endswith("/api/internal"):
+            return remote_storage_url[: -len("/api/internal")]
+        if remote_storage_url.endswith("/api"):
+            return remote_storage_url[: -len("/api")]
+        return remote_storage_url
+
+    return DEFAULT_BACKEND_API_URL
 
 
 # Patch E2B SDK at module load time

--- a/chat_shell/tests/test_skill_registry.py
+++ b/chat_shell/tests/test_skill_registry.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dynamic skill provider loading."""
+
+import io
+import sys
+import zipfile
+
+from chat_shell.skills import SkillToolContext
+from chat_shell.skills.registry import SkillToolRegistry
+
+
+def _build_out_of_order_skill_zip() -> bytes:
+    """Create a skill ZIP whose tool module appears before _base.py."""
+
+    provider_code = """
+from chat_shell.skills import SkillToolProvider
+
+
+class TestProvider(SkillToolProvider):
+    @property
+    def provider_name(self) -> str:
+        return "synthetic"
+
+    @property
+    def supported_tools(self) -> list[str]:
+        return ["echo"]
+
+    def create_tool(self, tool_name, context, tool_config=None):
+        if tool_name != "echo":
+            raise ValueError(f"Unknown tool: {tool_name}")
+        from .command_tool import EchoTool
+        return EchoTool()
+"""
+
+    command_tool_code = """
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class EchoInput(BaseModel):
+    text: str = Field(...)
+
+
+try:
+    from ._base import PREFIX
+except ImportError:
+    import sys
+
+    package_name = __name__.rsplit(".", 1)[0]
+    _base_module = sys.modules.get(f"{package_name}._base")
+    if _base_module:
+        PREFIX = _base_module.PREFIX
+    else:
+        raise ImportError(f"Cannot import _base from {package_name}")
+
+
+class EchoTool(BaseTool):
+    name: str = "echo"
+    description: str = "Echo text with a prefix"
+    args_schema: type[BaseModel] = EchoInput
+
+    def _run(self, text: str):
+        return f"{PREFIX}:{text}"
+"""
+
+    base_code = """
+PREFIX = "loaded"
+"""
+
+    init_code = """
+from . import _base
+"""
+
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        # Write command_tool before _base to reproduce the original failure mode.
+        zip_file.writestr("zip-order-skill/command_tool.py", command_tool_code)
+        zip_file.writestr("zip-order-skill/provider.py", provider_code)
+        zip_file.writestr("zip-order-skill/_base.py", base_code)
+        zip_file.writestr("zip-order-skill/__init__.py", init_code)
+    return buffer.getvalue()
+
+
+def test_load_provider_from_zip_handles_base_module_dependencies():
+    """Tool modules importing ._base should load regardless of ZIP entry order."""
+
+    skill_name = "zip-order-skill"
+    package_name = "skill_pkg_zip_order_skill"
+    registry = SkillToolRegistry()
+
+    provider = registry.load_provider_from_zip(
+        zip_content=_build_out_of_order_skill_zip(),
+        provider_config={"module": "provider", "class": "TestProvider"},
+        skill_name=skill_name,
+    )
+
+    assert provider is not None
+    registry.register(provider)
+
+    context = SkillToolContext(
+        task_id=1,
+        subtask_id=1,
+        user_id=1,
+        db_session=None,
+        ws_emitter=None,
+    )
+
+    tools = registry.create_tools_for_skill(
+        skill_config={"tools": [{"name": "echo", "provider": "synthetic"}]},
+        context=context,
+    )
+
+    assert len(tools) == 1
+    assert tools[0].invoke({"text": "hello"}) == "loaded:hello"
+
+    for module_name in list(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            sys.modules.pop(module_name, None)

--- a/executor/modes/local/__init__.py
+++ b/executor/modes/local/__init__.py
@@ -22,6 +22,7 @@ This allows backend's DeviceNamespace to route them correctly.
 from executor.modes.local.events import (
     ChatEvents,
     DeviceEvents,
+    SandboxEvents,
     TaskEvents,
 )
 from executor.modes.local.runner import LocalRunner
@@ -31,5 +32,6 @@ __all__ = [
     # Event classes
     "DeviceEvents",
     "TaskEvents",
+    "SandboxEvents",
     "ChatEvents",
 ]

--- a/executor/modes/local/events.py
+++ b/executor/modes/local/events.py
@@ -34,6 +34,12 @@ class TaskEvents:
     CLOSE_SESSION = "task:close-session"
 
 
+class SandboxEvents:
+    """Sandbox helper events for lightweight device-side execution."""
+
+    EXEC = "sandbox:exec"
+
+
 class ChatEvents:
     """Chat streaming events using OpenAI Responses API event types.
 

--- a/executor/modes/local/handlers.py
+++ b/executor/modes/local/handlers.py
@@ -9,7 +9,10 @@ This module implements handlers for events received from the Backend server.
 """
 
 import asyncio
+import os
+import subprocess
 import threading
+import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from shared.logger import setup_logger
@@ -369,9 +372,98 @@ class UpgradeHandler:
             pm = ProcessManager()
             success = pm.restart_executor()
             if success:
-                logger.info("[UpgradeHandler] New executor started, exiting current process")
+                logger.info(
+                    "[UpgradeHandler] New executor started, exiting current process"
+                )
                 import sys
+
                 sys.exit(0)
 
         # Schedule the restart without awaiting it
         asyncio.create_task(delayed_restart())
+
+
+class SandboxHandler:
+    """Handler for lightweight sandbox-style device commands."""
+
+    def __init__(self, runner: "LocalRunner"):
+        """Initialize the sandbox handler."""
+        self.runner = runner
+
+    async def handle_exec(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a shell command on the device and return an ack payload."""
+        command = str(data.get("command", "")).strip()
+        if not command:
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": "Command is required",
+                "exit_code": -1,
+                "execution_time": 0.0,
+            }
+
+        working_dir = str(data.get("working_dir") or os.path.expanduser("~"))
+        timeout_seconds = int(data.get("timeout_seconds") or 300)
+
+        logger.info(
+            "[SandboxHandler] Executing device command: cwd=%s, timeout=%ss, command=%s",
+            working_dir,
+            timeout_seconds,
+            command[:200],
+        )
+
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._execute_command_sync,
+            command,
+            working_dir,
+            timeout_seconds,
+        )
+
+    def _execute_command_sync(
+        self,
+        command: str,
+        working_dir: str,
+        timeout_seconds: int,
+    ) -> Dict[str, Any]:
+        """Execute a command synchronously in a worker thread."""
+        started_at = time.monotonic()
+
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                cwd=working_dir,
+                timeout=timeout_seconds,
+                encoding="utf-8",
+                errors="replace",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return {
+                "success": False,
+                "stdout": exc.stdout or "",
+                "stderr": (exc.stderr or "")
+                + f"\nCommand timed out after {timeout_seconds}s",
+                "exit_code": -1,
+                "execution_time": time.monotonic() - started_at,
+            }
+        except Exception as exc:
+            logger.error("[SandboxHandler] Device command failed: %s", exc)
+            return {
+                "success": False,
+                "stdout": "",
+                "stderr": str(exc),
+                "exit_code": -1,
+                "execution_time": time.monotonic() - started_at,
+            }
+
+        return {
+            "success": result.returncode == 0,
+            "stdout": result.stdout or "",
+            "stderr": result.stderr or "",
+            "exit_code": result.returncode,
+            "execution_time": time.monotonic() - started_at,
+        }

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -26,8 +26,8 @@ from typing import Any, Dict, Optional
 
 from executor.config import config
 from executor.config.device_config import DeviceConfig
-from executor.modes.local.events import ChatEvents, TaskEvents
-from executor.modes.local.handlers import TaskHandler, UpgradeHandler
+from executor.modes.local.events import ChatEvents, SandboxEvents, TaskEvents
+from executor.modes.local.handlers import SandboxHandler, TaskHandler, UpgradeHandler
 from executor.modes.local.heartbeat import LocalHeartbeatService
 from executor.modes.local.websocket_client import WebSocketClient
 from executor.services.updater.process_manager import ProcessManager
@@ -78,6 +78,7 @@ class LocalRunner:
         # Event handlers
         self.task_handler = TaskHandler(self)
         self.upgrade_handler = UpgradeHandler(self)
+        self.sandbox_handler = SandboxHandler(self)
 
         # Task queue for execution
         self.task_queue: asyncio.Queue = asyncio.Queue()
@@ -233,6 +234,7 @@ class LocalRunner:
         self.websocket_client.on(
             "device:upgrade", self.upgrade_handler.handle_upgrade_command
         )
+        self.websocket_client.on(SandboxEvents.EXEC, self.sandbox_handler.handle_exec)
 
         logger.info("WebSocket event handlers registered")
 

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -111,6 +111,7 @@ class WebSocketClient:
             self.device_name = device_config.device_name or self._get_device_name()
             self.device_type = device_config.device_type or "local"
             self.bind_shell = device_config.bind_shell or "claudecode"
+            self.capabilities = device_config.capabilities or []
         else:
             self.backend_url = backend_url or config.WEGENT_BACKEND_URL
             self.auth_token = self._normalize_token(
@@ -120,6 +121,7 @@ class WebSocketClient:
             self.device_name = self._get_device_name()
             self.device_type = "local"
             self.bind_shell = "claudecode"
+            self.capabilities = []
 
         # Reconnection settings
         reconnection_delay = reconnection_delay or config.LOCAL_RECONNECT_DELAY
@@ -478,6 +480,7 @@ class WebSocketClient:
                 "name": self.device_name,
                 "device_type": self.device_type,
                 "bind_shell": self.bind_shell,
+                "capabilities": self.capabilities,
                 "executor_version": get_version(),
                 "client_ip": self._get_client_ip(),
             }

--- a/executor/tests/test_local_sandbox_handler.py
+++ b/executor/tests/test_local_sandbox_handler.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for lightweight device sandbox command handling."""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from executor.modes.local.handlers import SandboxHandler
+
+
+class TestSandboxHandler:
+    """Tests for SandboxHandler."""
+
+    def test_execute_command_sync_returns_process_output(self):
+        """Successful subprocess output should be returned unchanged."""
+        handler = SandboxHandler(runner=MagicMock())
+
+        completed = subprocess.CompletedProcess(
+            args=["echo", "hello"],
+            returncode=0,
+            stdout="hello\n",
+            stderr="",
+        )
+
+        with patch(
+            "executor.modes.local.handlers.subprocess.run", return_value=completed
+        ):
+            result = handler._execute_command_sync(
+                command="echo hello",
+                working_dir="/tmp",
+                timeout_seconds=5,
+            )
+
+        assert result["success"] is True
+        assert result["stdout"] == "hello\n"
+        assert result["stderr"] == ""
+        assert result["exit_code"] == 0
+
+    def test_execute_command_sync_returns_timeout_error(self):
+        """Timeouts should surface as structured command failures."""
+        handler = SandboxHandler(runner=MagicMock())
+
+        with patch(
+            "executor.modes.local.handlers.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd="sleep 10",
+                timeout=1,
+                output="partial",
+                stderr="still running",
+            ),
+        ):
+            result = handler._execute_command_sync(
+                command="sleep 10",
+                working_dir="/tmp",
+                timeout_seconds=1,
+            )
+
+        assert result["success"] is False
+        assert result["stdout"] == "partial"
+        assert "timed out" in result["stderr"]
+        assert result["exit_code"] == -1


### PR DESCRIPTION
## Summary
- route Himalaya-related chat exec calls through the device backend instead of always creating a cloud sandbox
- add an internal backend bridge plus local executor sandbox exec handler for device-backed command execution
- harden chat_shell skill ZIP loading so sandbox tool modules with shared base files load reliably

## Testing
- `uv run --project /Users/crystal/dev/git/Wegent/backend/pyproject.toml pytest /Users/crystal/dev/git/Wegent/backend/tests/services/test_device_sandbox_service.py`
- `uv run --project /Users/crystal/dev/git/Wegent/chat_shell/pyproject.toml pytest /Users/crystal/dev/git/Wegent/chat_shell/tests/test_skill_registry.py`
- `uv run --project /Users/crystal/dev/git/Wegent/executor/pyproject.toml pytest /Users/crystal/dev/git/Wegent/executor/tests/test_local_sandbox_handler.py` *(did not complete cleanly in this environment; existing runner behavior appears to hang during collection/execution)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device sandbox command execution capability, allowing users to execute commands directly on connected devices.
  * Devices now register and report their capabilities for improved compatibility and command routing.

* **Tests**
  * Added tests for device sandbox execution service and skill registry loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->