### PR TITLE
[codex] Expose skills dir env var

### DIFF
--- a/docs/en/developer-guide/skill-development.md
+++ b/docs/en/developer-guide/skill-development.md
@@ -118,7 +118,7 @@ The Skill system has different implementations for different Shell types:
 | `clear_cache` | `true` | `false` |
 | `skip_existing` | `false` | `true` |
 
-ClaudeCode also injects a `WEGENT_SKILLS_DIR` environment variable at runtime. It points to the skills root directory for the current task. When a skill instruction needs to execute `scripts/xxx.sh`, resolve it to an absolute path such as `bash "$WEGENT_SKILLS_DIR/<skill-name>/scripts/xxx.sh"` instead of relying on the repository working directory.
+ClaudeCode also injects a `SKILLS_DIR` environment variable at runtime. It points to the skills root directory for the current task. When a skill instruction needs to execute `scripts/xxx.sh`, resolve it to an absolute path such as `bash "$SKILLS_DIR/<skill-name>/scripts/xxx.sh"` instead of relying on the repository working directory.
 
 ### Key Components
 

--- a/docs/en/developer-guide/skill-development.md
+++ b/docs/en/developer-guide/skill-development.md
@@ -118,6 +118,8 @@ The Skill system has different implementations for different Shell types:
 | `clear_cache` | `true` | `false` |
 | `skip_existing` | `false` | `true` |
 
+ClaudeCode also injects a `WEGENT_SKILLS_DIR` environment variable at runtime. It points to the skills root directory for the current task. When a skill instruction needs to execute `scripts/xxx.sh`, resolve it to an absolute path such as `bash "$WEGENT_SKILLS_DIR/<skill-name>/scripts/xxx.sh"` instead of relying on the repository working directory.
+
 ### Key Components
 
 1. **SkillDownloader** (`executor/services/api_client.py`)

--- a/docs/zh/developer-guide/skill-development.md
+++ b/docs/zh/developer-guide/skill-development.md
@@ -118,7 +118,7 @@ Skill 系统在不同的 Shell 类型中有不同的实现方式：
 | `clear_cache` | `true` | `false` |
 | `skip_existing` | `false` | `true` |
 
-ClaudeCode 运行时会额外注入环境变量 `WEGENT_SKILLS_DIR`，指向当前任务的 skills 根目录。Skill 指令中如果需要执行 `scripts/xxx.sh`，应解析为绝对路径，例如 `bash "$WEGENT_SKILLS_DIR/<skill-name>/scripts/xxx.sh"`，不要依赖仓库当前工作目录。
+ClaudeCode 运行时会额外注入环境变量 `SKILLS_DIR`，指向当前任务的 skills 根目录。Skill 指令中如果需要执行 `scripts/xxx.sh`，应解析为绝对路径，例如 `bash "$SKILLS_DIR/<skill-name>/scripts/xxx.sh"`，不要依赖仓库当前工作目录。
 
 ### 关键组件
 

--- a/docs/zh/developer-guide/skill-development.md
+++ b/docs/zh/developer-guide/skill-development.md
@@ -118,6 +118,8 @@ Skill 系统在不同的 Shell 类型中有不同的实现方式：
 | `clear_cache` | `true` | `false` |
 | `skip_existing` | `false` | `true` |
 
+ClaudeCode 运行时会额外注入环境变量 `WEGENT_SKILLS_DIR`，指向当前任务的 skills 根目录。Skill 指令中如果需要执行 `scripts/xxx.sh`，应解析为绝对路径，例如 `bash "$WEGENT_SKILLS_DIR/<skill-name>/scripts/xxx.sh"`，不要依赖仓库当前工作目录。
+
 ### 关键组件
 
 1. **SkillDownloader** (`executor/services/api_client.py`)

--- a/executor/agents/claude_code/docker_mode_strategy.py
+++ b/executor/agents/claude_code/docker_mode_strategy.py
@@ -115,7 +115,7 @@ class DockerModeStrategy(ExecutionModeStrategy):
         existing_env = dict(updated_options.get("env", {}))
         merged_env = {**existing_env, **env_config, **task_identity_env}
         runtime_env = {k: str(v) for k, v in merged_env.items()}
-        runtime_env["WEGENT_SKILLS_DIR"] = self.get_skills_directory()
+        runtime_env["SKILLS_DIR"] = self.get_skills_directory()
         updated_options["env"] = runtime_env
 
         return updated_options

--- a/executor/agents/claude_code/docker_mode_strategy.py
+++ b/executor/agents/claude_code/docker_mode_strategy.py
@@ -114,9 +114,9 @@ class DockerModeStrategy(ExecutionModeStrategy):
         updated_options = options.copy()
         existing_env = dict(updated_options.get("env", {}))
         merged_env = {**existing_env, **env_config, **task_identity_env}
-
-        if merged_env:
-            updated_options["env"] = {k: str(v) for k, v in merged_env.items()}
+        runtime_env = {k: str(v) for k, v in merged_env.items()}
+        runtime_env["WEGENT_SKILLS_DIR"] = self.get_skills_directory()
+        updated_options["env"] = runtime_env
 
         return updated_options
 

--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -136,6 +136,7 @@ class LocalModeStrategy(ExecutionModeStrategy):
         # Set CLAUDE_CONFIG_DIR to redirect all config reads/writes
         # This affects settings.json, claude.json, and skills locations
         env["CLAUDE_CONFIG_DIR"] = config_dir
