### PR TITLE
[codex] support object storage JWT auth

### DIFF
--- a/backend/app/api/endpoints/internal/object_storage.py
+++ b/backend/app/api/endpoints/internal/object_storage.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
 from app.core import security
+from app.models.user import User
 from app.services.object_storage import (
     InvalidObjectNameError,
     InvalidSkillIdentityError,
@@ -60,9 +61,10 @@ class DownloadURLResponse(BaseModel):
 def create_upload_url(
     request: UploadURLRequest,
     db: Session = Depends(get_db),
-    auth_context: security.AuthContext = Depends(security.get_auth_context),
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
 ) -> UploadURLResponse:
     """Issue a presigned upload URL scoped to one object."""
+    auth_context = security.AuthContext(user=current_user)
     try:
         grant = object_storage_upload_grant_service.create_upload_grant(
             db=db,
@@ -91,9 +93,10 @@ def create_upload_url(
 def create_download_url(
     request: DownloadURLRequest,
     db: Session = Depends(get_db),
-    auth_context: security.AuthContext = Depends(security.get_auth_context),
+    current_user: User = Depends(security.get_current_user_jwt_apikey_tasktoken),
 ) -> DownloadURLResponse:
     """Issue a presigned download URL scoped to one object."""
+    auth_context = security.AuthContext(user=current_user)
     try:
         grant: ObjectStorageDownloadGrant = (
             object_storage_upload_grant_service.create_download_grant(

--- a/backend/tests/api/endpoints/internal/test_object_storage_api.py
+++ b/backend/tests/api/endpoints/internal/test_object_storage_api.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
+from app.core.security import create_access_token
 from app.models.task import TaskResource
 from app.models.user import User
 from app.services.auth import create_skill_identity_token
@@ -74,7 +75,7 @@ def object_storage_test_client(test_db: Session) -> TestClient:
     return TestClient(app)
 
 
-def test_object_storage_upload_url_requires_developer_token(
+def test_object_storage_upload_url_requires_auth_token(
     object_storage_test_client: TestClient,
     test_user: User,
 ):
@@ -134,6 +135,45 @@ def test_object_storage_upload_url_returns_presigned_upload(
         "upload_url": "https://minio.example.com/upload",
         "object_key": f"publish/{test_user.user_name}/{task.id}/demo.zip",
         "expires_at": "2026-04-10T08:00:00Z",
+    }
+
+
+def test_object_storage_upload_url_accepts_jwt_token(
+    object_storage_test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    mocker,
+):
+    task = _create_task(test_db, task_id=9756, user_id=test_user.id)
+    token = create_skill_identity_token(
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+        runtime_type="executor",
+        runtime_name="executor-1",
+    )
+    auth_token = create_access_token(data={"sub": test_user.user_name})
+    expires_at = datetime(2026, 4, 10, 8, 30, tzinfo=timezone.utc)
+    mocker.patch.object(
+        object_storage_presign_service,
+        "generate_upload_url",
+        return_value=("https://minio.example.com/upload-jwt", expires_at),
+    )
+
+    response = object_storage_test_client.post(
+        "/api/internal/object-storage/upload-url",
+        headers={"Authorization": f"Bearer {auth_token}"},
+        json={
+            "task_id": task.id,
+            "object_name": "demo.zip",
+            "skill_identity_token": token,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "upload_url": "https://minio.example.com/upload-jwt",
+        "object_key": f"publish/{test_user.user_name}/{task.id}/demo.zip",
+        "expires_at": "2026-04-10T08:30:00Z",
     }
 
 


### PR DESCRIPTION
## Summary
- allow internal object storage URL grants to authenticate with JWT or task tokens in addition to existing API key auth
- preserve existing wg- API key AuthContext behavior, including service key impersonation
- add coverage for JWT-authenticated upload URL requests

## Validation
- `uv run pytest tests/api/endpoints/internal/test_object_storage_api.py`
