### PR TITLE
fix(chat-shell): normalize reasoning blocks for cross-model compatibility

### DIFF
--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -68,6 +68,9 @@ class MessageCreate(BaseModel):
         None, description="Tool calls for assistant messages"
     )
     metadata: Optional[dict] = Field(None, description="Additional metadata")
+    model_info: Optional[dict] = Field(
+        None, description="Provider/model metadata for think-block filtering"
+    )
 
 
 class MessageUpdate(BaseModel):
@@ -299,6 +302,7 @@ def subtask_to_messages(
             content=content,
             created_at=created_at,
             loaded_skills=loaded_skills,
+            model_info=result.get("model_info"),
         )
     ]
 
@@ -829,6 +833,27 @@ async def get_chat_history(
     return HistoryResponse(session_id=session_id, messages=messages)
 
 
+def _populate_subtask_content(subtask: Subtask, message: MessageCreate) -> None:
+    """Set prompt or result on a Subtask based on the message role."""
+    if subtask.role == SubtaskRole.USER:
+        subtask.prompt = (
+            message.content
+            if isinstance(message.content, str)
+            else json.dumps(message.content, ensure_ascii=False)
+        )
+    else:
+        result: dict = {
+            "value": (
+                message.content
+                if isinstance(message.content, str)
+                else json.dumps(message.content, ensure_ascii=False)
+            )
+        }
+        if message.model_info:
+            result["model_info"] = message.model_info
+        subtask.result = result
+
+
 @router.post("/history/{session_id}/messages", response_model=MessageIdResponse)
 async def append_message(
     session_id: str,
@@ -884,20 +909,7 @@ async def append_message(
     )
 
     # Set content based on role
-    if role == SubtaskRole.USER:
-        subtask.prompt = (
-            message.content
-            if isinstance(message.content, str)
-            else json.dumps(message.content, ensure_ascii=False)
-        )
-    else:
-        subtask.result = {
-            "value": (
-                message.content
-                if isinstance(message.content, str)
-                else json.dumps(message.content, ensure_ascii=False)
-            )
-        }
+    _populate_subtask_content(subtask, message)
 
     db.add(subtask)
     db.commit()
@@ -964,20 +976,7 @@ async def append_messages_batch(
             status=SubtaskStatus.COMPLETED,
         )
 
-        if role == SubtaskRole.USER:
-            subtask.prompt = (
-                message.content
-                if isinstance(message.content, str)
-                else json.dumps(message.content, ensure_ascii=False)
-            )
-        else:
-            subtask.result = {
-                "value": (
-                    message.content
-                    if isinstance(message.content, str)
-                    else json.dumps(message.content, ensure_ascii=False)
-                )
-            }
+        _populate_subtask_content(subtask, message)
 
         db.add(subtask)
         db.flush()  # Get ID without committing

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -94,6 +94,9 @@ class MessageResponse(BaseModel):
     reasoning_content: Any | None = None
     created_at: Optional[str] = None
     loaded_skills: Optional[list[str]] = None  # Skills loaded in this message turn
+    model_info: Optional[dict] = (
+        None  # Provider/model metadata for think-block filtering
+    )
 
 
 class HistoryResponse(BaseModel):
@@ -273,6 +276,7 @@ def subtask_to_messages(
                 tool_calls=msg.get("tool_calls"),
                 reasoning_content=msg.get("reasoning_content"),
                 created_at=created_at,
+                model_info=msg.get("model_info"),
             )
             responses.append(resp)
         # Attach loaded_skills to the last *assistant* message in the chain,

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -177,6 +177,7 @@ def _convert_validated_messages(
     context: str,
     target_provider: str = "",
     target_model_id: str = "",
+    target_api_format: str = "",
 ) -> list[BaseMessage]:
     """Validate canonical message linkage, then convert to LangChain messages.
 
@@ -189,7 +190,10 @@ def _convert_validated_messages(
         )
 
         messages = strip_foreign_reasoning_blocks(
-            messages, target_provider, target_model_id=target_model_id
+            messages,
+            target_provider,
+            target_model_id=target_model_id,
+            target_api_format=target_api_format,
         )
     _validate_tool_message_sequence(messages, context=context)
     return convert_to_messages(messages)
@@ -416,6 +420,7 @@ class LangGraphAgentBuilder:
         # Provider metadata set by LangChainModelFactory for think-block handling
         self._provider: str = getattr(llm, "_wegent_provider", "unknown")
         self._model_id: str = getattr(llm, "_wegent_model_id", "")
+        self._api_format: str = getattr(llm, "_wegent_api_format", "")
 
         # Get all LangChain tools from registry
         self.tools: list[BaseTool] = []
@@ -448,6 +453,7 @@ class LangGraphAgentBuilder:
             context="agent execution input messages",
             target_provider=self._provider,
             target_model_id=self._model_id,
+            target_api_format=self._api_format,
         )
         exec_config = {"configurable": config} if config else None
 
@@ -926,6 +932,7 @@ class LangGraphAgentBuilder:
             context="stream_execute input messages",
             target_provider=self._provider,
             target_model_id=self._model_id,
+            target_api_format=self._api_format,
         )
 
         exec_config = {"configurable": config} if config else None
@@ -984,6 +991,7 @@ class LangGraphAgentBuilder:
             context="stream_tokens input messages",
             target_provider=self._provider,
             target_model_id=self._model_id,
+            target_api_format=self._api_format,
         )
         add_span_event(
             "convert_to_messages_completed", {"lc_message_count": len(lc_messages)}

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -172,14 +172,145 @@ def _validate_tool_message_sequence(
 
 
 def _convert_validated_messages(
-    messages: list[dict[str, Any]], *, context: str
+    messages: list[dict[str, Any]],
+    *,
+    context: str,
+    target_provider: str = "",
+    target_model_id: str = "",
 ) -> list[BaseMessage]:
-    """Validate canonical message linkage, then convert to LangChain messages."""
+    """Validate canonical message linkage, then convert to LangChain messages.
+
+    When ``target_provider`` is set, foreign reasoning blocks are stripped
+    before conversion to prevent cross-model API errors.
+    """
+    if target_provider:
+        from chat_shell.messages.think_block_filter import (  # noqa: PLC0415
+            strip_foreign_reasoning_blocks,
+        )
+
+        messages = strip_foreign_reasoning_blocks(
+            messages, target_provider, target_model_id=target_model_id
+        )
     _validate_tool_message_sequence(messages, context=context)
     return convert_to_messages(messages)
 
 
-def _serialize_messages_chain(messages: list[BaseMessage]) -> list[dict[str, Any]]:
+def _normalize_content_block(block: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert a single provider-specific content block to canonical format.
+
+    Returns the normalized block, or None if the block should be dropped.
+
+    Canonical reasoning format (LangChain ``ReasoningContentBlock``)::
+
+        {"type": "reasoning", "reasoning": "<text>", "extras": {...}}
+    """
+    block_type = block.get("type")
+
+    if block_type == "thinking":
+        # Claude: {"type": "thinking", "thinking": "...", "signature": "...", ...}
+        reasoning_text = block.get("thinking", "")
+        extras = {k: v for k, v in block.items() if k not in ("type", "thinking")}
+        result: dict[str, Any] = {"type": "reasoning", "reasoning": reasoning_text}
+        if extras:
+            result["extras"] = extras
+        return result
+
+    # "text", "reasoning" (already canonical), or other block types: keep as-is
+    return block
+
+
+def _normalize_content_blocks(blocks: list) -> list:
+    """Normalize a list of content blocks to canonical format.
+
+    Handles:
+    - Claude ``thinking`` blocks → ``reasoning`` blocks
+    - OpenAI Responses API ``reasoning`` with ``summary`` → exploded ``reasoning`` blocks
+    - All other block types passed through unchanged
+    """
+    result: list = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            result.append(block)
+            continue
+
+        block_type = block.get("type")
+        if block_type == "reasoning" and "summary" in block:
+            # Explode OpenAI Responses API reasoning summary items
+            for item in block.get("summary") or []:
+                if isinstance(item, dict) and item.get("type") == "summary_text":
+                    text = item.get("text", "")
+                    reasoning_block: dict[str, Any] = {
+                        "type": "reasoning",
+                        "reasoning": text,
+                    }
+                    # Preserve non-summary fields as extras
+                    extras = {
+                        k: v
+                        for k, v in block.items()
+                        if k not in ("type", "summary", "reasoning")
+                    }
+                    if extras:
+                        reasoning_block["extras"] = extras
+                    result.append(reasoning_block)
+            if not block.get("summary"):
+                # Empty summary: keep a reasoning block without text but
+                # preserve non-summary fields (id, encrypted_content, etc.)
+                # so the block can round-trip correctly.
+                empty_block: dict[str, Any] = {
+                    "type": "reasoning",
+                    "reasoning": "",
+                }
+                extras = {
+                    k: v
+                    for k, v in block.items()
+                    if k not in ("type", "summary", "reasoning")
+                }
+                if extras:
+                    empty_block["extras"] = extras
+                result.append(empty_block)
+        else:
+            normalized = _normalize_content_block(block)
+            if normalized is not None:
+                result.append(normalized)
+    return result
+
+
+def _normalize_content_for_storage(msg: AIMessage) -> str | list:
+    """Normalize an AIMessage's content for cross-model compatible storage.
+
+    Converts provider-specific think blocks to canonical ``ReasoningContentBlock``
+    format. Also bridges ``reasoning_content`` from ``additional_kwargs``
+    (DeepSeek/Kimi/QwQ) into the content block list.
+
+    Returns:
+        Normalized content: either a string (no think blocks) or a list of blocks.
+    """
+    # Bridge reasoning_content from additional_kwargs into content blocks
+    reasoning_content = msg.additional_kwargs.get("reasoning_content")
+
+    if isinstance(msg.content, list):
+        normalized = _normalize_content_blocks(msg.content)
+        if reasoning_content:
+            normalized.insert(0, {"type": "reasoning", "reasoning": reasoning_content})
+        return normalized
+
+    # String content
+    if reasoning_content:
+        blocks: list[dict[str, Any]] = [
+            {"type": "reasoning", "reasoning": reasoning_content},
+        ]
+        if msg.content:
+            blocks.append({"type": "text", "text": msg.content})
+        return blocks
+
+    return msg.content
+
+
+def _serialize_messages_chain(
+    messages: list[BaseMessage],
+    provider: str = "",
+    model_id: str = "",
+) -> list[dict[str, Any]]:
     """Serialize LangChain messages to OpenAI-compatible dicts for history persistence.
 
     Converts AIMessage and ToolMessage objects produced during a single agent turn
@@ -188,11 +319,18 @@ def _serialize_messages_chain(messages: list[BaseMessage]) -> list[dict[str, Any
     2. Loaded back via ``langchain_core.messages.utils.convert_to_messages``
 
     Preserves tool_calls, tool results, and reasoning_content.
+    When ``provider`` is given, each assistant entry includes a ``model_info``
+    dict so downstream consumers can identify the originating model.
     """
     chain: list[dict[str, Any]] = []
     for msg in messages:
         if isinstance(msg, AIMessage):
-            entry: dict[str, Any] = {"role": "assistant", "content": msg.content}
+            # Normalize content: convert provider-specific think blocks to
+            # canonical ReasoningContentBlock format for cross-model compat.
+            content = _normalize_content_for_storage(msg)
+            entry: dict[str, Any] = {"role": "assistant", "content": content}
+            if provider:
+                entry["model_info"] = {"provider": provider, "model": model_id}
             if msg.tool_calls:
                 entry["tool_calls"] = [
                     {
@@ -212,12 +350,6 @@ def _serialize_messages_chain(messages: list[BaseMessage]) -> list[dict[str, Any
                     }
                     for tc in msg.tool_calls
                 ]
-            # Preserve reasoning content (DeepSeek R1 and similar models)
-            reasoning = msg.additional_kwargs.get("reasoning_content")
-            if reasoning:
-                entry.setdefault("additional_kwargs", {})[
-                    "reasoning_content"
-                ] = reasoning
             chain.append(entry)
         elif isinstance(msg, ToolMessage):
             entry = {
@@ -240,9 +372,11 @@ def _serialize_messages_chain(messages: list[BaseMessage]) -> list[dict[str, Any
 
 def _serialize_validated_messages_chain(
     messages: list[BaseMessage],
+    provider: str = "",
+    model_id: str = "",
 ) -> list[dict[str, Any]]:
     """Serialize a generated turn and fail fast on broken tool-call linkage."""
-    chain = _serialize_messages_chain(messages)
+    chain = _serialize_messages_chain(messages, provider=provider, model_id=model_id)
     _validate_tool_message_sequence(chain, context="serialized messages_chain")
     return chain
 
@@ -279,6 +413,10 @@ class LangGraphAgentBuilder:
         )
         self._agent = None
 
+        # Provider metadata set by LangChainModelFactory for think-block handling
+        self._provider: str = getattr(llm, "_wegent_provider", "unknown")
+        self._model_id: str = getattr(llm, "_wegent_model_id", "")
+
         # Get all LangChain tools from registry
         self.tools: list[BaseTool] = []
         if self.tool_registry:
@@ -308,6 +446,8 @@ class LangGraphAgentBuilder:
         lc_messages = _convert_validated_messages(
             messages,
             context="agent execution input messages",
+            target_provider=self._provider,
+            target_model_id=self._model_id,
         )
         exec_config = {"configurable": config} if config else None
 
@@ -784,6 +924,8 @@ class LangGraphAgentBuilder:
         lc_messages = _convert_validated_messages(
             messages,
             context="stream_execute input messages",
+            target_provider=self._provider,
+            target_model_id=self._model_id,
         )
 
         exec_config = {"configurable": config} if config else None
@@ -840,6 +982,8 @@ class LangGraphAgentBuilder:
         lc_messages = _convert_validated_messages(
             messages,
             context="stream_tokens input messages",
+            target_provider=self._provider,
+            target_model_id=self._model_id,
         )
         add_span_event(
             "convert_to_messages_completed", {"lc_message_count": len(lc_messages)}
@@ -1262,7 +1406,9 @@ class LangGraphAgentBuilder:
             if _collected_state_messages:
                 new_msgs = _collected_state_messages[len(lc_messages) :]
                 self._last_messages_chain = _serialize_validated_messages_chain(
-                    new_msgs
+                    new_msgs,
+                    provider=self._provider,
+                    model_id=self._model_id,
                 )
             else:
                 self._last_messages_chain = []
@@ -1342,7 +1488,9 @@ class LangGraphAgentBuilder:
             if _collected_state_messages:
                 new_msgs = _collected_state_messages[len(lc_messages) :]
                 self._last_messages_chain = _serialize_validated_messages_chain(
-                    new_msgs
+                    new_msgs,
+                    provider=self._provider,
+                    model_id=self._model_id,
                 )
             raise
 
@@ -1358,7 +1506,9 @@ class LangGraphAgentBuilder:
             if _collected_state_messages:
                 new_msgs = _collected_state_messages[len(lc_messages) :]
                 self._last_messages_chain = _serialize_validated_messages_chain(
-                    new_msgs
+                    new_msgs,
+                    provider=self._provider,
+                    model_id=self._model_id,
                 )
 
             # Build messages with the limit reached notice

--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -1,0 +1,414 @@
+"""Filter and normalize provider-specific message content for cross-model history.
+
+When users switch models mid-conversation (e.g. Claude → GPT → Gemini),
+historical messages may contain think/reasoning blocks in formats that the
+new model's API rejects.  This module provides a single public function,
+:func:`strip_foreign_reasoning_blocks`, which removes or retains reasoning
+blocks based on whether the message originated from the same provider as
+the current request target.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+# Canonical block type used for all normalized reasoning content.
+_REASONING_TYPE = "reasoning"
+
+# Provider-specific block types found in legacy (pre-normalization) data.
+_LEGACY_ANTHROPIC_TYPE = "thinking"
+
+
+def _infer_provider(msg: dict[str, Any]) -> str | None:
+    """Heuristically infer the originating provider from a message dict.
+
+    Used for legacy messages that lack a ``model_info`` field.
+
+    Returns:
+        Provider string (``"anthropic"``, ``"openai"``) or ``None`` if
+        no think blocks are present and provider cannot be determined.
+    """
+    content = msg.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == _LEGACY_ANTHROPIC_TYPE:
+                return "anthropic"
+            if block_type == _REASONING_TYPE and "summary" in block:
+                # OpenAI Responses API format (pre-normalization legacy)
+                return "openai"
+            if (
+                block_type == _REASONING_TYPE
+                and isinstance(block.get("extras"), dict)
+                and block["extras"].get("signature")
+            ):
+                # Canonical reasoning with Anthropic signature
+                return "anthropic"
+
+    # DeepSeek/Kimi: reasoning_content in additional_kwargs
+    additional_kwargs = msg.get("additional_kwargs")
+    if isinstance(additional_kwargs, dict) and additional_kwargs.get(
+        "reasoning_content"
+    ):
+        return "openai"
+
+    return None
+
+
+def _strip_reasoning_from_content(content: list) -> list:
+    """Remove all reasoning blocks from a content block list.
+
+    Returns:
+        The filtered list, or a single empty text block if all were removed.
+    """
+    filtered = [
+        block
+        for block in content
+        if not (
+            isinstance(block, dict)
+            and block.get("type") in (_REASONING_TYPE, _LEGACY_ANTHROPIC_TYPE)
+        )
+    ]
+    if not filtered:
+        return [{"type": "text", "text": ""}]
+    return filtered
+
+
+def _denormalize_for_anthropic(content: list) -> list:
+    """Convert canonical reasoning blocks back to Anthropic native thinking format.
+
+    Transforms ``{"type": "reasoning", "reasoning": "...", "extras": {"signature": "..."}}``
+    back to ``{"type": "thinking", "thinking": "...", "signature": "..."}``.
+
+    Reasoning blocks **without** a ``signature`` in ``extras`` are dropped
+    because the Claude API requires ``signature`` on every thinking block.
+    Such blocks originate from non-Claude providers (e.g. Kimi) that use
+    the Anthropic protocol without producing signatures.
+
+    Non-reasoning blocks are passed through unchanged.
+    """
+    result: list = []
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != _REASONING_TYPE:
+            result.append(block)
+            continue
+
+        extras = block.get("extras")
+        # Claude requires signature on every thinking block.  Drop blocks
+        # from providers that don't produce one (e.g. Kimi).
+        if not isinstance(extras, dict) or not extras.get("signature"):
+            continue
+
+        thinking_block: dict[str, Any] = {
+            "type": "thinking",
+            "thinking": block.get("reasoning", ""),
+        }
+        for k, v in extras.items():
+            thinking_block[k] = v
+        result.append(thinking_block)
+    return result
+
+
+def _denormalize_for_openai_responses(content: list) -> list:
+    """Convert canonical reasoning blocks back to OpenAI Responses API format.
+
+    Transforms exploded canonical blocks::
+
+        {"type": "reasoning", "reasoning": "text",
+         "extras": {"id": "rs_...", "encrypted_content": "gAAAA...", ...}}
+
+    back to the original Responses API structure::
+
+        {"type": "reasoning", "id": "rs_...",
+         "summary": [{"type": "summary_text", "text": "text"}],
+         "encrypted_content": "gAAAA..."}
+
+    Blocks without ``extras.id`` or ``extras.encrypted_content`` (i.e. not
+    originating from the Responses API) are passed through unchanged.
+
+    When reasoning blocks lack ``extras`` (legacy corrupted data) but
+    sibling text blocks carry an ``id`` (e.g. ``msg_...``), the text
+    block ``id`` is stripped to prevent the API from expecting a
+    reasoning item that no longer exists.
+    """
+    result: list = []
+    has_reasoning_id = False
+
+    for block in content:
+        if not isinstance(block, dict) or block.get("type") != _REASONING_TYPE:
+            result.append(block)
+            continue
+
+        extras = block.get("extras")
+        if not isinstance(extras, dict) or (
+            "id" not in extras and "encrypted_content" not in extras
+        ):
+            # Not an exploded Responses API reasoning block — pass through
+            result.append(block)
+            continue
+
+        has_reasoning_id = True
+
+        # Reconstruct the original Responses API format
+        rebuilt: dict[str, Any] = {"type": _REASONING_TYPE}
+        if "id" in extras:
+            rebuilt["id"] = extras["id"]
+
+        reasoning_text = block.get("reasoning", "")
+        rebuilt["summary"] = [{"type": "summary_text", "text": reasoning_text}]
+
+        if "encrypted_content" in extras:
+            rebuilt["encrypted_content"] = extras["encrypted_content"]
+
+        result.append(rebuilt)
+
+    # If no reasoning block had an id (corrupted/legacy data), strip ``id``
+    # from text blocks to prevent orphaned message references that the
+    # Responses API would reject.
+    if not has_reasoning_id:
+        result = [
+            (
+                {k: v for k, v in block.items() if k != "id"}
+                if isinstance(block, dict)
+                and block.get("type") in ("text", "output_text")
+                and "id" in block
+                else block
+            )
+            for block in result
+        ]
+
+    return result
+
+
+# Claude API requires tool_call IDs to match ^[a-zA-Z0-9_-]+$.
+# Other providers (e.g. Kimi) may produce IDs with dots, colons, etc.
+_ANTHROPIC_TOOL_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_INVALID_TOOL_ID_CHAR_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _sanitize_tool_ids_for_anthropic(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Replace tool call IDs that violate Anthropic's pattern constraint.
+
+    Claude requires ``^[a-zA-Z0-9_-]+$`` for tool_use and tool_result IDs.
+    IDs from other providers (e.g. Kimi's ``functions.load_skill:10``) are
+    sanitized by replacing invalid characters with ``_``.
+
+    A mapping is maintained so that the same original ID always produces the
+    same replacement, preserving the tool_call ↔ tool_result linkage.
+    """
+    # First pass: collect all IDs that need sanitization
+    id_map: dict[str, str] = {}
+
+    def _sanitize(original: str) -> str:
+        if not original or _ANTHROPIC_TOOL_ID_RE.match(original):
+            return original
+        if original not in id_map:
+            id_map[original] = _INVALID_TOOL_ID_CHAR_RE.sub("_", original)
+        return id_map[original]
+
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        needs_copy = False
+
+        # Check tool_calls on assistant messages
+        tool_calls = msg.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tc in tool_calls:
+                tcid = tc.get("id", "")
+                if tcid and not _ANTHROPIC_TOOL_ID_RE.match(tcid):
+                    needs_copy = True
+                    break
+
+        # Check tool_call_id on tool messages
+        tcid = msg.get("tool_call_id", "")
+        if tcid and not _ANTHROPIC_TOOL_ID_RE.match(tcid):
+            needs_copy = True
+
+        # Check function_call content blocks
+        content = msg.get("content")
+        if not needs_copy and isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "function_call":
+                    cid = block.get("call_id", "")
+                    if cid and not _ANTHROPIC_TOOL_ID_RE.match(cid):
+                        needs_copy = True
+                        break
+
+        if not needs_copy:
+            result.append(msg)
+            continue
+
+        sanitized = copy.deepcopy(msg)
+
+        if isinstance(sanitized.get("tool_calls"), list):
+            for tc in sanitized["tool_calls"]:
+                if "id" in tc:
+                    tc["id"] = _sanitize(tc["id"])
+                fn = tc.get("function", {})
+                if isinstance(fn, dict) and "id" in fn:
+                    fn["id"] = _sanitize(fn["id"])
+
+        if sanitized.get("tool_call_id"):
+            sanitized["tool_call_id"] = _sanitize(sanitized["tool_call_id"])
+
+        if isinstance(sanitized.get("content"), list):
+            for block in sanitized["content"]:
+                if isinstance(block, dict) and block.get("type") == "function_call":
+                    if "call_id" in block:
+                        block["call_id"] = _sanitize(block["call_id"])
+
+        result.append(sanitized)
+
+    return result
+
+
+def strip_foreign_reasoning_blocks(
+    messages: list[dict[str, Any]],
+    target_provider: str,
+    target_model_id: str = "",
+) -> list[dict[str, Any]]:
+    """Remove reasoning blocks from messages produced by a different provider.
+
+    For **same-provider** messages, reasoning blocks (including ``extras``
+    like ``signature``) are preserved to maintain multi-turn reasoning
+    continuity.
+
+    For **cross-provider** messages, reasoning blocks are stripped because:
+
+    1. Each provider's API rejects foreign think block types.
+    2. Provider-specific data (``signature``, ``encrypted_content``) is
+       meaningless cross-provider.
+    3. DeepSeek/Kimi explicitly forbid sending ``reasoning_content`` back.
+
+    For legacy messages without ``model_info``, the provider is inferred
+    heuristically from the content block types.
+
+    Args:
+        messages: Conversation history as a list of message dicts.
+        target_provider: The provider of the current request
+            (e.g. ``"anthropic"``, ``"openai"``, ``"google"``).
+        target_model_id: The model ID of the current request
+            (e.g. ``"claude-sonnet-4-6"``, ``"moonshot-kimi-k2.5"``).
+            Used for model-specific post-processing.
+
+    Returns:
+        A new list of message dicts with foreign reasoning blocks removed.
+        Original dicts are not mutated.
+    """
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            result.append(msg)
+            continue
+
+        # Determine source provider
+        model_info = msg.get("model_info")
+        if isinstance(model_info, dict):
+            source_provider = model_info.get("provider", "")
+        else:
+            source_provider = _infer_provider(msg) or ""
+
+        content = msg.get("content")
+
+        # Same provider: keep everything (denormalize to native format)
+        if source_provider == target_provider:
+            if target_provider == "anthropic" and isinstance(content, list):
+                denormalized = copy.deepcopy(msg)
+                denormalized["content"] = _denormalize_for_anthropic(content)
+                denormalized["response_metadata"] = {"model_provider": "anthropic"}
+                result.append(denormalized)
+            elif target_provider == "openai" and isinstance(content, list):
+                denormalized = copy.deepcopy(msg)
+                denormalized["content"] = _denormalize_for_openai_responses(content)
+                result.append(denormalized)
+            else:
+                result.append(msg)
+            continue
+
+        # Different provider (or unknown): strip reasoning blocks
+        needs_strip = False
+
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") in (
+                    _REASONING_TYPE,
+                    _LEGACY_ANTHROPIC_TYPE,
+                ):
+                    needs_strip = True
+                    break
+
+        # Also check legacy additional_kwargs.reasoning_content
+        additional_kwargs = msg.get("additional_kwargs")
+        has_legacy_reasoning = isinstance(additional_kwargs, dict) and bool(
+            additional_kwargs.get("reasoning_content")
+        )
+
+        if not needs_strip and not has_legacy_reasoning:
+            result.append(msg)
+            continue
+
+        # Create a deep copy and strip reasoning
+        stripped = copy.deepcopy(msg)
+
+        if isinstance(content, list) and needs_strip:
+            stripped["content"] = _strip_reasoning_from_content(content)
+
+        if has_legacy_reasoning:
+            new_kwargs = dict(additional_kwargs)  # type: ignore[arg-type]
+            del new_kwargs["reasoning_content"]
+            if new_kwargs:
+                stripped["additional_kwargs"] = new_kwargs
+            else:
+                stripped.pop("additional_kwargs", None)
+
+        result.append(stripped)
+
+    # Kimi rejects empty text content blocks (e.g. left over after stripping
+    # reasoning-only messages).  Filter them out when targeting Kimi models.
+    if "kimi" in target_model_id.lower():
+        result = _filter_empty_text_blocks(result)
+
+    # Claude requires tool_call IDs to match ^[a-zA-Z0-9_-]+$.
+    # Sanitize IDs from other providers (e.g. Kimi's "functions.load_skill:10").
+    if target_provider == "anthropic":
+        result = _sanitize_tool_ids_for_anthropic(result)
+
+    return result
+
+
+def _filter_empty_text_blocks(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Remove empty text blocks from assistant message content lists.
+
+    Some models (e.g. Kimi) reject requests containing empty text blocks.
+    These blocks typically appear after reasoning-only content is stripped.
+    """
+    filtered: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            filtered.append(msg)
+            continue
+
+        content = msg.get("content")
+        if not isinstance(content, list):
+            filtered.append(msg)
+            continue
+
+        non_empty = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and not block.get("text")
+            )
+        ]
+        if non_empty != content:
+            msg = {**msg, "content": non_empty}
+        filtered.append(msg)
+    return filtered

--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -21,6 +21,15 @@ _REASONING_TYPE = "reasoning"
 _LEGACY_ANTHROPIC_TYPE = "thinking"
 
 
+def _is_claude_model(model_id: str) -> bool:
+    """Check if a model ID represents a real Anthropic Claude model.
+
+    Non-Claude models (Minimax, GLM, Kimi) may use the Anthropic protocol
+    but produce invalid signatures that the Claude API rejects.
+    """
+    return model_id.lower().startswith("claude")
+
+
 def _infer_provider(msg: dict[str, Any]) -> str | None:
     """Heuristically infer the originating provider from a message dict.
 
@@ -328,10 +337,32 @@ def strip_foreign_reasoning_blocks(
         # Same provider: keep everything (denormalize to native format)
         if source_provider == target_provider:
             if target_provider == "anthropic" and isinstance(content, list):
-                denormalized = copy.deepcopy(msg)
-                denormalized["content"] = _denormalize_for_anthropic(content)
-                denormalized["response_metadata"] = {"model_provider": "anthropic"}
-                result.append(denormalized)
+                source_model = (
+                    model_info.get("model", "")
+                    if isinstance(model_info, dict)
+                    else ""
+                )
+                # Non-Claude models using the Anthropic protocol (Minimax,
+                # Kimi, GLM) may produce fake signatures that the Claude API
+                # rejects.  When we know the source model, only denormalize
+                # if it is actually Claude.  Legacy messages without
+                # model_info are assumed to be real Claude (backward compat).
+                has_model_info = isinstance(model_info, dict)
+                is_real_claude = not has_model_info or _is_claude_model(
+                    source_model
+                )
+                if is_real_claude:
+                    denormalized = copy.deepcopy(msg)
+                    denormalized["content"] = _denormalize_for_anthropic(content)
+                    denormalized["response_metadata"] = {
+                        "model_provider": "anthropic"
+                    }
+                    result.append(denormalized)
+                else:
+                    # Non-Claude model — strip reasoning blocks
+                    stripped = copy.deepcopy(msg)
+                    stripped["content"] = _strip_reasoning_from_content(content)
+                    result.append(stripped)
             elif (
                 target_provider == "openai"
                 and target_uses_responses

--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -41,13 +41,16 @@ def _infer_provider(msg: dict[str, Any]) -> str | None:
             if block_type == _REASONING_TYPE and "summary" in block:
                 # OpenAI Responses API format (pre-normalization legacy)
                 return "openai"
-            if (
-                block_type == _REASONING_TYPE
-                and isinstance(block.get("extras"), dict)
-                and block["extras"].get("signature")
+            if block_type == _REASONING_TYPE and isinstance(
+                block.get("extras"), dict
             ):
-                # Canonical reasoning with Anthropic signature
-                return "anthropic"
+                extras = block["extras"]
+                if extras.get("signature"):
+                    # Canonical reasoning with Anthropic signature
+                    return "anthropic"
+                if extras.get("id") or extras.get("encrypted_content"):
+                    # Canonical OpenAI Responses reasoning
+                    return "openai"
 
     # DeepSeek/Kimi: reasoning_content in additional_kwargs
     additional_kwargs = msg.get("additional_kwargs")
@@ -272,6 +275,7 @@ def strip_foreign_reasoning_blocks(
     messages: list[dict[str, Any]],
     target_provider: str,
     target_model_id: str = "",
+    target_api_format: str = "",
 ) -> list[dict[str, Any]]:
     """Remove reasoning blocks from messages produced by a different provider.
 
@@ -296,11 +300,16 @@ def strip_foreign_reasoning_blocks(
         target_model_id: The model ID of the current request
             (e.g. ``"claude-sonnet-4-6"``, ``"moonshot-kimi-k2.5"``).
             Used for model-specific post-processing.
+        target_api_format: The API format of the target model
+            (e.g. ``"responses"`` for OpenAI Responses API).
+            When empty, Chat Completions format is assumed for OpenAI.
 
     Returns:
         A new list of message dicts with foreign reasoning blocks removed.
         Original dicts are not mutated.
     """
+    target_uses_responses = target_api_format == "responses"
+
     result: list[dict[str, Any]] = []
     for msg in messages:
         if msg.get("role") != "assistant":
@@ -323,7 +332,15 @@ def strip_foreign_reasoning_blocks(
                 denormalized["content"] = _denormalize_for_anthropic(content)
                 denormalized["response_metadata"] = {"model_provider": "anthropic"}
                 result.append(denormalized)
-            elif target_provider == "openai" and isinstance(content, list):
+            elif (
+                target_provider == "openai"
+                and target_uses_responses
+                and isinstance(content, list)
+            ):
+                # Only denormalize to Responses API format when the target
+                # actually uses the Responses API.  Chat Completions reasoning
+                # models (DeepSeek/Kimi) handle canonical blocks via
+                # ChatOpenAIWithReasoning, so they need no denormalization.
                 denormalized = copy.deepcopy(msg)
                 denormalized["content"] = _denormalize_for_openai_responses(content)
                 result.append(denormalized)

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -296,6 +296,13 @@ class LangChainModelFactory:
         add_span_event("instantiating_model_class", {"class": model_class.__name__})
         model = model_class(**params)
         add_span_event("model_instance_created")
+
+        # Attach provider metadata for downstream think-block normalization.
+        # These are read by LangGraphAgentBuilder to tag serialized messages
+        # with model_info, enabling cross-model think-block filtering.
+        model._wegent_provider = provider  # type: ignore[attr-defined]
+        model._wegent_model_id = cfg["model_id"]  # type: ignore[attr-defined]
+
         return model
 
     @classmethod

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -302,6 +302,7 @@ class LangChainModelFactory:
         # with model_info, enabling cross-model think-block filtering.
         model._wegent_provider = provider  # type: ignore[attr-defined]
         model._wegent_model_id = cfg["model_id"]  # type: ignore[attr-defined]
+        model._wegent_api_format = cfg.get("api_format") or ""  # type: ignore[attr-defined]
 
         return model
 

--- a/chat_shell/chat_shell/models/openai_reasoning.py
+++ b/chat_shell/chat_shell/models/openai_reasoning.py
@@ -75,6 +75,11 @@ class ChatOpenAIWithReasoning(ChatOpenAI):
         enabled (e.g., Kimi, DeepSeek), ``reasoning_content`` must be present
         in assistant messages in the conversation history, otherwise the API
         returns a 400 error.
+
+        Handles two data formats:
+        - **Legacy**: ``reasoning_content`` in ``additional_kwargs``
+        - **Canonical**: ``{"type": "reasoning", "reasoning": "..."}`` blocks
+          in the message content list (written by normalized serialization)
         """
         # Capture original LangChain messages before they are converted
         lc_messages = self._convert_input(input_).to_messages()
@@ -87,12 +92,55 @@ class ChatOpenAIWithReasoning(ChatOpenAI):
         payload_messages = payload.get("messages")
         if payload_messages and len(payload_messages) == len(lc_messages):
             for lc_msg, api_msg in zip(lc_messages, payload_messages):
-                if (
-                    isinstance(lc_msg, AIMessage)
-                    and api_msg.get("role") == "assistant"
+                if not (
+                    isinstance(lc_msg, AIMessage) and api_msg.get("role") == "assistant"
                 ):
-                    reasoning = lc_msg.additional_kwargs.get("reasoning_content")
-                    if reasoning is not None:
-                        api_msg["reasoning_content"] = reasoning
+                    continue
+
+                # Path 1: Legacy format — reasoning_content in additional_kwargs
+                reasoning = lc_msg.additional_kwargs.get("reasoning_content")
+                if reasoning is not None:
+                    api_msg["reasoning_content"] = reasoning
+                    continue
+
+                # Path 2: Canonical format — reasoning blocks in content list.
+                # NOTE: We must read from the *original* LangChain message
+                # because LangChain's _convert_from_v1_to_chat_completions
+                # strips reasoning blocks from the payload content before
+                # our override runs.
+                lc_content = lc_msg.content
+                if not isinstance(lc_content, list):
+                    continue
+
+                reasoning_texts: list[str] = []
+                for block in lc_content:
+                    if isinstance(block, dict) and block.get("type") == "reasoning":
+                        text = block.get("reasoning", "")
+                        if text:
+                            reasoning_texts.append(text)
+
+                if reasoning_texts:
+                    api_msg["reasoning_content"] = "\n".join(reasoning_texts)
+                    # Clean up content: remove any stray reasoning blocks
+                    # that survived conversion (shouldn't happen, but be safe).
+                    api_content = api_msg.get("content")
+                    if isinstance(api_content, list):
+                        non_reasoning = [
+                            b
+                            for b in api_content
+                            if not (
+                                isinstance(b, dict)
+                                and b.get("type") == "reasoning"
+                            )
+                        ]
+                        if (
+                            len(non_reasoning) == 1
+                            and non_reasoning[0].get("type") == "text"
+                        ):
+                            api_msg["content"] = non_reasoning[0]["text"]
+                        elif non_reasoning:
+                            api_msg["content"] = non_reasoning
+                        elif not non_reasoning:
+                            api_msg["content"] = ""
 
         return payload

--- a/chat_shell/chat_shell/storage/interfaces.py
+++ b/chat_shell/chat_shell/storage/interfaces.py
@@ -31,6 +31,9 @@ class Message:
     loaded_skills: Optional[list] = (
         None  # Skills loaded via load_skill tool in this turn
     )
+    model_info: Optional[dict] = (
+        None  # Provider/model metadata for think-block filtering
+    )
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
@@ -52,6 +55,8 @@ class Message:
             result["metadata"] = self.metadata
         if self.loaded_skills:
             result["loaded_skills"] = self.loaded_skills
+        if self.model_info:
+            result["model_info"] = self.model_info
         return result
 
     @classmethod
@@ -67,6 +72,7 @@ class Message:
             created_at=data.get("created_at"),
             metadata=data.get("metadata", {}),
             loaded_skills=data.get("loaded_skills"),
+            model_info=data.get("model_info"),
         )
 
 

--- a/chat_shell/tests/test_cross_model_switch.py
+++ b/chat_shell/tests/test_cross_model_switch.py
@@ -283,3 +283,41 @@ class TestCrossModelSwitch:
         assert rb.get("encrypted_content") == "gAAAAABp1LL2_encrypted_data_here"
         # extras should not be present
         assert "extras" not in rb
+
+    def test_minimax_fake_signature_to_claude(self):
+        """Minimax message with fake signature does not break Claude target.
+
+        Simulates the exact scenario from task 23: Minimax (provider=anthropic)
+        produces a hex-hash signature, then conversation switches to Claude.
+        The fake signature must be stripped, not denormalized.
+        """
+        history = [
+            {"role": "user", "content": "Draw something"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "minimax thinking",
+                        "extras": {
+                            "index": 0,
+                            "signature": "080de92e77be80ab453d135b3971d802",
+                        },
+                    },
+                    {"type": "text", "text": "Here is a diagram"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "minimax-m2.7"},
+            },
+            {"role": "user", "content": "What do you think?"},
+        ]
+        # Target Claude — should not raise
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="anthropic"
+        )
+        assert len(lc_messages) == 3
+        # Minimax reasoning should be stripped
+        assistant_msg = lc_messages[1]
+        if isinstance(assistant_msg.content, list):
+            for block in assistant_msg.content:
+                if isinstance(block, dict):
+                    assert block.get("type") != "thinking"

--- a/chat_shell/tests/test_cross_model_switch.py
+++ b/chat_shell/tests/test_cross_model_switch.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for cross-model switching with think block compatibility.
+
+Simulates the full serialize → store → load → filter → convert cycle when
+switching between different LLM providers mid-conversation.
+"""
+
+from langchain_core.messages import AIMessage, ToolMessage
+
+from chat_shell.agents.graph_builder import (
+    _convert_validated_messages,
+    _serialize_messages_chain,
+)
+
+
+class TestCrossModelSwitch:
+    """End-to-end tests for cross-model think block round-trips."""
+
+    def test_claude_thinking_to_gpt(self):
+        """Claude thinking blocks are stripped when loading for GPT."""
+        # Step 1: Simulate Claude response with thinking
+        claude_msg = AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "Let me analyze...",
+                    "signature": "sig123",
+                },
+                {"type": "text", "text": "The answer is 42"},
+            ]
+        )
+        chain = _serialize_messages_chain(
+            [claude_msg], provider="anthropic", model_id="claude-sonnet"
+        )
+
+        # Step 2: Simulate history loading for GPT
+        history = [{"role": "user", "content": "What is 6*7?"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="openai"
+        )
+
+        # Verify: no thinking blocks in the converted messages
+        for msg in lc_messages:
+            if hasattr(msg, "content") and isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, dict):
+                        assert (
+                            block.get("type") != "thinking"
+                        ), "thinking block should be stripped for openai"
+                        # Canonical reasoning blocks should also be stripped
+                        assert (
+                            block.get("type") != "reasoning"
+                        ), "reasoning block should be stripped for cross-provider"
+
+    def test_deepseek_reasoning_to_claude(self):
+        """DeepSeek reasoning_content is stripped when loading for Claude."""
+        deepseek_msg = AIMessage(
+            content="The answer is 42",
+            additional_kwargs={"reasoning_content": "Step 1: multiply..."},
+        )
+        chain = _serialize_messages_chain(
+            [deepseek_msg], provider="openai", model_id="deepseek-r1"
+        )
+
+        history = [{"role": "user", "content": "What is 6*7?"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="anthropic"
+        )
+
+        # Verify: no reasoning blocks in the anthropic-targeted messages
+        for msg in lc_messages:
+            if hasattr(msg, "content") and isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, dict):
+                        assert block.get("type") != "reasoning"
+
+    def test_openai_responses_reasoning_to_gemini(self):
+        """OpenAI Responses API reasoning summary is stripped for Gemini."""
+        oai_msg = AIMessage(
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "I considered..."}],
+                    "id": "rs_abc",
+                },
+                {"type": "text", "text": "Final answer"},
+            ]
+        )
+        chain = _serialize_messages_chain(
+            [oai_msg], provider="openai", model_id="gpt-5"
+        )
+
+        history = [{"role": "user", "content": "Question?"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="google"
+        )
+
+        for msg in lc_messages:
+            if hasattr(msg, "content") and isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, dict):
+                        assert block.get("type") != "reasoning"
+
+    def test_same_provider_preserves_reasoning(self):
+        """Claude → Claude denormalizes reasoning back to thinking format."""
+        claude_msg = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "Analysis...", "signature": "sig"},
+                {"type": "text", "text": "Answer"},
+            ]
+        )
+        chain = _serialize_messages_chain(
+            [claude_msg], provider="anthropic", model_id="claude-sonnet"
+        )
+
+        history = [{"role": "user", "content": "Question"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="anthropic"
+        )
+
+        # Verify: thinking blocks are restored (not canonical reasoning)
+        has_thinking = False
+        for msg in lc_messages:
+            if hasattr(msg, "content") and isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, dict) and block.get("type") == "thinking":
+                        has_thinking = True
+                        assert block.get("thinking") == "Analysis..."
+                        assert block.get("signature") == "sig"
+        assert has_thinking, "Thinking blocks should be restored for same provider"
+
+    def test_claude_to_claude_round_trip_has_response_metadata(self):
+        """Full Claude round-trip produces AIMessage with correct response_metadata."""
+        claude_msg = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "Deep thought", "signature": "s1"},
+                {"type": "text", "text": "42"},
+            ]
+        )
+        chain = _serialize_messages_chain(
+            [claude_msg], provider="anthropic", model_id="claude-sonnet"
+        )
+
+        history = [{"role": "user", "content": "Meaning of life?"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="anthropic"
+        )
+
+        # The assistant message should have response_metadata set
+        assistant_msgs = [m for m in lc_messages if hasattr(m, "response_metadata")]
+        assert any(
+            m.response_metadata.get("model_provider") == "anthropic"
+            for m in assistant_msgs
+        ), "response_metadata['model_provider'] should be 'anthropic'"
+
+    def test_claude_to_claude_legacy_without_model_info(self):
+        """Legacy messages without model_info but with signature are denormalized."""
+        # Simulate legacy stored data: canonical reasoning with extras.signature
+        # but no model_info field
+        history = [
+            {"role": "user", "content": "Question"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "Legacy thought",
+                        "extras": {"signature": "legacy_sig"},
+                    },
+                    {"type": "text", "text": "Answer"},
+                ],
+                # No model_info — _infer_provider should detect signature
+            },
+        ]
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="anthropic"
+        )
+
+        # Verify denormalization happened
+        has_thinking = False
+        for msg in lc_messages:
+            if hasattr(msg, "content") and isinstance(msg.content, list):
+                for block in msg.content:
+                    if isinstance(block, dict) and block.get("type") == "thinking":
+                        has_thinking = True
+                        assert block.get("signature") == "legacy_sig"
+        assert has_thinking, "Legacy messages with signature should be denormalized"
+
+    def test_tool_call_sequence_preserved_across_model_switch(self):
+        """Tool call sequences remain valid after cross-model reasoning strip."""
+        msgs = [
+            AIMessage(
+                content=[
+                    {"type": "thinking", "thinking": "I should search"},
+                ],
+                tool_calls=[{"id": "call_1", "name": "search", "args": {"q": "test"}}],
+            ),
+            ToolMessage(content="Search result", tool_call_id="call_1", name="search"),
+            AIMessage(content="Based on the search..."),
+        ]
+        chain = _serialize_messages_chain(msgs, provider="anthropic", model_id="claude")
+
+        history = [{"role": "user", "content": "Find something"}] + chain
+        # Should not raise InvalidToolMessageSequenceError
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="openai"
+        )
+        assert len(lc_messages) == 4  # user + 3 from chain
+
+    def test_openai_responses_to_openai_responses_round_trip(self):
+        """GPT-5.4 Responses API reasoning blocks survive a same-provider round-trip.
+
+        Simulates: GPT-5.4 response with reasoning → serialize → store →
+        load → filter (same provider) → convert. The reasoning blocks must
+        be reconstructed to the original Responses API format with top-level
+        ``id``, ``summary`` structure, and ``encrypted_content``.
+        """
+        # Step 1: Simulate GPT-5.4 response with Responses API reasoning
+        oai_msg = AIMessage(
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": "I need to think about this."}
+                    ],
+                    "id": "rs_00a8759da22afc8f0069d4b2f63cd88195a5b413e3d1051685",
+                    "encrypted_content": "gAAAAABp1LL2_encrypted_data_here",
+                },
+                {
+                    "id": "msg_00a8759da22afc8f0069d4b2f88cc4819595f7e18d7ec92a63",
+                    "type": "text",
+                    "text": "The answer is 42.",
+                    "index": 1,
+                },
+            ]
+        )
+
+        # Step 2: Serialize (this will explode the reasoning block)
+        chain = _serialize_messages_chain(
+            [oai_msg], provider="openai", model_id="gpt-5.4"
+        )
+
+        # Verify exploded format in storage
+        stored_content = chain[0]["content"]
+        assert stored_content[0]["type"] == "reasoning"
+        assert "extras" in stored_content[0]
+        assert stored_content[0]["extras"]["id"] == (
+            "rs_00a8759da22afc8f0069d4b2f63cd88195a5b413e3d1051685"
+        )
+
+        # Step 3: Load and convert for same provider (GPT-5.4 → GPT-5.4)
+        history = [{"role": "user", "content": "What is 6*7?"}] + chain
+        lc_messages = _convert_validated_messages(
+            history, context="test", target_provider="openai"
+        )
+
+        # Step 4: Verify the reasoning block is reconstructed
+        assistant_msg = lc_messages[1]
+        assert isinstance(assistant_msg.content, list)
+
+        reasoning_blocks = [
+            b
+            for b in assistant_msg.content
+            if isinstance(b, dict) and b.get("type") == "reasoning"
+        ]
+        assert len(reasoning_blocks) >= 1
+
+        rb = reasoning_blocks[0]
+        # Top-level id must be present (not buried in extras)
+        assert rb.get("id") == (
+            "rs_00a8759da22afc8f0069d4b2f63cd88195a5b413e3d1051685"
+        )
+        # Summary structure must be rebuilt
+        assert "summary" in rb
+        assert rb["summary"] == [
+            {"type": "summary_text", "text": "I need to think about this."}
+        ]
+        # encrypted_content at top level
+        assert rb.get("encrypted_content") == "gAAAAABp1LL2_encrypted_data_here"
+        # extras should not be present
+        assert "extras" not in rb

