### PR TITLE
feat(backend): add /knowledge/list endpoint with OpenAPI-style auth

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -149,6 +149,11 @@ api_router.include_router(
     prefix="/knowledge-bases",
     tags=["knowledge-summary"],
 )
+api_router.include_router(
+    knowledge.knowledge_router,
+    prefix="/knowledge",
+    tags=["knowledge"],
+)
 # Unified share endpoints (Team, Task, KnowledgeBase)
 api_router.include_router(share.router, prefix="/share", tags=["share"])
 api_router.include_router(tables.router, prefix="/tables", tags=["tables"])

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -12,7 +12,7 @@ which provides a unified interface for both REST API and MCP tools.
 import asyncio
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
 from sqlalchemy.exc import IntegrityError
@@ -1565,16 +1565,19 @@ def get_document_chunk(
 knowledge_router = APIRouter()
 
 
-@knowledge_router.get("/list")
-@trace_sync("list_knowledge_bases", "knowledge.api")
-def list_knowledge_bases(
+@knowledge_router.get(
+    "/list",
+    response_model=Union[PersonalKnowledgeBaseGroup, AllGroupedKnowledgeResponse],
+)
+@trace_sync("list_knowledge_bases_v1", "knowledge.api")
+def list_knowledge_bases_v1(
     scope: str = Query(
         default="all",
         description="Scope of knowledge bases to return: 'personal' or 'all'",
     ),
     auth_context: AuthContext = Depends(get_auth_context),
     db: Session = Depends(get_db),
-):
+) -> Union[PersonalKnowledgeBaseGroup, AllGroupedKnowledgeResponse]:
     """
     List knowledge bases with flexible authentication.
 

--- a/backend/app/api/endpoints/knowledge.py
+++ b/backend/app/api/endpoints/knowledge.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_db
 from app.core import security
 from app.core.config import settings
+from app.core.security import AuthContext, get_auth_context
 from app.db.session import SessionLocal
 from app.models.user import User
 from app.schemas.knowledge import (
@@ -1556,3 +1557,71 @@ def get_document_chunk(
         document_id=document.id,
         kb_id=document.kind_id,
     )
+
+
+# ============== OpenAPI v1 Knowledge Base Endpoints ==============
+
+# Create a dedicated router for v1/knowledge-base endpoints
+knowledge_router = APIRouter()
+
+
+@knowledge_router.get("/list")
+@trace_sync("list_knowledge_bases", "knowledge.api")
+def list_knowledge_bases(
+    scope: str = Query(
+        default="all",
+        description="Scope of knowledge bases to return: 'personal' or 'all'",
+    ),
+    auth_context: AuthContext = Depends(get_auth_context),
+    db: Session = Depends(get_db),
+):
+    """
+    List knowledge bases with flexible authentication.
+
+    This endpoint is compatible with OpenAPI-style authentication,
+    supporting API keys via X-API-Key or Authorization headers,
+    and username specification via wegent-username header for service keys.
+
+    Args:
+        scope: Filter scope for knowledge bases
+            - "personal": Return only personal knowledge bases (created_by_me + shared_with_me)
+            - "all": Return all accessible knowledge bases (personal + groups + organization)
+            - Unrecognized values are treated as "all"
+
+    Returns:
+        - When scope="personal": PersonalKnowledgeBaseGroup schema
+          {
+            "created_by_me": [...],
+            "shared_with_me": [...]
+          }
+        - When scope="all": AllGroupedKnowledgeResponse schema
+          {
+            "personal": {"created_by_me": [...], "shared_with_me": [...]},
+            "groups": [...],
+            "organization": {...},
+            "summary": {...}
+          }
+
+    Authentication:
+        - Personal API key: Returns knowledge bases accessible to the key owner
+        - Service API key: Requires wegent-username header to specify the target user
+    """
+    current_user = auth_context.user
+
+    # Normalize scope: only "personal" is valid, everything else is treated as "all"
+    normalized_scope = scope.lower() if scope else "all"
+    if normalized_scope not in ("personal", "all"):
+        normalized_scope = "all"
+
+    if normalized_scope == "personal":
+        # Return personal knowledge bases grouped by ownership
+        return KnowledgeService.get_personal_knowledge_bases_grouped(
+            db=db,
+            user_id=current_user.id,
+        )
+    else:
+        # Return all accessible knowledge bases grouped by scope
+        return KnowledgeService.get_all_knowledge_bases_grouped(
+            db=db,
+            user_id=current_user.id,
+        )


### PR DESCRIPTION
Add new endpoint GET /api/knowledge/list for listing knowledge bases with flexible authentication support.

Features:
- Support API key auth via X-API-Key or Authorization headers
- Support username specification via wegent-username header for service keys
- Scope parameter: 'personal' (created_by_me + shared_with_me) or 'all'
- Unrecognized scope values default to 'all'
- Returns PersonalKnowledgeBaseGroup or AllGroupedKnowledgeResponse

Changes:
- Add knowledge_router in knowledge.py with /list endpoint
- Register knowledge_router in api.py with /knowledge prefix
- Use get_auth_context for OpenAPI-compatible authentication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new knowledge listing endpoint that lets users retrieve either their personal knowledge bases or all knowledge bases via a scope parameter.
* **Behavior Changes**
  * Scope handling normalized so only "personal" returns personal results; any other value returns all results.
  * Authentication handling improved for the new endpoint to ensure consistent user-specific access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->