### PR TITLE
fix(frontend): fix user search dropdown in group member management

### DIFF
--- a/frontend/src/components/common/UserSearchSelect.tsx
+++ b/frontend/src/components/common/UserSearchSelect.tsx
@@ -148,7 +148,9 @@ export function UserSearchSelect<T extends SearchUser = SearchUser>({
             value={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
             onFocus={() => {
-              if (searchResults.length > 0) {
+              // Show dropdown if there are search results or if user has typed something
+              // (to show "no results" or "loading" state)
+              if (searchResults.length > 0 || searchQuery.trim()) {
                 setShowDropdown(true)
               }
             }}

--- a/frontend/src/components/common/UserSearchSelect.tsx
+++ b/frontend/src/components/common/UserSearchSelect.tsx
@@ -64,16 +64,19 @@ export function UserSearchSelect<T extends SearchUser = SearchUser>({
 
   // Search users with 300ms debounce
   useEffect(() => {
-    if (!searchQuery.trim()) {
+    const trimmedQuery = searchQuery.trim()
+    if (!trimmedQuery) {
       setSearchResults([])
       setShowDropdown(false)
+      setIsSearching(false)
       return
     }
 
+    // Mark pending immediately so loading state is shown during debounce window
+    setIsSearching(true)
     const timeoutId = setTimeout(async () => {
-      setIsSearching(true)
       try {
-        const response = await userApis.searchUsers(searchQuery)
+        const response = await userApis.searchUsers(trimmedQuery)
         setSearchResults(response.users || [])
         setShowDropdown(true)
       } catch (error) {


### PR DESCRIPTION
## Summary

修复组成员管理界面输入名称无法关联出用户的问题。

## Problem

在组成员管理对话框中，用户搜索下拉框无法正确显示。原因是 `onFocus` 处理器只在有搜索结果时才显示下拉框，但没有考虑到：
1. 用户输入搜索词后，搜索结果通过 300ms debounce 异步加载
2. 如果用户在输入后点击输入框（获得焦点），而此时搜索结果尚未返回，下拉框不会显示

## Solution

修改 `UserSearchSelect` 组件中的 `onFocus` 处理器，当输入框有内容时也显示下拉框，确保"加载中"和"无结果"状态能正确显示。

## Changes

- `frontend/src/components/common/UserSearchSelect.tsx`: 更新 `onFocus` 条件

## Test Plan

- [ ] 打开组管理界面，点击"添加成员"
- [ ] 在搜索框输入用户名，验证下拉框是否正确显示搜索结果
- [ ] 输入不存在的用户名，验证是否显示"无结果"提示
- [ ] 快速输入后点击输入框，验证下拉框是否正确显示加载状态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search input now ignores extra whitespace and clears results when empty.
  * Loading and "no results" states display correctly while searching.
  * Focusing the search input shows the dropdown when a trimmed query is present so users see loading/no-results feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->