### PR TITLE
fix(start): scope local service startup and stop

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -132,6 +132,46 @@ EOF
 #        "embedded": don't exit, used when called from start_services
 init_config() {
     local mode="${1:-standalone}"
+    shift || true
+    local init_backend=false
+    local init_frontend=false
+    local init_chat_shell=false
+    local init_executor_manager=false
+    local init_knowledge_runtime=false
+    local init_wework=false
+
+    if [ $# -eq 0 ]; then
+        init_backend=true
+        init_frontend=true
+        init_chat_shell=true
+        init_executor_manager=true
+        init_knowledge_runtime=true
+        init_wework=true
+    else
+        local init_service
+        for init_service in "$@"; do
+            case "$init_service" in
+                backend)
+                    init_backend=true
+                    ;;
+                frontend)
+                    init_frontend=true
+                    ;;
+                chat_shell)
+                    init_chat_shell=true
+                    ;;
+                executor_manager)
+                    init_executor_manager=true
+                    ;;
+                knowledge_runtime)
+                    init_knowledge_runtime=true
+                    ;;
+                wework)
+                    init_wework=true
+                    ;;
+            esac
+        done
+    fi
     
     echo -e "${BLUE}╔════════════════════════════════════════════════════════╗${NC}"
     echo -e "${BLUE}║       Wegent Configuration Initialization Wizard       ║${NC}"
