### PR TITLE
fix(frontend): remove artifact chat bridge

### DIFF
--- a/frontend/src/__tests__/components/common/EnhancedMarkdown.test.tsx
+++ b/frontend/src/__tests__/components/common/EnhancedMarkdown.test.tsx
@@ -5,7 +5,6 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import EnhancedMarkdown from '@/components/common/EnhancedMarkdown'
-import { SANDBOXED_HTML_SEND_TO_CHAT_EVENT } from '@/components/common/SandboxedHtmlFrame'
 
 jest.mock('next/dynamic', () => () => {
   const DynamicComponent = () => null
@@ -52,12 +51,10 @@ title: Test
     expect(screen.getByText('# Body')).toBeInTheDocument()
   })
 
-  it('renders artifact HTML in a sandboxed iframe instead of the host markdown tree', () => {
-    const onSendMessage = jest.fn()
+  it('renders artifact HTML in a sandboxed iframe without exposing chat send APIs', () => {
     const { container } = render(
       <EnhancedMarkdown
         theme="light"
-        onSendMessage={onSendMessage}
         source={`Before
 
 <artifact title="午餐选择卡片">
@@ -87,18 +84,7 @@ After`}
     expect(iframe).toBeInTheDocument()
     expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
     expect(iframe).toHaveAttribute('srcdoc', expect.stringContaining('body { background: red; }'))
-    expect(iframe).toHaveAttribute('srcdoc', expect.stringContaining('window.sendToChat'))
-
-    window.dispatchEvent(
-      new MessageEvent('message', {
-        source: iframe?.contentWindow,
-        data: {
-          type: SANDBOXED_HTML_SEND_TO_CHAT_EVENT,
-          message: ' 我选择火锅 ',
-        },
-      })
-    )
-
-    expect(onSendMessage).toHaveBeenCalledWith('我选择火锅')
+    expect(iframe).not.toHaveAttribute('srcdoc', expect.stringContaining('window.sendToChat'))
+    expect(iframe).not.toHaveAttribute('srcdoc', expect.stringContaining('send-to-chat'))
   })
 })

--- a/frontend/src/components/common/EnhancedMarkdown.tsx
+++ b/frontend/src/components/common/EnhancedMarkdown.tsx
@@ -39,7 +39,6 @@ const MermaidDiagram = dynamic(() => import('./MermaidDiagram'), {
 interface EnhancedMarkdownProps {
   source: string
   theme: 'light' | 'dark'
-  onSendMessage?: (content: string) => void
   /** Custom components to override default rendering */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   components?: Record<string, React.ComponentType<any>>
@@ -136,15 +135,7 @@ function splitSpecialMarkdownBlocks(markdown: string): ContentPart[] {
   return parts
 }
 
-function ArtifactPreview({
-  title,
-  html,
-  onSendMessage,
-}: {
-  title: string
-  html: string
-  onSendMessage?: (content: string) => void
-}) {
+function ArtifactPreview({ title, html }: { title: string; html: string }) {
   return (
     <div className="my-4 overflow-hidden rounded-lg border border-border bg-surface">
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
@@ -155,7 +146,6 @@ function ArtifactPreview({
         content={html}
         className="block h-[520px] max-h-[70vh] min-h-[320px] w-full border-0 bg-white"
         testId="artifact-preview-iframe"
-        onSendMessage={onSendMessage}
       />
     </div>
   )
@@ -646,7 +636,6 @@ function preprocessCjkBoldEdgeCases(text: string): string {
 export const EnhancedMarkdown = memo(function EnhancedMarkdown({
   source,
   theme,
-  onSendMessage,
   components,
 }: EnhancedMarkdownProps) {
   // Extract frontmatter before processing
@@ -809,12 +798,7 @@ export const EnhancedMarkdown = memo(function EnhancedMarkdown({
 
         if (part.type === 'artifact') {
           return (
-            <ArtifactPreview
-              key={`artifact-${index}`}
-              title={part.title}
-              html={part.content}
-              onSendMessage={onSendMessage}
-            />
+            <ArtifactPreview key={`artifact-${index}`} title={part.title} html={part.content} />
           )
         }
 

--- a/frontend/src/components/common/SandboxedHtmlFrame.tsx
+++ b/frontend/src/components/common/SandboxedHtmlFrame.tsx
@@ -4,9 +4,7 @@
 
 'use client'
 
-import { CSSProperties, useEffect, useMemo, useRef } from 'react'
-
-export const SANDBOXED_HTML_SEND_TO_CHAT_EVENT = 'wegent:sandboxed-html-send-to-chat'
+import { CSSProperties } from 'react'
 
 export interface SandboxedHtmlFrameProps {
   content: string
@@ -17,31 +15,6 @@ export interface SandboxedHtmlFrameProps {
   testId?: string
   onLoad?: () => void
   onError?: () => void
-  onSendMessage?: (content: string) => void
-}
-
-function buildSrcDoc(content: string, shouldInjectSendToChat: boolean): string {
-  if (!shouldInjectSendToChat) return content
-
-  const bridgeScript = [
-    '<script>',
-    '(function () {',
-    '  window.sendToChat = function (message) {',
-    `    window.parent.postMessage({ type: '${SANDBOXED_HTML_SEND_TO_CHAT_EVENT}', message: String(message || '') }, '*');`,
-    '  };',
-    '}());',
-    '</script>',
-  ].join('\n')
-
-  if (/<head\b[^>]*>/i.test(content)) {
-    return content.replace(/<head\b[^>]*>/i, match => `${match}\n${bridgeScript}`)
-  }
-
-  if (/<html\b[^>]*>/i.test(content)) {
-    return content.replace(/<html\b[^>]*>/i, match => `${match}\n<head>${bridgeScript}</head>`)
-  }
-
-  return `${bridgeScript}\n${content}`
 }
 
 export function SandboxedHtmlFrame({
@@ -53,38 +26,11 @@ export function SandboxedHtmlFrame({
   testId,
   onLoad,
   onError,
-  onSendMessage,
 }: SandboxedHtmlFrameProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null)
-  const srcDoc = useMemo(
-    () => buildSrcDoc(content, Boolean(onSendMessage)),
-    [content, onSendMessage]
-  )
-
-  useEffect(() => {
-    if (!onSendMessage) return
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.source !== iframeRef.current?.contentWindow) return
-      const data = event.data as { type?: unknown; message?: unknown } | null
-      if (!data || data.type !== SANDBOXED_HTML_SEND_TO_CHAT_EVENT) return
-      if (typeof data.message !== 'string') return
-
-      const message = data.message.trim()
-      if (message) {
-        onSendMessage(message)
-      }
-    }
-
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
-  }, [onSendMessage])
-
   return (
     <iframe
-      ref={iframeRef}
       title={title}
-      srcDoc={srcDoc}
+      srcDoc={content}
       sandbox={sandbox}
       className={className}
       style={style}

--- a/frontend/src/features/tasks/components/message/MessageBubble.tsx
+++ b/frontend/src/features/tasks/components/message/MessageBubble.tsx
@@ -792,7 +792,6 @@ const MessageBubble = memo(
         <EnhancedMarkdown
           source={normalizedResult}
           theme={theme}
-          onSendMessage={onSendMessage}
           components={
             paragraphAction
               ? {
@@ -1332,7 +1331,6 @@ const MessageBubble = memo(
                 <EnhancedMarkdown
                   source={prefixText}
                   theme={theme}
-                  onSendMessage={onSendMessage}
                   components={{
                     a: ({ href, children }) => {
                       if (!href) {
@@ -1362,7 +1360,6 @@ const MessageBubble = memo(
                   <EnhancedMarkdown
                     source={suffixText}
                     theme={theme}
-                    onSendMessage={onSendMessage}
                     components={{
                       a: ({ href, children }) => {
                         if (!href) {
@@ -1394,7 +1391,6 @@ const MessageBubble = memo(
                 <EnhancedMarkdown
                   source={prefixText}
                   theme={theme}
-                  onSendMessage={onSendMessage}
                   components={{
                     a: ({ href, children }) => {
                       if (!href) {
@@ -1427,7 +1423,6 @@ const MessageBubble = memo(
                   <EnhancedMarkdown
                     source={suffixText}
                     theme={theme}
-                    onSendMessage={onSendMessage}
                     components={{
                       a: ({ href, children }) => {
                         if (!href) {
@@ -1661,7 +1656,6 @@ const MessageBubble = memo(
                         subtaskId={msg.subtaskId}
                         currentMessageIndex={index}
                         onAskUserSubmit={onAskUserSubmit}
-                        onSendMessage={onSendMessage}
                       />
                       <SourceReferences sources={msg.sources || msg.result?.sources || []} />
                       <GeminiAnnotations annotations={msg.result?.annotations || []} />

--- a/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/MixedContentView.tsx
@@ -69,8 +69,6 @@ interface MixedContentViewProps {
   currentMessageIndex?: number
   /** Callback when user submits an ask_user_question form - receives pre-formatted message string */
   onAskUserSubmit?: (askId: string, formattedMessage: string) => void
-  /** Callback when interactive HTML artifacts send a chat message */
-  onSendMessage?: (content: string) => void
 }
 
 /**
@@ -93,7 +91,6 @@ const MixedContentView = memo(function MixedContentView({
   subtaskId,
   currentMessageIndex,
   onAskUserSubmit,
-  onSendMessage,
 }: MixedContentViewProps) {
   const { t } = useTranslation('chat')
   // Extract tools from thinking (legacy mode)
@@ -531,7 +528,7 @@ const MixedContentView = memo(function MixedContentView({
               : item.content
           return (
             <div key={key} className="text-sm">
-              <EnhancedMarkdown source={textContent} theme={theme} onSendMessage={onSendMessage} />
+              <EnhancedMarkdown source={textContent} theme={theme} />
             </div>
           )
         } else if (item.type === 'video') {


### PR DESCRIPTION
## Summary
- Remove the injected `window.sendToChat` bridge from sandboxed HTML frames.
- Stop forwarding message send callbacks into artifact iframes.
- Update the artifact markdown regression test to assert no chat-send API is exposed in iframe `srcDoc`.

## Test Plan
- `npm test -- --runInBand`
- `npx tsc --noEmit`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Removed the message-sending capability from sandboxed artifacts to strengthen content isolation and improve security boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->