### PR TITLE
feat(projects): select workspace directory from device

### DIFF
--- a/backend/app/services/device/command_post_processor.py
+++ b/backend/app/services/device/command_post_processor.py
@@ -45,6 +45,24 @@ def _file_list_processor(result: CommandResult) -> CommandResult:
     return result
 
 
+def _directory_list_processor(result: CommandResult) -> CommandResult:
+    if not result.get("success"):
+        return result
+
+    entries = [
+        line.strip()
+        for line in str(result.get("stdout") or "").splitlines()
+        if line.strip()
+    ]
+    result["stdout"] = [
+        entry.rstrip("/")
+        for entry in entries
+        if entry.endswith("/") and entry.rstrip("/") not in {".", ".."}
+    ]
+    return result
+
+
 COMMAND_POST_PROCESSORS: dict[str, CommandPostProcessor] = {
     "file_list": _file_list_processor,
+    "directory_list": _directory_list_processor,
 }

--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -27,6 +27,10 @@ DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
         command="ls -a",
         post_processor="file_list",
     ),
+    "ls_dirs": LocalDeviceCommandDefinition(
+        command="ls -a -p",
+        post_processor="directory_list",
+    ),
     "git_clone": LocalDeviceCommandDefinition(command="git clone"),
 }
 

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -19,6 +19,9 @@ def test_local_device_command_registry_default_includes_diagnostic_commands():
 
     pwd_definition = resolve_local_device_command("pwd", settings.LOCAL_DEVICE_COMMANDS)
     ls_definition = resolve_local_device_command("ls_a", settings.LOCAL_DEVICE_COMMANDS)
+    ls_dirs_definition = resolve_local_device_command(
+        "ls_dirs", settings.LOCAL_DEVICE_COMMANDS
+    )
     git_clone_definition = resolve_local_device_command(
         "git_clone", settings.LOCAL_DEVICE_COMMANDS
     )
@@ -29,6 +32,9 @@ def test_local_device_command_registry_default_includes_diagnostic_commands():
     assert ls_definition is not None
     assert ls_definition.command == "ls -a"
     assert ls_definition.post_processor == "file_list"
+    assert ls_dirs_definition is not None
+    assert ls_dirs_definition.command == "ls -a -p"
+    assert ls_dirs_definition.post_processor == "directory_list"
     assert git_clone_definition is not None
     assert git_clone_definition.command == "git clone"
     assert git_clone_definition.post_processor is None
@@ -104,6 +110,23 @@ def test_file_list_post_processor_filters_special_entries():
     processed = apply_command_post_processor(result, "file_list")
 
     assert processed["stdout"] == [".env", "backend"]
+
+
+def test_directory_list_post_processor_keeps_only_directories():
+    """directory_list post processor should return clean directory names."""
+    from app.services.device.command_post_processor import apply_command_post_processor
+
+    result = {
+        "success": True,
+        "exit_code": 0,
+        "stdout": "./\n../\n.env\nbackend/\nfrontend/\nREADME.md\n",
+        "stderr": "",
+        "duration": 0.01,
+    }
+
+    processed = apply_command_post_processor(result, "directory_list")
+
+    assert processed["stdout"] == ["backend", "frontend"]
 
 
 @pytest.mark.asyncio

--- a/docs/en/developer-guide/local-device-command-rpc.md
+++ b/docs/en/developer-guide/local-device-command-rpc.md
@@ -64,7 +64,7 @@ When command startup fails, the command exits non-zero, or the command times out
 
 ## Security And Limits
 
-This feature follows a trusted Backend and restricted API model. The HTTP API does not accept raw commands; it accepts only configured keys. The real command must be configured by the Backend through the command registry or `LOCAL_DEVICE_COMMANDS`. The `pwd`, `ls_a`, and `git_clone` command keys are built in by default. `ls_a` uses the `file_list` post processor to filter `.` and `..` and return a file name array in `stdout`. To add a built-in command, add one entry to `DEFAULT_LOCAL_DEVICE_COMMANDS` in `backend/app/services/device/command_registry.py`.
+This feature follows a trusted Backend and restricted API model. The HTTP API does not accept raw commands; it accepts only configured keys. The real command must be configured by the Backend through the command registry or `LOCAL_DEVICE_COMMANDS`. The `pwd`, `ls_a`, `ls_dirs`, and `git_clone` command keys are built in by default. `ls_a` uses the `file_list` post processor to filter `.` and `..` and return a file name array in `stdout`; `ls_dirs` uses the `directory_list` post processor to return only subdirectory names in the current directory. To add a built-in command, add one entry to `DEFAULT_LOCAL_DEVICE_COMMANDS` in `backend/app/services/device/command_registry.py`.
 
 At runtime, add or override command definitions with a single environment variable. Simple commands can use string values; commands that need post processing can use object values:
 

--- a/docs/zh/developer-guide/local-device-command-rpc.md
+++ b/docs/zh/developer-guide/local-device-command-rpc.md
@@ -64,7 +64,7 @@ POST /api/devices/{device_id}/commands
 
 ## 安全与限制
 
