### PR TITLE
feat: 工具调用参数实时流式推送，前端展示更及时

### DIFF
--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -241,20 +241,47 @@ class ResponsesAPIEventParser:
             )
 
         elif event_type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value:
-            # function_call_arguments.delta -> incremental arguments update
-            # Standard OpenAI protocol: this event only contains delta, no status field
-            # Tool start is signaled by response.output_item.added with type=function_call
-            # We skip this event as it's just incremental argument streaming
-            return None
+            tool_use_id = _require_non_empty_tool_use_id(
+                data.get("call_id") or data.get("item_id"),
+                context="function_call_arguments.delta",
+            )
+            tool_key = self._tool_key(task_id, subtask_id, tool_use_id)
+            tool_context = self._tool_contexts.get(tool_key)
+            if tool_context is None:
+                logger.warning(
+                    "[ResponsesAPIEventParser] Missing function_call context for %s during arguments.delta",
+                    tool_key,
+                )
+                tool_context = {}
+            arguments_summary = data.get("arguments_summary")
+            if isinstance(arguments_summary, dict):
+                tool_context["arguments"] = arguments_summary
+            return ExecutionEvent(
+                type=EventType.TOOL_ARGUMENT_DELTA,
+                task_id=task_id,
+                subtask_id=subtask_id,
+                tool_name=tool_context.get("name"),
+                tool_use_id=tool_use_id,
+                tool_input=(
+                    arguments_summary if isinstance(arguments_summary, dict) else None
+                ),
+                data={
+                    "tool_protocol": "function_call",
+                    "argument_status": "streaming",
+                    "delta": data.get("delta", ""),
+                },
+                message_id=message_id,
+            )
 
         elif event_type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value:
-            # function_call_arguments.done -> TOOL_RESULT
+            # function_call_arguments.done marks argument generation complete.
+            # The execution result is emitted by response.output_item.done.
             tool_use_id = _require_non_empty_tool_use_id(
                 data.get("call_id") or data.get("item_id"),
                 context="function_call_arguments.done",
             )
             tool_key = self._tool_key(task_id, subtask_id, tool_use_id)
-            tool_context = self._tool_contexts.pop(tool_key, None)
+            tool_context = self._tool_contexts.get(tool_key)
             if tool_context is None:
                 logger.warning(
                     "[ResponsesAPIEventParser] Missing function_call context for %s; "
@@ -264,23 +291,25 @@ class ResponsesAPIEventParser:
                 tool_context = {}
             # Parse arguments from the event data to get tool_input
             arguments_str = data.get("arguments", "")
-            tool_input = None
-            if arguments_str:
+            tool_input = data.get("arguments_summary")
+            if not isinstance(tool_input, dict) and arguments_str:
                 try:
                     tool_input = json.loads(arguments_str)
                 except (json.JSONDecodeError, TypeError):
                     pass
+            if isinstance(tool_input, dict):
+                tool_context["arguments"] = tool_input
             return ExecutionEvent(
-                type=EventType.TOOL_RESULT,
+                type=EventType.TOOL_ARGUMENT_DONE,
                 task_id=task_id,
                 subtask_id=subtask_id,
                 tool_name=tool_context.get("name"),
                 tool_use_id=tool_use_id,
                 tool_input=tool_input or tool_context.get("arguments"),
-                tool_output=data.get("output"),
                 data={
                     "blocks": data.get("blocks", []),
                     "tool_protocol": "function_call",
+                    "argument_status": "done",
                 },
                 message_id=message_id,
             )
@@ -318,10 +347,15 @@ class ResponsesAPIEventParser:
                     except (json.JSONDecodeError, TypeError):
                         pass
                 tool_key = self._tool_key(task_id, subtask_id, call_id)
+                arguments_summary = data.get("arguments_summary")
                 self._tool_contexts[tool_key] = {
                     "protocol": "function_call",
                     "name": name,
-                    "arguments": arguments,
+                    "arguments": (
+                        arguments_summary
+                        if isinstance(arguments_summary, dict)
+                        else arguments
+                    ),
                 }
 
                 return ExecutionEvent(
@@ -330,11 +364,16 @@ class ResponsesAPIEventParser:
                     subtask_id=subtask_id,
                     tool_use_id=call_id,
                     tool_name=name,
-                    tool_input=arguments,
+                    tool_input=(
+                        arguments_summary
+                        if isinstance(arguments_summary, dict)
+                        else arguments
+                    ),
                     data={
                         "blocks": data.get("blocks", []),
                         "display_name": data.get("display_name"),
                         "tool_protocol": "function_call",
+                        "argument_status": data.get("argument_status"),
                     },
                     message_id=message_id,
                 )
@@ -471,6 +510,43 @@ class ResponsesAPIEventParser:
 
         elif event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value:
             item = data.get("item", {})
+            if item.get("type") == "function_call":
+                call_id = _require_non_empty_tool_use_id(
+                    item.get("call_id") or item.get("id"),
+                    context="response.output_item.done(function_call)",
+                )
+                tool_key = self._tool_key(task_id, subtask_id, call_id)
+                tool_context = self._tool_contexts.pop(tool_key, None)
+                if tool_context is None:
+                    logger.warning(
+                        "[ResponsesAPIEventParser] Missing function_call completion context for %s; "
+                        "continuing with self-contained completion payload",
+                        tool_key,
+                    )
+                    tool_context = {}
+                arguments_str = item.get("arguments", "")
+                tool_input = tool_context.get("arguments")
+                if not isinstance(tool_input, dict) and arguments_str:
+                    try:
+                        tool_input = json.loads(arguments_str)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                status = item.get("status", "completed")
+                return ExecutionEvent(
+                    type=EventType.TOOL_RESULT,
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    tool_name=tool_context.get("name") or item.get("name"),
+                    tool_use_id=call_id,
+                    tool_input=tool_input,
+                    tool_output=item.get("output"),
+                    data={
+                        "tool_protocol": "function_call",
+                        "status": status,
+                        "error": item.get("error"),
+                    },
+                    message_id=message_id,
+                )
             if item.get("type") != "shell_call":
                 return None
             call_id = _require_non_empty_tool_use_id(

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -99,6 +99,8 @@ class StatusUpdatingEmitter(ResultEmitter):
         elif event.type in (
             EventType.CHUNK.value,
             EventType.TOOL_START.value,
+            EventType.TOOL_ARGUMENT_DELTA.value,
+            EventType.TOOL_ARGUMENT_DONE.value,
             EventType.TOOL_RESULT.value,
         ):
             await session_manager.touch_task_streaming_activity(self._task_id)
@@ -118,6 +120,29 @@ class StatusUpdatingEmitter(ResultEmitter):
                 tool_protocol=tool_protocol,
                 server_label=server_label,
             )
+            if event.data and event.data.get("argument_status") == "streaming":
+                await session_manager.update_tool_block_status(
+                    subtask_id=self._subtask_id,
+                    tool_use_id=event.tool_use_id or "",
+                    status="generating_arguments",
+                    tool_input=event.tool_input,
+                )
+        elif event.type == EventType.TOOL_ARGUMENT_DELTA.value:
+            if event.tool_use_id:
+                await session_manager.update_tool_block_status(
+                    subtask_id=self._subtask_id,
+                    tool_use_id=event.tool_use_id,
+                    status="generating_arguments",
+                    tool_input=event.tool_input,
+                )
+        elif event.type == EventType.TOOL_ARGUMENT_DONE.value:
+            if event.tool_use_id:
+                await session_manager.update_tool_block_status(
+                    subtask_id=self._subtask_id,
+                    tool_use_id=event.tool_use_id,
+                    status="pending",
+                    tool_input=event.tool_input,
+                )
         elif event.type == EventType.TOOL_RESULT.value:
             # Update tool block status when result arrives
             if event.tool_use_id:

--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -115,6 +115,12 @@ class WebSocketResultEmitter(BaseResultEmitter):
             # Emit chat:block_created event for tool start
             await self._emit_block_created(event, webpage_ws_emitter)
 
+        elif event.type == EventType.TOOL_ARGUMENT_DELTA.value:
+            await self._emit_tool_argument_delta(event, webpage_ws_emitter)
+
+        elif event.type == EventType.TOOL_ARGUMENT_DONE.value:
+            await self._emit_tool_argument_done(event, webpage_ws_emitter)
+
         elif event.type == EventType.TOOL_RESULT.value:
             # Emit chat:block_updated event for tool result
             await self._emit_block_updated(event, webpage_ws_emitter)
@@ -243,6 +249,9 @@ class WebSocketResultEmitter(BaseResultEmitter):
             tool_input=event.tool_input or {},
             display_name=display_name,
         )
