### PR TITLE
feat(chat_shell): add WebFetchTool for HTTP download capability

### DIFF
--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -779,6 +779,13 @@ class ChatContext:
                 search_engine,
                 default_max_results,
             )
+        # Add WebFetchTool for HTTP requests (enables two-step download flows
+        # like DingTalk download_file where MCP returns URL + headers)
+        from chat_shell.tools.builtin import WebFetchTool
+
+        extra_tools.append(WebFetchTool())
+        logger.debug("[CHAT_CONTEXT] Added WebFetchTool")
+
         # Add DataTableTool if table_contexts provided
         logger.debug(
             "[CHAT_CONTEXT] Checking table_contexts: has_table_contexts=%s, count=%d",

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -11,9 +11,11 @@ from .knowledge_base import KnowledgeBaseTool
 from .knowledge_listing import KbHeadTool, KbLsTool, KBToolCallCounter
 from .load_skill import LoadSkillTool
 from .silent_exit import SilentExitException
+from .web_fetch import WebFetchTool
 from .web_search import WebSearchTool
 
 __all__ = [
+    "WebFetchTool",
     "WebSearchTool",
     "KnowledgeBaseTool",
     "KbLsTool",

--- a/chat_shell/chat_shell/tools/builtin/web_fetch.py
+++ b/chat_shell/chat_shell/tools/builtin/web_fetch.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Web fetch tool for making HTTP requests.
+
+Provides the WebFetchTool that allows AI agents to make HTTP requests
+with custom headers. This is essential for two-step download flows
+(e.g., DingTalk document download) where an MCP tool returns a URL
+and the agent must perform the actual HTTP GET.
+"""
+
+import base64
+import json
+import logging
+from typing import Optional
+
+import httpx
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+# Limits
+MAX_RESPONSE_SIZE = 10 * 1024 * 1024  # 10 MB
+MAX_TEXT_PREVIEW = 50_000  # 50K chars for text responses
+DEFAULT_TIMEOUT = 30.0  # seconds
+
+# Content types considered as text
+TEXT_CONTENT_TYPES = {
+    "text/",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-yaml",
+    "application/yaml",
+    "application/xhtml+xml",
+    "application/svg+xml",
+}
+
+
+def _is_text_content_type(content_type: str) -> bool:
+    """Check if the content type is text-based."""
+    ct_lower = content_type.lower()
+    return any(ct_lower.startswith(t) for t in TEXT_CONTENT_TYPES)
+
+
+class WebFetchInput(BaseModel):
+    """Input schema for the web fetch tool."""
+
+    url: str = Field(description="The URL to fetch")
+    method: str = Field(
+        default="GET",
+        description="HTTP method (GET or POST)",
+    )
+    headers: Optional[dict[str, str]] = Field(
+        default=None,
+        description="Custom HTTP headers as key-value pairs",
+    )
+    body: Optional[str] = Field(
+        default=None,
+        description="Request body for POST requests",
+    )
+    timeout: Optional[float] = Field(
+        default=None,
+        description="Request timeout in seconds (default: 30)",
+    )
+
+
+class WebFetchTool(BaseTool):
+    """Fetch content from a URL with custom headers.
+
+    Makes HTTP GET or POST requests and returns the response content.
+    For text responses, returns the content directly.
+    For binary responses, returns base64-encoded content with metadata.
+
+    This tool enables two-step download flows where an MCP tool
+    (e.g., DingTalk download_file) returns a URL and headers,
+    and the agent needs to perform the actual HTTP request.
+    """
+
+    name: str = "web_fetch"
+    display_name: str = "Web Fetch"
+    description: str = (
+        "Fetch content from a URL using HTTP GET or POST. "
+        "Supports custom headers for authenticated requests. "
+        "Returns text content directly or base64-encoded binary data. "
+        "Use this when you need to download files or fetch web content "
+        "with specific headers (e.g., after getting download credentials "
+        "from an MCP tool)."
+    )
+    args_schema: type[BaseModel] = WebFetchInput
+
+    def _run(
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict[str, str]] = None,
+        body: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **_,
+    ) -> str:
+        """Synchronous execution (delegates to async)."""
+        import asyncio
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            # Running inside an event loop, use sync httpx
+            return self._run_sync(url, method, headers, body, timeout)
+        return asyncio.run(self._arun(url, method, headers, body, timeout))
+
+    def _run_sync(
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict[str, str]] = None,
+        body: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> str:
+        """Synchronous HTTP request."""
+        effective_timeout = timeout or DEFAULT_TIMEOUT
+        method_upper = method.upper()
+
+        if method_upper not in ("GET", "POST"):
+            return json.dumps({"error": "Only GET and POST methods are supported"})
+
+        try:
+            with httpx.Client(
+                timeout=effective_timeout,
+                follow_redirects=True,
+                max_redirects=5,
+            ) as client:
+                if method_upper == "POST":
+                    response = client.post(
+                        url,
+                        headers=headers,
+                        content=body.encode("utf-8") if body else None,
+                    )
+                else:
+                    response = client.get(url, headers=headers)
+
+            return self._format_response(response, url)
+
+        except httpx.TimeoutException:
+            return json.dumps(
+                {"error": f"Request timed out after {effective_timeout}s"}
+            )
+        except httpx.TooManyRedirects:
+            return json.dumps({"error": "Too many redirects"})
+        except Exception as e:
+            logger.warning("[WebFetchTool] Request failed: url=%s error=%s", url, e)
+            return json.dumps({"error": f"Request failed: {str(e)}"})
+
+    async def _arun(
+        self,
+        url: str,
+        method: str = "GET",
+        headers: Optional[dict[str, str]] = None,
+        body: Optional[str] = None,
+        timeout: Optional[float] = None,
+        **_,
+    ) -> str:
+        """Async HTTP request."""
+        effective_timeout = timeout or DEFAULT_TIMEOUT
+        method_upper = method.upper()
+
+        if method_upper not in ("GET", "POST"):
+            return json.dumps({"error": "Only GET and POST methods are supported"})
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=effective_timeout,
+                follow_redirects=True,
+                max_redirects=5,
+            ) as client:
+                if method_upper == "POST":
+                    response = await client.post(
+                        url,
+                        headers=headers,
+                        content=body.encode("utf-8") if body else None,
+                    )
+                else:
+                    response = await client.get(url, headers=headers)
+
+            return self._format_response(response, url)
+
+        except httpx.TimeoutException:
+            return json.dumps(
+                {"error": f"Request timed out after {effective_timeout}s"}
+            )
+        except httpx.TooManyRedirects:
+            return json.dumps({"error": "Too many redirects"})
+        except Exception as e:
+            logger.warning("[WebFetchTool] Request failed: url=%s error=%s", url, e)
+            return json.dumps({"error": f"Request failed: {str(e)}"})
+
+    def _format_response(self, response: httpx.Response, url: str) -> str:
+        """Format HTTP response for LLM consumption."""
+        status_code = response.status_code
+        content_type = response.headers.get("content-type", "")
+        content_length = len(response.content)
+
+        if status_code >= 400:
+            error_body = ""
+            try:
+                error_body = response.text[:1000]
+            except Exception:
+                pass
+            return json.dumps(
+                {
+                    "error": f"HTTP {status_code}",
+                    "status_code": status_code,
+                    "body_preview": error_body,
+                },
+                ensure_ascii=False,
+            )
+
+        if content_length > MAX_RESPONSE_SIZE:
+            return json.dumps(
+                {
+                    "error": f"Response too large: {content_length} bytes (max {MAX_RESPONSE_SIZE})",
+                    "status_code": status_code,
+                    "content_type": content_type,
+                    "content_length": content_length,
+                }
+            )
+
+        # Text response
+        if _is_text_content_type(content_type):
+            text = response.text
+            truncated = len(text) > MAX_TEXT_PREVIEW
+            return json.dumps(
+                {
+                    "status_code": status_code,
+                    "content_type": content_type,
+                    "content": text[:MAX_TEXT_PREVIEW],
+                    "truncated": truncated,
+                    "content_length": content_length,
+                },
+                ensure_ascii=False,
+            )
+
+        # Binary response - return base64
+        encoded = base64.b64encode(response.content).decode("ascii")
+        return json.dumps(
+            {
+                "status_code": status_code,
+                "content_type": content_type,
+                "content_base64": encoded,
+                "content_length": content_length,
+                "encoding": "base64",
+            }
+        )

--- a/chat_shell/tests/test_web_fetch.py
+++ b/chat_shell/tests/test_web_fetch.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the WebFetchTool."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from chat_shell.tools.builtin.web_fetch import (
+    MAX_TEXT_PREVIEW,
+    WebFetchTool,
+    _is_text_content_type,
+)
+
+
+class TestIsTextContentType:
+    """Tests for _is_text_content_type helper."""
+
+    def test_text_html(self):
+        assert _is_text_content_type("text/html; charset=utf-8") is True
+
+    def test_text_plain(self):
+        assert _is_text_content_type("text/plain") is True
+
+    def test_application_json(self):
+        assert _is_text_content_type("application/json") is True
+
+    def test_application_xml(self):
+        assert _is_text_content_type("application/xml") is True
+
+    def test_application_pdf(self):
+        assert _is_text_content_type("application/pdf") is False
+
+    def test_image_png(self):
+        assert _is_text_content_type("image/png") is False
+
+    def test_octet_stream(self):
+        assert _is_text_content_type("application/octet-stream") is False
+
+
+class TestWebFetchTool:
+    """Tests for WebFetchTool."""
+
+    def setup_method(self):
+        self.tool = WebFetchTool()
+
+    def test_tool_name(self):
+        assert self.tool.name == "web_fetch"
+
+    def test_unsupported_method(self):
+        result = json.loads(self.tool._run_sync("https://example.com", method="DELETE"))
+        assert "error" in result
+        assert "Only GET and POST" in result["error"]
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_successful_text_response(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/html; charset=utf-8"}
+        mock_response.text = "<html><body>Hello</body></html>"
+        mock_response.content = b"<html><body>Hello</body></html>"
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(
+            self.tool._run_sync("https://example.com", headers={"X-Test": "value"})
+        )
+
+        assert result["status_code"] == 200
+        assert "content" in result
+        assert "Hello" in result["content"]
+        assert result["truncated"] is False
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_successful_json_response(self, mock_client_cls):
+        body = json.dumps({"data": "test"})
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = body
+        mock_response.content = body.encode()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(self.tool._run_sync("https://api.example.com/data"))
+
+        assert result["status_code"] == 200
+        assert "content" in result
+        assert '"data"' in result["content"]
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_binary_response_base64(self, mock_client_cls):
+        binary_content = b"\x89PNG\r\n\x1a\n\x00"
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "image/png"}
+        mock_response.content = binary_content
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(self.tool._run_sync("https://example.com/image.png"))
+
+        assert result["status_code"] == 200
+        assert "content_base64" in result
+        assert result["encoding"] == "base64"
+        assert result["content_type"] == "image/png"
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_http_error_response(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.text = "Not Found"
+        mock_response.content = b"Not Found"
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(self.tool._run_sync("https://example.com/missing"))
+
+        assert result["status_code"] == 404
+        assert "error" in result
+        assert "HTTP 404" in result["error"]
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_timeout_error(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = httpx.TimeoutException("Connection timed out")
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(self.tool._run_sync("https://slow.example.com", timeout=5))
+
+        assert "error" in result
+        assert "timed out" in result["error"]
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_post_request(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = '{"result": "ok"}'
+        mock_response.content = b'{"result": "ok"}'
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(
+            self.tool._run_sync(
+                "https://api.example.com/submit",
+                method="POST",
+                body='{"key": "value"}',
+            )
+        )
+
+        assert result["status_code"] == 200
+        mock_client.post.assert_called_once()
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_custom_headers_passed(self, mock_client_cls):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.text = "{}"
+        mock_response.content = b"{}"
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        custom_headers = {
+            "Authorization": "Bearer token123",
+            "X-Custom-Header": "value",
+        }
+        self.tool._run_sync("https://api.example.com", headers=custom_headers)
+
+        mock_client.get.assert_called_once_with(
+            "https://api.example.com", headers=custom_headers
+        )
+
+    @patch("chat_shell.tools.builtin.web_fetch.httpx.Client")
+    def test_truncated_large_text(self, mock_client_cls):
+        large_text = "x" * (MAX_TEXT_PREVIEW + 1000)
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.text = large_text
+        mock_response.content = large_text.encode()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        result = json.loads(self.tool._run_sync("https://example.com/large"))
+
+        assert result["truncated"] is True
+        assert len(result["content"]) == MAX_TEXT_PREVIEW
+
+
+class TestWebFetchToolAsync:
+    """Tests for async WebFetchTool methods."""
+
+    def setup_method(self):
+        self.tool = WebFetchTool()
+
+    @pytest.mark.asyncio
+    async def test_async_text_response(self):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"content-type": "text/plain"}
+        mock_response.text = "Hello async"
+        mock_response.content = b"Hello async"
+
+        with patch("chat_shell.tools.builtin.web_fetch.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_cls.return_value = mock_client
+
+            result = json.loads(await self.tool._arun("https://example.com"))
+
+            assert result["status_code"] == 200
+            assert result["content"] == "Hello async"
+
+    @pytest.mark.asyncio
+    async def test_async_unsupported_method(self):
+        result = json.loads(await self.tool._arun("https://example.com", method="PUT"))
+        assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_async_timeout(self):
+        with patch("chat_shell.tools.builtin.web_fetch.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+            mock_cls.return_value = mock_client
+
+            result = json.loads(await self.tool._arun("https://slow.example.com"))
+
+            assert "error" in result
+            assert "timed out" in result["error"]


### PR DESCRIPTION
## Summary

Chat shell tasks lacked the ability to make HTTP requests with custom headers, which is required for two-step download flows like DingTalk download_file where the MCP tool returns a URL and signed headers that the agent must use to perform the actual HTTP GET.

Without this tool, chat_shell could not complete file downloads from DingTalk documents because no sandbox existed to execute curl commands.

## Changes

1. **chat_shell/chat_shell/tools/builtin/web_fetch.py** (new):
   - Add WebFetchTool builtin tool supporting GET/POST with custom headers
   - Return text content directly or base64-encode binary responses
   - Handle timeouts, redirects, and HTTP errors gracefully
   - Support both sync and async execution modes

2. **chat_shell/chat_shell/tools/builtin/__init__.py**:
   - Export WebFetchTool from builtin tools module

3. **chat_shell/chat_shell/services/context.py**:
   - Register WebFetchTool in chat context tool loading for all enabled tasks

4. **chat_shell/tests/test_web_fetch.py** (new):
   - Add 20 comprehensive test cases covering text/binary responses, error handling, etc.

## Test Plan

- [x] All 482 chat_shell tests pass (including 20 new WebFetchTool tests)
- [x] Code formatted with black and isort

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a web fetch tool enabling HTTP requests (GET/POST) with customizable headers, request body, and timeout settings. Supports fetching and displaying both text and binary content from web URLs. Includes error handling for timeouts, HTTP failures, and unsupported methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->