### PR TITLE
fix(frontend): handle pending chat task replacement

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
@@ -13,6 +13,7 @@ const mockAddUserMessage = jest.fn()
 const mockUpdateUserMessage = jest.fn()
 const mockToast = jest.fn()
 const mockSendChatGuidance = jest.fn().mockResolvedValue({ success: true })
+const mockRefreshSelectedTaskDetail = jest.fn()
 
 let isMachineStreamingMock = true
 let taskInputMessageMock = 'next question'
@@ -33,7 +34,7 @@ jest.mock('@/features/tasks/contexts/taskContext', () => ({
   useTaskContext: () => ({
     selectedTaskDetail: selectedTaskDetailMock,
     refreshTasks: jest.fn(),
-    refreshSelectedTaskDetail: jest.fn(),
+    refreshSelectedTaskDetail: mockRefreshSelectedTaskDetail,
     markTaskAsViewed: jest.fn(),
   }),
 }))
@@ -260,6 +261,26 @@ describe('useChatStreamHandlers queue integration', () => {
     const { result } = renderQueueableHook()
 
     expect(result.current.canQueueMessage).toBe(false)
+  })
+
+  it('does not show a destructive send error while the task is still pending', async () => {
+    isMachineStreamingMock = false
+    selectedTaskDetailMock = {
+      id: 42,
+      status: 'PENDING',
+      is_group_chat: false,
+      subtasks: [],
+    } as unknown as TaskDetail
+    mockContextSendMessage.mockRejectedValueOnce(new Error('Unknown error'))
+
+    const { result } = renderQueueableHook()
+
+    await act(async () => {
+      await result.current.handleSendMessage()
+    })
+
+    expect(mockToast).not.toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }))
+    expect(mockRefreshSelectedTaskDetail).toHaveBeenCalledWith(false)
   })
 
   it('shows a retry action that resends a failed queued message', async () => {

--- a/frontend/src/__tests__/features/tasks/components/input/chat-send-state.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/chat-send-state.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import type { ChatInputControlsProps } from '@/features/tasks/components/input/ChatInputControls'
 import { ChatInputControls } from '@/features/tasks/components/input/ChatInputControls'
 import { getChatSendState } from '@/features/tasks/components/input/chatSendState'
@@ -62,8 +62,10 @@ jest.mock('@/features/tasks/components/input/SendButton', () => ({
 
 jest.mock('@/components/ui/action-button', () => ({
   __esModule: true,
-  ActionButton: ({ title }: { title?: string }) => (
-    <button type="button">{title || 'Action'}</button>
+  ActionButton: ({ title, onClick }: { title?: string; onClick?: () => void }) => (
+    <button type="button" aria-label={title || 'Action'} onClick={onClick}>
+      {title || 'Action'}
+    </button>
   ),
 }))
 
@@ -157,6 +159,23 @@ describe('ChatInputControls send state', () => {
 
     expect(screen.getByRole('button', { name: 'Stop generating' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Queue message' })).toBeInTheDocument()
+  })
+
+  it('shows a cancel task action for pending non-group tasks', () => {
+    const onCancelTask = jest.fn()
+
+    render(
+      <ChatInputControls
+        {...createProps()}
+        selectedTaskDetail={{ status: 'PENDING', is_group_chat: false } as never}
+        onCancelTask={onCancelTask}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel task' }))
+
+    expect(onCancelTask).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('loading-dots')).not.toBeInTheDocument()
   })
 })
 
@@ -261,7 +280,7 @@ describe('getChatSendState', () => {
     })
   })
 
-  it('shows pending loading for non-group pending task', () => {
+  it('uses cancel as the primary action for non-group pending task', () => {
     expect(
       getChatSendState({
         isLoading: false,
@@ -279,10 +298,10 @@ describe('getChatSendState', () => {
         canQueueMessage: false,
       })
     ).toEqual({
-      primaryAction: 'loading',
-      isPrimaryDisabled: true,
+      primaryAction: 'cancel',
+      isPrimaryDisabled: false,
       showStopAction: false,
-      showPendingAction: true,
+      showPendingAction: false,
     })
   })
 

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -5,7 +5,7 @@
 'use client'
 
 import React, { useEffect, useCallback, useMemo, useState, useRef } from 'react'
-import { ShieldX } from 'lucide-react'
+import { Command, MessageSquareText, ShieldX, X } from 'lucide-react'
 import { useSearchParams } from 'next/navigation'
 import MessagesArea from '../message/MessagesArea'
 import { QuickAccessCards } from './QuickAccessCards'
@@ -35,6 +35,16 @@ import { useTaskContext } from '../../contexts/taskContext'
 import { useTaskStateMachine } from '../../hooks/useTaskStateMachine'
 import { useOptionalChatStreamContext } from '../../contexts/chatStreamContext'
 import { Button } from '@/components/ui/button'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { useToast } from '@/hooks/use-toast'
 import { useScrollManagement } from '../hooks/useScrollManagement'
 import { useFloatingInput } from '../hooks/useFloatingInput'
@@ -158,6 +168,9 @@ function ChatAreaContent({
   const [pipelineStageInfo, setPipelineStageInfo] = useState<PipelineStageInfo | null>(null)
   const [isPipelineNextStepOpen, setIsPipelineNextStepOpen] = useState(false)
   const [isPipelineNextStepConfirming, setIsPipelineNextStepConfirming] = useState(false)
+  const [pendingReplacementMessage, setPendingReplacementMessage] = useState<string | null>(null)
+  const [isPendingReplacementOpen, setIsPendingReplacementOpen] = useState(false)
+  const [isPendingReplacementConfirming, setIsPendingReplacementConfirming] = useState(false)
   const { quote, clearQuote, formatQuoteForMessage } = useQuote()
 
   // Task context
@@ -755,6 +768,42 @@ function ChatAreaContent({
   const selectedContextsRef = useRef(chatState.selectedContexts)
   selectedContextsRef.current = chatState.selectedContexts
 
+  const shouldConfirmPendingReplacement =
+    selectedTaskDetail?.status === 'PENDING' && !selectedTaskDetail?.is_group_chat
+
+  const sendOrConfirmPendingReplacement = useCallback(
+    async (message: string) => {
+      const trimmedMessage = message.trim()
+      if (!trimmedMessage && !chatState.shouldHideChatInput) return
+
+      if (shouldConfirmPendingReplacement) {
+        setPendingReplacementMessage(trimmedMessage)
+        setIsPendingReplacementOpen(true)
+        return
+      }
+
+      await streamHandlers.handleSendMessage(trimmedMessage)
+    },
+    [chatState.shouldHideChatInput, shouldConfirmPendingReplacement, streamHandlers]
+  )
+
+  const handleConfirmPendingReplacement = useCallback(async () => {
+    if (!pendingReplacementMessage || isPendingReplacementConfirming) return
+
+    setIsPendingReplacementConfirming(true)
+    try {
+      const cancelled = await streamHandlers.handleCancelTask()
+      if (!cancelled) return
+
+      const message = pendingReplacementMessage
+      setPendingReplacementMessage(null)
+      setIsPendingReplacementOpen(false)
+      await streamHandlers.handleSendMessage(message)
+    } finally {
+      setIsPendingReplacementConfirming(false)
+    }
+  }, [pendingReplacementMessage, isPendingReplacementConfirming, streamHandlers])
+
   // Handle queue message loaded from inbox - adds the message(s) as context(s)
   // Supports both single message and batch processing
   const handleQueueMessageLoaded = useCallback(
@@ -817,9 +866,9 @@ function ChatAreaContent({
       const existingInput = taskInputMessageRef.current.trim()
       const combinedMessage = existingInput ? `${content}\n\n---\n\n${existingInput}` : content
       setTaskInputMessage('')
-      await handleSendMessageRef.current(combinedMessage)
+      await sendOrConfirmPendingReplacement(combinedMessage)
     },
-    [setTaskInputMessage]
+    [sendOrConfirmPendingReplacement, setTaskInputMessage]
   )
 
   // Callback for child components to send messages with a specific model (for regeneration)
@@ -1184,7 +1233,7 @@ function ChatAreaContent({
       if (quote) {
         clearQuote()
       }
-      await streamHandlers.handleSendMessage(message)
+      await sendOrConfirmPendingReplacement(message)
     },
     onSendGuidance: async () => {
       const baseMessage = chatState.taskInputMessage.trim()
@@ -1236,13 +1285,15 @@ function ChatAreaContent({
     isAttachmentReadyToSend: chatState.isAttachmentReadyToSend,
     isSubtaskStreaming: streamHandlers.isSubtaskStreaming,
     onStopStream: streamHandlers.stopStream,
+    onCancelTask: streamHandlers.handleCancelTask,
+    isCancelling: streamHandlers.isCancelling,
     onSendMessage: () => {
       // Format message with quote if present, then clear quote
       const message = formatQuoteForMessage(chatState.taskInputMessage.trim())
       if (quote) {
         clearQuote()
       }
-      streamHandlers.handleSendMessage(message)
+      void sendOrConfirmPendingReplacement(message)
     },
     // Whether there are no available teams for current mode
     hasNoTeams: filteredTeams.length === 0,
@@ -1511,6 +1562,75 @@ function ChatAreaContent({
           onConfirm={handlePipelineNextStepConfirm}
         />
       )}
+      <AlertDialog
+        open={isPendingReplacementOpen}
+        onOpenChange={open => {
+          if (isPendingReplacementConfirming) return
+          setIsPendingReplacementOpen(open)
+          if (!open) {
+            setPendingReplacementMessage(null)
+          }
+        }}
+      >
+        <AlertDialogContent className="w-[520px] max-w-[calc(100vw-32px)] gap-0 overflow-hidden rounded-2xl border-border bg-base p-0 shadow-2xl">
+          <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+            <Command className="h-4 w-4 text-text-secondary" />
+            <span className="text-sm text-text-secondary">
+              {t('chat:pending_task_confirm.eyebrow')}
+            </span>
+            <AlertDialogCancel
+              disabled={isPendingReplacementConfirming}
+              className="ml-auto mt-0 h-8 w-8 rounded-full border-0 bg-transparent p-0 text-text-muted hover:bg-surface hover:text-text-primary"
+            >
+              <X className="h-4 w-4" />
+              <span className="sr-only">{t('chat:pending_task_confirm.wait')}</span>
+            </AlertDialogCancel>
+          </div>
+          <AlertDialogHeader className="space-y-0 px-5 py-5 text-left">
+            <div className="flex items-start gap-3 rounded-xl bg-surface p-4">
+              <MessageSquareText className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+              <div>
+                <AlertDialogTitle className="text-sm font-semibold text-text-primary">
+                  {t('chat:pending_task_confirm.title')}
+                </AlertDialogTitle>
+                <AlertDialogDescription className="mt-1 text-sm leading-6 text-text-secondary">
+                  {t('chat:pending_task_confirm.description')}
+                </AlertDialogDescription>
+              </div>
+            </div>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="grid grid-cols-2 gap-2 px-5 pb-5 pt-0 sm:space-x-0">
+            <AlertDialogCancel
+              disabled={isPendingReplacementConfirming}
+              className="mt-0 flex h-auto flex-col items-start justify-start gap-0 rounded-xl border-border bg-base px-4 py-3 text-left hover:bg-surface"
+            >
+              <span className="block text-sm font-medium text-text-primary">
+                {t('chat:pending_task_confirm.wait')}
+              </span>
+              <span className="mt-1 block text-xs font-normal text-text-secondary">
+                {t('chat:pending_task_confirm.wait_hint')}
+              </span>
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={event => {
+                event.preventDefault()
+                void handleConfirmPendingReplacement()
+              }}
+              disabled={isPendingReplacementConfirming}
+              className="flex h-auto flex-col items-start justify-start gap-0 rounded-xl border border-primary bg-primary/8 px-4 py-3 text-left hover:bg-primary/12"
+            >
+              <span className="block text-sm font-medium text-primary">
+                {isPendingReplacementConfirming
+                  ? t('chat:pending_task_confirm.confirming')
+                  : t('chat:pending_task_confirm.confirm')}
+              </span>
+              <span className="mt-1 block text-xs font-normal text-text-secondary">
+                {t('chat:pending_task_confirm.confirm_hint')}
+              </span>
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       {extension?.teamEdit?.renderDialog()}
     </div>
   )

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -164,7 +164,7 @@ export interface ChatStreamHandlers {
     subtaskId?: number
   }) => Promise<boolean>
   handleRetryWithModel: (message: { subtaskId?: number }, model: UnifiedModel) => Promise<boolean>
-  handleCancelTask: () => Promise<void>
+  handleCancelTask: () => Promise<boolean>
   stopStream: () => Promise<void>
   resetStreamingState: () => void
 
@@ -490,6 +490,11 @@ export function useChatStreamHandlers({
   // Helper: handle send errors
   const handleSendError = useCallback(
     (error: Error, message: string) => {
+      if (selectedTaskDetail?.status === 'PENDING') {
+        refreshSelectedTaskDetail(false)
+        return
+      }
+
       resetStreamingState()
       const parsedError = parseError(error)
       lastFailedMessageRef.current = message
@@ -509,7 +514,14 @@ export function useChatStreamHandlers({
           : undefined,
       })
     },
-    [resetStreamingState, toast, t, createRetryButton]
+    [
+      selectedTaskDetail?.status,
+      refreshSelectedTaskDetail,
+      resetStreamingState,
+      toast,
+      t,
+      createRetryButton,
+    ]
   )
 
   const prepareChatSend = useCallback(
@@ -1612,7 +1624,7 @@ export function useChatStreamHandlers({
 
   // Handle cancel task
   const handleCancelTask = useCallback(async () => {
-    if (!selectedTaskDetail?.id || isCancelling) return
+    if (!selectedTaskDetail?.id || isCancelling) return false
 
     setIsCancelling(true)
 
@@ -1630,6 +1642,7 @@ export function useChatStreamHandlers({
 
       refreshTasks()
       refreshSelectedTaskDetail(false)
+      return true
     } catch (err: unknown) {
       const errorMessage =
         err instanceof Error && err.message === 'Cancel operation timed out'
@@ -1659,6 +1672,7 @@ export function useChatStreamHandlers({
         refreshTasks()
         refreshSelectedTaskDetail(false)
       }
+      return false
     } finally {
       setIsCancelling(false)
     }

--- a/frontend/src/features/tasks/components/input/ChatInputCard.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputCard.tsx
@@ -200,6 +200,8 @@ export function ChatInputCard({
   isSubtaskStreaming,
   canSendGuidance,
   onStopStream,
+  onCancelTask,
+  isCancelling,
   onSendMessage,
   onSendGuidance,
   // Skill selector props
@@ -608,6 +610,8 @@ export function ChatInputCard({
             canQueueMessage={canQueueMessage}
             canSendGuidance={canSendGuidance}
             onStopStream={onStopStream}
+            onCancelTask={onCancelTask}
+            isCancelling={isCancelling}
             onSendMessage={onSendMessage}
             onSendGuidance={onSendGuidance}
             hasNoTeams={hasNoTeams}

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -115,6 +115,8 @@ export interface ChatInputControlsProps {
 
   // Actions
   onStopStream: () => void
+  onCancelTask?: () => void
+  isCancelling?: boolean
   onSendMessage: () => void
   onSendGuidance?: () => void
 
@@ -227,6 +229,8 @@ export function ChatInputControls({
   canQueueMessage = false,
   canSendGuidance = false,
   onStopStream,
+  onCancelTask,
+  isCancelling = false,
   onSendMessage,
   onSendGuidance,
   hasNoTeams = false,
@@ -312,6 +316,22 @@ export function ChatInputControls({
       />
     )
 
+    const renderCancelTaskAction = () => {
+      if (isCancelling) {
+        return renderStoppingAction()
+      }
+
+      return (
+        <ActionButton
+          onClick={onCancelTask}
+          title="Cancel task"
+          icon={<CircleStop className="h-4 w-4 text-orange-500" />}
+          className="hover:bg-orange-100"
+          data-testid="cancel-task-button"
+        />
+      )
+    }
+
     if (sendState.primaryAction === 'loading') {
       if (sendState.showStopAction) {
         return renderStoppingAction()
@@ -326,6 +346,10 @@ export function ChatInputControls({
 
     if (sendState.primaryAction === 'stop') {
       return renderStopAction()
+    }
+
+    if (sendState.primaryAction === 'cancel') {
+      return renderCancelTaskAction()
     }
 
     if (sendState.primaryAction === 'queue') {
@@ -396,6 +420,8 @@ export function ChatInputControls({
         canQueueMessage={canQueueMessage}
         canSendGuidance={canSendGuidance}
         onStopStream={onStopStream}
+        onCancelTask={onCancelTask}
+        isCancelling={isCancelling}
         onSendMessage={onSendMessage}
         onSendGuidance={onSendGuidance}
         hasNoTeams={hasNoTeams}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -98,6 +98,8 @@ export interface MobileChatInputControlsProps {
 
   // Actions
   onStopStream: () => void
+  onCancelTask?: () => void
+  isCancelling?: boolean
   onSendMessage: () => void
   onSendGuidance?: () => void
 
@@ -161,6 +163,8 @@ export function MobileChatInputControls({
   canQueueMessage = false,
   canSendGuidance = false,
   onStopStream,
+  onCancelTask,
+  isCancelling = false,
   onSendMessage,
   onSendGuidance,
   hasNoTeams = false,
@@ -242,6 +246,22 @@ export function MobileChatInputControls({
       />
     )
 
+    const renderCancelTaskAction = () => {
+      if (isCancelling) {
+        return renderStoppingAction()
+      }
+
+      return (
+        <ActionButton
+          onClick={onCancelTask}
+          title="Cancel task"
+          icon={<CircleStop className="h-4 w-4 text-orange-500" />}
+          className="hover:bg-orange-100"
+          data-testid="cancel-task-button"
+        />
+      )
+    }
+
     if (sendState.primaryAction === 'loading') {
       if (sendState.showStopAction) {
         return renderStoppingAction()
@@ -256,6 +276,10 @@ export function MobileChatInputControls({
 
     if (sendState.primaryAction === 'stop') {
       return renderStopAction()
+    }
+
+    if (sendState.primaryAction === 'cancel') {
+      return renderCancelTaskAction()
     }
 
     if (sendState.primaryAction === 'queue') {

--- a/frontend/src/features/tasks/components/input/chatSendState.ts
+++ b/frontend/src/features/tasks/components/input/chatSendState.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export type ChatPrimaryAction = 'send' | 'queue' | 'stop' | 'loading'
+export type ChatPrimaryAction = 'send' | 'queue' | 'stop' | 'cancel' | 'loading'
 
 interface ChatSendStateInput {
   isLoading: boolean
@@ -76,10 +76,10 @@ export function getChatSendState(input: ChatSendStateInput): ChatSendState {
 
   if (input.selectedTaskStatus === 'PENDING') {
     return {
-      primaryAction: 'loading',
-      isPrimaryDisabled: true,
+      primaryAction: 'cancel',
+      isPrimaryDisabled: false,
       showStopAction: false,
-      showPendingAction: true,
+      showPendingAction: false,
     }
   }
 

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -58,6 +58,16 @@
     "send_failed": "Failed to send guidance",
     "no_active_stream": "No active response can receive guidance"
   },
+  "pending_task_confirm": {
+    "eyebrow": "Task handoff confirmation",
+    "title": "Previous task has not started",
+    "description": "Before sending a new message, choose what to do with the task that has not started.",
+    "wait": "Keep waiting",
+    "wait_hint": "Keep the current task",
+    "confirm": "Cancel previous and send",
+    "confirm_hint": "Start this new message",
+    "confirming": "Processing..."
+  },
   "status": {
     "typing": "AI is typing...",
     "thinking": "AI is thinking...",

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -58,6 +58,16 @@
     "send_failed": "引导发送失败",
     "no_active_stream": "当前没有可接收引导的回复"
   },
+  "pending_task_confirm": {
+    "eyebrow": "任务接续确认",
+    "title": "上一条任务尚未开始",
+    "description": "发送新消息前，需要先处理上一条未开始的任务。",
+    "wait": "继续等待",
+    "wait_hint": "保留当前任务",
+    "confirm": "取消上一条并发送",
+    "confirm_hint": "开始这条新消息",
+    "confirming": "处理中..."
+  },
   "status": {
     "typing": "AI 正在输入...",
     "thinking": "AI 正在思考...",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now cancel pending tasks before they start processing
  * A confirmation dialog appears when attempting to cancel a task to prevent accidental actions
  * Cancel button is visible in the chat input area when a task is pending

* **Chores**
  * Added translation strings for task cancellation confirmation UI in English and Chinese

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->