### PR TITLE
fix: harden browser-tool linux recovery

### DIFF
--- a/deps/browser/relay-server/chrome-extension/background.js
+++ b/deps/browser/relay-server/chrome-extension/background.js
@@ -356,8 +356,17 @@ function onDebuggerDetach(source, reason) {
 
 chrome.action.onClicked.addListener(() => void connectOrToggleForActiveTab())
 
-chrome.runtime.onInstalled.addListener(() => {
-  void chrome.runtime.openOptionsPage()
+chrome.runtime.onInstalled.addListener((details) => {
+  // Only open options page for user-initiated installs (from chrome://extensions).
+  // Skip when loaded via --load-extension to avoid blocking auto-attach.
+  if (details.reason === 'install') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabsList) => {
+      const url = tabsList?.[0]?.url || ''
+      if (url.startsWith('chrome://extensions')) {
+        void chrome.runtime.openOptionsPage()
+      }
+    })
+  }
 })
 
 function scheduleAutoAttach(delayMs) {

--- a/deps/browser/relay-server/package-lock.json
+++ b/deps/browser/relay-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wegent/cdp-relay-server",
-  "version": "0.1.11",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wegent/cdp-relay-server",
-      "version": "0.1.11",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.18.0"

--- a/deps/browser/relay-server/package.json
+++ b/deps/browser/relay-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wegent/cdp-relay-server",
-  "version": "0.1.11",
+  "version": "0.1.16",
   "description": "Chrome DevTools Protocol relay server and browser automation tool",
   "type": "module",
   "main": "dist/index.js",

--- a/deps/browser/relay-server/src/cli.ts
+++ b/deps/browser/relay-server/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { ensureRelayServer } from "./relay-server.js";
-import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, openSync, lstatSync } from "node:fs";
+import { writeFileSync, mkdirSync, existsSync, readFileSync, unlinkSync, readlinkSync, openSync, lstatSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { homedir, platform } from "node:os";
 import { spawn, type ChildProcess } from "node:child_process";
@@ -147,8 +147,44 @@ function getChromePath(): string | null {
   return null;
 }
 
+function isChromeRunning(): boolean {
+  const userDataDir = getChromeUserDataDir();
+  const lockFile = join(userDataDir, "SingletonLock");
+  try {
+    const stats = lstatSync(lockFile);
+    if (!stats.isSymbolicLink() && !stats.isFile()) {
+      return false;
+    }
+
+    // Verify the process is actually alive via SingletonLock symlink target: <hostname>-<pid>
+    if (stats.isSymbolicLink()) {
+      const target = readlinkSync(lockFile);
+      const match = target.match(/-(\d+)$/);
+      if (match) {
+        try {
+          process.kill(Number(match[1]), 0);
+        } catch {
+          try { unlinkSync(lockFile); } catch { /* ignore */ }
+          return false;
+        }
+      }
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getChromeUserDataDir(): string {
+  const defaultDir = join(homedir(), ".config", "google-chrome");
+  if (existsSync(defaultDir)) {
+    return defaultDir;
+  }
+  return join(homedir(), ".wegent-executor", "browser", "chrome-profile");
+}
+
 function isExtensionInstalled(userDataDir: string): boolean {
-  // Check if extension was previously installed by looking for our marker file
   const markerFile = join(userDataDir, ".extension-installed");
   return existsSync(markerFile);
 }
@@ -159,21 +195,10 @@ function markExtensionInstalled(userDataDir: string): void {
   writeFileSync(markerFile, new Date().toISOString());
 }
 
-function isChromeRunningWithProfile(): boolean {
-  const userDataDir = join(getBrowserPrefix(), "chrome-profile");
-  const lockFile = join(userDataDir, "SingletonLock");
-  try {
-    const stats = lstatSync(lockFile);
-    return stats.isSymbolicLink() || stats.isFile();
-  } catch {
-    return false;
-  }
-}
-
 function launchChrome(extensionPath: string): ChildProcess | null {
-  // Don't launch if Chrome is already running with our profile
-  if (isChromeRunningWithProfile()) {
-    console.log("Chrome is already running with this profile.");
+  // Don't launch if Chrome is already running
+  if (isChromeRunning()) {
+    console.log("Chrome is already running.");
     return null;
   }
 
@@ -183,8 +208,7 @@ function launchChrome(extensionPath: string): ChildProcess | null {
     return null;
   }
 
-  const userDataDir = join(getBrowserPrefix(), "chrome-profile");
-  const firstRun = !isExtensionInstalled(userDataDir);
+  const userDataDir = getChromeUserDataDir();
 
   const args = [
     `--user-data-dir=${userDataDir}`,
@@ -197,6 +221,7 @@ function launchChrome(extensionPath: string): ChildProcess | null {
   console.log(`  Chrome: ${chromePath}`);
   console.log(`  Profile: ${userDataDir}`);
 
+  const firstRun = !isExtensionInstalled(userDataDir);
   if (firstRun) {
     console.log(`\n*** FIRST RUN: Please install the extension manually ***`);
     console.log(`  1. Enable "Developer mode" (top right)`);
@@ -213,7 +238,7 @@ function launchChrome(extensionPath: string): ChildProcess | null {
 
   child.unref();
 
-  // On macOS, use osascript to open chrome://extensions after Chrome starts
+  // On macOS first run, open chrome://extensions to guide extension install
   if (firstRun && platform() === "darwin") {
     spawn("osascript", ["-e", `
       delay 2

--- a/deps/browser/relay-server/src/tool-cli.ts
+++ b/deps/browser/relay-server/src/tool-cli.ts
@@ -5,9 +5,82 @@
  * Command-line interface for browser automation
  */
 
+import * as fs from "node:fs";
 import { executeBrowserTool } from "./tool.js";
 
+const LINUX_GUI_ENV_DEFAULTS = {
+  DISPLAY: ":0",
+  WAYLAND_DISPLAY: "wayland-0",
+} as const;
+
+function getLinuxRuntimeDir(): string {
+  if (process.env.XDG_RUNTIME_DIR) {
+    return process.env.XDG_RUNTIME_DIR;
+  }
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : 1000;
+  return `/run/user/${uid}`;
+}
+
+function getLinuxDbusSessionBusAddress(): string {
+  if (process.env.DBUS_SESSION_BUS_ADDRESS) {
+    return process.env.DBUS_SESSION_BUS_ADDRESS;
+  }
+
+  return `unix:path=${getLinuxRuntimeDir()}/bus`;
+}
+
+function resolveLinuxXauthority(): string | null {
+  const runtimeDir = getLinuxRuntimeDir();
+
+  try {
+    const candidates = fs
+      .readdirSync(runtimeDir)
+      .filter((name) => name.startsWith(".mutter-Xwaylandauth."));
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    candidates.sort();
+    return `${runtimeDir}/${candidates[candidates.length - 1]}`;
+  } catch {
+    return null;
+  }
+}
+
+function applyLinuxGuiEnvDefaults(): void {
+  if (process.platform !== "linux") {
+    return;
+  }
+
+  if (!process.env.DISPLAY) {
+    process.env.DISPLAY = LINUX_GUI_ENV_DEFAULTS.DISPLAY;
+  }
+
+  if (!process.env.WAYLAND_DISPLAY) {
+    process.env.WAYLAND_DISPLAY = LINUX_GUI_ENV_DEFAULTS.WAYLAND_DISPLAY;
+  }
+
+  if (!process.env.XDG_RUNTIME_DIR) {
+    process.env.XDG_RUNTIME_DIR = getLinuxRuntimeDir();
+  }
+
+  if (!process.env.DBUS_SESSION_BUS_ADDRESS) {
+    process.env.DBUS_SESSION_BUS_ADDRESS = getLinuxDbusSessionBusAddress();
+  }
+
+  if (!process.env.XAUTHORITY) {
+    const xauthority = resolveLinuxXauthority();
+    if (xauthority) {
+      process.env.XAUTHORITY = xauthority;
+    }
+  }
+}
+
 async function main() {
+  applyLinuxGuiEnvDefaults();
+
   const input = process.argv[2];
 
   if (!input || input === "--help" || input === "-h") {

--- a/deps/browser/relay-server/src/tool.ts
+++ b/deps/browser/relay-server/src/tool.ts
@@ -27,12 +27,6 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const DEFAULT_BROWSER_PREFIX = path.join(os.homedir(), ".wegent-executor", "browser");
-
-function getBrowserPrefix(): string {
-  return process.env.BROWSER_PREFIX || DEFAULT_BROWSER_PREFIX;
-}
-
 function getExtensionPath(): string {
   // Check multiple possible locations
   const possiblePaths = [
@@ -86,22 +80,55 @@ function getChromePath(): string | null {
   return null;
 }
 
-function isChromeRunningWithProfile(): boolean {
-  const userDataDir = path.join(getBrowserPrefix(), "chrome-profile");
+function isChromeRunning(): boolean {
+  const userDataDir = getChromeUserDataDir();
   const lockFile = path.join(userDataDir, "SingletonLock");
-  // On macOS/Linux, SingletonLock is a symlink when Chrome is running
-  // On Windows, it's a file
   try {
     const stats = fs.lstatSync(lockFile);
-    return stats.isSymbolicLink() || stats.isFile();
+    if (!stats.isSymbolicLink() && !stats.isFile()) {
+      return false;
+    }
+
+    // Verify the process is actually alive via SingletonLock symlink target: <hostname>-<pid>
+    if (stats.isSymbolicLink()) {
+      const target = fs.readlinkSync(lockFile);
+      const match = target.match(/-(\d+)$/);
+      if (match) {
+        try {
+          process.kill(Number(match[1]), 0);
+        } catch {
+          try { fs.unlinkSync(lockFile); } catch { /* ignore */ }
+          return false;
+        }
+      }
+    }
+
+    return true;
   } catch {
     return false;
   }
 }
 
+function getChromeUserDataDir(): string {
+  const defaultDir = path.join(os.homedir(), ".config", "google-chrome");
+  if (fs.existsSync(defaultDir)) {
+    return defaultDir;
+  }
+  return path.join(os.homedir(), ".wegent-executor", "browser", "chrome-profile");
+}
+
+function getChromeLaunchArgs(url?: string): string[] {
+  return [
+    `--user-data-dir=${getChromeUserDataDir()}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+    url || "about:blank",
+  ];
+}
+
 function launchBrowserWithInstructions(url?: string): { launched: boolean; message: string } {
-  // Don't launch if Chrome is already running with our profile
-  if (isChromeRunningWithProfile()) {
+  // Don't launch if Chrome is already running
+  if (isChromeRunning()) {
     return {
       launched: false,
       message: "Chrome is already running. Please click the extension icon on a tab to attach.",
@@ -116,19 +143,8 @@ function launchBrowserWithInstructions(url?: string): { launched: boolean; messa
     };
   }
 
-  const userDataDir = path.join(getBrowserPrefix(), "chrome-profile");
-  // Use provided URL, or open a blank page if none provided
-  const targetUrl = url || "about:blank";
-
-  const args = [
-    `--user-data-dir=${userDataDir}`,
-    "--no-first-run",
-    "--no-default-browser-check",
-    targetUrl,
-  ];
-
   try {
-    const child = spawn(chromePath, args, {
+    const child = spawn(chromePath, getChromeLaunchArgs(url), {
       detached: true,
       stdio: "ignore",
     });
@@ -183,7 +199,8 @@ function openExtensionsPage(): { opened: boolean; message: string } {
   // For other platforms, return instructions
   return {
     opened: false,
-    message: `Please install the extension manually:
+    message: `If the extension is already installed, open a normal web page in Chrome and click the extension icon to attach.
+If it is not installed yet:
 1. Go to chrome://extensions
 2. Enable "Developer mode" (top right toggle)
 3. Click "Load unpacked"
@@ -208,6 +225,22 @@ function openUrlInChrome(url: string): void {
     } catch {
       // Ignore errors
     }
+    return;
+  }
+
+  const chromePath = process.env.CHROME_PATH || getChromePath();
+  if (!chromePath) {
+    return;
+  }
+
+  try {
+    const child = spawn(chromePath, getChromeLaunchArgs(url), {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  } catch {
+    // Ignore errors
   }
 }
 
@@ -405,9 +438,6 @@ async function tryEnsureConnected(params: BrowserToolParams): Promise<{
   connected: boolean;
   error?: string;
 }> {
-  const initialAttachWaitMs = 2500;
-  const graceAttachWaitMs = 1500;
-
   const status = await getStatus();
 
   if (!status.relayRunning) {
@@ -421,7 +451,7 @@ async function tryEnsureConnected(params: BrowserToolParams): Promise<{
     return { connected: true };
   }
 
-  const chromeRunning = isChromeRunningWithProfile();
+  const chromeRunning = isChromeRunning();
   const targetUrl = (params.action === "open" || params.action === "navigate") ? params.url : undefined;
 
   if (!chromeRunning) {
@@ -435,6 +465,11 @@ async function tryEnsureConnected(params: BrowserToolParams): Promise<{
     // Extension may auto-attach to the new tab
     openUrlInChrome(targetUrl);
   }
+
+  // Cold-starting Chrome on cloud desktops can take noticeably longer than opening a new
+  // tab in an already-running browser, so use a wider wait window for first launch.
+  const initialAttachWaitMs = chromeRunning ? 5000 : 12000;
+  const graceAttachWaitMs = chromeRunning ? 3000 : 5000;
 
   // Wait for extension to attach.
   // Extension auto-attach can be slightly delayed after browser/tab activation.
@@ -727,7 +762,7 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
 
       if (params.ensure) {
         const ensureUrl = typeof params.url === "string" ? params.url : undefined;
-        const running = isChromeRunningWithProfile();
+        const running = isChromeRunning();
         if (!running) {
           const launchResult = launchBrowserWithInstructions(ensureUrl);
           launched = launchResult.launched;
@@ -736,7 +771,7 @@ export async function executeBrowserTool(params: BrowserToolParams): Promise<Bro
           openUrlInChrome(ensureUrl);
         }
         waitedForAttach = true;
-        await waitForConnection(5000);
+        await waitForConnection(running ? 5000 : 12000);
       }
 
       const status = await getStatus();


### PR DESCRIPTION
## Summary
- improve browser-tool Linux recovery for cloud desktop environments
- inject Linux GUI session defaults in `tool-cli` using dynamic uid and Xauthority discovery
- reuse the default Chrome profile, support opening URLs on Linux, and extend cold-start attach waits
- avoid opening the extension options page for auto-loaded installs and align CLI Chrome detection with runtime behavior

## Testing
- cd deps/browser/relay-server && npm run typecheck
- cd deps/browser/relay-server && npm run build
- validated on cloud hosts by installing published package versions and rerunning browser-tool tasks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Chrome process detection with PID verification to ensure Chrome is actually running
  * Added Linux GUI environment initialization for improved browser automation support

* **Bug Fixes**
  * Extension options page now opens only on initial installation
  * Improved connection timeouts that adapt based on Chrome's running state
  * Refined extension attachment instructions for end-users

* **Version**
  * Package version updated to 0.1.16

<!-- end of auto-generated comment: release notes by coderabbit.ai -->