### PR TITLE
fix(frontend): recover messages after socket connects

### DIFF
--- a/frontend/src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { useUnifiedMessages } from '@/features/tasks/hooks/useUnifiedMessages'
+
+const recoverMock = jest.fn(() => Promise.resolve())
+
+let socketConnected = false
+
+jest.mock('@/features/tasks/contexts/taskContext', () => ({
+  useTaskContext: () => ({
+    selectedTaskDetail: { id: 42 },
+  }),
+}))
+
+jest.mock('@/features/common/UserContext', () => ({
+  useUser: () => ({
+    user: { id: 1, user_name: 'tester' },
+  }),
+}))
+
+jest.mock('@/contexts/SocketContext', () => ({
+  useSocket: () => ({
+    isConnected: socketConnected,
+  }),
+}))
+
+jest.mock('@/features/tasks/hooks/useTaskStateMachine', () => ({
+  useTaskStateMachine: () => ({
+    messages: new Map(),
+    isStreaming: false,
+    recover: recoverMock,
+    isInitialized: true,
+  }),
+}))
+
+function Probe() {
+  useUnifiedMessages({
+    team: null,
+    isGroupChat: false,
+  })
+
+  return null
+}
+
+describe('useUnifiedMessages', () => {
+  beforeEach(() => {
+    socketConnected = false
+    recoverMock.mockClear()
+  })
+
+  it('waits for the socket connection before recovering task messages', async () => {
+    const { rerender } = render(<Probe />)
+
+    expect(recoverMock).not.toHaveBeenCalled()
+
+    socketConnected = true
+    rerender(<Probe />)
+
+    await waitFor(() => {
+      expect(recoverMock).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/features/tasks/hooks/useUnifiedMessages.ts
+++ b/frontend/src/features/tasks/hooks/useUnifiedMessages.ts
@@ -26,6 +26,7 @@ import { useMemo, useEffect } from 'react'
 import { useTaskStateMachine } from './useTaskStateMachine'
 import { useUser } from '@/features/common/UserContext'
 import { useTaskContext } from '../contexts/taskContext'
+import { useSocket } from '@/contexts/SocketContext'
 import type { Team, Attachment, SubtaskContextBrief } from '@/types/api'
 import type { SourceReference } from '@/types/socket'
 import type { MessageBlock } from '../components/message/thinking/types'
@@ -197,6 +198,7 @@ export function useUnifiedMessages({
 }: UseUnifiedMessagesOptions): UseUnifiedMessagesResult {
   const { selectedTaskDetail } = useTaskContext()
   const { user } = useUser()
+  const { isConnected } = useSocket()
 
   const taskId = selectedTaskDetail?.id
 
@@ -224,18 +226,20 @@ export function useUnifiedMessages({
     isInitialized,
   } = useTaskStateMachine(effectiveTaskId, syncOptions)
 
-  // Trigger recovery when task changes
-  // Subtasks are now fetched from joinTask response, not passed as parameter
+  // Trigger recovery when the task and socket are both ready.
+  // recover() is not a connection probe: it intentionally no-ops while disconnected.
+  // On page refresh, task detail can load before Socket.IO connects, so wait for
+  // the connected state before asking the state machine to join and sync messages.
   // IMPORTANT: Do NOT recover if already streaming - this would interrupt the stream
   useEffect(() => {
-    if (!effectiveTaskId || !isInitialized) return
+    if (!effectiveTaskId || !isInitialized || !isConnected) return
 
     // Only recover for positive task IDs (real tasks, not pending)
     // Skip recovery if already streaming to avoid interrupting active streams
     if (effectiveTaskId > 0 && !isStreaming) {
       recover()
     }
-  }, [effectiveTaskId, isInitialized, recover, isStreaming])
+  }, [effectiveTaskId, isInitialized, isConnected, recover, isStreaming])
 
   // Build unified message list from state machine messages
   const result = useMemo<UseUnifiedMessagesResult>(() => {


### PR DESCRIPTION
## Summary
- Wait for Socket.IO to connect before running `useUnifiedMessages` recovery.
- Prevent refresh-time recovery from no-oping when task detail loads before the socket is ready.
- Add a hook regression test covering the disconnected-to-connected recovery timing.

## Test Plan
- `npm test -- --runInBand src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx src/__tests__/features/tasks/state/TaskStateMachine.test.ts src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message recovery now properly waits for socket connection before attempting to restore state, preventing recovery operations from occurring during disconnected states.

* **Tests**
  * Added comprehensive test coverage for message recovery behavior, including verification of socket connectivity requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1075)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->