### PR TITLE
fix(knowledge): resolve NotFoundException when updating document content

### DIFF
--- a/backend/app/api/endpoints/internal/conversion_callback.py
+++ b/backend/app/api/endpoints/internal/conversion_callback.py
@@ -123,12 +123,38 @@ def conversion_completed_callback(
             detail=f"Missing key in index_dispatch_payload: {e}",
         )
 
+    # Verify attachment_id belongs to the target document to prevent
+    # cross-write: if the payload is mis-bound, content would be written
+    # into the wrong attachment and then indexed against the wrong KB.
+    from app.models.knowledge import KnowledgeDocument
+
+    doc = (
+        db.query(KnowledgeDocument)
+        .filter(KnowledgeDocument.id == request.document_id)
+        .first()
+    )
+    if not doc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Document {request.document_id} not found",
+        )
+    if doc.attachment_id != attachment_id:
+        logger.error(
+            f"[ConversionCallback] attachment_id mismatch: "
+            f"document_id={request.document_id} expects attachment_id={doc.attachment_id}, "
+            f"but payload provides attachment_id={attachment_id}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="attachment_id does not belong to the target document",
+        )
+
     try:
-        context_service.overwrite_attachment(
+        context_service.overwrite_attachment_internal(
             db=db,
             context_id=attachment_id,
-            user_id=None,
             filename=request.converted_name,
+            reason="conversion_callback",
             binary_data=markdown_bytes,
         )
     except Exception:

--- a/backend/app/api/endpoints/internal/conversion_callback.py
+++ b/backend/app/api/endpoints/internal/conversion_callback.py
@@ -123,9 +123,9 @@ def conversion_completed_callback(
             detail=f"Missing key in index_dispatch_payload: {e}",
         )
 
-    # Verify attachment_id belongs to the target document to prevent
-    # cross-write: if the payload is mis-bound, content would be written
-    # into the wrong attachment and then indexed against the wrong KB.
+    # Verify dispatch payload is bound to the correct document and KB.
+    # Without this, a mis-bound callback could overwrite the right attachment
+    # but then queue indexing for a different document/KB.
     from app.models.knowledge import KnowledgeDocument
 
     doc = (
@@ -147,6 +147,27 @@ def conversion_completed_callback(
         raise HTTPException(
             status_code=400,
             detail="attachment_id does not belong to the target document",
+        )
+
+    payload_document_id = payload.get("document_id")
+    payload_kb_id = payload.get("knowledge_base_id")
+    if payload_document_id is not None and payload_document_id != doc.id:
+        logger.error(
+            f"[ConversionCallback] document_id mismatch in payload: "
+            f"expected={doc.id}, got={payload_document_id}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="payload document_id does not match the target document",
+        )
+    if payload_kb_id is not None and str(doc.kind_id) != str(payload_kb_id):
+        logger.error(
+            f"[ConversionCallback] knowledge_base_id mismatch in payload: "
+            f"expected={doc.kind_id}, got={payload_kb_id}"
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="payload knowledge_base_id does not match the target document's KB",
         )
 
     try:

--- a/backend/app/api/endpoints/internal/conversion_callback.py
+++ b/backend/app/api/endpoints/internal/conversion_callback.py
@@ -127,7 +127,7 @@ def conversion_completed_callback(
         context_service.overwrite_attachment(
             db=db,
             context_id=attachment_id,
-            user_id=user_id,
+            user_id=None,
             filename=request.converted_name,
             binary_data=markdown_bytes,
         )

--- a/backend/app/api/endpoints/internal/conversion_callback.py
+++ b/backend/app/api/endpoints/internal/conversion_callback.py
@@ -116,7 +116,6 @@ def conversion_completed_callback(
     payload = request.index_dispatch_payload
     try:
         attachment_id = payload["attachment_id"]
-        user_id = payload["user_id"]
     except KeyError as e:
         raise HTTPException(
             status_code=400,

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -432,7 +432,11 @@ class ContextService:
         )
 
         storage_backend = get_storage_backend(db)
-        storage_key = context.storage_key or generate_storage_key(context.id, user_id)
+        # Use context.user_id (original owner) for storage key generation,
+        # not the optional caller user_id which may be None
+        storage_key = context.storage_key or generate_storage_key(
+            context.id, context.user_id
+        )
 
         self._reset_attachment_context(
             context=context,

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -405,35 +405,84 @@ class ContextService:
         self,
         db: Session,
         context_id: int,
-        user_id: Optional[int] = None,
-        filename: str = "",
-        binary_data: bytes = b"",
+        user_id: int,
+        filename: str,
+        binary_data: bytes,
     ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
         """
-        Overwrite an existing attachment with new content.
+        Overwrite an existing attachment with owner validation.
 
         Args:
             db: Database session
             context_id: Attachment context ID to overwrite
-            user_id: Optional user ID for ownership validation.
-                     Pass None when caller has already performed permission checks.
+            user_id: User ID for ownership validation (required)
             filename: New filename
             binary_data: New file binary data
 
         Returns:
             Tuple of (Updated SubtaskContext record, TruncationInfo if truncated)
+
+        Raises:
+            NotFoundException: If context not found or user is not the owner
         """
-        context = self.get_context_optional(db, context_id, user_id)
-        if context is None or context.context_type != ContextType.ATTACHMENT.value:
+        context = self.get_context(db, context_id, user_id)
+        if context.context_type != ContextType.ATTACHMENT.value:
             raise NotFoundException(f"Context {context_id} not found")
 
+        return self._overwrite_attachment_impl(db, context, filename, binary_data)
+
+    def overwrite_attachment_internal(
+        self,
+        db: Session,
+        context_id: int,
+        filename: str,
+        reason: str,
+        binary_data: bytes,
+    ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
+        """
+        Overwrite an existing attachment without owner validation.
+
+        Trusted internal path — caller must enforce business-level authorization
+        before calling. Used by knowledge management and conversion callbacks
+        where the caller has already verified permissions at a higher level.
+
+        Args:
+            db: Database session
+            context_id: Attachment context ID to overwrite
+            filename: New filename
+            reason: Audit reason (e.g. "knowledge_manage", "conversion_callback")
+            binary_data: New file binary data
+
+        Returns:
+            Tuple of (Updated SubtaskContext record, TruncationInfo if truncated)
+
+        Raises:
+            NotFoundException: If context not found
+        """
+        context = self.get_context(db, context_id)
+        if context.context_type != ContextType.ATTACHMENT.value:
+            raise NotFoundException(f"Context {context_id} not found")
+
+        logger.info(
+            f"Internal attachment overwrite: context_id={context_id}, "
+            f"reason={reason}, owner_user_id={context.user_id}"
+        )
+
+        return self._overwrite_attachment_impl(db, context, filename, binary_data)
+
+    def _overwrite_attachment_impl(
+        self,
+        db: Session,
+        context: SubtaskContext,
+        filename: str,
+        binary_data: bytes,
+    ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
+        """Shared implementation for attachment overwrite."""
         extension, file_size, mime_type = self._validate_attachment_input(
             filename, binary_data
         )
 
         storage_backend = get_storage_backend(db)
-        # Use context.user_id (original owner) for storage key generation,
-        # not the optional caller user_id which may be None
         storage_key = context.storage_key or generate_storage_key(
             context.id, context.user_id
         )

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -405,9 +405,9 @@ class ContextService:
         self,
         db: Session,
         context_id: int,
-        user_id: int,
-        filename: str,
-        binary_data: bytes,
+        user_id: Optional[int] = None,
+        filename: str = "",
+        binary_data: bytes = b"",
     ) -> Tuple[SubtaskContext, Optional[TruncationInfo]]:
         """
         Overwrite an existing attachment with new content.
@@ -415,7 +415,8 @@ class ContextService:
         Args:
             db: Database session
             context_id: Attachment context ID to overwrite
-            user_id: User ID (ownership validation)
+            user_id: Optional user ID for ownership validation.
+                     Pass None when caller has already performed permission checks.
             filename: New filename
             binary_data: New file binary data
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -110,6 +110,7 @@ class DocumentDeleteResult:
 
     success: bool
     kb_id: Optional[int] = None
+    error: Optional[str] = None
 
 
 @dataclass
@@ -1241,8 +1242,9 @@ class KnowledgeService:
             .filter(Kind.id == doc.kind_id, Kind.kind == "KnowledgeBase")
             .first()
         )
-        if kb:
-            KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
+        if not kb:
+            raise ValueError("Knowledge base not found for document")
+        KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
 
         if data.name is not None:
             doc.name = data.name
@@ -1296,8 +1298,11 @@ class KnowledgeService:
             .filter(Kind.id == doc.kind_id, Kind.kind == "KnowledgeBase")
             .first()
         )
-        if kb:
-            KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
+        if not kb:
+            return DocumentDeleteResult(
+                success=False, kb_id=None, error="Knowledge base not found for document"
+            )
+        KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
 
         # Store document_id (used as doc_ref in RAG), kind_id, and attachment_id before deletion for cleanup
         doc_ref = str(doc.id)  # document_id is used as doc_ref in RAG indexing
@@ -1507,8 +1512,9 @@ class KnowledgeService:
             .filter(Kind.id == doc.kind_id, Kind.kind == "KnowledgeBase")
             .first()
         )
-        if kb:
-            KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
+        if not kb:
+            raise ValueError("Knowledge base not found for document")
+        KnowledgeService._assert_can_manage_document(db, kb, doc, user_id)
 
         if not doc.attachment_id:
             raise ValueError("Document has no attachment to update")
@@ -1527,11 +1533,11 @@ class KnowledgeService:
         filename = context.original_filename or _build_attachment_filename(
             doc.name, doc.file_extension
         )
-        context_service.overwrite_attachment(
+        context_service.overwrite_attachment_internal(
             db=db,
             context_id=context.id,
-            user_id=None,
             filename=filename,
+            reason="knowledge_manage",
             binary_data=binary_content,
         )
 

--- a/backend/app/services/knowledge/knowledge_service.py
+++ b/backend/app/services/knowledge/knowledge_service.py
@@ -1530,7 +1530,7 @@ class KnowledgeService:
         context_service.overwrite_attachment(
             db=db,
             context_id=context.id,
-            user_id=user_id,
+            user_id=None,
             filename=filename,
             binary_data=binary_content,
         )

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -2080,8 +2080,14 @@ class KnowledgeOrchestrator:
             .filter(Kind.id == document.kind_id, Kind.kind == "KnowledgeBase")
             .first()
         )
-        if kb:
-            KnowledgeService._assert_can_manage_document(db, kb, document, user.id)
+        if not kb:
+            return {
+                "success": False,
+                "document": None,
+                "error_code": "KB_NOT_FOUND",
+                "error_message": "Knowledge base not found for document",
+            }
+        KnowledgeService._assert_can_manage_document(db, kb, document, user.id)
 
         if document.source_type != DocumentSourceType.WEB.value:
             return {

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -2117,7 +2117,7 @@ class KnowledgeOrchestrator:
                 attachment, _ = context_service.overwrite_attachment(
                     db=db,
                     context_id=document.attachment_id,
-                    user_id=user.id,
+                    user_id=None,
                     filename=document.name,
                     binary_data=content_bytes,
                 )

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -2072,6 +2072,17 @@ class KnowledgeOrchestrator:
                 "error_message": "Document not found or access denied",
             }
 
+        # Verify manage permission before mutating content
+        from app.models.kind import Kind
+
+        kb = (
+            db.query(Kind)
+            .filter(Kind.id == document.kind_id, Kind.kind == "KnowledgeBase")
+            .first()
+        )
+        if kb:
+            KnowledgeService._assert_can_manage_document(db, kb, document, user.id)
+
         if document.source_type != DocumentSourceType.WEB.value:
             return {
                 "success": False,

--- a/backend/app/services/knowledge/orchestrator.py
+++ b/backend/app/services/knowledge/orchestrator.py
@@ -2131,11 +2131,11 @@ class KnowledgeOrchestrator:
         if document.attachment_id:
             # Try to overwrite existing attachment
             try:
-                attachment, _ = context_service.overwrite_attachment(
+                attachment, _ = context_service.overwrite_attachment_internal(
                     db=db,
                     context_id=document.attachment_id,
-                    user_id=None,
                     filename=document.name,
+                    reason="web_refresh",
                     binary_data=content_bytes,
                 )
                 logger.info(

--- a/backend/tests/services/knowledge/test_knowledge_service.py
+++ b/backend/tests/services/knowledge/test_knowledge_service.py
@@ -63,7 +63,7 @@ class TestKnowledgeServiceUpdateDocumentContent:
         mock_overwrite_attachment.assert_called_once_with(
             db=db,
             context_id=20,
-            user_id=99,
+            user_id=None,
             filename="release-notes.md",
             binary_data="# Updated release notes".encode("utf-8"),
         )

--- a/backend/tests/services/knowledge/test_knowledge_service.py
+++ b/backend/tests/services/knowledge/test_knowledge_service.py
@@ -48,7 +48,7 @@ class TestKnowledgeServiceUpdateDocumentContent:
         with (
             patch.object(KnowledgeService, "get_document", return_value=document),
             patch.object(
-                context_service, "overwrite_attachment"
+                context_service, "overwrite_attachment_internal"
             ) as mock_overwrite_attachment,
         ):
             result = KnowledgeService.update_document_content(
@@ -63,8 +63,8 @@ class TestKnowledgeServiceUpdateDocumentContent:
         mock_overwrite_attachment.assert_called_once_with(
             db=db,
             context_id=20,
-            user_id=None,
             filename="release-notes.md",
+            reason="knowledge_manage",
             binary_data="# Updated release notes".encode("utf-8"),
         )
         db.refresh.assert_called_once_with(document)


### PR DESCRIPTION
overwrite_attachment enforced user_id ownership check that conflicted with knowledge domain's permission model — the context creator may differ from the authorized editor. Make user_id optional and pass None from knowledge callers that already perform their own permission checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental attachment overwrites by validating payload/document identity and returning an error when mismatched or missing.
  * Surface errors when a document's knowledge base record is missing during update/delete flows.

* **Chores**
  * Tightened permission checks to verify manage rights before modifying documents or attachments.
  * Added a trusted, audited internal overwrite path for controlled internal updates.

* **Tests**
  * Updated tests to reflect new overwrite and permission behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->