+        if event.data and event.data.get("argument_status") == "streaming":
+            block["status"] = "generating_arguments"
+            block["argument_status"] = "streaming"
 
         await ws_emitter.emit_block_created(
             task_id=event.task_id,
@@ -252,6 +261,28 @@ class WebSocketResultEmitter(BaseResultEmitter):
         logger.debug(
             f"[WebSocketResultEmitter] chat:block_created emitted: "
             f"task_id={event.task_id}, tool_name={event.tool_name}"
+        )
+
+    async def _emit_tool_argument_delta(
+        self, event: ExecutionEvent, ws_emitter
+    ) -> None:
+        """Emit a partial tool argument update."""
+        await ws_emitter.emit_block_updated(
+            task_id=event.task_id,
+            subtask_id=event.subtask_id,
+            block_id=event.tool_use_id or "",
+            tool_input=event.tool_input,
+            status="generating_arguments",
+        )
+
+    async def _emit_tool_argument_done(self, event: ExecutionEvent, ws_emitter) -> None:
+        """Emit completion of tool argument generation."""
+        await ws_emitter.emit_block_updated(
+            task_id=event.task_id,
+            subtask_id=event.subtask_id,
+            block_id=event.tool_use_id or "",
+            tool_input=event.tool_input,
+            status=BlockStatus.PENDING.value,
         )
 
     async def _emit_direct_block_created(

--- a/backend/tests/services/execution/test_responses_api_event_parser.py
+++ b/backend/tests/services/execution/test_responses_api_event_parser.py
@@ -55,7 +55,7 @@ class TestResponsesAPIEventParserToolIds:
             )
 
     def test_tool_result_parses_arguments_as_tool_input(self):
-        """Test that function_call_arguments.done event parses arguments as tool_input."""
+        """Test that function_call_arguments.done emits argument completion, not tool result."""
         parser = ResponsesAPIEventParser()
 
         parser.parse(
@@ -86,10 +86,56 @@ class TestResponsesAPIEventParserToolIds:
         )
 
         assert result is not None
+        assert result.type == "tool_argument_done"
         assert result.tool_use_id == "tool_123"
-        assert result.tool_output == "File created successfully"
+        assert result.tool_output is None
         assert result.tool_input == {"path": "/test/file.py", "content": "hello"}
         assert result.tool_name == "write_file"
+        assert result.data["argument_status"] == "done"
+
+    def test_tool_argument_delta_updates_sanitized_summary(self):
+        parser = ResponsesAPIEventParser()
+
+        parser.parse(
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+            event_type=ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value,
+            data={
+                "item": {
+                    "type": "function_call",
+                    "id": "tool_delta",
+                    "name": "write_file",
+                    "arguments": "",
+                },
+                "arguments_summary": {"file_path": "/tmp/out.txt"},
+            },
+        )
+
+        result = parser.parse(
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+            event_type=ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value,
+            data={
+                "item_id": "tool_delta",
+                "delta": '{"content":"hello',
+                "arguments_summary": {
+                    "file_path": "/tmp/out.txt",
+                    "content": {"omitted": True, "length": 5},
+                },
+            },
+        )
+
+        assert result is not None
+        assert result.type == "tool_argument_delta"
+        assert result.tool_use_id == "tool_delta"
+        assert result.tool_name == "write_file"
+        assert result.tool_input == {
+            "file_path": "/tmp/out.txt",
+            "content": {"omitted": True, "length": 5},
+        }
+        assert result.data["argument_status"] == "streaming"
 
     def test_tool_result_with_empty_arguments(self):
         """Test that function_call_arguments.done event handles empty arguments."""
@@ -123,8 +169,9 @@ class TestResponsesAPIEventParserToolIds:
         )
 
         assert result is not None
+        assert result.type == "tool_argument_done"
         assert result.tool_use_id == "tool_456"
-        assert result.tool_output == "Success"
+        assert result.tool_output is None
         assert result.tool_input == {}
 
     def test_tool_result_without_arguments(self):
@@ -158,8 +205,9 @@ class TestResponsesAPIEventParserToolIds:
         )
 
         assert result is not None
+        assert result.type == "tool_argument_done"
         assert result.tool_use_id == "tool_789"
-        assert result.tool_output == "Done"
+        assert result.tool_output is None
         assert result.tool_input == {}
 
     def test_mcp_tool_start_and_completion(self):
@@ -369,11 +417,11 @@ class TestResponsesAPIEventParserToolIds:
         )
 
         assert result is not None
