### PR TITLE
feat(backend): gate dingtalk mcp through skills

### DIFF
--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -381,7 +381,7 @@ async def build_execution_request(
                         request=request,
                         bot=bot,
                         team=team,
-                        user_id=user.id,
+                        user=user,
                     )
 
         return request

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -20,7 +20,9 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.models.subtask import Subtask
 from app.models.task import TaskResource
-from app.schemas.kind import Bot, Ghost, Shell, Skill as SkillCRD, Team
+from app.schemas.kind import Bot, Ghost, Shell
+from app.schemas.kind import Skill as SkillCRD
+from app.schemas.kind import Team
 from app.services.auth import create_skill_identity_token
 from app.services.mcp_provider_registry import (
     get_mcp_service_by_skill_name,
@@ -1278,9 +1280,7 @@ class TaskRequestBuilder:
             return None
 
         preferences = getattr(user, "preferences", None)
-        user_mcps = user_mcp_service.get_enabled_decrypted_mcp_preferences(
-            preferences
-        )
+        user_mcps = user_mcp_service.get_enabled_decrypted_mcp_preferences(preferences)
         if not user_mcps:
             return None
 

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -1278,7 +1278,9 @@ class TaskRequestBuilder:
             return None
 
         preferences = getattr(user, "preferences", None)
-        user_mcps = user_mcp_service.get_decrypted_mcp_preferences(preferences)
+        user_mcps = user_mcp_service.get_enabled_decrypted_mcp_preferences(
+            preferences
+        )
         if not user_mcps:
             return None
 
@@ -1312,7 +1314,14 @@ class TaskRequestBuilder:
         if skill_crd.spec.mcpServers:
             skill_data["mcpServers"] = skill_crd.spec.mcpServers
 
-        runtime_service = get_mcp_service_by_skill_name(skill_crd.metadata.name)
+        is_public_default_runtime_skill = (
+            skill.user_id == 0 and skill_crd.metadata.namespace == "default"
+        )
+        runtime_service = (
+            get_mcp_service_by_skill_name(skill_crd.metadata.name)
+            if is_public_default_runtime_skill
+            else None
+        )
         if runtime_service:
             provider, service = runtime_service
             configured_server = None
@@ -1883,6 +1892,10 @@ Response template:
         url = server.get("url", "")
         if not url:
             return False
+
+        # Runtime placeholders are resolved after request build.
+        if "${{" in url and "}}" in url:
+            return True
 
         # URLs pointing to our own backend are always reachable.
         # Checking them with a synchronous HTTP request would deadlock

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -20,9 +20,12 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.models.subtask import Subtask
 from app.models.task import TaskResource
-from app.schemas.kind import Bot, Ghost, Shell, Team
+from app.schemas.kind import Bot, Ghost, Shell, Skill as SkillCRD, Team
 from app.services.auth import create_skill_identity_token
-from app.services.mcp_provider_registry import list_mcp_providers
+from app.services.mcp_provider_registry import (
+    get_mcp_service_by_skill_name,
+    list_mcp_providers,
+)
 from app.services.readers import KindType, kindReader
 from app.services.user_mcp_service import user_mcp_service
 from shared.models import ExecutionRequest
@@ -201,6 +204,7 @@ class TaskRequestBuilder:
             self._get_bot_skills(
                 bot=bot,
                 team=team,
+                user=user,
                 user_id=user.id,
                 user_preload_skills=user_preload_skills,
             )
@@ -220,10 +224,6 @@ class TaskRequestBuilder:
             override_model_name=override_model_name,
             force_override=force_override,
         )
-
-        user_mcp_servers = self._load_user_mcp_servers(user)
-        if bot_config and user_mcp_servers:
-            self._merge_user_mcp_into_bot_config(bot_config, user_mcp_servers)
 
         # Merge user-selected skills into bot_config so Executor downloads them
         if bot_config and resolved_skills:
@@ -321,6 +321,7 @@ class TaskRequestBuilder:
             attachments=attachments or [],
             is_subscription=is_subscription,
             system_mcp_config=system_mcp_config,
+            task_data=self._build_request_task_data(user),
             trace_context=trace_context,
             executor_name=subtask.executor_name,
         )
@@ -331,7 +332,7 @@ class TaskRequestBuilder:
         request: ExecutionRequest,
         bot: Kind,
         team: Kind,
