### PR TITLE
fix(chat_shell): validate legacy thinking blocks and merge duplicate reasoning summaries

### DIFF
--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -99,11 +99,27 @@ def _denormalize_for_anthropic(content: list) -> list:
     Such blocks originate from non-Claude providers (e.g. Kimi) that use
     the Anthropic protocol without producing signatures.
 
-    Non-reasoning blocks are passed through unchanged.
+    Non-reasoning blocks are passed through unchanged.  Legacy ``thinking``
+    blocks (pre-normalization data) are validated: kept if they carry a
+    ``signature``, dropped otherwise.
     """
     result: list = []
     for block in content:
-        if not isinstance(block, dict) or block.get("type") != _REASONING_TYPE:
+        if not isinstance(block, dict):
+            result.append(block)
+            continue
+
+        block_type = block.get("type")
+
+        # Legacy "thinking" blocks stored before normalization was introduced.
+        # Claude API requires signature on every thinking block, so drop
+        # legacy blocks that lack one.
+        if block_type == _LEGACY_ANTHROPIC_TYPE:
+            if block.get("signature"):
+                result.append(block)
+            continue
+
+        if block_type != _REASONING_TYPE:
             result.append(block)
             continue
 

--- a/chat_shell/chat_shell/messages/think_block_filter.py
+++ b/chat_shell/chat_shell/messages/think_block_filter.py
@@ -137,6 +137,10 @@ def _denormalize_for_openai_responses(content: list) -> list:
          "summary": [{"type": "summary_text", "text": "text"}],
          "encrypted_content": "gAAAA..."}
 
+    Multiple canonical blocks that share the same ``extras.id`` (produced
+    when the original reasoning block had multiple ``summary_text`` items)
+    are merged back into a single Responses API reasoning item.
+
     Blocks without ``extras.id`` or ``extras.encrypted_content`` (i.e. not
     originating from the Responses API) are passed through unchanged.
 
@@ -147,6 +151,10 @@ def _denormalize_for_openai_responses(content: list) -> list:
     """
     result: list = []
     has_reasoning_id = False
+    # Track the last rebuilt reasoning item by id so that consecutive
+    # canonical blocks that were exploded from the same original reasoning
+    # block are merged back into one item with multiple summary_text entries.
+    _last_reasoning_by_id: dict[str, dict[str, Any]] = {}
 
     for block in content:
         if not isinstance(block, dict) or block.get("type") != _REASONING_TYPE:
@@ -174,19 +182,29 @@ def _denormalize_for_openai_responses(content: list) -> list:
             continue
 
         has_reasoning_id = True
+        reasoning_text = block.get("reasoning", "")
+        block_id = extras.get("id")
+
+        # Merge into an existing rebuilt item if one shares the same id
+        if block_id and block_id in _last_reasoning_by_id:
+            _last_reasoning_by_id[block_id]["summary"].append(
+                {"type": "summary_text", "text": reasoning_text}
+            )
+            continue
 
         # Reconstruct the original Responses API format
         rebuilt: dict[str, Any] = {"type": _REASONING_TYPE}
-        if "id" in extras:
-            rebuilt["id"] = extras["id"]
+        if block_id:
+            rebuilt["id"] = block_id
 
-        reasoning_text = block.get("reasoning", "")
         rebuilt["summary"] = [{"type": "summary_text", "text": reasoning_text}]
 
         if "encrypted_content" in extras:
             rebuilt["encrypted_content"] = extras["encrypted_content"]
 
         result.append(rebuilt)
+        if block_id:
+            _last_reasoning_by_id[block_id] = rebuilt
 
     # If no reasoning block had an id (corrupted/legacy data), strip ``id``
     # from text blocks to prevent orphaned message references that the

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -326,7 +326,7 @@ class TestStripForeignReasoningBlocks:
         assert messages[0]["content"] == original_content
 
     def test_openai_same_provider_multiple_reasoning_blocks(self):
-        """Multiple exploded reasoning blocks are each reconstructed."""
+        """Multiple exploded reasoning blocks with same id are merged back."""
         messages = [
             {
                 "role": "assistant",
@@ -352,16 +352,13 @@ class TestStripForeignReasoningBlocks:
         assert result[0]["content"][0] == {
             "type": "reasoning",
             "id": "rs_1",
-            "summary": [{"type": "summary_text", "text": "Step 1"}],
+            "summary": [
+                {"type": "summary_text", "text": "Step 1"},
+                {"type": "summary_text", "text": "Step 2"},
+            ],
             "encrypted_content": "enc1",
         }
-        assert result[0]["content"][1] == {
-            "type": "reasoning",
-            "id": "rs_1",
-            "summary": [{"type": "summary_text", "text": "Step 2"}],
-            "encrypted_content": "enc1",
-        }
-        assert result[0]["content"][2] == {"type": "text", "text": "answer"}
+        assert result[0]["content"][1] == {"type": "text", "text": "answer"}
 
     def test_openai_same_provider_orphaned_text_id_stripped(self):
         """When reasoning blocks lack extras (corrupted data), text block ids are stripped.

--- a/chat_shell/tests/test_think_block_filter.py
+++ b/chat_shell/tests/test_think_block_filter.py
@@ -101,12 +101,49 @@ class TestStripForeignReasoningBlocks:
                 ],
             },
         ]
-        # Same provider (anthropic inferred) -> keep
+        # Same provider (anthropic inferred): legacy thinking without signature
+        # should be dropped to prevent 400 errors from Claude API.
         result = strip_foreign_reasoning_blocks(messages, "anthropic")
-        assert len(result[0]["content"]) == 2
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
 
         # Different provider -> strip
         result = strip_foreign_reasoning_blocks(messages, "openai")
+        assert result[0]["content"] == [{"type": "text", "text": "answer"}]
+
+    def test_legacy_thinking_block_with_signature_preserved(self):
+        """Legacy thinking blocks WITH signature are preserved on same-provider."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "thinking",
+                        "thinking": "old format with sig",
+                        "signature": "valid_sig_abc",
+                    },
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        content = result[0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "thinking"
+        assert content[0]["signature"] == "valid_sig_abc"
+
+    def test_legacy_thinking_block_without_signature_dropped(self):
+        """Legacy thinking blocks WITHOUT signature are dropped on same-provider."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "no sig", "index": 0},
+                    {"type": "text", "text": "answer"},
+                ],
+            },
+        ]
+        result = strip_foreign_reasoning_blocks(messages, "anthropic")
+        # Thinking block without signature dropped; text block remains
         assert result[0]["content"] == [{"type": "text", "text": "answer"}]
 
     def test_legacy_reasoning_content_in_additional_kwargs(self):


### PR DESCRIPTION
## Summary
- drop legacy Anthropic `thinking` blocks that do not carry a `signature`, while preserving valid signed legacy blocks
- merge canonical reasoning blocks that share the same `extras.id` back into a single Responses API reasoning item with multiple `summary_text` entries
- add regression coverage for legacy Claude history replay and duplicate OpenAI reasoning summary reconstruction

## Why
Older chat histories can still contain pre-normalization `thinking` blocks. Replaying unsigned legacy blocks to Claude can trigger 400 errors because Claude requires a signature on every thinking block. In addition, reasoning blocks that were exploded during normalization should be reconstructed as a single Responses API item when they originated from the same reasoning id.

## Testing
- cd chat_shell && uv run pytest tests/test_think_block_filter.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved processing and consolidation of reasoning blocks for better message handling across multiple AI providers

* **Tests**
  * Updated test cases to validate reasoning block behavior and merging logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->