-        assert result.type == "tool_result"
+        assert result.type == "tool_argument_done"
         assert result.tool_use_id == "missing_tool"
         assert result.tool_name is None
         assert result.tool_input == {"path": "/tmp/test.py"}
-        assert result.tool_output == "done"
+        assert result.tool_output is None
         assert result.data["tool_protocol"] == "function_call"
 
     def test_mcp_tool_completion_without_context_still_updates_block(self):

--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -41,6 +41,7 @@ from ..llm_logging import log_direct_llm_request as _log_direct_llm_request
 from ..llm_logging import log_direct_llm_response as _log_direct_llm_response
 from ..llm_logging import log_llm_request_event as _log_llm_request_event
 from ..llm_logging import log_llm_response_event as _log_llm_response_event
+from ..tools.argument_stream import ToolCallStreamTracker
 from ..tools.base import ToolRegistry
 from ..tools.builtin.silent_exit import SilentExitException
 
@@ -1067,6 +1068,11 @@ class LangGraphAgentBuilder:
         first_token_received = False
         llm_request_start_time: float | None = None
         ttft_ms: float | None = None  # Time to first token in milliseconds
+        tool_argument_tracker = (
+            ToolCallStreamTracker(on_tool_event=on_tool_event)
+            if on_tool_event
+            else None
+        )
 
         # Get tracer for LLM request span
         tracer = otel_trace.get_tracer("chat_shell.agents")
@@ -1178,6 +1184,11 @@ class LangGraphAgentBuilder:
                                 else "N/A"
                             ),
                         )
+                        tool_call_chunks = getattr(chunk, "tool_call_chunks", None)
+                        if tool_argument_tracker and tool_call_chunks:
+                            await tool_argument_tracker.process_tool_call_chunks(
+                                tool_call_chunks
+                            )
 
                     # Check for reasoning_content (DeepSeek R1 and similar reasoning models)
                     # reasoning_content may be in additional_kwargs or as a direct attribute
@@ -1459,16 +1470,32 @@ class LangGraphAgentBuilder:
                     run_id = event.get("run_id", "")
                     # Get tool input data from event
                     tool_input_data = event.get("data", {})
+                    tool_use_id = event.get("tool_use_id")
+                    tool_arguments_streamed = False
+                    if tool_argument_tracker:
+                        finalize_result = await tool_argument_tracker.finalize(
+                            call_id=tool_use_id or run_id,
+                            tool_name=tool_name,
+                            arguments=(
+                                tool_input_data.get("input", {})
+                                if isinstance(tool_input_data, dict)
+                                else {}
+                            ),
+                        )
+                        if finalize_result.was_streamed:
+                            tool_use_id = finalize_result.tool_use_id
+                            tool_arguments_streamed = True
                     # Notify callback if provided
                     if on_tool_event:
-                        on_tool_event(
-                            "tool_start",
-                            {
-                                "name": tool_name,
-                                "run_id": run_id,
-                                "data": tool_input_data,
-                            },
-                        )
+                        payload = {
+                            "name": tool_name,
+                            "run_id": run_id,
+                            "data": tool_input_data,
+                            "tool_arguments_streamed": tool_arguments_streamed,
+                        }
+                        if tool_use_id:
+                            payload["tool_use_id"] = tool_use_id
+                        on_tool_event("tool_start", payload)
                         # Yield empty string to trigger _emit_pending_events() in chat_service
                         # This ensures tool events are sent immediately instead of being buffered
                         yield ""

