### PR TITLE
Feat/executor no claude code build

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -17,7 +17,7 @@ on:
 env:
   GIT_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.merge_commit_sha || 'main' }}
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  IMAGE_PREFIX: ghcr.io/${{ toLower(github.repository_owner) }}
 
 concurrency:
   group: publish-image

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -623,7 +623,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }} --target-platform Linux
 
       - name: Rename binary with platform suffix
         run: |
@@ -634,6 +634,44 @@ jobs:
         with:
           name: wegent-executor-linux-amd64
           path: executor/dist/wegent-executor-linux-amd64
+          retention-days: 1
+
+  build-executor-local-linux-amd64-no-cc:
+    needs: prepare-release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build (without Claude Code)
+        working-directory: executor
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }} --target-platform Linux --without-claude-code
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor-no-cc executor/dist/wegent-executor-linux-amd64-no-cc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-linux-amd64-no-cc
+          path: executor/dist/wegent-executor-linux-amd64-no-cc
           retention-days: 1
 
   build-executor-local-linux-arm64:
@@ -661,7 +699,7 @@ jobs:
           GITHUB_REPO: ${{ github.repository }}
         run: |
           uv sync --group build
-          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }}
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }} --target-platform Linux
 
       - name: Rename binary with platform suffix
         run: |
@@ -672,6 +710,44 @@ jobs:
         with:
           name: wegent-executor-linux-arm64
           path: executor/dist/wegent-executor-linux-arm64
+          retention-days: 1
+
+  build-executor-local-linux-arm64-no-cc:
+    needs: prepare-release
+    runs-on: ubuntu-22.04-arm
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies and build (without Claude Code)
+        working-directory: executor
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+        run: |
+          uv sync --group build
+          uv run python scripts/build_local.py --version ${{ needs.prepare-release.outputs.new_version }} --target-platform Linux --without-claude-code
+
+      - name: Rename binary with platform suffix
+        run: |
+          mv executor/dist/wegent-executor-no-cc executor/dist/wegent-executor-linux-arm64-no-cc
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wegent-executor-linux-arm64-no-cc
+          path: executor/dist/wegent-executor-linux-arm64-no-cc
           retention-days: 1
 
   # ============================================================================
@@ -795,7 +871,9 @@ jobs:
       - build-executor-local-macos-arm64
       - build-executor-local-macos-amd64
       - build-executor-local-linux-amd64
+      - build-executor-local-linux-amd64-no-cc
       - build-executor-local-linux-arm64
+      - build-executor-local-linux-arm64-no-cc
       - build-executor-local-windows-amd64
     runs-on: ubuntu-latest
     permissions:
@@ -872,7 +950,9 @@ jobs:
             ./executor-binaries/wegent-executor-macos-arm64
             ./executor-binaries/wegent-executor-macos-amd64
             ./executor-binaries/wegent-executor-linux-amd64
+            ./executor-binaries/wegent-executor-linux-amd64-no-cc
             ./executor-binaries/wegent-executor-linux-arm64
+            ./executor-binaries/wegent-executor-linux-arm64-no-cc
             ./executor-binaries/wegent-executor-windows-amd64.exe
             ./executor/scripts/local_executor_install.sh
             ./executor/scripts/local_executor_install.ps1

--- a/docs/en/user-guide/ai-devices/local-device-support.md
+++ b/docs/en/user-guide/ai-devices/local-device-support.md
@@ -80,6 +80,22 @@ curl -fsSL https://github.com/wecode-ai/Wegent/releases/download/v1.0.0/local_ex
 $env:WEGENT_VERSION='v1.0.0'; irm https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.ps1 | iex
 ```
 
+#### Version Without Claude Code
+
+If you don't need Claude Code functionality, you can download a lightweight version without Claude Code. This version has a smaller file size and is suitable for scenarios where you only need to use other AI models.
+
+On the [GitHub Releases](https://github.com/wecode-ai/Wegent/releases) page, download files with the `-no-cc` suffix:
+- `wegent-executor-linux-amd64-no-cc`
+- `wegent-executor-linux-arm64-no-cc`
+
+Usage is the same as the standard version:
+
+```bash
+wegent-executor-no-cc --mode local --token YOUR_JWT_TOKEN
+```
+
+> **Note**: The version without Claude Code cannot use Bots with ClaudeCode shell type.
+
 #### Manual Installation (Development)
 
 1. Clone or download the Wegent repository

--- a/docs/zh/user-guide/ai-devices/local-device-support.md
+++ b/docs/zh/user-guide/ai-devices/local-device-support.md
@@ -82,6 +82,22 @@ curl -fsSL https://github.com/wecode-ai/Wegent/releases/download/v1.0.0/local_ex
 $env:WEGENT_VERSION='v1.0.0'; irm https://github.com/wecode-ai/Wegent/releases/latest/download/local_executor_install.ps1 | iex
 ```
 
