### PR TITLE
fix(frontend): show mobile input menu

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { MobileChatInputControlsProps } from '@/features/tasks/components/input/MobileChatInputControls'
 import { MobileChatInputControls } from '@/features/tasks/components/input/MobileChatInputControls'
 import type { Team } from '@/types/api'
@@ -72,12 +72,14 @@ jest.mock('@/components/ui/button', () => ({
     children,
     className,
     disabled,
+    ...props
   }: {
     children: React.ReactNode
     className?: string
     disabled?: boolean
+    [key: string]: unknown
   }) => (
-    <button type="button" className={className} disabled={disabled}>
+    <button type="button" className={className} disabled={disabled} {...props}>
       {children}
     </button>
   ),
@@ -146,8 +148,10 @@ const buildProps = (): MobileChatInputControlsProps => ({
 })
 
 describe('MobileChatInputControls layout', () => {
-  it('keeps the send button inside the input controls when the model label is long', () => {
+  it('keeps long selector labels clipped without clipping the overflow menu', () => {
     render(<MobileChatInputControls {...buildProps()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
 
     const sendSlot = screen.getByTestId('send-button').parentElement
     const rightControls = sendSlot?.parentElement
@@ -155,13 +159,15 @@ describe('MobileChatInputControls layout', () => {
     const root = rightControls?.parentElement
 
     expect(root).toHaveClass('min-w-0')
-    expect(root).toHaveClass('overflow-hidden')
+    expect(root).not.toHaveClass('overflow-hidden')
     expect(rightControls).toHaveClass('flex-1')
     expect(rightControls).toHaveClass('min-w-0')
+    expect(rightControls).toHaveClass('overflow-hidden')
     expect(rightControls).toHaveClass('justify-end')
     expect(modelSlot).toHaveClass('flex-1')
     expect(modelSlot).toHaveClass('min-w-0')
     expect(modelSlot).toHaveClass('overflow-hidden')
     expect(sendSlot).toHaveClass('flex-shrink-0')
+    expect(screen.getByText('Attach')).toBeInTheDocument()
   })
 })

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -262,7 +262,7 @@ export function MobileChatInputControls({
 
   return (
     <div
-      className={`flex items-center px-3 gap-2 min-w-0 overflow-hidden ${shouldHideChatInput ? 'py-3' : 'pb-2 pt-1'}`}
+      className={`flex items-center px-3 gap-2 min-w-0 overflow-visible ${shouldHideChatInput ? 'py-3' : 'pb-2 pt-1'}`}
     >
       {/* Left: secondary actions menu - hidden when hideSelectors is true */}
       <div
@@ -276,6 +276,7 @@ export function MobileChatInputControls({
           size="sm"
           aria-expanded={moreMenuOpen}
           aria-label="More actions"
+          data-testid="mobile-input-more-actions-button"
           title="More actions"
           onClick={() => setMoreMenuOpen(open => !open)}
           className="h-8 w-8 p-0 rounded-full border border-border bg-base text-text-muted hover:text-text-primary hover:bg-hover"
@@ -284,7 +285,10 @@ export function MobileChatInputControls({
         </Button>
 
         {moreMenuOpen && (
-          <div className="absolute bottom-full left-0 z-50 mb-2 w-56 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md">
+          <div
+            data-testid="mobile-input-more-actions-menu"
+            className="absolute bottom-full left-0 z-50 mb-2 w-56 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          >
             {hasSecondaryActions && (
               <div className="flex flex-col">
                 {showAttachmentAction && (


### PR DESCRIPTION
## Summary
- Allow the mobile chat input controls wrapper to overflow so the plus-menu can render above the input card.
- Keep selector text clipping scoped to the right-side controls so long labels still stay inside the bar.
- Add regression coverage for opening the mobile more-actions menu.

## Test Plan
- npm test -- MobileChatInputControls.layout.test.tsx --runInBand
- npx tsc --noEmit --pretty false
- npm run lint
- pre-push hook: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved overflow handling in mobile chat input controls to ensure the "More actions" menu displays properly without being cut off.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1089)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->