### PR TITLE
feat(knowledge): add source_config parameter for document origin trac…

### DIFF
--- a/backend/app/mcp_server/tools/knowledge.py
+++ b/backend/app/mcp_server/tools/knowledge.py
@@ -365,6 +365,10 @@ def create_knowledge_base(
             "This is the PREFERRED method - content is read directly from storage without "
             "passing through the model output window."
         ),
+        "source_config": (
+            "Optional source configuration dict for tracking document origin. "
+            "Example: {'url': 'https://...', 'source': 'dingtalk', 'updated_at': '2026-04-16T10:00:00Z', 'scraped_at': '2026-04-16T11:00:00Z'}"
+        ),
         "trigger_indexing": "Whether to trigger RAG indexing (default: True)",
         "trigger_summary": "Whether to trigger summary generation (default: True)",
     },
@@ -379,6 +383,7 @@ def create_document(
     file_extension: Optional[str] = None,
     url: Optional[str] = None,
     attachment_id: Optional[int] = None,
+    source_config: Optional[Dict[str, Any]] = None,
     trigger_indexing: bool = True,
     trigger_summary: bool = True,
 ) -> Dict[str, Any]:
@@ -404,6 +409,7 @@ def create_document(
         file_extension: File extension (for source_type="file", e.g., "txt", "md", "pdf")
         url: URL to scrape (for source_type="web")
         attachment_id: Existing attachment ID (for source_type="attachment")
+        source_config: Optional source configuration dict for tracking document origin
         trigger_indexing: Whether to trigger RAG indexing (default: True)
         trigger_summary: Whether to trigger summary generation (default: True)
 
@@ -428,6 +434,7 @@ def create_document(
             file_extension=file_extension,
             url=url,
             attachment_id=attachment_id,
+            source_config=source_config,
             trigger_indexing=trigger_indexing,
             trigger_summary=trigger_summary,
         )

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -330,6 +330,14 @@ class KnowledgeDocumentCreate(BaseModel):
         description="Source configuration (e.g., {'url': '...'} for table)",
     )
 
+    @field_validator("source_config", mode="before")
+    @classmethod
+    def ensure_source_config_dict(cls, v):
+        """Convert None to empty dict for backward compatibility."""
+        if v is None:
+            return {}
+        return v
+
 
 class KnowledgeDocumentUpdate(BaseModel):
     """Schema for updating a knowledge document."""

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1231,7 +1231,7 @@ class KnowledgeOrchestrator:
                 attachment_id=attachment.id,
                 file_extension=normalized_ext,
                 file_size=len(binary_data),
