### PR TITLE
feat(knowledge): add comprehensive extension system for KB permissions and external integrations

### DIFF
--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -6,6 +6,7 @@
 Knowledge base and document service using kinds table.
 """
 
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -55,6 +56,9 @@ from app.services.knowledge.permission_policy import (
     can_manage_accessible_knowledge_base_documents,
     can_manage_accessible_knowledge_document,
 )
+from app.services.readers.kb_permissions import kb_permission_resolver
+
+logger = logging.getLogger(__name__)
 
 
 def _build_attachment_filename(name: str, file_extension: str) -> str:
@@ -420,12 +424,26 @@ class KnowledgeService:
             # Get knowledge bases bound to group chats where user is a member
             bound_kb_ids = KnowledgeService._get_bound_kb_ids_for_user(db, user_id)
 
-            # Single query to get personal, team, organization, shared, and bound knowledge bases
-            # Personal: user_id matches and namespace is "default"
-            # Team: namespace is in accessible_groups
+            # External resolver: returns additional KB IDs the user can access
+            # via extension rules (e.g. department / employee bindings).
+            # Errors are caught so a faulty extension cannot break the core listing path.
+            try:
+                ext_kb_ids = kb_permission_resolver.get_accessible_kb_ids(db, user_id)
+            except Exception as e:
+                logger.warning(
+                    f"kb_permissions extension get_accessible_kb_ids failed: {e}; "
+                    "falling back to empty list"
+                )
+                ext_kb_ids = []
+
+            # Single query to get personal, team, organization, shared, bound, and
+            # externally-accessible knowledge bases.
+            # Personal:  user_id matches and namespace is "default"
+            # Team:      namespace is in accessible_groups
             # Organization: namespace has level='organization'
-            # Shared: id is in shared_kb_ids
-            # Bound: id is in bound_kb_ids (personal KBs bound to group chats)
+            # Shared:    id is in shared_kb_ids
+            # Bound:     id is in bound_kb_ids (personal KBs bound to group chats)
+            # External:  id is in ext_kb_ids (e.g. department / employee bindings)
             query = db.query(Kind).filter(
                 Kind.kind == "KnowledgeBase",
                 Kind.is_active == True,
@@ -444,6 +462,9 @@ class KnowledgeService:
 
             if bound_kb_ids:
                 conditions.append(Kind.id.in_(bound_kb_ids))
+
+            if ext_kb_ids:
+                conditions.append(Kind.id.in_(ext_kb_ids))
 
             if conditions:
                 from sqlalchemy import or_
@@ -2027,7 +2048,9 @@ class KnowledgeService:
             return True, BaseRole.Owner, False
 
         has_access, role, is_creator = knowledge_share_service.get_user_kb_permission(
-            db, knowledge_base_id, user_id
+            db,
+            knowledge_base_id,
+            user_id,
         )
 
         effective_role = BaseRole(role) if role is not None else None

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -7,6 +7,7 @@ Knowledge base and document service using kinds table.
 """
 
 import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Optional
 
@@ -56,6 +57,9 @@ from app.services.knowledge.permission_policy import (
     can_manage_accessible_knowledge_base_documents,
     can_manage_accessible_knowledge_document,
 )
+from app.services.readers.kb_permissions import kb_permission_resolver
+
+logger = logging.getLogger(__name__)
 
 
 def _build_attachment_filename(name: str, file_extension: str) -> str:
@@ -444,12 +448,26 @@ class KnowledgeService:
             # Get knowledge bases bound to group chats where user is a member
             bound_kb_ids = KnowledgeService._get_bound_kb_ids_for_user(db, user_id)
 
-            # Single query to get personal, team, organization, shared, and bound knowledge bases
-            # Personal: user_id matches and namespace is "default"
-            # Team: namespace is in accessible_groups
+            # External resolver: returns additional KB IDs the user can access
+            # via extension rules (e.g. department / employee bindings).
+            # Errors are caught so a faulty extension cannot break the core listing path.
+            try:
+                ext_kb_ids = kb_permission_resolver.get_accessible_kb_ids(db, user_id)
+            except Exception as e:
+                logger.warning(
+                    f"kb_permissions extension get_accessible_kb_ids failed: {e}; "
+                    "falling back to empty list"
+                )
+                ext_kb_ids = []
+
+            # Single query to get personal, team, organization, shared, bound, and
+            # externally-accessible knowledge bases.
+            # Personal:  user_id matches and namespace is "default"
+            # Team:      namespace is in accessible_groups
             # Organization: namespace has level='organization'