@@ -165,69 +205,94 @@ init_config() {
     # === Service Ports ===
     echo -e "${BLUE}━━━ Service Ports ━━━${NC}"
     echo ""
+    local setting_index=1
 
     # Backend Port
-    echo -e "${CYAN}1. Backend Port${NC}"
-    echo -e "   The port for Backend API service."
-    read -p "   Backend Port [$DEFAULT_BACKEND_PORT]: " input_backend_port
-    BACKEND_PORT=${input_backend_port:-$DEFAULT_BACKEND_PORT}
-    echo ""
+    if [ "$init_backend" = true ]; then
+        echo -e "${CYAN}${setting_index}. Backend Port${NC}"
+        echo -e "   The port for Backend API service."
+        read -p "   Backend Port [$DEFAULT_BACKEND_PORT]: " input_backend_port
+        BACKEND_PORT=${input_backend_port:-$DEFAULT_BACKEND_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Chat Shell Port
-    echo -e "${CYAN}2. Chat Shell Port${NC}"
-    echo -e "   The port for Chat Shell service."
-    read -p "   Chat Shell Port [$DEFAULT_CHAT_SHELL_PORT]: " input_chat_shell_port
-    CHAT_SHELL_PORT=${input_chat_shell_port:-$DEFAULT_CHAT_SHELL_PORT}
-    echo ""
+    if [ "$init_chat_shell" = true ]; then
+        echo -e "${CYAN}${setting_index}. Chat Shell Port${NC}"
+        echo -e "   The port for Chat Shell service."
+        read -p "   Chat Shell Port [$DEFAULT_CHAT_SHELL_PORT]: " input_chat_shell_port
+        CHAT_SHELL_PORT=${input_chat_shell_port:-$DEFAULT_CHAT_SHELL_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Executor Manager Port
-    echo -e "${CYAN}3. Executor Manager Port${NC}"
-    echo -e "   The port for Executor Manager service."
-    read -p "   Executor Manager Port [$DEFAULT_EXECUTOR_MANAGER_PORT]: " input_executor_manager_port
-    EXECUTOR_MANAGER_PORT=${input_executor_manager_port:-$DEFAULT_EXECUTOR_MANAGER_PORT}
-    echo ""
+    if [ "$init_executor_manager" = true ]; then
+        echo -e "${CYAN}${setting_index}. Executor Manager Port${NC}"
+        echo -e "   The port for Executor Manager service."
+        read -p "   Executor Manager Port [$DEFAULT_EXECUTOR_MANAGER_PORT]: " input_executor_manager_port
+        EXECUTOR_MANAGER_PORT=${input_executor_manager_port:-$DEFAULT_EXECUTOR_MANAGER_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Knowledge Runtime Port
-    echo -e "${CYAN}4. Knowledge Runtime Port${NC}"
-    echo -e "   The port for Knowledge Runtime service (RAG operations)."
-    read -p "   Knowledge Runtime Port [$DEFAULT_KNOWLEDGE_RUNTIME_PORT]: " input_knowledge_runtime_port
-    KNOWLEDGE_RUNTIME_PORT=${input_knowledge_runtime_port:-$DEFAULT_KNOWLEDGE_RUNTIME_PORT}
-    echo ""
+    if [ "$init_knowledge_runtime" = true ]; then
+        echo -e "${CYAN}${setting_index}. Knowledge Runtime Port${NC}"
+        echo -e "   The port for Knowledge Runtime service (RAG operations)."
+        read -p "   Knowledge Runtime Port [$DEFAULT_KNOWLEDGE_RUNTIME_PORT]: " input_knowledge_runtime_port
+        KNOWLEDGE_RUNTIME_PORT=${input_knowledge_runtime_port:-$DEFAULT_KNOWLEDGE_RUNTIME_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Frontend Port
-    echo -e "${CYAN}5. Frontend Port${NC}"
-    echo -e "   The port where the web UI will be accessible."
-    read -p "   Frontend Port [$DEFAULT_WEGENT_FRONTEND_PORT]: " input_frontend_port
-    WEGENT_FRONTEND_PORT=${input_frontend_port:-$DEFAULT_WEGENT_FRONTEND_PORT}
-    echo ""
+    if [ "$init_frontend" = true ]; then
+        echo -e "${CYAN}${setting_index}. Frontend Port${NC}"
+        echo -e "   The port where the web UI will be accessible."
+        read -p "   Frontend Port [$DEFAULT_WEGENT_FRONTEND_PORT]: " input_frontend_port
+        WEGENT_FRONTEND_PORT=${input_frontend_port:-$DEFAULT_WEGENT_FRONTEND_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # WeWork Port
-    echo -e "${CYAN}6. WeWork Port${NC}"
-    echo -e "   The port for WeWork multi-platform workspace app."
-    read -p "   WeWork Port [$DEFAULT_WEWORK_PORT]: " input_wework_port
-    WEWORK_PORT=${input_wework_port:-$DEFAULT_WEWORK_PORT}
-    echo ""
+    if [ "$init_wework" = true ]; then
+        echo -e "${CYAN}${setting_index}. WeWork Port${NC}"
+        echo -e "   The port for WeWork multi-platform workspace app."
+        read -p "   WeWork Port [$DEFAULT_WEWORK_PORT]: " input_wework_port
+        WEWORK_PORT=${input_wework_port:-$DEFAULT_WEWORK_PORT}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # === Other Settings ===
     echo -e "${BLUE}━━━ Other Settings ━━━${NC}"
     echo ""
 
     # Executor Image
-    echo -e "${CYAN}7. Executor Docker Image${NC}"
-    echo -e "   The Docker image used for task execution."
-    read -p "   Executor Image [$DEFAULT_EXECUTOR_IMAGE]: " input_image
-    EXECUTOR_IMAGE=${input_image:-$DEFAULT_EXECUTOR_IMAGE}
-    echo ""
+    if [ "$init_executor_manager" = true ]; then
+        echo -e "${CYAN}${setting_index}. Executor Docker Image${NC}"
+        echo -e "   The Docker image used for task execution."
+        read -p "   Executor Image [$DEFAULT_EXECUTOR_IMAGE]: " input_image
+        EXECUTOR_IMAGE=${input_image:-$DEFAULT_EXECUTOR_IMAGE}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Socket URL
-    echo -e "${CYAN}8. Socket URL${NC}"
-    echo -e "   The WebSocket URL for real-time communication."
-    echo -e "   For remote access, use your machine's IP address."
-    echo -e "   Detected local IP: ${GREEN}$local_ip${NC}"
-    local default_socket="http://$local_ip:$BACKEND_PORT"
-    read -p "   Socket URL [$default_socket]: " input_socket_url
-    WEGENT_SOCKET_URL=${input_socket_url:-$default_socket}
-    echo ""
+    if [ "$init_backend" = true ] || [ "$init_frontend" = true ]; then
+        echo -e "${CYAN}${setting_index}. Socket URL${NC}"
+        echo -e "   The WebSocket URL for real-time communication."
+        echo -e "   For remote access, use your machine's IP address."
+        echo -e "   Detected local IP: ${GREEN}$local_ip${NC}"
+        local default_socket="http://$local_ip:$BACKEND_PORT"
+        read -p "   Socket URL [$default_socket]: " input_socket_url
+        WEGENT_SOCKET_URL=${input_socket_url:-$default_socket}
+        setting_index=$((setting_index + 1))
+        echo ""
+    fi
 
     # Show summary
     echo -e "${BLUE}════════════════════════════════════════════════════════${NC}"
@@ -775,6 +840,149 @@ KNOWLEDGE_RUNTIME_URL=""
 
 # PID file directory
 PID_DIR="$SCRIPT_DIR/.pids"
+AUTO_PORT_SEARCH_LIMIT=100
+
+normalize_service_name() {
+    case "$1" in
+        all)
+            echo "all"
+            ;;
+        backend|be|api)
+            echo "backend"
+            ;;
+        frontend|fe|ui)
+            echo "frontend"
+            ;;
+        chat_shell|cs|chat)
+            echo "chat_shell"
+            ;;
+        executor_manager|em|executor)
+            echo "executor_manager"
+            ;;
+        knowledge_runtime|kr|knowledge)
+            echo "knowledge_runtime"
+            ;;
+        wework|ww)
+            echo "wework"
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+valid_service_names() {
+    echo "all, backend|be|api, frontend|fe|ui, chat_shell|cs|chat, executor_manager|em|executor, knowledge_runtime|kr|knowledge, wework|ww"
+}
+
+get_configured_service_port() {
+    case "$1" in
+        backend)
+            echo "$BACKEND_PORT"
+            ;;
+        frontend)
+            echo "$WEGENT_FRONTEND_PORT"
+            ;;
+        chat_shell)
+            echo "$CHAT_SHELL_PORT"
+            ;;
+        executor_manager)
+            echo "$EXECUTOR_MANAGER_PORT"
+            ;;
+        knowledge_runtime)
+            echo "$KNOWLEDGE_RUNTIME_PORT"
+            ;;
+        wework)
+            echo "$WEWORK_PORT"
+            ;;
+    esac
+}
+
+set_configured_service_port() {
+    local service=$1
+    local port=$2
+
+    case "$service" in
+        backend)
+            BACKEND_PORT="$port"
+            ;;
+        frontend)
+            WEGENT_FRONTEND_PORT="$port"
+            ;;
+        chat_shell)
+            CHAT_SHELL_PORT="$port"
+            ;;
+        executor_manager)
+            EXECUTOR_MANAGER_PORT="$port"
+            ;;
+        knowledge_runtime)
+            KNOWLEDGE_RUNTIME_PORT="$port"
+            ;;
+        wework)
+            WEWORK_PORT="$port"
+            ;;
+    esac
+}
+
+service_port_set_by_cli() {
+    case "$1" in
+        backend)
+            [ -n "$CLI_BACKEND_PORT" ]
+            ;;
+        frontend)
+            [ -n "$CLI_WEGENT_FRONTEND_PORT" ]
+            ;;
+        chat_shell)
+            [ -n "$CLI_CHAT_SHELL_PORT" ]
+            ;;
+        executor_manager)
+            [ -n "$CLI_EXECUTOR_MANAGER_PORT" ]
+            ;;
+        knowledge_runtime)
+            [ -n "$CLI_KNOWLEDGE_RUNTIME_PORT" ]
+            ;;
+        wework)
+            [ -n "$CLI_WEWORK_PORT" ]
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+get_runtime_service_port() {
+    local service=$1
+    local port_file="$PID_DIR/${service}.port"
+
+    if [ -f "$port_file" ]; then
+        cat "$port_file"
+    else
+        get_configured_service_port "$service"
+    fi
+}
+
+write_runtime_service_port() {
+    local service=$1
+    local port=$2
+
+    echo "$port" > "$PID_DIR/${service}.port"
+}
+
+remove_runtime_service_port() {
+    local service=$1
+
+    rm -f "$PID_DIR/${service}.port"
+}
+
+get_tracked_services() {
+    local service
+
+    for service in backend frontend chat_shell executor_manager knowledge_runtime wework; do
+        if [ -f "$PID_DIR/${service}.pid" ]; then
+            echo "$service"
+        fi
+    done
+}
 
 show_help() {
     cat << EOF
@@ -790,14 +998,18 @@ Options:
   -p, --port PORT               Frontend port (default: $DEFAULT_WEGENT_FRONTEND_PORT)
   -e, --executor-image IMG      Executor image (default: $DEFAULT_EXECUTOR_IMAGE)
   --socket-url URL              Socket direct url (auto-computed from BACKEND_PORT)
-    --clean-frontend-cache        Remove frontend .next cache before starting frontend
+  --clean-frontend-cache        Remove frontend .next cache before starting frontend
   --init                        Interactive configuration initialization
-  --stop [services...]          Stop services (default: all). Can specify multiple:
-                                backend|be|api, frontend|fe|ui, chat_shell|cs|chat, executor_manager|em|executor, knowledge_runtime|kr|knowledge
+  --stop [services...]          Stop tracked services by default. Can specify multiple:
+                                $(valid_service_names)
   -g, --graceful                Use graceful shutdown with stop/restart (SIGTERM, wait 30s, then SIGKILL)
   --restart [services...]       Restart services (default: all)
   --status                      Check service status
   -h, --help                    Show help information
+
+Service Selection:
+  Passing service names without --stop/--restart starts only those services.
+  Example: $0 backend frontend
 
 Configuration File:
   The script uses the .env configuration file in the project root.
@@ -822,7 +1034,9 @@ Configuration File:
 
 Examples:
   $0                                    # Start with default configuration
-    $0 --clean-frontend-cache             # Start after clearing frontend .next cache
+  $0 backend frontend                   # Start only backend and frontend
+  $0 be fe                              # Start only backend and frontend (short names)
+  $0 --clean-frontend-cache             # Start after clearing frontend .next cache
   $0 --init                             # Initialize configuration interactively
   $0 -b 8001                            # Specify backend port as 8001
   $0 -c 8101                            # Specify chat shell port as 8101
@@ -831,7 +1045,8 @@ Examples:
   $0 -p 8080                            # Specify frontend port as 8080
   $0 -e my-executor:latest              # Specify custom executor image
   $0 --socket-url http://192.168.1.100:8000  # Specify socket URL with your IP
-  $0 --stop                             # Stop all services (force kill)
+  $0 --stop                             # Stop services tracked by .pids (force kill)
+  $0 --stop all                         # Stop all known services (force kill)
   $0 --stop backend frontend            # Stop only backend and frontend
   $0 --stop be cs kr                    # Stop backend, chat_shell, knowledge_runtime (short names)
   $0 --stop --graceful                  # Stop with graceful shutdown
@@ -843,6 +1058,8 @@ EOF
 
 # Parse arguments
 ACTION="start"
+START_SERVICES=()
+STOP_SERVICES=()
 
 # Track which variables were set via command line (to override config file)
 CLI_BACKEND_PORT=""
@@ -932,9 +1149,21 @@ case $1 in
         exit 0
         ;;
     *)
