### PR TITLE
fix(services): 使用 async with 确保 OpenAI 流式响应正确关闭

### DIFF
--- a/backend/app/services/chat_shell_model_service.py
+++ b/backend/app/services/chat_shell_model_service.py
@@ -7,7 +7,8 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from contextlib import asynccontextmanager
+from typing import Any, AsyncIterator
 
 from openai import AsyncOpenAI
 
@@ -179,7 +180,12 @@ async def create_response(
     tools: list[dict[str, Any]] | None = None,
     stream: bool = False,
 ) -> Any:
-    """Call chat_shell /v1/responses in stateless mode."""
+    """Call chat_shell /v1/responses in stateless mode (non-streaming).
+
+    For streaming, use :func:`create_streaming_response` instead which
+    returns an async context manager that ensures the underlying httpx
+    connection is properly closed.
+    """
     client = _build_client()
     return await client.responses.create(
         model=model,
@@ -192,6 +198,37 @@ async def create_response(
             "model_config": model_config or {},
         },
     )
+
+
+@asynccontextmanager
+async def create_streaming_response(
+    *,
+    model: str,
+    input_messages: list[dict[str, Any]],
+    instructions: str | None = None,
+    model_config: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+) -> AsyncIterator[Any]:
+    """Call chat_shell /v1/responses in streaming mode.
+
+    Returns an async context manager that ensures the underlying httpx
+    connection is properly closed when the caller is done iterating,
+    preventing orphan CancelScope corruption in anyio.
+    """
+    client = _build_client()
+    async with await client.responses.create(
+        model=model,
+        input=input_messages,
+        instructions=instructions,
+        tools=tools if tools else None,
+        stream=True,
+        extra_body={
+            "metadata": _merge_metadata(metadata),
+            "model_config": model_config or {},
+        },
+    ) as stream:
+        yield stream
 
 
 async def complete_text(

--- a/backend/app/services/execution/agents/base_intent_analyzer.py
+++ b/backend/app/services/execution/agents/base_intent_analyzer.py
@@ -35,19 +35,18 @@ class BaseIntentAnalyzer:
         """
         from openai import AsyncOpenAI
 
-        client = AsyncOpenAI(
+        async with AsyncOpenAI(
             api_key=model_config.get("api_key"),
             base_url=model_config.get("base_url"),
-        )
-
-        try:
-            response = await client.chat.completions.create(
-                model=model_config.get("model_id", "gpt-4o-mini"),
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0,
-                response_format={"type": "json_object"},
-            )
-            return json.loads(response.choices[0].message.content)
-        except Exception as e:
-            logger.exception(f"[{self.__class__.__name__}] LLM call failed: {e}")
-            return None
+        ) as client:
+            try:
+                response = await client.chat.completions.create(
+                    model=model_config.get("model_id", "gpt-4o-mini"),
+                    messages=[{"role": "user", "content": prompt}],
+                    temperature=0,
+                    response_format={"type": "json_object"},
+                )
+                return json.loads(response.choices[0].message.content)
+            except Exception as e:
+                logger.exception(f"[{self.__class__.__name__}] LLM call failed: {e}")
+                return None

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -17,10 +17,8 @@ For SSE mode (Chat shell), uses OpenAI AsyncClient to consume the
 OpenAI Responses API compatible endpoint.
 """
 
-import asyncio
 import json
 import logging
-from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
@@ -41,7 +39,6 @@ from shared.models.responses_api import ResponsesAPIStreamEvents
 from shared.utils.http_client import traced_async_client
 
 from .emitters import (
-    CompositeResultEmitter,
     ResultEmitter,
     ResultEmitterFactory,
     StatusUpdatingEmitter,
@@ -748,7 +745,16 @@ class ExecutionDispatcher:
             f"[ExecutionDispatcher] About to call client.responses.create: "
             f"task_id={request.task_id}, subtask_id={request.subtask_id}"
         )
-        stream = await client.responses.create(
+        # Use async with to ensure stream is properly closed on exit.
+        # Without this, breaking out of the stream loop leaves the underlying
+        # httpx Response open. When GC eventually collects it, httpcore's
+        # AsyncShieldCancellation enters an anyio CancelScope at an unexpected
+        # time, corrupting the scope stack of whichever asyncio Task happens
+        # to be running. If that task belongs to an MCP session manager, the
+        # corrupted scope stack causes a RuntimeError ("Attempted to exit a
+        # cancel scope that isn't the current task's current cancel scope")
+        # that cascades through all nested MCP session managers.
+        async with await client.responses.create(
             model=openai_request.get("model", ""),
             input=openai_request.get("input", ""),
             instructions=openai_request.get("instructions"),
@@ -758,129 +764,134 @@ class ExecutionDispatcher:
                 "metadata": openai_request.get("metadata", {}),
                 "model_config": openai_request.get("model_config", {}),
             },
-        )
-        logger.info(
-            f"[ExecutionDispatcher] Stream created, starting to iterate events: "
-            f"task_id={request.task_id}, subtask_id={request.subtask_id}"
-        )
+        ) as stream:
+            logger.info(
+                f"[ExecutionDispatcher] Stream created, starting to iterate events: "
+                f"task_id={request.task_id}, subtask_id={request.subtask_id}"
+            )
 