+        env["WEGENT_SKILLS_DIR"] = self.get_skills_directory(config_dir)
 
         # Add ANTHROPIC_CUSTOM_HEADERS if configured via environment variable
         if config.ANTHROPIC_CUSTOM_HEADERS:

--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -136,7 +136,7 @@ class LocalModeStrategy(ExecutionModeStrategy):
         # Set CLAUDE_CONFIG_DIR to redirect all config reads/writes
         # This affects settings.json, claude.json, and skills locations
         env["CLAUDE_CONFIG_DIR"] = config_dir
-        env["WEGENT_SKILLS_DIR"] = self.get_skills_directory(config_dir)
+        env["SKILLS_DIR"] = self.get_skills_directory(config_dir)
 
         # Add ANTHROPIC_CUSTOM_HEADERS if configured via environment variable
         if config.ANTHROPIC_CUSTOM_HEADERS:

--- a/executor/tests/agents/test_mode_strategy.py
+++ b/executor/tests/agents/test_mode_strategy.py
@@ -221,7 +221,7 @@ class TestLocalModeStrategy:
             == task_identity_env["WEGENT_SKILL_USER_NAME"]
         )
         assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
-        assert result["env"]["WEGENT_SKILLS_DIR"] == "/workspace/12345/.claude/skills"
+        assert result["env"]["SKILLS_DIR"] == "/workspace/12345/.claude/skills"
 
     def test_configure_client_options_sets_claude_config_dir(self, strategy):
         """Test that CLAUDE_CONFIG_DIR is set correctly."""
@@ -231,7 +231,7 @@ class TestLocalModeStrategy:
         result = strategy.configure_client_options(options, config_dir, {}, {})
 
         assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
-        assert result["env"]["WEGENT_SKILLS_DIR"] == "/workspace/12345/.claude/skills"
+        assert result["env"]["SKILLS_DIR"] == "/workspace/12345/.claude/skills"
 
     def test_configure_client_options_adds_anthropic_custom_headers(self, strategy):
         """Test that ANTHROPIC_CUSTOM_HEADERS is added when configured."""
@@ -419,7 +419,7 @@ class TestDockerModeStrategy:
         assert result["env"]["SOME_VAR"] == "value"
         assert result["env"]["WEGENT_SKILL_IDENTITY_TOKEN"] == "skill-jwt"
         assert result["env"]["WEGENT_SKILL_USER_NAME"] == "alice"
-        assert result["env"]["WEGENT_SKILLS_DIR"] == strategy.get_skills_directory()
+        assert result["env"]["SKILLS_DIR"] == strategy.get_skills_directory()
         assert original_options["env"] == {"SOME_VAR": "value"}
         assert "WEGENT_SKILL_IDENTITY_TOKEN" not in os.environ
 

--- a/executor/tests/agents/test_mode_strategy.py
+++ b/executor/tests/agents/test_mode_strategy.py
@@ -221,6 +221,7 @@ class TestLocalModeStrategy:
             == task_identity_env["WEGENT_SKILL_USER_NAME"]
         )
         assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
+        assert result["env"]["WEGENT_SKILLS_DIR"] == "/workspace/12345/.claude/skills"
 
     def test_configure_client_options_sets_claude_config_dir(self, strategy):
         """Test that CLAUDE_CONFIG_DIR is set correctly."""
@@ -230,6 +231,7 @@ class TestLocalModeStrategy:
         result = strategy.configure_client_options(options, config_dir, {}, {})
 
         assert result["env"]["CLAUDE_CONFIG_DIR"] == config_dir
+        assert result["env"]["WEGENT_SKILLS_DIR"] == "/workspace/12345/.claude/skills"
 
     def test_configure_client_options_adds_anthropic_custom_headers(self, strategy):
         """Test that ANTHROPIC_CUSTOM_HEADERS is added when configured."""
@@ -417,6 +419,7 @@ class TestDockerModeStrategy:
         assert result["env"]["SOME_VAR"] == "value"
         assert result["env"]["WEGENT_SKILL_IDENTITY_TOKEN"] == "skill-jwt"
         assert result["env"]["WEGENT_SKILL_USER_NAME"] == "alice"
+        assert result["env"]["WEGENT_SKILLS_DIR"] == strategy.get_skills_directory()
         assert original_options["env"] == {"SOME_VAR": "value"}
         assert "WEGENT_SKILL_IDENTITY_TOKEN" not in os.environ
 


### PR DESCRIPTION
## What changed

This change exposes the deployed ClaudeCode skills root directory through a stable `WEGENT_SKILLS_DIR` environment variable in both local and docker execution modes.

It also documents the runtime contract in the skill development guide and extends the executor mode strategy tests to verify the new variable is present.

## Why

Skills need a consistent way to resolve bundled helper scripts with absolute paths during executor runs.

Before this change, ClaudeCode tasks only exposed `CLAUDE_CONFIG_DIR`, which is intended for the SDK configuration directory and not as the explicit runtime contract for skill path resolution.

## Impact

Skills can now reliably reference helper scripts under the deployed skills directory via `WEGENT_SKILLS_DIR`.

This keeps the contract narrow: executor provides the environment variable, and each skill is responsible for using it.

## Validation

- `cd /Users/crystal/dev/git/Wegent/executor && uv run pytest tests/agents/test_mode_strategy.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime support for a SKILLS_DIR environment variable to point to the task-scoped skills directory for both Docker and local execution modes.

* **Documentation**
  * Updated English and Chinese developer guides with guidance to run skill scripts using absolute paths (examples use the SKILLS_DIR convention).

* **Tests**
  * Added assertions to validate SKILLS_DIR is injected into the runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->