### PR TITLE
fix(frontend): improve remote workspace file UX

### DIFF
--- a/frontend/src/__tests__/app/(tasks)/chat/ChatPageMobile.remote-workspace.test.tsx
+++ b/frontend/src/__tests__/app/(tasks)/chat/ChatPageMobile.remote-workspace.test.tsx
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { ChatPageMobile } from '@/app/(tasks)/chat/ChatPageMobile'
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: () => null,
+  }),
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/layout/TopNavigation', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: ReactNode }) => (
+    <div>
+      <div>top-navigation</div>
+      <div>{children}</div>
+    </div>
+  ),
+}))
+
+jest.mock('@/features/tasks/components/sidebar', () => ({
+  TaskSidebar: () => <div>task-sidebar</div>,
+  SearchDialog: () => <div>search-dialog</div>,
+}))
+
+jest.mock('@/features/theme/ThemeToggle', () => ({
+  ThemeToggle: () => <div>theme-toggle</div>,
+}))
+
+jest.mock('@/features/common/UserContext', () => ({
+  useUser: () => ({ user: null }),
+}))
+
+jest.mock('@/contexts/TeamContext', () => ({
+  useTeamContext: () => ({
+    teams: [],
+    isTeamsLoading: false,
+    refreshTeams: jest.fn().mockResolvedValue([]),
+    addTeam: jest.fn(),
+  }),
+}))
+
+jest.mock('@/contexts/DeviceContext', () => ({
+  useDevices: () => ({
+    selectedDeviceId: null,
+    devices: [],
+  }),
+}))
+
+jest.mock('@/features/tasks/contexts/taskContext', () => ({
+  useTaskContext: () => ({
+    refreshTasks: jest.fn(),
+    selectedTaskDetail: {
+      id: 42,
+      title: 'Task 42',
+      status: 'RUNNING',
+      team: {
+        agent_type: 'chat',
+        bots: [],
+      },
+    },
+    setSelectedTask: jest.fn(),
+    refreshSelectedTaskDetail: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/tasks/contexts/chatStreamContext', () => ({
+  useChatStreamContext: () => ({
+    clearAllStreams: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/tasks/hooks/useSearchShortcut', () => ({
+  useSearchShortcut: () => ({
+    shortcutDisplayText: 'Ctrl+K',
+  }),
+}))
+
+jest.mock('@/features/tasks/components/chat', () => ({
+  ChatArea: () => <div>chat-area</div>,
+}))
+
+jest.mock('@/features/tasks/components/group-chat', () => ({
+  CreateGroupChatDialog: () => <div>create-group-chat-dialog</div>,
+}))
+
+jest.mock('@/apis/groups', () => ({
+  listGroups: jest.fn(() => new Promise(() => {})),
+}))
+
+jest.mock('@/features/settings/services/bots', () => ({
+  fetchBotsList: jest.fn().mockResolvedValue([]),
+}))
+
+jest.mock('@/features/settings/components/TeamEditDialog', () => ({
+  __esModule: true,
+  default: () => <div>team-edit-dialog</div>,
+}))
+
+jest.mock('@/features/tasks/hooks/useTeamEditExtension', () => ({
+  useTeamEditExtension: () => ({}),
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/features/tasks/components/remote-workspace', () => ({
+  RemoteWorkspaceEntry: ({ taskId }: { taskId?: number | null }) => (
+    <div data-testid="remote-workspace-entry">{String(taskId)}</div>
+  ),
+}))
+
+describe('ChatPageMobile remote workspace integration', () => {
+  test('chat mobile renders remote workspace entry in top nav when task selected', () => {
+    render(<ChatPageMobile />)
+
+    expect(screen.getByTestId('remote-workspace-entry')).toHaveTextContent('42')
+  })
+})

--- a/frontend/src/__tests__/app/(tasks)/code/CodePageMobile.remote-workspace.test.tsx
+++ b/frontend/src/__tests__/app/(tasks)/code/CodePageMobile.remote-workspace.test.tsx
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+import { CodePageMobile } from '@/app/(tasks)/code/CodePageMobile'
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: (key: string) => (key === 'taskId' ? '84' : null),
+  }),
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/layout/TopNavigation', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: ReactNode }) => (
+    <div>
+      <div>top-navigation</div>
+      <div>{children}</div>
+    </div>
+  ),
+}))
+
+jest.mock('@/features/tasks/components/sidebar', () => ({
+  TaskSidebar: () => <div>task-sidebar</div>,
+  SearchDialog: () => <div>search-dialog</div>,
+}))
+
+jest.mock('@/features/theme/ThemeToggle', () => ({
+  ThemeToggle: () => <div>theme-toggle</div>,
+}))
+
+jest.mock('@/features/common/UserContext', () => ({
+  useUser: () => ({ user: null }),
+}))
+
+jest.mock('@/contexts/TeamContext', () => ({
+  useTeamContext: () => ({
+    teams: [],
+    isTeamsLoading: false,
+    refreshTeams: jest.fn().mockResolvedValue([]),
+    addTeam: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/tasks/contexts/taskContext', () => ({
+  useTaskContext: () => ({
+    selectedTaskDetail: { id: 84, title: 'Task 84', status: 'RUNNING' },
+    setSelectedTask: jest.fn(),
+    refreshTasks: jest.fn(),
+    refreshSelectedTaskDetail: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/tasks/contexts/chatStreamContext', () => ({
+  useChatStreamContext: () => ({
+    clearAllStreams: jest.fn(),
+  }),
+}))
+
+jest.mock('@/features/tasks/hooks/useSearchShortcut', () => ({
+  useSearchShortcut: () => ({
+    shortcutDisplayText: 'Ctrl+K',
+  }),
+}))
+
+jest.mock('@/features/tasks/components/chat', () => ({
+  ChatArea: () => <div>chat-area</div>,
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/features/tasks/components/remote-workspace', () => ({
+  RemoteWorkspaceEntry: ({ taskId }: { taskId?: number | null }) => (
+    <div data-testid="remote-workspace-entry">{String(taskId)}</div>
+  ),
+}))
+
+describe('CodePageMobile remote workspace integration', () => {
+  test('code mobile renders remote workspace entry in top nav when task selected', () => {
+    render(<CodePageMobile />)
+
+    expect(screen.getByTestId('remote-workspace-entry')).toHaveTextContent('84')
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom'
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { remoteWorkspaceApis } from '@/apis/remoteWorkspace'
+import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { RemoteWorkspaceDialog } from '@/features/tasks/components/remote-workspace/RemoteWorkspaceDialog'
 
 jest.mock('@/apis/remoteWorkspace', () => ({
@@ -19,10 +20,18 @@ jest.mock('@/features/layout/hooks/useMediaQuery', () => ({
   useIsMobile: jest.fn(() => false),
 }))
 
+jest.mock('@/features/theme/ThemeProvider', () => ({
+  useTheme: () => ({
+    theme: 'light',
+  }),
+}))
+
 const translations: Record<string, string> = {
   'remote_workspace.title': 'Remote Workspace',
   'remote_workspace.root': 'Workspace',
   'remote_workspace.parent': 'Parent',
+  'remote_workspace.parent_entry': 'Parent folder',
+  'remote_workspace.parent_entry_hint': 'Go back one level',
   'remote_workspace.search_placeholder': 'Search files',
   'remote_workspace.sort.label': 'Sort',
   'remote_workspace.sort.options.name_asc': 'Name (A-Z)',
@@ -35,6 +44,8 @@ const translations: Record<string, string> = {
   'remote_workspace.actions.cancel': 'Cancel',
   'remote_workspace.actions.preview': 'Preview',
   'remote_workspace.actions.refresh': 'Refresh',
+  'remote_workspace.download_confirm.title': 'Download selected files?',
+  'remote_workspace.download_confirm.description': 'Download selected files.',
   'remote_workspace.columns.select_all': 'Select all files',
   'remote_workspace.columns.name': 'Name',
   'remote_workspace.columns.size': 'Size',
@@ -90,6 +101,7 @@ describe('RemoteWorkspaceDialog', () => {
     jest.clearAllMocks()
     ;(remoteWorkspaceApis.getTree as jest.Mock).mockReset()
     ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReset()
+    ;(useIsMobile as jest.Mock).mockReturnValue(false)
   })
 
   function mockRootEntries() {
@@ -277,7 +289,7 @@ describe('RemoteWorkspaceDialog', () => {
     expect(rows[2]).toHaveTextContent('diagram.png')
   })
 
-  test('single click does not navigate directory and double click navigates', async () => {
+  test('single click navigates directory without a checkbox and readable parent row returns upward', async () => {
     ;(remoteWorkspaceApis.getTree as jest.Mock)
       .mockResolvedValueOnce({
         path: '/workspace',
@@ -313,19 +325,45 @@ describe('RemoteWorkspaceDialog', () => {
       expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
     })
 
+    expect(screen.queryByRole('button', { name: 'Parent' })).not.toBeInTheDocument()
+
     const user = userEvent.setup({ pointerEventsCheck: 0 })
     const fileTable = await screen.findByRole('table')
     const directoryNode = await within(fileTable).findByText(/^src$/i)
+    expect(screen.queryByRole('checkbox', { name: 'select-src' })).not.toBeInTheDocument()
     await user.click(directoryNode)
-
-    expect(remoteWorkspaceApis.getTree).toHaveBeenCalledTimes(1)
-
-    await user.dblClick(directoryNode)
 
     await waitFor(() => {
       expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace/src')
     })
     expect(screen.getByText(/index\.ts/i)).toBeInTheDocument()
+    expect(within(fileTable).getByText(/^Parent folder$/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/^0\s+selected$/i).length).toBeGreaterThan(0)
+
+    await user.click(within(fileTable).getByText(/^Parent folder$/i))
+
+    expect(screen.queryByText(/index\.ts/i)).not.toBeInTheDocument()
+    expect(within(fileTable).queryByText(/^Parent folder$/i)).not.toBeInTheDocument()
+    expect(within(fileTable).getByText(/^src$/i)).toBeInTheDocument()
+  })
+
+  test('select all only selects files', async () => {
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReturnValue(
+      '/api/tasks/1/remote-workspace/file'
+    )
+
+    render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.click(screen.getByRole('checkbox', { name: 'Select all files' }))
+
+    expect(screen.getAllByText(/^2\s+selected$/i).length).toBeGreaterThan(0)
+    expect(screen.queryByRole('checkbox', { name: 'select-src' })).not.toBeInTheDocument()
   })
 
   test('double click file opens preview dialog', async () => {
@@ -447,6 +485,211 @@ describe('RemoteWorkspaceDialog', () => {
 
     expect(screen.getAllByText(/^2\s+selected$/i).length).toBeGreaterThan(0)
     expect(screen.getByText('Multiple items selected')).toBeInTheDocument()
+  })
+
+  test('desktop toolbar downloads all selected files', async () => {
+    const originalFetch = global.fetch
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      blob: jest.fn().mockResolvedValue(new Blob(['file'])),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:remote-workspace-file'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    })
+    const anchorClickMock = jest
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockImplementation(
+      (_taskId: number, path: string, disposition: string) =>
+        `/api/tasks/1/remote-workspace/file?path=${encodeURIComponent(path)}&disposition=${disposition}`
+    )
+
+    try {
+      render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+      await waitFor(() => {
+        expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+      })
+
+      await screen.findByText(/diagram\.png/i)
+
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      await user.click(screen.getByRole('checkbox', { name: 'select-diagram.png' }))
+      await user.click(screen.getByRole('checkbox', { name: 'select-notes.txt' }))
+
+      const downloadButton = screen.getByRole('button', { name: 'Download' })
+      expect(downloadButton).toBeEnabled()
+      await user.click(downloadButton)
+
+      expect(fetchMock).not.toHaveBeenCalled()
+      const confirmDialog = screen.getByRole('alertdialog', {
+        name: 'Download selected files?',
+      })
+      expect(confirmDialog).toBeInTheDocument()
+      await user.click(within(confirmDialog).getByRole('button', { name: 'Download' }))
+
+      await waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      })
+      expect(remoteWorkspaceApis.getFileUrl).toHaveBeenCalledWith(
+        1,
+        '/workspace/diagram.png',
+        'attachment'
+      )
+      expect(remoteWorkspaceApis.getFileUrl).toHaveBeenCalledWith(
+        1,
+        '/workspace/notes.txt',
+        'attachment'
+      )
+    } finally {
+      global.fetch = originalFetch
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreateObjectURL,
+      })
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      })
+      anchorClickMock.mockRestore()
+    }
+  })
+
+  test('mobile opens file preview directly and keeps download inside preview tab', async () => {
+    ;(useIsMobile as jest.Mock).mockReturnValue(true)
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReturnValue(
+      '/api/tasks/1/remote-workspace/file'
+    )
+
+    render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.click(await screen.findByText(/diagram\.png/i))
+
+    expect(screen.getByText('Path: /workspace/diagram.png')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument()
+    expect(screen.queryByTestId('remote-workspace-mobile-preview-button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('remote-workspace-mobile-download-button')).not.toBeInTheDocument()
+    expect(screen.queryByText(/^1\s+selected/i)).not.toBeInTheDocument()
+  })
+
+  test('mobile renders text file preview content', async () => {
+    const originalFetch = global.fetch
+    const originalCreateObjectURL = URL.createObjectURL
+    const originalRevokeObjectURL = URL.revokeObjectURL
+    let unmount: (() => void) | undefined
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      blob: jest.fn().mockResolvedValue({
+        text: jest.fn().mockResolvedValue('hello mobile preview'),
+      }),
+    }) as unknown as typeof fetch
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: jest.fn(() => 'blob:remote-workspace-preview'),
+    })
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      configurable: true,
+      value: jest.fn(),
+    })
+    ;(useIsMobile as jest.Mock).mockReturnValue(true)
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReturnValue(
+      '/api/tasks/1/remote-workspace/file'
+    )
+
+    try {
+      ;({ unmount } = render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />))
+
+      await waitFor(() => {
+        expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+      })
+
+      const user = userEvent.setup({ pointerEventsCheck: 0 })
+      await user.click(await screen.findByText(/notes\.txt/i))
+
+      expect(await screen.findByText('hello mobile preview')).toBeInTheDocument()
+      expect(
+        screen.queryByText('This file type is not supported for preview. Please download.')
+      ).not.toBeInTheDocument()
+    } finally {
+      unmount?.()
+      global.fetch = originalFetch
+      Object.defineProperty(URL, 'createObjectURL', {
+        configurable: true,
+        value: originalCreateObjectURL,
+      })
+      Object.defineProperty(URL, 'revokeObjectURL', {
+        configurable: true,
+        value: originalRevokeObjectURL,
+      })
+    }
+  })
+
+  test('mobile shows parent row in child directories', async () => {
+    ;(useIsMobile as jest.Mock).mockReturnValue(true)
+    ;(remoteWorkspaceApis.getTree as jest.Mock)
+      .mockResolvedValueOnce({
+        path: '/workspace',
+        entries: [
+          {
+            name: 'src',
+            path: '/workspace/src',
+            is_directory: true,
+            size: 0,
+            modified_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace/src',
+        entries: [
+          {
+            name: 'index.ts',
+            path: '/workspace/src/index.ts',
+            is_directory: false,
+            size: 200,
+            modified_at: null,
+          },
+        ],
+      })
+
+    render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    expect(screen.queryByRole('button', { name: 'Parent' })).not.toBeInTheDocument()
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.click(await screen.findByText(/^src$/i))
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace/src')
+    })
+    expect(screen.getByText('Path: /workspace/src')).toBeInTheDocument()
+    expect(screen.getByText(/^Parent folder$/i)).toBeInTheDocument()
+    expect(screen.getByText('Go back one level')).toBeInTheDocument()
+
+    await user.click(screen.getByText(/^Parent folder$/i))
+
+    expect(screen.getByText('Path: /workspace')).toBeInTheDocument()
+    expect(screen.queryByText(/^Parent folder$/i)).not.toBeInTheDocument()
   })
 
   test('keeps file list scroll inside dialog content area', async () => {

--- a/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceEntry.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceEntry.test.tsx
@@ -10,6 +10,7 @@ import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspa
 jest.mock('@/apis/remoteWorkspace', () => ({
   remoteWorkspaceApis: {
     getStatus: jest.fn(),
+    getTree: jest.fn(),
   },
 }))
 
@@ -30,6 +31,7 @@ jest.mock('@/hooks/useTranslation', () => ({
         'remote_workspace.reason_booting': 'Remote workspace is booting',
         'remote_workspace.reason_warming': 'Remote workspace is warming up',
         'remote_workspace.reason_starting': 'Remote workspace is starting',
+        'remote_workspace.status.has_files': 'Files',
         'tasks:remote_workspace.button': 'Remote Workspace',
         'tasks:remote_workspace.unavailable': 'Remote session unavailable',
       }
@@ -41,6 +43,10 @@ jest.mock('@/hooks/useTranslation', () => ({
 describe('RemoteWorkspaceEntry', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(remoteWorkspaceApis.getTree as jest.Mock).mockResolvedValue({
+      path: '/workspace',
+      entries: [],
+    })
   })
 
   afterEach(() => {
@@ -104,6 +110,176 @@ describe('RemoteWorkspaceEntry', () => {
     expect(button).toHaveClass('h-8')
     expect(button).toHaveClass('rounded-[7px]')
     expect(button).toHaveClass('text-sm')
+  })
+
+  test('shows file hint when root tree has any entry', async () => {
+    ;(remoteWorkspaceApis.getStatus as jest.Mock).mockResolvedValue({
+      connected: true,
+      available: true,
+      root_path: '/workspace',
+      reason: null,
+    })
+    ;(remoteWorkspaceApis.getTree as jest.Mock).mockResolvedValue({
+      path: '/workspace',
+      entries: [
+        {
+          name: 'src',
+          path: '/workspace/src',
+          is_directory: true,
+          size: 0,
+        },
+      ],
+    })
+
+    render(<RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId('remote-workspace-file-hint')).toHaveTextContent('Files')
+    })
+  })
+
+  test('shows visible file hint inside icon button when root tree has entries', async () => {
+    ;(remoteWorkspaceApis.getStatus as jest.Mock).mockResolvedValue({
+      connected: true,
+      available: true,
+      root_path: '/workspace',
+      reason: null,
+    })
+    ;(remoteWorkspaceApis.getTree as jest.Mock).mockResolvedValue({
+      path: '/workspace',
+      entries: [
+        {
+          name: 'output',
+          path: '/workspace/output',
+          is_directory: true,
+          size: 0,
+        },
+      ],
+    })
+
+    render(<RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" display="icon" />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    await waitFor(() => {
+      const button = screen.getByTestId('remote-workspace-button')
+      expect(button).toHaveClass('min-w-[64px]')
+      expect(screen.getByTestId('remote-workspace-file-hint')).toHaveTextContent('Files')
+      expect(screen.getByTestId('remote-workspace-file-hint')).not.toHaveClass('absolute')
+    })
+  })
+
+  test('hides file hint when root tree is empty', async () => {
+    ;(remoteWorkspaceApis.getStatus as jest.Mock).mockResolvedValue({
+      connected: true,
+      available: true,
+      root_path: '/workspace',
+      reason: null,
+    })
+    ;(remoteWorkspaceApis.getTree as jest.Mock).mockResolvedValue({
+      path: '/workspace',
+      entries: [],
+    })
+
+    render(<RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    expect(screen.queryByTestId('remote-workspace-file-hint')).not.toBeInTheDocument()
+  })
+
+  test('refreshes file hint after task status changes', async () => {
+    ;(remoteWorkspaceApis.getStatus as jest.Mock).mockResolvedValue({
+      connected: true,
+      available: true,
+      root_path: '/workspace',
+      reason: null,
+    })
+    ;(remoteWorkspaceApis.getTree as jest.Mock)
+      .mockResolvedValueOnce({
+        path: '/workspace',
+        entries: [],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace',
+        entries: [
+          {
+            name: 'output',
+            path: '/workspace/output',
+            is_directory: true,
+            size: 0,
+          },
+        ],
+      })
+
+    const { rerender } = render(<RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByTestId('remote-workspace-file-hint')).not.toBeInTheDocument()
+
+    rerender(<RemoteWorkspaceEntry taskId={1} taskStatus="COMPLETED" />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('remote-workspace-file-hint')).toHaveTextContent('Files')
+    })
+  })
+
+  test('refreshes file hint when refresh key changes without task status change', async () => {
+    ;(remoteWorkspaceApis.getStatus as jest.Mock).mockResolvedValue({
+      connected: true,
+      available: true,
+      root_path: '/workspace',
+      reason: null,
+    })
+    ;(remoteWorkspaceApis.getTree as jest.Mock)
+      .mockResolvedValueOnce({
+        path: '/workspace',
+        entries: [],
+      })
+      .mockResolvedValueOnce({
+        path: '/workspace',
+        entries: [
+          {
+            name: 'result.html',
+            path: '/workspace/result.html',
+            is_directory: false,
+            size: 128,
+          },
+        ],
+      })
+
+    const { rerender } = render(
+      <RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" refreshKey="round-1" display="icon" />
+    )
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.queryByTestId('remote-workspace-file-hint')).not.toBeInTheDocument()
+
+    rerender(
+      <RemoteWorkspaceEntry taskId={1} taskStatus="RUNNING" refreshKey="round-2" display="icon" />
+    )
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('remote-workspace-file-hint')).toHaveTextContent('Files')
+    })
   })
 
   test('keeps button visible and disabled when workspace is not connected', async () => {

--- a/frontend/src/__tests__/features/tasks/components/remote-workspace/i18n.test.ts
+++ b/frontend/src/__tests__/features/tasks/components/remote-workspace/i18n.test.ts
@@ -11,6 +11,8 @@ type RemoteWorkspaceTranslations = {
   title?: string
   root?: string
   parent?: string
+  parent_entry?: string
+  parent_entry_hint?: string
   search_placeholder?: string
   sort?: {
     label?: string
@@ -25,6 +27,10 @@ type RemoteWorkspaceTranslations = {
     download?: string
     refresh?: string
   }
+  download_confirm?: {
+    title?: string
+    description?: string
+  }
   columns?: {
     select_all?: string
     name?: string
@@ -36,6 +42,7 @@ type RemoteWorkspaceTranslations = {
     path?: string
     selected?: string
     items?: string
+    has_files?: string
   }
   detail?: {
     title?: string
@@ -73,6 +80,8 @@ function assertRemoteWorkspaceKeys(locale: RemoteWorkspaceTranslations) {
   expect(locale.title).toBeTruthy()
   expect(locale.root).toBeTruthy()
   expect(locale.parent).toBeTruthy()
+  expect(locale.parent_entry).toBeTruthy()
+  expect(locale.parent_entry_hint).toBeTruthy()
   expect(locale.search_placeholder).toBeTruthy()
   expect(locale.sort?.label).toBeTruthy()
   expect(locale.sort?.options?.name_asc).toBeTruthy()
@@ -81,6 +90,8 @@ function assertRemoteWorkspaceKeys(locale: RemoteWorkspaceTranslations) {
   expect(locale.sort?.options?.modified_desc).toBeTruthy()
   expect(locale.actions?.download).toBeTruthy()
   expect(locale.actions?.refresh).toBeTruthy()
+  expect(locale.download_confirm?.title).toBeTruthy()
+  expect(locale.download_confirm?.description).toBeTruthy()
   expect(locale.columns?.select_all).toBeTruthy()
   expect(locale.columns?.name).toBeTruthy()
   expect(locale.columns?.size).toBeTruthy()
@@ -89,6 +100,7 @@ function assertRemoteWorkspaceKeys(locale: RemoteWorkspaceTranslations) {
   expect(locale.status?.path).toBeTruthy()
   expect(locale.status?.selected).toBeTruthy()
   expect(locale.status?.items).toBeTruthy()
+  expect(locale.status?.has_files).toBeTruthy()
   expect(locale.detail?.title).toBeTruthy()
   expect(locale.detail?.no_file_selected).toBeTruthy()
   expect(locale.detail?.multiple_selected).toBeTruthy()

--- a/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
@@ -29,6 +29,7 @@ import { fetchBotsList } from '@/features/settings/services/bots'
 import TeamEditDialog from '@/features/settings/components/TeamEditDialog'
 import type { BaseRole } from '@/types/base-role'
 import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
+import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
 
 /**
  * Mobile-specific implementation of Chat Page
@@ -48,8 +49,13 @@ export function ChatPageMobile() {
   const { teams, isTeamsLoading, refreshTeams } = useTeamContext()
 
   // Task context for refreshing task list
-  const { refreshTasks, selectedTaskDetail, setSelectedTask, refreshSelectedTaskDetail } =
-    useTaskContext()
+  const {
+    refreshTasks,
+    selectedTask,
+    selectedTaskDetail,
+    setSelectedTask,
+    refreshSelectedTaskDetail,
+  } = useTaskContext()
 
   // Device context - when a device is selected, switch to 'task' mode
   const { selectedDeviceId, devices } = useDevices()
@@ -263,11 +269,19 @@ export function ChatPageMobile() {
               variant="outline"
               size="sm"
               onClick={() => setIsCreateGroupChatOpen(true)}
-              className="gap-1 h-11 min-w-[44px] pl-2 pr-3 rounded-[7px] text-sm"
+              className="h-8 w-8 p-0 rounded-[7px]"
             >
-              <UserGroupIcon className="h-4 w-4" />
+              <UserGroupIcon className="h-3.5 w-3.5" />
               <span className="sr-only">{t('groupChat.create.button')}</span>
             </Button>
+          )}
+          {(selectedTask?.id || selectedTaskDetail?.id) && (
+            <RemoteWorkspaceEntry
+              taskId={selectedTask?.id || selectedTaskDetail?.id}
+              taskStatus={selectedTaskDetail?.status}
+              refreshKey={selectedTaskDetail?.updated_at}
+              display="icon"
+            />
           )}
           {shareButton}
           <ThemeToggle />

--- a/frontend/src/app/(tasks)/code/CodePageMobile.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageMobile.tsx
@@ -17,6 +17,7 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
 import { ChatArea } from '@/features/tasks/components/chat'
+import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
 
 /**
  * Mobile-specific implementation of Code Page
@@ -40,8 +41,13 @@ export function CodePageMobile() {
   const { teams, isTeamsLoading, refreshTeams } = useTeamContext()
 
   // Task context for workbench data
-  const { selectedTaskDetail, setSelectedTask, refreshTasks, refreshSelectedTaskDetail } =
-    useTaskContext()
+  const {
+    selectedTask,
+    selectedTaskDetail,
+    setSelectedTask,
+    refreshTasks,
+    refreshSelectedTaskDetail,
+  } = useTaskContext()
 
   // Get current task title for top navigation
   const currentTaskTitle = selectedTaskDetail?.title
@@ -132,6 +138,14 @@ export function CodePageMobile() {
           onMembersChanged={handleMembersChanged}
           isSidebarCollapsed={false}
         >
+          {(selectedTask?.id || selectedTaskDetail?.id) && (
+            <RemoteWorkspaceEntry
+              taskId={selectedTask?.id || selectedTaskDetail?.id}
+              taskStatus={selectedTaskDetail?.status}
+              refreshKey={selectedTaskDetail?.updated_at}
+              display="icon"
+            />
+          )}
           {shareButton}
           <ThemeToggle />
           {/* Note: Open menu and workbench toggle are hidden on mobile for simplicity */}

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.tsx
@@ -67,8 +67,8 @@ export function RemoteWorkspaceDialog({
 
   // Blob for file preview (to support authenticated file access)
   const [previewBlob, setPreviewBlob] = useState<Blob | null>(null)
-  const [_isPreviewLoading, setIsPreviewLoading] = useState(false)
-  const [_previewError, setPreviewError] = useState<string | null>(null)
+  const [isPreviewLoading, setIsPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
 
   const expandPathToDirectory = useCallback(
     (path: string) => {
@@ -239,14 +239,6 @@ export function RemoteWorkspaceDialog({
     return resolvePreviewKind(previewEntry.name)
   }, [previewEntry])
 
-  const inlineUrl = useMemo(() => {
-    if (!previewEntry) {
-      return ''
-    }
-
-    return remoteWorkspaceApis.getFileUrl(taskId, previewEntry.path, 'inline')
-  }, [previewEntry, taskId])
-
   const downloadUrl = useMemo(() => {
     if (!previewEntry) {
       return ''
@@ -263,13 +255,20 @@ export function RemoteWorkspaceDialog({
 
   // Effect to load blob for previews
   useEffect(() => {
-    if (!isPreviewDialogOpen || !previewEntry) {
+    const shouldLoadPreviewBlob = isPreviewDialogOpen || isMobile
+
+    if (!shouldLoadPreviewBlob || !previewEntry) {
       setPreviewBlob(null)
+      setIsPreviewLoading(false)
+      setPreviewError(null)
       return
     }
 
     // Load blob for all previewable types (image, pdf, excel, text)
     if (previewKind === 'unsupported' || previewKind === 'none') {
+      setPreviewBlob(null)
+      setIsPreviewLoading(false)
+      setPreviewError(null)
       return
     }
 
@@ -303,9 +302,10 @@ export function RemoteWorkspaceDialog({
     return () => {
       setPreviewBlob(null)
     }
-  }, [isPreviewDialogOpen, previewEntry, previewKind, taskId, t])
+  }, [isMobile, isPreviewDialogOpen, previewEntry, previewKind, taskId, t])
 
-  const canGoParent = Boolean(getParentPath(rootPath, currentPath))
+  const parentPath = getParentPath(rootPath, currentPath)
+  const canGoParent = Boolean(parentPath)
   const breadcrumbs = useMemo(
     () => buildBreadcrumbSegments(rootPath, currentPath),
     [currentPath, rootPath]
@@ -350,9 +350,17 @@ export function RemoteWorkspaceDialog({
     [navigateToDirectory]
   )
 
-  const handleSelectEntry = useCallback((entry: RemoteWorkspaceTreeEntry) => {
-    setSelectedPaths([entry.path])
-  }, [])
+  const handleSelectEntry = useCallback(
+    (entry: RemoteWorkspaceTreeEntry) => {
+      if (entry.is_directory) {
+        navigateToDirectory(entry.path)
+        return
+      }
+
+      setSelectedPaths([entry.path])
+    },
+    [navigateToDirectory]
+  )
 
   const handleOpenEntryDesktop = useCallback(
     (entry: RemoteWorkspaceTreeEntry) => {
@@ -398,6 +406,10 @@ export function RemoteWorkspaceDialog({
 
   const handleToggleEntrySelection = useCallback(
     (entry: RemoteWorkspaceTreeEntry, checked: boolean) => {
+      if (entry.is_directory) {
+        return
+      }
+
       setSelectedPaths(previous => {
         if (checked) {
           if (previous.includes(entry.path)) {
@@ -419,7 +431,7 @@ export function RemoteWorkspaceDialog({
         return
       }
 
-      setSelectedPaths(visibleEntries.map(entry => entry.path))
+      setSelectedPaths(visibleEntries.filter(entry => !entry.is_directory).map(entry => entry.path))
     },
     [visibleEntries]
   )
@@ -499,7 +511,9 @@ export function RemoteWorkspaceDialog({
             selectedPaths={selectedPathSet}
             selectedEntries={selectedEntries}
             previewKind={previewKind}
-            inlineUrl={inlineUrl}
+            previewBlob={previewBlob}
+            isPreviewLoading={isPreviewLoading}
+            previewError={previewError}
             searchKeyword={searchKeyword}
             sortOption={sortOption}
             canGoParent={canGoParent}
@@ -519,7 +533,6 @@ export function RemoteWorkspaceDialog({
             }
             onSearchChange={setSearchKeyword}
             onSortChange={setSortOption}
-            onToggleEntrySelection={handleToggleEntrySelection}
             onOpenEntry={handleOpenEntryMobile}
           />
         ) : (
@@ -544,7 +557,6 @@ export function RemoteWorkspaceDialog({
             pathInputError={pathInputError}
             isPathEditing={isPathEditing}
             canGoParent={canGoParent}
-            canDownloadPreview={canDownloadPreview}
             isPreviewDialogOpen={isPreviewDialogOpen}
             onDownload={handleDownloadFile}
             onGoRoot={() => navigateToDirectory(rootPath)}

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx
@@ -5,8 +5,19 @@
 'use client'
 
 import { Download, X } from 'lucide-react'
+import { useState } from 'react'
 
 import { type RemoteWorkspaceTreeEntry } from '@/apis/remoteWorkspace'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
@@ -17,6 +28,7 @@ import { TFunction } from 'i18next'
 import {
   formatModifiedAt,
   formatSize,
+  getMimeTypeFromPreviewKind,
   resolvePreviewKind,
   type BreadcrumbSegment,
   type PreviewKind,
@@ -49,7 +61,6 @@ type RemoteWorkspaceDialogDesktopProps = {
   pathInputError: string | null
   isPathEditing: boolean
   canGoParent: boolean
-  canDownloadPreview: boolean
   isPreviewDialogOpen: boolean
   onDownload: (entry: RemoteWorkspaceTreeEntry) => void
   onGoRoot: () => void
@@ -117,7 +128,6 @@ export function RemoteWorkspaceDialogDesktop({
   pathInputError,
   isPathEditing,
   canGoParent,
-  canDownloadPreview,
   isPreviewDialogOpen,
   onGoRoot,
   onGoParent,
@@ -138,10 +148,28 @@ export function RemoteWorkspaceDialogDesktop({
   onPreviewDialogOpenChange,
   onDownload,
 }: RemoteWorkspaceDialogDesktopProps) {
+  const [isDownloadConfirmOpen, setIsDownloadConfirmOpen] = useState(false)
+  const selectableEntries = visibleEntries.filter(entry => !entry.is_directory)
   const allEntriesSelected =
-    visibleEntries.length > 0 && visibleEntries.every(entry => selectedPaths.has(entry.path))
+    selectableEntries.length > 0 && selectableEntries.every(entry => selectedPaths.has(entry.path))
   const selectedCount = selectedPaths.size
   const detailEntry = selectedEntries.length === 1 ? selectedEntries[0] : null
+  const downloadableSelectedEntries = selectedEntries.filter(entry => !entry.is_directory)
+  const downloadableSelectedCount = downloadableSelectedEntries.length
+  const handleDownloadSelectedEntries = () => {
+    if (downloadableSelectedCount === 1) {
+      onDownload(downloadableSelectedEntries[0])
+      return
+    }
+
+    if (downloadableSelectedCount > 1) {
+      setIsDownloadConfirmOpen(true)
+    }
+  }
+  const handleConfirmDownloadSelectedEntries = () => {
+    downloadableSelectedEntries.forEach(entry => onDownload(entry))
+    setIsDownloadConfirmOpen(false)
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -149,15 +177,6 @@ export function RemoteWorkspaceDialogDesktop({
         <div className="flex flex-wrap items-center gap-2">
           <Button type="button" variant="outline" size="sm" onClick={onGoRoot}>
             {t('remote_workspace.root')}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={onGoParent}
-            disabled={!canGoParent}
-          >
-            {t('remote_workspace.parent')}
           </Button>
           <div className="w-full min-w-[200px] flex-1 md:max-w-[420px]">
             <Input
@@ -198,20 +217,15 @@ export function RemoteWorkspaceDialogDesktop({
           >
             {t('remote_workspace.actions.preview', 'Preview')}
           </Button>
-          {canDownloadPreview && previewEntry ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => onDownload(previewEntry)}
-            >
-              {t('remote_workspace.actions.download')}
-            </Button>
-          ) : (
-            <Button type="button" variant="outline" size="sm" disabled>
-              {t('remote_workspace.actions.download')}
-            </Button>
-          )}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={downloadableSelectedCount === 0}
+            onClick={handleDownloadSelectedEntries}
+          >
+            {t('remote_workspace.actions.download')}
+          </Button>
         </div>
 
         {isPathEditing ? (
@@ -287,6 +301,7 @@ export function RemoteWorkspaceDialogDesktop({
                     <Checkbox
                       aria-label={t('remote_workspace.columns.select_all')}
                       checked={allEntriesSelected}
+                      disabled={selectableEntries.length === 0}
                       onCheckedChange={checked => onToggleAllEntries(Boolean(checked))}
                     />
                   </th>
@@ -330,10 +345,31 @@ export function RemoteWorkspaceDialogDesktop({
                   </tr>
                 )}
 
+                {!isTreeLoading && !treeError && canGoParent && (
+                  <tr
+                    className="cursor-pointer hover:bg-surface"
+                    data-testid="remote-workspace-parent-row"
+                    onClick={onGoParent}
+                  >
+                    <td className="px-3 py-2 align-middle" />
+                    <td className="px-3 py-2 align-middle">
+                      <span className="block max-w-[280px] truncate rounded px-1 py-1 text-left text-text-primary">
+                        {t('remote_workspace.parent_entry', 'Parent folder')}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 align-middle text-text-muted">
+                      {t('remote_workspace.types.folder', 'Folder')}
+                    </td>
+                    <td className="px-3 py-2 align-middle text-text-muted">--</td>
+                    <td className="px-3 py-2 align-middle text-text-muted">--</td>
+                  </tr>
+                )}
+
                 {!isTreeLoading &&
                   !treeError &&
                   visibleEntries.map(entry => {
-                    const isSelected = selectedPaths.has(entry.path)
+                    const isSelectable = !entry.is_directory
+                    const isSelected = isSelectable && selectedPaths.has(entry.path)
 
                     return (
                       <tr
@@ -343,19 +379,28 @@ export function RemoteWorkspaceDialogDesktop({
                             ? 'bg-primary/10 cursor-pointer'
                             : 'hover:bg-surface cursor-pointer'
                         }
-                        onClick={() => onSelectEntry(entry)}
+                        onClick={() => {
+                          if (entry.is_directory) {
+                            onOpenEntry(entry)
+                            return
+                          }
+
+                          onSelectEntry(entry)
+                        }}
                         onDoubleClick={() => onOpenEntry(entry)}
                       >
                         <td className="px-3 py-2 align-middle">
-                          <Checkbox
-                            checked={isSelected}
-                            onCheckedChange={checked =>
-                              onToggleEntrySelection(entry, Boolean(checked))
-                            }
-                            onClick={event => event.stopPropagation()}
-                            onDoubleClick={event => event.stopPropagation()}
-                            aria-label={`select-${entry.name}`}
-                          />
+                          {isSelectable && (
+                            <Checkbox
+                              checked={isSelected}
+                              onCheckedChange={checked =>
+                                onToggleEntrySelection(entry, Boolean(checked))
+                              }
+                              onClick={event => event.stopPropagation()}
+                              onDoubleClick={event => event.stopPropagation()}
+                              aria-label={`select-${entry.name}`}
+                            />
+                          )}
                         </td>
                         <td className="px-3 py-2 align-middle">
                           <span className="block max-w-[280px] truncate rounded px-1 py-1 text-left text-text-primary">
@@ -440,6 +485,28 @@ export function RemoteWorkspaceDialogDesktop({
           </span>
         </div>
       </footer>
+
+      <AlertDialog open={isDownloadConfirmOpen} onOpenChange={setIsDownloadConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('remote_workspace.download_confirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('remote_workspace.download_confirm.description', {
+                count: downloadableSelectedCount,
+              })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('remote_workspace.actions.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              className="border-primary bg-primary text-white hover:bg-primary/90"
+              onClick={handleConfirmDownloadSelectedEntries}
+            >
+              {t('remote_workspace.actions.download')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <Dialog
         open={isPreviewDialogOpen && Boolean(previewEntry)}
@@ -533,33 +600,5 @@ function getFileIcon(previewKind: PreviewKind): string {
       return '📃'
     default:
       return '📎'
-  }
-}
-
-/**
- * Convert preview kind to MIME type
- */
-function getMimeTypeFromPreviewKind(previewKind: PreviewKind, filename: string): string {
-  switch (previewKind) {
-    case 'image':
-      return 'image/png'
-    case 'pdf':
-      return 'application/pdf'
-    case 'excel':
-      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
-    case 'text':
-      // Return appropriate mime type based on file extension
-      if (filename.endsWith('.py')) return 'text/x-python'
-      if (filename.endsWith('.js')) return 'application/javascript'
-      if (filename.endsWith('.ts')) return 'application/typescript'
-      if (filename.endsWith('.json')) return 'application/json'
-      if (filename.endsWith('.md')) return 'text/markdown'
-      if (filename.endsWith('.html') || filename.endsWith('.htm')) return 'text/html'
-      if (filename.endsWith('.css')) return 'text/css'
-      if (filename.endsWith('.xml')) return 'application/xml'
-      if (filename.endsWith('.yaml') || filename.endsWith('.yml')) return 'application/yaml'
-      return 'text/plain'
-    default:
-      return 'application/octet-stream'
   }
 }

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx
@@ -4,11 +4,11 @@
 
 'use client'
 
-import Image from 'next/image'
+import { useState } from 'react'
 
 import { type RemoteWorkspaceTreeEntry } from '@/apis/remoteWorkspace'
+import { FilePreview } from '@/components/common/FilePreview'
 import { Button } from '@/components/ui/button'
-import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
@@ -17,6 +17,7 @@ import { TFunction } from 'i18next'
 import {
   formatModifiedAt,
   formatSize,
+  getMimeTypeFromPreviewKind,
   resolvePreviewKind,
   type PreviewKind,
   type SortOption,
@@ -31,7 +32,9 @@ type RemoteWorkspaceDialogMobileProps = {
   selectedPaths: Set<string>
   selectedEntries: RemoteWorkspaceTreeEntry[]
   previewKind: PreviewKind
-  inlineUrl: string
+  previewBlob: Blob | null
+  isPreviewLoading: boolean
+  previewError: string | null
   searchKeyword: string
   sortOption: SortOption
   canGoParent: boolean
@@ -42,7 +45,6 @@ type RemoteWorkspaceDialogMobileProps = {
   onRefresh: () => void
   onSearchChange: (value: string) => void
   onSortChange: (value: SortOption) => void
-  onToggleEntrySelection: (entry: RemoteWorkspaceTreeEntry, checked: boolean) => void
   onOpenEntry: (entry: RemoteWorkspaceTreeEntry) => void
 }
 
@@ -77,7 +79,9 @@ export function RemoteWorkspaceDialogMobile({
   selectedPaths,
   selectedEntries,
   previewKind,
-  inlineUrl,
+  previewBlob,
+  isPreviewLoading,
+  previewError,
   searchKeyword,
   sortOption,
   canGoParent,
@@ -87,12 +91,17 @@ export function RemoteWorkspaceDialogMobile({
   onRefresh,
   onSearchChange,
   onSortChange,
-  onToggleEntrySelection,
   onOpenEntry,
   onDownload,
 }: RemoteWorkspaceDialogMobileProps) {
-  const selectedCount = selectedPaths.size
+  const [activeTab, setActiveTab] = useState('files')
   const detailEntry = selectedEntries.length === 1 ? selectedEntries[0] : null
+  const footerLabel = `${visibleEntries.length} ${t('remote_workspace.status.items')}`
+
+  const handleEntryOpen = (entry: RemoteWorkspaceTreeEntry) => {
+    onOpenEntry(entry)
+    setActiveTab(entry.is_directory ? 'files' : 'preview')
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -106,16 +115,6 @@ export function RemoteWorkspaceDialogMobile({
             onClick={onGoRoot}
           >
             {t('remote_workspace.root')}
-          </Button>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-11 min-w-[44px]"
-            onClick={onGoParent}
-            disabled={!canGoParent}
-          >
-            {t('remote_workspace.parent')}
           </Button>
           <Button
             type="button"
@@ -158,7 +157,11 @@ export function RemoteWorkspaceDialogMobile({
         {t('remote_workspace.status.path')}: {currentPath}
       </p>
 
-      <Tabs defaultValue="files" className="flex min-h-0 flex-1 flex-col px-4 py-3">
+      <Tabs
+        value={activeTab}
+        onValueChange={setActiveTab}
+        className="flex min-h-0 flex-1 flex-col px-4 py-3"
+      >
         <TabsList className="grid w-full grid-cols-2">
           <TabsTrigger value="files">{t('remote_workspace.mobile.tabs.files')}</TabsTrigger>
           <TabsTrigger value="preview">{t('remote_workspace.mobile.tabs.preview')}</TabsTrigger>
@@ -172,6 +175,26 @@ export function RemoteWorkspaceDialogMobile({
           {!isTreeLoading && !treeError && visibleEntries.length === 0 && (
             <p className="text-sm text-text-muted">{t('remote_workspace.tree.empty')}</p>
           )}
+          {!isTreeLoading && !treeError && canGoParent && (
+            <div className="mb-2 rounded-md border border-border bg-base p-3">
+              <button
+                type="button"
+                className="flex min-h-[44px] w-full flex-col items-start justify-center text-left"
+                data-testid="remote-workspace-mobile-parent-row"
+                onClick={() => {
+                  onGoParent()
+                  setActiveTab('files')
+                }}
+              >
+                <span className="text-sm text-text-primary">
+                  {t('remote_workspace.parent_entry', 'Parent folder')}
+                </span>
+                <span className="mt-1 text-xs text-text-muted">
+                  {t('remote_workspace.parent_entry_hint', 'Go back one level')}
+                </span>
+              </button>
+            </div>
+          )}
           {!isTreeLoading &&
             !treeError &&
             visibleEntries.map(entry => {
@@ -182,25 +205,18 @@ export function RemoteWorkspaceDialogMobile({
                   key={entry.path}
                   className={`mb-2 rounded-md border p-3 ${isSelected ? 'border-primary bg-primary/10' : 'border-border bg-base'}`}
                 >
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      checked={isSelected}
-                      onCheckedChange={checked => onToggleEntrySelection(entry, Boolean(checked))}
-                      aria-label={`select-${entry.name}`}
-                    />
-                    <button
-                      type="button"
-                      className="min-h-[44px] flex-1 text-left text-sm text-text-primary"
-                      onClick={() => onOpenEntry(entry)}
-                    >
-                      {entry.name}
-                    </button>
-                  </div>
-                  <div className="mt-1 text-xs text-text-muted">
-                    {resolveTypeLabel(entry, t)} ·{' '}
-                    {entry.is_directory ? '--' : formatSize(entry.size)} ·{' '}
-                    {formatModifiedAt(entry.modified_at)}
-                  </div>
+                  <button
+                    type="button"
+                    className="flex min-h-[44px] w-full flex-col items-start justify-center text-left"
+                    onClick={() => handleEntryOpen(entry)}
+                  >
+                    <span className="text-sm text-text-primary">{entry.name}</span>
+                    <span className="mt-1 text-xs text-text-muted">
+                      {resolveTypeLabel(entry, t)} ·{' '}
+                      {entry.is_directory ? '--' : formatSize(entry.size)} ·{' '}
+                      {formatModifiedAt(entry.modified_at)}
+                    </span>
+                  </button>
                 </div>
               )
             })}
@@ -244,34 +260,35 @@ export function RemoteWorkspaceDialogMobile({
               )}
 
               {!detailEntry.is_directory && (
-                <div className="min-h-[220px] rounded-md border border-border bg-surface p-3">
-                  {previewKind === 'image' && inlineUrl && (
-                    <Image
-                      src={inlineUrl}
-                      alt={detailEntry.name}
-                      width={1200}
-                      height={900}
-                      unoptimized
-                      className="max-h-[300px] max-w-full object-contain"
-                    />
-                  )}
-                  {previewKind === 'pdf' && inlineUrl && (
-                    <iframe
-                      title={detailEntry.name}
-                      src={inlineUrl}
-                      className="h-[300px] w-full rounded-md border border-border"
-                    />
-                  )}
-                  {previewKind === 'text' && (
-                    <p className="text-sm text-text-muted">
-                      {t('remote_workspace.preview.unsupported')}
-                    </p>
-                  )}
+                <div className="h-[360px] rounded-md border border-border bg-surface p-3">
                   {previewKind === 'unsupported' && (
                     <p className="text-sm text-text-muted">
                       {t('remote_workspace.preview.unsupported')}
                     </p>
                   )}
+                  {previewKind !== 'unsupported' && previewError && (
+                    <p className="text-sm text-error">{previewError}</p>
+                  )}
+                  {previewKind !== 'unsupported' &&
+                    !previewError &&
+                    (isPreviewLoading || !previewBlob) && (
+                      <p className="text-sm text-text-muted">
+                        {t('remote_workspace.preview.loading')}
+                      </p>
+                    )}
+                  {previewKind !== 'unsupported' &&
+                    !previewError &&
+                    !isPreviewLoading &&
+                    previewBlob && (
+                      <FilePreview
+                        fileBlob={previewBlob}
+                        filename={detailEntry.name}
+                        mimeType={getMimeTypeFromPreviewKind(previewKind, detailEntry.name)}
+                        fileSize={detailEntry.size}
+                        showToolbar={false}
+                        onDownload={() => onDownload(detailEntry)}
+                      />
+                    )}
                 </div>
               )}
             </div>
@@ -279,9 +296,8 @@ export function RemoteWorkspaceDialogMobile({
         </TabsContent>
       </Tabs>
 
-      <footer className="border-t border-border px-4 py-2 text-xs text-text-muted">
-        {selectedCount} {t('remote_workspace.status.selected')} · {visibleEntries.length}{' '}
-        {t('remote_workspace.status.items')}
+      <footer className="flex min-h-[60px] items-center justify-between gap-3 border-t border-border px-4 py-2 text-xs text-text-muted">
+        <span className="min-w-0 truncate">{footerLabel}</span>
       </footer>
     </div>
   )

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceEntry.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceEntry.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { FolderOpen } from 'lucide-react'
 
 import { remoteWorkspaceApis, type RemoteWorkspaceStatusResponse } from '@/apis/remoteWorkspace'
 import { Button } from '@/components/ui/button'
@@ -18,6 +19,9 @@ type RemoteWorkspaceEntryProps = {
   taskStatus?: string | null
   forceDisabled?: boolean
   disabledReason?: string
+  display?: 'label' | 'icon'
+  touchTarget?: boolean
+  refreshKey?: string | number | null
 }
 
 const UNAVAILABLE_RETRY_DELAYS_MS = [1000, 2000, 4000, 8000]
@@ -27,15 +31,20 @@ export function RemoteWorkspaceEntry({
   taskStatus,
   forceDisabled = false,
   disabledReason,
+  display = 'label',
+  touchTarget = false,
+  refreshKey,
 }: RemoteWorkspaceEntryProps) {
   const { t } = useTranslation('tasks')
   const [status, setStatus] = useState<RemoteWorkspaceStatusResponse | null>(null)
   const [isInitialLoading, setIsInitialLoading] = useState(false)
   const [hasLoadError, setHasLoadError] = useState(false)
+  const [hasWorkspaceEntries, setHasWorkspaceEntries] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
   const isMountedRef = useRef(true)
   const latestTaskIdRef = useRef<number | null>(null)
   const requestSequenceRef = useRef(0)
+  const treeRequestSequenceRef = useRef(0)
   const previousTaskIdRef = useRef<number | null>(null)
   const previousTaskStatusRef = useRef<string | null | undefined>(undefined)
   const retryAttemptRef = useRef(0)
@@ -78,7 +87,7 @@ export function RemoteWorkspaceEntry({
           requestSequenceRef.current === requestSequence
         ) {
           setHasLoadError(false)
-          setStatus(payload)
+          setStatus({ ...payload })
         }
       } catch {
         if (
@@ -104,13 +113,46 @@ export function RemoteWorkspaceEntry({
     [taskId]
   )
 
+  const loadWorkspaceEntryHint = useCallback(
+    async (rootPath: string) => {
+      if (!taskId) {
+        return
+      }
+
+      const requestTaskId = taskId
+      const requestSequence = ++treeRequestSequenceRef.current
+
+      try {
+        const payload = await remoteWorkspaceApis.getTree(requestTaskId, rootPath)
+        if (
+          isMountedRef.current &&
+          latestTaskIdRef.current === requestTaskId &&
+          treeRequestSequenceRef.current === requestSequence
+        ) {
+          setHasWorkspaceEntries(payload.entries.length > 0)
+        }
+      } catch {
+        if (
+          isMountedRef.current &&
+          latestTaskIdRef.current === requestTaskId &&
+          treeRequestSequenceRef.current === requestSequence
+        ) {
+          setHasWorkspaceEntries(false)
+        }
+      }
+    },
+    [taskId]
+  )
+
   useEffect(() => {
     if (!taskId) {
       clearRetryTimer()
       retryAttemptRef.current = 0
       latestTaskIdRef.current = null
       requestSequenceRef.current += 1
+      treeRequestSequenceRef.current += 1
       setStatus(null)
+      setHasWorkspaceEntries(false)
       setIsOpen(false)
       setIsInitialLoading(false)
       setHasLoadError(false)
@@ -131,8 +173,10 @@ export function RemoteWorkspaceEntry({
       clearRetryTimer()
       retryAttemptRef.current = 0
       setStatus(null)
+      setHasWorkspaceEntries(false)
       setIsOpen(false)
       setHasLoadError(false)
+      treeRequestSequenceRef.current += 1
       void loadStatus()
       return
     }
@@ -143,6 +187,15 @@ export function RemoteWorkspaceEntry({
       void loadStatus({ silent: true })
     }
   }, [clearRetryTimer, loadStatus, taskId, taskStatus])
+
+  useEffect(() => {
+    if (!taskId || !status?.connected || !status.available) {
+      setHasWorkspaceEntries(false)
+      return
+    }
+
+    void loadWorkspaceEntryHint(status.root_path || '/workspace')
+  }, [loadWorkspaceEntryHint, refreshKey, status, taskId])
 
   useEffect(() => {
     clearRetryTimer()
@@ -232,6 +285,40 @@ export function RemoteWorkspaceEntry({
     title = resolveUnavailableReason(status.reason)
   }
 
+  const isIconOnly = display === 'icon'
+  const shouldInlineIconHint = isIconOnly && hasWorkspaceEntries
+  const buttonLabel = t('remote_workspace.button')
+  const buttonTitle = title ?? (isIconOnly ? buttonLabel : undefined)
+  const buttonClassName = [
+    'relative overflow-visible',
+    isIconOnly
+      ? touchTarget
+        ? shouldInlineIconHint
+          ? 'h-11 min-w-[72px] px-2'
+          : 'h-11 w-11'
+        : shouldInlineIconHint
+          ? 'h-8 min-w-[64px] px-2'
+          : 'h-8 w-8'
+      : touchTarget
+        ? 'h-11 min-w-[44px]'
+        : 'h-8',
+    isIconOnly ? (shouldInlineIconHint ? 'gap-1' : 'p-0') : 'pl-2 pr-3',
+    'rounded-[7px] text-sm',
+  ].join(' ')
+  const fileHintLabel = t('remote_workspace.status.has_files')
+  const fileHint = hasWorkspaceEntries ? (
+    <span
+      className={
+        isIconOnly
+          ? 'rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm'
+          : 'ml-1 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm'
+      }
+      data-testid="remote-workspace-file-hint"
+    >
+      {fileHintLabel}
+    </span>
+  ) : null
+
   return (
     <>
       <TooltipProvider delayDuration={120}>
@@ -241,15 +328,27 @@ export function RemoteWorkspaceEntry({
               <Button
                 variant="outline"
                 size="sm"
-                className="h-8 pl-2 pr-3 rounded-[7px] text-sm"
+                className={buttonClassName}
                 onClick={() => {
                   void loadStatus({ silent: true })
                   setIsOpen(true)
                 }}
                 disabled={disabled}
-                title={title}
+                title={buttonTitle}
+                aria-label={isIconOnly ? buttonLabel : undefined}
+                data-testid="remote-workspace-button"
               >
-                {t('remote_workspace.button')}
+                {isIconOnly ? (
+                  <>
+                    <FolderOpen className="h-4 w-4" aria-hidden="true" />
+                    {fileHint}
+                  </>
+                ) : (
+                  <>
+                    {buttonLabel}
+                    {fileHint}
+                  </>
+                )}
               </Button>
             </span>
           </TooltipTrigger>

--- a/frontend/src/features/tasks/components/remote-workspace/remote-workspace-utils.ts
+++ b/frontend/src/features/tasks/components/remote-workspace/remote-workspace-utils.ts
@@ -69,6 +69,30 @@ export function resolvePreviewKind(fileName: string): PreviewKind {
   return 'unsupported'
 }
 
+export function getMimeTypeFromPreviewKind(previewKind: PreviewKind, filename: string): string {
+  switch (previewKind) {
+    case 'image':
+      return 'image/png'
+    case 'pdf':
+      return 'application/pdf'
+    case 'excel':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    case 'text':
+      if (filename.endsWith('.py')) return 'text/x-python'
+      if (filename.endsWith('.js')) return 'application/javascript'
+      if (filename.endsWith('.ts')) return 'application/typescript'
+      if (filename.endsWith('.json')) return 'application/json'
+      if (filename.endsWith('.md')) return 'text/markdown'
+      if (filename.endsWith('.html') || filename.endsWith('.htm')) return 'text/html'
+      if (filename.endsWith('.css')) return 'text/css'
+      if (filename.endsWith('.xml')) return 'application/xml'
+      if (filename.endsWith('.yaml') || filename.endsWith('.yml')) return 'application/yaml'
+      return 'text/plain'
+    default:
+      return 'application/octet-stream'
+  }
+}
+
 function parseModifiedAt(modifiedAt?: string | null): number {
   if (!modifiedAt) {
     return 0

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -19,6 +19,8 @@
     "title": "Remote Workspace",
     "root": "Workspace",
     "parent": "Parent",
+    "parent_entry": "Parent folder",
+    "parent_entry_hint": "Go back one level",
     "search_placeholder": "Search for the current file list",
     "sort": {
       "label": "Sort",
@@ -36,6 +38,10 @@
       "preview": "Preview",
       "refresh": "Refresh"
     },
+    "download_confirm": {
+      "title": "Download selected files?",
+      "description": "This will download {{count}} selected files. Your browser may show multiple download prompts."
+    },
     "columns": {
       "select_all": "Select all files",
       "name": "Name",
@@ -46,7 +52,8 @@
     "status": {
       "path": "Path",
       "selected": "selected",
-      "items": "items"
+      "items": "items",
+      "has_files": "Files"
     },
     "path": {
       "edit": "Edit path",

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -19,6 +19,8 @@
     "title": "远程工作区",
     "root": "工作区",
     "parent": "上级目录",
+    "parent_entry": "返回上级目录",
+    "parent_entry_hint": "回到上一层文件夹",
     "search_placeholder": "搜索当前文件列表",
     "sort": {
       "label": "排序",
@@ -36,6 +38,10 @@
       "preview": "预览",
       "refresh": "刷新"
     },
+    "download_confirm": {
+      "title": "确认下载所选文件？",
+      "description": "将下载 {{count}} 个已选文件，浏览器可能会显示多个下载提示。"
+    },
     "columns": {
       "select_all": "全选文件",
       "name": "名称",
@@ -46,7 +52,8 @@
     "status": {
       "path": "路径",
       "selected": "已选中",
-      "items": "项"
+      "items": "项",
+      "has_files": "有文件"
     },
     "path": {
       "edit": "编辑路径",


### PR DESCRIPTION
## Summary
- Add mobile remote workspace entry points with a visible i18n file hint badge when files exist.
- Improve remote workspace browsing: directories navigate on click, parent rows use readable copy, mobile file preview opens directly.
- Support desktop multi-file download confirmation and mobile text/HTML/code previews via the shared FilePreview flow.

## Test Plan
- npm test -- --runTestsByPath src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceEntry.test.tsx src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx src/__tests__/features/tasks/components/remote-workspace/i18n.test.ts src/__tests__/app/(tasks)/chat/ChatPageMobile.remote-workspace.test.tsx src/__tests__/app/(tasks)/code/CodePageMobile.remote-workspace.test.tsx --runInBand
- npx tsc --noEmit --pretty false
- git diff --check -- <changed frontend files>

## Notes
- Existing test output still includes a Next.js multiple-lockfile warning and existing Radix Dialog accessibility warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote workspace entry with file availability indicator now displays in mobile navigation
  * Download confirmation dialog for multiple selected files
  * Improved file preview experience with enhanced loading and error states
  * Parent folder navigation moved to dedicated UI element for easier access

* **Tests**
  * Added comprehensive test coverage for remote workspace mobile integration and file operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1094)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->