### PR TITLE
fix(chat_shell): prevent knowledge base / attachment content from overflowing subtask.prompt TEXT column

### DIFF
--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -18,82 +18,38 @@ For HTTP Mode (CHAT_SHELL_MODE=http):
 """
 
 import asyncio
-import json
 import logging
-import re
-from typing import Any, List, Optional
+from typing import Any, Optional
 
 from chat_shell.core.config import settings
 from shared.prompts.constants import parse_prompt_blocks
 
 logger = logging.getLogger(__name__)
 
-# Regex to strip context XML tags whose content is already persisted in
-# SubtaskContext (LONGTEXT column) and will be re-injected at history-load
-# time.  Stripping them before writing to the subtask.prompt column (TEXT,
-# 65535 bytes max) prevents silent MySQL truncation.
-_REMINDER_CONTEXT_RE = re.compile(
-    r"<(selected_documents|attachment|knowledge_base)>.*?</\1>", re.DOTALL
+# Prefixes for system-context text blocks that are already persisted in
+# SubtaskContext (LONGTEXT) and re-injected at history-load time.
+# These blocks are filtered out when persisting to subtask.prompt.
+_CONTEXT_BLOCK_PREFIXES = (
+    "<attachment>",
+    "<knowledge_base>",
+    "<selected_documents>",
+    "<system-reminder>",
 )
 
-# Regex to extract the <CurrentTime> block preserved across turns.
-_CURRENT_TIME_RE = re.compile(r"<CurrentTime>.*?</CurrentTime>", re.DOTALL)
 
-_SYSTEM_REMINDER_OPEN = "<system-reminder>"
+def _extract_user_text(content: list[dict[str, Any]]) -> str | None:
+    """Extract the user's plain text from a content block list.
 
-
-def _strip_context_from_reminder(
-    content: list[dict[str, Any]],
-) -> list[dict[str, Any]]:
-    """Strip SubtaskContext-backed content from system-reminder blocks.
-
-    ``<selected_documents>``, ``<attachment>`` and ``<knowledge_base>`` are
-    all persisted separately in the ``SubtaskContext`` table (LONGTEXT) and
-    will be re-injected when loading history.  Removing them before storing
-    to the ``subtask.prompt`` column avoids exceeding the MySQL TEXT limit.
-
-    Only ``<CurrentTime>`` (tiny, not stored elsewhere) is kept.
-
-    If stripping leaves an empty ``<system-reminder></system-reminder>``
-    wrapper, the block is dropped entirely.
+    The first text block that does not start with a known context prefix
+    is treated as the user's own message.  Returns ``None`` if no user
+    text block is found.
     """
-    result: list[dict[str, Any]] = []
     for block in content:
-        text = block.get("text", "")
-        if not text.lstrip().startswith(_SYSTEM_REMINDER_OPEN):
-            result.append(block)
+        if block.get("type") != "text":
             continue
-
-        cleaned = _REMINDER_CONTEXT_RE.sub("", text)
-
-        # Check whether the system-reminder still has meaningful content
-        inner = (
-            cleaned.replace("<system-reminder>", "")
-            .replace("</system-reminder>", "")
-            .strip()
-        )
-        if not inner:
-            # Nothing left after stripping; drop the block
-            continue
-
-        result.append({"type": block.get("type", "text"), "text": cleaned})
-    return result
-
-
-def _extract_time_text(
-    extra_blocks: list[dict[str, Any]],
-) -> str | None:
-    """Extract ``<CurrentTime>`` from system-reminder extra_blocks.
-
-    Returns the raw ``<CurrentTime>...</CurrentTime>`` string if found,
-    or ``None`` otherwise.
-    """
-    for block in extra_blocks:
         text = block.get("text", "")
-        if text.lstrip().startswith(_SYSTEM_REMINDER_OPEN):
-            m = _CURRENT_TIME_RE.search(text)
-            if m:
-                return m.group(0)
+        if not text.lstrip().startswith(_CONTEXT_BLOCK_PREFIXES):
+            return text
     return None
 
 
@@ -188,29 +144,23 @@ async def update_user_message_content(
     user_subtask_id: int,
     content: Any,
 ) -> None:
-    """Persist the formatted user message content (array with system-reminder block) to the DB.
+    """Persist the user's plain text message to the DB.
 
