### PR TITLE
fix(frontend): sandbox HTML artifacts

### DIFF
--- a/frontend/src/__tests__/components/common/EnhancedMarkdown.test.tsx
+++ b/frontend/src/__tests__/components/common/EnhancedMarkdown.test.tsx
@@ -5,6 +5,7 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
+import { SANDBOXED_HTML_SEND_TO_CHAT_EVENT } from '@/components/common/SandboxedHtmlFrame'
 
 jest.mock('next/dynamic', () => () => {
   const DynamicComponent = () => null
@@ -49,5 +50,55 @@ title: Test
     expect(screen.getByText('sidebar_position')).toBeInTheDocument()
     expect(screen.getByText('1')).toBeInTheDocument()
     expect(screen.getByText('# Body')).toBeInTheDocument()
+  })
+
+  it('renders artifact HTML in a sandboxed iframe instead of the host markdown tree', () => {
+    const onSendMessage = jest.fn()
+    const { container } = render(
+      <EnhancedMarkdown
+        theme="light"
+        onSendMessage={onSendMessage}
+        source={`Before
+
+<artifact title="午餐选择卡片">
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+  <style>
+    body { background: red; }
+  </style>
+</head>
+<body>
+  <button onclick="sendToChat('我选择火锅')">火锅</button>
+</body>
+</html>
+</artifact>
+
+After`}
+      />
+    )
+
+    expect(screen.getByText('Before')).toBeInTheDocument()
+    expect(screen.getByText('After')).toBeInTheDocument()
+    expect(screen.getByText('午餐选择卡片')).toBeInTheDocument()
+    expect(screen.queryByText(/background: red/)).not.toBeInTheDocument()
+
+    const iframe = container.querySelector('iframe')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    expect(iframe).toHaveAttribute('srcdoc', expect.stringContaining('body { background: red; }'))
+    expect(iframe).toHaveAttribute('srcdoc', expect.stringContaining('window.sendToChat'))
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe?.contentWindow,
+        data: {
+          type: SANDBOXED_HTML_SEND_TO_CHAT_EVENT,
+          message: ' 我选择火锅 ',
+        },
+      })
+    )
+
+    expect(onSendMessage).toHaveBeenCalledWith('我选择火锅')
   })
 })

--- a/frontend/src/components/common/EnhancedMarkdown.tsx
+++ b/frontend/src/components/common/EnhancedMarkdown.tsx
@@ -19,6 +19,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import { oneDark, oneLight } from 'react-syntax-highlighter/dist/esm/styles/prism'
 import { createSchemeAwareUrlTransform } from '@/lib/scheme'
 import { createSmartMarkdownComponents } from '@/components/common/SmartUrlRenderer'
+import { SandboxedHtmlFrame } from '@/components/common/SandboxedHtmlFrame'
 
 import 'katex/dist/katex.min.css'
 
