### PR TITLE
fix: sync renamed public team in personal list

### DIFF
--- a/frontend/src/__tests__/features/admin/publicTeamPayload.test.ts
+++ b/frontend/src/__tests__/features/admin/publicTeamPayload.test.ts
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AdminPublicTeam } from '@/apis/admin'
+import {
+  buildPublicTeamUpdateData,
+  resolvePublicTeamName,
+} from '@/features/admin/utils/publicTeamPayload'
+
+const makeEditingTeam = (): AdminPublicTeam => ({
+  id: 7,
+  name: 'old-agent',
+  namespace: 'default',
+  display_name: 'Old Agent',
+  description: 'desc',
+  json: {},
+  is_active: true,
+  created_at: '2026-05-19T00:00:00Z',
+  updated_at: '2026-05-19T00:00:00Z',
+})
+
+describe('publicTeamPayload', () => {
+  it('prefers the edited name when resolving the persisted public team name', () => {
+    const resolved = resolvePublicTeamName(
+      '  new-agent  ',
+      { metadata: { name: 'json-agent' } },
+      'fallback-agent'
+    )
+
+    expect(resolved).toBe('new-agent')
+  })
+
+  it('falls back to metadata.name and then the provided fallback', () => {
+    expect(resolvePublicTeamName('', { metadata: { name: 'json-agent' } }, 'fallback-agent')).toBe(
+      'json-agent'
+    )
+    expect(resolvePublicTeamName('', {}, 'fallback-agent')).toBe('fallback-agent')
+  })
+
+  it('includes the resolved name in public team update payloads', () => {
+    const updateData = buildPublicTeamUpdateData({
+      editingTeam: makeEditingTeam(),
+      name: 'renamed-agent',
+      namespace: 'default',
+      teamJson: { metadata: { name: 'ignored-json-name' } },
+      isActive: false,
+    })
+
+    expect(updateData).toEqual({
+      name: 'renamed-agent',
+      json: { metadata: { name: 'ignored-json-name' } },
+      is_active: false,
+    })
+  })
+
+  it('adds namespace only when the namespace changes', () => {
+    const updateData = buildPublicTeamUpdateData({
+      editingTeam: makeEditingTeam(),
+      name: '',
+      namespace: 'community',
+      teamJson: { metadata: { name: 'json-agent' } },
+      isActive: true,
+    })
+
+    expect(updateData).toEqual({
+      name: 'json-agent',
+      namespace: 'community',
+      json: { metadata: { name: 'json-agent' } },
+      is_active: true,
+    })
+  })
+})

--- a/frontend/src/__tests__/utils/team.test.ts
+++ b/frontend/src/__tests__/utils/team.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Team } from '@/types/api'
+import { getTeamDisplayName, sortTeamsByUpdatedAt } from '@/utils/team'
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 1,
+  name: 'agent-name',
+  displayName: null,
+  namespace: 'default',
+  description: '',
+  bots: [],
+  workflow: {},
+  is_active: true,
+  user_id: 1,
+  created_at: '2026-05-18T00:00:00Z',
+  updated_at: '2026-05-18T00:00:00Z',
+  ...overrides,
+})
+
+describe('team utils', () => {
+  it('prefers displayName over name for team labels', () => {
+    expect(getTeamDisplayName(makeTeam({ displayName: 'Spec Agent' }))).toBe('Spec Agent')
+  })
+
+  it('falls back to name when displayName is empty', () => {
+    expect(getTeamDisplayName(makeTeam({ displayName: '   ' }))).toBe('agent-name')
+    expect(getTeamDisplayName(makeTeam())).toBe('agent-name')
+  })
+
+  it('sorts teams by updated_at descending', () => {
+    const teams = [
+      makeTeam({ id: 1, updated_at: '2026-05-18T00:00:00Z' }),
+      makeTeam({ id: 2, updated_at: '2026-05-19T00:00:00Z' }),
+    ]
+
+    expect(sortTeamsByUpdatedAt(teams).map(team => team.id)).toEqual([2, 1])
+  })
+})

--- a/frontend/src/features/admin/components/PublicTeamEditDialog.tsx
+++ b/frontend/src/features/admin/components/PublicTeamEditDialog.tsx
@@ -32,13 +32,9 @@ import TeamEditDrawer from '@/features/settings/components/TeamEditDrawer'
 import { useTranslation } from '@/hooks/useTranslation'
 import { UnifiedShell } from '@/apis/shells'
 import { BotEditRef } from '@/features/settings/components/BotEdit'
