### PR TITLE
feat(admin): add created_at field to device monitor list

### DIFF
--- a/backend/app/api/endpoints/admin/device_monitor.py
+++ b/backend/app/api/endpoints/admin/device_monitor.py
@@ -83,6 +83,7 @@ class AdminDeviceInfo(BaseModel):
     executor_version: Optional[str] = Field(None, description="Executor version")
     slot_used: int = Field(0, description="Number of slots in use")
     slot_max: int = Field(0, description="Maximum slots")
+    created_at: Optional[str] = Field(None, description="Device creation timestamp")
 
 
 class AdminDeviceListResponse(BaseModel):
@@ -234,6 +235,11 @@ def _build_device_info(
         executor_version = None
         slot_used = 0
 
+    # Format created_at as ISO string
+    created_at_str = None
+    if kind.created_at:
+        created_at_str = kind.created_at.isoformat()
+
     return AdminDeviceInfo(
         id=kind.id,
         device_id=device_id,
@@ -247,6 +253,7 @@ def _build_device_info(
         executor_version=executor_version,
         slot_used=slot_used,
         slot_max=5,  # MAX_DEVICE_SLOTS default
+        created_at=created_at_str,
     )
 
 

--- a/frontend/src/apis/admin.ts
+++ b/frontend/src/apis/admin.ts
@@ -429,6 +429,7 @@ export interface AdminDeviceInfo {
   executor_version: string | null
   slot_used: number
   slot_max: number
+  created_at: string | null
 }
 
 export interface AdminDeviceListResponse {

--- a/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
+++ b/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
@@ -425,6 +425,12 @@ export function DeviceMonitorPanel() {
                             {t('admin:device_monitor.columns.ip')}: {device.client_ip}
                           </span>
                         )}
+                        {device.created_at && (
+                          <span>
+                            {t('admin:device_monitor.columns.created_at')}:{' '}
+                            {new Date(device.created_at).toLocaleString()}
+                          </span>
+                        )}
                       </div>
                     </div>
                     {/* Action Buttons */}

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -837,7 +837,8 @@
       "status": "Status",
       "user": "Owner",
       "version": "Version",
-      "ip": "IP Address"
+      "ip": "IP Address",
+      "created_at": "Created At"
     },
     "errors": {
       "load_failed": "Failed to load device list",

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -837,7 +837,8 @@
       "status": "状态",
       "user": "所属用户",
       "version": "版本",
-      "ip": "IP 地址"
+      "ip": "IP 地址",
+      "created_at": "创建时间"
     },
     "errors": {
       "load_failed": "加载设备列表失败",


### PR DESCRIPTION
- Add created_at field to AdminDeviceInfo schema in backend
- Add created_at to AdminDeviceInfo TypeScript interface
- Display creation time in device list UI
- Add i18n translations for created_at column (zh-CN and en)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device Monitor now displays device creation timestamps with localized labels in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->