### PR TITLE
fix: fix welcome timezone

### DIFF
--- a/backend/app/services/work_queue_service.py
+++ b/backend/app/services/work_queue_service.py
@@ -6,7 +6,7 @@
 
 import logging
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy import and_, func
@@ -379,13 +379,13 @@ class WorkQueueService:
                     "role": "ASSISTANT",
                     "content": WELCOME_MESSAGE_ZH,
                     "senderUserName": "wegent",
-                    "createdAt": datetime.now().isoformat(),
+                    "createdAt": datetime.now(timezone.utc).isoformat(),
                 },
                 {
                     "role": "ASSISTANT",
                     "content": WELCOME_MESSAGE_EN,
                     "senderUserName": "wegent",
-                    "createdAt": datetime.now().isoformat(),
+                    "createdAt": datetime.now(timezone.utc).isoformat(),
                 },
             ],
             note="",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Welcome message timestamps now use UTC instead of local time, ensuring consistent timestamp recording regardless of server location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->