### PR TITLE
fix(openapi): wrap responses reasoning with thinking tags

### DIFF
--- a/backend/app/services/chat/trigger/__init__.py
+++ b/backend/app/services/chat/trigger/__init__.py
@@ -30,7 +30,17 @@ from .lifecycle import (
     persist_completed_result,
     prepare_execution_session,
 )
-from .unified import trigger_ai_response_unified
+
+
+def __getattr__(name: str):
+    """Lazy-load the full trigger pipeline only when needed."""
+    if name == "trigger_ai_response_unified":
+        from .unified import trigger_ai_response_unified
+
+        return trigger_ai_response_unified
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Core

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -34,6 +34,7 @@ from app.core.async_utils import run_in_main_loop
 from app.db.session import SessionLocal
 from app.models.subtask import Subtask
 from app.models.task import TaskResource
+from app.services.openapi.thinking_tags import unwrap_thinking_content
 from app.services.task_status import extract_task_error
 from shared.models import (
     EventType,
@@ -47,7 +48,6 @@ from shared.utils.http_client import traced_async_client
 from .emitters import (
     ResultEmitter,
     ResultEmitterFactory,
-    StatusUpdatingEmitter,
     WebSocketResultEmitter,
 )
 from .polling_dispatcher import dispatch_polling
@@ -118,16 +118,45 @@ def extract_completed_result(response_data: dict) -> dict:
     :class:`EmitterBridgeTransport` so the field list is maintained in one
     place.
     """
-    # Extract text content from response output
-    value = ""
+    # Extract text and reasoning content from response output.
+    value_parts: list[str] = []
+    reasoning_parts: list[str] = []
     for item in response_data.get("output", []):
-        if isinstance(item, dict):
-            for content_block in item.get("content", []):
-                if isinstance(content_block, dict) and content_block.get("text"):
-                    value += content_block["text"]
+        if not isinstance(item, dict):
+            continue
+
+        if item.get("type") == "reasoning":
+            for summary in item.get("summary") or []:
+                if not isinstance(summary, dict):
+                    continue
+                text = summary.get("text")
+                if isinstance(text, str) and text:
+                    reasoning_parts.append(unwrap_thinking_content(text))
+            for content_block in item.get("content") or []:
+                if not isinstance(content_block, dict):
+                    continue
+                text = content_block.get("text")
+                if isinstance(text, str) and text:
+                    reasoning_parts.append(unwrap_thinking_content(text))
+            continue
+
+        for content_block in item.get("content", []):
+            if not isinstance(content_block, dict):
+                continue
+            text = content_block.get("text")
+            if not isinstance(text, str) or not text:
+                continue
+            if content_block.get("type") == "reasoning":
+                reasoning_parts.append(unwrap_thinking_content(text))
+            else:
+                value_parts.append(text)
+
+    reasoning_content = response_data.get("reasoning_content")
+    if reasoning_content is None and reasoning_parts:
+        reasoning_content = "\n".join(reasoning_parts)
 
     return {
-        "value": value,
+        "value": "".join(value_parts),
         "usage": response_data.get("usage"),
         "sources": response_data.get("sources"),
         "blocks": response_data.get("blocks"),
@@ -136,7 +165,7 @@ def extract_completed_result(response_data: dict) -> dict:
         "loaded_skills": response_data.get("loaded_skills"),
         "stop_reason": response_data.get("stop_reason"),
         "messages_chain": response_data.get("messages_chain"),
-        "reasoning_content": response_data.get("reasoning_content"),
+        "reasoning_content": reasoning_content,
     }
 
 
@@ -336,6 +365,16 @@ class ResponsesAPIEventParser:
                     message_id=message_id,
                 )
             return None
+
+        elif event_type == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value:
+            # response.reasoning_summary_text.delta -> THINKING
+            return ExecutionEvent(
+                type=EventType.THINKING,
+                task_id=task_id,
+                subtask_id=subtask_id,
+                content=data.get("delta", ""),
+                message_id=message_id,
+            )
 
         elif event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value:
             # response.output_item.added -> check if it's a function_call
@@ -700,6 +739,8 @@ class ExecutionDispatcher:
             # Wrap emitter with StatusUpdatingEmitter for unified status updates
             # This ensures task status is updated to COMPLETED/FAILED/CANCELLED
             # when terminal events are received, regardless of execution mode
+            from .emitters import StatusUpdatingEmitter
+
             wrapped_emitter = StatusUpdatingEmitter(
                 wrapped=emitter,
                 task_id=request.task_id,
@@ -1821,6 +1862,8 @@ class ExecutionDispatcher:
         # If emitter is provided, also emit error event to frontend
         if emitter is not None:
             # Wrap with StatusUpdatingEmitter for unified status updates
+            from .emitters import StatusUpdatingEmitter
+
             wrapped_emitter = StatusUpdatingEmitter(
                 wrapped=emitter,
                 task_id=request.task_id,

--- a/backend/app/services/execution/emitters/__init__.py
+++ b/backend/app/services/execution/emitters/__init__.py
@@ -15,8 +15,18 @@ from .composite import CompositeResultEmitter
 from .factory import EmitterType, ResultEmitterFactory
 from .protocol import ResultEmitter, StreamableEmitter
 from .sse import DirectSSEEmitter, SSEResultEmitter
-from .status_updating import StatusUpdatingEmitter
 from .websocket import WebSocketResultEmitter
+
+
+def __getattr__(name: str):
+    """Lazy-load emitters that pull in broader chat dependencies."""
+    if name == "StatusUpdatingEmitter":
+        from .status_updating import StatusUpdatingEmitter
+
+        return StatusUpdatingEmitter
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Protocol

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -19,15 +19,20 @@ page refresh recovery.
 import logging
 from typing import Any, Dict, Optional
 
-from app.services.chat.trigger.lifecycle import (
-    collect_completed_result,
-    persist_completed_result,
-)
 from shared.models import EventType, ExecutionEvent
 
 from .protocol import ResultEmitter
 
 logger = logging.getLogger(__name__)
+
+
+def _get_lifecycle_handlers():
+    from app.services.chat.trigger.lifecycle import (
+        collect_completed_result,
+        persist_completed_result,
+    )
+
+    return collect_completed_result, persist_completed_result
 
 
 class StatusUpdatingEmitter(ResultEmitter):
@@ -297,6 +302,9 @@ class StatusUpdatingEmitter(ResultEmitter):
             result: Optional result data from the event
         """
         try:
+            collect_completed_result, persist_completed_result = (
+                _get_lifecycle_handlers()
+            )
             final_result = await collect_completed_result(
                 self._subtask_id,
                 status="COMPLETED",
@@ -339,6 +347,9 @@ class StatusUpdatingEmitter(ResultEmitter):
             error_code: Classified error code (e.g., 'context_length_exceeded')
         """
         try:
+            collect_completed_result, persist_completed_result = (
+                _get_lifecycle_handlers()
+            )
             result = await collect_completed_result(
                 self._subtask_id,
                 status="FAILED",
@@ -376,6 +387,9 @@ class StatusUpdatingEmitter(ResultEmitter):
         task completion handler and other event subscribers.
         """
         try:
+            collect_completed_result, persist_completed_result = (
+                _get_lifecycle_handlers()
+            )
             result = await collect_completed_result(
                 self._subtask_id,
                 status="CANCELLED",

--- a/backend/app/services/execution/inprocess_executor.py
+++ b/backend/app/services/execution/inprocess_executor.py
@@ -402,6 +402,15 @@ class EmitterBridgeTransport(EventTransport):
                 )
             return None
 
+        elif event_type == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value:
+            return ExecutionEvent(
+                type=EventType.THINKING.value,
+                task_id=self.task_id,
+                subtask_id=self.subtask_id,
+                content=data.get("delta", ""),
+                message_id=message_id,
+            )
+
         # Skip lifecycle events
         elif event_type in (
             ResponsesAPIStreamEvents.RESPONSE_CREATED.value,

--- a/backend/app/services/openapi/__init__.py
+++ b/backend/app/services/openapi/__init__.py
@@ -15,7 +15,6 @@ Note: chat_response module is deprecated. OpenAPI responses now use the unified
 trigger architecture via build_execution_request + dispatch_sse_stream.
 """
 
-from app.services.openapi.chat_session import ChatSessionSetup, setup_chat_session
 from app.services.openapi.helpers import (
     extract_input_text,
     get_team_shell_type,
@@ -24,7 +23,31 @@ from app.services.openapi.helpers import (
     subtask_status_to_message_status,
     wegent_status_to_openai_status,
 )
-from app.services.openapi.mcp import load_bot_mcp_tools, load_server_mcp_tools
+
+
+def __getattr__(name: str):
+    """Lazy-load heavier helpers so utility imports stay lightweight."""
+    if name in {"ChatSessionSetup", "setup_chat_session"}:
+        from app.services.openapi.chat_session import (
+            ChatSessionSetup,
+            setup_chat_session,
+        )
+
+        return {
+            "ChatSessionSetup": ChatSessionSetup,
+            "setup_chat_session": setup_chat_session,
+        }[name]
+
+    if name in {"load_bot_mcp_tools", "load_server_mcp_tools"}:
+        from app.services.openapi.mcp import load_bot_mcp_tools, load_server_mcp_tools
+
+        return {
+            "load_bot_mcp_tools": load_bot_mcp_tools,
+            "load_server_mcp_tools": load_server_mcp_tools,
+        }[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # chat_session

--- a/backend/app/services/openapi/output_builder.py
+++ b/backend/app/services/openapi/output_builder.py
@@ -20,6 +20,7 @@ from app.schemas.openapi_response import (
     ShellCallOutputItem,
 )
 from app.services.openapi.helpers import subtask_status_to_message_status
+from app.services.openapi.thinking_tags import wrap_thinking_content
 
 SHELL_TOOL_NAMES = {"exec", "command_tool"}
 
@@ -109,7 +110,11 @@ def _build_message_content(
     content: list[OutputTextContent] = []
     if reasoning:
         content.append(
-            OutputTextContent(type="reasoning", text=reasoning, annotations=[])
+            OutputTextContent(
+                type="reasoning",
+                text=wrap_thinking_content(reasoning),
+                annotations=[],
+            )
         )
     if text:
         content.append(OutputTextContent(type="output_text", text=text, annotations=[]))

--- a/backend/app/services/openapi/streaming.py
+++ b/backend/app/services/openapi/streaming.py
@@ -192,6 +192,7 @@ class OpenAPIStreamingService:
         sequence_number = 0
         reasoning_started = False
         reasoning_complete = False
+        reasoning_emitted = False
         next_output_index = 0
         message_started = False
         reasoning_output_index: Optional[int] = None
@@ -314,6 +315,7 @@ class OpenAPIStreamingService:
                                     "type": "response.reasoning_summary_text.delta",
                                 }
                             )
+                            reasoning_emitted = True
                             sequence_number += 1
 
                     elif chunk.type == "text":
@@ -322,8 +324,11 @@ class OpenAPIStreamingService:
                             # If we had reasoning before, close it first
                             if reasoning_started and not reasoning_complete:
                                 reasoning_complete = True
-                                yield _format_sse_event(build_reasoning_close_event())
-                                sequence_number += 1
+                                if reasoning_emitted:
+                                    yield _format_sse_event(
+                                        build_reasoning_close_event()
+                                    )
+                                    sequence_number += 1
 
                             accumulated_text += chunk.content
 
@@ -615,8 +620,9 @@ class OpenAPIStreamingService:
             # Close text output items
             if reasoning_started and not reasoning_complete:
                 reasoning_complete = True
-                yield _format_sse_event(build_reasoning_close_event())
-                sequence_number += 1
+                if reasoning_emitted:
+                    yield _format_sse_event(build_reasoning_close_event())
+                    sequence_number += 1
 
             if accumulated_text:
                 # Official OpenAI event: response.output_text.done

--- a/backend/app/services/openapi/streaming.py
+++ b/backend/app/services/openapi/streaming.py
@@ -26,6 +26,11 @@ from app.schemas.openapi_response import (
     ShellCallOutputItem,
 )
 from app.services.openapi.output_builder import normalize_tool_output
+from app.services.openapi.thinking_tags import (
+    THINKING_CLOSE_TAG,
+    THINKING_OPEN_TAG,
+    wrap_thinking_content,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -213,6 +218,16 @@ class OpenAPIStreamingService:
                 return existing
             return allocate_output_index()
 
+        def build_reasoning_close_event() -> Dict[str, Any]:
+            return {
+                "content_index": 0,
+                "delta": THINKING_CLOSE_TAG,
+                "item_id": message_id,
+                "output_index": reasoning_output_index,
+                "sequence_number": sequence_number,
+                "type": "response.reasoning_summary_text.delta",
+            }
+
         try:
             # Event 1: response.created
             initial_response = ResponseObject(
@@ -284,12 +299,15 @@ class OpenAPIStreamingService:
 
                         # Accumulate reasoning content
                         if chunk.content and not reasoning_complete:
+                            delta = chunk.content
+                            if accumulated_reasoning == "":
+                                delta = f"{THINKING_OPEN_TAG}{delta}"
                             accumulated_reasoning += chunk.content
                             # Official OpenAI event: response.reasoning_summary_text.delta
                             yield _format_sse_event(
                                 {
                                     "content_index": 0,
-                                    "delta": chunk.content,
+                                    "delta": delta,
                                     "item_id": message_id,
                                     "output_index": reasoning_output_index,
                                     "sequence_number": sequence_number,
@@ -304,8 +322,8 @@ class OpenAPIStreamingService:
                             # If we had reasoning before, close it first
                             if reasoning_started and not reasoning_complete:
                                 reasoning_complete = True
-                                # Note: OpenAI doesn't have explicit reasoning "done" event
-                                # We transition directly to text output
+                                yield _format_sse_event(build_reasoning_close_event())
+                                sequence_number += 1
 
                             accumulated_text += chunk.content
 
@@ -595,6 +613,11 @@ class OpenAPIStreamingService:
                         sequence_number += 1
 
             # Close text output items
+            if reasoning_started and not reasoning_complete:
+                reasoning_complete = True
+                yield _format_sse_event(build_reasoning_close_event())
+                sequence_number += 1
+
             if accumulated_text:
                 # Official OpenAI event: response.output_text.done
                 yield _format_sse_event(
@@ -655,7 +678,12 @@ class OpenAPIStreamingService:
                     id=_generate_message_id(),
                     status="completed",
                     role="assistant",
-                    content=[{"type": "reasoning", "text": accumulated_reasoning}],
+                    content=[
+                        {
+                            "type": "reasoning",
+                            "text": wrap_thinking_content(accumulated_reasoning),
+                        }
+                    ],
                 )
             if accumulated_text and message_output_index is not None:
                 completed_output_items[message_output_index] = OutputMessage(

--- a/backend/app/services/openapi/thinking_tags.py
+++ b/backend/app/services/openapi/thinking_tags.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utilities for exposing reasoning content with thinking tags."""
+
+THINKING_OPEN_TAG = "<thinking>"
+THINKING_CLOSE_TAG = "</thinking>"
+
+
+def is_thinking_wrapped(content: str) -> bool:
+    """Return whether content is already wrapped in thinking tags."""
+    stripped = content.strip()
+    return stripped.startswith(THINKING_OPEN_TAG) and stripped.endswith(
+        THINKING_CLOSE_TAG
+    )
+
+
+def wrap_thinking_content(content: str) -> str:
+    """Wrap reasoning content for external Responses API consumers."""
+    if not content:
+        return ""
+    if is_thinking_wrapped(content):
+        return content
+    return f"{THINKING_OPEN_TAG}{content}{THINKING_CLOSE_TAG}"
+
+
+def unwrap_thinking_content(content: str) -> str:
+    """Remove thinking tags from content when storing internal reasoning."""
+    if not content or not is_thinking_wrapped(content):
+        return content
+
+    stripped = content.strip()
+    return stripped[len(THINKING_OPEN_TAG) : -len(THINKING_CLOSE_TAG)]

--- a/backend/tests/services/execution/test_extract_completed_result.py
+++ b/backend/tests/services/execution/test_extract_completed_result.py
@@ -27,6 +27,44 @@ class TestExtractCompletedResult:
         result = extract_completed_result(response_data)
         assert result["value"] == "Hello world"
 
+    def test_separates_reasoning_content_from_output_text(self):
+        """Reasoning text is stored separately instead of leaking into value."""
+        response_data = {
+            "output": [
+                {
+                    "content": [
+                        {"type": "reasoning", "text": "<thinking>Think</thinking>"},
+                        {"type": "output_text", "text": "Answer"},
+                    ]
+                }
+            ]
+        }
+
+        result = extract_completed_result(response_data)
+
+        assert result["value"] == "Answer"
+        assert result["reasoning_content"] == "Think"
+
+    def test_extracts_official_reasoning_summary_output_item(self):
+        """OpenAI reasoning output items are converted to reasoning_content."""
+        response_data = {
+            "output": [
+                {
+                    "type": "reasoning",
+                    "summary": [
+                        {"type": "summary_text", "text": "Step 1"},
+                        {"type": "summary_text", "text": "Step 2"},
+                    ],
+                },
+                {"content": [{"type": "output_text", "text": "Answer"}]},
+            ]
+        }
+
+        result = extract_completed_result(response_data)
+
+        assert result["value"] == "Answer"
+        assert result["reasoning_content"] == "Step 1\nStep 2"
+
     def test_empty_output(self):
         """Empty output produces empty value."""
         result = extract_completed_result({"output": []})

--- a/backend/tests/services/execution/test_responses_api_event_parser.py
+++ b/backend/tests/services/execution/test_responses_api_event_parser.py
@@ -16,6 +16,38 @@ from app.services.execution.inprocess_executor import EmitterBridgeTransport
 from shared.models.responses_api import ResponsesAPIStreamEvents
 
 
+class TestResponsesAPIEventParserReasoning:
+    def test_reasoning_summary_text_delta_maps_to_thinking(self):
+        parser = ResponsesAPIEventParser()
+
+        result = parser.parse(
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+            event_type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+            data={"delta": "<thinking>Step 1"},
+        )
+
+        assert result is not None
+        assert result.type == "thinking"
+        assert result.content == "<thinking>Step 1"
+
+    def test_legacy_reasoning_part_added_maps_to_thinking(self):
+        parser = ResponsesAPIEventParser()
+
+        result = parser.parse(
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+            event_type=ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value,
+            data={"part": {"type": "reasoning", "text": "legacy thinking"}},
+        )
+
+        assert result is not None
+        assert result.type == "thinking"
+        assert result.content == "legacy thinking"
+
+
 class TestResponsesAPIEventParserToolIds:
     def test_tool_start_requires_non_empty_id(self):
         parser = ResponsesAPIEventParser()

--- a/backend/tests/services/openapi/test_output_builder.py
+++ b/backend/tests/services/openapi/test_output_builder.py
@@ -86,9 +86,23 @@ def test_build_response_output_includes_reasoning_content():
     assert len(output) == 1
     assert output[0].type == "message"
     assert [part.type for part in output[0].content] == ["reasoning", "output_text"]
-    assert output[0].content[0].text == "Thinking summary"
+    assert output[0].content[0].text == "<thinking>Thinking summary</thinking>"
     assert output[0].content[1].text == "Final answer"
     assert output[0].status == "completed"
+
+
+def test_build_response_output_does_not_double_wrap_reasoning_content():
+    subtask = _assistant_subtask(
+        subtask_id=103,
+        result={
+            "value": "Final answer",
+            "reasoning_content": "<thinking>Already wrapped</thinking>",
+        },
+    )
+
+    output = build_response_output([subtask])
+
+    assert output[0].content[0].text == "<thinking>Already wrapped</thinking>"
 
 
 def test_build_response_output_matches_tool_block_by_id():

--- a/backend/tests/services/openapi/test_streaming_reasoning.py
+++ b/backend/tests/services/openapi/test_streaming_reasoning.py
@@ -95,9 +95,10 @@ class TestStreamingServiceReasoning:
         reasoning_deltas = [
             e for e in events if e["type"] == "response.reasoning_summary_text.delta"
         ]
-        assert len(reasoning_deltas) == 2
-        assert reasoning_deltas[0]["delta"] == "Step 1: "
+        assert len(reasoning_deltas) == 3
+        assert reasoning_deltas[0]["delta"] == "<thinking>Step 1: "
         assert reasoning_deltas[1]["delta"] == "Analyze the problem"
+        assert reasoning_deltas[2]["delta"] == "</thinking>"
 
         # Check text events
         text_deltas = [
@@ -179,14 +180,16 @@ class TestStreamingServiceReasoning:
         reasoning_deltas = [
             e for e in events if e["type"] == "response.reasoning_summary_text.delta"
         ]
-        assert len(reasoning_deltas) == 1
-        assert reasoning_deltas[0]["delta"] == "Just thinking"
+        assert len(reasoning_deltas) == 2
+        assert reasoning_deltas[0]["delta"] == "<thinking>Just thinking"
+        assert reasoning_deltas[1]["delta"] == "</thinking>"
 
         # Check final response includes reasoning
         completed_event = [e for e in events if e["type"] == "response.completed"][0]
         output = completed_event["response"]["output"]
         assert len(output) == 1
         assert output[0]["content"][0]["type"] == "reasoning"
+        assert output[0]["content"][0]["text"] == "<thinking>Just thinking</thinking>"
 
     @pytest.mark.asyncio
     async def test_function_call_stream(self, streaming_service):

--- a/backend/tests/services/openapi/test_streaming_reasoning.py
+++ b/backend/tests/services/openapi/test_streaming_reasoning.py
@@ -192,6 +192,53 @@ class TestStreamingServiceReasoning:
         assert output[0]["content"][0]["text"] == "<thinking>Just thinking</thinking>"
 
     @pytest.mark.asyncio
+    async def test_empty_reasoning_before_text_does_not_emit_close_tag(
+        self, streaming_service
+    ):
+        async def stream():
+            yield StreamingChunk(type="reasoning", content="")
+            yield StreamingChunk(type="text", content="Answer")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        reasoning_deltas = [
+            e["delta"]
+            for e in events
+            if e["type"] == "response.reasoning_summary_text.delta"
+        ]
+        assert reasoning_deltas == []
+
+    @pytest.mark.asyncio
+    async def test_empty_reasoning_only_stream_does_not_emit_close_tag(
+        self, streaming_service
+    ):
+        async def stream():
+            yield StreamingChunk(type="reasoning", content="")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        reasoning_deltas = [
+            e["delta"]
+            for e in events
+            if e["type"] == "response.reasoning_summary_text.delta"
+        ]
+        assert reasoning_deltas == []
+
+    @pytest.mark.asyncio
     async def test_function_call_stream(self, streaming_service):
         async def function_call_stream():
             yield StreamingChunk(


### PR DESCRIPTION
## Summary
- Wrap external OpenAI Responses API reasoning content with `<thinking>` tags in both streaming and final outputs.
- Add shared thinking tag helpers and keep internal completed-result parsing from mixing reasoning into answer text.
- Parse `response.reasoning_summary_text.delta` as internal thinking events and cover official-style reasoning summaries.

## Test Plan
- [x] `cd backend && uv run pytest tests/services/openapi tests/services/execution/test_extract_completed_result.py tests/services/execution/test_responses_api_event_parser.py tests/services/execution/test_emitters.py tests/services/execution/test_status_updating_emitter.py -q`
- [x] `cd backend && uv run black --check app/services/openapi/__init__.py app/services/openapi/output_builder.py app/services/openapi/streaming.py app/services/openapi/thinking_tags.py app/services/execution/dispatcher.py app/services/execution/inprocess_executor.py app/services/execution/emitters/__init__.py app/services/execution/emitters/status_updating.py app/services/chat/trigger/__init__.py tests/services/openapi/test_output_builder.py tests/services/openapi/test_streaming_reasoning.py tests/services/execution/test_extract_completed_result.py tests/services/execution/test_responses_api_event_parser.py && uv run isort --check-only app/services/openapi/__init__.py app/services/openapi/output_builder.py app/services/openapi/streaming.py app/services/openapi/thinking_tags.py app/services/execution/dispatcher.py app/services/execution/inprocess_executor.py app/services/execution/emitters/__init__.py app/services/execution/emitters/status_updating.py app/services/chat/trigger/__init__.py tests/services/openapi/test_output_builder.py tests/services/openapi/test_streaming_reasoning.py tests/services/execution/test_extract_completed_result.py tests/services/execution/test_responses_api_event_parser.py`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant "reasoning" is now wrapped in <thinking>...</thinking> tags and preserved when already wrapped.
  * Streaming now emits explicit thinking open/close deltas so partial reasoning appears progressively.

* **Bug Fixes**
  * Reasoning content is separated from user-visible output so only non-reasoning text is shown as final value.

* **Tests**
  * Added/updated tests covering reasoning wrapping, streaming deltas, and extraction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->