### PR TITLE
feat(executor): add local device command rpc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - English version: [`docs/en/developer-guide/dynamic-context.md`](docs/en/developer-guide/dynamic-context.md)
 - Exposing capabilities guide (how to make features available to AI agents): [`docs/zh/developer-guide/exposing-capabilities.md`](docs/zh/developer-guide/exposing-capabilities.md)
 - English version: [`docs/en/developer-guide/exposing-capabilities.md`](docs/en/developer-guide/exposing-capabilities.md)
+- Local device command RPC (Backend-to-local-executor command execution): [`docs/zh/developer-guide/local-device-command-rpc.md`](docs/zh/developer-guide/local-device-command-rpc.md)
+- English version: [`docs/en/developer-guide/local-device-command-rpc.md`](docs/en/developer-guide/local-device-command-rpc.md)
 
 **📚 Documentation Writing Rules:**
 - All documentation files MUST include frontmatter with `sidebar_position` for ordering:
@@ -634,4 +636,3 @@ cd backend && uv run alembic revision --autogenerate -m "msg" && uv run alembic 
 ```
 
 **Ports:** 3000 (frontend), 8000 (backend), 8001 (chat shell), 8200 (knowledge runtime), 9090 (converter metrics), 3306 (MySQL), 6379 (Redis)
-

--- a/README.md
+++ b/README.md
@@ -474,12 +474,20 @@ Thanks to the following developers for their contributions and efforts to make t
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/cocowh">
+            <img src="https://avatars.githubusercontent.com/u/17496282?v=4" width="80;" alt="cocowh"/>
+            <br />
+            <sub><b>Birch</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/graindt">
             <img src="https://avatars.githubusercontent.com/u/3962041?v=4" width="80;" alt="graindt"/>
             <br />
             <sub><b>Graindt</b></sub>
         </a>
-    </td>
+    </td></tr>
+<tr>
     <td align="center">
         <a href="https://github.com/qingchengliu">
             <img src="https://avatars.githubusercontent.com/u/20255838?v=4" width="80;" alt="qingchengliu"/>

--- a/README_zh.md
+++ b/README_zh.md
@@ -475,12 +475,20 @@ docker compose up -d     # 启动
         </a>
     </td>
     <td align="center">
+        <a href="https://github.com/cocowh">
+            <img src="https://avatars.githubusercontent.com/u/17496282?v=4" width="80;" alt="cocowh"/>
+            <br />
+            <sub><b>Birch</b></sub>
+        </a>
+    </td>
+    <td align="center">
         <a href="https://github.com/graindt">
             <img src="https://avatars.githubusercontent.com/u/3962041?v=4" width="80;" alt="graindt"/>
             <br />
             <sub><b>Graindt</b></sub>
         </a>
-    </td>
+    </td></tr>
+<tr>
     <td align="center">
         <a href="https://github.com/qingchengliu">
             <img src="https://avatars.githubusercontent.com/u/20255838?v=4" width="80;" alt="qingchengliu"/>

--- a/backend/app/api/endpoints/devices.py
+++ b/backend/app/api/endpoints/devices.py
@@ -19,7 +19,19 @@ from sqlalchemy.orm import Session
 from app.api.dependencies import get_db
 from app.core import security
 from app.models.user import User
-from app.schemas.device import DeviceInfo, DeviceListResponse
+from app.schemas.device import (
+    DeviceCommandRequest,
+    DeviceCommandResponse,
+    DeviceInfo,
+    DeviceListResponse,
+)
+from app.services.device.command_service import (
+    DeviceCommandConfigurationError,
+    DeviceCommandError,
+    DeviceCommandNotFoundError,
+    DeviceCommandUnknownKeyError,
+    execute_configured_device_command,
+)
 from app.services.device_service import device_service
 
 logger = logging.getLogger(__name__)
@@ -362,3 +374,67 @@ async def trigger_device_upgrade(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to trigger upgrade: {str(e)}",
         )
+
+
+@router.post("/{device_id}/commands", response_model=DeviceCommandResponse)
+async def execute_device_command(
+    device_id: str,
+    request: DeviceCommandRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(security.get_current_user),
+) -> DeviceCommandResponse:
+    """
+    Execute a shell command on an online local executor device.
+
+    The backend sends a Socket.IO RPC to the target local executor and waits for
+    the completed process result.
+    """
+    user_id = current_user.id
+    try:
+        result = await execute_configured_device_command(
+            db=db,
+            user_id=user_id,
+            device_id=device_id,
+            command_key=request.command_key,
+            path=request.path or request.cwd,
+            args=request.args,
+            env=request.env,
+            timeout_seconds=request.timeout_seconds,
+            max_output_bytes=request.max_output_bytes,
+        )
+    except DeviceCommandNotFoundError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
+        )
+    except DeviceCommandUnknownKeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+    except DeviceCommandConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(exc),
+        )
+    except DeviceCommandError as exc:
+        logger.warning(
+            "[Device Command] Command RPC failed: user_id=%s, device_id=%s, error=%s",
+            user_id,
+            device_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+    logger.info(
+        "[Device Command] Command completed: user_id=%s, device_id=%s, "
+        "exit_code=%s, duration=%s",
+        user_id,
+        device_id,
+        result.get("exit_code"),
+        result.get("duration"),
+    )
+    return DeviceCommandResponse(**result)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -68,6 +68,27 @@ def _normalize_rag_runtime_mode_mapping(value: Mapping[Any, Any]) -> dict[str, s
     return normalized_mapping
 
 
+def _parse_json_object_setting(value: Any, setting_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return {
+            str(key).strip(): item for key, item in value.items() if str(key).strip()
+        }
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{setting_name} must be a JSON object") from exc
+        if not isinstance(parsed, Mapping):
+            raise ValueError(f"{setting_name} must be a JSON object")
+        return _parse_json_object_setting(parsed, setting_name)
+    raise ValueError(f"{setting_name} must be a mapping")
+
+
 class Settings(BaseSettings):
     # Project configuration
     PROJECT_NAME: str = "Task Manager Backend"
@@ -109,6 +130,9 @@ class Settings(BaseSettings):
     # Latest Executor version (manually updated when releasing new versions)
     # This is used to show upgrade warnings in the UI
     EXECUTOR_LATEST_VERSION: str = "1.0.0"
+    # Optional local device command overrides/additions. API callers pass the key;
+    # Backend resolves the shell command and optional post processor from registry.
+    LOCAL_DEVICE_COMMANDS: dict[str, Any] = {}
 
     # Executor version checking configuration
     # If EXECUTOR_REGISTRY_URL is set, version is fetched from registry
@@ -271,6 +295,12 @@ class Settings(BaseSettings):
                     pass
             return [item.strip() for item in raw.split(",") if item.strip()]
         return v
+
+    @field_validator("LOCAL_DEVICE_COMMANDS", mode="before")
+    @classmethod
+    def parse_local_device_commands(cls, v: Any) -> dict[str, Any]:
+        """Parse local device command map from JSON settings."""
+        return _parse_json_object_setting(v, "LOCAL_DEVICE_COMMANDS")
 
     @field_validator("RAG_RUNTIME_MODE", mode="before")
     @classmethod

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -8,7 +8,7 @@ Device schemas for request/response validation.
 
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -133,6 +133,55 @@ class DeviceListResponse(BaseModel):
 
     items: List[DeviceInfo]
     total: int
+
+
+class DeviceCommandRequest(BaseModel):
+    """Request model for executing a command on a local device."""
+
+    command_key: str = Field(
+        ...,
+        min_length=1,
+        description="Configured command key to execute",
+    )
+    path: Optional[str] = Field(None, description="Execution path for the command")
+    args: List[str] = Field(
+        default_factory=list,
+        description="Command arguments appended after the configured command",
+    )
+    cwd: Optional[str] = Field(
+        None,
+        description="Deprecated alias for path; path takes precedence when both are set",
+    )
+    env: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables for the command",
+    )
+    timeout_seconds: int = Field(
+        default=60,
+        gt=0,
+        le=600,
+        description="Command timeout in seconds",
+    )
+    max_output_bytes: int = Field(
+        default=1024 * 1024,
+        gt=0,
+        le=5 * 1024 * 1024,
+        description="Maximum stdout and stderr bytes returned separately",
+    )
+
+
+class DeviceCommandResponse(BaseModel):
+    """Response model for a completed local device command."""
+
+    success: bool
+    exit_code: Optional[int] = None
+    stdout: Union[str, List[str]] = ""
+    stderr: str = ""
+    duration: float
+    timed_out: bool = False
+    error: Optional[str] = None
+    stdout_truncated: bool = False
+    stderr_truncated: bool = False
 
 
 class DeviceRegisterPayload(BaseModel):

--- a/backend/app/services/device/command_post_processor.py
+++ b/backend/app/services/device/command_post_processor.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Post processors for local device command results."""
+
+from collections.abc import Callable
+from typing import Any
+
+
+class CommandPostProcessorError(ValueError):
+    """Raised when a configured command post processor is invalid."""
+
+
+CommandResult = dict[str, Any]
+CommandPostProcessor = Callable[[CommandResult], CommandResult]
+
+
+def apply_command_post_processor(
+    result: CommandResult,
+    processor_name: str | None,
+) -> CommandResult:
+    """Apply a registered post processor to a command result."""
+    if not processor_name:
+        return result
+
+    processor = COMMAND_POST_PROCESSORS.get(processor_name)
+    if processor is None:
+        raise CommandPostProcessorError(
+            f"Unknown local device command post processor: {processor_name}"
+        )
+    return processor(dict(result))
+
+
+def _file_list_processor(result: CommandResult) -> CommandResult:
+    if not result.get("success"):
+        return result
+
+    entries = [
+        line.strip()
+        for line in str(result.get("stdout") or "").splitlines()
+        if line.strip()
+    ]
+    result["stdout"] = [entry for entry in entries if entry not in {".", ".."}]
+    return result
+
+
+COMMAND_POST_PROCESSORS: dict[str, CommandPostProcessor] = {
+    "file_list": _file_list_processor,
+}

--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local device command registry."""
+
+import shlex
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class CommandRegistryError(ValueError):
+    """Raised when a local device command definition is invalid."""
+
+
+@dataclass(frozen=True)
+class LocalDeviceCommandDefinition:
+    """Resolved local device command definition."""
+
+    command: str
+    post_processor: str | None = None
+
+
+DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
+    "pwd": LocalDeviceCommandDefinition(command="pwd"),
+    "ls_a": LocalDeviceCommandDefinition(
+        command="ls -a",
+        post_processor="file_list",
+    ),
+    "git_clone": LocalDeviceCommandDefinition(command="git clone"),
+}
+
+
+def resolve_local_device_command(
+    command_key: str,
+    configured_commands: Mapping[str, Any] | None = None,
+) -> LocalDeviceCommandDefinition | None:
+    """Resolve a command key from config overrides first, then built-in defaults."""
+    key = command_key.strip()
+    if not key:
+        return None
+
+    configured_commands = configured_commands or {}
+    default_definition = DEFAULT_LOCAL_DEVICE_COMMANDS.get(key)
+    if key in configured_commands:
+        return _parse_command_definition(
+            key,
+            configured_commands[key],
+            default_definition=default_definition,
+        )
+    return default_definition
+
+
+def build_local_device_command_argv(
+    command: str, args: list[str] | None = None
+) -> list[str]:
+    """Build an argv array from a configured command and request args."""
+    argv = shlex.split(command)
+    if not argv:
+        raise CommandRegistryError("Local device command resolved to an empty argv")
+    return [*argv, *(args or [])]
+
+
+def _parse_command_definition(
+    command_key: str,
+    raw_definition: Any,
+    default_definition: LocalDeviceCommandDefinition | None = None,
+) -> LocalDeviceCommandDefinition:
+    if isinstance(raw_definition, str):
+        command = raw_definition.strip()
+        if not command:
+            raise CommandRegistryError(
+                f"Local device command '{command_key}' has an empty command"
+            )
+        return LocalDeviceCommandDefinition(
+            command=command,
+            post_processor=(
+                default_definition.post_processor if default_definition else None
+            ),
+        )
+
+    if isinstance(raw_definition, Mapping):
+        command = str(raw_definition.get("command", "")).strip()
+        if not command:
+            raise CommandRegistryError(
+                f"Local device command '{command_key}' must define command"
+            )
+
+        raw_post_processor = raw_definition.get(
+            "post_processor",
+            default_definition.post_processor if default_definition else None,
+        )
+        post_processor = (
+            str(raw_post_processor).strip() if raw_post_processor is not None else None
+        )
+        return LocalDeviceCommandDefinition(
+            command=command,
+            post_processor=post_processor or None,
+        )
+
+    raise CommandRegistryError(
+        f"Local device command '{command_key}' must be a command string or object"
+    )

--- a/backend/app/services/device/command_service.py
+++ b/backend/app/services/device/command_service.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend RPC service for executing commands on local devices."""
+
+import logging
+from typing import Any, Mapping, Optional
+
+from app.core.config import settings
+from app.core.socketio import get_sio
+from app.services.device.command_post_processor import (
+    CommandPostProcessorError,
+    apply_command_post_processor,
+)
+from app.services.device.command_registry import (
+    CommandRegistryError,
+    build_local_device_command_argv,
+    resolve_local_device_command,
+)
+from app.services.device_service import device_service
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMMAND_TIMEOUT_SECONDS = 60
+MAX_COMMAND_TIMEOUT_SECONDS = 600
+DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
+MAX_OUTPUT_BYTES = 5 * 1024 * 1024
+SOCKET_ACK_GRACE_SECONDS = 5
+
+
+class DeviceCommandError(RuntimeError):
+    """Raised when a local device command cannot be dispatched or completed."""
+
+
+class DeviceCommandNotFoundError(DeviceCommandError):
+    """Raised when a local device does not exist or is not owned by the user."""
+
+
+class DeviceCommandUnknownKeyError(DeviceCommandError):
+    """Raised when a configured command key cannot be resolved."""
+
+
+class DeviceCommandConfigurationError(DeviceCommandError):
+    """Raised when configured command metadata is invalid."""
+
+
+class LocalDeviceCommandService:
+    """Send command RPC requests to connected local executor devices."""
+
+    async def execute_command(
+        self,
+        user_id: int,
+        device_id: str,
+        command: str,
+        path: Optional[str] = None,
+        args: Optional[list[str]] = None,
+        cwd: Optional[str] = None,
+        env: Optional[dict[str, Any]] = None,
+        timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+        max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    ) -> dict[str, Any]:
+        """Execute a command on an online local device and wait for the result."""
+        normalized_timeout = self._clamp_positive_int(
+            timeout_seconds,
+            default=DEFAULT_COMMAND_TIMEOUT_SECONDS,
+            upper_bound=MAX_COMMAND_TIMEOUT_SECONDS,
+        )
+        normalized_max_output = self._clamp_positive_int(
+            max_output_bytes,
+            default=DEFAULT_MAX_OUTPUT_BYTES,
+            upper_bound=MAX_OUTPUT_BYTES,
+        )
+
+        online_info = await device_service.get_device_online_info(user_id, device_id)
+        if not online_info:
+            raise DeviceCommandError(f"Device '{device_id}' is offline")
+
+        socket_id = online_info.get("socket_id")
+        if not socket_id:
+            raise DeviceCommandError(f"Device '{device_id}' has no socket information")
+
+        payload = {
+            "command": command,
+            "cwd": path or cwd,
+            "args": args or [],
+            "argv": build_local_device_command_argv(command, args or []),
+            "env": env or {},
+            "timeout_seconds": normalized_timeout,
+            "max_output_bytes": normalized_max_output,
+        }
+
+        logger.info(
+            "[LocalDeviceCommandService] Sending command RPC: "
+            "user_id=%s, device_id=%s, socket_id=%s, timeout=%s, command=%s",
+            user_id,
+            device_id,
+            socket_id,
+            normalized_timeout,
+            command[:200],
+        )
+
+        sio = get_sio()
+        try:
+            result = await sio.call(
+                "device:execute_command",
+                payload,
+                to=socket_id,
+                namespace="/local-executor",
+                timeout=normalized_timeout + SOCKET_ACK_GRACE_SECONDS,
+            )
+        except Exception as exc:
+            raise DeviceCommandError(f"Command RPC failed: {exc}") from exc
+
+        if not isinstance(result, dict):
+            raise DeviceCommandError("Command RPC returned an invalid response")
+        return result
+
+    def _clamp_positive_int(
+        self,
+        value: Any,
+        default: int,
+        upper_bound: int,
+    ) -> int:
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            parsed = default
+        if parsed <= 0:
+            return default
+        return min(parsed, upper_bound)
+
+
+local_device_command_service = LocalDeviceCommandService()
+
+
+async def execute_configured_device_command(
+    *,
+    db: Any,
+    user_id: int,
+    device_id: str,
+    command_key: str,
+    path: Optional[str] = None,
+    args: Optional[list[str]] = None,
+    env: Optional[dict[str, Any]] = None,
+    timeout_seconds: int = DEFAULT_COMMAND_TIMEOUT_SECONDS,
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
+    command_config: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Execute a configured local device command for internal Backend callers."""
+    device_kind = device_service.get_device_by_device_id(db, user_id, device_id)
+    if not device_kind:
+        raise DeviceCommandNotFoundError("Device not found or access denied")
+
+    try:
+        command_definition = resolve_local_device_command(
+            command_key,
+            (
+                settings.LOCAL_DEVICE_COMMANDS
+                if command_config is None
+                else command_config
+            ),
+        )
+    except CommandRegistryError as exc:
+        raise DeviceCommandConfigurationError(str(exc)) from exc
+
+    if command_definition is None:
+        raise DeviceCommandUnknownKeyError(
+            f"Device command key '{command_key}' is not configured"
+        )
+
+    result = await local_device_command_service.execute_command(
+        user_id=user_id,
+        device_id=device_id,
+        command=command_definition.command,
+        path=path,
+        args=args or [],
+        env=env or {},
+        timeout_seconds=timeout_seconds,
+        max_output_bytes=max_output_bytes,
+    )
+
+    try:
+        return apply_command_post_processor(
+            result,
+            command_definition.post_processor,
+        )
+    except CommandPostProcessorError as exc:
+        raise DeviceCommandConfigurationError(str(exc)) from exc

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for local device command RPC service."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def test_local_device_command_registry_default_includes_diagnostic_commands():
+    """Default command registry should include basic diagnostic commands."""
+    from app.core.config import Settings
+    from app.services.device.command_registry import resolve_local_device_command
+
+    settings = Settings()
+
+    pwd_definition = resolve_local_device_command("pwd", settings.LOCAL_DEVICE_COMMANDS)
+    ls_definition = resolve_local_device_command("ls_a", settings.LOCAL_DEVICE_COMMANDS)
+    git_clone_definition = resolve_local_device_command(
+        "git_clone", settings.LOCAL_DEVICE_COMMANDS
+    )
+
+    assert pwd_definition is not None
+    assert pwd_definition.command == "pwd"
+    assert pwd_definition.post_processor is None
+    assert ls_definition is not None
+    assert ls_definition.command == "ls -a"
+    assert ls_definition.post_processor == "file_list"
+    assert git_clone_definition is not None
+    assert git_clone_definition.command == "git clone"
+    assert git_clone_definition.post_processor is None
+
+
+def test_local_device_command_registry_supports_inline_post_processor():
+    """One command config object should contain command and post processor."""
+    from app.services.device.command_registry import resolve_local_device_command
+
+    definition = resolve_local_device_command(
+        "repo_files",
+        {
+            "repo_files": {
+                "command": "ls -a",
+                "post_processor": "file_list",
+            }
+        },
+    )
+
+    assert definition is not None
+    assert definition.command == "ls -a"
+    assert definition.post_processor == "file_list"
+
+
+def test_local_device_command_registry_keeps_default_processor_for_string_override():
+    """A simple string override should not drop a built-in post processor."""
+    from app.services.device.command_registry import resolve_local_device_command
+
+    definition = resolve_local_device_command("ls_a", {"ls_a": "ls -a"})
+
+    assert definition is not None
+    assert definition.command == "ls -a"
+    assert definition.post_processor == "file_list"
+
+
+def test_local_device_command_registry_builds_argv_with_request_args():
+    """Command argv should append request args without shell string concatenation."""
+    from app.services.device.command_registry import build_local_device_command_argv
+
+    argv = build_local_device_command_argv("ls -a", ["backend", "docs"])
+
+    assert argv == ["ls", "-a", "backend", "docs"]
+
+
+def test_local_device_command_registry_builds_git_clone_argv():
+    """git_clone should support repository URL and target directory args."""
+    from app.services.device.command_registry import (
+        build_local_device_command_argv,
+        resolve_local_device_command,
+    )
+
+    definition = resolve_local_device_command("git_clone")
+
+    assert definition is not None
+    assert build_local_device_command_argv(
+        definition.command,
+        ["https://github.com/wecode-ai/Wegent.git", "Wegent"],
+    ) == ["git", "clone", "https://github.com/wecode-ai/Wegent.git", "Wegent"]
+
+
+def test_file_list_post_processor_filters_special_entries():
+    """file_list post processor should return a clean file name list."""
+    from app.services.device.command_post_processor import apply_command_post_processor
+
+    result = {
+        "success": True,
+        "exit_code": 0,
+        "stdout": ".\n..\n.env\nbackend\n\n",
+        "stderr": "",
+        "duration": 0.01,
+    }
+
+    processed = apply_command_post_processor(result, "file_list")
+
+    assert processed["stdout"] == [".env", "backend"]
+
+
+@pytest.mark.asyncio
+async def test_execute_command_calls_registered_device_socket(monkeypatch):
+    """Service should send command RPC to the target device socket."""
+    from app.services.device import command_service
+
+    mock_sio = AsyncMock()
+    mock_sio.call.return_value = {
+        "success": True,
+        "exit_code": 0,
+        "stdout": "ok\n",
+        "stderr": "",
+        "duration": 0.01,
+        "timed_out": False,
+    }
+
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_online_info",
+        AsyncMock(return_value={"socket_id": "socket-123"}),
+    )
+    monkeypatch.setattr(command_service, "get_sio", lambda: mock_sio)
+
+    result = await command_service.local_device_command_service.execute_command(
+        user_id=7,
+        device_id="device-abc",
+        command="pwd",
+        path="/tmp",
+        args=["-P"],
+        env={"A": "B"},
+        timeout_seconds=5,
+        max_output_bytes=1024,
+    )
+
+    assert result["success"] is True
+    assert result["stdout"] == "ok\n"
+    mock_sio.call.assert_awaited_once_with(
+        "device:execute_command",
+        {
+            "command": "pwd",
+            "cwd": "/tmp",
+            "args": ["-P"],
+            "argv": ["pwd", "-P"],
+            "env": {"A": "B"},
+            "timeout_seconds": 5,
+            "max_output_bytes": 1024,
+        },
+        to="socket-123",
+        namespace="/local-executor",
+        timeout=10,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_command_rejects_offline_device(monkeypatch):
+    """Service should reject devices without online socket information."""
+    from app.services.device import command_service
+
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_online_info",
+        AsyncMock(return_value=None),
+    )
+
+    with pytest.raises(command_service.DeviceCommandError) as exc_info:
+        await command_service.local_device_command_service.execute_command(
+            user_id=7,
+            device_id="offline-device",
+            command="pwd",
+        )
+
+    assert "offline" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_execute_configured_device_command_resolves_executes_and_post_processes(
+    monkeypatch,
+):
+    """Internal service API should resolve key, execute command, and post-process."""
+    from app.services.device import command_service
+
+    execute_mock = AsyncMock(
+        return_value={
+            "success": True,
+            "exit_code": 0,
+            "stdout": ".\n..\nbackend\n",
+            "stderr": "",
+            "duration": 0.02,
+            "timed_out": False,
+        }
+    )
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: object(),
+    )
+    monkeypatch.setattr(
+        command_service.local_device_command_service,
+        "execute_command",
+        execute_mock,
+    )
+
+    result = await command_service.execute_configured_device_command(
+        db=object(),
+        user_id=7,
+        device_id="device-abc",
+        command_key="repo_files",
+        path="/tmp",
+        args=["backend"],
+        env={"A": "B"},
+        timeout_seconds=5,
+        max_output_bytes=1024,
+        command_config={
+            "repo_files": {
+                "command": "ls -a",
+                "post_processor": "file_list",
+            }
+        },
+    )
+
+    assert result["stdout"] == ["backend"]
+    execute_mock.assert_awaited_once_with(
+        user_id=7,
+        device_id="device-abc",
+        command="ls -a",
+        path="/tmp",
+        args=["backend"],
+        env={"A": "B"},
+        timeout_seconds=5,
+        max_output_bytes=1024,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_configured_device_command_rejects_unowned_device(monkeypatch):
+    """Internal service API should reject devices the user does not own."""
+    from app.services.device import command_service
+
+    monkeypatch.setattr(
+        command_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: None,
+    )
+
+    with pytest.raises(command_service.DeviceCommandNotFoundError):
+        await command_service.execute_configured_device_command(
+            db=object(),
+            user_id=7,
+            device_id="device-abc",
+            command_key="pwd",
+        )
+
+
+@pytest.mark.asyncio
+async def test_execute_device_command_endpoint_maps_request_to_service(monkeypatch):
+    """Endpoint should delegate HTTP request data to the internal service API."""
+    from app.api.endpoints import devices
+    from app.schemas.device import DeviceCommandRequest
+
+    service_mock = AsyncMock(
+        return_value={
+            "success": True,
+            "exit_code": 0,
+            "stdout": "ok",
+            "stderr": "",
+            "duration": 0.02,
+            "timed_out": False,
+        }
+    )
+    monkeypatch.setattr(devices, "execute_configured_device_command", service_mock)
+    db = object()
+
+    response = await devices.execute_device_command(
+        device_id="device-abc",
+        request=DeviceCommandRequest(
+            command_key="repo_status",
+            path="/tmp",
+            args=["--short"],
+            env={"A": "B"},
+            timeout_seconds=5,
+            max_output_bytes=1024,
+        ),
+        db=db,
+        current_user=SimpleNamespace(id=7),
+    )
+
+    assert response.success is True
+    assert response.stdout == "ok"
+    service_mock.assert_awaited_once_with(
+        db=db,
+        user_id=7,
+        device_id="device-abc",
+        command_key="repo_status",
+        path="/tmp",
+        args=["--short"],
+        env={"A": "B"},
+        timeout_seconds=5,
+        max_output_bytes=1024,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_device_command_endpoint_applies_configured_post_processor(
+    monkeypatch,
+):
+    """Endpoint should return post-processed internal service results."""
+    from app.api.endpoints import devices
+    from app.schemas.device import DeviceCommandRequest
+
+    service_mock = AsyncMock(
+        return_value={
+            "success": True,
+            "exit_code": 0,
+            "stdout": [".env", "backend"],
+            "stderr": "",
+            "duration": 0.02,
+            "timed_out": False,
+        }
+    )
+    monkeypatch.setattr(devices, "execute_configured_device_command", service_mock)
+
+    response = await devices.execute_device_command(
+        device_id="device-abc",
+        request=DeviceCommandRequest(command_key="repo_files"),
+        db=object(),
+        current_user=SimpleNamespace(id=7),
+    )
+
+    assert response.success is True
+    assert response.stdout == [".env", "backend"]
+
+
+@pytest.mark.asyncio
+async def test_execute_device_command_endpoint_rejects_unknown_command_key(monkeypatch):
+    """Endpoint should reject command keys missing from backend configuration."""
+    from fastapi import HTTPException
+
+    from app.api.endpoints import devices
+    from app.schemas.device import DeviceCommandRequest
+
+    async def raise_unknown_key(**kwargs):
+        raise devices.DeviceCommandUnknownKeyError(
+            "Device command key 'repo_status' is not configured"
+        )
+
+    monkeypatch.setattr(devices, "execute_configured_device_command", raise_unknown_key)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await devices.execute_device_command(
+            device_id="device-abc",
+            request=DeviceCommandRequest(command_key="repo_status"),
+            db=object(),
+            current_user=SimpleNamespace(id=7),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "not configured" in exc_info.value.detail

--- a/docs/en/developer-guide/local-device-command-rpc.md
+++ b/docs/en/developer-guide/local-device-command-rpc.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 18
+---
+
+# Local Device Command RPC
+
+Local device command RPC lets the Backend send a preconfigured shell command to a specific online local executor device and wait for the completed result. It is intended for operational checks, workspace diagnostics, and backend-initiated probes. It does not participate in the Task/Subtask lifecycle and does not create chat messages.
+
+## Architecture
+
+The communication path is:
+
+1. The API caller sends a `command_key`.
+2. Backend resolves the real shell command from `LOCAL_DEVICE_COMMANDS`.
+3. Backend reads the target device Socket.IO `socket_id` from Redis online device state.
+4. Backend calls `device:execute_command` in the `/local-executor` namespace.
+5. The local executor `CommandHandler` executes the command on the local machine.
+6. The executor returns the completed result as the Socket.IO ack.
+7. Backend optionally post-processes the result according to the command definition's `post_processor`.
+
+This RPC is decoupled from `task:execute`, so it is suitable for short commands and one-shot diagnostics. Long-running interactive terminals and streaming stdout/stderr are outside the first version.
+
+## API
+
+Request:
+
+```http
+POST /api/devices/{device_id}/commands
+```
+
+Body:
+
+```json
+{
+  "command_key": "repo_status",
+  "path": "/optional/path",
+  "args": ["--short"],
+  "env": {
+    "KEY": "VALUE"
+  },
+  "timeout_seconds": 60,
+  "max_output_bytes": 1048576
+}
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "exit_code": 0,
+  "stdout": "...",
+  "stderr": "",
+  "duration": 0.42,
+  "timed_out": false,
+  "stdout_truncated": false,
+  "stderr_truncated": false
+}
+```
+
+When command startup fails, the command exits non-zero, or the command times out, `success` is `false`. Timeout results include `timed_out=true` and `error`.
+
+`path` is the command execution directory. `cwd` remains as a backward-compatible alias; when both are provided, `path` wins. `args` is an array appended after the configured command and is not concatenated into a shell string. For example, `command_key=ls_a`, `path=/repo`, and `args=["backend"]` executes `["ls", "-a", "backend"]` in `/repo`.
+
+## Security And Limits
+
+This feature follows a trusted Backend and restricted API model. The HTTP API does not accept raw commands; it accepts only configured keys. The real command must be configured by the Backend through the command registry or `LOCAL_DEVICE_COMMANDS`. The `pwd`, `ls_a`, and `git_clone` command keys are built in by default. `ls_a` uses the `file_list` post processor to filter `.` and `..` and return a file name array in `stdout`. To add a built-in command, add one entry to `DEFAULT_LOCAL_DEVICE_COMMANDS` in `backend/app/services/device/command_registry.py`.
+
+At runtime, add or override command definitions with a single environment variable. Simple commands can use string values; commands that need post processing can use object values:
+
+```bash
+LOCAL_DEVICE_COMMANDS='{"repo_status":"git status","repo_files":{"command":"ls -a","post_processor":"file_list"}}'
+```
+
+Pass `git_clone` parameters through `args`, for example:
+
+```json
+{
+  "command_key": "git_clone",
+  "path": "/Users/yunpeng7/AIGCWorkSpace",
+  "args": ["https://github.com/wecode-ai/Wegent.git", "Wegent"]
+}
+```
+
+Default protections are:
+
+- Only devices owned by the current user and currently online can be called.
+- The API can execute only command keys present in `LOCAL_DEVICE_COMMANDS`.
+- Command results can use only Backend-registered post processors; API callers cannot pass arbitrary post processor functions.
+- Default timeout is 60 seconds, capped at 600 seconds.
+- stdout and stderr are each capped at 1 MiB by default and 5 MiB maximum.
+- Backend and executor logs include command, device, duration, and exit code metadata.
+
+Because commands run on the user's machine, callers must treat this API as high privilege and avoid exposing it to untrusted entry points.
+
+## Executor Behavior
+
+The local executor prefers Backend-provided `argv`; it falls back to the system shell only when `argv` is missing. If `path`/`cwd` is empty, the executor uses its current working directory. `env` is merged into the current process environment. On timeout, the executor terminates the command process group and returns a timeout result.

--- a/docs/zh/developer-guide/local-device-command-rpc.md
+++ b/docs/zh/developer-guide/local-device-command-rpc.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 18
+---
+
+# 本地设备命令 RPC
+
+本地设备命令 RPC 允许 Backend 向指定在线 local executor 设备下发一条预配置的本机 shell 命令，并等待命令完成后拿到结果。该能力用于运维检查、工作区诊断和后端主动探测，不参与 Task/Subtask 生命周期，也不会产生聊天消息。
+
+## 架构
+
+通信路径如下：
+
+1. API 调用方传入 `command_key`。
+2. Backend 从 `LOCAL_DEVICE_COMMANDS` 配置中解析出实际 shell 命令。
+3. Backend 从 Redis 在线设备信息中读取目标设备的 Socket.IO `socket_id`。
+4. Backend 在 `/local-executor` namespace 上调用 `device:execute_command`。
+5. local executor 的 `CommandHandler` 在本机执行命令。
+6. executor 通过 Socket.IO ack 一次性返回完成结果。
+7. Backend 按命令定义中的 `post_processor` 对结果做可选后处理。
+
+该 RPC 与 `task:execute` 解耦，适合短命令和一次性诊断命令。长时间交互式终端、实时 stdout/stderr 流式输出不在第一版范围内。
+
+## API
+
+请求：
+
+```http
+POST /api/devices/{device_id}/commands
+```
+
+请求体：
+
+```json
+{
+  "command_key": "repo_status",
+  "path": "/optional/path",
+  "args": ["--short"],
+  "env": {
+    "KEY": "VALUE"
+  },
+  "timeout_seconds": 60,
+  "max_output_bytes": 1048576
+}
+```
+
+响应：
+
+```json
+{
+  "success": true,
+  "exit_code": 0,
+  "stdout": "...",
+  "stderr": "",
+  "duration": 0.42,
+  "timed_out": false,
+  "stdout_truncated": false,
+  "stderr_truncated": false
+}
+```
+
+命令启动失败、返回非零退出码或超时时，`success` 为 `false`。超时结果会包含 `timed_out=true` 和 `error`。
+
+`path` 是命令执行目录；`cwd` 仍作为旧字段兼容，两个字段同时传入时优先使用 `path`。`args` 是追加到配置命令后的参数数组，不会拼接成 shell 字符串。例如 `command_key=ls_a`、`path=/repo`、`args=["backend"]` 会在 `/repo` 下执行 `["ls", "-a", "backend"]`。
+
+## 安全与限制
+
+该能力按“Backend 可信、API 受限”模型设计。HTTP API 不接受原始命令，只接受配置 key；实际命令必须由 Backend 通过命令 registry 或 `LOCAL_DEVICE_COMMANDS` 预配置。默认内置 `pwd`、`ls_a` 和 `git_clone` 命令 key，其中 `ls_a` 会使用 `file_list` 后处理器过滤 `.`、`..` 并在 `stdout` 中返回文件名数组。新增内置命令只需要在 `backend/app/services/device/command_registry.py` 的 `DEFAULT_LOCAL_DEVICE_COMMANDS` 中增加一项。
+
+运行时可通过一个环境变量增加或覆盖配置。简单命令可以直接写字符串；需要后处理时写对象：
+
+```bash
+LOCAL_DEVICE_COMMANDS='{"repo_status":"git status","repo_files":{"command":"ls -a","post_processor":"file_list"}}'
+```
+
+`git_clone` 的参数通过 `args` 传入，例如：
+
+```json
+{
+  "command_key": "git_clone",
+  "path": "/Users/yunpeng7/AIGCWorkSpace",
+  "args": ["https://github.com/wecode-ai/Wegent.git", "Wegent"]
+}
+```
+
+默认保护包括：
+
+- 只有当前用户拥有且在线的设备可以被调用。
+- API 只能执行 `LOCAL_DEVICE_COMMANDS` 中存在的命令 key。
+- 命令结果只能使用 Backend 已注册的后处理器，API 调用方不能传入任意后处理函数。
+- 默认超时 60 秒，最大 600 秒。
+- stdout 和 stderr 分别默认最多返回 1 MiB，最大 5 MiB。
+- Backend 和 executor 均记录命令、设备、耗时和退出码日志。
+
+由于命令在用户本机执行，调用方必须把该 API 当作高权限操作处理，不应暴露给非可信入口。
+
+## Executor 行为
+
+local executor 优先使用 Backend 下发的 `argv` 执行命令；缺少 `argv` 时才回退到系统 shell。`path`/`cwd` 为空时使用 executor 当前工作目录；`env` 会合并到当前进程环境中。命令超时时，executor 会终止命令进程组并返回超时结果。

--- a/executor/modes/local/command_handler.py
+++ b/executor/modes/local/command_handler.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command RPC handler for local executor mode."""
+
+import asyncio
+import os
+import signal
+import time
+from typing import Any, Optional
+
+from executor.platform_compat import sanitize_ld_library_path
+from shared.logger import setup_logger
+
+logger = setup_logger("local_command_handler")
+
+DEFAULT_TIMEOUT_SECONDS = 60.0
+MAX_TIMEOUT_SECONDS = 600.0
+DEFAULT_MAX_OUTPUT_BYTES = 1024 * 1024
+MAX_OUTPUT_BYTES = 5 * 1024 * 1024
+
+
+class CommandHandler:
+    """Execute backend-requested commands on the local machine."""
+
+    async def handle_execute_command(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Execute a command and return a completed process result."""
+        started_at = time.monotonic()
+        command = data.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return self._error_result(
+                "command is required",
+                duration=self._elapsed(started_at),
+            )
+
+        cwd = self._normalize_cwd(data.get("cwd"))
+        argv = self._normalize_argv(data.get("argv"))
+        env = self._build_env(data.get("env"))
+        timeout_seconds = self._normalize_float(
+            data.get("timeout_seconds"),
+            default=DEFAULT_TIMEOUT_SECONDS,
+            upper_bound=MAX_TIMEOUT_SECONDS,
+        )
+        max_output_bytes = int(
+            self._normalize_float(
+                data.get("max_output_bytes"),
+                default=DEFAULT_MAX_OUTPUT_BYTES,
+                upper_bound=MAX_OUTPUT_BYTES,
+            )
+        )
+
+        logger.info(
+            "[CommandHandler] Executing command: cwd=%s, timeout=%s, mode=%s, command=%s",
+            cwd or os.getcwd(),
+            timeout_seconds,
+            "argv" if argv else "shell",
+            command[:200],
+        )
+
+        try:
+            process = await self._create_process(command, argv=argv, cwd=cwd, env=env)
+        except Exception as exc:
+            logger.exception("[CommandHandler] Failed to start command")
+            return self._error_result(str(exc), duration=self._elapsed(started_at))
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError:
+            await self._terminate_process(process)
+            duration = self._elapsed(started_at)
+            return self._error_result(
+                f"Command timed out after {timeout_seconds:g} seconds",
+                duration=duration,
+                timed_out=True,
+            )
+
+        stdout_text, stdout_truncated = self._decode_and_truncate(
+            stdout, max_output_bytes
+        )
+        stderr_text, stderr_truncated = self._decode_and_truncate(
+            stderr, max_output_bytes
+        )
+        exit_code = process.returncode
+
+        return {
+            "success": exit_code == 0,
+            "exit_code": exit_code,
+            "stdout": stdout_text,
+            "stderr": stderr_text,
+            "duration": self._elapsed(started_at),
+            "timed_out": False,
+            "stdout_truncated": stdout_truncated,
+            "stderr_truncated": stderr_truncated,
+        }
+
+    async def _create_process(
+        self,
+        command: str,
+        argv: Optional[list[str]],
+        cwd: Optional[str],
+        env: dict[str, str],
+    ) -> asyncio.subprocess.Process:
+        kwargs: dict[str, Any] = {}
+        if os.name != "nt":
+            kwargs["start_new_session"] = True
+
+        if argv:
+            return await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=cwd,
+                env=env,
+                **kwargs,
+            )
+
+        return await asyncio.create_subprocess_shell(
+            command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=cwd,
+            env=env,
+            **kwargs,
+        )
+
+    async def _terminate_process(self, process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+
+        try:
+            if os.name != "nt":
+                os.killpg(process.pid, signal.SIGTERM)
+            else:
+                process.terminate()
+            await asyncio.wait_for(process.wait(), timeout=2)
+        except Exception:
+            logger.warning("[CommandHandler] Graceful termination failed; killing")
+            try:
+                if os.name != "nt":
+                    os.killpg(process.pid, signal.SIGKILL)
+                else:
+                    process.kill()
+            except ProcessLookupError:
+                return
+            await process.wait()
+
+    def _build_env(self, extra_env: Any) -> dict[str, str]:
+        env = os.environ.copy()
+        sanitize_ld_library_path(env)
+        if isinstance(extra_env, dict):
+            for key, value in extra_env.items():
+                if isinstance(key, str) and key:
+                    env[key] = "" if value is None else str(value)
+        return env
+
+    def _normalize_cwd(self, cwd: Any) -> Optional[str]:
+        if cwd is None:
+            return None
+        if not isinstance(cwd, str) or not cwd.strip():
+            return None
+        return cwd
+
+    def _normalize_argv(self, argv: Any) -> Optional[list[str]]:
+        if not isinstance(argv, list):
+            return None
+        normalized = [item for item in argv if isinstance(item, str)]
+        if len(normalized) != len(argv) or not normalized:
+            return None
+        if not normalized[0].strip():
+            return None
+        return normalized
+
+    def _normalize_float(
+        self,
+        value: Any,
+        default: float,
+        upper_bound: float,
+    ) -> float:
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            parsed = default
+        if parsed <= 0:
+            return default
+        return min(parsed, upper_bound)
+
+    def _decode_and_truncate(self, data: bytes, max_bytes: int) -> tuple[str, bool]:
+        truncated = len(data) > max_bytes
+        if truncated:
+            data = data[:max_bytes]
+        return data.decode("utf-8", errors="replace"), truncated
+
+    def _error_result(
+        self,
+        error: str,
+        duration: float,
+        timed_out: bool = False,
+    ) -> dict[str, Any]:
+        return {
+            "success": False,
+            "exit_code": None,
+            "stdout": "",
+            "stderr": "",
+            "duration": duration,
+            "timed_out": timed_out,
+            "error": error,
+        }
+
+    def _elapsed(self, started_at: float) -> float:
+        return round(time.monotonic() - started_at, 6)

--- a/executor/modes/local/events.py
+++ b/executor/modes/local/events.py
@@ -20,6 +20,7 @@ class DeviceEvents:
 
     REGISTER = "device:register"
     HEARTBEAT = "device:heartbeat"
+    EXECUTE_COMMAND = "device:execute_command"
 
 
 class TaskEvents:

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -26,7 +26,8 @@ from typing import Any, Dict, Optional
 
 from executor.config import config
 from executor.config.device_config import DeviceConfig
-from executor.modes.local.events import ChatEvents, TaskEvents
+from executor.modes.local.command_handler import CommandHandler
+from executor.modes.local.events import ChatEvents, DeviceEvents, TaskEvents
 from executor.modes.local.extension_handler import DeviceExtensionHandler
 from executor.modes.local.handlers import TaskHandler, UpgradeHandler
 from executor.modes.local.heartbeat import LocalHeartbeatService
@@ -78,6 +79,7 @@ class LocalRunner:
 
         # Event handlers
         self.task_handler = TaskHandler(self)
+        self.command_handler = CommandHandler()
         self.upgrade_handler = UpgradeHandler(self)
         self.extension_handler = DeviceExtensionHandler(self)
 
@@ -229,6 +231,10 @@ class LocalRunner:
         )
         self.websocket_client.on(
             ChatEvents.MESSAGE, self.task_handler.handle_chat_message
+        )
+        self.websocket_client.on(
+            DeviceEvents.EXECUTE_COMMAND,
+            self.command_handler.handle_execute_command,
         )
 
         # Upgrade handler

--- a/executor/tests/test_local_command_handler.py
+++ b/executor/tests/test_local_command_handler.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for local executor command RPC handling."""
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_execute_command_uses_argv_and_cwd(tmp_path):
+    """Command handler should execute argv args in the requested working directory."""
+    from executor.modes.local.command_handler import CommandHandler
+
+    target = tmp_path / "target.txt"
+    target.write_text("ok", encoding="utf-8")
+    handler = CommandHandler()
+
+    result = await handler.handle_execute_command(
+        {
+            "command": "cat",
+            "argv": ["cat", "target.txt"],
+            "cwd": str(tmp_path),
+            "timeout_seconds": 5,
+            "max_output_bytes": 1024,
+        }
+    )
+
+    assert result["success"] is True
+    assert result["stdout"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_execute_command_argv_does_not_invoke_shell():
+    """Command argv args should not be interpreted by a shell."""
+    from executor.modes.local.command_handler import CommandHandler
+
+    handler = CommandHandler()
+
+    result = await handler.handle_execute_command(
+        {
+            "command": "printf %s",
+            "argv": ["printf", "%s", "hello; echo hacked"],
+            "timeout_seconds": 5,
+            "max_output_bytes": 1024,
+        }
+    )
+
+    assert result["success"] is True
+    assert result["stdout"] == "hello; echo hacked"
+
+
+@pytest.mark.asyncio
+async def test_execute_command_returns_completed_process_result():
+    """Command handler should return stdout, stderr, exit code, and duration."""
+    from executor.modes.local.command_handler import CommandHandler
+
+    handler = CommandHandler()
+
+    result = await handler.handle_execute_command(
+        {
+            "command": "printf 'hello'",
+            "timeout_seconds": 5,
+            "max_output_bytes": 1024,
+        }
+    )
+
+    assert result["success"] is True
+    assert result["exit_code"] == 0
+    assert result["stdout"] == "hello"
+    assert result["stderr"] == ""
+    assert result["duration"] >= 0
+    assert result["timed_out"] is False
+
+
+@pytest.mark.asyncio
+async def test_execute_command_times_out_and_returns_error():
+    """Command handler should kill long commands and return a timeout result."""
+    from executor.modes.local.command_handler import CommandHandler
+
+    handler = CommandHandler()
+
+    result = await handler.handle_execute_command(
+        {
+            "command": "sleep 2",
+            "timeout_seconds": 0.1,
+            "max_output_bytes": 1024,
+        }
+    )
+
+    assert result["success"] is False
+    assert result["exit_code"] is None
+    assert result["timed_out"] is True
+    assert "timed out" in result["error"].lower()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run pre-configured commands on connected local devices via POST /api/devices/{device_id}/commands (args, env, path/cwd, timeouts, output limits); built-in diagnostics (pwd, ls, git_clone) and post-processing supported.

* **Documentation**
  * Added developer guides (EN/ZH) detailing the local device command RPC behavior and API.

* **Tests**
  * Added extensive tests for registry, argv building, post-processing, service and endpoint behavior.

* **Chores**
  * Updated documentation list and quick reference ports (adds converter metrics port 9090) and refreshed contributors in README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->