@@ -38,9 +39,126 @@ const MermaidDiagram = dynamic(() => import('./MermaidDiagram'), {
 interface EnhancedMarkdownProps {
   source: string
   theme: 'light' | 'dark'
+  onSendMessage?: (content: string) => void
   /** Custom components to override default rendering */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components?: Record<string, React.ComponentType<any>>
+}
+
+type ContentPart =
+  | { type: 'markdown' | 'mermaid' | 'latex'; content: string }
+  | { type: 'artifact'; title: string; content: string }
+
+const DEFAULT_ARTIFACT_TITLE = 'Artifact'
+
+function parseArtifactTitle(attributes: string): string {
+  const match = attributes.match(/\btitle\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i)
+  const title = (match?.[1] || match?.[2] || match?.[3] || '').trim()
+  return title || DEFAULT_ARTIFACT_TITLE
+}
+
+function isInsideFencedCodeBlock(source: string, index: number): boolean {
+  const precedingText = source.slice(0, index)
+  const fenceMatches = precedingText.match(/^```/gm)
+  return (fenceMatches?.length ?? 0) % 2 === 1
+}
+
+function splitArtifactBlocks(source: string): ContentPart[] {
+  const parts: ContentPart[] = []
+  const artifactRegex = /<artifact\b([^>]*)>([\s\S]*?)<\/artifact>/gi
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = artifactRegex.exec(source)) !== null) {
+    if (isInsideFencedCodeBlock(source, match.index)) {
+      continue
+    }
+
+    const markdownContent = source.slice(lastIndex, match.index)
+    if (markdownContent.trim()) {
+      parts.push({ type: 'markdown', content: markdownContent })
+    }
+
+    const artifactContent = match[2].trim()
+    if (artifactContent) {
+      parts.push({
+        type: 'artifact',
+        title: parseArtifactTitle(match[1]),
+        content: artifactContent,
+      })
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  const remainingContent = source.slice(lastIndex)
+  if (remainingContent.trim()) {
+    parts.push({ type: 'markdown', content: remainingContent })
+  }
+
+  return parts
+}
+
+function splitSpecialMarkdownBlocks(markdown: string): ContentPart[] {
+  const parts: ContentPart[] = []
+  const specialBlockRegex = /```(mermaid|latex)\s*\n([\s\S]*?)```/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = specialBlockRegex.exec(markdown)) !== null) {
+    if (match.index > lastIndex) {
+      const markdownContent = markdown.slice(lastIndex, match.index)
+      if (markdownContent.trim()) {
+        parts.push({ type: 'markdown', content: markdownContent })
+      }
+    }
+
+    const blockType = match[1] as 'mermaid' | 'latex'
+    const blockCode = match[2].trim()
+    if (blockCode) {
+      parts.push({ type: blockType, content: blockCode })
+    }
+
+    lastIndex = match.index + match[0].length
+  }
+
+  if (lastIndex < markdown.length) {
+    const remainingContent = markdown.slice(lastIndex)
+    if (remainingContent.trim()) {
+      parts.push({ type: 'markdown', content: remainingContent })
+    }
+  }
+
+  if (parts.length === 0 && markdown.trim()) {
+    parts.push({ type: 'markdown', content: markdown })
+  }
+
+  return parts
+}
+
+function ArtifactPreview({
+  title,
+  html,
+  onSendMessage,
+}: {
+  title: string
+  html: string
+  onSendMessage?: (content: string) => void
+}) {
+  return (
+    <div className="my-4 overflow-hidden rounded-lg border border-border bg-surface">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-xs font-medium text-text-secondary">{title}</span>
+      </div>
+      <SandboxedHtmlFrame
+        title={title}
+        content={html}
+        className="block h-[520px] max-h-[70vh] min-h-[320px] w-full border-0 bg-white"
+        testId="artifact-preview-iframe"
+        onSendMessage={onSendMessage}
+      />
+    </div>
+  )
 }
 
 /**
@@ -528,66 +646,36 @@ function preprocessCjkBoldEdgeCases(text: string): string {
 export const EnhancedMarkdown = memo(function EnhancedMarkdown({
   source,
   theme,
+  onSendMessage,
   components,
 }: EnhancedMarkdownProps) {
   // Extract frontmatter before processing
   const { frontmatter, body } = useMemo(() => extractFrontmatter(source), [source])
 
-  // Pre-process source:
-  // 1. Convert \[...\] and \(...\) to dollar syntax for LaTeX
-  // 2. Fix CJK punctuation + ** edge cases (CommonMark right-flanking delimiter rule)
-  // 3. Convert bare URLs to markdown link format (iOS 16 Safari compatibility)
-  const processedSource = useMemo(
-    () => autolinkUrls(preprocessCjkBoldEdgeCases(preprocessLatexSyntax(body))),
-    [body]
-  )
+  const contentParts = useMemo(() => {
+    const rawParts = splitArtifactBlocks(body)
+    const normalizedParts =
+      rawParts.length > 0 ? rawParts : [{ type: 'markdown' as const, content: body }]
+
+    return normalizedParts.flatMap(part => {
+      if (part.type === 'artifact') return [part]
+
+      const processedMarkdown = autolinkUrls(
+        preprocessCjkBoldEdgeCases(preprocessLatexSyntax(part.content))
+      )
+      return splitSpecialMarkdownBlocks(processedMarkdown)
+    })
+  }, [body])
 
   // Check if source contains math formulas
-  const hasMath = useMemo(() => containsMathFormulas(processedSource), [processedSource])
-
-  // Parse the source to extract mermaid blocks, latex blocks, and regular content
-  const contentParts = useMemo(() => {
-    const parts: Array<{ type: 'markdown' | 'mermaid' | 'latex'; content: string }> = []
-    // Combined regex to match both mermaid and latex code blocks
-    const specialBlockRegex = /```(mermaid|latex)\s*\n([\s\S]*?)```/g
-
-    let lastIndex = 0
-    let match
-
-    while ((match = specialBlockRegex.exec(processedSource)) !== null) {
-      // Add markdown content before this special block
-      if (match.index > lastIndex) {
-        const markdownContent = processedSource.slice(lastIndex, match.index)
-        if (markdownContent.trim()) {
-          parts.push({ type: 'markdown', content: markdownContent })
-        }
-      }
-
-      // Add the special block (mermaid or latex)
-      const blockType = match[1] as 'mermaid' | 'latex'
-      const blockCode = match[2].trim()
-      if (blockCode) {
-        parts.push({ type: blockType, content: blockCode })
-      }
-
-      lastIndex = match.index + match[0].length
-    }
-
-    // Add remaining markdown content after the last special block
-    if (lastIndex < processedSource.length) {
-      const remainingContent = processedSource.slice(lastIndex)
-      if (remainingContent.trim()) {
-        parts.push({ type: 'markdown', content: remainingContent })
-      }
-    }
-
-    // If no special blocks found, return the entire source as markdown
-    if (parts.length === 0 && processedSource.trim()) {
-      parts.push({ type: 'markdown', content: processedSource })
-    }
-
-    return parts
-  }, [processedSource])
+  const hasMath = useMemo(
+    () =>
+      contentParts.some(
+        part =>
+          (part.type === 'markdown' || part.type === 'latex') && containsMathFormulas(part.content)
+      ),
+    [contentParts]
+  )
 
   // Default components with link handling and code block rendering
   const defaultComponents = useMemo(
@@ -701,7 +789,7 @@ export const EnhancedMarkdown = memo(function EnhancedMarkdown({
     return (
       <div className="wmde-markdown markdown-content" data-color-mode={theme}>
         {frontmatter && <FrontmatterBlock yaml={frontmatter} />}
-        {renderMarkdown(processedSource)}
+        {renderMarkdown(contentParts[0].content)}
       </div>
     )
   }
@@ -717,6 +805,17 @@ export const EnhancedMarkdown = memo(function EnhancedMarkdown({
 
         if (part.type === 'latex') {
           return <LaTeXBlock key={`latex-${index}`} code={part.content} />
+        }
+
+        if (part.type === 'artifact') {
+          return (
+            <ArtifactPreview
+              key={`artifact-${index}`}
+              title={part.title}
+              html={part.content}
+              onSendMessage={onSendMessage}
+            />
+          )
         }
 
         return (

--- a/frontend/src/components/common/FilePreview/preview-renderers/HtmlPreview.tsx
+++ b/frontend/src/components/common/FilePreview/preview-renderers/HtmlPreview.tsx
@@ -4,10 +4,11 @@
 
 'use client'
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import { TextPreview } from './TextPreview'
+import { SandboxedHtmlFrame } from '@/components/common/SandboxedHtmlFrame'
 
 export interface HtmlPreviewProps {
   content: string
@@ -36,8 +37,6 @@ export function HtmlPreview({
     }
     onViewModeChange?.(value)
   }
-
-  const iframeRef = useRef<HTMLIFrameElement>(null)
 
   // Reset loading state when content changes
   useEffect(() => {
@@ -76,10 +75,9 @@ export function HtmlPreview({
                 </div>
               </div>
             )}
-            <iframe
-              ref={iframeRef}
+            <SandboxedHtmlFrame
               title={filename}
-              srcDoc={content}
+              content={content}
               className="w-full h-full border-0"
               sandbox="allow-scripts allow-popups allow-forms"
               onLoad={handleIframeLoad}

--- a/frontend/src/components/common/SandboxedHtmlFrame.tsx
+++ b/frontend/src/components/common/SandboxedHtmlFrame.tsx
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { CSSProperties, useEffect, useMemo, useRef } from 'react'
+
+export const SANDBOXED_HTML_SEND_TO_CHAT_EVENT = 'wegent:sandboxed-html-send-to-chat'
+
+export interface SandboxedHtmlFrameProps {
+  content: string
+  title: string
+  sandbox?: string
+  className?: string
+  style?: CSSProperties
+  testId?: string
+  onLoad?: () => void
+  onError?: () => void
+  onSendMessage?: (content: string) => void
+}
+
+function buildSrcDoc(content: string, shouldInjectSendToChat: boolean): string {
+  if (!shouldInjectSendToChat) return content
+
+  const bridgeScript = [
+    '<script>',
+    '(function () {',
+    '  window.sendToChat = function (message) {',
+    `    window.parent.postMessage({ type: '${SANDBOXED_HTML_SEND_TO_CHAT_EVENT}', message: String(message || '') }, '*');`,
+    '  };',
+    '}());',
+    '</script>',
+  ].join('\n')
+
+  if (/<head\b[^>]*>/i.test(content)) {
+    return content.replace(/<head\b[^>]*>/i, match => `${match}\n${bridgeScript}`)
+  }
+
+  if (/<html\b[^>]*>/i.test(content)) {
+    return content.replace(/<html\b[^>]*>/i, match => `${match}\n<head>${bridgeScript}</head>`)
+  }
+
+  return `${bridgeScript}\n${content}`
+}
+
+export function SandboxedHtmlFrame({
+  content,
+  title,
+  sandbox = 'allow-scripts',
+  className,
+  style,
+  testId,
+  onLoad,
+  onError,
+  onSendMessage,
+}: SandboxedHtmlFrameProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null)
+  const srcDoc = useMemo(
+    () => buildSrcDoc(content, Boolean(onSendMessage)),
+    [content, onSendMessage]
+  )
+
+  useEffect(() => {
+    if (!onSendMessage) return
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow) return
+      const data = event.data as { type?: unknown; message?: unknown } | null
+      if (!data || data.type !== SANDBOXED_HTML_SEND_TO_CHAT_EVENT) return
+      if (typeof data.message !== 'string') return
+
+      const message = data.message.trim()
+      if (message) {
+        onSendMessage(message)
+      }
+    }
+
+    window.addEventListener('message', handleMessage)
+    return () => window.removeEventListener('message', handleMessage)
+  }, [onSendMessage])
+
+  return (
+    <iframe
+      ref={iframeRef}
+      title={title}
+      srcDoc={srcDoc}
+      sandbox={sandbox}
+      className={className}
+      style={style}
+      data-testid={testId}
+      onLoad={onLoad}
+      onError={onError}
+    />
+  )
+}

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -787,6 +787,7 @@ const MessageBubble = memo(
         <EnhancedMarkdown
           source={normalizedResult}
           theme={theme}
+          onSendMessage={onSendMessage}
           components={
             paragraphAction
               ? {
@@ -1326,6 +1327,7 @@ const MessageBubble = memo(
                 <EnhancedMarkdown
                   source={prefixText}
                   theme={theme}
+                  onSendMessage={onSendMessage}
                   components={{
                     a: ({ href, children }) => {
                       if (!href) {
@@ -1355,6 +1357,7 @@ const MessageBubble = memo(
                   <EnhancedMarkdown
                     source={suffixText}
                     theme={theme}
+                    onSendMessage={onSendMessage}
                     components={{
                       a: ({ href, children }) => {
                         if (!href) {
@@ -1386,6 +1389,7 @@ const MessageBubble = memo(
                 <EnhancedMarkdown
                   source={prefixText}
                   theme={theme}
+                  onSendMessage={onSendMessage}
                   components={{
                     a: ({ href, children }) => {
                       if (!href) {
@@ -1418,6 +1422,7 @@ const MessageBubble = memo(
                   <EnhancedMarkdown
                     source={suffixText}
                     theme={theme}
+                    onSendMessage={onSendMessage}
                     components={{
                       a: ({ href, children }) => {
                         if (!href) {
@@ -1649,6 +1654,7 @@ const MessageBubble = memo(
                         subtaskId={msg.subtaskId}
                         currentMessageIndex={index}
                         onAskUserSubmit={onAskUserSubmit}
+                        onSendMessage={onSendMessage}
                       />
                       <SourceReferences sources={msg.sources || msg.result?.sources || []} />
                       <GeminiAnnotations annotations={msg.result?.annotations || []} />

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -68,6 +68,8 @@ interface MixedContentViewProps {
   currentMessageIndex?: number
   /** Callback when user submits an ask_user_question form - receives pre-formatted message string */
   onAskUserSubmit?: (askId: string, formattedMessage: string) => void
+  /** Callback when interactive HTML artifacts send a chat message */
+  onSendMessage?: (content: string) => void
 }
 
 /**
@@ -90,6 +92,7 @@ const MixedContentView = memo(function MixedContentView({
   subtaskId,
   currentMessageIndex,
   onAskUserSubmit,
+  onSendMessage,
 }: MixedContentViewProps) {
   const { t } = useTranslation('chat')
   // Extract tools from thinking (legacy mode)
@@ -520,7 +523,7 @@ const MixedContentView = memo(function MixedContentView({
               : item.content
           return (
             <div key={key} className="text-sm">
-              <EnhancedMarkdown source={textContent} theme={theme} />
+              <EnhancedMarkdown source={textContent} theme={theme} onSendMessage={onSendMessage} />
             </div>
           )
         } else if (item.type === 'video') {


### PR DESCRIPTION
## Summary
- Add a reusable SandboxedHtmlFrame for srcDoc iframe rendering and sendToChat bridging.
- Render <artifact> HTML blocks outside the markdown host tree to prevent global CSS from affecting Wegent.
- Reuse the sandbox frame in HTML file preview and route artifact sendToChat events through existing chat callbacks.

## Test Plan
- npm test -- --runTestsByPath src/__tests__/components/common/EnhancedMarkdown.test.tsx src/__tests__/features/tasks/components/message/MessageBubble.test.tsx src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx src/__tests__/components/common/FilePreviewDialog.test.tsx
- npx tsc --noEmit
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTML artifacts embedded in messages now render in secure sandboxed environments.
  * Interactive artifacts can send messages back to chat for seamless content sharing.

* **Refactor**
  * Enhanced HTML content rendering with improved security and messaging capabilities throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->