### PR TITLE
fix: 修复对话输入框多行输入时自动滚动到底部的问题

### DIFF
--- a/frontend/src/features/tasks/components/input/ChatInput.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInput.tsx
@@ -121,6 +121,7 @@ export default function ChatInput({
   const { user } = useUser()
   const editableRef = useRef<HTMLDivElement>(null)
   const badgeRef = useRef<HTMLSpanElement>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [badgeWidth, setBadgeWidth] = useState(0)
 
   // Track if we should show placeholder
@@ -219,6 +220,13 @@ export default function ChatInput({
     element.innerHTML = htmlContent
   }, [])
 
+  // Auto-scroll to bottom when content changes
+  const scrollToBottom = useCallback(() => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollTop = scrollContainerRef.current.scrollHeight
+    }
+  }, [])
+
   // Sync contenteditable content with message prop
   useEffect(() => {
     if (editableRef.current) {
@@ -239,9 +247,12 @@ export default function ChatInput({
           selection.removeAllRanges()
           selection.addRange(range)
         }
+
+        // Scroll to bottom after content update
+        scrollToBottom()
       }
     }
-  }, [message, getTextWithNewlines, setContentWithNewlines])
+  }, [message, getTextWithNewlines, setContentWithNewlines, scrollToBottom])
 
   // Auto focus the input when autoFocus is true and not disabled
   useEffect(() => {
@@ -329,6 +340,9 @@ export default function ChatInput({
       setMessage(text)
       setShowPlaceholder(!text)
 
+      // Auto-scroll to bottom when content changes
+      scrollToBottom()
+
       // Helper function to get cursor position for autocomplete menus
       const getCursorPosition = () => {
         const selection = window.getSelection()
@@ -410,6 +424,7 @@ export default function ChatInput({
       showSkillSelector,
       availableSkills.length,
       showSkillMenu,
+      scrollToBottom,
     ]
   )
 
@@ -717,6 +732,7 @@ export default function ChatInput({
       {/* Scrollable container that includes both badge and editable content */}
       <div className="relative">
         <div
+          ref={scrollContainerRef}
           className="w-full custom-scrollbar transition-all duration-300 ease-in-out"
           style={{
             minHeight,


### PR DESCRIPTION
修复了用户使用 Shift+Enter 换行时，输入框不会自动滚动到最新行的问题。

主要修改：
- 添加 scrollContainerRef 引用滚动容器
- 添加 scrollToBottom 函数实现自动滚动到底部
- 在 handleInput 和 useEffect 中调用 scrollToBottom
- 确保用户在输入多行文本时始终能看到最新的输入行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat input auto-scroll behavior to ensure typed content and incoming messages automatically scroll into view, enhancing the messaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->