### PR TITLE
fix(group): resolve duplicate argument in get_entity_resolver calls

### DIFF
--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -343,9 +343,7 @@ def add_entity_member_endpoint(
         )
 
     # Validate entity_id via resolver if implemented
-    resolver = get_entity_resolver(
-        member_create.entity_type, entity_type=member_create.entity_type
-    )
+    resolver = get_entity_resolver(member_create.entity_type)
     if resolver and not resolver.validate_entity_id(db, member_create.entity_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -605,7 +603,7 @@ def add_entity_members_batch_endpoint(
             )
 
         # Validate entity_id via resolver if implemented
-        resolver = get_entity_resolver(m.entity_type, entity_type=m.entity_type)
+        resolver = get_entity_resolver(m.entity_type)
         if resolver and not resolver.validate_entity_id(db, m.entity_id):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
The entity member add and batch add endpoints were calling get_entity_resolver(entity_type, entity_type=entity_type), causing TypeError: got multiple values for argument 'entity_type'. This bug was masked by the resolver cache short-circuit path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal API endpoint efficiency by streamlining resolver initialization calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->