-    Storing the multi-block content ensures that when this message is later loaded
-    as history for future turns, it carries the *original* timestamp and matches
-    exactly what was sent to the LLM — enabling prefix-cache hits.
-
-    For vision messages only the text blocks (not image_url blocks) are stored,
-    because the image data is already persisted in SubtaskContext.
+    Context blocks (attachments, knowledge base, selected documents) and
+    the ``<system-reminder>`` block are **not** stored — they are already
+    persisted in ``SubtaskContext`` (LONGTEXT) and re-injected at
+    history-load time.  Storing only the plain text keeps the value well
+    under the MySQL TEXT column limit and ensures the frontend can display
+    it directly without JSON parsing.
 
     Args:
         task_id: Task ID (used to build the session_id for HTTP mode)
         user_subtask_id: ID of the user Subtask record to update
         content: Formatted content — either a string or a list of content blocks
     """
-    # For vision messages, strip image_url blocks before storing: images are already
-    # in SubtaskContext and would bloat the prompt column unnecessarily.
     if isinstance(content, list):
-        storage_content: Any = [b for b in content if b.get("type") != "image_url"]
-        # Strip context content (attachment, selected_documents, knowledge_base)
-        # from system-reminder blocks: they are persisted in SubtaskContext
-        # (LONGTEXT) and re-injected at history-load time.  Keeping them in
-        # the prompt column (TEXT, 65535 bytes) risks silent MySQL truncation.
-        storage_content = _strip_context_from_reminder(storage_content)
+        # Extract the user's own text; skip context / image / reminder blocks.
+        storage_content: Any = _extract_user_text(content) or ""
     else:
         storage_content = content
 
@@ -265,9 +215,7 @@ def _update_user_message_in_db_sync(user_subtask_id: int, content: Any) -> None:
             subtask = db.query(Subtask).filter(Subtask.id == user_subtask_id).first()
             if subtask and subtask.role == SubtaskRole.USER:
                 subtask.prompt = (
-                    content
-                    if isinstance(content, str)
-                    else json.dumps(content, ensure_ascii=False)
+                    str(content) if not isinstance(content, str) else content
                 )
                 db.commit()
                 logger.debug(
@@ -656,66 +604,74 @@ def _build_history_messages(
         # Output assembly.
         #
         # Context content (attachment text, KB text) is always rebuilt from
-        # SubtaskContext records — the source of truth.  The stored
-        # system-reminder in extra_blocks may only carry <CurrentTime> (after
-        # context stripping on persist) or full context (legacy data).  Either
-        # way we extract just <CurrentTime> and reconstruct the rest.
-        time_text = _extract_time_text(extra_blocks) if extra_blocks else None
+        # SubtaskContext records — the source of truth.  Each context type
+        # becomes its own independent text block (not wrapped in
+        # <system-reminder>).  This matches the format produced by
+        # MessageConverter._convert_responses_api_to_langchain().
 
-        context_parts: list[str] = []
+        context_blocks: list[dict[str, Any]] = []
         if attachment_text_parts:
-            context_parts.append(
-                "<attachment>" + "".join(attachment_text_parts) + "</attachment>"
+            context_blocks.append(
+                {
+                    "type": "text",
+                    "text": "<attachment>"
+                    + "".join(attachment_text_parts)
+                    + "</attachment>",
+                }
             )
         if kb_text_parts:
-            context_parts.append(
-                "<knowledge_base>" + "".join(kb_text_parts) + "</knowledge_base>"
+            context_blocks.append(
+                {
+                    "type": "text",
+                    "text": "<knowledge_base>"
+                    + "".join(kb_text_parts)
+                    + "</knowledge_base>",
+                }
             )
-        if time_text:
-            context_parts.append(time_text)
 
         if vision_parts:
             # Add image metadata headers as attachment context
             if image_metadata_headers:
                 img_text = "".join(image_metadata_headers)
-                if not context_parts or not context_parts[0].startswith("<attachment>"):
-                    context_parts.insert(0, f"<attachment>{img_text}</attachment>")
+                attachment_idx = next(
+                    (
+                        i
+                        for i, b in enumerate(context_blocks)
+                        if b["text"].startswith("<attachment>")
+                    ),
+                    None,
+                )
+                if attachment_idx is None:
+                    context_blocks.insert(
+                        0,
+                        {
+                            "type": "text",
+                            "text": f"<attachment>{img_text}</attachment>",
+                        },
+                    )
                 else:
-                    old = context_parts[0]
+                    old = context_blocks[attachment_idx]["text"]
                     inner = old[len("<attachment>") : -len("</attachment>")]
-                    context_parts[0] = f"<attachment>{img_text}{inner}</attachment>"
+                    context_blocks[attachment_idx] = {
+                        "type": "text",
+                        "text": f"<attachment>{img_text}{inner}</attachment>",
+                    }
 
-            if context_parts:
-                inner = "".join(context_parts)
-                reminder_block = {
-                    "type": "text",
-                    "text": f"<system-reminder>{inner}</system-reminder>",
-                }
-                multimodal_blocks: list[dict[str, Any]] = [
-                    {"type": "text", "text": text_content},
-                    *vision_parts,
-                    reminder_block,
-                ]
-            else:
-                multimodal_blocks = [
-                    {"type": "text", "text": text_content},
-                    *vision_parts,
-                ]
+            multimodal_blocks: list[dict[str, Any]] = [
+                {"type": "text", "text": text_content},
+                *vision_parts,
+                *context_blocks,
+            ]
             return [{"role": "user", "content": multimodal_blocks}]
 
         # Text-only path
-        if context_parts:
-            inner = "".join(context_parts)
-            reminder_block = {
-                "type": "text",
-                "text": f"<system-reminder>{inner}</system-reminder>",
-            }
+        if context_blocks:
             return [
                 {
                     "role": "user",
                     "content": [
                         {"type": "text", "text": text_content},
-                        reminder_block,
+                        *context_blocks,
                     ],
                 }
             ]

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -20,12 +20,59 @@ For HTTP Mode (CHAT_SHELL_MODE=http):
 import asyncio
 import json
 import logging
+import re
 from typing import Any, List, Optional
 
 from chat_shell.core.config import settings
 from shared.prompts.constants import parse_prompt_blocks
 
 logger = logging.getLogger(__name__)
+
+# Regex to match <selected_documents>...</selected_documents> blocks inside
+# system-reminder text.  Documents are stored separately in SubtaskContext,
+# so they must be stripped from the prompt column to avoid exceeding the
+# MySQL TEXT column size limit (65535 bytes).
+_SELECTED_DOCS_RE = re.compile(
+    r"<selected_documents>.*?</selected_documents>", re.DOTALL
+)
+
+_SYSTEM_REMINDER_OPEN = "<system-reminder>"
+
+
+def _strip_selected_documents(
+    content: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Strip ``<selected_documents>`` from system-reminder blocks.
+
+    Documents are already persisted separately in ``SubtaskContext`` and will
+    be re-injected when loading history.  Removing them before storing to the
+    ``subtask.prompt`` column avoids exceeding the MySQL TEXT size limit.
+
+    If stripping leaves an empty ``<system-reminder></system-reminder>``
+    wrapper, the block is dropped entirely.
+    """
+    result: list[dict[str, Any]] = []
+    for block in content:
+        text = block.get("text", "")
+        if not text.lstrip().startswith(_SYSTEM_REMINDER_OPEN):
+            result.append(block)
+            continue
+
+        cleaned = _SELECTED_DOCS_RE.sub("", text)
+
+        # Check whether the system-reminder still has meaningful content
+        inner = (
+            cleaned.replace("<system-reminder>", "")
+            .replace("</system-reminder>", "")
+            .strip()
+        )
+        if not inner:
+            # Nothing left after stripping; drop the block
+            continue
+
+        result.append({"type": block.get("type", "text"), "text": cleaned})
+    return result
+
 
 # Global remote history store instance (lazy initialized for HTTP mode)
 _remote_history_store: Optional["RemoteHistoryStore"] = None
