### PR TITLE
feat(knowledge): add creator and updated time columns to document list

### DIFF
--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -353,6 +353,7 @@ class KnowledgeDocumentResponse(BaseModel):
     file_size: int
     status: DocumentStatus
     user_id: int
+    user_name: Optional[str] = Field(None, description="Creator username")
     is_active: bool
     index_status: DocumentIndexStatus
     index_generation: int

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -656,9 +656,24 @@ class KnowledgeOrchestrator:
             user_id=user.id,
         )
 
+        # Batch query user names to avoid N+1 queries
+        user_ids = list({doc.user_id for doc in documents if doc.user_id})
+        user_map: Dict[int, User] = {}
+        if user_ids:
+            users = db.query(User).filter(User.id.in_(user_ids)).all()
+            user_map = {u.id: u for u in users}
+
+        # Build response items with user_name populated
+        items = []
+        for doc in documents:
+            resp = KnowledgeDocumentResponse.model_validate(doc)
+            user_obj = user_map.get(doc.user_id)
+            resp.user_name = user_obj.user_name if user_obj else f"User {doc.user_id}"
+            items.append(resp)
+
         return KnowledgeDocumentListResponse(
             total=len(documents),
-            items=[KnowledgeDocumentResponse.model_validate(doc) for doc in documents],
+            items=items,
         )
 
     def _get_document_with_access_or_raise(

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -92,13 +92,8 @@ export function DocumentItem({
     return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
   }
 
-  // Check if the document has been modified since creation (compare at second level)
-  const isUnmodified = (() => {
-    const created = Date.parse(document.created_at)
-    const updated = Date.parse(document.updated_at)
-    if (Number.isNaN(created) || Number.isNaN(updated)) return false
-    return Math.floor(created / 1000) === Math.floor(updated / 1000)
-  })()
+  // Check if the document has been modified since creation
+  const isUnmodified = document.updated_at === document.created_at
 
   const handleCheckboxChange = (checked: boolean) => {
     onSelect?.(document, checked)

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -92,6 +92,13 @@ export function DocumentItem({
     return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`
   }
 
+  // Check if the document has been modified since creation (compare at second level)
+  const isUnmodified = (() => {
+    const created = new Date(document.created_at).getTime()
+    const updated = new Date(document.updated_at).getTime()
+    return Math.abs(updated - created) < 1000
+  })()
+
   const handleCheckboxChange = (checked: boolean) => {
     onSelect?.(document, checked)
   }
@@ -268,6 +275,14 @@ export function DocumentItem({
                 {formatFileSize(document.file_size)}
               </span>
             )}
+            {/* Creator */}
+            <span className="text-[9px] text-text-muted">
+              {document.user_name || `User ${document.user_id}`}
+            </span>
+            {/* Updated time - show "-" if not modified */}
+            <span className="text-[9px] text-text-muted">
+              {isUnmodified ? '-' : formatDateTime(document.updated_at)}
+            </span>
             {/* Status indicator */}
             {document.is_active ? (
               <span
@@ -379,7 +394,7 @@ export function DocumentItem({
   // Normal mode: Table row layout
   return (
     <div
-      className={`flex items-center gap-4 px-4 py-3 bg-base hover:bg-surface transition-colors group min-w-[800px] ${showBorder ? 'border-b border-border' : ''} ${onViewDetail ? 'cursor-pointer' : ''}`}
+      className={`flex items-center gap-4 px-4 py-3 bg-base hover:bg-surface transition-colors group min-w-[1064px] ${showBorder ? 'border-b border-border' : ''} ${onViewDetail ? 'cursor-pointer' : ''}`}
       onClick={handleRowClick}
     >
       {/* Checkbox for batch selection */}
@@ -471,9 +486,21 @@ export function DocumentItem({
           {isTable || isWeb ? '-' : formatFileSize(document.file_size)}
         </span>
       </div>
-      {/* Upload date with time */}
+      {/* Creator */}
+      <div className="w-24 flex-shrink-0 text-center" data-testid="creator-cell">
+        <span className="text-xs text-text-muted">
+          {document.user_name || `User ${document.user_id}`}
+        </span>
+      </div>
+      {/* Created date with time */}
       <div className="w-40 flex-shrink-0 text-center">
         <span className="text-xs text-text-muted">{formatDateTime(document.created_at)}</span>
+      </div>
+      {/* Updated date with time */}
+      <div className="w-40 flex-shrink-0 text-center" data-testid="updated-at-cell">
+        <span className="text-xs text-text-muted">
+          {isUnmodified ? '-' : formatDateTime(document.updated_at)}
+        </span>
       </div>
 
       {/* Index status (is_active) */}

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -94,9 +94,10 @@ export function DocumentItem({
 
   // Check if the document has been modified since creation (compare at second level)
   const isUnmodified = (() => {
-    const created = new Date(document.created_at).getTime()
-    const updated = new Date(document.updated_at).getTime()
-    return Math.abs(updated - created) < 1000
+    const created = Date.parse(document.created_at)
+    const updated = Date.parse(document.updated_at)
+    if (Number.isNaN(created) || Number.isNaN(updated)) return false
+    return Math.floor(created / 1000) === Math.floor(updated / 1000)
   })()
 
   const handleCheckboxChange = (checked: boolean) => {

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -113,7 +113,7 @@ interface DocumentListProps {
   isOrganization?: boolean
 }
 
-type SortField = 'name' | 'size' | 'date'
+type SortField = 'name' | 'size' | 'date' | 'updatedAt'
 type SortOrder = 'asc' | 'desc'
 
 export function DocumentList({
@@ -261,6 +261,9 @@ export function DocumentList({
           break
         case 'date':
           comparison = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+          break
+        case 'updatedAt':
+          comparison = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
           break
       }
       return sortOrder === 'asc' ? comparison : -comparison
@@ -770,7 +773,7 @@ export function DocumentList({
             /* Normal mode: Table layout with folder tree - single bordered container */
             <div className="border border-border rounded-lg overflow-hidden">
               {/* Table header */}
-              <div className="flex items-center gap-4 px-4 py-2.5 bg-surface text-xs text-text-muted font-medium min-w-[800px] border-b border-border">
+              <div className="flex items-center gap-4 px-4 py-2.5 bg-surface text-xs text-text-muted font-medium min-w-[1064px] border-b border-border">
                 {/* Checkbox for select all */}
                 {canManageAllDocuments && (
                   <div className="flex-shrink-0">
@@ -813,12 +816,22 @@ export function DocumentList({
                   {t('document.document.columns.size')}
                   <SortIcon field="size" />
                 </div>
+                <div className="w-24 flex-shrink-0 text-center">
+                  {t('document.document.columns.creator')}
+                </div>
                 <div
                   className="w-40 flex-shrink-0 text-center cursor-pointer hover:text-text-primary select-none"
                   onClick={() => handleSort('date')}
                 >
                   {t('document.document.columns.date')}
                   <SortIcon field="date" />
+                </div>
+                <div
+                  className="w-40 flex-shrink-0 text-center cursor-pointer hover:text-text-primary select-none"
+                  onClick={() => handleSort('updatedAt')}
+                >
+                  {t('document.document.columns.updatedAt')}
+                  <SortIcon field="updatedAt" />
                 </div>
                 <div className="w-24 flex-shrink-0 text-center">
                   {t('document.document.columns.indexStatus')}

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -197,9 +197,11 @@
       "download": "Download",
       "columns": {
         "name": "Name",
+        "creator": "Creator",
         "type": "Type",
         "size": "Size",
-        "date": "Date",
+        "date": "Created",
+        "updatedAt": "Updated",
         "status": "Status",
         "indexStatus": "Index",
         "actions": "Actions"

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -197,9 +197,11 @@
       "download": "下载",
       "columns": {
         "name": "名称",
+        "creator": "创建人",
         "type": "类型",
         "size": "大小",
         "date": "创建时间",
+        "updatedAt": "更新时间",
         "status": "状态",
         "indexStatus": "索引",
         "actions": "操作"

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -361,6 +361,7 @@ export interface KnowledgeDocument {
   file_size: number
   status: DocumentStatus
   user_id: number
+  user_name?: string
   is_active: boolean
   index_status: DocumentIndexStatus
   index_generation: number


### PR DESCRIPTION
## Summary

- Add "Creator" column and "Updated Time" column to knowledge document list, keeping the original "Created Time" column
- Backend: Add `user_name` field to `KnowledgeDocumentResponse` schema with batch user query to avoid N+1
- Frontend: Add `user_name` to `KnowledgeDocument` type, new table columns, and compact mode display
- Show "-" for updated time when document has not been modified since creation

## Changes

### Backend
1. **`backend/app/schemas/knowledge.py`**: Added `user_name: Optional[str]` field to `KnowledgeDocumentResponse`
2. **`backend/app/services/knowledge/orchestrator.py`**: Modified `list_documents` to batch query user names via `User` model and populate `user_name` in each response item

### Frontend
3. **`frontend/src/types/knowledge.ts`**: Added `user_name?: string` to `KnowledgeDocument` interface
4. **`frontend/src/i18n/locales/zh-CN/knowledge.json`**: Added `creator` (创建人) and `updatedAt` (更新时间) translation keys, changed `date` to 创建时间
5. **`frontend/src/i18n/locales/en/knowledge.json`**: Added `creator` (Creator) and `updatedAt` (Updated) translation keys, changed `date` to Created
6. **`frontend/src/features/knowledge/document/components/DocumentList.tsx`**:
   - Added `updatedAt` to `SortField` type
   - Added "Creator" and "Updated" column headers in table
   - Added sort handler for `updatedAt` field
   - Updated table min-width to accommodate new columns
7. **`frontend/src/features/knowledge/document/components/DocumentItem.tsx`**:
   - Added `isUnmodified` helper to compare `created_at` and `updated_at` at second level
   - Added "Creator" cell (`document.user_name || User {user_id}`)
   - Added "Updated Time" cell (shows "-" when unmodified)
   - Added creator and updated time display in compact mode
   - Added `data-testid` attributes (`creator-cell`, `updated-at-cell`)
   - Updated row min-width to accommodate new columns

## Column Order
☑ □ Name | Type | Size | **Creator** | Created Time | **Updated Time** | Index | Actions

## Test plan

- [ ] Verify "Creator" column displays user_name for each document, falls back to "User {id}" if empty
- [ ] Verify "Updated Time" column shows formatted datetime, or "-" if document not modified
- [ ] Verify sorting works for both "Created Time" and "Updated Time" columns
- [ ] Verify compact mode (notebook sidebar) shows creator and updated time
- [ ] Verify backend batch query does not cause N+1 performance issues
- [ ] Verify existing functionality (checkbox, actions, index status) still works correctly
- [ ] Verify responsive layout with new columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API can include a creator username for documents.
  * Document lists now show the creator's name and an "Updated" column.
  * Documents can be sorted by update time; table headers changed to "Created" and "Updated".
  * Display shows '-' when created and updated timestamps are identical.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->