### PR TITLE
fix(frontend): render thinking blocks inline

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
@@ -22,6 +22,21 @@ jest.mock('@/features/tasks/components/message/thinking/components/GuidanceBlock
   ),
 }))
 
+jest.mock('@/features/tasks/components/message/thinking/ReasoningDisplay', () => ({
+  __esModule: true,
+  default: ({
+    reasoningContent,
+    isStreaming,
+  }: {
+    reasoningContent: string
+    isStreaming?: boolean
+  }) => (
+    <div data-testid="inline-thinking-block" data-streaming={isStreaming ? 'true' : 'false'}>
+      {reasoningContent}
+    </div>
+  ),
+}))
+
 jest.mock('@/components/common/EnhancedMarkdown', () => ({
   __esModule: true,
   default: ({ source }: { source: string }) => <div>{source}</div>,
@@ -57,6 +72,65 @@ jest.mock('@/features/tasks/components/message/block-registry', () => ({
 jest.mock('@/features/prompt-optimization/block-renderer', () => ({}))
 
 describe('MixedContentView', () => {
+  it('renders thinking blocks in chronological order as standalone collapsible items', () => {
+    render(
+      <MixedContentView
+        thinking={null}
+        content=""
+        theme="light"
+        blocks={[
+          {
+            id: 'thinking-1',
+            type: 'thinking',
+            status: 'done',
+            content: 'First thought.',
+          },
+          {
+            id: 'text-1',
+            type: 'text',
+            status: 'done',
+            content: 'First answer.',
+          },
+          {
+            id: 'tool-1',
+            type: 'tool',
+            status: 'done',
+            tool_name: 'Read',
+            tool_use_id: 'tool-1',
+            tool_input: { file_path: 'README.md' },
+          },
+          {
+            id: 'thinking-2',
+            type: 'thinking',
+            status: 'streaming',
+            content: 'Second thought.',
+          },
+          {
+            id: 'text-2',
+            type: 'text',
+            status: 'streaming',
+            content: 'Final answer.',
+          },
+        ]}
+      />
+    )
+
+    const firstThought = screen.getByText('First thought.')
+    const firstAnswer = screen.getByText('First answer.')
+    const toolBlock = screen.getByTestId('tool-block')
+    const secondThought = screen.getByText('Second thought.')
+    const finalAnswer = screen.getByText('Final answer.')
+
+    expect(firstThought.compareDocumentPosition(firstAnswer)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(firstAnswer.compareDocumentPosition(toolBlock)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(toolBlock.compareDocumentPosition(secondThought)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(secondThought.compareDocumentPosition(finalAnswer)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+    expect(screen.getAllByTestId('inline-thinking-block')).toHaveLength(2)
+    expect(screen.getByText('Second thought.')).toHaveAttribute('data-streaming', 'true')
+  })
+
   it('renders only the interactive form block that contains questions', () => {
     render(
       <MixedContentView

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -62,6 +62,42 @@ describe('TaskStateMachine', () => {
     })
   })
 
+  it('preserves new done text blocks when inline thinking blocks exist', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: jest.fn(),
+      isConnected: () => true,
+    })
+
+    machine.handleChatStart(42, 'Chat', 7)
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'Thought.' })
+    machine.handleChatChunk(42, 'First answer.')
+    machine.handleChatDone(42, 'First answer. Late answer.', {
+      blocks: [
+        {
+          id: 'done-duplicate-text',
+          type: 'text',
+          content: 'First answer.',
+          status: 'done',
+        },
+        {
+          id: 'done-late-text',
+          type: 'text',
+          content: 'Late answer.',
+          status: 'done',
+        },
+      ],
+    })
+
+    const message = machine.getState().messages.get('ai-42')
+    const blocks = message?.result?.blocks ?? []
+
+    expect(blocks.map(block => block.type)).toEqual(['thinking', 'text', 'text'])
+    expect(
+      blocks.map(block => (block.type === 'text' || block.type === 'thinking' ? block.content : ''))
+    ).toEqual(['Thought.', 'First answer.', 'Late answer.'])
+    expect(blocks.every(block => block.status === 'done')).toBe(true)
+  })
+
   it('does not debounce a recovery that exits before the socket is connected', async () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000)
     const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -5,6 +5,63 @@
 import { TaskStateMachine } from '@/features/tasks/state'
 
 describe('TaskStateMachine', () => {
+  it('stores reasoning chunks as chronological thinking blocks', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: jest.fn(),
+      isConnected: () => true,
+    })
+
+    machine.handleChatStart(42, 'Chat', 7)
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'First thought. ' })
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'Still thinking.' })
+    machine.handleChatChunk(42, 'First answer.')
+    machine.handleChatChunk(42, '', {
+      blocks: [
+        {
+          id: 'tool-1',
+          type: 'tool',
+          tool_use_id: 'tool-1',
+          tool_name: 'Read',
+          tool_input: { file_path: 'README.md' },
+          status: 'pending',
+        },
+      ],
+    })
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'Second thought.' })
+    machine.handleChatChunk(42, 'Final answer.')
+
+    const message = machine.getState().messages.get('ai-42')
+    const blocks = message?.result?.blocks ?? []
+
+    expect(blocks.map(block => block.type)).toEqual([
+      'thinking',
+      'text',
+      'tool',
+      'thinking',
+      'text',
+    ])
+    expect(blocks[0]).toMatchObject({
+      type: 'thinking',
+      content: 'First thought. Still thinking.',
+      status: 'done',
+    })
+    expect(blocks[1]).toMatchObject({
+      type: 'text',
+      content: 'First answer.',
+      status: 'done',
+    })
+    expect(blocks[3]).toMatchObject({
+      type: 'thinking',
+      content: 'Second thought.',
+      status: 'done',
+    })
+    expect(blocks[4]).toMatchObject({
+      type: 'text',
+      content: 'Final answer.',
+      status: 'streaming',
+    })
+  })
+
   it('does not debounce a recovery that exits before the socket is connected', async () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000)
     const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -98,6 +98,24 @@ describe('TaskStateMachine', () => {
     expect(blocks.every(block => block.status === 'done')).toBe(true)
   })
 
+  it('finalizes streaming blocks on chat done without event result', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: jest.fn(),
+      isConnected: () => true,
+    })
+
+    machine.handleChatStart(42, 'Chat', 7)
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'Thought.' })
+    machine.handleChatChunk(42, 'Final answer.')
+    machine.handleChatDone(42, 'Final answer.')
+
+    const message = machine.getState().messages.get('ai-42')
+    const blocks = message?.result?.blocks ?? []
+
+    expect(blocks.map(block => block.type)).toEqual(['thinking', 'text'])
+    expect(blocks.every(block => block.status === 'done')).toBe(true)
+  })
+
   it('does not debounce a recovery that exits before the socket is connected', async () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000)
     const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -629,6 +629,11 @@ const MessageBubble = memo(
       return hasClarificationMarker || hasFinalPromptMarker
     }, [msg.content, msg.type, msg.result?.blocks, recoveredAskUserFormData])
 
