### PR TITLE
feat(share): improve team share UX with auto-navigation and joined state

### DIFF
--- a/backend/app/schemas/shared_team.py
+++ b/backend/app/schemas/shared_team.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -51,6 +51,7 @@ class TeamShareInfo(BaseModel):
     user_name: str
     team_id: int
     team_name: str
+    bind_mode: Optional[List[str]] = None
 
 
 class JoinSharedTeamRequest(BaseModel):

--- a/backend/app/services/shared_team.py
+++ b/backend/app/services/shared_team.py
@@ -159,6 +159,11 @@ class SharedTeamService:
                     user_name=user.user_name,
                     team_id=team_id,
                     team_name=team.name,
+                    bind_mode=(
+                        team.json.get("spec", {}).get("bind_mode")
+                        if isinstance(team.json, dict)
+                        else None
+                    ),
                 )
             else:
                 # Without database session, return basic info with placeholder names

--- a/frontend/src/apis/team.ts
+++ b/frontend/src/apis/team.ts
@@ -37,6 +37,7 @@ export interface TeamShareInfoResponse {
   user_name: string
   team_id: number
   team_name: string
+  bind_mode?: string[]
 }
 
 // Team Share Join Request Type

--- a/frontend/src/app/(tasks)/chat/page.tsx
+++ b/frontend/src/app/(tasks)/chat/page.tsx
@@ -107,11 +107,7 @@ export default function ChatPage() {
         <DeviceParamSync />
       </Suspense>
       <Suspense>
-        <TeamShareHandler
-          teams={teams}
-          onTeamSelected={() => {}}
-          onRefreshTeams={handleRefreshTeams}
-        />
+        <TeamShareHandler teams={teams} onRefreshTeams={handleRefreshTeams} />
       </Suspense>
       <Suspense>
         <TaskShareHandler onTaskCopied={refreshTasks} />

--- a/frontend/src/app/(tasks)/code/page.tsx
+++ b/frontend/src/app/(tasks)/code/page.tsx
@@ -71,11 +71,7 @@ export default function CodePage() {
         <DeviceTaskSync />
       </Suspense>
       <Suspense>
-        <TeamShareHandler
-          teams={teams}
-          onTeamSelected={() => {}}
-          onRefreshTeams={handleRefreshTeams}
-        />
+        <TeamShareHandler teams={teams} onRefreshTeams={handleRefreshTeams} />
       </Suspense>
       {/* Onboarding tour */}
       <OnboardingTour

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -34,9 +34,6 @@ function TasksPageContent() {
   // Mobile sidebar state
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false)
 
-  // Selected team state for sharing
-  const [selectedTeamForNewTask, setSelectedTeamForNewTask] = useState<Team | null>(null)
-
   const handleRefreshTeams = async (): Promise<Team[]> => {
     return await refreshTeams()
   }
@@ -50,11 +47,7 @@ function TasksPageContent() {
         <DeviceTaskSync />
       </Suspense>
       <Suspense>
-        <TeamShareHandler
-          teams={teams}
-          onTeamSelected={setSelectedTeamForNewTask}
-          onRefreshTeams={handleRefreshTeams}
-        />
+        <TeamShareHandler teams={teams} onRefreshTeams={handleRefreshTeams} />
       </Suspense>
       <div className="flex smart-h-screen bg-base text-text-primary box-border">
         {/* Responsive sidebar */}
@@ -77,7 +70,7 @@ function TasksPageContent() {
           <ChatArea
             teams={teams}
             isTeamsLoading={isTeamsLoading}
-            selectedTeamForNewTask={selectedTeamForNewTask}
+            selectedTeamForNewTask={null}
             taskType="code"
           />
         </div>

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -329,6 +329,8 @@ function ChatAreaContent({
   const searchParams = useSearchParams()
   const taskIdFromUrl =
     searchParams.get('taskId') || searchParams.get('task_id') || searchParams.get('taskid')
+  // Get teamId from URL for auto-selecting a specific team (e.g. after accepting a share invite)
+  const teamIdFromUrl = searchParams.get('teamId')
 
   // Track initialization and last synced task for team selection
   const hasInitializedTeamRef = useRef(false)
@@ -401,6 +403,20 @@ function ChatAreaContent({
       }
     }
 
+    // Case 2a: teamId URL param present - select specific team regardless of initialization state
+    // This handles navigation after accepting a share invite (/chat?teamId=xxx)
+    if (!taskIdFromUrl && teamIdFromUrl) {
+      const targetTeamId = Number(teamIdFromUrl)
+      const teamFromUrl =
+        filteredTeams.find(t => t.id === targetTeamId) || teams.find(t => t.id === targetTeamId)
+      if (teamFromUrl) {
+        handleTeamChange(teamFromUrl)
+        hasInitializedTeamRef.current = true
+        lastSyncedTaskIdRef.current = null
+        return
+      }
+    }
+
     // Case 2: New chat (no taskId in URL) - use default team from server config
     if (!taskIdFromUrl && !hasInitializedTeamRef.current) {
       // Use the default team computed from server config
@@ -434,8 +450,10 @@ function ChatAreaContent({
     }
   }, [
     filteredTeams,
+    teams,
     selectedTaskDetail,
     taskIdFromUrl,
+    teamIdFromUrl,
     selectedTeam,
     handleTeamChange,
     findDefaultTeamForMode,

--- a/frontend/src/features/tasks/components/share/TeamShareHandler.tsx
+++ b/frontend/src/features/tasks/components/share/TeamShareHandler.tsx
@@ -17,18 +17,24 @@ import Modal from '@/features/common/Modal'
 
 interface TeamShareHandlerProps {
   teams: Team[]
-  onTeamSelected: (team: Team) => void
   onRefreshTeams: () => Promise<Team[]>
+}
+
+/**
+ * Determine the target page based on team's bind_mode.
+ * Mirrors the logic in TeamList.tsx getTargetPage.
+ */
+function getTargetPage(bindMode?: string[]): 'chat' | 'code' {
+  if (bindMode && bindMode.length === 1) {
+    if (bindMode[0] === 'code') return 'code'
+  }
+  return 'chat'
 }
 
 /**
  * Handle team sharing URL parameter detection, join logic, and modal display
  */
-export default function TeamShareHandler({
-  teams,
-  onTeamSelected,
-  onRefreshTeams,
-}: TeamShareHandlerProps) {
+export default function TeamShareHandler({ teams, onRefreshTeams }: TeamShareHandlerProps) {
   const { t } = useTranslation()
   const { toast } = useToast()
   const { user } = useUser()
@@ -49,6 +55,11 @@ export default function TeamShareHandler({
     url.searchParams.delete('teamShare')
     router.replace(url.pathname + url.search)
   }, [router])
+
+  const navigateToTeam = (teamId: number, bindMode?: string[]) => {
+    const targetPage = getTargetPage(bindMode)
+    router.push(`/${targetPage}?teamId=${teamId}`)
+  }
 
   useEffect(() => {
     const teamShareToken = searchParams.get('teamShare')
@@ -87,12 +98,11 @@ export default function TeamShareHandler({
     }
 
     if (isTeamAlreadyJoined) {
-      // Find the existing team and select it
-      const existingTeam = teams.find((team: Team) => team.id === shareInfo?.team_id)
-      if (existingTeam) {
-        onTeamSelected(existingTeam)
-      }
-      handleCloseModal()
+      // Close modal state without URL cleanup - navigating away handles it
+      setIsModalOpen(false)
+      setShareInfo(null)
+      setError(null)
+      navigateToTeam(shareInfo.team_id, shareInfo.bind_mode)
       return
     }
 
@@ -105,16 +115,13 @@ export default function TeamShareHandler({
         title: t('common:teams.share.join_success', { teamName: shareInfo?.team_name || '' }),
       })
 
-      // First refresh team list, wait for refresh to complete and get latest team list
-      const updatedTeams = await onRefreshTeams()
-
-      // Find the newly joined team from the refreshed team list and select it
-      const newTeam = updatedTeams.find(team => team.id === shareInfo.team_id)
-      if (newTeam) {
-        onTeamSelected(newTeam)
-      }
-
-      handleCloseModal()
+      // Refresh team list, then navigate to the joined team
+      await onRefreshTeams()
+      // Close modal state without URL cleanup - navigating away handles it
+      setIsModalOpen(false)
+      setShareInfo(null)
+      setError(null)
+      navigateToTeam(shareInfo.team_id, shareInfo.bind_mode)
     } catch (err) {
       console.error('Failed to join shared team:', err)
       const errorMessage = (err as Error)?.message || t('common:teams.share.join_failed')
@@ -147,12 +154,6 @@ export default function TeamShareHandler({
         <span>
           <span className={highlightClass}> {teamName} </span>
           {t('common:teams.share.self_share_suffix')}
-        </span>
-      ),
-      'teams.share.already_joined_message': () => (
-        <span>
-          <span className={highlightClass}> {teamName} </span>
-          {t('common:teams.share.already_joined_suffix')}
         </span>
       ),
       'teams.share.confirm_message': () =>
@@ -203,14 +204,14 @@ export default function TeamShareHandler({
             </AlertDescription>
           </Alert>
         ) : isTeamAlreadyJoined ? (
-          <Alert variant="warning">
-            <AlertDescription>
-              {renderMessageWithHighlight(
-                'teams.share.already_joined_message',
-                shareInfo.team_name
-              )}
-            </AlertDescription>
-          </Alert>
+          <div className="text-center space-y-2">
+            <p className="text-text-primary text-base font-semibold">
+              {t('common:teams.share.already_joined_title')}
+            </p>
+            <p className="text-text-secondary text-sm">
+              {t('common:teams.share.already_joined_message', { teamName: shareInfo.team_name })}
+            </p>
+          </div>
         ) : (
           <>
             <div className="text-center">
@@ -245,15 +246,27 @@ export default function TeamShareHandler({
         >
           {t('common:actions.cancel')}
         </Button>
-        <Button
-          onClick={handleConfirmJoin}
-          variant="default"
-          size="sm"
-          disabled={!!isSelfShare || isJoining}
-          style={{ flex: 1 }}
-        >
-          {isJoining ? t('common:teams.share.joining') : t('common:teams.share.confirm_join')}
-        </Button>
+        {isTeamAlreadyJoined ? (
+          <Button
+            onClick={handleConfirmJoin}
+            variant="primary"
+            size="sm"
+            style={{ flex: 1 }}
+            data-testid="share-start-chat-button"
+          >
+            {t('common:teams.share.start_chat')}
+          </Button>
+        ) : (
+          <Button
+            onClick={handleConfirmJoin}
+            variant="default"
+            size="sm"
+            disabled={!!isSelfShare || isJoining}
+            style={{ flex: 1 }}
+          >
+            {isJoining ? t('common:teams.share.joining') : t('common:teams.share.confirm_join')}
+          </Button>
+        )}
       </div>
     </Modal>
   )

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -353,6 +353,8 @@
       "confirm_join": "Confirm Join",
       "self_share_message": "\"{{teamName}}\" is your own agent, no need to join.",
       "already_joined_message": "\"{{teamName}}\" is already in your agent list, no need to join again.",
+      "already_joined_title": "Agent Already Joined",
+      "start_chat": "Start Chat",
       "fetch_info_failed": "Failed to fetch shared agent information",
       "join_failed": "Failed to join agent, please try again",
       "join_success": "Successfully joined agent \"{{teamName}}\"",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -353,6 +353,8 @@
       "confirm_join": "确认加入",
       "self_share_message": "「{{teamName}}」是您的智能体，无须加入。",
       "already_joined_message": "「{{teamName}}」已在您的智能体列表中，无须重复加入。",
+      "already_joined_title": "智能体已加入",
+      "start_chat": "开始聊天",
       "fetch_info_failed": "获取分享智能体信息失败",
       "join_failed": "加入智能体失败，请重试",
       "join_success": "成功加入智能体「{{teamName}}」",


### PR DESCRIPTION
- After joining a shared team, auto-navigate to /chat or /code based on team's bind_mode
- If team already joined, show "智能体已加入" with "开始聊天" button instead of warning
- Add bind_mode to TeamShareInfo backend response for routing decisions
- Handle ?teamId= URL param in ChatArea to auto-select team after navigation
- Remove onTeamSelected prop from TeamShareHandler (replaced by router.push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bind_mode` support to team sharing, enabling configuration-based routing to chat or code pages.
  * Improved team joining workflow with direct navigation to the appropriate team page.

* **Bug Fixes & Improvements**
  * Enhanced team selection handling when joining shared teams.
  * Added new UI messaging for agents already joined to a team ("Agent Already Joined", "Start Chat").

* **Localization**
  * Added English and Chinese translations for team sharing status messages.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1105)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->