### PR TITLE
feat(backend): add object storage API for skill artifact upload/download

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -60,6 +60,7 @@ from app.api.endpoints.internal import bots_router as internal_bots_router
 from app.api.endpoints.internal import (
     callback_router,
     chat_storage_router,
+    object_storage_router,
     rag_content_router,
     services_router,
     skills_router,
@@ -217,6 +218,11 @@ api_router.include_router(
 )
 api_router.include_router(
     services_router, prefix="/internal", tags=["internal-services"]
+)
+api_router.include_router(
+    object_storage_router,
+    prefix="/internal",
+    tags=["internal-object-storage"],
 )
 api_router.include_router(
     workspace_archives_router,

--- a/backend/app/api/endpoints/internal/__init__.py
+++ b/backend/app/api/endpoints/internal/__init__.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from .bots import router as bots_router
 from .callback import router as callback_router
 from .chat_storage import router as chat_storage_router
+from .object_storage import router as object_storage_router
 from .rag_content import router as rag_content_router
 from .services import router as services_router
 from .skills import router as skills_router
@@ -25,6 +26,7 @@ __all__ = [
     "bots_router",
     "callback_router",
     "chat_storage_router",
+    "object_storage_router",
     "rag_content_router",
     "services_router",
     "skills_router",

--- a/backend/app/api/endpoints/internal/object_storage.py
+++ b/backend/app/api/endpoints/internal/object_storage.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal object storage endpoints."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core import security
+from app.services.object_storage import (
+    InvalidObjectNameError,
+    InvalidSkillIdentityError,
+    ObjectStorageDownloadGrant,
+    ObjectStoragePermissionError,
+    TaskScopeNotFoundError,
+    object_storage_upload_grant_service,
+)
+
+router = APIRouter(prefix="/object-storage", tags=["internal-object-storage"])
+
+
+class UploadURLRequest(BaseModel):
+    """Request a presigned upload URL for one object."""
+
+    task_id: int = Field(..., description="Task ID owning the storage scope")
+    object_name: str = Field(..., description="Artifact file name, for example app.zip")
+    skill_identity_token: str = Field(..., description="Skill identity JWT")
+
+
+class UploadURLResponse(BaseModel):
+    """Presigned upload URL response."""
+
+    upload_url: str
+    object_key: str
+    expires_at: datetime
+
+
+class DownloadURLRequest(BaseModel):
+    """Request a presigned download URL for one object."""
+
+    task_id: int = Field(..., description="Task ID owning the storage scope")
+    object_name: str = Field(..., description="Artifact file name, for example app.zip")
+    skill_identity_token: str = Field(..., description="Skill identity JWT")
+
+
+class DownloadURLResponse(BaseModel):
+    """Presigned download URL response."""
+
+    download_url: str
+    object_key: str
+    expires_at: datetime
+
+
+@router.post("/upload-url", response_model=UploadURLResponse)
+def create_upload_url(
+    request: UploadURLRequest,
+    db: Session = Depends(get_db),
+    auth_context: security.AuthContext = Depends(security.get_auth_context),
+) -> UploadURLResponse:
+    """Issue a presigned upload URL scoped to one object."""
+    try:
+        grant = object_storage_upload_grant_service.create_upload_grant(
+            db=db,
+            auth_context=auth_context,
+            skill_identity_token=request.skill_identity_token,
+            task_id=request.task_id,
+            object_name=request.object_name,
+        )
+    except InvalidObjectNameError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except InvalidSkillIdentityError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ObjectStoragePermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except TaskScopeNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return UploadURLResponse(
+        upload_url=grant.upload_url,
+        object_key=grant.object_key,
+        expires_at=grant.expires_at,
+    )
+
+
+@router.post("/download-url", response_model=DownloadURLResponse)
+def create_download_url(
+    request: DownloadURLRequest,
+    db: Session = Depends(get_db),
+    auth_context: security.AuthContext = Depends(security.get_auth_context),
+) -> DownloadURLResponse:
+    """Issue a presigned download URL scoped to one object."""
+    try:
+        grant: ObjectStorageDownloadGrant = (
+            object_storage_upload_grant_service.create_download_grant(
+                db=db,
+                auth_context=auth_context,
+                skill_identity_token=request.skill_identity_token,
+                task_id=request.task_id,
+                object_name=request.object_name,
+            )
+        )
+    except InvalidObjectNameError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except InvalidSkillIdentityError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except ObjectStoragePermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except TaskScopeNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return DownloadURLResponse(
+        download_url=grant.download_url,
+        object_key=grant.object_key,
+        expires_at=grant.expires_at,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -179,6 +179,9 @@ class Settings(BaseSettings):
     WORKSPACE_ARCHIVE_ENABLED: bool = True
     WORKSPACE_ARCHIVE_TIMEZONE: str = "Asia/Shanghai"
 
+    # Publish storage configuration
+    PUBLISH_PRESIGNED_UPLOAD_EXPIRE_SECONDS: int = 3600
+
     # Frontend URL configuration
     FRONTEND_URL: str = "http://localhost:3000"
 

--- a/backend/app/services/object_storage/__init__.py
+++ b/backend/app/services/object_storage/__init__.py
@@ -9,9 +9,9 @@ from app.services.object_storage.presign_service import (
     object_storage_presign_service,
 )
 from app.services.object_storage.upload_grant_service import (
-    ObjectStorageDownloadGrant,
     InvalidObjectNameError,
     InvalidSkillIdentityError,
+    ObjectStorageDownloadGrant,
     ObjectStoragePermissionError,
     ObjectStorageUploadGrant,
     TaskScopeNotFoundError,

--- a/backend/app/services/object_storage/__init__.py
+++ b/backend/app/services/object_storage/__init__.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Object storage services."""
+
+from app.services.object_storage.presign_service import (
+    ObjectStoragePresignService,
+    object_storage_presign_service,
+)
+from app.services.object_storage.upload_grant_service import (
+    ObjectStorageDownloadGrant,
+    InvalidObjectNameError,
+    InvalidSkillIdentityError,
+    ObjectStoragePermissionError,
+    ObjectStorageUploadGrant,
+    TaskScopeNotFoundError,
+    object_storage_upload_grant_service,
+)
+
+__all__ = [
+    "InvalidObjectNameError",
+    "InvalidSkillIdentityError",
+    "ObjectStorageDownloadGrant",
+    "ObjectStoragePermissionError",
+    "ObjectStoragePresignService",
+    "ObjectStorageUploadGrant",
+    "TaskScopeNotFoundError",
+    "object_storage_presign_service",
+    "object_storage_upload_grant_service",
+]

--- a/backend/app/services/object_storage/presign_service.py
+++ b/backend/app/services/object_storage/presign_service.py
@@ -1,0 +1,95 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Presigned URL generation for object storage."""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from minio import Minio
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class ObjectStoragePresignService:
+    """Generate presigned object storage URLs using attachment S3 settings."""
+
+    def __init__(self) -> None:
+        self._client: Optional[Minio] = None
+
+    @property
+    def client(self) -> Minio:
+        """Lazy initialize a MinIO client from attachment S3 configuration."""
+        if self._client is None:
+            endpoint = settings.ATTACHMENT_S3_ENDPOINT
+            access_key = settings.ATTACHMENT_S3_ACCESS_KEY
+            secret_key = settings.ATTACHMENT_S3_SECRET_KEY
+
+            if not endpoint or not access_key or not secret_key:
+                raise ValueError(
+                    "MinIO configuration not set. "
+                    "Set ATTACHMENT_S3_ENDPOINT, ATTACHMENT_S3_ACCESS_KEY, "
+                    "and ATTACHMENT_S3_SECRET_KEY environment variables."
+                )
+
+            secure = settings.ATTACHMENT_S3_USE_SSL
+            host = endpoint.replace("https://", "").replace("http://", "")
+
+            self._client = Minio(
+                host,
+                access_key=access_key,
+                secret_key=secret_key,
+                secure=secure,
+                region=settings.ATTACHMENT_S3_REGION,
+            )
+
+        return self._client
+
+    def generate_upload_url(
+        self,
+        *,
+        bucket: str,
+        object_key: str,
+        expires_seconds: int,
+    ) -> tuple[str, datetime]:
+        """Generate a presigned PUT URL for one object."""
+        upload_url = self.client.presigned_put_object(
+            bucket,
+            object_key,
+            expires=timedelta(seconds=expires_seconds),
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_seconds)
+        logger.info(
+            "Generated presigned upload URL for bucket=%s key=%s",
+            bucket,
+            object_key,
+        )
+        return upload_url, expires_at
+
+    def generate_download_url(
+        self,
+        *,
+        bucket: str,
+        object_key: str,
+        expires_seconds: int,
+    ) -> tuple[str, datetime]:
+        """Generate a presigned GET URL for one object."""
+        download_url = self.client.presigned_get_object(
+            bucket,
+            object_key,
+            expires=timedelta(seconds=expires_seconds),
+        )
+        expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_seconds)
+        logger.info(
+            "Generated presigned download URL for bucket=%s key=%s",
+            bucket,
+            object_key,
+        )
+        return download_url, expires_at
+
+
+object_storage_presign_service = ObjectStoragePresignService()

--- a/backend/app/services/object_storage/upload_grant_service.py
+++ b/backend/app/services/object_storage/upload_grant_service.py
@@ -1,0 +1,197 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Issue scoped object storage URL grants."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import PurePosixPath
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.security import AuthContext
+from app.models.task import TaskResource
+from app.services.auth import verify_skill_identity_token
+from app.services.object_storage import object_storage_presign_service
+
+
+class ObjectStorageGrantError(Exception):
+    """Base class for object storage grant errors."""
+
+
+class InvalidSkillIdentityError(ObjectStorageGrantError):
+    """Raised when the skill identity token is invalid."""
+
+
+class ObjectStoragePermissionError(ObjectStorageGrantError):
+    """Raised when the caller is not allowed to access the storage scope."""
+
+
+class InvalidObjectNameError(ObjectStorageGrantError):
+    """Raised when the requested object name is unsafe."""
+
+
+class TaskScopeNotFoundError(ObjectStorageGrantError):
+    """Raised when the requested task does not exist or is not accessible."""
+
+
+@dataclass
+class ObjectStorageUploadGrant:
+    """Presigned upload grant for one object."""
+
+    upload_url: str
+    object_key: str
+    expires_at: datetime
+
+
+@dataclass
+class ObjectStorageDownloadGrant:
+    """Presigned download grant for one object."""
+
+    download_url: str
+    object_key: str
+    expires_at: datetime
+
+
+class ObjectStorageUploadGrantService:
+    """Validate task scope and mint scoped object storage URLs."""
+
+    def create_upload_grant(
+        self,
+        *,
+        db: Session,
+        auth_context: AuthContext,
+        skill_identity_token: str,
+        task_id: int,
+        object_name: str,
+    ) -> ObjectStorageUploadGrant:
+        object_key = self._resolve_object_key(
+            db=db,
+            auth_context=auth_context,
+            skill_identity_token=skill_identity_token,
+            task_id=task_id,
+            object_name=object_name,
+        )
+        upload_url, expires_at = object_storage_presign_service.generate_upload_url(
+            bucket=settings.WORKSPACE_ARCHIVE_BUCKET,
+            object_key=object_key,
+            expires_seconds=settings.PUBLISH_PRESIGNED_UPLOAD_EXPIRE_SECONDS,
+        )
+        return ObjectStorageUploadGrant(
+            upload_url=upload_url,
+            object_key=object_key,
+            expires_at=expires_at,
+        )
+
+    def create_download_grant(
+        self,
+        *,
+        db: Session,
+        auth_context: AuthContext,
+        skill_identity_token: str,
+        task_id: int,
+        object_name: str,
+    ) -> ObjectStorageDownloadGrant:
+        object_key = self._resolve_object_key(
+            db=db,
+            auth_context=auth_context,
+            skill_identity_token=skill_identity_token,
+            task_id=task_id,
+            object_name=object_name,
+        )
+        download_url, expires_at = object_storage_presign_service.generate_download_url(
+            bucket=settings.WORKSPACE_ARCHIVE_BUCKET,
+            object_key=object_key,
+            expires_seconds=settings.PUBLISH_PRESIGNED_UPLOAD_EXPIRE_SECONDS,
+        )
+        return ObjectStorageDownloadGrant(
+            download_url=download_url,
+            object_key=object_key,
+            expires_at=expires_at,
+        )
+
+    @staticmethod
+    def generate_publish_object_key(
+        *, user_name: str, task_id: int, object_name: str
+    ) -> str:
+        """Build the canonical publish object key."""
+        safe_name = PurePosixPath(object_name).name
+        return f"publish/{user_name}/{task_id}/{safe_name}"
+
+    @staticmethod
+    def _validate_object_name(object_name: str) -> str:
+        candidate = object_name.strip()
+        if not candidate:
+            raise InvalidObjectNameError("Object name is required")
+        if "\\" in candidate:
+            raise InvalidObjectNameError("Object name must not contain path separators")
+
+        normalized = PurePosixPath(candidate).name
+        if normalized != candidate or candidate in {".", ".."}:
+            raise InvalidObjectNameError("Object name must be a single file name")
+
+        return normalized
+
+    def _resolve_object_key(
+        self,
+        *,
+        db: Session,
+        auth_context: AuthContext,
+        skill_identity_token: str,
+        task_id: int,
+        object_name: str,
+    ) -> str:
+        self._validate_skill_identity(
+            auth_context=auth_context,
+            skill_identity_token=skill_identity_token,
+        )
+        safe_object_name = self._validate_object_name(object_name)
+        self._require_task_scope(db=db, auth_context=auth_context, task_id=task_id)
+        return self.generate_publish_object_key(
+            user_name=auth_context.user.user_name,
+            task_id=task_id,
+            object_name=safe_object_name,
+        )
+
+    @staticmethod
+    def _validate_skill_identity(
+        *,
+        auth_context: AuthContext,
+        skill_identity_token: str,
+    ) -> None:
+        token_info = verify_skill_identity_token(skill_identity_token)
+        if token_info is None:
+            raise InvalidSkillIdentityError("Invalid skill identity token")
+
+        if (
+            token_info.user_id != auth_context.user.id
+            or token_info.user_name != auth_context.user.user_name
+        ):
+            raise ObjectStoragePermissionError(
+                "Skill identity token does not match the authenticated user"
+            )
+
+    @staticmethod
+    def _require_task_scope(
+        *,
+        db: Session,
+        auth_context: AuthContext,
+        task_id: int,
+    ) -> None:
+        task = (
+            db.query(TaskResource)
+            .filter(
+                TaskResource.id == task_id,
+                TaskResource.kind == "Task",
+                TaskResource.user_id == auth_context.user.id,
+                TaskResource.is_active.in_(TaskResource.is_active_query()),
+            )
+            .first()
+        )
+        if task is None:
+            raise TaskScopeNotFoundError("Task not found")
+
+
+object_storage_upload_grant_service = ObjectStorageUploadGrantService()

--- a/backend/tests/api/endpoints/internal/test_object_storage_api.py
+++ b/backend/tests/api/endpoints/internal/test_object_storage_api.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for internal object storage API endpoints."""
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.models.task import TaskResource
+from app.models.user import User
+from app.services.auth import create_skill_identity_token
+from app.services.object_storage import object_storage_presign_service
+
+
+def _create_task(test_db: Session, task_id: int, user_id: int) -> TaskResource:
+    task = TaskResource(
+        id=task_id,
+        user_id=user_id,
+        kind="Task",
+        name=f"task-{task_id}",
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Task",
+            "metadata": {"name": f"task-{task_id}", "namespace": "default"},
+            "spec": {},
+            "status": {},
+        },
+        is_active=TaskResource.STATE_ACTIVE,
+        project_id=0,
+        is_group_chat=False,
+    )
+    test_db.add(task)
+    test_db.commit()
+    test_db.refresh(task)
+    return task
+
+
+def _load_object_storage_router():
+    module_path = (
+        Path(__file__).resolve().parents[4]
+        / "app/api/endpoints/internal/object_storage.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "object_storage_endpoint_test_module", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.router
+
+
+@pytest.fixture
+def object_storage_test_client(test_db: Session) -> TestClient:
+    app = FastAPI()
+    app.include_router(_load_object_storage_router(), prefix="/api/internal")
+
+    def override_get_db():
+        try:
+            yield test_db
+        except Exception:
+            test_db.rollback()
+            raise
+
+    app.dependency_overrides[get_db] = override_get_db
+    return TestClient(app)
+
+
+def test_object_storage_upload_url_requires_developer_token(
+    object_storage_test_client: TestClient,
+    test_user: User,
+):
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+
+    response = object_storage_test_client.post(
+        "/api/internal/object-storage/upload-url",
+        json={
+            "task_id": 1,
+            "object_name": "demo.zip",
+            "skill_identity_token": token,
+        },
+    )
+
+    assert response.status_code == 401
+
+
+def test_object_storage_upload_url_returns_presigned_upload(
+    object_storage_test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key,
+    mocker,
+):
+    task = _create_task(test_db, task_id=9753, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    raw_api_key, _ = test_api_key
+    expires_at = datetime(2026, 4, 10, 8, 0, tzinfo=timezone.utc)
+    mocker.patch.object(
+        object_storage_presign_service,
+        "generate_upload_url",
+        return_value=("https://minio.example.com/upload", expires_at),
+    )
+
+    response = object_storage_test_client.post(
+        "/api/internal/object-storage/upload-url",
+        headers={"X-API-Key": raw_api_key},
+        json={
+            "task_id": task.id,
+            "object_name": "demo.zip",
+            "skill_identity_token": token,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "upload_url": "https://minio.example.com/upload",
+        "object_key": f"publish/{test_user.user_name}/{task.id}/demo.zip",
+        "expires_at": "2026-04-10T08:00:00Z",
+    }
+
+
+def test_object_storage_upload_url_rejects_mismatched_skill_identity(
+    object_storage_test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key,
+):
+    task = _create_task(test_db, task_id=9754, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id + 1,
+        user_name="other-user",
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    raw_api_key, _ = test_api_key
+
+    response = object_storage_test_client.post(
+        "/api/internal/object-storage/upload-url",
+        headers={"X-API-Key": raw_api_key},
+        json={
+            "task_id": task.id,
+            "object_name": "demo.zip",
+            "skill_identity_token": token,
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == (
+        "Skill identity token does not match the authenticated user"
+    )
+
+
+def test_object_storage_download_url_returns_presigned_download(
+    object_storage_test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key,
+    mocker,
+):
+    task = _create_task(test_db, task_id=9755, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    raw_api_key, _ = test_api_key
+    expires_at = datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc)
+    mocker.patch.object(
+        object_storage_presign_service,
+        "generate_download_url",
+        return_value=("https://minio.example.com/download", expires_at),
+    )
+
+    response = object_storage_test_client.post(
+        "/api/internal/object-storage/download-url",
+        headers={"X-API-Key": raw_api_key},
+        json={
+            "task_id": task.id,
+            "object_name": "demo.zip",
+            "skill_identity_token": token,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "download_url": "https://minio.example.com/download",
+        "object_key": f"publish/{test_user.user_name}/{task.id}/demo.zip",
+        "expires_at": "2026-04-10T09:00:00Z",
+    }

--- a/backend/tests/mcp_server/test_interactive_form_question.py
+++ b/backend/tests/mcp_server/test_interactive_form_question.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.mcp_server.auth import TaskTokenInfo
-from app.mcp_server.tools.interactive_form_question import _generate_ask_id, interactive_form_question
+from app.mcp_server.tools.interactive_form_question import (
+    _generate_ask_id,
+    interactive_form_question,
+)
 
 
 class TestGenerateAskId:
@@ -46,7 +49,9 @@ class TestInteractiveFormTool:
             "app.mcp_server.tools.interactive_form_question._notify_frontend",
             new_callable=AsyncMock,
         ):
-            result = await interactive_form_question(token_info=token, question="Any question?")
+            result = await interactive_form_question(
+                token_info=token, question="Any question?"
+            )
 
         assert result["__silent_exit__"] is True
         assert "reason" in result
@@ -137,7 +142,8 @@ class TestInteractiveFormTool:
         mock_notify = AsyncMock()
 
         with patch(
-            "app.mcp_server.tools.interactive_form_question._notify_frontend", mock_notify
+            "app.mcp_server.tools.interactive_form_question._notify_frontend",
+            mock_notify,
         ):
             await interactive_form_question(token_info=token, question="Hello?")
 

--- a/backend/tests/services/execution/test_emitters.py
+++ b/backend/tests/services/execution/test_emitters.py
@@ -108,7 +108,6 @@ class TestWebSocketResultEmitter:
             # Should not raise exception
             await emitter.emit_start(task_id=1, subtask_id=1)
 
-
     @pytest.mark.asyncio
     async def test_emit_thinking_event(self):
         """Test emitting THINKING event sends reasoning_chunk via chat:chunk."""
@@ -138,7 +137,9 @@ class TestWebSocketResultEmitter:
             assert call_kwargs["subtask_id"] == 1
             assert call_kwargs["content"] == ""
             assert call_kwargs["offset"] == 0
-            assert call_kwargs["result"] == {"reasoning_chunk": "Let me reason about this..."}
+            assert call_kwargs["result"] == {
+                "reasoning_chunk": "Let me reason about this..."
+            }
 
 
 class TestSSEResultEmitter:

--- a/backend/tests/services/object_storage/test_upload_grant_service.py
+++ b/backend/tests/services/object_storage/test_upload_grant_service.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for object storage upload grant service."""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.security import AuthContext
+from app.models.task import TaskResource
+from app.models.user import User
+from app.services.auth import create_skill_identity_token
+from app.services.object_storage import (
+    InvalidObjectNameError,
+    InvalidSkillIdentityError,
+    ObjectStoragePermissionError,
+    TaskScopeNotFoundError,
+    object_storage_presign_service,
+    object_storage_upload_grant_service,
+)
+
+
+def _create_task(test_db: Session, task_id: int, user_id: int) -> TaskResource:
+    task = TaskResource(
+        id=task_id,
+        user_id=user_id,
+        kind="Task",
+        name=f"task-{task_id}",
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Task",
+            "metadata": {"name": f"task-{task_id}", "namespace": "default"},
+            "spec": {},
+            "status": {},
+        },
+        is_active=TaskResource.STATE_ACTIVE,
+        project_id=0,
+        is_group_chat=False,
+    )
+    test_db.add(task)
+    test_db.commit()
+    test_db.refresh(task)
+    return task
+
+
+def test_create_upload_grant_returns_presigned_upload(
+    test_db: Session,
+    test_user: User,
+    mocker,
+):
+    _create_task(test_db, task_id=2468, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    expires_at = datetime(2026, 4, 10, 8, 0, tzinfo=timezone.utc)
+    generate_upload_url = mocker.patch.object(
+        object_storage_presign_service,
+        "generate_upload_url",
+        return_value=("https://minio.example.com/upload", expires_at),
+    )
+
+    grant = object_storage_upload_grant_service.create_upload_grant(
+        db=test_db,
+        auth_context=AuthContext(user=test_user),
+        skill_identity_token=token,
+        task_id=2468,
+        object_name="demo.zip",
+    )
+
+    assert grant.upload_url == "https://minio.example.com/upload"
+    assert grant.object_key == "publish/testuser/2468/demo.zip"
+    assert grant.expires_at == expires_at
+    assert generate_upload_url.call_args.kwargs["bucket"] == settings.WORKSPACE_ARCHIVE_BUCKET
+
+
+def test_create_download_grant_returns_presigned_download(
+    test_db: Session,
+    test_user: User,
+    mocker,
+):
+    _create_task(test_db, task_id=2469, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    expires_at = datetime(2026, 4, 10, 9, 0, tzinfo=timezone.utc)
+    generate_download_url = mocker.patch.object(
+        object_storage_presign_service,
+        "generate_download_url",
+        return_value=("https://minio.example.com/download", expires_at),
+    )
+
+    grant = object_storage_upload_grant_service.create_download_grant(
+        db=test_db,
+        auth_context=AuthContext(user=test_user),
+        skill_identity_token=token,
+        task_id=2469,
+        object_name="demo.zip",
+    )
+
+    assert grant.download_url == "https://minio.example.com/download"
+    assert grant.object_key == "publish/testuser/2469/demo.zip"
+    assert grant.expires_at == expires_at
+    assert (
+        generate_download_url.call_args.kwargs["bucket"]
+        == settings.WORKSPACE_ARCHIVE_BUCKET
+    )
+
+
+def test_create_upload_grant_rejects_invalid_skill_identity(
+    test_db: Session,
+    test_user: User,
+):
+    with pytest.raises(InvalidSkillIdentityError):
+        object_storage_upload_grant_service.create_upload_grant(
+            db=test_db,
+            auth_context=AuthContext(user=test_user),
+            skill_identity_token="invalid-token",
+            task_id=2468,
+            object_name="demo.zip",
+        )
+
+
+def test_create_upload_grant_rejects_mismatched_identity(
+    test_db: Session,
+    test_user: User,
+):
+    token = create_skill_identity_token(
+        user_id=test_user.id + 1,
+        user_name="other-user",
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+
+    with pytest.raises(ObjectStoragePermissionError):
+        object_storage_upload_grant_service.create_upload_grant(
+            db=test_db,
+            auth_context=AuthContext(user=test_user),
+            skill_identity_token=token,
+            task_id=2468,
+            object_name="demo.zip",
+        )
+
+
+def test_create_upload_grant_rejects_invalid_object_name(
+    test_db: Session,
+    test_user: User,
+):
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+
+    with pytest.raises(InvalidObjectNameError):
+        object_storage_upload_grant_service.create_upload_grant(
+            db=test_db,
+            auth_context=AuthContext(user=test_user),
+            skill_identity_token=token,
+            task_id=2468,
+            object_name="nested/demo.zip",
+        )
+
+
+def test_create_upload_grant_rejects_missing_task(
+    test_db: Session,
+    test_user: User,
+):
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+
+    with pytest.raises(TaskScopeNotFoundError):
+        object_storage_upload_grant_service.create_upload_grant(
+            db=test_db,
+            auth_context=AuthContext(user=test_user),
+            skill_identity_token=token,
+            task_id=9999,
+            object_name="demo.zip",
+        )

--- a/backend/tests/services/object_storage/test_upload_grant_service.py
+++ b/backend/tests/services/object_storage/test_upload_grant_service.py
@@ -78,7 +78,10 @@ def test_create_upload_grant_returns_presigned_upload(
     assert grant.upload_url == "https://minio.example.com/upload"
     assert grant.object_key == "publish/testuser/2468/demo.zip"
     assert grant.expires_at == expires_at
-    assert generate_upload_url.call_args.kwargs["bucket"] == settings.WORKSPACE_ARCHIVE_BUCKET
+    assert (
+        generate_upload_url.call_args.kwargs["bucket"]
+        == settings.WORKSPACE_ARCHIVE_BUCKET
+    )
 
 
 def test_create_download_grant_returns_presigned_download(

--- a/backend/tests/utils/test_prompt_utils.py
+++ b/backend/tests/utils/test_prompt_utils.py
@@ -109,7 +109,10 @@ class TestExtractDisplayPrompt:
         """Legacy selected_documents array: display prompt must be the user question, not system context."""
         prompt = json.dumps(
             [
-                {"type": "text", "text": "<selected_documents>docs</selected_documents>"},
+                {
+                    "type": "text",
+                    "text": "<selected_documents>docs</selected_documents>",
+                },
                 {"type": "text", "text": "real user question"},
             ]
         )
@@ -119,9 +122,15 @@ class TestExtractDisplayPrompt:
         """Legacy selected_documents + user question + system-reminder."""
         prompt = json.dumps(
             [
-                {"type": "text", "text": "<selected_documents>docs</selected_documents>"},
+                {
+                    "type": "text",
+                    "text": "<selected_documents>docs</selected_documents>",
+                },
                 {"type": "text", "text": "What does this mean?"},
-                {"type": "text", "text": "<system-reminder><CurrentTime>2025-01-01</CurrentTime></system-reminder>"},
+                {
+                    "type": "text",
+                    "text": "<system-reminder><CurrentTime>2025-01-01</CurrentTime></system-reminder>",
+                },
             ]
         )
         assert extract_display_prompt(prompt) == "What does this mean?"
@@ -169,7 +178,4 @@ class TestExtractDisplayPrompt:
                 },
             ]
         )
-        assert (
-            extract_display_prompt(prompt)
-            == "What is the weather today?"
-        )
+        assert extract_display_prompt(prompt) == "What is the weather today?"


### PR DESCRIPTION
## Summary

Add internal API endpoints for presigned URL generation to support skill artifact upload and download operations.

## Changes

- Add `ObjectStorageUploadGrantService` for presigned URL generation
- Add `/internal/object-storage/upload-url` endpoint for generating presigned upload URLs
- Add `/internal/object-storage/download-url` endpoint for generating presigned download URLs
- Add `PUBLISH_PRESIGNED_UPLOAD_EXPIRE_SECONDS` configuration option (default: 3600s)
- Add comprehensive tests for the new functionality

## API Endpoints

### POST /internal/object-storage/upload-url
Request a presigned upload URL for skill artifacts.

### POST /internal/object-storage/download-url
Request a presigned download URL for skill artifacts.

## Test Plan
- [ ] Unit tests pass: `cd backend && uv run pytest tests/services/object_storage/ tests/api/endpoints/internal/test_object_storage_api.py`
- [ ] Integration test with actual S3-compatible storage
- [ ] Verify presigned URLs work correctly for upload/download

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added internal presigned URL endpoints for secure object upload and download.
  * Introduced configurable presigned URL expiration (default: 1 hour).
  * Enforced object name validation, skill identity verification, and task scope access control.

* **Chores**
  * Exposed object-storage services through the service package surface.

* **Tests**
  * Added unit and API tests covering presign generation, permission checks, name validation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->