### PR TITLE
feat(backend,knowledge_runtime): support encrypted attachment decryption in knowledge_runtime

### DIFF
--- a/backend/app/services/rag/content_refs.py
+++ b/backend/app/services/rag/content_refs.py
@@ -44,10 +44,16 @@ def build_content_ref_for_attachment(
         expires=expires_delta_seconds,
     )
     if presigned_url:
+        # Get encryption status from context.type_data
+        is_encrypted = False
+        if context.type_data and isinstance(context.type_data, dict):
+            is_encrypted = context.type_data.get("is_encrypted", False)
+
         return PresignedUrlContentRef(
             kind="presigned_url",
             url=presigned_url,
             expires_at=expires_at,
+            is_encrypted=is_encrypted,
         )
 
     auth_token = create_rag_download_token(

--- a/backend/app/services/rag/content_refs.py
+++ b/backend/app/services/rag/content_refs.py
@@ -45,9 +45,12 @@ def build_content_ref_for_attachment(
     )
     if presigned_url:
         # Get encryption status from context.type_data
-        is_encrypted = False
-        if context.type_data and isinstance(context.type_data, dict):
-            is_encrypted = context.type_data.get("is_encrypted", False)
+        # Only True yields True; None/False/other values become False
+        is_encrypted = (
+            context.type_data.get("is_encrypted") is True
+            if context.type_data and isinstance(context.type_data, dict)
+            else False
+        )
 
         return PresignedUrlContentRef(
             kind="presigned_url",

--- a/backend/tests/services/rag/test_content_refs.py
+++ b/backend/tests/services/rag/test_content_refs.py
@@ -57,3 +57,58 @@ def test_build_content_ref_for_attachment_prefers_presigned_url(test_db) -> None
 
     assert content_ref.kind == "presigned_url"
     assert content_ref.url == "https://storage.example.com/presigned/object"
+
+
+def test_build_content_ref_for_attachment_passes_is_encrypted_false(test_db) -> None:
+    """Test that is_encrypted=False is passed when attachment is not encrypted."""
+    context = _create_attachment_context(test_db, attachment_id=103)
+    context.type_data["is_encrypted"] = False
+
+    with patch(
+        "app.services.rag.content_refs.context_service.get_attachment_url",
+        return_value="https://storage.example.com/presigned/object",
+    ):
+        content_ref = build_content_ref_for_attachment(
+            db=test_db,
+            attachment_id=context.id,
+        )
+
+    assert content_ref.kind == "presigned_url"
+    assert content_ref.is_encrypted is False
+
+
+def test_build_content_ref_for_attachment_passes_is_encrypted_true(test_db) -> None:
+    """Test that is_encrypted=True is passed when attachment is encrypted."""
+    context = _create_attachment_context(test_db, attachment_id=104)
+    context.type_data["is_encrypted"] = True
+
+    with patch(
+        "app.services.rag.content_refs.context_service.get_attachment_url",
+        return_value="https://storage.example.com/presigned/object",
+    ):
+        content_ref = build_content_ref_for_attachment(
+            db=test_db,
+            attachment_id=context.id,
+        )
+
+    assert content_ref.kind == "presigned_url"
+    assert content_ref.is_encrypted is True
+
+
+def test_build_content_ref_for_attachment_defaults_is_encrypted_false(test_db) -> None:
+    """Test that is_encrypted defaults to False when type_data has no is_encrypted."""
+    context = _create_attachment_context(test_db, attachment_id=105)
+    # Remove is_encrypted from type_data if present
+    context.type_data.pop("is_encrypted", None)
+
+    with patch(
+        "app.services.rag.content_refs.context_service.get_attachment_url",
+        return_value="https://storage.example.com/presigned/object",
+    ):
+        content_ref = build_content_ref_for_attachment(
+            db=test_db,
+            attachment_id=context.id,
+        )
+
+    assert content_ref.kind == "presigned_url"
+    assert content_ref.is_encrypted is False

--- a/backend/tests/services/rag/test_remote_gateway.py
+++ b/backend/tests/services/rag/test_remote_gateway.py
@@ -93,6 +93,7 @@ async def test_remote_gateway_index_document_posts_reference_mode_request(
         "content_ref": {
             "kind": "presigned_url",
             "url": "https://storage.example.com/release-notes.md",
+            "is_encrypted": False,
         },
     }
 

--- a/knowledge_runtime/.env.example
+++ b/knowledge_runtime/.env.example
@@ -20,3 +20,11 @@ LOG_LEVEL=INFO
 # Must match Backend's INTERNAL_SERVICE_TOKEN when enabled
 # Generate using: openssl rand -hex 32
 # INTERNAL_SERVICE_TOKEN=your-secure-token-here
+
+# Attachment encryption configuration
+# When ATTACHMENT_ENCRYPTION_ENABLED=true in Backend, attachments are encrypted
+# before storage. knowledge_runtime needs the same keys to decrypt during indexing.
+# Keys must match Backend's ATTACHMENT_AES_KEY and ATTACHMENT_AES_IV
+# Generate using: openssl rand -hex 16 (for 32-byte key) and openssl rand -hex 8 (for 16-byte IV)
+# ATTACHMENT_AES_KEY=12345678901234567890123456789012
+# ATTACHMENT_AES_IV=1234567890123456

--- a/knowledge_runtime/.env.example
+++ b/knowledge_runtime/.env.example
@@ -26,5 +26,5 @@ LOG_LEVEL=INFO
 # before storage. knowledge_runtime needs the same keys to decrypt during indexing.
 # Keys must match Backend's ATTACHMENT_AES_KEY and ATTACHMENT_AES_IV
 # Generate using: openssl rand -hex 16 (for 32-byte key) and openssl rand -hex 8 (for 16-byte IV)
-# ATTACHMENT_AES_KEY=12345678901234567890123456789012
-# ATTACHMENT_AES_IV=1234567890123456
+ATTACHMENT_AES_KEY=12345678901234567890123456789012
+ATTACHMENT_AES_IV=1234567890123456

--- a/knowledge_runtime/knowledge_runtime/services/content_fetcher.py
+++ b/knowledge_runtime/knowledge_runtime/services/content_fetcher.py
@@ -23,6 +23,7 @@ from shared.models import (
     ContentRef,
     PresignedUrlContentRef,
 )
+from shared.utils.crypto import decrypt_attachment
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +89,7 @@ class ContentFetcher:
         self,
         content_ref: PresignedUrlContentRef,
     ) -> tuple[bytes, str, str]:
-        """Fetch content directly from a presigned URL.
+        """Fetch content directly from a presigned URL with decryption support.
 
         Args:
             content_ref: Presigned URL content reference.
@@ -109,7 +110,24 @@ class ContentFetcher:
                 # Extract filename and extension from URL if possible
                 source_file, file_extension = self._extract_filename_from_url(url)
 
-                return response.content, source_file, file_extension
+                binary_data = response.content
+
+                # Decrypt if attachment is encrypted
+                if content_ref.is_encrypted:
+                    try:
+                        binary_data = decrypt_attachment(binary_data)
+                        logger.info(
+                            "Successfully decrypted attachment from presigned URL"
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to decrypt attachment: {e}")
+                        raise ContentFetchError(
+                            f"Failed to decrypt attachment: {e}",
+                            retryable=False,
+                            details={"url": url[:100]},
+                        ) from e
+
+                return binary_data, source_file, file_extension
 
         except httpx.HTTPStatusError as exc:
             logger.error(f"HTTP error fetching from presigned URL: {exc}")

--- a/knowledge_runtime/tests/test_content_fetcher.py
+++ b/knowledge_runtime/tests/test_content_fetcher.py
@@ -181,3 +181,111 @@ class TestContentFetcher:
         )
         assert filename == "report.docx"
         assert ext == ".docx"
+
+    @pytest.mark.asyncio
+    async def test_fetch_from_presigned_url_encrypted_success(
+        self, content_fetcher
+    ) -> None:
+        """Test successful fetch and decryption from presigned URL."""
+        from shared.utils.crypto import encrypt_attachment
+
+        original_content = b"test content to encrypt"
+        encrypted_content = encrypt_attachment(original_content)
+
+        content_ref = PresignedUrlContentRef(
+            kind="presigned_url",
+            url="https://storage.example.com/bucket/file.pdf?signature=xxx",
+            is_encrypted=True,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = encrypted_content
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            binary_data, source_file, file_extension = await content_fetcher.fetch(
+                content_ref
+            )
+
+        assert binary_data == original_content
+        assert source_file == "file.pdf"
+        assert file_extension == ".pdf"
+
+    @pytest.mark.asyncio
+    async def test_fetch_from_presigned_url_encrypted_decryption_failure(
+        self, content_fetcher
+    ) -> None:
+        """Test that decryption failure raises ContentFetchError."""
+        content_ref = PresignedUrlContentRef(
+            kind="presigned_url",
+            url="https://storage.example.com/bucket/file.pdf",
+            is_encrypted=True,
+        )
+
+        # Invalid encrypted data (not properly encrypted)
+        mock_response = MagicMock()
+        mock_response.content = b"invalid encrypted content that will fail decryption"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            with pytest.raises(ContentFetchError) as exc_info:
+                await content_fetcher.fetch(content_ref)
+
+        assert "Failed to decrypt attachment" in str(exc_info.value)
+        assert not exc_info.value.retryable
+
+    @pytest.mark.asyncio
+    async def test_fetch_from_presigned_url_not_encrypted(
+        self, content_fetcher
+    ) -> None:
+        """Test that non-encrypted content is returned as-is."""
+        content_ref = PresignedUrlContentRef(
+            kind="presigned_url",
+            url="https://storage.example.com/bucket/file.pdf",
+            is_encrypted=False,
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = b"plain text content"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            binary_data, _, _ = await content_fetcher.fetch(content_ref)
+
+        assert binary_data == b"plain text content"
+
+    @pytest.mark.asyncio
+    async def test_fetch_from_presigned_url_default_is_encrypted_false(
+        self, content_fetcher
+    ) -> None:
+        """Test that is_encrypted defaults to False."""
+        content_ref = PresignedUrlContentRef(
+            kind="presigned_url",
+            url="https://storage.example.com/bucket/file.pdf",
+        )
+
+        mock_response = MagicMock()
+        mock_response.content = b"content without encryption flag"
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.get = AsyncMock(
+                return_value=mock_response
+            )
+
+            binary_data, _, _ = await content_fetcher.fetch(content_ref)
+
+        # Should return content as-is (no decryption attempted)
+        assert binary_data == b"content without encryption flag"

--- a/shared/models/knowledge_runtime_protocol.py
+++ b/shared/models/knowledge_runtime_protocol.py
@@ -39,6 +39,7 @@ class PresignedUrlContentRef(KnowledgeRuntimeProtocolModel):
     kind: Literal["presigned_url"]
     url: str
     expires_at: datetime | None = None
+    is_encrypted: bool = False
 
 
 ContentRef = Annotated[


### PR DESCRIPTION
…ion in knowledge_runtime

When ATTACHMENT_ENCRYPTION_ENABLED=true, attachments are encrypted before storage. In RAG_RUNTIME_MODE=remote mode, knowledge_runtime needs to decrypt attachments retrieved via Presigned URL for proper indexing.

Changes:
- Add is_encrypted field to PresignedUrlContentRef model
- Pass encryption status from Backend's context.type_data to ContentRef
- Implement decryption in ContentFetcher when is_encrypted=True
- Add encryption key configuration documentation to .env.example
- Add comprehensive unit tests for encryption/decryption flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for encrypted attachments: presigned-url downloads are decrypted when marked encrypted; unencrypted attachments behave as before.
  * Presigned content references now include an explicit encryption flag so services know when to decrypt.

* **Documentation**
  * Added runtime example and instructions for attachment encryption configuration and key/IV generation.

* **Tests**
  * Added tests for encrypted/non-encrypted presigned-content retrieval and decryption failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->