### PR TITLE
[codex] Improve device monitor filters

### DIFF
--- a/backend/app/api/endpoints/admin/device_monitor.py
+++ b/backend/app/api/endpoints/admin/device_monitor.py
@@ -6,9 +6,10 @@
 
 import logging
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Query, status
+from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
@@ -28,6 +29,7 @@ router = APIRouter(prefix="/device-monitor")
 
 # Stats cache configuration
 _STATS_CACHE = {"data": None, "timestamp": 0, "ttl": 30}  # 30 seconds cache
+VersionFilterOperator = Literal["gt", "gte", "eq", "lt", "lte"]
 
 
 # ==================== Request/Response Models ====================
@@ -257,14 +259,68 @@ def _build_device_info(
     )
 
 
+def _normalize_version_filter(
+    version_op: Optional[VersionFilterOperator], version: Optional[str]
+) -> Optional[tuple[VersionFilterOperator, Version]]:
+    """Normalize version filter query params."""
+    normalized_version = (version or "").strip()
+    if not normalized_version:
+        return None
+
+    try:
+        parsed_version = Version(normalized_version)
+    except InvalidVersion as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid version filter: {normalized_version}",
+        ) from exc
+
+    return (version_op or "gte", parsed_version)
+
+
+def _matches_version_filter(
+    executor_version: Optional[str],
+    version_filter: tuple[VersionFilterOperator, Version],
+) -> bool:
+    """Check whether an executor version matches the requested filter."""
+    if not executor_version:
+        return False
+
+    try:
+        parsed_executor_version = Version(executor_version.strip())
+    except InvalidVersion:
+        logger.warning(
+            f"[DeviceMonitor] Skipping device with invalid executor version: {executor_version}"
+        )
+        return False
+
+    version_op, target_version = version_filter
+    if version_op == "gt":
+        return parsed_executor_version > target_version
+    if version_op == "gte":
+        return parsed_executor_version >= target_version
+    if version_op == "eq":
+        return parsed_executor_version == target_version
+    if version_op == "lt":
+        return parsed_executor_version < target_version
+    return parsed_executor_version <= target_version
+
+
 @router.get("/devices", response_model=AdminDeviceListResponse)
 async def get_all_devices(
     page: int = Query(1, ge=1, description="Page number"),
     limit: int = Query(20, ge=1, le=100, description="Items per page"),
+    status: Optional[DeviceStatusEnum] = Query(None, description="Filter by status"),
     device_type: Optional[str] = Query(None, description="Filter by device type"),
     bind_shell: Optional[str] = Query(None, description="Filter by bind shell"),
     search: Optional[str] = Query(
         None, description="Search by device name, ID or username"
+    ),
+    version_op: Optional[VersionFilterOperator] = Query(
+        None, description="Version comparison operator"
+    ),
+    version: Optional[str] = Query(
+        None, description="Filter online devices by executor version"
     ),
     db: Session = Depends(get_db),
     current_user: User = Depends(security.get_admin_user),
@@ -291,6 +347,9 @@ async def get_all_devices(
     Returns:
         AdminDeviceListResponse with paginated devices
     """
+    effective_version = None if status == DeviceStatusEnum.OFFLINE else version
+    normalized_version_filter = _normalize_version_filter(version_op, effective_version)
+
     # Step 1: If search term provided, find matching user IDs first
     search_user_ids: Optional[List[int]] = None
     if search:
@@ -302,29 +361,73 @@ async def get_all_devices(
     # Step 2: Build optimized query with SQL-level filtering
     query = _build_device_query(db, device_type, bind_shell, search, search_user_ids)
 
-    # Step 3: Get total count and paginated results
-    total = query.count()
-    offset = (page - 1) * limit
-    page_kinds = query.offset(offset).limit(limit).all()
+    if normalized_version_filter is None and status is None:
+        # Step 3: Get total count and paginated results
+        total = query.count()
+        offset = (page - 1) * limit
+        page_kinds = query.offset(offset).limit(limit).all()
 
-    # Step 4: Build user map only for current page (not all devices)
-    page_user_ids = list({d.user_id for d in page_kinds})
-    users_map: Dict[int, str] = {}
-    if page_user_ids:
-        users = db.query(User).filter(User.id.in_(page_user_ids)).all()
-        users_map = {u.id: u.user_name for u in users}
+        # Step 4: Build user map only for current page (not all devices)
+        page_user_ids = list({d.user_id for d in page_kinds})
+        users_map: Dict[int, str] = {}
+        if page_user_ids:
+            users = db.query(User).filter(User.id.in_(page_user_ids)).all()
+            users_map = {u.id: u.user_name for u in users}
 
-    # Step 5: Get Redis status for current page only (batch query)
-    online_info_map = await _get_devices_redis_status(page_kinds)
+        # Step 5: Get Redis status for current page only (batch query)
+        online_info_map = await _get_devices_redis_status(page_kinds)
 
-    # Step 6: Build device info list
-    items = []
-    for kind in page_kinds:
+        # Step 6: Build device info list
+        items = []
+        for kind in page_kinds:
+            spec = kind.json.get("spec", {}) if kind.json else {}
+            device_id = spec.get("deviceId", kind.name)
+            redis_key = local_device_provider.generate_online_key(kind.user_id, device_id)
+            online_info = online_info_map.get(redis_key)
+
+            device_info = _build_device_info(kind, users_map, online_info)
+            items.append(device_info)
+
+        return AdminDeviceListResponse(items=items, total=total)
+
+    # Version filtering requires live online info, so filter before pagination.
+    candidate_kinds = query.all()
+    online_info_map = await _get_devices_redis_status(candidate_kinds)
+    filtered_pairs: list[tuple[Kind, Dict[str, Any]]] = []
+
+    for kind in candidate_kinds:
         spec = kind.json.get("spec", {}) if kind.json else {}
         device_id = spec.get("deviceId", kind.name)
         redis_key = local_device_provider.generate_online_key(kind.user_id, device_id)
         online_info = online_info_map.get(redis_key)
 
+        status_val = (
+            online_info.get("status", DeviceStatusEnum.ONLINE.value)
+            if online_info
+            else DeviceStatusEnum.OFFLINE.value
+        )
+        if status is not None and status_val != status.value:
+            continue
+
+        if normalized_version_filter is not None and not _matches_version_filter(
+            online_info.get("executor_version") if online_info else None,
+            normalized_version_filter,
+        ):
+            continue
+
+        filtered_pairs.append((kind, online_info))
+
+    total = len(filtered_pairs)
+    offset = (page - 1) * limit
+    page_pairs = filtered_pairs[offset : offset + limit]
+    page_user_ids = list({kind.user_id for kind, _ in page_pairs})
+    users_map: Dict[int, str] = {}
+    if page_user_ids:
+        users = db.query(User).filter(User.id.in_(page_user_ids)).all()
+        users_map = {u.id: u.user_name for u in users}
+
+    items = []
+    for kind, online_info in page_pairs:
         device_info = _build_device_info(kind, users_map, online_info)
         items.append(device_info)
 

--- a/backend/app/api/endpoints/admin/device_monitor.py
+++ b/backend/app/api/endpoints/admin/device_monitor.py
@@ -382,7 +382,9 @@ async def get_all_devices(
         for kind in page_kinds:
             spec = kind.json.get("spec", {}) if kind.json else {}
             device_id = spec.get("deviceId", kind.name)
-            redis_key = local_device_provider.generate_online_key(kind.user_id, device_id)
+            redis_key = local_device_provider.generate_online_key(
+                kind.user_id, device_id
+            )
             online_info = online_info_map.get(redis_key)
 
             device_info = _build_device_info(kind, users_map, online_info)

--- a/backend/tests/api/endpoints/test_admin_device_monitor_api.py
+++ b/backend/tests/api/endpoints/test_admin_device_monitor_api.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from packaging.version import Version
+from sqlalchemy.orm import Session
+
+from app.api.endpoints.admin import device_monitor
+from app.models.kind import Kind
+from app.models.user import User
+
+
+def _create_device_kind(test_db: Session, user_id: int, device_id: str, name: str) -> Kind:
+    device = Kind(
+        user_id=user_id,
+        kind="Device",
+        name=device_id,
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Device",
+            "metadata": {
+                "name": device_id,
+                "namespace": "default",
+                "displayName": name,
+            },
+            "spec": {
+                "deviceId": device_id,
+                "displayName": name,
+                "deviceType": "local",
+                "bindShell": "claudecode",
+            },
+            "status": {"state": "Available"},
+        },
+        is_active=True,
+    )
+    test_db.add(device)
+    test_db.commit()
+    test_db.refresh(device)
+    return device
+
+
+@pytest.mark.asyncio
+async def test_admin_device_monitor_filters_online_devices_by_version(
+    test_db: Session,
+    test_admin_user: User,
+    test_user: User,
+):
+    online_device = _create_device_kind(test_db, test_user.id, "device-online", "Online")
+    busy_device = _create_device_kind(test_db, test_user.id, "device-busy", "Busy")
+    _create_device_kind(test_db, test_user.id, "device-offline", "Offline")
+
+    online_key = device_monitor.local_device_provider.generate_online_key(
+        test_user.id, "device-online"
+    )
+    busy_key = device_monitor.local_device_provider.generate_online_key(
+        test_user.id, "device-busy"
+    )
+    offline_key = device_monitor.local_device_provider.generate_online_key(
+        test_user.id, "device-offline"
+    )
+
+    with patch(
+        "app.api.endpoints.admin.device_monitor.cache_manager.mget",
+        new=AsyncMock(
+            return_value={
+                online_key: {
+                    "status": "online",
+                    "executor_version": "1.7.0",
+                    "running_task_ids": [],
+                },
+                busy_key: {
+                    "status": "busy",
+                    "executor_version": "1.8.0",
+                    "running_task_ids": [],
+                },
+                offline_key: None,
+            }
+        ),
+    ):
+        response = await device_monitor.get_all_devices(
+            page=1,
+            limit=20,
+            status=None,
+            device_type=None,
+            bind_shell=None,
+            search=None,
+            version_op="gte",
+            version="1.7.0",
+            db=test_db,
+            current_user=test_admin_user,
+        )
+
+    assert response.total == 2
+    assert {item.device_id for item in response.items} == {
+        online_device.name,
+        busy_device.name,
+    }
+    assert {item.status.value for item in response.items} == {"online", "busy"}
+
+
+@pytest.mark.asyncio
+async def test_admin_device_monitor_ignores_version_filter_for_offline_status(
+    test_db: Session,
+    test_admin_user: User,
+    test_user: User,
+):
+    _create_device_kind(test_db, test_user.id, "device-online", "Online")
+    offline_device = _create_device_kind(test_db, test_user.id, "device-offline", "Offline")
+
+    online_key = device_monitor.local_device_provider.generate_online_key(
+        test_user.id, "device-online"
+    )
+    offline_key = device_monitor.local_device_provider.generate_online_key(
+        test_user.id, "device-offline"
+    )
+
+    with patch(
+        "app.api.endpoints.admin.device_monitor.cache_manager.mget",
+        new=AsyncMock(
+            return_value={
+                online_key: {
+                    "status": "online",
+                    "executor_version": "1.5.0",
+                    "running_task_ids": [],
+                },
+                offline_key: None,
+            }
+        ),
+    ):
+        response = await device_monitor.get_all_devices(
+            page=1,
+            limit=20,
+            status=device_monitor.DeviceStatusEnum.OFFLINE,
+            device_type=None,
+            bind_shell=None,
+            search=None,
+            version_op="gte",
+            version="9.9.9",
+            db=test_db,
+            current_user=test_admin_user,
+        )
+
+    assert response.total == 1
+    assert response.items[0].device_id == offline_device.name
+    assert response.items[0].status.value == "offline"
+
+
+def test_admin_device_monitor_rejects_invalid_version_filter():
+    with pytest.raises(HTTPException) as exc_info:
+        device_monitor._normalize_version_filter("gte", "bad-version")
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Invalid version filter: bad-version"
+
+
+def test_admin_device_monitor_matches_version_filter():
+    version_filter = ("lte", Version("1.6.5"))
+
+    assert device_monitor._matches_version_filter("1.6.5", version_filter) is True
+    assert device_monitor._matches_version_filter("1.6.4", version_filter) is True
+    assert device_monitor._matches_version_filter("1.7.0", version_filter) is False
+    assert device_monitor._matches_version_filter(None, version_filter) is False

--- a/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
+++ b/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
@@ -43,16 +43,21 @@ jest.mock('@/components/ui/tooltip', () => ({
 }))
 
 jest.mock('@/components/ui/select', () => {
+  type MockSelectChildProps = {
+    children?: React.ReactNode
+    value?: string
+  }
+
   const collectOptions = (children: React.ReactNode): Array<{ value: string; label: React.ReactNode }> => {
     const options: Array<{ value: string; label: React.ReactNode }> = []
 
     React.Children.forEach(children, child => {
-      if (!React.isValidElement(child)) {
+      if (!React.isValidElement<MockSelectChildProps>(child)) {
         return
       }
 
       if ((child.type as { displayName?: string }).displayName === 'MockSelectItem') {
-        options.push({ value: child.props.value as string, label: child.props.children })
+        options.push({ value: child.props.value ?? '', label: child.props.children })
       }
 
       if (child.props.children) {
@@ -73,16 +78,16 @@ jest.mock('@/components/ui/select', () => {
     }
   ): React.ReactNode =>
     React.Children.map(children, child => {
-      if (!React.isValidElement(child)) {
+      if (!React.isValidElement<MockSelectChildProps>(child)) {
         return child
       }
 
       if ((child.type as { displayName?: string }).displayName === 'MockSelectTrigger') {
-        return React.cloneElement(child, props)
+        return React.cloneElement(child as React.ReactElement<typeof props>, props)
       }
 
       if (child.props.children) {
-        return React.cloneElement(child, {
+        return React.cloneElement(child as React.ReactElement<MockSelectChildProps>, {
           children: injectTriggerProps(child.props.children, props),
         })
       }

--- a/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
+++ b/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
@@ -4,9 +4,10 @@
 
 import '@testing-library/jest-dom'
 import React from 'react'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import DeviceMonitorPanel from '@/features/admin/components/DeviceMonitorPanel'
 import { adminApis } from '@/apis/admin'
+import { toast } from 'sonner'
 
 const mockT = (key: string) => key
 
@@ -149,6 +150,7 @@ jest.mock('@/components/ui/select', () => {
 
 describe('DeviceMonitorPanel', () => {
   const mockedAdminApis = adminApis as jest.Mocked<typeof adminApis>
+  const mockedToast = toast as jest.Mocked<typeof toast>
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -197,7 +199,7 @@ describe('DeviceMonitorPanel', () => {
 
     await waitFor(() => {
       expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
-    }, { timeout: 1000 })
+    }, { timeout: 1200 })
 
     expect(mockedAdminApis.getDeviceStats).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('device-card-device-1')).toBeInTheDocument()
@@ -216,7 +218,7 @@ describe('DeviceMonitorPanel', () => {
 
     await waitFor(() => {
       expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
-    }, { timeout: 1000 })
+    }, { timeout: 1200 })
 
     expect(mockedAdminApis.getDevices).toHaveBeenLastCalledWith(
       1,
@@ -225,10 +227,29 @@ describe('DeviceMonitorPanel', () => {
       undefined,
       undefined,
       undefined,
-      'gte',
+      'lt',
       '1.6.5'
     )
     expect(mockedAdminApis.getDeviceStats).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not send incomplete version filters while typing', async () => {
+    render(<DeviceMonitorPanel />)
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByTestId('version-filter-input'), {
+      target: { value: '1.' },
+    })
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 700))
+    })
+
+    expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(1)
+    expect(mockedToast.error).not.toHaveBeenCalled()
   })
 
   it('disables version filter when offline status is selected', async () => {
@@ -244,7 +265,7 @@ describe('DeviceMonitorPanel', () => {
 
     await waitFor(() => {
       expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
-    }, { timeout: 1000 })
+    }, { timeout: 1200 })
 
     expect(screen.getByTestId('version-filter-input')).toBeDisabled()
     expect(mockedAdminApis.getDevices).toHaveBeenLastCalledWith(

--- a/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
+++ b/frontend/src/__tests__/features/admin/DeviceMonitorPanel.test.tsx
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import DeviceMonitorPanel from '@/features/admin/components/DeviceMonitorPanel'
+import { adminApis } from '@/apis/admin'
+
+const mockT = (key: string) => key
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: mockT,
+  }),
+}))
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+    info: jest.fn(),
+  },
+}))
+
+jest.mock('@/apis/admin', () => ({
+  adminApis: {
+    getDeviceStats: jest.fn(),
+    getDevices: jest.fn(),
+    upgradeDevice: jest.fn(),
+    restartDevice: jest.fn(),
+    migrateDevice: jest.fn(),
+  },
+}))
+
+jest.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/components/ui/select', () => {
+  const collectOptions = (children: React.ReactNode): Array<{ value: string; label: React.ReactNode }> => {
+    const options: Array<{ value: string; label: React.ReactNode }> = []
+
+    React.Children.forEach(children, child => {
+      if (!React.isValidElement(child)) {
+        return
+      }
+
+      if ((child.type as { displayName?: string }).displayName === 'MockSelectItem') {
+        options.push({ value: child.props.value as string, label: child.props.children })
+      }
+
+      if (child.props.children) {
+        options.push(...collectOptions(child.props.children))
+      }
+    })
+
+    return options
+  }
+
+  const injectTriggerProps = (
+    children: React.ReactNode,
+    props: {
+      value?: string
+      onValueChange?: (value: string) => void
+      disabled?: boolean
+      options: Array<{ value: string; label: React.ReactNode }>
+    }
+  ): React.ReactNode =>
+    React.Children.map(children, child => {
+      if (!React.isValidElement(child)) {
+        return child
+      }
+
+      if ((child.type as { displayName?: string }).displayName === 'MockSelectTrigger') {
+        return React.cloneElement(child, props)
+      }
+
+      if (child.props.children) {
+        return React.cloneElement(child, {
+          children: injectTriggerProps(child.props.children, props),
+        })
+      }
+
+      return child
+    })
+
+  const Select = ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value?: string
+    onValueChange?: (value: string) => void
+    disabled?: boolean
+    children: React.ReactNode
+  }) => {
+    const options = collectOptions(children)
+    return <>{injectTriggerProps(children, { value, onValueChange, disabled, options })}</>
+  }
+
+  const SelectTrigger = ({
+    value,
+    onValueChange,
+    disabled,
+    options,
+    children: _children,
+    ...props
+  }: {
+    value?: string
+    onValueChange?: (value: string) => void
+    disabled?: boolean
+    options?: Array<{ value: string; label: React.ReactNode }>
+    children?: React.ReactNode
+  } & React.SelectHTMLAttributes<HTMLSelectElement>) => (
+    <select
+      {...props}
+      value={value}
+      onChange={event => onValueChange?.(event.target.value)}
+      disabled={disabled}
+    >
+      {options?.map(option => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  )
+  SelectTrigger.displayName = 'MockSelectTrigger'
+
+  const SelectContent = ({ children }: { children: React.ReactNode }) => <>{children}</>
+  const SelectValue = () => null
+  const SelectItem = ({ children }: { value: string; children: React.ReactNode }) => <>{children}</>
+  SelectItem.displayName = 'MockSelectItem'
+
+  return {
+    Select,
+    SelectTrigger,
+    SelectContent,
+    SelectValue,
+    SelectItem,
+  }
+})
+
+describe('DeviceMonitorPanel', () => {
+  const mockedAdminApis = adminApis as jest.Mocked<typeof adminApis>
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockedAdminApis.getDeviceStats.mockResolvedValue({
+      total: 1,
+      user_count: 1,
+      by_status: { online: 1, offline: 0, busy: 0 },
+      by_device_type: { local: 1, cloud: 0 },
+      by_bind_shell: { claudecode: 1, openclaw: 0 },
+    })
+
+    mockedAdminApis.getDevices.mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 1,
+          device_id: 'device-1',
+          name: 'macOS-device',
+          status: 'online',
+          device_type: 'local',
+          bind_shell: 'claudecode',
+          user_id: 1,
+          user_name: 'alice',
+          client_ip: '127.0.0.1',
+          executor_version: '1.7.0',
+          slot_used: 0,
+          slot_max: 0,
+          created_at: '2026-03-31T12:00:00',
+        },
+      ],
+    })
+  })
+
+  it('refreshes only the device list when search changes', async () => {
+    render(<DeviceMonitorPanel />)
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDeviceStats).toHaveBeenCalledTimes(1)
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByTestId('device-search-input'), {
+      target: { value: 'mac' },
+    })
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
+    }, { timeout: 1000 })
+
+    expect(mockedAdminApis.getDeviceStats).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('device-card-device-1')).toBeInTheDocument()
+  })
+
+  it('passes version filter params when version input changes', async () => {
+    render(<DeviceMonitorPanel />)
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByTestId('version-filter-input'), {
+      target: { value: '1.6.5' },
+    })
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
+    }, { timeout: 1000 })
+
+    expect(mockedAdminApis.getDevices).toHaveBeenLastCalledWith(
+      1,
+      20,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'gte',
+      '1.6.5'
+    )
+    expect(mockedAdminApis.getDeviceStats).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables version filter when offline status is selected', async () => {
+    render(<DeviceMonitorPanel />)
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByTestId('device-status-filter-select'), {
+      target: { value: 'offline' },
+    })
+
+    await waitFor(() => {
+      expect(mockedAdminApis.getDevices).toHaveBeenCalledTimes(2)
+    }, { timeout: 1000 })
+
+    expect(screen.getByTestId('version-filter-input')).toBeDisabled()
+    expect(mockedAdminApis.getDevices).toHaveBeenLastCalledWith(
+      1,
+      20,
+      'offline',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
+  })
+})

--- a/frontend/src/apis/admin.ts
+++ b/frontend/src/apis/admin.ts
@@ -415,6 +415,7 @@ export interface IMChannelStatus {
 export type DeviceStatus = 'online' | 'offline' | 'busy'
 export type DeviceType = 'local' | 'cloud'
 export type BindShell = 'claudecode' | 'openclaw'
+export type VersionFilterOperator = 'gt' | 'gte' | 'eq' | 'lt' | 'lte'
 
 export interface AdminDeviceInfo {
   id: number
@@ -959,13 +960,19 @@ export const adminApis = {
   async getDevices(
     page: number = 1,
     limit: number = 20,
+    status?: DeviceStatus,
     deviceType?: DeviceType,
     bindShell?: BindShell,
-    search?: string
+    search?: string,
+    versionOp?: VersionFilterOperator,
+    version?: string
   ): Promise<AdminDeviceListResponse> {
     const params = new URLSearchParams()
     params.append('page', String(page))
     params.append('limit', String(limit))
+    if (status) {
+      params.append('status', status)
+    }
     if (deviceType) {
       params.append('device_type', deviceType)
     }
@@ -974,6 +981,10 @@ export const adminApis = {
     }
     if (search) {
       params.append('search', search)
+    }
+    if (versionOp && version) {
+      params.append('version_op', versionOp)
+      params.append('version', version)
     }
     return apiClient.get(`/admin/device-monitor/devices?${params.toString()}`)
   },

--- a/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
+++ b/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
@@ -42,10 +42,11 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { cn, isVersionAtLeast } from '@/lib/utils'
+import { cn, isCompleteVersionString, isVersionAtLeast } from '@/lib/utils'
 
 // Minimum version required for auto-upgrade support
 const MIN_AUTO_UPGRADE_VERSION = '1.6.5'
+const FILTER_DEBOUNCE_MS = 600
 
 interface StatCardProps {
   title: string
@@ -144,36 +145,56 @@ export function DeviceMonitorPanel() {
   const [deviceTypeFilter, setDeviceTypeFilter] = useState<string>('all')
   const [bindShellFilter, setBindShellFilter] = useState<string>('all')
   const [statusFilter, setStatusFilter] = useState<string>('all')
-  const [versionFilterOp, setVersionFilterOp] = useState<VersionFilterOperator>('gte')
+  const [versionFilterOp, setVersionFilterOp] = useState<VersionFilterOperator>('lt')
   const [versionFilter, setVersionFilter] = useState('')
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
-  const [debouncedVersionFilter, setDebouncedVersionFilter] = useState('')
+  const [appliedVersionFilter, setAppliedVersionFilter] = useState('')
   const [page, setPage] = useState(1)
   const limit = 20
-
-  // Debounce search input
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setPage(1)
-      setDebouncedSearch(search)
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [search])
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setPage(1)
-      setDebouncedVersionFilter(versionFilter)
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [versionFilter])
 
   useEffect(() => {
     if (statusFilter === 'offline' && versionFilter) {
       setVersionFilter('')
     }
   }, [statusFilter, versionFilter])
+
+  const applySearchFilter = useCallback(() => {
+    setPage(1)
+    setDebouncedSearch(search.trim())
+  }, [search])
+
+  const applyVersionFilter = useCallback(() => {
+    const normalizedVersion = versionFilter.trim()
+
+    if (!normalizedVersion) {
+      setPage(1)
+      setAppliedVersionFilter('')
+      return
+    }
+
+    if (!isCompleteVersionString(normalizedVersion)) {
+      return
+    }
+
+    setPage(1)
+    setAppliedVersionFilter(normalizedVersion)
+  }, [versionFilter])
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      applySearchFilter()
+    }, FILTER_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [applySearchFilter])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      applyVersionFilter()
+    }, FILTER_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [applyVersionFilter])
 
   const loadStats = useCallback(async () => {
     setIsStatsLoading(true)
@@ -199,8 +220,7 @@ export function DeviceMonitorPanel() {
       const bindShell = bindShellFilter === 'all' ? undefined : (bindShellFilter as BindShell)
       const status = statusFilter === 'all' ? undefined : (statusFilter as DeviceStatus)
       const searchTerm = debouncedSearch.trim() || undefined
-      const normalizedVersion = debouncedVersionFilter.trim()
-      const version = statusFilter === 'offline' ? undefined : (normalizedVersion || undefined)
+      const version = statusFilter === 'offline' ? undefined : (appliedVersionFilter || undefined)
 
       const data = await adminApis.getDevices(
         page,
@@ -229,7 +249,7 @@ export function DeviceMonitorPanel() {
         setHasLoadedDevices(true)
       }
     }
-  }, [page, statusFilter, deviceTypeFilter, bindShellFilter, debouncedSearch, debouncedVersionFilter, versionFilterOp, t])
+  }, [page, statusFilter, deviceTypeFilter, bindShellFilter, debouncedSearch, appliedVersionFilter, versionFilterOp, t])
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true)
@@ -395,8 +415,8 @@ export function DeviceMonitorPanel() {
       )}
 
       {/* Filters */}
-      <div className="flex flex-col sm:flex-row gap-4">
-        <div className="relative flex-1">
+      <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap">
+        <div className="relative flex-1 lg:min-w-[280px]">
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-text-muted" />
           <Input
             placeholder={t('admin:device_monitor.search_placeholder')}
@@ -413,7 +433,10 @@ export function DeviceMonitorPanel() {
             setStatusFilter(value)
           }}
         >
-          <SelectTrigger className="w-[140px]" data-testid="device-status-filter-select">
+          <SelectTrigger
+            className="w-full sm:w-[140px]"
+            data-testid="device-status-filter-select"
+          >
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -430,7 +453,7 @@ export function DeviceMonitorPanel() {
             setDeviceTypeFilter(value)
           }}
         >
-          <SelectTrigger className="w-[140px]" data-testid="device-type-filter-select">
+          <SelectTrigger className="w-full sm:w-[140px]" data-testid="device-type-filter-select">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -446,7 +469,7 @@ export function DeviceMonitorPanel() {
             setBindShellFilter(value)
           }}
         >
-          <SelectTrigger className="w-[160px]" data-testid="bind-shell-filter-select">
+          <SelectTrigger className="w-full sm:w-[160px]" data-testid="bind-shell-filter-select">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -459,7 +482,7 @@ export function DeviceMonitorPanel() {
             </SelectItem>
           </SelectContent>
         </Select>
-        <div className="flex gap-2 sm:w-auto">
+        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
           <Select
             value={versionFilterOp}
             onValueChange={value => {
@@ -468,7 +491,10 @@ export function DeviceMonitorPanel() {
             }}
             disabled={statusFilter === 'offline'}
           >
-            <SelectTrigger className="w-[120px]" data-testid="version-operator-filter-select">
+            <SelectTrigger
+              className="w-full sm:w-[120px]"
+              data-testid="version-operator-filter-select"
+            >
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -483,7 +509,7 @@ export function DeviceMonitorPanel() {
             placeholder={t('admin:device_monitor.version_filter.placeholder')}
             value={versionFilter}
             onChange={e => setVersionFilter(e.target.value)}
-            className="sm:w-[160px]"
+            className="w-full sm:w-[220px]"
             data-testid="version-filter-input"
             disabled={statusFilter === 'offline'}
           />

--- a/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
+++ b/frontend/src/features/admin/components/DeviceMonitorPanel.tsx
@@ -4,9 +4,17 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
-import { adminApis, AdminDeviceInfo, AdminDeviceStats, DeviceType, BindShell } from '@/apis/admin'
+import {
+  adminApis,
+  AdminDeviceInfo,
+  AdminDeviceStats,
+  DeviceStatus,
+  DeviceType,
+  BindShell,
+  VersionFilterOperator,
+} from '@/apis/admin'
 import { toast } from 'sonner'
 import {
   Monitor,
@@ -124,56 +132,104 @@ export function DeviceMonitorPanel() {
   const [stats, setStats] = useState<AdminDeviceStats | null>(null)
   const [devices, setDevices] = useState<AdminDeviceInfo[]>([])
   const [total, setTotal] = useState(0)
-  const [isLoading, setIsLoading] = useState(true)
+  const [hasLoadedStats, setHasLoadedStats] = useState(false)
+  const [hasLoadedDevices, setHasLoadedDevices] = useState(false)
+  const [isStatsLoading, setIsStatsLoading] = useState(false)
+  const [isDevicesLoading, setIsDevicesLoading] = useState(false)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [actionLoading, setActionLoading] = useState<Record<string, string>>({})
+  const latestDevicesRequestRef = useRef(0)
 
   // Filter states
   const [deviceTypeFilter, setDeviceTypeFilter] = useState<string>('all')
   const [bindShellFilter, setBindShellFilter] = useState<string>('all')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [versionFilterOp, setVersionFilterOp] = useState<VersionFilterOperator>('gte')
+  const [versionFilter, setVersionFilter] = useState('')
   const [search, setSearch] = useState('')
   const [debouncedSearch, setDebouncedSearch] = useState('')
+  const [debouncedVersionFilter, setDebouncedVersionFilter] = useState('')
   const [page, setPage] = useState(1)
   const limit = 20
 
   // Debounce search input
   useEffect(() => {
     const timer = setTimeout(() => {
+      setPage(1)
       setDebouncedSearch(search)
     }, 300)
     return () => clearTimeout(timer)
   }, [search])
 
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setPage(1)
+      setDebouncedVersionFilter(versionFilter)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [versionFilter])
+
+  useEffect(() => {
+    if (statusFilter === 'offline' && versionFilter) {
+      setVersionFilter('')
+    }
+  }, [statusFilter, versionFilter])
+
   const loadStats = useCallback(async () => {
+    setIsStatsLoading(true)
     try {
       const data = await adminApis.getDeviceStats()
       setStats(data)
     } catch (error) {
       console.error('Failed to load device stats:', error)
       toast.error(t('admin:device_monitor.errors.load_stats_failed'))
+    } finally {
+      setIsStatsLoading(false)
+      setHasLoadedStats(true)
     }
   }, [t])
 
   const loadDevices = useCallback(async () => {
+    const requestId = latestDevicesRequestRef.current + 1
+    latestDevicesRequestRef.current = requestId
+    setIsDevicesLoading(true)
+
     try {
       const deviceType = deviceTypeFilter === 'all' ? undefined : (deviceTypeFilter as DeviceType)
       const bindShell = bindShellFilter === 'all' ? undefined : (bindShellFilter as BindShell)
+      const status = statusFilter === 'all' ? undefined : (statusFilter as DeviceStatus)
       const searchTerm = debouncedSearch.trim() || undefined
+      const normalizedVersion = debouncedVersionFilter.trim()
+      const version = statusFilter === 'offline' ? undefined : (normalizedVersion || undefined)
 
-      const data = await adminApis.getDevices(page, limit, deviceType, bindShell, searchTerm)
+      const data = await adminApis.getDevices(
+        page,
+        limit,
+        status,
+        deviceType,
+        bindShell,
+        searchTerm,
+        version ? versionFilterOp : undefined,
+        version
+      )
+      if (requestId !== latestDevicesRequestRef.current) {
+        return
+      }
       setDevices(data.items)
       setTotal(data.total)
     } catch (error) {
+      if (requestId !== latestDevicesRequestRef.current) {
+        return
+      }
       console.error('Failed to load devices:', error)
       toast.error(t('admin:device_monitor.errors.load_failed'))
+    } finally {
+      if (requestId === latestDevicesRequestRef.current) {
+        setIsDevicesLoading(false)
+        setHasLoadedDevices(true)
+      }
     }
-  }, [page, deviceTypeFilter, bindShellFilter, debouncedSearch, t])
-
-  const loadData = useCallback(async () => {
-    setIsLoading(true)
-    await Promise.all([loadStats(), loadDevices()])
-    setIsLoading(false)
-  }, [loadStats, loadDevices])
+  }, [page, statusFilter, deviceTypeFilter, bindShellFilter, debouncedSearch, debouncedVersionFilter, versionFilterOp, t])
 
   const handleRefresh = useCallback(async () => {
     setIsRefreshing(true)
@@ -182,12 +238,14 @@ export function DeviceMonitorPanel() {
   }, [loadStats, loadDevices])
 
   useEffect(() => {
-    loadData()
-  }, [loadData])
+    void loadStats()
+  }, [loadStats])
 
   useEffect(() => {
-    setPage(1)
-  }, [deviceTypeFilter, bindShellFilter, debouncedSearch])
+    void loadDevices()
+  }, [loadDevices])
+
+  const isInitialLoading = !hasLoadedStats || !hasLoadedDevices
 
   // Device action handlers
   const handleUpgrade = useCallback(
@@ -271,7 +329,7 @@ export function DeviceMonitorPanel() {
     [actionLoading, t]
   )
 
-  if (isLoading) {
+  if (isInitialLoading) {
     return (
       <div className="flex items-center justify-center py-20">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
@@ -292,7 +350,9 @@ export function DeviceMonitorPanel() {
           <p className="text-text-muted text-sm">{t('admin:device_monitor.description')}</p>
         </div>
         <Button variant="outline" size="icon" onClick={handleRefresh} disabled={isRefreshing}>
-          <RefreshCw className={cn('h-4 w-4', isRefreshing && 'animate-spin')} />
+          <RefreshCw
+            className={cn('h-4 w-4', (isRefreshing || isStatsLoading) && 'animate-spin')}
+          />
         </Button>
       </div>
 
@@ -346,7 +406,30 @@ export function DeviceMonitorPanel() {
             data-testid="device-search-input"
           />
         </div>
-        <Select value={deviceTypeFilter} onValueChange={setDeviceTypeFilter}>
+        <Select
+          value={statusFilter}
+          onValueChange={value => {
+            setPage(1)
+            setStatusFilter(value)
+          }}
+        >
+          <SelectTrigger className="w-[140px]" data-testid="device-status-filter-select">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t('admin:device_monitor.filters.all_status')}</SelectItem>
+            <SelectItem value="online">{t('admin:device_monitor.status.online')}</SelectItem>
+            <SelectItem value="offline">{t('admin:device_monitor.status.offline')}</SelectItem>
+            <SelectItem value="busy">{t('admin:device_monitor.status.busy')}</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={deviceTypeFilter}
+          onValueChange={value => {
+            setPage(1)
+            setDeviceTypeFilter(value)
+          }}
+        >
           <SelectTrigger className="w-[140px]" data-testid="device-type-filter-select">
             <SelectValue />
           </SelectTrigger>
@@ -356,7 +439,13 @@ export function DeviceMonitorPanel() {
             <SelectItem value="cloud">{t('admin:device_monitor.device_type.cloud')}</SelectItem>
           </SelectContent>
         </Select>
-        <Select value={bindShellFilter} onValueChange={setBindShellFilter}>
+        <Select
+          value={bindShellFilter}
+          onValueChange={value => {
+            setPage(1)
+            setBindShellFilter(value)
+          }}
+        >
           <SelectTrigger className="w-[160px]" data-testid="bind-shell-filter-select">
             <SelectValue />
           </SelectTrigger>
@@ -370,10 +459,51 @@ export function DeviceMonitorPanel() {
             </SelectItem>
           </SelectContent>
         </Select>
+        <div className="flex gap-2 sm:w-auto">
+          <Select
+            value={versionFilterOp}
+            onValueChange={value => {
+              setPage(1)
+              setVersionFilterOp(value as VersionFilterOperator)
+            }}
+            disabled={statusFilter === 'offline'}
+          >
+            <SelectTrigger className="w-[120px]" data-testid="version-operator-filter-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="gte">{t('admin:device_monitor.version_filter.operators.gte')}</SelectItem>
+              <SelectItem value="gt">{t('admin:device_monitor.version_filter.operators.gt')}</SelectItem>
+              <SelectItem value="eq">{t('admin:device_monitor.version_filter.operators.eq')}</SelectItem>
+              <SelectItem value="lt">{t('admin:device_monitor.version_filter.operators.lt')}</SelectItem>
+              <SelectItem value="lte">{t('admin:device_monitor.version_filter.operators.lte')}</SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            placeholder={t('admin:device_monitor.version_filter.placeholder')}
+            value={versionFilter}
+            onChange={e => setVersionFilter(e.target.value)}
+            className="sm:w-[160px]"
+            data-testid="version-filter-input"
+            disabled={statusFilter === 'offline'}
+          />
+        </div>
       </div>
 
       {/* Device List */}
-      <div className="bg-base border border-border rounded-md p-2 w-full max-h-[50vh] flex flex-col overflow-y-auto">
+      <div
+        className="relative bg-base border border-border rounded-md p-2 w-full max-h-[50vh] flex flex-col overflow-y-auto"
+        aria-busy={isDevicesLoading}
+      >
+        {isDevicesLoading && (
+          <div
+            className="absolute top-3 right-3 z-10 flex items-center gap-2 rounded-md border border-border bg-base/95 px-2 py-1 text-xs text-text-muted backdrop-blur-sm"
+            data-testid="device-list-loading"
+          >
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+            <span>{t('admin:device_monitor.loading')}</span>
+          </div>
+        )}
         {devices.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-12 text-center">
             <Monitor className="w-12 h-12 text-text-muted mb-4" />

--- a/frontend/src/i18n/locales/en/admin.json
+++ b/frontend/src/i18n/locales/en/admin.json
@@ -807,6 +807,16 @@
       "all_device_type": "All Types",
       "all_bind_shell": "All Shells"
     },
+    "version_filter": {
+      "placeholder": "Filter by version, e.g. 1.6.5",
+      "operators": {
+        "gt": ">",
+        "gte": ">=",
+        "eq": "=",
+        "lt": "<",
+        "lte": "<="
+      }
+    },
     "status": {
       "online": "Online",
       "offline": "Offline",

--- a/frontend/src/i18n/locales/zh-CN/admin.json
+++ b/frontend/src/i18n/locales/zh-CN/admin.json
@@ -807,6 +807,16 @@
       "all_device_type": "全部类型",
       "all_bind_shell": "全部 Shell"
     },
+    "version_filter": {
+      "placeholder": "按版本筛选，如 1.6.5",
+      "operators": {
+        "gt": ">",
+        "gte": ">=",
+        "eq": "=",
+        "lt": "<",
+        "lte": "<="
+      }
+    },
     "status": {
       "online": "在线",
       "offline": "离线",

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -78,3 +78,24 @@ export function isVersionAtLeast(version: string, targetVersion: string): boolea
   }
   return true
 }
+
+export function isCompleteVersionString(version: string): boolean {
+  const normalizedVersion = version.trim()
+
+  if (!normalizedVersion || normalizedVersion.endsWith('.') || normalizedVersion.endsWith('-')) {
+    return false
+  }
+
+  const [baseVersion, ...suffixParts] = normalizedVersion.split('-')
+  const versionSegments = baseVersion.split('.')
+  if (versionSegments.some(segment => !/^\d+$/.test(segment))) {
+    return false
+  }
+
+  if (suffixParts.length === 0) {
+    return true
+  }
+
+  const suffix = suffixParts.join('-')
+  return /^[0-9A-Za-z.-]+$/.test(suffix) && !suffix.endsWith('.') && !suffix.endsWith('-')
+}


### PR DESCRIPTION
## What changed
- split device monitor loading so searching and filtering only refresh the device list instead of the whole page
- add status filtering and online-only version range filtering for device monitor
- disable version filtering when the device status filter is set to offline
- improve the filter row layout and widen the version input so the placeholder is fully visible
- treat incomplete version input as an editing state so values like `1.` do not trigger backend validation errors
- default the version operator to `<`

## Why
The admin device monitor page mixed page-level loading with list filtering and sent version filter requests too aggressively. That caused full-page refreshes while typing, confusing version filtering behavior for offline devices, and backend errors from partial version input.

## Impact
Admins can now focus on offline devices or outdated online devices without the page flashing or failing while they type. The filter controls are clearer, and version filtering behaves predictably for online devices only.

## Root cause
The previous implementation coupled stats and list fetching, applied version filtering to every debounced edit, and relied on a narrower filter layout that clipped the version input placeholder.

## Validation
- `cd frontend && npm run lint -- --file src/features/admin/components/DeviceMonitorPanel.tsx --file src/lib/utils.ts --file src/__tests__/features/admin/DeviceMonitorPanel.test.tsx`
- `cd frontend && npm test -- --runTestsByPath src/__tests__/features/admin/DeviceMonitorPanel.test.tsx --runInBand`
- `cd backend && uv run pytest tests/api/endpoints/test_admin_device_monitor_api.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added version filtering for device monitor with comparison operators (greater than, greater-or-equal, equal, less than, less-or-equal).
  * Added device status filtering capability.
  * Improved UI responsiveness with optimized loading states and request handling.

* **Tests**
  * Added comprehensive test coverage for new filtering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->