-        echo -e "${RED}Unknown parameter: $1${NC}"
-        show_help
-        exit 1
+        if [ "$ACTION" = "start" ]; then
+            if normalized_service=$(normalize_service_name "$1"); then
+                START_SERVICES+=("$normalized_service")
+                shift
+            else
+                echo -e "${RED}Unknown parameter or service: $1${NC}"
+                echo -e "Valid services: $(valid_service_names)"
+                show_help
+                exit 1
+            fi
+        else
+            echo -e "${RED}Unknown parameter: $1${NC}"
+            show_help
+            exit 1
+        fi
         ;;
 esac
 done
@@ -954,17 +1183,78 @@ load_config
 [ -n "$CLI_WEGENT_SOCKET_URL" ] && WEGENT_SOCKET_URL="$CLI_WEGENT_SOCKET_URL"
 [ -n "$CLI_CLEAN_FRONTEND_CACHE" ] && CLEAN_FRONTEND_CACHE="$CLI_CLEAN_FRONTEND_CACHE"
 
-# Compute derived URLs based on configured ports (if not already set from config)
-LOCAL_IP=$(get_local_ip)
-[ -z "$WEGENT_SOCKET_URL" ] && WEGENT_SOCKET_URL="http://$LOCAL_IP:$BACKEND_PORT"
-# TASK_API_DOMAIN should be the same as WEGENT_SOCKET_URL (both point to backend)
-[ -z "$TASK_API_DOMAIN" ] && TASK_API_DOMAIN="$WEGENT_SOCKET_URL"
-[ -z "$EXECUTOR_MANAGER_URL" ] && EXECUTOR_MANAGER_URL="http://localhost:$EXECUTOR_MANAGER_PORT"
-[ -z "$KNOWLEDGE_RUNTIME_URL" ] && KNOWLEDGE_RUNTIME_URL="http://localhost:$KNOWLEDGE_RUNTIME_PORT"
-[ -z "$BACKEND_API_URL" ] && BACKEND_API_URL="http://$LOCAL_IP:$BACKEND_PORT"
+url_port_matches() {
+    local url=$1
+    local expected_port=$2
+    local actual_port
 
-export BACKEND_API_URL="$BACKEND_API_URL"
-export KNOWLEDGE_RUNTIME_URL="$KNOWLEDGE_RUNTIME_URL"
+    actual_port=$(echo "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' | sed -E 's#^[^/:]+:([0-9]+).*#\1#')
+    [ "$actual_port" = "$expected_port" ]
+}
+
+replace_url_port() {
+    local url=$1
+    local port=$2
+
+    echo "$url" | sed -E "s#(^[a-zA-Z][a-zA-Z0-9+.-]*://[^/:]+):[0-9]+#\1:$port#"
+}
+
+update_url_port_if_matches() {
+    local url=$1
+    local old_port=$2
+    local new_port=$3
+
+    if [ -n "$url" ] && url_port_matches "$url" "$old_port"; then
+        replace_url_port "$url" "$new_port"
+    else
+        echo "$url"
+    fi
+}
+
+compute_derived_urls() {
+    local previous_backend_port="${1:-}"
+    local previous_executor_manager_port="${2:-}"
+    local previous_knowledge_runtime_port="${3:-}"
+    local previous_socket_url="$WEGENT_SOCKET_URL"
+
+    LOCAL_IP=$(get_local_ip)
+
+    if [ -z "$WEGENT_SOCKET_URL" ]; then
+        WEGENT_SOCKET_URL="http://$LOCAL_IP:$BACKEND_PORT"
+    elif [ -n "$previous_backend_port" ] && [ "$BACKEND_PORT" != "$previous_backend_port" ] && [ -z "$CLI_WEGENT_SOCKET_URL" ]; then
+        WEGENT_SOCKET_URL=$(update_url_port_if_matches "$WEGENT_SOCKET_URL" "$previous_backend_port" "$BACKEND_PORT")
+    fi
+
+    if [ -z "$TASK_API_DOMAIN" ] || [ "$TASK_API_DOMAIN" = "$previous_socket_url" ]; then
+        TASK_API_DOMAIN="$WEGENT_SOCKET_URL"
+    elif [ -n "$previous_backend_port" ] && [ "$BACKEND_PORT" != "$previous_backend_port" ]; then
+        TASK_API_DOMAIN=$(update_url_port_if_matches "$TASK_API_DOMAIN" "$previous_backend_port" "$BACKEND_PORT")
+    fi
+
+    if [ -z "$EXECUTOR_MANAGER_URL" ]; then
+        EXECUTOR_MANAGER_URL="http://localhost:$EXECUTOR_MANAGER_PORT"
+    elif [ -n "$previous_executor_manager_port" ] && [ "$EXECUTOR_MANAGER_PORT" != "$previous_executor_manager_port" ]; then
+        EXECUTOR_MANAGER_URL=$(update_url_port_if_matches "$EXECUTOR_MANAGER_URL" "$previous_executor_manager_port" "$EXECUTOR_MANAGER_PORT")
+    fi
+
+    if [ -z "$KNOWLEDGE_RUNTIME_URL" ]; then
+        KNOWLEDGE_RUNTIME_URL="http://localhost:$KNOWLEDGE_RUNTIME_PORT"
+    elif [ -n "$previous_knowledge_runtime_port" ] && [ "$KNOWLEDGE_RUNTIME_PORT" != "$previous_knowledge_runtime_port" ]; then
+        KNOWLEDGE_RUNTIME_URL=$(update_url_port_if_matches "$KNOWLEDGE_RUNTIME_URL" "$previous_knowledge_runtime_port" "$KNOWLEDGE_RUNTIME_PORT")
+    fi
+
+    if [ -z "$BACKEND_API_URL" ]; then
+        BACKEND_API_URL="http://$LOCAL_IP:$BACKEND_PORT"
+    elif [ -n "$previous_backend_port" ] && [ "$BACKEND_PORT" != "$previous_backend_port" ]; then
+        BACKEND_API_URL=$(update_url_port_if_matches "$BACKEND_API_URL" "$previous_backend_port" "$BACKEND_PORT")
+    fi
+
+    export BACKEND_API_URL="$BACKEND_API_URL"
+    export KNOWLEDGE_RUNTIME_URL="$KNOWLEDGE_RUNTIME_URL"
+}
+
+# Compute derived URLs based on configured ports (if not already set from config)
+compute_derived_urls
 
 # Create PID directory
 mkdir -p "$PID_DIR"
@@ -986,6 +1276,93 @@ check_port() {
         fi
         return 1
     fi
+    return 0
+}
+
+RESOLVED_START_PORTS=()
+
+is_reserved_start_port() {
+    local candidate=$1
+    local current_service="${2:-}"
+    local ignore_configured_ports="${3:-false}"
+    local reserved_port
+    local reserved_service
+
+    for reserved_port in "${RESOLVED_START_PORTS[@]}"; do
+        if [ "$candidate" = "$reserved_port" ]; then
+            return 0
+        fi
+    done
+
+    if [ "$ignore_configured_ports" = true ]; then
+        return 1
+    fi
+
+    for reserved_service in backend frontend chat_shell executor_manager knowledge_runtime wework; do
+        if [ "$reserved_service" = "$current_service" ]; then
+            continue
+        fi
+
+        reserved_port=$(get_configured_service_port "$reserved_service")
+        if [ "$candidate" = "$reserved_port" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+find_available_port() {
+    local start_port=$1
+    local service=$2
+    local ignore_configured_ports="${3:-false}"
+    local port=$start_port
+    local attempts=0
+
+    while [ "$attempts" -le "$AUTO_PORT_SEARCH_LIMIT" ]; do
+        if check_port "$port" "$service" && ! is_reserved_start_port "$port" "$service" "$ignore_configured_ports"; then
+            echo "$port"
+            return 0
+        fi
+
+        port=$((port + 1))
+        attempts=$((attempts + 1))
+    done
+
+    return 1
+}
+
+resolve_start_service_port() {
+    local service=$1
+    local label=$2
+    local current_port
+    local ignore_configured_ports=false
+    local new_port
+
+    current_port=$(get_configured_service_port "$service")
+
+    if service_port_set_by_cli "$service"; then
+        ignore_configured_ports=true
+    fi
+
+    if check_port "$current_port" "$service" && ! is_reserved_start_port "$current_port" "$service" "$ignore_configured_ports"; then
+        RESOLVED_START_PORTS+=("$current_port")
+        return 0
+    fi
+
+    if ! new_port=$(find_available_port "$((current_port + 1))" "$service" "$ignore_configured_ports"); then
+        echo -e "  ${RED}●${NC} Unable to find an available port for $label after $current_port"
+        return 1
+    fi
+
+    if ! check_port "$current_port" "$service"; then
+        echo -e "  ${YELLOW}●${NC} Port $current_port ($label) is already in use; using $new_port"
+    else
+        echo -e "  ${YELLOW}●${NC} Port $current_port ($label) conflicts with another selected service; using $new_port"
+    fi
+
+    set_configured_service_port "$service" "$new_port"
+    RESOLVED_START_PORTS+=("$new_port")
     return 0
 }
 
@@ -1033,7 +1410,7 @@ check_socket_url_ip() {
         echo ""
         echo -e "${YELLOW}Continue startup? [y/N]:${NC} \c"
         read -r confirm
-        if [[ "$confirm" = ^[Nn]$ ]]; then
+        if [[ "$confirm" =~ ^[Nn]$ ]]; then
             echo -e "${YELLOW}Startup cancelled${NC}"
             exit 1
         fi
@@ -1041,92 +1418,56 @@ check_socket_url_ip() {
     fi
 }
 
-# Check all required ports
-check_all_ports() {
-    local ports=("$BACKEND_PORT:Backend" "$CHAT_SHELL_PORT:Chat Shell" "$EXECUTOR_MANAGER_PORT:Executor Manager" "$KNOWLEDGE_RUNTIME_PORT:Knowledge Runtime" "$WEGENT_FRONTEND_PORT:Frontend")
-    local conflicts=()
-
-    for item in "${ports[@]}"; do
-        local port="${item%%:*}"
-        local service="${item##*:}"
-        if ! check_port "$port" "$service"; then
-            conflicts+=("$port ($service)")
-        fi
-    done
-
-    if [ ${#conflicts[@]} -gt 0 ]; then
-        echo -e "${RED}Port conflict! The following ports are already in use:${NC}"
-        for conflict in "${conflicts[@]}"; do
-            echo -e "  ${RED}●${NC} $conflict"
-        done
-        echo ""
-        echo -e "${YELLOW}Solutions:${NC}"
-        echo -e "  1. Stop the process occupying the port:"
-        echo -e "     ${BLUE}lsof -i :PORT${NC}  # View occupying process"
-        echo -e "     ${BLUE}kill -9 PID${NC}    # Stop process"
-        echo ""
-        echo -e "  2. Or run ${BLUE}$0 --stop${NC} to stop previously started services"
-        echo ""
-        echo -e "  3. If frontend port conflicts, specify another port:"
-        echo -e "     ${BLUE}$0 -p 3001${NC}"
-        return 1
-    fi
-    return 0
-}
-
 # Stop services (all or specified)
 # Usage: stop_services <graceful> [service1 service2 ...]
-# Services: backend, frontend, chat_shell, executor_manager
+# Services: backend, frontend, chat_shell, executor_manager, knowledge_runtime, wework
 stop_services() {
     local graceful="${1:-false}"
     shift
 
     # Define all services and their ports
     local all_services=("backend" "frontend" "chat_shell" "executor_manager" "knowledge_runtime" "wework")
-    local all_ports=("$BACKEND_PORT" "$WEGENT_FRONTEND_PORT" "$CHAT_SHELL_PORT" "$EXECUTOR_MANAGER_PORT" "$KNOWLEDGE_RUNTIME_PORT" "$WEWORK_PORT")
+    local all_ports=()
+
+    for service in "${all_services[@]}"; do
+        all_ports+=("$(get_runtime_service_port "$service")")
+    done
+
+    local tracked_services=()
+    local tracked_service
+    while IFS= read -r tracked_service; do
+        [ -n "$tracked_service" ] || continue
+        tracked_services+=("$tracked_service")
+    done < <(get_tracked_services)
 
     # Determine which services to stop
     local services=()
     local service_ports=()
 
     if [ $# -eq 0 ]; then
-        # No specific services provided, stop all
-        services=("${all_services[@]}")
-        service_ports=("${all_ports[@]}")
+        # No specific services provided, stop only services this script tracks.
+        services=("${tracked_services[@]}")
+        for service in "${services[@]}"; do
+            service_ports+=("$(get_runtime_service_port "$service")")
+        done
     else
         # Parse specified services
         for svc in "$@"; do
-            case "$svc" in
-                backend|be|api)
-                    services+=("backend")
-                    service_ports+=("$BACKEND_PORT")
-                    ;;
-                frontend|fe|ui)
-                    services+=("frontend")
-                    service_ports+=("$WEGENT_FRONTEND_PORT")
-                    ;;
-                chat_shell|cs|chat)
-                    services+=("chat_shell")
-                    service_ports+=("$CHAT_SHELL_PORT")
-                    ;;
-                executor_manager|em|executor)
-                    services+=("executor_manager")
-                    service_ports+=("$EXECUTOR_MANAGER_PORT")
-                    ;;
-                knowledge_runtime|kr|knowledge)
-                    services+=("knowledge_runtime")
-                    service_ports+=("$KNOWLEDGE_RUNTIME_PORT")
-                    ;;
-                wework|ww)
-                    services+=("wework")
-                    service_ports+=("$WEWORK_PORT")
-                    ;;
-                *)
-                    echo -e "${RED}Unknown service: $svc${NC}"
-                    echo -e "Valid services: backend|be|api, frontend|fe|ui, chat_shell|cs|chat, executor_manager|em|executor, knowledge_runtime|kr|knowledge, wework|ww"
-                    return 1
-                    ;;
-            esac
+            local service
+            if ! service=$(normalize_service_name "$svc"); then
+                echo -e "${RED}Unknown service: $svc${NC}"
+                echo -e "Valid services: $(valid_service_names)"
+                return 1
+            fi
+
+            if [ "$service" = "all" ]; then
+                services=("${all_services[@]}")
+                service_ports=("${all_ports[@]}")
+                break
+            else
+                services+=("$service")
+                service_ports+=("$(get_runtime_service_port "$service")")
+            fi
         done
     fi
 
@@ -1151,7 +1492,8 @@ stop_services() {
 
                 # For backend service in graceful mode, call shutdown API first (like K8s preStop hook)
                 if [ "$graceful" = "true" ] && [ "$service" = "backend" ]; then
-                    local backend_port="${service_ports[0]}"
+                    local backend_port
+                    backend_port=$(get_runtime_service_port "backend")
                     echo -e "    Calling /api/shutdown/wait (K8s preStop style)..."
                     curl -s -X POST "http://localhost:${backend_port}/api/shutdown/wait" -m 30 2>/dev/null || true
                     echo ""
@@ -1256,6 +1598,7 @@ stop_services() {
     # Clean up PID files
     for service in "${services[@]}"; do
         rm -f "$PID_DIR/${service}.pid"
+        remove_runtime_service_port "$service"
     done
 
     # Force kill any processes still occupying our ports (safety net)
@@ -1320,11 +1663,11 @@ show_status() {
     echo -e "${BLUE}Wegent Service Status:${NC}"
     echo ""
 
-    local services=("backend:$BACKEND_PORT" "frontend:$WEGENT_FRONTEND_PORT" "chat_shell:$CHAT_SHELL_PORT" "executor_manager:$EXECUTOR_MANAGER_PORT" "knowledge_runtime:$KNOWLEDGE_RUNTIME_PORT" "wework:$WEWORK_PORT")
+    local services=("backend" "frontend" "chat_shell" "executor_manager" "knowledge_runtime" "wework")
 
-    for item in "${services[@]}"; do
-        local service="${item%%:*}"
-        local port="${item##*:}"
+    for service in "${services[@]}"; do
+        local port
+        port=$(get_runtime_service_port "$service")
         local pid_file="$PID_DIR/${service}.pid"
 
         if [ -f "$pid_file" ]; then
@@ -1351,6 +1694,7 @@ start_service() {
     local name=$1
     local dir=$2
     local cmd=$3
+    local port="${4:-}"
     local log_file="$PID_DIR/${name}.log"
 
     echo -e "  Starting ${BLUE}$name${NC}..."
@@ -1366,6 +1710,9 @@ start_service() {
 
     if kill -0 "$pid" 2>/dev/null; then
         echo $pid > "$PID_DIR/${name}.pid"
+        if [ -n "$port" ]; then
+            write_runtime_service_port "$name" "$port"
+        fi
         echo -e "    ${GREEN}✓${NC} $name started (PID: $pid)"
     else
         echo -e "    ${RED}✗${NC} $name failed to start, check log: $log_file"
@@ -1420,6 +1767,7 @@ check_service_health() {
 # Start all services
 start_services() {
     # Parse arguments: if services specified, only start those
+    local all_services=("backend" "frontend" "chat_shell" "executor_manager" "knowledge_runtime" "wework")
     local specified_services=()
     local start_backend=false
     local start_frontend=false
@@ -1439,32 +1787,44 @@ start_services() {
     else
         # Parse specified services
         for svc in "$@"; do
-            case "$svc" in
-                backend|be|api)
+            local service
+            if ! service=$(normalize_service_name "$svc"); then
+                echo -e "${RED}Unknown service: $svc${NC}"
+                echo -e "Valid services: $(valid_service_names)"
+                exit 1
+            fi
+
+            case "$service" in
+                all)
                     start_backend=true
-                    specified_services+=("backend")
-                    ;;
-                frontend|fe|ui)
                     start_frontend=true
-                    specified_services+=("frontend")
-                    ;;
-                chat_shell|cs|chat)
                     start_chat_shell=true
-                    specified_services+=("chat_shell")
-                    ;;
-                executor_manager|em|executor)
                     start_executor_manager=true
-                    specified_services+=("executor_manager")
-                    ;;
-                knowledge_runtime|kr|knowledge)
                     start_knowledge_runtime=true
-                    specified_services+=("knowledge_runtime")
-                    ;;
-                wework|ww)
                     start_wework=true
-                    specified_services+=("wework")
+                    specified_services=("${all_services[@]}")
+                    break
+                    ;;
+                backend)
+                    start_backend=true
+                    ;;
+                frontend)
+                    start_frontend=true
+                    ;;
+                chat_shell)
+                    start_chat_shell=true
+                    ;;
+                executor_manager)
+                    start_executor_manager=true
+                    ;;
+                knowledge_runtime)
+                    start_knowledge_runtime=true
+                    ;;
+                wework)
+                    start_wework=true
                     ;;
             esac
