### PR TITLE
fix(frontend): show 'device deleted' status for tasks with deleted de…

### DIFF
--- a/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
@@ -59,16 +59,29 @@ export function ChatPageDesktop() {
   const { selectedDeviceId, devices } = useDevices()
   const selectedDevice = devices.find(d => d.device_id === selectedDeviceId)
 
+  // For existing tasks, also check the task's device_id
+  const taskDevice = selectedTaskDetail?.device_id
+    ? devices.find(d => d.device_id === selectedTaskDetail.device_id)
+    : null
+  const isTaskDeviceDeleted =
+    selectedTaskDetail?.device_id &&
+    !devices.some(d => d.device_id === selectedTaskDetail.device_id)
+  const isTaskDeviceOffline = taskDevice?.status === 'offline'
+
   // Determine taskType based on device selection
   // When a device is selected, use 'task' mode (same as /devices/chat)
   // Otherwise, use 'chat' mode
   const taskType = selectedDeviceId ? 'task' : 'chat'
 
   // Compute disabled reason for device mode
-  const disabledReason =
-    selectedDeviceId && (!selectedDevice || selectedDevice.status === 'offline')
+  // Consider both currently selected device and task's associated device
+  const disabledReason = isTaskDeviceDeleted
+    ? t('devices:device_deleted_hint')
+    : isTaskDeviceOffline
       ? t('devices:device_offline_cannot_send')
-      : undefined
+      : selectedDeviceId && (!selectedDevice || selectedDevice.status === 'offline')
+        ? t('devices:device_offline_cannot_send')
+        : undefined
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskDetail?.title

--- a/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
@@ -48,16 +48,29 @@ export function ChatPageMobile() {
   const { selectedDeviceId, devices } = useDevices()
   const selectedDevice = devices.find(d => d.device_id === selectedDeviceId)
 
+  // For existing tasks, also check the task's device_id
+  const taskDevice = selectedTaskDetail?.device_id
+    ? devices.find(d => d.device_id === selectedTaskDetail.device_id)
+    : null
+  const isTaskDeviceDeleted =
+    selectedTaskDetail?.device_id &&
+    !devices.some(d => d.device_id === selectedTaskDetail.device_id)
+  const isTaskDeviceOffline = taskDevice?.status === 'offline'
+
   // Determine taskType based on device selection
   // When a device is selected, use 'task' mode (same as /devices/chat)
   // Otherwise, use 'chat' mode
   const taskType = selectedDeviceId ? 'task' : 'chat'
 
   // Compute disabled reason for device mode
-  const disabledReason =
-    selectedDeviceId && (!selectedDevice || selectedDevice.status === 'offline')
+  // Consider both currently selected device and task's associated device
+  const disabledReason = isTaskDeviceDeleted
+    ? t('devices:device_deleted_hint')
+    : isTaskDeviceOffline
       ? t('devices:device_offline_cannot_send')
-      : undefined
+      : selectedDeviceId && (!selectedDevice || selectedDevice.status === 'offline')
+        ? t('devices:device_offline_cannot_send')
+        : undefined
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskDetail?.title

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -24,7 +24,7 @@ import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { paths } from '@/config/paths'
 import { useDevices } from '@/contexts/DeviceContext'
 import { useTeamContext } from '@/contexts/TeamContext'
-import { Monitor, WifiOff, Trash2 } from 'lucide-react'
+import { Monitor, WifiOff } from 'lucide-react'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { TaskParamSync, DeviceTaskSync, DeviceParamSync } from '@/features/tasks/components/params'
 import { isOpenClawDevice } from '@/features/devices/utils/device-status'
@@ -168,41 +168,32 @@ export default function DeviceChatPage() {
           onMembersChanged={handleMembersChanged}
           isSidebarCollapsed={isCollapsed}
         >
-          {/* Device selector in top bar */}
-          <div className="flex items-center gap-2 mr-2">
-            {isTaskDeviceDeleted ? (
-              <>
-                <Trash2 className="w-4 h-4 text-red-500" />
-                <div className="flex items-center gap-2 bg-red-50 border border-red-300 rounded-md px-2 py-1 text-sm text-red-600">
-                  {t('device_deleted')}
-                </div>
-              </>
-            ) : (
-              <>
-                <Monitor className="w-4 h-4 text-text-muted" />
-                <select
-                  value={selectedDeviceId || ''}
-                  onChange={e => handleDeviceSelect(e.target.value)}
-                  className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
-                >
-                  <option value="" disabled>
-                    {t('select_device')}
+          {/* Device selector in top bar - hide when task's device is deleted */}
+          {!isTaskDeviceDeleted && (
+            <div className="flex items-center gap-2 mr-2">
+              <Monitor className="w-4 h-4 text-text-muted" />
+              <select
+                value={selectedDeviceId || ''}
+                onChange={e => handleDeviceSelect(e.target.value)}
+                className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+              >
+                <option value="" disabled>
+                  {t('select_device')}
+                </option>
+                {devices.map(device => (
+                  <option key={device.device_id} value={device.device_id}>
+                    {device.name} (
+                    {device.status === 'online'
+                      ? t('status_online')
+                      : device.status === 'busy'
+                        ? t('status_busy')
+                        : t('status_offline')}
+                    )
                   </option>
-                  {devices.map(device => (
-                    <option key={device.device_id} value={device.device_id}>
-                      {device.name} (
-                      {device.status === 'online'
-                        ? t('status_online')
-                        : device.status === 'busy'
-                          ? t('status_busy')
-                          : t('status_offline')}
-                      )
-                    </option>
-                  ))}
-                </select>
-              </>
-            )}
-          </div>
+                ))}
+              </select>
+            </div>
+          )}
           {isMobile ? <ThemeToggle /> : <GithubStarButton />}
         </TopNavigation>
 

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -243,9 +243,11 @@ export default function DeviceChatPage() {
                 ? t('device_deleted_hint')
                 : hasMessages && taskDevice?.status === 'offline'
                   ? t('device_offline_cannot_send')
-                  : !selectedDevice || selectedDevice.status === 'offline'
-                    ? t('device_offline_cannot_send')
-                    : undefined
+                  : hasMessages && !selectedTaskDetail?.device_id
+                    ? undefined // Task was created with cloud mode, allow sending
+                    : !selectedDevice || selectedDevice.status === 'offline'
+                      ? t('device_offline_cannot_send')
+                      : undefined
             }
             hideSelectors={isOpenClaw}
           />

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -123,6 +123,13 @@ export default function DeviceChatPage() {
   // Get selected device info
   const selectedDevice = devices.find(d => d.device_id === selectedDeviceId)
 
+  // For existing tasks, use task's device_id instead of selectedDeviceId for display
+  const taskDevice = selectedTaskDetail?.device_id
+    ? devices.find(d => d.device_id === selectedTaskDetail.device_id)
+    : null
+  // Task is considered to have messages if it has a non-empty title and was created
+  const hasMessages = !!(selectedTaskDetail && selectedTaskDetail.id)
+
   // Check if selected device is OpenClaw type
   const isOpenClaw = selectedDevice ? isOpenClawDevice(selectedDevice) : false
 
@@ -172,26 +179,51 @@ export default function DeviceChatPage() {
           {!isTaskDeviceDeleted && (
             <div className="flex items-center gap-2 mr-2">
               <Monitor className="w-4 h-4 text-text-muted" />
-              <select
-                value={selectedDeviceId || ''}
-                onChange={e => handleDeviceSelect(e.target.value)}
-                className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
-              >
-                <option value="" disabled>
-                  {t('select_device')}
-                </option>
-                {devices.map(device => (
-                  <option key={device.device_id} value={device.device_id}>
-                    {device.name} (
-                    {device.status === 'online'
+              {/* For existing tasks with messages, show read-only device info */}
+              {hasMessages && taskDevice ? (
+                <div className="flex items-center gap-1.5 bg-surface border border-border rounded-md px-2 py-1 text-sm">
+                  <span className="truncate max-w-[150px]">{taskDevice.name}</span>
+                  <span
+                    className={`w-2 h-2 rounded-full ${
+                      taskDevice.status === 'online'
+                        ? 'bg-green-500'
+                        : taskDevice.status === 'busy'
+                          ? 'bg-yellow-500'
+                          : 'bg-gray-400'
+                    }`}
+                  />
+                  <span className="text-text-muted text-xs">
+                    (
+                    {taskDevice.status === 'online'
                       ? t('status_online')
-                      : device.status === 'busy'
+                      : taskDevice.status === 'busy'
                         ? t('status_busy')
                         : t('status_offline')}
                     )
+                  </span>
+                </div>
+              ) : (
+                <select
+                  value={selectedDeviceId || ''}
+                  onChange={e => handleDeviceSelect(e.target.value)}
+                  className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="" disabled>
+                    {t('select_device')}
                   </option>
-                ))}
-              </select>
+                  {devices.map(device => (
+                    <option key={device.device_id} value={device.device_id}>
+                      {device.name} (
+                      {device.status === 'online'
+                        ? t('status_online')
+                        : device.status === 'busy'
+                          ? t('status_busy')
+                          : t('status_offline')}
+                      )
+                    </option>
+                  ))}
+                </select>
+              )}
             </div>
           )}
           {isMobile ? <ThemeToggle /> : <GithubStarButton />}
@@ -209,9 +241,11 @@ export default function DeviceChatPage() {
             disabledReason={
               isTaskDeviceDeleted
                 ? t('device_deleted_hint')
-                : !selectedDevice || selectedDevice.status === 'offline'
+                : hasMessages && taskDevice?.status === 'offline'
                   ? t('device_offline_cannot_send')
-                  : undefined
+                  : !selectedDevice || selectedDevice.status === 'offline'
+                    ? t('device_offline_cannot_send')
+                    : undefined
             }
             hideSelectors={isOpenClaw}
           />

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useState, useCallback, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import {
@@ -24,7 +24,7 @@ import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { paths } from '@/config/paths'
 import { useDevices } from '@/contexts/DeviceContext'
 import { useTeamContext } from '@/contexts/TeamContext'
-import { Monitor, WifiOff } from 'lucide-react'
+import { Monitor, WifiOff, Trash2 } from 'lucide-react'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { TaskParamSync, DeviceTaskSync, DeviceParamSync } from '@/features/tasks/components/params'
 import { isOpenClawDevice } from '@/features/devices/utils/device-status'
@@ -126,6 +126,12 @@ export default function DeviceChatPage() {
   // Check if selected device is OpenClaw type
   const isOpenClaw = selectedDevice ? isOpenClawDevice(selectedDevice) : false
 
+  // Check if task was associated with a device that has been deleted
+  const isTaskDeviceDeleted = useMemo(() => {
+    if (!selectedTaskDetail?.device_id) return false
+    return !devices.some(d => d.device_id === selectedTaskDetail.device_id)
+  }, [selectedTaskDetail?.device_id, devices])
+
   return (
     <div className="flex smart-h-screen bg-base text-text-primary box-border">
       {/* URL parameter sync */}
@@ -164,27 +170,38 @@ export default function DeviceChatPage() {
         >
           {/* Device selector in top bar */}
           <div className="flex items-center gap-2 mr-2">
-            <Monitor className="w-4 h-4 text-text-muted" />
-            <select
-              value={selectedDeviceId || ''}
-              onChange={e => handleDeviceSelect(e.target.value)}
-              className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
-            >
-              <option value="" disabled>
-                {t('select_device')}
-              </option>
-              {devices.map(device => (
-                <option key={device.device_id} value={device.device_id}>
-                  {device.name} (
-                  {device.status === 'online'
-                    ? t('status_online')
-                    : device.status === 'busy'
-                      ? t('status_busy')
-                      : t('status_offline')}
-                  )
-                </option>
-              ))}
-            </select>
+            {isTaskDeviceDeleted ? (
+              <>
+                <Trash2 className="w-4 h-4 text-red-500" />
+                <div className="flex items-center gap-2 bg-red-50 border border-red-300 rounded-md px-2 py-1 text-sm text-red-600">
+                  {t('device_deleted')}
+                </div>
+              </>
+            ) : (
+              <>
+                <Monitor className="w-4 h-4 text-text-muted" />
+                <select
+                  value={selectedDeviceId || ''}
+                  onChange={e => handleDeviceSelect(e.target.value)}
+                  className="bg-surface border border-border rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="" disabled>
+                    {t('select_device')}
+                  </option>
+                  {devices.map(device => (
+                    <option key={device.device_id} value={device.device_id}>
+                      {device.name} (
+                      {device.status === 'online'
+                        ? t('status_online')
+                        : device.status === 'busy'
+                          ? t('status_busy')
+                          : t('status_offline')}
+                      )
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
           </div>
           {isMobile ? <ThemeToggle /> : <GithubStarButton />}
         </TopNavigation>
@@ -199,9 +216,11 @@ export default function DeviceChatPage() {
             taskType="task"
             onRefreshTeams={handleRefreshTeams}
             disabledReason={
-              !selectedDevice || selectedDevice.status === 'offline'
-                ? t('device_offline_cannot_send')
-                : undefined
+              isTaskDeviceDeleted
+                ? t('device_deleted_hint')
+                : !selectedDevice || selectedDevice.status === 'offline'
+                  ? t('device_offline_cannot_send')
+                  : undefined
             }
             hideSelectors={isOpenClaw}
           />

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -35,6 +35,7 @@ import { useAttachmentUpload } from '../hooks/useAttachmentUpload'
 import { useSchemeMessageActions } from '@/lib/scheme'
 import { useSkillSelector } from '../../hooks/useSkillSelector'
 import { useModelSelection } from '../../hooks/useModelSelection'
+import { useDevices } from '@/contexts/DeviceContext'
 
 /**
  * Threshold in pixels for determining when to collapse selectors.
@@ -111,6 +112,15 @@ function ChatAreaContent({
 
   // Task context
   const { selectedTaskDetail, setSelectedTask, accessDenied } = useTaskContext()
+
+  // Device context - for detecting deleted device
+  const { devices } = useDevices()
+
+  // Check if task was associated with a device that has been deleted
+  const isTaskDeviceDeleted = useMemo(() => {
+    if (!selectedTaskDetail?.device_id) return false
+    return !devices.some(d => d.device_id === selectedTaskDetail.device_id)
+  }, [selectedTaskDetail?.device_id, devices])
 
   // Use useTaskStateMachine hook for reactive state updates (SINGLE SOURCE OF TRUTH per AGENTS.md)
   const { state: taskState } = useTaskStateMachine(selectedTaskDetail?.id)
@@ -1040,6 +1050,8 @@ function ChatAreaContent({
     onGenerateModeChange,
     // Hide all selectors (for OpenClaw devices)
     hideSelectors,
+    // Whether the task's device has been deleted
+    isTaskDeviceDeleted,
   }
 
   return (

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -5,7 +5,8 @@
 'use client'
 
 import React, { useRef, useState, useCallback } from 'react'
-import { Upload, Sparkles } from 'lucide-react'
+import Link from 'next/link'
+import { Upload, Sparkles, Plus } from 'lucide-react'
 import ChatInput from './ChatInput'
 import InputBadgeDisplay from './InputBadgeDisplay'
 import ExternalApiParamsInput from '../params/ExternalApiParamsInput'
@@ -16,6 +17,7 @@ import { QuoteCard } from '../text-selection'
 import { ConnectionStatusBanner } from './ConnectionStatusBanner'
 import type { Team, ChatTipItem, TaskType } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
+import { paths } from '@/config/paths'
 import type { SkillSelectorPopoverRef } from '../selector/SkillSelectorPopover'
 
 export interface ChatInputCardProps extends Omit<
@@ -76,6 +78,9 @@ export interface ChatInputCardProps extends Omit<
   // Reason why input is disabled (e.g., device offline). Shows as placeholder text.
   disabledReason?: string
 
+  // Whether the task's device has been deleted (shows clickable prompt overlay)
+  isTaskDeviceDeleted?: boolean
+
   // Hide all selectors (for OpenClaw devices) - only show text input + send button
   hideSelectors?: boolean
 }
@@ -121,6 +126,7 @@ export function ChatInputCard({
   inputControlsRef,
   hasNoTeams = false,
   disabledReason,
+  isTaskDeviceDeleted = false,
   hideSelectors,
   // ChatInputControls props
   selectedModel,
@@ -257,6 +263,20 @@ export function ChatInputCard({
             </div>
             <p className="text-lg font-medium text-primary">释放以上传文件</p>
             <p className="text-sm text-text-muted mt-1">支持 PDF, Word, TXT, Markdown 等格式</p>
+          </div>
+        )}
+
+        {/* Device Deleted Overlay - shows clickable prompt when task's device is deleted */}
+        {isTaskDeviceDeleted && (
+          <div className="absolute inset-0 z-40 rounded-3xl bg-base/95 backdrop-blur-sm flex flex-col items-center justify-center transition-all">
+            <p className="text-sm text-text-muted mb-3">{t('devices:device_deleted_hint')}</p>
+            <Link
+              href={paths.chat.getHref()}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-full bg-primary text-white text-sm font-medium hover:bg-primary/90 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              <span>{t('devices:start_new_chat')}</span>
+            </Link>
           </div>
         )}
 

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -31,8 +31,6 @@ import {
   Check,
   Settings,
   Cpu,
-  Trash2,
-  Plus,
 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -44,7 +42,6 @@ import {
 } from '@/features/devices/utils/execution-target'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
-import Link from 'next/link'
 import { paths } from '@/config/paths'
 import type { DeviceInfo } from '@/apis/devices'
 
@@ -460,68 +457,55 @@ export function DeviceSelectorTab({
 
   // Read-only mode for existing chats
   if (hasMessages) {
+    // When device is deleted, don't show any selector - the prompt will be shown in the input area
+    if (isTaskDeviceDeleted) {
+      return null
+    }
+
     return (
       <TooltipProvider>
-        <div className="flex items-center gap-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div
-                className={cn(
-                  'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
-                  'bg-surface border border-border',
-                  'text-xs text-text-secondary',
-                  isTaskDeviceDeleted && 'border-red-300 bg-red-50',
-                  className
-                )}
-              >
-                {isTaskDeviceDeleted ? (
-                  <>
-                    <Trash2 className="w-3.5 h-3.5 text-red-500" />
-                    <span className="text-red-600">{t('device_deleted')}</span>
-                  </>
-                ) : selectedDevice ? (
-                  <>
-                    {selectedDevice.device_type === 'cloud' ? (
-                      <Server className="w-3.5 h-3.5" />
-                    ) : (
-                      <Monitor className="w-3.5 h-3.5" />
-                    )}
-                    <span className="truncate max-w-[160px]">
-                      {selectedDevice.device_type === 'cloud'
-                        ? t('cloud_device_prefix')
-                        : t('local_device_prefix')}
-                      {selectedDevice.name}
-                    </span>
-                    <span
-                      className={cn(
-                        'w-1.5 h-1.5 rounded-full',
-                        getStatusColor(selectedDevice.status)
-                      )}
-                    />
-                  </>
-                ) : (
-                  <>
-                    <Cloud className="w-3.5 h-3.5" />
-                    <span>{t('cloud_mode')}</span>
-                  </>
-                )}
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="top">
-              <p>{isTaskDeviceDeleted ? t('device_deleted_hint') : t('select_device_hint')}</p>
-            </TooltipContent>
-          </Tooltip>
-          {/* Show "Start New Chat" link when device is deleted */}
-          {isTaskDeviceDeleted && (
-            <Link
-              href={paths.chat.getHref()}
-              className="flex items-center gap-1 px-2 py-1.5 rounded-md bg-primary/10 border border-primary/20 text-xs text-primary hover:bg-primary/20 transition-colors"
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
+                'bg-surface border border-border',
+                'text-xs text-text-secondary',
+                className
+              )}
             >
-              <Plus className="w-3.5 h-3.5" />
-              <span>{t('start_new_chat')}</span>
-            </Link>
-          )}
-        </div>
+              {selectedDevice ? (
+                <>
+                  {selectedDevice.device_type === 'cloud' ? (
+                    <Server className="w-3.5 h-3.5" />
+                  ) : (
+                    <Monitor className="w-3.5 h-3.5" />
+                  )}
+                  <span className="truncate max-w-[160px]">
+                    {selectedDevice.device_type === 'cloud'
+                      ? t('cloud_device_prefix')
+                      : t('local_device_prefix')}
+                    {selectedDevice.name}
+                  </span>
+                  <span
+                    className={cn(
+                      'w-1.5 h-1.5 rounded-full',
+                      getStatusColor(selectedDevice.status)
+                    )}
+                  />
+                </>
+              ) : (
+                <>
+                  <Cloud className="w-3.5 h-3.5" />
+                  <span>{t('cloud_mode')}</span>
+                </>
+              )}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            <p>{t('select_device_hint')}</p>
+          </TooltipContent>
+        </Tooltip>
       </TooltipProvider>
     )
   }

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -32,6 +32,7 @@ import {
   Settings,
   Cpu,
   Trash2,
+  Plus,
 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -43,6 +44,7 @@ import {
 } from '@/features/devices/utils/execution-target'
 import { toast } from 'sonner'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { paths } from '@/config/paths'
 import type { DeviceInfo } from '@/apis/devices'
 
@@ -460,54 +462,66 @@ export function DeviceSelectorTab({
   if (hasMessages) {
     return (
       <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className={cn(
-                'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
-                'bg-surface border border-border',
-                'text-xs text-text-secondary',
-                isTaskDeviceDeleted && 'border-red-300 bg-red-50',
-                className
-              )}
-            >
-              {isTaskDeviceDeleted ? (
-                <>
-                  <Trash2 className="w-3.5 h-3.5 text-red-500" />
-                  <span className="text-red-600">{t('device_deleted')}</span>
-                </>
-              ) : selectedDevice ? (
-                <>
-                  {selectedDevice.device_type === 'cloud' ? (
-                    <Server className="w-3.5 h-3.5" />
-                  ) : (
-                    <Monitor className="w-3.5 h-3.5" />
-                  )}
-                  <span className="truncate max-w-[160px]">
-                    {selectedDevice.device_type === 'cloud'
-                      ? t('cloud_device_prefix')
-                      : t('local_device_prefix')}
-                    {selectedDevice.name}
-                  </span>
-                  <span
-                    className={cn(
-                      'w-1.5 h-1.5 rounded-full',
-                      getStatusColor(selectedDevice.status)
+        <div className="flex items-center gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
+                  'bg-surface border border-border',
+                  'text-xs text-text-secondary',
+                  isTaskDeviceDeleted && 'border-red-300 bg-red-50',
+                  className
+                )}
+              >
+                {isTaskDeviceDeleted ? (
+                  <>
+                    <Trash2 className="w-3.5 h-3.5 text-red-500" />
+                    <span className="text-red-600">{t('device_deleted')}</span>
+                  </>
+                ) : selectedDevice ? (
+                  <>
+                    {selectedDevice.device_type === 'cloud' ? (
+                      <Server className="w-3.5 h-3.5" />
+                    ) : (
+                      <Monitor className="w-3.5 h-3.5" />
                     )}
-                  />
-                </>
-              ) : (
-                <>
-                  <Cloud className="w-3.5 h-3.5" />
-                  <span>{t('cloud_mode')}</span>
-                </>
-              )}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            <p>{isTaskDeviceDeleted ? t('device_deleted_hint') : t('select_device_hint')}</p>
-          </TooltipContent>
-        </Tooltip>
+                    <span className="truncate max-w-[160px]">
+                      {selectedDevice.device_type === 'cloud'
+                        ? t('cloud_device_prefix')
+                        : t('local_device_prefix')}
+                      {selectedDevice.name}
+                    </span>
+                    <span
+                      className={cn(
+                        'w-1.5 h-1.5 rounded-full',
+                        getStatusColor(selectedDevice.status)
+                      )}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <Cloud className="w-3.5 h-3.5" />
+                    <span>{t('cloud_mode')}</span>
+                  </>
+                )}
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>{isTaskDeviceDeleted ? t('device_deleted_hint') : t('select_device_hint')}</p>
+            </TooltipContent>
+          </Tooltip>
+          {/* Show "Start New Chat" link when device is deleted */}
+          {isTaskDeviceDeleted && (
+            <Link
+              href={paths.chat.getHref()}
+              className="flex items-center gap-1 px-2 py-1.5 rounded-md bg-primary/10 border border-primary/20 text-xs text-primary hover:bg-primary/20 transition-colors"
+            >
+              <Plus className="w-3.5 h-3.5" />
+              <span>{t('start_new_chat')}</span>
+            </Link>
+          )}
+        </div>
       </TooltipProvider>
     )
   }

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -31,6 +31,7 @@ import {
   Check,
   Settings,
   Cpu,
+  Trash2,
 } from 'lucide-react'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
@@ -327,6 +328,13 @@ export function DeviceSelectorTab({
       : null
   }, [devices, selectedDeviceId, hasMessages, taskDeviceId])
 
+  // Check if the task was associated with a device that has been deleted
+  const isTaskDeviceDeleted = useMemo(() => {
+    if (!hasMessages || !taskDeviceId) return false
+    // If taskDeviceId exists but device not found in devices list, it means the device was deleted
+    return !devices.some(device => device.device_id === taskDeviceId)
+  }, [hasMessages, taskDeviceId, devices])
+
   useEffect(() => {
     if (hasMessages || isLoading || autoSelectionInitializedRef.current) {
       return
@@ -459,10 +467,16 @@ export function DeviceSelectorTab({
                 'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
                 'bg-surface border border-border',
                 'text-xs text-text-secondary',
+                isTaskDeviceDeleted && 'border-red-300 bg-red-50',
                 className
               )}
             >
-              {selectedDevice ? (
+              {isTaskDeviceDeleted ? (
+                <>
+                  <Trash2 className="w-3.5 h-3.5 text-red-500" />
+                  <span className="text-red-600">{t('device_deleted')}</span>
+                </>
+              ) : selectedDevice ? (
                 <>
                   {selectedDevice.device_type === 'cloud' ? (
                     <Server className="w-3.5 h-3.5" />
@@ -491,7 +505,7 @@ export function DeviceSelectorTab({
             </div>
           </TooltipTrigger>
           <TooltipContent side="top">
-            <p>{t('select_device_hint')}</p>
+            <p>{isTaskDeviceDeleted ? t('device_deleted_hint') : t('select_device_hint')}</p>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
+++ b/frontend/src/features/tasks/components/input/DeviceSelectorTab.tsx
@@ -462,6 +462,35 @@ export function DeviceSelectorTab({
       return null
     }
 
+    // If task has device_id but device not found (and not deleted), don't show "Public Mode"
+    // This handles the case where devices list is still loading or data inconsistency
+    if (taskDeviceId && !selectedDevice) {
+      // Show a loading/unknown state instead of misleading "Public Mode"
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div
+                className={cn(
+                  'flex items-center gap-1.5 px-2 py-1.5 rounded-md',
+                  'bg-surface border border-border',
+                  'text-xs text-text-secondary',
+                  className
+                )}
+              >
+                <Monitor className="w-3.5 h-3.5" />
+                <span className="truncate max-w-[160px]">{t('local_device_prefix')}...</span>
+                <span className="w-1.5 h-1.5 rounded-full bg-gray-400" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>{t('device_offline_hint')}</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )
+    }
+
     return (
       <TooltipProvider>
         <Tooltip>

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -39,6 +39,7 @@
   "device_offline_cannot_send": "Device is offline, cannot send tasks",
   "device_deleted": "Device Deleted",
   "device_deleted_hint": "The device associated with this chat has been deleted",
+  "start_new_chat": "Start New Chat",
   "device_busy_hint": "Device is busy with another task",
   "select_another_device": "Please select another device or wait for current task to complete",
   "refresh": "Refresh",

--- a/frontend/src/i18n/locales/en/devices.json
+++ b/frontend/src/i18n/locales/en/devices.json
@@ -37,6 +37,8 @@
   "select_device_hint": "Select a device from the top to start sending tasks",
   "device_offline_hint": "Device is offline, please select another",
   "device_offline_cannot_send": "Device is offline, cannot send tasks",
+  "device_deleted": "Device Deleted",
+  "device_deleted_hint": "The device associated with this chat has been deleted",
   "device_busy_hint": "Device is busy with another task",
   "select_another_device": "Please select another device or wait for current task to complete",
   "refresh": "Refresh",

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -39,6 +39,7 @@
   "device_offline_cannot_send": "设备不在线，无法发送任务",
   "device_deleted": "设备已删除",
   "device_deleted_hint": "此会话关联的设备已被删除",
+  "start_new_chat": "开始新对话",
   "device_busy_hint": "设备正在执行其他任务",
   "select_another_device": "请选择其他设备或等待当前任务完成",
   "refresh": "刷新",

--- a/frontend/src/i18n/locales/zh-CN/devices.json
+++ b/frontend/src/i18n/locales/zh-CN/devices.json
@@ -37,6 +37,8 @@
   "select_device_hint": "从顶部选择一个在线设备开始发送任务",
   "device_offline_hint": "设备已离线,请选择其他设备",
   "device_offline_cannot_send": "设备不在线，无法发送任务",
+  "device_deleted": "设备已删除",
+  "device_deleted_hint": "此会话关联的设备已被删除",
   "device_busy_hint": "设备正在执行其他任务",
   "select_another_device": "请选择其他设备或等待当前任务完成",
   "refresh": "刷新",


### PR DESCRIPTION
…vices

When a device is deleted, historical chat sessions associated with that device now display a clear "Device Deleted" status instead of incorrectly showing "Public Mode". This provides better UX consistency:

- DeviceSelectorTab: Shows red "Device Deleted" badge when task's device is deleted
- Device chat page: Top device selector shows deletion status
- Chat input is disabled with appropriate hint message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chats detect when the associated device was deleted, show a "Device Deleted" state with an overlay and a primary action to start a new chat.
  * Top/device selector UI hides for deleted-task devices; read-only or unknown-device displays are shown instead.
  * Disabled/offline hints now prioritize deleted-device messaging when applicable.

* **Localization**
  * Added English and Chinese translations for deleted-device messaging and "Start New Chat".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->