### PR TITLE
feat(knowledge): migrate personal knowledge base to group

### DIFF
--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from typing import Optional, Union
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
@@ -526,11 +526,23 @@ def migrate_knowledge_base_to_group(
             },
         )
         return result
+    except IntegrityError as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A knowledge base with this name already exists in the target group",
+        ) from e
+    except SQLAlchemyError as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Database error during migration: {str(e)}",
+        ) from e
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
-        )
+        ) from e
 
 
 # ============== Knowledge Document Endpoints ==============
@@ -1611,7 +1623,7 @@ knowledge_router = APIRouter()
 
 @knowledge_router.get(
     "/list",
-    response_model=Union[PersonalKnowledgeBaseGroup, AllGroupedKnowledgeResponse],
+    response_model=KnowledgeBaseListResponse,
 )
 @trace_sync("list_knowledge_bases_v1", "knowledge.api")
 def list_knowledge_bases_v1(
@@ -1621,7 +1633,7 @@ def list_knowledge_bases_v1(
     ),
     auth_context: AuthContext = Depends(get_auth_context),
     db: Session = Depends(get_db),
-) -> Union[PersonalKnowledgeBaseGroup, AllGroupedKnowledgeResponse]:
+):
     """
     List knowledge bases with flexible authentication.
 
@@ -1635,20 +1647,6 @@ def list_knowledge_bases_v1(
             - "all": Return all accessible knowledge bases (personal + groups + organization)
             - Unrecognized values are treated as "all"
 
-    Returns:
-        - When scope="personal": PersonalKnowledgeBaseGroup schema
-          {
-            "created_by_me": [...],
-            "shared_with_me": [...]
-          }
-        - When scope="all": AllGroupedKnowledgeResponse schema
-          {
-            "personal": {"created_by_me": [...], "shared_with_me": [...]},
-            "groups": [...],
-            "organization": {...},
-            "summary": {...}
-          }
-
     Authentication:
         - Personal API key: Returns knowledge bases accessible to the key owner
         - Service API key: Requires wegent-username header to specify the target user
@@ -1660,15 +1658,9 @@ def list_knowledge_bases_v1(
     if normalized_scope not in ("personal", "all"):
         normalized_scope = "all"
 
-    if normalized_scope == "personal":
-        # Return personal knowledge bases grouped by ownership
-        return KnowledgeService.get_personal_knowledge_bases_grouped(
-            db=db,
-            user_id=current_user.id,
-        )
-    else:
-        # Return all accessible knowledge bases grouped by scope
-        return KnowledgeService.get_all_knowledge_bases_grouped(
-            db=db,
-            user_id=current_user.id,
-        )
+    # Use Orchestrator for unified business logic (REST API and MCP tools share the same logic)
+    return knowledge_orchestrator.list_knowledge_bases(
+        db=db,
+        user=current_user,
+        scope=normalized_scope,
+    )

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -33,6 +33,8 @@ from app.schemas.knowledge import (
     DocumentDetailResponse,
     KnowledgeBaseCreate,
     KnowledgeBaseListResponse,
+    KnowledgeBaseMigrateRequest,
+    KnowledgeBaseMigrateResponse,
     KnowledgeBaseResponse,
     KnowledgeBaseTypeUpdate,
     KnowledgeBaseUpdate,
@@ -482,6 +484,48 @@ def update_knowledge_base_type(
             knowledge_base,
             KnowledgeService.get_document_count(db, knowledge_base.id),
         )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+
+@router.post(
+    "/{knowledge_base_id}/migrate",
+    response_model=KnowledgeBaseMigrateResponse,
+)
+@trace_sync("migrate_knowledge_base_to_group", "knowledge.api")
+def migrate_knowledge_base_to_group(
+    knowledge_base_id: int,
+    data: KnowledgeBaseMigrateRequest,
+    current_user: User = Depends(security.get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Migrate a personal knowledge base to a group.
+
+    - Only personal knowledge bases (namespace='default') can be migrated
+    - Only the creator of the knowledge base can migrate it
+    - User must have Maintainer or Owner permission in the target group
+    - Target group name must be a valid group namespace
+    """
+    try:
+        result = KnowledgeService.migrate_knowledge_base_to_group(
+            db=db,
+            knowledge_base_id=knowledge_base_id,
+            user_id=current_user.id,
+            target_group_name=data.target_group_name,
+        )
+        add_span_event(
+            "knowledge.base.migrated",
+            {
+                "kb_id": str(knowledge_base_id),
+                "user_id": str(current_user.id),
+                "target_group": data.target_group_name,
+            },
+        )
+        return result
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/app/schemas/kind.py
+++ b/backend/app/schemas/kind.py
@@ -491,15 +491,19 @@ class KnowledgeBaseTaskRef(BaseModel):
     """Reference to a KnowledgeBase bound to a Task (group chat)
 
     Note: The 'id' field stores Kind.id for stable references.
-    The 'name' field stores the display name (spec.name) for backward compatibility.
+    The 'name' field stores the display name (spec.name) for display purposes.
     When looking up a knowledge base:
-    1. If 'id' exists, query by Kind.id directly (preferred)
-    2. If 'id' is None, fall back to name + namespace lookup (legacy data)
+    1. Query by Kind.id directly (id is the unique identifier)
+    2. Legacy data with namespace field will be ignored during lookup
+
+    The namespace field was removed because:
+    - Knowledge base ID is globally unique and sufficient for lookup
+    - When KB migrates from personal to group namespace, we don't need to update all task refs
     """
 
     id: Optional[int] = None  # Knowledge base Kind.id (primary reference)
