### PR TITLE
feat(backend): add knowledge base RAG support to /v1/responses API

### DIFF
--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -386,6 +386,9 @@ async def _create_non_streaming_response_unified(
     preload_skills = tool_settings.get("preload_skills", [])
     user_id = user.id
 
+    # Extract knowledge base names from tool settings
+    knowledge_base_names = tool_settings.get("knowledge_base_names", [])
+
     # Build execution request
     try:
         execution_request = await build_execution_request(
@@ -398,6 +401,7 @@ async def _create_non_streaming_response_unified(
             enable_deep_thinking=enable_chat_bot,
             enable_web_search=enable_chat_bot and settings.WEB_SEARCH_ENABLED,
             preload_skills=preload_skills,
+            knowledge_base_names=knowledge_base_names,
         )
     except Exception as e:
         logger.error(f"Failed to build execution request: {e}")
@@ -664,6 +668,9 @@ async def _create_streaming_response_unified(
     user_id = user.id
     user_name = user.user_name
 
+    # Extract knowledge base names from tool settings
+    knowledge_base_names = tool_settings.get("knowledge_base_names", [])
+
     # Build execution request using unified builder
     try:
         execution_request = await build_execution_request(
@@ -676,6 +683,7 @@ async def _create_streaming_response_unified(
             enable_deep_thinking=enable_chat_bot,
             enable_web_search=enable_chat_bot and settings.WEB_SEARCH_ENABLED,
             preload_skills=preload_skills,
+            knowledge_base_names=knowledge_base_names,
         )
     finally:
         # Close the database session before streaming starts

--- a/backend/app/schemas/openapi_response.py
+++ b/backend/app/schemas/openapi_response.py
@@ -34,6 +34,8 @@ class WegentTool(BaseModel):
     - mcp: Custom MCP server configuration
       Allows connecting to user-provided MCP servers for additional tools
     - skill: Preload specific skills for the bot
+    - knowledge_base: Enable knowledge base RAG for this request
+      Allows querying specific knowledge bases by name
 
     Note:
     - Bot/Ghost MCP tools are always available by default (no user tool needed)
@@ -41,6 +43,7 @@ class WegentTool(BaseModel):
     - Use wegent_code_bot to enable code tasks with a git repository
     - Use mcp type with mcp_servers to add custom MCP servers
     - Use skill type with skills to preload specific skills
+    - Use knowledge_base type with knowledge_base_names to enable RAG on specific KBs
 
     Examples:
         # Enable all server-side capabilities
@@ -68,11 +71,17 @@ class WegentTool(BaseModel):
 
         # Preload specific skills
         {"type": "skill", "preload_skills": ["skill_a", "skill_b"]}
+
+        # Enable knowledge base RAG with specific KBs
+        {
+            "type": "knowledge_base",
+            "knowledge_base_names": ["default#my_kb", "org#team_kb"]
+        }
     """
 
     type: str = Field(
         ...,
-        description="Tool type: 'wegent_chat_bot' (server capabilities), 'wegent_code_bot' (code task with git repo), 'mcp' (custom MCP servers), or 'skill' (preload skills)",
+        description="Tool type: 'wegent_chat_bot' (server capabilities), 'wegent_code_bot' (code task with git repo), 'mcp' (custom MCP servers), 'skill' (preload skills), or 'knowledge_base' (KB RAG)",
     )
     mcp_servers: Optional[List[Dict[str, Any]]] = Field(
         default=None,
@@ -85,6 +94,10 @@ class WegentTool(BaseModel):
     workspace: Optional[WorkspaceConfig] = Field(
         default=None,
         description="Workspace configuration for code tasks. Required when type='wegent_code_bot'",
+    )
+    knowledge_base_names: Optional[List[str]] = Field(
+        default=None,
+        description="List of knowledge base names in 'namespace#name' format. Required when type='knowledge_base'",
     )
 
 

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -282,14 +282,27 @@ async def build_execution_request(
 
         # Process knowledge base names from API request (OpenAPI v1/responses)
         # This creates SubtaskContext records for KBs specified in the request
-        if user_subtask_id and knowledge_base_names:
+        processed_subtask_id = None
+        if knowledge_base_names:
+            processed_subtask_id = (
+                user_subtask_id if user_subtask_id else assistant_subtask.id
+            )
+            logger.info(
+                "[build_execution_request] Will create KB contexts for subtask_id: %d (user_subtask_id was %s)",
+                processed_subtask_id,
+                str(user_subtask_id),
+            )
             await _create_kb_contexts_from_api_request(
-                db, user.id, user_subtask_id, knowledge_base_names
+                db, user.id, processed_subtask_id, knowledge_base_names
             )
 
         # Process contexts (attachments, knowledge bases, etc.)
-        if user_subtask_id:
-            request = await _process_contexts(db, request, user_subtask_id, user.id)
+        # If we created KB contexts, we need to process them regardless of whether it's user_subtask or assistant subtask
+        context_subtask_id = (
+            user_subtask_id if user_subtask_id else processed_subtask_id
+        )
+        if context_subtask_id:
+            request = await _process_contexts(db, request, context_subtask_id, user.id)
 
         return request
 

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -19,6 +19,8 @@ Key changes from the original trigger_ai_response:
 import logging
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
+from fastapi import HTTPException
+
 from app.db.session import SessionLocal
 from app.models.kind import Kind
 from app.models.subtask import Subtask
@@ -399,6 +401,10 @@ async def _create_kb_contexts_from_api_request(
             len(contexts),
             user_subtask_id,
         )
+    except HTTPException:
+        # Re-raise HTTPException from KnowledgeBaseNameResolver to propagate
+        # permission errors (403) and not-found errors (404) to the caller
+        raise
     except Exception as e:
         # Log error but don't fail the request - KB context creation is best-effort
         logger.warning(

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -17,7 +17,7 @@ Key changes from the original trigger_ai_response:
 """
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from app.db.session import SessionLocal
 from app.models.kind import Kind
@@ -142,6 +142,7 @@ async def build_execution_request(
     enable_clarification: bool = False,
     preload_skills: Optional[list] = None,
     previous_bot_id: Optional[int] = None,
+    knowledge_base_names: Optional[List[Dict[str, str]]] = None,
 ):
     """Build ExecutionRequest without dispatching.
 
@@ -164,6 +165,7 @@ async def build_execution_request(
         enable_web_search: Whether to enable web search (default: False)
         enable_clarification: Whether to enable clarification mode (default: False)
         preload_skills: Optional list of skills to preload
+        knowledge_base_names: Optional list of KB names in {'namespace': str, 'name': str} format
 
     Returns:
         ExecutionRequest ready for dispatch
@@ -278,6 +280,13 @@ async def build_execution_request(
         # Note: This is different from request.subtask_id which is the assistant subtask.
         request.user_subtask_id = user_subtask_id
 
+        # Process knowledge base names from API request (OpenAPI v1/responses)
+        # This creates SubtaskContext records for KBs specified in the request
+        if user_subtask_id and knowledge_base_names:
+            await _create_kb_contexts_from_api_request(
+                db, user.id, user_subtask_id, knowledge_base_names
+            )
+
         # Process contexts (attachments, knowledge bases, etc.)
         if user_subtask_id:
             request = await _process_contexts(db, request, user_subtask_id, user.id)
@@ -346,3 +355,42 @@ async def _process_contexts(
     )
 
     return request
+
+
+async def _create_kb_contexts_from_api_request(
+    db: "Session",
+    user_id: int,
+    user_subtask_id: int,
+    knowledge_base_names: List[Dict[str, str]],
+) -> None:
+    """Create SubtaskContext records for knowledge bases from API request.
+
+    This function creates KB contexts for OpenAPI v1/responses requests
+    that specify knowledge_base_names in the tools field. The created
+    contexts are then processed by the existing RAG pipeline.
+
+    Args:
+        db: Database session
+        user_id: User ID for permission checking
+        user_subtask_id: User subtask ID to attach contexts to
+        knowledge_base_names: List of dicts with 'namespace' and 'name' keys
+    """
+    from app.services.openapi.kb_context import KnowledgeBaseContextCreator
+
+    try:
+        creator = KnowledgeBaseContextCreator(db, user_id)
+        contexts = creator.create_contexts(user_subtask_id, knowledge_base_names)
+        logger.info(
+            "[build_execution_request] Created %d KB contexts from API request "
+            "for subtask %d",
+            len(contexts),
+            user_subtask_id,
+        )
+    except Exception as e:
+        # Log error but don't fail the request - KB context creation is best-effort
+        logger.warning(
+            "[build_execution_request] Failed to create KB contexts from API request "
+            "for subtask %d: %s",
+            user_subtask_id,
+            e,
+        )

--- a/backend/app/services/knowledge/task_knowledge_base_service.py
+++ b/backend/app/services/knowledge/task_knowledge_base_service.py
@@ -8,7 +8,7 @@ Service for task knowledge base (group chat) binding management.
 
 import logging
 from datetime import datetime
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -115,6 +115,23 @@ class TaskKnowledgeBaseService:
         if not kb:
             return False
 
+        # Use the extracted permission check logic
+        return self._check_kb_access_permission(db, user_id, kb)
+
+    def _check_kb_access_permission(self, db: Session, user_id: int, kb: Kind) -> bool:
+        """Check if user has access to a knowledge base.
+
+        This is the core permission checking logic extracted for reuse.
+        It checks access based on KB type (personal, organization, team).
+
+        Args:
+            db: Database session
+            user_id: User ID
+            kb: Knowledge base Kind object (already fetched from DB)
+
+        Returns:
+            True if user has access to the knowledge base
+        """
         # For personal knowledge base (default namespace)
         if kb.namespace == "default":
             # Creator always has access
@@ -263,6 +280,48 @@ class TaskKnowledgeBaseService:
             )
             .first()
         )
+
+    def batch_get_knowledge_base_by_names(
+        self, db: Session, namespace: str, names: List[str]
+    ) -> Dict[str, Kind]:
+        """Batch get knowledge bases by display names in a namespace.
+
+        This method performs a single database query to get all knowledge bases
+        in the specified namespace, then filters by display name in memory.
+        This is more efficient than querying for each name individually.
+
+        Args:
+            db: Database session
+            namespace: Knowledge base namespace
+            names: List of knowledge base display names (spec.name)
+
+        Returns:
+            Dictionary mapping display name to Kind object
+        """
+        if not names:
+            return {}
+
+        # Query all active KBs in this namespace (single DB query)
+        namespace_kbs = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == "KnowledgeBase",
+                Kind.namespace == namespace,
+                Kind.is_active == True,
+            )
+            .all()
+        )
+
+        # Build display_name -> KB mapping
+        result: Dict[str, Kind] = {}
+        name_set = set(names)
+        for kb in namespace_kbs:
+            kb_spec = kb.json.get("spec", {}) if kb.json else {}
+            display_name = kb_spec.get("name")
+            if display_name and display_name in name_set:
+                result[display_name] = kb
+
+        return result
 
     def get_knowledge_bases_by_ids(
         self, db: Session, kb_ids: List[int]

--- a/backend/app/services/knowledge/task_knowledge_base_service.py
+++ b/backend/app/services/knowledge/task_knowledge_base_service.py
@@ -8,7 +8,7 @@ Service for task knowledge base (group chat) binding management.
 
 import logging
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import List, Optional
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -115,23 +115,6 @@ class TaskKnowledgeBaseService:
         if not kb:
             return False
 
-        # Use the extracted permission check logic
-        return self._check_kb_access_permission(db, user_id, kb)
-
-    def _check_kb_access_permission(self, db: Session, user_id: int, kb: Kind) -> bool:
-        """Check if user has access to a knowledge base.
-
-        This is the core permission checking logic extracted for reuse.
-        It checks access based on KB type (personal, organization, team).
-
-        Args:
-            db: Database session
-            user_id: User ID
-            kb: Knowledge base Kind object (already fetched from DB)
-
-        Returns:
-            True if user has access to the knowledge base
-        """
         # For personal knowledge base (default namespace)
         if kb.namespace == "default":
             # Creator always has access
@@ -280,48 +263,6 @@ class TaskKnowledgeBaseService:
             )
             .first()
         )
-
-    def batch_get_knowledge_base_by_names(
-        self, db: Session, namespace: str, names: List[str]
-    ) -> Dict[str, Kind]:
-        """Batch get knowledge bases by display names in a namespace.
-
-        This method performs a single database query to get all knowledge bases
-        in the specified namespace, then filters by display name in memory.
-        This is more efficient than querying for each name individually.
-
-        Args:
-            db: Database session
-            namespace: Knowledge base namespace
-            names: List of knowledge base display names (spec.name)
-
-        Returns:
-            Dictionary mapping display name to Kind object
-        """
-        if not names:
-            return {}
-
-        # Query all active KBs in this namespace (single DB query)
-        namespace_kbs = (
-            db.query(Kind)
-            .filter(
-                Kind.kind == "KnowledgeBase",
-                Kind.namespace == namespace,
-                Kind.is_active == True,
-            )
-            .all()
-        )
-
-        # Build display_name -> KB mapping
-        result: Dict[str, Kind] = {}
-        name_set = set(names)
-        for kb in namespace_kbs:
-            kb_spec = kb.json.get("spec", {}) if kb.json else {}
-            display_name = kb_spec.get("name")
-            if display_name and display_name in name_set:
-                result[display_name] = kb
-
-        return result
 
     def get_knowledge_bases_by_ids(
         self, db: Session, kb_ids: List[int]

--- a/backend/app/services/openapi/helpers.py
+++ b/backend/app/services/openapi/helpers.py
@@ -80,12 +80,14 @@ def parse_wegent_tools(tools: Optional[List[WegentTool]]) -> Dict[str, Any]:
         - mcp_servers: dict (custom MCP server configurations, format: {name: config})
         - preload_skills: list (skills to preload for the bot)
         - workspace: dict (git workspace info for code tasks, contains git_url, branch, git_repo, git_domain)
+        - knowledge_base_names: list (knowledge base names in 'namespace#name' format)
     """
     result: Dict[str, Any] = {
         "enable_chat_bot": False,
         "mcp_servers": {},
         "preload_skills": [],
         "workspace": None,
+        "knowledge_base_names": [],
     }
     if tools:
         for tool in tools:
@@ -124,7 +126,46 @@ def parse_wegent_tools(tools: Optional[List[WegentTool]]) -> Dict[str, Any]:
             elif tool.type == "skill" and tool.preload_skills:
                 # Add skills to preload_skills list
                 result["preload_skills"].extend(tool.preload_skills)
+            elif tool.type == "knowledge_base" and tool.knowledge_base_names:
+                # Parse and validate knowledge base names
+                for kb_name in tool.knowledge_base_names:
+                    parsed = parse_knowledge_base_name(kb_name)
+                    result["knowledge_base_names"].append(parsed)
     return result
+
+
+def parse_knowledge_base_name(kb_name: str) -> Dict[str, str]:
+    """
+    Parse knowledge base name in 'namespace#name' format.
+
+    Args:
+        kb_name: Knowledge base name string in format 'namespace#name'
+                 or just 'name' (defaults to 'default' namespace)
+
+    Returns:
+        Dict with 'namespace' and 'name' keys
+
+    Raises:
+        HTTPException: If the format is invalid
+    """
+    if not kb_name:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Knowledge base name cannot be empty",
+        )
+
+    parts = kb_name.split("#")
+    if len(parts) == 2:
+        return {"namespace": parts[0], "name": parts[1]}
+    elif len(parts) == 1:
+        # Default to 'default' namespace if not specified
+        return {"namespace": "default", "name": parts[0]}
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid knowledge base name format: '{kb_name}'. "
+            f"Expected format: 'namespace#name' or 'name'",
+        )
 
 
 def _extract_repo_from_url(git_url: str) -> Optional[str]:

--- a/backend/app/services/openapi/kb_context.py
+++ b/backend/app/services/openapi/kb_context.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Knowledge base context creation for OpenAPI v1/responses endpoint.
+
+This module provides functionality to create SubtaskContext records
+for knowledge bases specified in API requests.
+"""
+
+import logging
+from typing import List, Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
+from app.services.openapi.kb_resolver import (
+    KnowledgeBaseNameResolver,
+    ResolvedKnowledgeBase,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class KnowledgeBaseContextCreator:
+    """
+    Creator for knowledge base SubtaskContext records.
+
+    This class handles the creation of SubtaskContext records for
+    knowledge bases specified in OpenAPI requests, enabling RAG
+    functionality through the existing context processing pipeline.
+    """
+
+    def __init__(self, db: Session, user_id: int):
+        """
+        Initialize the creator.
+
+        Args:
+            db: Database session
+            user_id: ID of the user creating the contexts
+        """
+        self.db = db
+        self.user_id = user_id
+        self.resolver = KnowledgeBaseNameResolver(db, user_id)
+
+    def create_contexts(
+        self,
+        subtask_id: int,
+        kb_names: List[dict],
+    ) -> List[SubtaskContext]:
+        """
+        Create SubtaskContext records for knowledge bases.
+
+        This method resolves knowledge base names to IDs and creates
+        corresponding SubtaskContext records that will be processed
+        by the existing RAG pipeline.
+
+        Args:
+            subtask_id: ID of the subtask to attach contexts to
+            kb_names: List of dicts with 'namespace' and 'name' keys
+
+        Returns:
+            List of created SubtaskContext records
+        """
+        if not kb_names:
+            return []
+
+        # Resolve KB names to IDs
+        resolution_result = self.resolver.resolve(kb_names, raise_on_error=True)
+
+        if not resolution_result.resolved:
+            logger.warning(
+                "[KBContextCreator] No knowledge bases resolved for subtask %d",
+                subtask_id,
+            )
+            return []
+
+        # Create SubtaskContext records
+        contexts = []
+        for kb in resolution_result.resolved:
+            context = self._create_kb_context(subtask_id, kb)
+            contexts.append(context)
+
+        # Batch insert all contexts
+        if contexts:
+            self.db.add_all(contexts)
+            self.db.commit()
+
+            # Refresh to get IDs
+            for ctx in contexts:
+                self.db.refresh(ctx)
+
+            logger.info(
+                "[KBContextCreator] Created %d KB contexts for subtask %d: %s",
+                len(contexts),
+                subtask_id,
+                [ctx.id for ctx in contexts],
+            )
+
+        return contexts
+
+    def _create_kb_context(
+        self,
+        subtask_id: int,
+        kb: ResolvedKnowledgeBase,
+    ) -> SubtaskContext:
+        """
+        Create a single knowledge base SubtaskContext.
+
+        Args:
+            subtask_id: ID of the subtask to attach context to
+            kb: ResolvedKnowledgeBase with ID and metadata
+
+        Returns:
+            SubtaskContext object (not yet committed)
+        """
+        # Build type_data with knowledge_id for RAG processing
+        type_data = {
+            "knowledge_id": kb.kb_id,
+            "document_count": None,  # Will be populated by RAG service if needed
+        }
+
+        context = SubtaskContext(
+            subtask_id=subtask_id,
+            user_id=self.user_id,
+            context_type=ContextType.KNOWLEDGE_BASE.value,
+            name=kb.display_name,
+            status=ContextStatus.READY.value,
+            type_data=type_data,
+            knowledge_id=kb.kb_id,
+        )
+
+        logger.debug(
+            "[KBContextCreator] Creating KB context: subtask_id=%d, kb_id=%d, name=%s",
+            subtask_id,
+            kb.kb_id,
+            kb.display_name,
+        )
+
+        return context
+
+
+def create_kb_contexts_for_subtask(
+    db: Session,
+    user_id: int,
+    subtask_id: int,
+    kb_names: List[dict],
+) -> List[SubtaskContext]:
+    """
+    Convenience function to create KB contexts for a subtask.
+
+    Args:
+        db: Database session
+        user_id: ID of the user creating the contexts
+        subtask_id: ID of the subtask to attach contexts to
+        kb_names: List of dicts with 'namespace' and 'name' keys
+
+    Returns:
+        List of created SubtaskContext records
+    """
+    creator = KnowledgeBaseContextCreator(db, user_id)
+    return creator.create_contexts(subtask_id, kb_names)

--- a/backend/app/services/openapi/kb_context.py
+++ b/backend/app/services/openapi/kb_context.py
@@ -128,7 +128,6 @@ class KnowledgeBaseContextCreator:
             name=kb.display_name,
             status=ContextStatus.READY.value,
             type_data=type_data,
-            knowledge_id=kb.kb_id,
         )
 
         logger.debug(
@@ -139,25 +138,3 @@ class KnowledgeBaseContextCreator:
         )
 
         return context
-
-
-def create_kb_contexts_for_subtask(
-    db: Session,
-    user_id: int,
-    subtask_id: int,
-    kb_names: List[dict],
-) -> List[SubtaskContext]:
-    """
-    Convenience function to create KB contexts for a subtask.
-
-    Args:
-        db: Database session
-        user_id: ID of the user creating the contexts
-        subtask_id: ID of the subtask to attach contexts to
-        kb_names: List of dicts with 'namespace' and 'name' keys
-
-    Returns:
-        List of created SubtaskContext records
-    """
-    creator = KnowledgeBaseContextCreator(db, user_id)
-    return creator.create_contexts(subtask_id, kb_names)

--- a/backend/app/services/openapi/kb_resolver.py
+++ b/backend/app/services/openapi/kb_resolver.py
@@ -61,6 +61,38 @@ class KnowledgeBaseNameResolver:
         self.user_id = user_id
         self.kb_service = TaskKnowledgeBaseService()
 
+    def _batch_query_kbs(
+        self, namespace_groups: Dict[str, List[Dict]]
+    ) -> Dict[tuple[str, str], Kind]:
+        """
+        Batch query knowledge bases by namespace.
+
+        This method uses TaskKnowledgeBaseService.batch_get_knowledge_base_by_names
+        to perform efficient batch queries per namespace.
+
+        Args:
+            namespace_groups: Dict mapping namespace to list of KB refs
+
+        Returns:
+            Dict mapping (namespace, display_name) to Kind object
+        """
+        kb_lookup: Dict[tuple[str, str], Kind] = {}
+
+        for namespace, refs in namespace_groups.items():
+            # Extract names for this namespace
+            names = [ref.get("name", "") for ref in refs if ref.get("name")]
+
+            # Use service method for batch query
+            kb_map = self.kb_service.batch_get_knowledge_base_by_names(
+                self.db, namespace, names
+            )
+
+            # Convert to (namespace, name) -> KB lookup
+            for name, kb in kb_map.items():
+                kb_lookup[(namespace, name)] = kb
+
+        return kb_lookup
+
     def resolve(
         self,
         kb_names: List[Dict[str, str]],
@@ -68,6 +100,12 @@ class KnowledgeBaseNameResolver:
     ) -> KnowledgeBaseResolutionResult:
         """
         Resolve a list of knowledge base names to IDs.
+
+        This method uses batch queries to minimize database round-trips:
+        1. Groups KB refs by namespace
+        2. Queries each namespace once to get all KBs
+        3. Matches names in memory
+        4. Performs permission checks using cached KB objects
 
         Args:
             kb_names: List of dicts with 'namespace' and 'name' keys
@@ -84,6 +122,15 @@ class KnowledgeBaseNameResolver:
         not_found: List[Dict[str, str]] = []
         no_access: List[Dict[str, str]] = []
 
+        if not kb_names:
+            return KnowledgeBaseResolutionResult(
+                resolved=resolved,
+                not_found=not_found,
+                no_access=no_access,
+            )
+
+        # Step 1: Group KB refs by namespace for batch querying
+        namespace_groups: Dict[str, List[Dict]] = {}
         for kb_ref in kb_names:
             namespace = kb_ref.get("namespace", "default")
             name = kb_ref.get("name", "")
@@ -96,8 +143,24 @@ class KnowledgeBaseNameResolver:
                 not_found.append(kb_ref)
                 continue
 
-            # Look up the knowledge base by display name
-            kb = self.kb_service.get_knowledge_base_by_name(self.db, name, namespace)
+            if namespace not in namespace_groups:
+                namespace_groups[namespace] = []
+            namespace_groups[namespace].append(kb_ref)
+
+        # Step 2: Batch query KBs by namespace and build lookup map
+        kb_lookup = self._batch_query_kbs(namespace_groups)
+
+        # Step 3: Resolve each KB ref and check permissions
+        for kb_ref in kb_names:
+            namespace = kb_ref.get("namespace", "default")
+            name = kb_ref.get("name", "")
+
+            if not name:
+                # Already handled in step 1
+                continue
+
+            # Look up KB from cached results
+            kb = kb_lookup.get((namespace, name))
 
             if not kb:
                 logger.warning(
@@ -108,9 +171,9 @@ class KnowledgeBaseNameResolver:
                 not_found.append(kb_ref)
                 continue
 
-            # Check user access permission
-            if not self.kb_service.can_access_knowledge_base(
-                self.db, self.user_id, name, namespace
+            # Check user access permission using cached KB object
+            if not self.kb_service._check_kb_access_permission(
+                self.db, self.user_id, kb
             ):
                 logger.warning(
                     "[KBResolver] User %s has no access to KB: namespace=%s, name=%s",

--- a/backend/app/services/openapi/kb_resolver.py
+++ b/backend/app/services/openapi/kb_resolver.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Knowledge base name resolver for OpenAPI v1/responses endpoint.
+
+This module provides functionality to resolve knowledge base display names
+to their internal IDs with permission checking.
+"""
+
+import logging
+from typing import Dict, List, NamedTuple, Optional
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.services.knowledge.task_knowledge_base_service import (
+    TaskKnowledgeBaseService,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ResolvedKnowledgeBase(NamedTuple):
+    """Result of resolving a knowledge base name."""
+
+    kb_id: int
+    namespace: str
+    name: str
+    display_name: str
+
+
+class KnowledgeBaseResolutionResult(NamedTuple):
+    """Result of batch knowledge base name resolution."""
+
+    resolved: List[ResolvedKnowledgeBase]
+    not_found: List[Dict[str, str]]
+    no_access: List[Dict[str, str]]
+
+
+class KnowledgeBaseNameResolver:
+    """
+    Resolver for knowledge base names to IDs with permission checking.
+
+    This class handles the resolution of knowledge base display names
+    (in 'namespace#name' format) to their internal Kind IDs, including
+    permission validation for the requesting user.
+    """
+
+    def __init__(self, db: Session, user_id: int):
+        """
+        Initialize the resolver.
+
+        Args:
+            db: Database session
+            user_id: ID of the user requesting KB access
+        """
+        self.db = db
+        self.user_id = user_id
+        self.kb_service = TaskKnowledgeBaseService()
+
+    def resolve(
+        self,
+        kb_names: List[Dict[str, str]],
+        raise_on_error: bool = True,
+    ) -> KnowledgeBaseResolutionResult:
+        """
+        Resolve a list of knowledge base names to IDs.
+
+        Args:
+            kb_names: List of dicts with 'namespace' and 'name' keys
+            raise_on_error: If True, raise HTTPException on any error.
+                           If False, return partial results and errors.
+
+        Returns:
+            KnowledgeBaseResolutionResult with resolved KBs and errors
+
+        Raises:
+            HTTPException: If raise_on_error=True and any KB not found or no access
+        """
+        resolved: List[ResolvedKnowledgeBase] = []
+        not_found: List[Dict[str, str]] = []
+        no_access: List[Dict[str, str]] = []
+
+        for kb_ref in kb_names:
+            namespace = kb_ref.get("namespace", "default")
+            name = kb_ref.get("name", "")
+
+            if not name:
+                logger.warning(
+                    "[KBResolver] Empty knowledge base name in reference: %s",
+                    kb_ref,
+                )
+                not_found.append(kb_ref)
+                continue
+
+            # Look up the knowledge base by display name
+            kb = self.kb_service.get_knowledge_base_by_name(self.db, name, namespace)
+
+            if not kb:
+                logger.warning(
+                    "[KBResolver] Knowledge base not found: namespace=%s, name=%s",
+                    namespace,
+                    name,
+                )
+                not_found.append(kb_ref)
+                continue
+
+            # Check user access permission
+            if not self.kb_service.can_access_knowledge_base(
+                self.db, self.user_id, name, namespace
+            ):
+                logger.warning(
+                    "[KBResolver] User %s has no access to KB: namespace=%s, name=%s",
+                    self.user_id,
+                    namespace,
+                    name,
+                )
+                no_access.append(kb_ref)
+                continue
+
+            # Extract display name from spec
+            kb_spec = kb.json.get("spec", {}) if kb.json else {}
+            display_name = kb_spec.get("name", name)
+
+            resolved.append(
+                ResolvedKnowledgeBase(
+                    kb_id=kb.id,
+                    namespace=namespace,
+                    name=name,
+                    display_name=display_name,
+                )
+            )
+            logger.debug(
+                "[KBResolver] Resolved KB: namespace=%s, name=%s -> id=%d",
+                namespace,
+                name,
+                kb.id,
+            )
+
+        # Handle errors based on raise_on_error flag
+        if raise_on_error:
+            self._handle_errors(resolved, not_found, no_access)
+
+        return KnowledgeBaseResolutionResult(
+            resolved=resolved,
+            not_found=not_found,
+            no_access=no_access,
+        )
+
+    def _handle_errors(
+        self,
+        resolved: List[ResolvedKnowledgeBase],
+        not_found: List[Dict[str, str]],
+        no_access: List[Dict[str, str]],
+    ) -> None:
+        """
+        Handle resolution errors by raising appropriate exceptions.
+
+        Args:
+            resolved: List of successfully resolved KBs
+            not_found: List of KB refs that were not found
+            no_access: List of KB refs that user has no access to
+
+        Raises:
+            HTTPException: With appropriate error message
+        """
+        if not_found:
+            kb_list = [
+                f"{r.get('namespace', 'default')}#{r.get('name', '')}"
+                for r in not_found
+            ]
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Knowledge base(s) not found: {', '.join(kb_list)}",
+            )
+
+        if no_access:
+            kb_list = [
+                f"{r.get('namespace', 'default')}#{r.get('name', '')}"
+                for r in no_access
+            ]
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access denied to knowledge base(s): {', '.join(kb_list)}",
+            )
+
+    def resolve_single(
+        self,
+        namespace: str,
+        name: str,
+        raise_on_error: bool = True,
+    ) -> Optional[ResolvedKnowledgeBase]:
+        """
+        Resolve a single knowledge base name to ID.
+
+        Args:
+            namespace: Knowledge base namespace
+            name: Knowledge base display name
+            raise_on_error: If True, raise HTTPException on error
+
+        Returns:
+            ResolvedKnowledgeBase if found and accessible, None otherwise
+
+        Raises:
+            HTTPException: If raise_on_error=True and KB not found or no access
+        """
+        result = self.resolve([{"namespace": namespace, "name": name}], raise_on_error)
+
+        if result.resolved:
+            return result.resolved[0]
+        return None
+
+
+def resolve_knowledge_base_names(
+    db: Session,
+    user_id: int,
+    kb_names: List[Dict[str, str]],
+    raise_on_error: bool = True,
+) -> KnowledgeBaseResolutionResult:
+    """
+    Convenience function to resolve knowledge base names.
+
+    Args:
+        db: Database session
+        user_id: ID of the user requesting KB access
+        kb_names: List of dicts with 'namespace' and 'name' keys
+        raise_on_error: If True, raise HTTPException on any error
+
+    Returns:
+        KnowledgeBaseResolutionResult with resolved KBs and errors
+    """
+    resolver = KnowledgeBaseNameResolver(db, user_id)
+    return resolver.resolve(kb_names, raise_on_error)

--- a/backend/app/services/openapi/kb_resolver.py
+++ b/backend/app/services/openapi/kb_resolver.py
@@ -10,15 +10,12 @@ to their internal IDs with permission checking.
 """
 
 import logging
-from typing import Dict, List, NamedTuple, Optional
+from typing import Dict, List, NamedTuple, Tuple
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.models.kind import Kind
-from app.services.knowledge.task_knowledge_base_service import (
-    TaskKnowledgeBaseService,
-)
+from app.services.knowledge.knowledge_service import KnowledgeService
 
 logger = logging.getLogger(__name__)
 
@@ -59,39 +56,43 @@ class KnowledgeBaseNameResolver:
         """
         self.db = db
         self.user_id = user_id
-        self.kb_service = TaskKnowledgeBaseService()
 
-    def _batch_query_kbs(
-        self, namespace_groups: Dict[str, List[Dict]]
-    ) -> Dict[tuple[str, str], Kind]:
+    def _get_accessible_kb_lookup(self) -> Dict[Tuple[str, str], int]:
         """
-        Batch query knowledge bases by namespace.
+        Get a lookup dictionary of accessible knowledge bases for the user.
 
-        This method uses TaskKnowledgeBaseService.batch_get_knowledge_base_by_names
-        to perform efficient batch queries per namespace.
-
-        Args:
-            namespace_groups: Dict mapping namespace to list of KB refs
+        This method uses KnowledgeService.get_all_knowledge_bases_grouped() to get
+        all knowledge bases the user has access to, then builds a lookup dictionary
+        mapping (namespace, name) to kb_id for efficient permission checking.
 
         Returns:
-            Dict mapping (namespace, display_name) to Kind object
+            Dict mapping (namespace, display_name) to kb_id
         """
-        kb_lookup: Dict[tuple[str, str], Kind] = {}
+        # Get all accessible knowledge bases grouped by scope
+        grouped_kbs = KnowledgeService.get_all_knowledge_bases_grouped(
+            self.db, self.user_id
+        )
 
-        for namespace, refs in namespace_groups.items():
-            # Extract names for this namespace
-            names = [ref.get("name", "") for ref in refs if ref.get("name")]
+        lookup: Dict[Tuple[str, str], int] = {}
 
-            # Use service method for batch query
-            kb_map = self.kb_service.batch_get_knowledge_base_by_names(
-                self.db, namespace, names
-            )
+        # Add personal knowledge bases (created_by_me)
+        for kb in grouped_kbs.personal.created_by_me:
+            lookup[(kb.namespace, kb.name)] = kb.id
 
-            # Convert to (namespace, name) -> KB lookup
-            for name, kb in kb_map.items():
-                kb_lookup[(namespace, name)] = kb
+        # Add shared knowledge bases (shared_with_me)
+        for kb in grouped_kbs.personal.shared_with_me:
+            lookup[(kb.namespace, kb.name)] = kb.id
 
-        return kb_lookup
+        # Add group knowledge bases
+        for group in grouped_kbs.groups:
+            for kb in group.knowledge_bases:
+                lookup[(kb.namespace, kb.name)] = kb.id
+
+        # Add organization knowledge bases
+        for kb in grouped_kbs.organization.knowledge_bases:
+            lookup[(kb.namespace, kb.name)] = kb.id
+
+        return lookup
 
     def resolve(
         self,
@@ -101,11 +102,8 @@ class KnowledgeBaseNameResolver:
         """
         Resolve a list of knowledge base names to IDs.
 
-        This method uses batch queries to minimize database round-trips:
-        1. Groups KB refs by namespace
-        2. Queries each namespace once to get all KBs
-        3. Matches names in memory
-        4. Performs permission checks using cached KB objects
+        This method compares input kb_names against the user's accessible knowledge bases
+        (from get_all_knowledge_bases_grouped) to resolve names to IDs with permission checking.
 
         Args:
             kb_names: List of dicts with 'namespace' and 'name' keys
@@ -129,8 +127,10 @@ class KnowledgeBaseNameResolver:
                 no_access=no_access,
             )
 
-        # Step 1: Group KB refs by namespace for batch querying
-        namespace_groups: Dict[str, List[Dict]] = {}
+        # Get all accessible KBs for the user (single query)
+        accessible_kb_lookup = self._get_accessible_kb_lookup()
+
+        # Resolve each KB ref by comparing against accessible KBs
         for kb_ref in kb_names:
             namespace = kb_ref.get("namespace", "default")
             name = kb_ref.get("name", "")
@@ -143,64 +143,31 @@ class KnowledgeBaseNameResolver:
                 not_found.append(kb_ref)
                 continue
 
-            if namespace not in namespace_groups:
-                namespace_groups[namespace] = []
-            namespace_groups[namespace].append(kb_ref)
+            # Check if KB is in accessible list
+            kb_id = accessible_kb_lookup.get((namespace, name))
 
-        # Step 2: Batch query KBs by namespace and build lookup map
-        kb_lookup = self._batch_query_kbs(namespace_groups)
-
-        # Step 3: Resolve each KB ref and check permissions
-        for kb_ref in kb_names:
-            namespace = kb_ref.get("namespace", "default")
-            name = kb_ref.get("name", "")
-
-            if not name:
-                # Already handled in step 1
-                continue
-
-            # Look up KB from cached results
-            kb = kb_lookup.get((namespace, name))
-
-            if not kb:
+            if kb_id is None:
                 logger.warning(
-                    "[KBResolver] Knowledge base not found: namespace=%s, name=%s",
-                    namespace,
-                    name,
-                )
-                not_found.append(kb_ref)
-                continue
-
-            # Check user access permission using cached KB object
-            if not self.kb_service._check_kb_access_permission(
-                self.db, self.user_id, kb
-            ):
-                logger.warning(
-                    "[KBResolver] User %s has no access to KB: namespace=%s, name=%s",
-                    self.user_id,
+                    "[KBResolver] Knowledge base not found or no access: namespace=%s, name=%s",
                     namespace,
                     name,
                 )
                 no_access.append(kb_ref)
                 continue
 
-            # Extract display name from spec
-            kb_spec = kb.json.get("spec", {}) if kb.json else {}
-            display_name = kb_spec.get("name", name)
-
             resolved.append(
                 ResolvedKnowledgeBase(
-                    kb_id=kb.id,
+                    kb_id=kb_id,
                     namespace=namespace,
                     name=name,
-                    display_name=display_name,
+                    display_name=name,
                 )
             )
             logger.debug(
                 "[KBResolver] Resolved KB: namespace=%s, name=%s -> id=%d",
                 namespace,
                 name,
-                kb.id,
+                kb_id,
             )
 
         # Handle errors based on raise_on_error flag
@@ -249,32 +216,6 @@ class KnowledgeBaseNameResolver:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail=f"Access denied to knowledge base(s): {', '.join(kb_list)}",
             )
-
-    def resolve_single(
-        self,
-        namespace: str,
-        name: str,
-        raise_on_error: bool = True,
-    ) -> Optional[ResolvedKnowledgeBase]:
-        """
-        Resolve a single knowledge base name to ID.
-
-        Args:
-            namespace: Knowledge base namespace
-            name: Knowledge base display name
-            raise_on_error: If True, raise HTTPException on error
-
-        Returns:
-            ResolvedKnowledgeBase if found and accessible, None otherwise
-
-        Raises:
-            HTTPException: If raise_on_error=True and KB not found or no access
-        """
-        result = self.resolve([{"namespace": namespace, "name": name}], raise_on_error)
-
-        if result.resolved:
-            return result.resolved[0]
-        return None
 
 
 def resolve_knowledge_base_names(

--- a/backend/tests/services/openapi/test_helpers_kb.py
+++ b/backend/tests/services/openapi/test_helpers_kb.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for OpenAPI helpers - knowledge base related functions.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.openapi_response import WegentTool
+from app.services.openapi.helpers import parse_knowledge_base_name, parse_wegent_tools
+
+
+class TestParseKnowledgeBaseName:
+    """Test cases for parse_knowledge_base_name function."""
+
+    def test_parse_with_namespace_and_name(self):
+        """Test parsing 'namespace#name' format."""
+        # Act
+        result = parse_knowledge_base_name("default#my_kb")
+
+        # Assert
+        assert result["namespace"] == "default"
+        assert result["name"] == "my_kb"
+
+    def test_parse_with_org_namespace(self):
+        """Test parsing with organization namespace."""
+        # Act
+        result = parse_knowledge_base_name("org#team_kb")
+
+        # Assert
+        assert result["namespace"] == "org"
+        assert result["name"] == "team_kb"
+
+    def test_parse_name_only_defaults_to_default_namespace(self):
+        """Test parsing name only defaults to 'default' namespace."""
+        # Act
+        result = parse_knowledge_base_name("my_kb")
+
+        # Assert
+        assert result["namespace"] == "default"
+        assert result["name"] == "my_kb"
+
+    def test_parse_empty_name_raises_error(self):
+        """Test parsing empty name raises HTTPException."""
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            parse_knowledge_base_name("")
+
+        assert exc_info.value.status_code == 400
+        assert "cannot be empty" in exc_info.value.detail.lower()
+
+    def test_parse_multiple_hashes_raises_error(self):
+        """Test parsing with multiple hashes raises HTTPException."""
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            parse_knowledge_base_name("default#my#kb")
+
+        assert exc_info.value.status_code == 400
+        assert "invalid" in exc_info.value.detail.lower()
+
+    def test_parse_special_characters_in_name(self):
+        """Test parsing names with special characters."""
+        # Act
+        result = parse_knowledge_base_name("default#my-kb_123")
+
+        # Assert
+        assert result["namespace"] == "default"
+        assert result["name"] == "my-kb_123"
+
+
+class TestParseWegentToolsWithKnowledgeBase:
+    """Test cases for parse_wegent_tools with knowledge_base type."""
+
+    def test_parse_knowledge_base_tool(self):
+        """Test parsing knowledge_base tool type."""
+        # Arrange
+        tools = [
+            WegentTool(
+                type="knowledge_base",
+                knowledge_base_names=["default#kb1", "org#kb2"],
+            )
+        ]
+
+        # Act
+        result = parse_wegent_tools(tools)
+
+        # Assert
+        assert len(result["knowledge_base_names"]) == 2
+        assert result["knowledge_base_names"][0] == {
+            "namespace": "default",
+            "name": "kb1",
+        }
+        assert result["knowledge_base_names"][1] == {"namespace": "org", "name": "kb2"}
+
+    def test_parse_knowledge_base_without_names(self):
+        """Test parsing knowledge_base tool without knowledge_base_names."""
+        # Arrange
+        tools = [WegentTool(type="knowledge_base")]
+
+        # Act
+        result = parse_wegent_tools(tools)
+
+        # Assert
+        assert result["knowledge_base_names"] == []
+
+    def test_parse_knowledge_base_with_default_namespace(self):
+        """Test parsing knowledge_base tool with names without explicit namespace."""
+        # Arrange
+        tools = [WegentTool(type="knowledge_base", knowledge_base_names=["kb1"])]
+
+        # Act
+        result = parse_wegent_tools(tools)
+
+        # Assert
+        assert len(result["knowledge_base_names"]) == 1
+        assert result["knowledge_base_names"][0] == {
+            "namespace": "default",
+            "name": "kb1",
+        }
+
+    def test_parse_mixed_tools(self):
+        """Test parsing mixed tool types including knowledge_base."""
+        # Arrange
+        tools = [
+            WegentTool(type="wegent_chat_bot"),
+            WegentTool(type="knowledge_base", knowledge_base_names=["default#kb1"]),
+            WegentTool(type="skill", preload_skills=["skill1"]),
+        ]
+
+        # Act
+        result = parse_wegent_tools(tools)
+
+        # Assert
+        assert result["enable_chat_bot"] is True
+        assert len(result["knowledge_base_names"]) == 1
+        assert result["knowledge_base_names"][0]["name"] == "kb1"
+        assert result["preload_skills"] == ["skill1"]
+
+    def test_parse_empty_tools(self):
+        """Test parsing empty tools list."""
+        # Act
+        result = parse_wegent_tools([])
+
+        # Assert
+        assert result["knowledge_base_names"] == []
+        assert result["enable_chat_bot"] is False
+
+    def test_parse_none_tools(self):
+        """Test parsing None tools."""
+        # Act
+        result = parse_wegent_tools(None)
+
+        # Assert
+        assert result["knowledge_base_names"] == []
+        assert result["enable_chat_bot"] is False
+
+    def test_parse_invalid_kb_name_format(self):
+        """Test parsing with invalid KB name format raises error."""
+        # Arrange
+        tools = [
+            WegentTool(
+                type="knowledge_base",
+                knowledge_base_names=["invalid#format#name"],
+            )
+        ]
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            parse_wegent_tools(tools)
+
+        assert exc_info.value.status_code == 400

--- a/backend/tests/services/openapi/test_kb_context.py
+++ b/backend/tests/services/openapi/test_kb_context.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for KnowledgeBaseContextCreator.
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.services.openapi.kb_context import (
+    KnowledgeBaseContextCreator,
+    create_kb_contexts_for_subtask,
+)
+from app.services.openapi.kb_resolver import ResolvedKnowledgeBase
+
+
+class TestKnowledgeBaseContextCreator:
+    """Test cases for KnowledgeBaseContextCreator."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        db = MagicMock()
+        db.add_all = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+        return db
+
+    @pytest.fixture
+    def mock_resolver(self):
+        """Create a mock KnowledgeBaseNameResolver."""
+        with patch(
+            "app.services.openapi.kb_context.KnowledgeBaseNameResolver"
+        ) as mock_resolver_class:
+            mock_resolver = MagicMock()
+            mock_resolver_class.return_value = mock_resolver
+            yield mock_resolver
+
+    @pytest.fixture
+    def mock_context_class(self):
+        """Mock SubtaskContext class."""
+        with patch("app.services.openapi.kb_context.SubtaskContext") as mock_ctx:
+            yield mock_ctx
+
+    @pytest.fixture
+    def creator(self, mock_db, mock_resolver):
+        """Create a KnowledgeBaseContextCreator instance."""
+        return KnowledgeBaseContextCreator(mock_db, user_id=1)
+
+    def test_create_contexts_success(
+        self, creator, mock_resolver, mock_db, mock_context_class
+    ):
+        """Test creating contexts for resolved knowledge bases."""
+        # Arrange
+        resolved_kb = ResolvedKnowledgeBase(
+            kb_id=123, namespace="default", name="my_kb", display_name="My KB"
+        )
+        mock_resolution_result = MagicMock()
+        mock_resolution_result.resolved = [resolved_kb]
+        mock_resolution_result.not_found = []
+        mock_resolution_result.no_access = []
+        mock_resolver.resolve.return_value = mock_resolution_result
+
+        # Mock context instance
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+
+        kb_names = [{"namespace": "default", "name": "my_kb"}]
+
+        # Act
+        contexts = creator.create_contexts(subtask_id=456, kb_names=kb_names)
+
+        # Assert
+        assert len(contexts) == 1
+        mock_context_class.assert_called_once()
+        mock_db.add_all.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_create_contexts_empty_list(self, creator):
+        """Test creating contexts with empty KB names list."""
+        # Act
+        contexts = creator.create_contexts(subtask_id=456, kb_names=[])
+
+        # Assert
+        assert len(contexts) == 0
+
+    def test_create_contexts_no_resolution(self, creator, mock_resolver):
+        """Test creating contexts when no KBs are resolved."""
+        # Arrange
+        mock_resolution_result = MagicMock()
+        mock_resolution_result.resolved = []
+        mock_resolution_result.not_found = [{"namespace": "default", "name": "missing"}]
+        mock_resolution_result.no_access = []
+        mock_resolver.resolve.return_value = mock_resolution_result
+
+        kb_names = [{"namespace": "default", "name": "missing"}]
+
+        # Act
+        contexts = creator.create_contexts(subtask_id=456, kb_names=kb_names)
+
+        # Assert
+        assert len(contexts) == 0
+
+    def test_create_contexts_multiple_kbs(
+        self, creator, mock_resolver, mock_db, mock_context_class
+    ):
+        """Test creating contexts for multiple knowledge bases."""
+        # Arrange
+        resolved_kbs = [
+            ResolvedKnowledgeBase(1, "default", "kb1", "KB 1"),
+            ResolvedKnowledgeBase(2, "org", "kb2", "KB 2"),
+        ]
+        mock_resolution_result = MagicMock()
+        mock_resolution_result.resolved = resolved_kbs
+        mock_resolution_result.not_found = []
+        mock_resolution_result.no_access = []
+        mock_resolver.resolve.return_value = mock_resolution_result
+
+        # Mock context instances
+        mock_contexts = [MagicMock(), MagicMock()]
+        mock_context_class.side_effect = mock_contexts
+
+        kb_names = [
+            {"namespace": "default", "name": "kb1"},
+            {"namespace": "org", "name": "kb2"},
+        ]
+
+        # Act
+        contexts = creator.create_contexts(subtask_id=789, kb_names=kb_names)
+
+        # Assert
+        assert len(contexts) == 2
+        assert mock_context_class.call_count == 2
+        mock_db.add_all.assert_called_once()
+
+    def test_create_kb_context_private_method(self, creator, mock_context_class):
+        """Test the _create_kb_context private method."""
+        # Arrange
+        kb = ResolvedKnowledgeBase(
+            kb_id=999, namespace="default", name="test_kb", display_name="Test KB"
+        )
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+
+        # Act
+        context = creator._create_kb_context(subtask_id=100, kb=kb)
+
+        # Assert
+        assert context == mock_context
+        mock_context_class.assert_called_once()
+        call_kwargs = mock_context_class.call_args.kwargs
+        assert call_kwargs["subtask_id"] == 100
+        assert call_kwargs["user_id"] == 1
+        assert call_kwargs["name"] == "Test KB"
+        assert call_kwargs["knowledge_id"] == 999
+
+
+class TestCreateKbContextsForSubtaskFunction:
+    """Test cases for create_kb_contexts_for_subtask convenience function."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        db = MagicMock()
+        db.add_all = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+        return db
+
+    @patch("app.services.openapi.kb_context.KnowledgeBaseNameResolver")
+    @patch("app.services.openapi.kb_context.SubtaskContext")
+    def test_convenience_function(
+        self, mock_context_class, mock_resolver_class, mock_db
+    ):
+        """Test the convenience function works correctly."""
+        # Arrange
+        mock_resolver = MagicMock()
+        mock_resolver_class.return_value = mock_resolver
+
+        resolved_kb = ResolvedKnowledgeBase(
+            kb_id=123, namespace="default", name="test_kb", display_name="Test KB"
+        )
+        mock_resolution_result = MagicMock()
+        mock_resolution_result.resolved = [resolved_kb]
+        mock_resolution_result.not_found = []
+        mock_resolution_result.no_access = []
+        mock_resolver.resolve.return_value = mock_resolution_result
+
+        mock_context = MagicMock()
+        mock_context_class.return_value = mock_context
+
+        kb_names = [{"namespace": "default", "name": "test_kb"}]
+
+        # Act
+        contexts = create_kb_contexts_for_subtask(mock_db, 1, 456, kb_names)
+
+        # Assert
+        assert len(contexts) == 1
+
+    @patch("app.services.openapi.kb_context.KnowledgeBaseNameResolver")
+    def test_convenience_function_empty_list(self, mock_resolver_class, mock_db):
+        """Test the convenience function with empty list."""
+        # Act
+        contexts = create_kb_contexts_for_subtask(mock_db, 1, 456, [])
+
+        # Assert
+        assert len(contexts) == 0
+
+
+class TestKnowledgeBaseContextCreatorErrorHandling:
+    """Test error handling in KnowledgeBaseContextCreator."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        db = MagicMock()
+        db.add_all = MagicMock()
+        db.commit = MagicMock()
+        db.refresh = MagicMock()
+        return db
+
+    @pytest.fixture
+    def mock_resolver(self):
+        """Create a mock KnowledgeBaseNameResolver."""
+        with patch(
+            "app.services.openapi.kb_context.KnowledgeBaseNameResolver"
+        ) as mock_resolver_class:
+            mock_resolver = MagicMock()
+            mock_resolver_class.return_value = mock_resolver
+            yield mock_resolver
+
+    def test_resolver_raises_exception(self, mock_db, mock_resolver):
+        """Test handling when resolver raises an exception."""
+        # Arrange
+        from fastapi import HTTPException
+
+        mock_resolver.resolve.side_effect = HTTPException(
+            status_code=404, detail="Knowledge base not found"
+        )
+
+        creator = KnowledgeBaseContextCreator(mock_db, user_id=1)
+        kb_names = [{"namespace": "default", "name": "nonexistent"}]
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            creator.create_contexts(subtask_id=456, kb_names=kb_names)
+
+        assert exc_info.value.status_code == 404

--- a/backend/tests/services/openapi/test_kb_context.py
+++ b/backend/tests/services/openapi/test_kb_context.py
@@ -12,7 +12,6 @@ import pytest
 
 from app.services.openapi.kb_context import (
     KnowledgeBaseContextCreator,
-    create_kb_contexts_for_subtask,
 )
 from app.services.openapi.kb_resolver import ResolvedKnowledgeBase
 
@@ -155,59 +154,8 @@ class TestKnowledgeBaseContextCreator:
         assert call_kwargs["subtask_id"] == 100
         assert call_kwargs["user_id"] == 1
         assert call_kwargs["name"] == "Test KB"
-        assert call_kwargs["knowledge_id"] == 999
-
-
-class TestCreateKbContextsForSubtaskFunction:
-    """Test cases for create_kb_contexts_for_subtask convenience function."""
-
-    @pytest.fixture
-    def mock_db(self):
-        """Create a mock database session."""
-        db = MagicMock()
-        db.add_all = MagicMock()
-        db.commit = MagicMock()
-        db.refresh = MagicMock()
-        return db
-
-    @patch("app.services.openapi.kb_context.KnowledgeBaseNameResolver")
-    @patch("app.services.openapi.kb_context.SubtaskContext")
-    def test_convenience_function(
-        self, mock_context_class, mock_resolver_class, mock_db
-    ):
-        """Test the convenience function works correctly."""
-        # Arrange
-        mock_resolver = MagicMock()
-        mock_resolver_class.return_value = mock_resolver
-
-        resolved_kb = ResolvedKnowledgeBase(
-            kb_id=123, namespace="default", name="test_kb", display_name="Test KB"
-        )
-        mock_resolution_result = MagicMock()
-        mock_resolution_result.resolved = [resolved_kb]
-        mock_resolution_result.not_found = []
-        mock_resolution_result.no_access = []
-        mock_resolver.resolve.return_value = mock_resolution_result
-
-        mock_context = MagicMock()
-        mock_context_class.return_value = mock_context
-
-        kb_names = [{"namespace": "default", "name": "test_kb"}]
-
-        # Act
-        contexts = create_kb_contexts_for_subtask(mock_db, 1, 456, kb_names)
-
-        # Assert
-        assert len(contexts) == 1
-
-    @patch("app.services.openapi.kb_context.KnowledgeBaseNameResolver")
-    def test_convenience_function_empty_list(self, mock_resolver_class, mock_db):
-        """Test the convenience function with empty list."""
-        # Act
-        contexts = create_kb_contexts_for_subtask(mock_db, 1, 456, [])
-
-        # Assert
-        assert len(contexts) == 0
+        assert "knowledge_id" not in call_kwargs
+        assert call_kwargs["type_data"]["knowledge_id"] == 999
 
 
 class TestKnowledgeBaseContextCreatorErrorHandling:

--- a/backend/tests/services/openapi/test_kb_resolver.py
+++ b/backend/tests/services/openapi/test_kb_resolver.py
@@ -28,176 +28,189 @@ class TestKnowledgeBaseNameResolver:
         return MagicMock()
 
     @pytest.fixture
-    def mock_kb_service(self):
-        """Create a mock TaskKnowledgeBaseService."""
+    def resolver(self, mock_db):
+        """Create a KnowledgeBaseNameResolver instance."""
         with patch(
             "app.services.openapi.kb_resolver.TaskKnowledgeBaseService"
         ) as mock_service_class:
             mock_service = MagicMock()
             mock_service_class.return_value = mock_service
-            yield mock_service
+            yield KnowledgeBaseNameResolver(mock_db, user_id=1)
 
-    @pytest.fixture
-    def resolver(self, mock_db, mock_kb_service):
-        """Create a KnowledgeBaseNameResolver instance."""
-        return KnowledgeBaseNameResolver(mock_db, user_id=1)
+    def _create_mock_kb(self, kb_id, namespace, name, user_id=1):
+        """Helper to create a mock KB object."""
+        mock_kb = MagicMock()
+        mock_kb.id = kb_id
+        mock_kb.namespace = namespace
+        mock_kb.user_id = user_id
+        mock_kb.json = {"spec": {"name": name}}
+        return mock_kb
 
-    def test_resolve_single_kb_success(self, resolver, mock_kb_service):
+    def test_resolve_single_kb_success(self, resolver, mock_db):
         """Test resolving a single knowledge base successfully."""
-        # Arrange
-        mock_kb = MagicMock()
-        mock_kb.id = 123
-        mock_kb.namespace = "default"
-        mock_kb.json = {"spec": {"name": "my_kb"}}
-        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
-        mock_kb_service.can_access_knowledge_base.return_value = True
+        mock_kb = self._create_mock_kb(123, "default", "my_kb", user_id=1)
 
-        kb_names = [{"namespace": "default", "name": "my_kb"}]
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("default", "my_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = True
 
-        # Act
-        result = resolver.resolve(kb_names, raise_on_error=True)
+            kb_names = [{"namespace": "default", "name": "my_kb"}]
+            result = resolver.resolve(kb_names, raise_on_error=True)
 
-        # Assert
-        assert len(result.resolved) == 1
-        assert result.resolved[0].kb_id == 123
-        assert result.resolved[0].namespace == "default"
-        assert result.resolved[0].name == "my_kb"
-        assert result.resolved[0].display_name == "my_kb"
-        assert len(result.not_found) == 0
-        assert len(result.no_access) == 0
+            assert len(result.resolved) == 1
+            assert result.resolved[0].kb_id == 123
+            assert result.resolved[0].namespace == "default"
+            assert result.resolved[0].name == "my_kb"
+            assert len(result.not_found) == 0
+            assert len(result.no_access) == 0
 
-    def test_resolve_multiple_kbs_success(self, resolver, mock_kb_service):
+    def test_resolve_multiple_kbs_success(self, resolver, mock_db):
         """Test resolving multiple knowledge bases successfully."""
+        mock_kb1 = self._create_mock_kb(1, "default", "kb1", user_id=1)
+        mock_kb2 = self._create_mock_kb(2, "org", "kb2", user_id=999)
 
-        # Arrange
-        def mock_get_kb(db, name, namespace):
-            mock_kb = MagicMock()
-            mock_kb.id = 1 if name == "kb1" else 2
-            mock_kb.namespace = namespace
-            mock_kb.json = {"spec": {"name": name}}
-            return mock_kb
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {
+                ("default", "kb1"): mock_kb1,
+                ("org", "kb2"): mock_kb2,
+            }
+            resolver.kb_service._check_kb_access_permission.return_value = True
 
-        mock_kb_service.get_knowledge_base_by_name.side_effect = mock_get_kb
-        mock_kb_service.can_access_knowledge_base.return_value = True
+            kb_names = [
+                {"namespace": "default", "name": "kb1"},
+                {"namespace": "org", "name": "kb2"},
+            ]
+            result = resolver.resolve(kb_names, raise_on_error=True)
 
-        kb_names = [
-            {"namespace": "default", "name": "kb1"},
-            {"namespace": "org", "name": "kb2"},
-        ]
+            assert len(result.resolved) == 2
+            kb_ids = {r.kb_id for r in result.resolved}
+            assert kb_ids == {1, 2}
 
-        # Act
-        result = resolver.resolve(kb_names, raise_on_error=True)
-
-        # Assert
-        assert len(result.resolved) == 2
-        assert result.resolved[0].kb_id == 1
-        assert result.resolved[1].kb_id == 2
-        assert len(result.not_found) == 0
-        assert len(result.no_access) == 0
-
-    def test_resolve_kb_not_found(self, resolver, mock_kb_service):
+    def test_resolve_kb_not_found(self, resolver, mock_db):
         """Test resolving a KB that doesn't exist."""
-        # Arrange
-        mock_kb_service.get_knowledge_base_by_name.return_value = None
-        kb_names = [{"namespace": "default", "name": "nonexistent"}]
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {}
 
-        # Act & Assert
-        with pytest.raises(HTTPException) as exc_info:
-            resolver.resolve(kb_names, raise_on_error=True)
+            kb_names = [{"namespace": "default", "name": "nonexistent"}]
 
-        assert exc_info.value.status_code == 404
-        assert "not found" in exc_info.value.detail.lower()
+            with pytest.raises(HTTPException) as exc_info:
+                resolver.resolve(kb_names, raise_on_error=True)
 
-    def test_resolve_kb_no_access(self, resolver, mock_kb_service):
+            assert exc_info.value.status_code == 404
+
+    def test_resolve_kb_no_access(self, resolver, mock_db):
         """Test resolving a KB without access permission."""
-        # Arrange
-        mock_kb = MagicMock()
-        mock_kb.id = 123
-        mock_kb.namespace = "default"
-        mock_kb.json = {"spec": {"name": "private_kb"}}
-        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
-        mock_kb_service.can_access_knowledge_base.return_value = False
+        mock_kb = self._create_mock_kb(123, "default", "private_kb", user_id=999)
 
-        kb_names = [{"namespace": "default", "name": "private_kb"}]
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("default", "private_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = False
 
-        # Act & Assert
-        with pytest.raises(HTTPException) as exc_info:
-            resolver.resolve(kb_names, raise_on_error=True)
+            kb_names = [{"namespace": "default", "name": "private_kb"}]
 
-        assert exc_info.value.status_code == 403
-        assert "access denied" in exc_info.value.detail.lower()
+            with pytest.raises(HTTPException) as exc_info:
+                resolver.resolve(kb_names, raise_on_error=True)
 
-    def test_resolve_partial_failure_no_raise(self, resolver, mock_kb_service):
+            assert exc_info.value.status_code == 403
+
+    def test_resolve_partial_failure_no_raise(self, resolver, mock_db):
         """Test partial failure with raise_on_error=False."""
-        # Arrange
-        mock_kb = MagicMock()
-        mock_kb.id = 123
-        mock_kb.namespace = "default"
-        mock_kb.json = {"spec": {"name": "existing_kb"}}
+        mock_kb = self._create_mock_kb(123, "default", "existing_kb", user_id=1)
 
-        def mock_get_kb(db, name, namespace):
-            if name == "existing_kb":
-                return mock_kb
-            return None
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("default", "existing_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = True
 
-        mock_kb_service.get_knowledge_base_by_name.side_effect = mock_get_kb
-        mock_kb_service.can_access_knowledge_base.return_value = True
+            kb_names = [
+                {"namespace": "default", "name": "existing_kb"},
+                {"namespace": "default", "name": "nonexistent"},
+            ]
+            result = resolver.resolve(kb_names, raise_on_error=False)
 
-        kb_names = [
-            {"namespace": "default", "name": "existing_kb"},
-            {"namespace": "default", "name": "nonexistent"},
-        ]
+            assert len(result.resolved) == 1
+            assert len(result.not_found) == 1
 
-        # Act
-        result = resolver.resolve(kb_names, raise_on_error=False)
-
-        # Assert
-        assert len(result.resolved) == 1
-        assert len(result.not_found) == 1
-        assert result.resolved[0].name == "existing_kb"
-        assert result.not_found[0]["name"] == "nonexistent"
-
-    def test_resolve_empty_name(self, resolver, mock_kb_service):
+    def test_resolve_empty_name(self, resolver, mock_db):
         """Test resolving with empty name."""
-        # Arrange
         kb_names = [{"namespace": "default", "name": ""}]
-
-        # Act
         result = resolver.resolve(kb_names, raise_on_error=False)
 
-        # Assert
         assert len(result.resolved) == 0
         assert len(result.not_found) == 1
 
-    def test_resolve_single_method(self, resolver, mock_kb_service):
+    def test_resolve_single_method(self, resolver, mock_db):
         """Test resolve_single convenience method."""
-        # Arrange
-        mock_kb = MagicMock()
-        mock_kb.id = 456
-        mock_kb.namespace = "org"
-        mock_kb.json = {"spec": {"name": "team_kb"}}
-        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
-        mock_kb_service.can_access_knowledge_base.return_value = True
+        mock_kb = self._create_mock_kb(456, "org", "team_kb", user_id=999)
 
-        # Act
-        result = resolver.resolve_single("org", "team_kb")
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("org", "team_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = True
 
-        # Assert
-        assert result is not None
-        assert result.kb_id == 456
-        assert result.namespace == "org"
-        assert result.name == "team_kb"
+            result = resolver.resolve_single("org", "team_kb")
 
-    def test_resolve_single_not_found(self, resolver, mock_kb_service):
+            assert result is not None
+            assert result.kb_id == 456
+
+    def test_resolve_single_not_found(self, resolver, mock_db):
         """Test resolve_single with non-existent KB."""
-        # Arrange
-        mock_kb_service.get_knowledge_base_by_name.return_value = None
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {}
 
-        # Act & Assert
-        with pytest.raises(HTTPException) as exc_info:
-            resolver.resolve_single("default", "nonexistent")
+            with pytest.raises(HTTPException) as exc_info:
+                resolver.resolve_single("default", "nonexistent")
 
-        assert exc_info.value.status_code == 404
+            assert exc_info.value.status_code == 404
+
+    def test_resolve_organization_kb_access(self, resolver, mock_db):
+        """Test resolving organization KB - all users have access."""
+        mock_kb = self._create_mock_kb(100, "org-namespace", "org_kb", user_id=999)
+
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("org-namespace", "org_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = True
+
+            kb_names = [{"namespace": "org-namespace", "name": "org_kb"}]
+            result = resolver.resolve(kb_names, raise_on_error=True)
+
+            assert len(result.resolved) == 1
+            assert result.resolved[0].kb_id == 100
+
+    def test_resolve_team_kb_with_group_membership(self, resolver, mock_db):
+        """Test resolving team KB with group membership."""
+        mock_kb = self._create_mock_kb(200, "team-ns", "team_kb", user_id=999)
+
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("team-ns", "team_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = True
+
+            kb_names = [{"namespace": "team-ns", "name": "team_kb"}]
+            result = resolver.resolve(kb_names, raise_on_error=True)
+
+            assert len(result.resolved) == 1
+            assert result.resolved[0].kb_id == 200
+
+    def test_resolve_team_kb_no_group_membership(self, resolver, mock_db):
+        """Test resolving team KB without group membership."""
+        mock_kb = self._create_mock_kb(200, "team-ns", "team_kb", user_id=999)
+
+        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
+            mock_batch_query.return_value = {("team-ns", "team_kb"): mock_kb}
+            resolver.kb_service._check_kb_access_permission.return_value = False
+
+            kb_names = [{"namespace": "team-ns", "name": "team_kb"}]
+
+            with pytest.raises(HTTPException) as exc_info:
+                resolver.resolve(kb_names, raise_on_error=True)
+
+            assert exc_info.value.status_code == 403
+
+    def test_resolve_empty_list(self, resolver, mock_db):
+        """Test resolving empty list of KB names."""
+        result = resolver.resolve([], raise_on_error=True)
+
+        assert len(result.resolved) == 0
+        assert len(result.not_found) == 0
+        assert len(result.no_access) == 0
 
 
 class TestResolveKnowledgeBaseNamesFunction:
@@ -208,28 +221,28 @@ class TestResolveKnowledgeBaseNamesFunction:
         """Create a mock database session."""
         return MagicMock()
 
-    @patch("app.services.openapi.kb_resolver.TaskKnowledgeBaseService")
-    def test_convenience_function(self, mock_service_class, mock_db):
+    def test_convenience_function(self, mock_db):
         """Test the convenience function works correctly."""
-        # Arrange
-        mock_service = MagicMock()
-        mock_service_class.return_value = mock_service
-
         mock_kb = MagicMock()
         mock_kb.id = 789
         mock_kb.namespace = "default"
+        mock_kb.user_id = 1
         mock_kb.json = {"spec": {"name": "test_kb"}}
-        mock_service.get_knowledge_base_by_name.return_value = mock_kb
-        mock_service.can_access_knowledge_base.return_value = True
 
-        kb_names = [{"namespace": "default", "name": "test_kb"}]
+        with patch("app.services.openapi.kb_resolver.TaskKnowledgeBaseService"):
+            with patch.object(
+                KnowledgeBaseNameResolver, "_batch_query_kbs"
+            ) as mock_batch_query:
+                mock_batch_query.return_value = {("default", "test_kb"): mock_kb}
 
-        # Act
-        result = resolve_knowledge_base_names(mock_db, 1, kb_names)
+                resolver = KnowledgeBaseNameResolver(mock_db, 1)
+                resolver.kb_service._check_kb_access_permission.return_value = True
 
-        # Assert
-        assert len(result.resolved) == 1
-        assert result.resolved[0].kb_id == 789
+                kb_names = [{"namespace": "default", "name": "test_kb"}]
+                result = resolve_knowledge_base_names(mock_db, 1, kb_names)
+
+                assert len(result.resolved) == 1
+                assert result.resolved[0].kb_id == 789
 
 
 class TestResolvedKnowledgeBase:
@@ -237,12 +250,10 @@ class TestResolvedKnowledgeBase:
 
     def test_named_tuple_fields(self):
         """Test ResolvedKnowledgeBase has correct fields."""
-        # Act
         resolved = ResolvedKnowledgeBase(
             kb_id=1, namespace="default", name="test", display_name="Test KB"
         )
 
-        # Assert
         assert resolved.kb_id == 1
         assert resolved.namespace == "default"
         assert resolved.name == "test"
@@ -254,17 +265,14 @@ class TestKnowledgeBaseResolutionResult:
 
     def test_named_tuple_fields(self):
         """Test KnowledgeBaseResolutionResult has correct fields."""
-        # Arrange
         resolved = [ResolvedKnowledgeBase(1, "default", "kb1", "KB1")]
         not_found = [{"namespace": "default", "name": "missing"}]
         no_access = [{"namespace": "org", "name": "private"}]
 
-        # Act
         result = KnowledgeBaseResolutionResult(
             resolved=resolved, not_found=not_found, no_access=no_access
         )
 
-        # Assert
         assert len(result.resolved) == 1
         assert len(result.not_found) == 1
         assert len(result.no_access) == 1

--- a/backend/tests/services/openapi/test_kb_resolver.py
+++ b/backend/tests/services/openapi/test_kb_resolver.py
@@ -30,29 +30,38 @@ class TestKnowledgeBaseNameResolver:
     @pytest.fixture
     def resolver(self, mock_db):
         """Create a KnowledgeBaseNameResolver instance."""
-        with patch(
-            "app.services.openapi.kb_resolver.TaskKnowledgeBaseService"
-        ) as mock_service_class:
-            mock_service = MagicMock()
-            mock_service_class.return_value = mock_service
-            yield KnowledgeBaseNameResolver(mock_db, user_id=1)
+        return KnowledgeBaseNameResolver(mock_db, user_id=1)
 
-    def _create_mock_kb(self, kb_id, namespace, name, user_id=1):
-        """Helper to create a mock KB object."""
+    def _create_mock_accessible_kb(self, kb_id, namespace, name):
+        """Helper to create a mock accessible KB for _get_accessible_kb_lookup."""
         mock_kb = MagicMock()
         mock_kb.id = kb_id
         mock_kb.namespace = namespace
-        mock_kb.user_id = user_id
-        mock_kb.json = {"spec": {"name": name}}
+        mock_kb.name = name
         return mock_kb
+
+    def _create_mock_grouped_response(
+        self, created_by_me=None, shared_with_me=None, groups=None, org_kbs=None
+    ):
+        """Helper to create a mock AllGroupedKnowledgeResponse."""
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = created_by_me or []
+        mock_response.personal.shared_with_me = shared_with_me or []
+        mock_response.groups = groups or []
+        mock_response.organization.knowledge_bases = org_kbs or []
+        return mock_response
 
     def test_resolve_single_kb_success(self, resolver, mock_db):
         """Test resolving a single knowledge base successfully."""
-        mock_kb = self._create_mock_kb(123, "default", "my_kb", user_id=1)
+        accessible_kb = self._create_mock_accessible_kb(123, "default", "my_kb")
+        grouped_response = self._create_mock_grouped_response(
+            created_by_me=[accessible_kb]
+        )
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("default", "my_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "default", "name": "my_kb"}]
             result = resolver.resolve(kb_names, raise_on_error=True)
@@ -66,15 +75,16 @@ class TestKnowledgeBaseNameResolver:
 
     def test_resolve_multiple_kbs_success(self, resolver, mock_db):
         """Test resolving multiple knowledge bases successfully."""
-        mock_kb1 = self._create_mock_kb(1, "default", "kb1", user_id=1)
-        mock_kb2 = self._create_mock_kb(2, "org", "kb2", user_id=999)
+        accessible_kb1 = self._create_mock_accessible_kb(1, "default", "kb1")
+        accessible_kb2 = self._create_mock_accessible_kb(2, "org", "kb2")
+        grouped_response = self._create_mock_grouped_response(
+            created_by_me=[accessible_kb1], org_kbs=[accessible_kb2]
+        )
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {
-                ("default", "kb1"): mock_kb1,
-                ("org", "kb2"): mock_kb2,
-            }
-            resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [
                 {"namespace": "default", "name": "kb1"},
@@ -88,23 +98,29 @@ class TestKnowledgeBaseNameResolver:
 
     def test_resolve_kb_not_found(self, resolver, mock_db):
         """Test resolving a KB that doesn't exist."""
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {}
+        grouped_response = self._create_mock_grouped_response()
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "default", "name": "nonexistent"}]
 
             with pytest.raises(HTTPException) as exc_info:
                 resolver.resolve(kb_names, raise_on_error=True)
 
-            assert exc_info.value.status_code == 404
+            assert exc_info.value.status_code == 403
 
     def test_resolve_kb_no_access(self, resolver, mock_db):
         """Test resolving a KB without access permission."""
-        mock_kb = self._create_mock_kb(123, "default", "private_kb", user_id=999)
+        # KB exists in database but not in accessible list
+        grouped_response = self._create_mock_grouped_response()
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("default", "private_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = False
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "default", "name": "private_kb"}]
 
@@ -115,11 +131,15 @@ class TestKnowledgeBaseNameResolver:
 
     def test_resolve_partial_failure_no_raise(self, resolver, mock_db):
         """Test partial failure with raise_on_error=False."""
-        mock_kb = self._create_mock_kb(123, "default", "existing_kb", user_id=1)
+        accessible_kb = self._create_mock_accessible_kb(123, "default", "existing_kb")
+        grouped_response = self._create_mock_grouped_response(
+            created_by_me=[accessible_kb]
+        )
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("default", "existing_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [
                 {"namespace": "default", "name": "existing_kb"},
@@ -128,46 +148,32 @@ class TestKnowledgeBaseNameResolver:
             result = resolver.resolve(kb_names, raise_on_error=False)
 
             assert len(result.resolved) == 1
-            assert len(result.not_found) == 1
+            assert len(result.no_access) == 1
 
     def test_resolve_empty_name(self, resolver, mock_db):
         """Test resolving with empty name."""
-        kb_names = [{"namespace": "default", "name": ""}]
-        result = resolver.resolve(kb_names, raise_on_error=False)
+        grouped_response = self._create_mock_grouped_response()
 
-        assert len(result.resolved) == 0
-        assert len(result.not_found) == 1
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
-    def test_resolve_single_method(self, resolver, mock_db):
-        """Test resolve_single convenience method."""
-        mock_kb = self._create_mock_kb(456, "org", "team_kb", user_id=999)
+            kb_names = [{"namespace": "default", "name": ""}]
+            result = resolver.resolve(kb_names, raise_on_error=False)
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("org", "team_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = True
-
-            result = resolver.resolve_single("org", "team_kb")
-
-            assert result is not None
-            assert result.kb_id == 456
-
-    def test_resolve_single_not_found(self, resolver, mock_db):
-        """Test resolve_single with non-existent KB."""
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {}
-
-            with pytest.raises(HTTPException) as exc_info:
-                resolver.resolve_single("default", "nonexistent")
-
-            assert exc_info.value.status_code == 404
+            assert len(result.resolved) == 0
+            assert len(result.not_found) == 1
 
     def test_resolve_organization_kb_access(self, resolver, mock_db):
         """Test resolving organization KB - all users have access."""
-        mock_kb = self._create_mock_kb(100, "org-namespace", "org_kb", user_id=999)
+        accessible_kb = self._create_mock_accessible_kb(100, "org-namespace", "org_kb")
+        grouped_response = self._create_mock_grouped_response(org_kbs=[accessible_kb])
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("org-namespace", "org_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "org-namespace", "name": "org_kb"}]
             result = resolver.resolve(kb_names, raise_on_error=True)
@@ -177,11 +183,15 @@ class TestKnowledgeBaseNameResolver:
 
     def test_resolve_team_kb_with_group_membership(self, resolver, mock_db):
         """Test resolving team KB with group membership."""
-        mock_kb = self._create_mock_kb(200, "team-ns", "team_kb", user_id=999)
+        accessible_kb = self._create_mock_accessible_kb(200, "team-ns", "team_kb")
+        mock_group = MagicMock()
+        mock_group.knowledge_bases = [accessible_kb]
+        grouped_response = self._create_mock_grouped_response(groups=[mock_group])
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("team-ns", "team_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "team-ns", "name": "team_kb"}]
             result = resolver.resolve(kb_names, raise_on_error=True)
@@ -191,11 +201,13 @@ class TestKnowledgeBaseNameResolver:
 
     def test_resolve_team_kb_no_group_membership(self, resolver, mock_db):
         """Test resolving team KB without group membership."""
-        mock_kb = self._create_mock_kb(200, "team-ns", "team_kb", user_id=999)
+        # KB not in accessible list (user not in group)
+        grouped_response = self._create_mock_grouped_response()
 
-        with patch.object(resolver, "_batch_query_kbs") as mock_batch_query:
-            mock_batch_query.return_value = {("team-ns", "team_kb"): mock_kb}
-            resolver.kb_service._check_kb_access_permission.return_value = False
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = grouped_response
 
             kb_names = [{"namespace": "team-ns", "name": "team_kb"}]
 
@@ -213,6 +225,156 @@ class TestKnowledgeBaseNameResolver:
         assert len(result.no_access) == 0
 
 
+class TestGetAccessibleKbLookup:
+    """Test cases for _get_accessible_kb_lookup method."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return MagicMock()
+
+    @pytest.fixture
+    def resolver(self, mock_db):
+        """Create a KnowledgeBaseNameResolver instance."""
+        return KnowledgeBaseNameResolver(mock_db, user_id=1)
+
+    def test_get_accessible_kb_lookup_personal(self, resolver, mock_db):
+        """Test _get_accessible_kb_lookup includes personal KBs."""
+        mock_kb = MagicMock()
+        mock_kb.id = 1
+        mock_kb.namespace = "default"
+        mock_kb.name = "my_kb"
+
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = [mock_kb]
+        mock_response.personal.shared_with_me = []
+        mock_response.groups = []
+        mock_response.organization.knowledge_bases = []
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
+
+            lookup = resolver._get_accessible_kb_lookup()
+
+            assert lookup == {("default", "my_kb"): 1}
+
+    def test_get_accessible_kb_lookup_shared(self, resolver, mock_db):
+        """Test _get_accessible_kb_lookup includes shared KBs."""
+        mock_kb = MagicMock()
+        mock_kb.id = 2
+        mock_kb.namespace = "default"
+        mock_kb.name = "shared_kb"
+
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = []
+        mock_response.personal.shared_with_me = [mock_kb]
+        mock_response.groups = []
+        mock_response.organization.knowledge_bases = []
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
+
+            lookup = resolver._get_accessible_kb_lookup()
+
+            assert lookup == {("default", "shared_kb"): 2}
+
+    def test_get_accessible_kb_lookup_group(self, resolver, mock_db):
+        """Test _get_accessible_kb_lookup includes group KBs."""
+        mock_kb = MagicMock()
+        mock_kb.id = 3
+        mock_kb.namespace = "team-ns"
+        mock_kb.name = "team_kb"
+
+        mock_group = MagicMock()
+        mock_group.knowledge_bases = [mock_kb]
+
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = []
+        mock_response.personal.shared_with_me = []
+        mock_response.groups = [mock_group]
+        mock_response.organization.knowledge_bases = []
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
+
+            lookup = resolver._get_accessible_kb_lookup()
+
+            assert lookup == {("team-ns", "team_kb"): 3}
+
+    def test_get_accessible_kb_lookup_organization(self, resolver, mock_db):
+        """Test _get_accessible_kb_lookup includes organization KBs."""
+        mock_kb = MagicMock()
+        mock_kb.id = 4
+        mock_kb.namespace = "org-ns"
+        mock_kb.name = "org_kb"
+
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = []
+        mock_response.personal.shared_with_me = []
+        mock_response.groups = []
+        mock_response.organization.knowledge_bases = [mock_kb]
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
+
+            lookup = resolver._get_accessible_kb_lookup()
+
+            assert lookup == {("org-ns", "org_kb"): 4}
+
+    def test_get_accessible_kb_lookup_combined(self, resolver, mock_db):
+        """Test _get_accessible_kb_lookup combines all sources."""
+        personal_kb = MagicMock()
+        personal_kb.id = 1
+        personal_kb.namespace = "default"
+        personal_kb.name = "personal_kb"
+
+        shared_kb = MagicMock()
+        shared_kb.id = 2
+        shared_kb.namespace = "default"
+        shared_kb.name = "shared_kb"
+
+        group_kb = MagicMock()
+        group_kb.id = 3
+        group_kb.namespace = "team-ns"
+        group_kb.name = "group_kb"
+
+        org_kb = MagicMock()
+        org_kb.id = 4
+        org_kb.namespace = "org-ns"
+        org_kb.name = "org_kb"
+
+        mock_group = MagicMock()
+        mock_group.knowledge_bases = [group_kb]
+
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = [personal_kb]
+        mock_response.personal.shared_with_me = [shared_kb]
+        mock_response.groups = [mock_group]
+        mock_response.organization.knowledge_bases = [org_kb]
+
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
+
+            lookup = resolver._get_accessible_kb_lookup()
+
+            assert lookup == {
+                ("default", "personal_kb"): 1,
+                ("default", "shared_kb"): 2,
+                ("team-ns", "group_kb"): 3,
+                ("org-ns", "org_kb"): 4,
+            }
+
+
 class TestResolveKnowledgeBaseNamesFunction:
     """Test cases for resolve_knowledge_base_names convenience function."""
 
@@ -223,26 +385,27 @@ class TestResolveKnowledgeBaseNamesFunction:
 
     def test_convenience_function(self, mock_db):
         """Test the convenience function works correctly."""
-        mock_kb = MagicMock()
-        mock_kb.id = 789
-        mock_kb.namespace = "default"
-        mock_kb.user_id = 1
-        mock_kb.json = {"spec": {"name": "test_kb"}}
+        accessible_kb = MagicMock()
+        accessible_kb.id = 789
+        accessible_kb.namespace = "default"
+        accessible_kb.name = "test_kb"
 
-        with patch("app.services.openapi.kb_resolver.TaskKnowledgeBaseService"):
-            with patch.object(
-                KnowledgeBaseNameResolver, "_batch_query_kbs"
-            ) as mock_batch_query:
-                mock_batch_query.return_value = {("default", "test_kb"): mock_kb}
+        mock_response = MagicMock()
+        mock_response.personal.created_by_me = [accessible_kb]
+        mock_response.personal.shared_with_me = []
+        mock_response.groups = []
+        mock_response.organization.knowledge_bases = []
 
-                resolver = KnowledgeBaseNameResolver(mock_db, 1)
-                resolver.kb_service._check_kb_access_permission.return_value = True
+        with patch(
+            "app.services.openapi.kb_resolver.KnowledgeService.get_all_knowledge_bases_grouped"
+        ) as mock_get_grouped:
+            mock_get_grouped.return_value = mock_response
 
-                kb_names = [{"namespace": "default", "name": "test_kb"}]
-                result = resolve_knowledge_base_names(mock_db, 1, kb_names)
+            kb_names = [{"namespace": "default", "name": "test_kb"}]
+            result = resolve_knowledge_base_names(mock_db, 1, kb_names)
 
-                assert len(result.resolved) == 1
-                assert result.resolved[0].kb_id == 789
+            assert len(result.resolved) == 1
+            assert result.resolved[0].kb_id == 789
 
 
 class TestResolvedKnowledgeBase:

--- a/backend/tests/services/openapi/test_kb_resolver.py
+++ b/backend/tests/services/openapi/test_kb_resolver.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for KnowledgeBaseNameResolver.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.openapi.kb_resolver import (
+    KnowledgeBaseNameResolver,
+    KnowledgeBaseResolutionResult,
+    ResolvedKnowledgeBase,
+    resolve_knowledge_base_names,
+)
+
+
+class TestKnowledgeBaseNameResolver:
+    """Test cases for KnowledgeBaseNameResolver."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_kb_service(self):
+        """Create a mock TaskKnowledgeBaseService."""
+        with patch(
+            "app.services.openapi.kb_resolver.TaskKnowledgeBaseService"
+        ) as mock_service_class:
+            mock_service = MagicMock()
+            mock_service_class.return_value = mock_service
+            yield mock_service
+
+    @pytest.fixture
+    def resolver(self, mock_db, mock_kb_service):
+        """Create a KnowledgeBaseNameResolver instance."""
+        return KnowledgeBaseNameResolver(mock_db, user_id=1)
+
+    def test_resolve_single_kb_success(self, resolver, mock_kb_service):
+        """Test resolving a single knowledge base successfully."""
+        # Arrange
+        mock_kb = MagicMock()
+        mock_kb.id = 123
+        mock_kb.namespace = "default"
+        mock_kb.json = {"spec": {"name": "my_kb"}}
+        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
+        mock_kb_service.can_access_knowledge_base.return_value = True
+
+        kb_names = [{"namespace": "default", "name": "my_kb"}]
+
+        # Act
+        result = resolver.resolve(kb_names, raise_on_error=True)
+
+        # Assert
+        assert len(result.resolved) == 1
+        assert result.resolved[0].kb_id == 123
+        assert result.resolved[0].namespace == "default"
+        assert result.resolved[0].name == "my_kb"
+        assert result.resolved[0].display_name == "my_kb"
+        assert len(result.not_found) == 0
+        assert len(result.no_access) == 0
+
+    def test_resolve_multiple_kbs_success(self, resolver, mock_kb_service):
+        """Test resolving multiple knowledge bases successfully."""
+
+        # Arrange
+        def mock_get_kb(db, name, namespace):
+            mock_kb = MagicMock()
+            mock_kb.id = 1 if name == "kb1" else 2
+            mock_kb.namespace = namespace
+            mock_kb.json = {"spec": {"name": name}}
+            return mock_kb
+
+        mock_kb_service.get_knowledge_base_by_name.side_effect = mock_get_kb
+        mock_kb_service.can_access_knowledge_base.return_value = True
+
+        kb_names = [
+            {"namespace": "default", "name": "kb1"},
+            {"namespace": "org", "name": "kb2"},
+        ]
+
+        # Act
+        result = resolver.resolve(kb_names, raise_on_error=True)
+
+        # Assert
+        assert len(result.resolved) == 2
+        assert result.resolved[0].kb_id == 1
+        assert result.resolved[1].kb_id == 2
+        assert len(result.not_found) == 0
+        assert len(result.no_access) == 0
+
+    def test_resolve_kb_not_found(self, resolver, mock_kb_service):
+        """Test resolving a KB that doesn't exist."""
+        # Arrange
+        mock_kb_service.get_knowledge_base_by_name.return_value = None
+        kb_names = [{"namespace": "default", "name": "nonexistent"}]
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            resolver.resolve(kb_names, raise_on_error=True)
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in exc_info.value.detail.lower()
+
+    def test_resolve_kb_no_access(self, resolver, mock_kb_service):
+        """Test resolving a KB without access permission."""
+        # Arrange
+        mock_kb = MagicMock()
+        mock_kb.id = 123
+        mock_kb.namespace = "default"
+        mock_kb.json = {"spec": {"name": "private_kb"}}
+        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
+        mock_kb_service.can_access_knowledge_base.return_value = False
+
+        kb_names = [{"namespace": "default", "name": "private_kb"}]
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            resolver.resolve(kb_names, raise_on_error=True)
+
+        assert exc_info.value.status_code == 403
+        assert "access denied" in exc_info.value.detail.lower()
+
+    def test_resolve_partial_failure_no_raise(self, resolver, mock_kb_service):
+        """Test partial failure with raise_on_error=False."""
+        # Arrange
+        mock_kb = MagicMock()
+        mock_kb.id = 123
+        mock_kb.namespace = "default"
+        mock_kb.json = {"spec": {"name": "existing_kb"}}
+
+        def mock_get_kb(db, name, namespace):
+            if name == "existing_kb":
+                return mock_kb
+            return None
+
+        mock_kb_service.get_knowledge_base_by_name.side_effect = mock_get_kb
+        mock_kb_service.can_access_knowledge_base.return_value = True
+
+        kb_names = [
+            {"namespace": "default", "name": "existing_kb"},
+            {"namespace": "default", "name": "nonexistent"},
+        ]
+
+        # Act
+        result = resolver.resolve(kb_names, raise_on_error=False)
+
+        # Assert
+        assert len(result.resolved) == 1
+        assert len(result.not_found) == 1
+        assert result.resolved[0].name == "existing_kb"
+        assert result.not_found[0]["name"] == "nonexistent"
+
+    def test_resolve_empty_name(self, resolver, mock_kb_service):
+        """Test resolving with empty name."""
+        # Arrange
+        kb_names = [{"namespace": "default", "name": ""}]
+
+        # Act
+        result = resolver.resolve(kb_names, raise_on_error=False)
+
+        # Assert
+        assert len(result.resolved) == 0
+        assert len(result.not_found) == 1
+
+    def test_resolve_single_method(self, resolver, mock_kb_service):
+        """Test resolve_single convenience method."""
+        # Arrange
+        mock_kb = MagicMock()
+        mock_kb.id = 456
+        mock_kb.namespace = "org"
+        mock_kb.json = {"spec": {"name": "team_kb"}}
+        mock_kb_service.get_knowledge_base_by_name.return_value = mock_kb
+        mock_kb_service.can_access_knowledge_base.return_value = True
+
+        # Act
+        result = resolver.resolve_single("org", "team_kb")
+
+        # Assert
+        assert result is not None
+        assert result.kb_id == 456
+        assert result.namespace == "org"
+        assert result.name == "team_kb"
+
+    def test_resolve_single_not_found(self, resolver, mock_kb_service):
+        """Test resolve_single with non-existent KB."""
+        # Arrange
+        mock_kb_service.get_knowledge_base_by_name.return_value = None
+
+        # Act & Assert
+        with pytest.raises(HTTPException) as exc_info:
+            resolver.resolve_single("default", "nonexistent")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestResolveKnowledgeBaseNamesFunction:
+    """Test cases for resolve_knowledge_base_names convenience function."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return MagicMock()
+
+    @patch("app.services.openapi.kb_resolver.TaskKnowledgeBaseService")
+    def test_convenience_function(self, mock_service_class, mock_db):
+        """Test the convenience function works correctly."""
+        # Arrange
+        mock_service = MagicMock()
+        mock_service_class.return_value = mock_service
+
+        mock_kb = MagicMock()
+        mock_kb.id = 789
+        mock_kb.namespace = "default"
+        mock_kb.json = {"spec": {"name": "test_kb"}}
+        mock_service.get_knowledge_base_by_name.return_value = mock_kb
+        mock_service.can_access_knowledge_base.return_value = True
+
+        kb_names = [{"namespace": "default", "name": "test_kb"}]
+
+        # Act
+        result = resolve_knowledge_base_names(mock_db, 1, kb_names)
+
+        # Assert
+        assert len(result.resolved) == 1
+        assert result.resolved[0].kb_id == 789
+
+
+class TestResolvedKnowledgeBase:
+    """Test cases for ResolvedKnowledgeBase named tuple."""
+
+    def test_named_tuple_fields(self):
+        """Test ResolvedKnowledgeBase has correct fields."""
+        # Act
+        resolved = ResolvedKnowledgeBase(
+            kb_id=1, namespace="default", name="test", display_name="Test KB"
+        )
+
+        # Assert
+        assert resolved.kb_id == 1
+        assert resolved.namespace == "default"
+        assert resolved.name == "test"
+        assert resolved.display_name == "Test KB"
+
+
+class TestKnowledgeBaseResolutionResult:
+    """Test cases for KnowledgeBaseResolutionResult named tuple."""
+
+    def test_named_tuple_fields(self):
+        """Test KnowledgeBaseResolutionResult has correct fields."""
+        # Arrange
+        resolved = [ResolvedKnowledgeBase(1, "default", "kb1", "KB1")]
+        not_found = [{"namespace": "default", "name": "missing"}]
+        no_access = [{"namespace": "org", "name": "private"}]
+
+        # Act
+        result = KnowledgeBaseResolutionResult(
+            resolved=resolved, not_found=not_found, no_access=no_access
+        )
+
+        # Assert
+        assert len(result.resolved) == 1
+        assert len(result.not_found) == 1
+        assert len(result.no_access) == 1


### PR DESCRIPTION
Implement knowledge base Q&A functionality for the OpenAI-compatible /v1/responses endpoint with the following changes:

Schema Changes:
- Add knowledge_base_names field to WegentTool schema
- Support namespace#name format for KB specification

New Services:
- KnowledgeBaseNameResolver: resolves KB display names to IDs with permission checking via TaskKnowledgeBaseService
- KnowledgeBaseContextCreator: creates SubtaskContext records for API-specified KBs to integrate with existing RAG pipeline

Integration:
- Extend parse_wegent_tools() to handle knowledge_base tool type
- Add parse_knowledge_base_name() for namespace#name parsing
- Modify build_execution_request() to accept knowledge_base_names
- Add _create_kb_contexts_from_api_request() for KB context injection
- Update openapi_responses.py endpoints to pass KB names parameter

Testing:
- Add comprehensive unit tests for KB name resolution
- Add tests for KB context creation
- Add tests for helper functions with KB support
- All 32 new tests passing

The implementation reuses the existing RAG flow through prepare_contexts_for_chat() and KnowledgeBaseTool, ensuring consistency with the web UI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge-base RAG support added to OpenAPI responses: requests can include named knowledge bases to augment answers.
  * Per-request knowledge-base selection with access checks ensures users only use KBs they can access.
  * KB context creation is applied when KBs are provided; failures in resolving KBs surface as clear errors while non-KB requests remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->