### PR TITLE
fix(backend): avoid ghost name collision and deduplicate name availability logic

### DIFF
--- a/backend/app/services/adapters/bot_kinds.py
+++ b/backend/app/services/adapters/bot_kinds.py
@@ -399,18 +399,26 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
                     name: ref.model_dump() for name, ref in preload_skill_refs.items()
                 }
 
+        ghost_name = self._find_available_name(
+            db,
+            base_name=f"{obj_in.name}-ghost",
+            kind="Ghost",
+            user_id=user_id,
+            namespace=namespace,
+        )
+
         ghost_json = {
             "kind": "Ghost",
             "spec": ghost_spec,
             "status": {"state": "Available"},
-            "metadata": {"name": f"{obj_in.name}-ghost", "namespace": namespace},
+            "metadata": {"name": ghost_name, "namespace": namespace},
             "apiVersion": "agent.wecode.io/v1",
         }
 
         ghost = Kind(
             user_id=user_id,
             kind="Ghost",
-            name=f"{obj_in.name}-ghost",
+            name=ghost_name,
             namespace=namespace,
             json=ghost_json,
             is_active=True,
@@ -499,7 +507,7 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
         bot_json = {
             "kind": "Bot",
             "spec": {
-                "ghostRef": {"name": f"{obj_in.name}-ghost", "namespace": namespace},
+                "ghostRef": {"name": ghost_name, "namespace": namespace},
                 "shellRef": {"name": shell_ref_name, "namespace": shell_ref_namespace},
                 "modelRef": {"name": model_ref_name, "namespace": model_ref_namespace},
             },
@@ -2058,21 +2066,22 @@ class BotKindsService(BaseService[Kind, BotCreate, BotUpdate]):
 
         return resolved
 
-    def find_available_bot_name(
+    def _find_available_name(
         self,
         db: Session,
         *,
         base_name: str,
+        kind: str,
         user_id: int,
         namespace: str = "default",
     ) -> str:
-        """Find an available bot name by appending (2), (3), etc. if needed."""
+        """Find an available name by appending (2), (3), etc. if needed."""
         is_group_namespace = namespace != "default"
         candidate = base_name
         counter = 2
         while True:
             query = db.query(Kind).filter(
-                Kind.kind == "Bot",
+                Kind.kind == kind,
                 Kind.name == candidate,
                 Kind.namespace == namespace,
                 Kind.is_active == True,

--- a/backend/app/services/adapters/team_kinds.py
+++ b/backend/app/services/adapters/team_kinds.py
@@ -2152,36 +2152,6 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
             "preload_skills": sorted(all_preload_skills),
         }
 
-    def _find_available_name(
-        self,
-        db: Session,
-        *,
-        base_name: str,
-        kind: str,
-        user_id: int,
-        namespace: str,
-    ) -> str:
-        """Return the first available name: base_name → base_name (2) → base_name (3) ..."""
-        is_group_namespace = namespace != "default"
-        candidate = base_name
-        counter = 2
-        while True:
-            query = db.query(Kind).filter(
-                Kind.kind == kind,
-                Kind.name == candidate,
-                Kind.namespace == namespace,
-                Kind.is_active == True,
-            )
-            # For personal namespace, scope uniqueness check to the user
-            # For group namespaces, uniqueness is across all users in the namespace
-            if not is_group_namespace:
-                query = query.filter(Kind.user_id == user_id)
-            existing = query.first()
-            if not existing:
-                return candidate
-            candidate = f"{base_name} ({counter})"
-            counter += 1
-
     def copy_team(
         self,
         db: Session,
@@ -2255,9 +2225,10 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                 raise HTTPException(status_code=400, detail="Leader bot not found")
 
             # Find available bot name in the destination namespace
-            bot_name = bot_kinds_service.find_available_bot_name(
+            bot_name = bot_kinds_service._find_available_name(
                 db,
                 base_name=f"Copy of {original_bot.name}",
+                kind="Bot",
                 user_id=user_id,
                 namespace=dest_namespace,
             )
@@ -2307,9 +2278,10 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
                 if bot:
                     if dest_namespace != original.namespace:
                         # Clone the bot into the destination namespace
-                        bot_name = bot_kinds_service.find_available_bot_name(
+                        bot_name = bot_kinds_service._find_available_name(
                             db,
                             base_name=bot.name,
+                            kind="Bot",
                             user_id=user_id,
                             namespace=dest_namespace,
                         )
@@ -2348,7 +2320,7 @@ class TeamKindsService(BaseService[Kind, TeamCreate, TeamUpdate]):
         # Determine group_name for permission check
         group_name = dest_namespace if dest_namespace != "default" else None
 
-        team_name = self._find_available_name(
+        team_name = bot_kinds_service._find_available_name(
             db,
             base_name=f"Copy of {original.name}",
             kind="Team",


### PR DESCRIPTION
- Fix bug where creating a bot with a duplicate name would fail because the associated Ghost resource used a hardcoded name without checking for collisions.

- Extract and generalize _find_available_name() in BotKindsService to support any Kind type, replacing the duplicate implementation in TeamKindsService.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced ghost and bot name generation logic to better ensure unique names are assigned during creation and team copying operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1106)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->