### PR TITLE
fix(share): restore short-circuit logic in get_user_kb_permission for…

### DIFF
--- a/backend/app/services/share/knowledge_share_service.py
+++ b/backend/app/services/share/knowledge_share_service.py
@@ -748,10 +748,13 @@ class KnowledgeShareService(UnifiedShareService):
         roles.extend(r)
         sources.extend(s)
 
-        # 6. Group chat binding
-        r, s = self._source_group_chat_binding(db, kb, user_id, include_sources)
-        roles.extend(r)
-        sources.extend(s)
+        # 6. Group chat binding — only check if no other permission sources found.
+        # When the user already has access via creator/member/entity/org/group,
+        # group_chat_binding (fixed Reporter role) cannot be the decisive source.
+        if kb.namespace == "default" and not roles:
+            r, s = self._source_group_chat_binding(db, kb, user_id, include_sources)
+            roles.extend(r)
+            sources.extend(s)
 
         effective_role = get_highest_role(roles) if roles else None
         has_access = len(roles) > 0 or is_creator


### PR DESCRIPTION
… performance

The previous implementation called _compute_kb_access_core with include_sources=False, which unconditionally executed all 6 permission sources including _source_group_chat_binding -> _is_kb_bound_to_user_group_chat. This caused severe performance degradation on /folders and /documents endpoints because every request triggered 2x TaskResource full-table queries + Python-side JSON parsing, even for creators or explicitly shared users.

This fix restores short-circuit evaluation:
- Creator -> immediate return (Owner)
- Direct member + Entity permission -> checked together, highest role wins
- Organization -> immediate return
- Group membership -> immediate return
- Group chat binding -> last resort (only for personal KBs)

The _compute_kb_access_core method is preserved for get_my_permission_sources() which needs to collect all permission sources for visualization.

290 knowledge-related tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked knowledge-base permission evaluation into an explicit, priority-ordered short-circuit sequence for clearer, faster access decisions.
  * Personal KB "group chat binding" is now treated strictly as a fallback — considered only when no other roles are found and the KB is the default namespace.
  * Clarified ordering for creator, organization, team, entity, and personal KB fallbacks and updated related docs/comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1122)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->