### PR TITLE
修复订阅消息报错的400: Task is still running的问题；记录钉钉接口请求失败的状态码,header\body

### DIFF
--- a/backend/app/services/channels/dingtalk/sender.py
+++ b/backend/app/services/channels/dingtalk/sender.py
@@ -361,6 +361,11 @@ class DingTalkRobotSender:
             logger.error(
                 f"[DingTalkSender] HTTP error creating AI card: {error_code} - {error_msg}"
             )
+            logger.error(
+                f"[DingTalkSender] Response status: {e.response.status_code}, "
+                f"headers: {dict(e.response.headers)}, "
+                f"body: {e.response.text}"
+            )
 
             return {
                 "success": False,

--- a/backend/app/tasks/subscription_tasks.py
+++ b/backend/app/tasks/subscription_tasks.py
@@ -544,13 +544,16 @@ async def _create_subscription_task(
         )
 
         if bound_task:
-            # Check if bound task is still RUNNING, cancel it before reuse
+            # Check if bound task is still RUNNING or PENDING, cancel it before reuse
             from app.schemas.kind import Task
 
             bound_task_crd = Task.model_validate(bound_task.json)
-            if bound_task_crd.status and bound_task_crd.status.status == "RUNNING":
+            bound_task_status = (
+                bound_task_crd.status.status if bound_task_crd.status else None
+            )
+            if bound_task_status in ("RUNNING", "PENDING"):
                 logger.warning(
-                    f"[subscription_tasks] Bound task {ctx.bound_task_id} is still RUNNING, "
+                    f"[subscription_tasks] Bound task {ctx.bound_task_id} is still {bound_task_status}, "
                     f"cancelling it before reuse for subscription {ctx.subscription.id}"
                 )
                 # Cancel the running task using the same method as subscription cancel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error diagnostics for DingTalk channel failures with additional response details
  * Improved subscription task management to properly handle pending task states during reuse

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1059)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->