### PR TITLE
feat(knowledge-doc-converter): add doc-converter prefix to S3 path

### DIFF
--- a/knowledge_doc_converter/knowledge_doc_converter/tasks/conversion_task.py
+++ b/knowledge_doc_converter/knowledge_doc_converter/tasks/conversion_task.py
@@ -200,7 +200,7 @@ def convert_document_task(
             safe_filename = (
                 filename_without_ext.replace("..", "").replace("\\", "/").strip("/")
             )
-            s3_base_path = f"{safe_kb_name}/{document_id}/{safe_filename}"
+            s3_base_path = f"doc-converter/{safe_kb_name}/{document_id}/{safe_filename}"
 
             result = convert_document(
                 binary_data=binary_data,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the S3 storage path structure for converted documents to include an additional organizational prefix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->