### PR TITLE
feat(frontend): rename RestrictedAnalyst role from '盲分析师' to '访客' in …

### DIFF
--- a/frontend/src/i18n/locales/zh-CN/groups.json
+++ b/frontend/src/i18n/locales/zh-CN/groups.json
@@ -26,7 +26,7 @@
       "Maintainer": "管理员",
       "Developer": "开发者",
       "Reporter": "使用者",
-      "RestrictedAnalyst": "盲分析师"
+      "RestrictedAnalyst": "访客"
     },
     "actions": {
       "addMember": "添加成员",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -391,12 +391,12 @@
         "Maintainer": "管理员",
         "Developer": "开发者",
         "Reporter": "使用者",
-        "RestrictedAnalyst": "盲分析师",
+        "RestrictedAnalyst": "访客",
         "OwnerDescription": "创建者，拥有所有权限（仅创建者可拥有此角色）",
         "MaintainerDescription": "管理员，可以管理成员和编辑内容",
         "DeveloperDescription": "开发者，可以编辑内容",
         "ReporterDescription": "使用者，仅可查看内容",
-        "RestrictedAnalystDescription": "盲分析师，仅可使用部分内容"
+        "RestrictedAnalystDescription": "访客，仅可使用部分内容"
       },
       "viewDescription": "仅可浏览知识库内容",
       "editDescription": "可添加、修改和删除文档",

--- a/frontend/src/i18n/locales/zh-CN/shared-knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/shared-knowledge.json
@@ -21,7 +21,7 @@
   "maintainer_role_desc": "可以管理此知识库的成员和设置",
   "developer_role_desc": "可以查看和编辑此知识库中的文档",
   "reporter_role_desc": "可以查看此知识库中的文档",
-  "restricted_analyst_role_desc": "盲分析师，只能访问部分资源",
+  "restricted_analyst_role_desc": "访客，只能访问部分资源",
   "submit_request": "提交申请",
   "request_submitted": "申请已提交",
   "request_submitted_desc": "您的访问请求已提交，请等待所有者审批。",

--- a/frontend/src/types/base-role.ts
+++ b/frontend/src/types/base-role.ts
@@ -100,7 +100,7 @@ export const ROLE_DISPLAY_NAMES: Record<BaseRole, string> = {
   Maintainer: '管理员',
   Developer: '开发者',
   Reporter: '使用者',
-  RestrictedAnalyst: '盲分析师',
+  RestrictedAnalyst: '访客',
 }
 
 /**


### PR DESCRIPTION
…Chinese locale

Update Chinese display name for the RestrictedAnalyst role across all i18n files:
- groups.json: role name and description
- knowledge.json: role name and description
- shared-knowledge.json: role description
- base-role.ts: ROLE_DISPLAY_NAMES constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Chinese localization for a restricted access role label across the application to maintain consistent terminology in groups, knowledge bases, and shared resources sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->