### PR TITLE
feat(skill): strip mcpServers from ZIP binary before storage 

### DIFF
--- a/backend/app/services/adapters/skill_kinds.py
+++ b/backend/app/services/adapters/skill_kinds.py
@@ -285,11 +285,11 @@ class SkillKindsService:
                 detail=f"Skill name '{name}' already exists in namespace '{namespace}'",
             )
 
-        # Sanitize ZIP: strip mcpServers from SKILL.md before storage
-        file_content = SkillValidator.sanitize_zip(file_content)
-
-        # Validate ZIP package and extract metadata
+        # Validate original ZIP first to capture full metadata (including mcpServers)
         metadata = SkillValidator.validate_zip(file_content, file_name)
+
+        # Sanitize ZIP binary: strip mcpServers from SKILL.md before storage
+        file_content = SkillValidator.sanitize_zip(file_content)
 
         # Build skill JSON
         skill_json = {
@@ -307,6 +307,7 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
+                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
                 "source": source,
             },
@@ -670,11 +671,11 @@ class SkillKindsService:
         if not skill_kind:
             raise HTTPException(status_code=404, detail="Skill not found")
 
-        # Sanitize ZIP: strip mcpServers from SKILL.md before storage
-        file_content = SkillValidator.sanitize_zip(file_content)
-
-        # Validate new ZIP package
+        # Validate original ZIP first to capture full metadata (including mcpServers)
         metadata = SkillValidator.validate_zip(file_content, file_name)
+
+        # Sanitize ZIP binary: strip mcpServers from SKILL.md before storage
+        file_content = SkillValidator.sanitize_zip(file_content)
 
         # Update skill_kind JSON
         skill_json = skill_kind.json
@@ -690,6 +691,7 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
+                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
             }
         )

--- a/backend/app/services/adapters/skill_kinds.py
+++ b/backend/app/services/adapters/skill_kinds.py
@@ -285,6 +285,9 @@ class SkillKindsService:
                 detail=f"Skill name '{name}' already exists in namespace '{namespace}'",
             )
 
+        # Sanitize ZIP: strip mcpServers from SKILL.md before storage
+        file_content = SkillValidator.sanitize_zip(file_content)
+
         # Validate ZIP package and extract metadata
         metadata = SkillValidator.validate_zip(file_content, file_name)
 
@@ -304,7 +307,6 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
-                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
                 "source": source,
             },
@@ -668,6 +670,9 @@ class SkillKindsService:
         if not skill_kind:
             raise HTTPException(status_code=404, detail="Skill not found")
 
+        # Sanitize ZIP: strip mcpServers from SKILL.md before storage
+        file_content = SkillValidator.sanitize_zip(file_content)
+
         # Validate new ZIP package
         metadata = SkillValidator.validate_zip(file_content, file_name)
 
@@ -685,7 +690,6 @@ class SkillKindsService:
                 "config": metadata.get("config"),
                 "tools": metadata.get("tools"),
                 "provider": metadata.get("provider"),
-                "mcpServers": metadata.get("mcpServers"),
                 "preload": metadata.get("preload", False),
             }
         )

--- a/backend/app/services/skill_service.py
+++ b/backend/app/services/skill_service.py
@@ -238,3 +238,70 @@ class SkillValidator:
         )
         body = frontmatter_pattern.sub("", content).strip()
         return body
+
+    @staticmethod
+    def sanitize_zip(file_content: bytes) -> bytes:
+        """Rebuild ZIP with mcpServers stripped from SKILL.md frontmatter.
+
+        Returns original bytes unchanged if ZIP has no SKILL.md or no mcpServers.
+        """
+        if not zipfile.is_zipfile(io.BytesIO(file_content)):
+            return file_content
+
+        frontmatter_pattern = re.compile(
+            r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL | re.MULTILINE
+        )
+
+        with zipfile.ZipFile(io.BytesIO(file_content), "r") as zin:
+            # Find SKILL.md path
+            skill_md_path = None
+            skill_md_content = None
+            for info in zin.filelist:
+                if info.filename.endswith("/"):
+                    continue
+                parts = info.filename.split("/")
+                if len(parts) == 2 and parts[1] == "SKILL.md":
+                    skill_md_path = info.filename
+                    with zin.open(info) as f:
+                        skill_md_content = f.read().decode("utf-8", errors="ignore")
+                    break
+
+            if not skill_md_content or not skill_md_path:
+                return file_content
+
+            match = frontmatter_pattern.search(skill_md_content)
+            if not match:
+                return file_content
+
+            try:
+                metadata = yaml.safe_load(match.group(1))
+            except yaml.YAMLError:
+                return file_content
+
+            if not isinstance(metadata, dict) or "mcpServers" not in metadata:
+                return file_content
+
+            # Strip mcpServers and rebuild SKILL.md
+            metadata.pop("mcpServers")
+            new_yaml = yaml.safe_dump(
+                metadata,
+                allow_unicode=True,
+                sort_keys=False,
+                default_flow_style=False,
+            ).rstrip("\n")
+            body = frontmatter_pattern.sub("", skill_md_content).strip()
+            new_skill_md = f"---\n{new_yaml}\n---\n\n{body}\n"
+
+            # Rebuild ZIP replacing SKILL.md entry
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+                for info in zin.filelist:
+                    if info.filename.endswith("/"):
+                        continue
+                    if info.filename == skill_md_path:
+                        zout.writestr(info, new_skill_md)
+                    else:
+                        with zin.open(info) as f:
+                            zout.writestr(info, f.read())
+
+            return buf.getvalue()

--- a/backend/tests/services/test_skill_service.py
+++ b/backend/tests/services/test_skill_service.py
@@ -276,3 +276,44 @@ Support for 中文、日本語、한국어
         assert result["description"] == "技能描述 (Chinese characters)"
         assert result["author"] == "作者"
         assert result["tags"] == ["测试", "调试"]
+
+    def test_sanitize_zip_removes_mcp_servers_from_binary(self):
+        """Sanitized ZIP binary should not contain mcpServers in SKILL.md."""
+        skill_md_content = """---
+description: "Skill with MCP servers"
+version: "1.0.0"
+mcpServers:
+  myServer:
+    type: "streamable-http"
+    url: "http://mcp.example.com/server"
+---
+
+# Body content
+
+"""
+        zip_content = self.create_test_zip({"SKILL.md": skill_md_content}, "test.zip")
+
+        sanitized = SkillValidator.sanitize_zip(zip_content)
+
+        # Verify ZIP is still valid and SKILL.md no longer contains mcpServers
+        with zipfile.ZipFile(io.BytesIO(sanitized), "r") as zf:
+            with zf.open("test/SKILL.md") as f:
+                new_content = f.read().decode("utf-8")
+        assert "mcpServers" not in new_content
+        assert "description" in new_content
+
+    def test_sanitize_zip_no_mcp_servers_unchanged(self):
+        """ZIP without mcpServers should pass through sanitize_zip unchanged."""
+        skill_md_content = """---
+description: "Clean skill"
+version: "1.0.0"
+---
+
+# Body
+
+"""
+        zip_content = self.create_test_zip({"SKILL.md": skill_md_content}, "test.zip")
+
+        sanitized = SkillValidator.sanitize_zip(zip_content)
+
+        assert sanitized == zip_content


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation and sanitization of skill package files during upload and storage processes
  * Improved metadata extraction and handling to ensure consistency across skill creation and updates

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1061)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->