### PR TITLE
fix(backend): strip system-reminder blocks from all user-facing prompt outputs

### DIFF
--- a/backend/app/schemas/knowledge_qa_history.py
+++ b/backend/app/schemas/knowledge_qa_history.py
@@ -9,7 +9,7 @@ Pydantic schemas for knowledge base QA history query.
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class KnowledgeBaseTypeData(BaseModel):
@@ -97,6 +97,13 @@ class QAHistoryItem(BaseModel):
         None, description="Knowledge base configuration"
     )
     created_at: datetime = Field(..., description="Record creation time")
+
+    @field_serializer("user_prompt")
+    def clean_user_prompt(self, value: Optional[str]) -> Optional[str]:
+        """Strip system-injected metadata blocks from user prompt before serialization."""
+        from app.utils.prompt_utils import extract_display_prompt
+
+        return extract_display_prompt(value)
 
 
 class PaginationInfo(BaseModel):

--- a/backend/app/schemas/subtask.py
+++ b/backend/app/schemas/subtask.py
@@ -235,6 +235,13 @@ class SubtaskInDB(SubtaskBase):
 
         return result
 
+    @field_serializer("prompt")
+    def clean_prompt(self, value: Optional[str]) -> Optional[str]:
+        """Strip system-injected metadata blocks from prompt before serialization."""
+        from app.utils.prompt_utils import extract_display_prompt
+
+        return extract_display_prompt(value)
+
     @field_serializer("result")
     def mask_result(self, value: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
         """Mask sensitive data in result field before serialization"""

--- a/backend/app/services/export/docx_generator.py
+++ b/backend/app/services/export/docx_generator.py
@@ -228,8 +228,12 @@ def _add_message(doc: Document, subtask: Subtask, task: Kind, user: User, db: Se
             _add_knowledge_bases(doc, knowledge_base_contexts)
 
     # Message content — strip system-injected metadata (<system-reminder> etc.) for user messages
-    content = extract_display_prompt(subtask.prompt) if is_user else _extract_result_value(subtask.result)
-    content = content or ''
+    content = (
+        extract_display_prompt(subtask.prompt)
+        if is_user
+        else _extract_result_value(subtask.result)
+    )
+    content = content or ""
 
     # Remove special markers
     content = _clean_content(content)

--- a/backend/app/services/export/docx_generator.py
+++ b/backend/app/services/export/docx_generator.py
@@ -27,6 +27,7 @@ from app.models.kind import Kind
 from app.models.subtask import Subtask
 from app.models.subtask_context import SubtaskContext
 from app.models.user import User
+from app.utils.prompt_utils import extract_display_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -226,8 +227,9 @@ def _add_message(doc: Document, subtask: Subtask, task: Kind, user: User, db: Se
         if knowledge_base_contexts:
             _add_knowledge_bases(doc, knowledge_base_contexts)
 
-    # Message content
-    content = subtask.prompt if is_user else _extract_result_value(subtask.result)
+    # Message content — strip system-injected metadata (<system-reminder> etc.) for user messages
+    content = extract_display_prompt(subtask.prompt) if is_user else _extract_result_value(subtask.result)
+    content = content or ''
 
     # Remove special markers
     content = _clean_content(content)

--- a/backend/app/services/shared_task.py
+++ b/backend/app/services/shared_task.py
@@ -37,6 +37,7 @@ from app.schemas.shared_task import (
     TaskShareInfo,
     TaskShareResponse,
 )
+from shared.prompts.constants import parse_prompt_blocks
 
 logger = logging.getLogger(__name__)
 
@@ -918,11 +919,16 @@ class SharedTaskService:
             if sub.sender_user_id and sub.sender_user_id > 0:
                 sender_user_name = user_name_map.get(sub.sender_user_id)
 
+            # Strip system-injected metadata (<system-reminder>, attachment
+            # blocks, etc.) from the stored prompt so the public share view
+            # only shows the user's actual message text.
+            clean_prompt, _ = parse_prompt_blocks(sub.prompt or "")
+
             public_subtasks.append(
                 PublicSubtaskData(
                     id=sub.id,
                     role=sub.role,
-                    prompt=sub.prompt or "",
+                    prompt=clean_prompt,
                     result=sub.result,
                     status=sub.status,
                     created_at=sub.created_at,

--- a/backend/tests/schemas/test_qa_history_prompt_sanitization.py
+++ b/backend/tests/schemas/test_qa_history_prompt_sanitization.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for QAHistoryItem user_prompt field serialization.
+
+Verifies that system-injected metadata blocks (<system-reminder>) stored in
+Subtask.prompt are stripped before the value is returned via QAHistoryItem.user_prompt
+in the knowledge base QA history API.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from app.schemas.knowledge_qa_history import QAHistoryItem
+
+
+def _make_qa_item_data(user_prompt=None, **kwargs):
+    """Build a minimal dict accepted by QAHistoryItem."""
+    base = {
+        "task_id": 1,
+        "user_id": 1,
+        "subtask_id": 10,
+        "subtask_context_id": 20,
+        "created_at": datetime(2025, 1, 1, 12, 0, 0),
+    }
+    if user_prompt is not None:
+        base["user_prompt"] = user_prompt
+    base.update(kwargs)
+    return base
+
+
+class TestQAHistoryItemUserPromptSerialization:
+    """Tests for the clean_user_prompt field_serializer in QAHistoryItem."""
+
+    def test_plain_text_prompt_returned_unchanged(self):
+        """Plain text user_prompt must not be modified."""
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt="What is RAG?"))
+        result = item.model_dump()
+        assert result["user_prompt"] == "What is RAG?"
+
+    def test_none_prompt_returned_as_none(self):
+        """None user_prompt must remain None (or empty)."""
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt=None))
+        result = item.model_dump()
+        assert result["user_prompt"] is None
+
+    def test_json_array_prompt_strips_system_reminder(self):
+        """JSON array user_prompt with <system-reminder> must be stripped."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Search documents for quarterly report"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01 09:00</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt=raw_prompt))
+        result = item.model_dump()
+        assert result["user_prompt"] == "Search documents for quarterly report"
+
+    def test_json_array_prompt_with_attachment_metadata(self):
+        """JSON array with attachment metadata block is stripped correctly."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Summarize this document"},
+                {
+                    "type": "text",
+                    "text": (
+                        "<system-reminder>"
+                        "<Attachment>report.pdf (uploaded)</Attachment>"
+                        "</system-reminder>"
+                    ),
+                },
+            ]
+        )
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt=raw_prompt))
+        result = item.model_dump()
+        assert result["user_prompt"] == "Summarize this document"
+
+    def test_json_serialization_also_strips(self):
+        """model_dump(mode='json') also passes through the serializer."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Find relevant chapters"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-03-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt=raw_prompt))
+        result = item.model_dump(mode="json")
+        assert result["user_prompt"] == "Find relevant chapters"
+
+    def test_invalid_json_returned_as_is(self):
+        """Non-JSON strings should be returned unchanged (treated as plain text)."""
+        prompt = "[not valid json"
+        item = QAHistoryItem(**_make_qa_item_data(user_prompt=prompt))
+        result = item.model_dump()
+        assert result["user_prompt"] == prompt

--- a/backend/tests/schemas/test_subtask_prompt_sanitization.py
+++ b/backend/tests/schemas/test_subtask_prompt_sanitization.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for SubtaskInDB prompt field serialization.
+
+Verifies that system-injected metadata blocks (<system-reminder>) stored in
+Subtask.prompt are stripped before the value is returned to the frontend via
+the SubtaskInDB schema.
+"""
+
+import json
+from datetime import datetime
+
+import pytest
+
+from app.schemas.subtask import SubtaskInDB, SubtaskRole, SubtaskStatus
+
+
+def _make_subtask_data(prompt=None, **kwargs):
+    """Build a minimal dict accepted by SubtaskInDB."""
+    base = {
+        "id": 1,
+        "user_id": 1,
+        "task_id": 1,
+        "team_id": 1,
+        "title": "test",
+        "role": SubtaskRole.USER,
+        "status": SubtaskStatus.COMPLETED,
+        "created_at": datetime(2025, 1, 1, 12, 0, 0),
+        "updated_at": datetime(2025, 1, 1, 12, 0, 0),
+    }
+    if prompt is not None:
+        base["prompt"] = prompt
+    base.update(kwargs)
+    return base
+
+
+class TestSubtaskInDBPromptSerialization:
+    """Tests for the clean_prompt field_serializer in SubtaskInDB."""
+
+    def test_plain_text_prompt_returned_unchanged(self):
+        """Plain text prompts must not be modified."""
+        data = _make_subtask_data(prompt="Hello, please help me")
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] == "Hello, please help me"
+
+    def test_none_prompt_returned_as_none(self):
+        """None prompt must remain None."""
+        data = _make_subtask_data(prompt=None)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] is None
+
+    def test_json_array_prompt_strips_system_reminder(self):
+        """JSON array prompt containing a <system-reminder> block must be stripped."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "What is the weather today?"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01 12:00</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        data = _make_subtask_data(prompt=raw_prompt)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] == "What is the weather today?"
+
+    def test_json_array_prompt_with_multiple_system_blocks(self):
+        """All extra blocks (system-reminder, attachment metadata) are stripped."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Analyze this file"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><Attachment>report.pdf</Attachment></system-reminder>",
+                },
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-06-01 09:00</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        data = _make_subtask_data(prompt=raw_prompt)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] == "Analyze this file"
+
+    def test_json_array_single_block_no_system_reminder(self):
+        """Single-block JSON array without system-reminder returns the text."""
+        raw_prompt = json.dumps([{"type": "text", "text": "Simple question"}])
+        data = _make_subtask_data(prompt=raw_prompt)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] == "Simple question"
+
+    def test_json_serialization_also_strips_system_reminder(self):
+        """model_dump(mode='json') also passes through the serializer."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "User message"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        data = _make_subtask_data(prompt=raw_prompt)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump(mode="json")
+        assert result["prompt"] == "User message"
+
+    def test_assistant_role_prompt_none_not_affected(self):
+        """ASSISTANT subtasks normally have None prompt — serializer handles gracefully."""
+        data = _make_subtask_data(role=SubtaskRole.ASSISTANT, prompt=None)
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        assert result["prompt"] is None
+
+    def test_empty_string_prompt_returned_as_empty(self):
+        """Empty string prompt must not raise and must return an empty/falsy value."""
+        data = _make_subtask_data(prompt="")
+        subtask = SubtaskInDB(**data)
+        result = subtask.model_dump()
+        # extract_display_prompt("") returns "" (falsy but not None)
+        assert result["prompt"] == "" or result["prompt"] is None

--- a/backend/tests/services/test_docx_generator_prompt_sanitization.py
+++ b/backend/tests/services/test_docx_generator_prompt_sanitization.py
@@ -16,8 +16,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from docx import Document
 
-from app.services.export.docx_generator import _add_message
 from app.schemas.subtask import SubtaskRole
+from app.services.export.docx_generator import _add_message
 
 
 def _make_user_subtask(prompt: str, contexts=None):

--- a/backend/tests/services/test_docx_generator_prompt_sanitization.py
+++ b/backend/tests/services/test_docx_generator_prompt_sanitization.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for docx_generator prompt sanitization.
+
+Verifies that system-injected metadata blocks (<system-reminder>) stored in
+Subtask.prompt are stripped before being written to the exported DOCX document.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from docx import Document
+
+from app.services.export.docx_generator import _add_message
+from app.schemas.subtask import SubtaskRole
+
+
+def _make_user_subtask(prompt: str, contexts=None):
+    """Create a minimal mock Subtask with USER role."""
+    subtask = MagicMock()
+    subtask.role = MagicMock()
+    subtask.role.value = "USER"
+    subtask.prompt = prompt
+    subtask.result = None
+    subtask.contexts = contexts or []
+    subtask.sender_user_id = None
+    subtask.updated_at = datetime(2025, 1, 1, 12, 0, 0)
+    return subtask
+
+
+def _make_assistant_subtask(result_value: str):
+    """Create a minimal mock Subtask with ASSISTANT role."""
+    subtask = MagicMock()
+    subtask.role = MagicMock()
+    subtask.role.value = "ASSISTANT"
+    subtask.prompt = None
+    subtask.result = {"value": result_value}
+    subtask.contexts = []
+    subtask.sender_user_id = None
+    subtask.updated_at = datetime(2025, 1, 1, 12, 0, 0)
+    return subtask
+
+
+def _make_task_and_user():
+    """Create mock task (Kind) and user objects."""
+    task = MagicMock()
+    task.user_id = 1
+    task.json = {"spec": {"teamRef": {"name": "TestTeam"}}}
+    user = MagicMock()
+    user.user_name = "Alice"
+    return task, user
+
+
+class TestDocxGeneratorPromptSanitization:
+    """Tests for prompt sanitization in _add_message."""
+
+    def test_plain_text_prompt_written_to_document(self):
+        """Plain text user prompt appears as-is in DOCX content."""
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_user_subtask("What is the capital of France?")
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        # Collect all paragraph text from the document
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "What is the capital of France?" in full_text
+
+    def test_system_reminder_stripped_from_docx_output(self):
+        """<system-reminder> block in JSON array prompt must NOT appear in DOCX."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Summarize the attached report"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01 09:00</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_user_subtask(raw_prompt)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+
+        # User text must be present
+        assert "Summarize the attached report" in full_text
+        # System metadata must NOT appear
+        assert "<system-reminder>" not in full_text
+        assert "CurrentTime" not in full_text
+        # Raw JSON array bracket must NOT appear as literal text
+        assert full_text.count("[{") == 0
+
+    def test_json_array_with_multiple_system_blocks(self):
+        """All extra system blocks are removed; only user text is written."""
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Review this codebase"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><Attachment>repo.zip</Attachment></system-reminder>",
+                },
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-03-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_user_subtask(raw_prompt)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Review this codebase" in full_text
+        assert "<system-reminder>" not in full_text
+
+    def test_assistant_message_uses_result_not_prompt(self):
+        """ASSISTANT messages render result.value, not prompt."""
+        doc = Document()
+        task, user = _make_task_and_user()
+        subtask = _make_assistant_subtask("Paris is the capital of France.")
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        _add_message(doc, subtask, task, user, db)
+
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Paris is the capital of France." in full_text