-import {
-  adminApis,
-  AdminPublicTeam,
-  AdminPublicTeamCreate,
-  AdminPublicTeamUpdate,
-} from '@/apis/admin'
+import { adminApis, AdminPublicTeam, AdminPublicTeamCreate } from '@/apis/admin'
 import { publicResourceApis } from '@/apis/publicResources'
+import { buildPublicTeamUpdateData, resolvePublicTeamName } from '../utils/publicTeamPayload'
 
 // Import sub-components from settings
 import TeamBasicInfoForm from '@/features/settings/components/team-edit/TeamBasicInfoForm'
@@ -752,21 +748,18 @@ export default function PublicTeamEditDialog({
 
       // Create or update team
       if (editingTeam) {
-        const updateData: AdminPublicTeamUpdate = {
-          json: teamJson,
-          is_active: isActive,
-        }
-        if (namespace !== editingTeam.namespace) {
-          updateData.namespace = namespace
-        }
+        const updateData = buildPublicTeamUpdateData({
+          editingTeam,
+          name,
+          namespace,
+          teamJson,
+          isActive,
+        })
         await adminApis.updatePublicTeam(editingTeam.id, updateData)
         toast({ title: t('public_teams.success.updated') })
       } else {
         const createData: AdminPublicTeamCreate = {
-          name:
-            name.trim() ||
-            (teamJson.metadata as Record<string, unknown>)?.name?.toString() ||
-            'new-team',
+          name: resolvePublicTeamName(name, teamJson, 'new-team'),
           namespace,
           json: teamJson,
         }

--- a/frontend/src/features/admin/utils/publicTeamPayload.ts
+++ b/frontend/src/features/admin/utils/publicTeamPayload.ts
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AdminPublicTeam, AdminPublicTeamUpdate } from '@/apis/admin'
+
+const getMetadataName = (teamJson: Record<string, unknown>): string | undefined => {
+  const metadata = teamJson.metadata
+  if (!metadata || typeof metadata !== 'object') return undefined
+
+  const name = (metadata as Record<string, unknown>).name
+  return typeof name === 'string' && name.trim() ? name.trim() : undefined
+}
+
+export const resolvePublicTeamName = (
+  name: string,
+  teamJson: Record<string, unknown>,
+  fallback: string
+): string => {
+  return name.trim() || getMetadataName(teamJson) || fallback
+}
+
+export const buildPublicTeamUpdateData = ({
+  editingTeam,
+  name,
+  namespace,
+  teamJson,
+  isActive,
+}: {
+  editingTeam: AdminPublicTeam
+  name: string
+  namespace: string
+  teamJson: Record<string, unknown>
+  isActive: boolean
+}): AdminPublicTeamUpdate => {
+  const updateData: AdminPublicTeamUpdate = {
+    name: resolvePublicTeamName(name, teamJson, editingTeam.name),
+    json: teamJson,
+    is_active: isActive,
+  }
+
+  if (namespace !== editingTeam.namespace) {
+    updateData.namespace = namespace
+  }
+
+  return updateData
+}

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -37,7 +37,7 @@ import TeamCreationWizard from './wizard/TeamCreationWizard'
 import { TeamApiCallButton } from './TeamApiCallButton'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useToast } from '@/hooks/use-toast'
-import { sortTeamsByUpdatedAt } from '@/utils/team'
+import { getTeamDisplayName, sortTeamsByUpdatedAt } from '@/utils/team'
 import { isGroupTeam, isPublicTeam, isSharedTeam } from '@/utils/team-permissions'
 import type { BaseRole } from '@/types/base-role'
 import { sortBotsByUpdatedAt } from '@/utils/bot'
@@ -562,6 +562,7 @@ export default function TeamList({
                       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-0 min-w-0">
                         <ResourceListItem
                           name={team.name}
+                          displayName={getTeamDisplayName(team)}
                           description={team.description}
                           icon={
                             <TeamIconDisplay

--- a/frontend/src/utils/team.ts
+++ b/frontend/src/utils/team.ts
@@ -10,6 +10,10 @@ const parseTimestamp = (value?: string) => {
   return Number.isFinite(timestamp) ? timestamp : 0
 }
 
+export const getTeamDisplayName = (team: Pick<Team, 'name' | 'displayName'>) => {
+  return team.displayName?.trim() || team.name
+}
+
 export const sortTeamsByUpdatedAt = (teams: Team[]) => {
   return [...teams].sort((a, b) => parseTimestamp(b.updated_at) - parseTimestamp(a.updated_at))
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for team utilities and public team payload operations.

* **New Features**
  * Introduced team display name functionality that intelligently falls back between display name and name fields.
  * Enhanced admin team editing with improved name resolution and conditional namespace updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->