### PR TITLE
fix(frontend): fix chat history not displayed when navigating from co…

### DIFF
--- a/frontend/src/app/(tasks)/knowledge/[namespace]/[kbName]/[[...docPath]]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/[namespace]/[kbName]/[[...docPath]]/page.tsx
@@ -29,6 +29,7 @@ import {
   ResizableSidebar,
   CollapsedSidebarButtons,
 } from '@/features/tasks/components/sidebar'
+import { TaskParamSync } from '@/features/tasks/components/params'
 import '@/app/tasks/tasks.css'
 import '@/features/common/scrollbar.css'
 import { GithubStarButton } from '@/features/layout/GithubStarButton'
@@ -158,6 +159,11 @@ function KnowledgeVirtualPageContent() {
 
   return (
     <div className="flex smart-h-screen bg-base text-text-primary box-border">
+      {/* TaskParamSync handles URL taskId parameter synchronization with TaskContext */}
+      <Suspense>
+        <TaskParamSync />
+      </Suspense>
+
       {/* Collapsed sidebar floating buttons */}
       {isCollapsed && !isMobile && (
         <CollapsedSidebarButtons onExpand={handleToggleCollapsed} onNewTask={handleNewTask} />

--- a/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
@@ -13,6 +13,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Library, FileText, Shield } from 'lucide-react'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -138,11 +139,18 @@ export function KnowledgeDetailPanel({
     })
   }, [selectedKb, user, myPermission?.role, namespaceRoleMap])
 
+  // Get search params to check for taskId in URL
+  // Support multiple parameter formats for compatibility
+  const searchParams = useSearchParams()
+  const taskIdFromUrl =
+    searchParams.get('taskId') || searchParams.get('task_id') || searchParams.get('taskid')
+
   // Determine KB type
   const isNotebook = selectedKb?.kb_type === 'notebook'
 
   // Reset state when KB changes
   // For notebook mode, also clear the selected task to show a fresh chat interface
+  // BUT only if there's no taskId in URL - preserve task when navigating from history
   useEffect(() => {
     setActiveTab('documents')
     setSelectedDocumentIds([])
@@ -150,10 +158,11 @@ export function KnowledgeDetailPanel({
 
     // Clear selected task when entering notebook mode to prevent showing
     // a previously selected task from the tasks page
-    if (selectedKb?.kb_type === 'notebook') {
+    // Skip if URL contains taskId (user navigating from history/conversation)
+    if (selectedKb?.kb_type === 'notebook' && !taskIdFromUrl) {
       setSelectedTask(null)
     }
-  }, [selectedKb?.id, selectedKb?.kb_type, setSelectedTask])
+  }, [selectedKb?.id, selectedKb?.kb_type, setSelectedTask, taskIdFromUrl])
 
   // When a notebook KB is selected, show chat interface with document panel
   // Simplified layout: direct left-right split without extra header bars


### PR DESCRIPTION
…nversation to knowledge base

When users navigate from a historical conversation to a knowledge base notebook, the chat history was not being displayed because the taskId URL parameter was not being synchronized with TaskContext.

Root cause: Knowledge base pages were missing TaskParamSync component that other pages (chat, code) use to sync URL taskId with TaskContext.

Changes:
- Add TaskParamSync component to knowledge base virtual URL page
- Support all taskId parameter formats (taskId, task_id, taskid) in KnowledgeDetailPanel
- Preserve selected task when taskId is present in URL

Fixes: Chat history now displays correctly when entering knowledge base from history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task state persistence in the knowledge area to ensure task selection is correctly maintained when navigating between documents and pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->