### PR TITLE
fix(knowledge): remove unreachable XMind parser return

### DIFF
--- a/knowledge_engine/knowledge_engine/parsers/xmind.py
+++ b/knowledge_engine/knowledge_engine/parsers/xmind.py
@@ -36,7 +36,6 @@ def _topic_to_markdown(topic: dict[str, Any], depth: int = 0) -> list[str]:
         lines.extend(_topic_to_markdown(child, depth + 1))
 
     return lines
-    return lines
 
 
 def _sheet_to_markdown(sheet: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary
- remove the duplicated unreachable return in the XMind topic markdown converter
- keep child topic recursion unchanged

## Verification
- cd knowledge_engine && uv run pytest tests/test_indexer_xmind.py -q
- cd knowledge_engine && uv run black --check knowledge_engine/parsers/xmind.py
- cd knowledge_engine && uv run isort --check-only knowledge_engine/parsers/xmind.py
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XMind file parsing to properly convert topics to markdown format, eliminating spurious numeric tokens and unnecessary blank lines from the output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1081)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->