--- a/backend/tests/services/test_shared_task_prompt_sanitization.py
+++ b/backend/tests/services/test_shared_task_prompt_sanitization.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for shared_task service prompt sanitization.
+
+Verifies that system-injected metadata blocks (<system-reminder>) stored in
+Subtask.prompt are stripped before being returned via the public shared-task
+API endpoint (get_public_shared_task).
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from shared.prompts.constants import parse_prompt_blocks
+
+
+class TestParsePromptBlocksForPublicShare:
+    """
+    Pure-unit tests for parse_prompt_blocks — the function used by
+    get_public_shared_task to sanitize prompt values before returning them
+    to unauthenticated viewers.
+    """
+
+    def test_plain_text_returned_unchanged(self):
+        """Plain text prompts pass through parse_prompt_blocks unchanged."""
+        text = "What is the meaning of life?"
+        result, extra = parse_prompt_blocks(text)
+        assert result == text
+        assert extra == []
+
+    def test_empty_string_returns_empty(self):
+        """Empty string is handled gracefully."""
+        result, extra = parse_prompt_blocks("")
+        assert result == ""
+        assert extra == []
+
+    def test_json_array_extracts_first_text_block(self):
+        """JSON array with system-reminder returns only the user text."""
+        raw = json.dumps(
+            [
+                {"type": "text", "text": "Show me the project structure"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        result, extra = parse_prompt_blocks(raw)
+        assert result == "Show me the project structure"
+        assert len(extra) > 0  # system-reminder was extracted as extra
+
+    def test_json_array_multiple_system_blocks(self):
+        """Multiple system-reminder blocks are all captured in extra."""
+        raw = json.dumps(
+            [
+                {"type": "text", "text": "Explain this code"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><Attachment>main.py</Attachment></system-reminder>",
+                },
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-06-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+        result, extra = parse_prompt_blocks(raw)
+        assert result == "Explain this code"
+        assert len(extra) == 2
+
+    def test_clean_prompt_used_in_public_subtask_data(self):
+        """
+        Simulate the get_public_shared_task logic:
+        clean_prompt, _ = parse_prompt_blocks(sub.prompt or "")
+        PublicSubtaskData(prompt=clean_prompt, ...)
+
+        The resulting prompt field must not contain any system-reminder content.
+        """
+        from app.schemas.shared_task import PublicSubtaskData
+
+        raw_prompt = json.dumps(
+            [
+                {"type": "text", "text": "Review the codebase"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01</CurrentTime></system-reminder>",
+                },
+            ]
+        )
+
+        clean_prompt, _ = parse_prompt_blocks(raw_prompt or "")
+        subtask_data = PublicSubtaskData(
+            id=1,
+            role="USER",
+            prompt=clean_prompt,
+            status="COMPLETED",
+            created_at=datetime(2025, 1, 1),
+            updated_at=datetime(2025, 1, 1),
+        )
+
+        assert subtask_data.prompt == "Review the codebase"
+        assert "<system-reminder>" not in subtask_data.prompt
+        assert "CurrentTime" not in subtask_data.prompt
+
+    def test_none_like_empty_string_for_missing_prompt(self):
+        """sub.prompt or '' pattern: None equivalent (empty string) handled cleanly."""
+        result, extra = parse_prompt_blocks("")
+        assert result == ""
+        assert extra == []


### PR DESCRIPTION
## Problem

When Chat Shell sends messages with , it appends system metadata to the user message stored in  as a JSON array:

```json
[
  {"type": "text", "text": "<user's actual message>"},
  {"type": "text", "text": "<system-reminder><CurrentTime>2025-01-01 12:00</CurrentTime></system-reminder>"}
]
```

This internal metadata (timestamps for prompt caching, attachment metadata, etc.) was leaking into multiple user-facing API responses and document exports, showing users raw JSON or `<system-reminder>` XML tags instead of their clean message text.

## Root Cause

Several serialization paths returned `Subtask.prompt` to the frontend without calling `extract_display_prompt()` (which strips the system blocks). While most paths were already clean, four were missed.

## Fixes

### 1. `SubtaskInDB.prompt` —  API (list & get endpoints)

Added a `@field_serializer("prompt")` to `SubtaskInDB` in `backend/app/schemas/subtask.py`.

**Impact:** The `/subtasks?task_id=xxx` endpoint is called by `SubscriptionConversationDialog` (feed page conversation viewer) and any other frontend component using `subtaskApis.listSubtasks()`. Without this fix, the dialog would render raw JSON like `[{"type":"text","text":"..."},...]}` to users.

### 2. `QAHistoryItem.user_prompt` —  API

Added a `@field_serializer("user_prompt")` to `QAHistoryItem` in `backend/app/schemas/knowledge_qa_history.py`.

**Impact:** The knowledge base QA history page would show system-injected metadata in the "User's question" column instead of the actual question text.

### 3. `docx_generator._add_message` — DOCX chat export

Changed `subtask.prompt` to `extract_display_prompt(subtask.prompt)` in `backend/app/services/export/docx_generator.py`.

**Impact:** Exported Word documents would contain raw JSON array strings or `<system-reminder>` XML in user message blocks.

### 4. `shared_task.get_public_shared_task` — public share link view

Changed `sub.prompt` to `clean_prompt, _ = parse_prompt_blocks(sub.prompt or "")` in `backend/app/services/shared_task.py`.

**Impact:** The unauthenticated public share page (accessible via share link without login) would display system metadata to any viewer.

## Already-Clean Paths (verified, no change needed)

| Path | How it's clean |
|------|---------------|
| `subtask.py::get_by_task` (group chat poll) | Uses `extract_display_prompt()` |
| `task_detail_helpers.py` (task detail API) | Uses `extract_display_prompt()` |
| `chat_namespace.py` WebSocket events | Uses `extract_display_prompt()` |
| `openapi_responses.py` | Uses `extract_display_prompt()` |
| Group chat broadcast | Uses `payload.message` (original frontend input) |
| Subscription execution `prompt` | Plain text from template resolution, no system blocks |
| PDF export | Uses `msg.content` from frontend state (already sanitized by API) |
| PPT / Excel / image / video | No chat-to-these-formats export pipeline exists |

## Tests Added (24 new tests, all passing)

| File | Tests | Coverage |
|------|-------|----------|
| `tests/schemas/test_subtask_prompt_sanitization.py` | 8 | `SubtaskInDB.clean_prompt` serializer |
| `tests/schemas/test_qa_history_prompt_sanitization.py` | 6 | `QAHistoryItem.clean_user_prompt` serializer |
| `tests/services/test_docx_generator_prompt_sanitization.py` | 4 | DOCX export sanitization |
| `tests/services/test_shared_task_prompt_sanitization.py` | 6 | Public share API sanitization |

```
24 passed in 1.53s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompts no longer display internal system-injected metadata blocks in API responses, document exports, and displayed histories.

* **Tests**
  * Added comprehensive test coverage for prompt sanitization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->