### PR TITLE
fix(frontend): prevent mobile input selector overflow

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { MobileChatInputControlsProps } from '@/features/tasks/components/input/MobileChatInputControls'
+import { MobileChatInputControls } from '@/features/tasks/components/input/MobileChatInputControls'
+import type { Team } from '@/types/api'
+
+jest.mock('@/features/tasks/components/selector/MobileModelSelector', () => ({
+  __esModule: true,
+  default: () => (
+    <button type="button" data-testid="mobile-model-selector">
+      官网:kimi-k2.5-preview-with-a-very-long-model-name
+    </button>
+  ),
+}))
+
+jest.mock('@/features/tasks/components/selector/MobileRepositorySelector', () => ({
+  __esModule: true,
+  default: () => <button type="button">Repository</button>,
+}))
+
+jest.mock('@/features/tasks/components/selector/MobileBranchSelector', () => ({
+  __esModule: true,
+  default: () => <button type="button">Branch</button>,
+}))
+
+jest.mock('@/features/tasks/components/clarification/MobileClarificationToggle', () => ({
+  __esModule: true,
+  default: () => <button type="button">Clarification</button>,
+}))
+
+jest.mock('@/features/tasks/components/MobileCorrectionModeToggle', () => ({
+  __esModule: true,
+  default: () => <button type="button">Correction</button>,
+}))
+
+jest.mock('@/features/tasks/components/chat/ChatContextInput', () => ({
+  __esModule: true,
+  default: () => <button type="button">Context</button>,
+}))
+
+jest.mock('@/features/tasks/components/AttachmentButton', () => ({
+  __esModule: true,
+  default: () => <button type="button">Attach</button>,
+}))
+
+jest.mock('@/features/tasks/components/input/SendButton', () => ({
+  __esModule: true,
+  default: () => (
+    <button type="button" data-testid="send-button">
+      Send
+    </button>
+  ),
+}))
+
+jest.mock('@/features/tasks/components/message/LoadingDots', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loading-dots" />,
+}))
+
+jest.mock('@/components/ui/action-button', () => ({
+  ActionButton: ({ title }: { title?: string }) => <button type="button">{title || 'Action'}</button>,
+}))
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    className,
+    disabled,
+  }: {
+    children: React.ReactNode
+    className?: string
+    disabled?: boolean
+  }) => (
+    <button type="button" className={className} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}))
+
+jest.mock('@/components/ui/dropdown', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div data-testid="dropdown-separator" />,
+}))
+
+jest.mock('@/features/tasks/components/selector/SkillSelectorPopover', () => ({
+  __esModule: true,
+  default: () => <button type="button">Skills</button>,
+}))
+
+const selectedTeam: Team = {
+  id: 1,
+  name: 'wegent-assistant',
+  displayName: 'Wegent智能助理',
+  description: '',
+  bots: [],
+  workflow: {},
+  is_active: true,
+  user_id: 1,
+  created_at: '',
+  updated_at: '',
+  agent_type: 'chat',
+}
+
+const buildProps = (): MobileChatInputControlsProps => ({
+  taskType: 'chat',
+  selectedTeam,
+  selectedModel: {
+    id: 'long-model',
+    name: '官网:kimi-k2.5-preview-with-a-very-long-model-name',
+    type: 'user',
+  },
+  setSelectedModel: jest.fn(),
+  forceOverride: false,
+  setForceOverride: jest.fn(),
+  showRepositorySelector: false,
+  selectedRepo: null,
+  setSelectedRepo: jest.fn(),
+  selectedBranch: null,
+  setSelectedBranch: jest.fn(),
+  selectedTaskDetail: null,
+  enableClarification: false,
+  setEnableClarification: jest.fn(),
+  selectedContexts: [],
+  setSelectedContexts: jest.fn(),
+  onFileSelect: jest.fn(),
+  isLoading: false,
+  isStreaming: false,
+  isStopping: false,
+  hasMessages: false,
+  shouldHideChatInput: false,
+  isModelSelectionRequired: false,
+  isAttachmentReadyToSend: true,
+  taskInputMessage: 'hello',
+  isSubtaskStreaming: false,
+  onStopStream: jest.fn(),
+  onSendMessage: jest.fn(),
+})
+
+describe('MobileChatInputControls layout', () => {
+  it('keeps the send button inside the input controls when the model label is long', () => {
+    render(<MobileChatInputControls {...buildProps()} />)
+
+    const sendSlot = screen.getByTestId('send-button').parentElement
+    const rightControls = sendSlot?.parentElement
+    const modelSlot = screen.getByTestId('mobile-model-selector').parentElement
+    const root = rightControls?.parentElement
+
+    expect(root).toHaveClass('min-w-0')
+    expect(root).toHaveClass('overflow-hidden')
+    expect(rightControls).toHaveClass('flex-1')
+    expect(rightControls).toHaveClass('min-w-0')
+    expect(rightControls).toHaveClass('justify-end')
+    expect(modelSlot).toHaveClass('flex-1')
+    expect(modelSlot).toHaveClass('min-w-0')
+    expect(modelSlot).toHaveClass('overflow-hidden')
+    expect(sendSlot).toHaveClass('flex-shrink-0')
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/selector/mobile-selector-truncation.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/mobile-selector-truncation.test.tsx
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type React from 'react'
+import MobileModelSelector from '@/features/tasks/components/selector/MobileModelSelector'
+import MobileTeamSelector from '@/features/tasks/components/selector/MobileTeamSelector'
+import type { Team } from '@/types/api'
+
+const longModelName = '官网:kimi-k2.5-preview-with-a-very-long-model-name'
+const longTeamName = '一个名字特别特别长的Wegent智能助理用于验证截断'
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback || key,
+  }),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}))
+
+jest.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DrawerContent: () => null,
+  DrawerTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@/components/ui/switch', () => ({
+  Switch: () => <button type="button">Switch</button>,
+}))
+
+jest.mock('@/components/ui/tag', () => ({
+  Tag: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span className={className}>{children}</span>
+  ),
+}))
+
+jest.mock('@/features/settings/components/teams/TeamIconDisplay', () => ({
+  TeamIconDisplay: ({ className }: { className?: string }) => (
+    <span data-testid="team-icon" className={className} />
+  ),
+}))
+
+jest.mock('@/features/tasks/components/selector/SystemTeamTag', () => ({
+  __esModule: true,
+  default: ({ className }: { className?: string }) => (
+    <span data-testid="system-team-tag" className={className} />
+  ),
+}))
+
+jest.mock('@/features/tasks/components/selector/useTeamFavorites', () => ({
+  useTeamFavorites: () => ({
+    favoriteTeamIdSet: new Set<number>(),
+    favoriteUpdatingTeamId: null,
+    handleToggleFavorite: jest.fn(),
+    quickAccessMetaLoaded: false,
+    systemRecommendedTeamIdSet: new Set<number>(),
+  }),
+}))
+
+jest.mock('@/features/tasks/hooks/useModelSelection', () => ({
+  DEFAULT_MODEL_NAME: '__default__',
+  useModelSelection: () => ({
+    selectedModel: {
+      id: 'long-model',
+      name: longModelName,
+      displayName: longModelName,
+      type: 'user',
+    },
+    forceOverride: false,
+    filteredModels: [],
+    showDefaultOption: false,
+    isLoading: false,
+    isMixedTeam: false,
+    isModelRequired: false,
+    error: null,
+    getDisplayText: () => longModelName,
+    selectModelByKey: jest.fn(),
+    setForceOverride: jest.fn(),
+  }),
+}))
+
+const selectedTeam: Team = {
+  id: 1,
+  name: 'long-team',
+  displayName: longTeamName,
+  description: '',
+  bots: [],
+  workflow: {},
+  is_active: true,
+  user_id: 1,
+  created_at: '',
+  updated_at: '',
+  agent_type: 'chat',
+}
+
+describe('mobile selector truncation', () => {
+  it('constrains the mobile model selector text to the available trigger width', () => {
+    render(
+      <MobileModelSelector
+        selectedModel={null}
+        setSelectedModel={jest.fn()}
+        forceOverride={false}
+        setForceOverride={jest.fn()}
+        selectedTeam={selectedTeam}
+        disabled={false}
+      />
+    )
+
+    const label = screen.getByText(longModelName)
+    const trigger = label.closest('button')
+
+    expect(trigger).toHaveClass('w-full')
+    expect(label).toHaveClass('truncate')
+    expect(label).toHaveClass('flex-1')
+    expect(label).toHaveClass('min-w-0')
+  })
+
+  it('constrains the mobile agent selector text to the available trigger width', () => {
+    render(
+      <MobileTeamSelector
+        selectedTeam={selectedTeam}
+        teams={[selectedTeam]}
+        onTeamSelect={jest.fn()}
+        disabled={false}
+      />
+    )
+
+    const label = screen.getByText(longTeamName)
+    const trigger = label.closest('button')
+
+    expect(trigger).toHaveClass('w-full')
+    expect(label).toHaveClass('truncate')
+    expect(label).toHaveClass('flex-1')
+    expect(label).toHaveClass('min-w-0')
+  })
+})

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -262,7 +262,7 @@ export function MobileChatInputControls({
 
   return (
     <div
-      className={`flex items-center justify-between px-3 gap-2 ${shouldHideChatInput ? 'py-3' : 'pb-2 pt-1'}`}
+      className={`flex items-center px-3 gap-2 min-w-0 overflow-hidden ${shouldHideChatInput ? 'py-3' : 'pb-2 pt-1'}`}
     >
       {/* Left: secondary actions menu - hidden when hideSelectors is true */}
       <div
@@ -362,11 +362,11 @@ export function MobileChatInputControls({
         )}
       </div>
 
-      {/* Right: Model selector, Send button */}
-      <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+      {/* Right: Agent selector, Model selector, Send button */}
+      <div className="ml-auto flex flex-1 items-center justify-end gap-2 min-w-0 overflow-hidden">
         {canSwitchTeam && selectedTeamForDisplay && onTeamChange && (
           <div
-            className={`min-w-0 overflow-hidden ${hideSelectors ? 'opacity-50 pointer-events-none' : ''}`}
+            className={`flex-1 min-w-0 overflow-hidden ${hideSelectors ? 'opacity-50 pointer-events-none' : ''}`}
           >
             <MobileTeamSelector
               selectedTeam={selectedTeamForDisplay}
@@ -380,7 +380,7 @@ export function MobileChatInputControls({
         )}
         {selectedTeam && (
           <div
-            className={`min-w-0 overflow-hidden ${hideSelectors ? 'opacity-50 pointer-events-none' : ''}`}
+            className={`flex-1 min-w-0 overflow-hidden ${hideSelectors ? 'opacity-50 pointer-events-none' : ''}`}
           >
             <MobileModelSelector
               selectedModel={selectedModel}

--- a/frontend/src/features/tasks/components/selector/MobileModelSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileModelSelector.tsx
@@ -127,7 +127,7 @@ export default function MobileModelSelector({
           type="button"
           disabled={isDisabled}
           className={cn(
-            'flex items-center min-w-0 max-w-full rounded-full px-3 py-2 h-9',
+            'flex w-full items-center min-w-0 max-w-full rounded-full px-3 py-2 h-9',
             'border transition-colors overflow-hidden',
             modelSelection.isModelRequired
               ? 'border-error text-error bg-error/5'
@@ -138,7 +138,9 @@ export default function MobileModelSelector({
             'disabled:cursor-not-allowed disabled:opacity-50'
           )}
         >
-          <span className="truncate text-xs min-w-0">{modelSelection.getDisplayText()}</span>
+          <span className="flex-1 truncate text-xs min-w-0">
+            {modelSelection.getDisplayText()}
+          </span>
         </button>
       </DrawerTrigger>
 

--- a/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileTeamSelector.tsx
@@ -94,7 +94,7 @@ export default function MobileTeamSelector({
           type="button"
           disabled={isDisabled}
           className={cn(
-            'flex items-center min-w-0 max-w-full rounded-full px-3 py-2 h-9',
+            'flex w-full items-center min-w-0 max-w-full rounded-full px-3 py-2 h-9',
             'border border-border bg-base text-text-primary transition-colors overflow-hidden',
             isLoading ? 'animate-pulse' : '',
             'focus:outline-none focus:ring-0',
@@ -110,7 +110,7 @@ export default function MobileTeamSelector({
               className="text-text-muted flex-shrink-0"
             />
           )}
-          <span className="truncate text-xs min-w-0">
+          <span className="flex-1 truncate text-xs min-w-0">
             {triggerText || selectedTeamDisplayName || t('common:teams.select_team')}
           </span>
           {triggerText && <ChevronDown className="w-2.5 h-2.5 text-text-muted flex-shrink-0" />}
@@ -193,15 +193,18 @@ export default function MobileTeamSelector({
                         className="flex-shrink-0 text-text-muted"
                       />
                       <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="text-[15px] text-text-primary truncate">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span className="text-[15px] text-text-primary truncate flex-1 min-w-0">
                             {displayName}
                           </span>
-                          {isSystemTeam && <SystemTeamTag className="text-[11px] py-0 px-1.5" />}
+                          {isSystemTeam && (
+                            <SystemTeamTag className="text-[11px] py-0 px-1.5 flex-shrink-0" />
+                          )}
                           {isGroupTeam && (
                             <Tag
-                              className="text-[11px] !m-0 flex-shrink-0 py-0 px-1.5"
+                              className="text-[11px] !m-0 flex-shrink-0 py-0 px-1.5 max-w-[120px] truncate"
                               variant="info"
+                              title={team.namespace}
                             >
                               {team.namespace}
                             </Tag>


### PR DESCRIPTION
## Summary\n- Keep the mobile input control row width-constrained so the send button stays inside the input card\n- Make mobile model and agent selector triggers use full-width, truncating labels\n- Add regression tests for long selector labels and send-button layout\n\n## Verification\n- npm test -- --runTestsByPath src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx src/__tests__/features/tasks/components/selector/mobile-selector-truncation.test.tsx src/__tests__/features/tasks/components/input/ChatInputCard.layout.test.tsx src/__tests__/features/tasks/components/input/chat-send-state.test.tsx src/__tests__/features/tasks/components/input/chat-context-visibility.test.tsx\n- npx eslint src/features/tasks/components/input/MobileChatInputControls.tsx src/features/tasks/components/selector/MobileModelSelector.tsx src/features/tasks/components/selector/MobileTeamSelector.tsx src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx src/__tests__/features/tasks/components/selector/mobile-selector-truncation.test.tsx\n\nNote: the local browser opened /chat successfully, but the visible page was blocked by the onboarding overlay, so visual verification was limited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added layout tests for mobile chat input controls and model/team selectors to verify text truncation and overflow handling.

* **Style**
  * Improved mobile selector layout to better handle long model and team names with proper text truncation, ensuring send button remains accessible and properly aligned.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1086)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->