### PR TITLE
fix(frontend): pass taskId when navigating to knowledge chat from history

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -176,7 +176,8 @@ export default function TaskListSection({
       if (task.task_type === 'knowledge' && task.knowledge_base_id) {
         // Knowledge type tasks navigate to the dedicated KB chat page
         // This ensures full task functionality (follow-up questions, link sharing, etc.)
-        targetPath = `/knowledge/document/${task.knowledge_base_id}`
+        // Include taskId in URL so the page can load the correct chat history
+        targetPath = `/knowledge/document/${task.knowledge_base_id}?taskId=${task.id}`
       } else if (task.task_type === 'task') {
         // Task type tasks navigate to device chat page
         targetPath = '/devices/chat'


### PR DESCRIPTION
## Summary

修复 notebook 型知识库聊天时，点击历史聊天不能正确加载历史聊天的问题。

## Problem

When clicking a knowledge-type task in the sidebar history list, the navigation to the knowledge chat page was missing the taskId parameter. This caused the page to create a new chat instead of loading the existing conversation history.

## Solution

Include taskId parameter in the target URL for knowledge type tasks:
```
/knowledge/document/{knowledgeBaseId}?taskId={task.id}
```

This matches the behavior when creating new tasks (handled in useChatStreamHandlers.tsx).

## Changes

- Modified TaskListSection.tsx to pass taskId when navigating to knowledge chat page

## Test Plan

- [ ] Click a knowledge-type task in the sidebar history list
- [ ] Verify the URL includes taskId parameter
- [ ] Verify the page loads the existing conversation history instead of creating a new chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation reliability for knowledge-based tasks to ensure proper task identification when accessing knowledge documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->