+#### 不包含 Claude Code 的版本
+
+如果您不需要使用 Claude Code 功能，可以下载不含 Claude Code 的精简版本。该版本体积更小，适合只需要使用其他 AI 模型的场景。
+
+在 [GitHub Releases](https://github.com/wecode-ai/Wegent/releases) 页面下载带有 `-no-cc` 后缀的文件：
+- `wegent-executor-linux-amd64-no-cc`
+- `wegent-executor-linux-arm64-no-cc`
+
+使用方法与标准版本相同：
+
+```bash
+wegent-executor-no-cc --mode local --token YOUR_JWT_TOKEN
+```
+
+> **注意**：不含 Claude Code 的版本无法使用 ClaudeCode shell 类型的 Bot。
+
 #### 手动安装（开发环境）
 
 1. 克隆或下载 Wegent 仓库

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -323,6 +323,7 @@ def build_executable(
     target_arch: str | None = None,
     target_platform: str | None = None,
     version: str | None = None,
+    without_claude_code: bool = False,
 ):
     """Build the executable using PyInstaller.
 
@@ -332,6 +333,7 @@ def build_executable(
         target_platform: Target platform for cross-compilation (e.g., 'Windows', 'Darwin', 'Linux').
                         If None, builds for the current platform.
         version: Version string to embed in the binary. If None, reads from pyproject.toml.
+        without_claude_code: If True, builds a version without Claude Code support.
     """
     project_root = get_project_root()
     executor_root = get_executor_root()
@@ -345,6 +347,8 @@ def build_executable(
     print(f"Building version: {version}")
     if target_platform:
         print(f"Target platform: {target_platform}")
+    if without_claude_code:
+        print("Building WITHOUT Claude Code support")
     original_version_content = embed_version_in_source(version)
 
     # Get GitHub repo from environment and embed it
@@ -358,8 +362,19 @@ def build_executable(
         # Determine output name based on platform
         if platform.system() == "Windows":
             output_name = "wegent-executor.exe"
+            pyinstaller_name = "wegent-executor"
         else:
             output_name = "wegent-executor"
+            pyinstaller_name = "wegent-executor"
+
+        # Adjust names if building without Claude Code
+        if without_claude_code:
+            if platform.system() == "Windows":
+                output_name = "wegent-executor-no-cc.exe"
+                pyinstaller_name = "wegent-executor-no-cc"
+            else:
+                output_name = "wegent-executor-no-cc"
+                pyinstaller_name = "wegent-executor-no-cc"
 
         # PyInstaller command
         cmd = [
@@ -367,7 +382,7 @@ def build_executable(
             "-m",
             "PyInstaller",
             "--onefile",
-            "--name=wegent-executor",
+            f"--name={pyinstaller_name}",
             f"--distpath={executor_root / 'dist'}",
             f"--workpath={executor_root / 'build'}",
             f"--specpath={executor_root}",
@@ -458,59 +473,68 @@ def build_executable(
             "--hidden-import=anyio",
             "--hidden-import=anyio._backends",
             "--hidden-import=anyio._backends._asyncio",
-            # Claude Code SDK
-            "--hidden-import=claude_code_sdk",
-            # MCP dependencies (required by claude_agent_sdk -> mcp)
-            "--hidden-import=starlette",
-            "--hidden-import=starlette.applications",
-            "--hidden-import=starlette.responses",
-            "--hidden-import=starlette.routing",
-            "--hidden-import=starlette.middleware",
-            "--hidden-import=starlette.requests",
-            "--hidden-import=starlette.websockets",
-            "--hidden-import=starlette.staticfiles",
-            "--hidden-import=starlette.templating",
-            "--hidden-import=starlette.background",
-            "--hidden-import=starlette.concurrency",
-            "--hidden-import=starlette.config",
-            "--hidden-import=starlette.convertors",
-            "--hidden-import=starlette.datastructures",
-            "--hidden-import=starlette.endpoints",
-            "--hidden-import=starlette.exceptions",
-            "--hidden-import=starlette.formparsers",
-            "--hidden-import=starlette.middleware.authentication",
-            "--hidden-import=starlette.middleware.base",
-            "--hidden-import=starlette.middleware.cors",
-            "--hidden-import=starlette.middleware.errors",
-            "--hidden-import=starlette.middleware.gzip",
-            "--hidden-import=starlette.middleware.httpsredirect",
-            "--hidden-import=starlette.middleware.sessions",
-            "--hidden-import=starlette.middleware.trustedhost",
-            "--hidden-import=starlette.middleware.wsgi",
-            "--hidden-import=starlette.schemas",
-            "--hidden-import=starlette.status",
-            "--hidden-import=starlette.testclient",
-            "--hidden-import=starlette.types",
-            "--hidden-import=sse_starlette",
-            "--hidden-import=sse_starlette.sse",
-            # Tokenizer plugin used by tiktoken at runtime
-            "--hidden-import=tiktoken_ext.openai_public",
-            # SSL certificates (needed for HTTPS connections)
-            "--collect-data=certifi",
-            "--collect-data=tiktoken",
-            "--collect-data=tiktoken_ext",
         ]
 
+        # Add Claude Code SDK hidden imports only if not excluded
+        if not without_claude_code:
+            cmd += [
+                # Claude Code SDK
+                "--hidden-import=claude_code_sdk",
+                # MCP dependencies (required by claude_agent_sdk -> mcp)
+                "--hidden-import=starlette",
+                "--hidden-import=starlette.applications",
+                "--hidden-import=starlette.responses",
+                "--hidden-import=starlette.routing",
+                "--hidden-import=starlette.middleware",
+                "--hidden-import=starlette.requests",
+                "--hidden-import=starlette.websockets",
+                "--hidden-import=starlette.staticfiles",
+                "--hidden-import=starlette.templating",
+                "--hidden-import=starlette.background",
+                "--hidden-import=starlette.concurrency",
+                "--hidden-import=starlette.config",
+                "--hidden-import=starlette.convertors",
+                "--hidden-import=starlette.datastructures",
+                "--hidden-import=starlette.endpoints",
+                "--hidden-import=starlette.exceptions",
+                "--hidden-import=starlette.formparsers",
+                "--hidden-import=starlette.middleware.authentication",
+                "--hidden-import=starlette.middleware.base",
+                "--hidden-import=starlette.middleware.cors",
+                "--hidden-import=starlette.middleware.errors",
+                "--hidden-import=starlette.middleware.gzip",
+                "--hidden-import=starlette.middleware.httpsredirect",
+                "--hidden-import=starlette.middleware.sessions",
+                "--hidden-import=starlette.middleware.trustedhost",
+                "--hidden-import=starlette.middleware.wsgi",
+                "--hidden-import=starlette.schemas",
+                "--hidden-import=starlette.status",
+                "--hidden-import=starlette.testclient",
+                "--hidden-import=starlette.types",
+                "--hidden-import=sse_starlette",
+                "--hidden-import=sse_starlette.sse",
+                # Tokenizer plugin used by tiktoken at runtime
+                "--hidden-import=tiktoken_ext.openai_public",
+                # SSL certificates (needed for HTTPS connections)
+                "--collect-data=certifi",
+                "--collect-data=tiktoken",
+                "--collect-data=tiktoken_ext",
+            ]
+
         # Add Claude CLI binary for Linux and Windows (macOS uses system-installed)
-        claude_binary = find_claude_agent_sdk_binary(target_platform=effective_platform)
-        if claude_binary:
-            src_path, dest_dir = claude_binary
-            cmd.append(f"--add-binary={src_path}{os.pathsep}{dest_dir}")
-            print(f"Adding Claude CLI binary to build: {src_path} -> {dest_dir}")
-        elif effective_platform in ["Windows", "Linux"]:
-            print(
-                f"Warning: Claude CLI binary not found for {effective_platform}, executor may fail"
+        # Skip if without_claude_code is True
+        if not without_claude_code:
+            claude_binary = find_claude_agent_sdk_binary(
+                target_platform=effective_platform
             )
+            if claude_binary:
+                src_path, dest_dir = claude_binary
+                cmd.append(f"--add-binary={src_path}{os.pathsep}{dest_dir}")
+                print(f"Adding Claude CLI binary to build: {src_path} -> {dest_dir}")
+            elif effective_platform in ["Windows", "Linux"]:
+                print(
+                    f"Warning: Claude CLI binary not found for {effective_platform}, executor may fail"
+                )
 
         # Continue with remaining options
         cmd += [
@@ -549,6 +573,15 @@ def build_executable(
             for imp in windows_imports:
                 cmd.insert(-1, imp)
             print("Added Windows-specific hidden imports")
+
+        # Exclude Claude Code SDK if without_claude_code is True
+        if without_claude_code:
+            cmd += [
+                "--exclude-module=claude_code_sdk",
+                "--exclude-module=claude_agent_sdk",
+                "--exclude-module=mcp",
+            ]
+            print("Building without Claude Code support (excluded modules)")
 
         # Add target architecture for cross-compilation on macOS
         if target_arch and platform.system() == "Darwin":
@@ -604,6 +637,11 @@ def main():
         "--version",
         help="Override version number (defaults to pyproject.toml version)",
     )
+    parser.add_argument(
+        "--without-claude-code",
+        action="store_true",
+        help="Build a version without Claude Code support (smaller binary, no Claude Code dependency)",
+    )
     args = parser.parse_args()
 
     print("=" * 60)
@@ -615,6 +653,8 @@ def main():
         print(f"Target architecture: {args.target_arch}")
     if args.target_platform:
         print(f"Target platform: {args.target_platform}")
+    if args.without_claude_code:
+        print("Build mode: WITHOUT Claude Code support")
     print()
 
     # Clean previous builds
@@ -625,6 +665,7 @@ def main():
         target_arch=args.target_arch,
         target_platform=args.target_platform,
         version=args.version,
+        without_claude_code=args.without_claude_code,
     )
 
     print()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lightweight Wegent Executor builds for Linux (x86_64 and ARM64) that exclude Claude Code, yielding smaller binaries.

* **Documentation**
  * Added install/run instructions for the lightweight executor, including local run command and note that it cannot be used with ClaudeCode shell-type bots.

* **Chores**
  * Release artifacts and release packaging updated to include the new lightweight Linux binaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->