### PR TITLE
fix: sanitize PyInstaller LD_LIBRARY_PATH for child processes

### DIFF
--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -28,7 +28,7 @@ from typing import Any, Dict, Tuple
 
 from executor.agents.claude_code.mode_strategy import ExecutionModeStrategy
 from executor.config import config
-from executor.platform_compat import get_permissions_manager
+from executor.platform_compat import get_permissions_manager, sanitize_ld_library_path
 from shared.logger import setup_logger
 
 logger = setup_logger("local_mode_strategy")
@@ -129,9 +129,13 @@ class LocalModeStrategy(ExecutionModeStrategy):
             # Ensure all values are strings (required by SDK)
             updated_options["env"] = {k: str(v) for k, v in merged_env.items()}
 
+        # Fix PyInstaller LD_LIBRARY_PATH issue for child processes.
+        # See: https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html
+        env = updated_options.get("env", {})
+        sanitize_ld_library_path(env)
+
         # Set CLAUDE_CONFIG_DIR to redirect all config reads/writes
         # This affects settings.json, claude.json, and skills locations
-        env = updated_options.get("env", {})
         env["CLAUDE_CONFIG_DIR"] = config_dir
 
         # Add ANTHROPIC_CUSTOM_HEADERS if configured via environment variable

--- a/executor/modes/local/extension_handler.py
+++ b/executor/modes/local/extension_handler.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from executor.config import config
+from executor.platform_compat import sanitize_ld_library_path
 from shared.logger import setup_logger
 
 if TYPE_CHECKING:
@@ -123,11 +124,9 @@ class DeviceExtensionHandler:
     ) -> dict[str, Any]:
         env = os.environ.copy()
 
-        # Fix PyInstaller LD_LIBRARY_PATH issue: restore original system library path
-        # so subprocess tools (e.g., openssl) use correct system libraries instead of
-        # PyInstaller's bundled versions which may be incompatible.
-        if "LD_LIBRARY_PATH_ORIG" in env:
-            env["LD_LIBRARY_PATH"] = env["LD_LIBRARY_PATH_ORIG"]
+        # Fix PyInstaller LD_LIBRARY_PATH issue for child processes.
+        # See: https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html
+        sanitize_ld_library_path(env)
 
         env["WEGENT_EXTENSION_NAME"] = extension_name
         env["WEGENT_EXTENSION_ACTION"] = action

--- a/executor/platform_compat/__init__.py
+++ b/executor/platform_compat/__init__.py
@@ -24,6 +24,7 @@ Usage:
     permissions = get_permissions_manager()
 """
 
+import os
 import sys
 
 # Detect platform once at import time
@@ -103,6 +104,41 @@ def get_user_info_provider():
     return _user_info_provider_instance
 
 
+def sanitize_ld_library_path(env: dict) -> dict:
+    """Sanitize LD_LIBRARY_PATH for subprocess environments in PyInstaller builds.
+
+    PyInstaller's bootloader prepends its extraction directory (/tmp/_MEIxxxxxx) to
+    LD_LIBRARY_PATH, which causes child processes to load wrong shared libraries.
+    This function restores the original value or clears it.
+
+    Only affects Linux. macOS is unaffected because PyInstaller rewrites library paths
+    in binaries directly and does not modify DYLD_LIBRARY_PATH.
+
+    See: https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html
+
+    Args:
+        env: Environment variables dict (will be modified in-place).
+
+    Returns:
+        The same env dict, for convenience.
+    """
+    if not getattr(sys, "frozen", False):
+        return env
+
+    # Read original value from os.environ (set by PyInstaller's bootloader),
+    # not from the passed-in env dict which may be a partial options dict.
+    ld_orig = os.environ.get("LD_LIBRARY_PATH_ORIG")
+    if ld_orig is not None:
+        env["LD_LIBRARY_PATH"] = ld_orig
+    else:
+        # No ORIG saved — clear LD_LIBRARY_PATH by setting it to empty string.
+        # Using pop() would be insufficient when env is a partial options dict
+        # that gets merged with os.environ (the polluted value would survive).
+        env["LD_LIBRARY_PATH"] = ""
+
+    return env
+
+
 __all__ = [
     "IS_WINDOWS",
     "IS_MACOS",
@@ -111,6 +147,7 @@ __all__ = [
     "get_permissions_manager",
     "get_signal_handler",
     "get_user_info_provider",
+    "sanitize_ld_library_path",
     # Command line utilities
     "prepare_options_for_windows",
     "write_json_config",


### PR DESCRIPTION
## Summary

- PyInstaller's bootloader prepends `/tmp/_MEIxxxxxx` to `LD_LIBRARY_PATH`, causing child processes (Claude Code, shell commands like bash/git/curl) to load wrong shared libraries (e.g., `libtinfo.so.6`)
- Extract `sanitize_ld_library_path()` into `executor/platform_compat/` and apply it in both `local_mode_strategy.py` (Claude SDK subprocess) and `extension_handler.py` (extension script subprocess)
- Restores original `LD_LIBRARY_PATH` from `LD_LIBRARY_PATH_ORIG` if available, otherwise clears it
- Only affects PyInstaller frozen builds (Linux); macOS is unaffected per [PyInstaller docs](https://pyinstaller.org/en/stable/common-issues-and-pitfalls.html)

## Before
```
/bin/bash: /tmp/_MEIxxxxxx/libtinfo.so.6: no version information available (required by /bin/bash)
```

## After
Clean output, no library warnings.

## Test plan
- [x] Verified on cloud device (10.2.248.54), task 975843 — no `libtinfo` warning in output
- [ ] Run existing executor unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed environment variable handling for child processes in PyInstaller-frozen builds on Linux, ensuring proper library path resolution for spawned subprocess execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->