### PR TITLE
fix(frontend): notify task state hooks after manager init

### DIFF
--- a/frontend/src/__tests__/features/tasks/hooks/useTaskStateMachine.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useTaskStateMachine.test.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import { useTaskStateMachine } from '@/features/tasks/hooks/useTaskStateMachine'
+import { taskStateManager } from '@/features/tasks/state'
+
+function Probe({ onRender }: { onRender: (isInitialized: boolean) => void }) {
+  const { isInitialized } = useTaskStateMachine(42)
+
+  onRender(isInitialized)
+
+  return null
+}
+
+describe('useTaskStateMachine', () => {
+  it('reacts when TaskStateManager is initialized after the first render', async () => {
+    const onRender = jest.fn()
+
+    render(<Probe onRender={onRender} />)
+
+    expect(onRender).toHaveBeenLastCalledWith(false)
+
+    act(() => {
+      taskStateManager.initialize({
+        joinTask: jest.fn(),
+        isConnected: () => true,
+      })
+    })
+
+    await waitFor(() => {
+      expect(onRender).toHaveBeenLastCalledWith(true)
+    })
+  })
+})

--- a/frontend/src/features/tasks/hooks/useTaskStateMachine.ts
+++ b/frontend/src/features/tasks/hooks/useTaskStateMachine.ts
@@ -35,9 +35,16 @@ export function useTaskStateMachine(
   syncOptions?: SyncOptions
 ): UseTaskStateMachineResult {
   const [state, setState] = useState<TaskStateData | null>(null)
+  const [isInitialized, setIsInitialized] = useState(() => taskStateManager.isInitialized())
 
-  // Check if manager is initialized
-  const isInitialized = taskStateManager.isInitialized()
+  useEffect(() => {
+    const syncInitializationState = () => {
+      setIsInitialized(taskStateManager.isInitialized())
+    }
+
+    syncInitializationState()
+    return taskStateManager.subscribeInitialization(syncInitializationState)
+  }, [])
 
   // Subscribe to state changes
   // Subscribe to state changes

--- a/frontend/src/features/tasks/state/TaskStateManager.ts
+++ b/frontend/src/features/tasks/state/TaskStateManager.ts
@@ -24,6 +24,7 @@ class TaskStateManagerImpl {
   private machines: Map<number, TaskStateMachine> = new Map()
   private deps: TaskStateMachineDeps | null = null
   private globalListeners: Set<(taskId: number, state: TaskStateData) => void> = new Set()
+  private initializationListeners: Set<() => void> = new Set()
 
   /**
    * Initialize the manager with dependencies from SocketContext
@@ -31,6 +32,7 @@ class TaskStateManagerImpl {
    */
   initialize(deps: TaskStateMachineDeps): void {
     this.deps = deps
+    this.notifyInitializationListeners()
   }
 
   /**
@@ -38,6 +40,20 @@ class TaskStateManagerImpl {
    */
   isInitialized(): boolean {
     return this.deps !== null
+  }
+
+  /**
+   * Subscribe to initialization changes.
+   *
+   * Hooks may render before ChatStreamProvider initializes the manager. This
+   * lets them re-render once dependencies are available instead of getting
+   * stuck with an uninitialized snapshot.
+   */
+  subscribeInitialization(listener: () => void): () => void {
+    this.initializationListeners.add(listener)
+    return () => {
+      this.initializationListeners.delete(listener)
+    }
   }
 
   /**
@@ -205,6 +221,16 @@ class TaskStateManagerImpl {
         listener(taskId, state)
       } catch (err) {
         console.error('[TaskStateManager] Error in global listener:', err)
+      }
+    })
+  }
+
+  private notifyInitializationListeners(): void {
+    this.initializationListeners.forEach(listener => {
+      try {
+        listener()
+      } catch (err) {
+        console.error('[TaskStateManager] Error in initialization listener:', err)
       }
     })
   }


### PR DESCRIPTION
## Summary
- Add TaskStateManager initialization listeners so hooks re-render when the manager is initialized after their first render.
- Let `useTaskStateMachine` recover from the ChatStreamProvider initialization race instead of staying stuck with `isInitialized=false`.
- Add a hook regression test for manager initialization after first render.

## Context
Follow-up to #1075. The remaining blank refresh case can show a `task:join` ack from TaskContext while the message state machine never starts its own recover/sync path.

## Test Plan
- `npm test -- --runInBand src/__tests__/features/tasks/hooks/useTaskStateMachine.test.tsx src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx src/__tests__/features/tasks/state/TaskStateMachine.test.ts src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for task initialization state management.

* **Improvements**
  * Enhanced reactive initialization tracking to improve system responsiveness and reliability during startup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1077)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->