### PR TITLE
fix(frontend): avoid dropping task recovery before socket ready

### DIFF
--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -5,6 +5,33 @@
 import { TaskStateMachine } from '@/features/tasks/state'
 
 describe('TaskStateMachine', () => {
+  it('does not debounce a recovery that exits before the socket is connected', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000)
+    const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
+    let connected = false
+
+    const machine = new TaskStateMachine(100, {
+      joinTask,
+      isConnected: () => connected,
+    })
+
+    await machine.recover()
+    expect(joinTask).not.toHaveBeenCalled()
+
+    connected = true
+    await machine.recover()
+
+    expect(joinTask).toHaveBeenCalledTimes(1)
+    expect(joinTask).toHaveBeenCalledWith(100, {
+      forceRefresh: true,
+      afterMessageId: undefined,
+    })
+
+    nowSpy.mockRestore()
+    consoleInfoSpy.mockRestore()
+  })
+
   it('refreshes timestamp when the same AI message receives a new chat:error event', () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000)
 

--- a/frontend/src/features/tasks/contexts/chatStreamContext.tsx
+++ b/frontend/src/features/tasks/contexts/chatStreamContext.tsx
@@ -213,11 +213,10 @@ export function ChatStreamProvider({ children }: { children: ReactNode }) {
 
   // Ref to track temporary task ID to real task ID mapping
   const tempToRealTaskIdRef = useRef<Map<number, number>>(new Map())
-  // Ref to track isConnected state for TaskStateManager initialization
+  // Ref read by TaskStateManager deps. Keep it current during render so
+  // child recovery effects in the same commit see the latest socket state.
   const isConnectedRef = useRef(isConnected)
-  useEffect(() => {
-    isConnectedRef.current = isConnected
-  }, [isConnected])
+  isConnectedRef.current = isConnected
 
   // Initialize TaskStateManager with dependencies on mount
   useEffect(() => {

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -518,17 +518,19 @@ export class TaskStateMachine {
       return
     }
 
+    // Check WebSocket connection before consuming the recovery debounce window.
+    // A recovery scheduled during a connection-state race must be able to retry
+    // immediately once the socket is actually available.
+    if (!this.deps.isConnected()) {
+      return
+    }
+
     // Debounce check
     const now = Date.now()
     if (!event.force && now - this.lastRecoveryTime < this.recoveryDebounceMs) {
       return
     }
     this.lastRecoveryTime = now
-
-    // Check WebSocket connection
-    if (!this.deps.isConnected()) {
-      return
-    }
 
     // Transition to joining
     this.state = { ...this.state, status: 'joining', error: null }


### PR DESCRIPTION
## Summary
- Keep the TaskStateManager connection ref synchronized during render so child recovery effects see the latest socket state.
- Avoid consuming the TaskStateMachine recovery debounce window when recovery exits before the socket is actually connected.
- Add a regression test for retrying recovery after an initial disconnected no-op.

## Test Plan
- npm test -- --runInBand src/__tests__/contexts/SocketContext.reconnect.test.tsx src/__tests__/contexts/SocketContext.auth.test.ts src/__tests__/features/tasks/hooks/useUnifiedMessages.test.tsx src/__tests__/features/tasks/hooks/useTaskStateMachine.test.tsx src/__tests__/features/tasks/state/TaskStateMachine.test.ts src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx src/__tests__/features/tasks/components/chat/ChatArea.pipeline-next-step.test.tsx src/__tests__/features/tasks/components/chat/ChatArea.queue-message-handler.test.tsx
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage to verify correct state recovery behavior during connection state transitions.

* **Bug Fixes**
  * Improved connection state synchronization to enhance reliability of task recovery operations.
  * Optimized recovery operation timing to reduce delays when network connectivity changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1082)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->