### PR TITLE
fix(frontend): refine AI processing indicator animation

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/message/StreamingWaitIndicator.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/StreamingWaitIndicator.test.tsx
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import fs from 'node:fs'
+import path from 'node:path'
+import { act, render, screen } from '@testing-library/react'
+
+import StreamingWaitIndicator from '@/features/tasks/components/message/StreamingWaitIndicator'
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+const readGlobalCss = () => fs.readFileSync(path.join(process.cwd(), 'src/app/globals.css'), 'utf8')
+
+const getCssRule = (css: string, selector: string) => {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const matches = Array.from(
+    css.matchAll(new RegExp(`${escapedSelector} \\{([\\s\\S]*?)\\n\\}`, 'g'))
+  )
+  return matches.at(-1)?.[1] ?? ''
+}
+
+describe('StreamingWaitIndicator', () => {
+  it('uses one animated purple runner dot instead of the old three-dot typing indicator', () => {
+    render(<StreamingWaitIndicator isWaiting={true} />)
+
+    const indicator = screen.getByTestId('streaming-wait-indicator')
+    const track = screen.getByTestId('streaming-wait-runner-track')
+    const dot = screen.getByTestId('streaming-wait-runner-dot')
+
+    expect(indicator).toContainElement(track)
+    expect(track).toContainElement(dot)
+    expect(dot).toHaveClass('streaming-wait-runner-dot')
+    expect(track.querySelectorAll('[data-testid="streaming-wait-runner-dot"]')).toHaveLength(1)
+    expect(indicator.querySelectorAll('.animate-pulse')).toHaveLength(0)
+  })
+
+  it('can render a fixed message while reusing the runner animation', () => {
+    render(<StreamingWaitIndicator isWaiting={true} message="thinking.processing" />)
+
+    const indicator = screen.getByTestId('streaming-wait-indicator')
+
+    expect(screen.getByTestId('streaming-wait-runner-dot')).toBeInTheDocument()
+    expect(indicator.querySelectorAll('.animate-pulse')).toHaveLength(0)
+    expect(screen.getAllByText('thinking.processing')).toHaveLength(2)
+  })
+
+  it('keeps the runner dot as one continuous shape instead of split top and bottom pieces', () => {
+    const css = readGlobalCss()
+
+    expect(css).not.toContain('.streaming-wait-runner-dot::before')
+    expect(css).not.toContain('.streaming-wait-runner-dot::after')
+  })
+
+  it('keeps horizontal travel continuous without mid-route position stops', () => {
+    const css = readGlobalCss()
+
+    expect(css).not.toContain('left: 36%')
+    expect(css).not.toContain('left: 68%')
+  })
+
+  it('clips the moving runner highlight to text glyphs while it crosses the message', () => {
+    render(<StreamingWaitIndicator isWaiting={true} />)
+
+    const css = readGlobalCss()
+    const trackRule = getCssRule(css, '.streaming-wait-runner-track')
+    const textMask = screen.getByTestId('streaming-wait-runner-text-mask')
+    const maskRule = css.slice(
+      css.indexOf('.streaming-wait-runner-text-mask {\n  position: absolute')
+    )
+
+    expect(textMask).toHaveAttribute('aria-hidden', 'true')
+    expect(textMask).toHaveTextContent('tasks:streaming_wait.thinking')
+    expect(trackRule).toContain('--runner-dot-size: 0.75rem')
+    expect(maskRule).toContain('background-clip: text')
+    expect(maskRule).toContain('-webkit-text-fill-color: transparent')
+  })
+
+  it('changes progressive text only after a full runner animation lap completes', () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date('2026-05-13T00:00:00.000Z'))
+
+    render(<StreamingWaitIndicator isWaiting={true} />)
+
+    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(2)
+
+    act(() => {
+      jest.advanceTimersByTime(5300)
+    })
+
+    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(2)
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+
+    expect(screen.getAllByText('tasks:streaming_wait.analyzing')).toHaveLength(2)
+
+    jest.useRealTimers()
+  })
+
+  it('positions the runner one pixel below the text centerline', () => {
+    const css = readGlobalCss()
+    const trackRule = getCssRule(css, '.streaming-wait-runner-track')
+    const dotRule = getCssRule(css, '.streaming-wait-runner-dot')
+
+    expect(trackRule).toContain('--runner-y-offset: 1px')
+    expect(dotRule).toContain('top: calc(50% + var(--runner-y-offset))')
+  })
+
+  it('adds two playful hops while the runner pauses on the right side', () => {
+    const css = readGlobalCss()
+
+    expect(css).toMatch(
+      /38%,\s+44% \{[\s\S]*translateY\(-50%\) translateY\(-4px\) scaleX\(0\.94\) scaleY\(1\.08\)/
+    )
+    expect(css).toMatch(
+      /41%,\s+47% \{[\s\S]*translateY\(-50%\) translateY\(1px\) scaleX\(1\.16\) scaleY\(0\.84\)/
+    )
+  })
+
+  it('waits about 0.5 seconds on the right side before hopping', () => {
+    const css = readGlobalCss()
+    const dotRule = getCssRule(css, '.streaming-wait-runner-dot')
+    const maskRule = css.slice(
+      css.indexOf('.streaming-wait-runner-text-mask {\n  position: absolute')
+    )
+
+    expect(dotRule).toContain('animation: streaming-wait-runner-travel 5.4s linear infinite')
+    expect(maskRule).toContain('animation: streaming-wait-runner-text-mask 5.4s linear infinite')
+    expect(css).toMatch(
+      /26%,\s+35% \{[\s\S]*left: calc\(100% - var\(--runner-dot-size\)\);[\s\S]*transform: translateY\(-50%\) scale\(1\);/
+    )
+  })
+})

--- a/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
@@ -182,6 +182,10 @@ describe('MixedContentView', () => {
     )
 
     expect(screen.getByText('雨后的清晨')).toBeInTheDocument()
-    expect(screen.queryByText('thinking.processing')).toBeInTheDocument()
+    const indicator = screen.getByTestId('streaming-wait-indicator')
+
+    expect(screen.getAllByText('thinking.processing')).toHaveLength(2)
+    expect(screen.getByTestId('streaming-wait-runner-dot')).toBeInTheDocument()
+    expect(indicator.querySelectorAll('.animate-pulse')).toHaveLength(0)
   })
 })

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -570,6 +570,201 @@ button:focus-visible {
   animation-delay: 2s;
 }
 
