### PR TITLE
feat: v1/responses 接口支持输出reasoning；修复订阅消息一直running的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ coverage/
 executor/build/
 executor/dist/
 docs/superpowers/
+.worktrees/

--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -393,6 +393,11 @@ async def _create_non_streaming_response_unified(
     # This ensures KB tools and skill tools are actually added to the agent
     enable_tools = enable_chat_bot or bool(knowledge_base_names)
 
+    # Convert reasoning config from Pydantic model to dict
+    reasoning_config = None
+    if request_body.reasoning:
+        reasoning_config = request_body.reasoning.model_dump()
+
     # Build execution request
     try:
         execution_request = await build_execution_request(
@@ -407,6 +412,7 @@ async def _create_non_streaming_response_unified(
             enable_web_search=enable_chat_bot and settings.WEB_SEARCH_ENABLED,
             preload_skills=preload_skills,
             knowledge_base_names=knowledge_base_names,
+            reasoning_config=reasoning_config,
         )
     except Exception as e:
         logger.error(f"Failed to build execution request: {e}")
@@ -680,6 +686,11 @@ async def _create_streaming_response_unified(
     # This ensures KB tools and skill tools are actually added to the agent
     enable_tools = enable_chat_bot or bool(knowledge_base_names)
 
+    # Convert reasoning config from Pydantic model to dict
+    reasoning_config = None
+    if request_body.reasoning:
+        reasoning_config = request_body.reasoning.model_dump()
+
     # Build execution request using unified builder
     try:
         execution_request = await build_execution_request(
@@ -694,6 +705,7 @@ async def _create_streaming_response_unified(
             enable_web_search=enable_chat_bot and settings.WEB_SEARCH_ENABLED,
             preload_skills=preload_skills,
             knowledge_base_names=knowledge_base_names,
+            reasoning_config=reasoning_config,
         )
     finally:
         # Close the database session before streaming starts
@@ -704,12 +716,14 @@ async def _create_streaming_response_unified(
         db.close()
 
     async def raw_chat_stream():
-        """Generate raw text chunks from ExecutionDispatcher."""
+        """Generate raw text and reasoning chunks from ExecutionDispatcher."""
         import asyncio
 
         from app.services.execution.emitters import SSEResultEmitter
+        from app.services.openapi.streaming import StreamingChunk
 
         accumulated_content = ""
+        accumulated_reasoning = ""
 
         try:
             cancel_event = await session_manager.register_stream(assistant_subtask_id)
@@ -740,7 +754,13 @@ async def _create_streaming_response_unified(
                         content = event.content or ""
                         if content:
                             accumulated_content += content
-                            yield content
+                            yield StreamingChunk(type="text", content=content)
+                    elif event.type == EventType.THINKING.value:
+                        # Handle reasoning/thinking content
+                        reasoning = event.content or ""
+                        if reasoning:
+                            accumulated_reasoning += reasoning
+                            yield StreamingChunk(type="reasoning", content=reasoning)
                     elif event.type == EventType.ERROR.value:
                         error_msg = event.error or "Unknown error"
                         logger.error(f"[OPENAPI] Error from execution: {error_msg}")
@@ -760,7 +780,11 @@ async def _create_streaming_response_unified(
             if not cancel_event.is_set() and not await session_manager.is_cancelled(
                 assistant_subtask_id
             ):
+                # Include reasoning in result if present
                 result = {"value": accumulated_content}
+                if accumulated_reasoning:
+                    result["reasoning"] = accumulated_reasoning
+
                 await session_manager.save_streaming_content(
                     assistant_subtask_id, accumulated_content
                 )

--- a/backend/app/schemas/openapi_response.py
+++ b/backend/app/schemas/openapi_response.py
@@ -116,6 +116,41 @@ class InputItem(BaseModel):
     content: Union[str, List[InputTextContent]]
 
 
+class ReasoningConfig(BaseModel):
+    """Configuration for model reasoning/thinking.
+
+    Compatible with OpenAI's reasoning configuration for o-series and gpt-5 models.
+
+    Examples:
+        # High reasoning effort (more thorough thinking)
+        {"effort": "high"}
+
+        # Medium reasoning effort (default for most reasoning models)
+        {"effort": "medium"}
+
+        # Low reasoning effort (faster responses)
+        {"effort": "low"}
+
+        # Disable reasoning for gpt-5.1 models
+        {"effort": "none"}
+
+        # With summary output
+        {"effort": "medium", "summary": "concise"}
+    """
+
+    effort: Literal["none", "minimal", "low", "medium", "high", "xhigh"] = Field(
+        default="medium",
+        description="Constrains effort on reasoning. Supported values: 'none', 'minimal', 'low', 'medium', 'high', 'xhigh'. "
+        "Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning. "
+        "gpt-5.1 defaults to 'none'. Models before gpt-5.1 default to 'medium'.",
+    )
+    summary: Literal["auto", "concise", "detailed"] = Field(
+        default="auto",
+        description="A summary of the reasoning performed by the model. "
+        "One of 'auto', 'concise', or 'detailed'.",
+    )
+
+
 class ResponseCreateInput(BaseModel):
     """Request schema for creating a response."""
 
@@ -139,12 +174,17 @@ class ResponseCreateInput(BaseModel):
         default=False,
         description="If True, return immediately with 'in_progress' status and run task in background",
     )
+    reasoning: Optional[ReasoningConfig] = Field(
+        default=None,
+        description="Configuration for model reasoning/thinking. Supported for gpt-5 and o-series models. "
+        "Controls reasoning effort and summary output.",
+    )
 
 
 class OutputTextContent(BaseModel):
     """Text content in output message."""
 
-    type: Literal["output_text"] = "output_text"
+    type: Literal["output_text", "reasoning"] = "output_text"
     text: str
     annotations: List[Any] = Field(default_factory=list)
 

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -362,7 +362,7 @@ class SubscriptionList(BaseModel):
 class SubscriptionBase(BaseModel):
     """Base Subscription model for API."""
 
-    name: str = Field(..., description="Subscription unique identifier")
+    name: Optional[str] = Field(None, description="Subscription unique identifier")
     display_name: str = Field(..., description="Display name")
     description: Optional[str] = Field(None, description="Subscription description")
     task_type: SubscriptionTaskType = Field(

--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -186,6 +186,7 @@ async def build_execution_request(
     preload_skills: Optional[list] = None,
     previous_bot_id: Optional[int] = None,
     knowledge_base_names: Optional[List[Dict[str, str]]] = None,
+    reasoning_config: Optional[Dict[str, Any]] = None,
 ):
     """Build ExecutionRequest without dispatching.
 
@@ -209,6 +210,7 @@ async def build_execution_request(
         enable_clarification: Whether to enable clarification mode (default: False)
         preload_skills: Optional list of skills to preload
         knowledge_base_names: Optional list of KB names in {'namespace': str, 'name': str} format
+        reasoning_config: Optional reasoning config dict with 'effort' and 'summary' keys
 
     Returns:
         ExecutionRequest ready for dispatch
@@ -270,6 +272,27 @@ async def build_execution_request(
             override_model_name=override_model_name,
             force_override=force_override,
             previous_bot_id=previous_bot_id,
+        )
+
+        # Merge reasoning_config from API request into model_config
+        # Priority: API request reasoning_config > model's think_config
+        if reasoning_config:
+            request.model_config["reasoning"] = reasoning_config
+            logger.info(
+                "[build_execution_request] Applied reasoning config from API request: %s",
+                reasoning_config,
+            )
+        elif request.model_config.get("think_config"):
+            # If no API reasoning_config but model has think_config, use it
+            request.model_config["reasoning"] = request.model_config["think_config"]
+            logger.info(
+                "[build_execution_request] Applied reasoning config from model think_config: %s",
+                request.model_config["think_config"],
+            )
+
+        # Store reasoning_config in ExecutionRequest for downstream access
+        request.reasoning_config = reasoning_config or request.model_config.get(
+            "reasoning"
         )
 
         # Merge user-selected generate_params into videoConfig for video models

--- a/backend/app/services/openapi/streaming.py
+++ b/backend/app/services/openapi/streaming.py
@@ -12,8 +12,9 @@ It converts internal chat streaming to the OpenAI-compatible event format.
 import json
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, AsyncGenerator, Dict, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from app.schemas.openapi_response import (
     OutputMessage,
@@ -48,11 +49,21 @@ def _format_sse_event(data: Dict[str, Any]) -> str:
     return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
+@dataclass
+class StreamingChunk:
+    """A chunk of streaming data, either text or reasoning."""
+
+    type: str  # "text" or "reasoning"
+    content: str
+
+
 class OpenAPIStreamingService:
     """
     Service for generating OpenAI v1/responses compatible streaming output.
 
     Converts internal chat streaming responses to the OpenAI SSE event format.
+    Follows OpenAI Responses API specification:
+    https://platform.openai.com/docs/api-reference/responses-streaming
     """
 
     def __init__(self):
@@ -62,7 +73,7 @@ class OpenAPIStreamingService:
         self,
         response_id: str,
         model_string: str,
-        chat_stream: AsyncGenerator[str, None],
+        chat_stream: AsyncGenerator[Union[str, StreamingChunk], None],
         created_at: Optional[int] = None,
         previous_response_id: Optional[str] = None,
     ) -> AsyncGenerator[str, None]:
@@ -75,7 +86,7 @@ class OpenAPIStreamingService:
         Args:
             response_id: Response ID (format: resp_{task_id})
             model_string: Model string from request
-            chat_stream: Async generator yielding text chunks
+            chat_stream: Async generator yielding text chunks or StreamingChunk objects
             created_at: Unix timestamp (defaults to now)
             previous_response_id: Optional previous response ID
 
@@ -87,7 +98,11 @@ class OpenAPIStreamingService:
 
         message_id = _generate_message_id()
         accumulated_text = ""
+        accumulated_reasoning = ""
         sequence_number = 0
+        reasoning_started = False
+        reasoning_complete = False
+        output_index = 0
 
         try:
             # Event 1: response.created
@@ -118,123 +133,217 @@ class OpenAPIStreamingService:
             )
             sequence_number += 1
 
-            # Event 3: response.output_item.added
-            yield _format_sse_event(
-                {
-                    "item": {
-                        "content": [],
-                        "id": message_id,
-                        "role": "assistant",
-                        "status": "in_progress",
-                        "type": "message",
-                    },
-                    "output_index": 0,
-                    "sequence_number": sequence_number,
-                    "type": "response.output_item.added",
-                }
-            )
-            sequence_number += 1
-
-            # Event 4: response.content_part.added
-            yield _format_sse_event(
-                {
-                    "content_index": 0,
-                    "item_id": message_id,
-                    "output_index": 0,
-                    "part": {
-                        "annotations": [],
-                        "text": "",
-                        "type": "output_text",
-                    },
-                    "sequence_number": sequence_number,
-                    "type": "response.content_part.added",
-                }
-            )
-            sequence_number += 1
-
-            # Stream text deltas
+            # Process stream chunks
             async for chunk in chat_stream:
-                if chunk:
-                    accumulated_text += chunk
-                    yield _format_sse_event(
-                        {
-                            "content_index": 0,
-                            "delta": chunk,
-                            "item_id": message_id,
-                            "output_index": 0,
-                            "sequence_number": sequence_number,
-                            "type": "response.output_text.delta",
-                        }
-                    )
-                    sequence_number += 1
+                if chunk is None:
+                    continue
 
-            # Event: response.output_text.done
-            yield _format_sse_event(
-                {
-                    "content_index": 0,
-                    "item_id": message_id,
-                    "output_index": 0,
-                    "sequence_number": sequence_number,
-                    "text": accumulated_text,
-                    "type": "response.output_text.done",
-                }
-            )
-            sequence_number += 1
+                # Handle StreamingChunk objects
+                if isinstance(chunk, StreamingChunk):
+                    if chunk.type == "reasoning":
+                        # Start reasoning output if not started
+                        if not reasoning_started:
+                            reasoning_started = True
+                            output_index = 0
+                            # Official OpenAI event: response.reasoning_summary_part.added
+                            yield _format_sse_event(
+                                {
+                                    "item": {
+                                        "id": _generate_message_id(),
+                                        "object": "response.output_item",
+                                        "status": "in_progress",
+                                        "summary": [],
+                                        "type": "reasoning",
+                                    },
+                                    "output_index": output_index,
+                                    "sequence_number": sequence_number,
+                                    "type": "response.reasoning_summary_part.added",
+                                }
+                            )
+                            sequence_number += 1
 
-            # Event: response.content_part.done
-            yield _format_sse_event(
-                {
-                    "content_index": 0,
-                    "item_id": message_id,
-                    "output_index": 0,
-                    "part": {
-                        "annotations": [],
-                        "text": accumulated_text,
-                        "type": "output_text",
-                    },
-                    "sequence_number": sequence_number,
-                    "type": "response.content_part.done",
-                }
-            )
-            sequence_number += 1
+                        # Accumulate reasoning content
+                        if chunk.content and not reasoning_complete:
+                            accumulated_reasoning += chunk.content
+                            # Official OpenAI event: response.reasoning_summary_text.delta
+                            yield _format_sse_event(
+                                {
+                                    "content_index": 0,
+                                    "delta": chunk.content,
+                                    "item_id": message_id,
+                                    "output_index": output_index,
+                                    "sequence_number": sequence_number,
+                                    "type": "response.reasoning_summary_text.delta",
+                                }
+                            )
+                            sequence_number += 1
 
-            # Event: response.output_item.done
-            yield _format_sse_event(
-                {
-                    "item": {
-                        "content": [
+                    elif chunk.type == "text":
+                        # Handle text content
+                        if chunk.content:
+                            # If we had reasoning before, close it first
+                            if reasoning_started and not reasoning_complete:
+                                reasoning_complete = True
+                                output_index += 1
+                                # Note: OpenAI doesn't have explicit reasoning "done" event
+                                # We transition directly to text output
+
+                            accumulated_text += chunk.content
+
+                            # Start text output if this is the first text chunk
+                            if output_index == 0 or (
+                                reasoning_started and output_index == 1
+                            ):
+                                if output_index == 0:
+                                    output_index = 0
+
+                                # Official OpenAI event: response.output_item.added
+                                yield _format_sse_event(
+                                    {
+                                        "item": {
+                                            "content": [],
+                                            "id": message_id,
+                                            "role": "assistant",
+                                            "status": "in_progress",
+                                            "type": "message",
+                                        },
+                                        "output_index": output_index,
+                                        "sequence_number": sequence_number,
+                                        "type": "response.output_item.added",
+                                    }
+                                )
+                                sequence_number += 1
+
+                                # Official OpenAI event: response.content_part.added
+                                yield _format_sse_event(
+                                    {
+                                        "content_index": 0,
+                                        "item_id": message_id,
+                                        "output_index": output_index,
+                                        "part": {
+                                            "annotations": [],
+                                            "text": "",
+                                            "type": "output_text",
+                                        },
+                                        "sequence_number": sequence_number,
+                                        "type": "response.content_part.added",
+                                    }
+                                )
+                                sequence_number += 1
+
+                            # Official OpenAI event: response.output_text.delta
+                            yield _format_sse_event(
+                                {
+                                    "content_index": 0,
+                                    "delta": chunk.content,
+                                    "item_id": message_id,
+                                    "output_index": output_index,
+                                    "sequence_number": sequence_number,
+                                    "type": "response.output_text.delta",
+                                }
+                            )
+                            sequence_number += 1
+
+                else:
+                    # Handle plain string (backward compatibility)
+                    if chunk:
+                        accumulated_text += chunk
+                        # Official OpenAI event: response.output_text.delta
+                        yield _format_sse_event(
                             {
-                                "annotations": [],
-                                "text": accumulated_text,
-                                "type": "output_text",
+                                "content_index": 0,
+                                "delta": chunk,
+                                "item_id": message_id,
+                                "output_index": 0,
+                                "sequence_number": sequence_number,
+                                "type": "response.output_text.delta",
                             }
-                        ],
-                        "id": message_id,
-                        "role": "assistant",
-                        "status": "completed",
-                        "type": "message",
-                    },
-                    "output_index": 0,
-                    "sequence_number": sequence_number,
-                    "type": "response.output_item.done",
-                }
-            )
-            sequence_number += 1
+                        )
+                        sequence_number += 1
 
-            # Event: response.completed
-            final_response = ResponseObject(
-                id=response_id,
-                created_at=created_at,
-                status="completed",
-                model=model_string,
-                output=[
+            # Close text output items
+            if accumulated_text:
+                # Official OpenAI event: response.output_text.done
+                yield _format_sse_event(
+                    {
+                        "content_index": 0,
+                        "item_id": message_id,
+                        "output_index": output_index,
+                        "sequence_number": sequence_number,
+                        "text": accumulated_text,
+                        "type": "response.output_text.done",
+                    }
+                )
+                sequence_number += 1
+
+                # Official OpenAI event: response.content_part.done
+                yield _format_sse_event(
+                    {
+                        "content_index": 0,
+                        "item_id": message_id,
+                        "output_index": output_index,
+                        "part": {
+                            "annotations": [],
+                            "text": accumulated_text,
+                            "type": "output_text",
+                        },
+                        "sequence_number": sequence_number,
+                        "type": "response.content_part.done",
+                    }
+                )
+                sequence_number += 1
+
+                # Official OpenAI event: response.output_item.done
+                yield _format_sse_event(
+                    {
+                        "item": {
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": accumulated_text,
+                                    "type": "output_text",
+                                }
+                            ],
+                            "id": message_id,
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
+                        "output_index": output_index,
+                        "sequence_number": sequence_number,
+                        "type": "response.output_item.done",
+                    }
+                )
+                sequence_number += 1
+
+            # Build final output items
+            output_items = []
+            if accumulated_reasoning:
+                output_items.append(
+                    OutputMessage(
+                        id=_generate_message_id(),
+                        status="completed",
+                        role="assistant",
+                        content=[{"type": "reasoning", "text": accumulated_reasoning}],
+                    )
+                )
+            if accumulated_text:
+                output_items.append(
                     OutputMessage(
                         id=message_id,
                         status="completed",
                         role="assistant",
                         content=[OutputTextContent(text=accumulated_text)],
                     )
-                ],
+                )
+
+            # Official OpenAI event: response.completed
+            final_response = ResponseObject(
+                id=response_id,
+                created_at=created_at,
+                status="completed",
+                model=model_string,
+                output=output_items,
                 previous_response_id=previous_response_id,
             )
             yield _format_sse_event(
@@ -247,7 +356,7 @@ class OpenAPIStreamingService:
 
         except Exception as e:
             logger.exception(f"Error during streaming response: {e}")
-            # Event: response.failed
+            # Official OpenAI event: response.failed (or error)
             error_response = ResponseObject(
                 id=response_id,
                 created_at=created_at,

--- a/backend/app/services/subscription/execution.py
+++ b/backend/app/services/subscription/execution.py
@@ -235,6 +235,25 @@ class BackgroundExecutionManager:
             f"previous_status={current_status.value}{running_info}"
         )
 
+        # Cancel associated task if exists (task_id > 0)
+        if execution.task_id and execution.task_id > 0:
+            # Run async cancel in background to not block the response
+            # This ensures executor is notified to stop the actual execution
+            import asyncio
+
+            try:
+                # Try to get running loop (Python 3.10+ recommended way)
+                loop = asyncio.get_running_loop()
+                # Schedule as background task
+                asyncio.create_task(
+                    self._cancel_associated_task_async(db, execution.task_id, user_id)
+                )
+            except RuntimeError:
+                # No event loop running, use asyncio.run
+                asyncio.run(
+                    self._cancel_associated_task_async(db, execution.task_id, user_id)
+                )
+
         # Emit WebSocket event
         emit_background_execution_update(
             db=db,
@@ -277,6 +296,200 @@ class BackgroundExecutionManager:
                     exec_dict["team_name"] = team.name
 
         return BackgroundExecutionInDB(**exec_dict)
+
+    async def cancel_task_by_id(
+        self,
+        db: Session,
+        task_id: int,
+        user_id: int,
+    ) -> bool:
+        """Cancel a task by its ID.
+
+        This method cancels a task and its subtasks, and notifies the executor to stop.
+        It is used both when cancelling a subscription execution and when cleaning up
+        stuck tasks before reusing them.
+
+        Args:
+            db: Database session
+            task_id: ID of the task to cancel
+            user_id: ID of the user requesting cancellation
+
+        Returns:
+            True if cancellation was successful, False otherwise
+        """
+        return await self._do_cancel_task(db, task_id, user_id)
+
+    async def _cancel_associated_task_async(
+        self,
+        db: Session,
+        task_id: int,
+        user_id: int,
+    ) -> None:
+        """Cancel the associated Task and its Subtasks when execution is cancelled.
+
+        This method ensures that when a subscription execution is cancelled:
+        1. The associated Task status is updated to CANCELLED
+        2. Running Subtasks are properly cancelled
+        3. The executor is notified to stop the actual execution
+
+        Args:
+            db: Database session
+            task_id: ID of the task to cancel
+            user_id: ID of the user requesting cancellation
+        """
+        await self._do_cancel_task(db, task_id, user_id)
+
+    async def _do_cancel_task(
+        self,
+        db: Session,
+        task_id: int,
+        user_id: int,
+    ) -> bool:
+        """Internal method to cancel a task and its subtasks.
+
+        Args:
+            db: Database session
+            task_id: ID of the task to cancel
+            user_id: ID of the user requesting cancellation
+
+        Returns:
+            True if cancellation was successful, False otherwise
+        """
+        from datetime import datetime
+
+        from app.models.subtask import Subtask, SubtaskStatus
+        from app.models.task import TaskResource
+        from app.schemas.kind import Task
+        from app.services.execution import execution_dispatcher
+        from shared.models import ExecutionRequest
+
+        try:
+            # Get the task
+            task = (
+                db.query(TaskResource)
+                .filter(
+                    TaskResource.id == task_id,
+                    TaskResource.kind == "Task",
+                    TaskResource.is_active.in_(TaskResource.is_active_query()),
+                )
+                .first()
+            )
+
+            if not task:
+                logger.warning(
+                    f"[Subscription] Cannot cancel associated task: task {task_id} not found"
+                )
+                return False
+
+            # Get shell_type from task labels
+            task_crd = Task.model_validate(task.json)
+            shell_type = "Chat"  # Default to Chat
+            if task_crd.metadata.labels:
+                source = task_crd.metadata.labels.get("source", "")
+                if source == "chat_shell":
+                    shell_type = "Chat"
+                # Add more shell type mappings as needed
+
+            # Find running subtask to cancel
+            running_subtask = (
+                db.query(Subtask)
+                .filter(
+                    Subtask.task_id == task_id,
+                    Subtask.status.in_([SubtaskStatus.PENDING, SubtaskStatus.RUNNING]),
+                )
+                .first()
+            )
+
+            if running_subtask:
+                # Build ExecutionRequest for cancel
+                cancel_request = ExecutionRequest(
+                    task_id=task_id,
+                    subtask_id=running_subtask.id,
+                    bot=[{"shell_type": shell_type}],
+                    user={"id": user_id},
+                )
+
+                # Determine device_id if this is a device task
+                device_id = None
+                executor_name = running_subtask.executor_name
+                if executor_name and executor_name.startswith("device-"):
+                    device_id = executor_name[7:]  # Remove "device-" prefix
+
+                logger.info(
+                    f"[Subscription] Cancelling task via ExecutionDispatcher: "
+                    f"task_id={task_id}, subtask_id={running_subtask.id}, "
+                    f"shell_type={shell_type}, device_id={device_id}"
+                )
+
+                # Call execution_dispatcher to notify executor to stop
+                try:
+                    cancel_success = await execution_dispatcher.cancel(
+                        cancel_request, device_id
+                    )
+                    if cancel_success:
+                        logger.info(
+                            f"[Subscription] Cancel request sent successfully for task {task_id}"
+                        )
+                    else:
+                        logger.warning(
+                            f"[Subscription] Cancel request failed for task {task_id}, "
+                            "executor may have already completed"
+                        )
+                except Exception as cancel_err:
+                    logger.error(
+                        f"[Subscription] Error calling execution_dispatcher.cancel: {cancel_err}",
+                        exc_info=True,
+                    )
+                    # Continue to update database state even if cancel request fails
+
+            # Update task status to CANCELLED if not already in terminal state
+            current_task_status = task_crd.status.status if task_crd.status else None
+            final_states = ["COMPLETED", "FAILED", "CANCELLED", "DELETE"]
+
+            if current_task_status not in final_states:
+                if task_crd.status:
+                    task_crd.status.status = "CANCELLED"
+                    task_crd.status.updatedAt = datetime.now().isoformat()
+                    task_crd.status.completedAt = datetime.now().isoformat()
+                task.json = task_crd.model_dump(mode="json", exclude_none=True)
+                flag_modified(task, "json")
+                logger.info(
+                    f"[Subscription] Updated task {task_id} status to CANCELLED"
+                )
+
+            # Cancel all running subtasks in database
+            running_subtasks = (
+                db.query(Subtask)
+                .filter(
+                    Subtask.task_id == task_id,
+                    Subtask.status.in_([SubtaskStatus.PENDING, SubtaskStatus.RUNNING]),
+                )
+                .all()
+            )
+
+            for subtask in running_subtasks:
+                subtask.status = SubtaskStatus.CANCELLED
+                subtask.progress = 100
+                subtask.completed_at = datetime.now()
+                subtask.updated_at = datetime.now()
+                logger.info(
+                    f"[Subscription] Updated subtask {subtask.id} status to CANCELLED"
+                )
+
+            db.commit()
+            logger.info(
+                f"[Subscription] Successfully cancelled task {task_id} and its subtasks"
+            )
+            return True
+
+        except Exception as e:
+            logger.error(
+                f"[Subscription] Failed to cancel associated task {task_id}: {e}",
+                exc_info=True,
+            )
+            # Don't re-raise - we don't want to fail the execution cancellation
+            # if the task cancellation fails
+            return False
 
     def delete_execution(
         self,

--- a/backend/app/services/subscription/execution.py
+++ b/backend/app/services/subscription/execution.py
@@ -246,13 +246,11 @@ class BackgroundExecutionManager:
                 loop = asyncio.get_running_loop()
                 # Schedule as background task
                 asyncio.create_task(
-                    self._cancel_associated_task_async(db, execution.task_id, user_id)
+                    self.cancel_task_by_id(db, execution.task_id, user_id)
                 )
             except RuntimeError:
                 # No event loop running, use asyncio.run
-                asyncio.run(
-                    self._cancel_associated_task_async(db, execution.task_id, user_id)
-                )
+                asyncio.run(self.cancel_task_by_id(db, execution.task_id, user_id))
 
         # Emit WebSocket event
         emit_background_execution_update(
@@ -317,29 +315,9 @@ class BackgroundExecutionManager:
         Returns:
             True if cancellation was successful, False otherwise
         """
-        return await self._do_cancel_task(db, task_id, user_id)
+        return await self._cancel_task_internal(db, task_id, user_id)
 
-    async def _cancel_associated_task_async(
-        self,
-        db: Session,
-        task_id: int,
-        user_id: int,
-    ) -> None:
-        """Cancel the associated Task and its Subtasks when execution is cancelled.
-
-        This method ensures that when a subscription execution is cancelled:
-        1. The associated Task status is updated to CANCELLED
-        2. Running Subtasks are properly cancelled
-        3. The executor is notified to stop the actual execution
-
-        Args:
-            db: Database session
-            task_id: ID of the task to cancel
-            user_id: ID of the user requesting cancellation
-        """
-        await self._do_cancel_task(db, task_id, user_id)
-
-    async def _do_cancel_task(
+    async def _cancel_task_internal(
         self,
         db: Session,
         task_id: int,

--- a/backend/app/services/subscription/service.py
+++ b/backend/app/services/subscription/service.py
@@ -10,8 +10,8 @@ on Subscription resources stored in the kinds table.
 """
 
 import logging
-import string
 import secrets
+import string
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -82,7 +82,7 @@ def generate_unique_subscription_name(
 
     for attempt in range(max_retries):
         # Generate random 8-character suffix
-        suffix = ''.join(secrets.choice(alphabet) for _ in range(8))
+        suffix = "".join(secrets.choice(alphabet) for _ in range(8))
         name = f"sub-{suffix}"
 
         # Check if name already exists

--- a/backend/app/services/subscription/service.py
+++ b/backend/app/services/subscription/service.py
@@ -10,6 +10,7 @@ on Subscription resources stored in the kinds table.
 """
 
 import logging
+import string
 import secrets
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -53,6 +54,56 @@ from app.services.subscription.market_access import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def generate_unique_subscription_name(
+    db: Session,
+    user_id: int,
+    namespace: str = "default",
+    max_retries: int = 3,
+) -> str:
+    """Generate a unique subscription name.
+
+    Format: sub-{random_suffix} where random_suffix is 8 chars [a-z0-9]
+
+    Args:
+        db: Database session
+        user_id: User ID for uniqueness check
+        namespace: Resource namespace
+        max_retries: Maximum attempts to generate unique name
+
+    Returns:
+        Unique subscription name
+
+    Raises:
+        RuntimeError: If unable to generate unique name after max_retries
+    """
+    alphabet = string.ascii_lowercase + string.digits
+
+    for attempt in range(max_retries):
+        # Generate random 8-character suffix
+        suffix = ''.join(secrets.choice(alphabet) for _ in range(8))
+        name = f"sub-{suffix}"
+
+        # Check if name already exists
+        existing = (
+            db.query(Kind)
+            .filter(
+                Kind.user_id == user_id,
+                Kind.kind == "Subscription",
+                Kind.name == name,
+                Kind.namespace == namespace,
+                Kind.is_active == True,
+            )
+            .first()
+        )
+
+        if not existing:
+            return name
+
+    raise RuntimeError(
+        f"Failed to generate unique subscription name after {max_retries} attempts"
+    )
 
 
 def _validate_execution_target(

--- a/backend/app/services/subscription/service.py
+++ b/backend/app/services/subscription/service.py
@@ -221,24 +221,30 @@ class SubscriptionService:
             subscription_in.trigger_config,
         )
 
-        # Validate subscription name uniqueness
-        existing = (
-            db.query(Kind)
-            .filter(
-                Kind.user_id == user_id,
-                Kind.kind == "Subscription",
-                Kind.name == subscription_in.name,
-                Kind.namespace == subscription_in.namespace,
-                Kind.is_active == True,
+        # Auto-generate name if not provided, otherwise validate uniqueness
+        if subscription_in.name is None:
+            subscription_in.name = generate_unique_subscription_name(
+                db, user_id, subscription_in.namespace
             )
-            .first()
-        )
+        else:
+            # Validate subscription name uniqueness for user-provided names
+            existing = (
+                db.query(Kind)
+                .filter(
+                    Kind.user_id == user_id,
+                    Kind.kind == "Subscription",
+                    Kind.name == subscription_in.name,
+                    Kind.namespace == subscription_in.namespace,
+                    Kind.is_active == True,
+                )
+                .first()
+            )
 
-        if existing:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Subscription with name '{subscription_in.name}' already exists",
-            )
+            if existing:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Subscription with name '{subscription_in.name}' already exists",
+                )
 
         # Validate team exists
         team = (

--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -537,6 +537,7 @@ async def _create_subscription_task(
         SubscriptionExecutionTargetType,
     )
     from app.services.chat.storage import TaskCreationParams, create_chat_task
+    from app.services.subscription.execution import background_execution_manager
 
     ws = ctx.workspace_info
 
@@ -587,11 +588,43 @@ async def _create_subscription_task(
         )
 
         if bound_task:
-            reuse_task_id = ctx.bound_task_id
-            logger.info(
-                f"[subscription_tasks] Reusing bound task {ctx.bound_task_id} for subscription {ctx.subscription.id} "
-                f"(preserve_history=True)"
-            )
+            # Check if bound task is still RUNNING, cancel it before reuse
+            from app.schemas.kind import Task
+
+            bound_task_crd = Task.model_validate(bound_task.json)
+            if bound_task_crd.status and bound_task_crd.status.status == "RUNNING":
+                logger.warning(
+                    f"[subscription_tasks] Bound task {ctx.bound_task_id} is still RUNNING, "
+                    f"cancelling it before reuse for subscription {ctx.subscription.id}"
+                )
+                # Cancel the running task using the same method as subscription cancel
+                cancel_success = await background_execution_manager.cancel_task_by_id(
+                    db=db,
+                    task_id=ctx.bound_task_id,
+                    user_id=ctx.user.id,
+                )
+                if cancel_success:
+                    logger.info(
+                        f"[subscription_tasks] Successfully cancelled bound task {ctx.bound_task_id}"
+                    )
+                    # Refresh bound_task to get updated status
+                    db.refresh(bound_task)
+                    # Set reuse_task_id to reuse the cancelled task
+                    reuse_task_id = ctx.bound_task_id
+                else:
+                    logger.error(
+                        f"[subscription_tasks] Failed to cancel bound task {ctx.bound_task_id}, "
+                        f"will create new task for subscription {ctx.subscription.id}"
+                    )
+                    # Don't reuse this task since we couldn't cancel it
+                    reuse_task_id = None
+            else:
+                # Task is not RUNNING, safe to reuse
+                reuse_task_id = ctx.bound_task_id
+                logger.info(
+                    f"[subscription_tasks] Reusing bound task {ctx.bound_task_id} for subscription {ctx.subscription.id} "
+                    f"(preserve_history=True)"
+                )
         else:
             logger.warning(
                 f"[subscription_tasks] Bound task {ctx.bound_task_id} not found or inactive, "

--- a/backend/tests/services/chat/test_reasoning_config.py
+++ b/backend/tests/services/chat/test_reasoning_config.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reasoning config propagation from OpenAPI to ExecutionRequest."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.schemas.openapi_response import ReasoningConfig, ResponseCreateInput
+
+
+class TestReasoningConfigSchema:
+    """Tests for ReasoningConfig schema."""
+
+    def test_reasoning_config_defaults(self):
+        """Test ReasoningConfig with default values."""
+        config = ReasoningConfig()
+        assert config.effort == "medium"
+        assert config.summary == "auto"
+
+    def test_reasoning_config_custom_values(self):
+        """Test ReasoningConfig with custom values."""
+        config = ReasoningConfig(effort="high", summary="detailed")
+        assert config.effort == "high"
+        assert config.summary == "detailed"
+
+    def test_reasoning_config_literal_validation(self):
+        """Test ReasoningConfig validates literal values."""
+        # Valid values
+        ReasoningConfig(effort="none")
+        ReasoningConfig(effort="minimal")
+        ReasoningConfig(effort="low")
+        ReasoningConfig(effort="medium")
+        ReasoningConfig(effort="high")
+        ReasoningConfig(effort="xhigh")
+        ReasoningConfig(summary="auto")
+        ReasoningConfig(summary="concise")
+        ReasoningConfig(summary="detailed")
+
+    def test_reasoning_config_in_response_create_input(self):
+        """Test ResponseCreateInput accepts reasoning config."""
+        reasoning = ReasoningConfig(effort="high", summary="concise")
+        input_data = ResponseCreateInput(
+            model="default#my_team",
+            input="Hello",
+            reasoning=reasoning,
+        )
+        assert input_data.reasoning.effort == "high"
+        assert input_data.reasoning.summary == "concise"
+
+    def test_response_create_input_without_reasoning(self):
+        """Test ResponseCreateInput without reasoning config."""
+        input_data = ResponseCreateInput(
+            model="default#my_team",
+            input="Hello",
+        )
+        assert input_data.reasoning is None
+
+
+class TestExecutionRequestReasoningConfig:
+    """Tests for reasoning_config field in ExecutionRequest."""
+
+    def test_execution_request_has_reasoning_config_field(self):
+        """Test ExecutionRequest dataclass has reasoning_config field."""
+        from shared.models.execution import ExecutionRequest
+
+        # Create request without reasoning_config
+        request = ExecutionRequest()
+        assert request.reasoning_config is None
+
+        # Create request with reasoning_config
+        request_with_config = ExecutionRequest(
+            reasoning_config={"effort": "high", "summary": "detailed"}
+        )
+        assert request_with_config.reasoning_config == {
+            "effort": "high",
+            "summary": "detailed",
+        }
+
+    def test_execution_request_to_dict_includes_reasoning_config(self):
+        """Test ExecutionRequest.to_dict() includes reasoning_config."""
+        from shared.models.execution import ExecutionRequest
+
+        request = ExecutionRequest(
+            reasoning_config={"effort": "medium", "summary": "auto"}
+        )
+        data = request.to_dict()
+        assert data["reasoning_config"] == {"effort": "medium", "summary": "auto"}
+
+    def test_execution_request_from_dict_preserves_reasoning_config(self):
+        """Test ExecutionRequest.from_dict() preserves reasoning_config."""
+        from shared.models.execution import ExecutionRequest
+
+        data = {
+            "task_id": 1,
+            "reasoning_config": {"effort": "low", "summary": "concise"},
+        }
+        request = ExecutionRequest.from_dict(data)
+        assert request.reasoning_config == {"effort": "low", "summary": "concise"}

--- a/backend/tests/services/openapi/test_streaming_reasoning.py
+++ b/backend/tests/services/openapi/test_streaming_reasoning.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for OpenAPI streaming service with reasoning support."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.openapi.streaming import (
+    OpenAPIStreamingService,
+    StreamingChunk,
+    _format_sse_event,
+)
+
+
+class TestStreamingChunk:
+    """Tests for StreamingChunk dataclass."""
+
+    def test_streaming_chunk_text(self):
+        """Test creating a text StreamingChunk."""
+        chunk = StreamingChunk(type="text", content="Hello world")
+        assert chunk.type == "text"
+        assert chunk.content == "Hello world"
+
+    def test_streaming_chunk_reasoning(self):
+        """Test creating a reasoning StreamingChunk."""
+        chunk = StreamingChunk(type="reasoning", content="Let me think...")
+        assert chunk.type == "reasoning"
+        assert chunk.content == "Let me think..."
+
+
+class TestStreamingServiceReasoning:
+    """Tests for OpenAPIStreamingService with reasoning events."""
+
+    @pytest.fixture
+    def streaming_service(self):
+        return OpenAPIStreamingService()
+
+    @pytest.mark.asyncio
+    async def test_text_only_stream(self, streaming_service):
+        """Test streaming with text chunks only (backward compatibility)."""
+
+        async def text_stream():
+            yield "Hello"
+            yield " world"
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=text_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        # Check that we have the expected events
+        event_types = [e["type"] for e in events]
+        assert "response.created" in event_types
+        assert "response.in_progress" in event_types
+        assert "response.output_text.delta" in event_types
+        assert "response.completed" in event_types
+
+        # Check text content
+        text_deltas = [
+            e["delta"] for e in events if e["type"] == "response.output_text.delta"
+        ]
+        assert "".join(text_deltas) == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_stream(self, streaming_service):
+        """Test streaming with reasoning chunks."""
+
+        async def reasoning_stream():
+            yield StreamingChunk(type="reasoning", content="Step 1: ")
+            yield StreamingChunk(type="reasoning", content="Analyze the problem")
+            yield StreamingChunk(type="text", content="The answer is 42")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=reasoning_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        event_types = [e["type"] for e in events]
+
+        # Check reasoning events
+        assert "response.output_item.added" in event_types
+        reasoning_deltas = [
+            e for e in events if e["type"] == "response.reasoning_summary_text.delta"
+        ]
+        assert len(reasoning_deltas) == 2
+        assert reasoning_deltas[0]["delta"] == "Step 1: "
+        assert reasoning_deltas[1]["delta"] == "Analyze the problem"
+
+        # Check text events
+        text_deltas = [
+            e["delta"] for e in events if e["type"] == "response.output_text.delta"
+        ]
+        assert "".join(text_deltas) == "The answer is 42"
+
+    @pytest.mark.asyncio
+    async def test_mixed_reasoning_and_text(self, streaming_service):
+        """Test streaming with interleaved reasoning and text."""
+
+        async def mixed_stream():
+            yield StreamingChunk(type="reasoning", content="Thinking...")
+            yield StreamingChunk(type="text", content="Answer")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=mixed_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        event_types = [e["type"] for e in events]
+
+        # Should have reasoning events first, then text events
+        reasoning_indices = [
+            i for i, e in enumerate(events) if "reasoning" in e["type"]
+        ]
+        text_indices = [
+            i for i, e in enumerate(events) if e["type"] == "response.output_text.delta"
+        ]
+
+        assert reasoning_indices
+        assert text_indices
+        # All reasoning should come before text
+        assert max(reasoning_indices) < min(text_indices)
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self, streaming_service):
+        """Test streaming with empty content."""
+
+        async def empty_stream():
+            if False:
+                yield "never"
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=empty_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        # Should still have lifecycle events
+        event_types = [e["type"] for e in events]
+        assert "response.created" in event_types
+        assert "response.completed" in event_types
+
+    @pytest.mark.asyncio
+    async def test_reasoning_only_stream(self, streaming_service):
+        """Test streaming with only reasoning, no text."""
+
+        async def reasoning_only_stream():
+            yield StreamingChunk(type="reasoning", content="Just thinking")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=reasoning_only_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        # Should have reasoning events
+        reasoning_deltas = [
+            e for e in events if e["type"] == "response.reasoning_summary_text.delta"
+        ]
+        assert len(reasoning_deltas) == 1
+        assert reasoning_deltas[0]["delta"] == "Just thinking"
+
+        # Check final response includes reasoning
+        completed_event = [e for e in events if e["type"] == "response.completed"][0]
+        output = completed_event["response"]["output"]
+        assert len(output) == 1
+        assert output[0]["content"][0]["type"] == "reasoning"

--- a/backend/tests/services/subscription/test_cancel_execution.py
+++ b/backend/tests/services/subscription/test_cancel_execution.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cancel_execution with task cancellation."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.subscription import BackgroundExecution
+from app.models.subtask import Subtask, SubtaskStatus
+from app.models.task import TaskResource
+from app.schemas.subscription import BackgroundExecutionStatus
+from app.services.subscription.execution import background_execution_manager
+
+
+def create_task_json(status="RUNNING", progress=0, completed_at=None):
+    """Create a valid Task JSON with all required fields."""
+    status_obj = {
+        "status": status,
+        "progress": progress,
+        "updatedAt": datetime.now().isoformat(),
+    }
+    if completed_at:
+        status_obj["completedAt"] = completed_at
+
+    return {
+        "apiVersion": "agent.wecode.io/v1",
+        "kind": "Task",
+        "spec": {
+            "title": "Test Task",
+            "prompt": "Test prompt",
+            "teamRef": {"name": "test-team", "namespace": "default", "user_id": 1},
+            "workspaceRef": {"name": "test-workspace", "namespace": "default"},
+        },
+        "status": status_obj,
+        "metadata": {"name": "test-task", "namespace": "default"},
+    }
+
+
+class TestCancelExecutionWithTask:
+    """Tests that cancel_execution properly cancels associated tasks."""
+
+    def test_cancel_execution_updates_task_status(self, test_db, test_user):
+        """Test that cancel_execution updates associated task status to CANCELLED."""
+        # Create a task with valid JSON
+        task = TaskResource(
+            user_id=test_user.id,
+            kind="Task",
+            name="test-task",
+            namespace="default",
+            json=create_task_json(status="RUNNING", progress=50),
+            is_active=TaskResource.STATE_ACTIVE,
+        )
+        test_db.add(task)
+        test_db.commit()
+        test_db.refresh(task)
+
+        # Create an execution with task_id
+        execution = BackgroundExecution(
+            user_id=test_user.id,
+            subscription_id=1,
+            task_id=task.id,
+            trigger_type="manual",
+            trigger_reason="Test",
+            prompt="Test prompt",
+            status=BackgroundExecutionStatus.RUNNING.value,
+            retry_attempt=0,
+        )
+        test_db.add(execution)
+        test_db.commit()
+        test_db.refresh(execution)
+
+        # Cancel the execution
+        result = background_execution_manager.cancel_execution(
+            test_db, execution_id=execution.id, user_id=test_user.id
+        )
+
+        # Verify execution status
+        assert result.status == BackgroundExecutionStatus.CANCELLED
+
+        # Verify task status is updated
+        test_db.refresh(task)
+        task_crd = task.json
+        assert task_crd["status"]["status"] == "CANCELLED"
+
+    def test_cancel_execution_updates_subtasks(self, test_db, test_user):
+        """Test that cancel_execution updates running subtasks to CANCELLED."""
+        # Create a task with valid JSON
+        task = TaskResource(
+            user_id=test_user.id,
+            kind="Task",
+            name="test-task",
+            namespace="default",
+            json=create_task_json(status="RUNNING"),
+            is_active=TaskResource.STATE_ACTIVE,
+        )
+        test_db.add(task)
+        test_db.commit()
+        test_db.refresh(task)
+
+        # Create running subtasks with all required fields
+        from datetime import datetime
+
+        from app.models.subtask import SubtaskRole
+
+        placeholder_date = datetime(1970, 1, 1)
+        subtask1 = Subtask(
+            task_id=task.id,
+            user_id=test_user.id,
+            team_id=1,
+            title="Test subtask 1",
+            bot_ids=[],
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.RUNNING,
+            progress=50,
+            completed_at=placeholder_date,
+            executor_namespace="",
+            executor_name="",
+            prompt="",
+            message_id=1,
+            sender_type="",
+            sender_user_id=0,
+            reply_to_subtask_id=0,
+        )
+        subtask2 = Subtask(
+            task_id=task.id,
+            user_id=test_user.id,
+            team_id=1,
+            title="Test subtask 2",
+            bot_ids=[],
+            role=SubtaskRole.ASSISTANT,
+            status=SubtaskStatus.PENDING,
+            progress=0,
+            completed_at=placeholder_date,
+            executor_namespace="",
+            executor_name="",
+            prompt="",
+            message_id=1,
+            sender_type="",
+            sender_user_id=0,
+            reply_to_subtask_id=0,
+        )
+        test_db.add(subtask1)
+        test_db.add(subtask2)
+        test_db.commit()
+
+        # Create an execution with task_id
+        execution = BackgroundExecution(
+            user_id=test_user.id,
+            subscription_id=1,
+            task_id=task.id,
+            trigger_type="manual",
+            trigger_reason="Test",
+            prompt="Test prompt",
+            status=BackgroundExecutionStatus.RUNNING.value,
+            retry_attempt=0,
+        )
+        test_db.add(execution)
+        test_db.commit()
+        test_db.refresh(execution)
+
+        # Cancel the execution
+        background_execution_manager.cancel_execution(
+            test_db, execution_id=execution.id, user_id=test_user.id
+        )
+
+        # Verify subtasks are cancelled
+        test_db.refresh(subtask1)
+        test_db.refresh(subtask2)
+        assert subtask1.status == SubtaskStatus.CANCELLED
+        assert subtask2.status == SubtaskStatus.CANCELLED
+        assert subtask1.progress == 100
+        assert subtask2.progress == 100
+
+    def test_cancel_execution_without_task_id(self, test_db, test_user):
+        """Test that cancel_execution works when no task is associated."""
+        # Create an execution without task_id (task_id=0)
+        execution = BackgroundExecution(
+            user_id=test_user.id,
+            subscription_id=1,
+            task_id=0,  # No task
+            trigger_type="manual",
+            trigger_reason="Test",
+            prompt="Test prompt",
+            status=BackgroundExecutionStatus.PENDING.value,
+            retry_attempt=0,
+        )
+        test_db.add(execution)
+        test_db.commit()
+        test_db.refresh(execution)
+
+        # Cancel should work without error
+        result = background_execution_manager.cancel_execution(
+            test_db, execution_id=execution.id, user_id=test_user.id
+        )
+
+        assert result.status == BackgroundExecutionStatus.CANCELLED
+
+    def test_cancel_execution_skips_terminal_state_tasks(self, test_db, test_user):
+        """Test that cancel_execution skips tasks already in terminal state."""
+        # Create a completed task
+        completed_time = datetime.now().isoformat()
+        task = TaskResource(
+            user_id=test_user.id,
+            kind="Task",
+            name="test-task",
+            namespace="default",
+            json=create_task_json(
+                status="COMPLETED", progress=100, completed_at=completed_time
+            ),
+            is_active=TaskResource.STATE_ACTIVE,
+        )
+        test_db.add(task)
+        test_db.commit()
+        test_db.refresh(task)
+
+        # Create an execution with task_id
+        execution = BackgroundExecution(
+            user_id=test_user.id,
+            subscription_id=1,
+            task_id=task.id,
+            trigger_type="manual",
+            trigger_reason="Test",
+            prompt="Test prompt",
+            status=BackgroundExecutionStatus.RUNNING.value,
+            retry_attempt=0,
+        )
+        test_db.add(execution)
+        test_db.commit()
+        test_db.refresh(execution)
+
+        # Cancel the execution
+        background_execution_manager.cancel_execution(
+            test_db, execution_id=execution.id, user_id=test_user.id
+        )
+
+        # Verify task status is still COMPLETED (not changed)
+        test_db.refresh(task)
+        task_crd = task.json
+        assert task_crd["status"]["status"] == "COMPLETED"
+        assert task_crd["status"]["completedAt"] == completed_time

--- a/backend/tests/services/subscription/test_name_generation.py
+++ b/backend/tests/services/subscription/test_name_generation.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for subscription name generation."""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.kind import Kind
+from app.services.subscription.service import (
+    generate_unique_subscription_name,
+    subscription_service,
+)
+
+
+class TestGenerateUniqueSubscriptionName:
+    """Test cases for generate_unique_subscription_name function."""
+
+    def test_generates_name_with_correct_format(self, test_db: Session):
+        """Test that generated name follows the expected format."""
+        name = generate_unique_subscription_name(test_db, user_id=1)
+
+        # Should start with 'sub-'
+        assert name.startswith("sub-")
+        # Should have 8 random characters after 'sub-'
+        suffix = name[4:]
+        assert len(suffix) == 8
+        # Should only contain lowercase letters and digits
+        assert suffix.isalnum()
+        assert suffix.islower() or suffix.isdigit()
+
+    def test_generates_unique_names(self, test_db: Session):
+        """Test that multiple calls generate different names."""
+        names = set()
+        for _ in range(10):
+            name = generate_unique_subscription_name(test_db, user_id=1)
+            names.add(name)
+
+        # All names should be unique
+        assert len(names) == 10
+
+    def test_avoids_existing_names(self, test_db: Session):
+        """Test that generated name doesn't collide with existing subscriptions."""
+        # Create an existing subscription
+        existing_name = "sub-abc12345"
+        existing = Kind(
+            user_id=1,
+            kind="Subscription",
+            name=existing_name,
+            namespace="default",
+            json={"spec": {}, "metadata": {"name": existing_name}},
+            is_active=True,
+        )
+        test_db.add(existing)
+        test_db.commit()
+
+        # Generate a new name - should be different
+        name = generate_unique_subscription_name(test_db, user_id=1)
+        assert name != existing_name
+
+    def test_different_users_can_have_same_name_pattern(self, test_db: Session):
+        """Test that name uniqueness is per-user."""
+        name1 = generate_unique_subscription_name(test_db, user_id=1)
+        name2 = generate_unique_subscription_name(test_db, user_id=2)
+
+        # Same user should get different names
+        name3 = generate_unique_subscription_name(test_db, user_id=1)
+        assert name1 != name3
+
+    def test_retries_on_collision(self, test_db: Session, monkeypatch):
+        """Test that function retries when collision occurs."""
+        # First, create a subscription with a known name
+        existing_name = "sub-aaaaaaaa"
+        existing = Kind(
+            user_id=1,
+            kind="Subscription",
+            name=existing_name,
+            namespace="default",
+            json={"spec": {}, "metadata": {"name": existing_name}},
+            is_active=True,
+        )
+        test_db.add(existing)
+        test_db.commit()
+
+        # Mock secrets.choice to always return 'a' to force collision
+        call_count = 0
+
+        def mock_choice(alphabet):
+            nonlocal call_count
+            call_count += 1
+            return "a"
+
+        monkeypatch.setattr(
+            "app.services.subscription.service.secrets.choice", mock_choice
+        )
+
+        # Should retry and eventually fail after max_retries
+        with pytest.raises(
+            RuntimeError, match="Failed to generate unique subscription name"
+        ):
+            generate_unique_subscription_name(test_db, user_id=1)
+
+        # Should have attempted max_retries times (default is 3)
+        # Each name generation calls choice 8 times (for 8 characters)
+        # So 3 retries × 8 characters = 24 calls
+        assert call_count == 24
+
+
+class TestCreateSubscriptionAutoName:
+    """Test cases for auto-name generation in create_subscription."""
+
+    def test_auto_generates_name_when_not_provided(self, test_db: Session, test_user):
+        """Test that name is auto-generated when not provided."""
+        from app.schemas.subscription import (
+            SubscriptionCreate,
+            SubscriptionExecutionTarget,
+        )
+
+        # Create a team first
+        team = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="test-team",
+            namespace="default",
+            json={"spec": {}, "metadata": {"name": "test-team"}},
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+        test_db.refresh(team)
+
+        subscription_in = SubscriptionCreate(
+            name=None,  # Not provided
+            namespace="default",
+            display_name="Test Subscription",
+            team_id=team.id,
+            trigger_type="cron",
+            trigger_config={"expression": "0 0 * * *"},
+            execution_target=SubscriptionExecutionTarget(type="managed"),
+            prompt_template="Test prompt template",
+        )
+
+        result = subscription_service.create_subscription(
+            test_db, subscription_in=subscription_in, user_id=test_user.id
+        )
+
+        # Name should be auto-generated
+        assert result.name is not None
+        assert result.name.startswith("sub-")
+
+    def test_uses_provided_name_when_given(self, test_db: Session, test_user):
+        """Test that user-provided name is used when given."""
+        from app.schemas.subscription import (
+            SubscriptionCreate,
+            SubscriptionExecutionTarget,
+        )
+
+        # Create a team first
+        team = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="test-team",
+            namespace="default",
+            json={"spec": {}, "metadata": {"name": "test-team"}},
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+        test_db.refresh(team)
+
+        subscription_in = SubscriptionCreate(
+            name="my-custom-name",
+            namespace="default",
+            display_name="Test Subscription",
+            team_id=team.id,
+            trigger_type="cron",
+            trigger_config={"expression": "0 0 * * *"},
+            execution_target=SubscriptionExecutionTarget(type="managed"),
+            prompt_template="Test prompt template",
+        )
+
+        result = subscription_service.create_subscription(
+            test_db, subscription_in=subscription_in, user_id=test_user.id
+        )
+
+        assert result.name == "my-custom-name"
+
+    def test_rejects_duplicate_user_provided_name(self, test_db: Session, test_user):
+        """Test that duplicate user-provided names are rejected."""
+        from fastapi import HTTPException
+
+        from app.schemas.subscription import (
+            SubscriptionCreate,
+            SubscriptionExecutionTarget,
+        )
+
+        # Create a team first
+        team = Kind(
+            user_id=test_user.id,
+            kind="Team",
+            name="test-team",
+            namespace="default",
+            json={"spec": {}, "metadata": {"name": "test-team"}},
+            is_active=True,
+        )
+        test_db.add(team)
+        test_db.commit()
+        test_db.refresh(team)
+
+        # Create first subscription
+        subscription_in = SubscriptionCreate(
+            name="duplicate-name",
+            namespace="default",
+            display_name="First Subscription",
+            team_id=team.id,
+            trigger_type="cron",
+            trigger_config={"expression": "0 0 * * *"},
+            execution_target=SubscriptionExecutionTarget(type="managed"),
+            prompt_template="Test prompt template",
+        )
+
+        subscription_service.create_subscription(
+            test_db, subscription_in=subscription_in, user_id=test_user.id
+        )
+
+        # Try to create second with same name
+        subscription_in2 = SubscriptionCreate(
+            name="duplicate-name",
+            namespace="default",
+            display_name="Second Subscription",
+            team_id=team.id,
+            trigger_type="cron",
+            trigger_config={"expression": "0 0 * * *"},
+            execution_target=SubscriptionExecutionTarget(type="managed"),
+            prompt_template="Test prompt template",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            subscription_service.create_subscription(
+                test_db, subscription_in=subscription_in2, user_id=test_user.id
+            )
+
+        assert "already exists" in str(exc_info.value.detail)

--- a/chat_shell/chat_shell/models/factory.py
+++ b/chat_shell/chat_shell/models/factory.py
@@ -225,7 +225,8 @@ class LangChainModelFactory:
             ),
         }
         model_type = model_config.get("model", "openai")
-        think_config = model_config.get("think_config")
+        # Support both think_config (legacy) and reasoning (OpenAI Responses API format)
+        think_config = model_config.get("think_config") or model_config.get("reasoning")
 
         # User-configured temperature from model env takes priority over kwargs
         config_temperature = model_config.get("temperature")

--- a/frontend/src/features/feed/components/SubscriptionForm.tsx
+++ b/frontend/src/features/feed/components/SubscriptionForm.tsx
@@ -793,15 +793,7 @@ export function SubscriptionForm({
 
         toast.success(t('update_success'))
       } else {
-        const generatedName =
-          displayName
-            .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-')
-            .replace(/^-|-$/g, '')
-            .slice(0, 50) || `subscription-${Date.now()}`
-
         const createData: SubscriptionCreateRequest = {
-          name: generatedName,
           display_name: displayName,
           description: description || undefined,
           task_type: taskType,

--- a/frontend/src/types/subscription.ts
+++ b/frontend/src/types/subscription.ts
@@ -166,7 +166,7 @@ export interface Subscription {
 
 // Subscription creation request
 export interface SubscriptionCreateRequest {
-  name: string
+  name?: string
   namespace?: string
   display_name: string
   description?: string

--- a/shared/models/execution.py
+++ b/shared/models/execution.py
@@ -190,6 +190,11 @@ class ExecutionRequest:
     validation_params: Optional[dict] = None  # Validation task parameters
     sandbox_metadata: Optional[dict] = None  # Sandbox task metadata
 
+    # === Reasoning Configuration ===
+    reasoning_config: Optional[dict] = (
+        None  # Reasoning/thinking config: {effort, summary}
+    )
+
     # === Workspace Recovery ===
     skip_git_clone: bool = False  # Skip git clone for workspace recovery from archive
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning configuration options with adjustable effort levels and summary preferences
  * Subscriptions now auto-generate unique names for streamlined creation
  * Task cancellation now available during subscription management operations
  * Enhanced streaming responses to support multiple output types simultaneously

* **Improvements**
  * Simplified subscription creation workflow on the client

<!-- end of auto-generated comment: release notes by coderabbit.ai -->