### PR TITLE
fix(chat-shell): preserve legacy responses reasoning blocks and truncate persisted tool results

### DIFF
--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -310,6 +310,32 @@ def _normalize_content_for_storage(msg: AIMessage) -> str | list:
     return msg.content
 
 
+def _truncate_tool_result_for_storage(content: str) -> str:
+    """Truncate a tool result string if it exceeds the configured maximum length.
+
+    Keeps the beginning (60%) and end (40%) of the content with a truncation
+    notice in between, following the same pattern as
+    ``ToolResultTruncationStrategy._truncate_content``.
+    """
+    from chat_shell.core.config import settings  # noqa: PLC0415
+
+    max_len = settings.MAX_TOOL_RESULT_LENGTH
+    if max_len <= 0 or len(content) <= max_len:
+        return content
+
+    begin_length = int(max_len * 0.6)
+    end_length = max_len - begin_length
+    removed = len(content) - max_len
+
+    return (
+        content[:begin_length] + f"\n\n[... Tool output truncated at serialization. "
+        f"Original: {len(content)} chars, "
+        f"removed {removed} chars from middle, "
+        f"keeping first {begin_length} and last {end_length} chars ...]\n\n"
+        + content[-end_length:]
+    )
+
+
 def _serialize_messages_chain(
     messages: list[BaseMessage],
     provider: str = "",
@@ -356,13 +382,13 @@ def _serialize_messages_chain(
                 ]
             chain.append(entry)
         elif isinstance(msg, ToolMessage):
+            content_str = (
+                msg.content if isinstance(msg.content, str) else json.dumps(msg.content)
+            )
+            content_str = _truncate_tool_result_for_storage(content_str)
             entry = {
                 "role": "tool",
-                "content": (
-                    msg.content
-                    if isinstance(msg.content, str)
-                    else json.dumps(msg.content)
-                ),
+                "content": content_str,
                 "tool_call_id": _require_non_empty_tool_id(
                     msg.tool_call_id,
                     "serialized messages_chain: tool message tool_call_id",

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -91,6 +91,12 @@ class Settings(BaseSettings):
     MESSAGE_COMPRESSION_LAST_MESSAGES: int = 10
     MESSAGE_COMPRESSION_ATTACHMENT_LENGTH: int = 50000
 
+    # Maximum length (in characters) for a single tool result stored in
+    # messages_chain.  Results exceeding this limit are truncated at
+    # serialization time (beginning + end kept, middle removed).
+    # Set to 0 to disable.
+    MAX_TOOL_RESULT_LENGTH: int = 50000
+
     # MCP configuration for Chat Shell
     CHAT_MCP_ENABLED: bool = False
     CHAT_MCP_SERVERS: str = "{}"

--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -50,9 +50,7 @@ def _infer_provider(msg: dict[str, Any]) -> str | None:
             if block_type == _REASONING_TYPE and "summary" in block:
                 # OpenAI Responses API format (pre-normalization legacy)
                 return "openai"
-            if block_type == _REASONING_TYPE and isinstance(
-                block.get("extras"), dict
-            ):
+            if block_type == _REASONING_TYPE and isinstance(block.get("extras"), dict):
                 extras = block["extras"]
                 if extras.get("signature"):
                     # Canonical reasoning with Anthropic signature
@@ -159,6 +157,18 @@ def _denormalize_for_openai_responses(content: list) -> list:
         if not isinstance(extras, dict) or (
             "id" not in extras and "encrypted_content" not in extras
         ):
+            # Check for raw (pre-normalization) Responses API format where
+            # ``id``, ``summary``, ``encrypted_content`` live at the top
+            # level instead of inside ``extras``.  These blocks are already
+            # in valid Responses API format and can be passed through, but
+            # we must set ``has_reasoning_id`` so that sibling text-block
+            # ids are preserved (the API needs them to pair the reasoning
+            # item with its output message).
+            if "summary" in block and ("id" in block or "encrypted_content" in block):
+                has_reasoning_id = True
+                result.append(block)
+                continue
+
             # Not an exploded Responses API reasoning block — pass through
             result.append(block)
             continue
@@ -338,9 +348,7 @@ def strip_foreign_reasoning_blocks(
         if source_provider == target_provider:
             if target_provider == "anthropic" and isinstance(content, list):
                 source_model = (
-                    model_info.get("model", "")
-                    if isinstance(model_info, dict)
-                    else ""
+                    model_info.get("model", "") if isinstance(model_info, dict) else ""
                 )
                 # Non-Claude models using the Anthropic protocol (Minimax,
                 # Kimi, GLM) may produce fake signatures that the Claude API
@@ -348,15 +356,11 @@ def strip_foreign_reasoning_blocks(
                 # if it is actually Claude.  Legacy messages without
                 # model_info are assumed to be real Claude (backward compat).
                 has_model_info = isinstance(model_info, dict)
-                is_real_claude = not has_model_info or _is_claude_model(
-                    source_model
-                )
+                is_real_claude = not has_model_info or _is_claude_model(source_model)
                 if is_real_claude:
                     denormalized = copy.deepcopy(msg)
                     denormalized["content"] = _denormalize_for_anthropic(content)
-                    denormalized["response_metadata"] = {
-                        "model_provider": "anthropic"
-                    }
+                    denormalized["response_metadata"] = {"model_provider": "anthropic"}
                     result.append(denormalized)
                 else:
                     # Non-Claude model — strip reasoning blocks
@@ -426,6 +430,53 @@ def strip_foreign_reasoning_blocks(
     # Sanitize IDs from other providers (e.g. Kimi's "functions.load_skill:10").
     if target_provider == "anthropic":
         result = _sanitize_tool_ids_for_anthropic(result)
+
+    # Ensure every assistant message ending with a reasoning block has a
+    # following output item.  The Responses API rejects orphaned reasoning
+    # items, so we append a placeholder text block as a safety net.
+    if target_uses_responses:
+        result = _ensure_reasoning_has_output(result)
+
+    return result
+
+
+def _ensure_reasoning_has_output(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Ensure assistant messages don't end with an orphaned reasoning block.
+
+    The OpenAI Responses API requires that every ``reasoning`` item is
+    followed by its output (a ``message`` or ``function_call`` item).
+    When the last content block of an assistant message is ``reasoning``
+    (and the message has no ``tool_calls``), the API will reject it.
+
+    This function appends a placeholder ``text`` block so that the
+    reasoning block always has a valid following item.
+    """
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            result.append(msg)
+            continue
+
+        content = msg.get("content")
+        if not isinstance(content, list) or not content:
+            result.append(msg)
+            continue
+
+        last_block = content[-1]
+        has_tool_calls = bool(msg.get("tool_calls"))
+        is_orphaned_reasoning = (
+            isinstance(last_block, dict)
+            and last_block.get("type") in (_REASONING_TYPE, _LEGACY_ANTHROPIC_TYPE)
+            and not has_tool_calls
+        )
+
+        if is_orphaned_reasoning:
+            patched = {**msg, "content": list(content) + [{"type": "text", "text": ""}]}
+            result.append(patched)
+        else:
+            result.append(msg)
 
     return result
 

--- a/chat_shell/tests/test_serialize_messages_chain.py
+++ b/chat_shell/tests/test_serialize_messages_chain.py
@@ -276,3 +276,73 @@ class TestSerializeMessagesChain:
         assert result[0]["content"] == [
             {"type": "reasoning", "reasoning": "thinking..."},
         ]
+
+
+class TestToolResultTruncationAtSerialization:
+    """Tests for tool result truncation in _serialize_messages_chain."""
+
+    def test_short_tool_result_unchanged(self):
+        """Tool results within the limit are not truncated."""
+        msg = ToolMessage(
+            content="short result",
+            tool_call_id="call_1",
+            name="test_tool",
+        )
+        result = _serialize_messages_chain([msg])
+        assert result[0]["content"] == "short result"
+
+    def test_long_tool_result_truncated(self, monkeypatch):
+        """Tool results exceeding MAX_TOOL_RESULT_LENGTH are truncated."""
+        # Set a small limit for testing
+        from chat_shell.core import config as config_module
+
+        original_settings = config_module.settings
+        monkeypatch.setattr(
+            config_module,
+            "settings",
+            type(original_settings).model_construct(
+                **{
+                    **original_settings.model_dump(),
+                    "MAX_TOOL_RESULT_LENGTH": 200,
+                }
+            ),
+        )
+
+        long_content = "A" * 500
+        msg = ToolMessage(
+            content=long_content,
+            tool_call_id="call_1",
+            name="test_tool",
+        )
+        result = _serialize_messages_chain([msg])
+        content = result[0]["content"]
+        assert len(content) < 500
+        assert "Tool output truncated at serialization" in content
+        # Beginning and end preserved
+        assert content.startswith("A" * 50)
+        assert content.endswith("A" * 50)
+
+    def test_truncation_disabled_when_zero(self, monkeypatch):
+        """Setting MAX_TOOL_RESULT_LENGTH=0 disables truncation."""
+        from chat_shell.core import config as config_module
+
+        original_settings = config_module.settings
+        monkeypatch.setattr(
+            config_module,
+            "settings",
+            type(original_settings).model_construct(
+                **{
+                    **original_settings.model_dump(),
+                    "MAX_TOOL_RESULT_LENGTH": 0,
+                }
+            ),
+        )
+
+        long_content = "B" * 100000
+        msg = ToolMessage(
+            content=long_content,
+            tool_call_id="call_1",
+            name="test_tool",
+        )
+        result = _serialize_messages_chain([msg])
+        assert result[0]["content"] == long_content

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -280,7 +280,9 @@ class TestStripForeignReasoningBlocks:
         assert reasoning_block == {
             "type": "reasoning",
             "id": "rs_abc123",
-            "summary": [{"type": "summary_text", "text": "I considered the options..."}],
+            "summary": [
+                {"type": "summary_text", "text": "I considered the options..."}
+            ],
             "encrypted_content": "gAAAA_encrypted_data",
         }
         # Text block unchanged
@@ -515,6 +517,198 @@ class TestStripForeignReasoningBlocks:
             for b in content
         )
 
+    # ---- Fix 1: raw Responses API format recognition ----
+
+    def test_openai_same_provider_raw_format_preserves_text_id(self):
+        """Raw Responses API reasoning blocks (no extras) preserve sibling text block ids.
+
+        When reasoning blocks have id/summary/encrypted_content at the top
+        level (pre-normalization format), has_reasoning_id must be set to
+        True so that sibling text block ids are NOT stripped.
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "id": "rs_abc123",
+                        "type": "reasoning",
+                        "index": 0,
+                        "summary": [
+                            {"type": "summary_text", "text": "Thinking..."},
+                        ],
+                        "encrypted_content": "gAAAA_encrypted",
+                    },
+                    {
+                        "id": "msg_xyz789",
+                        "type": "text",
+                        "text": "Final answer",
+                        "index": 1,
+                    },
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        text_block = result[0]["content"][1]
+        # id must be preserved (not stripped)
+        assert text_block.get("id") == "msg_xyz789"
+        assert text_block["text"] == "Final answer"
+        # reasoning block passed through unchanged
+        assert result[0]["content"][0]["id"] == "rs_abc123"
+
+    def test_openai_same_provider_raw_format_empty_summary(self):
+        """Raw format with empty summary list still preserves text ids."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "id": "rs_test",
+                        "type": "reasoning",
+                        "index": 0,
+                        "summary": [],
+                        "encrypted_content": "gAAAA_data",
+                    },
+                    {
+                        "id": "msg_test",
+                        "type": "text",
+                        "text": "answer",
+                    },
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        # Text block id preserved
+        assert result[0]["content"][1].get("id") == "msg_test"
+        # Reasoning block unchanged
+        assert result[0]["content"][0]["id"] == "rs_test"
+        assert result[0]["content"][0]["summary"] == []
+
+    def test_openai_same_provider_raw_format_only_id_no_encrypted(self):
+        """Raw format with only id (no encrypted_content) still sets has_reasoning_id."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "id": "rs_only_id",
+                        "type": "reasoning",
+                        "summary": [{"type": "summary_text", "text": "thought"}],
+                    },
+                    {
+                        "id": "msg_abc",
+                        "type": "text",
+                        "text": "answer",
+                    },
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        assert result[0]["content"][1].get("id") == "msg_abc"
+
+    # ---- Fix 3: reasoning sequence validation ----
+
+    def test_reasoning_only_content_gets_empty_text_appended(self):
+        """Assistant message with only reasoning block gets a placeholder text block."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc"},
+                    },
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5.4"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        content = result[0]["content"]
+        # Reasoning is denormalized, then a placeholder text is appended
+        assert len(content) == 2
+        assert content[0]["type"] == "reasoning"
+        assert content[-1] == {"type": "text", "text": ""}
+
+    def test_reasoning_with_text_unchanged(self):
+        """Assistant message with reasoning + text is not modified."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "thinking...",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc"},
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5.4"},
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        content = result[0]["content"]
+        # Reasoning denormalized + text block = 2 blocks, no placeholder added
+        assert len(content) == 2
+        assert content[-1]["type"] == "text"
+        assert content[-1]["text"] == "answer"
+
+    def test_reasoning_with_tool_calls_not_patched(self):
+        """Assistant with reasoning + tool_calls should NOT get a placeholder text."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "reasoning",
+                        "reasoning": "",
+                        "extras": {"id": "rs_1", "encrypted_content": "enc"},
+                    },
+                ],
+                "model_info": {"provider": "openai", "model": "gpt-5.4"},
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    },
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(
+            messages, "openai", target_api_format="responses"
+        )
+        content = result[0]["content"]
+        # Should NOT have a placeholder — tool_calls serve as the output
+        assert len(content) == 1
+        assert content[0]["type"] == "reasoning"
+
+    def test_non_responses_api_no_reasoning_validation(self):
+        """Reasoning validation only applies to Responses API format."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "reasoning", "reasoning": "thinking..."},
+                ],
+            },
+        ]
+        # Chat Completions format — no target_api_format
+        result = strip_foreign_reasoning_blocks(messages, "openai")
+        content = result[0]["content"]
+        # Should NOT be patched for non-Responses API
+        assert len(content) == 1
+
 
 class TestInferProvider:
     """Tests for _infer_provider heuristic."""
@@ -587,8 +781,11 @@ class TestSanitizeToolIdsForAnthropic:
                     },
                 ],
                 "tool_calls": [
-                    {"id": "functions.load_skill:10", "type": "function",
-                     "function": {"name": "load_skill", "arguments": "{}"}}
+                    {
+                        "id": "functions.load_skill:10",
+                        "type": "function",
+                        "function": {"name": "load_skill", "arguments": "{}"},
+                    }
                 ],
                 "model_info": {"provider": "openai", "model": "moonshot-kimi-k2.5"},
             },
