### PR TITLE
fix(chat_shell): add missing auth header to _get_kb_info_via_http req…

### DIFF
--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -716,8 +716,9 @@ class KnowledgeBaseTool(BaseTool):
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
                 headers = {}
-                if self.auth_token:
-                    headers["Authorization"] = f"Bearer {self.auth_token}"
+                auth_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "") or self.auth_token
+                if auth_token:
+                    headers["Authorization"] = f"Bearer {auth_token}"
 
                 response = await client.post(
                     f"{backend_url}/api/internal/rag/kb-size",
@@ -996,8 +997,9 @@ class KnowledgeBaseTool(BaseTool):
             payload["user_name"] = self.user_name
 
         headers = {}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
+        auth_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "") or self.auth_token
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
 
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -995,10 +995,15 @@ class KnowledgeBaseTool(BaseTool):
         if self.user_name is not None:
             payload["user_name"] = self.user_name
 
+        headers = {}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(
                 f"{backend_url}/api/internal/rag/retrieve",
                 json=payload,
+                headers=headers,
             )
 
             if response.status_code != 200:

--- a/chat_shell/chat_shell/tools/builtin/knowledge_base.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_base.py
@@ -715,9 +715,14 @@ class KnowledgeBaseTool(BaseTool):
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
+                headers = {}
+                if self.auth_token:
+                    headers["Authorization"] = f"Bearer {self.auth_token}"
+
                 response = await client.post(
                     f"{backend_url}/api/internal/rag/kb-size",
                     json={"knowledge_base_ids": self.knowledge_base_ids},
+                    headers=headers,
                 )
 
                 if response.status_code == 200:

--- a/chat_shell/chat_shell/tools/builtin/knowledge_listing.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_listing.py
@@ -139,6 +139,9 @@ class KbLsTool(BaseTool):
     # Database session (optional, used in package mode)
     db_session: Optional[Any] = None
 
+    # User JWT for backend internal API calls that require authentication
+    auth_token: str = ""
+
     # Shared call counter (set when creating the tool, shared with kb_head)
     _call_counter: Optional[KBToolCallCounter] = PrivateAttr(default=None)
 
@@ -281,10 +284,15 @@ class KbLsTool(BaseTool):
 
         try:
             add_span_event("http_request_started")
+            headers = {}
+            if self.auth_token:
+                headers["Authorization"] = f"Bearer {self.auth_token}"
+
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     f"{backend_url}/api/internal/rag/list-docs",
                     json={"knowledge_base_id": knowledge_base_id},
+                    headers=headers,
                 )
 
                 if response.status_code != 200:
@@ -381,6 +389,9 @@ class KbHeadTool(BaseTool):
 
     # User subtask ID for persistence (optional, enables kb_head tracking)
     user_subtask_id: Optional[int] = None
+
+    # User JWT for backend internal API calls that require authentication
+    auth_token: str = ""
 
     # Shared call counter (set when creating the tool, shared with kb_ls)
     _call_counter: Optional[KBToolCallCounter] = PrivateAttr(default=None)
@@ -531,10 +542,15 @@ class KbHeadTool(BaseTool):
             }
 
         add_span_event("http_request_started")
+        headers = {}
+        if self.auth_token:
+            headers["Authorization"] = f"Bearer {self.auth_token}"
+
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(
                 f"{backend_url}/api/internal/rag/read-docs",
                 json=request_data,
+                headers=headers,
             )
 
             if response.status_code != 200:

--- a/chat_shell/chat_shell/tools/builtin/knowledge_listing.py
+++ b/chat_shell/chat_shell/tools/builtin/knowledge_listing.py
@@ -284,9 +284,12 @@ class KbLsTool(BaseTool):
 
         try:
             add_span_event("http_request_started")
+            from chat_shell.core.config import settings
+
             headers = {}
-            if self.auth_token:
-                headers["Authorization"] = f"Bearer {self.auth_token}"
+            auth_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "") or self.auth_token
+            if auth_token:
+                headers["Authorization"] = f"Bearer {auth_token}"
 
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
@@ -542,9 +545,12 @@ class KbHeadTool(BaseTool):
             }
 
         add_span_event("http_request_started")
+        from chat_shell.core.config import settings
+
         headers = {}
-        if self.auth_token:
-            headers["Authorization"] = f"Bearer {self.auth_token}"
+        auth_token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "") or self.auth_token
+        if auth_token:
+            headers["Authorization"] = f"Bearer {auth_token}"
 
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -254,8 +254,10 @@ async def _check_any_kb_has_rag_enabled(
 
         add_span_event("querying_backend_api")
         headers = {}
-        if auth_token:
-            headers["Authorization"] = f"Bearer {auth_token}"
+        # Priority: INTERNAL_SERVICE_TOKEN (service-to-service) > auth_token (task token)
+        token = getattr(settings, "INTERNAL_SERVICE_TOKEN", "") or auth_token
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
             set_span_attribute("auth_token_provided", True)
         else:
             set_span_attribute("auth_token_provided", False)

--- a/chat_shell/chat_shell/tools/knowledge_factory.py
+++ b/chat_shell/chat_shell/tools/knowledge_factory.py
@@ -132,6 +132,7 @@ async def prepare_knowledge_base_tools(
         kb_ls_tool = KbLsTool(
             knowledge_base_ids=knowledge_base_ids,
             db_session=db,
+            auth_token=auth_token,
         )
         kb_ls_tool._call_counter = exploration_call_counter
 
@@ -140,6 +141,7 @@ async def prepare_knowledge_base_tools(
             user_id=user_id,
             db_session=db,
             user_subtask_id=user_subtask_id,
+            auth_token=auth_token,
         )
         kb_head_tool._call_counter = exploration_call_counter
 


### PR DESCRIPTION
…uest

The _get_kb_info_via_http method was making HTTP POST requests to the backend's /internal/rag/kb-size endpoint without an Authorization header. After the backend added verify_internal_service_token dependency to all internal RAG endpoints, these requests started returning 401, causing the knowledge base info to be empty and triggering rag_not_configured.

The auth_token was already available in the KnowledgeBaseTool instance but was never passed to the HTTP request. This fix adds the Authorization: Bearer header when auth_token is present, consistent with the fix already applied to _check_any_kb_has_rag_enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge-base HTTP endpoints now support optional Bearer-token authentication for secured size and retrieval calls, enabling authenticated internal API requests.
  * Knowledge listing and preview tools now accept and propagate an authentication token so listing, preview, and retrieval work end-to-end with protected APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->