### PR TITLE
feat(frontend): add fullscreen file preview

### DIFF
--- a/frontend/src/__tests__/components/common/FilePreviewDialog.test.tsx
+++ b/frontend/src/__tests__/components/common/FilePreviewDialog.test.tsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { FilePreviewDialog } from '@/components/common/FilePreview/FilePreviewDialog'
+
+jest.mock('@/components/common/FilePreview/FilePreview', () => ({
+  FilePreview: () => <div data-testid="mock-file-preview">Preview content</div>,
+}))
+
+jest.mock('@/apis/attachments', () => ({
+  downloadAttachment: jest.fn(),
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'actions.close': 'Close',
+        'actions.download': 'Download',
+        'actions.exit_fullscreen': 'Exit fullscreen',
+        'actions.fullscreen': 'Fullscreen',
+        'actions.preview': 'Preview',
+        'attachment.html.source_mode': 'Source',
+      }
+
+      return translations[key] || key
+    },
+  }),
+}))
+
+describe('FilePreviewDialog', () => {
+  const defaultProps = {
+    open: true,
+    onClose: jest.fn(),
+    attachmentId: 1,
+    filename: 'report.pdf',
+    mimeType: 'application/pdf',
+    fileSize: 1024,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('toggles application fullscreen preview from the toolbar', () => {
+    render(<FilePreviewDialog {...defaultProps} />)
+
+    const dialog = screen.getByRole('dialog')
+    const fullscreenButton = screen.getByTestId('file-preview-fullscreen-button')
+
+    expect(dialog).toHaveClass('max-w-5xl')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Fullscreen')
+
+    fireEvent.click(fullscreenButton)
+
+    expect(dialog).toHaveClass('max-w-none', 'h-dvh')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Exit fullscreen')
+
+    fireEvent.click(fullscreenButton)
+
+    expect(dialog).toHaveClass('max-w-5xl')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Fullscreen')
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx
@@ -42,6 +42,9 @@ const translations: Record<string, string> = {
   'remote_workspace.actions.open': 'Open',
   'remote_workspace.actions.go': 'Go',
   'remote_workspace.actions.cancel': 'Cancel',
+  'remote_workspace.actions.close': 'Close',
+  'remote_workspace.actions.exit_fullscreen': 'Exit fullscreen',
+  'remote_workspace.actions.fullscreen': 'Fullscreen preview',
   'remote_workspace.actions.preview': 'Preview',
   'remote_workspace.actions.refresh': 'Refresh',
   'remote_workspace.download_confirm.title': 'Download selected files?',
@@ -390,6 +393,36 @@ describe('RemoteWorkspaceDialog', () => {
     )
   })
 
+  test('desktop preview dialog toggles application fullscreen', async () => {
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReturnValue(
+      '/api/tasks/1/remote-workspace/file'
+    )
+
+    render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const fileNode = await screen.findByText(/diagram\.png/i)
+    await user.dblClick(fileNode)
+
+    const previewDialog = screen.getByRole('dialog', { name: 'Preview' })
+    const fullscreenButton = within(previewDialog).getByTestId(
+      'remote-workspace-preview-fullscreen-button'
+    )
+
+    expect(previewDialog).toHaveClass('!max-w-[1400px]')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Fullscreen preview')
+
+    await user.click(fullscreenButton)
+
+    expect(previewDialog).toHaveClass('!max-w-none', '!h-dvh')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Exit fullscreen')
+  })
+
   test('supports editing address bar and navigating on Enter', async () => {
     ;(remoteWorkspaceApis.getTree as jest.Mock)
       .mockResolvedValueOnce({
@@ -585,6 +618,34 @@ describe('RemoteWorkspaceDialog', () => {
     expect(screen.queryByTestId('remote-workspace-mobile-preview-button')).not.toBeInTheDocument()
     expect(screen.queryByTestId('remote-workspace-mobile-download-button')).not.toBeInTheDocument()
     expect(screen.queryByText(/^1\s+selected/i)).not.toBeInTheDocument()
+  })
+
+  test('mobile preview tab toggles application fullscreen', async () => {
+    ;(useIsMobile as jest.Mock).mockReturnValue(true)
+    mockRootEntries()
+    ;(remoteWorkspaceApis.getFileUrl as jest.Mock).mockReturnValue(
+      '/api/tasks/1/remote-workspace/file'
+    )
+
+    render(<RemoteWorkspaceDialog open taskId={1} onOpenChange={jest.fn()} />)
+
+    await waitFor(() => {
+      expect(remoteWorkspaceApis.getTree).toHaveBeenCalledWith(1, '/workspace')
+    })
+
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    await user.click(await screen.findByText(/diagram\.png/i))
+
+    const previewPanel = screen.getByTestId('remote-workspace-mobile-preview-panel')
+    const fullscreenButton = screen.getByTestId('remote-workspace-mobile-preview-fullscreen-button')
+
+    expect(previewPanel).toHaveClass('h-[360px]')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Fullscreen preview')
+
+    await user.click(fullscreenButton)
+
+    expect(previewPanel).toHaveClass('fixed', 'inset-0')
+    expect(fullscreenButton).toHaveAttribute('aria-label', 'Exit fullscreen')
   })
 
   test('mobile renders text file preview content', async () => {

--- a/frontend/src/components/common/FilePreview/FilePreviewDialog.tsx
+++ b/frontend/src/components/common/FilePreview/FilePreviewDialog.tsx
@@ -5,9 +5,15 @@
 'use client'
 
 import React, { useEffect, useState } from 'react'
-import { Download, X, Code, Eye } from 'lucide-react'
+import { Download, X, Code, Eye, Maximize2, Minimize2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { FilePreview } from './FilePreview'
 import { getPreviewType, formatFileSize } from './utils'
 import { downloadAttachment } from '@/apis/attachments'
@@ -51,18 +57,30 @@ export function FilePreviewDialog({
   const isHtml = previewType === 'html'
   const { t } = useTranslation('common')
   const [htmlIsSourceMode, setHtmlIsSourceMode] = useState(false)
+  const [isFullscreen, setIsFullscreen] = useState(false)
 
-  // Handle keyboard shortcut (Escape to close)
+  // Handle keyboard shortcut (Escape exits fullscreen before closing)
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && open) {
+        if (isFullscreen) {
+          setIsFullscreen(false)
+          return
+        }
+
         onClose()
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [open, onClose])
+  }, [isFullscreen, open, onClose])
+
+  useEffect(() => {
+    if (!open) {
+      setIsFullscreen(false)
+    }
+  }, [open])
 
   const handleDownload = async () => {
     try {
@@ -97,8 +115,13 @@ export function FilePreviewDialog({
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
-        className="max-w-5xl w-[90vw] h-[80vh] p-0 flex flex-col gap-0"
+        className={
+          isFullscreen
+            ? 'max-w-none !max-w-none w-screen !w-screen h-dvh !h-dvh p-0 flex flex-col gap-0 !left-0 !top-0 !translate-x-0 !translate-y-0 !rounded-none sm:!rounded-none !border-0'
+            : 'max-w-5xl w-[90vw] h-[80vh] p-0 flex flex-col gap-0'
+        }
         hideCloseButton
+        preventEscapeClose={isFullscreen}
       >
         <DialogHeader className="px-4 py-3 border-b border-border flex flex-col-reverse sm:flex-row sm:items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
@@ -112,6 +135,9 @@ export function FilePreviewDialog({
               )}
             </div>
           </div>
+          <DialogDescription className="sr-only">
+            {t('attachment.preview.dialog_description', { filename })}
+          </DialogDescription>
           <div className="flex items-center justify-end sm:justify-start gap-2 flex-shrink-0 overflow-x-auto pb-1 sm:pb-0">
             {/* HTML Preview Controls - only show for HTML files */}
             {isHtml && (
@@ -155,6 +181,17 @@ export function FilePreviewDialog({
                 size="sm"
               />
             )}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setIsFullscreen(current => !current)}
+              className="h-11 w-11 sm:h-9 sm:w-9"
+              aria-label={isFullscreen ? t('actions.exit_fullscreen') : t('actions.fullscreen')}
+              data-testid="file-preview-fullscreen-button"
+              title={isFullscreen ? t('actions.exit_fullscreen') : t('actions.fullscreen')}
+            >
+              {isFullscreen ? <Minimize2 className="w-5 h-5" /> : <Maximize2 className="w-5 h-5" />}
+            </Button>
             <Button
               variant="primary"
               size="sm"

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx
@@ -4,8 +4,8 @@
 
 'use client'
 
-import { Download, X } from 'lucide-react'
-import { useState } from 'react'
+import { Download, Maximize2, Minimize2, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 import { type RemoteWorkspaceTreeEntry } from '@/apis/remoteWorkspace'
 import {
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/alert-dialog'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 
 import { TFunction } from 'i18next'
@@ -149,6 +149,7 @@ export function RemoteWorkspaceDialogDesktop({
   onDownload,
 }: RemoteWorkspaceDialogDesktopProps) {
   const [isDownloadConfirmOpen, setIsDownloadConfirmOpen] = useState(false)
+  const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false)
   const selectableEntries = visibleEntries.filter(entry => !entry.is_directory)
   const allEntriesSelected =
     selectableEntries.length > 0 && selectableEntries.every(entry => selectedPaths.has(entry.path))
@@ -170,6 +171,34 @@ export function RemoteWorkspaceDialogDesktop({
     downloadableSelectedEntries.forEach(entry => onDownload(entry))
     setIsDownloadConfirmOpen(false)
   }
+  const handlePreviewDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      setIsPreviewFullscreen(false)
+    }
+    onPreviewDialogOpenChange(open)
+  }
+
+  useEffect(() => {
+    if (!isPreviewDialogOpen) {
+      setIsPreviewFullscreen(false)
+    }
+  }, [isPreviewDialogOpen])
+
+  useEffect(() => {
+    if (!isPreviewFullscreen) {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsPreviewFullscreen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isPreviewFullscreen])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -510,15 +539,26 @@ export function RemoteWorkspaceDialogDesktop({
 
       <Dialog
         open={isPreviewDialogOpen && Boolean(previewEntry)}
-        onOpenChange={onPreviewDialogOpenChange}
+        onOpenChange={handlePreviewDialogOpenChange}
       >
         <DialogContent
-          className="!flex !h-[90vh] !w-[96vw] !max-w-[1400px] !flex-col gap-0 overflow-hidden p-0"
-          aria-label="Preview"
+          className={
+            isPreviewFullscreen
+              ? '!fixed !inset-0 !left-0 !top-0 !flex !h-dvh !w-screen !max-w-none !translate-x-0 !translate-y-0 !flex-col gap-0 overflow-hidden !rounded-none !border-0 p-0 sm:!rounded-none'
+              : '!flex !h-[90vh] !w-[96vw] !max-w-[1400px] !flex-col gap-0 overflow-hidden p-0'
+          }
+          aria-label={t('remote_workspace.preview.title', 'Preview')}
           hideCloseButton
+          preventEscapeClose={isPreviewFullscreen}
         >
           {previewEntry && (
             <>
+              <DialogTitle className="sr-only">
+                {t('remote_workspace.preview.title', 'Preview')}
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                {previewEntry.name} · {previewEntry.path}
+              </DialogDescription>
               {/* Header - Same style as FilePreviewPage */}
               <header className="flex items-center justify-between px-4 py-3 border-b border-border dark:border-gray-700 bg-white dark:bg-gray-900 shrink-0">
                 <div className="flex items-center gap-3 min-w-0">
@@ -534,6 +574,29 @@ export function RemoteWorkspaceDialogDesktop({
                 </div>
 
                 <div className="flex items-center gap-2 flex-shrink-0">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setIsPreviewFullscreen(current => !current)}
+                    className="h-10 w-10"
+                    aria-label={
+                      isPreviewFullscreen
+                        ? t('remote_workspace.actions.exit_fullscreen', 'Exit fullscreen')
+                        : t('remote_workspace.actions.fullscreen', 'Fullscreen preview')
+                    }
+                    data-testid="remote-workspace-preview-fullscreen-button"
+                    title={
+                      isPreviewFullscreen
+                        ? t('remote_workspace.actions.exit_fullscreen', 'Exit fullscreen')
+                        : t('remote_workspace.actions.fullscreen', 'Fullscreen preview')
+                    }
+                  >
+                    {isPreviewFullscreen ? (
+                      <Minimize2 className="w-5 h-5" />
+                    ) : (
+                      <Maximize2 className="w-5 h-5" />
+                    )}
+                  </Button>
                   <Button variant="primary" size="sm" onClick={() => onDownload(previewEntry)}>
                     <Download className="w-4 h-4 mr-2" />
                     {t('remote_workspace.actions.download')}

--- a/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx
+++ b/frontend/src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx
@@ -4,7 +4,8 @@
 
 'use client'
 
-import { useState } from 'react'
+import { Maximize2, Minimize2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 import { type RemoteWorkspaceTreeEntry } from '@/apis/remoteWorkspace'
 import { FilePreview } from '@/components/common/FilePreview'
@@ -95,6 +96,7 @@ export function RemoteWorkspaceDialogMobile({
   onDownload,
 }: RemoteWorkspaceDialogMobileProps) {
   const [activeTab, setActiveTab] = useState('files')
+  const [isPreviewFullscreen, setIsPreviewFullscreen] = useState(false)
   const detailEntry = selectedEntries.length === 1 ? selectedEntries[0] : null
   const footerLabel = `${visibleEntries.length} ${t('remote_workspace.status.items')}`
 
@@ -102,6 +104,28 @@ export function RemoteWorkspaceDialogMobile({
     onOpenEntry(entry)
     setActiveTab(entry.is_directory ? 'files' : 'preview')
   }
+
+  useEffect(() => {
+    if (!detailEntry) {
+      setIsPreviewFullscreen(false)
+    }
+  }, [detailEntry])
+
+  useEffect(() => {
+    if (!isPreviewFullscreen) {
+      return
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsPreviewFullscreen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isPreviewFullscreen])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -260,35 +284,76 @@ export function RemoteWorkspaceDialogMobile({
               )}
 
               {!detailEntry.is_directory && (
-                <div className="h-[360px] rounded-md border border-border bg-surface p-3">
-                  {previewKind === 'unsupported' && (
-                    <p className="text-sm text-text-muted">
-                      {t('remote_workspace.preview.unsupported')}
-                    </p>
-                  )}
-                  {previewKind !== 'unsupported' && previewError && (
-                    <p className="text-sm text-error">{previewError}</p>
-                  )}
-                  {previewKind !== 'unsupported' &&
-                    !previewError &&
-                    (isPreviewLoading || !previewBlob) && (
+                <div
+                  className={
+                    isPreviewFullscreen
+                      ? 'fixed inset-0 z-[60] flex flex-col overflow-hidden bg-base p-4'
+                      : 'flex h-[360px] flex-col rounded-md border border-border bg-surface p-3'
+                  }
+                  data-testid="remote-workspace-mobile-preview-panel"
+                >
+                  <div className="mb-2 flex min-h-[44px] items-center justify-between gap-3">
+                    <div className={isPreviewFullscreen ? 'min-w-0' : 'sr-only'}>
+                      <p className="truncate text-sm font-medium text-text-primary">
+                        {detailEntry.name}
+                      </p>
+                      <p className="truncate text-xs text-text-muted">{detailEntry.path}</p>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setIsPreviewFullscreen(current => !current)}
+                      className="h-11 w-11"
+                      aria-label={
+                        isPreviewFullscreen
+                          ? t('remote_workspace.actions.exit_fullscreen', 'Exit fullscreen')
+                          : t('remote_workspace.actions.fullscreen', 'Fullscreen preview')
+                      }
+                      data-testid="remote-workspace-mobile-preview-fullscreen-button"
+                      title={
+                        isPreviewFullscreen
+                          ? t('remote_workspace.actions.exit_fullscreen', 'Exit fullscreen')
+                          : t('remote_workspace.actions.fullscreen', 'Fullscreen preview')
+                      }
+                    >
+                      {isPreviewFullscreen ? (
+                        <Minimize2 className="h-5 w-5" />
+                      ) : (
+                        <Maximize2 className="h-5 w-5" />
+                      )}
+                    </Button>
+                  </div>
+
+                  <div className="min-h-0 flex-1 overflow-hidden">
+                    {previewKind === 'unsupported' && (
                       <p className="text-sm text-text-muted">
-                        {t('remote_workspace.preview.loading')}
+                        {t('remote_workspace.preview.unsupported')}
                       </p>
                     )}
-                  {previewKind !== 'unsupported' &&
-                    !previewError &&
-                    !isPreviewLoading &&
-                    previewBlob && (
-                      <FilePreview
-                        fileBlob={previewBlob}
-                        filename={detailEntry.name}
-                        mimeType={getMimeTypeFromPreviewKind(previewKind, detailEntry.name)}
-                        fileSize={detailEntry.size}
-                        showToolbar={false}
-                        onDownload={() => onDownload(detailEntry)}
-                      />
+                    {previewKind !== 'unsupported' && previewError && (
+                      <p className="text-sm text-error">{previewError}</p>
                     )}
+                    {previewKind !== 'unsupported' &&
+                      !previewError &&
+                      (isPreviewLoading || !previewBlob) && (
+                        <p className="text-sm text-text-muted">
+                          {t('remote_workspace.preview.loading')}
+                        </p>
+                      )}
+                    {previewKind !== 'unsupported' &&
+                      !previewError &&
+                      !isPreviewLoading &&
+                      previewBlob && (
+                        <FilePreview
+                          fileBlob={previewBlob}
+                          filename={detailEntry.name}
+                          mimeType={getMimeTypeFromPreviewKind(previewKind, detailEntry.name)}
+                          fileSize={detailEntry.size}
+                          showToolbar={false}
+                          onDownload={() => onDownload(detailEntry)}
+                        />
+                      )}
+                  </div>
                 </div>
               )}
             </div>

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -49,6 +49,8 @@
     "download": "Download",
     "share": "Share",
     "preview": "Preview",
+    "fullscreen": "Fullscreen preview",
+    "exit_fullscreen": "Exit fullscreen",
     "generating": "Generating...",
     "zoom_in": "Zoom In",
     "zoom_out": "Zoom Out",
@@ -1392,7 +1394,8 @@
     "preview": {
       "label": "Preview",
       "loading": "Loading preview...",
-      "unavailable": "Preview unavailable"
+      "unavailable": "Preview unavailable",
+      "dialog_description": "Previewing file {{filename}}"
     },
     "truncation": {
       "notice": "⚠️ Content too long, auto-truncated ({{original}} chars → {{truncated}} chars)"

--- a/frontend/src/i18n/locales/en/tasks.json
+++ b/frontend/src/i18n/locales/en/tasks.json
@@ -33,7 +33,10 @@
     },
     "actions": {
       "cancel": "Cancel",
+      "close": "Close",
       "download": "Download",
+      "exit_fullscreen": "Exit fullscreen",
+      "fullscreen": "Fullscreen preview",
       "go": "Go",
       "preview": "Preview",
       "refresh": "Refresh"

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -49,6 +49,8 @@
     "download": "下载",
     "share": "分享",
     "preview": "预览",
+    "fullscreen": "全屏预览",
+    "exit_fullscreen": "退出全屏",
     "generating": "生成中...",
     "zoom_in": "放大",
     "zoom_out": "缩小",
@@ -1386,7 +1388,8 @@
     "preview": {
       "label": "预览",
       "loading": "正在加载预览...",
-      "unavailable": "暂无预览"
+      "unavailable": "暂无预览",
+      "dialog_description": "正在预览文件 {{filename}}"
     },
     "truncation": {
       "notice": "⚠️ 文件内容过长，已自动压缩（原始 {{original}} 字符 → 压缩至 {{truncated}} 字符）"

--- a/frontend/src/i18n/locales/zh-CN/tasks.json
+++ b/frontend/src/i18n/locales/zh-CN/tasks.json
@@ -33,7 +33,10 @@
     },
     "actions": {
       "cancel": "取消",
+      "close": "关闭",
       "download": "下载",
+      "exit_fullscreen": "退出全屏",
+      "fullscreen": "全屏预览",
       "go": "前往",
       "preview": "预览",
       "refresh": "刷新"


### PR DESCRIPTION
## Summary
- Add application-level fullscreen controls to remote workspace file previews on desktop and mobile.
- Add fullscreen support to the shared attachment file preview dialog.
- Add i18n labels and regression tests for fullscreen preview toggles.

## Test Plan
- npm test -- RemoteWorkspaceDialog.test.tsx FilePreviewDialog.test.tsx --runInBand
- npm run lint -- --file src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx --file src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx --file src/components/common/FilePreview/FilePreviewDialog.tsx --file src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx --file src/__tests__/components/common/FilePreviewDialog.test.tsx
- npx prettier --check src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogDesktop.tsx src/features/tasks/components/remote-workspace/RemoteWorkspaceDialogMobile.tsx src/__tests__/features/tasks/components/remote-workspace/RemoteWorkspaceDialog.test.tsx src/components/common/FilePreview/FilePreviewDialog.tsx src/__tests__/components/common/FilePreviewDialog.test.tsx src/i18n/locales/zh-CN/tasks.json src/i18n/locales/en/tasks.json src/i18n/locales/zh-CN/common.json src/i18n/locales/en/common.json
- Pre-push hook: ESLint, TypeScript, unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added fullscreen mode toggle to file preview dialogs with Escape key to exit
  * Mobile and desktop preview panels now support expanded full-screen viewing
  * Enhanced accessibility with screen-reader labels for fullscreen controls

* **Tests**
  * Added comprehensive test coverage for fullscreen preview functionality

* **Localization**
  * Added fullscreen preview labels in English and Simplified Chinese

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1098)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->