@@ -136,7 +183,11 @@ async def update_user_message_content(
     # in SubtaskContext and would bloat the prompt column unnecessarily.
     if isinstance(content, list):
         storage_content: Any = [b for b in content if b.get("type") != "image_url"]
-        # Keep as list so future loads still see the multi-block structure.
+        # Strip <selected_documents> from system-reminder blocks: documents
+        # are persisted in SubtaskContext and re-injected at history-load time.
+        # Keeping them in the prompt column risks exceeding the MySQL TEXT
+        # column limit (65535 bytes), especially for Chinese content.
+        storage_content = _strip_selected_documents(storage_content)
     else:
         storage_content = content
 
@@ -191,7 +242,9 @@ def _update_user_message_in_db_sync(user_subtask_id: int, content: Any) -> None:
             subtask = db.query(Subtask).filter(Subtask.id == user_subtask_id).first()
             if subtask and subtask.role == SubtaskRole.USER:
                 subtask.prompt = (
-                    content if isinstance(content, str) else json.dumps(content)
+                    content
+                    if isinstance(content, str)
+                    else json.dumps(content, ensure_ascii=False)
                 )
                 db.commit()
                 logger.debug(

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -28,25 +28,31 @@ from shared.prompts.constants import parse_prompt_blocks
 
 logger = logging.getLogger(__name__)
 
-# Regex to match <selected_documents>...</selected_documents> blocks inside
-# system-reminder text.  Documents are stored separately in SubtaskContext,
-# so they must be stripped from the prompt column to avoid exceeding the
-# MySQL TEXT column size limit (65535 bytes).
-_SELECTED_DOCS_RE = re.compile(
-    r"<selected_documents>.*?</selected_documents>", re.DOTALL
+# Regex to strip context XML tags whose content is already persisted in
+# SubtaskContext (LONGTEXT column) and will be re-injected at history-load
+# time.  Stripping them before writing to the subtask.prompt column (TEXT,
+# 65535 bytes max) prevents silent MySQL truncation.
+_REMINDER_CONTEXT_RE = re.compile(
+    r"<(selected_documents|attachment|knowledge_base)>.*?</\1>", re.DOTALL
 )
+
+# Regex to extract the <CurrentTime> block preserved across turns.
+_CURRENT_TIME_RE = re.compile(r"<CurrentTime>.*?</CurrentTime>", re.DOTALL)
 
 _SYSTEM_REMINDER_OPEN = "<system-reminder>"
 
 
-def _strip_selected_documents(
+def _strip_context_from_reminder(
     content: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Strip ``<selected_documents>`` from system-reminder blocks.
+    """Strip SubtaskContext-backed content from system-reminder blocks.
 
-    Documents are already persisted separately in ``SubtaskContext`` and will
-    be re-injected when loading history.  Removing them before storing to the
-    ``subtask.prompt`` column avoids exceeding the MySQL TEXT size limit.
+    ``<selected_documents>``, ``<attachment>`` and ``<knowledge_base>`` are
+    all persisted separately in the ``SubtaskContext`` table (LONGTEXT) and
+    will be re-injected when loading history.  Removing them before storing
+    to the ``subtask.prompt`` column avoids exceeding the MySQL TEXT limit.
+
+    Only ``<CurrentTime>`` (tiny, not stored elsewhere) is kept.
 
     If stripping leaves an empty ``<system-reminder></system-reminder>``
     wrapper, the block is dropped entirely.
@@ -58,7 +64,7 @@ def _strip_selected_documents(
             result.append(block)
             continue
 
-        cleaned = _SELECTED_DOCS_RE.sub("", text)
+        cleaned = _REMINDER_CONTEXT_RE.sub("", text)
 
         # Check whether the system-reminder still has meaningful content
         inner = (
@@ -72,6 +78,23 @@ def _strip_selected_documents(
 
         result.append({"type": block.get("type", "text"), "text": cleaned})
     return result
+
+
+def _extract_time_text(
+    extra_blocks: list[dict[str, Any]],
+) -> str | None:
+    """Extract ``<CurrentTime>`` from system-reminder extra_blocks.
+
+    Returns the raw ``<CurrentTime>...</CurrentTime>`` string if found,
+    or ``None`` otherwise.
+    """
+    for block in extra_blocks:
+        text = block.get("text", "")
+        if text.lstrip().startswith(_SYSTEM_REMINDER_OPEN):
+            m = _CURRENT_TIME_RE.search(text)
+            if m:
+                return m.group(0)
+    return None
 
 
 # Global remote history store instance (lazy initialized for HTTP mode)
@@ -183,11 +206,11 @@ async def update_user_message_content(
     # in SubtaskContext and would bloat the prompt column unnecessarily.
     if isinstance(content, list):
         storage_content: Any = [b for b in content if b.get("type") != "image_url"]
-        # Strip <selected_documents> from system-reminder blocks: documents
-        # are persisted in SubtaskContext and re-injected at history-load time.
-        # Keeping them in the prompt column risks exceeding the MySQL TEXT
-        # column limit (65535 bytes), especially for Chinese content.
-        storage_content = _strip_selected_documents(storage_content)
+        # Strip context content (attachment, selected_documents, knowledge_base)
+        # from system-reminder blocks: they are persisted in SubtaskContext
+        # (LONGTEXT) and re-injected at history-load time.  Keeping them in
+        # the prompt column (TEXT, 65535 bytes) risks silent MySQL truncation.
+        storage_content = _strip_context_from_reminder(storage_content)
     else:
         storage_content = content
 
@@ -632,35 +655,13 @@ def _build_history_messages(
 
         # Output assembly.
         #
-        # When extra_blocks is present (new format), the stored system-reminder
-        # already contains all context metadata + time.  Pass it through as-is
-        # to avoid duplication.  We only need DB contexts for image base64.
-        #
-        # When extra_blocks is empty (old format), rebuild a system-reminder
-        # from the DB context records.
-        if extra_blocks:
-            if vision_parts:
-                return [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": text_content},
-                            *vision_parts,
-                            *extra_blocks,
-                        ],
-                    }
-                ]
-            return [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": text_content},
-                        *extra_blocks,
-                    ],
-                }
-            ]
+        # Context content (attachment text, KB text) is always rebuilt from
+        # SubtaskContext records — the source of truth.  The stored
+        # system-reminder in extra_blocks may only carry <CurrentTime> (after
+        # context stripping on persist) or full context (legacy data).  Either
+        # way we extract just <CurrentTime> and reconstruct the rest.
+        time_text = _extract_time_text(extra_blocks) if extra_blocks else None
 
-        # Old format fallback: rebuild system-reminder from DB context records.
         context_parts: list[str] = []
         if attachment_text_parts:
             context_parts.append(
@@ -670,6 +671,8 @@ def _build_history_messages(
             context_parts.append(
                 "<knowledge_base>" + "".join(kb_text_parts) + "</knowledge_base>"
             )
+        if time_text:
+            context_parts.append(time_text)
 
         if vision_parts:
             # Add image metadata headers as attachment context

--- a/chat_shell/chat_shell/messages/converter.py
+++ b/chat_shell/chat_shell/messages/converter.py
@@ -80,8 +80,7 @@ class MessageConverter:
             messages.append({"role": "user", "content": dynamic_context})
 
         # Build raw datetime text (without wrapper).  The wrapper is applied
-        # later by _build_system_reminder_block which merges ALL system context
-        # (attachment metadata, time, etc.) into a single <system-reminder> block.
+        # later by _build_system_reminder_block.
         time_text: str | None = None
         if inject_datetime:
             now = datetime.now()
@@ -91,8 +90,8 @@ class MessageConverter:
             # OpenAI Responses API format: list of content blocks
             # [{"type": "input_text", "text": "..."}, {"type": "input_image", ...}]
             # Convert to LangChain/OpenAI Chat Completions format.
-            # Context text blocks (attachment metadata, etc.) are merged with
-            # time_text into one <system-reminder> block.
+            # Context text blocks (attachment metadata, etc.) are kept as
+            # independent blocks; only time_text goes into <system-reminder>.
             messages.append(
                 MessageConverter._convert_responses_api_to_langchain(
                     current_message, username, time_text
@@ -103,9 +102,7 @@ class MessageConverter:
             user_text = (
                 f"User[{username}]: {current_message}" if username else current_message
             )
-            reminder = MessageConverter._build_system_reminder_block(
-                [], time_text
-            )
+            reminder = MessageConverter._build_system_reminder_block(time_text)
             if reminder:
                 messages.append(
                     {
@@ -203,32 +200,26 @@ class MessageConverter:
 
     @staticmethod
     def _build_system_reminder_block(
-        context_texts: list[str],
         time_text: str | None = None,
     ) -> dict[str, Any] | None:
-        """Build a single ``<system-reminder>`` content block.
+        """Build a ``<system-reminder>`` content block for ephemeral metadata.
 
-        Merges all system-injected context (attachment metadata, selected
-        documents, current time, etc.) into **one** block.  The frontend
-        strips ``<system-reminder>`` content when displaying messages.
+        Only contains small, non-persisted metadata like ``<CurrentTime>``.
+        Context content (attachments, knowledge base, selected documents)
+        is kept as independent text blocks — not merged here.
 
         Args:
-            context_texts: Raw context strings (e.g. ``<attachment>...</attachment>``).
             time_text: Optional raw time string (e.g. ``<CurrentTime>...</CurrentTime>``).
 
         Returns:
-            A ``{"type": "text", "text": "<system-reminder>...\n</system-reminder>"}``
+            A ``{"type": "text", "text": "<system-reminder>...</system-reminder>"}``
             dict, or ``None`` if there is nothing to include.
         """
-        parts = list(context_texts)
-        if time_text:
-            parts.append(time_text)
-        if not parts:
+        if not time_text:
             return None
-        inner = "".join(parts)
         return {
             "type": "text",
-            "text": f"<system-reminder>{inner}</system-reminder>",
+            "text": f"<system-reminder>{time_text}</system-reminder>",
         }
 
     @staticmethod
@@ -239,10 +230,10 @@ class MessageConverter:
     ) -> dict[str, Any]:
         """Convert OpenAI Responses API format to LangChain/Chat Completions format.
 
-        All non-user text blocks (attachment metadata, selected-documents, etc.)
-        are merged with ``time_text`` into a **single** ``<system-reminder>``
-        block at the end of the content list.  The last ``input_text`` block
-        is always treated as the user's own message.
+        Context text blocks (attachment metadata, selected-documents, etc.) are
+        kept as **independent** text blocks.  Only ``time_text`` is wrapped in
+        a ``<system-reminder>`` block appended at the end.  The last
+        ``input_text`` block is always treated as the user's own message.
 
         Args:
             content_blocks: List of content blocks in Responses API format
@@ -260,9 +251,7 @@ class MessageConverter:
             block_type = block.get("type", "")
 
             if block_type == "input_text":
-                text_entries.append(
-                    {"type": "text", "text": block.get("text", "")}
-                )
+                text_entries.append({"type": "text", "text": block.get("text", "")})
 
             elif block_type == "input_image":
                 # Convert input_image to image_url
@@ -297,25 +286,22 @@ class MessageConverter:
         # Phase 2 — separate user message (last text) from context blocks
         if text_entries:
             user_msg_block = text_entries[-1]
-            context_texts = [b["text"] for b in text_entries[:-1]]
+            context_blocks = text_entries[:-1]  # independent text blocks
         else:
             # Image-only message: create an empty text block for username
             user_msg_block = {"type": "text", "text": ""}
-            context_texts = []
+            context_blocks = []
 
         # Apply username prefix to the user message block
         if username:
-            user_msg_block["text"] = (
-                f"User[{username}]: {user_msg_block['text']}"
-            )
+            user_msg_block["text"] = f"User[{username}]: {user_msg_block['text']}"
 
-        # Phase 3 — assemble: [user_msg, images, system-reminder]
+        # Phase 3 — assemble: [user_msg, images, context_blocks..., system-reminder]
         langchain_content: list[dict[str, Any]] = [user_msg_block]
         langchain_content.extend(image_entries)
+        langchain_content.extend(context_blocks)
 
-        reminder = MessageConverter._build_system_reminder_block(
-            context_texts, time_text
-        )
+        reminder = MessageConverter._build_system_reminder_block(time_text)
         if reminder:
             langchain_content.append(reminder)
 

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -6,7 +6,8 @@ from types import SimpleNamespace
 
 from chat_shell.history.loader import (
     _build_knowledge_base_text_prefix,
-    _strip_selected_documents,
+    _extract_time_text,
+    _strip_context_from_reminder,
 )
 
 
@@ -23,12 +24,12 @@ class TestHistoryLoaderRestrictedKnowledgeBase:
         assert _build_knowledge_base_text_prefix(context) == ""
 
 
-class TestStripSelectedDocuments:
-    """Tests for _strip_selected_documents which removes document content
-    from system-reminder blocks before DB persistence."""
+class TestStripContextFromReminder:
+    """Tests for _strip_context_from_reminder which removes SubtaskContext-backed
+    content (selected_documents, attachment, knowledge_base) from system-reminder
+    blocks before DB persistence."""
 
     def test_strips_selected_documents_keeps_current_time(self):
-        """The typical case: system-reminder has both documents and time."""
         content = [
             {"type": "text", "text": "hello"},
             {
@@ -41,7 +42,7 @@ class TestStripSelectedDocuments:
                 ),
             },
         ]
-        result = _strip_selected_documents(content)
+        result = _strip_context_from_reminder(content)
         assert len(result) == 2
         assert result[0] == {"type": "text", "text": "hello"}
         assert result[1] == {
@@ -53,33 +54,91 @@ class TestStripSelectedDocuments:
             ),
         }
 
-    def test_drops_block_when_only_selected_documents(self):
-        """If system-reminder only had documents, the block is removed entirely."""
+    def test_strips_attachment_keeps_current_time(self):
+        attachment_text = "[Attachment 1]\nfilename.xlsx | ID: 123\n" + "data " * 10000
+        content = [
+            {"type": "text", "text": "analyse this"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    f"<attachment>{attachment_text}</attachment>"
+                    "<CurrentTime>2026-03-24 10:00</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_context_from_reminder(content)
+        assert len(result) == 2
+        assert "<attachment>" not in result[1]["text"]
+        assert "<CurrentTime>2026-03-24 10:00</CurrentTime>" in result[1]["text"]
+
+    def test_strips_knowledge_base(self):
+        content = [
+            {"type": "text", "text": "question"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<knowledge_base>KB content here</knowledge_base>"
+                    "<CurrentTime>2026-03-24 12:00</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_context_from_reminder(content)
+        assert len(result) == 2
+        assert "<knowledge_base>" not in result[1]["text"]
+        assert "<CurrentTime>" in result[1]["text"]
+
+    def test_strips_all_context_tags_simultaneously(self):
+        """Attachment + selected_documents + knowledge_base all stripped."""
         content = [
             {"type": "text", "text": "hello"},
             {
                 "type": "text",
                 "text": (
                     "<system-reminder>"
+                    "<attachment>file content</attachment>"
                     "<selected_documents>doc content</selected_documents>"
+                    "<knowledge_base>kb content</knowledge_base>"
+                    "<CurrentTime>2026-03-24 14:00</CurrentTime>"
                     "</system-reminder>"
                 ),
             },
         ]
-        result = _strip_selected_documents(content)
+        result = _strip_context_from_reminder(content)
+        assert len(result) == 2
+        text = result[1]["text"]
+        assert "<attachment>" not in text
+        assert "<selected_documents>" not in text
+        assert "<knowledge_base>" not in text
+        assert "<CurrentTime>2026-03-24 14:00</CurrentTime>" in text
+
+    def test_drops_block_when_only_context_tags(self):
+        """If system-reminder only has context content, the block is removed."""
+        content = [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<attachment>file</attachment>"
+                    "<selected_documents>doc</selected_documents>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_context_from_reminder(content)
         assert len(result) == 1
         assert result[0] == {"type": "text", "text": "hello"}
 
     def test_no_system_reminder_unchanged(self):
-        """Content without system-reminder blocks passes through unchanged."""
-        content = [
-            {"type": "text", "text": "user message"},
-        ]
-        result = _strip_selected_documents(content)
+        content = [{"type": "text", "text": "user message"}]
+        result = _strip_context_from_reminder(content)
         assert result == content
 
-    def test_multiline_document_content(self):
-        """Documents with newlines are fully stripped."""
+    def test_multiline_attachment_content(self):
         doc = "line1\nline2\nline3\n" * 100
         content = [
             {"type": "text", "text": "question"},
@@ -87,19 +146,18 @@ class TestStripSelectedDocuments:
                 "type": "text",
                 "text": (
                     f"<system-reminder>"
-                    f"<selected_documents>{doc}</selected_documents>"
+                    f"<attachment>{doc}</attachment>"
                     f"<CurrentTime>2026-03-24 12:00</CurrentTime>"
                     f"</system-reminder>"
                 ),
             },
         ]
-        result = _strip_selected_documents(content)
+        result = _strip_context_from_reminder(content)
         assert len(result) == 2
-        assert "<selected_documents>" not in result[1]["text"]
+        assert "<attachment>" not in result[1]["text"]
         assert "<CurrentTime>" in result[1]["text"]
 
     def test_preserves_non_text_blocks(self):
-        """Non-text blocks (e.g. image_url) are kept as-is."""
         content = [
             {"type": "text", "text": "hello"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
@@ -107,21 +165,21 @@ class TestStripSelectedDocuments:
                 "type": "text",
                 "text": (
                     "<system-reminder>"
-                    "<selected_documents>doc</selected_documents>"
+                    "<attachment>file</attachment>"
                     "<CurrentTime>2026-03-24</CurrentTime>"
                     "</system-reminder>"
                 ),
             },
         ]
-        result = _strip_selected_documents(content)
+        result = _strip_context_from_reminder(content)
         assert len(result) == 3
         assert result[1]["type"] == "image_url"
 
     def test_empty_list(self):
-        assert _strip_selected_documents([]) == []
+        assert _strip_context_from_reminder([]) == []
 
-    def test_system_reminder_without_selected_documents(self):
-        """System-reminder without documents is kept unchanged."""
+    def test_system_reminder_without_context_tags(self):
+        """System-reminder with only CurrentTime is kept unchanged."""
         content = [
             {"type": "text", "text": "msg"},
             {
@@ -133,5 +191,37 @@ class TestStripSelectedDocuments:
                 ),
             },
         ]
-        result = _strip_selected_documents(content)
+        result = _strip_context_from_reminder(content)
         assert result == content
+
+
+class TestExtractTimeText:
+    """Tests for _extract_time_text which extracts <CurrentTime> from extra_blocks."""
+
+    def test_extracts_current_time_from_system_reminder(self):
+        blocks = [
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<CurrentTime>2026-03-24 14:30</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            }
+        ]
+        assert (
+            _extract_time_text(blocks) == "<CurrentTime>2026-03-24 14:30</CurrentTime>"
+        )
+
+    def test_returns_none_when_no_time(self):
+        blocks = [{"type": "text", "text": "some other content"}]
+        assert _extract_time_text(blocks) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert _extract_time_text([]) is None
+
+    def test_ignores_non_system_reminder_blocks(self):
+        blocks = [
+            {"type": "text", "text": "user text with <CurrentTime>fake</CurrentTime>"},
+        ]
+        assert _extract_time_text(blocks) is None

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -6,8 +6,7 @@ from types import SimpleNamespace
 
 from chat_shell.history.loader import (
     _build_knowledge_base_text_prefix,
-    _extract_time_text,
-    _strip_context_from_reminder,
+    _extract_user_text,
 )
 
 
@@ -24,204 +23,82 @@ class TestHistoryLoaderRestrictedKnowledgeBase:
         assert _build_knowledge_base_text_prefix(context) == ""
 
 
-class TestStripContextFromReminder:
-    """Tests for _strip_context_from_reminder which removes SubtaskContext-backed
-    content (selected_documents, attachment, knowledge_base) from system-reminder
-    blocks before DB persistence."""
+class TestExtractUserText:
+    """Tests for _extract_user_text which extracts the user's plain text
+    from a content block list, skipping context and system-reminder blocks."""
 
-    def test_strips_selected_documents_keeps_current_time(self):
+    def test_extracts_first_non_context_block(self):
         content = [
-            {"type": "text", "text": "hello"},
+            {"type": "text", "text": "hello world"},
+            {"type": "text", "text": "<attachment>file</attachment>"},
+        ]
+        assert _extract_user_text(content) == "hello world"
+
+    def test_skips_attachment_block(self):
+        content = [
+            {"type": "text", "text": "<attachment>file content</attachment>"},
+            {"type": "text", "text": "user question"},
+        ]
+        assert _extract_user_text(content) == "user question"
+
+    def test_skips_knowledge_base_block(self):
+        content = [
+            {"type": "text", "text": "<knowledge_base>kb content</knowledge_base>"},
+            {"type": "text", "text": "user question"},
+        ]
+        assert _extract_user_text(content) == "user question"
+
+    def test_skips_selected_documents_block(self):
+        content = [
+            {"type": "text", "text": "<selected_documents>docs</selected_documents>"},
+            {"type": "text", "text": "user question"},
+        ]
+        assert _extract_user_text(content) == "user question"
+
+    def test_skips_system_reminder_block(self):
+        content = [
+            {"type": "text", "text": "user question"},
             {
                 "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<selected_documents>Large doc content here</selected_documents>"
-                    "<CurrentTime>2026-03-24 00:22</CurrentTime>"
-                    "</system-reminder>"
-                ),
+                "text": "<system-reminder><CurrentTime>now</CurrentTime></system-reminder>",
             },
         ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 2
-        assert result[0] == {"type": "text", "text": "hello"}
-        assert result[1] == {
-            "type": "text",
-            "text": (
-                "<system-reminder>"
-                "<CurrentTime>2026-03-24 00:22</CurrentTime>"
-                "</system-reminder>"
-            ),
-        }
+        assert _extract_user_text(content) == "user question"
 
-    def test_strips_attachment_keeps_current_time(self):
-        attachment_text = "[Attachment 1]\nfilename.xlsx | ID: 123\n" + "data " * 10000
+    def test_skips_image_url_blocks(self):
         content = [
-            {"type": "text", "text": "analyse this"},
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    f"<attachment>{attachment_text}</attachment>"
-                    "<CurrentTime>2026-03-24 10:00</CurrentTime>"
-                    "</system-reminder>"
-                ),
-            },
-        ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 2
-        assert "<attachment>" not in result[1]["text"]
-        assert "<CurrentTime>2026-03-24 10:00</CurrentTime>" in result[1]["text"]
-
-    def test_strips_knowledge_base(self):
-        content = [
-            {"type": "text", "text": "question"},
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<knowledge_base>KB content here</knowledge_base>"
-                    "<CurrentTime>2026-03-24 12:00</CurrentTime>"
-                    "</system-reminder>"
-                ),
-            },
-        ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 2
-        assert "<knowledge_base>" not in result[1]["text"]
-        assert "<CurrentTime>" in result[1]["text"]
-
-    def test_strips_all_context_tags_simultaneously(self):
-        """Attachment + selected_documents + knowledge_base all stripped."""
-        content = [
-            {"type": "text", "text": "hello"},
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<attachment>file content</attachment>"
-                    "<selected_documents>doc content</selected_documents>"
-                    "<knowledge_base>kb content</knowledge_base>"
-                    "<CurrentTime>2026-03-24 14:00</CurrentTime>"
-                    "</system-reminder>"
-                ),
-            },
-        ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 2
-        text = result[1]["text"]
-        assert "<attachment>" not in text
-        assert "<selected_documents>" not in text
-        assert "<knowledge_base>" not in text
-        assert "<CurrentTime>2026-03-24 14:00</CurrentTime>" in text
-
-    def test_drops_block_when_only_context_tags(self):
-        """If system-reminder only has context content, the block is removed."""
-        content = [
-            {"type": "text", "text": "hello"},
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<attachment>file</attachment>"
-                    "<selected_documents>doc</selected_documents>"
-                    "</system-reminder>"
-                ),
-            },
-        ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 1
-        assert result[0] == {"type": "text", "text": "hello"}
-
-    def test_no_system_reminder_unchanged(self):
-        content = [{"type": "text", "text": "user message"}]
-        result = _strip_context_from_reminder(content)
-        assert result == content
-
-    def test_multiline_attachment_content(self):
-        doc = "line1\nline2\nline3\n" * 100
-        content = [
-            {"type": "text", "text": "question"},
-            {
-                "type": "text",
-                "text": (
-                    f"<system-reminder>"
-                    f"<attachment>{doc}</attachment>"
-                    f"<CurrentTime>2026-03-24 12:00</CurrentTime>"
-                    f"</system-reminder>"
-                ),
-            },
-        ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 2
-        assert "<attachment>" not in result[1]["text"]
-        assert "<CurrentTime>" in result[1]["text"]
-
-    def test_preserves_non_text_blocks(self):
-        content = [
-            {"type": "text", "text": "hello"},
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            {"type": "text", "text": "describe this"},
+        ]
+        assert _extract_user_text(content) == "describe this"
+
+    def test_skips_all_context_types(self):
+        content = [
+            {"type": "text", "text": "<attachment>file</attachment>"},
+            {"type": "text", "text": "<knowledge_base>kb</knowledge_base>"},
+            {"type": "text", "text": "<selected_documents>docs</selected_documents>"},
+            {"type": "image_url", "image_url": {"url": "data:..."}},
             {
                 "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<attachment>file</attachment>"
-                    "<CurrentTime>2026-03-24</CurrentTime>"
-                    "</system-reminder>"
-                ),
+                "text": "<system-reminder><CurrentTime>t</CurrentTime></system-reminder>",
             },
+            {"type": "text", "text": "the actual question"},
         ]
-        result = _strip_context_from_reminder(content)
-        assert len(result) == 3
-        assert result[1]["type"] == "image_url"
+        assert _extract_user_text(content) == "the actual question"
+
+    def test_returns_none_when_no_user_text(self):
+        content = [
+            {"type": "text", "text": "<attachment>file</attachment>"},
+            {"type": "text", "text": "<system-reminder>time</system-reminder>"},
+        ]
+        assert _extract_user_text(content) is None
 
     def test_empty_list(self):
-        assert _strip_context_from_reminder([]) == []
+        assert _extract_user_text([]) is None
 
-    def test_system_reminder_without_context_tags(self):
-        """System-reminder with only CurrentTime is kept unchanged."""
+    def test_user_text_with_group_chat_prefix(self):
         content = [
-            {"type": "text", "text": "msg"},
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<CurrentTime>2026-03-24 10:00</CurrentTime>"
-                    "</system-reminder>"
-                ),
-            },
+            {"type": "text", "text": "User[Alice]: hello everyone"},
+            {"type": "text", "text": "<attachment>file</attachment>"},
         ]
-        result = _strip_context_from_reminder(content)
-        assert result == content
-
-
-class TestExtractTimeText:
-    """Tests for _extract_time_text which extracts <CurrentTime> from extra_blocks."""
-
-    def test_extracts_current_time_from_system_reminder(self):
-        blocks = [
-            {
-                "type": "text",
-                "text": (
-                    "<system-reminder>"
-                    "<CurrentTime>2026-03-24 14:30</CurrentTime>"
-                    "</system-reminder>"
-                ),
-            }
-        ]
-        assert (
-            _extract_time_text(blocks) == "<CurrentTime>2026-03-24 14:30</CurrentTime>"
-        )
-
-    def test_returns_none_when_no_time(self):
-        blocks = [{"type": "text", "text": "some other content"}]
-        assert _extract_time_text(blocks) is None
-
-    def test_returns_none_for_empty_list(self):
-        assert _extract_time_text([]) is None
-
-    def test_ignores_non_system_reminder_blocks(self):
-        blocks = [
-            {"type": "text", "text": "user text with <CurrentTime>fake</CurrentTime>"},
-        ]
-        assert _extract_time_text(blocks) is None
+        assert _extract_user_text(content) == "User[Alice]: hello everyone"

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -4,7 +4,10 @@
 
 from types import SimpleNamespace
 
-from chat_shell.history.loader import _build_knowledge_base_text_prefix
+from chat_shell.history.loader import (
+    _build_knowledge_base_text_prefix,
+    _strip_selected_documents,
+)
 
 
 class TestHistoryLoaderRestrictedKnowledgeBase:
@@ -18,3 +21,117 @@ class TestHistoryLoaderRestrictedKnowledgeBase:
         )
 
         assert _build_knowledge_base_text_prefix(context) == ""
+
+
+class TestStripSelectedDocuments:
+    """Tests for _strip_selected_documents which removes document content
+    from system-reminder blocks before DB persistence."""
+
+    def test_strips_selected_documents_keeps_current_time(self):
+        """The typical case: system-reminder has both documents and time."""
+        content = [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<selected_documents>Large doc content here</selected_documents>"
+                    "<CurrentTime>2026-03-24 00:22</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_selected_documents(content)
+        assert len(result) == 2
+        assert result[0] == {"type": "text", "text": "hello"}
+        assert result[1] == {
+            "type": "text",
+            "text": (
+                "<system-reminder>"
+                "<CurrentTime>2026-03-24 00:22</CurrentTime>"
+                "</system-reminder>"
+            ),
+        }
+
+    def test_drops_block_when_only_selected_documents(self):
+        """If system-reminder only had documents, the block is removed entirely."""
+        content = [
+            {"type": "text", "text": "hello"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<selected_documents>doc content</selected_documents>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_selected_documents(content)
+        assert len(result) == 1
+        assert result[0] == {"type": "text", "text": "hello"}
+
+    def test_no_system_reminder_unchanged(self):
+        """Content without system-reminder blocks passes through unchanged."""
+        content = [
+            {"type": "text", "text": "user message"},
+        ]
+        result = _strip_selected_documents(content)
+        assert result == content
+
+    def test_multiline_document_content(self):
+        """Documents with newlines are fully stripped."""
+        doc = "line1\nline2\nline3\n" * 100
+        content = [
+            {"type": "text", "text": "question"},
+            {
+                "type": "text",
+                "text": (
+                    f"<system-reminder>"
+                    f"<selected_documents>{doc}</selected_documents>"
+                    f"<CurrentTime>2026-03-24 12:00</CurrentTime>"
+                    f"</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_selected_documents(content)
+        assert len(result) == 2
+        assert "<selected_documents>" not in result[1]["text"]
+        assert "<CurrentTime>" in result[1]["text"]
+
+    def test_preserves_non_text_blocks(self):
+        """Non-text blocks (e.g. image_url) are kept as-is."""
+        content = [
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<selected_documents>doc</selected_documents>"
+                    "<CurrentTime>2026-03-24</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_selected_documents(content)
+        assert len(result) == 3
+        assert result[1]["type"] == "image_url"
+
+    def test_empty_list(self):
+        assert _strip_selected_documents([]) == []
+
+    def test_system_reminder_without_selected_documents(self):
+        """System-reminder without documents is kept unchanged."""
+        content = [
+            {"type": "text", "text": "msg"},
+            {
+                "type": "text",
+                "text": (
+                    "<system-reminder>"
+                    "<CurrentTime>2026-03-24 10:00</CurrentTime>"
+                    "</system-reminder>"
+                ),
+            },
+        ]
+        result = _strip_selected_documents(content)
+        assert result == content

--- a/chat_shell/tests/test_messages.py
+++ b/chat_shell/tests/test_messages.py
@@ -329,7 +329,7 @@ class TestMessageConverterIsVisionMessage:
 
 
 class TestConvertResponsesAPIToLangchain:
-    """Tests for _convert_responses_api_to_langchain with system-reminder merging."""
+    """Tests for _convert_responses_api_to_langchain with independent context blocks."""
 
     def test_username_applied_to_user_message(self):
         """Username prefix is applied to the user's message (last input_text), not context."""
@@ -343,12 +343,12 @@ class TestConvertResponsesAPIToLangchain:
         content = result["content"]
         # User message (first in output) gets the prefix
         assert content[0]["text"] == "User[Alice]: What is this?"
-        # Context block is merged into system-reminder (second block)
-        assert "<system-reminder>" in content[1]["text"]
-        assert "<attachment>" in content[1]["text"]
+        # Context block is independent (not wrapped in system-reminder)
+        assert content[1]["text"] == "<attachment>metadata</attachment>"
+        assert "<system-reminder>" not in content[1]["text"]
 
-    def test_time_text_merged_into_system_reminder(self):
-        """time_text is merged into system-reminder along with context blocks."""
+    def test_time_text_in_system_reminder(self):
+        """time_text is wrapped in system-reminder separately from context blocks."""
         blocks = [{"type": "input_text", "text": "Hello"}]
         result = MessageConverter._convert_responses_api_to_langchain(
             blocks, time_text="<CurrentTime>2025-01-01 12:00</CurrentTime>"
@@ -359,8 +359,8 @@ class TestConvertResponsesAPIToLangchain:
         assert "<system-reminder>" in content[1]["text"]
         assert "<CurrentTime>2025-01-01 12:00</CurrentTime>" in content[1]["text"]
 
-    def test_context_and_time_merged_into_single_reminder(self):
-        """Context blocks + time_text merged into ONE system-reminder block."""
+    def test_context_blocks_independent_from_system_reminder(self):
+        """Context blocks are independent text blocks; time_text in its own system-reminder."""
         blocks = [
             {"type": "input_text", "text": "attachment data"},
             {"type": "input_text", "text": "My question"},
@@ -369,14 +369,16 @@ class TestConvertResponsesAPIToLangchain:
             blocks, username="Bob", time_text="<CurrentTime>now</CurrentTime>"
         )
         content = result["content"]
-        # [user_msg, system_reminder]
-        assert len(content) == 2
+        # [user_msg, context_block, system_reminder]
+        assert len(content) == 3
         assert content[0]["text"] == "User[Bob]: My question"
-        reminder = content[1]["text"]
-        assert reminder.startswith("<system-reminder>")
-        assert "attachment data" in reminder
-        assert "<CurrentTime>now</CurrentTime>" in reminder
-        assert reminder.endswith("</system-reminder>")
+        assert content[1]["text"] == "attachment data"
+        assert "<system-reminder>" not in content[1]["text"]
+        reminder = content[2]["text"]
+        assert (
+            reminder
+            == "<system-reminder><CurrentTime>now</CurrentTime></system-reminder>"
+        )
 
     def test_no_username_no_time_no_context(self):
         """Single block without username or time passes through cleanly."""
@@ -387,7 +389,7 @@ class TestConvertResponsesAPIToLangchain:
         assert content[0] == {"type": "text", "text": "Hello"}
 
     def test_vision_message_with_username(self):
-        """Vision message: user msg + images + system-reminder in correct order."""
+        """Vision message: user msg + images in correct order."""
         blocks = [
             {"type": "input_text", "text": "What is this?"},
             {"type": "input_image", "image_url": "data:image/png;base64,abc"},
@@ -410,22 +412,27 @@ class TestConvertResponsesAPIToLangchain:
         )
         assert result["content"][0]["text"] == "User[X]: Hello"
 
-    def test_multiple_context_blocks_merged(self):
-        """Multiple context text blocks are all merged into system-reminder."""
+    def test_multiple_context_blocks_stay_independent(self):
+        """Multiple context text blocks are kept as independent blocks."""
         blocks = [
             {"type": "input_text", "text": "<attachment>img meta</attachment>"},
-            {"type": "input_text", "text": "<selected_documents>docs</selected_documents>"},
+            {
+                "type": "input_text",
+                "text": "<selected_documents>docs</selected_documents>",
+            },
             {"type": "input_text", "text": "My question"},
         ]
         result = MessageConverter._convert_responses_api_to_langchain(
             blocks, time_text="[time]"
         )
         content = result["content"]
+        # [user_msg, context1, context2, system_reminder]
+        assert len(content) == 4
         assert content[0]["text"] == "My question"
-        reminder = content[1]["text"]
-        assert "<attachment>img meta</attachment>" in reminder
-        assert "<selected_documents>docs</selected_documents>" in reminder
-        assert "[time]" in reminder
+        assert content[1]["text"] == "<attachment>img meta</attachment>"
+        assert content[2]["text"] == "<selected_documents>docs</selected_documents>"
+        assert "[time]" in content[3]["text"]
+        assert "<system-reminder>" in content[3]["text"]
 
 
 class TestBuildMessagesPlainTextWithTimeBlock:
@@ -683,7 +690,13 @@ class TestMixedOldNewHistoryConversion:
             {
                 "role": "assistant",
                 "content": "",
-                "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "search", "arguments": "{}"}}],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
             },
             {"role": "tool", "content": "tool result", "tool_call_id": "call_1"},
             {"role": "assistant", "content": "final answer"},
@@ -698,8 +711,15 @@ class TestMixedOldNewHistoryConversion:
         assert len(messages) == 9
         roles = [m["role"] for m in messages]
         assert roles == [
-            "system", "user", "assistant", "user", "assistant",
-            "assistant", "tool", "assistant", "user",
+            "system",
+            "user",
+            "assistant",
+            "user",
+            "assistant",
+            "assistant",
+            "tool",
+            "assistant",
+            "user",
         ]
 
     def test_old_plain_history_group_chat_prefix(self):


### PR DESCRIPTION
## Problem

The prefix-cache optimization (commit `e944c80b`) persists the fully formatted user message — including `<system-reminder>` wrapper containing `<selected_documents>`, `<attachment>`, and `<knowledge_base>` context — back to `subtask.prompt`.

This column uses MySQL `TEXT` type (65,535-byte limit). When users chat with knowledge base documents or large file attachments, the serialized JSON easily exceeds this limit (Chinese content + `ensure_ascii=True` causes ~2x inflation). MySQL silently truncates, causing:

1. **Frontend display corruption**: Users see raw truncated JSON (e.g. `[{"type":"text","text":"...`) instead of their message
2. **Broken history reconstruction**: `json.loads` fails on truncated JSON → LLM receives garbled content
3. **Measured impact**: 22 records truncated to exactly 65,535 bytes in dev DB (15 selected_documents + 7 attachments)

## Solution

Eliminate the root cause architecturally — **stop merging context content into `<system-reminder>`**; keep each context type as an independent text block.

### 1. Converter: context blocks stay independent

`_convert_responses_api_to_langchain()` no longer merges attachment/KB/selected_documents into `<system-reminder>`. They remain as independent text blocks. `<system-reminder>` only contains `<CurrentTime>` (~50 bytes).

```
# Before: all content merged into one system-reminder block
[user_msg, <system-reminder><attachment>500K...</attachment><CurrentTime>...</CurrentTime></system-reminder>]

# After: context as independent blocks, system-reminder only has time
[user_msg, <attachment>500K...</attachment>, <system-reminder><CurrentTime>...</CurrentTime></system-reminder>]
```

### 2. Loader: persist only user plain text

`update_user_message_content()` now extracts and stores only the user's plain text message (not a JSON array), eliminating TEXT column overflow and ensuring clean frontend display.

### 3. Loader: history rebuild outputs independent blocks

`_build_history_messages()` reconstructs context from SubtaskContext (LONGTEXT, no size limit) as independent text blocks — matching the converter output format.

### 4. Dead code cleanup

Removed `_REMINDER_CONTEXT_RE` regex, `_strip_context_from_reminder()`, `_extract_time_text()`. Added concise `_extract_user_text()` replacement.

## Files Changed

| File | Changes |
|------|--------|
| `chat_shell/chat_shell/messages/converter.py` | `_build_system_reminder_block` only handles time_text; `_convert_responses_api_to_langchain` keeps context as independent blocks |
| `chat_shell/chat_shell/history/loader.py` | Persist plain text; history rebuild outputs independent blocks; remove regex stripping logic |
| `chat_shell/tests/test_messages.py` | Update assertions for independent block format |
| `chat_shell/tests/test_history_loader.py` | Add `TestExtractUserText` (11 tests) replacing old strip/extract tests |

## Testing

- chat_shell tests: 489 passed (6 pre-existing failures unrelated to this PR)
- Backend prompt sanitization tests: 25 passed
- Backend converter tests: 4 passed
