### PR TITLE
fix(frontend): clear device selection when switching to cloud-mode tasks

### DIFF
--- a/frontend/src/features/tasks/components/params/DeviceTaskSync.tsx
+++ b/frontend/src/features/tasks/components/params/DeviceTaskSync.tsx
@@ -33,11 +33,11 @@ export default function DeviceTaskSync() {
       return
     }
 
-    // Task has no device_id — keep current selection as-is
-    // This handles:
-    // 1. Newly created task where device_id hasn't been saved yet (race condition)
-    // 2. Cloud executor tasks where device selection should not be affected
+    // Task has no device_id — clear device selection to match cloud mode
     if (!selectedTaskDetail.device_id) {
+      if (selectedDeviceId) {
+        setSelectedDeviceId(null)
+      }
       lastProcessedTaskIdRef.current = selectedTaskDetail.id
       return
     }


### PR DESCRIPTION
DeviceTaskSync previously kept the selectedDeviceId unchanged when switching to a task without device_id. This caused cloud-mode conversations to inadvertently route subtasks to a previously selected device, resulting in execution mode switches mid-conversation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device selection synchronization when loading tasks without device associations. Device selection is now properly cleared in these cases, improving handling of cloud executor tasks and race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->