### PR TITLE
fix(frontend): reduce route initial bundle size

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -52,6 +52,7 @@ const config: Config = {
   transformIgnorePatterns: [
     '/node_modules/(?!(react-markdown|remark-|rehype-|mdast-util-|micromark|micromark-|unist-|unist-util-|vfile|vfile-message|hast-|hast-util-|bail|ccount|comma-separated-tokens|property-information|space-separated-tokens|trim-lines|html-void-elements|decode-named-character-reference|character-entities|is-plain-obj|longest-streak|markdown-table|escape-string-regexp|stringify-entities|entities|web-namespaces|zwitch|direction)/)',
   ],
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
 }
 
 export default createJestConfig(config)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -49,28 +49,10 @@ const nextConfig = {
             'remark-gfm': path.resolve(__dirname, 'src/lib/remark-gfm-safe.ts'),
           }
 
-          // Handle chunk loading issues
+          // Keep Next.js route-aware chunk splitting. A single global vendors
+          // chunk makes every route download dependencies it does not use.
           config.optimization = {
             ...config.optimization,
-            // Prevent over-aggressive code splitting that can cause chunk loading errors
-            splitChunks: {
-              ...config.optimization?.splitChunks,
-              chunks: 'all',
-              cacheGroups: {
-                vendor: {
-                  test: /[\\/]node_modules[\\/]/,
-                  name: 'vendors',
-                  chunks: 'all',
-                  priority: 10,
-                },
-                common: {
-                  name: 'common',
-                  minChunks: 2,
-                  chunks: 'all',
-                  priority: 5,
-                },
-              },
-            },
             // Enable module concatenation to reduce bundle size
             concatenateModules: true,
           }