--- a/chat_shell/tests/test_cross_model_switch.py
+++ b/chat_shell/tests/test_cross_model_switch.py
@@ -254,7 +254,8 @@ class TestCrossModelSwitch:
         # Step 3: Load and convert for same provider (GPT-5.4 → GPT-5.4)
         history = [{"role": "user", "content": "What is 6*7?"}] + chain
         lc_messages = _convert_validated_messages(
-            history, context="test", target_provider="openai"
+            history, context="test", target_provider="openai",
+            target_api_format="responses",
         )
 
         # Step 4: Verify the reasoning block is reconstructed

--- a/chat_shell/tests/test_serialize_messages_chain.py
+++ b/chat_shell/tests/test_serialize_messages_chain.py
@@ -70,18 +70,20 @@ class TestSerializeMessagesChain:
         assert tc["function"]["arguments"] == "{}"
 
     def test_ai_message_with_reasoning_content(self):
-        """Reasoning content from DeepSeek R1 models is preserved."""
+        """Reasoning content from DeepSeek R1 models is bridged to canonical blocks."""
         msg = AIMessage(
             content="Final answer",
             additional_kwargs={"reasoning_content": "I think therefore I am"},
         )
         result = _serialize_messages_chain([msg])
         assert len(result) == 1
-        assert result[0]["content"] == "Final answer"
-        assert (
-            result[0]["additional_kwargs"]["reasoning_content"]
-            == "I think therefore I am"
-        )
+        # reasoning_content is now stored as a canonical reasoning block
+        assert result[0]["content"] == [
+            {"type": "reasoning", "reasoning": "I think therefore I am"},
+            {"type": "text", "text": "Final answer"},
+        ]
+        # No longer in additional_kwargs
+        assert "additional_kwargs" not in result[0]
 
     def test_tool_message_string_content(self):
         """ToolMessage with string content."""
