### PR TITLE
fix(chat_shell): prefix mcp tool names

### DIFF
--- a/chat_shell/chat_shell/tools/mcp/client.py
+++ b/chat_shell/chat_shell/tools/mcp/client.py
@@ -282,7 +282,10 @@ class MCPClient:
             return
 
         add_span_event("creating_multi_server_client")
-        self._client = MultiServerMCPClient(connections=self.connections)
+        self._client = MultiServerMCPClient(
+            connections=self.connections,
+            tool_name_prefix=True,
+        )
 
         # Load tools from each server individually to handle failures gracefully
         # This avoids the issue where one failing server causes all tools to fail

--- a/chat_shell/tests/test_mcp_client_variable_substitution.py
+++ b/chat_shell/tests/test_mcp_client_variable_substitution.py
@@ -13,7 +13,12 @@ StdioConnection, StreamableHttpConnection) which are plain dicts,
 so we use dict-style access (conn["key"]) not attribute access.
 """
 
-from chat_shell.tools.mcp.client import build_connections
+from unittest.mock import patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from chat_shell.tools.mcp.client import MCPClient, build_connections
 from shared.models.execution import ExecutionRequest
 
 
@@ -136,3 +141,55 @@ class TestBuildConnectionsVariableSubstitution:
         assert conn["headers"]["X-User"] == "testuser"
         assert conn["headers"]["X-Task"] == "999"
         assert conn["headers"]["X-Team"] == "50"
+
+
+class TestMCPClientToolNamePrefix:
+    """Tests that MCPClient uses the adapter's official server-name prefix."""
+
+    @pytest.mark.asyncio
+    async def test_connect_enables_official_tool_name_prefix(self) -> None:
+        """MCP tools should be named with the official server_tool format."""
+
+        def list_files() -> str:
+            """List files from the fake MCP server."""
+            return "[]"
+
+        class FakeMultiServerMCPClient:
+            def __init__(
+                self,
+                connections,
+                *,
+                tool_name_prefix: bool = False,
+                **_kwargs,
+            ) -> None:
+                self.connections = connections
+                self.tool_name_prefix = tool_name_prefix
+
+            async def get_tools(self, *, server_name: str | None = None):
+                tool_name = (
+                    f"{server_name}_list_files"
+                    if self.tool_name_prefix
+                    else "list_files"
+                )
+                return [
+                    StructuredTool.from_function(
+                        func=list_files,
+                        name=tool_name,
+                    )
+                ]
+
+        config = {
+            "filesystem": {
+                "type": "streamable-http",
+                "url": "http://mcp.example.com/stream",
+            }
+        }
+
+        with patch(
+            "chat_shell.tools.mcp.client.MultiServerMCPClient",
+            FakeMultiServerMCPClient,
+        ):
+            client = MCPClient(config)
+            await client.connect()
+
+        assert [tool.name for tool in client.get_tools()] == ["filesystem_list_files"]


### PR DESCRIPTION
## Summary
- Enable langchain-mcp-adapters official server-name prefixing for Chat Shell MCP tools
- Add regression coverage proving MCP tools are exposed as `server_tool` instead of the bare tool name

## Test Plan
- `cd chat_shell && uv run pytest tests/test_mcp_client_variable_substitution.py tests/test_skill_mcp_loader.py tests/test_tool_events.py tests/test_dynamic_skill_tools.py`
- `git diff --check -- chat_shell/chat_shell/tools/mcp/client.py chat_shell/tests/test_mcp_client_variable_substitution.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tools loaded from multiple MCP servers now use prefixed names (e.g., `filesystem_list_files`) to properly distinguish tools from different servers.

* **Tests**
  * Added verification test to confirm tool name prefix format works correctly for MCP client connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1101)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->