-        user_id: int,
+        user: User,
     ) -> ExecutionRequest:
         """Resolve request-level preload skills into full skill and MCP config.
 
@@ -363,6 +364,9 @@ class TaskRequestBuilder:
         if not missing_skill_names:
             return request
 
+        if not request.task_data:
+            request.task_data = self._build_request_task_data(user)
+
         user_preload_skills = []
         for skill_name in requested_skill_names:
             skill_ref = (request.skill_refs or {}).get(skill_name, {})
@@ -390,7 +394,8 @@ class TaskRequestBuilder:
         ) = self._get_bot_skills(
             bot=bot,
             team=team,
-            user_id=user_id,
+            user=user,
+            user_id=user.id,
             user_preload_skills=user_preload_skills,
         )
 
@@ -879,6 +884,7 @@ class TaskRequestBuilder:
         self,
         bot: Kind,
         team: Kind,
+        user: User,
         user_id: int,
         user_preload_skills: list | None = None,
     ) -> tuple[list[dict], list[str], list[str], dict[str, dict]]:
@@ -960,7 +966,7 @@ class TaskRequestBuilder:
             for skill_name in ghost_crd.spec.skills:
                 skill = self._find_skill(skill_name, team)
                 if skill:
-                    skill_data = self._build_skill_data(skill)
+                    skill_data = self._build_skill_data(skill, user=user)
                     skills.append(skill_data)
                     existing_skill_names.add(skill_name)
 
@@ -1053,7 +1059,7 @@ class TaskRequestBuilder:
                     team_namespace=team_namespace,
                 )
                 if skill:
-                    skill_data = self._build_skill_data(skill)
+                    skill_data = self._build_skill_data(skill, user=user)
                     skills.append(skill_data)
                     existing_skill_names.add(skill_name)
                     preload_skills.append(skill_name)
@@ -1265,17 +1271,29 @@ class TaskRequestBuilder:
                 )
             return None
 
-    def _build_skill_data(self, skill: Kind) -> dict:
+    @staticmethod
+    def _build_request_task_data(user: User | None) -> dict[str, Any] | None:
+        """Build runtime task data exposed to MCP placeholder substitution."""
+        if not user:
+            return None
+
+        preferences = getattr(user, "preferences", None)
+        user_mcps = user_mcp_service.get_decrypted_mcp_preferences(preferences)
+        if not user_mcps:
+            return None
+
+        return {"user_mcps": user_mcps}
+
+    def _build_skill_data(self, skill: Kind, *, user: User | None = None) -> dict:
         """Build skill data dictionary from a Skill Kind object.
 
         Args:
             skill: Skill Kind object from database