@@ -173,7 +175,104 @@ class TestSerializeMessagesChain:
         assert result[0]["role"] == "assistant"
 
     def test_ai_message_list_content(self):
-        """AIMessage with list content (e.g. Claude thinking blocks)."""
+        """AIMessage with list content (e.g. text blocks) is preserved."""
         msg = AIMessage(content=[{"type": "text", "text": "hello"}])
         result = _serialize_messages_chain([msg])
         assert result[0]["content"] == [{"type": "text", "text": "hello"}]
+
+    def test_claude_thinking_blocks_normalized(self):
+        """Claude thinking blocks are converted to canonical reasoning format."""
+        msg = AIMessage(
+            content=[
+                {
+                    "type": "thinking",
+                    "thinking": "Let me reason...",
+                    "signature": "abc123",
+                },
+                {"type": "text", "text": "The answer is 42"},
+            ]
+        )
+        result = _serialize_messages_chain([msg])
+        content = result[0]["content"]
+        assert len(content) == 2
+        assert content[0] == {
+            "type": "reasoning",
+            "reasoning": "Let me reason...",
+            "extras": {"signature": "abc123"},
+        }
+        assert content[1] == {"type": "text", "text": "The answer is 42"}
+
+    def test_openai_responses_reasoning_exploded(self):
+        """OpenAI Responses API reasoning blocks with summary are exploded."""
+        msg = AIMessage(
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": "Step 1"},
+                        {"type": "summary_text", "text": "Step 2"},
+                    ],
+                    "id": "rs_abc",
+                },
+                {"type": "text", "text": "Done"},
+            ]
+        )
+        result = _serialize_messages_chain([msg])
+        content = result[0]["content"]
+        assert len(content) == 3
+        assert content[0]["type"] == "reasoning"
+        assert content[0]["reasoning"] == "Step 1"
+        assert content[0]["extras"] == {"id": "rs_abc"}
+        assert content[1]["type"] == "reasoning"
+        assert content[1]["reasoning"] == "Step 2"
+        assert content[2] == {"type": "text", "text": "Done"}
+
+    def test_openai_responses_reasoning_empty_summary_preserves_extras(self):
+        """OpenAI Responses API reasoning blocks with empty summary preserve id/encrypted_content."""
+        msg = AIMessage(
+            content=[
+                {
+                    "type": "reasoning",
+                    "summary": [],
+                    "id": "rs_abc",
+                    "encrypted_content": "gAAAA_data",
+                },
+                {"type": "text", "text": "Answer"},
+            ]
+        )
+        result = _serialize_messages_chain([msg])
+        content = result[0]["content"]
+        assert len(content) == 2
+        reasoning = content[0]
+        assert reasoning["type"] == "reasoning"
+        assert reasoning["reasoning"] == ""
+        assert reasoning["extras"]["id"] == "rs_abc"
+        assert reasoning["extras"]["encrypted_content"] == "gAAAA_data"
+
+    def test_model_info_added_when_provider_given(self):
+        """model_info is added to each assistant entry when provider is passed."""
+        msg = AIMessage(content="Hello")
+        result = _serialize_messages_chain(
+            [msg], provider="anthropic", model_id="claude-sonnet-4-20250514"
+        )
+        assert result[0]["model_info"] == {
+            "provider": "anthropic",
+            "model": "claude-sonnet-4-20250514",
+        }
+
+    def test_model_info_absent_when_no_provider(self):
+        """model_info is omitted when provider is not given (backward compat)."""
+        msg = AIMessage(content="Hello")
+        result = _serialize_messages_chain([msg])
+        assert "model_info" not in result[0]
+
+    def test_reasoning_content_only_no_text(self):
+        """AIMessage with only reasoning_content and empty content."""
+        msg = AIMessage(
+            content="",
+            additional_kwargs={"reasoning_content": "thinking..."},
+        )
+        result = _serialize_messages_chain([msg])
+        assert result[0]["content"] == [
+            {"type": "reasoning", "reasoning": "thinking..."},
+        ]

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -273,7 +273,9 @@ class TestStripForeignReasoningBlocks:
                 "model_info": {"provider": "openai", "model": "gpt-5.4"},
             },
         ]