-    name: str  # Display name (spec.name), kept for backward compatibility
-    namespace: str = "default"
+    name: str  # Display name (spec.name), kept for display purposes
+    # Note: namespace field removed - use id for lookup, existing data with namespace is ignored
     boundBy: Optional[str] = None  # Username of the person who bound this KB
     boundAt: Optional[str] = None  # Binding timestamp in ISO format
 

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -698,3 +698,26 @@ class CitationSource(BaseModel):
     chunk_index: int = Field(
         ..., ge=0, description="Chunk index in document (0-based), for precise location"
     )
+
+
+# ============== Knowledge Base Migration Schemas ==============
+
+
+class KnowledgeBaseMigrateRequest(BaseModel):
+    """Schema for migrating knowledge base to group request."""
+
+    target_group_name: str = Field(
+        ...,
+        min_length=1,
+        description="Target group name (namespace) to migrate the knowledge base to",
+    )
+
+
+class KnowledgeBaseMigrateResponse(BaseModel):
+    """Schema for knowledge base migration response."""
+
+    success: bool = Field(..., description="Whether migration succeeded")
+    message: str = Field(..., description="Migration result message")
+    knowledge_base_id: int = Field(..., description="Knowledge base ID")
+    old_namespace: str = Field(..., description="Original namespace")
+    new_namespace: str = Field(..., description="New namespace after migration")

--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -282,11 +282,11 @@ def create_new_task(
             .first()
         )
         if kb:
