### PR TITLE
[codex] Use WEGENT_EXECUTOR_HOME for executor state files

### DIFF
--- a/executor/config/device_config.py
+++ b/executor/config/device_config.py
@@ -26,6 +26,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from executor.config.config import WEGENT_EXECUTOR_HOME
+
 logger = logging.getLogger(__name__)
 
 
@@ -254,10 +256,9 @@ def _get_default_config_path() -> Path:
     """Get the default config file path.
 
     Returns:
-        Path to ~/.wegent-executor/device-config.json
+        Path to ${WEGENT_EXECUTOR_HOME}/device-config.json
     """
-    home = Path.home()
-    return home / ".wegent-executor" / "device-config.json"
+    return Path(WEGENT_EXECUTOR_HOME).expanduser() / "device-config.json"
 
 
 def _create_default_config() -> DeviceConfig:

--- a/executor/services/pid_manager.py
+++ b/executor/services/pid_manager.py
@@ -15,6 +15,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional
 
+from executor.config.config import WEGENT_EXECUTOR_HOME
 from executor.platform_compat import IS_WINDOWS
 
 logger = logging.getLogger(__name__)
@@ -40,9 +41,9 @@ class PIDManager:
         """Initialize PID manager.
 
         Args:
-            pid_dir: Directory for PID files. Defaults to ~/.wegent-executor
+            pid_dir: Directory for PID files. Defaults to WEGENT_EXECUTOR_HOME
         """
-        self.pid_dir = pid_dir or (Path.home() / ".wegent-executor")
+        self.pid_dir = pid_dir or Path(WEGENT_EXECUTOR_HOME).expanduser()
 
     def write_pid_file(self, version: str) -> Path:
         """Write PID file with current process information.


### PR DESCRIPTION
## Summary
- route `executor/config/device_config.py` default config path through `WEGENT_EXECUTOR_HOME`
- route `executor/services/pid_manager.py` default PID directory through `WEGENT_EXECUTOR_HOME`
- keep the effective default unchanged when `WEGENT_EXECUTOR_HOME` is unset (`~/.wegent-executor`)

## Why
The executor was splitting local state across two base directories. Workspace and logs already respected `WEGENT_EXECUTOR_HOME`, but `device-config.json` and `executor.pid` were still hard-coded to `~/.wegent-executor`. This change makes those state files follow the same base directory.

## Validation
- imported `executor.config.device_config._get_default_config_path()` and confirmed it resolves to `/Users/crystal/.wecode/wegent-executor/device-config.json` in the current environment
- imported `executor.services.pid_manager.PIDManager` and confirmed its default `pid_dir` resolves to `/Users/crystal/.wecode/wegent-executor`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default storage paths for configuration and process management to use a centralized, configurable home directory setting instead of hardcoded defaults, providing greater flexibility in deployment and data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->