--- a/frontend/src/__tests__/app/(tasks)/chat/ChatPageDesktop.remote-workspace.test.tsx
+++ b/frontend/src/__tests__/app/(tasks)/chat/ChatPageDesktop.remote-workspace.test.tsx
@@ -162,5 +162,7 @@ describe('ChatPageDesktop remote workspace integration', () => {
     render(<ChatPageDesktop />)
 
     expect(screen.getByTestId('remote-workspace-entry')).toHaveTextContent('42:false')
+    expect(screen.queryByText('search-dialog')).not.toBeInTheDocument()
+    expect(screen.queryByText('create-group-chat-dialog')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/app/(tasks)/code/CodePageDesktop.remote-workspace.test.tsx
+++ b/frontend/src/__tests__/app/(tasks)/code/CodePageDesktop.remote-workspace.test.tsx
@@ -97,8 +97,9 @@ jest.mock('@/features/tasks/hooks/useSearchShortcut', () => ({
   }),
 }))
 
-jest.mock('@/features/tasks/components', () => ({
-  Workbench: () => <div>workbench</div>,
+jest.mock('@/features/tasks/components/workbench/Workbench', () => ({
+  __esModule: true,
+  default: () => <div>workbench</div>,
 }))
 
 jest.mock('@/features/tasks/components/chat', () => ({
@@ -118,9 +119,11 @@ jest.mock('@/features/tasks/components/remote-workspace', () => ({
 }))
 
 describe('CodePageDesktop remote workspace integration', () => {
-  test('code desktop renders remote workspace entry in top nav when task selected', () => {
+  test('code desktop renders remote workspace entry in top nav when task selected', async () => {
     render(<CodePageDesktop />)
 
     expect(screen.getByTestId('remote-workspace-entry')).toHaveTextContent('84')
+    expect(screen.queryByText('search-dialog')).not.toBeInTheDocument()
+    expect(await screen.findByText('workbench')).toBeInTheDocument()
   })
 })

--- a/frontend/src/__tests__/config/next-config-performance.test.ts
+++ b/frontend/src/__tests__/config/next-config-performance.test.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+describe('Next.js production chunking configuration', () => {
+  const originalTurbopack = process.env.TURBOPACK
+
+  beforeEach(() => {
+    jest.resetModules()
+    delete process.env.TURBOPACK
+  })
+
+  afterEach(() => {
+    if (originalTurbopack === undefined) {
+      delete process.env.TURBOPACK
+    } else {
+      process.env.TURBOPACK = originalTurbopack
+    }
+  })
+
+  test('does not force all node_modules into a single initial vendors chunk', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const nextConfig = require('../../../next.config.js')
+    const webpackConfig = {
+      resolve: { alias: {} },
+      optimization: {
+        splitChunks: {
+          cacheGroups: {},
+        },
+      },
+    }
+
+    const result = nextConfig.webpack(webpackConfig, {
+      isServer: false,
+      _dev: false,
+    })
+
+    expect(result.optimization.splitChunks.cacheGroups.vendor).toBeUndefined()
+    expect(result.optimization.splitChunks.cacheGroups.common).toBeUndefined()
+  })
+})

--- a/frontend/src/__tests__/config/route-import-performance.test.ts
+++ b/frontend/src/__tests__/config/route-import-performance.test.ts
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import fs from 'fs'
+import path from 'path'
+
+const rootDir = path.resolve(__dirname, '../../..')
+
+function readSource(relativePath: string): string {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8')
+}
+
+function expectNoStaticImport(relativePath: string, importPath: string) {
+  const escapedImportPath = importPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  expect(readSource(relativePath)).not.toMatch(
+    new RegExp(`^import\\s+(?!type\\b)[\\s\\S]*?from\\s+['"]${escapedImportPath}['"]`, 'm')
+  )
+}
+
+describe('route import performance', () => {
+  test.each([
+    'src/app/(tasks)/knowledge/page.tsx',
+    'src/app/(tasks)/knowledge/[namespace]/[kbName]/[[...docPath]]/page.tsx',
+    'src/app/(tasks)/knowledge/project/[projectId]/page.tsx',
+  ])('knowledge route avoids the feature barrel: %s', relativePath => {
+    expect(readSource(relativePath)).not.toContain("from '@/features/knowledge'")
+  })
+
+  test.each([
+    'src/app/(tasks)/feed/page.tsx',
+    'src/app/(tasks)/feed/invitations/page.tsx',
+    'src/app/(tasks)/feed/subscriptions/page.tsx',
+  ])('feed route avoids the components barrel: %s', relativePath => {
+    expect(readSource(relativePath)).not.toContain("from '@/features/feed/components'")
+  })
+
+  test('device chat route does not synchronously import the full ChatArea module', () => {
+    expect(readSource('src/app/(tasks)/devices/chat/page.tsx')).not.toContain(
+      "import { ChatArea } from '@/features/tasks/components/chat'"
+    )
+  })
+
+  test('legacy tasks route dynamically loads the full ChatArea module', () => {
+    expect(readSource('src/app/tasks/page.tsx')).not.toContain(
+      "import { ChatArea } from '@/features/tasks/components/chat'"
+    )
+  })
+
+  test('shared task route dynamically loads the full message renderer', () => {
+    expect(readSource('src/app/shared/task/page.tsx')).not.toContain('import { MessageBubble')
+  })
+
+  test.each([
+    '@/features/admin/components/UserList',
+    '@/features/admin/components/PublicModelList',
+    '@/features/admin/components/PublicRetrieverList',
+    '@/features/admin/components/PublicSkillList',
+    '@/features/admin/components/PublicGhostList',
+    '@/features/admin/components/PublicShellList',
+    '@/features/admin/components/PublicTeamList',
+    '@/features/admin/components/PublicBotList',
+    '@/features/admin/components/TemplateList',
+    '@/features/admin/components/ApiKeyManagement',
+    '@/features/admin/components/SystemConfigPanel',
+    '@/features/admin/components/BackgroundExecutionMonitorPanel',
+    '@/features/admin/components/DeviceMonitorPanel',
+    '@/features/admin/components/IMChannelList',
+  ])('admin route does not statically import tab panel: %s', importPath => {
+    expectNoStaticImport('src/app/admin/page.tsx', importPath)
+  })
+
+  test.each([
+    '@/features/settings/components/TeamListWithScope',
+    '@/features/settings/components/ModelListWithScope',
+    '@/features/settings/components/RetrieverListWithScope',
+    '@/features/settings/components/ShellListWithScope',
+    '@/features/settings/components/SkillListWithScope',
+  ])('resource library manager does not statically import scoped manager: %s', importPath => {
+    expectNoStaticImport('src/features/resource-library/components/MyResources.tsx', importPath)
+  })
+
+  test.each([
+    './SubscriptionTimeline',
+    './SubscriptionForm',
+    './SubscriptionList',
+    './FollowingSubscriptionList',
+    './RentalSubscriptionList',
+    './DiscoverPageInline',
+    './MarketPageInline',
+  ])('feed landing content does not statically import inactive panel: %s', importPath => {
+    expectNoStaticImport('src/features/feed/components/SubscriptionPage.tsx', importPath)
+  })
+
+  test.each([
+    '@/features/feed/components/SubscriptionForm',
+    '@/features/feed/components/SubscriptionList',
+    '@/features/feed/components/FollowingSubscriptionList',
+    '@/features/feed/components/RentalSubscriptionList',
+  ])('feed subscriptions page does not statically import inactive panel: %s', importPath => {
+    expectNoStaticImport('src/app/(tasks)/feed/subscriptions/page.tsx', importPath)
+  })
+
+  test.each([
+    'src/features/feed/components/SubscriptionList.tsx',
+    'src/features/feed/components/SubscriptionTimeline.tsx',
+    'src/features/feed/components/DiscoverHistoryDialog.tsx',
+  ])('feed component dynamically loads conversation dialog: %s', relativePath => {
+    expectNoStaticImport(relativePath, './SubscriptionConversationDialog')
+  })
+})

--- a/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
@@ -176,16 +176,25 @@ describe('MyResources', () => {
     expect(await screen.findByTestId('agent-resource-manager')).toBeInTheDocument()
 
     fireEvent.click(screen.getByTestId('managed-resource-model-tab'))
-    expect(screen.getByTestId('model-resource-manager')).toHaveAttribute('data-scope', 'personal')
+    expect(await screen.findByTestId('model-resource-manager')).toHaveAttribute(
+      'data-scope',
+      'personal'
+    )
 
     fireEvent.click(screen.getByTestId('managed-resource-shell-tab'))
-    expect(screen.getByTestId('shell-resource-manager')).toHaveAttribute('data-scope', 'personal')
+    expect(await screen.findByTestId('shell-resource-manager')).toHaveAttribute(
+      'data-scope',
+      'personal'
+    )
 
     fireEvent.click(screen.getByTestId('managed-resource-skill-tab'))
-    expect(screen.getByTestId('skill-resource-manager')).toHaveAttribute('data-scope', 'personal')
+    expect(await screen.findByTestId('skill-resource-manager')).toHaveAttribute(
+      'data-scope',
+      'personal'
+    )
 
     fireEvent.click(screen.getByTestId('managed-resource-retriever-tab'))
-    expect(screen.getByTestId('retriever-resource-manager')).toHaveAttribute(
+    expect(await screen.findByTestId('retriever-resource-manager')).toHaveAttribute(
       'data-scope',
       'personal'
     )
@@ -205,8 +214,9 @@ describe('MyResources', () => {
     expect(screen.getByTestId('agent-resource-manager')).toHaveAttribute('data-group', 'platform')
 
     fireEvent.click(screen.getByTestId('managed-resource-model-tab'))
-    expect(screen.getByTestId('model-resource-manager')).toHaveAttribute('data-scope', 'group')
-    expect(screen.getByTestId('model-resource-manager')).toHaveAttribute('data-group', 'platform')
+    const modelResourceManager = await screen.findByTestId('model-resource-manager')
+    expect(modelResourceManager).toHaveAttribute('data-scope', 'group')
+    expect(modelResourceManager).toHaveAttribute('data-group', 'platform')
   })
 
   it('navigates to group management from the group resource dropdown', async () => {

--- a/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageDesktop.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { UserGroupIcon } from '@heroicons/react/24/outline'
 import { useTeamContext } from '@/contexts/TeamContext'
@@ -13,7 +14,6 @@ import {
   TaskSidebar,
   ResizableSidebar,
   CollapsedSidebarButtons,
-  SearchDialog,
 } from '@/features/tasks/components/sidebar'
 import { GithubStarButton } from '@/features/layout/GithubStarButton'
 import { Team } from '@/types/api'
@@ -32,11 +32,25 @@ import { useToast } from '@/hooks/use-toast'
 import { canEditTeam } from '@/utils/team-permissions'
 import { listGroups } from '@/apis/groups'
 import { fetchBotsList } from '@/features/settings/services/bots'
-import TeamEditDialog from '@/features/settings/components/TeamEditDialog'
 import type { BaseRole } from '@/types/base-role'
-import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
 import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
 import { useIsDesktop } from '@/features/layout/hooks/useMediaQuery'
+
+const SearchDialog = dynamic(() => import('@/features/tasks/components/sidebar/SearchDialog'), {
+  ssr: false,
+})
+
+const TeamEditDialog = dynamic(() => import('@/features/settings/components/TeamEditDialog'), {
+  ssr: false,
+})
+
+const CreateGroupChatDialog = dynamic(
+  () =>
+    import('@/features/tasks/components/group-chat/CreateGroupChatDialog').then(mod => ({
+      default: mod.CreateGroupChatDialog,
+    })),
+  { ssr: false }
+)
 
 /**
  * Desktop-specific implementation of Chat Page
@@ -357,14 +371,21 @@ export function ChatPageDesktop() {
         />
       </div>
       {/* Create Group Chat Dialog */}
-      <CreateGroupChatDialog open={isCreateGroupChatOpen} onOpenChange={setIsCreateGroupChatOpen} />
+      {isCreateGroupChatOpen && (
+        <CreateGroupChatDialog
+          open={isCreateGroupChatOpen}
+          onOpenChange={setIsCreateGroupChatOpen}
+        />
+      )}
       {/* Search Dialog - rendered at page level for global shortcut support */}
-      <SearchDialog
-        open={isSearchDialogOpen}
-        onOpenChange={setIsSearchDialogOpen}
-        shortcutDisplayText={shortcutDisplayText}
-        pageType="chat"
-      />
+      {isSearchDialogOpen && (
+        <SearchDialog
+          open={isSearchDialogOpen}
+          onOpenChange={setIsSearchDialogOpen}
+          shortcutDisplayText={shortcutDisplayText}
+          pageType="chat"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
+++ b/frontend/src/app/(tasks)/chat/ChatPageMobile.tsx
@@ -5,11 +5,12 @@
 'use client'
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { UserGroupIcon } from '@heroicons/react/24/outline'
 import { useTeamContext } from '@/contexts/TeamContext'
 import TopNavigation from '@/features/layout/TopNavigation'
-import { TaskSidebar, SearchDialog } from '@/features/tasks/components/sidebar'
+import { TaskSidebar } from '@/features/tasks/components/sidebar'
 import { ThemeToggle } from '@/features/theme/ThemeToggle'
 import { Team } from '@/types/api'
 import { saveLastTab } from '@/utils/userPreferences'
@@ -26,10 +27,24 @@ import { useToast } from '@/hooks/use-toast'
 import { canEditTeam } from '@/utils/team-permissions'
 import { listGroups } from '@/apis/groups'
 import { fetchBotsList } from '@/features/settings/services/bots'
-import TeamEditDialog from '@/features/settings/components/TeamEditDialog'
 import type { BaseRole } from '@/types/base-role'
-import { CreateGroupChatDialog } from '@/features/tasks/components/group-chat'
 import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
+
+const SearchDialog = dynamic(() => import('@/features/tasks/components/sidebar/SearchDialog'), {
+  ssr: false,
+})
+
+const TeamEditDialog = dynamic(() => import('@/features/settings/components/TeamEditDialog'), {
+  ssr: false,
+})
+
+const CreateGroupChatDialog = dynamic(
+  () =>
+    import('@/features/tasks/components/group-chat/CreateGroupChatDialog').then(mod => ({
+      default: mod.CreateGroupChatDialog,
+    })),
+  { ssr: false }
+)
 
 /**
  * Mobile-specific implementation of Chat Page
@@ -300,14 +315,21 @@ export function ChatPageMobile() {
         />
       </div>
       {/* Create Group Chat Dialog */}
-      <CreateGroupChatDialog open={isCreateGroupChatOpen} onOpenChange={setIsCreateGroupChatOpen} />
+      {isCreateGroupChatOpen && (
+        <CreateGroupChatDialog
+          open={isCreateGroupChatOpen}
+          onOpenChange={setIsCreateGroupChatOpen}
+        />
+      )}
       {/* Search Dialog - rendered at page level for global shortcut support */}
-      <SearchDialog
-        open={isSearchDialogOpen}
-        onOpenChange={setIsSearchDialogOpen}
-        shortcutDisplayText={shortcutDisplayText}
-        pageType="chat"
-      />
+      {isSearchDialogOpen && (
+        <SearchDialog
+          open={isSearchDialogOpen}
+          onOpenChange={setIsSearchDialogOpen}
+          shortcutDisplayText={shortcutDisplayText}
+          pageType="chat"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageDesktop.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useState, useEffect, useMemo, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams } from 'next/navigation'
 import { useTeamContext } from '@/contexts/TeamContext'
 import TopNavigation from '@/features/layout/TopNavigation'
@@ -12,7 +13,6 @@ import {
   TaskSidebar,
   ResizableSidebar,
   CollapsedSidebarButtons,
-  SearchDialog,
 } from '@/features/tasks/components/sidebar'
 import WorkbenchToggle from '@/features/layout/WorkbenchToggle'
 import { OpenMenu } from '@/features/tasks/components/input'
@@ -26,10 +26,17 @@ import { saveLastTab } from '@/utils/userPreferences'
 import { calculateOpenLinks } from '@/utils/openLinks'
 import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
-import { Workbench } from '@/features/tasks/components'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
 import { paths } from '@/config/paths'
+
+const SearchDialog = dynamic(() => import('@/features/tasks/components/sidebar/SearchDialog'), {
+  ssr: false,
+})
+
+const Workbench = dynamic(() => import('@/features/tasks/components/workbench/Workbench'), {
+  ssr: false,
+})
 
 /**
  * Desktop-specific implementation of Code Page
@@ -295,12 +302,14 @@ export function CodePageDesktop() {
         </div>
       </div>
       {/* Search Dialog - rendered at page level for global shortcut support */}
-      <SearchDialog
-        open={isSearchDialogOpen}
-        onOpenChange={setIsSearchDialogOpen}
-        shortcutDisplayText={shortcutDisplayText}
-        pageType="code"
-      />
+      {isSearchDialogOpen && (
+        <SearchDialog
+          open={isSearchDialogOpen}
+          onOpenChange={setIsSearchDialogOpen}
+          shortcutDisplayText={shortcutDisplayText}
+          pageType="code"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/code/CodePageMobile.tsx
+++ b/frontend/src/app/(tasks)/code/CodePageMobile.tsx
@@ -5,10 +5,11 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { useTeamContext } from '@/contexts/TeamContext'
 import TopNavigation from '@/features/layout/TopNavigation'
-import { TaskSidebar, SearchDialog } from '@/features/tasks/components/sidebar'
+import { TaskSidebar } from '@/features/tasks/components/sidebar'
 import { ThemeToggle } from '@/features/theme/ThemeToggle'
 import { Team } from '@/types/api'
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
@@ -18,6 +19,10 @@ import { useUser } from '@/features/common/UserContext'
 import { useSearchShortcut } from '@/features/tasks/hooks/useSearchShortcut'
 import { ChatArea } from '@/features/tasks/components/chat'
 import { RemoteWorkspaceEntry } from '@/features/tasks/components/remote-workspace'
+
+const SearchDialog = dynamic(() => import('@/features/tasks/components/sidebar/SearchDialog'), {
+  ssr: false,
+})
 
 /**
  * Mobile-specific implementation of Code Page
@@ -162,12 +167,14 @@ export function CodePageMobile() {
         </div>
       </div>
       {/* Search Dialog - rendered at page level for global shortcut support */}
-      <SearchDialog
-        open={isSearchDialogOpen}
-        onOpenChange={setIsSearchDialogOpen}
-        shortcutDisplayText={shortcutDisplayText}
-        pageType="code"
-      />
+      {isSearchDialogOpen && (
+        <SearchDialog
+          open={isSearchDialogOpen}
+          onOpenChange={setIsSearchDialogOpen}
+          shortcutDisplayText={shortcutDisplayText}
+          pageType="code"
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/devices/chat/page.tsx
+++ b/frontend/src/app/(tasks)/devices/chat/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useEffect, useState, useCallback, useMemo } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import {
@@ -25,11 +26,14 @@ import { paths } from '@/config/paths'
 import { useDevices } from '@/contexts/DeviceContext'
 import { useTeamContext } from '@/contexts/TeamContext'
 import { Monitor, WifiOff } from 'lucide-react'
-import { ChatArea } from '@/features/tasks/components/chat'
 import { TaskParamSync, DeviceTaskSync, DeviceParamSync } from '@/features/tasks/components/params'
 import { isOpenClawDevice } from '@/features/devices/utils/device-status'
 import { getPreferredExecutionDevice } from '@/features/devices/utils/execution-target'
 import { useProjectContext } from '@/features/projects/contexts/projectContext'
+
+const ChatArea = dynamic(() => import('@/features/tasks/components/chat/ChatArea'), {
+  ssr: false,
+})
 
 export default function DeviceChatPage() {
   const { t } = useTranslation('devices')

--- a/frontend/src/app/(tasks)/feed/invitations/page.tsx
+++ b/frontend/src/app/(tasks)/feed/invitations/page.tsx
@@ -13,7 +13,7 @@ import {
   ResizableSidebar,
   CollapsedSidebarButtons,
 } from '@/features/tasks/components/sidebar'
-import { SubscriptionInvitations } from '@/features/feed/components'
+import { SubscriptionInvitations } from '@/features/feed/components/SubscriptionInvitations'
 import { Button } from '@/components/ui/button'
 import '@/app/tasks/tasks.css'
 import '@/features/common/scrollbar.css'

--- a/frontend/src/app/(tasks)/feed/page.tsx
+++ b/frontend/src/app/(tasks)/feed/page.tsx
@@ -13,7 +13,7 @@ import {
   ResizableSidebar,
   CollapsedSidebarButtons,
 } from '@/features/tasks/components/sidebar'
-import { SubscriptionPage as SubscriptionPageContent } from '@/features/feed/components'
+import { SubscriptionPage as SubscriptionPageContent } from '@/features/feed/components/SubscriptionPage'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import '@/app/tasks/tasks.css'

--- a/frontend/src/app/(tasks)/feed/subscriptions/page.tsx
+++ b/frontend/src/app/(tasks)/feed/subscriptions/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, Plus } from 'lucide-react'
 import TopNavigation from '@/features/layout/TopNavigation'
@@ -13,12 +14,6 @@ import {
   ResizableSidebar,
   CollapsedSidebarButtons,
 } from '@/features/tasks/components/sidebar'
-import {
-  SubscriptionList,
-  SubscriptionForm,
-  FollowingSubscriptionList,
-  RentalSubscriptionList,
-} from '@/features/feed/components'
 import {
   SubscriptionProvider,
   useSubscriptionContext,
@@ -30,6 +25,31 @@ import '@/features/common/scrollbar.css'
 import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { Subscription } from '@/types/subscription'
+
+const SubscriptionList = dynamic(
+  () =>
+    import('@/features/feed/components/SubscriptionList').then(module => module.SubscriptionList),
+  { ssr: false }
+)
+const SubscriptionForm = dynamic(
+  () =>
+    import('@/features/feed/components/SubscriptionForm').then(module => module.SubscriptionForm),
+  { ssr: false }
+)
+const FollowingSubscriptionList = dynamic(
+  () =>
+    import('@/features/feed/components/FollowingSubscriptionList').then(
+      module => module.FollowingSubscriptionList
+    ),
+  { ssr: false }
+)
+const RentalSubscriptionList = dynamic(
+  () =>
+    import('@/features/feed/components/RentalSubscriptionList').then(
+      module => module.RentalSubscriptionList
+    ),
+  { ssr: false }
+)
 
 /**
  * Tab type for subscription management
@@ -144,12 +164,14 @@ function SubscriptionsPageContent() {
       </div>
 
       {/* Form Dialog */}
-      <SubscriptionForm
-        open={formOpen}
-        onOpenChange={setFormOpen}
-        subscription={editingSubscription}
-        onSuccess={handleFormSuccess}
-      />
+      {formOpen && (
+        <SubscriptionForm
+          open={formOpen}
+          onOpenChange={setFormOpen}
+          subscription={editingSubscription}
+          onSuccess={handleFormSuccess}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/knowledge/[namespace]/[kbName]/[[...docPath]]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/[namespace]/[kbName]/[[...docPath]]/page.tsx
@@ -22,6 +22,7 @@
  */
 
 import { Suspense, useState, useCallback, useEffect } from 'react'
+import dynamic from 'next/dynamic'
 import { useParams, useRouter } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import {
@@ -40,13 +41,24 @@ import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContex
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { paths } from '@/config/paths'
 import { Spinner } from '@/components/ui/spinner'
-import {
-  AddRepoModal,
-  useWikiProjects,
-  CancelConfirmDialog,
-  KnowledgeTabs,
-  KnowledgeDocumentPage,
-} from '@/features/knowledge'
+import { useWikiProjects } from '@/features/knowledge/useWikiProjects'
+import { KnowledgeTabs } from '@/features/knowledge/KnowledgeTabs'
+
+const AddRepoModal = dynamic(() => import('@/features/knowledge/AddRepoModal'), {
+  ssr: false,
+})
+
+const CancelConfirmDialog = dynamic(() => import('@/features/knowledge/CancelConfirmDialog'), {
+  ssr: false,
+})
+
+const KnowledgeDocumentPage = dynamic(
+  () =>
+    import('@/features/knowledge/document/components/KnowledgeDocumentPage').then(mod => ({
+      default: mod.KnowledgeDocumentPage,
+    })),
+  { ssr: false }
+)
 
 // Storage key for knowledge sidebar collapsed state
 const KNOWLEDGE_SIDEBAR_COLLAPSED_KEY = 'knowledge-sidebar-collapsed'
@@ -215,25 +227,29 @@ function KnowledgeVirtualPageContent() {
       </div>
 
       {/* Add repository modal */}
-      <AddRepoModal
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
-        formErrors={formErrors}
-        isSubmitting={isSubmitting}
-        onRepoChange={handleRepoChange}
-        onSubmit={handleSubmit}
-        selectedRepo={selectedRepo}
-        wikiConfig={wikiConfig}
-      />
+      {isModalOpen && (
+        <AddRepoModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          formErrors={formErrors}
+          isSubmitting={isSubmitting}
+          onRepoChange={handleRepoChange}
+          onSubmit={handleSubmit}
+          selectedRepo={selectedRepo}
+          wikiConfig={wikiConfig}
+        />
+      )}
       {/* Cancel confirm dialog */}
-      <CancelConfirmDialog
-        isOpen={confirmDialogOpen}
-        onClose={() => {
-          setConfirmDialogOpen(false)
-          setPendingCancelProjectId(null)
-        }}
-        onConfirm={confirmCancelGeneration}
-      />
+      {confirmDialogOpen && (
+        <CancelConfirmDialog
+          isOpen={confirmDialogOpen}
+          onClose={() => {
+            setConfirmDialogOpen(false)
+            setPendingCancelProjectId(null)
+          }}
+          onConfirm={confirmCancelGeneration}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/knowledge/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { Suspense, useState, useEffect, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter, useSearchParams } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import {
@@ -24,16 +25,30 @@ import { useChatStreamContext } from '@/features/tasks/contexts/chatStreamContex
 import { useTaskContext } from '@/features/tasks/contexts/taskContext'
 import { paths } from '@/config/paths'
 import { Spinner } from '@/components/ui/spinner'
-import {
-  WikiProjectList,
-  AddRepoModal,
-  useWikiProjects,
-  CancelConfirmDialog,
-  SearchBox,
-  KnowledgeTabs,
-  KnowledgeTabType,
-  KnowledgeDocumentPage,
-} from '@/features/knowledge'
+import { useWikiProjects } from '@/features/knowledge/useWikiProjects'
+import { SearchBox } from '@/features/knowledge/SearchBox'
+import { KnowledgeTabs } from '@/features/knowledge/KnowledgeTabs'
+import type { KnowledgeTabType } from '@/features/knowledge/KnowledgeTabs'
+
+const WikiProjectList = dynamic(() => import('@/features/knowledge/WikiProjectList'), {
+  ssr: false,
+})
+
+const AddRepoModal = dynamic(() => import('@/features/knowledge/AddRepoModal'), {
+  ssr: false,
+})
+
+const CancelConfirmDialog = dynamic(() => import('@/features/knowledge/CancelConfirmDialog'), {
+  ssr: false,
+})
+
+const KnowledgeDocumentPage = dynamic(
+  () =>
+    import('@/features/knowledge/document/components/KnowledgeDocumentPage').then(mod => ({
+      default: mod.KnowledgeDocumentPage,
+    })),
+  { ssr: false }
+)
 
 // Storage key for knowledge sidebar collapsed state
 const KNOWLEDGE_SIDEBAR_COLLAPSED_KEY = 'knowledge-sidebar-collapsed'
@@ -281,25 +296,29 @@ function KnowledgePageContent() {
       </div>
 
       {/* Add repository modal */}
-      <AddRepoModal
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
-        formErrors={formErrors}
-        isSubmitting={isSubmitting}
-        onRepoChange={handleRepoChange}
-        onSubmit={handleSubmit}
-        selectedRepo={selectedRepo}
-        wikiConfig={wikiConfig}
-      />
+      {isModalOpen && (
+        <AddRepoModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          formErrors={formErrors}
+          isSubmitting={isSubmitting}
+          onRepoChange={handleRepoChange}
+          onSubmit={handleSubmit}
+          selectedRepo={selectedRepo}
+          wikiConfig={wikiConfig}
+        />
+      )}
       {/* Cancel confirm dialog */}
-      <CancelConfirmDialog
-        isOpen={confirmDialogOpen}
-        onClose={() => {
-          setConfirmDialogOpen(false)
-          setPendingCancelProjectId(null)
-        }}
-        onConfirm={confirmCancelGeneration}
-      />
+      {confirmDialogOpen && (
+        <CancelConfirmDialog
+          isOpen={confirmDialogOpen}
+          onClose={() => {
+            setConfirmDialogOpen(false)
+            setPendingCancelProjectId(null)
+          }}
+          onConfirm={confirmCancelGeneration}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/app/(tasks)/knowledge/project/[projectId]/page.tsx
+++ b/frontend/src/app/(tasks)/knowledge/project/[projectId]/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import dynamic from 'next/dynamic'
 import { useParams, useRouter } from 'next/navigation'
 import TopNavigation from '@/features/layout/TopNavigation'
 import UserMenu from '@/features/layout/UserMenu'
@@ -13,13 +14,15 @@ import '@/features/common/scrollbar.css'
 import { GithubStarButton } from '@/features/layout/GithubStarButton'
 import { useTranslation } from '@/hooks/useTranslation'
 import { saveLastTab } from '@/utils/userPreferences'
-import {
-  wikiStyles,
-  WikiDetailSidebar,
-  useMermaidInit,
-  WikiContent,
-  useWikiDetail,
-} from '@/features/knowledge'
+import { wikiStyles } from '@/features/knowledge/wikiStyles'
+import { WikiDetailSidebar } from '@/features/knowledge/WikiDetailSidebar'
+import { useMermaidInit } from '@/features/knowledge/useMermaidInit'
+import { useWikiDetail } from '@/features/knowledge/useWikiDetail'
+
+const WikiContent = dynamic(
+  () => import('@/features/knowledge/WikiContent').then(mod => ({ default: mod.WikiContent })),
+  { ssr: false }
+)
 
 export default function WikiDetailPage() {
   const { t: _t } = useTranslation()

--- a/frontend/src/app/(tasks)/layout.tsx
+++ b/frontend/src/app/(tasks)/layout.tsx
@@ -4,6 +4,7 @@
 
 'use client'
 
+import dynamic from 'next/dynamic'
 import { UserProvider } from '@/features/common/UserContext'
 import { TaskContextProvider } from '@/features/tasks/contexts/taskContext'
 import { ChatStreamProvider } from '@/features/tasks/contexts/chatStreamContext'
@@ -11,9 +12,26 @@ import { SocketProvider } from '@/contexts/SocketContext'
 import { DeviceProvider } from '@/contexts/DeviceContext'
 import { TeamProvider } from '@/contexts/TeamContext'
 import { ProjectProvider } from '@/features/projects/contexts/projectContext'
-import { PetProvider, PetWidget, PetStreamingBridge } from '@/features/pet'
+import { PetProvider } from '@/features/pet/contexts/PetContext'
 import { SetupWizardProvider } from '@/features/admin/contexts/SetupWizardContext'
-import GlobalAdminSetupWizard from '@/features/admin/components/GlobalAdminSetupWizard'
+
+const PetWidget = dynamic(
+  () => import('@/features/pet/components/PetWidget').then(mod => ({ default: mod.PetWidget })),
+  { ssr: false }
+)
+
+const PetStreamingBridge = dynamic(
+  () =>
+    import('@/features/pet/components/PetStreamingBridge').then(mod => ({
+      default: mod.PetStreamingBridge,
+    })),
+  { ssr: false }
+)
+
+const GlobalAdminSetupWizard = dynamic(
+  () => import('@/features/admin/components/GlobalAdminSetupWizard'),
+  { ssr: false }
+)
 
 /**
  * Shared layout for chat and code pages to reuse TaskContextProvider and ChatStreamProvider

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -6,26 +6,13 @@
 
 import { Suspense, useState, useCallback, useEffect, useMemo } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import TopNavigation from '@/features/layout/TopNavigation'
 import { TaskSidebar, ResizableSidebar } from '@/features/tasks/components/sidebar'
-import { AdminTabNav, AdminTabId } from '@/features/admin/components/AdminTabNav'
+import { AdminTabNav } from '@/features/admin/components/AdminTabNav'
+import type { AdminTabId } from '@/features/admin/components/AdminTabNav'
 import { ShieldExclamationIcon } from '@heroicons/react/24/outline'
-import UserList from '@/features/admin/components/UserList'
-import PublicModelList from '@/features/admin/components/PublicModelList'
-import PublicRetrieverList from '@/features/admin/components/PublicRetrieverList'
-import PublicSkillList from '@/features/admin/components/PublicSkillList'
-import PublicGhostList from '@/features/admin/components/PublicGhostList'
-import PublicShellList from '@/features/admin/components/PublicShellList'
-import PublicTeamList from '@/features/admin/components/PublicTeamList'
-import PublicBotList from '@/features/admin/components/PublicBotList'
-import TemplateList from '@/features/admin/components/TemplateList'
-import ApiKeyManagement from '@/features/admin/components/ApiKeyManagement'
-import SystemConfigPanel from '@/features/admin/components/SystemConfigPanel'
-import BackgroundExecutionMonitorPanel from '@/features/admin/components/BackgroundExecutionMonitorPanel'
-import DeviceMonitorPanel from '@/features/admin/components/DeviceMonitorPanel'
-import GlobalAdminSetupWizard from '@/features/admin/components/GlobalAdminSetupWizard'
-import IMChannelList from '@/features/admin/components/IMChannelList'
 import { UserProvider, useUser } from '@/features/common/UserContext'
 import { TaskContextProvider } from '@/features/tasks/contexts/taskContext'
 import { ChatStreamProvider } from '@/features/tasks/contexts/chatStreamContext'
@@ -39,6 +26,53 @@ import { useIsMobile } from '@/features/layout/hooks/useMediaQuery'
 import { Button } from '@/components/ui/button'
 import '@/app/tasks/tasks.css'
 import '@/features/common/scrollbar.css'
+
+const UserList = dynamic(() => import('@/features/admin/components/UserList'), { ssr: false })
+const PublicModelList = dynamic(() => import('@/features/admin/components/PublicModelList'), {
+  ssr: false,
+})
+const PublicRetrieverList = dynamic(
+  () => import('@/features/admin/components/PublicRetrieverList'),
+  { ssr: false }
+)
+const PublicSkillList = dynamic(() => import('@/features/admin/components/PublicSkillList'), {
+  ssr: false,
+})
+const PublicGhostList = dynamic(() => import('@/features/admin/components/PublicGhostList'), {
+  ssr: false,
+})
+const PublicShellList = dynamic(() => import('@/features/admin/components/PublicShellList'), {
+  ssr: false,
+})
+const PublicTeamList = dynamic(() => import('@/features/admin/components/PublicTeamList'), {
+  ssr: false,
+})
+const PublicBotList = dynamic(() => import('@/features/admin/components/PublicBotList'), {
+  ssr: false,
+})
+const TemplateList = dynamic(() => import('@/features/admin/components/TemplateList'), {
+  ssr: false,
+})
+const ApiKeyManagement = dynamic(() => import('@/features/admin/components/ApiKeyManagement'), {
+  ssr: false,
+})
+const SystemConfigPanel = dynamic(() => import('@/features/admin/components/SystemConfigPanel'), {
+  ssr: false,
+})
+const BackgroundExecutionMonitorPanel = dynamic(
+  () => import('@/features/admin/components/BackgroundExecutionMonitorPanel'),
+  { ssr: false }
+)
+const DeviceMonitorPanel = dynamic(() => import('@/features/admin/components/DeviceMonitorPanel'), {
+  ssr: false,
+})
+const IMChannelList = dynamic(() => import('@/features/admin/components/IMChannelList'), {
+  ssr: false,
+})
+const GlobalAdminSetupWizard = dynamic(
+  () => import('@/features/admin/components/GlobalAdminSetupWizard'),
+  { ssr: false }
+)
 
 function AccessDenied() {
   const { t } = useTranslation()

--- a/frontend/src/app/shared/task/page.tsx
+++ b/frontend/src/app/shared/task/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import React, { useEffect, useState, Suspense } from 'react'
+import dynamic from 'next/dynamic'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -14,12 +15,16 @@ import { LogIn } from 'lucide-react'
 import { useTheme } from '@/features/theme/ThemeProvider'
 import TopNavigation from '@/features/layout/TopNavigation'
 import { GithubStarButton } from '@/features/layout/GithubStarButton'
-import { MessageBubble, type Message } from '@/features/tasks/components/message'
+import type { Message } from '@/features/tasks/components/message'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { User, SubtaskContextBrief } from '@/types/api'
 import { InAppBrowserGuard } from '@/components/InAppBrowserGuard'
 import { detectInAppBrowser } from '@/utils/browserDetection'
 import '@/features/common/scrollbar.css'
+
+const MessageBubble = dynamic(() => import('@/features/tasks/components/message/MessageBubble'), {
+  ssr: false,
+})
 
 /**
  * Public shared task page - no authentication required

--- a/frontend/src/app/tasks/page.tsx
+++ b/frontend/src/app/tasks/page.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { Suspense, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { teamService } from '@/features/tasks/service/teamService'
 import TopNavigation from '@/features/layout/TopNavigation'
 import { TaskSidebar } from '@/features/tasks/components/sidebar'
@@ -22,7 +23,10 @@ import { TaskContextProvider } from '@/features/tasks/contexts/taskContext'
 import { ChatStreamProvider } from '@/features/tasks/contexts/chatStreamContext'
 import { SocketProvider } from '@/contexts/SocketContext'
 import { DeviceProvider } from '@/contexts/DeviceContext'
-import { ChatArea } from '@/features/tasks/components/chat'
+
+const ChatArea = dynamic(() => import('@/features/tasks/components/chat/ChatArea'), {
+  ssr: false,
+})
 
 function TasksPageContent() {
   // Team state from service

--- a/frontend/src/features/feed/components/DiscoverHistoryDialog.tsx
+++ b/frontend/src/features/feed/components/DiscoverHistoryDialog.tsx
@@ -9,6 +9,7 @@
  * Displays the recent 5 execution history records for a discovered subscription.
  */
 import { useEffect, useState, useCallback } from 'react'
+import dynamic from 'next/dynamic'
 import {
   AlertCircle,
   CheckCircle2,
@@ -34,8 +35,15 @@ import { subscriptionApis } from '@/apis/subscription'
 import type { BackgroundExecution, BackgroundExecutionStatus } from '@/types/subscription'
 import { cn } from '@/lib/utils'
 import { parseUTCDate } from '@/lib/utils'
-import { SubscriptionConversationDialog } from './SubscriptionConversationDialog'
 import { EnhancedMarkdown } from '@/components/common/EnhancedMarkdown'
+
+const SubscriptionConversationDialog = dynamic(
+  () =>
+    import('./SubscriptionConversationDialog').then(
+      module => module.SubscriptionConversationDialog
+    ),
+  { ssr: false }
+)
 
 /**
  * Generic subscription info interface for the history dialog.
@@ -309,13 +317,15 @@ export function DiscoverHistoryDialog({
       </Dialog>
 
       {/* Conversation Dialog */}
-      <SubscriptionConversationDialog
-        taskId={dialogTaskId}
-        open={dialogTaskId !== null}
-        onOpenChange={open => {
-          if (!open) setDialogTaskId(null)
-        }}
-      />
+      {dialogTaskId !== null && (
+        <SubscriptionConversationDialog
+          taskId={dialogTaskId}
+          open={dialogTaskId !== null}
+          onOpenChange={open => {
+            if (!open) setDialogTaskId(null)
+          }}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/features/feed/components/SubscriptionList.tsx
+++ b/frontend/src/features/feed/components/SubscriptionList.tsx
@@ -8,6 +8,7 @@
  * Subscription configuration list component.
  */
 import { useCallback, useState } from 'react'
+import dynamic from 'next/dynamic'
 import {
   AlertCircle,
   CalendarClock,
@@ -66,7 +67,14 @@ import type {
 } from '@/types/subscription'
 import { toast } from 'sonner'
 import { formatUTCDate, parseUTCDate } from '@/lib/utils'
-import { SubscriptionConversationDialog } from './SubscriptionConversationDialog'
+
+const SubscriptionConversationDialog = dynamic(
+  () =>
+    import('./SubscriptionConversationDialog').then(
+      module => module.SubscriptionConversationDialog
+    ),
+  { ssr: false }
+)
 
 interface SubscriptionListProps {
   onCreateSubscription: () => void
@@ -797,13 +805,15 @@ export function SubscriptionList({
       </AlertDialog>
 
       {/* Conversation Dialog */}
-      <SubscriptionConversationDialog
-        taskId={dialogTaskId}
-        open={dialogTaskId !== null}
-        onOpenChange={open => {
-          if (!open) setDialogTaskId(null)
-        }}
-      />
+      {dialogTaskId !== null && (
+        <SubscriptionConversationDialog
+          taskId={dialogTaskId}
+          open={dialogTaskId !== null}
+          onOpenChange={open => {
+            if (!open) setDialogTaskId(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/features/feed/components/SubscriptionPage.tsx
+++ b/frontend/src/features/feed/components/SubscriptionPage.tsx
@@ -10,19 +10,42 @@
  * Supports multiple tabs for extensibility.
  */
 import { useState, useCallback, useEffect } from 'react'
+import dynamic from 'next/dynamic'
 import { Compass, Eye, EyeOff, Plus, Store, User } from 'lucide-react'
 import { SubscriptionProvider, useSubscriptionContext } from '../contexts/subscriptionContext'
-import { SubscriptionTimeline } from './SubscriptionTimeline'
-import { SubscriptionForm } from './SubscriptionForm'
-import { SubscriptionList } from './SubscriptionList'
-import { FollowingSubscriptionList } from './FollowingSubscriptionList'
-import { RentalSubscriptionList } from './RentalSubscriptionList'
-import { DiscoverPageInline } from './DiscoverPageInline'
-import { MarketPageInline } from './MarketPageInline'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { Subscription } from '@/types/subscription'
+
+const SubscriptionTimeline = dynamic(
+  () => import('./SubscriptionTimeline').then(module => module.SubscriptionTimeline),
+  { ssr: false }
+)
+const SubscriptionForm = dynamic(
+  () => import('./SubscriptionForm').then(module => module.SubscriptionForm),
+  { ssr: false }
+)
+const SubscriptionList = dynamic(
+  () => import('./SubscriptionList').then(module => module.SubscriptionList),
+  { ssr: false }
+)
+const FollowingSubscriptionList = dynamic(
+  () => import('./FollowingSubscriptionList').then(module => module.FollowingSubscriptionList),
+  { ssr: false }
+)
+const RentalSubscriptionList = dynamic(
+  () => import('./RentalSubscriptionList').then(module => module.RentalSubscriptionList),
+  { ssr: false }
+)
+const DiscoverPageInline = dynamic(
+  () => import('./DiscoverPageInline').then(module => module.DiscoverPageInline),
+  { ssr: false }
+)
+const MarketPageInline = dynamic(
+  () => import('./MarketPageInline').then(module => module.MarketPageInline),
+  { ssr: false }
+)
 
 /**
  * Tab configuration for extensibility.
@@ -280,13 +303,15 @@ function SubscriptionPageContent() {
         )}
       </div>
 
-      <SubscriptionForm
-        open={isFormOpen}
-        onOpenChange={setIsFormOpen}
-        subscription={editingSubscription}
-        onSuccess={handleFormSuccess}
-        initialData={formInitialData}
-      />
+      {isFormOpen && (
+        <SubscriptionForm
+          open={isFormOpen}
+          onOpenChange={setIsFormOpen}
+          subscription={editingSubscription}
+          onSuccess={handleFormSuccess}
+          initialData={formInitialData}
+        />
+      )}
     </div>
   )
 }

--- a/frontend/src/features/feed/components/SubscriptionTimeline.tsx
+++ b/frontend/src/features/feed/components/SubscriptionTimeline.tsx
@@ -9,6 +9,7 @@
  * Displays background executions as posts similar to social media feeds.
  */
 import { useMemo, useState } from 'react'
+import dynamic from 'next/dynamic'
 import {
   AlertCircle,
   Bot,
@@ -47,7 +48,14 @@ import { useTheme } from '@/features/theme/ThemeProvider'
 import { useSubscriptionContext } from '../contexts/subscriptionContext'
 import type { BackgroundExecution, BackgroundExecutionStatus } from '@/types/subscription'
 import { parseUTCDate } from '@/lib/utils'
-import { SubscriptionConversationDialog } from './SubscriptionConversationDialog'
+
+const SubscriptionConversationDialog = dynamic(
+  () =>
+    import('./SubscriptionConversationDialog').then(
+      module => module.SubscriptionConversationDialog
+    ),
+  { ssr: false }
+)
 
 interface SubscriptionTimelineProps {
   onCreateSubscription?: () => void
@@ -602,13 +610,15 @@ export function SubscriptionTimeline({
       )}
 
       {/* Conversation Dialog */}
-      <SubscriptionConversationDialog
-        taskId={dialogTaskId}
-        open={dialogTaskId !== null}
-        onOpenChange={open => {
-          if (!open) setDialogTaskId(null)
-        }}
-      />
+      {dialogTaskId !== null && (
+        <SubscriptionConversationDialog
+          taskId={dialogTaskId}
+          open={dialogTaskId !== null}
+          onOpenChange={open => {
+            if (!open) setDialogTaskId(null)
+          }}
+        />
+      )}
 
       {/* Delete Confirmation Dialog */}
       <AlertDialog

--- a/frontend/src/features/resource-library/components/MyResources.tsx
+++ b/frontend/src/features/resource-library/components/MyResources.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import { useCallback, useEffect, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { useRouter } from 'next/navigation'
 import { Boxes, Check, ChevronDown, Settings2, Users } from 'lucide-react'
 
@@ -17,11 +18,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown'
-import { ModelListWithScope } from '@/features/settings/components/ModelListWithScope'
-import { RetrieverListWithScope } from '@/features/settings/components/RetrieverListWithScope'
-import { ShellListWithScope } from '@/features/settings/components/ShellListWithScope'
-import { SkillListWithScope } from '@/features/settings/components/SkillListWithScope'
-import { TeamListWithScope } from '@/features/settings/components/TeamListWithScope'
 import { paths } from '@/config/paths'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
@@ -37,6 +33,42 @@ const managedResourceTypes: ManagedResourceType[] = [
   'shell',
   'retriever',
 ]
+
+const TeamListWithScope = dynamic(
+  () =>
+    import('@/features/settings/components/TeamListWithScope').then(
+      module => module.TeamListWithScope
+    ),
+  { ssr: false }
+)
+const ModelListWithScope = dynamic(
+  () =>
+    import('@/features/settings/components/ModelListWithScope').then(
+      module => module.ModelListWithScope
+    ),
+  { ssr: false }
+)
+const ShellListWithScope = dynamic(
+  () =>
+    import('@/features/settings/components/ShellListWithScope').then(
+      module => module.ShellListWithScope
+    ),
+  { ssr: false }
+)
+const SkillListWithScope = dynamic(
+  () =>
+    import('@/features/settings/components/SkillListWithScope').then(
+      module => module.SkillListWithScope
+    ),
+  { ssr: false }
+)
+const RetrieverListWithScope = dynamic(
+  () =>
+    import('@/features/settings/components/RetrieverListWithScope').then(
+      module => module.RetrieverListWithScope
+    ),
+  { ssr: false }
+)
 
 function getInitialSearchParam(name: string): string | null {
   if (typeof window === 'undefined') {


### PR DESCRIPTION
## Summary
- Remove the custom global vendors/common splitChunks override so Next.js can keep route-aware production chunking.
- Lazy-load heavy route-only panels and dialogs across chat/code, knowledge, feed, admin, resource library, shared task, and device chat routes.
- Add regression tests that guard against reintroducing route-wide barrels and synchronous heavy imports.

## Test Plan
- `git diff --check`
- `npm test -- --runInBand --runTestsByPath src/__tests__/config/next-config-performance.test.ts src/__tests__/config/route-import-performance.test.ts 'src/__tests__/app/(tasks)/chat/ChatPageDesktop.remote-workspace.test.tsx' 'src/__tests__/app/(tasks)/code/CodePageDesktop.remote-workspace.test.tsx'`
- `NEXT_TELEMETRY_DISABLED=1 npm run build`
- `npm test -- --passWithNoTests`
- Pre-push hook: ESLint, TypeScript check, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized initial page loads by converting multiple components to dynamic imports, reducing bundle size across chat, code, knowledge, feed, and admin sections.
  * Refined webpack configuration for improved automatic chunk splitting.

* **Tests**
  * Added performance validation tests to verify route imports avoid unnecessary static bundling and webpack chunking behavior is optimized.

* **Configuration**
  * Updated Jest and Next.js configurations for enhanced test isolation and code splitting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->