+            user: Optional user, reserved for future skill runtime expansion
 
         Returns:
             Dictionary containing skill metadata for chat configuration
         """
-        from app.schemas.kind import Skill as SkillCRD
-
         skill_crd = SkillCRD.model_validate(skill.json)
 
         skill_data = {
@@ -1293,6 +1311,25 @@ class TaskRequestBuilder:
 
         if skill_crd.spec.mcpServers:
             skill_data["mcpServers"] = skill_crd.spec.mcpServers
+
+        runtime_service = get_mcp_service_by_skill_name(skill_crd.metadata.name)
+        if runtime_service:
+            provider, service = runtime_service
+            configured_server = None
+            if user:
+                configured_server = user_mcp_service.get_enabled_mcp_server(
+                    getattr(user, "preferences", None),
+                    provider["provider_id"],
+                    service["service_id"],
+                )
+
+            if not configured_server:
+                skill_data.pop("mcpServers", None)
+                skill_data["prompt"] = self._build_unconfigured_provider_skill_prompt(
+                    skill_data.get("prompt"),
+                    provider_id=provider["provider_id"],
+                    service=service,
+                )
 
         if skill_crd.spec.tools:
             skill_data["tools"] = [
@@ -1313,6 +1350,43 @@ class TaskRequestBuilder:
                 )
 
         return skill_data
+
+    @staticmethod
+    def _build_unconfigured_provider_skill_prompt(
+        existing_prompt: str | None,
+        *,
+        provider_id: str,
+        service: dict[str, Any],
+    ) -> str:
+        """Build a guidance-only prompt when a provider skill is not configured."""
+        display_name = service.get("display_name") or service["service_id"]
+        modal_link = (
+            f"wegent://modal/mcp-provider-config?provider={provider_id}"
+            f"&service={service['service_id']}"
+        )
+
+        guidance_prompt = f"""
+## Configuration Required
+
+The current session does not have a usable {display_name} MCP configured.
+
+Required behavior:
+- Do not pretend to access DingTalk data or local files for this request.
+- Tell the user that {display_name} MCP is not available in the current session.
+- Ask the user to click [打开{display_name} MCP 配置弹窗]({modal_link}) to finish configuration.
+- Keep the guidance brief. If the user asks how to get the URL, tell them to get it from the DingTalk MCP page for this service.
+
+Response template:
+当前会话还没有可用的{display_name} MCP，所以我现在不能直接访问这个钉钉能力。
+
+请先点击 [打开{display_name} MCP 配置弹窗]({modal_link}) 完成配置。
+
+配置完成后，再让我继续处理你的钉钉请求。
+""".strip()
+
+        if existing_prompt:
+            return f"{existing_prompt.rstrip()}\n\n{guidance_prompt}"
+        return guidance_prompt
 
     # =========================================================================
     # Bot Configuration Building
@@ -1577,15 +1651,10 @@ class TaskRequestBuilder:
                                 server_entry["env"] = server_config["env"]
                             bot_mcp_servers.append(server_entry)
 
-        user_mcp_servers = self._load_user_mcp_servers(user)
-
-        # Merge system, user, and bot MCP servers (bot takes precedence)
+        # Merge system and bot MCP servers (bot takes precedence)
         # Build a dict to deduplicate by server name
         servers_by_name = {}
         for server in system_mcp_servers:
-            server_name = server.get("name", "server")
-            servers_by_name[server_name] = server
-        for server in user_mcp_servers:
             server_name = server.get("name", "server")
             servers_by_name[server_name] = server
         for server in bot_mcp_servers:
@@ -1596,20 +1665,14 @@ class TaskRequestBuilder:
 
         if merged_servers:
             logger.info(
-                "[TaskRequestBuilder] Built %d MCP servers (system=%d, user=%d, bot=%d): %s",
+                "[TaskRequestBuilder] Built %d MCP servers (system=%d, bot=%d): %s",
                 len(merged_servers),
                 len(system_mcp_servers),
-                len(user_mcp_servers),
                 len(bot_mcp_servers),
                 [s["name"] for s in merged_servers],
             )
 
         return merged_servers
-
-    @staticmethod
-    def _load_user_mcp_servers(user: User) -> list[dict[str, Any]]:
-        """Load user-scoped MCP servers from preferences."""
-        return user_mcp_service.list_mcp_servers(user.preferences)
 
     @staticmethod
     def _extract_prompt_text(message: Union[str, list]) -> str:
@@ -1638,7 +1701,7 @@ class TaskRequestBuilder:
         message: Union[str, list],
         preload_skills: list,
     ) -> list:
-        """Preload provider config guidance skills when relevant and needed."""
+        """Preload provider runtime skills or config guidance skills when relevant."""
         merged_preload_skills = list(preload_skills)
         prompt_text = self._extract_prompt_text(message).strip().lower()
         if not prompt_text:
@@ -1655,51 +1718,30 @@ class TaskRequestBuilder:
             if not keywords or not any(keyword in prompt_text for keyword in keywords):
                 continue
 
-            service_configs = user_mcp_service.list_provider_service_configs(
-                user.preferences, provider["provider_id"]
-            )
-            all_services_ready = all(
-                service.get("enabled") and (service.get("url") or "").strip()
-                for service in service_configs
-            )
-            if all_services_ready:
-                continue
-
-            guidance_skill = provider.get("guidance_skill")
-            if guidance_skill and guidance_skill not in existing_names:
-                merged_preload_skills.append(
-                    {
-                        "name": guidance_skill,
-                        "namespace": "default",
-                        "is_public": True,
-                    }
+            matched_services = [
+                service
+                for service in provider.get("services", {}).values()
+                if any(
+                    keyword in prompt_text
+                    for keyword in (service.get("message_keywords") or ())
                 )
-                existing_names.add(guidance_skill)
+            ]
+            if not matched_services:
+                matched_services = list(provider.get("services", {}).values())
+
+            for service in matched_services:
+                runtime_skill = service.get("skill_name")
+                if runtime_skill and runtime_skill not in existing_names:
+                    merged_preload_skills.append(
+                        {
+                            "name": runtime_skill,
+                            "namespace": "default",
+                            "is_public": True,
+                        }
+                    )
+                    existing_names.add(runtime_skill)
 
         return merged_preload_skills
-
-    @staticmethod
-    def _merge_user_mcp_into_bot_config(
-        bot_config_list: list[dict[str, Any]], user_mcp_servers: list[dict[str, Any]]
-    ) -> None:
-        """Inject user-scoped MCP servers into executor bot configs."""
-        if not user_mcp_servers:
-            return
-
-        supported_shell_types = {"ClaudeCode", "Agno"}
-        for bot_config in bot_config_list:
-            if bot_config.get("shell_type") not in supported_shell_types:
-                continue
-
-            merged_servers = {
-                server.get("name", "server"): server
-                for server in (bot_config.get("mcp_servers") or [])
-                if isinstance(server, dict)
-            }
-            for server in user_mcp_servers:
-                merged_servers[server.get("name", "server")] = dict(server)
-
-            bot_config["mcp_servers"] = list(merged_servers.values())
 
     # =========================================================================
     # Claude Code MCP Processing

--- a/backend/app/services/mcp_provider_registry.py
+++ b/backend/app/services/mcp_provider_registry.py
@@ -15,13 +15,15 @@ class MCPProviderServiceDefinition(TypedDict):
     service_id: str
     server_name: str
     detail_url: str
+    skill_name: str | None
+    display_name: str
+    message_keywords: tuple[str, ...]
 
 
 class MCPProviderDefinition(TypedDict):
     """Static definition for a provider and its supported MCP services."""
 
     provider_id: str
-    guidance_skill: str | None
     message_keywords: tuple[str, ...]
     services: dict[str, MCPProviderServiceDefinition]
 
@@ -29,18 +31,23 @@ class MCPProviderDefinition(TypedDict):
 MCP_PROVIDER_REGISTRY: dict[str, MCPProviderDefinition] = {
     "dingtalk": {
         "provider_id": "dingtalk",
-        "guidance_skill": "dingtalk-config-guide",
         "message_keywords": ("钉钉", "dingtalk"),
         "services": {
             "docs": {
                 "service_id": "docs",
                 "server_name": "dingtalk_docs",
                 "detail_url": "https://mcp.dingtalk.com/#/detail?mcpId=9629",
+                "skill_name": "dingtalk-docs",
+                "display_name": "钉钉文档",
+                "message_keywords": ("文档", "docs", "document"),
             },
             "ai_table": {
                 "service_id": "ai_table",
                 "server_name": "dingtalk_ai_table",
                 "detail_url": "https://mcp.dingtalk.com/#/detail?mcpId=9555",
+                "skill_name": "dingtalk-ai-table",
+                "display_name": "钉钉AI表格",
+                "message_keywords": ("ai表格", "table", "多维表", "notable", "表格"),
             },
         },
     }
@@ -75,3 +82,14 @@ def get_mcp_provider_service(
         return None
 
     return provider["services"].get(service_id)
+
+
+def get_mcp_service_by_skill_name(
+    skill_name: str,
+) -> tuple[MCPProviderDefinition, MCPProviderServiceDefinition] | None:
+    """Look up provider/service metadata by runtime skill name."""
+    for provider in list_mcp_providers():
+        for service in provider["services"].values():
+            if service.get("skill_name") == skill_name:
+                return provider, service
+    return None

--- a/backend/app/services/user_mcp_service.py
+++ b/backend/app/services/user_mcp_service.py
@@ -117,6 +117,42 @@ class UserMCPService:
         return mcps
 
     @staticmethod
+    def get_enabled_decrypted_mcp_preferences(
+        preferences: str | dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Return only enabled MCP services with decrypted URLs."""
+        mcps = UserMCPService.get_decrypted_mcp_preferences(preferences)
+        enabled_mcps: dict[str, Any] = {}
+
+        for provider_id, provider in mcps.items():
+            services = provider.get(MCP_SERVICES_KEY)
+            if not isinstance(services, dict):
+                continue
+
+            enabled_services: dict[str, Any] = {}
+            for service_id, service in services.items():
+                if not isinstance(service, dict):
+                    continue
+
+                if not service.get("enabled"):
+                    continue
+
+                credentials = service.get(MCP_CREDENTIALS_KEY)
+                url = credentials.get(MCP_URL_KEY) if isinstance(credentials, dict) else ""
+                if not isinstance(url, str) or not url.strip():
+                    continue
+
+                enabled_services[service_id] = service
+
+            if enabled_services:
+                enabled_mcps[provider_id] = {
+                    **provider,
+                    MCP_SERVICES_KEY: enabled_services,
+                }
+
+        return enabled_mcps
+
+    @staticmethod
     def get_enabled_mcp_server(
         preferences: str | dict[str, Any] | None,
         provider_id: str,

--- a/backend/app/services/user_mcp_service.py
+++ b/backend/app/services/user_mcp_service.py
@@ -6,8 +6,8 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 import json
+from copy import deepcopy
 from typing import Any
 
 from app.services.mcp_provider_registry import (
@@ -138,7 +138,11 @@ class UserMCPService:
                     continue
 
                 credentials = service.get(MCP_CREDENTIALS_KEY)
-                url = credentials.get(MCP_URL_KEY) if isinstance(credentials, dict) else ""
+                url = (
+                    credentials.get(MCP_URL_KEY)
+                    if isinstance(credentials, dict)
+                    else ""
+                )
                 if not isinstance(url, str) or not url.strip():
                     continue
 

--- a/backend/app/services/user_mcp_service.py
+++ b/backend/app/services/user_mcp_service.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import json
 from typing import Any
 
@@ -92,6 +93,58 @@ class UserMCPService:
         return configs
 
     @staticmethod
+    def get_decrypted_mcp_preferences(
+        preferences: str | dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Return the user MCP preferences subtree with decrypted URLs."""
+        prefs = UserMCPService.load_preferences(preferences)
+        mcps = deepcopy(prefs.get(MCP_ROOT_KEY) or {})
+
+        for provider in mcps.values():
+            services = provider.get(MCP_SERVICES_KEY)
+            if not isinstance(services, dict):
+                continue
+
+            for service in services.values():
+                credentials = service.get(MCP_CREDENTIALS_KEY)
+                if not isinstance(credentials, dict):
+                    continue
+
+                url = credentials.get(MCP_URL_KEY)
+                if isinstance(url, str) and url and is_data_encrypted(url):
+                    credentials[MCP_URL_KEY] = decrypt_sensitive_data(url) or ""
+
+        return mcps
+
+    @staticmethod
+    def get_enabled_mcp_server(
+        preferences: str | dict[str, Any] | None,
+        provider_id: str,
+        service_id: str,
+        *,
+        server_name: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Build a concrete MCP server config for an enabled provider service."""
+        service = get_mcp_provider_service(provider_id, service_id)
+        if not service:
+            return None
+
+        config = UserMCPService.get_provider_service_config(
+            preferences,
+            provider_id,
+            service_id,
+        )
+        url = (config.get("url") or "").strip()
+        if not config.get("enabled") or not url:
+            return None
+
+        return {
+            "name": server_name or service["server_name"],
+            "url": url,
+            "type": "streamable-http",
+        }
+
+    @staticmethod
     def set_provider_service_config(
         preferences: str | dict[str, Any] | None,
         *,
@@ -155,17 +208,13 @@ class UserMCPService:
             for service in UserMCPService.list_provider_service_configs(
                 preferences, current_provider_id
             ):
-                url = (service.get("url") or "").strip()
-                if not service.get("enabled") or not url:
-                    continue
-
-                servers.append(
-                    {
-                        "name": service["server_name"],
-                        "url": url,
-                        "type": "streamable-http",
-                    }
+                server = UserMCPService.get_enabled_mcp_server(
+                    preferences,
+                    current_provider_id,
+                    service["service_id"],
                 )
+                if server:
+                    servers.append(server)
 
         return servers
 

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -360,6 +360,34 @@ class TestPrepareMcpForClaudeCode:
 
         assert bot_config["mcp_servers"] == []
 
+    def test_placeholder_urls_are_preserved(self):
+        builder = TaskRequestBuilder.__new__(TaskRequestBuilder)
+        bot_config = {
+            "shell_type": "ClaudeCode",
+            "mcp_servers": [],
+        }
+        skill_configs = [
+            {
+                "name": "dingtalk-docs",
+                "mcpServers": {
+                    "dingtalk-docs": {
+                        "type": "streamable-http",
+                        "url": "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}",
+                    },
+                },
+            }
+        ]
+
+        builder._prepare_mcp_for_claude_code(bot_config, skill_configs)
+
+        assert bot_config["mcp_servers"] == [
+            {
+                "name": "dingtalk-docs",
+                "type": "http",
+                "url": "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}",
+            }
+        ]
+
     @patch.object(
         TaskRequestBuilder,
         "_check_mcp_server_reachable",

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -442,7 +442,7 @@ class TestResolveRequestPreloadSkills:
             request=request,
             bot=bot,
             team=team,
-            user_id=7,
+            user=SimpleNamespace(id=7, preferences="{}"),
         )
 
         assert result.skill_names == ["browser", "wegent-knowledge"]

--- a/backend/tests/services/execution/test_request_builder_skill_identity.py
+++ b/backend/tests/services/execution/test_request_builder_skill_identity.py
@@ -35,7 +35,6 @@ def test_build_generates_skill_identity_token(test_db, mocker):
         "_build_bot_config",
         return_value=[{"shell_type": "Chat", "skills": []}],
     )
-    mocker.patch.object(builder, "_load_user_mcp_servers", return_value=[])
     mocker.patch.object(builder, "_build_mcp_servers", return_value=[])
     mocker.patch.object(builder, "_is_group_chat", return_value=False)
     mocker.patch.object(builder, "_generate_auth_token", return_value="task-jwt")

--- a/backend/tests/services/execution/test_request_builder_user_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_user_mcp.py
@@ -42,6 +42,40 @@ class TestUserScopedMcpInjection:
             }
         }
 
+    def test_build_request_task_data_filters_disabled_services(self):
+        preferences = user_mcp_service.set_provider_service_config(
+            None,
+            provider_id="dingtalk",
+            service_id="docs",
+            enabled=True,
+            url="https://example.com/mcp?token=secret",
+        )
+        preferences = user_mcp_service.set_provider_service_config(
+            preferences,
+            provider_id="dingtalk",
+            service_id="ai_table",
+            enabled=False,
+            url="https://example.com/table?token=secret",
+        )
+        user = SimpleNamespace(preferences=user_mcp_service.dump_preferences(preferences))
+
+        task_data = TaskRequestBuilder._build_request_task_data(user)
+
+        assert task_data == {
+            "user_mcps": {
+                "dingtalk": {
+                    "services": {
+                        "docs": {
+                            "enabled": True,
+                            "credentials": {
+                                "url": "https://example.com/mcp?token=secret"
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
     def test_injects_service_skill_when_message_mentions_provider_and_service_missing(
         self, test_db
     ):
@@ -220,6 +254,42 @@ class TestUserScopedMcpInjection:
         assert "wegent://modal/mcp-provider-config?provider=dingtalk&service=docs" in (
             skill_data["prompt"]
         )
+
+    def test_build_skill_data_does_not_rewrite_non_public_skill_named_like_runtime_skill(
+        self, test_db
+    ):
+        builder = TaskRequestBuilder(test_db)
+        skill = SimpleNamespace(
+            id=301,
+            user_id=7,
+            json={
+                "kind": "Skill",
+                "metadata": {"name": "dingtalk-docs", "namespace": "workspace-team"},
+                "spec": {
+                    "description": "Custom skill",
+                    "prompt": "Custom prompt.",
+                    "bindShells": ["Chat"],
+                    "mcpServers": {
+                        "docs": {
+                            "type": "streamable-http",
+                            "url": "http://custom.example.com/mcp",
+                        }
+                    },
+                },
+            },
+        )
+
+        skill_data = builder._build_skill_data(
+            skill, user=SimpleNamespace(preferences="{}")
+        )
+
+        assert skill_data["prompt"] == "Custom prompt."
+        assert skill_data["mcpServers"] == {
+            "docs": {
+                "type": "streamable-http",
+                "url": "http://custom.example.com/mcp",
+            }
+        }
 
     def test_get_bot_skills_resolves_public_user_preload_skill(self, test_db, mocker):
         builder = TaskRequestBuilder(test_db)

--- a/backend/tests/services/execution/test_request_builder_user_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_user_mcp.py
@@ -57,7 +57,9 @@ class TestUserScopedMcpInjection:
             enabled=False,
             url="https://example.com/table?token=secret",
         )
-        user = SimpleNamespace(preferences=user_mcp_service.dump_preferences(preferences))
+        user = SimpleNamespace(
+            preferences=user_mcp_service.dump_preferences(preferences)
+        )
 
         task_data = TaskRequestBuilder._build_request_task_data(user)
 
@@ -118,12 +120,10 @@ class TestUserScopedMcpInjection:
                 "name": "dingtalk-ai-table",
                 "namespace": "default",
                 "is_public": True,
-            }
+            },
         ]
 
-    def test_injects_runtime_skill_when_matching_service_is_ready(
-        self, test_db
-    ):
+    def test_injects_runtime_skill_when_matching_service_is_ready(self, test_db):
         builder = TaskRequestBuilder(test_db)
         preferences = user_mcp_service.dump_preferences(
             user_mcp_service.set_provider_service_config(
@@ -150,9 +150,7 @@ class TestUserScopedMcpInjection:
             }
         ]
 
-    def test_does_not_inject_other_service_when_target_service_matches(
-        self, test_db
-    ):
+    def test_does_not_inject_other_service_when_target_service_matches(self, test_db):
         builder = TaskRequestBuilder(test_db)
         preferences = user_mcp_service.dump_preferences(
             user_mcp_service.set_provider_service_config(
@@ -317,9 +315,7 @@ class TestUserScopedMcpInjection:
                 },
             },
         )
-        skill = SimpleNamespace(
-            name="dingtalk-docs", user_id=0, namespace="default"
-        )
+        skill = SimpleNamespace(name="dingtalk-docs", user_id=0, namespace="default")
 
         mock_query = mocker.Mock()
         mock_query.filter.return_value.first.return_value = ghost

--- a/backend/tests/services/execution/test_request_builder_user_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_user_mcp.py
@@ -13,7 +13,7 @@ from app.services.user_mcp_service import user_mcp_service
 class TestUserScopedMcpInjection:
     """Tests for DingTalk Docs MCP injection."""
 
-    def test_load_user_mcp_servers_returns_provider_server_when_enabled(self):
+    def test_build_request_task_data_injects_decrypted_user_mcps(self):
         preferences = user_mcp_service.dump_preferences(
             user_mcp_service.set_provider_service_config(
                 None,
@@ -25,37 +25,24 @@ class TestUserScopedMcpInjection:
         )
         user = SimpleNamespace(preferences=preferences)
 
-        servers = TaskRequestBuilder._load_user_mcp_servers(user)
+        task_data = TaskRequestBuilder._build_request_task_data(user)
 
-        assert servers == [
-            {
-                "name": "dingtalk_docs",
-                "url": "https://example.com/mcp?token=secret",
-                "type": "streamable-http",
+        assert task_data == {
+            "user_mcps": {
+                "dingtalk": {
+                    "services": {
+                        "docs": {
+                            "enabled": True,
+                            "credentials": {
+                                "url": "https://example.com/mcp?token=secret"
+                            },
+                        }
+                    }
+                }
             }
-        ]
+        }
 
-    def test_merge_user_mcp_into_bot_config_only_updates_supported_shells(self):
-        bot_config_list = [
-            {"shell_type": "ClaudeCode", "mcp_servers": []},
-            {"shell_type": "Chat", "mcp_servers": []},
-        ]
-        user_mcp_servers = [
-            {
-                "name": "dingtalk_docs",
-                "url": "https://example.com/mcp?token=secret",
-                "type": "streamable-http",
-            }
-        ]
-
-        TaskRequestBuilder._merge_user_mcp_into_bot_config(
-            bot_config_list, user_mcp_servers
-        )
-
-        assert bot_config_list[0]["mcp_servers"] == user_mcp_servers
-        assert bot_config_list[1]["mcp_servers"] == []
-
-    def test_injects_provider_config_skill_when_message_mentions_provider_and_service_missing(
+    def test_injects_service_skill_when_message_mentions_provider_and_service_missing(
         self, test_db
     ):
         builder = TaskRequestBuilder(test_db)
@@ -69,40 +56,170 @@ class TestUserScopedMcpInjection:
 
         assert preload_skills == [
             {
-                "name": "dingtalk-config-guide",
+                "name": "dingtalk-docs",
                 "namespace": "default",
                 "is_public": True,
             }
         ]
 
-    def test_skips_provider_config_skill_when_all_registered_services_are_ready(
+    def test_injects_all_provider_service_skills_for_generic_dingtalk_request(
+        self, test_db
+    ):
+        builder = TaskRequestBuilder(test_db)
+        user = SimpleNamespace(preferences="{}")
+
+        preload_skills = builder._inject_conditional_provider_skills(
+            user=user,
+            message="帮我处理一下钉钉里的内容",
+            preload_skills=[],
+        )
+
+        assert preload_skills == [
+            {
+                "name": "dingtalk-docs",
+                "namespace": "default",
+                "is_public": True,
+            },
+            {
+                "name": "dingtalk-ai-table",
+                "namespace": "default",
+                "is_public": True,
+            }
+        ]
+
+    def test_injects_runtime_skill_when_matching_service_is_ready(
         self, test_db
     ):
         builder = TaskRequestBuilder(test_db)
         preferences = user_mcp_service.dump_preferences(
             user_mcp_service.set_provider_service_config(
-                user_mcp_service.set_provider_service_config(
-                    None,
-                    provider_id="dingtalk",
-                    service_id="docs",
-                    enabled=True,
-                    url="https://example.com/docs?token=secret",
-                ),
+                None,
                 provider_id="dingtalk",
-                service_id="ai_table",
+                service_id="docs",
                 enabled=True,
-                url="https://example.com/ai-table?token=secret",
+                url="https://example.com/docs?token=secret",
             )
         )
         user = SimpleNamespace(preferences=preferences)
 
         preload_skills = builder._inject_conditional_provider_skills(
             user=user,
-            message="帮我看一下钉钉表格",
+            message="帮我看一下钉钉文档",
             preload_skills=[],
         )
 
-        assert preload_skills == []
+        assert preload_skills == [
+            {
+                "name": "dingtalk-docs",
+                "namespace": "default",
+                "is_public": True,
+            }
+        ]
+
+    def test_does_not_inject_other_service_when_target_service_matches(
+        self, test_db
+    ):
+        builder = TaskRequestBuilder(test_db)
+        preferences = user_mcp_service.dump_preferences(
+            user_mcp_service.set_provider_service_config(
+                None,
+                provider_id="dingtalk",
+                service_id="docs",
+                enabled=True,
+                url="https://example.com/docs?token=secret",
+            )
+        )
+        user = SimpleNamespace(preferences=preferences)
+
+        preload_skills = builder._inject_conditional_provider_skills(
+            user=user,
+            message="总结一下我的钉钉文档",
+            preload_skills=[],
+        )
+
+        assert preload_skills == [
+            {
+                "name": "dingtalk-docs",
+                "namespace": "default",
+                "is_public": True,
+            }
+        ]
+
+    def test_build_skill_data_preserves_mcp_server_placeholders_when_service_ready(
+        self, test_db
+    ):
+        builder = TaskRequestBuilder(test_db)
+        preferences = user_mcp_service.dump_preferences(
+            user_mcp_service.set_provider_service_config(
+                None,
+                provider_id="dingtalk",
+                service_id="docs",
+                enabled=True,
+                url="https://example.com/docs?token=secret",
+            )
+        )
+        user = SimpleNamespace(preferences=preferences)
+        skill = SimpleNamespace(
+            id=101,
+            user_id=0,
+            json={
+                "kind": "Skill",
+                "metadata": {"name": "dingtalk-docs", "namespace": "default"},
+                "spec": {
+                    "description": "DingTalk docs runtime skill",
+                    "bindShells": ["Chat"],
+                    "mcpServers": {
+                        "docs": {
+                            "type": "streamable-http",
+                            "url": "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}",
+                        }
+                    },
+                },
+            },
+        )
+
+        skill_data = builder._build_skill_data(skill, user=user)
+
+        assert skill_data["mcpServers"] == {
+            "docs": {
+                "type": "streamable-http",
+                "url": "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}",
+            }
+        }
+
+    def test_build_skill_data_turns_runtime_skill_into_embedded_guide_when_service_missing(
+        self, test_db
+    ):
+        builder = TaskRequestBuilder(test_db)
+        skill = SimpleNamespace(
+            id=101,
+            user_id=0,
+            json={
+                "kind": "Skill",
+                "metadata": {"name": "dingtalk-docs", "namespace": "default"},
+                "spec": {
+                    "description": "DingTalk docs runtime skill",
+                    "prompt": "Use DingTalk docs MCP.",
+                    "bindShells": ["Chat"],
+                    "mcpServers": {
+                        "docs": {
+                            "type": "streamable-http",
+                            "url": "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}",
+                        }
+                    },
+                },
+            },
+        )
+
+        skill_data = builder._build_skill_data(
+            skill, user=SimpleNamespace(preferences="{}")
+        )
+
+        assert "mcpServers" not in skill_data
+        assert "Configuration Required" in skill_data["prompt"]
+        assert "wegent://modal/mcp-provider-config?provider=dingtalk&service=docs" in (
+            skill_data["prompt"]
+        )
 
     def test_get_bot_skills_resolves_public_user_preload_skill(self, test_db, mocker):
         builder = TaskRequestBuilder(test_db)
@@ -131,7 +248,7 @@ class TestUserScopedMcpInjection:
             },
         )
         skill = SimpleNamespace(
-            name="dingtalk-config-guide", user_id=0, namespace="default"
+            name="dingtalk-docs", user_id=0, namespace="default"
         )
 
         mock_query = mocker.Mock()
@@ -143,7 +260,7 @@ class TestUserScopedMcpInjection:
         mocker.patch.object(
             builder,
             "_build_skill_data",
-            return_value={"name": "dingtalk-config-guide"},
+            return_value={"name": "dingtalk-docs"},
         )
 
         (
@@ -154,10 +271,11 @@ class TestUserScopedMcpInjection:
         ) = builder._get_bot_skills(
             bot=bot,
             team=team,
+            user=SimpleNamespace(preferences="{}"),
             user_id=2,
             user_preload_skills=[
                 {
-                    "name": "dingtalk-config-guide",
+                    "name": "dingtalk-docs",
                     "namespace": "default",
                     "is_public": True,
                 }
@@ -165,17 +283,17 @@ class TestUserScopedMcpInjection:
         )
 
         find_skill_by_ref.assert_called_once_with(
-            "dingtalk-config-guide",
+            "dingtalk-docs",
             "default",
             True,
             2,
             team_namespace="default",
         )
-        assert skills == [{"name": "dingtalk-config-guide"}]
-        assert preload_skills == ["dingtalk-config-guide"]
-        assert user_selected_skills == ["dingtalk-config-guide"]
+        assert skills == [{"name": "dingtalk-docs"}]
+        assert preload_skills == ["dingtalk-docs"]
+        assert user_selected_skills == ["dingtalk-docs"]
         assert skill_refs == {
-            "dingtalk-config-guide": {
+            "dingtalk-docs": {
                 "skill_id": None,
                 "namespace": "default",
                 "is_public": True,
@@ -205,6 +323,7 @@ class TestUserScopedMcpInjection:
         result = builder._get_bot_skills(
             bot=bot,
             team=team,
+            user=SimpleNamespace(preferences="{}"),
             user_id=2,
             user_preload_skills=None,
         )

--- a/backend/tests/services/test_user_mcp_service.py
+++ b/backend/tests/services/test_user_mcp_service.py
@@ -47,6 +47,32 @@ class TestUserMCPService:
             "url": "https://example.com/mcp?token=secret",
         }
 
+    def test_get_decrypted_mcp_preferences_keeps_structure_and_decrypts_url(self):
+        preferences = user_mcp_service.set_provider_service_config(
+            None,
+            provider_id="dingtalk",
+            service_id="docs",
+            enabled=True,
+            url="https://example.com/mcp?token=secret",
+        )
+
+        decrypted = user_mcp_service.get_decrypted_mcp_preferences(
+            json.dumps(preferences)
+        )
+
+        assert decrypted == {
+            "dingtalk": {
+                "services": {
+                    "docs": {
+                        "enabled": True,
+                        "credentials": {
+                            "url": "https://example.com/mcp?token=secret"
+                        },
+                    }
+                }
+            }
+        }
+
     def test_list_mcp_servers_returns_enabled_services_only(self):
         preferences = user_mcp_service.set_provider_service_config(
             None,
@@ -65,3 +91,34 @@ class TestUserMCPService:
                 "type": "streamable-http",
             }
         ]
+
+    def test_get_enabled_mcp_server_returns_none_when_service_not_ready(self):
+        assert (
+            user_mcp_service.get_enabled_mcp_server(
+                None,
+                "dingtalk",
+                "docs",
+            )
+            is None
+        )
+
+    def test_get_enabled_mcp_server_returns_runtime_server_when_enabled(self):
+        preferences = user_mcp_service.set_provider_service_config(
+            None,
+            provider_id="dingtalk",
+            service_id="docs",
+            enabled=True,
+            url="https://example.com/mcp?token=secret",
+        )
+
+        server = user_mcp_service.get_enabled_mcp_server(
+            preferences,
+            "dingtalk",
+            "docs",
+        )
+
+        assert server == {
+            "name": "dingtalk_docs",
+            "url": "https://example.com/mcp?token=secret",
+            "type": "streamable-http",
+        }

--- a/backend/tests/services/test_user_mcp_service.py
+++ b/backend/tests/services/test_user_mcp_service.py
@@ -65,9 +65,7 @@ class TestUserMCPService:
                 "services": {
                     "docs": {
                         "enabled": True,
-                        "credentials": {
-                            "url": "https://example.com/mcp?token=secret"
-                        },
+                        "credentials": {"url": "https://example.com/mcp?token=secret"},
                     }
                 }
             }
@@ -98,9 +96,7 @@ class TestUserMCPService:
                 "services": {
                     "docs": {
                         "enabled": True,
-                        "credentials": {
-                            "url": "https://example.com/mcp?token=secret"
-                        },
+                        "credentials": {"url": "https://example.com/mcp?token=secret"},
                     }
                 }
             }

--- a/backend/tests/services/test_user_mcp_service.py
+++ b/backend/tests/services/test_user_mcp_service.py
@@ -73,6 +73,39 @@ class TestUserMCPService:
             }
         }
 
+    def test_get_enabled_decrypted_mcp_preferences_filters_disabled_services(self):
+        preferences = user_mcp_service.set_provider_service_config(
+            None,
+            provider_id="dingtalk",
+            service_id="docs",
+            enabled=True,
+            url="https://example.com/mcp?token=secret",
+        )
+        preferences = user_mcp_service.set_provider_service_config(
+            preferences,
+            provider_id="dingtalk",
+            service_id="ai_table",
+            enabled=False,
+            url="https://example.com/table?token=secret",
+        )
+
+        decrypted = user_mcp_service.get_enabled_decrypted_mcp_preferences(
+            json.dumps(preferences)
+        )
+
+        assert decrypted == {
+            "dingtalk": {
+                "services": {
+                    "docs": {
+                        "enabled": True,
+                        "credentials": {
+                            "url": "https://example.com/mcp?token=secret"
+                        },
+                    }
+                }
+            }
+        }
+
     def test_list_mcp_servers_returns_enabled_services_only(self):
         preferences = user_mcp_service.set_provider_service_config(
             None,


### PR DESCRIPTION
## Summary
- stop injecting configured DingTalk MCP servers globally and expose them through skills instead
- inject decrypted user MCP config into `task_data.user_mcps` so skill MCP URLs can be resolved from skill placeholders
- make DingTalk runtime skills fall back to an embedded configuration guide when the required MCP is not configured

## Testing
- `cd /Users/crystal/dev/git/Wegent/backend && uv run pytest /Users/crystal/dev/git/Wegent/backend/tests/services/execution/test_request_builder_user_mcp.py /Users/crystal/dev/git/Wegent/backend/tests/services/test_user_mcp_service.py /Users/crystal/dev/git/Wegent/backend/tests/services/execution/test_request_builder_mcp.py /Users/crystal/dev/git/Wegent/backend/tests/services/execution/test_request_builder_skill_identity.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills now adapt to each user’s enabled service settings, improving which provider skills appear and how they behave.
  * Skill prompts include a “Configuration Required” guidance link when a needed service isn’t enabled.

* **Refactor**
  * Request and skill preparation are user-aware and handle runtime provider behavior more robustly.
  * Placeholder service URLs are preserved during normalization to avoid accidental resolution or removal.

* **Tests**
  * Expanded coverage for user service preferences, placeholder handling, and provider-skill injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->