### PR TITLE
fix(frontend): route task joins through message state

### DIFF
--- a/frontend/src/__tests__/contexts/SocketContext.reconnect.test.tsx
+++ b/frontend/src/__tests__/contexts/SocketContext.reconnect.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { act, render, waitFor } from '@testing-library/react'
+import { SocketProvider, useSocket } from '@/contexts/SocketContext'
+
+const mockIo = jest.fn()
+const mockGetToken = jest.fn()
+const mockFetchRuntimeConfig = jest.fn()
+const mockRecoverAll = jest.fn()
+const mockIsInitialized = jest.fn()
+
+jest.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => mockIo(...args),
+}))
+
+jest.mock('@/apis/user', () => ({
+  getToken: () => mockGetToken(),
+  removeToken: jest.fn(),
+}))
+
+jest.mock('@/lib/runtime-config', () => ({
+  fetchRuntimeConfig: () => mockFetchRuntimeConfig(),
+  getSocketUrl: () => 'http://fallback-socket',
+}))
+
+jest.mock('@/features/tasks/state', () => ({
+  taskStateManager: {
+    isInitialized: () => mockIsInitialized(),
+    recoverAll: () => mockRecoverAll(),
+  },
+}))
+
+function createMockSocket() {
+  const socketHandlers = new Map<string, (...args: unknown[]) => void>()
+  const managerHandlers = new Map<string, (...args: unknown[]) => void>()
+  const emit = jest.fn((event: string, _payload: unknown, ack?: (response: unknown) => void) => {
+    if (event === 'task:join' && ack) {
+      ack({ subtasks: [] })
+    }
+  })
+
+  return {
+    connected: true,
+    emit,
+    on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      socketHandlers.set(event, handler)
+    }),
+    disconnect: jest.fn(),
+    io: {
+      on: jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+        managerHandlers.set(event, handler)
+      }),
+    },
+    triggerSocket: (event: string, ...args: unknown[]) => socketHandlers.get(event)?.(...args),
+    triggerManager: (event: string, ...args: unknown[]) => managerHandlers.get(event)?.(...args),
+  }
+}
+
+function SocketProbe({ onReady }: { onReady: (api: ReturnType<typeof useSocket>) => void }) {
+  const socketApi = useSocket()
+
+  React.useEffect(() => {
+    onReady(socketApi)
+  }, [onReady, socketApi])
+
+  return null
+}
+
+describe('SocketProvider reconnect recovery', () => {
+  let consoleInfoSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    mockGetToken.mockReturnValue('token')
+    mockFetchRuntimeConfig.mockResolvedValue({ socketDirectUrl: 'http://socket' })
+    mockIsInitialized.mockReturnValue(true)
+    mockRecoverAll.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore()
+  })
+
+  it('delegates reconnect recovery to TaskStateManager instead of issuing a raw task join', async () => {
+    const socket = createMockSocket()
+    mockIo.mockReturnValue(socket)
+
+    let socketApi: ReturnType<typeof useSocket> | undefined
+    render(
+      <SocketProvider>
+        <SocketProbe
+          onReady={api => {
+            socketApi = api
+          }}
+        />
+      </SocketProvider>
+    )
+
+    await waitFor(() => expect(socketApi?.socket).toBe(socket))
+
+    await act(async () => {
+      await socketApi!.joinTask(2384260)
+    })
+    expect(socket.emit).toHaveBeenCalledWith('task:join', { task_id: 2384260 }, expect.any(Function))
+
+    socket.emit.mockClear()
+
+    await act(async () => {
+      socket.triggerManager('reconnect', 1)
+    })
+
+    expect(mockRecoverAll).toHaveBeenCalledTimes(1)
+    expect(socket.emit).not.toHaveBeenCalledWith(
+      'task:join',
+      expect.objectContaining({ task_id: 2384260 }),
+      expect.any(Function)
+    )
+  })
+})

--- a/frontend/src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx
@@ -9,10 +9,13 @@ import { useUnifiedMessages } from '@/features/tasks/hooks/useUnifiedMessages'
 const recoverMock = jest.fn(() => Promise.resolve())
 
 let socketConnected = false
