### PR TITLE
feat(knowledge): add document conversion pipeline (PDF/Office to Markdown)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -236,7 +236,7 @@ KNOWLEDGE_INDEX_STALE_CONVERTING_SECONDS=1800
 
 # Conversion task distributed lock configuration
 # 转换任务分布式锁配置
-KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS=300
+KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS=10000
 KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS=60
 KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES=2
 KNOWLEDGE_CONVERSION_LOCK_RETRY_DELAY_SECONDS=30
@@ -270,6 +270,32 @@ MINERU_POLL_INTERVAL_SECONDS=3
 
 # Maximum time to wait for MinerU task completion (seconds)
 MINERU_MAX_WAIT_SECONDS=600
+
+# ==========================================
+# Document Conversion S3 Storage Configuration
+# MinerU 提取图片的 S3 存储配置
+# ==========================================
+
+# Enable S3 upload for extracted images
+# 是否启用 S3 图片上传
+WORKER_CONVERSION_S3_ENABLED=false
+
+# S3 endpoint URL (e.g., MinIO or AWS S3)
+# S3 服务端点地址
+WORKER_CONVERSION_S3_ENDPOINT=
+
+# S3 access key
+WORKER_CONVERSION_S3_ACCESS_KEY=
+
+# S3 SECRET key
+WORKER_CONVERSION_S3_SECRET_KEY=
+
+# S3 bucket name for storing images
+# S3 存储桶名称
+WORKER_CONVERSION_S3_BUCKET_NAME=
+
+# S3 region name
+WORKER_CONVERSION_S3_REGION_NAME=us-east-1
 
 # Data Table Configuration
 # JSON string containing table provider credentials (DingTalk, etc.)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -210,6 +210,67 @@ WIKI_MAX_CONTENT_SIZE=10485760
 # Base URL for internal wiki content writer
 WIKI_CONTENT_WRITE_BASE_URL=http://backend:8000
 
+
+
+# ==========================================
+# Knowledge Document Conversion Configuration
+# 知识库文档转换配置（PDF/PPTX 等转换为 Markdown）
+# ==========================================
+
+# Master switch for document conversion feature
+# 总开关：true 开启转换功能，false 关闭（走原来直接索引的逻辑）
+KNOWLEDGE_CONVERSION_ENABLED=false
+
+# Comma-separated list of file extensions that need conversion to markdown
+# 需要转换为 Markdown 的文件扩展名列表（逗号分隔），如：pdf,pptx,docx
+# 仅在 KNOWLEDGE_CONVERSION_ENABLED=true 时生效
+KNOWLEDGE_CONVERSION_FILE_TYPES=pdf
+
+# Celery queue name for document conversion tasks
+# 文档转换任务的 Celery 队列名称
+KNOWLEDGE_CONVERSION_QUEUE=knowledge_conversion
+
+# Stale detection timeout for CONVERTING status (seconds)
+# 转换状态过期时间（秒），超过此时间视为卡住，可被重新入队
+KNOWLEDGE_INDEX_STALE_CONVERTING_SECONDS=1800
+
+# Conversion task distributed lock configuration
+# 转换任务分布式锁配置
+KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS=300
+KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS=60
+KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES=2
+KNOWLEDGE_CONVERSION_LOCK_RETRY_DELAY_SECONDS=30
+
+# ==========================================
+# MinerU API Configuration
+# PDF 转 Markdown 的 MinerU API 配置
+# ==========================================
+
+# Base URL for MinerU API service
+# MinerU API 服务地址，为空则禁用 PDF 转换
+MINERU_API_BASE_URL=
+
+# MinerU backend type: "pipeline" or other supported backends
+MINERU_BACKEND=pipeline
+
+# MinerU parse method: "ocr", "auto", etc.
+MINERU_PARSE_METHOD=ocr
+
+# Language list for OCR (comma-separated, e.g., "ch,en")
+MINERU_LANG_LIST=ch
+
+# Enable formula recognition
+MINERU_FORMULA_ENABLE=true
+
+# Enable table recognition
+MINERU_TABLE_ENABLE=true
+
+# Polling interval for task status checks (seconds)
+MINERU_POLL_INTERVAL_SECONDS=3
+
+# Maximum time to wait for MinerU task completion (seconds)
+MINERU_MAX_WAIT_SECONDS=600
+
 # Data Table Configuration
 # JSON string containing table provider credentials (DingTalk, etc.)
 # Format: {"dingtalk":{"appKey":"YOUR_APP_KEY","appSecret":"YOUR_APP_secret","operatorId":"YOUR_OPERATOR_ID","userMapping":{"baseId":"YOUR_BASE_ID","sheetId":"YOUR_SHEET_ID"}}}

--- a/backend/app/core/celery_app.py
+++ b/backend/app/core/celery_app.py
@@ -43,6 +43,7 @@ celery_app = Celery(
     include=[
         "app.tasks.subscription_tasks",
         "app.tasks.knowledge_tasks",
+        "app.tasks.conversion_tasks",
     ],
 )
 
