### PR TITLE
fix(backend): add missing flag_modified import in check_due_subscript…

### DIFF
--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -700,6 +700,8 @@ def check_due_subscriptions(self):
 
     Runs every FLOW_SCHEDULER_INTERVAL_SECONDS (default: 60 seconds).
     """
+    from sqlalchemy.orm.attributes import flag_modified
+
     from app.core.distributed_lock import distributed_lock
     from app.db.session import get_db_session
     from app.models.kind import Kind


### PR DESCRIPTION
…ions

The check_due_subscriptions function used flag_modified() without importing it, causing NameError on every scheduler cycle and breaking all subscription auto-triggers. Introduced in #950.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription expiration handling to ensure subscription updates are correctly saved during background processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->