### PR TITLE
fix(executor): restore LD_LIBRARY_PATH for extension subprocesses

### DIFF
--- a/executor/modes/local/extension_handler.py
+++ b/executor/modes/local/extension_handler.py
@@ -122,6 +122,13 @@ class DeviceExtensionHandler:
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         env = os.environ.copy()
+
+        # Fix PyInstaller LD_LIBRARY_PATH issue: restore original system library path
+        # so subprocess tools (e.g., openssl) use correct system libraries instead of
+        # PyInstaller's bundled versions which may be incompatible.
+        if "LD_LIBRARY_PATH_ORIG" in env:
+            env["LD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH_ORIG"]
+
         env["WEGENT_EXTENSION_NAME"] = extension_name
         env["WEGENT_EXTENSION_ACTION"] = action
         env["WEGENT_EXTENSION_PAYLOAD"] = json.dumps(payload, ensure_ascii=True)


### PR DESCRIPTION
## Summary
- Fix PyInstaller LD_LIBRARY_PATH issue that caused extension scripts to fail on Linux
- Restore original system library path before spawning subprocesses so tools like `openssl` use correct system libraries

## Problem
PyInstaller sets `LD_LIBRARY_PATH` to include its bundled libraries directory (`/tmp/_MEIxxxxxx`). When executor spawns extension scripts, child processes inherit this path and load incompatible library versions, causing errors like:
- "Failed to encrypt mail password"
- `libtinfo.so.6: no version information available`

## Solution
Check for `LD_LIBRARY_PATH_ORIG` (set by PyInstaller to preserve the original value) and restore it in the subprocess environment before running extension scripts.

## Test plan
- [x] Tested himalaya mail config on Linux remote device - encryption now works
- [ ] Verify no regression on macOS (macOS uses `DYLD_LIBRARY_PATH`, not affected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected system library path resolution for extension script execution, ensuring scripts properly access required system libraries during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->