-        event_count = 0
-        last_cancel_check = 0
-        cancelled = False
-        terminal_event_type = ""
+            event_count = 0
+            last_cancel_check = 0
+            cancelled = False
+            terminal_event_type = ""
 
-        try:
-            # Process streaming events
-            async for event in stream:
-                event_count += 1
+            try:
+                # Process streaming events
+                async for event in stream:
+                    event_count += 1
 
-                # Check for cancellation every 10 events (to avoid too frequent Redis calls)
-                if event_count - last_cancel_check >= 10:
-                    last_cancel_check = event_count
-                    if await session_manager.is_cancelled(request.subtask_id):
+                    # Check for cancellation every 10 events (to avoid too frequent Redis calls)
+                    if event_count - last_cancel_check >= 10:
+                        last_cancel_check = event_count
+                        if await session_manager.is_cancelled(request.subtask_id):
+                            logger.info(
+                                f"[ExecutionDispatcher] Cancellation detected via Redis, "
+                                f"breaking stream loop: task_id={request.task_id}, "
+                                f"subtask_id={request.subtask_id}"
+                            )
+                            cancelled = True
+                            break
+
+                    # Also check local event (fast path, no Redis call)
+                    if cancel_event.is_set():
                         logger.info(
-                            f"[ExecutionDispatcher] Cancellation detected via Redis, "
+                            f"[ExecutionDispatcher] Cancellation detected via local event, "
                             f"breaking stream loop: task_id={request.task_id}, "
                             f"subtask_id={request.subtask_id}"
                         )
                         cancelled = True
                         break
 