@@ -611,8 +808,11 @@ class TestSanitizeToolIdsForAnthropic:
                 "role": "assistant",
                 "content": "answer",
                 "tool_calls": [
-                    {"id": "call_abc123", "type": "function",
-                     "function": {"name": "test", "arguments": "{}"}}
+                    {
+                        "id": "call_abc123",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
                 ],
                 "model_info": {"provider": "openai", "model": "gpt-5"},
             },
@@ -633,8 +833,11 @@ class TestSanitizeToolIdsForAnthropic:
                 "role": "assistant",
                 "content": "answer",
                 "tool_calls": [
-                    {"id": "functions.test:1", "type": "function",
-                     "function": {"name": "test", "arguments": "{}"}}
+                    {
+                        "id": "functions.test:1",
+                        "type": "function",
+                        "function": {"name": "test", "arguments": "{}"},
+                    }
                 ],
                 "model_info": {"provider": "openai", "model": "kimi"},
             },


### PR DESCRIPTION
## Summary

This PR improves Chat Shell history persistence for OpenAI Responses reasoning models and oversized tool outputs.

## Problem

- persisted `messages_chain` tool results could become too large and bloat stored conversation history
- legacy OpenAI Responses API reasoning blocks stored in raw database format were not reliably reconstructed on replay
- reasoning-only assistant history items could be rejected by the Responses API because they had no following output item

## Changes

- preserve legacy raw Responses API reasoning blocks (`type=reasoning` with top-level `summary`, `id`, and `encrypted_content`) when reloading same-provider history
- keep sibling assistant text block IDs for those raw Responses items so message/reasoning pairing remains valid
- append a placeholder text output when a Responses assistant message would otherwise end with a reasoning-only block
- truncate oversized tool results when serializing `messages_chain` for persistence
- add `CHAT_SHELL_MAX_TOOL_RESULT_LENGTH` to control persisted tool-result length
- add regression tests covering raw Responses payloads, reasoning-only histories, and tool-result truncation

## Testing

- `cd chat_shell && uv run pytest tests/test_serialize_messages_chain.py tests/test_think_block_filter.py tests/test_cross_model_switch.py tests/test_openai_reasoning.py -q`
- `cd chat_shell && uv run pytest -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool results are now automatically truncated when exceeding configured limits, preserving the beginning and end portions with a truncation notice in the middle.
  * Added configuration setting to control tool result truncation behavior; set to 0 to disable truncation entirely.

* **Bug Fixes**
  * Improved handling of reasoning blocks in the OpenAI Responses API format to ensure proper output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->