### PR TITLE
chore(frontend): add Socket.IO join diagnostics

### DIFF
--- a/frontend/src/contexts/SocketContext.tsx
+++ b/frontend/src/contexts/SocketContext.tsx
@@ -462,9 +462,21 @@ export function SocketProvider({ children }: { children: ReactNode }) {
             subtasks?: Array<Record<string, unknown>>
             error?: string
           }) => {
+            const subtasksCount = Array.isArray(response.subtasks) ? response.subtasks.length : null
+            const firstSubtask = Array.isArray(response.subtasks) ? response.subtasks[0] : undefined
+            const lastSubtask =
+              Array.isArray(response.subtasks) && response.subtasks.length > 0
+                ? response.subtasks[response.subtasks.length - 1]
+                : undefined
+
             if (response.streaming) {
               console.info('[StreamingJoinDebug] task:join ack', {
                 taskId,
+                forceRefresh,
+                afterMessageId,
+                subtasksCount,
+                firstMessageId: firstSubtask?.message_id,
+                lastMessageId: lastSubtask?.message_id,
                 subtaskId: response.streaming.subtask_id,
                 startedAt: response.streaming.started_at,
                 lastActivityAt: response.streaming.last_activity_at,
@@ -473,6 +485,11 @@ export function SocketProvider({ children }: { children: ReactNode }) {
             } else {
               console.info('[StreamingJoinDebug] task:join ack (no streaming)', {
                 taskId,
+                forceRefresh,
+                afterMessageId,
+                subtasksCount,
+                firstMessageId: firstSubtask?.message_id,
+                lastMessageId: lastSubtask?.message_id,
                 hasError: Boolean(response.error),
               })
             }

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -561,6 +561,22 @@ export class TaskStateMachine {
 
       // Pass subtasks to JOIN_SUCCESS event for immediate sync
       const subtasks = response.subtasks as TaskDetailSubtask[] | undefined
+      const messageIds = Array.isArray(subtasks)
+        ? subtasks
+            .map(subtask => subtask.message_id)
+            .filter((messageId): messageId is number => typeof messageId === 'number')
+        : []
+
+      console.info('[TaskStateMachine] recover join ack', {
+        taskId: this.state.taskId,
+        maxMessageId,
+        messagesBeforeSync: this.state.messages.size,
+        subtasksCount: Array.isArray(subtasks) ? subtasks.length : null,
+        firstMessageId: messageIds[0],
+        lastMessageId: messageIds[messageIds.length - 1],
+        hasStreaming: Boolean(response.streaming),
+        streamingSubtaskId: response.streaming?.subtask_id,
+      })
 
       await this.dispatch({
         type: 'JOIN_SUCCESS',
@@ -582,7 +598,15 @@ export class TaskStateMachine {
   private async doSync(subtasks?: TaskDetailSubtask[]): Promise<void> {
     try {
       if (subtasks && subtasks.length > 0) {
+        const messagesBefore = this.state.messages.size
         this.buildMessages(subtasks)
+        console.info('[TaskStateMachine] sync subtasks', {
+          taskId: this.state.taskId,
+          subtasksCount: subtasks.length,
+          messagesBefore,
+          messagesAfter: this.state.messages.size,
+          status: this.state.status,
+        })
       }
 
       // CRITICAL: If streamingInfo exists but no streaming message was created,
@@ -662,6 +686,11 @@ export class TaskStateMachine {
       this.applyPendingChunks()
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Sync failed'
+      console.error('[TaskStateMachine] sync failed', {
+        taskId: this.state.taskId,
+        subtasksCount: subtasks?.length ?? null,
+        error,
+      })
       await this.dispatch({ type: 'SYNC_ERROR', error: errorMsg })
     }
   }


### PR DESCRIPTION
## Summary
- Add Socket.IO task join ack diagnostics with force refresh, afterMessageId, subtask count, and message id range.
- Add TaskStateMachine recovery/sync diagnostics to distinguish ack delivery from subtask-to-message rendering issues.
- Log sync conversion failures explicitly without changing join, fallback, or retry behavior.

## Test Plan
- npm test -- --runTestsByPath src/__tests__/features/tasks/state/TaskStateMachine.test.ts
- git diff --check
- pre-push hook: ESLint, TypeScript check, and unit tests passed

## Notes
- Documentation update not needed: this is temporary frontend diagnostic instrumentation and does not change user-facing behavior, APIs, or configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging and diagnostics for task recovery and synchronization processes to improve system observability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1073)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->