### PR TITLE
fix(chat_shell): prevent orphaned tool call IDs in group chat history

### DIFF
--- a/chat_shell/chat_shell/compression/compressor.py
+++ b/chat_shell/chat_shell/compression/compressor.py
@@ -26,6 +26,8 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
+from chat_shell.messages.utils import group_tool_call_messages
+
 from .config import (
     CompressionConfig,
     get_model_context_config,
@@ -596,21 +598,25 @@ class MessageCompressor:
             details["final_tokens"] = current_tokens
             return result, details
 
-        # Step 2: Remove middle messages progressively
+        # Step 2: Remove middle message groups progressively
         # Keep first 2 and last 3 conversation messages minimum
         min_first = 2
         min_last = 3
 
-        while current_tokens > target_tokens and len(truncated_messages) > (
+        groups = group_tool_call_messages(truncated_messages)
+        total_msg_count = sum(len(g) for g in groups)
+        while current_tokens > target_tokens and total_msg_count > (
             min_first + min_last
         ):
-            # Remove from middle
-            middle_idx = len(truncated_messages) // 2
-            removed_msg = truncated_messages.pop(middle_idx)
+            # Remove a complete group from the middle
+            middle_idx = len(groups) // 2
+            removed_group = groups.pop(middle_idx)
+            total_msg_count -= len(removed_group)
             details["actions"].append(
-                f"removed_middle_message: role={removed_msg.get('role')}"
+                f"removed_middle_group: roles={[m.get('role') for m in removed_group]}"
             )
 
+            truncated_messages = [msg for g in groups for msg in g]
             result = system_messages + truncated_messages
             current_tokens = self.token_counter.count_messages(result)
 
@@ -656,10 +662,14 @@ class MessageCompressor:
             current_tokens = self.token_counter.count_messages(result)
             details["actions"].append(f"system_truncation: {current_tokens} tokens")
 
-        # Step 5: Last resort - keep only essential messages
+        # Step 5: Last resort - keep only essential message groups
         if current_tokens > target_tokens and len(final_messages) > 2:
-            # Keep only first and last conversation message
-            essential_messages = [final_messages[0], final_messages[-1]]
+            # Keep only first and last conversation groups
+            groups = group_tool_call_messages(final_messages)
+            if len(groups) > 2:
+                essential_messages = groups[0] + groups[-1]
+            else:
+                essential_messages = final_messages
             result = system_messages + essential_messages
             current_tokens = self.token_counter.count_messages(result)
             details["actions"].append(f"essential_only: {current_tokens} tokens")

--- a/chat_shell/chat_shell/compression/strategies.py
+++ b/chat_shell/chat_shell/compression/strategies.py
@@ -25,6 +25,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
 
+from chat_shell.messages.utils import group_tool_call_messages
+
 from .config import CompressionConfig
 from .token_counter import TokenCounter
 
@@ -658,6 +660,28 @@ class HistoryTruncationStrategy(CompressionStrategy):
         first_to_keep = config.first_messages_to_keep
         last_to_keep = config.last_messages_to_keep
 
+        # Adjust boundaries to avoid splitting tool call groups.
+        # If the boundary falls on a tool response, extend forward/backward
+        # to keep the entire group together.
+        while (
+            first_to_keep < len(conversation_messages)
+            and conversation_messages[first_to_keep].get("role") == "tool"
+        ):
+            first_to_keep += 1
+
+        last_start = len(conversation_messages) - last_to_keep
+        if (
+            last_start > 0
+            and last_start < len(conversation_messages)
+            and conversation_messages[last_start].get("role") == "tool"
+        ):
+            while (
+                last_start > 0
+                and conversation_messages[last_start].get("role") == "tool"
+            ):
+                last_start -= 1
+            last_to_keep = len(conversation_messages) - last_start
+
         # If conversation is small enough, no truncation possible
         if len(conversation_messages) <= (first_to_keep + last_to_keep):
             return messages, {"messages_removed": 0}
@@ -685,6 +709,14 @@ class HistoryTruncationStrategy(CompressionStrategy):
             if tokens_removed >= tokens_to_reduce:
                 break
             tokens_removed += msg_tokens
+            messages_to_remove += 1
+
+        # Ensure removal doesn't leave orphaned tool responses at start of kept middle
+        while (
+            messages_to_remove < len(middle_messages)
+            and middle_messages[messages_to_remove].get("role") == "tool"
+        ):
+            tokens_removed += middle_message_tokens[messages_to_remove][1]
             messages_to_remove += 1
 
         # Keep remaining middle messages

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -22,6 +22,7 @@ import logging
 from typing import Any, Optional
 
 from chat_shell.core.config import settings
+from chat_shell.messages.utils import group_tool_call_messages as _group_messages
 from shared.prompts.constants import parse_prompt_blocks
 
 logger = logging.getLogger(__name__)
@@ -868,36 +869,6 @@ def _build_knowledge_base_text_prefix(context) -> str:
     kb_name = context.name or "Knowledge Base"
     kb_id = context.knowledge_id or "unknown"
     return f"[Knowledge Base: {kb_name} (ID: {kb_id})]\n{context.extracted_text}\n\n"
-
-
-def _group_messages(history: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
-    """Group messages into atomic units for safe truncation.
-
-    A tool-call group consists of an assistant message with ``tool_calls``
-    followed by its corresponding ``tool`` response messages.  Splitting
-    such a group would produce orphaned ``function_call_output`` items
-    (without matching ``function_call``) when converted to the OpenAI
-    Responses API format, causing API errors.
-
-    Returns a list of groups where each group is a list of message dicts
-    that must be kept or removed together.
-    """
-    groups: list[list[dict[str, Any]]] = []
-    i = 0
-    while i < len(history):
-        msg = history[i]
-        if msg.get("role") == "assistant" and msg.get("tool_calls"):
-            # Collect assistant + all following tool responses as one group
-            group = [msg]
-            i += 1
-            while i < len(history) and history[i].get("role") == "tool":
-                group.append(history[i])
-                i += 1
-            groups.append(group)
-        else:
-            groups.append([msg])
-            i += 1
-    return groups
 
 
 def _truncate_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -870,11 +870,46 @@ def _build_knowledge_base_text_prefix(context) -> str:
     return f"[Knowledge Base: {kb_name} (ID: {kb_id})]\n{context.extracted_text}\n\n"
 
 
+def _group_messages(history: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Group messages into atomic units for safe truncation.
+
+    A tool-call group consists of an assistant message with ``tool_calls``
+    followed by its corresponding ``tool`` response messages.  Splitting
+    such a group would produce orphaned ``function_call_output`` items
+    (without matching ``function_call``) when converted to the OpenAI
+    Responses API format, causing API errors.
+
+    Returns a list of groups where each group is a list of message dicts
+    that must be kept or removed together.
+    """
+    groups: list[list[dict[str, Any]]] = []
+    i = 0
+    while i < len(history):
+        msg = history[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            # Collect assistant + all following tool responses as one group
+            group = [msg]
+            i += 1
+            while i < len(history) and history[i].get("role") == "tool":
+                group.append(history[i])
+                i += 1
+            groups.append(group)
+        else:
+            groups.append([msg])
+            i += 1
+    return groups
+
+
 def _truncate_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Truncate chat history keeping first N and last M messages.
 
     This is used for group chat to reduce prompt length while retaining
     the start of the conversation and the most recent context.
+
+    Tool-call groups (assistant with ``tool_calls`` + tool responses) are
+    treated as atomic units so that truncation never splits a group.
+    The actual number of messages kept may slightly exceed ``first_n + last_n``
+    to preserve group integrity.
     """
 
     first_n = settings.GROUP_CHAT_HISTORY_FIRST_MESSAGES
@@ -887,6 +922,34 @@ def _truncate_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if len(history) <= first_n + last_n:
         return history
 
-    # Handle edge case: history[-0:] returns full list, not empty list
-    tail = history[-last_n:] if last_n > 0 else []
-    return [*history[:first_n], *tail]
+    groups = _group_messages(history)
+
+    # Determine which groups to keep from the head (first_n messages)
+    head_count = 0
+    head_groups = 0
+    for g in groups:
+        if head_count >= first_n:
+            break
+        head_count += len(g)
+        head_groups += 1
+
+    # Determine which groups to keep from the tail (last_n messages)
+    tail_count = 0
+    tail_groups = 0
+    for g in reversed(groups):
+        if tail_count >= last_n:
+            break
+        tail_count += len(g)
+        tail_groups += 1
+
+    # If head + tail covers all groups, return as-is
+    if head_groups + tail_groups >= len(groups):
+        return history
+
+    head = groups[:head_groups]
+    tail = groups[len(groups) - tail_groups :] if tail_groups > 0 else []
+
+    result: list[dict[str, Any]] = []
+    for g in [*head, *tail]:
+        result.extend(g)
+    return result

--- a/chat_shell/chat_shell/messages/__init__.py
+++ b/chat_shell/chat_shell/messages/__init__.py
@@ -5,5 +5,6 @@
 """Chat Shell messages module."""
 
 from .converter import MessageConverter
+from .utils import group_tool_call_messages
 
-__all__ = ["MessageConverter"]
+__all__ = ["MessageConverter", "group_tool_call_messages"]

--- a/chat_shell/chat_shell/messages/utils.py
+++ b/chat_shell/chat_shell/messages/utils.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared utility functions for message processing."""
+
+from typing import Any
+
+
+def group_tool_call_messages(
+    messages: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    """Group messages into atomic units for safe truncation/removal.
+
+    A tool-call group consists of an assistant message with ``tool_calls``
+    followed by its corresponding ``tool`` response messages.  Splitting
+    such a group would produce orphaned ``function_call_output`` items
+    (without matching ``function_call``) when converted to the OpenAI
+    Responses API format, causing API errors.
+
+    Args:
+        messages: Flat list of message dicts.
+
+    Returns:
+        A list of groups where each group is a list of message dicts
+        that must be kept or removed together.
+    """
+    groups: list[list[dict[str, Any]]] = []
+    i = 0
+    while i < len(messages):
+        msg = messages[i]
+        if msg.get("role") == "assistant" and msg.get("tool_calls"):
+            group = [msg]
+            i += 1
+            while i < len(messages) and messages[i].get("role") == "tool":
+                group.append(messages[i])
+                i += 1
+            groups.append(group)
+        else:
+            groups.append([msg])
+            i += 1
+    return groups

--- a/chat_shell/tests/test_compression.py
+++ b/chat_shell/tests/test_compression.py
@@ -20,6 +20,29 @@ from chat_shell.compression.strategies import (
 from chat_shell.compression.token_counter import TokenCounter
 
 
+def _assert_tool_call_groups_intact(messages):
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+
+        if message.get("role") == "tool":
+            raise AssertionError("Found orphan tool message")
+
+        if message.get("role") == "assistant" and message.get("tool_calls"):
+            expected_ids = {tool_call["id"] for tool_call in message["tool_calls"]}
+            actual_ids = set()
+            index += 1
+
+            while index < len(messages) and messages[index].get("role") == "tool":
+                actual_ids.add(messages[index].get("tool_call_id"))
+                index += 1
+
+            assert expected_ids.issubset(actual_ids)
+            continue
+
+        index += 1
+
+
 class TestTokenCounter:
     """Tests for TokenCounter class."""
 
@@ -733,6 +756,102 @@ class TestHistoryTruncationStrategy:
         assert len(compressed) == len(messages)
         assert details["messages_removed"] == 0
 
+    def test_preserves_tool_call_group_when_first_boundary_hits_tool_result(self):
+        """Test first boundary adjustment keeps assistant tool call with its result."""
+        strategy = HistoryTruncationStrategy()
+        counter = TokenCounter(model_id="gpt-4")
+        config = CompressionConfig(first_messages_to_keep=2, last_messages_to_keep=2)
+
+        messages = [
+            {"role": "system", "content": "System prompt."},
+            {"role": "user", "content": "User 0"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Tool 1 output", "tool_call_id": "call_1"},
+            {"role": "assistant", "content": "Assistant middle " * 80},
+            {"role": "user", "content": "User 1"},
+            {"role": "assistant", "content": "Assistant 1"},
+        ]
+
+        compressed, details = strategy.compress(messages, counter, 200, config)
+
+        assert details["messages_removed"] > 0
+        assert any(msg.get("tool_calls") for msg in compressed)
+        _assert_tool_call_groups_intact(compressed)
+
+    def test_preserves_tool_call_group_when_last_boundary_hits_tool_result(self):
+        """Test last boundary adjustment keeps assistant tool call with its result."""
+        strategy = HistoryTruncationStrategy()
+        counter = TokenCounter(model_id="gpt-4")
+        config = CompressionConfig(first_messages_to_keep=1, last_messages_to_keep=2)
+
+        messages = [
+            {"role": "system", "content": "System prompt."},
+            {"role": "user", "content": "User 0"},
+            {"role": "assistant", "content": "Assistant 0 " * 80},
+            {"role": "user", "content": "User 1 " * 80},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Tool 2 output", "tool_call_id": "call_2"},
+            {"role": "assistant", "content": "Assistant 2"},
+        ]
+
+        compressed, details = strategy.compress(messages, counter, 300, config)
+
+        assert details["messages_removed"] > 0
+        assert any(msg.get("tool_calls") for msg in compressed)
+        _assert_tool_call_groups_intact(compressed)
+
+    def test_removes_tool_call_group_together_when_middle_removal_starts_with_tool_result(
+        self,
+    ):
+        """Test middle removal drops assistant tool call and tool result together."""
+        strategy = HistoryTruncationStrategy()
+        counter = TokenCounter(model_id="gpt-4")
+        config = CompressionConfig(first_messages_to_keep=1, last_messages_to_keep=1)
+
+        messages = [
+            {"role": "system", "content": "System prompt."},
+            {"role": "user", "content": "User 0"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_3",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Tool 3 output", "tool_call_id": "call_3"},
+            {"role": "user", "content": "User 1"},
+        ]
+
+        compressed, details = strategy.compress(messages, counter, 1, config)
+
+        assert details["messages_removed"] == 2
+        assert not any(msg.get("tool_calls") for msg in compressed)
+        assert not any(msg.get("role") == "tool" for msg in compressed)
+
 
 class TestMessageCompressor:
     """Tests for main MessageCompressor class."""
@@ -850,3 +969,49 @@ class TestMessageCompressor:
         # Should not compress
         assert not result.was_compressed
         assert result.messages == messages
+
+    def test_force_compression_keeps_essential_tool_call_group_intact(self):
+        """Test forced compression keeps assistant tool call and tool result together."""
+        compressor = MessageCompressor(model_id="gpt-4")
+
+        messages = [
+            {"role": "system", "content": "System prompt " * 400},
+            {"role": "user", "content": "User 0 " * 150},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_4",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "Tool 4 output " * 200,
+                "tool_call_id": "call_4",
+            },
+            {"role": "user", "content": "User 1 " * 150},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_5",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "content": "Tool 5 output " * 200,
+                "tool_call_id": "call_5",
+            },
+        ]
+
+        compressed, _ = compressor._force_compression_to_target(messages, 10)
+
+        _assert_tool_call_groups_intact(compressed)

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from chat_shell.history.loader import (
     _build_knowledge_base_text_prefix,
     _extract_user_text,
+    _truncate_history,
 )
 
 
@@ -102,3 +103,58 @@ class TestExtractUserText:
             {"type": "text", "text": "<attachment>file</attachment>"},
         ]
         assert _extract_user_text(content) == "User[Alice]: hello everyone"
+
+
+class TestTruncateHistory:
+    def test_preserves_tool_call_groups_at_head_and_tail_boundaries(self, monkeypatch):
+        monkeypatch.setattr(
+            "chat_shell.history.loader.settings.GROUP_CHAT_HISTORY_FIRST_MESSAGES", 2
+        )
+        monkeypatch.setattr(
+            "chat_shell.history.loader.settings.GROUP_CHAT_HISTORY_LAST_MESSAGES", 2
+        )
+
+        history = [
+            {"role": "user", "content": "User 0"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Result 1", "tool_call_id": "call_1"},
+            {"role": "assistant", "content": "Assistant 1"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "Result 2", "tool_call_id": "call_2"},
+            {"role": "assistant", "content": "Assistant 2"},
+        ]
+
+        truncated = _truncate_history(history)
+
+        assert [msg["role"] for msg in truncated] == [
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+        assert truncated[1]["tool_calls"][0]["id"] == "call_1"
+        assert truncated[2]["tool_call_id"] == "call_1"
+        assert truncated[3]["tool_calls"][0]["id"] == "call_2"
+        assert truncated[4]["tool_call_id"] == "call_2"


### PR DESCRIPTION
## Problem

dev error with gpt-5.4 model in group chat:

```json
{"error": {"message": "No tool call found for function call output with call_id call_xxxxx."}}
```

Two orphaned `function_call_output` items had no matching `function_call` entries in the request, causing the OpenAI Responses API to reject the request.

## Root Cause

**Tool call groups** (assistant message with `tool_calls` + subsequent tool response messages) are atomic units that must never be split. Multiple code paths were slicing message lists at fixed indices, breaking these groups:

1. **`_truncate_history()`** in `history/loader.py`: Blindly sliced at `first_n=10, last_n=20` boundaries, cutting through a 9-item tool call chain (5 `render_mermaid` calls from subtask 1394133).
2. **`HistoryTruncationStrategy.compress()`** in `compression/strategies.py`: Three boundary split points that could land on tool response messages.
3. **`_force_compression_to_target()`** in `compression/compressor.py`: Steps 2 and 5 removed/kept individual messages instead of atomic groups.

## Fix

### Shared utility: `group_tool_call_messages()`
Extracted into `chat_shell/messages/utils.py` — groups messages into atomic units where each assistant message with `tool_calls` is bundled with its following tool response messages.

### Changes by file

| File | Fix |
|------|-----|
| `messages/utils.py` | **NEW** — shared `group_tool_call_messages()` utility |
| `messages/__init__.py` | Export new utility |
| `history/loader.py` | `_truncate_history()` now truncates by atomic groups instead of individual messages |
| `compression/strategies.py` | Boundary adjustment: extends `first_to_keep` forward past trailing tool messages, extends `last_to_keep` backward to include assistant with tool_calls; post-removal orphan cleanup |
| `compression/compressor.py` | Step 2: removes middle groups via `group_tool_call_messages()`; Step 5: keeps first/last groups instead of individual messages |

## Comprehensive Audit

Audited all message manipulation code in chat_shell to confirm no other paths break tool call group integrity:

- **Safe**: `storage/memory.py`, `storage/sqlite.py`, `storage/remote.py`, `agents/graph_builder.py`, `messages/converter.py`, `services/chat_service.py`, `tools/builtin/load_skill.py`, `agent.py`, backend `get_chat_history` API, `AttachmentTruncationStrategy`, `ToolResultTruncationStrategy`

## Testing

All 95 related tests pass (`test_compression.py`, `test_history_loader.py`, `test_messages.py`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message compression algorithms to maintain integrity of tool call sequences by treating tool calls and their corresponding responses as indivisible units during conversation history truncation.

* **Tests**
  * Added extensive test coverage for tool-call grouping across compression boundaries, including scenarios where truncation points intersect with tool call/response pairs, and for forced compression edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->