@@ -67,6 +68,14 @@ celery_app.conf.update(
     task_default_retry_delay=60,  # 1 minute default retry delay
     # Default queue configuration
     task_default_queue=settings.CELERY_TASK_DEFAULT_QUEUE,
+    # Task routing: conversion tasks go to dedicated queue
+    # Main worker does NOT consume this queue
+    # Conversion worker: celery -A app.core.celery_app worker --queues=knowledge_conversion
+    task_routes={
+        "app.tasks.conversion_tasks.*": {
+            "queue": settings.KNOWLEDGE_CONVERSION_QUEUE,
+        },
+    },
     # Beat schedule for periodic tasks
     beat_schedule={
         "check-due-subscriptions": {

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -330,6 +330,47 @@ class Settings(BaseSettings):
     KNOWLEDGE_INDEX_STALE_QUEUED_SECONDS: int = 600
     KNOWLEDGE_INDEX_STALE_INDEXING_SECONDS: int = 2700
 
+    # Knowledge document conversion configuration
+    # Master switch for document conversion feature
+    # When False, conversion is disabled and files are indexed directly (original behavior)
+    # When True, files matching KNOWLEDGE_CONVERSION_FILE_TYPES will be converted to markdown
+    KNOWLEDGE_CONVERSION_ENABLED: bool = False
+
+    # Comma-separated list of file extensions that need conversion to markdown
+    # before indexing. Example: "pdf,pptx,docx"
+    # Only used when KNOWLEDGE_CONVERSION_ENABLED is True.
+    KNOWLEDGE_CONVERSION_FILE_TYPES: str = ""
+
+    # Celery queue name for document conversion tasks
+    KNOWLEDGE_CONVERSION_QUEUE: str = "knowledge_conversion"
+
+    # Stale detection timeout for CONVERTING status (seconds, default 30 min)
+    KNOWLEDGE_INDEX_STALE_CONVERTING_SECONDS: int = 1800
+
+    # Conversion task distributed lock configuration
+    KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS: int = 300
+    KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS: int = 60
+    KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES: int = 2
+    KNOWLEDGE_CONVERSION_LOCK_RETRY_DELAY_SECONDS: int = 30
+
+    # MinerU API configuration for PDF to Markdown conversion
+    # Base URL for MinerU API service (e.g., "http://10.2.40.157:8367")
+    MINERU_API_BASE_URL: str = ""
+    # MinerU backend type: "pipeline" or other supported backends
+    MINERU_BACKEND: str = "pipeline"
+    # MinerU parse method: "ocr", "auto", etc.
+    MINERU_PARSE_METHOD: str = "ocr"
+    # Language list for OCR (comma-separated, e.g., "ch,en")
+    MINERU_LANG_LIST: str = "ch"
+    # Enable formula recognition
+    MINERU_FORMULA_ENABLE: bool = True
+    # Enable table recognition
+    MINERU_TABLE_ENABLE: bool = True
+    # Polling interval for task status checks (seconds)
+    MINERU_POLL_INTERVAL_SECONDS: int = 3
+    # Maximum time to wait for MinerU task completion (seconds, default 10 min)
+    MINERU_MAX_WAIT_SECONDS: int = 600
+
     # Circuit breaker configuration
     CIRCUIT_BREAKER_FAIL_MAX: int = 5  # Open circuit after 5 consecutive failures
     CIRCUIT_BREAKER_RESET_TIMEOUT: int = 60  # Try to recover after 60 seconds
@@ -594,6 +635,26 @@ class Settings(BaseSettings):
     # OpenTelemetry configuration is centralized in shared/telemetry/config.py
     # Use: from shared.telemetry.config import get_otel_config
     # All OTEL_* environment variables are read from there
+
+    def needs_conversion(self, file_extension: str) -> bool:
+        """Check if a file extension requires conversion before indexing.
+
+        Conversion only occurs when:
+        1. KNOWLEDGE_CONVERSION_ENABLED is True (master switch)
+        2. KNOWLEDGE_CONVERSION_FILE_TYPES is not empty
+        3. The file extension is in the conversion list
+        """
+        if not self.KNOWLEDGE_CONVERSION_ENABLED:
+            return False
+        if not self.KNOWLEDGE_CONVERSION_FILE_TYPES:
+            return False
+        ext = file_extension.lstrip(".").lower()
+        types = [
+            t.strip().lower()
+            for t in self.KNOWLEDGE_CONVERSION_FILE_TYPES.split(",")
+            if t.strip()
+        ]
+        return ext in types
 
     def get_rag_runtime_mode(self, operation: str) -> str:
         """Resolve the effective RAG runtime mode for an operation."""

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -348,7 +348,8 @@ class Settings(BaseSettings):
     KNOWLEDGE_INDEX_STALE_CONVERTING_SECONDS: int = 1800
 
     # Conversion task distributed lock configuration
-    KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS: int = 300
+    # Lock timeout should be longer than task soft_time_limit to prevent premature expiration
+    KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS: int = 2000
     KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS: int = 60
     KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES: int = 2
     KNOWLEDGE_CONVERSION_LOCK_RETRY_DELAY_SECONDS: int = 30
@@ -370,6 +371,16 @@ class Settings(BaseSettings):
     MINERU_POLL_INTERVAL_SECONDS: int = 3
     # Maximum time to wait for MinerU task completion (seconds, default 10 min)
     MINERU_MAX_WAIT_SECONDS: int = 600
+
+    # Document conversion S3 storage configuration for extracted images
+    # When enabled, images extracted by MinerU will be uploaded to S3
+    # and markdown image references will be updated to S3 URLs
+    WORKER_CONVERSION_S3_ENABLED: bool = False
+    WORKER_CONVERSION_S3_ENDPOINT: str = ""
+    WORKER_CONVERSION_S3_ACCESS_KEY: str = ""
+    WORKER_CONVERSION_S3_SECRET_KEY: str = ""
+    WORKER_CONVERSION_S3_BUCKET_NAME: str = ""
+    WORKER_CONVERSION_S3_REGION_NAME: str = "us-east-1"
 
     # Circuit breaker configuration
     CIRCUIT_BREAKER_FAIL_MAX: int = 5  # Open circuit after 5 consecutive failures

--- a/backend/app/models/knowledge.py
+++ b/backend/app/models/knowledge.py
@@ -53,6 +53,7 @@ class DocumentIndexStatus(str, PyEnum):
 
     NOT_INDEXED = "not_indexed"
     QUEUED = "queued"
+    CONVERTING = "converting"
     INDEXING = "indexing"
     SUCCESS = "success"
     FAILED = "failed"

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -48,6 +48,7 @@ class DocumentIndexStatus(str, Enum):
 
     NOT_INDEXED = "not_indexed"
     QUEUED = "queued"
+    CONVERTING = "converting"
     INDEXING = "indexing"
     SUCCESS = "success"
     FAILED = "failed"

--- a/backend/app/services/knowledge/index_state_machine.py
+++ b/backend/app/services/knowledge/index_state_machine.py
@@ -45,6 +45,7 @@ class IndexExecutionDecision:
 
 ACTIVE_INDEX_STATUSES = {
     DocumentIndexStatus.QUEUED,
+    DocumentIndexStatus.CONVERTING,
     DocumentIndexStatus.INDEXING,
 }
 
@@ -73,6 +74,12 @@ def _get_active_index_stale_reason(
         and age_seconds >= settings.KNOWLEDGE_INDEX_STALE_INDEXING_SECONDS
     ):
         return "stale_indexing"
+
+    if (
+        document.index_status == DocumentIndexStatus.CONVERTING
+        and age_seconds >= settings.KNOWLEDGE_INDEX_STALE_CONVERTING_SECONDS
+    ):
+        return "stale_converting"
 
     return None
 
@@ -416,6 +423,129 @@ def mark_document_index_succeeded(
         document_id=document_id,
         generation=generation,
         reason="finalized" if updated > 0 else "stale_or_already_finalized",
+    )
+    return updated > 0
+
+
+@trace_sync(
+    span_name="knowledge.mark_document_conversion_started",
+    tracer_name="knowledge.state_machine",
+    extract_attributes=lambda db, document_id, generation: {
+        "knowledge.document_id": document_id,
+        "knowledge.index_generation": generation,
+    },
+)
+def mark_document_conversion_started(
+    db: Session,
+    document_id: int,
+    generation: int,
+) -> IndexExecutionDecision:
+    """Transition QUEUED -> CONVERTING when conversion worker picks up the task."""
+    document = (
+        db.query(KnowledgeDocument)
+        .filter(KnowledgeDocument.id == document_id)
+        .with_for_update()
+        .first()
+    )
+    if document is None:
+        db.rollback()
+        _record_transition(
+            "knowledge.conversion.start.skipped",
+            document_id=document_id,
+            generation=generation,
+            reason="document_not_found",
+        )
+        return IndexExecutionDecision(
+            should_execute=False,
+            reason="document_not_found",
+        )
+
+    if document.index_generation != generation:
+        db.rollback()
+        _record_transition(
+            "knowledge.conversion.start.skipped",
+            document_id=document_id,
+            generation=generation,
+            reason="stale_generation",
+            previous_status=document.index_status,
+        )
+        return IndexExecutionDecision(
+            should_execute=False,
+            reason="stale_generation",
+        )
+
+    current_status = document.index_status or DocumentIndexStatus.NOT_INDEXED
+    if current_status != DocumentIndexStatus.QUEUED:
+        db.rollback()
+        _record_transition(
+            "knowledge.conversion.start.skipped",
+            document_id=document_id,
+            generation=generation,
+            reason=f"unexpected_status_{current_status.value}",
+            previous_status=current_status,
+        )
+        return IndexExecutionDecision(
+            should_execute=False,
+            reason=f"unexpected_status_{current_status.value}",
+        )
+
+    document.index_status = DocumentIndexStatus.CONVERTING
+    document.updated_at = _utcnow()
+    db.commit()
+
+    _record_transition(
+        "knowledge.conversion.start.accepted",
+        document_id=document_id,
+        generation=generation,
+        reason="conversion_started",
+        previous_status=current_status,
+    )
+    return IndexExecutionDecision(
+        should_execute=True,
+        reason="conversion_started",
+    )
+
+
+@trace_sync(
+    span_name="knowledge.mark_document_conversion_succeeded",
+    tracer_name="knowledge.state_machine",
+    extract_attributes=lambda db, document_id, generation: {
+        "knowledge.document_id": document_id,
+        "knowledge.index_generation": generation,
+    },
+)
+def mark_document_conversion_succeeded(
+    db: Session,
+    document_id: int,
+    generation: int,
+) -> bool:
+    """Transition CONVERTING -> QUEUED after successful conversion.
+
+    The document returns to QUEUED so index_document_task can proceed
+    with the normal QUEUED -> INDEXING transition.
+    """
+    updated = (
+        db.query(KnowledgeDocument)
+        .filter(
+            KnowledgeDocument.id == document_id,
+            KnowledgeDocument.index_generation == generation,
+            KnowledgeDocument.index_status == DocumentIndexStatus.CONVERTING,
+        )
+        .update(
+            {
+                KnowledgeDocument.index_status: DocumentIndexStatus.QUEUED,
+                KnowledgeDocument.updated_at: _utcnow(),
+            },
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+
+    _record_transition(
+        "knowledge.conversion.finalize.success",
+        document_id=document_id,
+        generation=generation,
+        reason="converted" if updated > 0 else "stale_or_already_finalized",
     )
     return updated > 0
 

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1633,7 +1633,8 @@ class KnowledgeOrchestrator:
             raise RuntimeError(message)
 
         try:
-            if settings.needs_conversion(document.file_extension or ""):
+            normalized_extension = _normalize_file_extension(document.file_extension)
+            if settings.needs_conversion(normalized_extension):
                 # File type requires conversion before indexing
                 # Retrieve original filename from attachment record
                 from app.models.subtask_context import ContextType, SubtaskContext
@@ -1659,7 +1660,7 @@ class KnowledgeOrchestrator:
                     index_generation=generation,
                     user_id=index_owner_user_id,
                     user_name=user.user_name,
-                    file_extension=document.file_extension or "",
+                    file_extension=normalized_extension,
                     original_filename=original_filename,
                     retriever_name=retriever_name,
                     retriever_namespace=retriever_namespace,

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.models.kind import Kind
 from app.models.knowledge import KnowledgeDocument
 from app.models.task import TaskResource
@@ -1632,20 +1633,63 @@ class KnowledgeOrchestrator:
             raise RuntimeError(message)
 
         try:
-            async_result = index_document_task.delay(
-                knowledge_base_id=str(knowledge_base.id),
-                attachment_id=document.attachment_id,
-                retriever_name=retriever_name,
-                retriever_namespace=retriever_namespace,
-                embedding_model_name=embedding_model_name,
-                embedding_model_namespace=embedding_model_namespace,
-                user_id=index_owner_user_id,
-                user_name=user.user_name,
-                document_id=document.id,
-                index_generation=generation,
-                splitter_config_dict=splitter_config,
-                trigger_summary=trigger_summary,
-            )
+            if settings.needs_conversion(document.file_extension or ""):
+                # File type requires conversion before indexing
+                # Retrieve original filename from attachment record
+                from app.models.subtask_context import ContextType, SubtaskContext
+                from app.tasks.conversion_tasks import convert_document_task
+
+                attachment = (
+                    db.query(SubtaskContext)
+                    .filter(
+                        SubtaskContext.id == document.attachment_id,
+                        SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+                    )
+                    .first()
+                )
+                original_filename = (
+                    attachment.original_filename if attachment else document.name
+                )
+
+                async_result = convert_document_task.delay(
+                    document_id=document.id,
+                    attachment_id=document.attachment_id,
+                    knowledge_base_id=str(knowledge_base.id),
+                    index_generation=generation,
+                    user_id=index_owner_user_id,
+                    user_name=user.user_name,
+                    file_extension=document.file_extension or "",
+                    original_filename=original_filename,
+                    retriever_name=retriever_name,
+                    retriever_namespace=retriever_namespace,
+                    embedding_model_name=embedding_model_name,
+                    embedding_model_namespace=embedding_model_namespace,
+                    splitter_config_dict=splitter_config,
+                    trigger_summary=trigger_summary,
+                )
+
+                logger.info(
+                    f"[Orchestrator] Conversion task enqueued: "
+                    f"document_id={document.id}, file_ext={document.file_extension}, "
+                    f"index_generation={generation}, "
+                    f"celery_task_id={async_result.id}"
+                )
+            else:
+                # Direct indexing (no conversion needed)
+                async_result = index_document_task.delay(
+                    knowledge_base_id=str(knowledge_base.id),
+                    attachment_id=document.attachment_id,
+                    retriever_name=retriever_name,
+                    retriever_namespace=retriever_namespace,
+                    embedding_model_name=embedding_model_name,
+                    embedding_model_namespace=embedding_model_namespace,
+                    user_id=index_owner_user_id,
+                    user_name=user.user_name,
+                    document_id=document.id,
+                    index_generation=generation,
+                    splitter_config_dict=splitter_config,
+                    trigger_summary=trigger_summary,
+                )
         except Exception as exc:
             mark_document_index_enqueue_failed(
                 db=db,
@@ -1653,7 +1697,7 @@ class KnowledgeOrchestrator:
                 generation=generation,
             )
             logger.error(
-                f"[Orchestrator] Failed to enqueue RAG indexing task for document {document.id}: {exc}",
+                f"[Orchestrator] Failed to enqueue task for document {document.id}: {exc}",
                 exc_info=True,
             )
             raise

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -1655,6 +1655,7 @@ class KnowledgeOrchestrator:
                     document_id=document.id,
                     attachment_id=document.attachment_id,
                     knowledge_base_id=str(knowledge_base.id),
+                    knowledge_base_name=knowledge_base.name,
                     index_generation=generation,
                     user_id=index_owner_user_id,
                     user_name=user.user_name,

--- a/backend/app/tasks/conversion_tasks.py
+++ b/backend/app/tasks/conversion_tasks.py
@@ -464,8 +464,8 @@ def _extract_markdown_from_zip(
     queue=settings.KNOWLEDGE_CONVERSION_QUEUE,
     max_retries=settings.KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES,
     default_retry_delay=CONVERSION_RETRY_DELAY,
-    # Conversion with S3 image upload can take longer than default timeout
-    # Set longer limits: 30 minutes soft, 35 minutes hard
+    # Conversion with S3 image upload can take much longer than default timeout
+    # Set longer limits: 150 minutes soft, ~167 minutes hard
     soft_time_limit=9000,
     time_limit=10000,
 )

--- a/backend/app/tasks/conversion_tasks.py
+++ b/backend/app/tasks/conversion_tasks.py
@@ -1,0 +1,448 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Celery tasks for document format conversion.
+
+Converts documents (PDF, PPTX, etc.) to Markdown format before RAG indexing.
+These tasks run on dedicated conversion workers via a separate queue,
+isolated from the main Celery worker.
+
+Conversion worker startup (on dedicated conversion machine):
+    uv run celery -A app.core.celery_app worker \
+        --queues=knowledge_conversion \
+        --concurrency=2
+
+The main worker (uv run celery -A app.core.celery_app worker) does NOT
+consume conversion tasks because task_routes directs them to the
+knowledge_conversion queue.
+"""
+
+import asyncio
+import io
+import logging
+import zipfile
+from typing import Optional
+
+import httpx
+
+from app.core.celery_app import celery_app
+from app.core.config import settings
+from app.core.distributed_lock import distributed_lock
+from app.db.session import SessionLocal
+
+logger = logging.getLogger(__name__)
+
+CONVERSION_LOCK_TIMEOUT = settings.KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS
+CONVERSION_LOCK_EXTEND = settings.KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS
+CONVERSION_RETRY_DELAY = settings.KNOWLEDGE_CONVERSION_LOCK_RETRY_DELAY_SECONDS
+
+
+_MINERU_MIME_TYPES = {
+    "pdf": "application/pdf",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "doc": "application/msword",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "ppt": "application/vnd.ms-powerpoint",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "xls": "application/vnd.ms-excel",
+}
+
+
+def _convert_to_markdown(binary_data: bytes, file_extension: str) -> bytes:
+    """
+    Convert document binary to Markdown format via MinerU API.
+
+    Supported formats: pdf, docx, doc, pptx, ppt, xlsx, xls (anything MinerU accepts).
+
+    Args:
+        binary_data: Original file binary content
+        file_extension: Original file extension (e.g., ".pdf", ".docx")
+
+    Returns:
+        Markdown content as UTF-8 encoded bytes
+
+    Raises:
+        RuntimeError: If the file type is unsupported or MinerU fails
+    """
+    ext = file_extension.lstrip(".").lower()
+
+    if ext not in _MINERU_MIME_TYPES:
+        raise RuntimeError(
+            f"Conversion for '{ext}' is not supported. "
+            f"Supported types: {', '.join(_MINERU_MIME_TYPES)}"
+        )
+
+    return asyncio.run(_convert_with_mineru_async(binary_data, ext))
+
+
+async def _convert_with_mineru_async(binary_data: bytes, file_extension: str) -> bytes:
+    """
+    Async implementation of document to Markdown conversion using MinerU API.
+
+    Args:
+        binary_data: File binary content
+        file_extension: File extension without dot (e.g., "pdf", "docx", "pptx")
+    """
+    if not settings.MINERU_API_BASE_URL:
+        raise RuntimeError("MINERU_API_BASE_URL is not configured")
+
+    mime_type = _MINERU_MIME_TYPES.get(file_extension, "application/octet-stream")
+    filename = f"document.{file_extension}"
+    base_url = settings.MINERU_API_BASE_URL.rstrip("/")
+    task_id = None
+
+    async with httpx.AsyncClient() as client:
+        # Step 1: Submit task
+        try:
+            submit_url = f"{base_url}/tasks"
+            data = {
+                "backend": settings.MINERU_BACKEND,
+                "parse_method": settings.MINERU_PARSE_METHOD,
+                "lang_list": settings.MINERU_LANG_LIST,
+                "formula_enable": "true" if settings.MINERU_FORMULA_ENABLE else "false",
+                "table_enable": "true" if settings.MINERU_TABLE_ENABLE else "false",
+                "return_md": "true",
+                "return_images": "true",
+                "response_format_zip": "true",
+            }
+
+            files = {"files": (filename, binary_data, mime_type)}
+
+            logger.info(f"[MinerU] Submitting task to {submit_url}")
+            response = await client.post(
+                submit_url, data=data, files=files, timeout=60.0
+            )
+            response.raise_for_status()
+
+            result = response.json()
+            task_id = (
+                result.get("task_id") if isinstance(result, dict) else result.strip('"')
+            )
+            logger.info(f"[MinerU] Task submitted: {task_id}")
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to submit MinerU task: {e}")
+
+        # Step 2: Poll for completion
+        start_time = asyncio.get_event_loop().time()
+        max_wait = settings.MINERU_MAX_WAIT_SECONDS
+        poll_interval = settings.MINERU_POLL_INTERVAL_SECONDS
+
+        while True:
+            elapsed = asyncio.get_event_loop().time() - start_time
+            if elapsed > max_wait:
+                raise RuntimeError(f"MinerU task timeout after {max_wait}s: {task_id}")
+
+            try:
+                status_url = f"{base_url}/tasks/{task_id}"
+                status_resp = await client.get(status_url, timeout=10.0)
+                status_resp.raise_for_status()
+
+                status_data = status_resp.json()
+                status = (
+                    status_data.get("status", "").lower()
+                    if isinstance(status_data, dict)
+                    else status_data.strip('"').lower()
+                )
+
+                if status in ["completed", "done", "success"]:
+                    logger.info(f"[MinerU] Task completed: {task_id}")
+                    break
+                elif status in ["failed", "error"]:
+                    raise RuntimeError(f"MinerU task failed: {task_id}")
+                else:
+                    logger.debug(f"[MinerU] Task status: {status}, waiting...")
+                    await asyncio.sleep(poll_interval)
+
+            except Exception as e:
+                if isinstance(e, RuntimeError):
+                    raise
+                logger.warning(f"[MinerU] Status check error: {e}")
+                await asyncio.sleep(poll_interval)
+
+        # Step 3: Download result
+        try:
+            result_url = f"{base_url}/tasks/{task_id}/result"
+            logger.info(f"[MinerU] Downloading result from {result_url}")
+
+            result_resp = await client.get(result_url, timeout=120.0)
+            result_resp.raise_for_status()
+
+            content_type = result_resp.headers.get("content-type", "")
+
+            if "application/json" in content_type:
+                raise RuntimeError("MinerU returned JSON instead of ZIP")
+
+            # Extract markdown from ZIP
+            return _extract_markdown_from_zip(result_resp.content)
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to download MinerU result: {e}")
+
+
+def _extract_markdown_from_zip(zip_content: bytes) -> bytes:
+    """
+    Extract markdown content from MinerU result ZIP.
+
+    Args:
+        zip_content: ZIP file binary content
+
+    Returns:
+        Markdown content as UTF-8 encoded bytes
+    """
+    try:
+        with zipfile.ZipFile(io.BytesIO(zip_content)) as z:
+            # Find markdown files in the ZIP
+            md_files = [f for f in z.namelist() if f.endswith(".md")]
+
+            if not md_files:
+                raise RuntimeError("No markdown file found in MinerU result")
+
+            # Read the first markdown file (usually the main content)
+            md_file = md_files[0]
+            logger.info(f"[MinerU] Extracting markdown: {md_file}")
+
+            content = z.read(md_file)
+            return content
+
+    except zipfile.BadZipFile:
+        raise RuntimeError("Invalid ZIP file from MinerU result")
+
+
+@celery_app.task(
+    bind=True,
+    name="app.tasks.conversion_tasks.convert_document",
+    queue=settings.KNOWLEDGE_CONVERSION_QUEUE,
+    max_retries=settings.KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES,
+    default_retry_delay=CONVERSION_RETRY_DELAY,
+)
+def convert_document_task(
+    self,
+    document_id: int,
+    attachment_id: int,
+    knowledge_base_id: str,
+    index_generation: int,
+    user_id: int,
+    user_name: str,
+    file_extension: str,
+    original_filename: str,
+    # Pass-through parameters for index_document_task
+    retriever_name: str,
+    retriever_namespace: str,
+    embedding_model_name: str,
+    embedding_model_namespace: str,
+    splitter_config_dict: Optional[dict] = None,
+    trigger_summary: bool = True,
+):
+    """
+    Convert a document to Markdown format and then dispatch indexing.
+
+    State machine flow:
+        QUEUED -> CONVERTING -> (overwrite attachment) -> QUEUED -> index_document_task
+
+    This task:
+    1. Acquires a distributed lock for the document
+    2. Transitions state: QUEUED -> CONVERTING
+    3. Loads the attachment binary from storage
+    4. Converts the binary to Markdown via _convert_to_markdown()
+    5. Overwrites the attachment with Markdown content (file_extension -> .md)
+    6. Transitions state: CONVERTING -> QUEUED
+    7. Dispatches index_document_task to the default queue
+    """
+    from app.services.knowledge.index_state_machine import (
+        mark_document_conversion_started,
+        mark_document_conversion_succeeded,
+        mark_document_index_failed,
+    )
+
+    task_id = getattr(self.request, "id", "unknown")
+    retry_count = getattr(self.request, "retries", 0)
+    worker_hostname = getattr(self.request, "hostname", "unknown")
+
+    logger.info(
+        f"[Conversion] Task started: task_id={task_id}, "
+        f"worker={worker_hostname}, retry={retry_count}/{self.max_retries}, "
+        f"document_id={document_id}, file_ext={file_extension}, "
+        f"index_generation={index_generation}"
+    )
+
+    # Acquire distributed lock to prevent concurrent conversion
+    lock_name = f"knowledge:convert_document:{document_id}"
+    with distributed_lock.acquire_watchdog_context(
+        lock_name,
+        expire_seconds=CONVERSION_LOCK_TIMEOUT,
+        extend_interval_seconds=CONVERSION_LOCK_EXTEND,
+    ) as acquired:
+        if not acquired:
+            if retry_count < self.max_retries:
+                logger.warning(
+                    f"[Conversion] Lock held, scheduling retry: "
+                    f"task_id={task_id}, document_id={document_id}, "
+                    f"retry={retry_count + 1}/{self.max_retries}, "
+                    f"countdown={CONVERSION_RETRY_DELAY}s"
+                )
+                raise self.retry(
+                    exc=RuntimeError(
+                        f"conversion_lock_held:{document_id}:{index_generation}"
+                    ),
+                    countdown=CONVERSION_RETRY_DELAY,
+                )
+
+            logger.warning(
+                f"[Conversion] Lock retry exhausted: task_id={task_id}, "
+                f"document_id={document_id}, index_generation={index_generation}"
+            )
+            return {
+                "status": "skipped",
+                "reason": "lock_retry_exhausted",
+                "document_id": document_id,
+                "index_generation": index_generation,
+            }
+
+        # State transition: QUEUED -> CONVERTING
+        with SessionLocal() as db:
+            start_decision = mark_document_conversion_started(
+                db=db,
+                document_id=document_id,
+                generation=index_generation,
+            )
+
+        if not start_decision.should_execute:
+            logger.info(
+                f"[Conversion] Skipped: task_id={task_id}, "
+                f"document_id={document_id}, reason={start_decision.reason}"
+            )
+            return {
+                "status": "skipped",
+                "reason": start_decision.reason,
+                "document_id": document_id,
+                "index_generation": index_generation,
+            }
+
+        try:
+            # Load attachment binary from storage
+            from app.models.subtask_context import ContextType, SubtaskContext
+            from app.services.context.context_service import context_service
+
+            with SessionLocal() as db:
+                context = (
+                    db.query(SubtaskContext)
+                    .filter(
+                        SubtaskContext.id == attachment_id,
+                        SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+                    )
+                    .first()
+                )
+                if not context:
+                    raise ValueError(f"Attachment {attachment_id} not found")
+
+                binary_data = context_service.get_attachment_binary_data(
+                    db=db, context=context
+                )
+                if binary_data is None:
+                    raise ValueError(f"Attachment {attachment_id} has no binary data")
+
+            logger.info(
+                f"[Conversion] Loaded attachment binary: "
+                f"attachment_id={attachment_id}, size={len(binary_data)} bytes"
+            )
+
+            # Convert to Markdown
+            markdown_bytes = _convert_to_markdown(binary_data, file_extension)
+
+            logger.info(
+                f"[Conversion] Conversion completed: "
+                f"document_id={document_id}, "
+                f"original_size={len(binary_data)}, "
+                f"markdown_size={len(markdown_bytes)}"
+            )
+
+            # Overwrite attachment with Markdown content
+            # The .md filename causes overwrite_attachment to update
+            # type_data.file_extension to ".md", which the indexer uses
+            md_filename = f"{original_filename}.md"
+            with SessionLocal() as db:
+                context_service.overwrite_attachment(
+                    db=db,
+                    context_id=attachment_id,
+                    user_id=user_id,
+                    filename=md_filename,
+                    binary_data=markdown_bytes,
+                )
+
+            logger.info(
+                f"[Conversion] Attachment overwritten: "
+                f"attachment_id={attachment_id}, "
+                f"new_filename={md_filename}"
+            )
+
+            # State transition: CONVERTING -> QUEUED
+            with SessionLocal() as db:
+                succeeded = mark_document_conversion_succeeded(
+                    db=db,
+                    document_id=document_id,
+                    generation=index_generation,
+                )
+
+            if not succeeded:
+                logger.warning(
+                    f"[Conversion] State transition to QUEUED failed (stale): "
+                    f"document_id={document_id}, "
+                    f"index_generation={index_generation}"
+                )
+                return {
+                    "status": "skipped",
+                    "reason": "stale_conversion",
+                    "document_id": document_id,
+                    "index_generation": index_generation,
+                }
+
+            # Dispatch indexing task to the default queue
+            from app.tasks.knowledge_tasks import index_document_task
+
+            async_result = index_document_task.delay(
+                knowledge_base_id=knowledge_base_id,
+                attachment_id=attachment_id,
+                retriever_name=retriever_name,
+                retriever_namespace=retriever_namespace,
+                embedding_model_name=embedding_model_name,
+                embedding_model_namespace=embedding_model_namespace,
+                user_id=user_id,
+                user_name=user_name,
+                document_id=document_id,
+                index_generation=index_generation,
+                splitter_config_dict=splitter_config_dict,
+                trigger_summary=trigger_summary,
+            )
+
+            logger.info(
+                f"[Conversion] Completed and indexing dispatched: "
+                f"task_id={task_id}, document_id={document_id}, "
+                f"index_generation={index_generation}, "
+                f"index_task_id={async_result.id}"
+            )
+            return {
+                "status": "converted",
+                "document_id": document_id,
+                "index_generation": index_generation,
+                "index_task_id": async_result.id,
+            }
+
+        except Exception as exc:
+            # Mark as failed on any exception
+            with SessionLocal() as db:
+                mark_document_index_failed(
+                    db=db,
+                    document_id=document_id,
+                    generation=index_generation,
+                )
+
+            logger.error(
+                f"[Conversion] Error: task_id={task_id}, "
+                f"document_id={document_id}, "
+                f"index_generation={index_generation}, error={exc}",
+                exc_info=True,
+            )
+            raise

--- a/backend/app/tasks/conversion_tasks.py
+++ b/backend/app/tasks/conversion_tasks.py
@@ -22,8 +22,11 @@ knowledge_conversion queue.
 import asyncio
 import io
 import logging
+import os
+import re
 import zipfile
-from typing import Optional
+from typing import Optional, Tuple
+from urllib.parse import quote
 
 import httpx
 
@@ -33,6 +36,33 @@ from app.core.distributed_lock import distributed_lock
 from app.db.session import SessionLocal
 
 logger = logging.getLogger(__name__)
+
+# Lazy import boto3 for S3 operations
+_s3_client = None
+
+
+def _get_s3_client():
+    """Get or create S3 client for image upload."""
+    global _s3_client
+    if _s3_client is None and settings.WORKER_CONVERSION_S3_ENABLED:
+        try:
+            import boto3
+
+            _s3_client = boto3.client(
+                "s3",
+                endpoint_url=settings.WORKER_CONVERSION_S3_ENDPOINT,
+                aws_access_key_id=settings.WORKER_CONVERSION_S3_ACCESS_KEY,
+                aws_secret_access_key=settings.WORKER_CONVERSION_S3_SECRET_KEY,
+                region_name=settings.WORKER_CONVERSION_S3_REGION_NAME,
+            )
+            logger.info(
+                f"[S3] S3 client initialized for endpoint: {settings.WORKER_CONVERSION_S3_ENDPOINT}"
+            )
+        except Exception as e:
+            logger.error(f"[S3] Failed to initialize S3 client: {e}")
+            raise
+    return _s3_client
+
 
 CONVERSION_LOCK_TIMEOUT = settings.KNOWLEDGE_CONVERSION_LOCK_TIMEOUT_SECONDS
 CONVERSION_LOCK_EXTEND = settings.KNOWLEDGE_CONVERSION_LOCK_EXTEND_INTERVAL_SECONDS
@@ -50,7 +80,9 @@ _MINERU_MIME_TYPES = {
 }
 
 
-def _convert_to_markdown(binary_data: bytes, file_extension: str) -> bytes:
+def _convert_to_markdown(
+    binary_data: bytes, file_extension: str, base_dir_name: Optional[str] = None
+) -> Tuple[bytes, list]:
     """
     Convert document binary to Markdown format via MinerU API.
 
@@ -59,9 +91,10 @@ def _convert_to_markdown(binary_data: bytes, file_extension: str) -> bytes:
     Args:
         binary_data: Original file binary content
         file_extension: Original file extension (e.g., ".pdf", ".docx")
+        base_dir_name: Base directory name for S3 upload (derived from original filename)
 
     Returns:
-        Markdown content as UTF-8 encoded bytes
+        Tuple of (markdown content as bytes, uploaded_image_urls list)
 
     Raises:
         RuntimeError: If the file type is unsupported or MinerU fails
@@ -74,16 +107,22 @@ def _convert_to_markdown(binary_data: bytes, file_extension: str) -> bytes:
             f"Supported types: {', '.join(_MINERU_MIME_TYPES)}"
         )
 
-    return asyncio.run(_convert_with_mineru_async(binary_data, ext))
+    return asyncio.run(_convert_with_mineru_async(binary_data, ext, base_dir_name))
 
 
-async def _convert_with_mineru_async(binary_data: bytes, file_extension: str) -> bytes:
+async def _convert_with_mineru_async(
+    binary_data: bytes, file_extension: str, base_dir_name: Optional[str] = None
+) -> Tuple[bytes, list]:
     """
     Async implementation of document to Markdown conversion using MinerU API.
 
     Args:
         binary_data: File binary content
         file_extension: File extension without dot (e.g., "pdf", "docx", "pptx")
+        base_dir_name: Base directory name for S3 upload (derived from original filename)
+
+    Returns:
+        Tuple of (markdown content as bytes, uploaded_image_urls list)
     """
     if not settings.MINERU_API_BASE_URL:
         raise RuntimeError("MINERU_API_BASE_URL is not configured")
@@ -175,23 +214,70 @@ async def _convert_with_mineru_async(binary_data: bytes, file_extension: str) ->
             if "application/json" in content_type:
                 raise RuntimeError("MinerU returned JSON instead of ZIP")
 
-            # Extract markdown from ZIP
-            return _extract_markdown_from_zip(result_resp.content)
+            # Extract markdown from ZIP (with optional S3 image upload)
+            markdown_bytes, uploaded_images = _extract_markdown_from_zip(
+                result_resp.content, base_dir_name
+            )
+            return markdown_bytes, uploaded_images
 
         except Exception as e:
             raise RuntimeError(f"Failed to download MinerU result: {e}")
 
 
-def _extract_markdown_from_zip(zip_content: bytes) -> bytes:
+def _upload_image_to_s3(
+    image_data: bytes, object_name: str, content_type: str = "image/jpeg"
+) -> Optional[str]:
+    """Upload image to S3 and return the public URL."""
+    try:
+        s3_client = _get_s3_client()
+        if s3_client is None:
+            return None
+
+        bucket = settings.WORKER_CONVERSION_S3_BUCKET_NAME
+
+        # Upload using the original object_name (S3 supports UTF-8)
+        s3_client.upload_fileobj(
+            io.BytesIO(image_data),
+            bucket,
+            object_name,
+            ExtraArgs={"ContentType": content_type},
+        )
+
+        # Construct public URL with proper URL encoding for Chinese characters
+        # Split path and encode each segment to handle Chinese characters
+        endpoint = settings.WORKER_CONVERSION_S3_ENDPOINT.rstrip("/")
+
+        # URL encode the path segments for Chinese character support
+        # e.g., "我的知识库/文档名/images/xxx.jpg" -> "%E6%88%91%E7%9A%84%E7%9F%A5%E8%AF%86%E5%BA%93/%E6%96%87%E6%A1%A3%E5%90%8D/images/xxx.jpg"
+        path_parts = object_name.split("/")
+        encoded_parts = [quote(part, safe="") for part in path_parts]
+        encoded_path = "/".join(encoded_parts)
+
+        public_url = f"{endpoint}/{bucket}/{encoded_path}"
+
+        logger.info(f"[S3] Uploaded image: {object_name} -> {public_url}")
+        return public_url
+
+    except Exception as e:
+        logger.error(f"[S3] Failed to upload image {object_name}: {e}")
+        return None
+
+
+def _extract_markdown_from_zip(
+    zip_content: bytes, base_dir_name: Optional[str] = None
+) -> Tuple[bytes, list]:
     """
     Extract markdown content from MinerU result ZIP.
 
     Args:
         zip_content: ZIP file binary content
+        base_dir_name: Base directory name for S3 upload (derived from original filename)
 
     Returns:
-        Markdown content as UTF-8 encoded bytes
+        Tuple of (markdown content as UTF-8 encoded bytes, uploaded_image_urls list)
     """
+    uploaded_images: list = []
+
     try:
         with zipfile.ZipFile(io.BytesIO(zip_content)) as z:
             # Find markdown files in the ZIP
@@ -204,8 +290,169 @@ def _extract_markdown_from_zip(zip_content: bytes) -> bytes:
             md_file = md_files[0]
             logger.info(f"[MinerU] Extracting markdown: {md_file}")
 
-            content = z.read(md_file)
-            return content
+            content = z.read(md_file).decode("utf-8")
+
+            # If S3 is enabled, upload images and replace references
+            if settings.WORKER_CONVERSION_S3_ENABLED and base_dir_name:
+                # Find all image files in the ZIP for logging/debugging
+                all_image_files = [
+                    f
+                    for f in z.namelist()
+                    if f.lower().endswith(
+                        (
+                            ".png",
+                            ".jpg",
+                            ".jpeg",
+                            ".gif",
+                            ".webp",
+                            ".svg",
+                            ".bmp",
+                            ".tiff",
+                        )
+                    )
+                ]
+                logger.info(
+                    f"[S3] Found {len(all_image_files)} images in ZIP: {all_image_files}"
+                )
+
+                def process_image_upload(
+                    zf: zipfile.ZipFile,
+                    img_path: str,
+                    alt_text: str,
+                    base_dir: str,
+                    original_ref: Optional[str],
+                ) -> str:
+                    """Helper to process single image upload."""
+                    # Try to find the image in ZIP with various path strategies
+                    possible_paths = [img_path]
+
+                    # Strategy 1: Try with ./ prefix
+                    possible_paths.append(f"./{img_path}")
+
+                    # Strategy 2: Try just the filename (flat structure)
+                    flat_name = os.path.basename(img_path)
+                    possible_paths.append(flat_name)
+
+                    # Strategy 3: Try common MinerU directory prefixes
+                    # MinerU often puts images in document/ocr/images/ or similar
+                    if not img_path.startswith("document/"):
+                        possible_paths.append(f"document/{img_path}")
+                        possible_paths.append(f"document/ocr/{img_path}")
+                        possible_paths.append(f"./document/{img_path}")
+                        possible_paths.append(f"./document/ocr/{img_path}")
+
+                    # Strategy 4: Search for partial path match
+                    # If img_path is "images/xxx.jpg", find any path ending with it
+                    if "/" in img_path:
+                        path_suffix = img_path
+                        flat_name_only = os.path.basename(img_path)
+                        for zip_path in zf.namelist():
+                            if zip_path.endswith(path_suffix) or zip_path.endswith(
+                                flat_name_only
+                            ):
+                                if zip_path not in possible_paths:
+                                    possible_paths.append(zip_path)
+
+                    # Remove duplicates while preserving order
+                    seen = set()
+                    unique_paths = []
+                    for p in possible_paths:
+                        if p not in seen:
+                            seen.add(p)
+                            unique_paths.append(p)
+                    possible_paths = unique_paths
+
+                    logger.debug(
+                        f"[S3] Trying paths for {img_path}: {possible_paths[:5]}..."
+                    )  # Log first 5
+
+                    for try_path in possible_paths:
+                        if try_path in zf.namelist():
+                            try:
+                                img_data = zf.read(try_path)
+
+                                ext = os.path.splitext(try_path)[1].lower()
+                                content_type_map = {
+                                    ".png": "image/png",
+                                    ".jpg": "image/jpeg",
+                                    ".jpeg": "image/jpeg",
+                                    ".gif": "image/gif",
+                                    ".webp": "image/webp",
+                                    ".svg": "image/svg+xml",
+                                    ".bmp": "image/bmp",
+                                    ".tiff": "image/tiff",
+                                    ".tif": "image/tiff",
+                                }
+                                content_type = content_type_map.get(ext, "image/jpeg")
+
+                                # For S3 object name, use relative path from ZIP root or just the basename
+                                # Prefer to preserve directory structure if it exists
+                                s3_object_name = f"{base_dir}/{try_path}"
+                                s3_url = _upload_image_to_s3(
+                                    img_data, s3_object_name, content_type
+                                )
+
+                                if s3_url:
+                                    uploaded_images.append((try_path, s3_url))
+                                    return (
+                                        f"![{alt_text}]({s3_url})"
+                                        if alt_text
+                                        else s3_url
+                                    )
+
+                            except Exception as e:
+                                logger.warning(
+                                    f"[S3] Failed to process image {try_path}: {e}"
+                                )
+                                continue
+
+                    logger.warning(f"[S3] Image not found or upload failed: {img_path}")
+                    return original_ref if original_ref else img_path
+
+                # Process markdown image references: ![alt](path)
+                md_img_pattern = r"!\[([^\]]*)\]\(([^)]+)\)"
+
+                def replace_md_image_ref(match):
+                    alt_text = match.group(1)
+                    img_path = match.group(2)
+
+                    if img_path.startswith(("http://", "https://")):
+                        return match.group(0)
+
+                    img_path = img_path.lstrip("./").lstrip("/")
+                    return process_image_upload(
+                        z, img_path, alt_text, base_dir_name, match.group(0)
+                    )
+
+                content = re.sub(md_img_pattern, replace_md_image_ref, content)
+
+                # Process HTML img tags: <img src="path" ...>
+                html_img_pattern = r'<img[^>]+src=["\']([^"\']+)["\'][^>]*>'
+
+                def replace_html_image_ref(match):
+                    img_path = match.group(1)
+
+                    if img_path.startswith(("http://", "https://")):
+                        return match.group(0)
+
+                    img_path = img_path.lstrip("./").lstrip("/")
+                    s3_url = process_image_upload(z, img_path, "", base_dir_name, None)
+                    if s3_url and s3_url != match.group(0):
+                        return match.group(0).replace(match.group(1), s3_url)
+                    return match.group(0)
+
+                content = re.sub(
+                    html_img_pattern,
+                    replace_html_image_ref,
+                    content,
+                    flags=re.IGNORECASE,
+                )
+
+                logger.info(
+                    f"[S3] Uploaded {len(uploaded_images)} images for document: {base_dir_name}"
+                )
+
+            return content.encode("utf-8"), uploaded_images
 
     except zipfile.BadZipFile:
         raise RuntimeError("Invalid ZIP file from MinerU result")
@@ -217,12 +464,17 @@ def _extract_markdown_from_zip(zip_content: bytes) -> bytes:
     queue=settings.KNOWLEDGE_CONVERSION_QUEUE,
     max_retries=settings.KNOWLEDGE_CONVERSION_LOCK_MAX_RETRIES,
     default_retry_delay=CONVERSION_RETRY_DELAY,
+    # Conversion with S3 image upload can take longer than default timeout
+    # Set longer limits: 30 minutes soft, 35 minutes hard
+    soft_time_limit=9000,
+    time_limit=10000,
 )
 def convert_document_task(
     self,
     document_id: int,
     attachment_id: int,
     knowledge_base_id: str,
+    knowledge_base_name: str,
     index_generation: int,
     user_id: int,
     user_name: str,
@@ -349,14 +601,22 @@ def convert_document_task(
                 f"attachment_id={attachment_id}, size={len(binary_data)} bytes"
             )
 
-            # Convert to Markdown
-            markdown_bytes = _convert_to_markdown(binary_data, file_extension)
+            # Generate S3 path: {knowledge_base_name}/{filename_without_ext}
+            # S3 object path format: {knowledge_base_name}/{filename}/images/xxx.jpg
+            filename_without_ext = os.path.splitext(original_filename)[0]
+            s3_base_path = f"{knowledge_base_name}/{filename_without_ext}"
+
+            # Convert to Markdown (with optional S3 image upload)
+            markdown_bytes, uploaded_images = _convert_to_markdown(
+                binary_data, file_extension, s3_base_path
+            )
 
             logger.info(
                 f"[Conversion] Conversion completed: "
                 f"document_id={document_id}, "
                 f"original_size={len(binary_data)}, "
-                f"markdown_size={len(markdown_bytes)}"
+                f"markdown_size={len(markdown_bytes)}, "
+                f"images_uploaded={len(uploaded_images)}"
             )
 
             # Overwrite attachment with Markdown content

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -128,6 +128,7 @@ dependencies = [
     # Shared utilities (monorepo workspace dependency)
     "wegent-shared",
     "minio>=7.2.20",
+    "boto3>=1.42.96",
 ]
 
 [tool.uv.sources]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -128,7 +128,7 @@ dependencies = [
     # Shared utilities (monorepo workspace dependency)
     "wegent-shared",
     "minio>=7.2.20",
-    "boto3>=1.42.96",
+    "boto3>=1.42.97",
 ]
 
 [tool.uv.sources]

--- a/docker/conversion/Dockerfile
+++ b/docker/conversion/Dockerfile
@@ -32,7 +32,7 @@ RUN if [ ! -f .env ]; then cp .env.example .env; fi
 # Log level: info (production), debug (verbose troubleshooting)
 
 ENV CELERY_QUEUE=knowledge_conversion
-ENV CELERY_CONCURRENCY=10
+ENV CELERY_CONCURRENCY=2
 ENV CELERY_LOGLEVEL=info
 ENV CELERY_HOSTNAME=conversion-worker@%h
 

--- a/docker/conversion/Dockerfile
+++ b/docker/conversion/Dockerfile
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/wecode-ai/wegent-base-python3.12:1.2.1
+
+# Set working directory
+WORKDIR /app
+
+# Copy local workspace dependencies so backend can resolve them via
+# `pyproject.toml` [tool.uv.sources] relative paths from /app/backend:
+# - wegent-shared = { path = "../shared" } -> /app/shared
+# - wegent-chat-shell = { path = "../chat_shell" } -> /app/chat_shell
+# - wegent-knowledge-engine = { path = "../knowledge_engine" } -> /app/knowledge_engine
+COPY shared /app/shared
+COPY chat_shell /app/chat_shell
+COPY knowledge_engine /app/knowledge_engine
+
+# Copy pyproject.toml and install dependencies
+COPY backend/pyproject.toml /app/backend/pyproject.toml
+RUN cd /app/backend && uv pip install --system --no-cache -r pyproject.toml
+
+# Copy application code
+COPY backend /app
+
+# Create .env file (if it doesn't exist)
+RUN if [ ! -f .env ]; then cp .env.example .env; fi
+
+# Conversion Worker Configuration
+# Queue: knowledge_conversion (dedicated queue for document conversion tasks)
+# Concurrency: 2 (CPU-intensive tasks, limited by OCR processing capacity)
+# Log level: info (production), debug (verbose troubleshooting)
+
+ENV CELERY_QUEUE=knowledge_conversion
+ENV CELERY_CONCURRENCY=10
+ENV CELERY_LOGLEVEL=info
+ENV CELERY_HOSTNAME=conversion-worker@%h
+
+# Start command: Celery worker for knowledge conversion tasks
+# Uses exec form for proper signal handling (SIGTERM)
+CMD ["sh", "-c", "exec celery -A app.core.celery_app worker \
+    --queues=${CELERY_QUEUE} \
+    --concurrency=${CELERY_CONCURRENCY} \
+    --hostname=${CELERY_HOSTNAME} \
+    --loglevel=${CELERY_LOGLEVEL}"]

--- a/docs/en/developer-guide/knowledge-indexing-protection.md
+++ b/docs/en/developer-guide/knowledge-indexing-protection.md
@@ -29,19 +29,21 @@ The protection has three layers.
 
 The `knowledge_documents` table now stores:
 
-- `index_status`: `not_indexed | queued | indexing | success | failed`
+- `index_status`: `not_indexed | queued | converting | indexing | success | failed`
 - `index_generation`
 
 `index_generation` is the key field. Every valid new indexing attempt gets a new generation. Any older task becomes stale automatically.
 
 `not_indexed` is the explicit initial state. It separates "never indexed yet" from a real execution failure instead of overloading both into `failed`.
 
+`converting` is an intermediate state for documents that require format conversion (e.g., PDF, DOCX, PPTX, XLSX) before indexing. The conversion happens on dedicated workers via the `knowledge_conversion` queue. Once conversion completes, the document transitions back to `queued` and proceeds to `indexing`.
+
 ### 2. Business dedupe before enqueue
 
 Before sending a Celery task, the orchestrator updates database state first:
 
-- if the document is already `queued / indexing`, duplicate enqueue is skipped
-- if `queued / indexing` has been stuck too long, a new request can take over with a new generation
+- if the document is already `queued / converting / indexing`, duplicate enqueue is skipped
+- if `queued / converting / indexing` has been stuck too long, a new request can take over with a new generation
 - if the document is already `success`, normal retry requests are skipped
 - only flows that explicitly need a new attempt create a new generation
 
@@ -50,11 +52,12 @@ Current policy:
 - new document: create a new generation
 - retry for failed document: create a new generation
 - content update / web refresh: replace the active generation so old tasks become stale
-- long-lived `queued / indexing`: allow takeover after stale detection based on `updated_at`
+- long-lived `queued / converting / indexing`: allow takeover after stale detection based on `updated_at`
 
 Current default thresholds:
 
 - `queued` older than 10 minutes can be replaced by a new generation
+- `converting` older than 30 minutes can be replaced by a new generation
 - `indexing` older than 45 minutes can be replaced by a new generation
 
 ### 3. Final guard before worker execution
@@ -67,7 +70,7 @@ Before calling the embedding model, the Celery worker:
 The task only executes when:
 
 - the task generation matches the current database generation
-- the current status is still `queued` or `indexing`
+- the current status is still `queued`, `converting`, or `indexing`
 
 Otherwise it returns `skipped` and does not call the embedding model again.
 

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -117,6 +117,15 @@ EXECUTOR_WORKSPACE=/path/to/workspace
 KNOWLEDGE_CONVERSION_ENABLED=false
 KNOWLEDGE_CONVERSION_FILE_TYPES=pdf,docx,pptx,xlsx
 MINERU_API_BASE_URL=http://mineru-service:8367
+
+# Document Conversion S3 Storage Configuration (Optional)
+# Enable to upload extracted images to S3 and replace markdown image references
+WORKER_CONVERSION_S3_ENABLED=false
+WORKER_CONVERSION_S3_ENDPOINT=http://minio:9000
+WORKER_CONVERSION_S3_ACCESS_KEY=your_access_key
+WORKER_CONVERSION_S3_SECRET_KEY=your_secret_key
+WORKER_CONVERSION_S3_BUCKET_NAME=img
+WORKER_CONVERSION_S3_REGION_NAME=us-east-1
 ```
 
 ### Step 3: Start Services

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -111,6 +111,12 @@ ATTACHMENT_STORAGE_BACKEND=mysql
 # Executor Manager Configuration
 EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 EXECUTOR_WORKSPACE=/path/to/workspace
+
+# Document Conversion Configuration (Optional)
+# Enable to convert PDF, DOCX, PPTX, XLSX to Markdown before indexing
+KNOWLEDGE_CONVERSION_ENABLED=false
+KNOWLEDGE_CONVERSION_FILE_TYPES=pdf,docx,pptx,xlsx
+MINERU_API_BASE_URL=http://mineru-service:8367
 ```
 
 ### Step 3: Start Services

--- a/docs/zh/developer-guide/knowledge-indexing-protection.md
+++ b/docs/zh/developer-guide/knowledge-indexing-protection.md
@@ -31,19 +31,21 @@ sidebar_position: 12
 
 在 `knowledge_documents` 表新增字段：
 
-- `index_status`: `not_indexed | queued | indexing | success | failed`
+- `index_status`: `not_indexed | queued | converting | indexing | success | failed`
 - `index_generation`: 当前索引世代
 
 其中 `index_generation` 是这次改造的核心。每次“有效的新一轮索引”都会生成新的 generation，旧任务只要 generation 对不上，就必须退出。
 
-其中 `not_indexed` 是显式初始态，表示文档尚未建立过索引，不再把“未开始”和“执行失败”混成同一个 `failed` 状态。
+其中 `not_indexed` 是显式初始态，表示文档尚未建立过索引，不再把”未开始”和”执行失败”混成同一个 `failed` 状态。
+
+`converting` 是需要格式转换的文档的中间状态（如 PDF、DOCX、PPTX、XLSX 等）。转换任务在专门的 `knowledge_conversion` 队列上执行，完成后文档会回到 `queued` 状态，再继续进入 `indexing` 状态。
 
 ### 2. enqueue 前的业务去重
 
 在真正调用 Celery 之前，orchestrator 会先更新数据库状态：
 
-- 如果文档已经处于 `queued / indexing`，默认不再重复入队
-- 如果 `queued / indexing` 已经卡住太久，会允许新请求接管并生成新的 generation
+- 如果文档已经处于 `queued / converting / indexing`，默认不再重复入队
+- 如果 `queued / converting / indexing` 已经卡住太久，会允许新请求接管并生成新的 generation
 - 如果文档已经 `success`，普通重试请求直接跳过
 - 只有明确需要覆盖当前世代的场景，才会生成新的 generation
 
@@ -52,11 +54,12 @@ sidebar_position: 12
 - 新建文档：正常生成新 generation
 - 失败文档重试：生成新 generation
 - 文档内容被更新 / Web 文档刷新：允许覆盖当前世代，旧任务会自动变 stale
-- 长时间停留在 `queued / indexing`：按 `updated_at` 判定为 stale 后允许接管
+- 长时间停留在 `queued / converting / indexing`：按 `updated_at` 判定为 stale 后允许接管
 
 当前默认阈值：
 
 - `queued` 超过 10 分钟，允许新的 generation 接管
+- `converting` 超过 30 分钟，允许新的 generation 接管
 - `indexing` 超过 45 分钟，允许新的 generation 接管
 
 ### 3. worker 执行前的最终判定
@@ -69,7 +72,7 @@ Celery worker 在真正调用 embedding 之前，会先做两件事：
 只有满足下面条件才继续执行：
 
 - 当前任务的 generation 等于数据库里的当前 generation
-- 当前状态仍然是 `queued` 或 `indexing`
+- 当前状态仍然是 `queued`、`converting` 或 `indexing`
 
 否则直接返回 `skipped`，不会再次调用 embedding 模型。
 

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -117,6 +117,15 @@ EXECUTOR_WORKSPACE=/path/to/workspace
 KNOWLEDGE_CONVERSION_ENABLED=false
 KNOWLEDGE_CONVERSION_FILE_TYPES=pdf,docx,pptx,xlsx
 MINERU_API_BASE_URL=http://mineru-service:8367
+
+# 文档转换 S3 图片存储配置（可选）
+# 启用后将转换提取的图片上传到 S3，并替换 Markdown 中的图片引用
+WORKER_CONVERSION_S3_ENABLED=false
+WORKER_CONVERSION_S3_ENDPOINT=http://minio:9000
+WORKER_CONVERSION_S3_ACCESS_KEY=your_access_key
+WORKER_CONVERSION_S3_SECRET_KEY=your_secret_key
+WORKER_CONVERSION_S3_BUCKET_NAME=img
+WORKER_CONVERSION_S3_REGION_NAME=us-east-1
 ```
 
 ### 步骤 3: 启动服务

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -111,6 +111,12 @@ ATTACHMENT_STORAGE_BACKEND=mysql
 # Executor Manager 配置
 EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 EXECUTOR_WORKSPACE=/path/to/workspace
+
+# 文档转换配置（可选）
+# 启用后将 PDF、DOCX、PPTX、XLSX 转换为 Markdown 后再进行索引
+KNOWLEDGE_CONVERSION_ENABLED=false
+KNOWLEDGE_CONVERSION_FILE_TYPES=pdf,docx,pptx,xlsx
+MINERU_API_BASE_URL=http://mineru-service:8367
 ```
 
 ### 步骤 3: 启动服务

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,3 +1,4 @@
+ 
 /* tslint:disable */
 
 /**

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,4 +1,3 @@
- 
 /* tslint:disable */
 
 /**

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -288,7 +288,9 @@ export function DocumentItem({
                     </TooltipTrigger>
                     <TooltipContent side="top" className="max-w-xs">
                       <p className="text-xs">
-                        {t('knowledge:document.document.indexStatus.indexingHint')}
+                        {isConverting
+                          ? t('knowledge:document.document.indexStatus.convertingHint')
+                          : t('knowledge:document.document.indexStatus.indexingHint')}
                       </p>
                     </TooltipContent>
                   </Tooltip>

--- a/frontend/src/features/knowledge/document/components/DocumentItem.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentItem.tsx
@@ -153,8 +153,9 @@ export function DocumentItem({
   const isWeb = document.source_type === 'web'
   const isNotIndexed = document.index_status === 'not_indexed'
   const isIndexFailed = document.index_status === 'failed'
+  const isConverting = document.index_status === 'converting'
   const isBackendIndexing =
-    document.index_status === 'queued' || document.index_status === 'indexing'
+    document.index_status === 'queued' || document.index_status === 'indexing' || isConverting
   const showIndexingState = isReindexing || isBackendIndexing
   const canReindex =
     ragConfigured &&
@@ -531,13 +532,17 @@ export function DocumentItem({
                     size="sm"
                     className="whitespace-nowrap cursor-help bg-blue-500/10 text-blue-600 border-blue-500/20"
                   >
-                    {t('knowledge:document.document.indexStatus.indexing')}
+                    {isConverting
+                      ? t('knowledge:document.document.indexStatus.converting')
+                      : t('knowledge:document.document.indexStatus.indexing')}
                   </Badge>
                 </span>
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-xs">
                 <p className="text-xs">
-                  {t('knowledge:document.document.indexStatus.indexingHint')}
+                  {isConverting
+                    ? t('knowledge:document.document.indexStatus.convertingHint')
+                    : t('knowledge:document.document.indexStatus.indexingHint')}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -185,7 +185,9 @@
         "unavailable": "Index Unavailable",
         "unavailableHint": "AI will use other tools to browse documents (slightly less efficient than quick retrieval)",
         "indexing": "Indexing",
-        "indexingHint": "Index is being generated. Refresh the page later to check the latest status."
+        "indexingHint": "Index is being generated. Refresh the page later to check the latest status.",
+        "converting": "Converting",
+        "convertingHint": "Document is being converted to a searchable format. This may take a few minutes."
       },
       "reindex": "Reindex",
       "index": "Start Indexing",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -185,7 +185,9 @@
         "unavailable": "索引不可用",
         "unavailableHint": "AI 将使用其它工具浏览文档（效率略低于快速检索）",
         "indexing": "索引中",
-        "indexingHint": "索引正在生成中，稍后刷新页面查看最新状态"
+        "indexingHint": "索引正在生成中，稍后刷新页面查看最新状态",
+        "converting": "转换中",
+        "convertingHint": "文档正在转换为可检索的格式，可能需要几分钟。"
       },
       "reindex": "重新索引",
       "index": "开始索引",

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -16,7 +16,13 @@ export type DocumentStatus = 'enabled' | 'disabled'
 
 export type DocumentSourceType = 'file' | 'text' | 'table' | 'web'
 
-export type DocumentIndexStatus = 'not_indexed' | 'queued' | 'indexing' | 'success' | 'failed'
+export type DocumentIndexStatus =
+  | 'not_indexed'
+  | 'queued'
+  | 'converting'
+  | 'indexing'
+  | 'success'
+  | 'failed'
 
 export type KnowledgeResourceScope = 'personal' | 'organization' | 'group' | 'all'
 


### PR DESCRIPTION
Introduces a core document conversion pipeline into the RAG indexing workflow. This feature leverages MinerU to transform complex formats (PDF, DOCX, PPTX) into structured Markdown to improve retrieval quality.

Core Functionality:

Asynchronous Conversion: Added a dedicated Celery worker and queue (knowledge_conversion) to handle heavy conversion tasks.

Workflow Integration: Updated the orchestrator and index_state_machine to include a new CONVERTING stage, ensuring a seamless transition from raw files to indexed content.

UI/UX Updates: Added a "Converting" status indicator in the frontend DocumentItem component with full i18n support.

Key Features & Enhancements:

Image Hosting: Automatically extracts images from converted documents and uploads them to S3-compatible storage, replacing local paths with public URLs.

Resilience: Increased task timeouts and added retry-safe S3 client initialization.

Infrastructure: Provided a specialized Docker container for the conversion worker and expanded configuration for MinerU and S3 environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents (PDF, DOCX, PPTX, XLSX) can be converted to Markdown before indexing, routed to a dedicated conversion worker queue with retry/lock controls.
  * Optional MinerU-based conversion with OCR, formula/table detection, and polling/timeouts.
  * Extracted images can be uploaded to S3/MinIO and markdown/image links rewritten.
  * UI and translations show a new "converting" status during conversion.

* **Documentation**
  * Installation and developer guides updated with conversion and image-storage configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->