-该能力按“Backend 可信、API 受限”模型设计。HTTP API 不接受原始命令，只接受配置 key；实际命令必须由 Backend 通过命令 registry 或 `LOCAL_DEVICE_COMMANDS` 预配置。默认内置 `pwd`、`ls_a` 和 `git_clone` 命令 key，其中 `ls_a` 会使用 `file_list` 后处理器过滤 `.`、`..` 并在 `stdout` 中返回文件名数组。新增内置命令只需要在 `backend/app/services/device/command_registry.py` 的 `DEFAULT_LOCAL_DEVICE_COMMANDS` 中增加一项。
+该能力按“Backend 可信、API 受限”模型设计。HTTP API 不接受原始命令，只接受配置 key；实际命令必须由 Backend 通过命令 registry 或 `LOCAL_DEVICE_COMMANDS` 预配置。默认内置 `pwd`、`ls_a`、`ls_dirs` 和 `git_clone` 命令 key，其中 `ls_a` 会使用 `file_list` 后处理器过滤 `.`、`..` 并在 `stdout` 中返回文件名数组，`ls_dirs` 会使用 `directory_list` 后处理器只返回当前目录下的子目录名称数组。新增内置命令只需要在 `backend/app/services/device/command_registry.py` 的 `DEFAULT_LOCAL_DEVICE_COMMANDS` 中增加一项。
 
 运行时可通过一个环境变量增加或覆盖配置。简单命令可以直接写字符串；需要后处理时写对象：
 

--- a/frontend/src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx
+++ b/frontend/src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 import type { DeviceInfo } from '@/apis/devices'
+import { deviceApis } from '@/apis/devices'
+import { projectApis } from '@/apis/projects'
 import { ProjectCreateDialog } from '@/features/projects/components/ProjectCreateDialog'
 
 const createProjectMock = jest.fn()
@@ -35,6 +37,12 @@ jest.mock('@/hooks/useTranslation', () => ({
       if (key === 'workspace.deviceVersionUnsupported') {
         return `upgrade required from ${params?.version} to ${params?.requiredVersion}`
       }
+      if (key === 'workspace.projectNamePreview') {
+        return `project name: ${params?.name}`
+      }
+      if (key === 'workspace.directoryPicker.selected') {
+        return `selected: ${params?.path}`
+      }
       return key
     },
   }),
@@ -57,6 +65,12 @@ jest.mock('@/apis/projects', () => ({
   projectApis: {
     createProject: jest.fn(),
     updateProject: jest.fn(),
+  },
+}))
+
+jest.mock('@/apis/devices', () => ({
+  deviceApis: {
+    executeCommand: jest.fn(),
   },
 }))
 
@@ -103,18 +117,19 @@ describe('ProjectCreateDialog', () => {
     expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
   })
 
-  test('allows workspace project creation when the selected device version is exactly 1.0.0', async () => {
+  test('allows directory selection when the selected device version is exactly 1.0.0', async () => {
     devicesMock = [baseDevice]
 
     render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).not.toBeDisabled()
+      expect(screen.getByTestId('workspace-directory-picker-trigger')).not.toBeDisabled()
     })
+    expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
     expect(screen.queryByTestId('workspace-device-version-warning')).not.toBeInTheDocument()
   })
 
