### PR TITLE
fix(backend): add trailing slash to Gerrit account validation API

### DIFF
--- a/backend/app/repository/gerrit_provider.py
+++ b/backend/app/repository/gerrit_provider.py
@@ -520,10 +520,10 @@ class GerritProvider(RepositoryProvider):
 
         try:
             # Validate by getting account info
-            # GET /accounts/self
+            # GET /accounts/self/
             response = self._make_request(
                 method="GET",
-                url=f"{api_base_url}/accounts/self",
+                url=f"{api_base_url}/accounts/self/",
                 username=user_name,
                 http_password=decrypt_token,
                 auth_type=auth_type,

--- a/backend/tests/repository/test_gerrit_provider.py
+++ b/backend/tests/repository/test_gerrit_provider.py
@@ -113,7 +113,7 @@ class TestGerritProviderAuthType:
 
         gerrit_provider._make_request(
             method="GET",
-            url="https://gerrit.example.com/a/accounts/self",
+            url="https://gerrit.example.com/a/accounts/self/",
             username="testuser",
             http_password="testpassword",
             # No auth_type specified - should default to digest
@@ -139,7 +139,7 @@ class TestGerritProviderAuthType:
 
         gerrit_provider._make_request(
             method="GET",
-            url="https://gerrit.example.com/a/accounts/self",
+            url="https://gerrit.example.com/a/accounts/self/",
             username="testuser",
             http_password="testpassword",
             auth_type="digest",
@@ -161,7 +161,7 @@ class TestGerritProviderAuthType:
 
         gerrit_provider._make_request(
             method="GET",
-            url="https://gerrit.example.com/a/accounts/self",
+            url="https://gerrit.example.com/a/accounts/self/",
             username="testuser",
             http_password="testpassword",
             auth_type="basic",


### PR DESCRIPTION
Gerrit REST API 在某些环境下（如特定反向代理后）对 /accounts/self 会触发重定向，导致认证上下文丢失并返回 401。添加末尾斜杠可直接访问最终接口，提高兼容性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gerrit token validation endpoint compatibility by updating the API call format.

* **Tests**
  * Updated test cases to verify the corrected endpoint format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->