--- a/chat_shell/chat_shell/tools/argument_stream.py
+++ b/chat_shell/chat_shell/tools/argument_stream.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Track streamed tool-call arguments from LangChain message chunks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from shared.utils.tool_arguments import sanitize_tool_arguments
+
+
+@dataclass
+class ToolArgumentFinalizeResult:
+    """Result of reconciling streamed arguments with a real tool start."""
+
+    tool_use_id: str
+    arguments_summary: dict[str, Any]
+    was_streamed: bool
+
+
+@dataclass
+class _ToolArgumentState:
+    tool_use_id: str
+    stream_index: int | None
+    tool_name: str = "unknown"
+    args_text: str = ""
+    started: bool = False
+
+
+class ToolCallStreamTracker:
+    """Emit UI-safe lifecycle events while a model streams tool arguments."""
+
+    def __init__(
+        self,
+        *,
+        emitter: Any | None = None,
+        on_tool_event: Callable[[str, dict[str, Any]], None] | None = None,
+    ):
+        self.emitter = emitter
+        self.on_tool_event = on_tool_event
+        self._states: dict[str, _ToolArgumentState] = {}
+        self._index_to_key: dict[int, str] = {}
+
+    async def process_tool_call_chunks(self, chunks: Any) -> None:
+        """Process LangChain ``tool_call_chunks`` from a streamed AI chunk."""
+        if not chunks:
+            return
+
+        for raw_chunk in chunks:
+            chunk = self._normalize_chunk(raw_chunk)
+            stream_index = chunk.get("index")
+            tool_use_id = chunk.get("id")
+            key = self._state_key(tool_use_id, stream_index)
+            if key is None:
+                continue
+
+            state = self._states.get(key)
+            if state is None:
+                state = _ToolArgumentState(
+                    tool_use_id=key,
+                    stream_index=(
+                        stream_index if isinstance(stream_index, int) else None
+                    ),
+                    tool_name=chunk.get("name") or "unknown",
+                )
+                self._states[key] = state
+                if isinstance(stream_index, int):
+                    self._index_to_key[stream_index] = key
+
+            if chunk.get("name"):
+                state.tool_name = chunk["name"]
+
+            if not state.started:
+                await self._emit_start(state)
+                state.started = True
+
+            args_delta = chunk.get("args")
+            if args_delta is None:
+                continue
+            if not isinstance(args_delta, str):
+                args_delta = json.dumps(args_delta, ensure_ascii=False)
+            state.args_text += args_delta
+            await self._emit_delta(state, args_delta)
+
+    async def finalize(
+        self,
+        *,
+        call_id: str,
+        tool_name: str,
+        arguments: dict[str, Any] | None,
+        stream_index: int | None = None,
+    ) -> ToolArgumentFinalizeResult:
+        """Finalize streamed arguments when LangGraph reports ``on_tool_start``."""
+        key = self._find_key(call_id, stream_index, tool_name, arguments or {})
+        state = self._states.get(key) if key else None
+        tool_use_id = state.tool_use_id if state else call_id
+        summary = sanitize_tool_arguments(tool_name, arguments or {})
+
+        if state:
+            state.tool_name = tool_name or state.tool_name
+            await self._emit_done(tool_use_id, tool_name or state.tool_name, summary)
+            self._consume_state(key, state)
+            return ToolArgumentFinalizeResult(
+                tool_use_id=tool_use_id,
+                arguments_summary=summary,
+                was_streamed=True,
+            )
+
+        return ToolArgumentFinalizeResult(
+            tool_use_id=tool_use_id,
+            arguments_summary=summary,
+            was_streamed=False,
+        )
+
+    def _find_key(
+        self,
+        call_id: str,
+        stream_index: int | None,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> str | None:
+        if call_id in self._states:
+            return call_id
+        if stream_index is not None and stream_index in self._index_to_key:
+            return self._index_to_key[stream_index]
+        argument_matched_key = self._find_key_by_arguments(tool_name, arguments)
+        if argument_matched_key is not None:
+            return argument_matched_key
+        for key, state in self._states.items():
+            if state.tool_name == tool_name:
+                return key
+        return None
+
+    def _find_key_by_arguments(
+        self, tool_name: str, arguments: dict[str, Any]
+    ) -> str | None:
+        for key, state in self._states.items():
+            if state.tool_name != tool_name:
+                continue
+            parsed = self._parse_args_text(state.args_text)
+            if not isinstance(parsed, dict):
+                continue
+            if self._arguments_match(parsed, arguments):
+                return key
+        return None
+
+    def _arguments_match(
+        self, streamed_arguments: dict[str, Any], final_arguments: dict[str, Any]
+    ) -> bool:
+        for field_name in ("file_path", "path", "filename", "name"):
+            streamed_value = streamed_arguments.get(field_name)
+            final_value = final_arguments.get(field_name)
+            if streamed_value and final_value and streamed_value == final_value:
+                return True
+        return False
+
+    def _consume_state(self, key: str | None, state: _ToolArgumentState) -> None:
+        if key is not None:
+            self._states.pop(key, None)
+        if state.stream_index is not None:
+            self._index_to_key.pop(state.stream_index, None)
+
+    def _state_key(self, tool_use_id: Any, stream_index: Any) -> str | None:
+        if isinstance(tool_use_id, str) and tool_use_id.strip():
+            return tool_use_id
+        if isinstance(stream_index, int):
+            return (
+                self._index_to_key.get(stream_index) or f"stream_index:{stream_index}"
+            )
+        return None
+
+    def _normalize_chunk(self, chunk: Any) -> dict[str, Any]:
+        if isinstance(chunk, dict):
+            return dict(chunk)
+        return {
+            "index": getattr(chunk, "index", None),
+            "id": getattr(chunk, "id", None),
+            "name": getattr(chunk, "name", None),
+            "args": getattr(chunk, "args", None),
+        }
+
+    async def _emit_start(self, state: _ToolArgumentState) -> None:
+        payload = {
+            "call_id": state.tool_use_id,
+            "name": state.tool_name,
+            "arguments_summary": {},
+        }
+        if self.emitter is not None:
+            await self.emitter.tool_argument_start(**payload)
+        if self.on_tool_event is not None:
+            self.on_tool_event("tool_argument_start", payload)
+
+    async def _emit_delta(self, state: _ToolArgumentState, args_delta: str) -> None:
+        payload = {
+            "call_id": state.tool_use_id,
+            "name": state.tool_name,
+            "arguments_delta": args_delta,
+            "arguments_summary": self._partial_summary(state),
+        }
+        if self.emitter is not None:
+            await self.emitter.tool_argument_delta(
+                call_id=state.tool_use_id,
+                arguments_delta=args_delta,
+                arguments_summary=payload["arguments_summary"],
+            )
+        if self.on_tool_event is not None:
+            self.on_tool_event("tool_argument_delta", payload)
+
+    async def _emit_done(
+        self, tool_use_id: str, tool_name: str, arguments_summary: dict[str, Any]
+    ) -> None:
+        payload = {
+            "call_id": tool_use_id,
+            "name": tool_name,
+            "arguments_summary": arguments_summary,
+        }
+        if self.emitter is not None:
+            await self.emitter.tool_argument_done(
+                call_id=tool_use_id,
+                arguments_summary=arguments_summary,
+            )
+        if self.on_tool_event is not None:
+            self.on_tool_event("tool_argument_done", payload)
+
+    def _partial_summary(self, state: _ToolArgumentState) -> dict[str, Any]:
+        parsed = self._parse_args_text(state.args_text)
+        if not isinstance(parsed, dict):
+            return {}
+        return sanitize_tool_arguments(state.tool_name, parsed)
+
+    def _parse_args_text(self, args_text: str) -> Any:
+        try:
+            return json.loads(args_text)
+        except (json.JSONDecodeError, TypeError):
+            return None

--- a/chat_shell/chat_shell/tools/events.py
+++ b/chat_shell/chat_shell/tools/events.py
@@ -18,6 +18,7 @@ from chat_shell.services.streaming.core import should_display_tool_details
 from shared.models import ResponsesAPIEmitter
 from shared.telemetry.context.large_data import log_large_attribute
 from shared.telemetry.decorators import add_span_event
+from shared.utils.tool_arguments import sanitize_tool_arguments
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,12 @@ def create_tool_event_handler(
             _handle_tool_end(
                 state, emitter, agent_builder, tool_name, run_id, event_data
             )
+        elif kind == "tool_argument_start":
+            _handle_tool_argument_start(emitter, event_data)
+        elif kind == "tool_argument_delta":
+            _handle_tool_argument_delta(emitter, event_data)
+        elif kind == "tool_argument_done":
+            _handle_tool_argument_done(emitter, event_data)
 
     return handle_tool_event
 
@@ -178,16 +185,56 @@ def _handle_tool_start(
 
     # Emit tool_start event via ResponsesAPIEmitter
     # Only include arguments if tool is in whitelist
-    arguments = serializable_input if should_display_tool_details(tool_name) else None
+    arguments = (
+        sanitize_tool_arguments(tool_name, serializable_input)
+        if should_display_tool_details(tool_name)
+        else None
+    )
 
+    if not event_data.get("tool_arguments_streamed"):
+        _run_async(
+            emitter.tool_start(
+                call_id=tool_use_id,
+                name=tool_name,
+                arguments=arguments,
+                display_name=display_name,
+                tool_protocol=tool_protocol,
+                server_label=server_label,
+            )
+        )
+
+
+def _handle_tool_argument_start(
+    emitter: ResponsesAPIEmitter, event_data: dict[str, Any]
+) -> None:
     _run_async(
-        emitter.tool_start(
-            call_id=tool_use_id,
-            name=tool_name,
-            arguments=arguments,
-            display_name=display_name,
-            tool_protocol=tool_protocol,
-            server_label=server_label,
+        emitter.tool_argument_start(
+            call_id=event_data["call_id"],
+            name=event_data.get("name", "unknown"),
+            arguments_summary=event_data.get("arguments_summary"),
+        )
+    )
+
+
+def _handle_tool_argument_delta(
+    emitter: ResponsesAPIEmitter, event_data: dict[str, Any]
+) -> None:
+    _run_async(
+        emitter.tool_argument_delta(
+            call_id=event_data["call_id"],
+            arguments_delta=event_data.get("arguments_delta", ""),
+            arguments_summary=event_data.get("arguments_summary"),
+        )
+    )
+
+
+def _handle_tool_argument_done(
+    emitter: ResponsesAPIEmitter, event_data: dict[str, Any]
+) -> None:
+    _run_async(
+        emitter.tool_argument_done(
+            call_id=event_data["call_id"],
+            arguments_summary=event_data.get("arguments_summary"),
         )
     )
 
@@ -269,7 +316,11 @@ def _handle_tool_end(
 
     # Emit tool_done event via ResponsesAPIEmitter
     # Only include arguments if tool is in whitelist
-    arguments = tool_input if should_display_tool_details(tool_name) else None
+    arguments = (
+        sanitize_tool_arguments(tool_name, tool_input)
+        if should_display_tool_details(tool_name)
+        else None
+    )
     tool_instance = _get_tool_instance(agent_builder, tool_name)
     tool_protocol = (
         _normalize_protocol_type(

--- a/chat_shell/tests/test_tool_argument_streaming.py
+++ b/chat_shell/tests/test_tool_argument_streaming.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for streamed tool argument tracking in Chat Shell."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from chat_shell.tools.argument_stream import ToolCallStreamTracker
+
+
+@pytest.mark.asyncio
+async def test_tracker_emits_start_delta_and_done_with_sanitized_arguments():
+    emitter = AsyncMock()
+    tracker = ToolCallStreamTracker(emitter=emitter)
+
+    await tracker.process_tool_call_chunks(
+        [
+            {
+                "index": 0,
+                "id": "call_123",
+                "name": "write_file",
+                "args": '{"file_path":"/tmp/report.md","content":"',
+            }
+        ]
+    )
+    await tracker.process_tool_call_chunks(
+        [{"index": 0, "args": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]
+    )
+    result = await tracker.finalize(
+        call_id="call_123",
+        tool_name="write_file",
+        arguments={
+            "file_path": "/tmp/report.md",
+            "content": "x" * 5000,
+        },
+    )
+
+    emitter.tool_argument_start.assert_awaited_once()
+    emitter.tool_argument_delta.assert_awaited()
+    emitter.tool_argument_done.assert_awaited_once()
+
+    start_kwargs = emitter.tool_argument_start.await_args.kwargs
+    assert start_kwargs["call_id"] == "call_123"
+    assert start_kwargs["name"] == "write_file"
+
+    done_kwargs = emitter.tool_argument_done.await_args.kwargs
+    assert done_kwargs["call_id"] == "call_123"
+    assert done_kwargs["arguments_summary"]["file_path"] == "/tmp/report.md"
+    assert done_kwargs["arguments_summary"]["content"]["omitted"] is True
+    assert "x" * 5000 not in str(done_kwargs)
+    assert result.arguments_summary["content"]["length"] == 5000
+    assert result.tool_use_id == "call_123"
+    assert result.was_streamed is True
+
+
+@pytest.mark.asyncio
+async def test_tracker_aliases_index_only_stream_to_final_tool_call_id():
+    emitter = AsyncMock()
+    tracker = ToolCallStreamTracker(emitter=emitter)
+
+    await tracker.process_tool_call_chunks(
+        [{"index": 0, "name": "write_file", "args": '{"file_path":"/tmp/a.txt"'}]
+    )
+    result = await tracker.finalize(
+        call_id="run_final",
+        tool_name="write_file",
+        arguments={"file_path": "/tmp/a.txt", "content": "hello"},
+        stream_index=0,
+    )
+
+    start_kwargs = emitter.tool_argument_start.await_args.kwargs
+    assert start_kwargs["call_id"] == "stream_index:0"
+
+    done_kwargs = emitter.tool_argument_done.await_args.kwargs
+    assert done_kwargs["call_id"] == "stream_index:0"
+    assert result.tool_use_id == "stream_index:0"
+    assert result.arguments_summary["content"]["omitted"] is True
+
+
+@pytest.mark.asyncio
+async def test_tracker_finalizes_parallel_same_name_tools_in_stream_order():
+    emitter = AsyncMock()
+    tracker = ToolCallStreamTracker(emitter=emitter)
+
+    await tracker.process_tool_call_chunks(
+        [
+            {"index": 0, "name": "write_file", "args": '{"file_path":"/tmp/a.html"'},
+            {"index": 1, "name": "write_file", "args": '{"file_path":"/tmp/b.html"'},
+            {"index": 2, "name": "write_file", "args": '{"file_path":"/tmp/c.html"'},
+        ]
+    )
+
+    first = await tracker.finalize(
+        call_id="run_a",
+        tool_name="write_file",
+        arguments={"file_path": "/tmp/a.html", "content": "a"},
+    )
+    second = await tracker.finalize(
+        call_id="run_b",
+        tool_name="write_file",
+        arguments={"file_path": "/tmp/b.html", "content": "b"},
+    )
+    third = await tracker.finalize(
+        call_id="run_c",
+        tool_name="write_file",
+        arguments={"file_path": "/tmp/c.html", "content": "c"},
+    )
+
+    assert first.tool_use_id == "stream_index:0"
+    assert second.tool_use_id == "stream_index:1"
+    assert third.tool_use_id == "stream_index:2"
+    assert [
+        call.kwargs["call_id"] for call in emitter.tool_argument_done.await_args_list
+    ] == [
+        "stream_index:0",
+        "stream_index:1",
+        "stream_index:2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tracker_matches_parallel_same_name_tools_by_arguments_when_available():
+    emitter = AsyncMock()
+    tracker = ToolCallStreamTracker(emitter=emitter)
+
+    await tracker.process_tool_call_chunks(
+        [
+            {
+                "index": 0,
+                "name": "write_file",
+                "args": '{"file_path":"/tmp/a.html","content":"a"}',
+            },
+            {
+                "index": 1,
+                "name": "write_file",
+                "args": '{"file_path":"/tmp/b.html","content":"b"}',
+            },
+            {
+                "index": 2,
+                "name": "write_file",
+                "args": '{"file_path":"/tmp/c.html","content":"c"}',
+            },
+        ]
+    )
+
+    first_started = await tracker.finalize(
+        call_id="run_b",
+        tool_name="write_file",
+        arguments={"file_path": "/tmp/b.html", "content": "b"},
+    )
+
+    assert first_started.tool_use_id == "stream_index:1"

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -302,7 +302,13 @@ const MixedContentView = memo(function MixedContentView({
               toolName: normalizedToolName,
               displayName: block.display_name, // Pass display_name from block
               status:
-                (block.status as 'pending' | 'streaming' | 'invoking' | 'done' | 'error') || 'done',
+                (block.status as
+                  | 'generating_arguments'
+                  | 'pending'
+                  | 'streaming'
+                  | 'invoking'
+                  | 'done'
+                  | 'error') || 'done',
               toolUse: {
                 title: `Using ${normalizedToolName}`,
                 next_action: 'continue',

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -181,7 +181,10 @@ export const ToolBlock = memo(function ToolBlock({
   // For merged tools, check if any of them is still running
   const isRunning = useMemo(() => {
     const checkRunning = (status: string | undefined) =>
-      status === 'invoking' || status === 'streaming' || status === 'pending'
+      status === 'generating_arguments' ||
+      status === 'invoking' ||
+      status === 'streaming' ||
+      status === 'pending'
 
     if (count > 1 && mergedTools.length > 0) {
       return mergedTools.some(item => checkRunning(item.status))

--- a/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/tools/WriteToolRenderer.tsx
@@ -19,7 +19,17 @@ export function WriteToolRenderer({ tool }: ToolRendererProps) {
 
   const input = tool.toolUse.details?.input as Record<string, unknown> | undefined
   let filePath = input?.file_path as string | undefined
-  const content = input?.content as string | undefined
+  const rawContent = input?.content
+  const content = typeof rawContent === 'string' ? rawContent : undefined
+  const contentSummary =
+    rawContent && typeof rawContent === 'object'
+      ? (rawContent as {
+          omitted?: boolean
+          length?: number
+          preview?: string
+          sha256?: string
+        })
+      : undefined
 
   const outputRaw = (tool.toolResult?.details?.content || tool.toolResult?.details?.output) as
     | string
@@ -64,7 +74,16 @@ export function WriteToolRenderer({ tool }: ToolRendererProps) {
       )}
 
       {/* Content to Write */}
-      {content && (
+      {contentSummary?.omitted && (
+        <div>
+          <div className="text-xs font-medium text-text-secondary mb-1">Content</div>
+          <div className="text-xs text-text-tertiary bg-fill-tert p-2 rounded font-mono">
+            {contentSummary.length ?? 0} bytes generated
+          </div>
+        </div>
+      )}
+
+      {content && !contentSummary?.omitted && (
         <div>
           <div className="flex items-center justify-between mb-1">
             <div className="text-xs font-medium text-text-secondary">Content</div>
@@ -117,6 +136,11 @@ export function WriteToolRenderer({ tool }: ToolRendererProps) {
       {!output && tool.status === 'invoking' && (
         <div className="text-xs text-text-muted italic">
           {t('thinking.tool_executing') || 'Writing file...'}
+        </div>
+      )}
+      {!output && tool.status === 'generating_arguments' && (
+        <div className="text-xs text-text-muted italic">
+          {t('thinking.tool_generating_arguments') || 'Preparing file content...'}
         </div>
       )}
     </div>

--- a/frontend/src/features/tasks/components/message/thinking/types.ts
+++ b/frontend/src/features/tasks/components/message/thinking/types.ts
@@ -84,7 +84,13 @@ export interface ThinkingStep {
 /**
  * Tool execution status
  */
-export type ToolStatus = 'pending' | 'streaming' | 'invoking' | 'done' | 'error'
+export type ToolStatus =
+  | 'generating_arguments'
+  | 'pending'
+  | 'streaming'
+  | 'invoking'
+  | 'done'
+  | 'error'
 
 /**
  * Base interface for all message blocks.
@@ -94,6 +100,7 @@ interface BaseBlock {
   id: string // Unique block identifier
   status?:
     | 'pending'
+    | 'generating_arguments'
     | 'streaming'
     | 'done'
     | 'error'
@@ -123,6 +130,7 @@ export interface ToolBlock extends BaseBlock {
   display_name?: string // Display name for tool (optional)
   tool_input?: Record<string, unknown> // Tool input parameters
   tool_output?: unknown // Tool execution result
+  argument_status?: 'streaming' | 'done'
   metadata?: Record<string, unknown> // Additional metadata
 }
 

--- a/frontend/src/features/tasks/contexts/chatStreamContext.tsx
+++ b/frontend/src/features/tasks/contexts/chatStreamContext.tsx
@@ -448,7 +448,16 @@ export function ChatStreamProvider({ children }: { children: ReactNode }) {
    * Uses task_id from event payload directly
    */
   const handleBlockUpdated = useCallback((data: ChatBlockUpdatedPayload) => {
-    const { task_id: taskId, subtask_id, block_id, content, tool_output, tool_input, status } = data
+    const {
+      task_id: taskId,
+      subtask_id,
+      block_id,
+      content,
+      tool_output,
+      tool_input,
+      argument_status,
+      status,
+    } = data
 
     if (!taskId) {
       console.warn('[ChatStreamContext][block_updated] Missing task_id for subtask:', subtask_id)
@@ -465,6 +474,7 @@ export function ChatStreamProvider({ children }: { children: ReactNode }) {
       ...(content !== undefined && { content }),
       ...(tool_output !== undefined && { tool_output }),
       ...(tool_input !== undefined && { tool_input }),
+      ...(argument_status !== undefined && { argument_status }),
       ...(mappedStatus !== undefined && { status: mappedStatus }),
     }
 

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -235,7 +235,8 @@ export interface ChatBlock {
   guidance_id?: string
   loop_index?: number
   applied_at?: string
-  status?: 'pending' | 'streaming' | 'done' | 'error'
+  argument_status?: 'streaming' | 'done'
+  status?: 'generating_arguments' | 'pending' | 'streaming' | 'done' | 'error'
   timestamp?: number
 }
 
@@ -333,6 +334,7 @@ export interface ChatBlockUpdatedPayload {
   content?: string
   tool_output?: unknown
   tool_input?: Record<string, unknown>
+  argument_status?: 'streaming' | 'done'
   guidance_id?: string
   loop_index?: number
   applied_at?: string

--- a/shared/models/execution.py
+++ b/shared/models/execution.py
@@ -37,6 +37,8 @@ class EventType(str, Enum):
     THINKING = "thinking"
     TOOL = "tool"  # Generic tool event (for tool callbacks)
     TOOL_START = "tool_start"
+    TOOL_ARGUMENT_DELTA = "tool_argument_delta"
+    TOOL_ARGUMENT_DONE = "tool_argument_done"
     TOOL_RESULT = "tool_result"
     BLOCK_CREATED = "block_created"
     PROGRESS = "progress"

--- a/shared/models/responses_api.py
+++ b/shared/models/responses_api.py
@@ -813,7 +813,8 @@ class ResponsesAPIEventBuilder:
     def function_call_arguments_delta(
         self,
         call_id: str,
-        arguments: Optional[dict] = None,
+        arguments: Optional[Any] = None,
+        arguments_summary: Optional[dict] = None,
     ) -> dict:
         """Create response.function_call_arguments.delta event.
 
@@ -824,20 +825,26 @@ class ResponsesAPIEventBuilder:
         Returns:
             Event data dictionary
         """
-        delta = self._json_arguments(arguments)
-        return {
+        delta = (
+            arguments if isinstance(arguments, str) else self._json_arguments(arguments)
+        )
+        data = {
             "type": ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value,
             "response_id": self.response_id,
             "item_id": call_id,
             "output_index": self._tool_output_index,
             "delta": delta,
         }
+        if arguments_summary is not None:
+            data["arguments_summary"] = arguments_summary
+        return data
 
     def function_call_arguments_done(
         self,
         call_id: str,
         arguments: Optional[dict] = None,
         output: Optional[str] = None,
+        arguments_summary: Optional[dict] = None,
     ) -> dict:
         """Create response.function_call_arguments.done event.
 
@@ -860,6 +867,8 @@ class ResponsesAPIEventBuilder:
         # Add output as Wegent extension for tool result
         if output is not None:
             data["output"] = output
+        if arguments_summary is not None:
+            data["arguments_summary"] = arguments_summary
         return data
 
     def function_call_done(
@@ -867,6 +876,8 @@ class ResponsesAPIEventBuilder:
         call_id: str,
         name: str,
         arguments: Optional[dict] = None,
+        output: Optional[str] = None,
+        status: str = "completed",
     ) -> dict:
         """Create response.output_item.done event for function call.
 
@@ -881,7 +892,7 @@ class ResponsesAPIEventBuilder:
         args_str = self._json_arguments(arguments)
         output_index = self._tool_output_index
         self._tool_output_index += 1  # Increment for next tool call
-        return {
+        data = {
             "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value,
             "response_id": self.response_id,
             "output_index": output_index,
@@ -891,8 +902,12 @@ class ResponsesAPIEventBuilder:
                 "call_id": call_id,
                 "name": name,
                 "arguments": args_str,
+                "status": status,
             },
         }
+        if output is not None:
+            data["item"]["output"] = output
+        return data
 
     # ============================================================
     # MCP Call Events

--- a/shared/models/responses_api_emitter.py
+++ b/shared/models/responses_api_emitter.py
@@ -320,6 +320,83 @@ class ResponsesAPIEmitter:
             ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value, delta_data
         )
 
+    async def tool_argument_start(
+        self,
+        call_id: str,
+        name: str,
+        arguments_summary: Optional[dict] = None,
+        display_name: Optional[str] = None,
+        tool_protocol: str = "function_call",
+        server_label: Optional[str] = None,
+    ) -> Any:
+        """Emit the start of streamed tool argument generation."""
+        if hasattr(self.transport, "start_collecting"):
+            self.transport.start_collecting()
+
+        protocol_type = self._normalize_protocol_type(name, tool_protocol)
+        self._tool_contexts[call_id] = {
+            "protocol_type": protocol_type,
+            "name": name,
+            "arguments": arguments_summary,
+            "server_label": server_label,
+            "arguments_emitted": False,
+        }
+
+        if protocol_type != "function_call":
+            return await self.tool_start(
+                call_id=call_id,
+                name=name,
+                arguments=arguments_summary,
+                display_name=display_name,
+                tool_protocol=tool_protocol,
+                server_label=server_label,
+            )
+
+        added_data = self.builder.function_call_added(call_id, name, display_name)
+        added_data["argument_status"] = "streaming"
+        if arguments_summary is not None:
+            added_data["arguments_summary"] = arguments_summary
+        return await self._emit(
+            ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value, added_data
+        )
+
+    async def tool_argument_delta(
+        self,
+        call_id: str,
+        arguments_delta: str,
+        arguments_summary: Optional[dict] = None,
+    ) -> Any:
+        """Emit an incremental tool argument delta."""
+        delta_data = self.builder.function_call_arguments_delta(
+            call_id,
+            arguments_delta,
+            arguments_summary=arguments_summary,
+        )
+        return await self._emit(
+            ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value, delta_data
+        )
+
+    async def tool_argument_done(
+        self,
+        call_id: str,
+        arguments: Optional[dict] = None,
+        arguments_summary: Optional[dict] = None,
+    ) -> Any:
+        """Emit completion of streamed tool arguments without tool output."""
+        tool_context = self._tool_contexts.get(call_id)
+        if tool_context is not None:
+            tool_context["arguments"] = arguments_summary or arguments
+            tool_context["arguments_emitted"] = True
+
+        done_data = self.builder.function_call_arguments_done(
+            call_id,
+            arguments,
+            arguments_summary=arguments_summary,
+        )
+        return await self._emit(
+            ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value, done_data
+        )
+
     async def tool_done(
         self,
         call_id: str,
@@ -412,9 +489,10 @@ class ResponsesAPIEmitter:
                 ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value, item_done_data
             )
 
-        # Send arguments done (with output for tool result)
+        # Send arguments done. Tool output is carried by output_item.done so the
+        # argument lifecycle stays distinct from the execution result lifecycle.
         done_data = self.builder.function_call_arguments_done(
-            call_id, resolved_arguments, output
+            call_id, resolved_arguments
         )
         await self._emit(
             ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value, done_data
@@ -422,7 +500,11 @@ class ResponsesAPIEmitter:
 
         # Send function call done
         item_done_data = self.builder.function_call_done(
-            call_id, resolved_name, resolved_arguments
+            call_id,
+            resolved_name,
+            resolved_arguments,
+            output=output,
+            status=status,
         )
         return await self._emit(
             ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value, item_done_data

--- a/shared/tests/test_tool_argument_streaming.py
+++ b/shared/tests/test_tool_argument_streaming.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for streaming tool argument events and UI-safe argument summaries."""
+
+import pytest
+
+from shared.models import EmitterBuilder, GeneratorTransport
+from shared.utils.tool_arguments import sanitize_tool_arguments
+
+
+def test_sanitize_tool_arguments_omits_large_write_content():
+    args = {
+        "file_path": "/home/user/report.md",
+        "format": "text",
+        "content": "x" * 5000,
+    }
+
+    sanitized = sanitize_tool_arguments("write_file", args, max_string_length=64)
+
+    assert sanitized["file_path"] == "/home/user/report.md"
+    assert sanitized["format"] == "text"
+    assert sanitized["content"]["omitted"] is True
+    assert sanitized["content"]["length"] == 5000
+    assert sanitized["content"]["preview"] == "x" * 64
+    assert sanitized["content"]["sha256"]
+    assert "x" * 5000 not in str(sanitized)
+
+
+@pytest.mark.asyncio
+async def test_emitter_streams_tool_argument_lifecycle_with_sanitized_summary():
+    transport = GeneratorTransport()
+    emitter = EmitterBuilder().with_task(1, 2).with_transport(transport).build()
+
+    await emitter.tool_argument_start(
+        call_id="call_123",
+        name="write_file",
+        arguments_summary={"file_path": "/home/user/report.md"},
+    )
+    await emitter.tool_argument_delta(
+        call_id="call_123",
+        arguments_delta='{"content":"',
+        arguments_summary={
+            "file_path": "/home/user/report.md",
+            "content": {"omitted": True, "length": 1024},
+        },
+    )
+    await emitter.tool_argument_done(
+        call_id="call_123",
+        arguments_summary={
+            "file_path": "/home/user/report.md",
+            "content": {"omitted": True, "length": 2048},
+        },
+    )
+
+    events = transport.get_events()
+
+    assert [event_type for event_type, _ in events] == [
+        "response.output_item.added",
+        "response.function_call_arguments.delta",
+        "response.function_call_arguments.done",
+    ]
+    assert events[0][1]["item"]["type"] == "function_call"
+    assert events[0][1]["item"]["name"] == "write_file"
+    assert events[0][1]["arguments_summary"]["file_path"] == "/home/user/report.md"
+    assert events[1][1]["delta"] == '{"content":"'
+    assert events[1][1]["arguments_summary"]["content"]["omitted"] is True
+    assert events[2][1]["arguments_summary"]["content"]["length"] == 2048
+    assert "output" not in events[2][1]

--- a/shared/utils/tool_arguments.py
+++ b/shared/utils/tool_arguments.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for UI-safe tool argument summaries."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+LARGE_ARGUMENT_FIELDS = {
+    "base64",
+    "bytes",
+    "content",
+    "data",
+    "file_content",
+}
+
+
+def sanitize_tool_arguments(
+    tool_name: str,
+    arguments: Any,
+    *,
+    max_string_length: int = 2048,
+) -> Any:
+    """Return arguments safe to send to UI clients.
+
+    Large payload fields are summarized so file contents and binary data do not
+    enter WebSocket payloads, React state, or persisted block history.
+    """
+    return _sanitize_value(
+        arguments,
+        field_name="",
+        max_string_length=max_string_length,
+        force_large_fields=_force_large_fields(tool_name),
+    )
+
+
+def _force_large_fields(tool_name: str) -> set[str]:
+    normalized = tool_name.lower()
+    if "write" in normalized or "upload" in normalized:
+        return LARGE_ARGUMENT_FIELDS
+    return LARGE_ARGUMENT_FIELDS
+
+
+def _sanitize_value(
+    value: Any,
+    *,
+    field_name: str,
+    max_string_length: int,
+    force_large_fields: set[str],
+) -> Any:
+    normalized_field = field_name.lower()
+
+    if isinstance(value, dict):
+        return {
+            str(key): _sanitize_value(
+                child,
+                field_name=str(key),
+                max_string_length=max_string_length,
+                force_large_fields=force_large_fields,
+            )
+            for key, child in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            _sanitize_value(
+                child,
+                field_name=field_name,
+                max_string_length=max_string_length,
+                force_large_fields=force_large_fields,
+            )
+            for child in value
+        ]
+
+    if isinstance(value, str):
+        should_omit = (
+            normalized_field in force_large_fields or len(value) > max_string_length
+        )
+        if should_omit:
+            return {
+                "omitted": True,
+                "length": len(value),
+                "preview": value[:max_string_length],
+                "sha256": hashlib.sha256(value.encode("utf-8")).hexdigest(),
+            }
+        return value
+
+    if isinstance(value, (bytes, bytearray)):
+        raw = bytes(value)
+        return {
+            "omitted": True,
+            "length": len(raw),
+            "sha256": hashlib.sha256(raw).hexdigest(),
+        }
+
+    return value


### PR DESCRIPTION
## 背景

  工具调用参数生成阶段，前端此前需等参数完全生成后才能看到工具卡片出现，
  体感延迟明显，尤其是参数较大时（如 write_file 写入长文件）。

  ## 改动

  **后端 / shared**
  - 新增 `TOOL_ARGUMENT_DELTA` / `TOOL_ARGUMENT_DONE` 事件类型，
    将工具参数生成与工具执行结果的生命周期拆分
  - `TOOL_RESULT` 触发时机从 `function_call_arguments.done` 移至
    `response.output_item.done`，语义更准确
  - 新增 `sanitize_tool_arguments()` 工具函数，对超长字段（base64、
    file_content 等）做摘要处理，防止大体积内容进入 WebSocket 推送
  - `ResponsesAPIEmitter` 新增 `tool_argument_start / delta / done`
    三个方法，支持参数流式 emit
  - `function_call_done` 事件补充 `output` 和 `status` 字段

  **前端**
  - `ToolStatus` 新增 `generating_arguments` 状态
  - `ToolBlock` 的 `isRunning` 判断覆盖新状态，生成中显示加载动画
  - `chatStreamContext` 透传 `argument_status` 字段至 block 状态

  ## 效果

  工具参数生成阶段前端即可看到工具卡片出现并实时更新参数预览，
  执行完毕后再更新为结果状态。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming for tool arguments with incremental deltas and explicit argument-completion events
  * UI shows a distinct "generating arguments" tool status while arguments are being prepared

* **Improvements**
  * Sanitized summaries for large or sensitive argument payloads (size, preview, hash) instead of full content
  * Clearer separation between argument-generation and tool-result phases for more accurate progress reporting

* **Tests**
  * Added coverage for argument streaming, sanitization, and mapping streamed chunks to final tool calls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1121)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->