+            # Note: namespace is no longer stored - ID is sufficient for lookup
             knowledge_base_refs = [
                 {
                     "id": kb.id,
                     "name": kb.name,
-                    "namespace": kb.namespace,
                     "boundBy": user.user_name,
                     "boundAt": datetime.now().isoformat(),
                 }

--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -282,11 +282,12 @@ def create_new_task(
             .first()
         )
         if kb:
+            kb_spec = kb.json.get("spec", {}) if kb.json else {}
             # Note: namespace is no longer stored - ID is sufficient for lookup
             knowledge_base_refs = [
                 {
                     "id": kb.id,
-                    "name": kb.name,
+                    "name": kb_spec.get("name", kb.name),
                     "boundBy": user.user_name,
                     "boundAt": datetime.now().isoformat(),
                 }

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -2193,3 +2193,115 @@ class KnowledgeService:
             return None
 
         return doc
+
+    # ============== Knowledge Base Migration ==============
+
+    @staticmethod
+    def migrate_knowledge_base_to_group(
+        db: Session,
+        knowledge_base_id: int,
+        user_id: int,
+        target_group_name: str,
+    ) -> dict:
+        """
+        Migrate a personal knowledge base to a group.
+
+        Args:
+            db: Database session
+            knowledge_base_id: Knowledge base ID to migrate
+            user_id: Requesting user ID (must be the creator of the KB)
+            target_group_name: Target group name (namespace) to migrate to
+
+        Returns:
+            Dict with migration result information
+
+        Raises:
+            ValueError: If validation fails or permission denied
+        """
+        from sqlalchemy.orm.attributes import flag_modified
+
+        # Get the knowledge base
+        kb = (
+            db.query(Kind)
+            .filter(
+                Kind.id == knowledge_base_id,
+                Kind.kind == "KnowledgeBase",
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not kb:
+            raise ValueError("Knowledge base not found")
+
+        # Only personal knowledge bases (namespace='default') can be migrated
+        if kb.namespace != "default":
+            raise ValueError("Only personal knowledge bases can be migrated to groups")
+
+        # Only the creator can migrate
+        if kb.user_id != user_id:
+            raise ValueError("Only the creator can migrate this knowledge base")
+
+        # Check if user has access to the target group
+        target_role = get_effective_role_in_group(db, user_id, target_group_name)
+        if target_role is None:
+            raise ValueError(f"You don't have access to group '{target_group_name}'")
+
+        # Check if user has Maintainer+ permission in target group
+        if not check_group_permission(
+            db, user_id, target_group_name, GroupRole.Maintainer
+        ):
+            raise ValueError(
+                "You need Maintainer or Owner permission in the target group to migrate knowledge bases"
+            )
+
+        # Check for duplicate name in target group
+        kb_spec = kb.json.get("spec", {})
+        kb_name = kb_spec.get("name", "")
+
+        existing_in_target = (
+            db.query(Kind)
+            .filter(
+                Kind.kind == "KnowledgeBase",
+                Kind.namespace == target_group_name,
+                Kind.is_active == True,
+            )
+            .all()
+        )
+
+        for existing_kb in existing_in_target:
+            existing_spec = existing_kb.json.get("spec", {})
+            if existing_spec.get("name") == kb_name:
+                raise ValueError(
+                    f"A knowledge base with name '{kb_name}' already exists in the target group"
+                )
+
+        # Store old namespace for response
+        old_namespace = kb.namespace
+
+        # Update the namespace
+        kb.namespace = target_group_name
+
+        # Update the name in Kind record to reflect new namespace
+        # Format: kb-{user_id}-{namespace}-{name}
+        new_kb_name = f"kb-{user_id}-{target_group_name}-{kb_name}"
+        kb.name = new_kb_name
+
+        # Update the namespace in the JSON spec as well
+        kb_json = kb.json
+        if "metadata" not in kb_json:
+            kb_json["metadata"] = {}
+        kb_json["metadata"]["namespace"] = target_group_name
+        kb.json = kb_json
+        flag_modified(kb, "json")
+
+        db.commit()
+        db.refresh(kb)
+
+        return {
+            "success": True,
+            "message": f"Knowledge base '{kb_name}' migrated to group '{target_group_name}' successfully",
+            "knowledge_base_id": kb.id,
+            "old_namespace": old_namespace,
+            "new_namespace": target_group_name,
+        }

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -2226,7 +2226,6 @@ class KnowledgeService:
             .filter(
                 Kind.id == knowledge_base_id,
                 Kind.kind == "KnowledgeBase",
-                Kind.is_active == True,
             )
             .first()
         )
@@ -2264,7 +2263,6 @@ class KnowledgeService:
             .filter(
                 Kind.kind == "KnowledgeBase",
                 Kind.namespace == target_group_name,
-                Kind.is_active == True,
             )
             .all()
         )

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -2292,6 +2292,7 @@ class KnowledgeService:
         if "metadata" not in kb_json:
             kb_json["metadata"] = {}
         kb_json["metadata"]["namespace"] = target_group_name
+        kb_json["metadata"]["name"] = new_kb_name
         kb.json = kb_json
         flag_modified(kb, "json")
 

--- a/backend/app/services/knowledge/task_knowledge_base_service.py
+++ b/backend/app/services/knowledge/task_knowledge_base_service.py
@@ -602,7 +602,8 @@ class TaskKnowledgeBaseService:
         for idx, kb, needs_migration in found_kbs:
             ref = kb_refs[idx]
             kb_name = ref.get("name")
-            kb_namespace = ref.get("namespace", "default")
+            # Get namespace from the actual KB object, not from ref (ref may not have namespace for new data)
+            kb_namespace = kb.namespace
 
             if needs_migration:
                 refs_to_migrate.append((idx, kb.id))
@@ -755,10 +756,10 @@ class TaskKnowledgeBaseService:
         user_name = user.user_name if user else "Unknown"
 
         # Add new binding (include ID for stable references)
+        # Note: namespace is no longer stored - ID is sufficient for lookup
         new_ref = KnowledgeBaseTaskRef(
             id=kb.id,
             name=kb_name,
-            namespace=kb_namespace,
             boundBy=user_name,
             boundAt=datetime.utcnow().isoformat() + "Z",
         )
@@ -967,10 +968,10 @@ class TaskKnowledgeBaseService:
                     return False
 
             # Add new binding with ID for stable references
+            # Note: namespace is no longer stored - ID is sufficient for lookup
             new_ref = KnowledgeBaseTaskRef(
                 id=kb.id,
                 name=kb_name,
-                namespace=kb_namespace,
                 boundBy=user_name,
                 boundAt=datetime.utcnow().isoformat() + "Z",
             )

--- a/backend/tests/services/test_task_knowledge_base_sync.py
+++ b/backend/tests/services/test_task_knowledge_base_sync.py
@@ -103,7 +103,8 @@ class TestSyncSubtaskKBToTask:
                 kb_refs = mock_task.json["spec"]["knowledgeBaseRefs"]
                 assert len(kb_refs) == 1
                 assert kb_refs[0]["name"] == "Test KB"
-                assert kb_refs[0]["namespace"] == "default"
+                # Note: namespace is no longer stored in new refs - ID is sufficient
+                assert "namespace" not in kb_refs[0]
                 assert kb_refs[0]["boundBy"] == "testuser"
 
     def test_sync_kb_to_task_already_bound(self, service, mock_db, mock_knowledge_base):
@@ -597,7 +598,8 @@ class TestKBRefIdBasedLookup:
                                         assert len(kb_refs) == 1
                                         assert kb_refs[0]["id"] == 10
                                         assert kb_refs[0]["name"] == "Test KB"
-                                        assert kb_refs[0]["namespace"] == "default"
+                                        # Note: namespace is no longer stored in new refs
+                                        assert "namespace" not in kb_refs[0]
 
     def test_duplicate_check_with_id(self, service, mock_db, mock_knowledge_base):
         """Test that duplicate detection works with ID"""

--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -134,6 +134,35 @@ export interface DocumentReindexResponse {
   message: string
 }
 
+// ============== Knowledge Base Migration ==============
+
+/**
+ * Response for knowledge base migration
+ */
+export interface KnowledgeBaseMigrateResponse {
+  success: boolean
+  message: string
+  knowledge_base_id: number
+  old_namespace: string
+  new_namespace: string
+}
+
+/**
+ * Migrate a personal knowledge base to a group
+ * @param knowledgeBaseId The knowledge base ID to migrate
+ * @param targetGroupName The target group name (namespace) to migrate to
+ * @returns Migration result
+ */
+export async function migrateKnowledgeBaseToGroup(
+  knowledgeBaseId: number,
+  targetGroupName: string
+): Promise<KnowledgeBaseMigrateResponse> {
+  return apiClient.post<KnowledgeBaseMigrateResponse>(
+    `/knowledge-bases/${knowledgeBaseId}/migrate`,
+    { target_group_name: targetGroupName }
+  )
+}
+
 /**
  * Trigger re-indexing for a document
  * @param documentId The document ID to reindex

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseCard.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseCard.tsx
@@ -14,6 +14,7 @@ import {
   Database,
   Share2,
   MessageSquarePlus,
+  FolderOutput,
 } from 'lucide-react'
 import { Card } from '@/components/ui/card'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -26,10 +27,12 @@ interface KnowledgeBaseCardProps {
   onDelete?: () => void
   onShare?: () => void
   onCreateGroupChat?: () => void
+  onMigrate?: () => void
   canEdit?: boolean
   canDelete?: boolean
   canShare?: boolean
   canCreateGroupChat?: boolean
+  canMigrate?: boolean
 }
 
 export function KnowledgeBaseCard({
@@ -39,10 +42,12 @@ export function KnowledgeBaseCard({
   onDelete,
   onShare,
   onCreateGroupChat,
+  onMigrate,
   canEdit = true,
   canDelete = true,
   canShare = false,
   canCreateGroupChat = false,
+  canMigrate = false,
 }: KnowledgeBaseCardProps) {
   const { t } = useTranslation()
 
@@ -116,6 +121,20 @@ export function KnowledgeBaseCard({
         </div>
         {/* Action icons */}
         <div className="flex items-center gap-1">
+          {canMigrate && onMigrate && (
+            <button
+              type="button"
+              className="h-11 min-w-[44px] flex items-center justify-center rounded-md text-text-muted hover:text-primary hover:bg-primary/10 transition-colors md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100"
+              onClick={e => {
+                e.stopPropagation()
+                onMigrate()
+              }}
+              title={t('knowledge:document.migrate.title', '迁移到群组')}
+              aria-label={t('knowledge:document.migrate.title', '迁移到群组')}
+            >
+              <FolderOutput className="w-4 h-4" />
+            </button>
+          )}
           {canCreateGroupChat && onCreateGroupChat && (
             <button
               type="button"

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
@@ -27,7 +27,9 @@ import { KnowledgeGroupListPage } from './KnowledgeGroupListPage'
 import { CreateKnowledgeBaseDialog, type AvailableGroup } from './CreateKnowledgeBaseDialog'
 import { EditKnowledgeBaseDialog } from './EditKnowledgeBaseDialog'
 import { DeleteKnowledgeBaseDialog } from './DeleteKnowledgeBaseDialog'
+import { MigrateKnowledgeBaseDialog, type MigrationTargetGroup } from './MigrateKnowledgeBaseDialog'
 import { ShareLinkDialog } from '../../permission/components/ShareLinkDialog'
+import { migrateKnowledgeBaseToGroup } from '@/apis/knowledge'
 import type {
   KnowledgeBase,
   KnowledgeBaseCreate,
@@ -115,11 +117,13 @@ export function KnowledgeDocumentPageDesktop() {
   const [editingKb, setEditingKb] = useState<KnowledgeBase | null>(null)
   const [deletingKb, setDeletingKb] = useState<KnowledgeBase | null>(null)
   const [sharingKb, setSharingKb] = useState<KnowledgeBase | null>(null)
+  const [migratingKb, setMigratingKb] = useState<KnowledgeBase | null>(null)
 
   // Loading states for dialogs
   const [isCreating, setIsCreating] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [isMigrating, setIsMigrating] = useState(false)
 
   // Default teams config for saving model preference
   const [defaultTeamsConfig, setDefaultTeamsConfig] = useState<DefaultTeamsResponse | null>(null)
@@ -543,6 +547,54 @@ export function KnowledgeDocumentPageDesktop() {
       setIsDeleting(false)
     }
   }, [deletingKb, sidebar])
+
+  // Handle KB migrated
+  const handleMigrate = useCallback(
+    async (targetGroupName: string) => {
+      if (!migratingKb) return
+
+      setIsMigrating(true)
+      try {
+        await migrateKnowledgeBaseToGroup(migratingKb.id, targetGroupName)
+
+        // Refresh sidebar data
+        await sidebar.refreshAll()
+
+        // Clear selection if migrated KB was selected
+        if (migratingKb.id === sidebar.selectedKbId) {
+          sidebar.clearSelection()
+        }
+
+        setMigratingKb(null)
+      } finally {
+        setIsMigrating(false)
+      }
+    },
+    [migratingKb, sidebar]
+  )
+
+  // Check if KB can be migrated (only personal KBs created by current user)
+  const canMigrateKb = useCallback(
+    (kb: { id: number; namespace: string; user_id: number }) => {
+      // Only personal KBs (namespace='default') can be migrated
+      if (kb.namespace !== 'default') return false
+      // Only the creator can migrate
+      return kb.user_id === sidebar.currentUser?.id
+    },
+    [sidebar.currentUser]
+  )
+
+  // Build available target groups for migration (groups and organizations only)
+  const availableMigrationGroups = useMemo((): MigrationTargetGroup[] => {
+    return sidebar.groups
+      .filter(g => g.type === 'group' || g.type === 'organization')
+      .map(g => ({
+        id: g.id,
+        name: g.name,
+        displayName: g.displayName,
+        type: g.type as 'group' | 'organization',
+      }))
+  }, [sidebar.groups])
   // Check if KB is favorite
   const isFavorite = useCallback(
     (kbId: number) => {
@@ -779,6 +831,13 @@ export function KnowledgeDocumentPageDesktop() {
           personalCreatedByMe={isPersonalMode ? sidebar.personalCreatedByMe : undefined}
           personalSharedWithMe={isPersonalMode ? sidebar.personalSharedWithMe : undefined}
           getKbGroupInfo={sidebar.getKbGroupInfo}
+          onMigrateKb={kb => {
+            const fullKb =
+              sidebar.allKnowledgeBases.find(k => k.id === kb.id) ||
+              groupKbs.find(k => k.id === kb.id)
+            if (fullKb) setMigratingKb(fullKb)
+          }}
+          canMigrate={canMigrateKb}
         />
       )
     }
@@ -875,6 +934,15 @@ export function KnowledgeDocumentPageDesktop() {
         onOpenChange={open => !open && setSharingKb(null)}
         kbId={sharingKb?.id || 0}
         kbName={sharingKb?.name || ''}
+      />
+
+      <MigrateKnowledgeBaseDialog
+        open={!!migratingKb}
+        onOpenChange={open => !isMigrating && !open && setMigratingKb(null)}
+        knowledgeBase={migratingKb}
+        availableGroups={availableMigrationGroups}
+        onMigrate={handleMigrate}
+        loading={isMigrating}
       />
     </div>
   )

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
@@ -557,7 +557,7 @@ export function KnowledgeDocumentPageDesktop() {
       try {
         await migrateKnowledgeBaseToGroup(migratingKb.id, targetGroupName)
 
-        // Refresh sidebar data
+        // Refresh sidebar data only on success
         await sidebar.refreshAll()
 
         // Clear selection if migrated KB was selected
@@ -565,7 +565,12 @@ export function KnowledgeDocumentPageDesktop() {
           sidebar.clearSelection()
         }
 
+        // Only close dialog on success
         setMigratingKb(null)
+      } catch (error) {
+        // Re-throw the error so MigrateKnowledgeBaseDialog can handle it
+        // and display the error message to the user
+        throw error
       } finally {
         setIsMigrating(false)
       }

--- a/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
@@ -584,7 +584,7 @@ function KnowledgeBaseRow({
                 e.stopPropagation()
                 onMigrate()
               }}
-              title={tFunc('knowledge:document.migrate.title', '迁移到群组')}
+              title={tFunc('document.migrate.title', '迁移到群组')}
               data-testid={`migrate-kb-${kb.id}`}
             >
               <FolderOutput className="w-4 h-4 text-text-muted hover:text-primary transition-colors" />

--- a/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
@@ -25,6 +25,7 @@ import {
   ChevronUp,
   Pencil,
   Trash2,
+  FolderOutput,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
@@ -90,6 +91,10 @@ export interface KnowledgeGroupListPageProps {
   personalCreatedByMe?: KnowledgeBaseWithGroupInfo[]
   /** Knowledge bases shared with current user (for personal mode) */
   personalSharedWithMe?: KnowledgeBaseWithGroupInfo[]
+  /** Migrate a knowledge base to group */
+  onMigrateKb?: (kb: KbDataItem) => void
+  /** Check if user can migrate a KB (only for personal KBs created by user) */
+  canMigrate?: (kb: KbDataItem) => boolean
 }
 
 type SortBy = 'name' | 'updated' | 'group' | 'permission' | 'default'
@@ -176,6 +181,8 @@ export function KnowledgeGroupListPage({
   isPersonalMode = false,
   personalCreatedByMe = [],
   personalSharedWithMe = [],
+  onMigrateKb,
+  canMigrate,
 }: KnowledgeGroupListPageProps) {
   const { t } = useTranslation('knowledge')
   const [sortBy, setSortBy] = useState<SortBy>('default')
@@ -361,10 +368,12 @@ export function KnowledgeGroupListPage({
           onClick={() => onSelectKb(kb)}
           onEdit={onEditKb ? () => onEditKb(kb) : undefined}
           onDelete={onDeleteKb ? () => onDeleteKb(kb) : undefined}
+          onMigrate={onMigrateKb ? () => onMigrateKb(kb) : undefined}
           onToggleFavorite={onToggleFavorite ? e => handleToggleFavorite(e, kb) : undefined}
           isFavorite={isFavorite?.(kb.id)}
           showGroupInfo={showGroupColumn}
           groupInfo={getKbGroupInfo?.(kb)}
+          canMigrate={canMigrate?.(kb)}
           tFunc={t}
         />
       ))}
@@ -509,10 +518,12 @@ interface KnowledgeBaseRowProps {
   onClick: () => void
   onEdit?: () => void
   onDelete?: () => void
+  onMigrate?: () => void
   onToggleFavorite?: (e: React.MouseEvent) => void
   isFavorite?: boolean
   showGroupInfo?: boolean
   groupInfo?: KbGroupInfo
+  canMigrate?: boolean
   tFunc: ReturnType<typeof useTranslation>['t']
 }
 
@@ -521,10 +532,12 @@ function KnowledgeBaseRow({
   onClick,
   onEdit,
   onDelete,
+  onMigrate,
   onToggleFavorite: _onToggleFavorite,
   isFavorite,
   showGroupInfo,
   groupInfo,
+  canMigrate,
   tFunc,
 }: KnowledgeBaseRowProps) {
   return (
@@ -559,9 +572,24 @@ function KnowledgeBaseRow({
         {formatRelativeTime(kb.updated_at, tFunc)}
       </td>
 
-      {/* Actions column - Edit and Delete only */}
+      {/* Actions column - Migrate, Edit and Delete */}
       <td className="px-6 py-3">
         <div className="flex items-center justify-end gap-1">
+          {canMigrate && onMigrate && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={e => {
+                e.stopPropagation()
+                onMigrate()
+              }}
+              title={tFunc('knowledge:document.migrate.title', '迁移到群组')}
+              data-testid={`migrate-kb-${kb.id}`}
+            >
+              <FolderOutput className="w-4 h-4 text-text-muted hover:text-primary" />
+            </Button>
+          )}
           {onEdit && (
             <Button
               variant="ghost"

--- a/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeGroupListPage.tsx
@@ -587,7 +587,7 @@ function KnowledgeBaseRow({
               title={tFunc('knowledge:document.migrate.title', '迁移到群组')}
               data-testid={`migrate-kb-${kb.id}`}
             >
-              <FolderOutput className="w-4 h-4 text-text-muted hover:text-primary" />
+              <FolderOutput className="w-4 h-4 text-text-muted hover:text-primary transition-colors" />
             </Button>
           )}
           {onEdit && (

--- a/frontend/src/features/knowledge/document/components/MigrateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/MigrateKnowledgeBaseDialog.tsx
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useState, useMemo } from 'react'
+import { FolderOutput, Users, Building2, AlertCircle } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogDescription,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useTranslation } from '@/hooks/useTranslation'
+import type { KnowledgeBase } from '@/types/knowledge'
+
+/** Available group for migration target */
+export interface MigrationTargetGroup {
+  id: string
+  name: string
+  displayName: string
+  type: 'group' | 'organization'
+}
+
+interface MigrateKnowledgeBaseDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  knowledgeBase: KnowledgeBase | null
+  availableGroups: MigrationTargetGroup[]
+  onMigrate: (targetGroupName: string) => Promise<void>
+  loading?: boolean
+}
+
+/** Get icon for group type */
+function GroupTypeIcon({ type }: { type: 'group' | 'organization' }) {
+  switch (type) {
+    case 'organization':
+      return <Building2 className="w-4 h-4" />
+    case 'group':
+    default:
+      return <Users className="w-4 h-4" />
+  }
+}
+
+export function MigrateKnowledgeBaseDialog({
+  open,
+  onOpenChange,
+  knowledgeBase,
+  availableGroups,
+  onMigrate,
+  loading,
+}: MigrateKnowledgeBaseDialogProps) {
+  const { t } = useTranslation('knowledge')
+  const [selectedGroupId, setSelectedGroupId] = useState<string>('')
+  const [error, setError] = useState('')
+
+  // Reset state when dialog opens
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!newOpen) {
+      setSelectedGroupId('')
+      setError('')
+    }
+    onOpenChange(newOpen)
+  }
+
+  // Filter to only show group and organization types (not personal)
+  const validTargetGroups = useMemo(() => {
+    return availableGroups.filter(g => g.type === 'group' || g.type === 'organization')
+  }, [availableGroups])
+
+  const handleMigrate = async () => {
+    setError('')
+
+    if (!selectedGroupId) {
+      setError(t('document.migrate.selectGroupRequired', '请选择目标群组'))
+      return
+    }
+
+    const selectedGroup = validTargetGroups.find(g => g.id === selectedGroupId)
+    if (!selectedGroup) {
+      setError(t('document.migrate.invalidGroup', '无效的目标群组'))
+      return
+    }
+
+    try {
+      await onMigrate(selectedGroup.name)
+      handleOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('common:error'))
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md" data-testid="migrate-kb-dialog">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderOutput className="w-5 h-5 text-primary" />
+            {t('document.migrate.title', '迁移知识库')}
+          </DialogTitle>
+          <DialogDescription>
+            {t(
+              'document.migrate.description',
+              '将个人知识库迁移到群组，迁移后该知识库将属于目标群组'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          {/* Knowledge base info */}
+          {knowledgeBase && (
+            <div className="bg-surface p-3 rounded-md border border-border">
+              <div className="text-sm text-text-secondary">
+                {t('document.migrate.sourceKnowledgeBase', '待迁移知识库')}
+              </div>
+              <div className="font-medium text-text-primary mt-1">{knowledgeBase.name}</div>
+            </div>
+          )}
+
+          {/* Target group selector */}
+          <div className="space-y-2">
+            <Label>{t('document.migrate.targetGroup', '目标群组')} *</Label>
+            <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
+              <SelectTrigger data-testid="migrate-target-group">
+                <SelectValue
+                  placeholder={t('document.migrate.selectGroupPlaceholder', '选择要迁移到的群组')}
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {validTargetGroups.length === 0 ? (
+                  <div className="px-2 py-4 text-sm text-text-muted text-center">
+                    {t(
+                      'document.migrate.noAvailableGroups',
+                      '没有可迁移的群组，请先加入或创建一个群组'
+                    )}
+                  </div>
+                ) : (
+                  validTargetGroups.map(group => (
+                    <SelectItem key={group.id} value={group.id}>
+                      <div className="flex items-center gap-2">
+                        <GroupTypeIcon type={group.type} />
+                        <span>{group.displayName}</span>
+                      </div>
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Warning note */}
+          <div className="flex items-start gap-2 text-sm text-text-muted bg-surface p-3 rounded-md">
+            <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+            <div>
+              <p>{t('document.migrate.permissionNote', '您需要是目标群组的管理员才能执行迁移')}</p>
+              <p className="mt-1">
+                {t(
+                  'document.migrate.migrationNote',
+                  '迁移后，该知识库将从个人知识库移动到群组知识库，原分享权限将保留'
+                )}
+              </p>
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-error">{error}</p>}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={loading}
+            className="h-11 min-w-[44px]"
+            data-testid="cancel-migrate-kb"
+          >
+            {t('common:actions.cancel')}
+          </Button>
+          <Button
+            onClick={handleMigrate}
+            variant="primary"
+            disabled={loading || !selectedGroupId || validTargetGroups.length === 0}
+            className="h-11 min-w-[44px]"
+            data-testid="confirm-migrate-kb"
+          >
+            {loading
+              ? t('document.migrate.migrating', '迁移中...')
+              : t('document.migrate.confirm', '确认迁移')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/knowledge/document/components/index.ts
+++ b/frontend/src/features/knowledge/document/components/index.ts
@@ -4,6 +4,7 @@
 
 export { KnowledgeBaseCard } from './KnowledgeBaseCard'
 export { GroupCard } from './GroupCard'
+export { MigrateKnowledgeBaseDialog } from './MigrateKnowledgeBaseDialog'
 export { KnowledgeDocumentPage } from './KnowledgeDocumentPage'
 export { KnowledgeDocumentPageDesktop } from './KnowledgeDocumentPageDesktop'
 export { KnowledgeDocumentPageMobile } from './KnowledgeDocumentPageMobile'

--- a/frontend/src/features/knowledge/document/hooks/useKnowledgeSidebar.ts
+++ b/frontend/src/features/knowledge/document/hooks/useKnowledgeSidebar.ts
@@ -21,6 +21,7 @@ import type {
 } from '@/types/knowledge'
 import type { KbDataItem } from '../components/KnowledgeGroupListPage'
 import type { Group } from '@/types/group'
+import type { User } from '@/types/api'
 
 // Storage keys
 const RECENT_STORAGE_KEY = 'knowledge-recent-access'
@@ -100,6 +101,9 @@ export interface UseKnowledgeSidebarReturn {
 
   // Admin status
   isAdmin: boolean
+
+  // Current user
+  currentUser: User | null
 
   // Refresh
   refreshAll: () => Promise<void>
@@ -493,6 +497,9 @@ export function useKnowledgeSidebar(): UseKnowledgeSidebarReturn {
 
     // Admin status
     isAdmin,
+
+    // Current user
+    currentUser: user,
 
     // Refresh
     refreshAll,

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -532,6 +532,22 @@
       "addMembersFailed": "Failed to add group members. You can add them manually in the group chat.",
       "bindKbPartialFail": "Some knowledge bases failed to bind ({{failed}}/{{total}})",
       "bindKbFailed": "Failed to bind knowledge bases"
+    },
+    "migrate": {
+      "title": "Migrate to Group",
+      "description": "Migrate this personal knowledge base to a target group. After migration, the knowledge base will belong to the target group.",
+      "targetGroup": "Target Group",
+      "selectGroupPlaceholder": "Select a group to migrate to",
+      "noAvailableGroups": "No available groups. Please join or create a group first.",
+      "permissionNote": "You need to be a maintainer of the target group to perform migration",
+      "migrationNote": "After migration, the knowledge base will move from personal to group space. Original sharing permissions will be preserved.",
+      "selectGroupRequired": "Please select a target group",
+      "invalidGroup": "Invalid target group",
+      "migrating": "Migrating...",
+      "confirm": "Confirm Migration",
+      "sourceKnowledgeBase": "Source Knowledge Base",
+      "success": "Knowledge base migrated successfully",
+      "failed": "Failed to migrate knowledge base"
     }
   },
   "add_repository": "Add Repository",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -532,6 +532,22 @@
       "addMembersFailed": "添加组成员失败，可在群聊中手动添加",
       "bindKbPartialFail": "部分知识库关联失败（{{failed}}/{{total}}）",
       "bindKbFailed": "关联知识库失败"
+    },
+    "migrate": {
+      "title": "迁移到群组",
+      "description": "将此个人知识库迁移到目标群组，迁移后该知识库将属于目标群组",
+      "targetGroup": "目标群组",
+      "selectGroupPlaceholder": "选择要迁移到的群组",
+      "noAvailableGroups": "没有可迁移的群组，请先加入或创建一个群组",
+      "permissionNote": "您需要是目标群组的管理员才能执行迁移",
+      "migrationNote": "迁移后，该知识库将从个人知识库移动到群组知识库，原分享权限将保留",
+      "selectGroupRequired": "请选择目标群组",
+      "invalidGroup": "无效的目标群组",
+      "migrating": "迁移中...",
+      "confirm": "确认迁移",
+      "sourceKnowledgeBase": "待迁移知识库",
+      "success": "知识库迁移成功",
+      "failed": "知识库迁移失败"
     }
   },
   "add_repository": "添加仓库",


### PR DESCRIPTION
## Summary

This PR adds the ability to migrate personal knowledge bases to a target group with one click.

## Changes

### Backend
- Add POST /knowledge-bases/{id}/migrate endpoint to migrate personal KBs to a group
- Add KnowledgeBaseMigrateRequest and KnowledgeBaseMigrateResponse schemas
- Add migrate_knowledge_base_to_group service method with validation:
  - Only personal KBs (namespace='default') can be migrated
  - Only the creator can migrate their KB
  - User must have Maintainer+ role in target group
  - No duplicate names allowed in target group

### Frontend
- Add MigrateKnowledgeBaseDialog component for selecting target group
- Add migrate button to KnowledgeBaseCard (visible on hover for personal KBs)
- Integrate migration feature into KnowledgeDocumentPageDesktop and KnowledgeGroupListPage
- Add migrateKnowledgeBaseToGroup API function
- Export currentUser from useKnowledgeSidebar hook for permission checks

### i18n
- Add Chinese and English translations for migration feature

## Test Plan

- [ ] Verify migrate button appears only for personal KBs created by current user
- [ ] Verify migrate dialog shows only groups/orgs (not personal)
- [ ] Verify validation prevents migration to invalid groups
- [ ] Verify migration updates namespace correctly
- [ ] Verify translations work in both languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge base migration: migrate personal knowledge bases to groups via a new "Migrate to Group" dialog, per-row and card action buttons, confirm/loading UX, and backend endpoint to perform migration.
  * Localized UI strings for English and Chinese.

* **Bug Fixes / Validation**
  * Prevents name collisions, enforces target-group permission checks, refreshes sidebar and clears selection when a migrated KB was active, and surfaces success/failure outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->