-  test('allows workspace project creation when the selected device version is v1.7.11 or newer', async () => {
+  test('allows directory selection when the selected device version is v1.7.11 or newer', async () => {
     devicesMock = [
       {
         ...baseDevice,
@@ -125,8 +140,9 @@ describe('ProjectCreateDialog', () => {
     render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).not.toBeDisabled()
+      expect(screen.getByTestId('workspace-directory-picker-trigger')).not.toBeDisabled()
     })
+    expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
   })
   test('filters OpenClaw devices from workspace project creation', () => {
     devicesMock = [
@@ -149,5 +165,116 @@ describe('ProjectCreateDialog', () => {
 
     expect(screen.getByText('ClaudeCode Device')).toBeInTheDocument()
     expect(screen.queryByText('OpenClaw Device')).not.toBeInTheDocument()
+  })
+
+  test('creates workspace project from selected device directory', async () => {
+    devicesMock = [
+      {
+        ...baseDevice,
+        executor_version: 'v1.7.11',
+      },
+    ]
+    ;(deviceApis.executeCommand as jest.Mock).mockImplementation((_deviceId, request) => {
+      if (request.command_key === 'pwd') {
+        return Promise.resolve({
+          success: true,
+          exit_code: 0,
+          stdout: '/Users/dev\n',
+          stderr: '',
+          duration: 0.01,
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        exit_code: 0,
+        stdout: ['repo', 'tmp'],
+        stderr: '',
+        duration: 0.01,
+      })
+    })
+    ;(projectApis.createProject as jest.Mock).mockResolvedValue({ id: 10 })
+
+    render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
+
+    const pickerTrigger = await screen.findByTestId('workspace-directory-picker-trigger')
+    await waitFor(() => expect(pickerTrigger).not.toBeDisabled())
+    expect(screen.getByRole('button', { name: 'workspaceCreate.submit' })).toBeDisabled()
+
+    fireEvent.click(pickerTrigger)
+    const repoRow = await screen.findByText('repo')
+    fireEvent.click(repoRow)
+    fireEvent.click(screen.getByTestId('workspace-directory-confirm-button'))
+
+    expect(await screen.findByText('project name: repo')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'workspaceCreate.submit' }))
+
+    await waitFor(() => {
+      expect(projectApis.createProject).toHaveBeenCalledWith({
+        name: 'repo',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'local',
+            deviceId: 'device-1',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/Users/dev/repo',
+          },
+        },
+      })
+    })
+  })
+
+  test('double-click selects and opens a subdirectory in the directory picker', async () => {
+    devicesMock = [
+      {
+        ...baseDevice,
+        executor_version: 'v1.7.11',
+      },
+    ]
+    ;(deviceApis.executeCommand as jest.Mock).mockImplementation((_deviceId, request) => {
+      if (request.command_key === 'pwd') {
+        return Promise.resolve({
+          success: true,
+          exit_code: 0,
+          stdout: '/Users/dev\n',
+          stderr: '',
+          duration: 0.01,
+        })
+      }
+
+      return Promise.resolve({
+        success: true,
+        exit_code: 0,
+        stdout: request.path === '/Users/dev/repo' ? ['src'] : ['repo'],
+        stderr: '',
+        duration: 0.01,
+      })
+    })
+
+    render(<ProjectCreateDialog open={true} onOpenChange={jest.fn()} mode="workspace" />)
+
+    const pickerTrigger = await screen.findByTestId('workspace-directory-picker-trigger')
+    await waitFor(() => expect(pickerTrigger).not.toBeDisabled())
+    fireEvent.click(pickerTrigger)
+
+    const repoRow = await screen.findByText('repo')
+    fireEvent.doubleClick(repoRow)
+
+    await waitFor(() => {
+      expect(deviceApis.executeCommand).toHaveBeenCalledWith(
+        'device-1',
+        expect.objectContaining({
+          command_key: 'ls_dirs',
+          path: '/Users/dev/repo',
+        })
+      )
+    })
+    expect(await screen.findByText('src')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-directory-selected-path')).toHaveTextContent(
+      'selected: /Users/dev/repo'
+    )
   })
 })

--- a/frontend/src/apis/devices.ts
+++ b/frontend/src/apis/devices.ts
@@ -79,6 +79,27 @@ export interface UpgradeDeviceResponse {
   message: string
 }
 
+export interface DeviceCommandRequest {
+  command_key: string
+  path?: string
+  args?: string[]
+  env?: Record<string, string>
+  timeout_seconds?: number
+  max_output_bytes?: number
+}
+
+export interface DeviceCommandResponse {
+  success: boolean
+  exit_code?: number | null
+  stdout: string | string[]
+  stderr: string
+  duration: number
+  timed_out?: boolean
+  error?: string | null
+  stdout_truncated?: boolean
+  stderr_truncated?: boolean
+}
+
 /**
  * Device API services
  */
@@ -157,5 +178,17 @@ export const deviceApis = {
     alias: string
   ): Promise<{ message: string; alias: string }> {
     return apiClient.put(`/devices/${encodeURIComponent(deviceId)}/alias`, { alias })
+  },
+
+  /**
+   * Execute a configured command on an online device.
+   *
+   * The backend only accepts command keys registered in its command registry.
+   */
+  async executeCommand(
+    deviceId: string,
+    request: DeviceCommandRequest
+  ): Promise<DeviceCommandResponse> {
+    return apiClient.post(`/devices/${encodeURIComponent(deviceId)}/commands`, request)
   },
 }

--- a/frontend/src/features/projects/components/ProjectCreateDialog.tsx
+++ b/frontend/src/features/projects/components/ProjectCreateDialog.tsx
@@ -29,6 +29,8 @@ import { projectApis } from '@/apis/projects'
 import { useDevices } from '@/contexts/DeviceContext'
 import type { ProjectConfig } from '@/types/api'
 import { isVersionAtLeast } from '@/lib/utils'