+/* Single runner dot used while an AI message is waiting or still processing */
+.streaming-wait-runner-track {
+  --runner-dot-size: 0.75rem;
+  --runner-text-spot-size: 1.15rem;
+  --runner-y-offset: 1px;
+
+  position: relative;
+  isolation: isolate;
+  display: inline-flex;
+  min-height: 1.5rem;
+  align-items: center;
+  padding: 0 1.25rem;
+  color: rgb(var(--color-text-muted));
+}
+
+.streaming-wait-runner-text-wrap {
+  position: relative;
+  z-index: 2;
+  display: inline-block;
+}
+
+.streaming-wait-runner-text,
+.streaming-wait-runner-text-mask {
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+}
+
+.streaming-wait-runner-text-mask {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  color: transparent;
+  background-image: radial-gradient(
+    circle,
+    rgb(var(--color-primary)) 0 38%,
+    rgb(var(--color-primary) / 0.9) 48%,
+    transparent 70%
+  );
+  background-repeat: no-repeat;
+  background-size: var(--runner-text-spot-size) var(--runner-text-spot-size);
+  background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  pointer-events: none;
+  will-change: background-position, opacity;
+  animation: streaming-wait-runner-text-mask 5.4s linear infinite;
+}
+
+.streaming-wait-runner-dot {
+  position: absolute;
+  top: calc(50% + var(--runner-y-offset));
+  left: 0;
+  z-index: 1;
+  width: var(--runner-dot-size);
+  height: var(--runner-dot-size);
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle at 34% 28%, rgba(255, 255, 255, 0.72) 0 16%, transparent 24%),
+    rgb(var(--color-primary));
+  box-shadow:
+    0 1px 5px rgb(var(--color-primary) / 0.3),
+    inset -1px -1px 2px rgb(0 0 0 / 0.08);
+  transform: translateY(-50%) scale(1);
+  transform-origin: 50% 68%;
+  opacity: 1;
+  will-change: left, transform, border-radius, opacity;
+  animation: streaming-wait-runner-travel 5.4s linear infinite;
+}
+
+@keyframes streaming-wait-runner-travel {
+  0%,
+  10% {
+    left: 0;
+    opacity: 1;
+    border-radius: 9999px;
+    transform: translateY(-50%) scale(1);
+  }
+
+  13% {
+    opacity: 0;
+  }
+
+  18% {
+    opacity: 0;
+    border-radius: 58% 44% 50% 62% / 44% 54% 46% 56%;
+    transform: translateY(-50%) scaleX(1.42) scaleY(0.78) skewX(16deg) rotate(-3deg);
+  }
+
+  23% {
+    border-radius: 54% 46% 48% 60% / 46% 56% 44% 54%;
+    transform: translateY(-50%) scaleX(1.24) scaleY(0.86) skewX(10deg) rotate(-2deg);
+  }
+
+  26%,
+  35% {
+    left: calc(100% - var(--runner-dot-size));
+    opacity: 1;
+    border-radius: 9999px;
+    transform: translateY(-50%) scale(1);
+  }
+
+  38%,
+  44% {
+    border-radius: 56% 44% 54% 46% / 48% 52% 44% 56%;
+    transform: translateY(-50%) translateY(-4px) scaleX(0.94) scaleY(1.08);
+  }
+
+  41%,
+  47% {
+    border-radius: 52% 48% 46% 54% / 58% 58% 42% 42%;
+    transform: translateY(-50%) translateY(1px) scaleX(1.16) scaleY(0.84);
+  }
+
+  50% {
+    left: calc(100% - var(--runner-dot-size));
+    opacity: 1;
+    border-radius: 9999px;
+    transform: translateY(-50%) scale(1);
+  }
+
+  52% {
+    opacity: 0;
+  }
+
+  56% {
+    opacity: 0;
+    border-radius: 44% 58% 62% 50% / 54% 44% 56% 46%;
+    transform: translateY(-50%) scaleX(1.24) scaleY(0.86) skewX(-10deg) rotate(2deg);
+  }
+
+  66% {
+    border-radius: 44% 58% 62% 50% / 54% 44% 56% 46%;
+    transform: translateY(-50%) scaleX(1.42) scaleY(0.78) skewX(-16deg) rotate(3deg);
+  }
+
+  72%,
+  100% {
+    left: 0;
+    opacity: 1;
+    border-radius: 9999px;
+    transform: translateY(-50%) scale(1);
+  }
+}
+
+@keyframes streaming-wait-runner-text-mask {
+  0%,
+  10% {
+    opacity: 0;
+    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
+  }
+
+  13% {
+    opacity: 1;
+  }
+
+  26% {
+    opacity: 1;
+    background-position: calc(100% + var(--runner-text-spot-size))
+      calc(50% + var(--runner-y-offset));
+  }
+
+  30%,
+  50% {
+    opacity: 0;
+    background-position: calc(100% + var(--runner-text-spot-size))
+      calc(50% + var(--runner-y-offset));
+  }
+
+  52% {
+    opacity: 1;
+    background-position: calc(100% + var(--runner-text-spot-size))
+      calc(50% + var(--runner-y-offset));
+  }
+
+  72% {
+    opacity: 1;
+    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
+  }
+
+  76%,
+  100% {
+    opacity: 0;
+    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .streaming-wait-runner-dot,
+  .streaming-wait-runner-text-mask {
+    animation: none;
+  }
+}
+
 /* Pulse animation for unread task notification dots */
 @keyframes pulse-dot {
   0%,

--- a/frontend/src/features/tasks/components/message/StreamingWaitIndicator.tsx
+++ b/frontend/src/features/tasks/components/message/StreamingWaitIndicator.tsx
@@ -11,10 +11,12 @@ import { useTranslation } from '@/hooks/useTranslation'
  * Props for StreamingWaitIndicator component
  */
 interface StreamingWaitIndicatorProps {
-  /** Whether the indicator should be shown (waiting for first character) */
+  /** Whether the indicator should be shown */
   isWaiting: boolean
   /** Optional start time for calculating wait duration (defaults to current time when isWaiting becomes true) */
   startTime?: number
+  /** Optional fixed message for non-progressive waiting states */
+  message?: string
 }
 
 /**
@@ -28,27 +30,29 @@ interface WaitStage {
   messageKey: string
 }
 
+const RUNNER_ANIMATION_LAP_MS = 5400
+
 /**
  * Wait stages configuration:
- * - 0-500ms: No text, just dots
- * - 500ms-3s: "Thinking..."
- * - 3-6s: "Analyzing in depth..."
- * - 6-10s: "Please wait, generating response..."
- * - 10s+: "Response is taking longer than usual..."
+ * Text changes are aligned with complete runner animation laps.
+ * - 0-5.4s: "Thinking..."
+ * - 5.4-10.8s: "Analyzing in depth..."
+ * - 10.8-16.2s: "Please wait, generating response..."
+ * - 16.2s+: "Response is taking longer than usual..."
  */
 const WAIT_STAGES: WaitStage[] = [
-  { minTime: 10000, messageKey: 'tasks:streaming_wait.longer_than_usual' },
-  { minTime: 6000, messageKey: 'tasks:streaming_wait.generating_response' },
-  { minTime: 3000, messageKey: 'tasks:streaming_wait.analyzing' },
-  { minTime: 500, messageKey: 'tasks:streaming_wait.thinking' },
+  { minTime: RUNNER_ANIMATION_LAP_MS * 3, messageKey: 'tasks:streaming_wait.longer_than_usual' },
+  { minTime: RUNNER_ANIMATION_LAP_MS * 2, messageKey: 'tasks:streaming_wait.generating_response' },
+  { minTime: RUNNER_ANIMATION_LAP_MS, messageKey: 'tasks:streaming_wait.analyzing' },
+  { minTime: 0, messageKey: 'tasks:streaming_wait.thinking' },
 ]
 
 /**
- * StreamingWaitIndicator - Displays a typing indicator with progressive text
- * during the wait time before receiving the first character from the AI.
+ * StreamingWaitIndicator - Displays a runner indicator with progressive or fixed text
+ * while an AI message is waiting or still processing.
  *
  * Features:
- * - Three bouncing dots animation
+ * - Single purple runner dot animation
  * - Progressive text that changes based on wait duration
  * - i18n support for Chinese and English
  * - Calm UI design with low saturation colors
@@ -61,6 +65,7 @@ const WAIT_STAGES: WaitStage[] = [
 export default function StreamingWaitIndicator({
   isWaiting,
   startTime: externalStartTime,
+  message,
 }: StreamingWaitIndicatorProps) {
   const { t } = useTranslation()
   const [internalStartTime, setInternalStartTime] = useState<number | null>(null)
@@ -93,34 +98,40 @@ export default function StreamingWaitIndicator({
 
   // Determine current stage message based on elapsed time
   const stageMessage = useMemo(() => {
+    if (message) return message
+
     // Find the first stage whose minTime is <= elapsedTime (stages are sorted descending)
     const stage = WAIT_STAGES.find(s => elapsedTime >= s.minTime)
     return stage ? t(stage.messageKey) : null
-  }, [elapsedTime, t])
+  }, [elapsedTime, message, t])
 
   // Don't render if not waiting
   if (!isWaiting) return null
 
   return (
-    <div className="flex items-center gap-1">
-      {/* Progressive text message */}
-      {stageMessage && <span className="text-sm text-text-muted">{stageMessage}</span>}
-
-      {/* Typing indicator - three subtle pulsing dots */}
-      <div className="flex items-center gap-1 h-4">
+    <div
+      className="inline-flex items-center"
+      role="status"
+      aria-live="polite"
+      data-testid="streaming-wait-indicator"
+    >
+      <span className="streaming-wait-runner-track" data-testid="streaming-wait-runner-track">
+        <span className="streaming-wait-runner-text-wrap">
+          <span className="streaming-wait-runner-text">{stageMessage}</span>
+          <span
+            className="streaming-wait-runner-text-mask"
+            aria-hidden="true"
+            data-testid="streaming-wait-runner-text-mask"
+          >
+            {stageMessage}
+          </span>
+        </span>
         <span
-          className="w-1 h-1 rounded-full bg-text-muted/60 animate-pulse"
-          style={{ animationDelay: '0ms', animationDuration: '1.5s' }}
+          className="streaming-wait-runner-dot"
+          aria-hidden="true"
+          data-testid="streaming-wait-runner-dot"
         />
-        <span
-          className="w-1 h-1 rounded-full bg-text-muted/60 animate-pulse"
-          style={{ animationDelay: '300ms', animationDuration: '1.5s' }}
-        />
-        <span
-          className="w-1 h-1 rounded-full bg-text-muted/60 animate-pulse"
-          style={{ animationDelay: '600ms', animationDuration: '1.5s' }}
-        />
-      </div>
+      </span>
     </div>
   )
 }

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -15,6 +15,7 @@ import { processCitePatterns } from '../../../utils/processCitePatterns'
 import type { GeminiAnnotation } from '@/types/socket'
 import VideoPlayer from '../VideoPlayer'
 import { ImageGallery } from '../ImageGallery'
