### PR TITLE
fix: 修复上传无法识别的附件后无法继续发送消息的问题

### DIFF
--- a/frontend/src/hooks/useMultiAttachment.ts
+++ b/frontend/src/hooks/useMultiAttachment.ts
@@ -283,10 +283,7 @@ export function useMultiAttachment(options?: {
   }, [])
 
   const isUploading = state.uploadingFiles.size > 0
-  const isReadyToSend =
-    !isUploading &&
-    state.attachments.every(att => att.status === 'ready') &&
-    state.errors.size === 0
+  const isReadyToSend = !isUploading && state.attachments.every(att => att.status === 'ready')
 
   return {
     state,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment send availability. Users can now send attachments when all files are ready and no uploads are in progress, even if validation errors are present. Previously, errors would prevent sending altogether, restricting the user's ability to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->