-            # Shared: id is in shared_kb_ids
-            # Bound: id is in bound_kb_ids (personal KBs bound to group chats)
+            # Shared:    id is in shared_kb_ids
+            # Bound:     id is in bound_kb_ids (personal KBs bound to group chats)
+            # External:  id is in ext_kb_ids (e.g. department / employee bindings)
             query = db.query(Kind).filter(
                 Kind.kind == "KnowledgeBase",
                 Kind.is_active == True,
@@ -468,6 +486,9 @@ class KnowledgeService:
 
             if bound_kb_ids:
                 conditions.append(Kind.id.in_(bound_kb_ids))
+
+            if ext_kb_ids:
+                conditions.append(Kind.id.in_(ext_kb_ids))
 
             if conditions:
                 from sqlalchemy import or_
@@ -2112,7 +2133,9 @@ class KnowledgeService:
             return True, BaseRole.Owner, False
 
         has_access, role, is_creator = knowledge_share_service.get_user_kb_permission(
-            db, knowledge_base_id, user_id
+            db,
+            knowledge_base_id,
+            user_id,
         )
 
         effective_role = BaseRole(role) if role is not None else None

--- a/backend/app/services/readers/__init__.py
+++ b/backend/app/services/readers/__init__.py
@@ -14,14 +14,17 @@ Usage:
     from app.services.readers.groups import groupReader
     from app.services.readers.group_members import groupMemberReader
     from app.services.readers.shared_teams import sharedTeamReader
+    from app.services.readers.kb_permissions import kb_permission_resolver
 
     bot = kindReader.get_by_name_and_namespace(db, user_id, KindType.BOT, "default", "mybot")
     user = userReader.get_by_id(db, user_id)
     is_member = groupMemberReader.is_member(db, "group-name", user_id)
+    ids = kb_permission_resolver.get_accessible_kb_ids(db, user_id)
 """
 
 from app.services.readers.group_members import groupMemberReader
 from app.services.readers.groups import groupReader
+from app.services.readers.kb_permissions import kb_permission_resolver
 from app.services.readers.kinds import KindType, kindReader
 from app.services.readers.shared_teams import sharedTeamReader
 from app.services.readers.users import userReader
@@ -32,5 +35,6 @@ __all__ = [
     "groupReader",
     "groupMemberReader",
     "sharedTeamReader",
+    "kb_permission_resolver",
     "KindType",
 ]

--- a/backend/app/services/readers/kb_permissions.py
+++ b/backend/app/services/readers/kb_permissions.py
@@ -5,14 +5,16 @@
 """
 Knowledge base external permission resolver extension point.
 
-Loaded via SERVICE_EXTENSION mechanism, consistent with the
-groups/group_members reader pattern.
+Loaded via Python entry points mechanism.
 
 Usage (in extension package, e.g. myext/kb_permissions.py):
 
     from app.services.readers.kb_permissions import IKbPermissionResolver
 
     class MyResolver(IKbPermissionResolver):
+        def __init__(self, base: IKbPermissionResolver):
+            self._base = base
+
         def resolve(self, db, kb_id, user_id, kb):
             # return a role string or None
             ...
@@ -21,11 +23,13 @@ Usage (in extension package, e.g. myext/kb_permissions.py):
             # return list of kb_ids the user can access
             ...
 
-    def wrap(base: IKbPermissionResolver) -> MyResolver:
-        return MyResolver()
+Register in pyproject.toml:
+
+    [project.entry-points."wegent.kb_permissions"]
+    my_resolver = "myext.kb_permissions:MyResolver"
 """
 
-import importlib
+import importlib.metadata
 import logging
 import threading
 from abc import ABC, abstractmethod
@@ -34,6 +38,9 @@ from typing import Optional
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+# Entry point group for KB permission resolvers
+ENTRY_POINT_GROUP = "wegent.kb_permissions"
 
 
 # =============================================================================
@@ -80,7 +87,7 @@ class IKbPermissionResolver(ABC):
         """
         Return knowledge base IDs accessible to the user via external rules.
 
-        Called during list queries to extend the OR conditions.  Return an
+        Called during list queries to extend the OR conditions. Return an
         empty list when there are no additional IDs to include.
 
         Args:
@@ -123,33 +130,57 @@ class DefaultKbPermissionResolver(IKbPermissionResolver):
 # =============================================================================
 
 
-def _create_resolver() -> IKbPermissionResolver:
-    """Create resolver, wrapping with extension if SERVICE_EXTENSION is set."""
-    from app.core.config import settings
+def _load_from_entry_points(
+    base: IKbPermissionResolver,
+) -> Optional[IKbPermissionResolver]:
+    """
+    Load resolver from entry points.
 
-    base: IKbPermissionResolver = DefaultKbPermissionResolver()
+    Args:
+        base: The base resolver to pass to the loaded resolver's constructor.
 
-    if not settings.SERVICE_EXTENSION:
-        return base
+    Returns:
+        The loaded resolver instance, or None if no valid entry point found.
+    """
+    try:
+        entry_points = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+    except TypeError:
+        # Python < 3.10 compatibility
+        all_eps = importlib.metadata.entry_points()
+        entry_points = all_eps.get(ENTRY_POINT_GROUP, [])
+
+    if not entry_points:
+        return None
+
+    # Use the first entry point
+    ep = next(iter(entry_points))
 
     try:
-        ext = importlib.import_module(f"{settings.SERVICE_EXTENSION}.kb_permissions")
-        result = ext.wrap(base)
-        if result is None:
-            logger.warning(
-                "kb_permissions extension wrap() returned None; "
-                f"using default resolver ({settings.SERVICE_EXTENSION})"
+        resolver_class = ep.load()
+
+        if not issubclass(resolver_class, IKbPermissionResolver):
+            logger.error(
+                f"Entry point {ep.name} ({resolver_class}) does not implement IKbPermissionResolver"
             )
-        else:
-            logger.info("KB permission resolver extension loaded")
-            return result
-    except ImportError:
-        logger.warning(
-            "KB permission resolver extension module not found: "
-            f"{settings.SERVICE_EXTENSION}.kb_permissions"
-        )
-    except Exception as e:  # noqa: BLE001 - extension isolation boundary
-        logger.warning("Failed to load kb_permissions extension: %s", e, exc_info=True)
+            return None
+
+        result = resolver_class(base)
+        logger.info(f"KB permission resolver loaded from entry point: {ep.name}")
+        return result
+
+    except Exception as e:
+        logger.warning(f"Failed to load entry point {ep.name}: {e}", exc_info=True)
+        return None
+
+
+def _create_resolver() -> IKbPermissionResolver:
+    """Create resolver, loading from entry points if available."""
+    base: IKbPermissionResolver = DefaultKbPermissionResolver()
+
+    # Try to load from entry points
+    loaded = _load_from_entry_points(base)
+    if loaded is not None:
+        return loaded
 
     return base
 

--- a/backend/app/services/readers/kb_permissions.py
+++ b/backend/app/services/readers/kb_permissions.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 Wegent, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Knowledge base external permission resolver extension point.
+
+Loaded via SERVICE_EXTENSION mechanism, consistent with the
+groups/group_members reader pattern.
+
+Usage (in extension package, e.g. myext/kb_permissions.py):
+
+    from app.services.readers.kb_permissions import IKbPermissionResolver
+
+    class MyResolver(IKbPermissionResolver):
+        def resolve(self, db, kb_id, user_id, kb):
+            # return a role string or None
+            ...
+
+        def get_accessible_kb_ids(self, db, user_id):
+            # return list of kb_ids the user can access
+            ...
+
+    def wrap(base: IKbPermissionResolver) -> MyResolver:
+        return MyResolver()
+"""
+
+import importlib
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Interface
+# =============================================================================
+
+
+class IKbPermissionResolver(ABC):
+    """
+    Abstract interface for external knowledge base permission resolution.
+
+    Implementations return a role string when the external system grants
+    access, or None to fall through to the built-in permission logic.
+    """
+
+    @abstractmethod
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        """
+        Resolve permission for a single knowledge base access check.
+
+        Called after all built-in checks have returned False.
+
+        Args:
+            db:      Database session
+            kb_id:   Knowledge base ID
+            user_id: Requesting user ID
+            kb:      Kind object (knowledge base record)
+
+        Returns:
+            Role string ("Owner"/"Maintainer"/"Developer"/"Reporter") if the
+            external system grants access, None to continue with built-in
+            denial.
+        """
+        pass
+
+    @abstractmethod
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        """
+        Return knowledge base IDs accessible to the user via external rules.
+
+        Called during list queries to extend the OR conditions.  Return an
+        empty list when there are no additional IDs to include.
+
+        Args:
+            db:      Database session
+            user_id: Requesting user ID
+
+        Returns:
+            List of knowledge base IDs (may be empty).
+        """
+        pass
+
+
+# =============================================================================
+# Default Implementation
+# =============================================================================
+
+
+class DefaultKbPermissionResolver(IKbPermissionResolver):
+    """
+    No-op resolver used when no extension is configured.
+
+    Always returns None / [] so no extra permissions are granted.
+    """
+
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        return None
+
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        return []
+
+
+# =============================================================================
+# Loader
+# =============================================================================
+
+
+def _create_resolver() -> IKbPermissionResolver:
+    """Create resolver, wrapping with extension if SERVICE_EXTENSION is set."""
+    from app.core.config import settings
+
+    base: IKbPermissionResolver = DefaultKbPermissionResolver()
+
+    if not settings.SERVICE_EXTENSION:
+        return base
+
+    try:
+        ext = importlib.import_module(f"{settings.SERVICE_EXTENSION}.kb_permissions")
+        result = ext.wrap(base)
+        if result is None:
+            logger.warning(
+                "kb_permissions extension wrap() returned None; "
+                f"using default resolver ({settings.SERVICE_EXTENSION})"
+            )
+        else:
+            logger.info("KB permission resolver extension loaded")
+            return result
+    except ImportError:
+        logger.warning(
+            "KB permission resolver extension module not found: "
+            f"{settings.SERVICE_EXTENSION}.kb_permissions"
+        )
+    except Exception as e:
+        logger.warning(f"Failed to load kb_permissions extension: {e}")
+
+    return base
+
+
+# =============================================================================
+# Lazy Singleton
+# =============================================================================
+
+
+class _LazyReader:
+    """Lazy-loaded resolver proxy that delegates to the actual resolver instance."""
+
+    _instance: IKbPermissionResolver | None = None
+    _init_lock: threading.Lock = threading.Lock()
+
+    def _get(self) -> IKbPermissionResolver:
+        if self._instance is None:
+            with self._init_lock:
+                # Double-checked locking to ensure only one resolver is created
+                # under concurrent access.
+                if self._instance is None:
+                    self._instance = _create_resolver()
+        return self._instance
+
+    def __getattr__(self, name: str):
+        return getattr(self._get(), name)
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+kb_permission_resolver: IKbPermissionResolver = _LazyReader()  # type: ignore

--- a/backend/app/services/readers/kb_permissions.py
+++ b/backend/app/services/readers/kb_permissions.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2025 Wegent, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Knowledge base external permission resolver extension point.
+
+Loaded via SERVICE_EXTENSION mechanism, consistent with the
+groups/group_members reader pattern.
+
+Usage (in extension package, e.g. myext/kb_permissions.py):
+
+    from app.services.readers.kb_permissions import IKbPermissionResolver
+
+    class MyResolver(IKbPermissionResolver):
+        def resolve(self, db, kb_id, user_id, kb):
+            # return a role string or None
+            ...
+
+        def get_accessible_kb_ids(self, db, user_id):
+            # return list of kb_ids the user can access
+            ...
+
+    def wrap(base: IKbPermissionResolver) -> MyResolver:
+        return MyResolver()
+"""
+
+import importlib
+import logging
+import threading
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Interface
+# =============================================================================
+
+
+class IKbPermissionResolver(ABC):
+    """
+    Abstract interface for external knowledge base permission resolution.
+
+    Implementations return a role string when the external system grants
+    access, or None to fall through to the built-in permission logic.
+    """
+
+    @abstractmethod
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        """
+        Resolve permission for a single knowledge base access check.
+
+        Called after all built-in checks have returned False.
+
+        Args:
+            db:      Database session
+            kb_id:   Knowledge base ID
+            user_id: Requesting user ID
+            kb:      Kind object (knowledge base record)
+
+        Returns:
+            Role string ("Owner"/"Maintainer"/"Developer"/"Reporter") if the
+            external system grants access, None to continue with built-in
+            denial.
+        """
+        pass
+
+    @abstractmethod
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        """
+        Return knowledge base IDs accessible to the user via external rules.
+
+        Called during list queries to extend the OR conditions.  Return an
+        empty list when there are no additional IDs to include.
+
+        Args:
+            db:      Database session
+            user_id: Requesting user ID
+
+        Returns:
+            List of knowledge base IDs (may be empty).
+        """
+        pass
+
+
+# =============================================================================
+# Default Implementation
+# =============================================================================
+
+
+class DefaultKbPermissionResolver(IKbPermissionResolver):
+    """
+    No-op resolver used when no extension is configured.
+
+    Always returns None / [] so no extra permissions are granted.
+    """
+
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        return None
+
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        return []
+
+
+# =============================================================================
+# Loader
+# =============================================================================
+
+
+def _create_resolver() -> IKbPermissionResolver:
+    """Create resolver, wrapping with extension if SERVICE_EXTENSION is set."""
+    from app.core.config import settings
+
+    base: IKbPermissionResolver = DefaultKbPermissionResolver()
+
+    if not settings.SERVICE_EXTENSION:
+        return base
+
+    try:
+        ext = importlib.import_module(f"{settings.SERVICE_EXTENSION}.kb_permissions")
+        result = ext.wrap(base)
+        if result is None:
+            logger.warning(
+                "kb_permissions extension wrap() returned None; "
+                f"using default resolver ({settings.SERVICE_EXTENSION})"
+            )
+        else:
+            logger.info("KB permission resolver extension loaded")
+            return result
+    except ImportError:
+        logger.warning(
+            "KB permission resolver extension module not found: "
+            f"{settings.SERVICE_EXTENSION}.kb_permissions"
+        )
+    except Exception as e:  # noqa: BLE001 - extension isolation boundary
+        logger.warning("Failed to load kb_permissions extension: %s", e, exc_info=True)
+
+    return base
+
+
+# =============================================================================
+# Lazy Singleton
+# =============================================================================
+
+
+class _LazyReader:
+    """Lazy-loaded resolver proxy that delegates to the actual resolver instance."""
+
+    _instance: IKbPermissionResolver | None = None
+    _init_lock: threading.Lock = threading.Lock()
+
+    def _get(self) -> IKbPermissionResolver:
+        if self._instance is None:
+            with self._init_lock:
+                # Double-checked locking to ensure only one resolver is created
+                # under concurrent access.
+                if self._instance is None:
+                    self._instance = _create_resolver()
+        return self._instance
+
+    def __getattr__(self, name: str):
+        return getattr(self._get(), name)
+
+
+# =============================================================================
+# Export
+# =============================================================================
+
+kb_permission_resolver: IKbPermissionResolver = _LazyReader()  # type: ignore

--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -290,7 +290,13 @@ class KnowledgeShareService(UnifiedShareService):
         """
         Get user's permission for a knowledge base.
 
-        Priority: creator > explicit permission (ResourceMember) > group permission > task binding
+        Priority: creator > explicit permission (ResourceMember) > group permission
+                  > task binding > external resolver
+
+        Args:
+            db:                Database session
+            knowledge_base_id: Knowledge base ID
+            user_id:           Requesting user ID
 
         Returns:
             Tuple of (has_access, role, is_creator)
@@ -373,6 +379,14 @@ class KnowledgeShareService(UnifiedShareService):
             if self._is_kb_bound_to_user_group_chat(db, knowledge_base_id, user_id):
                 # User is member of a group chat that has this KB bound
                 return True, ResourceRole.Reporter.value, False
+
+        # External permission resolver (e.g. department / employee bindings).
+        # Called last so it never interferes with built-in access control.
+        from app.services.readers.kb_permissions import kb_permission_resolver
+
+        ext_role = kb_permission_resolver.resolve(db, knowledge_base_id, user_id, kb)
+        if ext_role is not None:
+            return True, ext_role, False
 
         return False, None, False
 

--- a/backend/tests/services/readers/test_kb_permission_resolver.py
+++ b/backend/tests/services/readers/test_kb_permission_resolver.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: 2025 Wegent, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for the KB permission resolver extension point.
+
+Covers:
+- DefaultKbPermissionResolver no-op behaviour
+- _create_resolver returns default when SERVICE_EXTENSION is unset
+- _create_resolver wraps with extension when SERVICE_EXTENSION is set
+- _LazyReader initialises lazily and delegates via __getattr__
+- ImportError produces a warning log and falls back to the default resolver
+- General exception produces a warning log and falls back to the default resolver
+- get_user_kb_permission calls the resolver as the final fallback
+"""
+
+import importlib
+import sys
+from types import ModuleType
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+# Use importlib.import_module to get the actual module object, not the
+# instance exported by app.services.share.__init__.py under the same name.
+_kss_module = importlib.import_module("app.services.share.knowledge_share_service")
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.services.readers.kb_permissions import (
+    DefaultKbPermissionResolver,
+    IKbPermissionResolver,
+    _create_resolver,
+    _LazyReader,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db() -> Session:
+    return MagicMock(spec=Session)
+
+
+def _make_kb(kb_id: int = 1) -> MagicMock:
+    kb = MagicMock()
+    kb.id = kb_id
+    return kb
+
+
+# ---------------------------------------------------------------------------
+# DefaultKbPermissionResolver
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_default_resolver_resolve_returns_none() -> None:
+    """DefaultKbPermissionResolver.resolve always returns None."""
+    resolver = DefaultKbPermissionResolver()
+    result = resolver.resolve(_make_db(), kb_id=1, user_id=42, kb=_make_kb())
+    assert result is None
+
+
+@pytest.mark.unit
+def test_default_resolver_get_accessible_kb_ids_returns_empty_list() -> None:
+    """DefaultKbPermissionResolver.get_accessible_kb_ids always returns []."""
+    resolver = DefaultKbPermissionResolver()
+    result = resolver.get_accessible_kb_ids(_make_db(), user_id=42)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _create_resolver — no extension configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_resolver_returns_default_when_no_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When SERVICE_EXTENSION is empty, _create_resolver returns DefaultKbPermissionResolver."""
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "SERVICE_EXTENSION", "")
+    result = _create_resolver()
+    assert isinstance(result, DefaultKbPermissionResolver)
+
+
+# ---------------------------------------------------------------------------
+# _create_resolver — extension loaded via wrap(base)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_resolver_wraps_with_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When SERVICE_EXTENSION is set and wrap() succeeds, the wrapped resolver is used."""
+
+    class _CustomResolver(IKbPermissionResolver):
+        def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+            return "Reporter"
+
+        def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+            return [10, 20]
+
+    def _fake_wrap(base: IKbPermissionResolver) -> IKbPermissionResolver:
+        return _CustomResolver()
+
+    fake_ext = ModuleType("myext.kb_permissions")
+    fake_ext.wrap = _fake_wrap  # type: ignore[attr-defined]
+
+    with patch("app.core.config.settings") as mock_settings:
+        mock_settings.SERVICE_EXTENSION = "myext"
+        with patch("importlib.import_module", return_value=fake_ext):
+            from app.services.readers import kb_permissions
+
+            result = kb_permissions._create_resolver()
+
+    assert isinstance(result, _CustomResolver)
+    assert result.resolve(_make_db(), kb_id=1, user_id=1, kb=_make_kb()) == "Reporter"
+    assert result.get_accessible_kb_ids(_make_db(), user_id=1) == [10, 20]
+
+
+# ---------------------------------------------------------------------------
+# _create_resolver — ImportError falls back to default with warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_resolver_falls_back_on_import_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """ImportError during extension load logs a warning and returns the default resolver."""
+    with patch("app.core.config.settings") as mock_settings:
+        mock_settings.SERVICE_EXTENSION = "missing_ext"
+        with patch("importlib.import_module", side_effect=ImportError("no module")):
+            import logging
+
+            with caplog.at_level(
+                logging.WARNING, logger="app.services.readers.kb_permissions"
+            ):
+                from app.services.readers import kb_permissions
+
+                result = kb_permissions._create_resolver()
+
+    assert isinstance(result, DefaultKbPermissionResolver)
+    assert any("not found" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _create_resolver — generic exception falls back to default with warning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_resolver_falls_back_on_general_exception(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-ImportError exception during extension load logs a warning and returns default."""
+    fake_ext = ModuleType("myext.kb_permissions")
+    fake_ext.wrap = MagicMock(side_effect=RuntimeError("boom"))  # type: ignore[attr-defined]
+
+    with patch("app.core.config.settings") as mock_settings:
+        mock_settings.SERVICE_EXTENSION = "myext"
+        with patch("importlib.import_module", return_value=fake_ext):
+            import logging
+
+            with caplog.at_level(
+                logging.WARNING, logger="app.services.readers.kb_permissions"
+            ):
+                from app.services.readers import kb_permissions
+
+                result = kb_permissions._create_resolver()
+
+    assert isinstance(result, DefaultKbPermissionResolver)
+    assert any("Failed to load" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _LazyReader — lazy initialisation and __getattr__ delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_lazy_reader_initialises_only_once() -> None:
+    """_LazyReader calls _create_resolver exactly once across multiple method calls."""
+    mock_resolver = MagicMock(spec=IKbPermissionResolver)
+    mock_resolver.get_accessible_kb_ids.return_value = [5]
+    mock_resolver.resolve.return_value = None
+
+    lazy = _LazyReader()
+    lazy._instance = None  # reset state for isolation
+
+    with patch(
+        "app.services.readers.kb_permissions._create_resolver",
+        return_value=mock_resolver,
+    ) as mock_create:
+        _ = lazy.get_accessible_kb_ids(_make_db(), user_id=1)
+        _ = lazy.get_accessible_kb_ids(_make_db(), user_id=2)
+        _ = lazy.resolve(_make_db(), kb_id=1, user_id=1, kb=_make_kb())
+
+    # _create_resolver should be called only once (lazy singleton)
+    assert mock_create.call_count == 1
+
+
+@pytest.mark.unit
+def test_lazy_reader_delegates_resolve_via_getattr() -> None:
+    """_LazyReader.__getattr__ transparently delegates to the underlying resolver."""
+    mock_resolver = MagicMock(spec=IKbPermissionResolver)
+    mock_resolver.resolve.return_value = "Developer"
+
+    lazy = _LazyReader()
+    lazy._instance = mock_resolver
+
+    result = lazy.resolve(_make_db(), kb_id=7, user_id=3, kb=_make_kb())
+
+    assert result == "Developer"
+    mock_resolver.resolve.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration: get_user_kb_permission calls resolver as final fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_user_kb_permission_calls_external_resolver_as_last_resort(
+    test_db: Session,
+) -> None:
+    """
+    When all built-in checks deny access, kb_permission_resolver.resolve is called
+    and its returned role is used.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from app.services.share.knowledge_share_service import KnowledgeShareService
+
+    service = KnowledgeShareService()
+    db = test_db
+
+    # Build a minimal mock KB that has no creator match, no group, no org, no share
+    mock_kb = MagicMock()
+    mock_kb.id = 99
+    mock_kb.user_id = 999  # not the requesting user
+    mock_kb.namespace = "default"
+    mock_kb.kind = "KnowledgeBase"
+    mock_kb.is_active = True
+
+    with (
+        patch.object(db, "query") as mock_query,
+        patch(
+            "app.services.readers.kb_permissions.kb_permission_resolver"
+        ) as mock_resolver,
+        patch.object(_kss_module, "is_organization_namespace", return_value=False),
+        patch.object(_kss_module, "is_restricted_analyst", return_value=False),
+    ):
+        # KB lookup returns mock_kb, subsequent explicit-permission lookup returns None
+        mock_query.return_value.filter.return_value.first.side_effect = [
+            mock_kb,  # KB lookup
+            None,  # no explicit ResourceMember
+        ]
+        # External resolver grants Reporter access
+        mock_resolver.resolve.return_value = "Reporter"
+
+        has_access, role, is_creator = service.get_user_kb_permission(
+            db, knowledge_base_id=99, user_id=1
+        )
+
+    assert has_access is True
+    assert role == "Reporter"
+    assert is_creator is False
+
+
+@pytest.mark.unit
+def test_get_user_kb_permission_external_resolver_not_called_when_creator(
+    test_db: Session,
+) -> None:
+    """
+    When the user is the KB creator, kb_permission_resolver.resolve must NOT be called.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from app.services.share.knowledge_share_service import KnowledgeShareService
+
+    service = KnowledgeShareService()
+    db = test_db
+
+    mock_kb = MagicMock()
+    mock_kb.id = 55
+    mock_kb.user_id = 7  # matches requesting user
+    mock_kb.namespace = "default"
+    mock_kb.kind = "KnowledgeBase"
+    mock_kb.is_active = True
+
+    with (
+        patch.object(db, "query") as mock_query,
+        patch(
+            "app.services.readers.kb_permissions.kb_permission_resolver"
+        ) as mock_resolver,
+        patch.object(_kss_module, "is_restricted_analyst", return_value=False),
+    ):
+        mock_query.return_value.filter.return_value.first.return_value = mock_kb
+
+        has_access, _role, is_creator = service.get_user_kb_permission(
+            db, knowledge_base_id=55, user_id=7
+        )
+
+    assert has_access is True
+    assert is_creator is True
+    mock_resolver.resolve.assert_not_called()

--- a/backend/tests/services/readers/test_kb_permission_resolver.py
+++ b/backend/tests/services/readers/test_kb_permission_resolver.py
@@ -7,12 +7,13 @@ Unit tests for the KB permission resolver extension point.
 
 Covers:
 - DefaultKbPermissionResolver no-op behaviour
-- _create_resolver returns default when SERVICE_EXTENSION is unset
-- _create_resolver wraps with extension when SERVICE_EXTENSION is set
+- _create_resolver returns default when no entry point is registered
+- _create_resolver loads from entry points when available
+- _load_from_entry_points validates interface implementation
 - _LazyReader initialises lazily and delegates via __getattr__
-- ImportError produces a warning log and falls back to the default resolver
-- General exception produces a warning log and falls back to the default resolver
-- get_user_kb_permission calls the resolver as the final fallback
+- Invalid entry point produces a warning log and falls back to default
+- Exception during entry point load falls back to default
+- get_user_kb_permission calls resolver as the final fallback
 """
 
 import importlib
@@ -29,15 +30,17 @@ import pytest
 from sqlalchemy.orm import Session
 
 from app.services.readers.kb_permissions import (
+    ENTRY_POINT_GROUP,
     DefaultKbPermissionResolver,
     IKbPermissionResolver,
     _create_resolver,
     _LazyReader,
+    _load_from_entry_points,
 )
 
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 def _make_db() -> Session:
@@ -50,9 +53,17 @@ def _make_kb(kb_id: int = 1) -> MagicMock:
     return kb
 
 
-# ---------------------------------------------------------------------------
+def _make_entry_point(name: str, target_class):
+    """Create a mock entry point."""
+    ep = MagicMock()
+    ep.name = name
+    ep.load.return_value = target_class
+    return ep
+
+
+# -----------------------------------------------------------------------------
 # DefaultKbPermissionResolver
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -71,117 +82,184 @@ def test_default_resolver_get_accessible_kb_ids_returns_empty_list() -> None:
     assert result == []
 
 
-# ---------------------------------------------------------------------------
-# _create_resolver — no extension configured
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
+# _load_from_entry_points
+# -----------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_create_resolver_returns_default_when_no_extension(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When SERVICE_EXTENSION is empty, _create_resolver returns DefaultKbPermissionResolver."""
-    from app.core.config import settings
+def test_load_from_entry_points_returns_none_when_no_entry_points() -> None:
+    """When no entry points are registered, return None."""
+    base = DefaultKbPermissionResolver()
 
-    monkeypatch.setattr(settings, "SERVICE_EXTENSION", "")
-    result = _create_resolver()
-    assert isinstance(result, DefaultKbPermissionResolver)
+    with patch("importlib.metadata.entry_points", return_value=[]):
+        result = _load_from_entry_points(base)
 
-
-# ---------------------------------------------------------------------------
-# _create_resolver — extension loaded via wrap(base)
-# ---------------------------------------------------------------------------
+    assert result is None
 
 
 @pytest.mark.unit
-def test_create_resolver_wraps_with_extension(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When SERVICE_EXTENSION is set and wrap() succeeds, the wrapped resolver is used."""
+def test_load_from_entry_points_loads_valid_resolver() -> None:
+    """When a valid entry point is registered, load and instantiate it."""
 
     class _CustomResolver(IKbPermissionResolver):
+        def __init__(self, base: IKbPermissionResolver):
+            self._base = base
+
         def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
             return "Reporter"
 
         def get_accessible_kb_ids(self, db, user_id) -> list[int]:
             return [10, 20]
 
-    def _fake_wrap(base: IKbPermissionResolver) -> IKbPermissionResolver:
-        return _CustomResolver()
+    base = DefaultKbPermissionResolver()
+    mock_ep = _make_entry_point("custom", _CustomResolver)
 
-    fake_ext = ModuleType("myext.kb_permissions")
-    fake_ext.wrap = _fake_wrap  # type: ignore[attr-defined]
-
-    with patch("app.core.config.settings") as mock_settings:
-        mock_settings.SERVICE_EXTENSION = "myext"
-        with patch("importlib.import_module", return_value=fake_ext):
-            from app.services.readers import kb_permissions
-
-            result = kb_permissions._create_resolver()
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        result = _load_from_entry_points(base)
 
     assert isinstance(result, _CustomResolver)
     assert result.resolve(_make_db(), kb_id=1, user_id=1, kb=_make_kb()) == "Reporter"
     assert result.get_accessible_kb_ids(_make_db(), user_id=1) == [10, 20]
 
 
-# ---------------------------------------------------------------------------
-# _create_resolver — ImportError falls back to default with warning
-# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_load_from_entry_points_skips_invalid_interface(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When entry point class does not implement IKbPermissionResolver, log error and return None."""
+
+    class _NotAResolver:
+        pass
+
+    base = DefaultKbPermissionResolver()
+    mock_ep = _make_entry_point("invalid", _NotAResolver)
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        import logging
+
+        with caplog.at_level(
+            logging.ERROR, logger="app.services.readers.kb_permissions"
+        ):
+            result = _load_from_entry_points(base)
+
+    assert result is None
+    assert any(
+        "does not implement IKbPermissionResolver" in rec.message
+        for rec in caplog.records
+    )
 
 
 @pytest.mark.unit
-def test_create_resolver_falls_back_on_import_error(
+def test_load_from_entry_points_handles_exception(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """ImportError during extension load logs a warning and returns the default resolver."""
-    with patch("app.core.config.settings") as mock_settings:
-        mock_settings.SERVICE_EXTENSION = "missing_ext"
-        with patch("importlib.import_module", side_effect=ImportError("no module")):
-            import logging
+    """When entry point load raises exception, log warning and return None."""
+    base = DefaultKbPermissionResolver()
+    mock_ep = _make_entry_point("broken", None)
+    mock_ep.load.side_effect = RuntimeError("load failed")
 
-            with caplog.at_level(
-                logging.WARNING, logger="app.services.readers.kb_permissions"
-            ):
-                from app.services.readers import kb_permissions
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        import logging
 
-                result = kb_permissions._create_resolver()
+        with caplog.at_level(
+            logging.WARNING, logger="app.services.readers.kb_permissions"
+        ):
+            result = _load_from_entry_points(base)
 
-    assert isinstance(result, DefaultKbPermissionResolver)
-    assert any("not found" in rec.message for rec in caplog.records)
-
-
-# ---------------------------------------------------------------------------
-# _create_resolver — generic exception falls back to default with warning
-# ---------------------------------------------------------------------------
+    assert result is None
+    assert any("Failed to load entry point" in rec.message for rec in caplog.records)
 
 
 @pytest.mark.unit
-def test_create_resolver_falls_back_on_general_exception(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A non-ImportError exception during extension load logs a warning and returns default."""
-    fake_ext = ModuleType("myext.kb_permissions")
-    fake_ext.wrap = MagicMock(side_effect=RuntimeError("boom"))  # type: ignore[attr-defined]
+def test_load_from_entry_points_uses_first_entry_point() -> None:
+    """When multiple entry points are registered, use the first one."""
 
-    with patch("app.core.config.settings") as mock_settings:
-        mock_settings.SERVICE_EXTENSION = "myext"
-        with patch("importlib.import_module", return_value=fake_ext):
-            import logging
+    class _FirstResolver(IKbPermissionResolver):
+        def __init__(self, base: IKbPermissionResolver):
+            self._base = base
 
-            with caplog.at_level(
-                logging.WARNING, logger="app.services.readers.kb_permissions"
-            ):
-                from app.services.readers import kb_permissions
+        def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+            return "First"
 
-                result = kb_permissions._create_resolver()
+        def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+            return [1]
+
+    class _SecondResolver(IKbPermissionResolver):
+        def __init__(self, base: IKbPermissionResolver):
+            self._base = base
+
+        def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+            return "Second"
+
+        def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+            return [2]
+
+    base = DefaultKbPermissionResolver()
+    mock_ep1 = _make_entry_point("first", _FirstResolver)
+    mock_ep2 = _make_entry_point("second", _SecondResolver)
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep1, mock_ep2]):
+        result = _load_from_entry_points(base)
+
+    assert isinstance(result, _FirstResolver)
+    assert result.resolve(_make_db(), kb_id=1, user_id=1, kb=_make_kb()) == "First"
+
+
+# -----------------------------------------------------------------------------
+# _create_resolver
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_create_resolver_returns_default_when_no_entry_points() -> None:
+    """When no entry points are registered, _create_resolver returns DefaultKbPermissionResolver."""
+    with patch("importlib.metadata.entry_points", return_value=[]):
+        result = _create_resolver()
 
     assert isinstance(result, DefaultKbPermissionResolver)
-    assert any("Failed to load" in rec.message for rec in caplog.records)
 
 
-# ---------------------------------------------------------------------------
+@pytest.mark.unit
+def test_create_resolver_loads_from_entry_points() -> None:
+    """When entry point is registered, _create_resolver loads it."""
+
+    class _CustomResolver(IKbPermissionResolver):
+        def __init__(self, base: IKbPermissionResolver):
+            self._base = base
+
+        def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+            return "Maintainer"
+
+        def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+            return [100, 200]
+
+    mock_ep = _make_entry_point("custom", _CustomResolver)
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        result = _create_resolver()
+
+    assert isinstance(result, _CustomResolver)
+
+
+@pytest.mark.unit
+def test_create_resolver_falls_back_to_default_on_invalid_entry_point() -> None:
+    """When entry point is invalid, fall back to DefaultKbPermissionResolver."""
+
+    class _NotAResolver:
+        pass
+
+    mock_ep = _make_entry_point("invalid", _NotAResolver)
+
+    with patch("importlib.metadata.entry_points", return_value=[mock_ep]):
+        result = _create_resolver()
+
+    assert isinstance(result, DefaultKbPermissionResolver)
+
+
+# -----------------------------------------------------------------------------
 # _LazyReader — lazy initialisation and __getattr__ delegation
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -221,9 +299,9 @@ def test_lazy_reader_delegates_resolve_via_getattr() -> None:
     mock_resolver.resolve.assert_called_once()
 
 
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Integration: get_user_kb_permission calls resolver as final fallback
-# ---------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 
 @pytest.mark.unit

--- a/docs/en/developer-guide/kb-permission-extension.md
+++ b/docs/en/developer-guide/kb-permission-extension.md
@@ -1,0 +1,428 @@
+---
+sidebar_position: 3
+---
+
+# Knowledge Base Extension System
+
+This document describes the knowledge base extension system, which provides multiple extension points for integrating external systems (such as ERP, department management, or custom permission systems) without modifying the open-source codebase.
+
+## Overview
+
+The knowledge base extension system uses a **registry + bridge** pattern: open-source components provide well-defined extension points, and external packages register their implementations during application initialization. This achieves clean separation between open-source and proprietary code.
+
+The system includes the following extension mechanisms:
+
+| Extension Point | Pattern | Description |
+|----------------|---------|-------------|
+| [Component Registry](#component-registry) | Override | Replace entire components (DocumentPanel, KnowledgeDetailPanel) |
+| [External Binding API](#external-binding-api) | Provider + Bridge | Search, add, remove, and sync external entity bindings |
+| [Permission Extension Tabs](#permission-extension-tabs) | Prop Injection | Add custom permission management tabs |
+| [Create KB Dialog Form Sections](#create-kb-dialog-extension) | State Bridge | Inject form sections at well-defined slot positions |
+| [Post-Creation Hooks](#post-creation-hook) | State Bridge | Run async operations after KB creation |
+| [Custom Role Select](#role-select-extension) | Component Bridge | Replace the role select dropdown in AddUserForm |
+
+## Component Registry
+
+The component registry allows external packages to override entire knowledge document components at runtime.
+
+### Registry Interface
+
+```typescript
+// frontend/src/features/knowledge/document/components/registry.ts
+
+export interface ComponentRegistry {
+  /** Document panel component for notebook KB right panel */
+  DocumentPanel?: ComponentType<DocumentPanelProps>
+  /** Knowledge detail panel component for classic KB detail view */
+  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
+}
+```
+
+### Registration
+
+Call `registerComponents()` during application initialization, before any components are rendered:
+
+```typescript
+import { registerComponents } from '@/features/knowledge/document/components'
+import { CustomDocumentPanel } from './CustomDocumentPanel'
+
+registerComponents({
+  DocumentPanel: CustomDocumentPanel,
+})
+```
+
+### Resolution
+
+Open-source components use `getComponent()` to resolve registered components at **render time** (not at module load time), giving external packages time to populate the registry first:
+
+```typescript
+import { getComponent } from '@/features/knowledge/document/components'
+import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
+import type { DocumentPanelProps } from './DocumentPanel'
+
+function DocumentPanel(props: DocumentPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('DocumentPanel', DefaultDocumentPanel),
+    []
+  )
+  return <Panel {...props} />
+}
+```
+
+### Utility Functions
+
+```typescript
+/** Check if a component has been registered */
+function hasComponent(name: keyof ComponentRegistry): boolean
+
+/** Clear all registered components (useful for testing) */
+function clearRegistry(): void
+```
+
+## External Binding API
+
+The external binding API allows external packages to bind external system entities (departments, employees, customers, etc.) to knowledge bases.
+
+### Architecture
+
+The binding system consists of two parts:
+
+1. **Binding Provider Registry** — Declares available external systems and their search capabilities
+2. **External Binding API** — Provides CRUD operations for bindings
+
+### Binding Provider Types
+
+```typescript
+// frontend/src/apis/knowledgeExtensions.ts
+
+export interface BindableItem {
+  id: string
+  name: string
+  fullPath?: string    // Hierarchy path, e.g., "Dept A / Team B"
+  avatar?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BindableTypeConfig {
+  type: string           // e.g., 'department', 'employee', 'customer'
+  displayName: string
+  icon?: string
+  allowMultiple: boolean
+}
+
+export interface BindingProvider {
+  name: string                   // Unique identifier, e.g., 'erp', 'oa'
+  displayName: string
+  icon?: string
+  searchable: boolean
+  bindableTypes: BindableTypeConfig[]
+  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
+  validate: (externalId: string, type: string) => Promise<boolean>
+  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
+}
+```
+
+### External Binding Data Model
+
+```typescript
+export interface ExternalBinding {
+  id: number
+  kbId: number
+  provider: string
+  bindableType: string
+  externalId: string
+  name: string
+  fullPath?: string
+  avatar?: string
+  metadata?: Record<string, unknown>
+  createdAt: string
+}
+
+export interface ExternalBindingCreate {
+  provider: string
+  bindableType: string
+  externalId: string
+}
+```
+
+### External Binding API Interface
+
+```typescript
+export interface ExternalBindingApi {
+  readonly providers: BindingProviderRegistry
+
+  search: (
+    keyword: string,
+    provider?: string,
+    type?: string
+  ) => Promise<Record<string, BindingSearchResult>>
+
+  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
+  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
+  remove: (kbId: number, bindingId: number) => Promise<void>
+  sync: (kbId: number, bindingId: number) => Promise<void>
+}
+```
+
+### Usage
+
+External packages register providers and set the API implementation during app initialization:
+
+```typescript
+import {
+  bindingProviderRegistry,
+  setExternalBindingApi,
+  type BindingProvider,
+} from '@/apis/knowledgeExtensions'
+
+// Register a binding provider (e.g., ERP department search)
+bindingProviderRegistry.register({
+  name: 'erp',
+  displayName: 'ERP System',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: 'Department', allowMultiple: true },
+  ],
+  search: async (keyword, type) => {
+    // Search ERP API for departments/employees
+    return { items: [...], hasMore: false }
+  },
+  validate: async (externalId, type) => {
+    // Validate external ID
+    return true
+  },
+})
+
+// Set the binding API implementation
+setExternalBindingApi({
+  providers: bindingProviderRegistry,
+  search: async (keyword, provider, type) => { /* ... */ },
+  list: async (kbId, provider) => { /* ... */ },
+  add: async (kbId, data) => { /* ... */ },
+  remove: async (kbId, bindingId) => { /* ... */ },
+  sync: async (kbId, bindingId) => { /* ... */ },
+})
+```
+
+### Accessing the API
+
+Open-source components check availability and access the API safely:
+
+```typescript
+import {
+  hasExternalBindingApi,
+  getExternalBindingApi,
+} from '@/apis/knowledgeExtensions'
+
+if (hasExternalBindingApi()) {
+  const api = getExternalBindingApi()
+  const bindings = await api.list(kbId)
+}
+```
+
+## Permission Extension Tabs
+
+The `KbPermissionsPanel` component provides an `extensionTabs` prop to add additional permission management tabs beyond the default personal permissions tab.
+
+### ExtensionTabConfig Interface
+
+```typescript
+export interface ExtensionTabConfig {
+  /** Unique identifier for this tab */
+  id: string
+  /** Display label for the tab */
+  label: string
+  /** Lucide icon component */
+  icon: React.ComponentType<{ className?: string }>
+  /** Component to render as tab content, receives kbId prop */
+  component: React.ComponentType<{ kbId: number }>
+  /** Whether this tab requires manage permission to be visible */
+  requiresManagePermission?: boolean
+}
+```
+
+### Usage
+
+```typescript
+import { Building2 } from 'lucide-react'
+import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
+
+const departmentTab: ExtensionTabConfig = {
+  id: 'department',
+  label: 'Department',
+  icon: Building2,
+  component: DepartmentPermissionTab,
+  requiresManagePermission: true,
+}
+
+// In your component:
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[departmentTab]}
+/>
+```
+
+The `KnowledgeDetailPanel` component also exposes this via the `permissionExtensionTabs` prop:
+
+```typescript
+<KnowledgeDetailPanel
+  selectedKb={selectedKb}
+  permissionExtensionTabs={[departmentTab]}
+/>
+```
+
+## Create KB Dialog Extension
+
+The create KB dialog (`CreateKnowledgeBaseDialog`) provides two extension mechanisms: form section injection and post-creation hooks.
+
+### Form Sections
+
+The `KnowledgeBaseForm` component defines well-defined slot positions for external packages to inject custom UI sections:
+
+```typescript
+export interface KnowledgeBaseFormSections {
+  /** Rendered after the description field, before summary settings */
+  afterDescription?: React.ReactNode
+
+  /** Rendered at the very end of the form, after advanced settings */
+  afterAdvanced?: React.ReactNode
+}
+```
+
+### Registering Form Sections
+
+External packages register form sections during app initialization:
+
+```typescript
+import { setCreateKbFormSections } from '@/features/knowledge/document/components'
+
+setCreateKbFormSections({
+  afterDescription: <AuthorizationSection />,
+  afterAdvanced: <CustomFooter />,
+})
+```
+
+### Post-Creation Hook
+
+Register a handler to be called after KB creation (e.g., to set up external bindings):
+
+```typescript
+import { setPostCreateHandler } from '@/features/knowledge/document/components'
+
+setPostCreateHandler(async (kbId) => {
+  await myBindingApi.apply(kbId)
+  await initializeExternalPermissions(kbId)
+})
+```
+
+### Read/Write Separation
+
+These extension points follow a **read/write separation** pattern:
+
+| File | Write (External Package) | Read (Open-Source Component) |
+|------|--------------------------|------------------------------|
+| `createKbDialogState.ts` | `setCreateKbFormSections()` | `getCreateKbFormSections()` |
+| `createKbDialogState.ts` | `setPostCreateHandler()` | `runPostCreateHandler()` |
+
+## Role Select Extension
+
+The `AddUserForm` component allows replacing the default role `<Select>` dropdown with a custom component.
+
+### RoleSelectComponent Props
+
+```typescript
+export interface RoleSelectComponentProps {
+  value: MemberRole
+  onChange: (role: MemberRole) => void
+}
+```
+
+### Registration
+
+```typescript
+import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
+import { ErpRoleSelect } from './ErpRoleSelect'
+
+setRoleSelectComponent(ErpRoleSelect)
+```
+
+When registered, `AddUserForm` renders the custom component instead of the default role dropdown. This is useful for ERP integrations that need to display custom role options alongside standard ones.
+
+### Clear
+
+Pass `undefined` to clear the registered component:
+
+```typescript
+setRoleSelectComponent(undefined)
+```
+
+## Backend Integration
+
+### Python Entry Points for Permission Resolvers
+
+The backend uses Python entry points to dynamically load permission resolver implementations:
+
+```toml
+[project.entry-points."wegent.kb_permissions"]
+department = "app.extensions.myext.kb_permissions:DepartmentPermissionResolver"
+```
+
+Implement the resolver interface:
+
+```python
+from app.services.readers.kb_permissions import IKbPermissionResolver
+
+class DepartmentPermissionResolver(IKbPermissionResolver):
+    def __init__(self, base: IKbPermissionResolver):
+        self._base = base
+
+    def resolve(self, db, kb_id, user_id, kb):
+        if self._has_department_access(db, kb_id, user_id):
+            return "Developer"
+        return self._base.resolve(db, kb_id, user_id, kb)
+
+    def get_accessible_kb_ids(self, db, user_id):
+        dept_ids = self._get_dept_accessible_kbs(db, user_id)
+        base_ids = self._base.get_accessible_kb_ids(db, user_id)
+        return list(set(dept_ids + base_ids))
+```
+
+## Best Practices
+
+1. **Initialize Early**: Call `registerComponents()`, `setExternalBindingApi()`, and other registration functions during application initialization (before any components are rendered).
+
+2. **Lazy Component Resolution**: Use `useMemo(() => getComponent(name, Default), [])` at render time, not module-level `getComponent()` calls. This ensures registered components are available even with non-deterministic module import ordering.
+
+3. **Unique IDs**: Ensure extension tab IDs and provider names are unique to avoid conflicts.
+
+4. **Permission Checks**: Use `requiresManagePermission` appropriately to hide extension tabs from users without management rights.
+
+5. **Error Boundaries**: Wrap extension components with error boundaries to prevent crashes from affecting the entire panel.
+
+6. **Error Handling**: Always check `hasExternalBindingApi()` before accessing the binding API, or use `getExternalBindingApi(true)` to throw a descriptive error.
+
+7. **Consistent Styling**: Use the project's design system components for consistent UI.
+
+8. **i18n Support**: Use the `useTranslation` hook for all user-facing text in extension components.
+
+## Extension Points Summary
+
+| File | Export | Type | Description |
+|------|--------|------|-------------|
+| `registry.ts` | `registerComponents()` | Override | Replace DocumentPanel or KnowledgeDetailPanel entirely |
+| `knowledgeExtensions.ts` | `setExternalBindingApi()` | Provider + Bridge | Set external binding API with searchable providers |
+| `knowledgeExtensions.ts` | `bindingProviderRegistry` | Registry | Register/unregister binding providers |
+| `knowledgeExtensions.ts` | `hasExternalBindingApi()` | Check | Check if binding API is available |
+| `knowledgeExtensions.ts` | `getExternalBindingApi()` | Access | Get the binding API instance |
+| `permission/components/KbPermissionsPanel.tsx` | `extensionTabs` prop | Prop Injection | Add custom permission management tabs |
+| `document/components/createKbDialogState.ts` | `setCreateKbFormSections()` | State Bridge | Inject form sections into create KB dialog |
+| `document/components/createKbDialogState.ts` | `setPostCreateHandler()` | State Bridge | Register post-creation hook |
+| `permission/components/add-user-form-state.ts` | `setRoleSelectComponent()` | Component Bridge | Replace role select in AddUserForm |
+| `document/components/index.ts` | Exports all above | N/A | Single import entry for all extension APIs |
+
+## See Also
+
+- [Permission System Concepts](../../concepts/permission-system.md)
+- [Backend Extension Guide](../backend-extensions.md)
+- [Component Design Guidelines](../component-design.md)

--- a/docs/en/developer-guide/kb-permission-extension.md
+++ b/docs/en/developer-guide/kb-permission-extension.md
@@ -1,374 +1,102 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Knowledge Base Extension System
 
-This document describes the knowledge base extension system, which provides multiple extension points for integrating external systems (such as ERP, department management, or custom permission systems) without modifying the open-source codebase.
+This document describes the knowledge base extension system, which provides multiple extension points for integrating external systems (such as DingTalk, WeCom, ERP, or custom permission systems) without modifying the open-source codebase.
 
 ## Overview
 
-The knowledge base extension system uses a **registry + bridge** pattern: open-source components provide well-defined extension points, and external packages register their implementations during application initialization. This achieves clean separation between open-source and proprietary code.
+The knowledge base extension system covers both **frontend** and **backend** layers, using a **registry + bridge** pattern: open-source components provide well-defined extension points, and external packages register their implementations during application initialization. This achieves clean separation between open-source and proprietary code.
 
-The system includes the following extension mechanisms:
+### Architecture Overview
 
-| Extension Point | Pattern | Description |
-|----------------|---------|-------------|
-| [Component Registry](#component-registry) | Override | Replace entire components (DocumentPanel, KnowledgeDetailPanel) |
-| [External Binding API](#external-binding-api) | Provider + Bridge | Search, add, remove, and sync external entity bindings |
-| [Permission Extension Tabs](#permission-extension-tabs) | Prop Injection | Add custom permission management tabs |
-| [Create KB Dialog Form Sections](#create-kb-dialog-extension) | State Bridge | Inject form sections at well-defined slot positions |
-| [Post-Creation Hooks](#post-creation-hook) | State Bridge | Run async operations after KB creation |
-| [Custom Role Select](#role-select-extension) | Component Bridge | Replace the role select dropdown in AddUserForm |
+```
+┌─────────────────────────────────────────────────────┐
+│                  External Package                   │
+│                                                     │
+│  ┌────────────────────┐  ┌────────────────────┐     │
+│  │ Permission         │  │ Frontend           │     │
+│  │ Resolver (Python)  │  │ Extensions (TS)    │     │
+│  └─────────┬──────────┘  └─────────┬──────────┘     │
+│            │                       │                │
+└────────────┼───────────────────────┼────────────────┘
+             │                       │
+             ▼                       ▼
+   ┌────────────────────┐  ┌────────────────────┐
+   │  Backend Entry     │  │  Registry / State  │
+   │  Points            │  │  Bridge Pattern    │
+   │  wegent.kb_        │  │                    │
+   │  permissions       │  │                    │
+   └─────────┬──────────┘  └─────────┬──────────┘
+             │                       │
+             ▼                       ▼
+   ┌─────────┬──────────┐  ┌─────────┬──────────┐
+   │  Permission        │  │  UI Extension      │
+   │  Resolution Chain  │  │  Points            │
+   │  (Chain of Resp.)  │  │  (Props/Registry)  │
+   └────────────────────┘  └────────────────────┘
+```Frontend and backend extension points can be used independently or combined for complete end-to-end integration scenarios.
 
-## Component Registry
+---
 
-The component registry allows external packages to override entire knowledge document components at runtime.
+## Backend Extension: Permission Resolver
 
-### Registry Interface
+The backend uses Python entry points to dynamically load external permission resolvers, extending knowledge base access control.
 
-```typescript
-// frontend/src/features/knowledge/document/components/registry.ts
+### Permission Resolver Interface
 
-export interface ComponentRegistry {
-  /** Document panel component for notebook KB right panel */
-  DocumentPanel?: ComponentType<DocumentPanelProps>
-  /** Knowledge detail panel component for classic KB detail view */
-  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
-}
+```python
+# backend/app/services/readers/kb_permissions.py
+
+class IKbPermissionResolver(ABC):
+    """
+    Abstract interface for external knowledge base permission resolution.
+    Implementations return a role string when the external system grants
+    access, or None to fall through to built-in permission logic.
+    """
+
+    @abstractmethod
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        """
+        Resolve permission for a single knowledge base access check.
+        Called after all built-in checks have returned False.
+
+        Returns:
+            "Owner"/"Maintainer"/"Developer"/"Reporter" if the external
+            system grants access, or None to continue with built-in denial.
+        """
+        pass
+
+    @abstractmethod
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        """
+        Return knowledge base IDs accessible to the user via external rules.
+        Called during list queries to extend the OR conditions.
+
+        Returns:
+            List of knowledge base IDs (may be empty).
+        """
+        pass
 ```
 
-### Registration
+### Registering an External Resolver
 
-Call `registerComponents()` during application initialization, before any components are rendered:
-
-```typescript
-import { registerComponents } from '@/features/knowledge/document/components'
-import { CustomDocumentPanel } from './CustomDocumentPanel'
-
-registerComponents({
-  DocumentPanel: CustomDocumentPanel,
-})
-```
-
-### Resolution
-
-Open-source components use `getComponent()` to resolve registered components at **render time** (not at module load time), giving external packages time to populate the registry first:
-
-```typescript
-import { getComponent } from '@/features/knowledge/document/components'
-import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
-import type { DocumentPanelProps } from './DocumentPanel'
-
-function DocumentPanel(props: DocumentPanelProps) {
-  const Panel = useMemo(
-    () => getComponent('DocumentPanel', DefaultDocumentPanel),
-    []
-  )
-  return <Panel {...props} />
-}
-```
-
-### Utility Functions
-
-```typescript
-/** Check if a component has been registered */
-function hasComponent(name: keyof ComponentRegistry): boolean
-
-/** Clear all registered components (useful for testing) */
-function clearRegistry(): void
-```
-
-## External Binding API
-
-The external binding API allows external packages to bind external system entities (departments, employees, customers, etc.) to knowledge bases.
-
-### Architecture
-
-The binding system consists of two parts:
-
-1. **Binding Provider Registry** — Declares available external systems and their search capabilities
-2. **External Binding API** — Provides CRUD operations for bindings
-
-### Binding Provider Types
-
-```typescript
-// frontend/src/apis/knowledgeExtensions.ts
-
-export interface BindableItem {
-  id: string
-  name: string
-  fullPath?: string    // Hierarchy path, e.g., "Dept A / Team B"
-  avatar?: string
-  metadata?: Record<string, unknown>
-}
-
-export interface BindableTypeConfig {
-  type: string           // e.g., 'department', 'employee', 'customer'
-  displayName: string
-  icon?: string
-  allowMultiple: boolean
-}
-
-export interface BindingProvider {
-  name: string                   // Unique identifier, e.g., 'erp', 'oa'
-  displayName: string
-  icon?: string
-  searchable: boolean
-  bindableTypes: BindableTypeConfig[]
-  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
-  validate: (externalId: string, type: string) => Promise<boolean>
-  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
-}
-```
-
-### External Binding Data Model
-
-```typescript
-export interface ExternalBinding {
-  id: number
-  kbId: number
-  provider: string
-  bindableType: string
-  externalId: string
-  name: string
-  fullPath?: string
-  avatar?: string
-  metadata?: Record<string, unknown>
-  createdAt: string
-}
-
-export interface ExternalBindingCreate {
-  provider: string
-  bindableType: string
-  externalId: string
-}
-```
-
-### External Binding API Interface
-
-```typescript
-export interface ExternalBindingApi {
-  readonly providers: BindingProviderRegistry
-
-  search: (
-    keyword: string,
-    provider?: string,
-    type?: string
-  ) => Promise<Record<string, BindingSearchResult>>
-
-  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
-  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
-  remove: (kbId: number, bindingId: number) => Promise<void>
-  sync: (kbId: number, bindingId: number) => Promise<void>
-}
-```
-
-### Usage
-
-External packages register providers and set the API implementation during app initialization:
-
-```typescript
-import {
-  bindingProviderRegistry,
-  setExternalBindingApi,
-  type BindingProvider,
-} from '@/apis/knowledgeExtensions'
-
-// Register a binding provider (e.g., ERP department search)
-bindingProviderRegistry.register({
-  name: 'erp',
-  displayName: 'ERP System',
-  searchable: true,
-  bindableTypes: [
-    { type: 'department', displayName: 'Department', allowMultiple: true },
-  ],
-  search: async (keyword, type) => {
-    // Search ERP API for departments/employees
-    return { items: [...], hasMore: false }
-  },
-  validate: async (externalId, type) => {
-    // Validate external ID
-    return true
-  },
-})
-
-// Set the binding API implementation
-setExternalBindingApi({
-  providers: bindingProviderRegistry,
-  search: async (keyword, provider, type) => { /* ... */ },
-  list: async (kbId, provider) => { /* ... */ },
-  add: async (kbId, data) => { /* ... */ },
-  remove: async (kbId, bindingId) => { /* ... */ },
-  sync: async (kbId, bindingId) => { /* ... */ },
-})
-```
-
-### Accessing the API
-
-Open-source components check availability and access the API safely:
-
-```typescript
-import {
-  hasExternalBindingApi,
-  getExternalBindingApi,
-} from '@/apis/knowledgeExtensions'
-
-if (hasExternalBindingApi()) {
-  const api = getExternalBindingApi()
-  const bindings = await api.list(kbId)
-}
-```
-
-## Permission Extension Tabs
-
-The `KbPermissionsPanel` component provides an `extensionTabs` prop to add additional permission management tabs beyond the default personal permissions tab.
-
-### ExtensionTabConfig Interface
-
-```typescript
-export interface ExtensionTabConfig {
-  /** Unique identifier for this tab */
-  id: string
-  /** Display label for the tab */
-  label: string
-  /** Lucide icon component */
-  icon: React.ComponentType<{ className?: string }>
-  /** Component to render as tab content, receives kbId prop */
-  component: React.ComponentType<{ kbId: number }>
-  /** Whether this tab requires manage permission to be visible */
-  requiresManagePermission?: boolean
-}
-```
-
-### Usage
-
-```typescript
-import { Building2 } from 'lucide-react'
-import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
-
-const departmentTab: ExtensionTabConfig = {
-  id: 'department',
-  label: 'Department',
-  icon: Building2,
-  component: DepartmentPermissionTab,
-  requiresManagePermission: true,
-}
-
-// In your component:
-<KbPermissionsPanel
-  kbId={kbId}
-  canManagePermissions={canManagePermissions}
-  extensionTabs={[departmentTab]}
-/>
-```
-
-The `KnowledgeDetailPanel` component also exposes this via the `permissionExtensionTabs` prop:
-
-```typescript
-<KnowledgeDetailPanel
-  selectedKb={selectedKb}
-  permissionExtensionTabs={[departmentTab]}
-/>
-```
-
-## Create KB Dialog Extension
-
-The create KB dialog (`CreateKnowledgeBaseDialog`) provides two extension mechanisms: form section injection and post-creation hooks.
-
-### Form Sections
-
-The `KnowledgeBaseForm` component defines well-defined slot positions for external packages to inject custom UI sections:
-
-```typescript
-export interface KnowledgeBaseFormSections {
-  /** Rendered after the description field, before summary settings */
-  afterDescription?: React.ReactNode
-
-  /** Rendered at the very end of the form, after advanced settings */
-  afterAdvanced?: React.ReactNode
-}
-```
-
-### Registering Form Sections
-
-External packages register form sections during app initialization:
-
-```typescript
-import { setCreateKbFormSections } from '@/features/knowledge/document/components'
-
-setCreateKbFormSections({
-  afterDescription: <AuthorizationSection />,
-  afterAdvanced: <CustomFooter />,
-})
-```
-
-### Post-Creation Hook
-
-Register a handler to be called after KB creation (e.g., to set up external bindings):
-
-```typescript
-import { setPostCreateHandler } from '@/features/knowledge/document/components'
-
-setPostCreateHandler(async (kbId) => {
-  await myBindingApi.apply(kbId)
-  await initializeExternalPermissions(kbId)
-})
-```
-
-### Read/Write Separation
-
-These extension points follow a **read/write separation** pattern:
-
-| File | Write (External Package) | Read (Open-Source Component) |
-|------|--------------------------|------------------------------|
-| `createKbDialogState.ts` | `setCreateKbFormSections()` | `getCreateKbFormSections()` |
-| `createKbDialogState.ts` | `setPostCreateHandler()` | `runPostCreateHandler()` |
-
-## Role Select Extension
-
-The `AddUserForm` component allows replacing the default role `<Select>` dropdown with a custom component.
-
-### RoleSelectComponent Props
-
-```typescript
-export interface RoleSelectComponentProps {
-  value: MemberRole
-  onChange: (role: MemberRole) => void
-}
-```
-
-### Registration
-
-```typescript
-import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
-import { ErpRoleSelect } from './ErpRoleSelect'
-
-setRoleSelectComponent(ErpRoleSelect)
-```
-
-When registered, `AddUserForm` renders the custom component instead of the default role dropdown. This is useful for ERP integrations that need to display custom role options alongside standard ones.
-
-### Clear
-
-Pass `undefined` to clear the registered component:
-
-```typescript
-setRoleSelectComponent(undefined)
-```
-
-## Backend Integration
-
-### Python Entry Points for Permission Resolvers
-
-The backend uses Python entry points to dynamically load permission resolver implementations:
+External packages declare entry points in `pyproject.toml`. The system loads them lazily on first use:
 
 ```toml
 [project.entry-points."wegent.kb_permissions"]
 department = "app.extensions.myext.kb_permissions:DepartmentPermissionResolver"
 ```
 
-Implement the resolver interface:
+The resolver implementation uses the **decorator pattern**, receiving the base resolver instance so it can delegate back to built-in logic:
 
 ```python
 from app.services.readers.kb_permissions import IKbPermissionResolver
@@ -388,41 +116,609 @@ class DepartmentPermissionResolver(IKbPermissionResolver):
         return list(set(dept_ids + base_ids))
 ```
 
+### Default Implementation
+
+When no extension is configured, the no-op default implementation is used:
+
+```python
+class DefaultKbPermissionResolver(IKbPermissionResolver):
+    def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+        return None  # No extra permissions granted
+
+    def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+        return []  # No extra KBs added
+```
+
+### Loading Mechanism
+
+The system uses `_LazyReader` for thread-safe lazy singleton loading:
+
+```python
+# Entry point is loaded on first use
+# Falls back to DefaultKbPermissionResolver if not configured or loading fails
+kb_permission_resolver: IKbPermissionResolver = _LazyReader()
+```
+
+### Permission Resolution Chain
+
+The external resolver is called as the **last step** in the built-in permission check chain, ensuring it never interferes with built-in access control:
+
+```
+creator → ResourceMember → group → task binding → external resolver
+```
+
+- **resolve()**: Called at the end of `KnowledgeShareService.get_user_kb_permission()`, as the final opportunity after all built-in checks fail
+- **get_accessible_kb_ids()**: Called in `KnowledgeService.list_knowledge_bases(scope=ALL)`, appending returned KB IDs to SQL OR conditions
+
+### Error Isolation
+
+Exceptions from the external resolver are caught during list queries to prevent a faulty extension from breaking the core listing functionality:
+
+```python
+try:
+    ext_kb_ids = kb_permission_resolver.get_accessible_kb_ids(db, user_id)
+except Exception as e:
+    logger.warning(f"kb_permissions extension get_accessible_kb_ids failed: {e}")
+    ext_kb_ids = []
+```
+
+---
+
+## Frontend Extensions
+
+The frontend provides multiple extension mechanisms covering component overrides, API injection, prop injection, and state bridge patterns.
+
+### Component Registry
+
+The component registry allows external packages to override core knowledge document components at runtime.
+
+#### Registry Interface
+
+```typescript
+// frontend/src/features/knowledge/document/components/registry.ts
+
+export interface ComponentRegistry {
+  /** Document panel component for notebook KB right panel */
+  DocumentPanel?: ComponentType<DocumentPanelProps>
+  /** Knowledge detail panel component for classic KB detail view */
+  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
+}
+```
+
+#### Registration
+
+Call `registerComponents()` during application initialization:
+
+```typescript
+import { registerComponents } from '@/features/knowledge/document/components'
+import { CustomDocumentPanel } from './CustomDocumentPanel'
+
+registerComponents({
+  DocumentPanel: CustomDocumentPanel,
+})
+```
+
+#### Resolution
+
+Open-source components use `getComponent()` at **render time** (not at module load time):
+
+```typescript
+import { getComponent } from '@/features/knowledge/document/components'
+import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
+
+function DocumentPanel(props: DocumentPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('DocumentPanel', DefaultDocumentPanel),
+    []
+  )
+  return <Panel {...props} />
+}
+```
+
+#### Utility Functions
+
+```typescript
+/** Check if a component has been registered */
+function hasComponent(name: keyof ComponentRegistry): boolean
+
+/** Clear all registered components (useful for testing) */
+function clearRegistry(): void
+```
+
+### External Binding API
+
+The external binding API allows external packages to bind external system entities (departments, employees, customers, etc.) to knowledge bases.
+
+#### Binding Provider Types
+
+```typescript
+// frontend/src/apis/knowledgeExtensions.ts
+
+export interface BindableItem {
+  id: string
+  name: string
+  fullPath?: string    // Hierarchy path, e.g., "Dept A / Team B"
+  avatar?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BindingProvider {
+  name: string                   // Unique identifier, e.g., 'erp', 'dingtalk'
+  displayName: string
+  icon?: string
+  searchable: boolean
+  bindableTypes: BindableTypeConfig[]
+  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
+  validate: (externalId: string, type: string) => Promise<boolean>
+  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
+}
+```
+
+#### Binding API Interface
+
+```typescript
+export interface ExternalBindingApi {
+  readonly providers: BindingProviderRegistry
+
+  search: (keyword: string, provider?: string, type?: string) =>
+    Promise<Record<string, BindingSearchResult>>
+  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
+  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
+  remove: (kbId: number, bindingId: number) => Promise<void>
+  sync: (kbId: number, bindingId: number) => Promise<void>
+}
+```
+
+#### Registration and Usage
+
+External packages set the API implementation during app initialization. Open-source components access it via safe getters:
+
+```typescript
+// Register provider + set API implementation
+import { bindingProviderRegistry, setExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+bindingProviderRegistry.register({
+  name: 'dingtalk',
+  displayName: 'DingTalk',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: 'Department', allowMultiple: true },
+    { type: 'user', displayName: 'Employee', allowMultiple: false },
+  ],
+  search: async (keyword, type) => { /* call DingTalk API to search */ },
+  validate: async (externalId, type) => { /* validate */ },
+})
+
+setExternalBindingApi({
+  providers: bindingProviderRegistry,
+  search: async (keyword, provider, type) => { /* ... */ },
+  list: async (kbId, provider) => { /* ... */ },
+  add: async (kbId, data) => { /* ... */ },
+  remove: async (kbId, bindingId) => { /* ... */ },
+  sync: async (kbId, bindingId) => { /* ... */ },
+})
+
+// Safe access by open-source components
+import { hasExternalBindingApi, getExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+if (hasExternalBindingApi()) {
+  const api = getExternalBindingApi()
+  const bindings = await api.list(kbId)
+}
+```
+
+### Permission Extension Tabs
+
+The `KbPermissionsPanel` component provides an `extensionTabs` prop to add additional permission management tabs beyond the default personal permissions tab.
+
+```typescript
+export interface ExtensionTabConfig {
+  id: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  component: React.ComponentType<{ kbId: number }>
+  requiresManagePermission?: boolean
+}
+```
+
+Usage example:
+
+```typescript
+import { Building2 } from 'lucide-react'
+import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
+
+const departmentTab: ExtensionTabConfig = {
+  id: 'department',
+  label: 'Department Permissions',
+  icon: Building2,
+  component: DepartmentPermissionTab,
+  requiresManagePermission: true,
+}
+
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[departmentTab]}
+/>
+```
+
+The `KnowledgeDetailPanel` also exposes this via the `permissionExtensionTabs` prop:
+
+```typescript
+<KnowledgeDetailPanel
+  selectedKb={selectedKb}
+  permissionExtensionTabs={[departmentTab]}
+/>
+```
+
+### Create KB Dialog Extensions
+
+The create KB dialog provides two extension mechanisms.
+
+#### Form Section Injection
+
+```typescript
+export interface KnowledgeBaseFormSections {
+  /** Rendered after the description field, before summary settings */
+  afterDescription?: React.ReactNode
+  /** Rendered at the end of the form, after advanced settings */
+  afterAdvanced?: React.ReactNode
+}
+```
+
+External packages register form sections:
+
+```typescript
+import { setCreateKbFormSections } from '@/features/knowledge/document/components'
+
+setCreateKbFormSections({
+  afterDescription: <AuthorizationSection />,
+})
+```
+
+#### Post-Creation Hook
+
+```typescript
+import { setPostCreateHandler } from '@/features/knowledge/document/components'
+
+setPostCreateHandler(async (kbId) => {
+  await initializeExternalPermissions(kbId)
+})
+```
+
+### Role Select Extension
+
+The `AddUserForm` allows replacing the default role dropdown with a custom component:
+
+```typescript
+import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
+import { ErpRoleSelect } from './ErpRoleSelect'
+
+setRoleSelectComponent(ErpRoleSelect)
+
+// Pass undefined to clear the registered component
+setRoleSelectComponent(undefined)
+```
+
+---
+
+## End-to-End Example: Integrating DingTalk Organization
+
+This example demonstrates how to combine frontend and backend extension points to integrate DingTalk's organizational structure into the KB permission system.
+
+### Scenario
+
+An enterprise uses DingTalk as its organization management system and wants to:
+1. Automatically grant KB access based on DingTalk department membership (backend)
+2. Search and bind DingTalk departments/employees in the permission management UI (frontend)
+3. Associate DingTalk approval scope when creating a KB (frontend form extension)
+
+### Step 1: Backend Permission Resolver
+
+Create a DingTalk department permission resolver that verifies user department membership through the DingTalk Open API.
+
+```python
+# myext/kb_permissions.py
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.services.readers.kb_permissions import IKbPermissionResolver
+
+class DingTalkPermissionResolver(IKbPermissionResolver):
+    """Resolves KB permissions based on DingTalk department membership."""
+
+    def __init__(self, base: IKbPermissionResolver):
+        self._base = base
+        self._client = self._init_dingtalk_client()
+
+    def _init_dingtalk_client(self):
+        """Initialize DingTalk Open Platform client."""
+        import dingtalk
+        return dingtalk.Client(
+            app_key=os.environ["DINGTALK_APP_KEY"],
+            app_secret=os.environ["DINGTALK_APP_SECRET"],
+        )
+
+    def _get_user_dept_ids(self, user_id: int) -> list[str]:
+        """Get DingTalk department IDs for a Wegent user. Requires user mapping."""
+        return []
+
+    def _get_kb_bound_dept_ids(self, kb_id: int) -> list[str]:
+        """Get DingTalk department IDs bound to a KB."""
+        return []
+
+    def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+        user_dept_ids = self._get_user_dept_ids(user_id)
+        bound_dept_ids = self._get_kb_bound_dept_ids(kb_id)
+
+        # Grant Developer role if user's departments overlap with KB-bound departments
+        if set(user_dept_ids) & set(bound_dept_ids):
+            return "Developer"
+
+        return self._base.resolve(db, kb_id, user_id, kb)
+
+    def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+        user_dept_ids = self._get_user_dept_ids(user_id)
+        if not user_dept_ids:
+            return self._base.get_accessible_kb_ids(db, user_id)
+
+        # Query all KB IDs bound to the user's departments
+        kb_ids = self._query_bound_kb_ids(db, user_dept_ids)
+
+        # Merge with built-in results
+        base_ids = self._base.get_accessible_kb_ids(db, user_id)
+        return list(set(kb_ids + base_ids))
+
+    def _query_bound_kb_ids(self, db, dept_ids: list[str]) -> list[int]:
+        """Query all KB IDs bound to the given DingTalk department IDs."""
+        return []
+```
+
+Register in `pyproject.toml`:
+
+```toml
+[project.entry-points."wegent.kb_permissions"]
+dingtalk = "myext.kb_permissions:DingTalkPermissionResolver"
+```
+
+### Step 2: Frontend Binding Provider
+
+Register a DingTalk binding provider on the frontend to enable department/employee search.
+
+```typescript
+// myext/dingtalk-binding.ts
+import {
+  bindingProviderRegistry,
+  setExternalBindingApi,
+  type BindingProvider,
+  type ExternalBindingApi,
+  type ExternalBinding,
+  type ExternalBindingCreate,
+  type BindingSearchResult,
+} from '@/apis/knowledgeExtensions'
+
+// Register DingTalk binding provider
+bindingProviderRegistry.register({
+  name: 'dingtalk',
+  displayName: 'DingTalk',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: 'Department', icon: 'building2', allowMultiple: true },
+    { type: 'user', displayName: 'Employee', icon: 'user', allowMultiple: false },
+  ],
+  search: async (keyword: string, type?: string): Promise<BindingSearchResult> => {
+    const response = await fetch(`/api/ext/dingtalk/search?keyword=${keyword}&type=${type || ''}`)
+    return response.json()
+  },
+  validate: async (externalId: string, type: string): Promise<boolean> => {
+    const response = await fetch(`/api/ext/dingtalk/validate?id=${externalId}&type=${type}`)
+    return response.ok
+  },
+})
+
+// Set binding API implementation
+class DingTalkBindingApi implements ExternalBindingApi {
+  providers = bindingProviderRegistry
+
+  async search(keyword: string, provider?: string, type?: string) {
+    const results: Record<string, BindingSearchResult> = {}
+    const providers = provider
+      ? [this.providers.get(provider)!].filter(Boolean)
+      : this.providers.getAll()
+
+    for (const p of providers) {
+      if (p.searchable) {
+        results[p.name] = await p.search(keyword, type)
+      }
+    }
+    return results
+  }
+
+  async list(kbId: number, provider?: string): Promise<ExternalBinding[]> {
+    const response = await fetch(`/api/ext/dingtalk/bindings?kbId=${kbId}`)
+    return response.json()
+  }
+
+  async add(kbId: number, data: ExternalBindingCreate): Promise<ExternalBinding> {
+    const response = await fetch(`/api/ext/dingtalk/bindings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kbId, ...data }),
+    })
+    return response.json()
+  }
+
+  async remove(kbId: number, bindingId: number): Promise<void> {
+    await fetch(`/api/ext/dingtalk/bindings/${bindingId}?kbId=${kbId}`, { method: 'DELETE' })
+  }
+
+  async sync(kbId: number, bindingId: number): Promise<void> {
+    await fetch(`/api/ext/dingtalk/bindings/${bindingId}/sync?kbId=${kbId}`, { method: 'POST' })
+  }
+}
+
+setExternalBindingApi(new DingTalkBindingApi())
+```
+
+### Step 3: Frontend Permission Extension Tab
+
+Create a DingTalk department permission tab to display and manage bound DingTalk departments for the current KB.
+
+```typescript
+// myext/DingTalkPermissionTab.tsx
+import { useState, useEffect } from 'react'
+import { getExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+export function DingTalkPermissionTab({ kbId }: { kbId: number }) {
+  const api = getExternalBindingApi()
+  const [bindings, setBindings] = useState<ExternalBinding[]>([])
+  const [searchResults, setSearchResults] = useState<BindingSearchResult | null>(null)
+
+  useEffect(() => {
+    api?.list(kbId).then(setBindings)
+  }, [kbId])
+
+  const handleSearch = async (keyword: string) => {
+    const results = await api?.search(keyword, 'dingtalk', 'department')
+    if (results) setSearchResults(results['dingtalk'] || null)
+  }
+
+  const handleAdd = async (externalId: string) => {
+    await api?.add(kbId, { provider: 'dingtalk', bindableType: 'department', externalId })
+    const updated = await api?.list(kbId)
+    setBindings(updated || [])
+  }
+
+  const handleRemove = async (bindingId: number) => {
+    await api?.remove(kbId, bindingId)
+    setBindings(bindings.filter(b => b.id !== bindingId))
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3>DingTalk Department Permissions</h3>
+
+      <input
+        placeholder="Search DingTalk departments..."
+        onChange={e => handleSearch(e.target.value)}
+        data-testid="dingtalk-dept-search"
+      />
+
+      {searchResults?.items.map(item => (
+        <div key={item.id}>
+          <span>{item.name}</span>
+          <button onClick={() => handleAdd(item.id)}>Add</button>
+        </div>
+      ))}
+
+      <h4>Bound Departments</h4>
+      {bindings.filter(b => b.provider === 'dingtalk').map(binding => (
+        <div key={binding.id}>
+          <span>{binding.name}</span>
+          <button onClick={() => handleRemove(binding.id)}>Remove</button>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+Inject into the permission panel:
+
+```typescript
+import { DingTalkPermissionTab } from './DingTalkPermissionTab'
+
+const dingtalkTab: ExtensionTabConfig = {
+  id: 'dingtalk-department',
+  label: 'DingTalk Departments',
+  icon: Building2,
+  component: DingTalkPermissionTab,
+  requiresManagePermission: true,
+}
+
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[dingtalkTab]}
+/>
+```
+
+### Step 4: Associate DingTalk Departments at KB Creation
+
+Use form section injection to add a DingTalk department selector in the create KB dialog.
+
+```typescript
+// myext/DingTalkDeptSelector.tsx
+export function DingTalkDeptSelector() {
+  return (
+    <div className="space-y-2">
+      <label>Link DingTalk Departments</label>
+      {/* Department selection UI */}
+      <p className="text-xs text-text-muted">
+        Members of selected departments will automatically gain access to this knowledge base
+      </p>
+    </div>
+  )
+}
+```
+
+Register form sections and post-creation hook:
+
+```typescript
+import { setCreateKbFormSections, setPostCreateHandler } from '@/features/knowledge/document/components'
+
+// Inject form section
+setCreateKbFormSections({
+  afterDescription: <DingTalkDeptSelector />,
+})
+
+// Post-creation hook: auto-bind selected DingTalk departments
+setPostCreateHandler(async (kbId) => {
+  const selectedDeptIds = getSelectedDeptIds()
+  const api = getExternalBindingApi()
+
+  for (const deptId of selectedDeptIds) {
+    await api?.add(kbId, {
+      provider: 'dingtalk',
+      bindableType: 'department',
+      externalId: deptId,
+    })
+  }
+})
+```
+
+---
+
+## Extension Points Summary
+
+| Layer | File | Interface | Pattern | Description |
+|-------|------|-----------|---------|-------------|
+| Backend | `kb_permissions.py` | `IKbPermissionResolver` | Entry Points + Decorator | Extend KB access permission resolution |
+| Frontend | `registry.ts` | `registerComponents()` | Override | Replace DocumentPanel or KnowledgeDetailPanel entirely |
+| Frontend | `knowledgeExtensions.ts` | `setExternalBindingApi()` | Provider + Bridge | Set external binding API with searchable providers |
+| Frontend | `knowledgeExtensions.ts` | `bindingProviderRegistry` | Registry | Register/unregister binding providers |
+| Frontend | `knowledgeExtensions.ts` | `hasExternalBindingApi()` | Check | Check if binding API is available |
+| Frontend | `knowledgeExtensions.ts` | `getExternalBindingApi()` | Access | Get the binding API instance |
+| Frontend | `KbPermissionsPanel.tsx` | `extensionTabs` prop | Prop Injection | Add custom permission management tabs |
+| Frontend | `createKbDialogState.ts` | `setCreateKbFormSections()` | State Bridge | Inject form sections into create KB dialog |
+| Frontend | `createKbDialogState.ts` | `setPostCreateHandler()` | State Bridge | Register post-creation hook |
+| Frontend | `add-user-form-state.ts` | `setRoleSelectComponent()` | Component Bridge | Replace role select in AddUserForm |
+
 ## Best Practices
 
 1. **Initialize Early**: Call `registerComponents()`, `setExternalBindingApi()`, and other registration functions during application initialization (before any components are rendered).
 
 2. **Lazy Component Resolution**: Use `useMemo(() => getComponent(name, Default), [])` at render time, not module-level `getComponent()` calls. This ensures registered components are available even with non-deterministic module import ordering.
 
-3. **Unique IDs**: Ensure extension tab IDs and provider names are unique to avoid conflicts.
+3. **Unique Identifiers**: Ensure extension tab IDs and provider names are unique to avoid conflicts.
 
 4. **Permission Checks**: Use `requiresManagePermission` appropriately to hide extension tabs from users without management rights.
 
 5. **Error Boundaries**: Wrap extension components with error boundaries to prevent crashes from affecting the entire panel.
 
-6. **Error Handling**: Always check `hasExternalBindingApi()` before accessing the binding API, or use `getExternalBindingApi(true)` to throw a descriptive error.
+6. **Error Handling**: Always check `hasExternalBindingApi()` before accessing the binding API, or use `getExternalBindingApi(true)` to throw a descriptive error. Backend list queries already isolate exceptions.
 
 7. **Consistent Styling**: Use the project's design system components for consistent UI.
 
 8. **i18n Support**: Use the `useTranslation` hook for all user-facing text in extension components.
 
-## Extension Points Summary
-
-| File | Export | Type | Description |
-|------|--------|------|-------------|
-| `registry.ts` | `registerComponents()` | Override | Replace DocumentPanel or KnowledgeDetailPanel entirely |
-| `knowledgeExtensions.ts` | `setExternalBindingApi()` | Provider + Bridge | Set external binding API with searchable providers |
-| `knowledgeExtensions.ts` | `bindingProviderRegistry` | Registry | Register/unregister binding providers |
-| `knowledgeExtensions.ts` | `hasExternalBindingApi()` | Check | Check if binding API is available |
-| `knowledgeExtensions.ts` | `getExternalBindingApi()` | Access | Get the binding API instance |
-| `permission/components/KbPermissionsPanel.tsx` | `extensionTabs` prop | Prop Injection | Add custom permission management tabs |
-| `document/components/createKbDialogState.ts` | `setCreateKbFormSections()` | State Bridge | Inject form sections into create KB dialog |
-| `document/components/createKbDialogState.ts` | `setPostCreateHandler()` | State Bridge | Register post-creation hook |
-| `permission/components/add-user-form-state.ts` | `setRoleSelectComponent()` | Component Bridge | Replace role select in AddUserForm |
-| `document/components/index.ts` | Exports all above | N/A | Single import entry for all extension APIs |
-
-## See Also
-
-- [Permission System Concepts](../../concepts/permission-system.md)
-- [Backend Extension Guide](../backend-extensions.md)
-- [Component Design Guidelines](../component-design.md)
+9. **Backend Exception Isolation**: Permission resolvers should handle exceptions gracefully. The system automatically catches exceptions from external resolvers during list queries.

--- a/docs/zh/developer-guide/kb-permission-extension.md
+++ b/docs/zh/developer-guide/kb-permission-extension.md
@@ -1,374 +1,103 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # 知识库扩展系统
 
-本文档介绍知识库扩展系统，该系统提供多种扩展点用于集成外部系统（如 ERP、部门管理或自定义权限系统），而无需修改开源代码库。
+本文档介绍知识库扩展系统，该系统提供多种扩展点用于集成外部系统（如钉钉、企业微信、ERP 或自定义权限系统），而无需修改开源代码库。
 
 ## 概述
 
-知识库扩展系统采用 **注册表 + 桥接** 模式：开源组件提供明确定义的扩展点，外部包在应用初始化期间注册其实现。这实现了开源代码与专有代码的清晰分离。
+知识库扩展系统涵盖**前端**和**后端**两个层面，采用 **注册表 + 桥接** 模式：开源组件提供明确定义的扩展点，外部包在应用初始化期间注册其实现，实现开源代码与专有代码的清晰分离。
 
-系统包含以下扩展机制：
+### 架构总览
 
-| 扩展点 | 模式 | 描述 |
-|--------|------|------|
-| [组件注册表](#组件注册表) | 覆盖 | 替换整个组件（DocumentPanel、KnowledgeDetailPanel） |
-| [外部绑定 API](#外部绑定-api) | 提供者 + 桥接 | 搜索、添加、删除和同步外部实体绑定 |
-| [权限扩展标签页](#权限扩展标签页) | Props 注入 | 添加自定义权限管理标签页 |
-| [创建知识库对话框扩展](#创建知识库对话框扩展) | 状态桥接 | 在明确定义的插槽位置注入表单区域 |
-| [创建后钩子](#创建后钩子) | 状态桥接 | 在知识库创建后执行异步操作 |
-| [自定义角色选择器](#角色选择器扩展) | 组件桥接 | 替换 AddUserForm 中的角色选择下拉框 |
+```
+┌─────────────────────────────────────────────────────┐
+│                  External Package                   │
+│                                                     │
+│  ┌────────────────────┐  ┌────────────────────┐     │
+│  │ Permission         │  │ Frontend           │     │
+│  │ Resolver (Python)  │  │ Extensions (TS)    │     │
+│  └─────────┬──────────┘  └─────────┬──────────┘     │
+│            │                       │                │
+└────────────┼───────────────────────┼────────────────┘
+             │                       │
+             ▼                       ▼
+   ┌────────────────────┐  ┌────────────────────┐
+   │  Backend Entry     │  │  Registry / State  │
+   │  Points            │  │  Bridge Pattern    │
+   │  wegent.kb_        │  │                    │
+   │  permissions       │  │                    │
+   └─────────┬──────────┘  └─────────┬──────────┘
+             │                       │
+             ▼                       ▼
+   ┌─────────┬──────────┐  ┌─────────┬──────────┐
+   │  Permission        │  │  UI Extension      │
+   │  Resolution Chain  │  │  Points            │
+   │  (Chain of Resp.)  │  │  (Props/Registry)  │
+   └────────────────────┘  └────────────────────┘
+```
+前端和后端的扩展点可以独立使用，也可以组合使用实现完整的端到端集成场景。
 
-## 组件注册表
+---
 
-组件注册表允许外部包在运行时覆盖整个知识文档组件。
+## 后端扩展：权限解析器
 
-### 注册表接口
+后端使用 Python entry points 机制动态加载外部权限解析器，实现对知识库访问控制的扩展。
 
-```typescript
-// frontend/src/features/knowledge/document/components/registry.ts
+### 权限解析接口
 
-export interface ComponentRegistry {
-  /** 笔记本 KB 右侧面板的文档面板组件 */
-  DocumentPanel?: ComponentType<DocumentPanelProps>
-  /** 经典 KB 详情视图的知识详情面板组件 */
-  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
-}
+```python
+# backend/app/services/readers/kb_permissions.py
+
+class IKbPermissionResolver(ABC):
+    """
+    外部知识库权限解析的抽象接口。
+    实现类在外部系统授予访问权限时返回角色字符串，
+    否则返回 None 以回退到内置权限逻辑。
+    """
+
+    @abstractmethod
+    def resolve(
+        self,
+        db: Session,
+        kb_id: int,
+        user_id: int,
+        kb: object,
+    ) -> Optional[str]:
+        """
+        解析单个知识库的访问权限。
+        在所有内置检查都返回 False 后被调用。
+
+        返回:
+            "Owner"/"Maintainer"/"Developer"/"Reporter" 之一（当外部系统授予访问权限），
+            或 None（继续执行内置拒绝逻辑）。
+        """
+        pass
+
+    @abstractmethod
+    def get_accessible_kb_ids(self, db: Session, user_id: int) -> list[int]:
+        """
+        返回用户通过外部规则可访问的知识库 ID 列表。
+        在列表查询时被调用，用于扩展 OR 条件。
+
+        返回:
+            知识库 ID 列表（可能为空）。
+        """
+        pass
 ```
 
-### 注册
+### 注册外部解析器
 
-在应用初始化期间、任何组件渲染之前调用 `registerComponents()`：
-
-```typescript
-import { registerComponents } from '@/features/knowledge/document/components'
-import { CustomDocumentPanel } from './CustomDocumentPanel'
-
-registerComponents({
-  DocumentPanel: CustomDocumentPanel,
-})
-```
-
-### 解析
-
-开源组件使用 `getComponent()` 在 **渲染时**（而非模块加载时）解析已注册的组件，这为外部包提供了先填充注册表的时间：
-
-```typescript
-import { getComponent } from '@/features/knowledge/document/components'
-import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
-import type { DocumentPanelProps } from './DocumentPanel'
-
-function DocumentPanel(props: DocumentPanelProps) {
-  const Panel = useMemo(
-    () => getComponent('DocumentPanel', DefaultDocumentPanel),
-    []
-  )
-  return <Panel {...props} />
-}
-```
-
-### 工具函数
-
-```typescript
-/** 检查组件是否已注册 */
-function hasComponent(name: keyof ComponentRegistry): boolean
-
-/** 清除所有已注册组件（主要用于测试） */
-function clearRegistry(): void
-```
-
-## 外部绑定 API
-
-外部绑定 API 允许外部包将外部系统实体（部门、员工、客户等）绑定到知识库。
-
-### 架构
-
-绑定系统由两部分组成：
-
-1. **绑定提供者注册表** — 声明可用的外部系统及其搜索能力
-2. **外部绑定 API** — 提供绑定的 CRUD 操作
-
-### 绑定提供者类型
-
-```typescript
-// frontend/src/apis/knowledgeExtensions.ts
-
-export interface BindableItem {
-  id: string
-  name: string
-  fullPath?: string    // 层级路径，例如 "部门 A / 团队 B"
-  avatar?: string
-  metadata?: Record<string, unknown>
-}
-
-export interface BindableTypeConfig {
-  type: string           // 例如 'department'、'employee'、'customer'
-  displayName: string
-  icon?: string
-  allowMultiple: boolean
-}
-
-export interface BindingProvider {
-  name: string                   // 唯一标识符，例如 'erp'、'oa'
-  displayName: string
-  icon?: string
-  searchable: boolean
-  bindableTypes: BindableTypeConfig[]
-  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
-  validate: (externalId: string, type: string) => Promise<boolean>
-  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
-}
-```
-
-### 外部绑定数据模型
-
-```typescript
-export interface ExternalBinding {
-  id: number
-  kbId: number
-  provider: string
-  bindableType: string
-  externalId: string
-  name: string
-  fullPath?: string
-  avatar?: string
-  metadata?: Record<string, unknown>
-  createdAt: string
-}
-
-export interface ExternalBindingCreate {
-  provider: string
-  bindableType: string
-  externalId: string
-}
-```
-
-### 外部绑定 API 接口
-
-```typescript
-export interface ExternalBindingApi {
-  readonly providers: BindingProviderRegistry
-
-  search: (
-    keyword: string,
-    provider?: string,
-    type?: string
-  ) => Promise<Record<string, BindingSearchResult>>
-
-  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
-  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
-  remove: (kbId: number, bindingId: number) => Promise<void>
-  sync: (kbId: number, bindingId: number) => Promise<void>
-}
-```
-
-### 使用方法
-
-外部包在应用初始化期间注册提供者并设置 API 实现：
-
-```typescript
-import {
-  bindingProviderRegistry,
-  setExternalBindingApi,
-  type BindingProvider,
-} from '@/apis/knowledgeExtensions'
-
-// 注册绑定提供者（例如 ERP 部门搜索）
-bindingProviderRegistry.register({
-  name: 'erp',
-  displayName: 'ERP 系统',
-  searchable: true,
-  bindableTypes: [
-    { type: 'department', displayName: '部门', allowMultiple: true },
-  ],
-  search: async (keyword, type) => {
-    // 搜索 ERP API 获取部门/员工
-    return { items: [...], hasMore: false }
-  },
-  validate: async (externalId, type) => {
-    // 验证外部 ID
-    return true
-  },
-})
-
-// 设置绑定 API 实现
-setExternalBindingApi({
-  providers: bindingProviderRegistry,
-  search: async (keyword, provider, type) => { /* ... */ },
-  list: async (kbId, provider) => { /* ... */ },
-  add: async (kbId, data) => { /* ... */ },
-  remove: async (kbId, bindingId) => { /* ... */ },
-  sync: async (kbId, bindingId) => { /* ... */ },
-})
-```
-
-### 访问 API
-
-开源组件安全地检查可用性并访问 API：
-
-```typescript
-import {
-  hasExternalBindingApi,
-  getExternalBindingApi,
-} from '@/apis/knowledgeExtensions'
-
-if (hasExternalBindingApi()) {
-  const api = getExternalBindingApi()
-  const bindings = await api.list(kbId)
-}
-```
-
-## 权限扩展标签页
-
-`KbPermissionsPanel` 组件提供了 `extensionTabs` prop 用于在默认的个人权限标签页之外添加额外的权限管理标签页。
-
-### ExtensionTabConfig 接口
-
-```typescript
-export interface ExtensionTabConfig {
-  /** 标签页唯一标识符 */
-  id: string
-  /** 标签页显示标签 */
-  label: string
-  /** Lucide 图标组件 */
-  icon: React.ComponentType<{ className?: string }>
-  /** 标签页内容组件，接收 kbId 属性 */
-  component: React.ComponentType<{ kbId: number }>
-  /** 此标签页是否需要管理权限才可见 */
-  requiresManagePermission?: boolean
-}
-```
-
-### 使用方法
-
-```typescript
-import { Building2 } from 'lucide-react'
-import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
-
-const departmentTab: ExtensionTabConfig = {
-  id: 'department',
-  label: '部门',
-  icon: Building2,
-  component: DepartmentPermissionTab,
-  requiresManagePermission: true,
-}
-
-// 在你的组件中：
-<KbPermissionsPanel
-  kbId={kbId}
-  canManagePermissions={canManagePermissions}
-  extensionTabs={[departmentTab]}
-/>
-```
-
-`KnowledgeDetailPanel` 组件也通过 `permissionExtensionTabs` prop 暴露此功能：
-
-```typescript
-<KnowledgeDetailPanel
-  selectedKb={selectedKb}
-  permissionExtensionTabs={[departmentTab]}
-/>
-```
-
-## 创建知识库对话框扩展
-
-创建知识库对话框（`CreateKnowledgeBaseDialog`）提供了两种扩展机制：表单区域注入和创建后钩子。
-
-### 表单区域
-
-`KnowledgeBaseForm` 组件定义了明确定义的插槽位置，供外部包注入自定义 UI 区域：
-
-```typescript
-export interface KnowledgeBaseFormSections {
-  /** 在描述字段之后、摘要设置之前渲染 */
-  afterDescription?: React.ReactNode
-
-  /** 在表单末尾、高级设置之后渲染 */
-  afterAdvanced?: React.ReactNode
-}
-```
-
-### 注册表单区域
-
-外部包在应用初始化期间注册表单区域：
-
-```typescript
-import { setCreateKbFormSections } from '@/features/knowledge/document/components'
-
-setCreateKbFormSections({
-  afterDescription: <AuthorizationSection />,
-  afterAdvanced: <CustomFooter />,
-})
-```
-
-### 创建后钩子
-
-注册一个在 KB 创建后调用的处理函数（例如，用于设置外部绑定）：
-
-```typescript
-import { setPostCreateHandler } from '@/features/knowledge/document/components'
-
-setPostCreateHandler(async (kbId) => {
-  await myBindingApi.apply(kbId)
-  await initializeExternalPermissions(kbId)
-})
-```
-
-### 读写分离
-
-这些扩展点遵循 **读写分离** 模式：
-
-| 文件 | 写（外部包） | 读（开源组件） |
-|------|-------------|---------------|
-| `createKbDialogState.ts` | `setCreateKbFormSections()` | `getCreateKbFormSections()` |
-| `createKbDialogState.ts` | `setPostCreateHandler()` | `runPostCreateHandler()` |
-
-## 角色选择器扩展
-
-`AddUserForm` 组件允许使用自定义组件替换默认的角色 `<Select>` 下拉框。
-
-### RoleSelectComponent Props
-
-```typescript
-export interface RoleSelectComponentProps {
-  value: MemberRole
-  onChange: (role: MemberRole) => void
-}
-```
-
-### 注册
-
-```typescript
-import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
-import { ErpRoleSelect } from './ErpRoleSelect'
-
-setRoleSelectComponent(ErpRoleSelect)
-```
-
-注册后，`AddUserForm` 将渲染自定义组件而不是默认的角色下拉框。这对于需要在标准角色选项旁边显示自定义角色选项的 ERP 集成非常有用。
-
-### 清除
-
-传递 `undefined` 以清除已注册的组件：
-
-```typescript
-setRoleSelectComponent(undefined)
-```
-
-## 后端集成
-
-### 权限解析器的 Python Entry Points
-
-后端使用 Python entry points 动态加载权限解析器实现：
+外部包在 `pyproject.toml` 中声明 entry point，系统在首次使用时自动加载：
 
 ```toml
 [project.entry-points."wegent.kb_permissions"]
 department = "app.extensions.myext.kb_permissions:DepartmentPermissionResolver"
 ```
 
-实现解析器接口：
+解析器实现采用**装饰器模式**，接收基础解析器实例，可以委派回内置逻辑：
 
 ```python
 from app.services.readers.kb_permissions import IKbPermissionResolver
@@ -388,41 +117,635 @@ class DepartmentPermissionResolver(IKbPermissionResolver):
         return list(set(dept_ids + base_ids))
 ```
 
+### 默认实现
+
+当没有配置任何扩展时，使用无操作默认实现：
+
+```python
+class DefaultKbPermissionResolver(IKbPermissionResolver):
+    def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+        return None  # 不授予额外权限
+
+    def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+        return []  # 不添加额外可访问 KB
+```
+
+### 加载机制
+
+系统使用 `_LazyReader` 实现线程安全的延迟加载单例：
+
+```python
+# 首次使用时加载 entry point
+# 如果加载失败或未配置，回退到 DefaultKbPermissionResolver
+kb_permission_resolver: IKbPermissionResolver = _LazyReader()
+```
+
+### 权限解析链
+
+外部解析器在内置权限检查链的**最后一步**被调用，确保不会干扰内置访问控制：
+
+```
+creator → ResourceMember → group → task binding → 外部解析器
+```
+
+- **resolve()**: 在 `KnowledgeShareService.get_user_kb_permission()` 末尾调用，作为所有内置检查失败后的最后机会
+- **get_accessible_kb_ids()**: 在 `KnowledgeService.list_knowledge_bases(scope=ALL)` 中调用，将返回的 KB ID 追加到 SQL OR 条件中
+
+### 错误隔离
+
+列表查询时捕获外部解析器的异常，防止故障扩展破坏核心列表功能：
+
+```python
+try:
+    ext_kb_ids = kb_permission_resolver.get_accessible_kb_ids(db, user_id)
+except Exception as e:
+    logger.warning(f"kb_permissions extension get_accessible_kb_ids failed: {e}")
+    ext_kb_ids = []
+```
+
+---
+
+## 前端扩展
+
+前端提供多种扩展机制，涵盖组件覆盖、API 注入、Props 注入和状态桥接等模式。
+
+### 组件注册表
+
+组件注册表允许外部包在运行时覆盖知识文档核心组件。
+
+#### 注册表接口
+
+```typescript
+// frontend/src/features/knowledge/document/components/registry.ts
+
+export interface ComponentRegistry {
+  /** 笔记本 KB 右侧面板的文档面板组件 */
+  DocumentPanel?: ComponentType<DocumentPanelProps>
+  /** 经典 KB 详情视图的知识详情面板组件 */
+  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
+}
+```
+
+#### 注册
+
+在应用初始化期间调用 `registerComponents()`：
+
+```typescript
+import { registerComponents } from '@/features/knowledge/document/components'
+import { CustomDocumentPanel } from './CustomDocumentPanel'
+
+registerComponents({
+  DocumentPanel: CustomDocumentPanel,
+})
+```
+
+#### 解析
+
+开源组件在**渲染时**（而非模块加载时）使用 `getComponent()` 解析已注册组件：
+
+```typescript
+import { getComponent } from '@/features/knowledge/document/components'
+import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
+
+function DocumentPanel(props: DocumentPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('DocumentPanel', DefaultDocumentPanel),
+    []
+  )
+  return <Panel {...props} />
+}
+```
+
+#### 工具函数
+
+```typescript
+/** 检查组件是否已注册 */
+function hasComponent(name: keyof ComponentRegistry): boolean
+
+/** 清除所有已注册组件（主要用于测试） */
+function clearRegistry(): void
+```
+
+### 外部绑定 API
+
+外部绑定 API 允许外部包将外部系统实体（部门、员工、客户等）绑定到知识库。
+
+#### 绑定提供者类型
+
+```typescript
+// frontend/src/apis/knowledgeExtensions.ts
+
+export interface BindableItem {
+  id: string
+  name: string
+  fullPath?: string    // 层级路径，例如 "部门 A / 团队 B"
+  avatar?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BindingProvider {
+  name: string                   // 唯一标识符，例如 'erp'、'dingtalk'
+  displayName: string
+  icon?: string
+  searchable: boolean
+  bindableTypes: BindableTypeConfig[]
+  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
+  validate: (externalId: string, type: string) => Promise<boolean>
+  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
+}
+```
+
+#### 绑定 API 接口
+
+```typescript
+export interface ExternalBindingApi {
+  readonly providers: BindingProviderRegistry
+
+  search: (keyword: string, provider?: string, type?: string) =>
+    Promise<Record<string, BindingSearchResult>>
+  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
+  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
+  remove: (kbId: number, bindingId: number) => Promise<void>
+  sync: (kbId: number, bindingId: number) => Promise<void>
+}
+```
+
+#### 注册和使用
+
+外部包在应用初始化期间设置 API 实现，开源组件通过安全访问器使用：
+
+```typescript
+// 注册提供者 + 设置 API 实现
+import { bindingProviderRegistry, setExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+bindingProviderRegistry.register({
+  name: 'dingtalk',
+  displayName: '钉钉',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: '部门', allowMultiple: true },
+    { type: 'user', displayName: '员工', allowMultiple: false },
+  ],
+  search: async (keyword, type) => { /* 调用钉钉 API 搜索 */ },
+  validate: async (externalId, type) => { /* 验证有效性 */ },
+})
+
+setExternalBindingApi({
+  providers: bindingProviderRegistry,
+  search: async (keyword, provider, type) => { /* ... */ },
+  list: async (kbId, provider) => { /* ... */ },
+  add: async (kbId, data) => { /* ... */ },
+  remove: async (kbId, bindingId) => { /* ... */ },
+  sync: async (kbId, bindingId) => { /* ... */ },
+})
+
+// 开源组件安全使用
+import { hasExternalBindingApi, getExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+if (hasExternalBindingApi()) {
+  const api = getExternalBindingApi()
+  const bindings = await api.list(kbId)
+}
+```
+
+### 权限扩展标签页
+
+`KbPermissionsPanel` 组件提供 `extensionTabs` prop，用于在默认的个人权限标签页之外添加额外标签页。
+
+```typescript
+export interface ExtensionTabConfig {
+  id: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  component: React.ComponentType<{ kbId: number }>
+  requiresManagePermission?: boolean
+}
+```
+
+使用示例：
+
+```typescript
+import { Building2 } from 'lucide-react'
+import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
+
+const departmentTab: ExtensionTabConfig = {
+  id: 'department',
+  label: '部门权限',
+  icon: Building2,
+  component: DepartmentPermissionTab,  // 自定义标签页组件
+  requiresManagePermission: true,
+}
+
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[departmentTab]}
+/>
+```
+
+`KnowledgeDetailPanel` 也通过 `permissionExtensionTabs` prop 暴露此功能：
+
+```typescript
+<KnowledgeDetailPanel
+  selectedKb={selectedKb}
+  permissionExtensionTabs={[departmentTab]}
+/>
+```
+
+### 创建知识库对话框扩展
+
+创建知识库对话框提供两种扩展机制。
+
+#### 表单区域注入
+
+```typescript
+export interface KnowledgeBaseFormSections {
+  /** 在描述字段之后、摘要设置之前渲染 */
+  afterDescription?: React.ReactNode
+  /** 在表单末尾、高级设置之后渲染 */
+  afterAdvanced?: React.ReactNode
+}
+```
+
+外部包注册表单区域：
+
+```typescript
+import { setCreateKbFormSections } from '@/features/knowledge/document/components'
+
+setCreateKbFormSections({
+  afterDescription: <AuthorizationSection />,
+})
+```
+
+#### 创建后钩子
+
+```typescript
+import { setPostCreateHandler } from '@/features/knowledge/document/components'
+
+setPostCreateHandler(async (kbId) => {
+  await initializeExternalPermissions(kbId)
+})
+```
+
+### 角色选择器扩展
+
+`AddUserForm` 允许用自定义组件替换默认的角色下拉框：
+
+```typescript
+import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
+import { ErpRoleSelect } from './ErpRoleSelect'
+
+setRoleSelectComponent(ErpRoleSelect)
+
+// 传递 undefined 清除已注册组件
+setRoleSelectComponent(undefined)
+```
+
+---
+
+## 端到端示例：集成钉钉组织架构
+
+以下示例展示如何结合前后端扩展点，将钉钉组织架构集成到知识库权限系统中。
+
+### 场景说明
+
+企业内部使用钉钉作为组织管理系统，希望在 Wegent 知识库中实现：
+1. 按钉钉部门自动授予知识库访问权限（后端）
+2. 在权限管理界面中搜索并绑定钉钉部门/员工（前端）
+3. 创建知识库时关联钉钉审批范围（前端表单扩展）
+
+### 第一步：后端权限解析器
+
+创建钉钉部门权限解析器，通过钉钉开放平台 API 验证用户部门归属。
+
+```python
+# myext/kb_permissions.py
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.services.readers.kb_permissions import IKbPermissionResolver
+
+class DingTalkPermissionResolver(IKbPermissionResolver):
+    """根据钉钉部门归属解析知识库权限。"""
+
+    def __init__(self, base: IKbPermissionResolver):
+        self._base = base
+        # 初始化钉钉 API 客户端
+        self._client = self._init_dingtalk_client()
+
+    def _init_dingtalk_client(self):
+        """初始化钉钉开放平台客户端"""
+        # 使用企业内部应用 AppKey/AppSecret
+        # 参考: https://open.dingtalk.com/document/orgapp-server
+        import dingtalk
+        return dingtalk.Client(
+            app_key=os.environ["DINGTALK_APP_KEY"],
+            app_secret=os.environ["DINGTALK_APP_SECRET"],
+        )
+
+    def _get_user_dept_ids(self, user_id: int) -> list[str]:
+        """根据 Wegent 用户 ID 获取钉钉部门 ID 列表。需要实现用户映射。"""
+        # 从数据库中查询用户绑定的钉钉用户信息
+        # 然后调用钉钉 API 获取用户部门
+        # dingtalk_user = self._client.get_user(user_ext_id)
+        # return dingtalk_user.department_ids
+        return []
+
+    def _get_kb_bound_dept_ids(self, kb_id: int) -> list[str]:
+        """获取知识库已绑定的钉钉部门 ID 列表。"""
+        # 从 external_bindings 表中查询 kb_id 对应的钉钉部门绑定
+        return []
+
+    def resolve(self, db, kb_id, user_id, kb) -> Optional[str]:
+        user_dept_ids = self._get_user_dept_ids(user_id)
+        bound_dept_ids = self._get_kb_bound_dept_ids(kb_id)
+
+        # 如果用户所属部门与 KB 绑定的部门有交集，授予 Developer 角色
+        if set(user_dept_ids) & set(bound_dept_ids):
+            return "Developer"
+
+        return self._base.resolve(db, kb_id, user_id, kb)
+
+    def get_accessible_kb_ids(self, db, user_id) -> list[int]:
+        user_dept_ids = self._get_user_dept_ids(user_id)
+        if not user_dept_ids:
+            return self._base.get_accessible_kb_ids(db, user_id)
+
+        # 查询用户部门绑定的所有 KB ID
+        # SELECT kb_id FROM external_bindings WHERE external_id IN :dept_ids
+        kb_ids = self._query_bound_kb_ids(db, user_dept_ids)
+
+        # 合并内置结果
+        base_ids = self._base.get_accessible_kb_ids(db, user_id)
+        return list(set(kb_ids + base_ids))
+
+    def _query_bound_kb_ids(self, db, dept_ids: list[str]) -> list[int]:
+        """查询指定钉钉部门绑定的所有 KB ID。"""
+        # 实际实现中从 external_bindings 表查询
+        return []
+```
+
+在 `pyproject.toml` 中注册：
+
+```toml
+[project.entry-points."wegent.kb_permissions"]
+dingtalk = "myext.kb_permissions:DingTalkPermissionResolver"
+```
+
+### 第二步：前端绑定提供者
+
+在前端注册钉钉绑定提供者，实现部门/员工搜索功能。
+
+```typescript
+// myext/dingtalk-binding.ts
+import {
+  bindingProviderRegistry,
+  setExternalBindingApi,
+  type BindingProvider,
+  type ExternalBindingApi,
+  type ExternalBinding,
+  type ExternalBindingCreate,
+  type BindingSearchResult,
+} from '@/apis/knowledgeExtensions'
+
+// 注册钉钉绑定提供者
+bindingProviderRegistry.register({
+  name: 'dingtalk',
+  displayName: '钉钉',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: '部门', icon: 'building2', allowMultiple: true },
+    { type: 'user', displayName: '员工', icon: 'user', allowMultiple: false },
+  ],
+  search: async (keyword: string, type?: string): Promise<BindingSearchResult> => {
+    // 调用后端代理 API 搜索钉钉组织架构
+    const response = await fetch(`/api/ext/dingtalk/search?keyword=${keyword}&type=${type || ''}`)
+    return response.json()
+  },
+  validate: async (externalId: string, type: string): Promise<boolean> => {
+    const response = await fetch(`/api/ext/dingtalk/validate?id=${externalId}&type=${type}`)
+    return response.ok
+  },
+})
+
+// 设置绑定 API 实现
+class DingTalkBindingApi implements ExternalBindingApi {
+  providers = bindingProviderRegistry
+
+  async search(keyword: string, provider?: string, type?: string) {
+    const results: Record<string, BindingSearchResult> = {}
+    const providers = provider
+      ? [this.providers.get(provider)!].filter(Boolean)
+      : this.providers.getAll()
+
+    for (const p of providers) {
+      if (p.searchable) {
+        results[p.name] = await p.search(keyword, type)
+      }
+    }
+    return results
+  }
+
+  async list(kbId: number, provider?: string): Promise<ExternalBinding[]> {
+    const response = await fetch(`/api/ext/dingtalk/bindings?kbId=${kbId}`)
+    return response.json()
+  }
+
+  async add(kbId: number, data: ExternalBindingCreate): Promise<ExternalBinding> {
+    const response = await fetch(`/api/ext/dingtalk/bindings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ kbId, ...data }),
+    })
+    return response.json()
+  }
+
+  async remove(kbId: number, bindingId: number): Promise<void> {
+    await fetch(`/api/ext/dingtalk/bindings/${bindingId}?kbId=${kbId}`, { method: 'DELETE' })
+  }
+
+  async sync(kbId: number, bindingId: number): Promise<void> {
+    await fetch(`/api/ext/dingtalk/bindings/${bindingId}/sync?kbId=${kbId}`, { method: 'POST' })
+  }
+}
+
+setExternalBindingApi(new DingTalkBindingApi())
+```
+
+### 第三步：前端权限扩展标签页
+
+创建钉钉部门权限管理标签页，显示当前 KB 已绑定的钉钉部门，并提供添加/移除功能。
+
+```typescript
+// myext/DingTalkPermissionTab.tsx
+import { useState, useEffect } from 'react'
+import { getExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+export function DingTalkPermissionTab({ kbId }: { kbId: number }) {
+  const api = getExternalBindingApi()
+  const [bindings, setBindings] = useState<ExternalBinding[]>([])
+  const [searchResults, setSearchResults] = useState<BindingSearchResult | null>(null)
+
+  useEffect(() => {
+    api?.list(kbId).then(setBindings)
+  }, [kbId])
+
+  const handleSearch = async (keyword: string) => {
+    const results = await api?.search(keyword, 'dingtalk', 'department')
+    if (results) setSearchResults(results['dingtalk'] || null)
+  }
+
+  const handleAdd = async (externalId: string) => {
+    await api?.add(kbId, { provider: 'dingtalk', bindableType: 'department', externalId })
+    const updated = await api?.list(kbId)
+    setBindings(updated || [])
+  }
+
+  const handleRemove = async (bindingId: number) => {
+    await api?.remove(kbId, bindingId)
+    setBindings(bindings.filter(b => b.id !== bindingId))
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3>钉钉部门权限</h3>
+
+      {/* 搜索钉钉部门 */}
+      <input
+        placeholder="搜索钉钉部门..."
+        onChange={e => handleSearch(e.target.value)}
+        data-testid="dingtalk-dept-search"
+      />
+
+      {/* 搜索结果 */}
+      {searchResults?.items.map(item => (
+        <div key={item.id}>
+          <span>{item.name}</span>
+          <button onClick={() => handleAdd(item.id)}>添加</button>
+        </div>
+      ))}
+
+      {/* 已绑定部门列表 */}
+      <h4>已绑定部门</h4>
+      {bindings.filter(b => b.provider === 'dingtalk').map(binding => (
+        <div key={binding.id}>
+          <span>{binding.name}</span>
+          <button onClick={() => handleRemove(binding.id)}>移除</button>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+注入到权限面板：
+
+```typescript
+import { DingTalkPermissionTab } from './DingTalkPermissionTab'
+
+const dingtalkTab: ExtensionTabConfig = {
+  id: 'dingtalk-department',
+  label: '钉钉部门',
+  icon: Building2,
+  component: DingTalkPermissionTab,
+  requiresManagePermission: true,
+}
+
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[dingtalkTab]}
+/>
+```
+
+### 第四步：创建知识库时关联钉钉部门
+
+通过表单区域注入，在创建知识库对话框中添加钉钉部门选择器。
+
+```typescript
+// myext/DingTalkDeptSelector.tsx
+import { useState } from 'react'
+import { getExternalBindingApi } from '@/apis/knowledgeExtensions'
+
+export function DingTalkDeptSelector() {
+  const [selectedDepts, setSelectedDepts] = useState<string[]>([])
+
+  const handleSelect = (deptId: string) => {
+    setSelectedDepts(prev =>
+      prev.includes(deptId) ? prev.filter(id => id !== deptId) : [...prev, deptId]
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <label>关联钉钉部门</label>
+      {/* 部门选择 UI，保存 selectedDepts 到组件状态 */}
+      <p className="text-xs text-text-muted">
+        创建后，所选部门的成员将自动获得此知识库的访问权限
+      </p>
+    </div>
+  )
+}
+```
+
+注册表单区域和创建后钩子：
+
+```typescript
+import { setCreateKbFormSections, setPostCreateHandler } from '@/features/knowledge/document/components'
+
+// 注入表单区域
+setCreateKbFormSections({
+  afterDescription: <DingTalkDeptSelector />,
+})
+
+// 注册创建后钩子：自动将选中的钉钉部门绑定到新 KB
+setPostCreateHandler(async (kbId) => {
+  // 从 DingTalkDeptSelector 状态读取选中的部门 ID
+  const selectedDeptIds = getSelectedDeptIds()
+  const api = getExternalBindingApi()
+
+  for (const deptId of selectedDeptIds) {
+    await api?.add(kbId, {
+      provider: 'dingtalk',
+      bindableType: 'department',
+      externalId: deptId,
+    })
+  }
+})
+```
+
+---
+
+## 扩展点汇总
+
+| 层 | 文件 | 接口 | 模式 | 描述 |
+|----|------|------|------|------|
+| 后端 | `kb_permissions.py` | `IKbPermissionResolver` | Entry Points + 装饰器 | 扩展知识库访问权限解析逻辑 |
+| 前端 | `registry.ts` | `registerComponents()` | 覆盖 | 替换 DocumentPanel 或 KnowledgeDetailPanel |
+| 前端 | `knowledgeExtensions.ts` | `setExternalBindingApi()` | 提供者 + 桥接 | 设置具有可搜索提供者的外部绑定 API |
+| 前端 | `knowledgeExtensions.ts` | `bindingProviderRegistry` | 注册表 | 注册/注销绑定提供者 |
+| 前端 | `knowledgeExtensions.ts` | `hasExternalBindingApi()` | 检查 | 检查绑定 API 是否可用 |
+| 前端 | `knowledgeExtensions.ts` | `getExternalBindingApi()` | 访问 | 获取绑定 API 实例 |
+| 前端 | `KbPermissionsPanel.tsx` | `extensionTabs` prop | Props 注入 | 添加自定义权限管理标签页 |
+| 前端 | `createKbDialogState.ts` | `setCreateKbFormSections()` | 状态桥接 | 向创建 KB 对话框注入表单区域 |
+| 前端 | `createKbDialogState.ts` | `setPostCreateHandler()` | 状态桥接 | 注册创建后钩子 |
+| 前端 | `add-user-form-state.ts` | `setRoleSelectComponent()` | 组件桥接 | 替换 AddUserForm 中的角色选择器 |
+
 ## 最佳实践
 
 1. **尽早初始化**：在应用初始化期间（在任何组件渲染之前）调用 `registerComponents()`、`setExternalBindingApi()` 和其他注册函数。
 
 2. **延迟组件解析**：在渲染时使用 `useMemo(() => getComponent(name, Default), [])`，而不是在模块级别调用 `getComponent()`。这确保即使模块导入顺序不确定，已注册的组件也可用。
 
-3. **唯一 ID**：确保扩展标签页 ID 和提供者名称唯一，以避免冲突。
+3. **唯一标识**：确保扩展标签页 ID 和提供者名称唯一，以避免冲突。
 
 4. **权限检查**：适当使用 `requiresManagePermission` 向没有管理权限的用户隐藏扩展标签页。
 
 5. **错误边界**：使用错误边界包装扩展组件，以防止崩溃影响整个面板。
 
-6. **错误处理**：在访问绑定 API 之前始终检查 `hasExternalBindingApi()`，或使用 `getExternalBindingApi(true)` 抛出自描述性错误。
+6. **错误处理**：在访问绑定 API 之前始终检查 `hasExternalBindingApi()`，或使用 `getExternalBindingApi(true)` 抛出自描述性错误。后端列表查询时已对异常进行隔离。
 
 7. **一致的样式**：使用项目设计系统组件保持 UI 一致性。
 
 8. **i18n 支持**：在扩展组件中使用 `useTranslation` 钩子处理所有面向用户的文本。
 
-## 扩展点汇总
-
-| 文件 | 导出 | 类型 | 描述 |
-|------|------|------|------|
-| `registry.ts` | `registerComponents()` | 覆盖 | 完全替换 DocumentPanel 或 KnowledgeDetailPanel |
-| `knowledgeExtensions.ts` | `setExternalBindingApi()` | 提供者 + 桥接 | 设置具有可搜索提供者的外部绑定 API |
-| `knowledgeExtensions.ts` | `bindingProviderRegistry` | 注册表 | 注册/注销绑定提供者 |
-| `knowledgeExtensions.ts` | `hasExternalBindingApi()` | 检查 | 检查绑定 API 是否可用 |
-| `knowledgeExtensions.ts` | `getExternalBindingApi()` | 访问 | 获取绑定 API 实例 |
-| `permission/components/KbPermissionsPanel.tsx` | `extensionTabs` prop | Props 注入 | 添加自定义权限管理标签页 |
-| `document/components/createKbDialogState.ts` | `setCreateKbFormSections()` | 状态桥接 | 向创建 KB 对话框注入表单区域 |
-| `document/components/createKbDialogState.ts` | `setPostCreateHandler()` | 状态桥接 | 注册创建后钩子 |
-| `permission/components/add-user-form-state.ts` | `setRoleSelectComponent()` | 组件桥接 | 替换 AddUserForm 中的角色选择器 |
-| `document/components/index.ts` | 导出以上所有 | N/A | 所有扩展 API 的统一导入入口 |
-
-## 另请参阅
-
-- [权限系统概念](../../concepts/permission-system.md)
-- [后端扩展指南](../backend-extensions.md)
-- [组件设计指南](../component-design.md)
+9. **后端异常隔离**：权限解析器应妥善处理异常，避免影响内置权限逻辑。列表查询时系统会自动捕获外部解析器的异常。

--- a/docs/zh/developer-guide/kb-permission-extension.md
+++ b/docs/zh/developer-guide/kb-permission-extension.md
@@ -1,0 +1,428 @@
+---
+sidebar_position: 3
+---
+
+# 知识库扩展系统
+
+本文档介绍知识库扩展系统，该系统提供多种扩展点用于集成外部系统（如 ERP、部门管理或自定义权限系统），而无需修改开源代码库。
+
+## 概述
+
+知识库扩展系统采用 **注册表 + 桥接** 模式：开源组件提供明确定义的扩展点，外部包在应用初始化期间注册其实现。这实现了开源代码与专有代码的清晰分离。
+
+系统包含以下扩展机制：
+
+| 扩展点 | 模式 | 描述 |
+|--------|------|------|
+| [组件注册表](#组件注册表) | 覆盖 | 替换整个组件（DocumentPanel、KnowledgeDetailPanel） |
+| [外部绑定 API](#外部绑定-api) | 提供者 + 桥接 | 搜索、添加、删除和同步外部实体绑定 |
+| [权限扩展标签页](#权限扩展标签页) | Props 注入 | 添加自定义权限管理标签页 |
+| [创建知识库对话框扩展](#创建知识库对话框扩展) | 状态桥接 | 在明确定义的插槽位置注入表单区域 |
+| [创建后钩子](#创建后钩子) | 状态桥接 | 在知识库创建后执行异步操作 |
+| [自定义角色选择器](#角色选择器扩展) | 组件桥接 | 替换 AddUserForm 中的角色选择下拉框 |
+
+## 组件注册表
+
+组件注册表允许外部包在运行时覆盖整个知识文档组件。
+
+### 注册表接口
+
+```typescript
+// frontend/src/features/knowledge/document/components/registry.ts
+
+export interface ComponentRegistry {
+  /** 笔记本 KB 右侧面板的文档面板组件 */
+  DocumentPanel?: ComponentType<DocumentPanelProps>
+  /** 经典 KB 详情视图的知识详情面板组件 */
+  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>
+}
+```
+
+### 注册
+
+在应用初始化期间、任何组件渲染之前调用 `registerComponents()`：
+
+```typescript
+import { registerComponents } from '@/features/knowledge/document/components'
+import { CustomDocumentPanel } from './CustomDocumentPanel'
+
+registerComponents({
+  DocumentPanel: CustomDocumentPanel,
+})
+```
+
+### 解析
+
+开源组件使用 `getComponent()` 在 **渲染时**（而非模块加载时）解析已注册的组件，这为外部包提供了先填充注册表的时间：
+
+```typescript
+import { getComponent } from '@/features/knowledge/document/components'
+import { DocumentPanel as DefaultDocumentPanel } from './DocumentPanel'
+import type { DocumentPanelProps } from './DocumentPanel'
+
+function DocumentPanel(props: DocumentPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('DocumentPanel', DefaultDocumentPanel),
+    []
+  )
+  return <Panel {...props} />
+}
+```
+
+### 工具函数
+
+```typescript
+/** 检查组件是否已注册 */
+function hasComponent(name: keyof ComponentRegistry): boolean
+
+/** 清除所有已注册组件（主要用于测试） */
+function clearRegistry(): void
+```
+
+## 外部绑定 API
+
+外部绑定 API 允许外部包将外部系统实体（部门、员工、客户等）绑定到知识库。
+
+### 架构
+
+绑定系统由两部分组成：
+
+1. **绑定提供者注册表** — 声明可用的外部系统及其搜索能力
+2. **外部绑定 API** — 提供绑定的 CRUD 操作
+
+### 绑定提供者类型
+
+```typescript
+// frontend/src/apis/knowledgeExtensions.ts
+
+export interface BindableItem {
+  id: string
+  name: string
+  fullPath?: string    // 层级路径，例如 "部门 A / 团队 B"
+  avatar?: string
+  metadata?: Record<string, unknown>
+}
+
+export interface BindableTypeConfig {
+  type: string           // 例如 'department'、'employee'、'customer'
+  displayName: string
+  icon?: string
+  allowMultiple: boolean
+}
+
+export interface BindingProvider {
+  name: string                   // 唯一标识符，例如 'erp'、'oa'
+  displayName: string
+  icon?: string
+  searchable: boolean
+  bindableTypes: BindableTypeConfig[]
+  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
+  validate: (externalId: string, type: string) => Promise<boolean>
+  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
+}
+```
+
+### 外部绑定数据模型
+
+```typescript
+export interface ExternalBinding {
+  id: number
+  kbId: number
+  provider: string
+  bindableType: string
+  externalId: string
+  name: string
+  fullPath?: string
+  avatar?: string
+  metadata?: Record<string, unknown>
+  createdAt: string
+}
+
+export interface ExternalBindingCreate {
+  provider: string
+  bindableType: string
+  externalId: string
+}
+```
+
+### 外部绑定 API 接口
+
+```typescript
+export interface ExternalBindingApi {
+  readonly providers: BindingProviderRegistry
+
+  search: (
+    keyword: string,
+    provider?: string,
+    type?: string
+  ) => Promise<Record<string, BindingSearchResult>>
+
+  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
+  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
+  remove: (kbId: number, bindingId: number) => Promise<void>
+  sync: (kbId: number, bindingId: number) => Promise<void>
+}
+```
+
+### 使用方法
+
+外部包在应用初始化期间注册提供者并设置 API 实现：
+
+```typescript
+import {
+  bindingProviderRegistry,
+  setExternalBindingApi,
+  type BindingProvider,
+} from '@/apis/knowledgeExtensions'
+
+// 注册绑定提供者（例如 ERP 部门搜索）
+bindingProviderRegistry.register({
+  name: 'erp',
+  displayName: 'ERP 系统',
+  searchable: true,
+  bindableTypes: [
+    { type: 'department', displayName: '部门', allowMultiple: true },
+  ],
+  search: async (keyword, type) => {
+    // 搜索 ERP API 获取部门/员工
+    return { items: [...], hasMore: false }
+  },
+  validate: async (externalId, type) => {
+    // 验证外部 ID
+    return true
+  },
+})
+
+// 设置绑定 API 实现
+setExternalBindingApi({
+  providers: bindingProviderRegistry,
+  search: async (keyword, provider, type) => { /* ... */ },
+  list: async (kbId, provider) => { /* ... */ },
+  add: async (kbId, data) => { /* ... */ },
+  remove: async (kbId, bindingId) => { /* ... */ },
+  sync: async (kbId, bindingId) => { /* ... */ },
+})
+```
+
+### 访问 API
+
+开源组件安全地检查可用性并访问 API：
+
+```typescript
+import {
+  hasExternalBindingApi,
+  getExternalBindingApi,
+} from '@/apis/knowledgeExtensions'
+
+if (hasExternalBindingApi()) {
+  const api = getExternalBindingApi()
+  const bindings = await api.list(kbId)
+}
+```
+
+## 权限扩展标签页
+
+`KbPermissionsPanel` 组件提供了 `extensionTabs` prop 用于在默认的个人权限标签页之外添加额外的权限管理标签页。
+
+### ExtensionTabConfig 接口
+
+```typescript
+export interface ExtensionTabConfig {
+  /** 标签页唯一标识符 */
+  id: string
+  /** 标签页显示标签 */
+  label: string
+  /** Lucide 图标组件 */
+  icon: React.ComponentType<{ className?: string }>
+  /** 标签页内容组件，接收 kbId 属性 */
+  component: React.ComponentType<{ kbId: number }>
+  /** 此标签页是否需要管理权限才可见 */
+  requiresManagePermission?: boolean
+}
+```
+
+### 使用方法
+
+```typescript
+import { Building2 } from 'lucide-react'
+import { KbPermissionsPanel, type ExtensionTabConfig } from '@/features/knowledge/permission/components'
+
+const departmentTab: ExtensionTabConfig = {
+  id: 'department',
+  label: '部门',
+  icon: Building2,
+  component: DepartmentPermissionTab,
+  requiresManagePermission: true,
+}
+
+// 在你的组件中：
+<KbPermissionsPanel
+  kbId={kbId}
+  canManagePermissions={canManagePermissions}
+  extensionTabs={[departmentTab]}
+/>
+```
+
+`KnowledgeDetailPanel` 组件也通过 `permissionExtensionTabs` prop 暴露此功能：
+
+```typescript
+<KnowledgeDetailPanel
+  selectedKb={selectedKb}
+  permissionExtensionTabs={[departmentTab]}
+/>
+```
+
+## 创建知识库对话框扩展
+
+创建知识库对话框（`CreateKnowledgeBaseDialog`）提供了两种扩展机制：表单区域注入和创建后钩子。
+
+### 表单区域
+
+`KnowledgeBaseForm` 组件定义了明确定义的插槽位置，供外部包注入自定义 UI 区域：
+
+```typescript
+export interface KnowledgeBaseFormSections {
+  /** 在描述字段之后、摘要设置之前渲染 */
+  afterDescription?: React.ReactNode
+
+  /** 在表单末尾、高级设置之后渲染 */
+  afterAdvanced?: React.ReactNode
+}
+```
+
+### 注册表单区域
+
+外部包在应用初始化期间注册表单区域：
+
+```typescript
+import { setCreateKbFormSections } from '@/features/knowledge/document/components'
+
+setCreateKbFormSections({
+  afterDescription: <AuthorizationSection />,
+  afterAdvanced: <CustomFooter />,
+})
+```
+
+### 创建后钩子
+
+注册一个在 KB 创建后调用的处理函数（例如，用于设置外部绑定）：
+
+```typescript
+import { setPostCreateHandler } from '@/features/knowledge/document/components'
+
+setPostCreateHandler(async (kbId) => {
+  await myBindingApi.apply(kbId)
+  await initializeExternalPermissions(kbId)
+})
+```
+
+### 读写分离
+
+这些扩展点遵循 **读写分离** 模式：
+
+| 文件 | 写（外部包） | 读（开源组件） |
+|------|-------------|---------------|
+| `createKbDialogState.ts` | `setCreateKbFormSections()` | `getCreateKbFormSections()` |
+| `createKbDialogState.ts` | `setPostCreateHandler()` | `runPostCreateHandler()` |
+
+## 角色选择器扩展
+
+`AddUserForm` 组件允许使用自定义组件替换默认的角色 `<Select>` 下拉框。
+
+### RoleSelectComponent Props
+
+```typescript
+export interface RoleSelectComponentProps {
+  value: MemberRole
+  onChange: (role: MemberRole) => void
+}
+```
+
+### 注册
+
+```typescript
+import { setRoleSelectComponent } from '@/features/knowledge/permission/components'
+import { ErpRoleSelect } from './ErpRoleSelect'
+
+setRoleSelectComponent(ErpRoleSelect)
+```
+
+注册后，`AddUserForm` 将渲染自定义组件而不是默认的角色下拉框。这对于需要在标准角色选项旁边显示自定义角色选项的 ERP 集成非常有用。
+
+### 清除
+
+传递 `undefined` 以清除已注册的组件：
+
+```typescript
+setRoleSelectComponent(undefined)
+```
+
+## 后端集成
+
+### 权限解析器的 Python Entry Points
+
+后端使用 Python entry points 动态加载权限解析器实现：
+
+```toml
+[project.entry-points."wegent.kb_permissions"]
+department = "app.extensions.myext.kb_permissions:DepartmentPermissionResolver"
+```
+
+实现解析器接口：
+
+```python
+from app.services.readers.kb_permissions import IKbPermissionResolver
+
+class DepartmentPermissionResolver(IKbPermissionResolver):
+    def __init__(self, base: IKbPermissionResolver):
+        self._base = base
+
+    def resolve(self, db, kb_id, user_id, kb):
+        if self._has_department_access(db, kb_id, user_id):
+            return "Developer"
+        return self._base.resolve(db, kb_id, user_id, kb)
+
+    def get_accessible_kb_ids(self, db, user_id):
+        dept_ids = self._get_dept_accessible_kbs(db, user_id)
+        base_ids = self._base.get_accessible_kb_ids(db, user_id)
+        return list(set(dept_ids + base_ids))
+```
+
+## 最佳实践
+
+1. **尽早初始化**：在应用初始化期间（在任何组件渲染之前）调用 `registerComponents()`、`setExternalBindingApi()` 和其他注册函数。
+
+2. **延迟组件解析**：在渲染时使用 `useMemo(() => getComponent(name, Default), [])`，而不是在模块级别调用 `getComponent()`。这确保即使模块导入顺序不确定，已注册的组件也可用。
+
+3. **唯一 ID**：确保扩展标签页 ID 和提供者名称唯一，以避免冲突。
+
+4. **权限检查**：适当使用 `requiresManagePermission` 向没有管理权限的用户隐藏扩展标签页。
+
+5. **错误边界**：使用错误边界包装扩展组件，以防止崩溃影响整个面板。
+
+6. **错误处理**：在访问绑定 API 之前始终检查 `hasExternalBindingApi()`，或使用 `getExternalBindingApi(true)` 抛出自描述性错误。
+
+7. **一致的样式**：使用项目设计系统组件保持 UI 一致性。
+
+8. **i18n 支持**：在扩展组件中使用 `useTranslation` 钩子处理所有面向用户的文本。
+
+## 扩展点汇总
+
+| 文件 | 导出 | 类型 | 描述 |
+|------|------|------|------|
+| `registry.ts` | `registerComponents()` | 覆盖 | 完全替换 DocumentPanel 或 KnowledgeDetailPanel |
+| `knowledgeExtensions.ts` | `setExternalBindingApi()` | 提供者 + 桥接 | 设置具有可搜索提供者的外部绑定 API |
+| `knowledgeExtensions.ts` | `bindingProviderRegistry` | 注册表 | 注册/注销绑定提供者 |
+| `knowledgeExtensions.ts` | `hasExternalBindingApi()` | 检查 | 检查绑定 API 是否可用 |
+| `knowledgeExtensions.ts` | `getExternalBindingApi()` | 访问 | 获取绑定 API 实例 |
+| `permission/components/KbPermissionsPanel.tsx` | `extensionTabs` prop | Props 注入 | 添加自定义权限管理标签页 |
+| `document/components/createKbDialogState.ts` | `setCreateKbFormSections()` | 状态桥接 | 向创建 KB 对话框注入表单区域 |
+| `document/components/createKbDialogState.ts` | `setPostCreateHandler()` | 状态桥接 | 注册创建后钩子 |
+| `permission/components/add-user-form-state.ts` | `setRoleSelectComponent()` | 组件桥接 | 替换 AddUserForm 中的角色选择器 |
+| `document/components/index.ts` | 导出以上所有 | N/A | 所有扩展 API 的统一导入入口 |
+
+## 另请参阅
+
+- [权限系统概念](../../concepts/permission-system.md)
+- [后端扩展指南](../backend-extensions.md)
+- [组件设计指南](../component-design.md)

--- a/frontend/src/apis/knowledgeExtensions.ts
+++ b/frontend/src/apis/knowledgeExtensions.ts
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: 2025 Wegent, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extension point for knowledge-related APIs.
+ *
+ * This module allows external packages to register additional API functions
+ * that can be used by knowledge components without modifying the open-source
+ * codebase.
+ *
+ * Usage (in external package):
+ * ```typescript
+ * import {
+ *   bindingProviderRegistry,
+ *   setExternalBindingApi,
+ *   type BindingProvider,
+ * } from '@/apis/knowledgeExtensions';
+ *
+ * // Register a binding provider (e.g., ERP department search)
+ * bindingProviderRegistry.register({
+ *   name: 'erp',
+ *   displayName: 'ERP System',
+ *   searchable: true,
+ *   bindableTypes: [{ type: 'department', displayName: 'Department', allowMultiple: true }],
+ *   search: async (keyword, type) => { ... },
+ *   validate: async (externalId, type) => { ... },
+ * });
+ *
+ * // Set the binding API implementation
+ * setExternalBindingApi({
+ *   providers: bindingProviderRegistry,
+ *   search: async (keyword, provider, type) => { ... },
+ *   list: async (kbId, provider) => { ... },
+ *   add: async (kbId, data) => { ... },
+ *   remove: async (kbId, bindingId) => { ... },
+ *   sync: async (kbId, bindingId) => { ... },
+ * });
+ * ```
+ */
+
+// ============== Binding Provider Types ==============
+
+/**
+ * Represents an item that can be bound to a knowledge base
+ */
+export interface BindableItem {
+  /** External system ID */
+  id: string
+  /** Display name */
+  name: string
+  /** Full path/name hierarchy (e.g., "Dept A / Team B") */
+  fullPath?: string
+  /** Avatar or icon URL */
+  avatar?: string
+  /** Additional metadata from external system */
+  metadata?: Record<string, unknown>
+}
+
+/**
+ * Result of searching bindable items
+ */
+export interface BindingSearchResult {
+  items: BindableItem[]
+  /** Whether more results are available */
+  hasMore: boolean
+  /** Total count if available */
+  total?: number
+}
+
+/**
+ * Configuration for a bindable type
+ */
+export interface BindableTypeConfig {
+  /** Type identifier, e.g., 'department', 'employee', 'customer' */
+  type: string
+  /** Display name, e.g., 'Department', 'Employee' */
+  displayName: string
+  /** Icon identifier */
+  icon?: string
+  /** Whether multiple items of this type can be bound */
+  allowMultiple: boolean
+}
+
+/**
+ * A binding provider represents an external system that can bind
+ * its entities (departments, employees, etc.) to knowledge bases.
+ */
+export interface BindingProvider {
+  /** Unique provider identifier, e.g., 'erp', 'oa', 'crm' */
+  name: string
+
+  /** Human-readable display name */
+  displayName: string
+
+  /** Optional icon URL or identifier */
+  icon?: string
+
+  /** Whether this provider supports search functionality */
+  searchable: boolean
+
+  /** Available bindable types from this provider */
+  bindableTypes: BindableTypeConfig[]
+
+  /**
+   * Search for bindable items in the external system
+   * @param keyword - Search keyword
+   * @param type - Optional type filter
+   * @returns Search results with items
+   */
+  search: (keyword: string, type?: string) => Promise<BindingSearchResult>
+
+  /**
+   * Validate if an external ID is valid and can be bound
+   * @param externalId - The external system ID
+   * @param type - The bindable type
+   * @returns Whether the binding is valid
+   */
+  validate: (externalId: string, type: string) => Promise<boolean>
+
+  /**
+   * Get item details by ID
+   * @param externalId - The external system ID
+   * @param type - The bindable type
+   * @returns Item details or null if not found
+   */
+  getItemDetails?: (externalId: string, type: string) => Promise<BindableItem | null>
+}
+
+// ============== Binding Types ==============
+
+/**
+ * Represents a binding between a knowledge base and an external entity
+ */
+export interface ExternalBinding {
+  /** Binding ID */
+  id: number
+  /** Knowledge base ID */
+  kbId: number
+  /** Provider name */
+  provider: string
+  /** Bindable type */
+  bindableType: string
+  /** External system ID */
+  externalId: string
+  /** Display name */
+  name: string
+  /** Full path from external system */
+  fullPath?: string
+  /** Avatar URL */
+  avatar?: string
+  /** Additional metadata */
+  metadata?: Record<string, unknown>
+  /** Creation timestamp */
+  createdAt: string
+}
+
+/**
+ * Data required to create a new binding
+ */
+export interface ExternalBindingCreate {
+  provider: string
+  bindableType: string
+  externalId: string
+}
+
+// ============== Extension Registry ==============
+
+/**
+ * Registry of binding providers
+ */
+class BindingProviderRegistry {
+  private providers: Map<string, BindingProvider> = new Map()
+
+  /**
+   * Register a new binding provider
+   * @param provider - The provider to register
+   * @throws Error if provider with same name already exists
+   */
+  register(provider: BindingProvider): void {
+    if (this.providers.has(provider.name)) {
+      throw new Error(`Binding provider '${provider.name}' is already registered`)
+    }
+    this.providers.set(provider.name, provider)
+  }
+
+  /**
+   * Unregister a binding provider
+   * @param name - Provider name
+   * @returns True if provider was removed
+   */
+  unregister(name: string): boolean {
+    return this.providers.delete(name)
+  }
+
+  /**
+   * Get a specific provider
+   * @param name - Provider name
+   * @returns The provider or undefined
+   */
+  get(name: string): BindingProvider | undefined {
+    return this.providers.get(name)
+  }
+
+  /**
+   * Get all registered providers
+   * @returns Array of all providers
+   */
+  getAll(): BindingProvider[] {
+    return Array.from(this.providers.values())
+  }
+
+  /**
+   * Check if a provider is registered
+   * @param name - Provider name
+   * @returns True if provider exists
+   */
+  has(name: string): boolean {
+    return this.providers.has(name)
+  }
+
+  /**
+   * Get total number of registered providers
+   */
+  get size(): number {
+    return this.providers.size
+  }
+}
+
+// ============== Knowledge API Extensions ==============
+
+/**
+ * Interface for external binding related operations
+ */
+export interface ExternalBindingApi {
+  /** Registry for binding providers */
+  readonly providers: BindingProviderRegistry
+
+  /**
+   * Search across all searchable providers or a specific one
+   * @param keyword - Search keyword
+   * @param provider - Optional provider name to limit search
+   * @param type - Optional type filter
+   * @returns Search results grouped by provider
+   */
+  search: (
+    keyword: string,
+    provider?: string,
+    type?: string
+  ) => Promise<Record<string, BindingSearchResult>>
+
+  /**
+   * List bindings for a knowledge base
+   * @param kbId - Knowledge base ID
+   * @param provider - Optional provider filter
+   * @returns List of bindings
+   */
+  list: (kbId: number, provider?: string) => Promise<ExternalBinding[]>
+
+  /**
+   * Add a new binding
+   * @param kbId - Knowledge base ID
+   * @param data - Binding creation data
+   * @returns Created binding
+   */
+  add: (kbId: number, data: ExternalBindingCreate) => Promise<ExternalBinding>
+
+  /**
+   * Remove a binding
+   * @param kbId - Knowledge base ID
+   * @param bindingId - Binding ID to remove
+   */
+  remove: (kbId: number, bindingId: number) => Promise<void>
+
+  /**
+   * Sync binding data from external system
+   * @param kbId - Knowledge base ID
+   * @param bindingId - Binding ID to sync
+   */
+  sync: (kbId: number, bindingId: number) => Promise<void>
+}
+
+/**
+ * Global registry for binding providers
+ * External packages can register their providers during app initialization
+ */
+export const bindingProviderRegistry = new BindingProviderRegistry()
+
+/**
+ * Global external binding API instance
+ * External packages should set this during app initialization
+ */
+export let externalBindingApi: ExternalBindingApi | undefined
+
+/**
+ * Set the external binding API implementation
+ * @param api - The API implementation
+ */
+export function setExternalBindingApi(api: ExternalBindingApi): void {
+  externalBindingApi = api
+}
+
+/**
+ * Check if external binding API is available
+ * @returns True if binding API has been registered
+ */
+export function hasExternalBindingApi(): boolean {
+  return externalBindingApi !== undefined
+}
+
+/**
+ * Get the external binding API if available
+ * @param throwIfMissing - Throw error if API not available
+ * @returns The binding API or undefined
+ * @throws Error if API is not available and throwIfMissing is true
+ */
+export function getExternalBindingApi(throwIfMissing = false): ExternalBindingApi | undefined {
+  if (throwIfMissing && !externalBindingApi) {
+    throw new Error(
+      'External binding API is not available. Ensure the binding extension is registered.'
+    )
+  }
+  return externalBindingApi
+}
+

--- a/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateKnowledgeBaseDialog.tsx
@@ -25,6 +25,7 @@ import {
 import { useTranslation } from '@/hooks/useTranslation'
 import type { SummaryModelRef, KnowledgeBaseType, RetrievalConfig } from '@/types/knowledge'
 import { KnowledgeBaseForm } from './KnowledgeBaseForm'
+import type { KnowledgeBaseFormSections } from './KnowledgeBaseForm'
 
 /** Available group for selection */
 export interface AvailableGroup {
@@ -67,6 +68,8 @@ interface CreateKnowledgeBaseDialogProps {
   defaultGroupId?: string
   /** Whether to show group selector (true when creating from "All" page) */
   showGroupSelector?: boolean
+  /** Extra form sections injected at well-defined slot positions */
+  formSections?: KnowledgeBaseFormSections
 }
 
 /** Get icon for group type */
@@ -95,6 +98,7 @@ export function CreateKnowledgeBaseDialog({
   availableGroups,
   defaultGroupId,
   showGroupSelector = false,
+  formSections,
 }: CreateKnowledgeBaseDialogProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
@@ -258,6 +262,7 @@ export function CreateKnowledgeBaseDialog({
         </DialogHeader>
         <div className="flex-1 overflow-y-auto space-y-4 py-4">
           <KnowledgeBaseForm
+            extraSections={formSections}
             typeSection={
               <>
                 {/* KB Type selector - subtle style */}

--- a/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
@@ -50,7 +50,7 @@ const getInitialCollapsed = (storageKey: string, defaultCollapsed: boolean): boo
   return defaultCollapsed
 }
 
-interface DocumentPanelProps {
+export interface DocumentPanelProps {
   knowledgeBase: KnowledgeBase
   canUpload?: boolean
   canManageAllDocuments?: boolean

--- a/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/EditKnowledgeBaseDialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { KnowledgeBaseForm } from './KnowledgeBaseForm'
+import type { KnowledgeBaseFormSections } from './KnowledgeBaseForm'
 import { ConvertKnowledgeBaseTypeDialog } from './ConvertKnowledgeBaseTypeDialog'
 import { useTranslation } from '@/hooks/useTranslation'
 import { getKnowledgeBase } from '@/apis/knowledge'
@@ -41,6 +42,8 @@ interface EditKnowledgeBaseDialogProps {
   bindModel?: string | null
   /** Callback when knowledge base type is converted */
   onTypeConverted?: (updatedKb: KnowledgeBase) => void
+  /** Extra form sections injected at well-defined slot positions */
+  formSections?: KnowledgeBaseFormSections
 }
 
 export function EditKnowledgeBaseDialog({
@@ -52,6 +55,7 @@ export function EditKnowledgeBaseDialog({
   knowledgeDefaultTeamId,
   bindModel,
   onTypeConverted,
+  formSections,
 }: EditKnowledgeBaseDialogProps) {
   const { t } = useTranslation()
   const { t: tKnowledge } = useTranslation('knowledge')
@@ -224,6 +228,7 @@ export function EditKnowledgeBaseDialog({
           </DialogHeader>
           <div className="flex-1 overflow-y-auto space-y-4 py-4">
             <KnowledgeBaseForm
+              extraSections={formSections}
               name={name}
               description={description}
               onNameChange={value => setName(value)}

--- a/frontend/src/features/knowledge/document/components/KnowledgeBaseForm.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeBaseForm.tsx
@@ -23,8 +23,43 @@ import type { KnowledgeResourceScope, RetrievalConfig, SummaryModelRef } from '@
 import { RetrievalSettingsSection } from './RetrievalSettingsSection'
 import { SummaryModelSelector } from './SummaryModelSelector'
 
+/**
+ * Well-defined slot positions within KnowledgeBaseForm for external
+ * packages to inject custom UI sections.
+ *
+ * Each property is a render slot at a specific location in the form layout.
+ * Multiple slots in the same position are supported via array concatenation.
+ *
+ * @example
+ * ```typescript
+ * <KnowledgeBaseForm
+ *   extraSections={{
+ *     afterDescription: <AuthorizationSection />,
+ *     afterAdvanced: <CustomFooter />,
+ *   }}
+ *   // ... other props
+ * />
+ * ```
+ */
+export interface KnowledgeBaseFormSections {
+  /**
+   * Rendered after the description field, before the summary settings section.
+   * Use this for authorization, permissions, or additional configuration that
+   * logically belongs between basic info and AI summary settings.
+   */
+  afterDescription?: React.ReactNode
+
+  /**
+   * Rendered at the very end of the form, after the advanced settings section.
+   * Use this for footers, disclaimers, or extra action buttons.
+   */
+  afterAdvanced?: React.ReactNode
+}
+
 interface KnowledgeBaseFormProps {
   typeSection?: ReactNode
+  /** Extra UI sections injected at well-defined form slot positions */
+  extraSections?: KnowledgeBaseFormSections
   name: string
   description: string
   onNameChange: (value: string) => void
@@ -63,6 +98,7 @@ interface KnowledgeBaseFormProps {
 
 export function KnowledgeBaseForm({
   typeSection,
+  extraSections,
   name,
   description,
   onNameChange,
@@ -223,6 +259,8 @@ export function KnowledgeBaseForm({
         />
       </div>
 
+      {extraSections?.afterDescription}
+
       <div className="space-y-3 border-b border-border pb-4">
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">
@@ -344,6 +382,8 @@ export function KnowledgeBaseForm({
           )}
         </div>
       )}
+
+      {extraSections?.afterAdvanced}
     </div>
   )
 }

--- a/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
@@ -24,7 +24,7 @@ import { ChatArea } from '@/features/tasks/components/chat'
 import { DocumentList, type KbGroupInfo } from './DocumentList'
 import { DocumentPanel } from './DocumentPanel'
 import { KnowledgeBaseSummaryCard } from './KnowledgeBaseSummaryCard'
-import { PermissionManagementTab } from '../../permission/components/PermissionManagementTab'
+import { KbPermissionsPanel, type ExtensionTabConfig } from '../../permission/components/KbPermissionsPanel'
 import { useKnowledgePermissions } from '../../permission/hooks/useKnowledgePermissions'
 import { useNamespaceRoleMap } from '../hooks/useNamespaceRoleMap'
 import {
@@ -35,7 +35,7 @@ import {
 import type { KnowledgeBase } from '@/types/knowledge'
 import type { Team } from '@/types/api'
 
-interface KnowledgeDetailPanelProps {
+export interface KnowledgeDetailPanelProps {
   /** Currently selected knowledge base */
   selectedKb: KnowledgeBase | null
   /** Whether the tree panel is collapsed */
@@ -50,6 +50,8 @@ interface KnowledgeDetailPanelProps {
   onGroupClick?: (groupId: string, groupType?: string) => void
   /** Initial document path to auto-open (from virtual URL path segments) */
   initialDocPath?: string
+  /** Extension tabs for permission management (e.g., ERP department permissions) */
+  permissionExtensionTabs?: ExtensionTabConfig[]
 }
 
 export function KnowledgeDetailPanel({
@@ -60,6 +62,7 @@ export function KnowledgeDetailPanel({
   groupInfo,
   onGroupClick,
   initialDocPath,
+  permissionExtensionTabs = [],
 }: KnowledgeDetailPanelProps) {
   const { t } = useTranslation('knowledge')
   const { user } = useUser()
@@ -261,7 +264,11 @@ export function KnowledgeDetailPanel({
                 </div>
                 {headerActions}
               </div>
-              <PermissionManagementTab kbId={selectedKb.id} />
+              <KbPermissionsPanel
+                kbId={selectedKb.id}
+                canManagePermissions={canManagePermissions}
+                extensionTabs={permissionExtensionTabs}
+              />
             </>
           )}
         </div>

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageDesktop.tsx
@@ -25,9 +25,33 @@ import { listKnowledgeBases } from '@/apis/knowledge'
 import { useKnowledgeSidebar, type KnowledgeGroup } from '../hooks/useKnowledgeSidebar'
 import { useNamespaceRoleMap } from '../hooks/useNamespaceRoleMap'
 import { KnowledgeSidebar } from './KnowledgeSidebar'
-import { KnowledgeDetailPanel } from './KnowledgeDetailPanel'
+import {
+  KnowledgeDetailPanel as DefaultKnowledgeDetailPanel,
+  type KnowledgeDetailPanelProps,
+} from './KnowledgeDetailPanel'
+import { getComponent } from './registry'
 import { KnowledgeGroupListPage, type KbDataItem } from './KnowledgeGroupListPage'
+
+/**
+ * Wrapper component that resolves KnowledgeDetailPanel from the registry at render time.
+ *
+ * This exists as a wrapper rather than a module-level getComponent() call so that
+ * external packages calling registerComponents() during app initialization have a
+ * chance to populate the registry before the component is first rendered.
+ *
+ * A module-level getComponent() evaluates when the module is first loaded, which
+ * may occur before registerComponents() has been called — especially in dev mode
+ * with HMR or when module import ordering is non-deterministic.
+ */
+function KnowledgeDetailPanel(props: KnowledgeDetailPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('KnowledgeDetailPanel', DefaultKnowledgeDetailPanel),
+    []
+  )
+  return <Panel {...props} />
+}
 import { CreateKnowledgeBaseDialog, type AvailableGroup } from './CreateKnowledgeBaseDialog'
+import { getCreateKbFormSections, runPostCreateHandler } from './createKbDialogState'
 import { EditKnowledgeBaseDialog } from './EditKnowledgeBaseDialog'
 import { DeleteKnowledgeBaseDialog } from './DeleteKnowledgeBaseDialog'
 import { MigrateKnowledgeBaseDialog, type MigrationTargetGroup } from './MigrateKnowledgeBaseDialog'
@@ -572,7 +596,7 @@ export function KnowledgeDocumentPageDesktop({
 
         // Use the appropriate API based on scope
         const { createKnowledgeBase } = await import('@/apis/knowledge')
-        await createKnowledgeBase({
+        const createdKb = await createKnowledgeBase({
           name: data.name,
           description: data.description,
           namespace,
@@ -584,6 +608,9 @@ export function KnowledgeDocumentPageDesktop({
           max_calls_per_conversation: data.max_calls_per_conversation,
           exempt_calls_before_check: data.exempt_calls_before_check,
         })
+
+        // Invoke registered post-create handler (e.g., external binding setup)
+        await runPostCreateHandler(createdKb.id)
 
         // Save model preference when summary is enabled and model is selected
         if (data.summary_enabled && data.summary_model_ref) {
@@ -1047,6 +1074,7 @@ export function KnowledgeDocumentPageDesktop({
         showGroupSelector={showGroupSelector}
         availableGroups={availableGroupsForCreate}
         defaultGroupId="personal"
+        formSections={getCreateKbFormSections()}
       />
       <EditKnowledgeBaseDialog
         open={!!editingKb}

--- a/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageMobile.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDocumentPageMobile.tsx
@@ -24,6 +24,7 @@ import { canManageNamespace } from '@/utils/namespace-permissions'
 import { useKnowledgeTree } from '../hooks/useKnowledgeTree'
 import { KnowledgeTree } from './KnowledgeTree'
 import { CreateKnowledgeBaseDialog } from './CreateKnowledgeBaseDialog'
+import { getCreateKbFormSections, runPostCreateHandler } from './createKbDialogState'
 import type {
   KnowledgeBase,
   KnowledgeBaseCreate,
@@ -170,7 +171,7 @@ export function KnowledgeDocumentPageMobile({
         const kbType = data.kb_type || createKbType
 
         const { createKnowledgeBase } = await import('@/apis/knowledge')
-        await createKnowledgeBase({
+        const createdKb = await createKnowledgeBase({
           name: data.name,
           description: data.description,
           namespace,
@@ -182,6 +183,9 @@ export function KnowledgeDocumentPageMobile({
           max_calls_per_conversation: data.max_calls_per_conversation,
           exempt_calls_before_check: data.exempt_calls_before_check,
         })
+
+        // Invoke registered post-create handler (e.g., external binding setup)
+        await runPostCreateHandler(createdKb.id)
 
         // Save model preference when summary is enabled and model is selected
         if (data.summary_enabled && data.summary_model_ref) {
@@ -257,6 +261,7 @@ export function KnowledgeDocumentPageMobile({
         kbType={createKbType}
         knowledgeDefaultTeamId={knowledgeDefaultTeamId}
         bindModel={knowledgeBindModel}
+        formSections={getCreateKbFormSections()}
       />
     </div>
   )

--- a/frontend/src/features/knowledge/document/components/createKbDialogState.ts
+++ b/frontend/src/features/knowledge/document/components/createKbDialogState.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2025 Wegent, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extension state for CreateKnowledgeBaseDialog.
+ *
+ * This module provides module-level state bridges that allow external packages
+ * to inject form sections and register post-creation hooks without modifying
+ * the open-source page component.
+ *
+ * This follows the same pattern as `knowledgeExtensions.ts` (setExternalBindingApi),
+ * providing a read/write separation: open-source components read (get/run),
+ * external packages write (set/register).
+ *
+ * Usage (in external package):
+ * ```typescript
+ * import {
+ *   setCreateKbFormSections,
+ *   setPostCreateHandler,
+ * } from '@/features/knowledge/document/components/createKbDialogState';
+ *
+ * // Inject custom form sections
+ * setCreateKbFormSections({
+ *   afterDescription: <MyAuthSection />,
+ * });
+ *
+ * // Register post-creation hook
+ * setPostCreateHandler(async (kbId) => {
+ *   await myBindingApi.apply(kbId);
+ * });
+ * ```
+ */
+
+import type { KnowledgeBaseFormSections } from './KnowledgeBaseForm'
+
+// ============== Form Sections Bridge ==============
+
+let _formSections: KnowledgeBaseFormSections | undefined
+
+/**
+ * Set the form sections to be injected into CreateKnowledgeBaseDialog.
+ * Called by external packages during app initialization.
+ *
+ * @param sections - Form sections or undefined to clear
+ */
+export function setCreateKbFormSections(
+  sections: KnowledgeBaseFormSections | undefined
+): void {
+  _formSections = sections
+}
+
+/**
+ * Get the registered form sections for CreateKnowledgeBaseDialog.
+ * Called by open-source page component when rendering the dialog.
+ *
+ * @returns The registered form sections or undefined
+ */
+export function getCreateKbFormSections(): KnowledgeBaseFormSections | undefined {
+  return _formSections
+}
+
+// ============== Post-Creation Hook ==============
+
+let _postCreateHandler: ((kbId: number) => Promise<void>) | undefined
+
+/**
+ * Register a handler to be called after a knowledge base is created.
+ * The handler receives the created KB's ID.
+ *
+ * @param handler - Async handler or undefined to clear
+ */
+export function setPostCreateHandler(
+  handler: ((kbId: number) => Promise<void>) | undefined
+): void {
+  _postCreateHandler = handler
+}
+
+/**
+ * Run the registered post-creation handler with the given KB ID.
+ * Called by open-source page component after successful KB creation.
+ *
+ * @param kbId - The created knowledge base ID
+ */
+export async function runPostCreateHandler(kbId: number): Promise<void> {
+  if (_postCreateHandler) {
+    await _postCreateHandler(kbId)
+  }
+}

--- a/frontend/src/features/knowledge/document/components/index.ts
+++ b/frontend/src/features/knowledge/document/components/index.ts
@@ -25,3 +25,21 @@ export { KnowledgeBaseSummaryCard } from './KnowledgeBaseSummaryCard'
 export { GuidedQuestions } from './GuidedQuestions'
 export { DocumentPanel } from './DocumentPanel'
 export { ChunksSection } from './ChunksSection'
+export type { KnowledgeBaseFormSections } from './KnowledgeBaseForm'
+
+// Component registry for extension support
+export {
+  registerComponents,
+  getComponent,
+  hasComponent,
+  clearRegistry,
+} from './registry'
+export type { ComponentRegistry } from './registry'
+
+// Create KB dialog state for extension support
+export {
+  setCreateKbFormSections,
+  getCreateKbFormSections,
+  setPostCreateHandler,
+  runPostCreateHandler,
+} from './createKbDialogState'

--- a/frontend/src/features/knowledge/document/components/registry.ts
+++ b/frontend/src/features/knowledge/document/components/registry.ts
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2025 Wegent, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Component registry for knowledge document components.
+ *
+ * This registry allows external packages (e.g., internal extensions) to
+ * register custom implementations of knowledge document components without
+ * modifying the open-source codebase.
+ *
+ * Usage (in external package):
+ * ```typescript
+ * import { registerComponents } from '@/features/knowledge/document/components';
+ * import { CustomDocumentPanel } from './CustomDocumentPanel';
+ *
+ * registerComponents({
+ *   DocumentPanel: CustomDocumentPanel,
+ * });
+ * ```
+ */
+
+import type { ComponentType } from 'react';
+import type { DocumentPanelProps } from './DocumentPanel';
+import type { KnowledgeDetailPanelProps } from './KnowledgeDetailPanel';
+
+/**
+ * Registry of overridable knowledge document components.
+ */
+export interface ComponentRegistry {
+  /** Document panel component for notebook KB right panel */
+  DocumentPanel?: ComponentType<DocumentPanelProps>;
+  /** Knowledge detail panel component for classic KB detail view */
+  KnowledgeDetailPanel?: ComponentType<KnowledgeDetailPanelProps>;
+}
+
+const registry: ComponentRegistry = {};
+
+/**
+ * Register component implementations.
+ *
+ * This function allows external packages to override default component
+ * implementations. It should be called during application initialization,
+ * before any components are rendered.
+ *
+ * @param components - Partial registry of components to register
+ *
+ * @example
+ * ```typescript
+ * import { registerComponents } from '@/features/knowledge/document/components';
+ * import { CustomDocumentPanel } from '@internal/package';
+ *
+ * registerComponents({
+ *   DocumentPanel: CustomDocumentPanel,
+ * });
+ * ```
+ */
+export function registerComponents(components: ComponentRegistry): void {
+  Object.assign(registry, components);
+}
+
+/**
+ * Get a registered component or return the default.
+ *
+ * @param name - Name of the component to get
+ * @param defaultComponent - Default component to return if not registered
+ * @returns The registered component or the default
+ *
+ * @example
+ * ```typescript
+ * const DocumentPanel = getComponent('DocumentPanel', DefaultDocumentPanel);
+ * ```
+ */
+export function getComponent<K extends keyof ComponentRegistry>(
+  name: K,
+  defaultComponent: NonNullable<ComponentRegistry[K]>
+): NonNullable<ComponentRegistry[K]> {
+  return registry[name] || defaultComponent;
+}
+
+/**
+ * Check if a component has been registered.
+ *
+ * @param name - Name of the component to check
+ * @returns True if the component has been registered
+ */
+export function hasComponent<K extends keyof ComponentRegistry>(name: K): boolean {
+  return name in registry && registry[name] !== undefined;
+}
+
+/**
+ * Clear all registered components.
+ *
+ * This is primarily useful for testing.
+ */
+export function clearRegistry(): void {
+  Object.keys(registry).forEach((key) => {
+    delete (registry as Record<string, unknown>)[key];
+  });
+}

--- a/frontend/src/features/knowledge/document/pages/KnowledgeBaseChatPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/pages/KnowledgeBaseChatPageDesktop.tsx
@@ -29,9 +29,29 @@ import { useTeamContext } from '@/contexts/TeamContext'
 import { useKnowledgeBaseDetail } from '@/features/knowledge/document/hooks'
 import { useNamespaceRoleMap } from '@/features/knowledge/document/hooks/useNamespaceRoleMap'
 import { useKnowledgePermissions } from '@/features/knowledge/permission/hooks/useKnowledgePermissions'
-import { DocumentPanel, KnowledgeBaseSummaryCard } from '@/features/knowledge/document/components'
+import {
+  DocumentPanel as DefaultDocumentPanel,
+  KnowledgeBaseSummaryCard,
+  getComponent,
+} from '@/features/knowledge/document/components'
+import type { DocumentPanelProps } from '@/features/knowledge/document/components/DocumentPanel'
 import { BoundKnowledgeBaseSummary } from '@/features/tasks/components/group-chat'
 import { taskKnowledgeBaseApi } from '@/apis/task-knowledge-base'
+
+/**
+ * Wrapper component that resolves DocumentPanel from the registry at render time.
+ *
+ * This exists as a wrapper rather than a module-level getComponent() call so that
+ * external packages calling registerComponents() during app initialization have a
+ * chance to populate the registry before the component is first rendered.
+ */
+function DocumentPanel(props: DocumentPanelProps) {
+  const Panel = useMemo(
+    () => getComponent('DocumentPanel', DefaultDocumentPanel),
+    []
+  )
+  return <Panel {...props} />
+}
 import {
   canManageKnowledgeBase,
   canManageKnowledgeBaseDocuments,

--- a/frontend/src/features/knowledge/index.ts
+++ b/frontend/src/features/knowledge/index.ts
@@ -32,3 +32,7 @@ export type { ContentWriteSummary, ContentWrite } from './wikiUtils'
 // Document Knowledge exports
 export { KnowledgeDocumentPage } from './document/components'
 export { useKnowledgeBases, useDocuments } from './document/hooks'
+
+// Permission extension exports
+export { KbPermissionsPanel } from './permission/components'
+export type { ExtensionTabConfig } from './permission/components'

--- a/frontend/src/features/knowledge/permission/components/KbPermissionsPanel.tsx
+++ b/frontend/src/features/knowledge/permission/components/KbPermissionsPanel.tsx
@@ -95,12 +95,6 @@ export function KbPermissionsPanel({
 
   const [activeTab, setActiveTab] = useState(visibleTabs[0]?.id || 'personal')
 
-  // Get the currently active tab component
-  const ActiveComponent = useMemo(() => {
-    const tab = visibleTabs.find(t => t.id === activeTab)
-    return tab?.component || PermissionManagementTab
-  }, [visibleTabs, activeTab])
-
   // Single tab mode: no tabs UI, just render the content
   if (visibleTabs.length === 1) {
     const TabComponent = visibleTabs[0].component

--- a/frontend/src/features/knowledge/permission/components/KbPermissionsPanel.tsx
+++ b/frontend/src/features/knowledge/permission/components/KbPermissionsPanel.tsx
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2025 Wegent, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * KbPermissionsPanel renders the permission management panel for a knowledge base.
+ *
+ * This component provides an extension point for adding additional permission tabs
+ * (e.g., department-level permissions via external ERP systems). By default, it
+ * only shows the personal permission management tab.
+ *
+ * Extension Example:
+ * ```typescript
+ * import { Building2 } from 'lucide-react'
+ * import { ErpDeptTab } from '@wecode/features/knowledge/components'
+ *
+ * const erpExtensionTab: ExtensionTabConfig = {
+ *   id: 'department',
+ *   label: 'Department',
+ *   icon: Building2,
+ *   component: ErpDeptTab,
+ *   requiresManagePermission: true,
+ * }
+ *
+ * <KbPermissionsPanel
+ *   kbId={kbId}
+ *   canManagePermissions={canManagePermissions}
+ *   extensionTabs={[erpExtensionTab]}
+ * />
+ * ```
+ */
+
+'use client'
+
+import { useState, useMemo } from 'react'
+import { Users } from 'lucide-react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs'
+import { useTranslation } from '@/hooks/useTranslation'
+import { PermissionManagementTab } from './PermissionManagementTab'
+
+/**
+ * Configuration for an extension permission tab.
+ */
+export interface ExtensionTabConfig {
+  /** Unique identifier for this tab */
+  id: string
+  /** Display label for the tab */
+  label: string
+  /** Lucide icon component */
+  icon: React.ComponentType<{ className?: string }>
+  /** Component to render as tab content, receives kbId prop */
+  component: React.ComponentType<{ kbId: number }>
+  /** Whether this tab requires manage permission to be visible */
+  requiresManagePermission?: boolean
+}
+
+interface KbPermissionsPanelProps {
+  /** Knowledge base ID */
+  kbId: number
+  /** Whether the current user can manage permissions */
+  canManagePermissions: boolean
+  /** Additional permission tabs injected by extensions */
+  extensionTabs?: ExtensionTabConfig[]
+}
+
+/**
+ * Knowledge base permissions panel with support for extension tabs.
+ *
+ * By default, only shows the personal permission management tab. Extensions can
+ * provide additional tabs (e.g., department permissions) via the extensionTabs prop.
+ */
+export function KbPermissionsPanel({
+  kbId,
+  canManagePermissions,
+  extensionTabs = [],
+}: KbPermissionsPanelProps) {
+  const { t } = useTranslation('knowledge')
+
+  // Build list of all visible tabs
+  const visibleTabs = useMemo(() => {
+    const tabs = [
+      {
+        id: 'personal',
+        label: t('document.permission.personal') || 'Personal',
+        icon: Users,
+        component: PermissionManagementTab,
+        requiresManagePermission: false,
+      },
+      ...extensionTabs.filter(
+        tab => !tab.requiresManagePermission || canManagePermissions
+      ),
+    ]
+    return tabs
+  }, [extensionTabs, canManagePermissions, t])
+
+  const [activeTab, setActiveTab] = useState(visibleTabs[0]?.id || 'personal')
+
+  // Get the currently active tab component
+  const ActiveComponent = useMemo(() => {
+    const tab = visibleTabs.find(t => t.id === activeTab)
+    return tab?.component || PermissionManagementTab
+  }, [visibleTabs, activeTab])
+
+  // Single tab mode: no tabs UI, just render the content
+  if (visibleTabs.length === 1) {
+    const TabComponent = visibleTabs[0].component
+    return <TabComponent kbId={kbId} />
+  }
+
+  // Multi-tab mode: render tabs
+  return (
+    <div className="space-y-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className="h-8">
+          {visibleTabs.map(tab => {
+            const Icon = tab.icon
+            return (
+              <TabsTrigger
+                key={tab.id}
+                value={tab.id}
+                className="gap-1 h-7 px-3 text-xs"
+                data-testid={`permission-tab-${tab.id}`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {tab.label}
+              </TabsTrigger>
+            )
+          })}
+        </TabsList>
+
+        {visibleTabs.map(tab => {
+          const TabComponent = tab.component
+          return (
+            <TabsContent key={tab.id} value={tab.id} className="mt-4">
+              <TabComponent kbId={kbId} />
+            </TabsContent>
+          )
+        })}
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/src/features/knowledge/permission/components/add-user-form-state.ts
+++ b/frontend/src/features/knowledge/permission/components/add-user-form-state.ts
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2025 Wegent, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Extension state for AddUserForm role select component.
+ *
+ * This module provides module-level state that allows external packages
+ * to inject a custom role selector component without modifying the
+ * open-source AddUserForm or its parent components.
+ *
+ * This follows the same pattern as `createKbDialogState.ts` (setCreateKbFormSections),
+ * providing a read/write separation: open-source components read (get),
+ * external packages write (set).
+ *
+ * Usage (in external package):
+ * ```typescript
+ * import { setRoleSelectComponent } from '@/features/knowledge/permission/components';
+ * import { ErpRoleSelect } from './ErpRoleSelect';
+ *
+ * setRoleSelectComponent(ErpRoleSelect);
+ * ```
+ */
+
+import type { ComponentType } from 'react'
+import type { MemberRole } from '@/types/knowledge'
+
+// ============== Types ==============
+
+export interface RoleSelectComponentProps {
+  /** Currently selected role value */
+  value: MemberRole
+  /** Role change callback */
+  onChange: (role: MemberRole) => void
+}
+
+// ============== Role Select Component Bridge ==============
+
+let _roleSelectComponent: ComponentType<RoleSelectComponentProps> | undefined
+
+/**
+ * Register a custom role select component for AddUserForm.
+ * Called by external packages during app initialization.
+ *
+ * When registered, AddUserForm renders this component instead of the
+ * default role `<Select>` dropdown. This is useful for ERP integrations
+ * that need to display custom role options alongside standard ones.
+ *
+ * @param component - Custom role select component or undefined to clear
+ */
+export function setRoleSelectComponent(
+  component: ComponentType<RoleSelectComponentProps> | undefined
+): void {
+  _roleSelectComponent = component
+}
+
+/**
+ * Get the registered custom role select component.
+ * Called by AddUserForm when rendering the role select field.
+ *
+ * @returns The registered component or undefined
+ */
+export function getRoleSelectComponent(): ComponentType<RoleSelectComponentProps> | undefined {
+  return _roleSelectComponent
+}

--- a/frontend/src/features/knowledge/permission/components/add-user-form.tsx
+++ b/frontend/src/features/knowledge/permission/components/add-user-form.tsx
@@ -17,6 +17,7 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { UserSearchSelect } from '@/components/common/UserSearchSelect'
 import type { MemberRole } from '@/types/knowledge'
 import type { SearchUser } from '@/types/api'
+import { getRoleSelectComponent } from './add-user-form-state'
 
 interface AddUserFormProps {
   selectedUsers: SearchUser[]
@@ -36,6 +37,7 @@ export function AddUserForm({
   error,
 }: AddUserFormProps) {
   const { t } = useTranslation('knowledge')
+  const RoleSelectComponent = getRoleSelectComponent()
 
   return (
     <form onSubmit={onSubmit}>
@@ -51,50 +53,54 @@ export function AddUserForm({
           />
         </div>
 
-        {/* Role Select */}
+        {/* Role Select — use custom component if registered, otherwise default dropdown */}
         <div className="space-y-2">
           <Label htmlFor="role">{t('document.permission.role.label')}</Label>
-          <Select value={role} onValueChange={v => onRoleChange(v as MemberRole)}>
-            <SelectTrigger id="role">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="Maintainer">
-                <div>
-                  <div className="font-medium">{t('document.permission.role.Maintainer')}</div>
-                  <div className="text-xs text-text-muted">
-                    {t('document.permission.role.MaintainerDescription')}
+          {RoleSelectComponent ? (
+            <RoleSelectComponent value={role} onChange={onRoleChange} />
+          ) : (
+            <Select value={role} onValueChange={v => onRoleChange(v as MemberRole)}>
+              <SelectTrigger id="role">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Maintainer">
+                  <div>
+                    <div className="font-medium">{t('document.permission.role.Maintainer')}</div>
+                    <div className="text-xs text-text-muted">
+                      {t('document.permission.role.MaintainerDescription')}
+                    </div>
                   </div>
-                </div>
-              </SelectItem>
-              <SelectItem value="Developer">
-                <div>
-                  <div className="font-medium">{t('document.permission.role.Developer')}</div>
-                  <div className="text-xs text-text-muted">
-                    {t('document.permission.role.DeveloperDescription')}
+                </SelectItem>
+                <SelectItem value="Developer">
+                  <div>
+                    <div className="font-medium">{t('document.permission.role.Developer')}</div>
+                    <div className="text-xs text-text-muted">
+                      {t('document.permission.role.DeveloperDescription')}
+                    </div>
                   </div>
-                </div>
-              </SelectItem>
-              <SelectItem value="Reporter">
-                <div>
-                  <div className="font-medium">{t('document.permission.role.Reporter')}</div>
-                  <div className="text-xs text-text-muted">
-                    {t('document.permission.role.ReporterDescription')}
+                </SelectItem>
+                <SelectItem value="Reporter">
+                  <div>
+                    <div className="font-medium">{t('document.permission.role.Reporter')}</div>
+                    <div className="text-xs text-text-muted">
+                      {t('document.permission.role.ReporterDescription')}
+                    </div>
                   </div>
-                </div>
-              </SelectItem>
-              <SelectItem value="RestrictedAnalyst">
-                <div>
-                  <div className="font-medium">
-                    {t('document.permission.role.RestrictedAnalyst')}
+                </SelectItem>
+                <SelectItem value="RestrictedAnalyst">
+                  <div>
+                    <div className="font-medium">
+                      {t('document.permission.role.RestrictedAnalyst')}
+                    </div>
+                    <div className="text-xs text-text-muted">
+                      {t('document.permission.role.RestrictedAnalystDescription')}
+                    </div>
                   </div>
-                  <div className="text-xs text-text-muted">
-                    {t('document.permission.role.RestrictedAnalystDescription')}
-                  </div>
-                </div>
-              </SelectItem>
-            </SelectContent>
-          </Select>
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          )}
         </div>
 
         {/* Error Message */}

--- a/frontend/src/features/knowledge/permission/components/index.ts
+++ b/frontend/src/features/knowledge/permission/components/index.ts
@@ -5,3 +5,10 @@
 export { ShareLinkDialog } from './ShareLinkDialog'
 export { PermissionManagementTab } from './PermissionManagementTab'
 export { AddUserDialog } from './add-user-dialog'
+export { KbPermissionsPanel } from './KbPermissionsPanel'
+export type { ExtensionTabConfig } from './KbPermissionsPanel'
+export {
+  setRoleSelectComponent,
+  getRoleSelectComponent,
+} from './add-user-form-state'
+export type { RoleSelectComponentProps } from './add-user-form-state'

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -363,6 +363,7 @@
       }
     },
     "permission": {
+      "personal": "Personal",
       "noAccess": "You do not have permission to perform this action",
       "share": "Share",
       "shareLink": "Invite to Collaborate",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -363,6 +363,7 @@
       }
     },
     "permission": {
+      "personal": "个人权限",
       "noAccess": "您没有操作权限",
       "share": "分享",
       "shareLink": "邀请协作",


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive extension system for the knowledge base module, enabling external packages to integrate custom permissions, entity bindings, UI components, and lifecycle hooks without modifying the open-source codebase.

### Backend — Permission Resolver Extension

- Add `IKbPermissionResolver` interface and `DefaultKbPermissionResolver` no-op base in `backend/app/services/readers/kb_permissions.py`, following the existing `groups` / `group_members` reader pattern
- `get_user_kb_permission()` calls the resolver as the final fallback after all built-in checks
- `list_knowledge_bases()` (ALL scope) calls `get_accessible_kb_ids()` to include externally-granted KBs
- Thread-safe lazy singleton via double-checked locking
- Defensive try/except guards at both call sites so a faulty extension cannot break core functionality

### Backend — Python Entry Points

- Use Python entry points (`wegent.kb_permissions`) for dynamic resolver loading instead of `SERVICE_EXTENSION` env var
- `_load_from_entry_points()` discovers and loads resolvers from installed packages
- Python < 3.10 compatibility for `entry_points()` API

```toml
[project.entry-points."wegent.kb_permissions"]
my_resolver = "myext.kb_permissions:MyResolver"
```

### Frontend — Component Registry

- Generic component registry in `registry.ts` to override `DocumentPanel` and `KnowledgeDetailPanel` at runtime
- `registerComponents()` / `getComponent()` / `hasComponent()` / `clearRegistry()`
- Lazy resolution via `useMemo` at render time to avoid module-load ordering issues

### Frontend — External Binding API

- `BindingProvider` / `BindingProviderRegistry`: Plugin-based architecture for external systems (ERP, OA, CRM)
- `ExternalBindingApi`: Unified CRUD operations (search, list, add, remove, sync)
- `setExternalBindingApi()` / `getExternalBindingApi()` / `hasExternalBindingApi()` pattern
- Comprehensive types: `BindableItem`, `BindingSearchResult`, `BindableTypeConfig`, `ExternalBinding`

### Frontend — Permission Extension Tabs

- `ExtensionTabConfig` interface in `KbPermissionsPanel` with id, label, icon, component, and requiresManagePermission
- `extensionTabs` prop on `KbPermissionsPanel` and `permissionExtensionTabs` on `KnowledgeDetailPanel`

### Frontend — Create KB Dialog Extension

- `KnowledgeBaseFormSections`: Well-defined slot positions (`afterDescription`, `afterAdvanced`)
- `setCreateKbFormSections()` / `getCreateKbFormSections()` for form section injection
- `setPostCreateHandler()` / `runPostCreateHandler()` for post-creation async hooks
- Fully wired on both Desktop and Mobile pages

### Frontend — Role Select Extension

- `setRoleSelectComponent()` / `getRoleSelectComponent()` for replacing the AddUserForm role dropdown
- Enables ERP integrations to show custom role options alongside standard ones

### Documentation

- Rewritten `docs/en/developer-guide/kb-permission-extension.md` and `docs/zh/developer-guide/kb-permission-extension.md`
- Covers all extension points with code examples, best practices, and a summary table

## Motivation

Internal deployments often need to extend the knowledge base system with:
- Department-level permissions from external identity systems
- Entity bindings to ERP/OA/CRM systems
- Custom UI sections in KB creation dialogs
- Post-creation workflows (e.g., auto-binding external entities)

This PR provides all necessary extension points while keeping service-specific code completely isolated in external packages.

## Files Changed

| Area | Files | Description |
|------|-------|-------------|
| Backend | 4 new + 2 modified | Permission resolver interface, entry points, lazy loader, tests |
| Frontend | 14 new/modified | Registry, binding API, permission tabs, form slots, state bridges |
| Docs | 2 files | Complete English and Chinese documentation |
| i18n | 2 files | Missing translation key `document.permission.personal` |

## Commits

This branch has been rebased into 2 logical commits:
1. `feat(backend)` — Permission resolver interface, default implementation, lazy singleton, and tests
2. `feat(frontend)` — All frontend extension points, backend entry points, and documentation

## Test Plan

### Backend
- [x] `DefaultKbPermissionResolver.resolve` always returns `None`
- [x] `DefaultKbPermissionResolver.get_accessible_kb_ids` always returns `[]`
- [x] Entry point loading works correctly with valid resolvers
- [x] `ImportError` logs a warning and falls back to default
- [x] General exception logs a warning and falls back to default
- [x] `_LazyReader` initialises only once (lazy singleton)
- [x] Creator check short-circuits before external resolver
- [x] All 128 existing KB permission tests pass without regression

### Frontend
- [x] Component registry resolves at render time (not module load time)
- [x] Register/unregister/has/clear work correctly
- [x] External binding API provider registration and lookup
- [x] Form sections render at correct slot positions
- [x] Post-creation hook fires after KB creation
- [x] Custom role select component renders instead of default dropdown