-        result = strip_foreign_reasoning_blocks(messages, "openai")
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
         reasoning_block = result[0]["content"][0]
         assert reasoning_block == {
             "type": "reasoning",
@@ -342,7 +344,9 @@ class TestStripForeignReasoningBlocks:
                 "model_info": {"provider": "openai", "model": "gpt-5"},
             },
         ]
-        result = strip_foreign_reasoning_blocks(messages, "openai")
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
         assert result[0]["content"][0] == {
             "type": "reasoning",
             "id": "rs_1",
@@ -378,7 +382,9 @@ class TestStripForeignReasoningBlocks:
                 "model_info": {"provider": "openai", "model": "gpt-5.4"},
             },
         ]
-        result = strip_foreign_reasoning_blocks(messages, "openai")
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
         text_block = result[0]["content"][1]
         # id should be stripped to prevent orphaned message reference
         assert "id" not in text_block

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -442,6 +442,57 @@ class TestStripForeignReasoningBlocks:
         # Kimi message: reasoning dropped (no signature), only text kept
         assert result[1]["content"] == [{"type": "text", "text": "A2"}]
 
+    def test_non_claude_anthropic_protocol_fake_signature_stripped(self):
+        """Minimax-style fake signature is stripped when targeting Claude.
+
+        Non-Claude models using the Anthropic protocol may produce hex-hash
+        signatures that the Claude API rejects as invalid.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "minimax thinking",
+                        "extras": {
+                            "index": 0,
+                            "signature": "080de92e77be80ab453d135b3971d802",
+                        },
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "minimax-m2.7"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Reasoning with fake signature must be stripped, not denormalized
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
+        # No response_metadata (not denormalized as Claude)
+        assert "response_metadata" not in result[0]
+
+    def test_legacy_anthropic_no_model_info_denormalized(self):
+        """Legacy messages without model_info are assumed Claude (backward compat)."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "legacy thought",
+                        "extras": {"signature": "EpwCCk...real_sig"},
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                # No model_info — legacy data
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Legacy messages should be denormalized (assumed Claude)
+        assert result[0]["content"][0]["type"] == "thinking"
+        assert result[0]["content"][0]["signature"] == "EpwCCk...real_sig"
+        assert "response_metadata" in result[0]
+
     def test_kimi_target_filters_empty_text_blocks(self):
         """Empty text blocks are filtered when targeting Kimi models."""
         messages = [

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -1,0 +1,586 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for think_block_filter module."""
+
+import pytest
+
+from chat_shell.messages.think_block_filter import (
+    _infer_provider,
+    strip_foreign_reasoning_blocks,
+)
+
+
+class TestStripForeignReasoningBlocks:
+    """Tests for strip_foreign_reasoning_blocks."""
+
+    def test_same_provider_preserves_reasoning(self):
+        """Anthropic same-provider reasoning blocks are denormalized to thinking format."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "thinking...",
+                        "extras": {"signature": "abc"},
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude-sonnet"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        content = result[0]["content"]
+        assert content[0] == {
+            "type": "thinking",
+            "thinking": "thinking...",
+            "signature": "abc",
+        }
+        assert content[1] == {"type": "text", "text": "answer"}
+
+    def test_cross_provider_strips_reasoning(self):
+        """Reasoning blocks from a different provider are removed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "thinking..."},
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude-sonnet"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
+
+    def test_user_messages_untouched(self):
+        """Non-assistant messages are passed through without modification."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "You are a bot"},
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result == messages
+
+    def test_no_think_blocks_untouched(self):
+        """Messages without reasoning blocks are passed through."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "plain text",
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result == messages
+
+    def test_all_reasoning_stripped_becomes_empty_text_block(self):
+        """If all content blocks are reasoning, content becomes an empty text block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "only thinking"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"] == [{"type": "text", "text": ""}]
+
+    def test_legacy_anthropic_thinking_blocks_inferred(self):
+        """Legacy Claude thinking blocks (no model_info) are detected heuristically."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "old format"},
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+        ]
+        # Same provider (anthropic inferred) -> keep
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert len(result[0]["content"]) == 2
+
+        # Different provider -> strip
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
+
+    def test_legacy_reasoning_content_in_additional_kwargs(self):
+        """Legacy additional_kwargs.reasoning_content is detected and stripped."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "additional_kwargs": {"reasoning_content": "deep thinking"},
+            },
+        ]
+        # Inferred as openai -> same provider keeps it
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert "additional_kwargs" in result[0]
+
+        # Different provider -> strip
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert "additional_kwargs" not in result[0]
+
+    def test_mixed_history_selective_stripping(self):
+        """Mixed provider history: cross-provider reasoning stripped, same-provider denormalized."""
+        messages = [
+            {"role": "user", "content": "Q1"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "claude thought",
+                        "extras": {"signature": "sig1"},
+                    },
+                    {"type": "text", "text": "A1"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+            {"role": "user", "content": "Q2"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "gpt thought"},
+                    {"type": "text", "text": "A2"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        # Target is openai: claude reasoning stripped, gpt reasoning kept
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[1]["content"] == [{"type": "text", "text": "A1"}]
+        assert len(result[3]["content"]) == 2  # both blocks preserved
+
+        # Target is anthropic: claude reasoning denormalized to thinking, gpt stripped
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert result[1]["content"][0] == {
+            "type": "thinking",
+            "thinking": "claude thought",
+            "signature": "sig1",
+        }
+        assert result[3]["content"] == [{"type": "text", "text": "A2"}]
+
+    def test_original_messages_not_mutated(self):
+        """The original message dicts are not modified in-place."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "thinking"},
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+        ]
+        original_content = list(messages[0]["content"])
+        strip_foreign_reasoning_blocks(messages, "openai")
+        assert messages[0]["content"] == original_content
+
+    def test_unknown_provider_no_model_info_no_reasoning(self):
+        """Messages without model_info and without reasoning are passed through."""
+        messages = [
+            {"role": "assistant", "content": "plain answer"},
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert result == messages
+
+    def test_anthropic_same_provider_sets_response_metadata(self):
+        """Denormalized Anthropic messages include response_metadata for LangChain."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "thought",
+                        "extras": {"signature": "sig"},
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # response_metadata is injected as top-level key for convert_to_messages
+        assert result[0]["response_metadata"] == {"model_provider": "anthropic"}
+
+    def test_anthropic_same_provider_does_not_mutate_original(self):
+        """Denormalization creates a deep copy, original is untouched."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "thought",
+                        "extras": {"signature": "sig"},
+                    },
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude"},
+            },
+        ]
+        original_content = list(messages[0]["content"])
+        strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert messages[0]["content"] == original_content
+        assert "response_metadata" not in messages[0]
+
+    def test_non_anthropic_same_provider_passes_through(self):
+        """Non-Anthropic same-provider messages without Responses API extras are not denormalized."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "thinking"},
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        # Plain reasoning blocks (no extras.id) pass through unchanged
+        assert result[0]["content"][0]["type"] == "reasoning"
+        assert result[0]["content"][0].get("reasoning") == "thinking"
+        assert "additional_kwargs" not in result[0]
+
+    def test_openai_same_provider_denormalizes_reasoning(self):
+        """OpenAI same-provider reasoning blocks with Responses API extras are reconstructed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "I considered the options...",
+                        "extras": {
+                            "id": "rs_abc123",
+                            "encrypted_content": "gAAAA_encrypted_data",
+                            "index": 0,
+                        },
+                    },
+                    {
+                        "id": "msg_xyz789",
+                        "type": "text",
+                        "text": "Final answer",
+                        "index": 1,
+                    },
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5.4"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        reasoning_block = result[0]["content"][0]
+        assert reasoning_block == {
+            "type": "reasoning",
+            "id": "rs_abc123",
+            "summary": [{"type": "summary_text", "text": "I considered the options..."}],
+            "encrypted_content": "gAAAA_encrypted_data",
+        }
+        # Text block unchanged
+        assert result[0]["content"][1]["type"] == "text"
+
+    def test_openai_same_provider_without_extras_id_passes_through(self):
+        """OpenAI reasoning blocks without extras.id/encrypted_content are not reconstructed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "plain thinking"},
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"][0] == {
+            "type": "reasoning",
+            "reasoning": "plain thinking",
+        }
+
+    def test_openai_same_provider_does_not_mutate_original(self):
+        """OpenAI denormalization creates a deep copy, original is untouched."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "thought",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc"},
+                    },
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        original_content = list(messages[0]["content"])
+        strip_foreign_reasoning_blocks(messages, "openai")
+        assert messages[0]["content"] == original_content
+
+    def test_openai_same_provider_multiple_reasoning_blocks(self):
+        """Multiple exploded reasoning blocks are each reconstructed."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "Step 1",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc1"},
+                    },
+                    {
+                        "type": "reasoning",
+                        "reasoning": "Step 2",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc1"},
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"][0] == {
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [{"type": "summary_text", "text": "Step 1"}],
+            "encrypted_content": "enc1",
+        }
+        assert result[0]["content"][1] == {
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [{"type": "summary_text", "text": "Step 2"}],
+            "encrypted_content": "enc1",
+        }
+        assert result[0]["content"][2] == {"type": "text", "text": "answer"}
+
+    def test_openai_same_provider_orphaned_text_id_stripped(self):
+        """When reasoning blocks lack extras (corrupted data), text block ids are stripped.
+
+        This prevents the API error where a message item references a reasoning
+        item that no longer exists.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": ""},
+                    {
+                        "id": "msg_abc123",
+                        "type": "text",
+                        "text": "answer",
+                        "index": 1,
+                    },
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5.4"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        text_block = result[0]["content"][1]
+        # id should be stripped to prevent orphaned message reference
+        assert "id" not in text_block
+        assert text_block["text"] == "answer"
+        # reasoning block passed through unchanged
+        assert result[0]["content"][0] == {"type": "reasoning", "reasoning": ""}
+
+    def test_anthropic_same_provider_drops_reasoning_without_signature(self):
+        """Reasoning blocks from Kimi (anthropic protocol, no signature) are dropped for Claude."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "kimi thought"},
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "moonshot-kimi-k2.5"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Reasoning without signature is dropped; only text remains
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
+
+    def test_anthropic_mixed_signature_and_no_signature(self):
+        """Only reasoning blocks with signature are kept for Claude target."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "claude thought",
+                        "extras": {"signature": "sig1"},
+                    },
+                    {"type": "text", "text": "A1"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "claude-sonnet"},
+            },
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "kimi thought"},
+                    {"type": "text", "text": "A2"},
+                ],
+                "model_info": {"provider": "anthropic", "model": "moonshot-kimi-k2.5"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Claude message: thinking denormalized with signature
+        assert result[0]["content"][0] == {
+            "type": "thinking",
+            "thinking": "claude thought",
+            "signature": "sig1",
+        }
+        # Kimi message: reasoning dropped (no signature), only text kept
+        assert result[1]["content"] == [{"type": "text", "text": "A2"}]
+
+    def test_kimi_target_filters_empty_text_blocks(self):
+        """Empty text blocks are filtered when targeting Kimi models."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "thought"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+        ]
+        # Cross-provider strip leaves empty text fallback
+        result = strip_foreign_reasoning_blocks(
+            messages, "anthropic", target_model_id="moonshot-kimi-k2.5"
+        )
+        # Empty text block should be filtered out for Kimi
+        content = result[0]["content"]
+        assert not any(
+            isinstance(b, dict) and b.get("type") == "text" and not b.get("text")
+            for b in content
+        )
+
+
+class TestInferProvider:
+    """Tests for _infer_provider heuristic."""
+
+    def test_legacy_thinking_block_returns_anthropic(self):
+        msg = {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "..."}],
+        }
+        assert _infer_provider(msg) == "anthropic"
+
+    def test_canonical_reasoning_with_signature_returns_anthropic(self):
+        msg = {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "reasoning",
+                    "reasoning": "...",
+                    "extras": {"signature": "abc"},
+                }
+            ],
+        }
+        assert _infer_provider(msg) == "anthropic"
+
+    def test_reasoning_with_summary_returns_openai(self):
+        msg = {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "x"}],
+                }
+            ],
+        }
+        assert _infer_provider(msg) == "openai"
+
+    def test_canonical_reasoning_without_extras_returns_none(self):
+        msg = {
+            "role": "assistant",
+            "content": [{"type": "reasoning", "reasoning": "..."}],
+        }
+        assert _infer_provider(msg) is None
+
+    def test_additional_kwargs_reasoning_content_returns_openai(self):
+        msg = {
+            "role": "assistant",
+            "content": "answer",
+            "additional_kwargs": {"reasoning_content": "deep thinking"},
+        }
+        assert _infer_provider(msg) == "openai"
+
+    def test_plain_text_returns_none(self):
+        msg = {"role": "assistant", "content": "plain answer"}
+        assert _infer_provider(msg) is None
+
+
+class TestSanitizeToolIdsForAnthropic:
+    """Tests for tool_call ID sanitization when targeting Claude."""
+
+    def test_kimi_tool_ids_sanitized_for_claude(self):
+        """Kimi-style tool IDs with dots and colons are sanitized."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "function_call",
+                        "call_id": "functions.load_skill:10",
+                        "name": "load_skill",
+                    },
+                ],
+                "tool_calls": [
+                    {"id": "functions.load_skill:10", "type": "function",
+                     "function": {"name": "load_skill", "arguments": "{}"}}
+                ],
+                "model_info": {"provider": "openai", "model": "moonshot-kimi-k2.5"},
+            },
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "functions.load_skill:10",
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Tool call ID should be sanitized
+        assert result[0]["tool_calls"][0]["id"] == "functions_load_skill_10"
+        assert result[0]["content"][0]["call_id"] == "functions_load_skill_10"
+        assert result[1]["tool_call_id"] == "functions_load_skill_10"
+
+    def test_valid_tool_ids_unchanged(self):
+        """Standard tool IDs matching Claude's pattern are not modified."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "tool_calls": [
+                    {"id": "call_abc123", "type": "function",
+                     "function": {"name": "test", "arguments": "{}"}}
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5"},
+            },
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_call_id": "call_abc123",
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        assert result[0]["tool_calls"][0]["id"] == "call_abc123"
+        assert result[1]["tool_call_id"] == "call_abc123"
+
+    def test_non_anthropic_target_no_sanitization(self):
+        """Tool IDs are not sanitized when targeting non-Anthropic providers."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "answer",
+                "tool_calls": [
+                    {"id": "functions.test:1", "type": "function",
+                     "function": {"name": "test", "arguments": "{}"}}
+                ],
+                "model_info": {"provider": "openai", "model": "kimi"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["tool_calls"][0]["id"] == "functions.test:1"

--- a/start.sh
+++ b/start.sh
@@ -554,6 +554,45 @@ check_python_env() {
     cd "$SCRIPT_DIR"
 }
 
+# Patch backend DATABASE_URL and REDIS_URL to use configured MYSQL_PORT and REDIS_PORT.
+# When start.sh runs services locally, MySQL/Redis are exposed on host ports from
+# MYSQL_PORT/REDIS_PORT in .env, but backend/.env hardcodes the default ports (3306/6379).
+# This function reads backend/.env, patches the ports, and exports them as env vars
+# so pydantic-settings (which prefers env vars over .env file values) picks them up.
+patch_backend_service_urls() {
+    local backend_env="$SCRIPT_DIR/backend/.env"
+
+    if [ ! -f "$backend_env" ]; then
+        return
+    fi
+
+    # Patch DATABASE_URL with MYSQL_PORT if configured
+    if [ -n "$MYSQL_PORT" ]; then
+        local db_url
+        db_url=$(grep "^DATABASE_URL=" "$backend_env" | cut -d'=' -f2-)
+        if [ -n "$db_url" ]; then
+            # Replace port in @host:PORT/ pattern (e.g., @localhost:3306/ -> @localhost:23306/)
+            local patched_db_url
+            patched_db_url=$(echo "$db_url" | sed -E "s/(@[^:@]+):[0-9]+\//\1:$MYSQL_PORT\//")
+            export DATABASE_URL="$patched_db_url"
+            echo -e "  ${GREEN}✓${NC} DATABASE_URL patched to use MYSQL_PORT=$MYSQL_PORT"
+        fi
+    fi
+
+    # Patch REDIS_URL with REDIS_PORT if configured
+    if [ -n "$REDIS_PORT" ]; then
+        local redis_url
+        redis_url=$(grep "^REDIS_URL=" "$backend_env" | cut -d'=' -f2-)
+        if [ -n "$redis_url" ]; then
+            # Replace port in ://host:PORT/ pattern (e.g., ://127.0.0.1:6379/ -> ://127.0.0.1:26379/)
+            local patched_redis_url
+            patched_redis_url=$(echo "$redis_url" | sed -E "s|(//[^:@/]+):[0-9]+/|\1:$REDIS_PORT/|")
+            export REDIS_URL="$patched_redis_url"
+            echo -e "  ${GREEN}✓${NC} REDIS_URL patched to use REDIS_PORT=$REDIS_PORT"
+        fi
+    fi
+}
+
 # Check frontend dependencies
 check_frontend_dependencies() {
     local frontend_dir="$SCRIPT_DIR/frontend"
@@ -1161,6 +1200,13 @@ start_services() {
     echo -e "${BLUE}Checking Python env...${NC}"
     check_python_env "backend" "Backend"
     check_python_env "chat_shell" "Chat Shell"
+    echo ""
+
+    # Patch backend connection URLs to use configured MYSQL_PORT / REDIS_PORT.
+    # backend/.env hardcodes default ports; this ensures the local backend process
+    # connects to the correct host ports exposed by docker-compose.
+    echo -e "${BLUE}Patching service connection URLs...${NC}"
+    patch_backend_service_urls
     echo ""
 
     # Check frontend dependencies

--- a/start.sh
+++ b/start.sh
@@ -571,9 +571,10 @@ patch_backend_service_urls() {
         local db_url
         db_url=$(grep "^DATABASE_URL=" "$backend_env" | cut -d'=' -f2-)
         if [ -n "$db_url" ]; then
-            # Replace port in @host:PORT/ pattern (e.g., @localhost:3306/ -> @localhost:23306/)
+            # Replace port in @host:PORT pattern (supports optional trailing slash)
+            # e.g., @localhost:3306/db -> @localhost:23306/db
             local patched_db_url
-            patched_db_url=$(echo "$db_url" | sed -E "s/(@[^:@]+):[0-9]+\//\1:$MYSQL_PORT\//")
+            patched_db_url=$(echo "$db_url" | sed -E "s#(@[^/:]+):[0-9]+(/|$)#\1:$MYSQL_PORT\2#")
             export DATABASE_URL="$patched_db_url"
             echo -e "  ${GREEN}✓${NC} DATABASE_URL patched to use MYSQL_PORT=$MYSQL_PORT"
         fi
@@ -584,9 +585,10 @@ patch_backend_service_urls() {
         local redis_url
         redis_url=$(grep "^REDIS_URL=" "$backend_env" | cut -d'=' -f2-)
         if [ -n "$redis_url" ]; then
-            # Replace port in ://host:PORT/ pattern (e.g., ://127.0.0.1:6379/ -> ://127.0.0.1:26379/)
+            # Replace port in host:PORT pattern (supports optional credentials and trailing slash)
+            # e.g., redis://127.0.0.1:6379/0 or redis://:pwd@127.0.0.1:6379/0
             local patched_redis_url
-            patched_redis_url=$(echo "$redis_url" | sed -E "s|(//[^:@/]+):[0-9]+/|\1:$REDIS_PORT/|")
+            patched_redis_url=$(echo "$redis_url" | sed -E "s#(//([^/@]+@)?[^/:]+):[0-9]+(/|$)#\1:$REDIS_PORT\3#")
             export REDIS_URL="$patched_redis_url"
             echo -e "  ${GREEN}✓${NC} REDIS_URL patched to use REDIS_PORT=$REDIS_PORT"
         fi


### PR DESCRIPTION
## Summary

When users switch LLM providers mid-conversation (e.g. Claude → GPT → Gemini → Kimi), historical messages contain provider-specific thinking/reasoning blocks that the new model's API rejects with 400 errors. This PR introduces a three-layer normalization architecture to enable seamless cross-model switching.

### Core Changes

- **Canonical storage format**: Serialize all provider-specific thinking blocks (`thinking`, `reasoning` with `summary`, `reasoning_content`) into a unified `{"type": "reasoning", "reasoning": "...", "extras": {...}}` format, with `model_info` metadata tagging the originating provider
- **Cross-provider filtering** (`think_block_filter.py`): On history load, strip foreign reasoning blocks while preserving same-provider blocks (with denormalization back to native format for API compatibility)
- **Provider-specific fixes**: Sanitize tool_call IDs for Anthropic's `^[a-zA-Z0-9_-]+$` constraint; filter empty text blocks for Kimi; bridge canonical reasoning blocks in `ChatOpenAIWithReasoning` for DeepSeek/Kimi

### Other Changes

- **`start.sh`**: Patch `DATABASE_URL` and `REDIS_URL` with configured `MYSQL_PORT`/`REDIS_PORT` so local backend connects to correct docker-compose exposed ports

### Backward Compatibility

- Old messages without `model_info` are handled via heuristic provider inference (`_infer_provider`) based on content block types
- Legacy `additional_kwargs.reasoning_content` format (DeepSeek/Kimi) is fully supported
- New `model_info` field on `MessageResponse` and `Message` is `Optional`, no schema migration needed

## Files Changed

| File | Change |
|------|--------|
| `chat_shell/messages/think_block_filter.py` | **New** - Core cross-model reasoning block filter |
| `chat_shell/agents/graph_builder.py` | Normalize content on serialize, filter on load |
| `chat_shell/models/factory.py` | Attach `_wegent_provider`/`_wegent_model_id` metadata to LLM instances |
| `chat_shell/models/openai_reasoning.py` | Support canonical reasoning blocks alongside legacy format |
| `chat_shell/storage/interfaces.py` | Add `model_info` field to `Message` dataclass |
| `backend/api/endpoints/internal/chat_storage.py` | Pass through `model_info` in `MessageResponse` |
| `start.sh` | Auto-patch backend DB/Redis URLs for local dev |
| `tests/test_think_block_filter.py` | **New** - 586 lines of unit tests |
| `tests/test_cross_model_switch.py` | **New** - End-to-end round-trip tests |
| `tests/test_serialize_messages_chain.py` | Updated for canonical format |

## Test Plan

- [x] Unit tests for `strip_foreign_reasoning_blocks` covering all provider combinations
- [x] Unit tests for normalization (`_normalize_content_blocks`, `_normalize_content_for_storage`)
- [x] Unit tests for denormalization (`_denormalize_for_anthropic`, `_denormalize_for_openai_responses`)
- [x] End-to-end round-trip tests: Claude→GPT, DeepSeek→Claude, OpenAI→Gemini, Kimi→Claude
- [x] Tool ID sanitization tests for Anthropic constraint
- [x] Legacy data (no `model_info`) backward compatibility tests
- [x] Manual test: switch models mid-conversation on staging and verify no API errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Normalized cross-model "thinking"/"reasoning" content with same-provider denormalization and provider-specific reconstruction (including OpenAI Responses).
  * Assistant messages now carry provider/model metadata that’s persisted and round-tripped.
  * Provider-specific tool-call ID sanitization for safer interoperability.

* **Tests**
  * Added comprehensive integration/unit tests for cross-model conversion, reasoning filtering/denormalization, and sequence preservation.

* **Chores**
  * Startup script now patches backend service URLs to respect runtime port overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->