### PR TITLE
fix(runtime): allow cleanup of tasks in any state, including deleted …

### DIFF
--- a/backend/app/services/adapters/executor_job.py
+++ b/backend/app/services/adapters/executor_job.py
@@ -182,17 +182,14 @@ class JobService(BaseService[Kind, None, None]):
         inactive_hours: int = 24,
         dry_run: bool = False,
     ) -> Dict[str, object]:
-        """Clean up executor resources for a single task after the stale window."""
-        task = await self._get_active_task_resource(db, task_id)
-        task_crd = Task.model_validate(task.json)
-        task_status = task_crd.status.status if task_crd.status else "PENDING"
+        """Clean up executor resources for a single task after the stale window.
 
-        if task_status not in ["COMPLETED", "FAILED", "CANCELLED"]:
-            return self._build_cleanup_result(
-                task_id,
-                "task_not_finished",
-                details={"inactive_hours": inactive_hours, "dry_run": dry_run},
-            )
+        The inactive_hours parameter is the sole eligibility gate. Task status is
+        intentionally not checked here — a pod stuck in RUNNING with no activity for
+        24h is just as stale as a COMPLETED one, and the admin explicitly requested
+        cleanup with the inactivity threshold.
+        """
+        task = await self._get_task_resource_any_state(db, task_id)
 
         subtasks = await self._get_cleanup_subtasks_for_task(db, task_id)
         if not subtasks:
@@ -785,6 +782,21 @@ class JobService(BaseService[Kind, None, None]):
             return task
 
         raise HTTPException(status_code=404, detail="Task not found")
