### PR TITLE
feat(backend): auto-delete old index before re-indexing

### DIFF
--- a/backend/app/services/knowledge/indexing.py
+++ b/backend/app/services/knowledge/indexing.py
@@ -369,6 +369,74 @@ def run_document_indexing(
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
         try:
+            rag_gateway = get_index_gateway()
+
+            # Delete old index before re-indexing (if document_id is provided)
+            if document_id is not None:
+                try:
+                    delete_spec = runtime_resolver.build_delete_runtime_spec(
+                        db=db,
+                        knowledge_base_id=int(knowledge_base_id),
+                        document_ref=str(document_id),
+                        index_owner_user_id=kb_info.index_owner_user_id,
+                    )
+                    delete_result = loop.run_until_complete(
+                        rag_gateway.delete_document_index(delete_spec, db=db)
+                    )
+                    deleted_chunks = delete_result.get("deleted_chunks", 0)
+                    if deleted_chunks > 0:
+                        logger.info(
+                            f"[Indexing] Deleted old index before re-indexing: document_id={document_id}, "
+                            f"deleted_chunks={deleted_chunks}"
+                        )
+                        add_span_event(
+                            "rag.indexing.old_index_deleted",
+                            {
+                                "kb_id": str(knowledge_base_id),
+                                "document_id": str(document_id),
+                                "deleted_chunks": deleted_chunks,
+                            },
+                        )
+                    else:
+                        # No old index found - document was never indexed before
+                        logger.info(
+                            f"[Indexing] No old index found for document {document_id}, proceeding with indexing"
+                        )
+                        add_span_event(
+                            "rag.indexing.old_index_not_found",
+                            {
+                                "kb_id": str(knowledge_base_id),
+                                "document_id": str(document_id),
+                            },
+                        )
+                except ValueError as e:
+                    # KB not found or config error - log warning and continue
+                    logger.warning(
+                        f"[Indexing] Cannot delete old index for document {document_id}: {e}"
+                    )
+                    add_span_event(
+                        "rag.indexing.old_index_delete_skipped",
+                        {
+                            "kb_id": str(knowledge_base_id),
+                            "document_id": str(document_id),
+                            "reason": str(e),
+                        },
+                    )
+                except Exception as e:
+                    # Unexpected error (HTTP/DB errors) - log error with details
+                    logger.error(
+                        f"[Indexing] Error deleting old index for document {document_id}: {type(e).__name__}: {e}"
+                    )
+                    add_span_event(
+                        "rag.indexing.old_index_delete_failed",
+                        {
+                            "kb_id": str(knowledge_base_id),
+                            "document_id": str(document_id),
+                            "error_type": type(e).__name__,
+                            "error": str(e),
+                        },
+                    )
+
             logger.info(
                 f"[Indexing] Starting gateway index_document: kb_id={knowledge_base_id}, "
                 f"index_owner_user_id={kb_info.index_owner_user_id}"
@@ -382,7 +450,6 @@ def run_document_indexing(
                     "embedding_model_namespace": embedding_model_namespace,
                 },
             )
-            rag_gateway = get_index_gateway()
             result = loop.run_until_complete(
                 rag_gateway.index_document(runtime_spec, db=db)
             )


### PR DESCRIPTION
Delete old document index before creating new one to prevent duplicate chunks and storage bloat when re-indexing documents.

- Delete old index only when document_id is provided (not first-time indexing)
- Log warning on delete failure without blocking indexing process
- Add telemetry events for tracking delete operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document re-indexing with more reliable cleanup of previous index entries to prevent duplicates or stale data
  * Increased resilience so indexing continues even if cleanup encounters issues
  * Added clearer reporting for outcomes of old-index cleanup (deleted, not found, or cleanup skipped/failed)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->