+import { ProjectDirectoryPickerDialog } from './ProjectDirectoryPickerDialog'
+import { FolderOpen } from 'lucide-react'
 
 const PROJECT_COLORS = [
   { id: 'red', value: '#EF4444' },
@@ -93,6 +95,7 @@ export function ProjectCreateDialog({
   // Workspace mode state
   const [deviceId, setDeviceId] = useState('')
   const [localPath, setLocalPath] = useState('')
+  const [directoryPickerOpen, setDirectoryPickerOpen] = useState(false)
 
   const [isCreating, setIsCreating] = useState(false)
 
@@ -137,7 +140,7 @@ export function ProjectCreateDialog({
   }
 
   const handleCreateWorkspace = async () => {
-    if (!deviceId || !selectedDeviceSupportsWorkspaceProject) return
+    if (!deviceId || !localPath.trim() || !selectedDeviceSupportsWorkspaceProject) return
 
     setIsCreating(true)
     try {
@@ -148,21 +151,15 @@ export function ProjectCreateDialog({
           deviceId,
         },
       }
-      if (localPath.trim()) {
-        config.workspace = {
-          source: 'local_path',
-          localPath: localPath.trim(),
-        }
+      config.workspace = {
+        source: 'local_path',
+        localPath: localPath.trim(),
       }
       const tempName = projectName || 'project'
-      const created = await projectApis.createProject({
+      await projectApis.createProject({
         name: tempName,
         config,
       })
-      // If no path was specified, rename to project{id} based on default folder name
-      if (!localPath.trim() && created.id) {
-        await projectApis.updateProject(created.id, { name: `project${created.id}` })
-      }
       await refreshProjects()
       resetForm()
       onOpenChange(false)
@@ -186,154 +183,186 @@ export function ProjectCreateDialog({
     setSelectedColor(null)
     setDeviceId('')
     setLocalPath('')
+    setDirectoryPickerOpen(false)
   }
 
   const canCreate = isWorkspaceMode
-    ? Boolean(deviceId) && selectedDeviceSupportsWorkspaceProject
+    ? Boolean(deviceId) && Boolean(localPath.trim()) && selectedDeviceSupportsWorkspaceProject
     : Boolean(name.trim())
 
+  const handleDeviceChange = (nextDeviceId: string) => {
+    setDeviceId(nextDeviceId)
+    setLocalPath('')
+  }
+
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[425px]">
-        <DialogHeader>
-          <DialogTitle>{t(isWorkspaceMode ? 'workspaceCreate.title' : 'create.title')}</DialogTitle>
-          <DialogDescription>
-            {t(isWorkspaceMode ? 'workspaceCreate.description' : 'create.description')}
-          </DialogDescription>
-        </DialogHeader>
+    <>
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-[425px]">
+          <DialogHeader>
+            <DialogTitle>
+              {t(isWorkspaceMode ? 'workspaceCreate.title' : 'create.title')}
+            </DialogTitle>
+            <DialogDescription>
+              {t(isWorkspaceMode ? 'workspaceCreate.description' : 'create.description')}
+            </DialogDescription>
+          </DialogHeader>
 
-        <div className="space-y-4 py-4">
-          {isWorkspaceMode ? (
-            <>
-              <div className="space-y-2">
-                <Label>{t('workspace.device')}</Label>
-                {onlineDevices.length === 0 ? (
-                  <p className="text-sm text-destructive">{t('workspace.noOnlineDevices')}</p>
-                ) : (
-                  <Select value={deviceId} onValueChange={setDeviceId} disabled={isCreating}>
-                    <SelectTrigger data-testid="workspace-device-select">
-                      <SelectValue placeholder={t('workspace.devicePlaceholder')} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {onlineDevices.map(device => (
-                        <SelectItem key={device.device_id} value={device.device_id}>
-                          <span className="flex items-center gap-2">
-                            <span
-                              className={`inline-block w-2 h-2 rounded-full ${
-                                device.status === 'online' ? 'bg-green-500' : 'bg-yellow-500'
-                              }`}
-                            />
-                            {device.name || device.device_id}
-                            {device.device_type === 'cloud' && (
-                              <span className="text-xs text-text-muted ml-1">
-                                ({t('workspace.cloud')})
-                              </span>
-                            )}
-                          </span>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-                {showDeviceVersionUnsupported && (
-                  <p
-                    className="text-sm text-destructive"
-                    data-testid="workspace-device-version-warning"
-                  >
-                    {t('workspace.deviceVersionUnsupported', {
-                      version:
-                        selectedDevice?.executor_version || t('workspace.unknownDeviceVersion'),
-                      requiredVersion: MIN_WORKSPACE_PROJECT_DEVICE_VERSION,
-                    })}
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="workspace-local-path">
-                  {t('workspace.directoryPath')}
-                  <span className="text-text-muted font-normal ml-1">({t('common:optional')})</span>
-                </Label>
-                <Input
-                  data-testid="workspace-local-path-input"
-                  id="workspace-local-path"
-                  placeholder={t('workspace.directoryPathPlaceholder')}
-                  value={localPath}
-                  onChange={e => setLocalPath(e.target.value)}
-                  disabled={isCreating}
-                />
-                {projectName ? (
-                  <p className="text-xs text-text-secondary">
-                    {t('workspace.projectNamePreview', { name: projectName })}
-                  </p>
-                ) : (
-                  <p className="text-xs text-text-muted">{t('workspace.defaultPathHint')}</p>
-                )}
-              </div>
-            </>
-          ) : (
-            <>
-              <div className="space-y-2">
-                <Label htmlFor="name">{t('create.nameLabel')}</Label>
-                <Input
-                  id="name"
-                  placeholder={t('create.namePlaceholder')}
-                  value={name}
-                  onChange={e => setName(e.target.value)}
-                  maxLength={100}
-                  disabled={isCreating}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="description">{t('create.descriptionLabel')}</Label>
-                <Textarea
-                  id="description"
-                  placeholder={t('create.descriptionPlaceholder')}
-                  value={description}
-                  onChange={e => setDescription(e.target.value)}
-                  rows={3}
-                  disabled={isCreating}
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label>{t('create.colorLabel')}</Label>
-                <div className="flex flex-wrap gap-2">
-                  {PROJECT_COLORS.map(color => (
-                    <button
-                      key={color.id}
-                      type="button"
-                      onClick={() =>
-                        setSelectedColor(selectedColor === color.value ? null : color.value)
-                      }
-                      className={`w-8 h-8 rounded-full border-2 transition-all ${
-                        selectedColor === color.value
-                          ? 'border-text-primary scale-110'
-                          : 'border-transparent hover:scale-105'
-                      }`}
-                      style={{ backgroundColor: color.value }}
-                      title={t(`colors.${color.id}`)}
+          <div className="space-y-4 py-4">
+            {isWorkspaceMode ? (
+              <>
+                <div className="space-y-2">
+                  <Label>{t('workspace.device')}</Label>
+                  {onlineDevices.length === 0 ? (
+                    <p className="text-sm text-destructive">{t('workspace.noOnlineDevices')}</p>
+                  ) : (
+                    <Select
+                      value={deviceId}
+                      onValueChange={handleDeviceChange}
                       disabled={isCreating}
-                    />
-                  ))}
+                    >
+                      <SelectTrigger data-testid="workspace-device-select">
+                        <SelectValue placeholder={t('workspace.devicePlaceholder')} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {onlineDevices.map(device => (
+                          <SelectItem key={device.device_id} value={device.device_id}>
+                            <span className="flex items-center gap-2">
+                              <span
+                                className={`inline-block w-2 h-2 rounded-full ${
+                                  device.status === 'online' ? 'bg-green-500' : 'bg-yellow-500'
+                                }`}
+                              />
+                              {device.name || device.device_id}
+                              {device.device_type === 'cloud' && (
+                                <span className="text-xs text-text-muted ml-1">
+                                  ({t('workspace.cloud')})
+                                </span>
+                              )}
+                            </span>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
+                  {showDeviceVersionUnsupported && (
+                    <p
+                      className="text-sm text-destructive"
+                      data-testid="workspace-device-version-warning"
+                    >
+                      {t('workspace.deviceVersionUnsupported', {
+                        version:
+                          selectedDevice?.executor_version || t('workspace.unknownDeviceVersion'),
+                        requiredVersion: MIN_WORKSPACE_PROJECT_DEVICE_VERSION,
+                      })}
+                    </p>
+                  )}
                 </div>
-              </div>
-            </>
-          )}
-        </div>
 
-        <div className="flex justify-end gap-2">
-          <Button variant="outline" onClick={handleClose} disabled={isCreating}>
-            {t('create.cancel')}
-          </Button>
-          <Button variant="primary" onClick={handleCreate} disabled={isCreating || !canCreate}>
-            {isCreating
-              ? t('common:actions.creating')
-              : t(isWorkspaceMode ? 'workspaceCreate.submit' : 'create.submit')}
-          </Button>
-        </div>
-      </DialogContent>
-    </Dialog>
+                <div className="space-y-2">
+                  <Label>{t('workspace.directoryPath')}</Label>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-10 w-full justify-start gap-2 px-3 font-normal"
+                    onClick={() => setDirectoryPickerOpen(true)}
+                    disabled={
+                      isCreating ||
+                      !deviceId ||
+                      !selectedDeviceSupportsWorkspaceProject ||
+                      onlineDevices.length === 0
+                    }
+                    data-testid="workspace-directory-picker-trigger"
+                  >
+                    <FolderOpen className="h-4 w-4 flex-none text-text-muted" />
+                    <span
+                      className={`min-w-0 flex-1 truncate text-left ${
+                        localPath ? 'text-text-primary' : 'text-text-muted'
+                      }`}
+                    >
+                      {localPath || t('workspace.selectDirectory')}
+                    </span>
+                  </Button>
+                  {projectName ? (
+                    <p className="text-xs text-text-secondary">
+                      {t('workspace.projectNamePreview', { name: projectName })}
+                    </p>
+                  ) : (
+                    <p className="text-xs text-text-muted">{t('workspace.selectDirectoryHint')}</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="space-y-2">
+                  <Label htmlFor="name">{t('create.nameLabel')}</Label>
+                  <Input
+                    id="name"
+                    placeholder={t('create.namePlaceholder')}
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                    maxLength={100}
+                    disabled={isCreating}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="description">{t('create.descriptionLabel')}</Label>
+                  <Textarea
+                    id="description"
+                    placeholder={t('create.descriptionPlaceholder')}
+                    value={description}
+                    onChange={e => setDescription(e.target.value)}
+                    rows={3}
+                    disabled={isCreating}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label>{t('create.colorLabel')}</Label>
+                  <div className="flex flex-wrap gap-2">
+                    {PROJECT_COLORS.map(color => (
+                      <button
+                        key={color.id}
+                        type="button"
+                        onClick={() =>
+                          setSelectedColor(selectedColor === color.value ? null : color.value)
+                        }
+                        className={`w-8 h-8 rounded-full border-2 transition-all ${
+                          selectedColor === color.value
+                            ? 'border-text-primary scale-110'
+                            : 'border-transparent hover:scale-105'
+                        }`}
+                        style={{ backgroundColor: color.value }}
+                        title={t(`colors.${color.id}`)}
+                        disabled={isCreating}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={handleClose} disabled={isCreating}>
+              {t('create.cancel')}
+            </Button>
+            <Button variant="primary" onClick={handleCreate} disabled={isCreating || !canCreate}>
+              {isCreating
+                ? t('common:actions.creating')
+                : t(isWorkspaceMode ? 'workspaceCreate.submit' : 'create.submit')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <ProjectDirectoryPickerDialog
+        open={directoryPickerOpen}
+        deviceId={deviceId}
+        initialPath={localPath}
+        onOpenChange={setDirectoryPickerOpen}
+        onConfirm={setLocalPath}
+      />
+    </>
   )
 }

--- a/frontend/src/features/projects/components/ProjectDirectoryPickerDialog.tsx
+++ b/frontend/src/features/projects/components/ProjectDirectoryPickerDialog.tsx
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Check, ChevronLeft, Folder, Loader2, RefreshCw } from 'lucide-react'
+
+import { deviceApis } from '@/apis/devices'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useTranslation } from '@/hooks/useTranslation'
+
+type ProjectDirectoryPickerDialogProps = {
+  open: boolean
+  deviceId: string
+  initialPath?: string
+  onOpenChange: (open: boolean) => void
+  onConfirm: (path: string) => void
+}
+
+type DirectoryEntry = {
+  name: string
+  path: string
+}
+
+function normalizeDirectoryPath(path: string): string {
+  const trimmed = path.trim()
+  if (!trimmed || trimmed === '/') return trimmed || '/'
+  return trimmed.replace(/\/+$/, '')
+}
+
+function joinDirectoryPath(parentPath: string, name: string): string {
+  const normalizedParent = normalizeDirectoryPath(parentPath)
+  if (!normalizedParent || normalizedParent === '/') return `/${name}`
+  return `${normalizedParent}/${name}`
+}
+
+function getParentDirectoryPath(path: string): string | null {
+  const normalized = normalizeDirectoryPath(path)
+  if (!normalized || normalized === '/') return null
+
+  const segments = normalized.split('/').filter(Boolean)
+  if (segments.length <= 1) return '/'
+  return `/${segments.slice(0, -1).join('/')}`
+}
+
+function getStdoutText(stdout: string | string[]): string {
+  return Array.isArray(stdout) ? stdout.join('\n') : stdout
+}
+
+function getDirectoryNames(stdout: string | string[]): string[] {
+  const values = Array.isArray(stdout) ? stdout : stdout.split('\n')
+  return values.map(value => value.trim()).filter(value => value && value !== '.' && value !== '..')
+}
+
+export function ProjectDirectoryPickerDialog({
+  open,
+  deviceId,
+  initialPath,
+  onOpenChange,
+  onConfirm,
+}: ProjectDirectoryPickerDialogProps) {
+  const { t } = useTranslation('projects')
+  const directoryLoadError = t('workspace.directoryPicker.error')
+  const [currentPath, setCurrentPath] = useState('')
+  const [selectedPath, setSelectedPath] = useState('')
+  const [directories, setDirectories] = useState<DirectoryEntry[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const parentPath = useMemo(() => getParentDirectoryPath(currentPath), [currentPath])
+
+  const loadDirectories = useCallback(
+    async (targetPath: string) => {
+      if (!deviceId) return
+
+      const normalizedPath = normalizeDirectoryPath(targetPath)
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await deviceApis.executeCommand(deviceId, {
+          command_key: 'ls_dirs',
+          path: normalizedPath,
+          timeout_seconds: 20,
+          max_output_bytes: 128 * 1024,
+        })
+
+        if (!response.success) {
+          throw new Error(response.error || response.stderr || directoryLoadError)
+        }
+
+        const entries = getDirectoryNames(response.stdout)
+          .sort((left, right) => left.localeCompare(right))
+          .map(name => ({
+            name,
+            path: joinDirectoryPath(normalizedPath, name),
+          }))
+
+        setCurrentPath(normalizedPath)
+        setDirectories(entries)
+      } catch (err) {
+        setDirectories([])
+        setError(err instanceof Error ? err.message : directoryLoadError)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [deviceId, directoryLoadError]
+  )
+
+  const initializeDirectory = useCallback(async () => {
+    if (!deviceId) return
+
+    const normalizedInitialPath = initialPath ? normalizeDirectoryPath(initialPath) : ''
+    if (normalizedInitialPath) {
+      setSelectedPath(normalizedInitialPath)
+      await loadDirectories(normalizedInitialPath)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    try {
+      const response = await deviceApis.executeCommand(deviceId, {
+        command_key: 'pwd',
+        timeout_seconds: 10,
+        max_output_bytes: 4096,
+      })
+
+      if (!response.success) {
+        throw new Error(response.error || response.stderr || directoryLoadError)
+      }
+
+      const rootPath = normalizeDirectoryPath(getStdoutText(response.stdout))
+      setSelectedPath(rootPath)
+      await loadDirectories(rootPath)
+    } catch (err) {
+      setDirectories([])
+      setError(err instanceof Error ? err.message : directoryLoadError)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [deviceId, directoryLoadError, initialPath, loadDirectories])
+
+  useEffect(() => {
+    if (!open) return
+
+    setCurrentPath('')
+    setSelectedPath('')
+    setDirectories([])
+    setError(null)
+    void initializeDirectory()
+  }, [initializeDirectory, open])
+
+  const handleOpenDirectory = (path: string) => {
+    setSelectedPath(path)
+    void loadDirectories(path)
+  }
+
+  const handleConfirm = () => {
+    if (!selectedPath) return
+    onConfirm(selectedPath)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[560px]" data-testid="workspace-directory-picker-dialog">
+        <DialogHeader>
+          <DialogTitle>{t('workspace.directoryPicker.title')}</DialogTitle>
+          <DialogDescription>{t('workspace.directoryPicker.description')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <div className="flex min-h-10 items-center gap-2 rounded-md border border-border bg-surface px-3 text-sm">
+            <Folder className="h-4 w-4 flex-none text-text-muted" />
+            <span className="min-w-0 flex-1 truncate text-text-secondary">
+              {currentPath || t('workspace.directoryPicker.loading')}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => currentPath && loadDirectories(currentPath)}
+              disabled={isLoading || !currentPath}
+              data-testid="workspace-directory-refresh-button"
+              title={t('workspace.directoryPicker.refresh')}
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
+          </div>
+
+          <div className="h-[280px] overflow-auto rounded-md border border-border">
+            {isLoading && directories.length === 0 ? (
+              <div className="flex h-full items-center justify-center gap-2 text-sm text-text-muted">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                {t('workspace.directoryPicker.loading')}
+              </div>
+            ) : error ? (
+              <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+                <p className="text-sm text-destructive">{error}</p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={initializeDirectory}
+                  data-testid="workspace-directory-retry-button"
+                >
+                  {t('workspace.directoryPicker.retry')}
+                </Button>
+              </div>
+            ) : (
+              <div className="divide-y divide-border">
+                {parentPath && (
+                  <button
+                    type="button"
+                    className="flex h-11 w-full items-center gap-2 px-3 text-left text-sm text-text-secondary hover:bg-surface"
+                    onClick={() => handleOpenDirectory(parentPath)}
+                    data-testid="workspace-directory-parent-row"
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    <span className="truncate">{t('workspace.directoryPicker.parent')}</span>
+                  </button>
+                )}
+
+                {directories.map(directory => {
+                  const isSelected = selectedPath === directory.path
+                  return (
+                    <button
+                      key={directory.path}
+                      type="button"
+                      className={`flex h-11 w-full items-center gap-2 px-3 text-left text-sm transition-colors ${
+                        isSelected
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-text-primary hover:bg-surface'
+                      }`}
+                      onClick={() => setSelectedPath(directory.path)}
+                      onDoubleClick={() => handleOpenDirectory(directory.path)}
+                      data-testid="workspace-directory-row"
+                    >
+                      <Folder className="h-4 w-4 flex-none text-text-muted" />
+                      <span className="min-w-0 flex-1 truncate">{directory.name}</span>
+                      {isSelected && <Check className="h-4 w-4 flex-none" />}
+                    </button>
+                  )
+                })}
+
+                {!isLoading && directories.length === 0 && !parentPath && (
+                  <p className="px-3 py-8 text-center text-sm text-text-muted">
+                    {t('workspace.directoryPicker.empty')}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div
+            className="min-h-5 text-xs text-text-secondary"
+            data-testid="workspace-directory-selected-path"
+          >
+            {selectedPath
+              ? t('workspace.directoryPicker.selected', { path: selectedPath })
+              : t('workspace.directoryPicker.selectHint')}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('create.cancel')}
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleConfirm}
+            disabled={!selectedPath || isLoading}
+            data-testid="workspace-directory-confirm-button"
+          >
+            {t('workspace.directoryPicker.confirm')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/features/projects/components/index.ts
+++ b/frontend/src/features/projects/components/index.ts
@@ -4,6 +4,7 @@
 
 export { ProjectSection } from './ProjectSection'
 export { ProjectCreateDialog } from './ProjectCreateDialog'
+export { ProjectDirectoryPickerDialog } from './ProjectDirectoryPickerDialog'
 export { ProjectEditDialog } from './ProjectEditDialog'
 export { ProjectDeleteDialog } from './ProjectDeleteDialog'
 export { DroppableProject } from './DroppableProject'

--- a/frontend/src/i18n/locales/en/projects.json
+++ b/frontend/src/i18n/locales/en/projects.json
@@ -45,6 +45,8 @@
     "devicePlaceholder": "Select a device",
     "directoryPath": "Directory Path",
     "directoryPathPlaceholder": "Enter local directory path",
+    "selectDirectory": "Select device directory",
+    "selectDirectoryHint": "Select the project directory from the chosen device",
     "projectNamePreview": "Project name: {{name}}",
     "newConversation": "New Conversation",
     "greeting": "What do you want to build in {{name}}?",
@@ -65,7 +67,20 @@
     "gitRepo": "Repository name (optional)",
     "gitBranch": "Branch, default main",
     "checkoutPath": "Checkout path (optional)",
-    "localPathPlaceholder": "Directory path"
+    "localPathPlaceholder": "Directory path",
+    "directoryPicker": {
+      "title": "Select Project Directory",
+      "description": "Click a directory to select it. Double-click to select and enter a subdirectory.",
+      "loading": "Loading directories...",
+      "error": "Failed to load directories",
+      "empty": "No subdirectories in the current directory",
+      "retry": "Retry",
+      "refresh": "Refresh",
+      "parent": "Parent directory",
+      "selected": "Selected: {{path}}",
+      "selectHint": "Select a directory",
+      "confirm": "Select Directory"
+    }
   },
   "edit": {
     "title": "Edit Project",

--- a/frontend/src/i18n/locales/zh-CN/projects.json
+++ b/frontend/src/i18n/locales/zh-CN/projects.json
@@ -45,6 +45,8 @@
     "devicePlaceholder": "选择设备",
     "directoryPath": "目录地址",
     "directoryPathPlaceholder": "输入本地目录路径",
+    "selectDirectory": "选择设备目录",
+    "selectDirectoryHint": "请从所选设备中选择项目所在目录",
     "projectNamePreview": "项目名称：{{name}}",
     "newConversation": "新建对话",
     "greeting": "要在{{name}}中构建什么？",
@@ -65,7 +67,20 @@
     "gitRepo": "仓库名称（可选）",
     "gitBranch": "分支，默认 main",
     "checkoutPath": "目标目录（可选）",
-    "localPathPlaceholder": "目录地址"
+    "localPathPlaceholder": "目录地址",
+    "directoryPicker": {
+      "title": "选择项目目录",
+      "description": "单击目录可选中，双击目录可选中并进入子目录。",
+      "loading": "正在加载目录...",
+      "error": "目录加载失败",
+      "empty": "当前目录下没有子目录",
+      "retry": "重试",
+      "refresh": "刷新",
+      "parent": "上级目录",
+      "selected": "已选择：{{path}}",
+      "selectHint": "请选择一个目录",
+      "confirm": "选择目录"
+    }
   },
   "edit": {
     "title": "编辑分组",


### PR DESCRIPTION
## Summary
- Replace manual workspace directory entry in project creation with a device-backed directory picker.
- Add default `ls_dirs` local-device command and `directory_list` post processor for safe directory listing.
- Support single-click directory selection and double-click select-and-enter behavior in the project create flow.
- Add frontend/backend tests and document the new local-device command.

## Task
- 4UMDIENB7b

## Tests
- `cd frontend && npm test -- src/__tests__/features/projects/components/ProjectCreateDialog.test.tsx --runInBand`
- `cd backend && uv run pytest tests/services/test_local_device_command_service.py`
- `cd frontend && npm run lint`
- `git diff --check`

## Integration Verification
- Deployed branch `feature/device-directory-picker` to integration environment at commit `811bd0b9`.
- Built frontend successfully with `npm run build`; served the integration frontend with `next start -p 3000` because the dev server hit a stale `.next` manifest issue.
- Started a temporary local executor `Codex sifang Verify 1711` with executor version `1.7.11`.
- Verified in browser: unsupported `1.7.9` device disables directory selection, `1.7.11` device enables it, picker opens from the selected device path, single click selects `frontend`, double click enters `docs`, confirmation fills `/cloudide/workspace/wegent/docs`, project name is derived as `docs`, and project creation succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added an interactive directory picker dialog for selecting project directories on connected devices during workspace project creation, featuring directory navigation, browsing, and error recovery.
  - Introduced a new device command for listing available subdirectories in the current working directory.

* **Documentation**
  - Updated developer guides (English and Chinese) to document the new directory listing command and its capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->