### PR TITLE
feat(admin): add updated_at field to device monitor list

### DIFF
--- a/backend/app/api/endpoints/admin/device_monitor.py
+++ b/backend/app/api/endpoints/admin/device_monitor.py
@@ -84,6 +84,7 @@ class AdminDeviceInfo(BaseModel):
     slot_used: int = Field(0, description="Number of slots in use")
     slot_max: int = Field(0, description="Maximum slots")
     created_at: Optional[str] = Field(None, description="Device creation timestamp")
+    updated_at: Optional[str] = Field(None, description="Device last update timestamp")
 
 
 class AdminDeviceListResponse(BaseModel):
@@ -235,10 +236,14 @@ def _build_device_info(
         executor_version = None
         slot_used = 0
 
-    # Format created_at as ISO string
+    # Format created_at and updated_at as ISO strings
     created_at_str = None
     if kind.created_at:
         created_at_str = kind.created_at.isoformat()
+
+    updated_at_str = None
+    if kind.updated_at:
+        updated_at_str = kind.updated_at.isoformat()
 
     return AdminDeviceInfo(
         id=kind.id,
@@ -254,6 +259,7 @@ def _build_device_info(
         slot_used=slot_used,
         slot_max=5,  # MAX_DEVICE_SLOTS default
         created_at=created_at_str,
+        updated_at=updated_at_str,
     )
 
 

--- a/frontend/src/apis/admin.ts
+++ b/frontend/src/apis/admin.ts
@@ -430,6 +430,7 @@ export interface AdminDeviceInfo {
   slot_used: number
   slot_max: number
   created_at: string | null
+  updated_at: string | null
 }
 
 export interface AdminDeviceListResponse {

--- a/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
+++ b/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
@@ -431,6 +431,12 @@ export function DeviceMonitorPanel() {
                             {new Date(device.created_at).toLocaleString()}
                           </span>
                         )}
+                        {device.updated_at && (
+                          <span>
+                            {t('admin:device_monitor.columns.updated_at')}:{' '}
+                            {new Date(device.updated_at).toLocaleString()}
+                          </span>
+                        )}
                       </div>
                     </div>
                     {/* Action Buttons */}

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -838,7 +838,8 @@
       "user": "Owner",
       "version": "Version",
       "ip": "IP Address",
-      "created_at": "Created At"
+      "created_at": "Created At",
+      "updated_at": "Updated At"
     },
     "errors": {
       "load_failed": "Failed to load device list",

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -838,7 +838,8 @@
       "user": "所属用户",
       "version": "版本",
       "ip": "IP 地址",
-      "created_at": "创建时间"
+      "created_at": "创建时间",
+      "updated_at": "更新时间"
     },
     "errors": {
       "load_failed": "加载设备列表失败",


### PR DESCRIPTION
## Summary

Add device last update timestamp to admin device monitoring page device list.

## Changes

- **Backend** (`backend/app/api/endpoints/admin/device_monitor.py`):
  - Add `updated_at` field to `AdminDeviceInfo` schema
  - Update `_build_device_info()` function to include `updated_at` from database

- **Frontend Types** (`frontend/src/apis/admin.ts`):
  - Add `updated_at` to `AdminDeviceInfo` interface

- **Frontend UI** (`frontend/src/features/admin/components/DeviceMonitorPanel.tsx`):
  - Display `updated_at` timestamp in device list cards (alongside existing `created_at`)

- **i18n** (`frontend/src/i18n/locales/en/admin.json`, `zh-CN/admin.json`):
  - Add `updated_at` translations: "Updated At" (en) / "更新时间" (zh-CN)

## Test Plan

- [ ] Verify `updated_at` field is returned in API response
- [ ] Verify `updated_at` is displayed in device list cards
- [ ] Verify translations work correctly in both English and Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The device monitor panel now displays a "Last Updated" timestamp for each device, providing visibility into when devices were most recently modified alongside creation date information.
  * Localization support added for English and Simplified Chinese interface labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->