+let mockSelectedTask: { id: number } | null = null
+let mockSelectedTaskDetail: { id: number } | null = { id: 42 }
 
 jest.mock('@/features/tasks/contexts/taskContext', () => ({
   useTaskContext: () => ({
-    selectedTaskDetail: { id: 42 },
+    selectedTask: mockSelectedTask,
+    selectedTaskDetail: mockSelectedTaskDetail,
   }),
 }))
 
@@ -49,6 +52,8 @@ function Probe() {
 describe('useUnifiedMessages', () => {
   beforeEach(() => {
     socketConnected = false
+    mockSelectedTask = null
+    mockSelectedTaskDetail = { id: 42 }
     recoverMock.mockClear()
   })
 
@@ -59,6 +64,18 @@ describe('useUnifiedMessages', () => {
 
     socketConnected = true
     rerender(<Probe />)
+
+    await waitFor(() => {
+      expect(recoverMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('recovers messages from selectedTask while task detail is still loading', async () => {
+    socketConnected = true
+    mockSelectedTask = { id: 42 }
+    mockSelectedTaskDetail = null
+
+    render(<Probe />)
 
     await waitFor(() => {
       expect(recoverMock).toHaveBeenCalledTimes(1)

--- a/frontend/src/contexts/SocketContext.tsx
+++ b/frontend/src/contexts/SocketContext.tsx
@@ -191,8 +191,6 @@ export function SocketProvider({ children }: { children: ReactNode }) {
   const joinedTasksRef = useRef<Set<number>>(new Set())
   // Use ref for socket to avoid dependency issues in connect callback
   const socketRef = useRef<Socket | null>(null)
-  // Track reconnection attempts for rejoining tasks
-  const hasReconnectedRef = useRef<boolean>(false)
   // Store reconnect callbacks - single source of truth for reconnection events
   const reconnectCallbacksRef = useRef<Set<ReconnectCallback>>(new Set())
 
@@ -233,20 +231,6 @@ export function SocketProvider({ children }: { children: ReactNode }) {
       setIsConnected(true)
       setConnectionError(null)
       setReconnectAttempts(0)
-
-      // If we were previously connected and this is a reconnect, rejoin tasks
-      // This handles both manual reconnects and transport upgrade scenarios
-      if (socketRef.current && joinedTasksRef.current.size > 0) {
-        const tasksToRejoin = Array.from(joinedTasksRef.current)
-
-        tasksToRejoin.forEach(taskId => {
-          newSocket.emit('task:join', { task_id: taskId }, (response: { error?: string }) => {
-            if (response?.error) {
-              console.error(`[Socket.IO] Failed to rejoin task ${taskId}:`, response.error)
-            }
-          })
-        })
-      }
     })
 
     newSocket.on('disconnect', (_: string) => {
@@ -262,18 +246,6 @@ export function SocketProvider({ children }: { children: ReactNode }) {
       setIsConnected(true)
       setConnectionError(null)
       setReconnectAttempts(0)
-      hasReconnectedRef.current = true
-
-      // Rejoin all previously joined task rooms
-      const tasksToRejoin = Array.from(joinedTasksRef.current)
-
-      tasksToRejoin.forEach(taskId => {
-        newSocket.emit('task:join', { task_id: taskId }, (response: { error?: string }) => {
-          if (response?.error) {
-            console.error(`[Socket.IO] Failed to rejoin task ${taskId}:`, response.error)
-          }
-        })
-      })
 
       // Trigger recovery for all active tasks via TaskStateManager
       // This handles message state recovery after WebSocket reconnection
@@ -387,7 +359,6 @@ export function SocketProvider({ children }: { children: ReactNode }) {
   /**
    * Join a task room
    * Prevents duplicate joins by checking if already joined
-   * If reconnected, always rejoin to ensure backend state is synced
    * @param taskId - The task ID to join
    * @param options - Join options
    * @param options.forceRefresh - If true, always emit task:join to get streaming status
@@ -419,21 +390,14 @@ export function SocketProvider({ children }: { children: ReactNode }) {
         return { error: 'Not connected' }
       }
 
-      // Check if already joined this task room to prevent duplicate joins
-      // Exception 1: If we just reconnected, always rejoin to sync backend state
-      // Exception 2: If forceRefresh is true, always request to get streaming status
-      // Exception 3: If afterMessageId is provided, this is an incremental sync request
+      // Check if already joined this task room to prevent duplicate joins.
+      // State-machine recovery passes forceRefresh/afterMessageId, so it never uses
+      // this dedupe path for refresh or reconnect recovery.
       const alreadyJoined = joinedTasksRef.current.has(taskId)
-      const shouldSkip =
-        alreadyJoined && !hasReconnectedRef.current && !forceRefresh && afterMessageId === undefined
+      const shouldSkip = alreadyJoined && !forceRefresh && afterMessageId === undefined
 
       if (shouldSkip) {
         return {}
-      }
-
-      // Clear reconnected flag after first join
-      if (hasReconnectedRef.current) {
-        hasReconnectedRef.current = false
       }
 
       // Add to set IMMEDIATELY to prevent concurrent duplicate joins

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -160,10 +160,11 @@ function ChatAreaContent({
   const { quote, clearQuote, formatQuoteForMessage } = useQuote()
 
   // Task context
-  const { selectedTaskDetail, setSelectedTask, accessDenied } = useTaskContext()
+  const { selectedTask, selectedTaskDetail, setSelectedTask, accessDenied } = useTaskContext()
+  const effectiveTaskId = selectedTask?.id ?? selectedTaskDetail?.id
 
   // Use useTaskStateMachine hook for reactive state updates (SINGLE SOURCE OF TRUTH per AGENTS.md)
-  const { state: taskState } = useTaskStateMachine(selectedTaskDetail?.id)
+  const { state: taskState } = useTaskStateMachine(effectiveTaskId)
 
   // Video model selection state - only enabled for video mode
   // Uses unified useModelSelection hook with modelCategoryType='video'
@@ -318,11 +319,11 @@ function ChatAreaContent({
   // Determine if there are messages to display (computed early for hooks)
   // Uses state machine messages as the single source of truth, not selectedTaskDetail.subtasks
   const hasMessagesForHooks = useMemo(() => {
-    const hasSelectedTask = selectedTaskDetail && selectedTaskDetail.id
+    const hasSelectedTask = Boolean(effectiveTaskId)
     // Check messages from state machine (single source of truth)
     const hasContextMessages = taskState?.messages && taskState.messages.size > 0
     return Boolean(hasSelectedTask || hasContextMessages)
-  }, [selectedTaskDetail, taskState?.messages])
+  }, [effectiveTaskId, taskState?.messages])
 
   // Get taskId from URL for team sync logic
   const searchParams = useSearchParams()
@@ -576,9 +577,9 @@ function ChatAreaContent({
   // Determine if there are messages to display (full computation)
   // Note: Now using taskState.messages from state machine instead of selectedTaskDetail.subtasks
   const hasMessages = useMemo(() => {
-    const hasSelectedTask = selectedTaskDetail && selectedTaskDetail.id
+    const hasSelectedTask = Boolean(effectiveTaskId)
     const hasNewTaskStream =
-      !selectedTaskDetail?.id && streamHandlers.pendingTaskId && streamHandlers.isStreaming
+      !effectiveTaskId && streamHandlers.pendingTaskId && streamHandlers.isStreaming
     const hasLocalPending = streamHandlers.localPendingMessage !== null
     // Use taskState from state machine (single source of truth)
     const hasUnifiedMessages = taskState?.messages && taskState.messages.size > 0
@@ -609,7 +610,7 @@ function ChatAreaContent({
       hasUnifiedMessages
     )
   }, [
-    selectedTaskDetail,
+    effectiveTaskId,
     streamHandlers.hasPendingUserMessage,
     streamHandlers.isStreaming,
     streamHandlers.pendingTaskId,

--- a/frontend/src/features/tasks/contexts/taskContext.tsx
+++ b/frontend/src/features/tasks/contexts/taskContext.tsx
@@ -95,7 +95,7 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
   const taskStatusMapRef = useRef<Map<number, TaskStatus>>(new Map())
 
   // WebSocket connection for real-time task updates
-  const { registerTaskHandlers, isConnected, leaveTask, joinTask, onReconnect } = useSocket()
+  const { registerTaskHandlers, isConnected, leaveTask, onReconnect } = useSocket()
 
   // Track previous task ID for leaving WebSocket room when switching tasks
   const previousTaskIdRef = useRef<number | null>(null)
@@ -711,10 +711,9 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
     }
   }
 
-  // Trigger task detail refresh and manage WebSocket room when selectedTask changes
-  // NOTE: joinTask is called here, and SocketContext's joinTask already has deduplication logic
-  // (joinedTasksRef.current.has(taskId) check), so multiple calls are safe but wasteful.
-  // We only call joinTask when isConnected is true to avoid unnecessary calls.
+  // Trigger task detail refresh when selectedTask changes.
+  // TaskStateMachine owns task:join so the join ack is always consumed into
+  // the single message state source instead of being discarded here.
   useEffect(() => {
     const currentTaskId = selectedTask?.id ?? null
     const previousTaskId = previousTaskIdRef.current
@@ -728,24 +727,12 @@ export const TaskContextProvider = ({ children }: { children: ReactNode }) => {
     previousTaskIdRef.current = currentTaskId
 
     if (selectedTask) {
-      // Only join task room when WebSocket is connected
-      // This prevents duplicate joins when both selectedTask and isConnected change
-      if (isConnected) {
-        joinTask(selectedTask.id)
-      }
-
       refreshSelectedTaskDetail(false) // Manual task selection, not auto-refresh
     } else {
       setSelectedTaskDetail(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTask, leaveTask, joinTask, isConnected])
-
-  // NOTE: Removed separate isConnected useEffect to prevent duplicate joinTask calls.
-  // The selectedTask useEffect above now handles both cases:
-  // 1. When selectedTask changes (and isConnected is true)
-  // 2. When isConnected changes (and selectedTask is set)
-  // This is because we added isConnected to the dependency array.
+  }, [selectedTask, leaveTask])
 
   // Mark task as viewed when selectedTaskDetail is loaded
   // This ensures we have the correct status and timestamps from the backend

--- a/frontend/src/features/tasks/hooks/useUnifiedMessages.ts
+++ b/frontend/src/features/tasks/hooks/useUnifiedMessages.ts
@@ -196,14 +196,14 @@ export function useUnifiedMessages({
   isGroupChat,
   pendingTaskId,
 }: UseUnifiedMessagesOptions): UseUnifiedMessagesResult {
-  const { selectedTaskDetail } = useTaskContext()
+  const { selectedTask, selectedTaskDetail } = useTaskContext()
   const { user } = useUser()
   const { isConnected } = useSocket()
 
-  const taskId = selectedTaskDetail?.id
+  const taskId = selectedTask?.id ?? selectedTaskDetail?.id
 
   // Determine effective task ID for querying state machine:
-  // - Use taskId (from selectedTaskDetail) if available
+  // - Use taskId (from selectedTask; selectedTaskDetail may load later) if available
   // - Otherwise use pendingTaskId (tempTaskId or taskId before selectedTaskDetail updates)
   const effectiveTaskId = taskId || pendingTaskId || undefined
 


### PR DESCRIPTION
## Summary
- Remove the TaskContext `task:join` path that joined rooms without consuming returned subtasks.
- Treat `selectedTask.id` as the current task identity, while `selectedTaskDetail` remains asynchronously loaded detail data.
- Route existing-task message recovery through `useUnifiedMessages -> TaskStateMachine.recover`, so the join ack is always synced into message state.

## Test Plan
- `npm test -- --runInBand src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx src/__tests__/features/tasks/hooks/useTaskStateMachine.test.tsx src/__tests__/features/tasks/state/TaskStateMachine.test.ts src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx src/__tests__/features/tasks/components/chat/ChatArea.pipeline-next-step.test.tsx src/__tests__/features/tasks/components/chat/ChatArea.queue-message-handler.test.tsx`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message recovery and synchronization when switching or reselecting tasks, including during socket reconnects.

* **Refactor**
  * Simplified task-room and message state handling to make task messaging more reliable and predictable.

* **Tests**
  * Added tests covering message recovery and socket reconnect behavior to prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1079)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->