+    const hasInlineThinkingBlocks = React.useMemo(
+      () => msg.result?.blocks?.some(block => block.type === 'thinking') ?? false,
+      [msg.result?.blocks]
+    )
+
     const renderProgressBar = (status: string, progress: number) => {
       const normalizedStatus = (status ?? '').toUpperCase()
       const isActiveStatus = ['RUNNING', 'PENDING', 'PROCESSING'].includes(normalizedStatus)
@@ -1554,12 +1559,14 @@ const MessageBubble = memo(
                 </div>
               )}
               {/* Show reasoning display for DeepSeek R1 and similar models */}
-              {!isUserTypeMessage && (msg.reasoningContent || msg.result?.reasoning_content) && (
-                <ReasoningDisplay
-                  reasoningContent={msg.reasoningContent || msg.result?.reasoning_content || ''}
-                  isStreaming={!!msg.isReasoningStreaming}
-                />
-              )}
+              {!isUserTypeMessage &&
+                !hasInlineThinkingBlocks &&
+                (msg.reasoningContent || msg.result?.reasoning_content) && (
+                  <ReasoningDisplay
+                    reasoningContent={msg.reasoningContent || msg.result?.reasoning_content || ''}
+                    isStreaming={!!msg.isReasoningStreaming}
+                  />
+                )}
               {/* Show tool blocks for messages with thinking but no blocks */}
               {!isUserTypeMessage &&
                 msg.thinking &&

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -9,6 +9,7 @@ import type { ThinkingStep, MessageBlock, ToolPair } from './types'
 import { useToolExtraction } from './hooks/useToolExtraction'
 import { ToolBlock } from './components/ToolBlock'
 import { GuidanceBlock } from './components/GuidanceBlock'
+import ReasoningDisplay from './ReasoningDisplay'
 import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
 import { normalizeToolName, normalizeStepDetails } from './utils/toolExtractor'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -134,6 +135,13 @@ const MixedContentView = memo(function MixedContentView({
               type: 'content' as const,
               content: textContent,
               blockId: block.id,
+            }
+          } else if (block.type === 'thinking') {
+            return {
+              type: 'thinking' as const,
+              content: block.content || '',
+              blockId: block.id,
+              status: block.status,
             }
           } else if (block.type === 'video') {
             // Video block - render VideoPlayer component
@@ -540,6 +548,17 @@ const MixedContentView = memo(function MixedContentView({
                 <div className="text-xs text-text-muted">{item.message}</div>
               )}
             </div>
+          )
+        } else if (item.type === 'thinking') {
+          if (!item.content || typeof item.content !== 'string' || !item.content.trim()) {
+            return null
+          }
+          return (
+            <ReasoningDisplay
+              key={item.blockId}
+              reasoningContent={item.content}
+              isStreaming={item.status === 'streaming'}
+            />
           )
         } else if (item.type === 'image') {
           // Render image block using ImageGallery component

--- a/frontend/src/features/tasks/state/TaskStateMachine.blockMerging.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.blockMerging.ts
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { MessageBlock } from '../components/message/thinking/types'
+
+export type StreamingBlockType = 'text' | 'thinking'
+
+interface MergeStreamingBlocksInput {
+  existingBlocks: MessageBlock[]
+  incomingBlocks: MessageBlock[]
+  content?: string
+  blockId?: string
+  reasoningChunk?: string
+}
+
+export function mergeStreamingBlocks({
+  existingBlocks,
+  incomingBlocks,
+  content,
+  blockId,
+  reasoningChunk,
+}: MergeStreamingBlocksInput): MessageBlock[] {
+  if (reasoningChunk) {
+    return mergeReasoningBlock(existingBlocks, reasoningChunk)
+  }
+
+  if (blockId && content) {
+    return mergeTextBlockWithId(existingBlocks, blockId, content)
+  }
+
+  if (content && !blockId && incomingBlocks.length === 0) {
+    return mergeTextWithoutBlockId(existingBlocks, content)
+  }
+
+  if (incomingBlocks.length === 0) {
+    return existingBlocks
+  }
+
+  return mergeIncomingBlocks(existingBlocks, incomingBlocks)
+}
+
+export function mergeReasoningBlock(
+  existingBlocks: MessageBlock[],
+  reasoningChunk: string
+): MessageBlock[] {
+  const blocksArray = finalizeStreamingBlocks(existingBlocks, ['text'])
+  const lastIndex = blocksArray.length - 1
+  const lastBlock = blocksArray[lastIndex]
+
+  if (lastBlock && lastBlock.type === 'thinking' && lastBlock.status === 'streaming') {
+    return blocksArray.map((block, index) =>
+      index === lastIndex && block.type === 'thinking'
+        ? {
+            ...block,
+            content: (block.content || '') + reasoningChunk,
+          }
+        : block
+    )
+  }
+
+  return [
+    ...blocksArray,
+    {
+      id: generateBlockId('thinking'),
+      type: 'thinking',
+      content: reasoningChunk,
+      status: 'streaming',
+      timestamp: Date.now(),
+    },
+  ]
+}
+
+export function finalizeStreamingBlocks(
+  blocks: MessageBlock[],
+  blockTypes: StreamingBlockType[]
+): MessageBlock[] {
+  const blockTypeSet = new Set<string>(blockTypes)
+
+  return blocks.map(block => {
+    if (block.status === 'streaming' && blockTypeSet.has(block.type)) {
+      return {
+        ...block,
+        status: 'done' as const,
+      }
+    }
+    return block
+  })
+}
+
+export function mergeBlocksForDone(
+  existingMessageBlocks: MessageBlock[],
+  incomingBlocks: MessageBlock[]
+): MessageBlock[] {
+  const existingBlocks = finalizeStreamingBlocks(existingMessageBlocks, ['text', 'thinking'])
+
+  if (existingBlocks.length === 0) {
+    return incomingBlocks
+  }
+
+  if (incomingBlocks.length === 0) {
+    return existingBlocks
+  }
+
+  if (existingBlocks.some(block => block.type === 'thinking')) {
+    return mergeDoneBlocksWithInlineThinking(existingBlocks, incomingBlocks)
+  }
+
+  return mergeDoneBlocksWithBackendOrder(existingBlocks, incomingBlocks)
+}
+
+function mergeTextBlockWithId(
+  existingBlocks: MessageBlock[],
+  blockId: string,
+  content: string
+): MessageBlock[] {
+  const finalizedBlocks = finalizeStreamingBlocks(existingBlocks, ['thinking'])
+  const blocksMap = new Map(finalizedBlocks.map(block => [block.id, block]))
+  const targetBlock = blocksMap.get(blockId)
+
+  if (targetBlock && targetBlock.type === 'text') {
+    blocksMap.set(blockId, {
+      ...targetBlock,
+      content: (targetBlock.content || '') + content,
+    })
+  } else if (!targetBlock) {
+    blocksMap.set(blockId, {
+      id: blockId,
+      type: 'text',
+      content,
+      status: 'streaming',
+      timestamp: Date.now(),
+    })
+  }
+
+  return Array.from(blocksMap.values())
+}
+
+function mergeTextWithoutBlockId(existingBlocks: MessageBlock[], content: string): MessageBlock[] {
+  const blocksArray = finalizeStreamingBlocks(existingBlocks, ['thinking'])
+  const lastIndex = blocksArray.length - 1
+  const lastBlock = blocksArray[lastIndex]
+
+  if (lastBlock && lastBlock.type === 'text' && lastBlock.status === 'streaming') {
+    return blocksArray.map((block, index) =>
+      index === lastIndex && block.type === 'text'
+        ? {
+            ...block,
+            content: (block.content || '') + content,
+          }
+        : block
+    )
+  }
+
+  return [
+    ...blocksArray,
+    {
+      id: generateBlockId('text'),
+      type: 'text',
+      content,
+      status: 'streaming',
+      timestamp: Date.now(),
+    },
+  ]
+}
+
+function mergeIncomingBlocks(
+  existingBlocks: MessageBlock[],
+  incomingBlocks: MessageBlock[]
+): MessageBlock[] {
+  const blocksArray = finalizeStreamingBlocks(existingBlocks, ['text', 'thinking'])
+  const blocksMap = new Map(blocksArray.map(block => [block.id, block]))
+
+  incomingBlocks.forEach(incomingBlock => {
+    const existingBlock = blocksMap.get(incomingBlock.id)
+    blocksMap.set(
+      incomingBlock.id,
+      existingBlock ? { ...existingBlock, ...incomingBlock } : incomingBlock
+    )
+  })
+
+  return Array.from(blocksMap.values())
+}
+
+function mergeDoneBlocksWithInlineThinking(
+  existingBlocks: MessageBlock[],
+  incomingBlocks: MessageBlock[]
+): MessageBlock[] {
+  const incomingBlocksMap = new Map(incomingBlocks.map(block => [block.id, block]))
+  const mergedBlocks = existingBlocks.map(existingBlock => {
+    const incomingBlock = incomingBlocksMap.get(existingBlock.id)
+    return incomingBlock ? { ...existingBlock, ...incomingBlock } : existingBlock
+  })
+  const existingIds = new Set(existingBlocks.map(block => block.id))
+  const appendedBlocks = incomingBlocks.filter(
+    block => !existingIds.has(block.id) && !hasDuplicateTextContent(existingBlocks, block)
+  )
+
+  return [...mergedBlocks, ...appendedBlocks]
+}
+
+function mergeDoneBlocksWithBackendOrder(
+  existingBlocks: MessageBlock[],
+  incomingBlocks: MessageBlock[]
+): MessageBlock[] {
+  const existingToolBlocksMap = new Map(
+    existingBlocks.filter(block => block.type !== 'text').map(block => [block.id, block])
+  )
+
+  return incomingBlocks.map(incomingBlock => {
+    if (incomingBlock.type === 'text') {
+      return incomingBlock
+    }
+
+    const existingBlock = existingToolBlocksMap.get(incomingBlock.id)
+    return existingBlock ? { ...existingBlock, ...incomingBlock } : incomingBlock
+  })
+}
+
+function hasDuplicateTextContent(
+  existingBlocks: MessageBlock[],
+  incomingBlock: MessageBlock
+): boolean {
+  return (
+    incomingBlock.type === 'text' &&
+    existingBlocks.some(
+      existingBlock =>
+        existingBlock.type === 'text' && existingBlock.content === incomingBlock.content
+    )
+  )
+}
+
+function generateBlockId(type: StreamingBlockType): string {
+  return `${type}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+}

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -28,6 +28,7 @@
 
 import type { TaskDetailSubtask } from '@/types/api'
 import type { MessageBlock } from '../components/message/thinking/types'
+import { mergeBlocksForDone, mergeStreamingBlocks } from './TaskStateMachine.blockMerging'
 
 /**
  * Task state machine status
@@ -120,8 +121,6 @@ interface PendingChunkEvent {
   sources?: UnifiedMessage['sources']
   blockId?: string
 }
-
-type StreamingBlockType = 'text' | 'thinking'
 
 /**
  * Task state data
@@ -798,91 +797,13 @@ export class TaskStateMachine {
     existingMessage: UnifiedMessage,
     chunk: PendingChunkEvent
   ): MessageBlock[] {
-    const existingBlocks = existingMessage.result?.blocks || []
-    const incomingBlocks = chunk.result?.blocks || []
-    const reasoningChunk = chunk.result?.reasoning_chunk
-
-    // Case 1: reasoning chunk - create/update a thinking block in chronological order
-    if (reasoningChunk) {
-      return this.mergeReasoningBlock(existingBlocks, reasoningChunk)
-    }
-
-    // Case 2: block_id with content - text block update (explicit block_id from backend)
-    if (chunk.blockId && chunk.content) {
-      const finalizedBlocks = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
-      const blocksMap = new Map(finalizedBlocks.map(b => [b.id, b]))
-      const targetBlock = blocksMap.get(chunk.blockId)
-
-      if (targetBlock && targetBlock.type === 'text') {
-        const updatedBlock = {
-          ...targetBlock,
-          content: (targetBlock.content || '') + chunk.content,
-        }
-        blocksMap.set(chunk.blockId, updatedBlock)
-      } else if (!targetBlock) {
-        const newBlock: MessageBlock = {
-          id: chunk.blockId,
-          type: 'text',
-          content: chunk.content,
-          status: 'streaming',
-          timestamp: Date.now(),
-        }
-        blocksMap.set(chunk.blockId, newBlock)
-      }
-
-      return Array.from(blocksMap.values())
-    }
-
-    // Case 3: Text content without block_id (ClaudeCode executor)
-    // Create or update a text block to maintain chronological order
-    if (chunk.content && !chunk.blockId && incomingBlocks.length === 0) {
-      const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
-
-      // Find the last text block that is still streaming
-      const lastBlock = blocksArray[blocksArray.length - 1]
-      if (lastBlock && lastBlock.type === 'text' && lastBlock.status === 'streaming') {
-        // Append to existing streaming text block
-        lastBlock.content = (lastBlock.content || '') + chunk.content
-        return blocksArray
-      }
-
-      // Create a new text block (after tool blocks or at the start)
-      const newTextBlock: MessageBlock = {
-        id: `text-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        type: 'text',
-        content: chunk.content,
-        status: 'streaming',
-        timestamp: Date.now(),
-      }
-      blocksArray.push(newTextBlock)
-      return blocksArray
-    }
-
-    // Case 4: No incoming blocks and no content - keep existing
-    if (incomingBlocks.length === 0) {
-      return existingBlocks
-    }
-
-    // Case 5: Tool/other blocks - merge by block.id
-    // CRITICAL: For partial updates (e.g., block_updated with only status),
-    // we must merge with existing block to preserve all fields
-    // Also: Finalize streaming text/thinking blocks before adding tool block
-    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text', 'thinking'])
-
-    const blocksMap = new Map(blocksArray.map(b => [b.id, b]))
-    incomingBlocks.forEach(incomingBlock => {
-      const existingBlock = blocksMap.get(incomingBlock.id)
-      if (existingBlock) {
-        // Merge: existing fields + incoming updates
-        // This preserves tool_name, tool_use_id, etc. when only status is updated
-        blocksMap.set(incomingBlock.id, { ...existingBlock, ...incomingBlock })
-      } else {
-        // New block - add as-is
-        blocksMap.set(incomingBlock.id, incomingBlock)
-      }
+    return mergeStreamingBlocks({
+      existingBlocks: existingMessage.result?.blocks || [],
+      incomingBlocks: chunk.result?.blocks || [],
+      content: chunk.content,
+      blockId: chunk.blockId,
+      reasoningChunk: chunk.result?.reasoning_chunk,
     })
-
-    return Array.from(blocksMap.values())
   }
 
   /**
@@ -1220,136 +1141,12 @@ export class TaskStateMachine {
     existingMessage: UnifiedMessage,
     event: Extract<Event, { type: 'CHAT_CHUNK' }>
   ): MessageBlock[] {
-    const existingBlocks = existingMessage.result?.blocks || []
-    const incomingBlocks = event.result?.blocks || []
-    const reasoningChunk = event.result?.reasoning_chunk
-
-    // Case 1: reasoning chunk - create/update a thinking block in chronological order
-    if (reasoningChunk) {
-      return this.mergeReasoningBlock(existingBlocks, reasoningChunk)
-    }
-
-    // Case 2: block_id with content - text block update (explicit block_id from backend)
-    if (event.blockId && event.content) {
-      const finalizedBlocks = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
-      const blocksMap = new Map(finalizedBlocks.map(b => [b.id, b]))
-      const targetBlock = blocksMap.get(event.blockId)
-
-      if (targetBlock && targetBlock.type === 'text') {
-        const updatedBlock = {
-          ...targetBlock,
-          content: (targetBlock.content || '') + event.content,
-        }
-        blocksMap.set(event.blockId, updatedBlock)
-      } else if (!targetBlock) {
-        const newBlock: MessageBlock = {
-          id: event.blockId,
-          type: 'text',
-          content: event.content,
-          status: 'streaming',
-          timestamp: Date.now(),
-        }
-        blocksMap.set(event.blockId, newBlock)
-      }
-
-      return Array.from(blocksMap.values())
-    }
-
-    // Case 3: Text content without block_id (ClaudeCode executor)
-    // Create or update a text block to maintain chronological order
-    if (event.content && !event.blockId && incomingBlocks.length === 0) {
-      const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
-
-      // Find the last text block that is still streaming
-      const lastBlock = blocksArray[blocksArray.length - 1]
-      if (lastBlock && lastBlock.type === 'text' && lastBlock.status === 'streaming') {
-        // Append to existing streaming text block
-        lastBlock.content = (lastBlock.content || '') + event.content
-        return blocksArray
-      }
-
-      // Create a new text block (after tool blocks or at the start)
-      const newTextBlock: MessageBlock = {
-        id: `text-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-        type: 'text',
-        content: event.content,
-        status: 'streaming',
-        timestamp: Date.now(),
-      }
-      blocksArray.push(newTextBlock)
-      return blocksArray
-    }
-
-    // Case 4: No incoming blocks and no content - keep existing
-    if (incomingBlocks.length === 0) {
-      return existingBlocks
-    }
-
-    // Case 5: Tool/other blocks - merge by block.id
-    // CRITICAL: For partial updates (e.g., block_updated with only status),
-    // we must merge with existing block to preserve all fields
-    // Also: Finalize streaming text/thinking blocks before adding tool block
-    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text', 'thinking'])
-
-    const blocksMap = new Map(blocksArray.map(b => [b.id, b]))
-    incomingBlocks.forEach(incomingBlock => {
-      const existingBlock = blocksMap.get(incomingBlock.id)
-      if (existingBlock) {
-        // Merge: existing fields + incoming updates
-        // This preserves tool_name, tool_use_id, etc. when only status is updated
-        blocksMap.set(incomingBlock.id, { ...existingBlock, ...incomingBlock })
-      } else {
-        // New block - add as-is
-        blocksMap.set(incomingBlock.id, incomingBlock)
-      }
-    })
-
-    return Array.from(blocksMap.values())
-  }
-
-  private mergeReasoningBlock(
-    existingBlocks: MessageBlock[],
-    reasoningChunk: string
-  ): MessageBlock[] {
-    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text'])
-    const lastBlock = blocksArray[blocksArray.length - 1]
-
-    if (lastBlock && lastBlock.type === 'thinking' && lastBlock.status === 'streaming') {
-      return blocksArray.map(block =>
-        block.id === lastBlock.id && block.type === 'thinking'
-          ? {
-              ...block,
-              content: (block.content || '') + reasoningChunk,
-            }
-          : block
-      )
-    }
-
-    const newThinkingBlock: MessageBlock = {
-      id: `thinking-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      type: 'thinking',
-      content: reasoningChunk,
-      status: 'streaming',
-      timestamp: Date.now(),
-    }
-
-    return [...blocksArray, newThinkingBlock]
-  }
-
-  private finalizeStreamingBlocks(
-    blocks: MessageBlock[],
-    blockTypes: StreamingBlockType[]
-  ): MessageBlock[] {
-    const blockTypeSet = new Set<string>(blockTypes)
-
-    return blocks.map(block => {
-      if (block.status === 'streaming' && blockTypeSet.has(block.type)) {
-        return {
-          ...block,
-          status: 'done' as const,
-        }
-      }
-      return block
+    return mergeStreamingBlocks({
+      existingBlocks: existingMessage.result?.blocks || [],
+      incomingBlocks: event.result?.blocks || [],
+      content: event.content,
+      blockId: event.blockId,
+      reasoningChunk: event.result?.reasoning_chunk,
     })
   }
 
@@ -1392,7 +1189,10 @@ export class TaskStateMachine {
     // CRITICAL FIX: Merge blocks instead of replacing
     // Preserve blocks accumulated during streaming (tool blocks and text blocks)
     // event.result.blocks may be incomplete or only contain final state
-    const mergedBlocks = this.mergeBlocksForDone(existingMessage, event)
+    const mergedBlocks = mergeBlocksForDone(
+      existingMessage.result?.blocks || [],
+      event.result?.blocks || []
+    )
 
     const newMessages = new Map(this.state.messages)
     newMessages.set(aiMessageId, {
@@ -1463,84 +1263,6 @@ export class TaskStateMachine {
       error: event.error,
       isStopping: false,
     }
-  }
-
-  /**
-   * Merge blocks for CHAT_DONE event
-   *
-   * Handles the merge of blocks accumulated during streaming with blocks from chat:done event.
-   *
-   * Key insight: During streaming, text blocks are created with IDs like `text-{timestamp}-xxx`.
-   * When chat:done arrives, it may contain text blocks with different IDs (e.g., `text-{timestamp2}`).
-   * If we simply merge by ID, both text blocks would be kept, causing duplicate content display.
-   *
-   * Strategy:
-   * 1. Preserve the streaming order when it contains inline thinking blocks
-   * 2. Otherwise preserve the original order from incomingBlocks
-   * 3. For tool blocks: merge with existing tool blocks to preserve streaming state
-   * 4. For text blocks: use incoming text blocks when backend order is authoritative
-   * 5. If no incoming blocks, keep existing blocks
-   * 6. If no existing blocks, use incoming blocks
-   */
-  private mergeBlocksForDone(
-    existingMessage: UnifiedMessage,
-    event: Extract<Event, { type: 'CHAT_DONE' }>
-  ): MessageBlock[] {
-    const existingBlocks = this.finalizeStreamingBlocks(existingMessage.result?.blocks || [], [
-      'text',
-      'thinking',
-    ])
-    const incomingBlocks = event.result?.blocks || []
-
-    // If no existing blocks, use incoming blocks
-    if (existingBlocks.length === 0) {
-      return incomingBlocks
-    }
-
-    // If no incoming blocks, keep existing blocks
-    if (incomingBlocks.length === 0) {
-      return existingBlocks
-    }
-
-    const hasInlineThinkingBlocks = existingBlocks.some(block => block.type === 'thinking')
-    if (hasInlineThinkingBlocks) {
-      const incomingBlocksMap = new Map(incomingBlocks.map(block => [block.id, block]))
-      const mergedBlocks = existingBlocks.map(existingBlock => {
-        const incomingBlock = incomingBlocksMap.get(existingBlock.id)
-        if (!incomingBlock) {
-          return existingBlock
-        }
-        return { ...existingBlock, ...incomingBlock }
-      })
-      const existingIds = new Set(existingBlocks.map(block => block.id))
-      const existingHasTextBlock = existingBlocks.some(block => block.type === 'text')
-      const appendedBlocks = incomingBlocks.filter(
-        block => !existingIds.has(block.id) && (block.type !== 'text' || !existingHasTextBlock)
-      )
-      return [...mergedBlocks, ...appendedBlocks]
-    }
-
-    // Build a map of existing tool blocks for merging
-    const existingToolBlocksMap = new Map(
-      existingBlocks.filter(b => b.type !== 'text').map(b => [b.id, b])
-    )
-
-    // CRITICAL FIX: Preserve the original order from incomingBlocks
-    // The backend returns blocks in correct chronological order: text-tool-text-tool-text
-    // We should NOT reorder them (previous bug: put all tools first, then all text)
-    return incomingBlocks.map(incomingBlock => {
-      if (incomingBlock.type === 'text') {
-        // Text blocks: use incoming directly (authoritative)
-        return incomingBlock
-      } else {
-        // Tool blocks: merge with existing to preserve streaming state
-        const existingBlock = existingToolBlocksMap.get(incomingBlock.id)
-        if (existingBlock) {
-          return { ...existingBlock, ...incomingBlock }
-        }
-        return incomingBlock
-      }
-    })
   }
 
   /**

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -121,6 +121,8 @@ interface PendingChunkEvent {
   blockId?: string
 }
 
+type StreamingBlockType = 'text' | 'thinking'
+
 /**
  * Task state data
  */
@@ -782,11 +784,12 @@ export class TaskStateMachine {
   /**
    * Merge blocks for pending chunk (similar to mergeBlocks but for PendingChunkEvent)
    *
-   * Handles four cases:
-   * 1. Text block streaming with blockId: blockId + content -> append content to existing text block
-   * 2. Text content without blockId: Create/update a text block to maintain chronological order
-   * 3. No incoming blocks and no content: keep existing blocks unchanged
-   * 4. Tool/other blocks: merge by block.id, preserving existing fields for partial updates
+   * Handles five cases:
+   * 1. Reasoning chunk: create/update a thinking block
+   * 2. Text block streaming with blockId: blockId + content -> append content to existing text block
+   * 3. Text content without blockId: create/update a text block to maintain chronological order
+   * 4. No incoming blocks and no content: keep existing blocks unchanged
+   * 5. Tool/other blocks: merge by block.id, preserving existing fields for partial updates
    *
    * CRITICAL: For ClaudeCode executor, text content arrives via chat:chunk without block_id.
    * We need to create text blocks on-the-fly to maintain tool-text-tool-text order.
@@ -797,10 +800,17 @@ export class TaskStateMachine {
   ): MessageBlock[] {
     const existingBlocks = existingMessage.result?.blocks || []
     const incomingBlocks = chunk.result?.blocks || []
+    const reasoningChunk = chunk.result?.reasoning_chunk
 
-    // Case 1: block_id with content - text block update (explicit block_id from backend)
+    // Case 1: reasoning chunk - create/update a thinking block in chronological order
+    if (reasoningChunk) {
+      return this.mergeReasoningBlock(existingBlocks, reasoningChunk)
+    }
+
+    // Case 2: block_id with content - text block update (explicit block_id from backend)
     if (chunk.blockId && chunk.content) {
-      const blocksMap = new Map(existingBlocks.map(b => [b.id, b]))
+      const finalizedBlocks = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
+      const blocksMap = new Map(finalizedBlocks.map(b => [b.id, b]))
       const targetBlock = blocksMap.get(chunk.blockId)
 
       if (targetBlock && targetBlock.type === 'text') {
@@ -823,10 +833,10 @@ export class TaskStateMachine {
       return Array.from(blocksMap.values())
     }
 
-    // Case 2: Text content without block_id (ClaudeCode executor)
+    // Case 3: Text content without block_id (ClaudeCode executor)
     // Create or update a text block to maintain chronological order
     if (chunk.content && !chunk.blockId && incomingBlocks.length === 0) {
-      const blocksArray = [...existingBlocks]
+      const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
 
       // Find the last text block that is still streaming
       const lastBlock = blocksArray[blocksArray.length - 1]
@@ -848,23 +858,16 @@ export class TaskStateMachine {
       return blocksArray
     }
 
-    // Case 3: No incoming blocks and no content - keep existing
+    // Case 4: No incoming blocks and no content - keep existing
     if (incomingBlocks.length === 0) {
       return existingBlocks
     }
 
-    // Case 4: Tool/other blocks - merge by block.id
+    // Case 5: Tool/other blocks - merge by block.id
     // CRITICAL: For partial updates (e.g., block_updated with only status),
     // we must merge with existing block to preserve all fields
-    // Also: Finalize any streaming text block before adding tool block
-    const blocksArray = [...existingBlocks]
-
-    // Finalize any streaming text block before adding new blocks
-    for (const block of blocksArray) {
-      if (block.type === 'text' && block.status === 'streaming') {
-        block.status = 'done'
-      }
-    }
+    // Also: Finalize streaming text/thinking blocks before adding tool block
+    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text', 'thinking'])
 
     const blocksMap = new Map(blocksArray.map(b => [b.id, b]))
     incomingBlocks.forEach(incomingBlock => {
@@ -1203,11 +1206,12 @@ export class TaskStateMachine {
   /**
    * Merge blocks for incremental updates
    *
-   * Handles four cases:
-   * 1. Text block streaming with blockId: blockId + content -> append content to existing text block
-   * 2. Text content without blockId: Create/update a text block to maintain chronological order
-   * 3. No incoming blocks and no content: keep existing blocks unchanged
-   * 4. Tool/other blocks: merge by block.id, preserving existing fields for partial updates
+   * Handles five cases:
+   * 1. Reasoning chunk: create/update a thinking block
+   * 2. Text block streaming with blockId: blockId + content -> append content to existing text block
+   * 3. Text content without blockId: create/update a text block to maintain chronological order
+   * 4. No incoming blocks and no content: keep existing blocks unchanged
+   * 5. Tool/other blocks: merge by block.id, preserving existing fields for partial updates
    *
    * CRITICAL: For ClaudeCode executor, text content arrives via chat:chunk without block_id.
    * We need to create text blocks on-the-fly to maintain tool-text-tool-text order.
@@ -1218,10 +1222,17 @@ export class TaskStateMachine {
   ): MessageBlock[] {
     const existingBlocks = existingMessage.result?.blocks || []
     const incomingBlocks = event.result?.blocks || []
+    const reasoningChunk = event.result?.reasoning_chunk
 
-    // Case 1: block_id with content - text block update (explicit block_id from backend)
+    // Case 1: reasoning chunk - create/update a thinking block in chronological order
+    if (reasoningChunk) {
+      return this.mergeReasoningBlock(existingBlocks, reasoningChunk)
+    }
+
+    // Case 2: block_id with content - text block update (explicit block_id from backend)
     if (event.blockId && event.content) {
-      const blocksMap = new Map(existingBlocks.map(b => [b.id, b]))
+      const finalizedBlocks = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
+      const blocksMap = new Map(finalizedBlocks.map(b => [b.id, b]))
       const targetBlock = blocksMap.get(event.blockId)
 
       if (targetBlock && targetBlock.type === 'text') {
@@ -1244,10 +1255,10 @@ export class TaskStateMachine {
       return Array.from(blocksMap.values())
     }
 
-    // Case 2: Text content without block_id (ClaudeCode executor)
+    // Case 3: Text content without block_id (ClaudeCode executor)
     // Create or update a text block to maintain chronological order
     if (event.content && !event.blockId && incomingBlocks.length === 0) {
-      const blocksArray = [...existingBlocks]
+      const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['thinking'])
 
       // Find the last text block that is still streaming
       const lastBlock = blocksArray[blocksArray.length - 1]
@@ -1269,23 +1280,16 @@ export class TaskStateMachine {
       return blocksArray
     }
 
-    // Case 3: No incoming blocks and no content - keep existing
+    // Case 4: No incoming blocks and no content - keep existing
     if (incomingBlocks.length === 0) {
       return existingBlocks
     }
 
-    // Case 4: Tool/other blocks - merge by block.id
+    // Case 5: Tool/other blocks - merge by block.id
     // CRITICAL: For partial updates (e.g., block_updated with only status),
     // we must merge with existing block to preserve all fields
-    // Also: Finalize any streaming text block before adding tool block
-    const blocksArray = [...existingBlocks]
-
-    // Finalize any streaming text block before adding new blocks
-    for (const block of blocksArray) {
-      if (block.type === 'text' && block.status === 'streaming') {
-        block.status = 'done'
-      }
-    }
+    // Also: Finalize streaming text/thinking blocks before adding tool block
+    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text', 'thinking'])
 
     const blocksMap = new Map(blocksArray.map(b => [b.id, b]))
     incomingBlocks.forEach(incomingBlock => {
@@ -1301,6 +1305,52 @@ export class TaskStateMachine {
     })
 
     return Array.from(blocksMap.values())
+  }
+
+  private mergeReasoningBlock(
+    existingBlocks: MessageBlock[],
+    reasoningChunk: string
+  ): MessageBlock[] {
+    const blocksArray = this.finalizeStreamingBlocks(existingBlocks, ['text'])
+    const lastBlock = blocksArray[blocksArray.length - 1]
+
+    if (lastBlock && lastBlock.type === 'thinking' && lastBlock.status === 'streaming') {
+      return blocksArray.map(block =>
+        block.id === lastBlock.id && block.type === 'thinking'
+          ? {
+              ...block,
+              content: (block.content || '') + reasoningChunk,
+            }
+          : block
+      )
+    }
+
+    const newThinkingBlock: MessageBlock = {
+      id: `thinking-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      type: 'thinking',
+      content: reasoningChunk,
+      status: 'streaming',
+      timestamp: Date.now(),
+    }
+
+    return [...blocksArray, newThinkingBlock]
+  }
+
+  private finalizeStreamingBlocks(
+    blocks: MessageBlock[],
+    blockTypes: StreamingBlockType[]
+  ): MessageBlock[] {
+    const blockTypeSet = new Set<string>(blockTypes)
+
+    return blocks.map(block => {
+      if (block.status === 'streaming' && blockTypeSet.has(block.type)) {
+        return {
+          ...block,
+          status: 'done' as const,
+        }
+      }
+      return block
+    })
   }
 
   /**
@@ -1425,17 +1475,21 @@ export class TaskStateMachine {
    * If we simply merge by ID, both text blocks would be kept, causing duplicate content display.
    *
    * Strategy:
-   * 1. Preserve the original order from incomingBlocks (backend returns correct order: text-tool-text-tool)
-   * 2. For tool blocks: merge with existing tool blocks to preserve streaming state
-   * 3. For text blocks: use incoming text blocks (they are authoritative)
-   * 4. If no incoming blocks, keep existing blocks
-   * 5. If no existing blocks, use incoming blocks
+   * 1. Preserve the streaming order when it contains inline thinking blocks
+   * 2. Otherwise preserve the original order from incomingBlocks
+   * 3. For tool blocks: merge with existing tool blocks to preserve streaming state
+   * 4. For text blocks: use incoming text blocks when backend order is authoritative
+   * 5. If no incoming blocks, keep existing blocks
+   * 6. If no existing blocks, use incoming blocks
    */
   private mergeBlocksForDone(
     existingMessage: UnifiedMessage,
     event: Extract<Event, { type: 'CHAT_DONE' }>
   ): MessageBlock[] {
-    const existingBlocks = existingMessage.result?.blocks || []
+    const existingBlocks = this.finalizeStreamingBlocks(existingMessage.result?.blocks || [], [
+      'text',
+      'thinking',
+    ])
     const incomingBlocks = event.result?.blocks || []
 
     // If no existing blocks, use incoming blocks
@@ -1446,6 +1500,24 @@ export class TaskStateMachine {
     // If no incoming blocks, keep existing blocks
     if (incomingBlocks.length === 0) {
       return existingBlocks
+    }
+
+    const hasInlineThinkingBlocks = existingBlocks.some(block => block.type === 'thinking')
+    if (hasInlineThinkingBlocks) {
+      const incomingBlocksMap = new Map(incomingBlocks.map(block => [block.id, block]))
+      const mergedBlocks = existingBlocks.map(existingBlock => {
+        const incomingBlock = incomingBlocksMap.get(existingBlock.id)
+        if (!incomingBlock) {
+          return existingBlock
+        }
+        return { ...existingBlock, ...incomingBlock }
+      })
+      const existingIds = new Set(existingBlocks.map(block => block.id))
+      const existingHasTextBlock = existingBlocks.some(block => block.type === 'text')
+      const appendedBlocks = incomingBlocks.filter(
+        block => !existingIds.has(block.id) && (block.type !== 'text' || !existingHasTextBlock)
+      )
+      return [...mergedBlocks, ...appendedBlocks]
     }
 
     // Build a map of existing tool blocks for merging

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -1193,6 +1193,15 @@ export class TaskStateMachine {
       existingMessage.result?.blocks || [],
       event.result?.blocks || []
     )
+    const mergedResult =
+      event.result || existingMessage.result?.blocks
+        ? {
+            ...existingMessage.result,
+            ...(event.result || {}),
+            thinking: event.result?.thinking || existingMessage.result?.thinking,
+            blocks: mergedBlocks,
+          }
+        : existingMessage.result
 
     const newMessages = new Map(this.state.messages)
     newMessages.set(aiMessageId, {
@@ -1208,14 +1217,7 @@ export class TaskStateMachine {
       // This prevents messageId from being overwritten with undefined/null
       messageId: event.messageId ?? existingMessage.messageId,
       sources: event.sources || existingMessage.sources,
-      result: event.result
-        ? {
-            ...existingMessage.result,
-            ...event.result,
-            thinking: event.result.thinking || existingMessage.result?.thinking,
-            blocks: mergedBlocks,
-          }
-        : existingMessage.result,
+      result: mergedResult,
     })
 
     // Update status to ready if this was the streaming subtask


### PR DESCRIPTION
## Summary
- Render model thinking as chronological inline blocks instead of a single top block.
- Reuse the collapsible reasoning display inside mixed content rendering.
- Preserve legacy top-level reasoning display for historical messages without inline blocks.

## Test Plan
- npm test -- --runTestsByPath src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx src/__tests__/features/tasks/state/TaskStateMachine.test.ts src/__tests__/features/tasks/components/message/MessageBubble.test.tsx --runInBand
- npx tsc --noEmit --pretty false
- pre-push hook: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages can display inline "thinking" blocks in mixed content; separate reasoning sections are suppressed when inline thinking exists.
  * Streaming "thinking" blocks are rendered alongside streamed text/tool blocks and finalize correctly.

* **Refactor**
  * Block merging logic for streaming and completion was centralized to improve consistency of streamed/finalized ordering.

* **Tests**
  * Expanded tests for mixed-content rendering, streamed reasoning/text merging, and finalization/order preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->