### PR TITLE
feat(backend): add attachment support to OpenAPI endpoints

### DIFF
--- a/backend/app/api/api.py
+++ b/backend/app/api/api.py
@@ -6,6 +6,7 @@
 from app.api.endpoints import (
     admin,
     api_keys,
+    attachments_open,
     auth,
     deep_research,
     devices,
@@ -153,6 +154,11 @@ api_router.include_router(
     knowledge.summary_router,
     prefix="/knowledge-bases",
     tags=["knowledge-summary"],
+)
+api_router.include_router(
+    attachments_open.router,
+    prefix="/v1/attachments",
+    tags=["attachments-open"],
 )
 api_router.include_router(
     knowledge_open.router,

--- a/backend/app/api/endpoints/attachments_open.py
+++ b/backend/app/api/endpoints/attachments_open.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Open API endpoints for attachment upload.
+
+These endpoints are designed for external callers and support flexible
+authentication via personal API keys or service API keys with the
+wegent-username header. Uses the unified context service for managing
+attachments as subtask contexts.
+"""
+
+import logging
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from sqlalchemy.orm import Session
+
+from app.api.dependencies import get_db
+from app.core.security import AuthContext, get_auth_context
+from app.models.subtask_context import SubtaskContext
+from app.schemas.subtask_context import AttachmentResponse, TruncationInfo
+from app.services.attachment.parser import DocumentParseError, DocumentParser
+from app.services.context import context_service
+from app.services.context.context_service import NotFoundException
+from shared.telemetry.decorators import trace_async
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Constants for attachment upload
+UPLOAD_CHUNK_SIZE_BYTES = 8192  # 8KB chunks for streaming read
+BYTES_PER_MIB = 1024 * 1024
+UNLINKED_SUBTASK_ID = 0  # subtask_id=0 indicates unlinked attachment
+
+
+def _build_attachment_response(
+    context: SubtaskContext,
+    truncation_info: Optional[TruncationInfo],
+) -> AttachmentResponse:
+    """Build AttachmentResponse from context and truncation info."""
+    response_truncation_info = None
+    if truncation_info and truncation_info.is_truncated:
+        response_truncation_info = TruncationInfo(
+            is_truncated=True,
+            original_length=truncation_info.original_length,
+            truncated_length=truncation_info.truncated_length,
+            truncation_message_key="content_truncated",
+        )
+
+    return AttachmentResponse.from_context(context, response_truncation_info)
+
+
+@router.post(
+    "/upload",
+    response_model=AttachmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@trace_async("upload_attachment_open", "attachments.api")
+async def upload_attachment_open(
+    file: Annotated[UploadFile, File(...)],
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    db: Annotated[Session, Depends(get_db)],
+) -> AttachmentResponse:
+    """
+    Upload a document file for use with OpenAPI endpoints.
+
+    This endpoint is designed for external callers and supports flexible
+    authentication via API keys. Uploaded attachments can be referenced
+    by their ID in subsequent API calls:
+    - POST /v1/responses with attachment_ids
+    - POST /knowledge/documents with source_type=attachment
+
+    Supported file types:
+    - PDF (.pdf)
+    - Word (.doc, .docx)
+    - PowerPoint (.ppt, .pptx)
+    - Excel (.xls, .xlsx, .csv)
+    - Plain text (.txt)
+    - Markdown (.md)
+    - Images (.jpg, .jpeg, .png, .gif, .bmp, .webp)
+
+    Limits:
+    - Maximum file size: 100 MB
+    - Maximum extracted text: 500,000 characters (auto-truncated if exceeded)
+
+    Authentication:
+        - Personal API key: Uploads attachment under the key owner's account
+        - Service API key: Requires wegent-username header to specify the target user
+
+    Returns:
+        Attachment details including ID, processing status, and truncation info.
+        The attachment ID can be used to reference this file in other API calls.
+
+    Example:
+        ```python
+        import requests
+
+        # Upload file
+        with open("document.pdf", "rb") as f:
+            response = requests.post(
+                "https://api.wegent.io/v1/attachments/upload",
+                headers={"X-API-Key": "wg-..."},
+                files={"file": f}
+            )
+        attachment_id = response.json()["id"]
+
+        # Use in chat
+        chat_response = requests.post(
+            "https://api.wegent.io/v1/responses",
+            headers={"X-API-Key": "wg-...", "Content-Type": "application/json"},
+            json={
+                "model": "default#my_team",
+                "input": "Analyze this document",
+                "attachment_ids": [attachment_id]
+            }
+        )
+        ```
+    """
+    current_user = auth_context.user
+
+    if not file.filename:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Filename is required",
+        )
+
+    logger.info(
+        f"[attachments_open.py] upload_attachment_open: user_id={current_user.id}, "
+        f"filename=<redacted>"
+    )
+
+    # Stream file content with bounded size check
+    binary_data = bytearray()
+    max_file_size = DocumentParser.get_max_file_size()
+
+    try:
+        while chunk := await file.read(UPLOAD_CHUNK_SIZE_BYTES):
+            binary_data.extend(chunk)
+            # Check size after each chunk
+            if len(binary_data) > max_file_size:
+                max_size_mb = max_file_size / BYTES_PER_MIB
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"File size exceeds maximum limit ({max_size_mb} MB)",
+                )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error reading uploaded file: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to read uploaded file",
+        ) from e
+
+    try:
+        # Upload attachment using context service (subtask_id=0 for unlinked attachments)
+        # Convert bytearray to bytes for type consistency
+        context, truncation_info = context_service.upload_attachment(
+            db=db,
+            user_id=current_user.id,
+            filename=file.filename,
+            binary_data=bytes(binary_data),
+            subtask_id=UNLINKED_SUBTASK_ID,  # Unlinked attachment - will be linked later via API
+        )
+
+        logger.info(
+            f"[attachments_open.py] Attachment uploaded: id={context.id}, "
+            f"user_id={current_user.id}, filename=<redacted>"
+        )
+
+        return _build_attachment_response(context, truncation_info)
+
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
+    except NotFoundException as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Attachment not found",
+        ) from e
+    except DocumentParseError as e:
+        error_code = getattr(e, "error_code", None)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "message": str(e),
+                "error_code": error_code,
+            },
+        ) from e
+    except Exception as e:
+        logger.error(f"Error uploading attachment: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to upload attachment",
+        ) from e

--- a/backend/app/api/endpoints/knowledge_open.py
+++ b/backend/app/api/endpoints/knowledge_open.py
@@ -230,19 +230,22 @@ async def create_document_open(
       extension via `file_extension` (required). Maximum decoded size: 10 MB.
     - **web**: Provide a URL via the `url` field. The page is scraped and
       converted to Markdown automatically.
+    - **attachment**: Provide an existing attachment ID via `attachment_id`.
+      The attachment must be uploaded via POST /v1/attachments/upload and belong
+      to the current user.
 
-    The `attachment` and `table` source types are not supported via this endpoint;
-    they are reserved for internal use and real-time external table integrations.
+    The `table` source type is not supported via this endpoint;
+    it is reserved for internal use and real-time external table integrations.
 
     Authentication:
         - Personal API key: Creates the document under the key owner's account
         - Service API key: Requires wegent-username header to specify the target user
     """
     current_user = auth_context.user
-    source_type = data.source_type.value  # e.g. "text", "file", "web", "table"
+    source_type = data.source_type.value  # e.g. "text", "file", "web", "attachment"
 
     # Reject unsupported source types early with a clear message
-    _SUPPORTED_SOURCE_TYPES = {"text", "file", "web"}
+    _SUPPORTED_SOURCE_TYPES = {"text", "file", "web", "attachment"}
     if source_type not in _SUPPORTED_SOURCE_TYPES:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -303,7 +306,7 @@ async def create_document_open(
                 detail="Web document creation succeeded but response is incomplete",
             )
         add_span_event(
-            "knowledge.document.created.web",
+            "knowledge.document.created",
             {
                 "document_id": str(document.id),
                 "knowledge_base_id": str(data.knowledge_base_id),
@@ -312,25 +315,50 @@ async def create_document_open(
         )
         return document
 
-    # text / file — all handled by create_document_with_content (sync)
+    # Prepare splitter config for text/file/attachment types
     splitter_config_dict = (
         data.splitter_config.model_dump(exclude_none=True)
         if data.splitter_config
         else None
     )
+
+    # attachment — requires attachment_id and validates ownership
+    if source_type == "attachment":
+        if not data.attachment_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="attachment_id is required when source_type is 'attachment'",
+            )
+
+    # Build common parameters for create_document_with_content
+    create_doc_params = {
+        "db": db,
+        "user": current_user,
+        "knowledge_base_id": data.knowledge_base_id,
+        "name": data.name,
+        "source_type": source_type,
+        "trigger_indexing": True,
+        "trigger_summary": True,
+        "splitter_config": splitter_config_dict,
+    }
+
+    # Add source-specific parameters
+    if source_type == "attachment":
+        create_doc_params["attachment_id"] = data.attachment_id
+    else:
+        # text / file
+        create_doc_params.update(
+            {
+                "content": data.content,
+                "file_base64": data.file_base64,
+                "file_extension": data.file_extension,
+            }
+        )
+
+    # Unified document creation with shared error handling
     try:
         document = knowledge_orchestrator.create_document_with_content(
-            db=db,
-            user=current_user,
-            knowledge_base_id=data.knowledge_base_id,
-            name=data.name,
-            source_type=source_type,
-            content=data.content,
-            file_base64=data.file_base64,
-            file_extension=data.file_extension,
-            trigger_indexing=True,
-            trigger_summary=True,
-            splitter_config=splitter_config_dict,
+            **create_doc_params
         )
     except ValueError as exc:
         error_msg = str(exc).lower()
@@ -354,7 +382,6 @@ async def create_document_open(
         {
             "document_id": str(document.id),
             "knowledge_base_id": str(data.knowledge_base_id),
-            "source_type": source_type,
             "user_id": str(current_user.id),
         },
     )

--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -50,6 +50,114 @@ from app.utils.prompt_utils import extract_display_prompt
 
 logger = logging.getLogger(__name__)
 
+
+def _validate_and_link_attachments(
+    db: Session,
+    user: User,
+    attachment_ids: list[int],
+    setup: Any,
+) -> None:
+    """Validate attachment ownership and link attachments to subtask.
+
+    Validates that:
+    - Attachments belong to the current user
+    - Attachments are of type ATTACHMENT
+    - Attachments are in READY status
+    - Attachments are either unlinked or already linked to the same task
+
+    This prevents attachments from being "stolen" from other active conversations
+    while still allowing retry scenarios within the same task.
+
+    Args:
+        db: Database session
+        user: Current authenticated user
+        attachment_ids: List of attachment IDs to validate and link
+        setup: Chat session setup containing task and subtask info
+
+    Raises:
+        HTTPException: 403 if any attachment IDs are invalid or unauthorized
+    """
+    from sqlalchemy import or_, select
+
+    from app.models.subtask import Subtask
+    from app.models.subtask_context import ContextType, SubtaskContext
+    from shared.models.db import ContextStatus
+
+    # Get the task ID from the setup
+    task_id = setup.task.id
+
+    # Build subquery: find all subtask IDs belonging to the same task
+    task_subtask_ids = (
+        select(Subtask.id)
+        .filter(Subtask.task_id == task_id, Subtask.user_id == user.id)
+        .scalar_subquery()
+    )
+
+    # Validate attachment ownership and state with row locking
+    # Only allow attachments that are:
+    # 1. Unlinked (subtask_id == 0), OR
+    # 2. Already linked to a subtask in the same task
+    valid_attachment_rows = (
+        db.query(SubtaskContext.id)
+        .filter(
+            SubtaskContext.id.in_(attachment_ids),
+            SubtaskContext.user_id == user.id,
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+            SubtaskContext.status == ContextStatus.READY.value,
+            or_(
+                SubtaskContext.subtask_id == 0,  # Unlinked
+                SubtaskContext.subtask_id.in_(task_subtask_ids),  # Same task
+            ),
+        )
+        .with_for_update()
+        .all()
+    )
+    valid_attachment_ids = [row[0] for row in valid_attachment_rows]
+
+    # Check if any requested IDs are invalid or don't belong to the user
+    invalid_ids = set(attachment_ids) - set(valid_attachment_ids)
+    if invalid_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid or unauthorized attachment IDs: {sorted(invalid_ids)}",
+        )
+
+    # Perform the linking using a conditional update that includes predicates
+    # This ensures atomic validation+linking and provides feedback on affected rows
+    from sqlalchemy import update
+
+    update_stmt = (
+        update(SubtaskContext)
+        .where(
+            SubtaskContext.id.in_(valid_attachment_ids),
+            SubtaskContext.user_id == user.id,
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+            SubtaskContext.status == ContextStatus.READY.value,
+            or_(
+                SubtaskContext.subtask_id == 0,
+                SubtaskContext.subtask_id.in_(task_subtask_ids),
+            ),
+        )
+        .values(subtask_id=setup.user_subtask.id)
+    )
+    result = db.execute(update_stmt)
+
+    # Verify all expected rows were updated
+    if result.rowcount != len(valid_attachment_ids):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Some attachments could not be linked. Please retry.",
+        )
+
+    # Note: We intentionally do NOT commit here.
+    # The transaction must remain open to keep the row locks held by with_for_update()
+    # until build_execution_request() has loaded the attachment contexts.
+    # The caller is responsible for committing after the execution request is built.
+    logger.info(
+        f"[OPENAPI] Linked {result.rowcount} attachments to subtask {setup.user_subtask.id}: {valid_attachment_ids}"
+    )
+
+
 router = APIRouter()
 
 # Get rate limiter instance
@@ -393,6 +501,15 @@ async def _create_non_streaming_response_unified(
     # This ensures KB tools and skill tools are actually added to the agent
     enable_tools = enable_chat_bot or bool(knowledge_base_names)
 
+    # Link attachments to user subtask if provided
+    if request_body.attachment_ids:
+        _validate_and_link_attachments(
+            db=db,
+            user=user,
+            attachment_ids=request_body.attachment_ids,
+            setup=setup,
+        )
+
     # Convert reasoning config from Pydantic model to dict
     reasoning_config = None
     if request_body.reasoning:
@@ -414,7 +531,12 @@ async def _create_non_streaming_response_unified(
             knowledge_base_names=knowledge_base_names,
             reasoning_config=reasoning_config,
         )
+        # Commit the transaction after execution request is built
+        # This releases the row locks held since _validate_and_link_attachments
+        db.commit()
     except Exception as e:
+        # Rollback on any error to avoid leaving transaction open
+        db.rollback()
         logger.error(f"Failed to build execution request: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -686,12 +808,22 @@ async def _create_streaming_response_unified(
     # This ensures KB tools and skill tools are actually added to the agent
     enable_tools = enable_chat_bot or bool(knowledge_base_names)
 
+    # Link attachments to user subtask if provided
+    if request_body.attachment_ids:
+        _validate_and_link_attachments(
+            db=db,
+            user=user,
+            attachment_ids=request_body.attachment_ids,
+            setup=setup,
+        )
+
     # Convert reasoning config from Pydantic model to dict
     reasoning_config = None
     if request_body.reasoning:
         reasoning_config = request_body.reasoning.model_dump()
 
     # Build execution request using unified builder
+    execution_request = None
     try:
         execution_request = await build_execution_request(
             task=setup.task,
@@ -707,12 +839,14 @@ async def _create_streaming_response_unified(
             knowledge_base_names=knowledge_base_names,
             reasoning_config=reasoning_config,
         )
+        # Commit the transaction after execution request is built
+        # This releases the row locks held since _validate_and_link_attachments
+        db.commit()
+    except Exception:
+        # Rollback on any error to avoid leaving transaction open
+        db.rollback()
+        raise
     finally:
-        # Close the database session before streaming starts
-        try:
-            db.rollback()
-        except Exception:
-            pass
         db.close()
 
     async def raw_chat_stream():

--- a/backend/app/api/endpoints/openapi_responses.py
+++ b/backend/app/api/endpoints/openapi_responses.py
@@ -38,6 +38,7 @@ from app.schemas.openapi_response import (
     ResponseObject,
 )
 from app.services.adapters.task_kinds import task_kinds_service
+from app.services.chat.preprocessing.contexts import link_contexts_to_subtask
 from app.services.openapi.helpers import (
     extract_input_text,
     parse_model_string,
@@ -49,114 +50,6 @@ from app.services.readers.kinds import KindType, kindReader
 from app.utils.prompt_utils import extract_display_prompt
 
 logger = logging.getLogger(__name__)
-
-
-def _validate_and_link_attachments(
-    db: Session,
-    user: User,
-    attachment_ids: list[int],
-    setup: Any,
-) -> None:
-    """Validate attachment ownership and link attachments to subtask.
-
-    Validates that:
-    - Attachments belong to the current user
-    - Attachments are of type ATTACHMENT
-    - Attachments are in READY status
-    - Attachments are either unlinked or already linked to the same task
-
-    This prevents attachments from being "stolen" from other active conversations
-    while still allowing retry scenarios within the same task.
-
-    Args:
-        db: Database session
-        user: Current authenticated user
-        attachment_ids: List of attachment IDs to validate and link
-        setup: Chat session setup containing task and subtask info
-
-    Raises:
-        HTTPException: 403 if any attachment IDs are invalid or unauthorized
-    """
-    from sqlalchemy import or_, select
-
-    from app.models.subtask import Subtask
-    from app.models.subtask_context import ContextType, SubtaskContext
-    from shared.models.db import ContextStatus
-
-    # Get the task ID from the setup
-    task_id = setup.task.id
-
-    # Build subquery: find all subtask IDs belonging to the same task
-    task_subtask_ids = (
-        select(Subtask.id)
-        .filter(Subtask.task_id == task_id, Subtask.user_id == user.id)
-        .scalar_subquery()
-    )
-
-    # Validate attachment ownership and state with row locking
-    # Only allow attachments that are:
-    # 1. Unlinked (subtask_id == 0), OR
-    # 2. Already linked to a subtask in the same task
-    valid_attachment_rows = (
-        db.query(SubtaskContext.id)
-        .filter(
-            SubtaskContext.id.in_(attachment_ids),
-            SubtaskContext.user_id == user.id,
-            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
-            SubtaskContext.status == ContextStatus.READY.value,
-            or_(
-                SubtaskContext.subtask_id == 0,  # Unlinked
-                SubtaskContext.subtask_id.in_(task_subtask_ids),  # Same task
-            ),
-        )
-        .with_for_update()
-        .all()
-    )
-    valid_attachment_ids = [row[0] for row in valid_attachment_rows]
-
-    # Check if any requested IDs are invalid or don't belong to the user
-    invalid_ids = set(attachment_ids) - set(valid_attachment_ids)
-    if invalid_ids:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Invalid or unauthorized attachment IDs: {sorted(invalid_ids)}",
-        )
-
-    # Perform the linking using a conditional update that includes predicates
-    # This ensures atomic validation+linking and provides feedback on affected rows
-    from sqlalchemy import update
-
-    update_stmt = (
-        update(SubtaskContext)
-        .where(
-            SubtaskContext.id.in_(valid_attachment_ids),
-            SubtaskContext.user_id == user.id,
-            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
-            SubtaskContext.status == ContextStatus.READY.value,
-            or_(
-                SubtaskContext.subtask_id == 0,
-                SubtaskContext.subtask_id.in_(task_subtask_ids),
-            ),
-        )
-        .values(subtask_id=setup.user_subtask.id)
-    )
-    result = db.execute(update_stmt)
-
-    # Verify all expected rows were updated
-    if result.rowcount != len(valid_attachment_ids):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Some attachments could not be linked. Please retry.",
-        )
-
-    # Note: We intentionally do NOT commit here.
-    # The transaction must remain open to keep the row locks held by with_for_update()
-    # until build_execution_request() has loaded the attachment contexts.
-    # The caller is responsible for committing after the execution request is built.
-    logger.info(
-        f"[OPENAPI] Linked {result.rowcount} attachments to subtask {setup.user_subtask.id}: {valid_attachment_ids}"
-    )
-
 
 router = APIRouter()
 
@@ -503,11 +396,16 @@ async def _create_non_streaming_response_unified(
 
     # Link attachments to user subtask if provided
     if request_body.attachment_ids:
-        _validate_and_link_attachments(
+        link_contexts_to_subtask(
             db=db,
-            user=user,
+            subtask_id=setup.user_subtask.id,
+            user_id=user.id,
             attachment_ids=request_body.attachment_ids,
-            setup=setup,
+            task=setup.task,
+        )
+        logger.info(
+            f"[OPENAPI] Linked {len(request_body.attachment_ids)} attachments "
+            f"to subtask {setup.user_subtask.id}"
         )
 
     # Convert reasoning config from Pydantic model to dict
@@ -531,12 +429,7 @@ async def _create_non_streaming_response_unified(
             knowledge_base_names=knowledge_base_names,
             reasoning_config=reasoning_config,
         )
-        # Commit the transaction after execution request is built
-        # This releases the row locks held since _validate_and_link_attachments
-        db.commit()
     except Exception as e:
-        # Rollback on any error to avoid leaving transaction open
-        db.rollback()
         logger.error(f"Failed to build execution request: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -810,11 +703,16 @@ async def _create_streaming_response_unified(
 
     # Link attachments to user subtask if provided
     if request_body.attachment_ids:
-        _validate_and_link_attachments(
+        link_contexts_to_subtask(
             db=db,
-            user=user,
+            subtask_id=setup.user_subtask.id,
+            user_id=user.id,
             attachment_ids=request_body.attachment_ids,
-            setup=setup,
+            task=setup.task,
+        )
+        logger.info(
+            f"[OPENAPI] Linked {len(request_body.attachment_ids)} attachments "
+            f"to subtask {setup.user_subtask.id}"
         )
 
     # Convert reasoning config from Pydantic model to dict
@@ -823,7 +721,6 @@ async def _create_streaming_response_unified(
         reasoning_config = request_body.reasoning.model_dump()
 
     # Build execution request using unified builder
-    execution_request = None
     try:
         execution_request = await build_execution_request(
             task=setup.task,
@@ -839,14 +736,12 @@ async def _create_streaming_response_unified(
             knowledge_base_names=knowledge_base_names,
             reasoning_config=reasoning_config,
         )
-        # Commit the transaction after execution request is built
-        # This releases the row locks held since _validate_and_link_attachments
-        db.commit()
-    except Exception:
-        # Rollback on any error to avoid leaving transaction open
-        db.rollback()
-        raise
     finally:
+        # Close the database session before streaming starts
+        try:
+            db.rollback()
+        except Exception:
+            pass
         db.close()
 
     async def raw_chat_stream():

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -40,6 +40,7 @@ class DocumentSourceType(str, Enum):
     TEXT = "text"
     TABLE = "table"
     WEB = "web"
+    ATTACHMENT = "attachment"
 
 
 class DocumentIndexStatus(str, Enum):
@@ -764,7 +765,7 @@ class KnowledgeDocumentCreateV1(BaseModel):
         DocumentSourceType.TEXT,
         description=(
             "Document source type: 'text' (inline content), 'file' (base64 binary), "
-            "'web' (URL scraping)"
+            "'web' (URL scraping), 'attachment' (existing attachment ID)"
         ),
     )
     # source_type=text
@@ -789,6 +790,11 @@ class KnowledgeDocumentCreateV1(BaseModel):
     url: Optional[str] = Field(
         None,
         description="URL to scrape (required for source_type='web')",
+    )
+    # source_type=attachment
+    attachment_id: Optional[int] = Field(
+        None,
+        description="Attachment context ID (required for source_type='attachment')",
     )
     # common optional
     splitter_config: Optional[SplitterConfig] = Field(

--- a/backend/app/schemas/openapi_response.py
+++ b/backend/app/schemas/openapi_response.py
@@ -9,7 +9,10 @@ Compatible with OpenAI Responses API format.
 
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, conint, conlist
+
+# Maximum number of attachment IDs allowed per request
+MAX_ATTACHMENT_IDS = 100
 
 
 class WorkspaceConfig(BaseModel):
@@ -178,6 +181,14 @@ class ResponseCreateInput(BaseModel):
         default=None,
         description="Configuration for model reasoning/thinking. Supported for gpt-5 and o-series models. "
         "Controls reasoning effort and summary output.",
+    )
+    attachment_ids: Optional[conlist(conint(ge=1), max_length=MAX_ATTACHMENT_IDS)] = (
+        Field(
+            default=None,
+            description="List of attachment context IDs from POST /v1/attachments/upload. "
+            "Attachments will be linked to this request and included in the context. "
+            f"Maximum {MAX_ATTACHMENT_IDS} attachments, each ID must be a positive integer.",
+        )
     )
 
 

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -18,12 +18,16 @@ eliminating the need to pass separate attachment_ids and knowledge_base_ids.
 import logging
 from typing import Any, List, Optional, Tuple
 
+from fastapi import HTTPException, status
 from langchain_core.tools import BaseTool
+from sqlalchemy import or_, select, update
 from sqlalchemy.orm import Session
 
 from app.models.knowledge import KnowledgeDocument
+from app.models.subtask import Subtask
 from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
 from app.services.context import context_service
+from shared.models.db import ContextStatus as DBContextStatus
 from shared.models.knowledge import (
     ChatContextsResult,
     KnowledgeBaseToolAccessMode,
@@ -373,6 +377,75 @@ def extract_knowledge_base_ids(
     return [c.knowledge_id for c in contexts if c.knowledge_id]
 
 
+def _validate_attachment_ownership(
+    db: Session,
+    attachment_ids: List[int],
+    user_id: int,
+    task_id: Optional[int] = None,
+) -> List[int]:
+    """Validate attachment ownership and state.
+
+    Validates that:
+    - Attachments belong to the current user
+    - Attachments are of type ATTACHMENT
+    - Attachments are in READY status
+    - Attachments are either unlinked or already linked to the same task
+
+    This prevents attachments from being "stolen" from other active conversations
+    while still allowing retry scenarios within the same task.
+
+    Args:
+        db: Database session
+        attachment_ids: List of attachment IDs to validate
+        user_id: User ID for ownership check
+        task_id: Optional task ID for cross-subtask validation
+
+    Returns:
+        List of valid attachment IDs
+
+    Raises:
+        HTTPException: 403 if any attachment IDs are invalid or unauthorized
+    """
+    # Build base filters
+    filters = [
+        SubtaskContext.id.in_(attachment_ids),
+        SubtaskContext.user_id == user_id,
+        SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+        SubtaskContext.status == ContextStatus.READY.value,
+    ]
+
+    # Add cross-subtask validation if task_id is provided
+    if task_id:
+        task_subtask_ids = (
+            select(Subtask.id)
+            .filter(Subtask.task_id == task_id, Subtask.user_id == user_id)
+            .scalar_subquery()
+        )
+        filters.append(
+            or_(
+                SubtaskContext.subtask_id == 0,  # Unlinked
+                SubtaskContext.subtask_id.in_(task_subtask_ids),  # Same task
+            )
+        )
+    else:
+        # Without task_id, only allow unlinked attachments
+        filters.append(SubtaskContext.subtask_id == 0)
+
+    # Query with row locking
+    valid_rows = db.query(SubtaskContext.id).filter(*filters).with_for_update().all()
+    valid_ids = [row[0] for row in valid_rows]
+
+    # Check for invalid IDs
+    invalid_ids = set(attachment_ids) - set(valid_ids)
+    if invalid_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Invalid or unauthorized attachment IDs: {sorted(invalid_ids)}",
+        )
+
+    return valid_ids
+
+
 def link_contexts_to_subtask(
     db: Session,
     subtask_id: int,
@@ -395,6 +468,9 @@ def link_contexts_to_subtask(
     When knowledge bases are created, they are automatically synced to the task-level
     knowledgeBaseRefs for future use across all subtasks.
 
+    SECURITY NOTE: When attachment_ids is provided, ownership validation is ALWAYS
+    performed to prevent attachment hijacking across users/tasks.
+
     Args:
         db: Database session
         subtask_id: Subtask ID to link contexts to
@@ -412,9 +488,17 @@ def link_contexts_to_subtask(
 
     linked_context_ids = []
 
-    # Collect attachment IDs to link
+    # Step 1: Validate and collect attachment IDs
     if attachment_ids:
-        linked_context_ids.extend(attachment_ids)
+        valid_attachment_ids = _validate_attachment_ownership(
+            db=db,
+            attachment_ids=attachment_ids,
+            user_id=user_id,
+            task_id=task.id if task else None,
+        )
+        linked_context_ids.extend(valid_attachment_ids)
+    else:
+        valid_attachment_ids = None
 
     # Prepare knowledge base, table, and selected_documents contexts for batch creation
     (
@@ -433,7 +517,11 @@ def link_contexts_to_subtask(
     # Execute all database operations in a single transaction
     try:
         created_context_ids = _batch_update_and_insert_contexts(
-            db, attachment_ids, all_contexts_to_create, subtask_id
+            db=db,
+            attachment_ids=valid_attachment_ids,
+            contexts_to_create=all_contexts_to_create,
+            subtask_id=subtask_id,
+            task_id=task.id if task else None,
         )
         linked_context_ids.extend(created_context_ids)
 
@@ -444,12 +532,12 @@ def link_contexts_to_subtask(
             )
 
         # Sync attachments to running sandbox (if sandbox is healthy)
-        if attachment_ids and task:
+        if valid_attachment_ids and task:
             _schedule_attachment_sync_to_sandbox(
                 db=db,
                 task_id=task.id,
                 subtask_id=subtask_id,
-                attachment_ids=attachment_ids,
+                attachment_ids=valid_attachment_ids,
             )
 
     except Exception as e:
@@ -755,27 +843,55 @@ def _batch_update_and_insert_contexts(
     attachment_ids: List[int] | None,
     contexts_to_create: List[SubtaskContext],
     subtask_id: int,
+    task_id: Optional[int] = None,
 ) -> List[int]:
     """
     Execute batch update and insert operations for contexts.
 
     Args:
         db: Database session
-        attachment_ids: List of attachment context IDs to update
+        attachment_ids: List of validated attachment context IDs to update
         contexts_to_create: List of contexts (KB or table) to insert
         subtask_id: Subtask ID for logging
+        task_id: Optional task ID for additional validation in update
 
     Returns:
         List of created context IDs
+
+    Raises:
+        HTTPException: 409 if attachment update count mismatch (concurrent modification)
     """
     created_context_ids = []
 
-    # Batch update existing attachments' subtask_id
+    # Batch update existing attachments' subtask_id with conditional validation
     if attachment_ids:
-        db.query(SubtaskContext).filter(SubtaskContext.id.in_(attachment_ids)).update(
-            {"subtask_id": subtask_id},
-            synchronize_session=False,
+        # Build update conditions
+        update_filters = [SubtaskContext.id.in_(attachment_ids)]
+
+        # Add task-level validation if task_id is provided
+        if task_id:
+            task_subtask_ids = (
+                select(Subtask.id).filter(Subtask.task_id == task_id).scalar_subquery()
+            )
+            update_filters.append(
+                or_(
+                    SubtaskContext.subtask_id == 0,
+                    SubtaskContext.subtask_id.in_(task_subtask_ids),
+                )
+            )
+
+        # Execute conditional update
+        update_stmt = (
+            update(SubtaskContext).where(*update_filters).values(subtask_id=subtask_id)
         )
+        result = db.execute(update_stmt)
+
+        # Verify all expected rows were updated
+        if result.rowcount != len(attachment_ids):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Some attachments could not be linked. Please retry.",
+            )
 
     # Batch add new contexts (KB and table)
     if contexts_to_create:


### PR DESCRIPTION
- Add /v1/attachments/upload endpoint for OpenAPI file uploads
- Add attachment_ids support to /v1/responses API
- Add source_type=attachment support to knowledge documents API
- Implement flexible authentication (API key + JWT) for attachment endpoints
- Unify code structure and span event naming in knowledge_open.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public attachment upload endpoint for unlinked uploads (POST /v1/attachments/upload).
  * Create knowledge documents from uploaded attachments via new "attachment" source type.
  * Accept attachment IDs when creating responses/queries to provide attachment context (max 100 IDs).

* **Bug Fixes**
  * Validation for missing/oversized uploads and unauthorized/invalid attachment IDs.
  * Atomic server-side linking of validated attachment IDs to the current request, with clearer error codes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->