### PR TITLE
fix(backend): correct attachment access check for group chat members

### DIFF
--- a/backend/app/api/endpoints/adapter/attachments.py
+++ b/backend/app/api/endpoints/adapter/attachments.py
@@ -92,13 +92,15 @@ def _ensure_attachment_access(db: Session, context, current_user: User) -> None:
                 has_access = True
             else:
                 # Check if user is a task member using ResourceMember
+                # Exclude share records (copied_resource_id > 0), only consider actual group chat members
                 task_member = (
                     db.query(ResourceMember)
                     .filter(
                         ResourceMember.resource_type == ResourceType.TASK,
                         ResourceMember.resource_id == subtask.task_id,
                         ResourceMember.user_id == current_user.id,
-                        ResourceMember.status == MemberStatus.APPROVED,
+                        ResourceMember.status == MemberStatus.APPROVED.value,
+                        ResourceMember.copied_resource_id == 0,
                     )
                     .first()
                 )
@@ -681,13 +683,15 @@ async def get_all_task_attachments(
     from app.models.share_link import ResourceType
 
     is_owner = task.user_id == current_user.id
+    # Exclude share records (copied_resource_id > 0), only consider actual group chat members
     is_member = (
         db.query(ResourceMember)
         .filter(
             ResourceMember.resource_type == ResourceType.TASK,
             ResourceMember.resource_id == task_id,
             ResourceMember.user_id == current_user.id,
-            ResourceMember.status == MemberStatus.APPROVED,
+            ResourceMember.status == MemberStatus.APPROVED.value,
+            ResourceMember.copied_resource_id == 0,
         )
         .first()
         is not None


### PR DESCRIPTION
Fixed attachment access permission check in _ensure_attachment_access() and get_all_task_attachments() endpoints:

1. Changed MemberStatus.APPROVED to MemberStatus.APPROVED.value to ensure proper string comparison in SQLAlchemy queries. The status column stores string values, but the code was comparing against the Enum object directly, which could cause query mismatches.

2. Added ResourceMember.copied_resource_id == 0 condition to exclude share records and only consider actual group chat members. This aligns with the logic in TaskMemberService.is_member() which also excludes share records.

This fixes the issue where some group chat members could not access attachments while others could, depending on how their membership status was stored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment access control logic to properly validate user membership status and authorization when accessing task-related attachments, ensuring consistent permission checks across all scenarios.
  * Enhanced filtering of attachment records to correctly exclude shared and copied items from appearing in task-wide attachment listings, improving data integrity and user access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->