### PR TITLE
fix(frontend): remove duplicate taskId query param in knowledge task …

### DIFF
--- a/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskListSection.tsx
@@ -176,8 +176,7 @@ export default function TaskListSection({
       if (task.task_type === 'knowledge' && task.knowledge_base_id) {
         // Knowledge type tasks navigate to the dedicated KB chat page
         // This ensures full task functionality (follow-up questions, link sharing, etc.)
-        // Include taskId in URL so the page can load the correct chat history
-        targetPath = `/knowledge/document/${task.knowledge_base_id}?taskId=${task.id}`
+        targetPath = `/knowledge/document/${task.knowledge_base_id}`
       } else if (task.task_type === 'task') {
         // Task type tasks navigate to device chat page
         targetPath = '/devices/chat'


### PR DESCRIPTION
…navigation

The knowledge branch pre-built taskId into targetPath, but the shared params.set('taskId') and router.push() also appended it, producing malformed URLs like /knowledge/document/123?taskId=456?taskId=456.

After redirect, searchParams.get('taskId') returned \"456?taskId=456\", Number() parsed it as NaN, and the app requested /api/tasks/NaN.

Revert the knowledge targetPath to a bare path so taskId is managed exclusively by the shared URLSearchParams, consistent with all other task types.

Fixes the regression introduced in 3fcef8e46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation routing for knowledge-type tasks to pass the correct identifier when opening knowledge documents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->