### PR TITLE
frontend: show 'indexing' status for documents pending indexing

### DIFF
--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -162,6 +162,18 @@ export function DocumentItem({
   const displayName =
     isWeb && document.name.endsWith('.md') ? document.name.slice(0, -3) : document.name
 
+  // Helper function to determine if document is indexing
+  // Document is considered "indexing" when:
+  // - isReindexing prop is true (explicit reindexing in progress), OR
+  // - status is 'enabled' (legacy check), OR
+  // - is_active is false AND it's not a table (new document being indexed)
+  // Note: We don't check ragConfigured here because even if RAG is not configured,
+  // the document is still in "indexing" state (waiting for indexing). The backend
+  // will skip actual indexing if RAG is not configured, but the UI should show
+  // "indexing" to indicate the document is not yet active.
+  const isIndexing =
+    isReindexing || document.status === 'enabled' || (!document.is_active && !isTable)
+
   const handleRowClick = () => {
     onViewDetail?.(document)
   }
@@ -244,7 +256,7 @@ export function DocumentItem({
                 className="w-1 h-1 rounded-full flex-shrink-0 bg-green-500"
                 title={t('knowledge:document.document.indexStatus.available')}
               />
-            ) : isReindexing ? (
+            ) : isIndexing ? (
               <TooltipProvider>
                 <Tooltip delayDuration={200}>
                   <TooltipTrigger asChild>
@@ -458,7 +470,7 @@ export function DocumentItem({
           <Badge variant="success" size="sm" className="whitespace-nowrap">
             {t('knowledge:document.document.indexStatus.available')}
           </Badge>
-        ) : isReindexing ? (
+        ) : isIndexing ? (
           <TooltipProvider>
             <Tooltip delayDuration={200}>
               <TooltipTrigger asChild>

--- a/frontend/src/i18n/locales/zh-CN/groups.json
+++ b/frontend/src/i18n/locales/zh-CN/groups.json
@@ -140,7 +140,7 @@
     },
     "roleDescriptions": {
       "Reporter": "只能查看群组资源，无法进行任何修改操作，可离开群组",
-      "Developer": "可查看、创建、编辑群组资源，可离开群组，但无法删除资源或管理成员",
+      "Developer": "可查看、编辑群组资源，可离开群组，但无法删除资源或管理成员",
       "Maintainer": "拥有除删除群组和转让Owner外的所有权限",
       "MaintainerDetails": {
         "title": "包括：",


### PR DESCRIPTION
fix(i18n): update Developer role description in Chinese locale
fix(frontend): show 'indexing' status for documents pending indexing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document status indicators now display indexing states based on additional document status conditions.

* **Localization**
  * Updated Chinese language permissions description for the Developer role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->