### PR TITLE
fix(dingtalk): set parentId for root-level nodes in wikispace sync

### DIFF
--- a/backend/app/services/dingtalk_wikispace_service.py
+++ b/backend/app/services/dingtalk_wikispace_service.py
@@ -294,6 +294,14 @@ class DingTalkWikiSpaceService:
         first_batch, first_token = DingTalkDocService._parse_list_nodes_result(
             first_result
         )
+
+        # Set parentId for root-level nodes to the knowledge base's nodeId.
+        # This ensures the directory tree correctly shows these nodes under
+        # the KB folder (which has nodeId = workspace_id).
+        for node in first_batch:
+            if not node.get("parentId"):
+                node["parentId"] = workspace_id
+
         all_nodes.extend(first_batch)
 
         # Recurse into sub-folders found in the first batch.
@@ -321,6 +329,12 @@ class DingTalkWikiSpaceService:
             }
             result = await session.call_tool(MCP_TOOL_LIST_NODES, args)
             batch, page_token = DingTalkDocService._parse_list_nodes_result(result)
+
+            # Set parentId for root-level nodes to the knowledge base's nodeId.
+            for node in batch:
+                if not node.get("parentId"):
+                    node["parentId"] = workspace_id
+
             all_nodes.extend(batch)
             for node in batch:
                 if node.get("nodeType") == "folder":

--- a/backend/tests/services/test_dingtalk_wikispace_service.py
+++ b/backend/tests/services/test_dingtalk_wikispace_service.py
@@ -15,8 +15,6 @@ import pytest
 from app.models.dingtalk_doc import DingTalkNodeSource, DingtalkSyncedNode
 from app.services.dingtalk_doc_service import DingTalkDocService
 from app.services.dingtalk_wikispace_service import (
-    MCP_TOOL_LIST_WIKI_SPACES,
-    WIKISPACE_SOURCE,
     DingTalkWikiSpaceService,
     _sanitize_url_for_telemetry,
 )
@@ -197,9 +195,16 @@ class TestListNodesInWikispace:
                 all_nodes=all_nodes,
             )
 
+        # parentId is set to workspace_id for root-level nodes to ensure
+        # the directory tree correctly shows them under the KB folder.
         assert all_nodes == [
-            {"nodeType": "folder", "workspaceId": "WS1"},
-            {"nodeId": "doc-1", "nodeType": "doc", "workspaceId": "WS1"},
+            {"nodeType": "folder", "workspaceId": "WS1", "parentId": "WS1"},
+            {
+                "nodeId": "doc-1",
+                "nodeType": "doc",
+                "workspaceId": "WS1",
+                "parentId": "WS1",
+            },
         ]
         mock_recursive.assert_not_awaited()
 


### PR DESCRIPTION
When listing documents within a knowledge base via list_nodes(workspaceId=kb_id), the returned root-level nodes did not have their parentId set to the KB's nodeId. This caused the directory tree to incorrectly display these nodes without proper parent-child relationship to the knowledge base folder.

The fix sets parentId to workspace_id for all root-level nodes, ensuring the directory tree correctly shows documents and folders under their respective knowledge base root folder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document tree structure normalization in DingTalk WikiSpace integration to properly organize root-level folders and files within the knowledge base hierarchy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->