+            specified_services+=("$service")
         done
     fi
 
@@ -1479,7 +1839,7 @@ start_services() {
         echo ""
 
         # Run the init config wizard in embedded mode (don't exit after saving)
-        if ! init_config "embedded"; then
+        if ! init_config "embedded" "${specified_services[@]}"; then
             echo -e "${RED}Configuration setup cancelled. Exiting.${NC}"
             exit 1
         fi
@@ -1526,6 +1886,40 @@ start_services() {
     echo -e "  ${GREEN}✓${NC} Node.js detected: $node_version (npm $npm_version)"
 
     echo ""
+    echo -e "${BLUE}Checking port usage...${NC}"
+    local previous_backend_port="$BACKEND_PORT"
+    local previous_executor_manager_port="$EXECUTOR_MANAGER_PORT"
+    local previous_knowledge_runtime_port="$KNOWLEDGE_RUNTIME_PORT"
+    local port_resolution_failed=false
+    RESOLVED_START_PORTS=()
+
+    if [ "$start_backend" = true ]; then
+        resolve_start_service_port "backend" "Backend" || port_resolution_failed=true
+    fi
+    if [ "$start_chat_shell" = true ]; then
+        resolve_start_service_port "chat_shell" "Chat Shell" || port_resolution_failed=true
+    fi
+    if [ "$start_executor_manager" = true ]; then
+        resolve_start_service_port "executor_manager" "Executor Manager" || port_resolution_failed=true
+    fi
+    if [ "$start_knowledge_runtime" = true ]; then
+        resolve_start_service_port "knowledge_runtime" "Knowledge Runtime" || port_resolution_failed=true
+    fi
+    if [ "$start_frontend" = true ]; then
+        resolve_start_service_port "frontend" "Frontend" || port_resolution_failed=true
+    fi
+    if [ "$start_wework" = true ]; then
+        resolve_start_service_port "wework" "WeWork" || port_resolution_failed=true
+    fi
+
+    if [ "$port_resolution_failed" = true ]; then
+        exit 1
+    fi
+
+    compute_derived_urls "$previous_backend_port" "$previous_executor_manager_port" "$previous_knowledge_runtime_port"
+    echo -e "${GREEN}✓ Required ports resolved${NC}"
+    echo ""
+
     echo -e "${GREEN}Configuration:${NC}"
     echo -e "  Backend Port:        $BACKEND_PORT"
     echo -e "  Chat Shell Port:     $CHAT_SHELL_PORT"
@@ -1542,51 +1936,6 @@ start_services() {
 
     # Check if WEGENT_SOCKET_URL IP matches local IP
     check_socket_url_ip
-
-    # Check port conflicts only for services being started
-    echo -e "${BLUE}Checking port usage...${NC}"
-    local port_conflict=false
-
-    if [ "$start_backend" = true ] && ! check_port "$BACKEND_PORT" "backend"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $BACKEND_PORT (Backend) is already in use"
-    fi
-    if [ "$start_chat_shell" = true ] && ! check_port "$CHAT_SHELL_PORT" "chat_shell"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $CHAT_SHELL_PORT (Chat Shell) is already in use"
-    fi
-    if [ "$start_executor_manager" = true ] && ! check_port "$EXECUTOR_MANAGER_PORT" "executor_manager"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $EXECUTOR_MANAGER_PORT (Executor Manager) is already in use"
-    fi
-    if [ "$start_knowledge_runtime" = true ] && ! check_port "$KNOWLEDGE_RUNTIME_PORT" "knowledge_runtime"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $KNOWLEDGE_RUNTIME_PORT (Knowledge Runtime) is already in use"
-    fi
-    if [ "$start_frontend" = true ] && ! check_port "$WEGENT_FRONTEND_PORT" "frontend"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $WEGENT_FRONTEND_PORT (Frontend) is already in use"
-    fi
-    if [ "$start_wework" = true ] && ! check_port "$WEWORK_PORT" "wework"; then
-        port_conflict=true
-        echo -e "  ${RED}●${NC} Port $WEWORK_PORT (WeWork) is already in use"
-    fi
-
-    if [ "$port_conflict" = true ]; then
-        echo ""
-        echo -e "${YELLOW}Solutions:${NC}"
-        echo -e "  1. Stop the process occupying the port:"
-        echo -e "     ${BLUE}lsof -i :PORT${NC}  # View occupying process"
-        echo -e "     ${BLUE}kill -9 PID${NC}    # Stop process"
-        echo ""
-        echo -e "  2. Or run ${BLUE}./start.sh --stop${NC} to stop previously started services"
-        echo ""
-        echo -e "  3. If frontend port conflicts, specify another port:"
-        echo -e "     ${BLUE}./start.sh -p 3001${NC}"
-        exit 1
-    fi
-    echo -e "${GREEN}✓ All required ports available${NC}"
-    echo ""
 
     # Sync Python dependencies
     echo -e "${BLUE}Checking Python dependencies...${NC}"
@@ -1661,7 +2010,8 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "backend" "backend" \
-            "export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=http://localhost:$BACKEND_PORT && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug"
+            "export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=http://localhost:$BACKEND_PORT && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug" \
+            "$BACKEND_PORT"
     fi
 
     # 2. Start Chat Shell
@@ -1670,7 +2020,8 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "chat_shell" "chat_shell" \
-            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug"
+            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug" \
+            "$CHAT_SHELL_PORT"
     fi
 
     # 3. Start Executor Manager
@@ -1682,7 +2033,8 @@ start_services() {
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         local CALLBACK_HOST="http://$LOCAL_IP:$EXECUTOR_MANAGER_PORT"
         start_service "executor_manager" "executor_manager" \
-            "export EXECUTOR_IMAGE=$EXECUTOR_IMAGE && export TASK_API_DOMAIN=$TASK_API_DOMAIN && export DOCKER_HOST_ADDR=localhost && export NO_PROXY=localhost,127.0.0.1 && export no_proxy=localhost,127.0.0.1 && export NETWORK=wegent-network && export CALLBACK_HOST=$CALLBACK_HOST && source .venv/bin/activate && uvicorn main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $EXECUTOR_MANAGER_PORT --log-level debug"
+            "export EXECUTOR_IMAGE=$EXECUTOR_IMAGE && export TASK_API_DOMAIN=$TASK_API_DOMAIN && export DOCKER_HOST_ADDR=localhost && export NO_PROXY=localhost,127.0.0.1 && export no_proxy=localhost,127.0.0.1 && export NETWORK=wegent-network && export CALLBACK_HOST=$CALLBACK_HOST && source .venv/bin/activate && uvicorn main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $EXECUTOR_MANAGER_PORT --log-level debug" \
+            "$EXECUTOR_MANAGER_PORT"
     fi
 
     # 4. Start Knowledge Runtime
@@ -1693,7 +2045,8 @@ start_services() {
         # --reload-dir: Watch shared and knowledge_engine modules for changes (editable dependencies)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "knowledge_runtime" "knowledge_runtime" \
-            "export INTERNAL_SERVICE_TOKEN=\$INTERNAL_SERVICE_TOKEN && export BACKEND_INTERNAL_URL=http://localhost:$BACKEND_PORT && export KNOWLEDGE_RUNTIME_URL=$KNOWLEDGE_RUNTIME_URL && source .venv/bin/activate && uvicorn knowledge_runtime.main:app --reload --reload-dir . --reload-dir ../shared --reload-dir ../knowledge_engine $RELOAD_EXCLUDE --host 0.0.0.0 --port $KNOWLEDGE_RUNTIME_PORT --log-level debug"
+            "export INTERNAL_SERVICE_TOKEN=\$INTERNAL_SERVICE_TOKEN && export BACKEND_INTERNAL_URL=http://localhost:$BACKEND_PORT && export KNOWLEDGE_RUNTIME_URL=$KNOWLEDGE_RUNTIME_URL && source .venv/bin/activate && uvicorn knowledge_runtime.main:app --reload --reload-dir . --reload-dir ../shared --reload-dir ../knowledge_engine $RELOAD_EXCLUDE --host 0.0.0.0 --port $KNOWLEDGE_RUNTIME_PORT --log-level debug" \
+            "$KNOWLEDGE_RUNTIME_PORT"
     fi
 
     # 5. Start Frontend (run in background)
@@ -1728,6 +2081,7 @@ start_services() {
         sleep 3
 
         if kill -0 "$frontend_pid" 2>/dev/null; then
+            write_runtime_service_port "frontend" "$WEGENT_FRONTEND_PORT"
             echo -e "    ${GREEN}✓${NC} frontend started (PID: $frontend_pid)"
         else
             echo -e "    ${RED}✗${NC} frontend failed to start, check log: $PID_DIR/frontend.log"
@@ -1761,6 +2115,7 @@ start_services() {
         sleep 3
 
         if kill -0 "$wework_pid" 2>/dev/null; then
+            write_runtime_service_port "wework" "$WEWORK_PORT"
             echo -e "    ${GREEN}✓${NC} wework started (PID: $wework_pid)"
         else
             echo -e "    ${RED}✗${NC} wework failed to start, check log: $PID_DIR/wework.log"
@@ -1854,7 +2209,11 @@ start_services() {
 # Execute action
 case $ACTION in
     start)
-        start_services
+        if [ ${#START_SERVICES[@]} -eq 0 ]; then
+            start_services
+        else
+            start_services "${START_SERVICES[@]}"
+        fi
         ;;
     init)
         init_config

--- a/tests/test_start_sh.sh
+++ b/tests/test_start_sh.sh
@@ -1,0 +1,325 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+STUB_DIR="$TMP_DIR/bin"
+mkdir -p "$STUB_DIR"
+
+ROOT_ENV="$REPO_ROOT/.env"
+BACKEND_ENV="$REPO_ROOT/backend/.env"
+ROOT_ENV_BACKUP="$TMP_DIR/root.env.backup"
+BACKEND_ENV_BACKUP="$TMP_DIR/backend.env.backup"
+ROOT_ENV_EXISTED=false
+BACKEND_ENV_EXISTED=false
+
+cleanup() {
+    if [ -d "$REPO_ROOT/.pids" ]; then
+        for pid_file in "$REPO_ROOT"/.pids/*.pid; do
+            [ -f "$pid_file" ] || continue
+            local pid
+            pid="$(cat "$pid_file" 2>/dev/null || true)"
+            if [ -n "$pid" ]; then
+                kill "$pid" 2>/dev/null || true
+            fi
+        done
+        rm -rf "$REPO_ROOT/.pids"
+    fi
+
+    if [ "$ROOT_ENV_EXISTED" = true ]; then
+        mv "$ROOT_ENV_BACKUP" "$ROOT_ENV"
+    else
+        rm -f "$ROOT_ENV"
+    fi
+
+    if [ "$BACKEND_ENV_EXISTED" = true ]; then
+        mv "$BACKEND_ENV_BACKUP" "$BACKEND_ENV"
+    else
+        rm -f "$BACKEND_ENV"
+    fi
+
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+if [ -f "$ROOT_ENV" ]; then
+    ROOT_ENV_EXISTED=true
+    cp "$ROOT_ENV" "$ROOT_ENV_BACKUP"
+fi
+
+if [ -f "$BACKEND_ENV" ]; then
+    BACKEND_ENV_EXISTED=true
+    cp "$BACKEND_ENV" "$BACKEND_ENV_BACKUP"
+fi
+
+cat > "$ROOT_ENV" <<'EOF'
+BACKEND_PORT=8000
+CHAT_SHELL_PORT=8100
+EXECUTOR_MANAGER_PORT=8001
+KNOWLEDGE_RUNTIME_PORT=8200
+WEGENT_FRONTEND_PORT=3000
+WEWORK_PORT=1420
+EXECUTOR_IMAGE=test-executor:latest
+WEGENT_SOCKET_URL=http://localhost:8000
+EOF
+
+cat > "$BACKEND_ENV" <<'EOF'
+DATABASE_URL=mysql+pymysql://root:123456@localhost:3306/wegent
+REDIS_URL=redis://localhost:6379/0
+EOF
+
+cat > "$STUB_DIR/lsof" <<'EOF'
+#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        :8000|:3000)
+            echo 99999
+            exit 0
+            ;;
+    esac
+done
+exit 1
+EOF
+
+cat > "$STUB_DIR/docker" <<'EOF'
+#!/bin/bash
+case "$1" in
+    --version)
+        echo "Docker version 27.0.0, build test"
+        ;;
+    ps)
+        echo "wegent-mysql"
+        echo "wegent-redis"
+        ;;
+    inspect)
+        echo "healthy"
+        ;;
+    compose)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+
+cat > "$STUB_DIR/uv" <<'EOF'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "uv 0.5.0"
+fi
+exit 0
+EOF
+
+cat > "$STUB_DIR/node" <<'EOF'
+#!/bin/bash
+echo "v20.0.0"
+EOF
+
+cat > "$STUB_DIR/npm" <<'EOF'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "10.0.0"
+fi
+exit 0
+EOF
+
+cat > "$STUB_DIR/curl" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$STUB_DIR/nc" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$STUB_DIR/file" <<'EOF'
+#!/bin/bash
+if [ "$1" = "--version" ]; then
+    echo "file-5.45"
+fi
+exit 0
+EOF
+
+cat > "$STUB_DIR/bash" <<'EOF'
+#!/bin/bash
+if [ "$1" = "-c" ]; then
+    sleep 60
+    exit 0
+fi
+exec /bin/bash "$@"
+EOF
+
+chmod +x "$STUB_DIR"/*
+
+run_start_with_stubs() {
+    local input="${1:-}"
+    shift || true
+
+    set +e
+    if [ -n "$input" ]; then
+        output="$(
+            cd "$REPO_ROOT"
+            printf "%b" "$input" | PATH="$STUB_DIR:$PATH" /bin/bash "$REPO_ROOT/start.sh" "$@" 2>&1
+        )"
+    else
+        output="$(
+            cd "$REPO_ROOT"
+            PATH="$STUB_DIR:$PATH" /bin/bash "$REPO_ROOT/start.sh" "$@" 2>&1
+        )"
+    fi
+    status=$?
+    set -e
+}
+
+reset_runtime_files() {
+    if [ -d "$REPO_ROOT/.pids" ]; then
+        for pid_file in "$REPO_ROOT"/.pids/*.pid; do
+            [ -f "$pid_file" ] || continue
+            local pid
+            pid="$(cat "$pid_file" 2>/dev/null || true)"
+            if [ -n "$pid" ]; then
+                kill "$pid" 2>/dev/null || true
+            fi
+        done
+        rm -rf "$REPO_ROOT/.pids"
+    fi
+}
+
+output=""
+status=0
+
+set +e
+run_start_with_stubs "" backend frontend
+set -e
+
+if [ "$status" -ne 0 ]; then
+    echo "Expected start.sh backend frontend to succeed"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "Port 8000 (Backend) is already in use; using 8002" <<< "$output"; then
+    echo "Expected backend port auto-selection message"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "Port 3000 (Frontend) is already in use; using 3001" <<< "$output"; then
+    echo "Expected frontend port auto-selection message"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "Services started: backend frontend" <<< "$output"; then
+    echo "Expected only backend and frontend to start"
+    echo "$output"
+    exit 1
+fi
+
+for unexpected in chat_shell executor_manager knowledge_runtime wework; do
+    if grep -q "Starting .*${unexpected}" <<< "$output"; then
+        echo "Unexpected service started: $unexpected"
+        echo "$output"
+        exit 1
+    fi
+done
+
+if [ "$(cat "$REPO_ROOT/.pids/backend.port")" != "8002" ]; then
+    echo "Expected backend runtime port file to contain 8002"
+    exit 1
+fi
+
+if [ "$(cat "$REPO_ROOT/.pids/frontend.port")" != "3001" ]; then
+    echo "Expected frontend runtime port file to contain 3001"
+    exit 1
+fi
+
+echo "start.sh service selection and auto port test passed"
+
+reset_runtime_files
+rm -f "$ROOT_ENV"
+
+run_start_with_stubs "\n\n\n\n" be fe
+
+if [ "$status" -ne 0 ]; then
+    echo "Expected first-run start.sh be fe to succeed"
+    echo "$output"
+    exit 1
+fi
+
+if grep -q "2. Chat Shell Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to skip Chat Shell prompt"
+    echo "$output"
+    exit 1
+fi
+
+if grep -q "3. Executor Manager Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to skip Executor Manager prompt"
+    echo "$output"
+    exit 1
+fi
+
+if grep -q "4. Knowledge Runtime Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to skip Knowledge Runtime prompt"
+    echo "$output"
+    exit 1
+fi
+
+if grep -q "6. WeWork Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to skip WeWork prompt"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "1. Backend Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to ask for Backend port"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "2. Frontend Port" <<< "$output"; then
+    echo "Expected first-run be fe setup to ask for Frontend port"
+    echo "$output"
+    exit 1
+fi
+
+echo "start.sh scoped first-run setup test passed"
+
+reset_runtime_files
+mkdir -p "$REPO_ROOT/.pids"
+echo "999998" > "$REPO_ROOT/.pids/backend.pid"
+echo "999997" > "$REPO_ROOT/.pids/frontend.pid"
+echo "8002" > "$REPO_ROOT/.pids/backend.port"
+echo "3001" > "$REPO_ROOT/.pids/frontend.port"
+
+run_start_with_stubs "" --stop
+
+if [ "$status" -ne 0 ]; then
+    echo "Expected start.sh --stop to stop tracked services"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "Stopping services: backend frontend" <<< "$output"; then
+    echo "Expected stop without service args to target only tracked backend/frontend"
+    echo "$output"
+    exit 1
+fi
+
+for unexpected in chat_shell executor_manager knowledge_runtime wework; do
+    if grep -q "Stopping services: .*${unexpected}" <<< "$output"; then
+        echo "Unexpected service targeted by default stop: $unexpected"
+        echo "$output"
+        exit 1
+    fi
+done
+
+echo "start.sh default stop tracked services test passed"


### PR DESCRIPTION
## Summary
- Allow ./start.sh service names like backend/frontend or be/fe to start only selected local services.
- Auto-select available ports for selected services and keep runtime port metadata for status/stop.
- Scope first-run setup and default stop behavior to tracked services, with --stop all for full cleanup.

## Test Plan
- [x] bash -n start.sh
- [x] bash -n tests/test_start_sh.sh
- [x] git diff --check
- [x] bash tests/test_start_sh.sh