### PR TITLE
fix(frontend): prevent stale pipeline indicator state

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/PipelineStageIndicator.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/PipelineStageIndicator.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { taskApis } from '@/apis/tasks'
@@ -187,5 +187,64 @@ describe('PipelineStageIndicator', () => {
     await screen.findByText(/Pipeline Progress/)
 
     expect(screen.queryByTestId('pipeline-next-step-button')).not.toBeInTheDocument()
+  })
+
+  it('ignores stale pipeline stage responses after switching to a non-pipeline task', async () => {
+    let resolveStageInfo: (stageInfo: PipelineStageInfo) => void = () => {}
+    const pendingStageInfo = new Promise<PipelineStageInfo>(resolve => {
+      resolveStageInfo = resolve
+    })
+    mockGetPipelineStageInfo.mockReturnValue(pendingStageInfo)
+
+    const onStageInfoChange = jest.fn()
+
+    const { rerender } = renderIndicator({ onStageInfoChange })
+
+    rerender(
+      <PipelineStageIndicator
+        taskId={43}
+        taskStatus="COMPLETED"
+        collaborationModel="route"
+        onStageInfoChange={onStageInfoChange}
+      />
+    )
+
+    await act(async () => {
+      resolveStageInfo(createStageInfo())
+      await pendingStageInfo
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Pipeline Progress/)).not.toBeInTheDocument()
+    })
+    expect(onStageInfoChange).not.toHaveBeenCalledWith(expect.objectContaining({ total_stages: 3 }))
+  })
+
+  it('clears previous stage info while loading a different pipeline task', async () => {
+    let resolveNextStageInfo: (stageInfo: PipelineStageInfo) => void = () => {}
+    const nextStageInfo = new Promise<PipelineStageInfo>(resolve => {
+      resolveNextStageInfo = resolve
+    })
+
+    mockGetPipelineStageInfo
+      .mockResolvedValueOnce(createStageInfo({ current_stage: 0 }))
+      .mockReturnValueOnce(nextStageInfo)
+
+    const { rerender } = renderIndicator({ taskId: 42 })
+
+    expect(await screen.findByText(/Pipeline Progress/)).toHaveTextContent('1/3')
+
+    rerender(
+      <PipelineStageIndicator taskId={43} taskStatus="RUNNING" collaborationModel="pipeline" />
+    )
+
+    expect(screen.queryByText(/Pipeline Progress/)).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveNextStageInfo(createStageInfo({ current_stage: 1 }))
+      await nextStageInfo
+    })
+
+    expect(await screen.findByText(/Pipeline Progress/)).toHaveTextContent('2/3')
   })
 })

--- a/frontend/src/features/tasks/components/chat/PipelineStageIndicator.tsx
+++ b/frontend/src/features/tasks/components/chat/PipelineStageIndicator.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { memo, useEffect, useState, useMemo } from 'react'
+import { memo, useEffect, useRef, useState, useMemo } from 'react'
 import { ArrowRight, CheckCircle2, Circle, Loader2, Clock, XCircle, PlayCircle } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { taskApis, PipelineStageInfo } from '@/apis/tasks'
@@ -48,33 +48,62 @@ const PipelineStageIndicator = memo(function PipelineStageIndicator({
   onNextStepClick,
 }: PipelineStageIndicatorProps) {
   const { t } = useTranslation()
-  const [stageInfo, setStageInfo] = useState<PipelineStageInfo | null>(null)
+  const [stageInfoState, setStageInfoState] = useState<{
+    taskId: number
+    info: PipelineStageInfo
+  } | null>(null)
   const [_loading, setLoading] = useState(false)
+  const stageInfoTaskIdRef = useRef<number | null>(null)
+  const stageInfo = stageInfoState?.taskId === taskId ? stageInfoState.info : null
 
   // Fetch pipeline stage info when task changes or status updates
   useEffect(() => {
+    let isActive = true
+
     if (!taskId || collaborationModel !== 'pipeline') {
-      setStageInfo(null)
+      stageInfoTaskIdRef.current = null
+      setStageInfoState(null)
       onStageInfoChange?.(null)
-      return
+      setLoading(false)
+      return () => {
+        isActive = false
+      }
+    }
+
+    if (stageInfoTaskIdRef.current !== taskId) {
+      stageInfoTaskIdRef.current = null
+      setStageInfoState(null)
+      onStageInfoChange?.(null)
     }
 
     const fetchStageInfo = async () => {
       setLoading(true)
       try {
         const info = await taskApis.getPipelineStageInfo(taskId)
-        setStageInfo(info)
+        if (!isActive) return
+
+        stageInfoTaskIdRef.current = taskId
+        setStageInfoState({ taskId, info })
         onStageInfoChange?.(info)
       } catch (error) {
+        if (!isActive) return
+
         console.error('Failed to fetch pipeline stage info:', error)
-        setStageInfo(null)
+        stageInfoTaskIdRef.current = null
+        setStageInfoState(null)
         onStageInfoChange?.(null)
       } finally {
-        setLoading(false)
+        if (isActive) {
+          setLoading(false)
+        }
       }
     }
 
     fetchStageInfo()
+
+    return () => {
+      isActive = false
+    }
   }, [taskId, taskStatus, collaborationModel, onStageInfoChange])
 
   // Build display stages with "Start" node prepended
@@ -100,7 +129,7 @@ const PipelineStageIndicator = memo(function PipelineStageIndicator({
   }, [stageInfo, t])
 
   // Don't render if not a pipeline task or no stage info
-  if (!stageInfo || stageInfo.total_stages <= 1) {
+  if (!taskId || collaborationModel !== 'pipeline' || !stageInfo || stageInfo.total_stages <= 1) {
     return null
   }
 


### PR DESCRIPTION
## Summary
- Bind pipeline stage info to the task it was fetched for so stale responses cannot render after switching tasks.
- Clear pipeline indicator state when moving to a different task or a non-pipeline task.
- Add regression coverage for stale stage-info responses and pipeline task switching.

## Test Plan
- [x] `npm test -- PipelineStageIndicator.test.tsx ChatArea.pipeline-next-step.test.tsx --runInBand`
- [x] `npx prettier --check src/features/tasks/components/chat/PipelineStageIndicator.tsx src/__tests__/features/tasks/components/chat/PipelineStageIndicator.test.tsx`
- [x] `npm run lint -- --file src/features/tasks/components/chat/PipelineStageIndicator.tsx --file src/__tests__/features/tasks/components/chat/PipelineStageIndicator.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pipeline stage indicator reliability when switching between tasks while requests are in-flight
  * Fixed state management to prevent outdated pipeline data from being incorrectly applied
  * Ensured proper cleanup of pipeline state when switching away from pipeline mode

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1080)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->