### PR TITLE
完善 Claude Code 模型切换与相关设置联动

### DIFF
--- a/backend/app/api/endpoints/adapter/chat.py
+++ b/backend/app/api/endpoints/adapter/chat.py
@@ -18,7 +18,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
@@ -69,6 +69,13 @@ class StreamChatRequest(BaseModel):
     offset: Optional[int] = None  # Character offset for resuming (0 = new stream)
     # Group chat flag
     is_group_chat: bool = False  # Whether this is a group chat
+
+    @model_validator(mode="after")
+    def default_model_selection_to_override(self) -> "StreamChatRequest":
+        """Treat an explicit model_id as an override selection."""
+        if self.model_id:
+            self.force_override_bot_model = True
+        return self
 
 
 @router.get("/check-direct-chat/{team_id}")

--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -576,7 +576,8 @@ def join_shared_task(
         user_id=current_user.id,
         team_id=user_team.id,
         model_id=request.model_id,
-        force_override_bot_model=request.force_override_bot_model or False,
+        force_override_bot_model=bool(request.model_id)
+        or bool(request.force_override_bot_model),
         force_override_bot_model_type=request.force_override_bot_model_type,
         git_repo_id=request.git_repo_id,
         git_url=request.git_url,

--- a/backend/app/schemas/shared_task.py
+++ b/backend/app/schemas/shared_task.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from typing import Any, List, Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class TaskShareInfo(BaseModel):
@@ -47,6 +47,13 @@ class JoinSharedTaskRequest(BaseModel):
     git_repo: Optional[str] = None  # Repository full name (e.g., "owner/repo")
     git_domain: Optional[str] = None  # Git domain (e.g., "github.com")
     branch_name: Optional[str] = None  # Git branch name
+
+    @model_validator(mode="after")
+    def default_model_selection_to_override(self) -> "JoinSharedTaskRequest":
+        """Treat an explicit model_id as an override selection."""
+        if self.model_id:
+            self.force_override_bot_model = True
+        return self
 
 
 class JoinSharedTaskResponse(BaseModel):

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from app.schemas.kind import SkillRefMeta
 from app.schemas.subtask import SubtaskWithBot
@@ -95,6 +95,13 @@ class TaskCreate(BaseModel):
     # Skill selection (user-selected skills for this message)
     # Backend determines preload vs download based on executor type
     additional_skills: Optional[List[SkillRef]] = None
+
+    @model_validator(mode="after")
+    def default_model_selection_to_override(self) -> "TaskCreate":
+        """Treat an explicit model_id as an override selection."""
+        if self.model_id:
+            self.force_override_bot_model = True
+        return self
 
 
 class TaskUpdate(BaseModel):

--- a/backend/app/services/chat/storage/task_manager.py
+++ b/backend/app/services/chat/storage/task_manager.py
@@ -91,6 +91,11 @@ class TaskCreationParams:
     # Used to save video_config to user subtask.result for display
     generate_params: Optional[Dict[str, Any]] = None
 
+    def __post_init__(self) -> None:
+        """Treat an explicit model_id as an override selection."""
+        if self.model_id:
+            self.force_override_bot_model = True
+
 
 def get_bot_ids_from_team(db: Session, team: Kind) -> List[int]:
     """

--- a/backend/app/services/shared_task.py
+++ b/backend/app/services/shared_task.py
@@ -326,6 +326,8 @@ class SharedTaskService:
         """Copy task and all its subtasks to new user"""
         from app.schemas.kind import Task, Team, Workspace
 
+        should_force_override_model = bool(model_id) or force_override_bot_model
+
         # Get the new team to get its name and namespace
         new_team = (
             db.query(Kind)
@@ -513,12 +515,12 @@ class SharedTaskService:
             del task_crd.metadata.labels["forceOverrideBotModelType"]
 
         # Update model configuration in metadata labels if provided by user during import
-        if model_id or force_override_bot_model:
+        if model_id or should_force_override_model:
             if not task_crd.metadata.labels:
                 task_crd.metadata.labels = {}
             if model_id:
                 task_crd.metadata.labels["modelId"] = model_id
-            if force_override_bot_model:
+            if should_force_override_model:
                 task_crd.metadata.labels["forceOverrideBotModel"] = "true"
             if force_override_bot_model_type:
                 task_crd.metadata.labels["forceOverrideBotModelType"] = (

--- a/backend/tests/schemas/test_task_model_override.py
+++ b/backend/tests/schemas/test_task_model_override.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from app.schemas.shared_task import JoinSharedTaskRequest
+from app.schemas.task import TaskCreate
+from app.services.chat.storage import TaskCreationParams
+
+
+def test_task_create_model_id_defaults_to_force_override():
+    task = TaskCreate(prompt="hello", model_id="gpt-5")
+
+    assert task.force_override_bot_model is True
+
+
+def test_join_shared_task_model_id_defaults_to_force_override():
+    request = JoinSharedTaskRequest(share_token="token", model_id="gpt-5")
+
+    assert request.force_override_bot_model is True
+
+
+def test_task_creation_params_model_id_defaults_to_force_override():
+    params = TaskCreationParams(message="hello", model_id="gpt-5")
+
+    assert params.force_override_bot_model is True

--- a/docs/superpowers/plans/2026-05-28-claude-code-model-switch.md
+++ b/docs/superpowers/plans/2026-05-28-claude-code-model-switch.md
@@ -1,0 +1,153 @@
+# Claude Code Model Switching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable model selection during existing ClaudeCode conversations.
+
+**Architecture:** Add one shared frontend capability helper in `messageService.ts`, then use it in desktop and mobile input controls. The existing send payload and backend/executor model override path remain unchanged.
+
+**Tech Stack:** Next.js 15, React 19, TypeScript, Jest.
+
+---
+
+### Task 1: Add Capability Helper
+
+**Files:**
+- Modify: `frontend/src/features/tasks/service/messageService.ts`
+- Modify: `frontend/src/__tests__/features/tasks/service/messageService.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add these tests to `frontend/src/__tests__/features/tasks/service/messageService.test.ts`:
+
+```typescript
+import {
+  canSwitchModelAfterMessages,
+  canUseChatContexts,
+} from '@/features/tasks/service/messageService'
+import type { Team } from '@/types/api'
+
+function createTeam(agentType: string, shellType?: string): Team {
+  return {
+    id: 1,
+    name: `${agentType} Team`,
+    description: '',
+    bots: shellType
+      ? [
+          {
+            bot_id: 1,
+            bot_prompt: '',
+            bot: { shell_type: shellType },
+          },
+        ]
+      : [],
+    workflow: {},
+    is_active: true,
+    user_id: 1,
+    created_at: '',
+    updated_at: '',
+    agent_type: agentType,
+  }
+}
+
+describe('messageService canSwitchModelAfterMessages', () => {
+  it('allows chat shell teams to switch models after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('chat'))).toBe(true)
+  })
+
+  it('allows ClaudeCode teams to switch models after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('ClaudeCode'))).toBe(true)
+  })
+
+  it('allows ClaudeCode teams detected from bot shell type', () => {
+    expect(canSwitchModelAfterMessages(createTeam('', 'ClaudeCode'))).toBe(true)
+  })
+
+  it('keeps unknown shells disabled after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('Dify'))).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/service/messageService.test.ts`
+
+Expected: FAIL with an export error for `canSwitchModelAfterMessages`.
+
+- [ ] **Step 3: Implement helper**
+
+Add this function to `frontend/src/features/tasks/service/messageService.ts` after `isClaudeCode`:
+
+```typescript
+/**
+ * Check whether the model selector should stay enabled after a task has messages.
+ *
+ * Chat Shell already supports per-message model switching. ClaudeCode receives the selected
+ * model through the existing task override path and executor model configuration.
+ */
+export function canSwitchModelAfterMessages(team: Team | null): boolean {
+  return isChatShell(team) || isClaudeCode(team)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/service/messageService.test.ts`
+
+Expected: PASS.
+
+### Task 2: Use Helper In Input Controls
+
+**Files:**
+- Modify: `frontend/src/features/tasks/components/input/ChatInputControls.tsx`
+- Modify: `frontend/src/features/tasks/components/input/MobileChatInputControls.tsx`
+
+- [ ] **Step 1: Update desktop import and disabled rule**
+
+Change the service import in `ChatInputControls.tsx` to include the helper:
+
+```typescript
+import {
+  canSwitchModelAfterMessages,
+  canUseChatContexts,
+  isChatShell,
+} from '../../service/messageService'
+```
+
+Change the model selector disabled prop to:
+
+```tsx
+disabled={isLoading || isStreaming || (hasMessages && !canSwitchModelAfterMessages(selectedTeam))}
+```
+
+- [ ] **Step 2: Update mobile import and disabled rule**
+
+Change the service import in `MobileChatInputControls.tsx` to include the helper:
+
+```typescript
+import {
+  canSwitchModelAfterMessages,
+  canUseChatContexts,
+  isChatShell,
+  teamRequiresWorkspace,
+} from '../../service/messageService'
+```
+
+Change the mobile model selector disabled prop to:
+
+```tsx
+disabled={isLoading || isStreaming || (hasMessages && !canSwitchModelAfterMessages(selectedTeam))}
+```
+
+- [ ] **Step 3: Run targeted test**
+
+Run: `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/service/messageService.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+Run: `cd frontend && npm run lint`
+
+Expected: PASS.

--- a/docs/superpowers/specs/2026-05-28-claude-code-model-switch-design.md
+++ b/docs/superpowers/specs/2026-05-28-claude-code-model-switch-design.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 1
+---
+
+# Claude Code Model Switching
+
+## Goal
+
+Allow users to switch the selected model while continuing an existing ClaudeCode conversation.
+
+## Context
+
+The message send path already carries model overrides:
+
+- The frontend maps the selected model to `force_override_bot_model`.
+- The backend persists that value in task metadata and resolves the model for the next execution request.
+- The Claude executor already receives the resolved model through Claude Code environment configuration.
+
+The current blocker is the frontend UI. Once a task has messages, both desktop and mobile input controls disable model selection for every non-Chat Shell team. ClaudeCode is in that non-Chat Shell group, so users cannot change the model during the conversation.
+
+## Design
+
+Replace the broad `hasMessages && !isChatShell(selectedTeam)` disable rule with a narrower rule that only disables model switching for shell types that cannot safely support it.
+
+ClaudeCode should remain enabled after messages exist, except while a request is loading or streaming. Chat Shell keeps the existing behavior. Other executor types remain conservative unless explicitly allowed by a shared helper.
+
+## Components
+
+- Add or reuse a frontend helper that determines whether a team can switch models after task creation.
+- Apply the helper in desktop `ChatInputControls`.
+- Apply the same helper in mobile `MobileChatInputControls`.
+- Keep the existing send payload unchanged.
+
+## Data Flow
+
+1. User changes the model in the selector during an existing ClaudeCode task.
+2. The selected model state updates in the same way it does before the first message.
+3. The next send includes `force_override_bot_model`.
+4. Backend task metadata and execution request resolution continue through the existing path.
+5. Claude executor receives the selected model through existing model configuration.
+
+## Error Handling
+
+Do not add new frontend error behavior. If the selected model is invalid, missing, or not allowed, the existing backend model resolver should reject the request and surface the existing chat error.
+
+## Testing
+
+Add focused frontend unit coverage for the helper:
+
+- Chat Shell can switch after messages.
+- ClaudeCode can switch after messages.
+- Unknown or unsupported shells stay disabled after messages.
+
+Run the frontend lint or targeted test command available in the repository.

--- a/frontend/e2e/tests/settings-bot.spec.ts
+++ b/frontend/e2e/tests/settings-bot.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect, TestData } from '../fixtures/test-fixtures'
 import type { Page } from '@playwright/test'
 
+const AGENT_RESOURCES_URL = '/resource-library?tab=mine&type=agent&scope=personal'
+
 // Detect current language environment and return appropriate text
 async function detectLanguage(page: Page): Promise<'en' | 'zh'> {
   // Check if Chinese text is visible on the page
@@ -24,10 +26,15 @@ test.describe('Settings - Bot Management', () => {
   let lang: 'en' | 'zh' = 'en'
 
   test.beforeEach(async ({ page }) => {
-    // Bot management is accessed through "Manage Bots" button in team tab
-    await page.goto('/settings?tab=team')
+    // Bot management moved with agent resources into Resource Library.
+    await page.goto(AGENT_RESOURCES_URL)
     await page.waitForLoadState('domcontentloaded')
-    // Wait for team page content to fully load - the title is "Team List" or "智能体列表"
+    await expect(page.locator('[data-testid="my-resources"]')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('[data-testid="managed-resource-agent-tab"]')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    // Wait for agent resource content to fully load - the title is "Team List" or "智能体列表"
     await expect(page.locator('h2:has-text("Team List"), h2:has-text("智能体列表")')).toBeVisible({
       timeout: 15000,
     })
@@ -37,7 +44,7 @@ test.describe('Settings - Bot Management', () => {
   })
 
   test('should access bot management via manage bots button', async ({ page }) => {
-    await expect(page).toHaveURL(/\/settings/)
+    await expect(page).toHaveURL(/\/resource-library/)
     const texts = getLocalizedText(lang)
 
     // Click "Manage Bots" button to open bot list dialog

--- a/frontend/e2e/tests/settings-model.spec.ts
+++ b/frontend/e2e/tests/settings-model.spec.ts
@@ -1,17 +1,22 @@
 import { test, expect, TestData } from '../fixtures/test-fixtures'
 
+const MODEL_RESOURCES_URL = '/resource-library?tab=mine&type=model&scope=personal'
+
 test.describe('Settings - Model Management', () => {
   test.beforeEach(async ({ page }) => {
-    // Use the correct tab parameter format: personal-models
-    await page.goto('/settings?tab=personal-models')
+    // Model management moved into Resource Library.
+    await page.goto(MODEL_RESOURCES_URL)
     await page.waitForLoadState('domcontentloaded')
-    // Wait for page to fully load
-    await page.waitForTimeout(1000)
+    await expect(page.locator('[data-testid="my-resources"]')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('[data-testid="managed-resource-model-tab"]')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
   })
 
   test('should access model management page', async ({ page }) => {
-    // Verify we're on settings page
-    await expect(page).toHaveURL(/\/settings/)
+    // Verify we're on Resource Library.
+    await expect(page).toHaveURL(/\/resource-library/)
 
     // Wait for model management title to load using data-testid for reliability
     await expect(page.locator('[data-testid="model-management-title"]')).toBeVisible({

--- a/frontend/e2e/tests/settings-team.spec.ts
+++ b/frontend/e2e/tests/settings-team.spec.ts
@@ -1,14 +1,22 @@
 import { test, expect, TestData } from '../fixtures/test-fixtures'
 
+const AGENT_RESOURCES_URL = '/resource-library?tab=mine&type=agent&scope=personal'
+
 test.describe('Settings - Team Management', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings?tab=team')
+    // Team/agent management moved into Resource Library.
+    await page.goto(AGENT_RESOURCES_URL)
     await page.waitForLoadState('domcontentloaded')
+    await expect(page.locator('[data-testid="my-resources"]')).toBeVisible({ timeout: 15000 })
+    await expect(page.locator('[data-testid="managed-resource-agent-tab"]')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
   })
 
   test('should access team management page', async ({ page }) => {
-    // Verify we're on settings page
-    await expect(page).toHaveURL(/\/settings/)
+    // Verify we're on Resource Library.
+    await expect(page).toHaveURL(/\/resource-library/)
 
     // Wait for team list title to load
     await expect(page.locator('h2:has-text("Team")')).toBeVisible({ timeout: 20000 })

--- a/frontend/src/__tests__/features/inbox/QueueEditDialog.test.tsx
+++ b/frontend/src/__tests__/features/inbox/QueueEditDialog.test.tsx
@@ -115,8 +115,6 @@ jest.mock('@/features/tasks/components/selector/ModelSelector', () => ({
   default: ({
     selectedModel,
     setSelectedModel,
-    forceOverride,
-    setForceOverride,
   }: {
     selectedModel: { name: string } | null
     setSelectedModel: (model: {
@@ -126,8 +124,6 @@ jest.mock('@/features/tasks/components/selector/ModelSelector', () => ({
       type: 'public'
       namespace: string
     }) => void
-    forceOverride: boolean
-    setForceOverride: (value: boolean) => void
   }) => (
     <div>
       <button
@@ -145,14 +141,6 @@ jest.mock('@/features/tasks/components/selector/ModelSelector', () => ({
       >
         Select GPT 5
       </button>
-      <label htmlFor="queue-force-override-model-switch">Override</label>
-      <input
-        id="queue-force-override-model-switch"
-        data-testid="queue-force-override-model-switch"
-        type="checkbox"
-        checked={forceOverride}
-        onChange={event => setForceOverride(event.target.checked)}
-      />
       <div data-testid="queue-current-model">{selectedModel?.name ?? 'none'}</div>
     </div>
   ),
@@ -164,7 +152,7 @@ describe('QueueEditDialog', () => {
     ;(createWorkQueue as jest.Mock).mockResolvedValue({ id: 1 })
   })
 
-  it('saves direct agent model override settings into queue auto process config', async () => {
+  it('saves selected direct agent models as force override by default', async () => {
     const user = userEvent.setup()
 
     render(<QueueEditDialog open onOpenChange={jest.fn()} />)
@@ -182,7 +170,6 @@ describe('QueueEditDialog', () => {
     })
 
     await user.click(screen.getByTestId('queue-select-gpt-5'))
-    await user.click(screen.getByTestId('queue-force-override-model-switch'))
     await user.click(screen.getByRole('button', { name: 'common:actions.save' }))
 
     await waitFor(() => {

--- a/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/SimpleTeamEditDialog.test.tsx
@@ -74,9 +74,12 @@ jest.mock('@/hooks/useTranslation', () => ({
         'settings:team.simple.executor.complex.description':
           'Complex executor for code tasks, device tasks, or multi-step complex tasks.',
         'settings:team.simple.executor.complex.title': 'Complex',
-        'settings:team.simple.executor.custom.description': 'Choose custom shell.',
+        'settings:team.simple.executor.custom.description': 'Use an executor you created.',
         'settings:team.simple.executor.custom.title': 'Custom',
-        'settings:team.simple.executor.custom_shell_placeholder': 'Choose custom shell',
+        'settings:team.simple.executor.custom_shell_placeholder': 'Choose custom executor',
+        'settings:team.simple.executor.manage_custom_shells_hint':
+          'Manage custom executors in Resource Library - Executors.',
+        'settings:team.simple.executor.no_custom_shells': 'No custom executors available',
         'settings:team.simple.executor.required': 'Choose executor',
         'settings:team.simple.executor.requires_complex_hint': 'Code requires complex.',
         'settings:team.simple.executor.simple.description': 'Chat executor.',

--- a/frontend/src/__tests__/features/settings/components/team-edit/ExecutorModeSelector.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/team-edit/ExecutorModeSelector.test.tsx
@@ -8,6 +8,8 @@ import type { ReactNode } from 'react'
 
 import type { UnifiedShell } from '@/apis/shells'
 import ExecutorModeSelector from '@/features/settings/components/team-edit/ExecutorModeSelector'
+import enSettings from '@/i18n/locales/en/settings.json'
+import zhSettings from '@/i18n/locales/zh-CN/settings.json'
 
 const shells: UnifiedShell[] = [
   { name: 'Chat', type: 'public', displayName: 'Chat', shellType: 'Chat' },
@@ -26,8 +28,11 @@ jest.mock('@/hooks/useTranslation', () => ({
         'settings:team.simple.executor.complex.description':
           'Complex executor for code tasks, device tasks, or multi-step complex tasks.',
         'settings:team.simple.executor.custom.title': 'Custom',
-        'settings:team.simple.executor.custom.description': 'Choose a custom shell.',
-        'settings:team.simple.executor.custom_shell_placeholder': 'Choose custom shell',
+        'settings:team.simple.executor.custom.description': 'Use an executor you created.',
+        'settings:team.simple.executor.custom_shell_placeholder': 'Choose custom executor',
+        'settings:team.simple.executor.no_custom_shells': 'No custom executors available',
+        'settings:team.simple.executor.manage_custom_shells_hint':
+          'Manage custom executors in Resource Library - Executors.',
       })[key] || key,
   }),
 }))
@@ -84,6 +89,32 @@ describe('ExecutorModeSelector', () => {
 
     expect(screen.getByText('Team Shell')).toBeInTheDocument()
     expect(onCustomShellChange).toHaveBeenCalledWith('team-shell')
+  })
+
+  it('shows an empty-state option when no custom shells exist', () => {
+    render(
+      <ExecutorModeSelector
+        value="custom"
+        onChange={jest.fn()}
+        shells={shells.filter(shell => shell.type === 'public')}
+        customShellName=""
+        onCustomShellChange={jest.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('No custom executors available')).toHaveLength(2)
+    expect(
+      screen.getByText('Manage custom executors in Resource Library - Executors.')
+    ).toBeInTheDocument()
+  })
+
+  it('uses executor terminology in localized custom executor descriptions', () => {
+    expect(zhSettings.team.simple.executor.custom.description).toBe(
+      '使用你创建的执行器，适合特殊运行环境。'
+    )
+    expect(enSettings.team.simple.executor.custom.description).toBe(
+      'Uses an executor you created for a specialized runtime.'
+    )
   })
 
   it('selects custom executor when the custom card is clicked', () => {

--- a/frontend/src/__tests__/features/tasks/components/selector/ModelSelector.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/selector/ModelSelector.test.tsx
@@ -4,7 +4,7 @@
 
 import '@testing-library/jest-dom'
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import ModelSelector from '@/features/tasks/components/selector/ModelSelector'
 import type { Model } from '@/features/tasks/hooks/useModelSelection'
 
@@ -77,8 +77,7 @@ jest.mock('@/features/tasks/hooks/useModelSelection', () => {
             return 'Select model'
           }
 
-          const displayText = selectedModel.displayName || selectedModel.name
-          return forceOverride ? `${displayText}(覆盖)` : displayText
+          return selectedModel.displayName || selectedModel.name
         },
         getBoundModelDisplayNames: () => [],
         getModelKey,
@@ -135,7 +134,7 @@ describe('ModelSelector', () => {
     })
   })
 
-  it('syncs an external forceOverride change into the selector display', async () => {
+  it('does not show override wording when external forceOverride is true', async () => {
     const externalSetSelectedModel = jest.fn()
     const externalSetForceOverride = jest.fn()
 
@@ -166,7 +165,31 @@ describe('ModelSelector', () => {
     )
 
     await waitFor(() => {
-      expect(screen.getByTestId('model-selector')).toHaveTextContent('Claude 3.5 Sonnet(覆盖)')
+      expect(screen.getByTestId('model-selector')).toHaveTextContent('Claude 3.5 Sonnet')
+      expect(screen.getByTestId('model-selector')).not.toHaveTextContent('覆盖')
+    })
+  })
+
+  it('does not show an override control in the dropdown', async () => {
+    render(
+      <ModelSelector
+        selectedModel={mockModel}
+        setSelectedModel={jest.fn()}
+        forceOverride={true}
+        setForceOverride={jest.fn()}
+        selectedTeam={null}
+        disabled={false}
+      />
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('model-selector')).toHaveTextContent('Claude 3.5 Sonnet')
+    })
+
+    fireEvent.click(screen.getByTestId('model-selector'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('覆盖默认模型')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
@@ -322,10 +322,10 @@ describe('TaskSidebar scroll structure', () => {
     const automationButton = screen.getAllByTestId('task-sidebar-nav-flow-button')[0]
     const moreButton = screen.getAllByTestId('task-sidebar-more-button')[0]
 
-    expect(logoSection).toHaveClass('pt-2', 'pb-3')
-    expect(newConversationButton).toHaveClass('h-11', 'min-w-[44px]')
-    expect(automationButton).toHaveClass('h-11', 'min-w-[44px]')
-    expect(moreButton).toHaveClass('h-11', 'min-w-[44px]')
+    expect(logoSection).toHaveClass('pt-2', 'pb-1.5')
+    expect(newConversationButton).toHaveClass('h-11', 'lg:h-10', 'min-w-[44px]')
+    expect(automationButton).toHaveClass('h-11', 'lg:h-10', 'min-w-[44px]')
+    expect(moreButton).toHaveClass('h-11', 'lg:h-10', 'min-w-[44px]')
     expect(newConversationButton).toHaveAttribute('data-testid', 'new-agent-button')
   })
 
@@ -433,6 +433,23 @@ describe('TaskSidebar scroll structure', () => {
     expect(
       within(collapsedGroupDock).queryByText('common:tasks.no_group_chats')
     ).not.toBeInTheDocument()
+  })
+
+  it('keeps the group chat dock visible after empty group chat loading has settled', () => {
+    Object.assign(mockTaskContext, {
+      groupTasks: [],
+      personalTasks: [],
+      hasMoreGroupTasks: false,
+    })
+
+    render(
+      <TaskSidebar isMobileSidebarOpen={false} setIsMobileSidebarOpen={jest.fn()} pageType="chat" />
+    )
+
+    const groupDock = screen.getAllByTestId('task-sidebar-group-chat-dock')[0]
+
+    expect(within(groupDock).getByText('common:tasks.group_chats')).toBeInTheDocument()
+    expect(within(groupDock).queryByText('common:tasks.no_group_chats')).not.toBeInTheDocument()
   })
 
   it('renders personal history as a flat list', () => {

--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
@@ -425,6 +425,14 @@ describe('TaskSidebar scroll structure', () => {
       within(updatedGroupDock).getByTestId('task-sidebar-group-chat-toggle')
     ).toBeInTheDocument()
     expect(within(updatedGroupDock).getByText('common:tasks.no_group_chats')).toBeInTheDocument()
+
+    fireEvent.click(within(updatedGroupDock).getByTestId('task-sidebar-group-chat-toggle'))
+
+    const collapsedGroupDock = screen.getAllByTestId('task-sidebar-group-chat-dock')[0]
+    expect(within(collapsedGroupDock).getByText('common:tasks.group_chats')).toBeInTheDocument()
+    expect(
+      within(collapsedGroupDock).queryByText('common:tasks.no_group_chats')
+    ).not.toBeInTheDocument()
   })
 
   it('renders personal history as a flat list', () => {

--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
@@ -393,6 +393,40 @@ describe('TaskSidebar scroll structure', () => {
     expect(within(groupDock).getByText('Group chat message')).toBeInTheDocument()
   })
 
+  it('keeps the group chat toggle visible after loading an empty group chat list', () => {
+    const loadAllGroupTasks = jest.fn().mockResolvedValue(undefined)
+    Object.assign(mockTaskContext, {
+      groupTasks: [],
+      personalTasks: [],
+      hasMoreGroupTasks: true,
+      loadAllGroupTasks,
+    })
+
+    const sidebarProps = {
+      isMobileSidebarOpen: false,
+      setIsMobileSidebarOpen: jest.fn(),
+      pageType: 'chat' as const,
+    }
+    const { rerender } = render(<TaskSidebar {...sidebarProps} />)
+
+    const groupDock = screen.getAllByTestId('task-sidebar-group-chat-dock')[0]
+    fireEvent.click(within(groupDock).getByTestId('task-sidebar-group-chat-toggle'))
+
+    expect(loadAllGroupTasks).toHaveBeenCalledTimes(1)
+
+    Object.assign(mockTaskContext, {
+      groupTasks: [],
+      hasMoreGroupTasks: false,
+    })
+    rerender(<TaskSidebar {...sidebarProps} />)
+
+    const updatedGroupDock = screen.getAllByTestId('task-sidebar-group-chat-dock')[0]
+    expect(
+      within(updatedGroupDock).getByTestId('task-sidebar-group-chat-toggle')
+    ).toBeInTheDocument()
+    expect(within(updatedGroupDock).getByText('common:tasks.no_group_chats')).toBeInTheDocument()
+  })
+
   it('renders personal history as a flat list', () => {
     const agentTask = createTask({ id: 1, title: 'Agent conversation' })
     const deviceTask = createTask({ id: 2, title: 'Device conversation' })

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+
+import { modelApis } from '@/apis/models'
+import {
+  DEFAULT_MODEL_NAME,
+  useModelSelection,
+  type Model,
+  type TeamWithBotDetails,
+} from '@/features/tasks/hooks/useModelSelection'
+
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? _key
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: mockTranslate,
+  }),
+}))
+
+jest.mock('@/apis/models', () => ({
+  modelApis: {
+    getUnifiedModels: jest.fn(),
+  },
+}))
+
+jest.mock('@/features/settings/services/bots', () => ({
+  isPredefinedModel: jest.fn(() => false),
+  getModelFromConfig: jest.fn(() => null),
+  getAllowedModelsFromConfig: jest.fn(() => []),
+}))
+
+jest.mock('@/utils/modelCompatibility', () => ({
+  getCompatibleProviderFromAgentType: jest.fn(() => null),
+}))
+
+jest.mock('@/utils/modelPreferences', () => ({
+  getGlobalModelPreference: jest.fn(() => null),
+  saveGlobalModelPreference: jest.fn(),
+}))
+
+const mockModel: Model = {
+  name: 'claude-3-5-sonnet',
+  displayName: 'Claude 3.5 Sonnet',
+  provider: 'anthropic',
+  modelId: 'claude-3-5-sonnet-20241022',
+  type: 'public',
+}
+
+const mockTeam: TeamWithBotDetails = {
+  id: 1,
+  name: 'chat-team',
+  namespace: 'default',
+  display_name: 'Chat Team',
+  description: '',
+  icon: '',
+  agent_type: 'chat',
+  is_mix_team: false,
+  bots: [],
+} as TeamWithBotDetails
+
+function mockDeferredModelLoad() {
+  let resolveModels!: (value: { data: Model[] }) => void
+  const promise = new Promise<{ data: Model[] }>(resolve => {
+    resolveModels = resolve
+  })
+  ;(modelApis.getUnifiedModels as jest.Mock).mockReturnValue(promise)
+  return {
+    async resolve() {
+      await act(async () => {
+        resolveModels({ data: [mockModel] })
+        await promise
+      })
+    },
+  }
+}
+
+async function renderModelSelectionHook() {
+  const modelLoad = mockDeferredModelLoad()
+  const hook = renderHook(() =>
+    useModelSelection({
+      teamId: 1,
+      taskId: null,
+      selectedTeam: mockTeam,
+    })
+  )
+
+  await modelLoad.resolve()
+
+  await waitFor(() => {
+    expect(hook.result.current.models).toHaveLength(1)
+    expect(hook.result.current.isLoading).toBe(false)
+  })
+
+  return hook
+}
+
+describe('useModelSelection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('selects concrete models as force override without showing override text', async () => {
+    const { result } = await renderModelSelectionHook()
+
+    act(() => {
+      result.current.selectModel(mockModel)
+    })
+
+    expect(result.current.forceOverride).toBe(true)
+    expect(result.current.getDisplayText()).toBe('Claude 3.5 Sonnet')
+  })
+
+  it('does not force override when selecting the default model', async () => {
+    const { result } = await renderModelSelectionHook()
+
+    act(() => {
+      result.current.selectModel({
+        name: DEFAULT_MODEL_NAME,
+        provider: '',
+        modelId: '',
+      })
+    })
+
+    expect(result.current.forceOverride).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -53,13 +53,18 @@ const mockTeam: TeamWithBotDetails = {
   id: 1,
   name: 'chat-team',
   namespace: 'default',
-  display_name: 'Chat Team',
+  displayName: 'Chat Team',
   description: '',
   icon: '',
   agent_type: 'chat',
   is_mix_team: false,
+  workflow: {},
+  is_active: true,
+  user_id: 1,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
   bots: [],
-} as TeamWithBotDetails
+}
 
 function mockDeferredModelLoad() {
   let resolveModels!: (value: { data: Model[] }) => void

--- a/frontend/src/__tests__/features/tasks/service/messageService.test.ts
+++ b/frontend/src/__tests__/features/tasks/service/messageService.test.ts
@@ -2,8 +2,34 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { canUseChatContexts } from '@/features/tasks/service/messageService'
+import {
+  canSwitchModelAfterMessages,
+  canUseChatContexts,
+} from '@/features/tasks/service/messageService'
 import type { Team } from '@/types/api'
+
+function createTeam(agentType: string, shellType?: string): Team {
+  return {
+    id: 1,
+    name: `${agentType} Team`,
+    description: '',
+    bots: shellType
+      ? [
+          {
+            bot_id: 1,
+            bot_prompt: '',
+            bot: { shell_type: shellType },
+          },
+        ]
+      : [],
+    workflow: {},
+    is_active: true,
+    user_id: 1,
+    created_at: '',
+    updated_at: '',
+    agent_type: agentType,
+  }
+}
 
 describe('messageService canUseChatContexts', () => {
   it('returns true for device task mode without requiring a chat shell team', () => {
@@ -29,5 +55,23 @@ describe('messageService canUseChatContexts', () => {
     } satisfies Team
 
     expect(canUseChatContexts('chat', team)).toBe(true)
+  })
+})
+
+describe('messageService canSwitchModelAfterMessages', () => {
+  it('allows chat shell teams to switch models after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('chat'))).toBe(true)
+  })
+
+  it('allows ClaudeCode teams to switch models after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('ClaudeCode'))).toBe(true)
+  })
+
+  it('allows ClaudeCode teams detected from bot shell type', () => {
+    expect(canSwitchModelAfterMessages(createTeam('', 'ClaudeCode'))).toBe(true)
+  })
+
+  it('keeps unknown shells disabled after messages exist', () => {
+    expect(canSwitchModelAfterMessages(createTeam('Dify'))).toBe(false)
   })
 })

--- a/frontend/src/features/inbox/components/QueueEditDialog.tsx
+++ b/frontend/src/features/inbox/components/QueueEditDialog.tsx
@@ -328,7 +328,7 @@ export function QueueEditDialog({ queue, open, onOpenChange }: QueueEditDialogPr
             namespace: selectedModel.namespace || 'default',
             name: selectedModel.name,
           }
-          shouldForceOverrideBotModel = forceOverrideBotModel
+          shouldForceOverrideBotModel = true
         }
       }
     }

--- a/frontend/src/features/knowledge/document/components/CreateGroupChatFromKnowledgeDialog.tsx
+++ b/frontend/src/features/knowledge/document/components/CreateGroupChatFromKnowledgeDialog.tsx
@@ -28,7 +28,7 @@ import { useToast } from '@/hooks/use-toast'
 import { useTeamContext } from '@/contexts/TeamContext'
 import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContext'
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
-import { ModelSelector, type Model } from '@/features/tasks/components/selector'
+import { DEFAULT_MODEL_NAME, ModelSelector, type Model } from '@/features/tasks/components/selector'
 import { useUser } from '@/features/common/UserContext'
 import { listGroupMembers } from '@/apis/groups'
 import { taskMemberApi } from '@/apis/task-member'
@@ -74,7 +74,6 @@ export function CreateGroupChatFromKnowledgeDialog({
   const [title, setTitle] = useState(defaultTitle)
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')
   const [selectedModel, setSelectedModel] = useState<Model | null>(null)
-  const [forceOverride, setForceOverride] = useState(false)
   const [isCreating, setIsCreating] = useState(false)
 
   const { teams, isTeamsLoading } = useTeamContext()
@@ -154,7 +153,6 @@ export function CreateGroupChatFromKnowledgeDialog({
     setTitle(defaultTitle)
     setSelectedTeamId('')
     setSelectedModel(null)
-    setForceOverride(false)
     setIsCreating(false)
   }
 
@@ -178,8 +176,12 @@ export function CreateGroupChatFromKnowledgeDialog({
           task_id: undefined,
           title: title,
           model_id:
-            selectedModel?.name === '__default__' ? undefined : selectedModel?.name || undefined,
-          force_override_bot_model: forceOverride,
+            selectedModel?.name === DEFAULT_MODEL_NAME
+              ? undefined
+              : selectedModel?.name || undefined,
+          force_override_bot_model: Boolean(
+            selectedModel && selectedModel.name !== DEFAULT_MODEL_NAME
+          ),
           is_group_chat: true,
         },
         {
@@ -352,8 +354,6 @@ export function CreateGroupChatFromKnowledgeDialog({
               <ModelSelector
                 selectedModel={selectedModel}
                 setSelectedModel={setSelectedModel}
-                forceOverride={forceOverride}
-                setForceOverride={setForceOverride}
                 selectedTeam={selectedTeam}
                 disabled={isCreating}
                 isLoading={false}

--- a/frontend/src/features/settings/components/team-edit/ExecutorModeSelector.tsx
+++ b/frontend/src/features/settings/components/team-edit/ExecutorModeSelector.tsx
@@ -58,6 +58,8 @@ export default function ExecutorModeSelector({
 }: ExecutorModeSelectorProps) {
   const { t } = useTranslation()
   const customShells = getCustomShells(shells)
+  const hasCustomShells = customShells.length > 0
+  const selectedCustomShellName = hasCustomShells ? customShellName : ''
 
   return (
     <section className="space-y-2">
@@ -107,23 +109,42 @@ export default function ExecutorModeSelector({
       {helperText && <p className="text-xs text-text-secondary">{helperText}</p>}
 
       {value === 'custom' && (
-        <Select value={customShellName} onValueChange={onCustomShellChange}>
-          <SelectTrigger className="bg-base">
-            <SelectValue
-              placeholder={t('settings:team.simple.executor.custom_shell_placeholder')}
-            />
-          </SelectTrigger>
-          <SelectContent>
-            {customShells.map(shell => (
-              <SelectItem
-                key={`${shell.type}-${shell.namespace || 'default'}-${shell.name}`}
-                value={shell.name}
-              >
-                {shell.displayName || shell.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <div className="space-y-1.5">
+          <Select value={selectedCustomShellName} onValueChange={onCustomShellChange}>
+            <SelectTrigger className="bg-base">
+              <SelectValue
+                placeholder={t(
+                  hasCustomShells
+                    ? 'settings:team.simple.executor.custom_shell_placeholder'
+                    : 'settings:team.simple.executor.no_custom_shells'
+                )}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {hasCustomShells ? (
+                customShells.map(shell => (
+                  <SelectItem
+                    key={`${shell.type}-${shell.namespace || 'default'}-${shell.name}`}
+                    value={shell.name}
+                  >
+                    {shell.displayName || shell.name}
+                  </SelectItem>
+                ))
+              ) : (
+                <SelectItem value="__no_custom_shells__" disabled>
+                  <span className="text-text-muted">
+                    {t('settings:team.simple.executor.no_custom_shells')}
+                  </span>
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+          {!hasCustomShells && (
+            <p className="text-xs leading-5 text-text-secondary">
+              {t('settings:team.simple.executor.manage_custom_shells_hint')}
+            </p>
+          )}
+        </div>
       )}
     </section>
   )

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -207,7 +207,6 @@ export interface GuidanceMessagePreview {
 export function useChatStreamHandlers({
   selectedTeam,
   selectedModel,
-  forceOverride,
   setSelectedModel,
   setForceOverride,
   selectedRepo,
@@ -684,7 +683,7 @@ export function useChatStreamHandlers({
         team_id: selectedTeam?.id ?? 0,
         task_id: selectedTaskDetail?.id,
         model_id: modelId,
-        force_override_bot_model: forceOverride,
+        force_override_bot_model: Boolean(modelId),
         force_override_bot_model_type: selectedModel?.type,
         attachment_ids: [...snapshotAttachments.map(a => a.id), ...queueAttachmentIds],
         enable_deep_thinking: enableDeepThinking,
@@ -779,7 +778,6 @@ export function useChatStreamHandlers({
       t,
       selectedTeam?.id,
       selectedTaskDetail,
-      forceOverride,
       enableDeepThinking,
       enableClarification,
       showRepositorySelector,
@@ -1539,7 +1537,7 @@ export function useChatStreamHandlers({
               message.subtaskId!,
               modelId,
               modelType,
-              forceOverride
+              Boolean(modelId)
             )
 
             if (result.error) {
@@ -1568,7 +1566,7 @@ export function useChatStreamHandlers({
         }
       )
     },
-    [retryMessage, selectedTaskDetail?.id, selectedModel, forceOverride, t, toast, traceAction]
+    [retryMessage, selectedTaskDetail?.id, selectedModel, t, toast, traceAction]
   )
 
   // Handle retry with a specific model (from error card recommendation)

--- a/frontend/src/features/tasks/components/group-chat/CreateGroupChatDialog.tsx
+++ b/frontend/src/features/tasks/components/group-chat/CreateGroupChatDialog.tsx
@@ -29,7 +29,7 @@ import {
 import { useTeamContext } from '@/contexts/TeamContext'
 import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContext'
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
-import { ModelSelector, type Model } from '@/features/tasks/components/selector'
+import { DEFAULT_MODEL_NAME, ModelSelector, type Model } from '@/features/tasks/components/selector'
 import { useUser } from '@/features/common/UserContext'
 
 interface CreateGroupChatDialogProps {
@@ -45,7 +45,6 @@ export function CreateGroupChatDialog({ open, onOpenChange }: CreateGroupChatDia
   const [selectedTeamId, setSelectedTeamId] = useState<string>('')
   const [isCreating, setIsCreating] = useState(false)
   const [selectedModel, setSelectedModel] = useState<Model | null>(null)
-  const [forceOverride, setForceOverride] = useState(false)
 
   const { teams, isTeamsLoading } = useTeamContext()
   const { sendMessage } = useChatStreamContext()
@@ -101,8 +100,12 @@ export function CreateGroupChatDialog({ open, onOpenChange }: CreateGroupChatDia
           task_id: undefined, // Let streaming API create the task
           title: title, // Pass custom title for the group chat
           model_id:
-            selectedModel?.name === '__default__' ? undefined : selectedModel?.name || undefined,
-          force_override_bot_model: forceOverride,
+            selectedModel?.name === DEFAULT_MODEL_NAME
+              ? undefined
+              : selectedModel?.name || undefined,
+          force_override_bot_model: Boolean(
+            selectedModel && selectedModel.name !== DEFAULT_MODEL_NAME
+          ),
           is_group_chat: true, // Mark this as a group chat
         },
         {
@@ -121,7 +124,6 @@ export function CreateGroupChatDialog({ open, onOpenChange }: CreateGroupChatDia
             setTitle('')
             setSelectedTeamId('')
             setSelectedModel(null)
-            setForceOverride(false)
             setIsCreating(false)
 
             // Refresh task list to show the new group chat
@@ -219,8 +221,6 @@ export function CreateGroupChatDialog({ open, onOpenChange }: CreateGroupChatDia
               <ModelSelector
                 selectedModel={selectedModel}
                 setSelectedModel={setSelectedModel}
-                forceOverride={forceOverride}
-                setForceOverride={setForceOverride}
                 selectedTeam={selectedTeam}
                 disabled={isCreating}
                 isLoading={false}

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -24,7 +24,11 @@ import type {
 } from '@/types/api'
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
-import { canUseChatContexts, isChatShell } from '../../service/messageService'
+import {
+  canSwitchModelAfterMessages,
+  canUseChatContexts,
+  isChatShell,
+} from '../../service/messageService'
 import { supportsAttachments } from '../../service/attachmentService'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { MobileChatInputControls } from './MobileChatInputControls'
@@ -628,7 +632,11 @@ export function ChatInputControls({
                 forceOverride={forceOverride}
                 setForceOverride={setForceOverride}
                 selectedTeam={selectedTeam}
-                disabled={isLoading || isStreaming || (hasMessages && !isChatShell(selectedTeam))}
+                disabled={
+                  isLoading ||
+                  isStreaming ||
+                  (hasMessages && !canSwitchModelAfterMessages(selectedTeam))
+                }
                 compact={shouldCollapseSelectors}
                 teamId={teamId}
                 taskId={taskId}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -29,6 +29,7 @@ import type {
 import type { ContextItem } from '@/types/context'
 import type { UnifiedSkill } from '@/apis/skills'
 import {
+  canSwitchModelAfterMessages,
   canUseChatContexts,
   isChatShell,
   teamRequiresWorkspace,
@@ -453,7 +454,11 @@ export function MobileChatInputControls({
               forceOverride={forceOverride}
               setForceOverride={setForceOverride}
               selectedTeam={selectedTeam}
-              disabled={isLoading || isStreaming || (hasMessages && !isChatShell(selectedTeam))}
+              disabled={
+                isLoading ||
+                isStreaming ||
+                (hasMessages && !canSwitchModelAfterMessages(selectedTeam))
+              }
               teamId={teamId}
               taskId={taskId}
               taskModelId={taskModelId}

--- a/frontend/src/features/tasks/components/selector/MobileModelSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/MobileModelSelector.tsx
@@ -10,7 +10,6 @@ import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import { paths } from '@/config/paths'
-import { Switch } from '@/components/ui/switch'
 import { Tag } from '@/components/ui/tag'
 import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
 import { useModelSelection } from '@/features/tasks/hooks/useModelSelection'
@@ -31,8 +30,8 @@ function getModelKey(model: Model): string {
 interface MobileModelSelectorProps {
   selectedModel: Model | null
   setSelectedModel: (model: Model | null) => void
-  forceOverride: boolean
-  setForceOverride: (force: boolean) => void
+  forceOverride?: boolean
+  setForceOverride?: (force: boolean) => void
   selectedTeam: Team | null
   disabled: boolean
   isLoading?: boolean
@@ -48,8 +47,8 @@ interface MobileModelSelectorProps {
 export default function MobileModelSelector({
   selectedModel: externalSelectedModel,
   setSelectedModel: externalSetSelectedModel,
-  forceOverride: externalForceOverride,
-  setForceOverride: externalSetForceOverride,
+  forceOverride: externalForceOverride = false,
+  setForceOverride: externalSetForceOverride = () => {},
   selectedTeam,
   disabled,
   isLoading: externalLoading,
@@ -138,9 +137,7 @@ export default function MobileModelSelector({
             'disabled:cursor-not-allowed disabled:opacity-50'
           )}
         >
-          <span className="flex-1 truncate text-xs min-w-0">
-            {modelSelection.getDisplayText()}
-          </span>
+          <span className="flex-1 truncate text-xs min-w-0">{modelSelection.getDisplayText()}</span>
         </button>
       </DrawerTrigger>
 
@@ -264,30 +261,8 @@ export default function MobileModelSelector({
         {/* Footer - compact single row */}
         {!isSearchFocused && (
           <div className="px-4 pb-4 pt-2">
-            <div className="flex items-center justify-between">
-              {/* Override toggle - left */}
-              {modelSelection.selectedModel && !modelSelection.isMixedTeam ? (
-                <button
-                  type="button"
-                  onClick={() => modelSelection.setForceOverride(!modelSelection.forceOverride)}
-                  className="flex items-center gap-2 active:opacity-70"
-                >
-                  <Switch
-                    checked={modelSelection.forceOverride}
-                    onCheckedChange={modelSelection.setForceOverride}
-                    disabled={disabled || externalLoading}
-                    onClick={e => e.stopPropagation()}
-                    className="scale-90"
-                  />
-                  <span className="text-[13px] text-[#8e8e93]">
-                    {t('common:task_submit.override_default_model', '覆盖默认')}
-                  </span>
-                </button>
-              ) : (
-                <div />
-              )}
-
-              {/* Settings link - right */}
+            <div className="flex items-center justify-end">
+              {/* Settings link */}
               <button
                 type="button"
                 onClick={() => {

--- a/frontend/src/features/tasks/components/selector/ModelSelector.tsx
+++ b/frontend/src/features/tasks/components/selector/ModelSelector.tsx
@@ -75,8 +75,8 @@ export interface TeamWithBotDetails extends Team {
 export interface ModelSelectorProps {
   selectedModel: Model | null
   setSelectedModel: (model: Model | null) => void
-  forceOverride: boolean
-  setForceOverride: (force: boolean) => void
+  forceOverride?: boolean
+  setForceOverride?: (force: boolean) => void
   selectedTeam: TeamWithBotDetails | null
   disabled: boolean
   isLoading?: boolean
@@ -120,8 +120,8 @@ function getModelSyncKey(model: Model | null): string | null {
 export default function ModelSelector({
   selectedModel: externalSelectedModel,
   setSelectedModel: externalSetSelectedModel,
-  forceOverride: externalForceOverride,
-  setForceOverride: externalSetForceOverride,
+  forceOverride: externalForceOverride = false,
+  setForceOverride: externalSetForceOverride = () => {},
   selectedTeam,
   disabled,
   isLoading: externalLoading,
@@ -147,6 +147,12 @@ export default function ModelSelector({
     disabled,
     modelCategoryType,
   })
+  const {
+    selectedModel: internalSelectedModel,
+    forceOverride: internalForceOverride,
+    selectModel: selectInternalModel,
+    setForceOverride: setInternalForceOverride,
+  } = modelSelection
 
   // Get icon based on model category type
   const IconComponent = useMemo(() => {
@@ -160,7 +166,7 @@ export default function ModelSelector({
     }
   }, [modelCategoryType])
 
-  const internalModelKey = getModelSyncKey(modelSelection.selectedModel)
+  const internalModelKey = getModelSyncKey(internalSelectedModel)
 
   // Sync selected model between external props and internal hook state.
   // Only the side that changed in this render cycle is allowed to drive the other side,
@@ -185,32 +191,28 @@ export default function ModelSelector({
 
     if (externalModelChanged) {
       if (externalSelectedModel && externalModelKey !== internalModelKey) {
-        modelSelection.selectModel(externalSelectedModel)
+        selectInternalModel(externalSelectedModel)
       } else if (!externalSelectedModel && previousExternalModelKey !== null && internalModelKey) {
-        modelSelection.selectModel(null)
+        selectInternalModel(null)
       }
       return
     }
 
-    if (
-      internalModelChanged &&
-      modelSelection.selectedModel &&
-      internalModelKey !== externalModelKey
-    ) {
-      externalSetSelectedModel(modelSelection.selectedModel)
+    if (internalModelChanged && internalSelectedModel && internalModelKey !== externalModelKey) {
+      externalSetSelectedModel(internalSelectedModel)
     }
   }, [
     externalModelKey,
     externalSelectedModel,
     internalModelKey,
-    modelSelection.selectedModel,
-    modelSelection.selectModel,
+    internalSelectedModel,
+    selectInternalModel,
     externalSetSelectedModel,
   ])
 
   // Apply the same one-direction-per-change rule for forceOverride to avoid update loops.
   const prevExternalForceOverrideRef = React.useRef(externalForceOverride)
-  const prevInternalForceOverrideRef = React.useRef(modelSelection.forceOverride)
+  const prevInternalForceOverrideRef = React.useRef(internalForceOverride)
   const hasSyncedForceOverrideRef = React.useRef(false)
 
   useEffect(() => {
@@ -220,27 +222,27 @@ export default function ModelSelector({
       ? previousExternalForceOverride !== externalForceOverride
       : externalForceOverride
     const internalForceOverrideChanged = hasSyncedForceOverrideRef.current
-      ? previousInternalForceOverride !== modelSelection.forceOverride
+      ? previousInternalForceOverride !== internalForceOverride
       : false
 
     prevExternalForceOverrideRef.current = externalForceOverride
-    prevInternalForceOverrideRef.current = modelSelection.forceOverride
+    prevInternalForceOverrideRef.current = internalForceOverride
     hasSyncedForceOverrideRef.current = true
 
     if (externalForceOverrideChanged) {
-      if (externalForceOverride !== modelSelection.forceOverride) {
-        modelSelection.setForceOverride(externalForceOverride)
+      if (externalForceOverride !== internalForceOverride) {
+        setInternalForceOverride(externalForceOverride)
       }
       return
     }
 
-    if (internalForceOverrideChanged && modelSelection.forceOverride !== externalForceOverride) {
-      externalSetForceOverride(modelSelection.forceOverride)
+    if (internalForceOverrideChanged && internalForceOverride !== externalForceOverride) {
+      externalSetForceOverride(internalForceOverride)
     }
   }, [
     externalForceOverride,
-    modelSelection.forceOverride,
-    modelSelection.setForceOverride,
+    internalForceOverride,
+    setInternalForceOverride,
     externalSetForceOverride,
   ])
 
@@ -294,11 +296,6 @@ export default function ModelSelector({
   const handleModelSelect = (value: string) => {
     modelSelection.selectModelByKey(value)
     setIsOpen(false)
-  }
-
-  // Handle force override checkbox
-  const handleForceOverrideChange = (checked: boolean | 'indeterminate') => {
-    modelSelection.setForceOverride(checked === true)
   }
 
   // Tooltip content for model selector
@@ -491,29 +488,8 @@ export default function ModelSelector({
                 </>
               )}
             </CommandList>
-            {/* Footer options - override and settings */}
+            {/* Footer options - advanced models and settings */}
             <div className="border-t border-border">
-              {/* Force override checkbox - always show when model is selected */}
-              {modelSelection.selectedModel && !modelSelection.isMixedTeam && (
-                <div
-                  className="flex items-center gap-2 px-3 py-2.5 cursor-pointer hover:bg-hover transition-colors duration-150"
-                  onClick={e => {
-                    e.stopPropagation()
-                    handleForceOverrideChange(!modelSelection.forceOverride)
-                  }}
-                >
-                  <Checkbox
-                    id="force-override-model-dropdown"
-                    checked={modelSelection.forceOverride}
-                    onCheckedChange={handleForceOverrideChange}
-                    disabled={disabled || externalLoading}
-                    className="h-4 w-4"
-                  />
-                  <span className="text-xs text-text-secondary">
-                    {t('common:task_submit.override_default_model', '覆盖默认模型')}
-                  </span>
-                </div>
-              )}
               {/* Show advanced models checkbox */}
               {modelSelection.hasAdvancedModels && (
                 <div

--- a/frontend/src/features/tasks/components/share/TaskShareHandler.tsx
+++ b/frontend/src/features/tasks/components/share/TaskShareHandler.tsx
@@ -58,7 +58,6 @@ export default function TaskShareHandler({ onTaskCopied }: TaskShareHandlerProps
   const [teams, setTeams] = useState<Team[]>([])
   const [selectedTeamId, setSelectedTeamId] = useState<number | null>(null)
   const [selectedModel, setSelectedModel] = useState<Model | null>(null)
-  const [forceOverride, setForceOverride] = useState(false)
   const [isTeamSelectorOpen, setIsTeamSelectorOpen] = useState(false)
   const [teamSearchValue, setTeamSearchValue] = useState('')
   // Repository and branch selection for code tasks
@@ -251,7 +250,7 @@ export default function TaskShareHandler({ onTaskCopied }: TaskShareHandlerProps
         share_token: shareToken,
         team_id: selectedTeamId,
         model_id: modelId,
-        force_override_bot_model: forceOverride,
+        force_override_bot_model: Boolean(modelId),
         force_override_bot_model_type: selectedModel?.type,
         git_repo_id: selectedRepo?.git_repo_id,
         git_url: selectedRepo?.git_url,
@@ -357,6 +356,7 @@ export default function TaskShareHandler({ onTaskCopied }: TaskShareHandlerProps
                   <button
                     type="button"
                     role="combobox"
+                    aria-controls="shared-task-team-selector-popover"
                     aria-expanded={isTeamSelectorOpen}
                     disabled={isCopying || teams.length === 0}
                     className={cn(
@@ -389,6 +389,7 @@ export default function TaskShareHandler({ onTaskCopied }: TaskShareHandlerProps
                 </PopoverTrigger>
 
                 <PopoverContent
+                  id="shared-task-team-selector-popover"
                   className={cn(
                     'p-0 w-[var(--radix-popover-trigger-width)] border border-border bg-background',
                     'shadow-lg rounded-md overflow-hidden'
@@ -460,8 +461,6 @@ export default function TaskShareHandler({ onTaskCopied }: TaskShareHandlerProps
                 selectedTeam={selectedTeam}
                 selectedModel={selectedModel}
                 setSelectedModel={setSelectedModel}
-                forceOverride={forceOverride}
-                setForceOverride={setForceOverride}
                 disabled={isCopying}
               />
             )}

--- a/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -40,6 +40,7 @@ export default function FixedGroupChatsSection({
 }: FixedGroupChatsSectionProps) {
   const { t } = useTranslation()
   const { projectTaskIds } = useProjectContext()
+  const [hasOpenedGroupChats, setHasOpenedGroupChats] = useState(false)
 
   const filteredGroupTasks = useMemo(
     () => groupTasks.filter(task => !projectTaskIds.has(task.id)),
@@ -51,7 +52,7 @@ export default function FixedGroupChatsSection({
   const orderedGroupChats = [...unreadGroupChats, ...readGroupChats]
   const collapsedGroupChatCount = orderedGroupChats.length
   const shouldShowGroupChats =
-    orderedGroupChats.length > 0 || hasMoreGroupTasks || isGroupChatsExpanded
+    orderedGroupChats.length > 0 || hasMoreGroupTasks || isGroupChatsExpanded || hasOpenedGroupChats
   const shouldShowEmptyState =
     isGroupChatsExpanded && orderedGroupChats.length === 0 && !loadingMoreGroupTasks
 
@@ -65,10 +66,14 @@ export default function FixedGroupChatsSection({
       })
 
   const handleToggleGroupChats = () => {
-    if (!isGroupChatsExpanded && hasMoreGroupTasks) {
-      void loadAllGroupTasks()
+    const nextExpanded = !isGroupChatsExpanded
+    if (nextExpanded) {
+      setHasOpenedGroupChats(true)
+      if (hasMoreGroupTasks) {
+        void loadAllGroupTasks()
+      }
     }
-    setIsGroupChatsExpanded(!isGroupChatsExpanded)
+    setIsGroupChatsExpanded(nextExpanded)
   }
 
   return (

--- a/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
@@ -50,7 +50,10 @@ export default function FixedGroupChatsSection({
   const readGroupChats = filteredGroupTasks.filter(task => !isTaskUnread(task))
   const orderedGroupChats = [...unreadGroupChats, ...readGroupChats]
   const collapsedGroupChatCount = orderedGroupChats.length
-  const shouldShowGroupChats = orderedGroupChats.length > 0 || hasMoreGroupTasks
+  const shouldShowGroupChats =
+    orderedGroupChats.length > 0 || hasMoreGroupTasks || isGroupChatsExpanded
+  const shouldShowEmptyState =
+    isGroupChatsExpanded && orderedGroupChats.length === 0 && !loadingMoreGroupTasks
 
   if (!shouldShowGroupChats) return null
 
@@ -107,6 +110,11 @@ export default function FixedGroupChatsSection({
                 enableDrag={true}
                 key={`group-chats-${viewStatusVersion}`}
               />
+            </div>
+          )}
+          {shouldShowEmptyState && (
+            <div className="px-1 py-2 text-xs text-text-muted">
+              {t('common:tasks.no_group_chats')}
             </div>
           )}
         </>

--- a/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
+++ b/frontend/src/features/tasks/components/sidebar/FixedGroupChatsSection.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -40,7 +40,6 @@ export default function FixedGroupChatsSection({
 }: FixedGroupChatsSectionProps) {
   const { t } = useTranslation()
   const { projectTaskIds } = useProjectContext()
-  const [hasOpenedGroupChats, setHasOpenedGroupChats] = useState(false)
 
   const filteredGroupTasks = useMemo(
     () => groupTasks.filter(task => !projectTaskIds.has(task.id)),
@@ -51,12 +50,8 @@ export default function FixedGroupChatsSection({
   const readGroupChats = filteredGroupTasks.filter(task => !isTaskUnread(task))
   const orderedGroupChats = [...unreadGroupChats, ...readGroupChats]
   const collapsedGroupChatCount = orderedGroupChats.length
-  const shouldShowGroupChats =
-    orderedGroupChats.length > 0 || hasMoreGroupTasks || isGroupChatsExpanded || hasOpenedGroupChats
   const shouldShowEmptyState =
     isGroupChatsExpanded && orderedGroupChats.length === 0 && !loadingMoreGroupTasks
-
-  if (!shouldShowGroupChats) return null
 
   const toggleLabel = isGroupChatsExpanded
     ? t('common:tasks.group_chats_collapse')
@@ -67,11 +62,8 @@ export default function FixedGroupChatsSection({
 
   const handleToggleGroupChats = () => {
     const nextExpanded = !isGroupChatsExpanded
-    if (nextExpanded) {
-      setHasOpenedGroupChats(true)
-      if (hasMoreGroupTasks) {
-        void loadAllGroupTasks()
-      }
+    if (nextExpanded && hasMoreGroupTasks) {
+      void loadAllGroupTasks()
     }
     setIsGroupChatsExpanded(nextExpanded)
   }

--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -328,7 +328,7 @@ export default function TaskSidebar({
               variant="ghost"
               onClick={() => handleNavigationClick(btn.path, btn.isActive, btn.buttonPageType)}
               data-testid={btn.testId ?? `task-sidebar-nav-${btn.buttonPageType}-button`}
-              className={`w-full justify-between px-3 h-11 min-w-[44px] text-sm rounded-md transition-all duration-200 ${
+              className={`w-full justify-between px-3 h-11 min-w-[44px] text-sm rounded-md transition-all duration-200 lg:h-10 ${
                 btn.isActive
                   ? 'bg-primary/10 text-primary font-medium hover:bg-primary/15'
                   : 'text-text-primary hover:bg-[rgb(238,238,238)] dark:hover:bg-white/10 hover:scale-[1.02]'
@@ -365,7 +365,7 @@ export default function TaskSidebar({
                           e.stopPropagation()
                           handleNavigationClick(btn.path, btn.isActive, btn.buttonPageType)
                         }}
-                        className="flex h-11 min-w-[44px] items-center gap-1 px-2 text-xs bg-primary text-white rounded-md hover:bg-primary/90 transition-colors"
+                        className="flex h-11 min-w-[44px] items-center gap-1 px-2 text-xs bg-primary text-white rounded-md hover:bg-primary/90 transition-colors lg:h-10"
                       >
                         <Plus className="h-3 w-3" />
                         <span>{t('common:tasks.new_task')}</span>
@@ -408,7 +408,7 @@ export default function TaskSidebar({
               variant="ghost"
               data-testid="task-sidebar-more-button"
               onFocus={() => openMoreNavigation(menuId)}
-              className={`w-full justify-between px-3 h-11 min-w-[44px] text-sm rounded-md transition-all duration-200 ${
+              className={`w-full justify-between px-3 h-11 min-w-[44px] text-sm rounded-md transition-all duration-200 lg:h-10 ${
                 hasActiveItem
                   ? 'bg-primary/10 text-primary font-medium hover:bg-primary/15'
                   : 'text-text-primary hover:bg-[rgb(238,238,238)] dark:hover:bg-white/10 hover:scale-[1.02]'
@@ -455,7 +455,7 @@ export default function TaskSidebar({
             <DropdownMenuItem
               key={btn.path}
               data-testid={`task-sidebar-more-${btn.buttonPageType}-button`}
-              className={`h-11 min-w-[44px] gap-2 px-2 text-sm ${
+              className={`h-11 min-w-[44px] gap-2 px-2 text-sm lg:h-10 ${
                 btn.isActive
                   ? 'bg-primary/10 text-primary font-medium focus:bg-primary/15'
                   : 'text-text-primary focus:bg-[rgb(238,238,238)] dark:focus:bg-white/10'
@@ -507,7 +507,7 @@ export default function TaskSidebar({
           >
             {/* Logo and Mode Indicator - matches Figma: left-[20px] top-[12px] */}
             <div
-              className={`${isCollapsed ? 'px-2' : 'px-5'} pt-2 pb-3`}
+              className={`${isCollapsed ? 'px-2' : 'px-5'} pt-2 pb-1.5`}
               data-testid="task-sidebar-logo-section"
             >
               {isCollapsed ? (
@@ -561,7 +561,7 @@ export default function TaskSidebar({
                             size="icon"
                             onClick={onToggleCollapsed}
                             data-testid="collapse-sidebar-button"
-                            className="h-11 min-w-[44px] w-11 p-0 text-text-muted hover:text-text-primary hover:bg-hover rounded-lg"
+                            className="h-11 min-w-[44px] w-11 p-0 text-text-muted hover:text-text-primary hover:bg-hover rounded-lg lg:h-10 lg:w-10 lg:min-w-10"
                             aria-label={t('common:sidebar.collapse')}
                           >
                             <PanelLeftClose className="h-4 w-4" />
@@ -585,7 +585,7 @@ export default function TaskSidebar({
                     variant="ghost"
                     onClick={handleNewAgentClick}
                     data-testid="new-agent-button"
-                    className="w-full justify-between px-3 h-11 min-w-[44px] text-sm text-text-primary hover:bg-[rgb(238,238,238)] dark:hover:bg-white/10 rounded-md group transition-all duration-200 hover:scale-[1.02]"
+                    className="w-full justify-between px-3 h-11 min-w-[44px] text-sm text-text-primary hover:bg-[rgb(238,238,238)] dark:hover:bg-white/10 rounded-md group transition-all duration-200 hover:scale-[1.02] lg:h-10"
                     size="sm"
                   >
                     <span className="flex items-center">

--- a/frontend/src/features/tasks/hooks/useModelSelection.ts
+++ b/frontend/src/features/tasks/hooks/useModelSelection.ts
@@ -162,9 +162,7 @@ export function useModelSelection({
   teamId,
   taskId,
   taskModelId,
-  initialForceOverride,
   selectedTeam,
-  disabled = false,
   modelCategoryType = 'llm',
 }: UseModelSelectionOptions): UseModelSelectionReturn {
   const { t } = useTranslation()
@@ -297,15 +295,6 @@ export function useModelSelection({
   }, [fetchModels])
 
   // -------------------------------------------------------------------------
-  // Auto-enable force override when team has predefined models
-  // -------------------------------------------------------------------------
-  useEffect(() => {
-    if (showDefaultOption && !disabled) {
-      setForceOverrideState(true)
-    }
-  }, [showDefaultOption, disabled])
-
-  // -------------------------------------------------------------------------
   // Model Selection Logic (Simplified)
   // Priority: 1. taskModelId (from API) -> 2. team's bind_model -> 3. global preference
   // -------------------------------------------------------------------------
@@ -337,7 +326,7 @@ export function useModelSelection({
         const foundModel = models.find(m => m.name === taskModelId || m.displayName === taskModelId)
         if (foundModel) {
           restoredModel = foundModel
-          restoredForceOverride = initialForceOverride
+          restoredForceOverride = true
         }
       }
 
@@ -355,7 +344,7 @@ export function useModelSelection({
           })
           if (foundModel) {
             restoredModel = foundModel
-            restoredForceOverride = preference.forceOverride
+            restoredForceOverride = true
           }
         }
       }
@@ -418,7 +407,6 @@ export function useModelSelection({
     teamId,
     taskId,
     taskModelId,
-    initialForceOverride,
     compatibleProvider,
   ])
 
@@ -458,6 +446,7 @@ export function useModelSelection({
   /** Select a model directly */
   const selectModel = useCallback((model: Model | null) => {
     setSelectedModel(model)
+    setForceOverrideState(Boolean(model && model.name !== DEFAULT_MODEL_NAME))
   }, [])
 
   /** Select model by key (format: "modelName:modelType") */
@@ -466,6 +455,7 @@ export function useModelSelection({
       if (key === DEFAULT_MODEL_NAME) {
         const defaultModel = { name: DEFAULT_MODEL_NAME, provider: '', modelId: '' }
         setSelectedModel(defaultModel)
+        setForceOverrideState(false)
         return
       }
 
@@ -473,6 +463,7 @@ export function useModelSelection({
       const model = filteredModels.find(m => m.name === modelName && m.type === modelType)
       if (model) {
         setSelectedModel(model)
+        setForceOverrideState(true)
       }
     },
     [filteredModels]
@@ -482,6 +473,7 @@ export function useModelSelection({
   const selectDefaultModel = useCallback(() => {
     const defaultModel = { name: DEFAULT_MODEL_NAME, provider: '', modelId: '' }
     setSelectedModel(defaultModel)
+    setForceOverrideState(false)
   }, [])
 
   /** Set force override flag */
@@ -546,20 +538,8 @@ export function useModelSelection({
       }
       return t('common:task_submit.default_model', '默认')
     }
-    const displayText = getModelDisplayTextHelper(selectedModel)
-    if (forceOverride && !isMixedTeam) {
-      return `${displayText}(${t('common:task_submit.override_short', '覆盖')})`
-    }
-    return displayText
-  }, [
-    selectedModel,
-    isLoading,
-    isModelRequired,
-    forceOverride,
-    isMixedTeam,
-    getBoundModelDisplayNames,
-    t,
-  ])
+    return getModelDisplayTextHelper(selectedModel)
+  }, [selectedModel, isLoading, isModelRequired, getBoundModelDisplayNames, t])
 
   // -------------------------------------------------------------------------
   // Return

--- a/frontend/src/features/tasks/service/messageService.ts
+++ b/frontend/src/features/tasks/service/messageService.ts
@@ -172,7 +172,7 @@ export async function sendMessage(params: {
     user_id: 0,
     user_name: '',
     model_id: model_id,
-    force_override_bot_model: force_override_bot_model,
+    force_override_bot_model: Boolean(model_id) || force_override_bot_model,
   }
 
   try {

--- a/frontend/src/features/tasks/service/messageService.ts
+++ b/frontend/src/features/tasks/service/messageService.ts
@@ -77,6 +77,16 @@ export function isClaudeCode(team: Team | null): boolean {
 }
 
 /**
+ * Check whether the model selector should stay enabled after a task has messages.
+ *
+ * Chat Shell already supports per-message model switching. ClaudeCode receives the selected
+ * model through the existing task override path and executor model configuration.
+ */
+export function canSwitchModelAfterMessages(team: Team | null): boolean {
+  return isChatShell(team) || isClaudeCode(team)
+}
+
+/**
  * Check if a task uses Chat Shell type based on team information.
  * Now relies solely on team.agent_type since subtasks are managed by TaskStateMachine.
  *

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -607,6 +607,7 @@
     "new_task": "New Task",
     "new_conversation": "New Conversation",
     "no_tasks": "No tasks",
+    "no_group_chats": "No group chats",
     "unknown_agent": "Unknown agent",
     "unknown_device": "Unknown device",
     "today": "Today",

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -1209,10 +1209,7 @@
   "task_submit": {
     "select_model": "Select Model",
     "search_model": "Search model...",
-    "force_override_model": "Force override Bot's bound model",
-    "override_default_model": "Override default model",
     "show_advanced_models": "Show advanced models",
-    "override_short": "Override",
     "mixed_team_warning": "This team contains multiple executor types, cannot specify a unified model",
     "default_model": "Default",
     "use_bot_model": "Use Bot's predefined model",

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -158,7 +158,9 @@
         "title": "Executor",
         "required": "Choose an available executor",
         "requires_complex_hint": "Code and device modes need Claude Code capability, so the complex executor is preferred.",
-        "custom_shell_placeholder": "Choose custom Shell",
+        "custom_shell_placeholder": "Choose custom executor",
+        "no_custom_shells": "No custom executors available",
+        "manage_custom_shells_hint": "Manage custom executors in Resource Library - Executors.",
         "simple": {
           "title": "Simple",
           "description": "Uses the Chat executor for conversation and lightweight Q&A."
@@ -169,7 +171,7 @@
         },
         "custom": {
           "title": "Custom",
-          "description": "Uses a Shell you created for a specialized runtime."
+          "description": "Uses an executor you created for a specialized runtime."
         }
       }
     }

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -1209,10 +1209,7 @@
   "task_submit": {
     "select_model": "选择模型",
     "search_model": "搜索模型...",
-    "force_override_model": "覆盖默认模型",
-    "override_default_model": "覆盖默认模型",
     "show_advanced_models": "显示高级模型",
-    "override_short": "覆盖",
     "mixed_team_warning": "当前智能体包含多种执行器类型，无法统一指定模型",
     "default_model": "默认模型",
     "use_bot_model": "使用 Bot 预设模型",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -607,6 +607,7 @@
     "new_task": "新任务",
     "new_conversation": "新对话",
     "no_tasks": "没有任务",
+    "no_group_chats": "暂无群聊",
     "unknown_agent": "未知智能体",
     "unknown_device": "未知设备",
     "today": "今天",

--- a/frontend/src/i18n/locales/zh-CN/settings.json
+++ b/frontend/src/i18n/locales/zh-CN/settings.json
@@ -158,7 +158,9 @@
         "title": "执行器",
         "required": "请选择一个可用执行器",
         "requires_complex_hint": "编码和设备模式需要 Claude Code 能力，已优先使用复杂执行器。",
-        "custom_shell_placeholder": "选择自定义 Shell",
+        "custom_shell_placeholder": "选择自定义执行器",
+        "no_custom_shells": "暂无自定义执行器",
+        "manage_custom_shells_hint": "可前往资源库 - 执行器管理自定义执行器。",
         "simple": {
           "title": "简单",
           "description": "使用 Chat 执行器，适合对话和轻量问答。"
@@ -169,7 +171,7 @@
         },
         "custom": {
           "title": "自定义",
-          "description": "使用你创建的 Shell，适合特殊运行环境。"
+          "description": "使用你创建的执行器，适合特殊运行环境。"
         }
       }
     }


### PR DESCRIPTION
## Summary
- 调整后端任务/共享任务的模型覆盖逻辑与相关 schema，补齐 Claude Code 模型切换的数据流
- 更新前端模型选择、执行器模式、消息发送和共享/群聊入口的联动行为，确保不同入口下的模型状态一致
- 修复 sidebar 群聊空状态与折叠显示问题，并同步补充中英文文案
- 更新相关单测、e2e 和设计/实现文档，覆盖主要回归场景

## Testing
- 已补充并更新前端单测与后端 schema 测试，覆盖模型切换和群聊空状态回归
- 本地验证通过：相关 frontend 测试通过，lint/格式检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model switching enabled during ClaudeCode conversations; select a different model for continued execution.
  * Resource management (models, agents/teams, executors) consolidated in Resource Library; moved from Settings.

* **Improvements**
  * Model selection now automatically applies override behavior—no manual toggle needed when selecting non-default models.
  * Simplified model selector UI with streamlined controls and cleaner interactions.
  * Refined model availability based on conversation type for better user experience.

* **Documentation**
  * Added implementation and design specifications for mid-conversation model switching in ClaudeCode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->