+import StreamingWaitIndicator from '../StreamingWaitIndicator'
 import { AskUserForm } from '../../clarification'
 import type { AskUserFormData } from '@/types/api'
 import { blockRendererRegistry } from '../block-registry'
@@ -599,9 +600,11 @@ const MixedContentView = memo(function MixedContentView({
 
       {/* Show "Processing..." indicator when task is running and last block is complete */}
       {shouldShowProcessing && (
-        <div className="flex items-center gap-2 text-xs text-text-muted italic px-2 py-1">
-          <div className="h-2 w-2 rounded-full bg-primary animate-pulse" />
-          <span>{t('thinking.processing') || 'Processing...'}</span>
+        <div className="px-2 py-1">
+          <StreamingWaitIndicator
+            isWaiting={true}
+            message={t('thinking.processing') || 'Processing...'}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Replace the old AI waiting/processing dot with a single purple runner animation that travels through the status text.
- Reuse the runner indicator for the running `MixedContentView` processing state.
- Add focused tests for the runner animation structure, timing, and processing-state rendering.

## Test Plan
- `npm test -- StreamingWaitIndicator.test.tsx MixedContentView.test.tsx messageBubbleStyles.test.ts --runInBand`
- `npm run lint -- --file src/features/tasks/components/message/StreamingWaitIndicator.tsx --file src/features/tasks/components/message/thinking/MixedContentView.tsx`
- `npx prettier --check src/features/tasks/components/message/StreamingWaitIndicator.tsx src/features/tasks/components/message/thinking/MixedContentView.tsx src/__tests__/features/tasks/components/message/StreamingWaitIndicator.test.tsx src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx src/app/globals.css`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the task processing wait indicator with an animated runner dot that moves across a track, replacing the previous pulsing dots animation.
  * Added support for custom wait messages alongside the animated runner visualization.

* **Tests**
  * Added comprehensive test coverage for the new animated runner indicator component.
  * Updated tests to validate the new processing UI behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->