+
+    async def _get_task_resource_any_state(
+        self, db: AsyncSession, task_id: int
+    ) -> TaskResource:
+        """Load a task resource by id regardless of its is_active state."""
+        result = await db.execute(
+            select(TaskResource).filter(
+                TaskResource.id == task_id,
+                TaskResource.kind == "Task",
+            )
+        )
+        task = result.scalars().first()
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return task
 
     async def _get_cleanup_subtasks_for_task(
         self, db: AsyncSession, task_id: int

--- a/backend/tests/services/test_preserve_executor.py
+++ b/backend/tests/services/test_preserve_executor.py
@@ -1000,7 +1000,7 @@ class TestCleanupTaskExecutorAPI(CleanupExecutorTestHelpers):
         with (
             patch.object(
                 job_service,
-                "_get_active_task_resource",
+                "_get_task_resource_any_state",
                 new_callable=AsyncMock,
                 return_value=mock_task,
             ),

--- a/backend/tests/services/test_runtime_cleanup.py
+++ b/backend/tests/services/test_runtime_cleanup.py
@@ -13,10 +13,19 @@ from app.services.adapters.executor_job import JobService
 
 
 class RuntimeCleanupHelpers:
-    def _task(self, task_id: int, updated_at: datetime, preserve: bool = False):
+    def _task(
+        self,
+        task_id: int,
+        updated_at: datetime,
+        preserve: bool = False,
+        deleted: bool = False,
+    ):
         task = Mock(spec=TaskResource)
         task.id = task_id
         task.updated_at = updated_at
+        task.is_active = (
+            TaskResource.STATE_DELETED if deleted else TaskResource.STATE_ACTIVE
+        )
         labels = {"taskType": "chat"}
         if preserve:
             labels["preserveExecutor"] = "true"
@@ -136,3 +145,113 @@ async def test_cleanup_stale_task_executors_deletes_executor_after_24_hours():
         "executor-stale", "default"
     )
     mark_deleted.assert_awaited_once_with([1])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_stale_task_executor_works_for_deleted_task():
+    """Soft-deleted tasks (is_active=STATE_DELETED) must still be cleanable."""
+    job_service_instance = JobService(Mock())
+    now = datetime.now()
+    deleted_task = RuntimeCleanupHelpers()._task(
+        200, now - timedelta(hours=48), deleted=True
+    )
+    stale_subtask = RuntimeCleanupHelpers()._subtask(
+        10, 200, now - timedelta(hours=25), "executor-deleted-task"
+    )
+
+    with (
+        patch.object(
+            job_service_instance,
+            "_get_task_resource_any_state",
+            new_callable=AsyncMock,
+            return_value=deleted_task,
+        ),
+        patch.object(
+            job_service_instance,
+            "_get_cleanup_subtasks_for_task",
+            new_callable=AsyncMock,
+            return_value=[stale_subtask],
+        ),
+        patch.object(
+            job_service_instance, "_mark_executor_deleted", new_callable=AsyncMock
+        ) as mark_deleted,
+        patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as executor_service,
+    ):
+        executor_service.delete_executor_task_async = AsyncMock(return_value=True)
+
+        result = await job_service_instance.cleanup_stale_task_executor(
+            AsyncMock(), task_id=200, inactive_hours=24, dry_run=False
+        )
+
+    assert result["deleted"] is True
+    executor_service.delete_executor_task_async.assert_awaited_once_with(
+        "executor-deleted-task", "default"
+    )
+    mark_deleted.assert_awaited_once_with([10])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_stale_task_executor_works_for_stuck_running_task():
+    """RUNNING tasks with stale pods must be cleanable — inactive_hours is the gate."""
+    job_service_instance = JobService(Mock())
+    now = datetime.now()
+
+    running_task = Mock(spec=TaskResource)
+    running_task.id = 300
+    running_task.updated_at = now - timedelta(hours=140)
+    running_task.is_active = TaskResource.STATE_ACTIVE
+    running_task.json = {
+        "kind": "Task",
+        "apiVersion": "agent.wecode.io/v1",
+        "metadata": {
+            "name": "task-300",
+            "namespace": "default",
+            "labels": {"taskType": "chat"},
+        },
+        "spec": {
+            "title": "Stuck Task",
+            "prompt": "test",
+            "teamRef": {"name": "team", "namespace": "default"},
+            "workspaceRef": {"name": "ws", "namespace": "default"},
+        },
+        "status": {"status": "RUNNING", "progress": 0},
+    }
+    stale_subtask = RuntimeCleanupHelpers()._subtask(
+        20, 300, now - timedelta(hours=140), "executor-stuck"
+    )
+
+    with (
+        patch.object(
+            job_service_instance,
+            "_get_task_resource_any_state",
+            new_callable=AsyncMock,
+            return_value=running_task,
+        ),
+        patch.object(
+            job_service_instance,
+            "_get_cleanup_subtasks_for_task",
+            new_callable=AsyncMock,
+            return_value=[stale_subtask],
+        ),
+        patch.object(
+            job_service_instance, "_mark_executor_deleted", new_callable=AsyncMock
+        ) as mark_deleted,
+        patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as executor_service,
+    ):
+        executor_service.delete_executor_task_async = AsyncMock(return_value=True)
+
+        result = await job_service_instance.cleanup_stale_task_executor(
+            AsyncMock(), task_id=300, inactive_hours=24, dry_run=False
+        )
+
+    assert result["deleted"] is True
+    executor_service.delete_executor_task_async.assert_awaited_once_with(
+        "executor-stuck", "default"
+    )
+    mark_deleted.assert_awaited_once_with([20])


### PR DESCRIPTION
…and stuck-running

Remove the terminal-status gate from cleanup_stale_task_executor so that soft-deleted and stuck-RUNNING tasks with stale pods are also eligible for cleanup when the inactivity threshold is met. Add _get_task_resource_any_state helper and corresponding unit tests for both scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale task executor cleanup now runs regardless of a task's active/state flag, ensuring executors for soft-deleted and stuck/running tasks are properly removed.

* **Tests**
  * Added and updated unit tests to cover cleanup behavior for soft-deleted tasks and stale running tasks, and to reflect the broader task-loading behavior used during cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->