-                source_config=source_config,
+                source_config=source_config or {},
             )
 
             return self._create_and_index_document(
@@ -1265,7 +1265,7 @@ class KnowledgeOrchestrator:
             attachment_id=attachment.id,
             file_extension=normalized_ext,
             file_size=len(binary_data),
-            source_config=source_config,
+            source_config=source_config or {},
         )
 
         return self._create_and_index_document(

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1103,6 +1103,7 @@ class KnowledgeOrchestrator:
         file_extension: Optional[str] = None,
         url: Optional[str] = None,
         attachment_id: Optional[int] = None,
+        source_config: Optional[Dict[str, Any]] = None,
         trigger_indexing: bool = True,
         trigger_summary: bool = True,
         splitter_config: Optional[Dict[str, Any]] = None,
@@ -1123,6 +1124,7 @@ class KnowledgeOrchestrator:
             file_extension: File extension for source_type="file"
             url: URL for source_type="web"
             attachment_id: Existing attachment ID for source_type="attachment"
+            source_config: Optional source configuration dict for tracking document origin
             trigger_indexing: Whether to trigger RAG indexing
             trigger_summary: Whether to trigger summary generation
             splitter_config: Optional splitter configuration dict
@@ -1229,6 +1231,7 @@ class KnowledgeOrchestrator:
                 attachment_id=attachment.id,
                 file_extension=normalized_ext,
                 file_size=len(binary_data),
+                source_config=source_config,
             )
 
             return self._create_and_index_document(
@@ -1262,6 +1265,7 @@ class KnowledgeOrchestrator:
             attachment_id=attachment.id,
             file_extension=normalized_ext,
             file_size=len(binary_data),
+            source_config=source_config,
         )
 
         return self._create_and_index_document(

--- a/backend/init_data/skills/dingtalk-knowledge/SKILL.md
+++ b/backend/init_data/skills/dingtalk-knowledge/SKILL.md
@@ -1,0 +1,213 @@
+---
+description: "Upload DingTalk documents, spreadsheets, and AI tables to knowledge base. Supports extracting content from DingTalk URLs and creating knowledge base documents with proper source attribution."
+displayName: "钉钉文档上传"
+version: "1.0.0"
+author: "Wegent Team"
+tags: ["dingtalk", "knowledge", "document", "spreadsheet", "ai-table"]
+bindShells:
+  - Chat
+  - Agno
+  - ClaudeCode
+provider:
+  module: provider
+  class: DingTalkKnowledgeProvider
+config:
+  unconfiguredGuide:
+    modalLink: "wegent://modal/mcp-provider-config?provider=dingtalk&service=docs"
+    modalText: "打开钉钉 MCP 配置弹窗"
+mcpServers:
+  dingtalk-docs:
+    type: streamable-http
+    url: "${{task_data.user_mcps.dingtalk.services.docs.credentials.url}}"
+    timeout: 300
+  dingtalk-table:
+    type: streamable-http
+    url: "${{task_data.user_mcps.dingtalk.services.table.credentials.url}}"
+    timeout: 300
+  dingtalk-ai-table:
+    type: streamable-http
+    url: "${{task_data.user_mcps.dingtalk.services.ai_table.credentials.url}}"
+    timeout: 300
+  wegent-knowledge:
+    type: streamable-http
+    url: "${{backend_url}}/mcp/knowledge/sse"
+    headers:
+      Authorization: "Bearer ${{task_token}}"
+    timeout: 300
+---
+
+# DingTalk Knowledge Upload Skill
+
+Upload DingTalk documents, spreadsheets, and AI tables to Wegent knowledge bases.
+
+## When To Use
+
+- The user wants to add a DingTalk document to a knowledge base
+- The user mentions URLs like:
+  - `https://alidocs.dingtalk.com/i/nodes/...` (DingTalk Docs)
+  - `https://alidocs.dingtalk.com/i/spreadsheet/...` (DingTalk Table)
+  - `https://alidocs.dingtalk.com/i/ai/...` (DingTalk AI Table)
+
+## Workflow
+
+When user wants to upload a DingTalk document to knowledge base:
+
+### Step 1: Parse URL
+Identify document type from the DingTalk URL:
+- Docs: `https://alidocs.dingtalk.com/i/nodes/{doc_id}`
+- Table: `https://alidocs.dingtalk.com/i/spreadsheet/{doc_id}`
+- AI Table: `https://alidocs.dingtalk.com/i/ai/{doc_id}`
+
+### Step 2: Get Document Info
+Use the appropriate DingTalk MCP tool to query document information:
+
+For docs (dingtalk-docs MCP):
+```
+get_document_info(document_id="xxx")
+```
+
+For tables (dingtalk-table MCP):
+```
+get_spreadsheet_info(spreadsheet_id="xxx")
+```
+
+For AI tables (dingtalk-ai-table MCP):
+```
+get_ai_table_info(table_id="xxx")
+```
+
+### Step 3: Get Document Content
+
+There are two ways to get document content depending on document type:
+
+#### Option A: Download File (for file-based documents)
+Call `download_file` tool to get the download URL:
+```
+download_file(nodeId="xxx")
+```
+
+If successful, it returns a `download_url` - proceed to Step 4A.
+If it returns an error saying "在线文档不支持直接下载" (online docs not supported), use Option B.
+
+#### Option B: Get Content (for online documents like adoc)
+If `download_file` fails for online documents, call:
+```
+get_document_content(nodeId="xxx")
+```
+
+This returns the document content that needs to be saved to a file in sandbox.
+
+### Step 4A: Download and Upload via Sandbox (for file-based documents)
+**CRITICAL: You MUST use the dingtalk_knowledge provider tool to download the file in sandbox.**
+
+If you got a `download_url` from Step 3A:
+1. Start a sandbox environment
+2. Use the dingtalk_knowledge provider tool to download the file in sandbox:
+```
+download_dingtalk_document(
+    download_url="{download_url_from_step_3}",
+    filename="document.docx"
+)
+```
+This returns an `attachment_id` that was created by uploading the file from sandbox to Wegent.
+
+**DO NOT** call `wegent-knowledge.create_document` directly with a URL - you must first download the file in sandbox using the provider tool.
+
+### Step 4B: Save Content and Upload via Sandbox (for online documents)
+**CRITICAL: You MUST use the dingtalk_knowledge provider tool to save content in sandbox.**
+
+If you got content from Step 3B:
+1. Start a sandbox environment
+2. Use the dingtalk_knowledge provider tool to save the content to a file in sandbox:
+```
+save_dingtalk_content(
+    content="{content_from_step_3b}",
+    filename="document.md"
+)
+```
+This returns an `attachment_id` that was created by uploading the file from sandbox to Wegent.
+
+**DO NOT** create the attachment directly - you must use the provider tool which handles sandbox file operations.
+
+### Step 5: Create Knowledge Base Document
+Use the wegent-knowledge MCP server's `create_document` tool to create the document in knowledge base with source attribution:
+
+```
+wegent-knowledge.create_document(
+    knowledge_base_id=123,
+    name="Document Name",
+    source_type="attachment",
+    attachment_id=456,
+    source_config={
+        "url": "https://alidocs.dingtalk.com/i/nodes/xxxxx",
+        "source": "dingtalk",
+        "updated_at": "2026-04-16T10:00:00Z",
+        "scraped_at": "2026-04-16T11:00:00Z"
+    },
+    trigger_indexing=true
+)
+```
+
+**Important:** This calls the Wegent knowledge MCP tool (defined in `backend/app/mcp_server/tools/knowledge.py`), NOT a provider tool.
+
+Parameters:
+- `knowledge_base_id`: The target knowledge base ID
+- `name`: Document name (use the document title from get_document_info)
+- `source_type`: Use "attachment" since we have an attachment_id
+- `attachment_id`: The attachment ID returned from Step 4A or 4B
+- `source_config`: JSON object with DingTalk source information
+- `trigger_indexing`: Set to true to enable RAG indexing
+
+Note:
+- `updated_at` should be the document's last update time from get_document_info
+- `scraped_at` should be the current time when uploading
+
+## Source Attribution
+
+When creating the knowledge base document, set the `source_config` field:
+```json
+{
+  "url": "https://alidocs.dingtalk.com/i/nodes/xxxxx",
+  "source": "dingtalk",
+  "updated_at": "2026-04-16T10:00:00Z",
+  "scraped_at": "2026-04-16T11:00:00Z"
+}
+```
+
+- `url`: The original DingTalk document URL
+- `source`: Always "dingtalk"
+- `updated_at`: The document's last update time from get_document_info
+- `scraped_at`: The current time when the document was uploaded
+
+## Error Handling
+
+If MCP tools report a permissions or configuration problem:
+1. Check if the user has configured the corresponding DingTalk MCP service
+2. Guide the user to Settings → Integrations → DingTalk to configure
+3. Do not proceed without proper configuration
+
+## Examples
+
+### Example 1: File-based Document (Word, Excel, etc.)
+
+User: "将钉钉文档 https://alidocs.dingtalk.com/i/nodes/nYMoOje9 添加到知识库 '产品文档'"
+
+Steps:
+1. Parse URL → doc_type="docs", doc_id="nYMoOje9"
+2. Call dingtalk-docs.get_document_info(document_id="nYMoOje9")
+3. Call dingtalk-docs.download_file(nodeId="nYMoOje9") to get download_url
+4. Call dingtalk_knowledge.download_dingtalk_document(download_url="...", filename="xxx.docx") to get attachment_id
+5. Call wegent-knowledge.create_document with attachment_id and source_config
+
+### Example 2: Online Document (adoc)
+
+User: "将钉钉文档 https://alidocs.dingtalk.com/i/nodes/AbCdEfGh 添加到知识库"
+
+Steps:
+1. Parse URL → doc_type="docs", doc_id="AbCdEfGh"
+2. Call dingtalk-docs.get_document_info(document_id="AbCdEfGh")
+3. Call dingtalk-docs.download_file(nodeId="AbCdEfGh")
+   - Returns error: "在线文档不支持直接下载。请使用 get_document_content 工具获取文档内容。"
+4. Call dingtalk-docs.get_document_content(nodeId="AbCdEfGh") to get content
+5. Call dingtalk_knowledge.save_dingtalk_content(content="...", filename="xxx.md") to get attachment_id
+6. Call wegent-knowledge.create_document with attachment_id and source_config

--- a/backend/init_data/skills/dingtalk-knowledge/SKILL.md
+++ b/backend/init_data/skills/dingtalk-knowledge/SKILL.md
@@ -100,12 +100,12 @@ This returns the document content that needs to be saved to a file in sandbox.
 ### Step 4A: Download and Upload via Sandbox (for file-based documents)
 **CRITICAL: You MUST use the dingtalk_knowledge provider tool to download the file in sandbox.**
 
-If you got a `download_url` from Step 3A:
+If you got a `download_url` from Option A:
 1. Start a sandbox environment
 2. Use the dingtalk_knowledge provider tool to download the file in sandbox:
-```
+```python
 download_dingtalk_document(
-    download_url="{download_url_from_step_3}",
+    download_url="{download_url_from_option_a}",
     filename="document.docx"
 )
 ```
@@ -116,12 +116,12 @@ This returns an `attachment_id` that was created by uploading the file from sand
 ### Step 4B: Save Content and Upload via Sandbox (for online documents)
 **CRITICAL: You MUST use the dingtalk_knowledge provider tool to save content in sandbox.**
 
-If you got content from Step 3B:
+If you got content from Option B:
 1. Start a sandbox environment
 2. Use the dingtalk_knowledge provider tool to save the content to a file in sandbox:
-```
+```python
 save_dingtalk_content(
-    content="{content_from_step_3b}",
+    content="{content_from_option_b}",
     filename="document.md"
 )
 ```
@@ -132,7 +132,7 @@ This returns an `attachment_id` that was created by uploading the file from sand
 ### Step 5: Create Knowledge Base Document
 Use the wegent-knowledge MCP server's `create_document` tool to create the document in knowledge base with source attribution:
 
-```
+```python
 wegent-knowledge.create_document(
     knowledge_base_id=123,
     name="Document Name",
@@ -144,7 +144,7 @@ wegent-knowledge.create_document(
         "updated_at": "2026-04-16T10:00:00Z",
         "scraped_at": "2026-04-16T11:00:00Z"
     },
-    trigger_indexing=true
+    trigger_indexing=True
 )
 ```
 

--- a/backend/init_data/skills/dingtalk-knowledge/provider.py
+++ b/backend/init_data/skills/dingtalk-knowledge/provider.py
@@ -1,0 +1,650 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""DingTalk Knowledge Tool Provider.
+
+This module provides the DingTalkKnowledgeProvider class that creates
+tools for downloading DingTalk documents and uploading them as attachments
+to Wegent.
+
+Tools provided:
+- download_dingtalk_document: Download DingTalk document from download URL and upload as attachment
+- save_dingtalk_content: Save DingTalk online document content to file and upload as attachment
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Optional
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from chat_shell.chat_shell.skills import SkillToolContext, SkillToolProvider
+
+logger = logging.getLogger(__name__)
+
+
+class DingTalkKnowledgeProvider(SkillToolProvider):
+    """Tool provider for DingTalk Knowledge operations.
+
+    This provider creates tools that help upload DingTalk documents
+    to Wegent knowledge bases. It handles:
+    - Document download from DingTalk export URL
+    - Upload as Wegent attachment
+    """
+
+    @property
+    def provider_name(self) -> str:
+        """Return the provider name used in SKILL.md."""
+        return "dingtalk_knowledge"
+
+    @property
+    def supported_tools(self) -> list[str]:
+        """Return the list of tools this provider can create."""
+        return ["download_dingtalk_document", "save_dingtalk_content"]
+
+    def create_tool(
+        self,
+        tool_name: str,
+        context: SkillToolContext,
+        tool_config: Optional[dict[str, Any]] = None,
+    ) -> BaseTool:
+        """Create a DingTalk Knowledge tool instance.
+
+        Args:
+            tool_name: Name of the tool to create
+            context: Context with dependencies
+            tool_config: Optional configuration
+
+        Returns:
+            Configured tool instance
+
+        Raises:
+            ValueError: If tool_name is unknown
+        """
+        logger.info(
+            f"[DingTalkKnowledgeProvider] Creating tool: {tool_name}, "
+            f"task_id={context.task_id}, user_id={context.user_id}"
+        )
+
+        if tool_name == "download_dingtalk_document":
+            return DownloadDingTalkDocumentTool(
+                task_id=context.task_id,
+                subtask_id=context.subtask_id,
+                user_id=context.user_id,
+                auth_token=context.auth_token,
+                ws_emitter=context.ws_emitter,
+            )
+        elif tool_name == "save_dingtalk_content":
+            return SaveDingTalkContentTool(
+                task_id=context.task_id,
+                subtask_id=context.subtask_id,
+                user_id=context.user_id,
+                auth_token=context.auth_token,
+                ws_emitter=context.ws_emitter,
+            )
+        else:
+            raise ValueError(f"Unknown tool: {tool_name}")
+
+    def validate_config(self, tool_config: dict[str, Any]) -> bool:
+        """Validate tool configuration.
+
+        Args:
+            tool_config: Configuration to validate
+
+        Returns:
+            True if valid
+        """
+        return True
+
+
+class DownloadDingTalkDocumentInput(BaseModel):
+    """Input schema for download_dingtalk_document tool."""
+
+    download_url: str = Field(
+        ...,
+        description="Download URL obtained from DingTalk MCP download_file tool (contains download_token)",
+    )
+    filename: str = Field(
+        ...,
+        description="Filename to save the document (e.g., 'document.docx')",
+    )
+    timeout_seconds: Optional[int] = Field(
+        default=300,
+        description="Download timeout in seconds",
+    )
+
+
+class DownloadDingTalkDocumentTool(BaseTool):
+    """Tool for downloading DingTalk document and uploading as Wegent attachment.
+
+    This tool:
+    1. Downloads the document from the provided download URL in sandbox
+    2. Uploads it to Wegent as an attachment
+    3. Returns the attachment_id for use in knowledge base
+    """
+
+    name: str = "download_dingtalk_document"
+    display_name: str = "下载钉钉文档"
+    description: str = """Download a DingTalk document from download URL and upload as Wegent attachment.
+
+This tool downloads a DingTalk document using the download URL obtained from DingTalk MCP's download_file tool,
+then uploads it to Wegent as an attachment for use in knowledge base.
+
+Prerequisites:
+1. Call DingTalk MCP's get_document_info to get document metadata
+2. Call DingTalk MCP's download_file to get the download_url with token
+3. Then call this tool with the download_url
+
+Parameters:
+- download_url (required): Download URL from DingTalk MCP download_file tool (contains download_token)
+- filename (required): Filename to save (e.g., 'document.docx', 'spreadsheet.xlsx')
+- timeout_seconds (optional): Download timeout (default: 300)
+
+Returns:
+- success: Whether the operation succeeded
+- attachment_id: ID of the uploaded attachment
+- filename: Name of the file
+- file_size: Size in bytes
+- download_url: Relative URL for downloading
+- error: Error message if failed
+
+Example:
+```
+# Step 1: Get document info
+dingtalk-docs.get_document_info(document_id="nYMoOje9")
+
+# Step 2: Get download URL (use nodeId for docs)
+dingtalk-docs.download_file(nodeId="nYMoOje9")
+# Returns: {"download_url": "https://...", "download_token": "..."}
+
+# Step 3: Download and upload
+download_dingtalk_document(
+    download_url="https://alidocs.dingtalk.com/...",
+    filename="产品需求文档.docx"
+)
+```
+
+Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
+"""
+
+    args_schema: type[BaseModel] = DownloadDingTalkDocumentInput
+
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    auth_token: str = ""
+    ws_emitter: Any = None
+
+    def _run(
+        self,
+        download_url: str,
+        filename: str,
+        timeout_seconds: Optional[int] = None,
+    ) -> str:
+        """Synchronous execution - not implemented."""
+        raise NotImplementedError(
+            "DownloadDingTalkDocumentTool only supports async execution"
+        )
+
+    async def _arun(
+        self,
+        download_url: str,
+        filename: str,
+        timeout_seconds: Optional[int] = None,
+    ) -> str:
+        """Download DingTalk document and upload as attachment."""
+        start_time = time.time()
+        effective_timeout = timeout_seconds or 300
+
+        logger.info(
+            f"[DownloadDingTalkDocumentTool] Downloading from {download_url[:50]}..., "
+            f"filename={filename}"
+        )
+
+        # Emit status update
+        if self.ws_emitter:
+            try:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={
+                        "download_url": download_url[:50] + "...",
+                        "filename": filename,
+                    },
+                    status="running",
+                )
+            except Exception as e:
+                logger.warning(f"Failed to emit tool status: {e}")
+
+        try:
+            # Import sandbox manager
+            from chat_shell.chat_shell.tools.sandbox import SandboxManager
+
+            # Get user info for sandbox manager
+            # We need user_name, try to get from context or use a default
+            user_name = f"user_{self.user_id}"
+
+            # Get or create sandbox manager singleton
+            sandbox_manager = SandboxManager.get_instance(
+                task_id=self.task_id,
+                user_id=self.user_id,
+                user_name=user_name,
+            )
+
+            # Get or create sandbox
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type="ClaudeCode",
+                workspace_ref=None,
+            )
+
+            if error:
+                raise RuntimeError(f"Failed to create sandbox: {error}")
+
+            # Prepare paths
+            temp_dir = f"/tmp/dingtalk_{int(time.time())}"
+            save_path = f"{temp_dir}/{filename}"
+
+            # Create temp directory
+            await sandbox.files.make_dir(temp_dir)
+
+            # Download file using curl
+            curl_cmd = f"curl -s -f -L -o '{save_path}' '{download_url}'"
+
+            logger.info(
+                f"[DownloadDingTalkDocumentTool] Executing download: {curl_cmd[:80]}..."
+            )
+
+            result = await sandbox.commands.run(
+                cmd=curl_cmd,
+                cwd="/home/user",
+                timeout=effective_timeout,
+            )
+
+            if result.exit_code != 0:
+                raise RuntimeError(f"Download failed: {result.stderr or 'HTTP error'}")
+
+            # Verify file exists and get size
+            file_info = await sandbox.files.get_info(save_path)
+            file_size = file_info.size
+
+            logger.info(f"[DownloadDingTalkDocumentTool] Downloaded {file_size} bytes")
+
+            # Upload to Wegent
+            api_base_url = os.getenv("BACKEND_API_URL", "http://backend:8000").rstrip(
+                "/"
+            )
+            upload_url = f"{api_base_url}/api/attachments/upload"
+
+            if not self.auth_token:
+                raise RuntimeError("No authentication token available")
+
+            # Build curl command for upload
+            upload_curl_cmd = (
+                f"curl -s -X POST "
+                f'-H "Authorization: Bearer {self.auth_token}" '
+                f'-F "file=@{save_path}" '
+                f'"{upload_url}"'
+            )
+
+            logger.info(f"[DownloadDingTalkDocumentTool] Uploading to Wegent")
+
+            upload_result = await sandbox.commands.run(
+                cmd=upload_curl_cmd,
+                cwd="/home/user",
+                timeout=effective_timeout,
+            )
+
+            if upload_result.exit_code != 0:
+                raise RuntimeError(
+                    f"Upload failed: {upload_result.stderr or 'Unknown error'}"
+                )
+
+            # Parse response
+            try:
+                api_response = json.loads(upload_result.stdout)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"Failed to parse upload response: {e}")
+
+            if "detail" in api_response:
+                error_detail = api_response["detail"]
+                raise RuntimeError(f"Upload API error: {error_detail}")
+
+            attachment_id = api_response.get("id")
+            if not attachment_id:
+                raise RuntimeError("No attachment_id in response")
+
+            execution_time = time.time() - start_time
+
+            response = {
+                "success": True,
+                "attachment_id": attachment_id,
+                "filename": filename,
+                "file_size": file_size,
+                "download_url": f"/api/attachments/{attachment_id}/download",
+                "message": "Document downloaded and uploaded successfully",
+                "execution_time": execution_time,
+            }
+
+            logger.info(
+                f"[DownloadDingTalkDocumentTool] Success: attachment_id={attachment_id}"
+            )
+
+            # Emit success status
+            if self.ws_emitter:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={"filename": filename},
+                    status="completed",
+                    output=response,
+                )
+
+            # Cleanup temp directory
+            try:
+                await sandbox.commands.run(cmd=f"rm -rf {temp_dir}", cwd="/home/user")
+            except Exception:
+                pass
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            logger.error(f"[DownloadDingTalkDocumentTool] Error: {e}", exc_info=True)
+
+            error_response = {
+                "success": False,
+                "attachment_id": None,
+                "filename": filename,
+                "file_size": 0,
+                "download_url": "",
+                "error": str(e),
+            }
+
+            if self.ws_emitter:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={"filename": filename},
+                    status="failed",
+                    error=str(e),
+                )
+
+            return json.dumps(error_response, ensure_ascii=False, indent=2)
+
+
+class SaveDingTalkContentInput(BaseModel):
+    """Input schema for save_dingtalk_content tool."""
+
+    content: str = Field(
+        ...,
+        description="Document content obtained from DingTalk MCP get_document_content tool",
+    )
+    filename: str = Field(
+        ...,
+        description="Filename to save the content (e.g., 'document.md', 'document.txt')",
+    )
+    timeout_seconds: Optional[int] = Field(
+        default=300,
+        description="Operation timeout in seconds",
+    )
+
+
+class SaveDingTalkContentTool(BaseTool):
+    """Tool for saving DingTalk online document content and uploading as attachment.
+
+    This tool is used for online documents (like adoc) that cannot be downloaded directly.
+    It:
+    1. Saves the content obtained from get_document_content to a file in sandbox
+    2. Uploads it to Wegent as an attachment
+    3. Returns the attachment_id for use in knowledge base
+    """
+
+    name: str = "save_dingtalk_content"
+    display_name: str = "保存钉钉文档内容"
+    description: str = """Save DingTalk online document content to a file and upload as Wegent attachment.
+
+This tool is for online documents (like adoc) that cannot be downloaded via download_file.
+It saves the content obtained from DingTalk MCP's get_document_content tool to a file,
+then uploads it to Wegent as an attachment.
+
+Prerequisites:
+1. Call DingTalk MCP's get_document_info to get document metadata
+2. Call DingTalk MCP's download_file - if it fails with "在线文档不支持直接下载"
+3. Call DingTalk MCP's get_document_content to get the document content
+4. Then call this tool with the content
+
+Parameters:
+- content (required): Document content from DingTalk MCP get_document_content tool
+- filename (required): Filename to save (e.g., 'document.md', 'notes.txt')
+- timeout_seconds (optional): Operation timeout (default: 300)
+
+Returns:
+- success: Whether the operation succeeded
+- attachment_id: ID of the uploaded attachment
+- filename: Name of the file
+- file_size: Size in bytes
+- download_url: Relative URL for downloading
+- error: Error message if failed
+
+Example:
+```
+# Step 1: Try download_file (will fail for online docs)
+dingtalk-docs.download_file(nodeId="nYMoOje9")
+# Returns error: "在线文档不支持直接下载。请使用 get_document_content 工具获取文档内容。"
+
+# Step 2: Get content
+dingtalk-docs.get_document_content(nodeId="nYMoOje9")
+# Returns: {"content": "# Title\\n\\nContent..."}
+
+# Step 3: Save content and upload
+save_dingtalk_content(
+    content="# Title\\n\\nContent...",
+    filename="产品需求文档.md"
+)
+```
+
+Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
+"""
+
+    args_schema: type[BaseModel] = SaveDingTalkContentInput
+
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    auth_token: str = ""
+    ws_emitter: Any = None
+
+    def _run(
+        self,
+        content: str,
+        filename: str,
+        timeout_seconds: Optional[int] = None,
+    ) -> str:
+        """Synchronous execution - not implemented."""
+        raise NotImplementedError(
+            "SaveDingTalkContentTool only supports async execution"
+        )
+
+    async def _arun(
+        self,
+        content: str,
+        filename: str,
+        timeout_seconds: Optional[int] = None,
+    ) -> str:
+        """Save content to file and upload as attachment."""
+        start_time = time.time()
+        effective_timeout = timeout_seconds or 300
+
+        logger.info(
+            f"[SaveDingTalkContentTool] Saving content, filename={filename}, "
+            f"content_length={len(content)}"
+        )
+
+        # Emit status update
+        if self.ws_emitter:
+            try:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={"filename": filename, "content_length": len(content)},
+                    status="running",
+                )
+            except Exception as e:
+                logger.warning(f"Failed to emit tool status: {e}")
+
+        try:
+            # Import sandbox manager
+            from chat_shell.chat_shell.tools.sandbox import SandboxManager
+
+            # Get user info for sandbox manager
+            user_name = f"user_{self.user_id}"
+
+            # Get or create sandbox manager singleton
+            sandbox_manager = SandboxManager.get_instance(
+                task_id=self.task_id,
+                user_id=self.user_id,
+                user_name=user_name,
+            )
+
+            # Get or create sandbox
+            sandbox, error = await sandbox_manager.get_or_create_sandbox(
+                shell_type="ClaudeCode",
+                workspace_ref=None,
+            )
+
+            if error:
+                raise RuntimeError(f"Failed to create sandbox: {error}")
+
+            # Prepare paths
+            temp_dir = f"/tmp/dingtalk_{int(time.time())}"
+            save_path = f"{temp_dir}/{filename}"
+
+            # Create temp directory
+            await sandbox.files.make_dir(temp_dir)
+
+            # Write content to file using Python in sandbox
+            # Escape content for shell command
+            escaped_content = content.replace("'", "'\"'\"'")
+            python_cmd = f'python3 -c \'open("{save_path}", "w", encoding="utf-8").write("{escaped_content}")\''
+
+            logger.info(f"[SaveDingTalkContentTool] Writing content to file")
+
+            result = await sandbox.commands.run(
+                cmd=python_cmd,
+                cwd="/home/user",
+                timeout=effective_timeout,
+            )
+
+            if result.exit_code != 0:
+                raise RuntimeError(f"Failed to write content: {result.stderr}")
+
+            # Verify file exists and get size
+            file_info = await sandbox.files.get_info(save_path)
+            file_size = file_info.size
+
+            logger.info(f"[SaveDingTalkContentTool] Saved {file_size} bytes")
+
+            # Upload to Wegent
+            api_base_url = os.getenv("BACKEND_API_URL", "http://backend:8000").rstrip(
+                "/"
+            )
+            upload_url = f"{api_base_url}/api/attachments/upload"
+
+            if not self.auth_token:
+                raise RuntimeError("No authentication token available")
+
+            # Build curl command for upload
+            upload_curl_cmd = (
+                f"curl -s -X POST "
+                f'-H "Authorization: Bearer {self.auth_token}" '
+                f'-F "file=@{save_path}" '
+                f'"{upload_url}"'
+            )
+
+            logger.info(f"[SaveDingTalkContentTool] Uploading to Wegent")
+
+            upload_result = await sandbox.commands.run(
+                cmd=upload_curl_cmd,
+                cwd="/home/user",
+                timeout=effective_timeout,
+            )
+
+            if upload_result.exit_code != 0:
+                raise RuntimeError(
+                    f"Upload failed: {upload_result.stderr or 'Unknown error'}"
+                )
+
+            # Parse response
+            try:
+                api_response = json.loads(upload_result.stdout)
+            except json.JSONDecodeError as e:
+                raise RuntimeError(f"Failed to parse upload response: {e}")
+
+            if "detail" in api_response:
+                error_detail = api_response["detail"]
+                raise RuntimeError(f"Upload API error: {error_detail}")
+
+            attachment_id = api_response.get("id")
+            if not attachment_id:
+                raise RuntimeError("No attachment_id in response")
+
+            execution_time = time.time() - start_time
+
+            response = {
+                "success": True,
+                "attachment_id": attachment_id,
+                "filename": filename,
+                "file_size": file_size,
+                "download_url": f"/api/attachments/{attachment_id}/download",
+                "message": "Content saved and uploaded successfully",
+                "execution_time": execution_time,
+            }
+
+            logger.info(
+                f"[SaveDingTalkContentTool] Success: attachment_id={attachment_id}"
+            )
+
+            # Emit success status
+            if self.ws_emitter:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={"filename": filename},
+                    status="completed",
+                    output=response,
+                )
+
+            # Cleanup temp directory
+            try:
+                await sandbox.commands.run(cmd=f"rm -rf {temp_dir}", cwd="/home/user")
+            except Exception:
+                pass
+
+            return json.dumps(response, ensure_ascii=False, indent=2)
+
+        except Exception as e:
+            logger.error(f"[SaveDingTalkContentTool] Error: {e}", exc_info=True)
+
+            error_response = {
+                "success": False,
+                "attachment_id": None,
+                "filename": filename,
+                "file_size": 0,
+                "download_url": "",
+                "error": str(e),
+            }
+
+            if self.ws_emitter:
+                await self.ws_emitter.emit_tool_call(
+                    task_id=self.task_id,
+                    tool_name=self.name,
+                    tool_input={"filename": filename},
+                    status="failed",
+                    error=str(e),
+                )
+
+            return json.dumps(error_response, ensure_ascii=False, indent=2)

--- a/backend/init_data/skills/dingtalk-knowledge/provider.py
+++ b/backend/init_data/skills/dingtalk-knowledge/provider.py
@@ -16,16 +16,21 @@ Tools provided:
 import json
 import logging
 import os
+import re
+import secrets
+import shlex
 import time
 from typing import Any, Optional
 
-from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from chat_shell.chat_shell.skills import SkillToolContext, SkillToolProvider
 
 logger = logging.getLogger(__name__)
+
+# Maximum file size for uploads (default 100MB)
+ATTACHMENT_MAX_BYTES = int(os.getenv("ATTACHMENT_MAX_BYTES", "104857600"))
 
 
 class DingTalkKnowledgeProvider(SkillToolProvider):
@@ -76,6 +81,7 @@ class DingTalkKnowledgeProvider(SkillToolProvider):
                 task_id=context.task_id,
                 subtask_id=context.subtask_id,
                 user_id=context.user_id,
+                user_name=context.user_name,
                 auth_token=context.auth_token,
                 ws_emitter=context.ws_emitter,
             )
@@ -84,6 +90,7 @@ class DingTalkKnowledgeProvider(SkillToolProvider):
                 task_id=context.task_id,
                 subtask_id=context.subtask_id,
                 user_id=context.user_id,
+                user_name=context.user_name,
                 auth_token=context.auth_token,
                 ws_emitter=context.ws_emitter,
             )
@@ -119,7 +126,256 @@ class DownloadDingTalkDocumentInput(BaseModel):
     )
 
 
-class DownloadDingTalkDocumentTool(BaseTool):
+def _validate_filename(filename: str) -> str:
+    """Validate and sanitize filename to prevent path traversal.
+
+    Args:
+        filename: Original filename
+
+    Returns:
+        Sanitized filename
+
+    Raises:
+        ValueError: If filename contains invalid characters
+    """
+    # Reject path separators and control characters
+    if re.search(r"[\/\x00-\x1f\x7f]", filename):
+        raise ValueError(
+            "Invalid filename: contains path separators or control characters"
+        )
+    # Reject parent directory references
+    if ".." in filename:
+        raise ValueError("Invalid filename: contains parent directory reference")
+    # Strip any leading/trailing whitespace
+    return filename.strip()
+
+
+def _generate_temp_dir_name() -> str:
+    """Generate a unique temporary directory name.
+
+    Returns:
+        Unique directory path in /tmp
+    """
+    return f"/tmp/dingtalk_{secrets.token_hex(16)}"
+
+
+class _DingTalkSandboxUploadTool(BaseTool):
+    """Base class for DingTalk sandbox upload tools.
+
+    Provides common functionality for:
+    - Sandbox acquisition and validation
+    - Temporary directory management
+    - File upload via curl
+    - Response parsing and status emission
+    - Cleanup
+    """
+
+    task_id: int = 0
+    subtask_id: int = 0
+    user_id: int = 0
+    user_name: Optional[str] = None
+    auth_token: str = ""
+    ws_emitter: Any = None
+
+    async def _prepare_sandbox(self, effective_timeout: int):
+        """Acquire sandbox and setup temp directory.
+
+        Args:
+            effective_timeout: Timeout for operations
+
+        Returns:
+            Tuple of (sandbox, temp_dir, save_path)
+
+        Raises:
+            RuntimeError: If sandbox creation fails
+        """
+        from chat_shell.chat_shell.tools.sandbox import SandboxManager
+
+        # Get user info for sandbox manager
+        # Use provided user_name if available, otherwise fallback
+        effective_user_name = self.user_name or f"user_{self.user_id}"
+
+        # Get or create sandbox manager singleton
+        sandbox_manager = SandboxManager.get_instance(
+            task_id=self.task_id,
+            user_id=self.user_id,
+            user_name=effective_user_name,
+        )
+
+        # Get or create sandbox
+        sandbox, error = await sandbox_manager.get_or_create_sandbox(
+            shell_type="ClaudeCode",
+            workspace_ref=None,
+        )
+
+        if error:
+            raise RuntimeError(f"Failed to create sandbox: {error}")
+
+        # Generate unique temp directory
+        temp_dir = _generate_temp_dir_name()
+
+        # Create temp directory
+        await sandbox.files.make_dir(temp_dir)
+
+        return sandbox, temp_dir
+
+    async def _upload_and_return(
+        self,
+        sandbox: Any,
+        save_path: str,
+        filename: str,
+        file_size: int,
+        temp_dir: str,
+        start_time: float,
+        effective_timeout: int,
+    ) -> str:
+        """Upload file to Wegent and return result.
+
+        Args:
+            sandbox: Sandbox instance
+            save_path: Path to file in sandbox
+            filename: Original filename
+            file_size: Size of file in bytes
+            temp_dir: Temp directory path for cleanup
+            start_time: Start time for execution time calculation
+            effective_timeout: Timeout for operations
+
+        Returns:
+            JSON response string
+        """
+        # Validate file size before upload
+        if file_size > ATTACHMENT_MAX_BYTES:
+            # Cleanup temp directory
+            try:
+                await sandbox.commands.run(
+                    cmd=["rm", "-rf", temp_dir],
+                    cwd="/home/user",
+                )
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"File size ({file_size} bytes) exceeds maximum allowed size "
+                f"({ATTACHMENT_MAX_BYTES} bytes)"
+            )
+
+        # Upload to Wegent
+        api_base_url = os.getenv("BACKEND_API_URL", "http://backend:8000").rstrip("/")
+        upload_url = f"{api_base_url}/api/attachments/upload"
+
+        if not self.auth_token:
+            raise RuntimeError("No authentication token available")
+
+        # Build curl command for upload using argument list (safer than shell string)
+        upload_curl_cmd = [
+            "curl",
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            f"Authorization: Bearer {self.auth_token}",
+            "-F",
+            f"file=@{save_path}",
+            upload_url,
+        ]
+
+        logger.info(f"[{self.__class__.__name__}] Uploading to Wegent")
+
+        upload_result = await sandbox.commands.run(
+            cmd=upload_curl_cmd,
+            cwd="/home/user",
+            timeout=effective_timeout,
+        )
+
+        if upload_result.exit_code != 0:
+            raise RuntimeError(
+                f"Upload failed: {upload_result.stderr or 'Unknown error'}"
+            )
+
+        # Parse response
+        try:
+            api_response = json.loads(upload_result.stdout)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Failed to parse upload response: {e}") from e
+
+        if "detail" in api_response:
+            error_detail = api_response["detail"]
+            raise RuntimeError(f"Upload API error: {error_detail}")
+
+        attachment_id = api_response.get("id")
+        if not attachment_id:
+            raise RuntimeError("No attachment_id in response")
+
+        execution_time = time.time() - start_time
+
+        response = {
+            "success": True,
+            "attachment_id": attachment_id,
+            "filename": filename,
+            "file_size": file_size,
+            "download_url": f"/api/attachments/{attachment_id}/download",
+            "message": "Document uploaded successfully",
+            "execution_time": execution_time,
+        }
+
+        logger.info(
+            f"[{self.__class__.__name__}] Success: attachment_id={attachment_id}"
+        )
+
+        # Emit success status
+        if self.ws_emitter:
+            await self.ws_emitter.emit_tool_call(
+                task_id=self.task_id,
+                tool_name=self.name,
+                tool_input={"filename": filename},
+                status="completed",
+                output=response,
+            )
+
+        # Cleanup temp directory
+        try:
+            await sandbox.commands.run(
+                cmd=["rm", "-rf", temp_dir],
+                cwd="/home/user",
+            )
+        except Exception:
+            pass
+
+        return json.dumps(response, ensure_ascii=False, indent=2)
+
+    async def _handle_error(self, filename: str, error: Exception) -> str:
+        """Handle error and return error response.
+
+        Args:
+            filename: Filename being processed
+            error: Exception that occurred
+
+        Returns:
+            JSON error response string
+        """
+        logger.error(f"[{self.__class__.__name__}] Error: {error}", exc_info=True)
+
+        error_response = {
+            "success": False,
+            "attachment_id": None,
+            "filename": filename,
+            "file_size": 0,
+            "download_url": "",
+            "error": str(error),
+        }
+
+        if self.ws_emitter:
+            await self.ws_emitter.emit_tool_call(
+                task_id=self.task_id,
+                tool_name=self.name,
+                tool_input={"filename": filename},
+                status="failed",
+                error=str(error),
+            )
+
+        return json.dumps(error_response, ensure_ascii=False, indent=2)
+
+
+class DownloadDingTalkDocumentTool(_DingTalkSandboxUploadTool):
     """Tool for downloading DingTalk document and uploading as Wegent attachment.
 
     This tool:
@@ -174,12 +430,6 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
 
     args_schema: type[BaseModel] = DownloadDingTalkDocumentInput
 
-    task_id: int = 0
-    subtask_id: int = 0
-    user_id: int = 0
-    auth_token: str = ""
-    ws_emitter: Any = None
-
     def _run(
         self,
         download_url: str,
@@ -201,10 +451,13 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
         start_time = time.time()
         effective_timeout = timeout_seconds or 300
 
-        logger.info(
-            f"[DownloadDingTalkDocumentTool] Downloading from {download_url[:50]}..., "
-            f"filename={filename}"
-        )
+        logger.info(f"[DownloadDingTalkDocumentTool] Downloading filename={filename}")
+
+        # Validate filename
+        try:
+            filename = _validate_filename(filename)
+        except ValueError as e:
+            return await self._handle_error(filename, e)
 
         # Emit status update
         if self.ws_emitter:
@@ -222,41 +475,25 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
                 logger.warning(f"Failed to emit tool status: {e}")
 
         try:
-            # Import sandbox manager
-            from chat_shell.chat_shell.tools.sandbox import SandboxManager
+            # Prepare sandbox
+            sandbox, temp_dir = await self._prepare_sandbox(effective_timeout)
 
-            # Get user info for sandbox manager
-            # We need user_name, try to get from context or use a default
-            user_name = f"user_{self.user_id}"
-
-            # Get or create sandbox manager singleton
-            sandbox_manager = SandboxManager.get_instance(
-                task_id=self.task_id,
-                user_id=self.user_id,
-                user_name=user_name,
-            )
-
-            # Get or create sandbox
-            sandbox, error = await sandbox_manager.get_or_create_sandbox(
-                shell_type="ClaudeCode",
-                workspace_ref=None,
-            )
-
-            if error:
-                raise RuntimeError(f"Failed to create sandbox: {error}")
-
-            # Prepare paths
-            temp_dir = f"/tmp/dingtalk_{int(time.time())}"
             save_path = f"{temp_dir}/{filename}"
 
-            # Create temp directory
-            await sandbox.files.make_dir(temp_dir)
-
-            # Download file using curl
-            curl_cmd = f"curl -s -f -L -o '{save_path}' '{download_url}'"
+            # Download file using curl with argument list (safer than shell string)
+            curl_cmd = [
+                "curl",
+                "-s",
+                "-f",
+                "-L",
+                "-o",
+                save_path,
+                "--",
+                download_url,
+            ]
 
             logger.info(
-                f"[DownloadDingTalkDocumentTool] Executing download: {curl_cmd[:80]}..."
+                f"[DownloadDingTalkDocumentTool] Executing download: curl -o {shlex.quote(save_path)} ..."
             )
 
             result = await sandbox.commands.run(
@@ -274,106 +511,19 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
 
             logger.info(f"[DownloadDingTalkDocumentTool] Downloaded {file_size} bytes")
 
-            # Upload to Wegent
-            api_base_url = os.getenv("BACKEND_API_URL", "http://backend:8000").rstrip(
-                "/"
+            # Upload and return result
+            return await self._upload_and_return(
+                sandbox=sandbox,
+                save_path=save_path,
+                filename=filename,
+                file_size=file_size,
+                temp_dir=temp_dir,
+                start_time=start_time,
+                effective_timeout=effective_timeout,
             )
-            upload_url = f"{api_base_url}/api/attachments/upload"
-
-            if not self.auth_token:
-                raise RuntimeError("No authentication token available")
-
-            # Build curl command for upload
-            upload_curl_cmd = (
-                f"curl -s -X POST "
-                f'-H "Authorization: Bearer {self.auth_token}" '
-                f'-F "file=@{save_path}" '
-                f'"{upload_url}"'
-            )
-
-            logger.info(f"[DownloadDingTalkDocumentTool] Uploading to Wegent")
-
-            upload_result = await sandbox.commands.run(
-                cmd=upload_curl_cmd,
-                cwd="/home/user",
-                timeout=effective_timeout,
-            )
-
-            if upload_result.exit_code != 0:
-                raise RuntimeError(
-                    f"Upload failed: {upload_result.stderr or 'Unknown error'}"
-                )
-
-            # Parse response
-            try:
-                api_response = json.loads(upload_result.stdout)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(f"Failed to parse upload response: {e}")
-
-            if "detail" in api_response:
-                error_detail = api_response["detail"]
-                raise RuntimeError(f"Upload API error: {error_detail}")
-
-            attachment_id = api_response.get("id")
-            if not attachment_id:
-                raise RuntimeError("No attachment_id in response")
-
-            execution_time = time.time() - start_time
-
-            response = {
-                "success": True,
-                "attachment_id": attachment_id,
-                "filename": filename,
-                "file_size": file_size,
-                "download_url": f"/api/attachments/{attachment_id}/download",
-                "message": "Document downloaded and uploaded successfully",
-                "execution_time": execution_time,
-            }
-
-            logger.info(
-                f"[DownloadDingTalkDocumentTool] Success: attachment_id={attachment_id}"
-            )
-
-            # Emit success status
-            if self.ws_emitter:
-                await self.ws_emitter.emit_tool_call(
-                    task_id=self.task_id,
-                    tool_name=self.name,
-                    tool_input={"filename": filename},
-                    status="completed",
-                    output=response,
-                )
-
-            # Cleanup temp directory
-            try:
-                await sandbox.commands.run(cmd=f"rm -rf {temp_dir}", cwd="/home/user")
-            except Exception:
-                pass
-
-            return json.dumps(response, ensure_ascii=False, indent=2)
 
         except Exception as e:
-            logger.error(f"[DownloadDingTalkDocumentTool] Error: {e}", exc_info=True)
-
-            error_response = {
-                "success": False,
-                "attachment_id": None,
-                "filename": filename,
-                "file_size": 0,
-                "download_url": "",
-                "error": str(e),
-            }
-
-            if self.ws_emitter:
-                await self.ws_emitter.emit_tool_call(
-                    task_id=self.task_id,
-                    tool_name=self.name,
-                    tool_input={"filename": filename},
-                    status="failed",
-                    error=str(e),
-                )
-
-            return json.dumps(error_response, ensure_ascii=False, indent=2)
+            return await self._handle_error(filename, e)
 
 
 class SaveDingTalkContentInput(BaseModel):
@@ -393,7 +543,7 @@ class SaveDingTalkContentInput(BaseModel):
     )
 
 
-class SaveDingTalkContentTool(BaseTool):
+class SaveDingTalkContentTool(_DingTalkSandboxUploadTool):
     """Tool for saving DingTalk online document content and uploading as attachment.
 
     This tool is used for online documents (like adoc) that cannot be downloaded directly.
@@ -452,12 +602,6 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
 
     args_schema: type[BaseModel] = SaveDingTalkContentInput
 
-    task_id: int = 0
-    subtask_id: int = 0
-    user_id: int = 0
-    auth_token: str = ""
-    ws_emitter: Any = None
-
     def _run(
         self,
         content: str,
@@ -484,6 +628,12 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
             f"content_length={len(content)}"
         )
 
+        # Validate filename
+        try:
+            filename = _validate_filename(filename)
+        except ValueError as e:
+            return await self._handle_error(filename, e)
+
         # Emit status update
         if self.ws_emitter:
             try:
@@ -497,41 +647,26 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
                 logger.warning(f"Failed to emit tool status: {e}")
 
         try:
-            # Import sandbox manager
-            from chat_shell.chat_shell.tools.sandbox import SandboxManager
+            # Prepare sandbox
+            sandbox, temp_dir = await self._prepare_sandbox(effective_timeout)
 
-            # Get user info for sandbox manager
-            user_name = f"user_{self.user_id}"
-
-            # Get or create sandbox manager singleton
-            sandbox_manager = SandboxManager.get_instance(
-                task_id=self.task_id,
-                user_id=self.user_id,
-                user_name=user_name,
-            )
-
-            # Get or create sandbox
-            sandbox, error = await sandbox_manager.get_or_create_sandbox(
-                shell_type="ClaudeCode",
-                workspace_ref=None,
-            )
-
-            if error:
-                raise RuntimeError(f"Failed to create sandbox: {error}")
-
-            # Prepare paths
-            temp_dir = f"/tmp/dingtalk_{int(time.time())}"
             save_path = f"{temp_dir}/{filename}"
 
-            # Create temp directory
-            await sandbox.files.make_dir(temp_dir)
+            # Write content to file using base64 encoding to avoid shell escaping issues
+            # Encode content to base64
+            import base64
 
-            # Write content to file using Python in sandbox
-            # Escape content for shell command
-            escaped_content = content.replace("'", "'\"'\"'")
-            python_cmd = f'python3 -c \'open("{save_path}", "w", encoding="utf-8").write("{escaped_content}")\''
+            content_bytes = content.encode("utf-8")
+            content_b64 = base64.b64encode(content_bytes).decode("ascii")
 
-            logger.info(f"[SaveDingTalkContentTool] Writing content to file")
+            # Use Python to decode base64 and write to file
+            python_cmd = [
+                "python3",
+                "-c",
+                f"import base64; open({shlex.quote(save_path)}, 'wb').write(base64.b64decode({shlex.quote(content_b64)}))",
+            ]
+
+            logger.info("[SaveDingTalkContentTool] Writing content to file")
 
             result = await sandbox.commands.run(
                 cmd=python_cmd,
@@ -548,103 +683,16 @@ Note: This tool requires sandbox access. Make sure the sandbox skill is loaded.
 
             logger.info(f"[SaveDingTalkContentTool] Saved {file_size} bytes")
 
-            # Upload to Wegent
-            api_base_url = os.getenv("BACKEND_API_URL", "http://backend:8000").rstrip(
-                "/"
+            # Upload and return result
+            return await self._upload_and_return(
+                sandbox=sandbox,
+                save_path=save_path,
+                filename=filename,
+                file_size=file_size,
+                temp_dir=temp_dir,
+                start_time=start_time,
+                effective_timeout=effective_timeout,
             )
-            upload_url = f"{api_base_url}/api/attachments/upload"
-
-            if not self.auth_token:
-                raise RuntimeError("No authentication token available")
-
-            # Build curl command for upload
-            upload_curl_cmd = (
-                f"curl -s -X POST "
-                f'-H "Authorization: Bearer {self.auth_token}" '
-                f'-F "file=@{save_path}" '
-                f'"{upload_url}"'
-            )
-
-            logger.info(f"[SaveDingTalkContentTool] Uploading to Wegent")
-
-            upload_result = await sandbox.commands.run(
-                cmd=upload_curl_cmd,
-                cwd="/home/user",
-                timeout=effective_timeout,
-            )
-
-            if upload_result.exit_code != 0:
-                raise RuntimeError(
-                    f"Upload failed: {upload_result.stderr or 'Unknown error'}"
-                )
-
-            # Parse response
-            try:
-                api_response = json.loads(upload_result.stdout)
-            except json.JSONDecodeError as e:
-                raise RuntimeError(f"Failed to parse upload response: {e}")
-
-            if "detail" in api_response:
-                error_detail = api_response["detail"]
-                raise RuntimeError(f"Upload API error: {error_detail}")
-
-            attachment_id = api_response.get("id")
-            if not attachment_id:
-                raise RuntimeError("No attachment_id in response")
-
-            execution_time = time.time() - start_time
-
-            response = {
-                "success": True,
-                "attachment_id": attachment_id,
-                "filename": filename,
-                "file_size": file_size,
-                "download_url": f"/api/attachments/{attachment_id}/download",
-                "message": "Content saved and uploaded successfully",
-                "execution_time": execution_time,
-            }
-
-            logger.info(
-                f"[SaveDingTalkContentTool] Success: attachment_id={attachment_id}"
-            )
-
-            # Emit success status
-            if self.ws_emitter:
-                await self.ws_emitter.emit_tool_call(
-                    task_id=self.task_id,
-                    tool_name=self.name,
-                    tool_input={"filename": filename},
-                    status="completed",
-                    output=response,
-                )
-
-            # Cleanup temp directory
-            try:
-                await sandbox.commands.run(cmd=f"rm -rf {temp_dir}", cwd="/home/user")
-            except Exception:
-                pass
-
-            return json.dumps(response, ensure_ascii=False, indent=2)
 
         except Exception as e:
-            logger.error(f"[SaveDingTalkContentTool] Error: {e}", exc_info=True)
-
-            error_response = {
-                "success": False,
-                "attachment_id": None,
-                "filename": filename,
-                "file_size": 0,
-                "download_url": "",
-                "error": str(e),
-            }
-
-            if self.ws_emitter:
-                await self.ws_emitter.emit_tool_call(
-                    task_id=self.task_id,
-                    tool_name=self.name,
-                    tool_input={"filename": filename},
-                    status="failed",
-                    error=str(e),
-                )
-
-            return json.dumps(error_response, ensure_ascii=False, indent=2)
+            return await self._handle_error(filename, e)


### PR DESCRIPTION
…king

- Add source_config optional parameter to create_document tool
- Pass source_config through orchestrator to store document metadata
- Add dingtalk-knowledge skill for DingTalk wiki integration

The source_config allows tracking document origin with fields like:
- url: source URL
- source: origin system (e.g., 'dingtalk')
- updated_at: last update timestamp
- scraped_at: scraping timestamp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document origin tracking: optional source metadata can be attached to uploaded knowledge documents and is preserved.
  * DingTalk integration: upload DingTalk documents, spreadsheets, and AI tables (file or online content) into the knowledge base via sandboxed upload tools that return attachments.

* **Documentation**
  * Added a skill guide with end-to-end examples, tool workflows, and metadata handling recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->