### PR TITLE
feat(frontend): support QuickCard reorder from More menu

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@/hooks/useTranslation', () => ({
         'common:teams.select_team': 'Select team',
         'common:teams.search_team': 'Search team',
         'common:teams.no_match': 'No match',
+        'common:teams.reorder_quick_access': 'Drag to reorder',
         'teams.no_teams_title': 'No teams',
         'teams.no_teams_description': 'Create a team first',
         'wizard:wizard_button': 'Create',
@@ -215,5 +216,66 @@ describe('QuickAccessCards', () => {
     const reorderedCards = within(container).getAllByTestId(/^quick-access-team-/)
     expect(reorderedCards[0]).toHaveTextContent('Favorite Team Display')
     expect(reorderedCards[1]).toHaveTextContent('System Team Display')
+  })
+
+  test('reorders quick access teams by dragging a hidden team in the more popover', async () => {
+    renderQuickAccessCards(
+      [
+        makeTeam({ id: 1, name: 'team-one', description: 'Description one' }),
+        makeTeam({ id: 2, name: 'team-two', description: 'Description two' }),
+        makeTeam({ id: 3, name: 'team-three', description: 'Description three' }),
+        makeTeam({ id: 4, name: 'team-four', description: 'Description four' }),
+        makeTeam({ id: 5, name: 'team-five', description: 'Description five' }),
+      ],
+      {
+        system_version: 2,
+        system_team_ids: [],
+        user_version: 2,
+        show_system_recommended: false,
+        teams: [
+          { id: 1, name: 'team-one', display_name: 'Team One', is_system: false },
+          { id: 2, name: 'team-two', display_name: 'Team Two', is_system: false },
+          { id: 3, name: 'team-three', display_name: 'Team Three', is_system: false },
+          { id: 4, name: 'team-four', display_name: 'Team Four', is_system: false },
+          { id: 5, name: 'team-five', display_name: 'Team Five', is_system: false },
+        ],
+      }
+    )
+
+    const container = await screen.findByTestId('quick-access-cards')
+    expect(within(container).queryByTestId('quick-access-team-team-five')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('More'))
+    const hiddenTeamHandle = await screen.findByTestId('quick-access-sort-handle-5')
+    const targetTeamRow = await screen.findByTestId('quick-access-more-team-team-two')
+
+    fireEvent.dragStart(hiddenTeamHandle, {
+      dataTransfer: {
+        effectAllowed: '',
+        setData: jest.fn(),
+      },
+    })
+    fireEvent.dragOver(targetTeamRow, {
+      dataTransfer: {
+        dropEffect: '',
+      },
+    })
+    fireEvent.drop(targetTeamRow)
+
+    await waitFor(() => {
+      expect(mockedUserApis.updateUser).toHaveBeenCalledWith({
+        preferences: expect.objectContaining({
+          send_key: 'enter',
+          quick_access: {
+            version: 2,
+            teams: [1, 5, 2, 3, 4],
+          },
+        }),
+      })
+    })
+
+    const reorderedCards = within(container).getAllByTestId(/^quick-access-team-/)
+    expect(reorderedCards[0]).toHaveTextContent('Team One')
+    expect(reorderedCards[1]).toHaveTextContent('Team Five')
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/selector/TeamSelectorButton.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/TeamSelectorButton.test.tsx
@@ -195,7 +195,7 @@ describe('TeamSelectorButton', () => {
     expect(setSelectedTeam).not.toHaveBeenCalled()
   })
 
-  it('preserves system recommended team ids when adding a user favorite', async () => {
+  it('keeps user favorites before system recommended teams when adding a favorite', async () => {
     mockQuickAccessTeams = [2, 3]
     mockedUserApis.getQuickAccess.mockResolvedValueOnce({
       system_version: 7,
@@ -231,7 +231,7 @@ describe('TeamSelectorButton', () => {
           send_key: 'enter',
           quick_access: {
             version: 7,
-            teams: [2, 3, 4],
+            teams: [3, 4, 2],
           },
         },
       })

--- a/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
+++ b/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
@@ -6,7 +6,7 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { SparklesIcon, ChevronDownIcon } from '@heroicons/react/24/outline'
-import { Check, Search } from 'lucide-react'
+import { Check, GripVertical, Search } from 'lucide-react'
 import { userApis } from '@/apis/user'
 import type { QuickAccessResponse, QuickAccessTeam, Team, UserPreferences } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -237,13 +237,19 @@ export function QuickAccessCards({
     [persistQuickAccessOrder, quickAccessTeams]
   )
 
-  const handleCardDragStart = (event: React.DragEvent<HTMLDivElement>, team: DisplayTeam) => {
+  const handleQuickAccessDragStart = (
+    event: React.DragEvent<HTMLElement>,
+    team: DisplayTeam
+  ) => {
     setDraggedTeamId(team.id)
     event.dataTransfer.effectAllowed = 'move'
     event.dataTransfer.setData('text/plain', String(team.id))
   }
 
-  const handleCardDragOver = (event: React.DragEvent<HTMLDivElement>, team: DisplayTeam) => {
+  const handleQuickAccessDragOver = (
+    event: React.DragEvent<HTMLElement>,
+    team: DisplayTeam
+  ) => {
     if (!draggedTeamId || draggedTeamId === team.id) return
 
     event.preventDefault()
@@ -251,7 +257,7 @@ export function QuickAccessCards({
     setDragOverTeamId(team.id)
   }
 
-  const handleCardDrop = (event: React.DragEvent<HTMLDivElement>, team: DisplayTeam) => {
+  const handleQuickAccessDrop = (event: React.DragEvent<HTMLElement>, team: DisplayTeam) => {
     event.preventDefault()
 
     if (!draggedTeamId) return
@@ -262,7 +268,7 @@ export function QuickAccessCards({
     setDragOverTeamId(null)
   }
 
-  const handleCardDragEnd = () => {
+  const handleQuickAccessDragEnd = () => {
     setDraggedTeamId(null)
     setDragOverTeamId(null)
     window.setTimeout(() => {
@@ -341,11 +347,11 @@ export function QuickAccessCards({
       <div
         draggable
         onClick={() => !isClicked && handleTeamClick(team)}
-        onDragStart={event => handleCardDragStart(event, team)}
-        onDragOver={event => handleCardDragOver(event, team)}
+        onDragStart={event => handleQuickAccessDragStart(event, team)}
+        onDragOver={event => handleQuickAccessDragOver(event, team)}
         onDragLeave={() => setDragOverTeamId(null)}
-        onDrop={event => handleCardDrop(event, team)}
-        onDragEnd={handleCardDragEnd}
+        onDrop={event => handleQuickAccessDrop(event, team)}
+        onDragEnd={handleQuickAccessDragEnd}
         data-testid={`quick-access-team-${team.name}`}
         className={`
           group relative flex flex-col justify-center
@@ -484,10 +490,14 @@ export function QuickAccessCards({
                 return (
                   <div
                     key={team.id}
+                    data-testid={`quick-access-more-team-${team.name}`}
                     className={`flex items-center gap-2 px-2 py-2 rounded-md cursor-pointer transition-colors ${
                       isSelected ? 'bg-primary/10' : 'hover:bg-hover'
-                    }`}
+                    } ${dragOverTeamId === team.id ? 'ring-2 ring-primary/40' : ''}`}
                     onClick={() => handleSelectTeamFromMore(team)}
+                    onDragOver={event => handleQuickAccessDragOver(event, team)}
+                    onDragLeave={() => setDragOverTeamId(null)}
+                    onDrop={event => handleQuickAccessDrop(event, team)}
                     role="button"
                     tabIndex={0}
                     onKeyDown={e => {
@@ -497,6 +507,22 @@ export function QuickAccessCards({
                       }
                     }}
                   >
+                    <button
+                      type="button"
+                      draggable={quickAccessTeams.length > 1}
+                      data-testid={`quick-access-sort-handle-${team.id}`}
+                      aria-label={t('common:teams.reorder_quick_access')}
+                      title={t('common:teams.reorder_quick_access')}
+                      onClick={event => event.stopPropagation()}
+                      onDragStart={event => {
+                        event.stopPropagation()
+                        handleQuickAccessDragStart(event, team)
+                      }}
+                      onDragEnd={handleQuickAccessDragEnd}
+                      className="h-7 w-7 flex-shrink-0 rounded-md inline-flex items-center justify-center cursor-grab active:cursor-grabbing text-text-muted hover:bg-hover hover:text-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                    >
+                      <GripVertical className="h-4 w-4" aria-hidden="true" />
+                    </button>
                     <div
                       className={`w-4 h-4 rounded border flex items-center justify-center flex-shrink-0 ${
                         isSelected

--- a/frontend/src/features/tasks/components/selector/TeamSelectorButton.tsx
+++ b/frontend/src/features/tasks/components/selector/TeamSelectorButton.tsx
@@ -48,6 +48,16 @@ interface TeamSelectorButtonProps {
 
 const getTeamDisplayName = (team: Team) => team.displayName?.trim() || team.name
 
+const addFavoriteBeforeSystemRecommendations = (
+  teamIds: number[],
+  teamId: number,
+  systemRecommendedTeamIds: Set<number>
+) => {
+  const userFavoriteIds = teamIds.filter(id => !systemRecommendedTeamIds.has(id))
+  const systemIds = teamIds.filter(id => systemRecommendedTeamIds.has(id))
+  return [...userFavoriteIds, teamId, ...systemIds]
+}
+
 export default function TeamSelectorButton({
   selectedTeam,
   setSelectedTeam,
@@ -170,7 +180,11 @@ export default function TeamSelectorButton({
       const isFavorite = currentTeamIds.includes(team.id)
       const nextTeamIds = isFavorite
         ? currentTeamIds.filter(teamId => teamId !== team.id)
-        : [...currentTeamIds, team.id]
+        : addFavoriteBeforeSystemRecommendations(
+            currentTeamIds,
+            team.id,
+            systemRecommendedTeamIdSet
+          )
 
       const nextQuickAccess = {
         ...(currentQuickAccess.version !== undefined

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -281,6 +281,7 @@
     "copy_skills_skip": "Agent Only",
     "copy_skills_count": "{{count}} skill(s)",
     "more": "More",
+    "reorder_quick_access": "Drag to reorder QuickCards",
     "more_teams": "View more teams",
     "more_actions": "More Actions",
     "no_teams": "No teams available",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -281,6 +281,7 @@
     "copy_skills_skip": "仅复制智能体",
     "copy_skills_count": "{{count}} 个 Skill",
     "more": "更多",
+    "reorder_quick_access": "拖拽调整 QuickCard 顺序",
     "more_teams": "查看更多智能体",
     "more_actions": "更多操作",
     "no_teams": "没有可用的智能体",


### PR DESCRIPTION
## Summary
- Add drag handles in the QuickCard More popover so hidden quick access agents can be reordered into the visible slots.
- Keep row clicks as agent selection while drag handles control ordering.
- Insert newly favorited agents before system recommended agents while preserving saved order afterward.

## Test Plan
- npm test -- QuickAccessCards.test.tsx --runInBand
- npm test -- TeamSelectorButton.test.tsx --runInBand
- npm run lint -- --file src/features/tasks/components/chat/QuickAccessCards.tsx --file src/features/tasks/components/selector/TeamSelectorButton.tsx --file src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx --file src/__tests__/features/tasks/components/selector/TeamSelectorButton.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick-access teams can now be reordered by dragging.
  * Added a drag handle for easy reordering of teams in the popover menu.
  * User favorite teams now display before system-recommended teams.

* **Tests**
  * Updated test coverage for team reordering and favorites ordering functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1083)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->