### PR TITLE
fix(frontend): add missing chat i18n keys

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -62,7 +62,9 @@ jest.mock('@/features/tasks/components/message/LoadingDots', () => ({
 }))
 
 jest.mock('@/components/ui/action-button', () => ({
-  ActionButton: ({ title }: { title?: string }) => <button type="button">{title || 'Action'}</button>,
+  ActionButton: ({ title }: { title?: string }) => (
+    <button type="button">{title || 'Action'}</button>
+  ),
 }))
 
 jest.mock('@/components/ui/button', () => ({
@@ -111,8 +113,9 @@ const buildProps = (): MobileChatInputControlsProps => ({
   taskType: 'chat',
   selectedTeam,
   selectedModel: {
-    id: 'long-model',
     name: '官网:kimi-k2.5-preview-with-a-very-long-model-name',
+    provider: 'moonshot',
+    modelId: 'kimi-k2.5-preview-with-a-very-long-model-name',
     type: 'user',
   },
   setSelectedModel: jest.fn(),

--- a/frontend/src/__tests__/i18n/missing-console-keys.test.ts
+++ b/frontend/src/__tests__/i18n/missing-console-keys.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import enChat from '@/i18n/locales/en/chat.json'
+import zhChat from '@/i18n/locales/zh-CN/chat.json'
+import enCommon from '@/i18n/locales/en/common.json'
+import zhCommon from '@/i18n/locales/zh-CN/common.json'
+
+describe('i18n console warning keys', () => {
+  test('has chat scrollbar marker translations in zh-CN and en', () => {
+    expect(enChat.scroll_to_bottom).toBeTruthy()
+    expect(zhChat.scroll_to_bottom).toBeTruthy()
+    expect(enCommon.scroll_to_bottom).toBeTruthy()
+    expect(zhCommon.scroll_to_bottom).toBeTruthy()
+  })
+
+  test('has common empty-state translations in zh-CN and en', () => {
+    expect(enCommon.noData).toBeTruthy()
+    expect(zhCommon.noData).toBeTruthy()
+  })
+})

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "Chat",
+  "scroll_to_bottom": "Scroll to bottom",
   "placeholder": {
     "input": "Type your message here...",
     "empty": "No messages yet. Start a conversation!"

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -4,6 +4,8 @@
     "description": "A whole dev team of AI agents in your editor."
   },
   "loading": "Loading...",
+  "noData": "No data",
+  "scroll_to_bottom": "Scroll to bottom",
   "repos": {
     "repository": "Select Repository",
     "branch": "Select Branch",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "聊天",
+  "scroll_to_bottom": "滚动到底部",
   "placeholder": {
     "input": "在此输入您的消息...",
     "empty": "还没有消息。开始对话吧！"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -4,6 +4,8 @@
     "description": "浏览器中的完整 AI 团队。"
   },
   "loading": "加载中...",
+  "noData": "暂无数据",
+  "scroll_to_bottom": "滚动到底部",
   "repos": {
     "repository": "选择仓库",
     "branch": "选择分支",


### PR DESCRIPTION
## Summary
- Add missing zh-CN/en translations for chat scroll-to-bottom and common empty-state labels
- Add i18n regression coverage for the missing console-warning keys
- Update the mobile chat input layout test fixture to match the current Model type

## Test Plan
- npm test -- missing-console-keys.test.ts --runInBand
- npm test -- MobileChatInputControls.layout.test.tsx --runInBand
- npx tsc --noEmit --pretty false
- pre-push hook: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added internationalization support for "Scroll to bottom" and "No data" UI labels in English and Chinese languages

* **Tests**
  * Added validation test to ensure all required translation keys are present in localization files

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1088)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->