### PR TITLE
[codex] remove Claude MCP HTTP probe

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -11,7 +11,6 @@ providing complete Bot, Model, Ghost, Shell, and Skill resolution.
 """
 
 import logging
-import urllib.request
 from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel
@@ -1754,18 +1753,13 @@ Response template:
 
     @staticmethod
     def _check_mcp_server_reachable(server: dict) -> bool:
-        """Check if an MCP server URL is reachable with a short timeout.
-
-        Sends a GET request (not HEAD, as some servers like SSE endpoints
-        don't support HEAD method and will timeout). Any HTTP response
-        (including 4xx/5xx) means the server is reachable. Only connection
-        failures are treated as unreachable.
+        """Check if an MCP server config is valid without probing the network.
 
         Args:
             server: Server config dict with 'url' and optional 'headers'
 
         Returns:
-            True if server responded or is stdio type, False on connection failure
+            True if the config should be kept, False for obviously invalid configs
         """
         server_type = server.get("type", "").lower()
 
@@ -1787,28 +1781,7 @@ Response template:
         if "${{backend_url}}" in url:
             return True
 
-        try:
-            # Use GET instead of HEAD because some servers (especially SSE endpoints)
-            # don't support HEAD method and will timeout
-            req = urllib.request.Request(url, method="GET")
-            # Add headers, skipping unresolved placeholders
-            headers = server.get("headers", server.get("auth", {}))
-            if isinstance(headers, dict):
-                for k, v in headers.items():
-                    if isinstance(v, str) and not v.startswith("${{"):
-                        req.add_header(k, v)
-            urllib.request.urlopen(req, timeout=5)
-            return True
-        except urllib.error.HTTPError:
-            # Any HTTP response (including 4xx/5xx) means the server is reachable
-            return True
-        except Exception as e:
-            logger.warning(
-                "[MCP-CHECK] Failed to check server reachability: url=%s, error=%s",
-                url,
-                str(e),
-            )
-            return False
+        return True
 
     def _filter_reachable_mcp_servers(self, mcp_servers: list) -> list:
         """Filter out unreachable MCP servers.

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -207,42 +207,15 @@ class TestCheckMcpServerReachable:
     def test_empty_url_returns_false(self):
         assert TaskRequestBuilder._check_mcp_server_reachable({"url": ""}) is False
 
-    @patch("app.services.execution.request_builder.urllib.request.urlopen")
-    def test_successful_response_returns_true(self, mock_urlopen):
+    def test_regular_url_returns_true(self):
         server = {"url": "http://mcp.example.com/server", "type": "http"}
         result = TaskRequestBuilder._check_mcp_server_reachable(server)
         assert result is True
 
-    @patch(
-        "app.services.execution.request_builder.urllib.request.urlopen",
-        side_effect=Exception("Connection refused"),
-    )
-    def test_connection_error_returns_false(self, mock_urlopen):
-        server = {"url": "http://192.0.2.1:9999/unreachable", "type": "http"}
+    def test_placeholder_url_returns_true(self):
+        server = {"url": "${{task_data.user_mcps.test.url}}", "type": "http"}
         result = TaskRequestBuilder._check_mcp_server_reachable(server)
-        assert result is False
-
-    def test_skips_placeholder_headers(self):
-        """Headers with ${{...}} placeholders should not be sent."""
-        import urllib.request
-
-        server = {
-            "url": "http://mcp.example.com/server",
-            "headers": {
-                "mcp-proxy-wegent-user": "${{user.name}}",
-                "X-Static": "fixed-value",
-            },
-        }
-        with patch(
-            "app.services.execution.request_builder.urllib.request.urlopen"
-        ) as mock_urlopen:
-            TaskRequestBuilder._check_mcp_server_reachable(server)
-            # Verify the request was made
-            assert mock_urlopen.called
-            req = mock_urlopen.call_args[0][0]
-            # Static header should be present, placeholder should not
-            assert req.get_header("X-static") == "fixed-value"
-            assert req.get_header("Mcp-proxy-wegent-user") is None
+        assert result is True
 
 
 class TestFilterReachableMcpServers:


### PR DESCRIPTION
## What changed
- remove the HTTP reachability probe from ClaudeCode MCP pre-check
- keep the existing filtering structure so empty MCP URLs are still removed
- update the focused tests to match the non-network behavior

## Why
The previous pre-check issued an HTTP request before ClaudeCode execution. This change removes that network probe while preserving the original lightweight config validation behavior.

## Validation
- `cd backend && uv run pytest tests/services/execution/test_request_builder_mcp.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP server validation to no longer remove servers due to temporary network connectivity issues. Servers are now validated based on configuration integrity only, improving reliability when network conditions fluctuate.

* **Tests**
  * Updated MCP server validation tests to align with configuration-based validation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->