-                # Also check local event (fast path, no Redis call)
-                if cancel_event.is_set():
-                    logger.info(
-                        f"[ExecutionDispatcher] Cancellation detected via local event, "
-                        f"breaking stream loop: task_id={request.task_id}, "
-                        f"subtask_id={request.subtask_id}"
+                    # Get event type from the event object
+                    event_type = getattr(event, "type", None)
+                    if not event_type:
+                        continue
+
+                    # Log every event for debugging
+                    if event_count <= 5 or event_type in (
+                        "response.completed",
+                        "error",
+                    ):
+                        logger.info(
+                            f"[ExecutionDispatcher] SSE event #{event_count}: type={event_type}, "
+                            f"task_id={request.task_id}, subtask_id={request.subtask_id}"
+                        )
+
+                    # Convert event to dict for parsing
+                    event_data = (
+                        event.model_dump()
+                        if hasattr(event, "model_dump")
+                        else vars(event)
                     )
-                    cancelled = True
-                    break
 
-                # Get event type from the event object
-                event_type = getattr(event, "type", None)
-                if not event_type:
-                    continue
-
-                # Log every event for debugging
-                if event_count <= 5 or event_type in ("response.completed", "error"):
-                    logger.info(
-                        f"[ExecutionDispatcher] SSE event #{event_count}: type={event_type}, "
-                        f"task_id={request.task_id}, subtask_id={request.subtask_id}"
-                    )
-
-                # Convert event to dict for parsing
-                event_data = (
-                    event.model_dump() if hasattr(event, "model_dump") else vars(event)
-                )
-
-                # Parse event using shared parser
-                parsed_event = self.event_parser.parse(
-                    task_id=request.task_id,
-                    subtask_id=request.subtask_id,
-                    message_id=request.message_id,
-                    event_type=event_type,
-                    data=event_data,
-                )
-
-                if parsed_event:
-                    logger.info(
-                        "[ExecutionDispatcher] Parsed SSE event -> internal event: "
-                        "task_id=%d, subtask_id=%d, request_id=%s, sse_event=%s, internal_event=%s",
-                        request.task_id,
-                        request.subtask_id,
-                        request_id,
-                        event_type,
-                        parsed_event.type,
-                    )
-                    await emitter.emit(parsed_event)
-
-                # Break out of loop on terminal events
-                # OpenAI SDK's stream iterator doesn't auto-exit after response.completed,
-                # so we need to manually break to avoid hanging
-                if event_type in (
-                    ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
-                    ResponsesAPIStreamEvents.ERROR.value,
-                    ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value,
-                ):
-                    terminal_event_type = event_type
-                    logger.info(
-                        f"[ExecutionDispatcher] Terminal event received, breaking stream loop: "
-                        f"task_id={request.task_id}, subtask_id={request.subtask_id}, "
-                        f"event_type={event_type}, request_id={request_id}"
-                    )
-                    break
-
-            # If cancelled, emit CANCELLED event
-            if cancelled:
-                await emitter.emit(
-                    ExecutionEvent(
-                        type=EventType.CANCELLED,
+                    # Parse event using shared parser
+                    parsed_event = self.event_parser.parse(
                         task_id=request.task_id,
                         subtask_id=request.subtask_id,
                         message_id=request.message_id,
+                        event_type=event_type,
+                        data=event_data,
                     )
-                )
 
-            if not cancelled and not terminal_event_type:
-                logger.warning(
-                    "[ExecutionDispatcher] SSE stream ended without terminal event: "
-                    "task_id=%d, subtask_id=%d, request_id=%s, total_events=%d",
-                    request.task_id,
-                    request.subtask_id,
-                    request_id,
-                    event_count,
-                )
+                    if parsed_event:
+                        logger.info(
+                            "[ExecutionDispatcher] Parsed SSE event -> internal event: "
+                            "task_id=%d, subtask_id=%d, request_id=%s, sse_event=%s, internal_event=%s",
+                            request.task_id,
+                            request.subtask_id,
+                            request_id,
+                            event_type,
+                            parsed_event.type,
+                        )
+                        await emitter.emit(parsed_event)
 
-            # Log when stream iteration completes
-            logger.info(
-                f"[ExecutionDispatcher] SSE stream completed: "
-                f"task_id={request.task_id}, subtask_id={request.subtask_id}, "
-                f"total_events={event_count}, cancelled={cancelled}, "
-                f"terminal_event_type={terminal_event_type or 'none'}, request_id={request_id}"
-            )
-        finally:
-            # Unregister stream to clean up
-            await session_manager.unregister_stream(request.subtask_id)
+                    # Break out of loop on terminal events
+                    # OpenAI SDK's stream iterator doesn't auto-exit after response.completed,
+                    # so we need to manually break to avoid hanging
+                    if event_type in (
+                        ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
+                        ResponsesAPIStreamEvents.ERROR.value,
+                        ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value,
+                    ):
+                        terminal_event_type = event_type
+                        logger.info(
+                            f"[ExecutionDispatcher] Terminal event received, breaking stream loop: "
+                            f"task_id={request.task_id}, subtask_id={request.subtask_id}, "
+                            f"event_type={event_type}, request_id={request_id}"
+                        )
+                        break
+
+                # If cancelled, emit CANCELLED event
+                if cancelled:
+                    await emitter.emit(
+                        ExecutionEvent(
+                            type=EventType.CANCELLED,
+                            task_id=request.task_id,
+                            subtask_id=request.subtask_id,
+                            message_id=request.message_id,
+                        )
+                    )
+
+                if not cancelled and not terminal_event_type:
+                    logger.warning(
+                        "[ExecutionDispatcher] SSE stream ended without terminal event: "
+                        "task_id=%d, subtask_id=%d, request_id=%s, total_events=%d",
+                        request.task_id,
+                        request.subtask_id,
+                        request_id,
+                        event_count,
+                    )
+
+                # Log when stream iteration completes
+                logger.info(
+                    f"[ExecutionDispatcher] SSE stream completed: "
+                    f"task_id={request.task_id}, subtask_id={request.subtask_id}, "
+                    f"total_events={event_count}, cancelled={cancelled}, "
+                    f"terminal_event_type={terminal_event_type or 'none'}, request_id={request_id}"
+                )
+            finally:
+                # Unregister stream to clean up
+                await session_manager.unregister_stream(request.subtask_id)
 
     async def _dispatch_image_generation(
         self,

--- a/backend/app/services/model_runtime/stateless_runtime_service.py
+++ b/backend/app/services/model_runtime/stateless_runtime_service.py
@@ -68,15 +68,13 @@ async def stream_response(
     metadata: dict[str, Any] | None = None,
     tools: list[dict[str, Any]] | None = None,
 ) -> AsyncIterator[str]:
-    stream = await chat_shell_model_service.create_response(
+    async with chat_shell_model_service.create_streaming_response(
         model=model,
         input_messages=normalize_input_messages(input_data),
         instructions=instructions,
         model_config=model_config,
         metadata=metadata,
         tools=tools,
-        stream=True,
-    )
-
-    async for event in stream:
-        yield serialize_stream_event(event)
+    ) as stream:
+        async for event in stream:
+            yield serialize_stream_event(event)

--- a/backend/app/services/prompt_draft/pipeline.py
+++ b/backend/app/services/prompt_draft/pipeline.py
@@ -295,25 +295,24 @@ async def stream_prompt_text_generation(
         json.dumps(metadata, ensure_ascii=False),
         safe_model_config_for_logging(model_config),
     )
-    stream = await chat_shell_model_service.create_response(
+    async with chat_shell_model_service.create_streaming_response(
         model=model_id,
         input_messages=input_messages,
         instructions=prompt_instructions,
         metadata=metadata,
         model_config=model_config,
-        stream=True,
-    )
-    async for event in stream:
-        event_type = getattr(event, "type", None)
-        if not event_type and hasattr(event, "model_dump"):
-            event_type = event.model_dump().get("type")
-        if event_type != "response.output_text.delta":
-            continue
-        delta = getattr(event, "delta", None)
-        if not isinstance(delta, str) and hasattr(event, "model_dump"):
-            delta = event.model_dump().get("delta")
-        if isinstance(delta, str) and delta:
-            yield delta
+    ) as stream:
+        async for event in stream:
+            event_type = getattr(event, "type", None)
+            if not event_type and hasattr(event, "model_dump"):
+                event_type = event.model_dump().get("type")
+            if event_type != "response.output_text.delta":
+                continue
+            delta = getattr(event, "delta", None)
+            if not isinstance(delta, str) and hasattr(event, "model_dump"):
+                delta = event.model_dump().get("delta")
+            if isinstance(delta, str) and delta:
+                yield delta
 
 
 async def generate_title_text(

--- a/backend/tests/services/execution/test_dispatcher_sse_request_id.py
+++ b/backend/tests/services/execution/test_dispatcher_sse_request_id.py
@@ -29,6 +29,12 @@ class _FakeStream:
     def __init__(self, events):
         self._events = list(events)
 
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return False
+
     def __aiter__(self):
         return self
 

--- a/backend/tests/services/test_prompt_draft_service.py
+++ b/backend/tests/services/test_prompt_draft_service.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from contextlib import asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -661,10 +662,14 @@ async def test_stream_prompt_generation_logs_do_not_include_model_secrets():
     async def _mock_stream():
         yield SimpleNamespace(type="response.output_text.delta", delta="你是")
 
+    @asynccontextmanager
+    async def _mock_streaming_response(**kwargs):
+        yield _mock_stream()
+
     with (
         patch(
-            "app.services.prompt_draft_service.chat_shell_model_service.create_response",
-            new=AsyncMock(return_value=_mock_stream()),
+            "app.services.prompt_draft_service.chat_shell_model_service.create_streaming_response",
+            new=_mock_streaming_response,
         ),
         patch("app.services.prompt_draft_service.logger.info") as mock_logger_info,
     ):
@@ -718,6 +723,11 @@ async def test_generate_prompt_draft_stream_raises_when_chat_shell_generation_fa
     _add_user_subtask(test_db, test_user, task, "帮我创建一个流程图")
     _add_assistant_subtask(test_db, test_user, task, "先告诉我主题和主要步骤。")
 
+    @asynccontextmanager
+    async def _mock_streaming_response_that_raises(**kwargs):
+        raise RuntimeError("stream boom")
+        yield  # never reached
+
     with (
         patch(
             "app.services.prompt_draft_service._resolve_model_config",
@@ -731,8 +741,8 @@ async def test_generate_prompt_draft_stream_raises_when_chat_shell_generation_fa
             ),
         ),
         patch(
-            "app.services.prompt_draft_service.chat_shell_model_service.create_response",
-            new=AsyncMock(side_effect=RuntimeError("stream boom")),
+            "app.services.prompt_draft_service.chat_shell_model_service.create_streaming_response",
+            new=_mock_streaming_response_that_raises,
         ),
     ):
         with pytest.raises(PromptDraftGenerationFailedError):


### PR DESCRIPTION
- 在 chat_shell_model_service 添加 create_streaming_response 函数
- 使用 @asynccontextmanager 确保流式响应资源被正确释放
- 修复 CancelScope 孤儿导致 MCP session manager 崩溃的问题
- 相关 Issue: https://github.com/modelcontextprotocol/python-sdk/issues/577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming response API for real-time chat and generation flows.

* **Improvements**
  * Safer streaming lifecycle and connection cleanup to reduce resource leaks and hanging streams.
  * Streaming flows (SSE, prompt generation, stateless runtime) now use the new streaming API for consistent behavior.
  * Tests updated to exercise the context-managed streaming path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->