### PR TITLE
fix(openapi): preserve split thinking blocks

### DIFF
--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -16,6 +16,7 @@ supporting page refresh recovery during streaming.
 import asyncio
 import json
 import logging
+import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -735,6 +736,10 @@ class SessionManager:
         """Generate Redis key for current text block ID."""
         return f"{STREAMING_KEY_PREFIX}text_block:{subtask_id}"
 
+    def _get_current_thinking_block_key(self, subtask_id: int) -> str:
+        """Generate Redis key for current thinking block ID."""
+        return f"{STREAMING_KEY_PREFIX}thinking_block:{subtask_id}"
+
     async def add_tool_block(
         self,
         subtask_id: int,
@@ -762,6 +767,7 @@ class SessionManager:
         try:
             # Finalize current text block before adding tool block
             await self._finalize_current_text_block(subtask_id)
+            await self._finalize_current_thinking_block(subtask_id)
 
             # Create tool block using unified function
             block = create_tool_block(
@@ -868,6 +874,7 @@ class SessionManager:
         try:
             # Finalize current text block before adding new block (to maintain order)
             await self._finalize_current_text_block(subtask_id)
+            await self._finalize_current_thinking_block(subtask_id)
 
             # Ensure block has id
             block_id = block.get("id")
@@ -931,6 +938,8 @@ class SessionManager:
             return
 
         try:
+            await self._finalize_current_thinking_block(subtask_id)
+
             # Append to accumulated content using Redis APPEND (O(1))
             streaming_key = self._get_streaming_key(subtask_id)
             text_block_key = self._get_current_text_block_key(subtask_id)
@@ -990,6 +999,63 @@ class SessionManager:
                 f"[SessionManager] Failed to add text content for subtask {subtask_id}: {e}"
             )
 
+    async def add_thinking_content(self, subtask_id: int, content: str) -> None:
+        """Add reasoning content to the current thinking block."""
+        if not content:
+            return
+
+        try:
+            await self._finalize_current_text_block(subtask_id)
+
+            thinking_block_key = self._get_current_thinking_block_key(subtask_id)
+            blocks_key = self._get_blocks_key(subtask_id)
+
+            redis_client = await self._cache._get_client()
+            try:
+                current_block_id = await redis_client.get(thinking_block_key)
+
+                if current_block_id:
+                    block_id = (
+                        current_block_id.decode()
+                        if isinstance(current_block_id, bytes)
+                        else current_block_id
+                    )
+                    blocks_raw = await redis_client.lrange(blocks_key, -1, -1)
+                    if blocks_raw:
+                        last_block = json.loads(blocks_raw[0])
+                        if last_block.get("id") == block_id:
+                            last_block["content"] = (
+                                last_block.get("content", "") + content
+                            )
+                            await redis_client.lset(
+                                blocks_key, -1, json.dumps(last_block)
+                            )
+                else:
+                    ts = int(asyncio.get_event_loop().time() * 1000)
+                    block = {
+                        "id": f"thinking-{uuid.uuid4().hex[:12]}",
+                        "type": "thinking",
+                        "content": content,
+                        "status": BlockStatus.STREAMING.value,
+                        "timestamp": ts,
+                    }
+                    await redis_client.rpush(blocks_key, json.dumps(block))
+                    await redis_client.set(
+                        thinking_block_key, block["id"], ex=STREAMING_TTL
+                    )
+                    logger.info(
+                        f"[SessionManager] Created thinking block for subtask {subtask_id}: "
+                        f"id={block['id']}"
+                    )
+
+                await redis_client.expire(blocks_key, STREAMING_TTL)
+            finally:
+                await redis_client.aclose()
+        except Exception as e:
+            logger.error(
+                f"[SessionManager] Failed to add thinking content for subtask {subtask_id}: {e}"
+            )
+
     async def _finalize_current_text_block(self, subtask_id: int) -> None:
         """Finalize the current text block by setting status to done."""
         try:
@@ -1024,6 +1090,40 @@ class SessionManager:
         except Exception as e:
             logger.warning(
                 f"[SessionManager] Failed to finalize text block for subtask {subtask_id}: {e}"
+            )
+
+    async def _finalize_current_thinking_block(self, subtask_id: int) -> None:
+        """Finalize the current thinking block by setting status to done."""
+        try:
+            thinking_block_key = self._get_current_thinking_block_key(subtask_id)
+            blocks_key = self._get_blocks_key(subtask_id)
+
+            redis_client = await self._cache._get_client()
+            try:
+                current_block_id = await redis_client.get(thinking_block_key)
+                if not current_block_id:
+                    return
+
+                block_id = (
+                    current_block_id.decode()
+                    if isinstance(current_block_id, bytes)
+                    else current_block_id
+                )
+
+                blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
+                for i, block_json in enumerate(blocks_raw):
+                    block = json.loads(block_json)
+                    if block.get("id") == block_id:
+                        block["status"] = BlockStatus.DONE.value
+                        await redis_client.lset(blocks_key, i, json.dumps(block))
+                        break
+
+                await redis_client.delete(thinking_block_key)
+            finally:
+                await redis_client.aclose()
+        except Exception as e:
+            logger.warning(
+                f"[SessionManager] Failed to finalize thinking block for subtask {subtask_id}: {e}"
             )
 
     async def get_blocks(self, subtask_id: int) -> List[Dict[str, Any]]:
@@ -1071,6 +1171,7 @@ class SessionManager:
         try:
             # Finalize current text block
             await self._finalize_current_text_block(subtask_id)
+            await self._finalize_current_thinking_block(subtask_id)
 
             # Get all blocks
             blocks_key = self._get_blocks_key(subtask_id)
@@ -1117,10 +1218,16 @@ class SessionManager:
             streaming_key = self._get_streaming_key(subtask_id)
             blocks_key = self._get_blocks_key(subtask_id)
             text_block_key = self._get_current_text_block_key(subtask_id)
+            thinking_block_key = self._get_current_thinking_block_key(subtask_id)
 
             redis_client = await self._cache._get_client()
             try:
-                await redis_client.delete(streaming_key, blocks_key, text_block_key)
+                await redis_client.delete(
+                    streaming_key,
+                    blocks_key,
+                    text_block_key,
+                    thinking_block_key,
+                )
                 logger.debug(
                     f"[SessionManager] Cleaned up streaming state for subtask {subtask_id}"
                 )

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -103,6 +103,26 @@ def _extract_shell_call_input(item: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _extract_reasoning_event_content(
+    event_type: str, data: dict[str, Any]
+) -> Optional[str]:
+    if event_type == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value:
+        delta = data.get("delta")
+        if delta is None:
+            return ""
+        return delta if isinstance(delta, str) else str(delta)
+
+    if event_type == ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value:
+        part = data.get("part", {})
+        if isinstance(part, dict) and part.get("type") == "reasoning":
+            text = part.get("text")
+            if text is None:
+                return ""
+            return text if isinstance(text, str) else str(text)
+
+    return None
+
+
 def _build_shell_call_context(item: dict[str, Any]) -> dict[str, Any]:
     return {
         "protocol": "shell_call",
@@ -120,11 +140,24 @@ def extract_completed_result(response_data: dict) -> dict:
     """
     # Extract text content from response output
     value = ""
+    reasoning_parts: list[str] = []
     for item in response_data.get("output", []):
         if isinstance(item, dict):
             for content_block in item.get("content", []):
-                if isinstance(content_block, dict) and content_block.get("text"):
-                    value += content_block["text"]
+                if not isinstance(content_block, dict):
+                    continue
+                text = content_block.get("text")
+                if not text:
+                    continue
+                block_type = content_block.get("type")
+                if block_type == "reasoning":
+                    reasoning_parts.append(text)
+                elif block_type in (None, "output_text", "text"):
+                    value += text
+
+    reasoning_content = response_data.get("reasoning_content")
+    if reasoning_content is None and reasoning_parts:
+        reasoning_content = "".join(reasoning_parts)
 
     return {
         "value": value,
@@ -136,7 +169,7 @@ def extract_completed_result(response_data: dict) -> dict:
         "loaded_skills": response_data.get("loaded_skills"),
         "stop_reason": response_data.get("stop_reason"),
         "messages_chain": response_data.get("messages_chain"),
-        "reasoning_content": response_data.get("reasoning_content"),
+        "reasoning_content": reasoning_content,
     }
 
 
@@ -324,15 +357,17 @@ class ResponsesAPIEventParser:
                 message_id=message_id,
             )
 
-        elif event_type == ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value:
-            # response.reasoning_summary_part.added -> THINKING
-            part = data.get("part", {})
-            if part.get("type") == "reasoning":
+        elif event_type in (
+            ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value,
+            ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+        ):
+            reasoning_content = _extract_reasoning_event_content(event_type, data)
+            if reasoning_content is not None:
                 return ExecutionEvent(
                     type=EventType.THINKING,
                     task_id=task_id,
                     subtask_id=subtask_id,
-                    content=part.get("text", ""),
+                    content=reasoning_content,
                     message_id=message_id,
                 )
             return None

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -102,6 +102,7 @@ class StatusUpdatingEmitter(ResultEmitter):
             EventType.TOOL_ARGUMENT_DELTA.value,
             EventType.TOOL_ARGUMENT_DONE.value,
             EventType.TOOL_RESULT.value,
+            EventType.THINKING.value,
         ):
             await session_manager.touch_task_streaming_activity(self._task_id)
 
@@ -165,6 +166,13 @@ class StatusUpdatingEmitter(ResultEmitter):
             content = event.content or ""
             if content:
                 await session_manager.add_text_content(
+                    subtask_id=self._subtask_id,
+                    content=content,
+                )
+        elif event.type == EventType.THINKING.value:
+            content = event.content or ""
+            if content:
+                await session_manager.add_thinking_content(
                     subtask_id=self._subtask_id,
                     content=content,
                 )

--- a/backend/app/services/execution/inprocess_executor.py
+++ b/backend/app/services/execution/inprocess_executor.py
@@ -32,6 +32,7 @@ from shared.status import TaskStatus
 
 from .dispatcher import (
     _build_shell_call_context,
+    _extract_reasoning_event_content,
     _extract_shell_call_input,
     _require_non_empty_tool_use_id,
     extract_completed_result,
@@ -389,15 +390,17 @@ class EmitterBridgeTransport(EventTransport):
                 message_id=message_id,
             )
 
-        # response.reasoning_summary_part.added -> THINKING
-        elif event_type == ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value:
-            part = data.get("part", {})
-            if part.get("type") == "reasoning":
+        elif event_type in (
+            ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value,
+            ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+        ):
+            reasoning_content = _extract_reasoning_event_content(event_type, data)
+            if reasoning_content is not None:
                 return ExecutionEvent(
                     type=EventType.THINKING.value,
                     task_id=self.task_id,
                     subtask_id=self.subtask_id,
-                    content=part.get("text", ""),
+                    content=reasoning_content,
                     message_id=message_id,
                 )
             return None

--- a/backend/app/services/openapi/output_builder.py
+++ b/backend/app/services/openapi/output_builder.py
@@ -394,7 +394,20 @@ def _build_items_from_blocks(
         return []
 
     output: list[ResponseOutputItem] = []
-    text_parts: list[str] = []
+    emitted_text = False
+    emitted_reasoning = False
+
+    def append_message(content: list[OutputTextContent]) -> None:
+        output.append(
+            OutputMessage(
+                type="message",
+                id=f"msg_{subtask.id}_{len(output)}",
+                status=_message_status(subtask, status_override),
+                role="assistant",
+                content=content,
+            )
+        )
+
     for block in blocks:
         if not isinstance(block, dict):
             continue
@@ -403,23 +416,31 @@ def _build_items_from_blocks(
         elif block.get("type") == "text":
             content = block.get("content")
             if isinstance(content, str) and content:
-                text_parts.append(content)
+                emitted_text = True
+                append_message(
+                    [
+                        OutputTextContent(
+                            type="output_text", text=content, annotations=[]
+                        )
+                    ]
+                )
+        elif block.get("type") == "thinking":
+            content = block.get("content")
+            if isinstance(content, str) and content:
+                emitted_reasoning = True
+                append_message(
+                    [OutputTextContent(type="reasoning", text=content, annotations=[])]
+                )
 
     final_text = (
-        content_override or "\n".join(text_parts) or str(result.get("value") or "")
+        "" if emitted_text else content_override or str(result.get("value") or "")
     )
     final_reasoning = str(result.get("reasoning_content") or "")
-    if final_text or final_reasoning:
-        output.append(
-            OutputMessage(
-                type="message",
-                id=f"msg_{subtask.id}",
-                status=_message_status(subtask, status_override),
-                role="assistant",
-                content=_build_message_content(
-                    text=final_text,
-                    reasoning=final_reasoning,
-                ),
+    if final_text or (final_reasoning and not emitted_reasoning):
+        append_message(
+            _build_message_content(
+                text=final_text,
+                reasoning="" if emitted_reasoning else final_reasoning,
             )
         )
 

--- a/backend/app/services/openapi/streaming.py
+++ b/backend/app/services/openapi/streaming.py
@@ -183,14 +183,12 @@ class OpenAPIStreamingService:
 
         message_id = _generate_message_id()
         accumulated_text = ""
-        accumulated_reasoning = ""
         sequence_number = 0
-        reasoning_started = False
-        reasoning_complete = False
         next_output_index = 0
         message_started = False
-        reasoning_output_index: Optional[int] = None
         message_output_index: Optional[int] = None
+        reasoning_segments: List[Dict[str, Any]] = []
+        current_reasoning_segment: Optional[Dict[str, Any]] = None
         tool_output_indexes: Dict[str, int] = {}
         completed_output_items: Dict[int, Any] = {}
         pending_user_input = False
@@ -212,6 +210,23 @@ class OpenAPIStreamingService:
             if existing is not None:
                 return existing
             return allocate_output_index()
+
+        def ensure_reasoning_segment() -> tuple[Dict[str, Any], bool]:
+            nonlocal current_reasoning_segment
+            if current_reasoning_segment is not None:
+                return current_reasoning_segment, False
+
+            current_reasoning_segment = {
+                "output_index": allocate_output_index(),
+                "item_id": _generate_message_id(),
+                "content": "",
+            }
+            reasoning_segments.append(current_reasoning_segment)
+            return current_reasoning_segment, True
+
+        def close_reasoning_segment() -> None:
+            nonlocal current_reasoning_segment
+            current_reasoning_segment = None
 
         try:
             # Event 1: response.created
@@ -261,21 +276,19 @@ class OpenAPIStreamingService:
                 # Handle StreamingChunk objects
                 if isinstance(chunk, StreamingChunk):
                     if chunk.type == "reasoning":
-                        # Start reasoning output if not started
-                        if not reasoning_started:
-                            reasoning_started = True
-                            reasoning_output_index = allocate_output_index()
+                        segment, created = ensure_reasoning_segment()
+                        if created:
                             # Official OpenAI event: response.reasoning_summary_part.added
                             yield _format_sse_event(
                                 {
                                     "item": {
-                                        "id": _generate_message_id(),
+                                        "id": segment["item_id"],
                                         "object": "response.output_item",
                                         "status": "in_progress",
                                         "summary": [],
                                         "type": "reasoning",
                                     },
-                                    "output_index": reasoning_output_index,
+                                    "output_index": segment["output_index"],
                                     "sequence_number": sequence_number,
                                     "type": "response.reasoning_summary_part.added",
                                 }
@@ -283,15 +296,15 @@ class OpenAPIStreamingService:
                             sequence_number += 1
 
                         # Accumulate reasoning content
-                        if chunk.content and not reasoning_complete:
-                            accumulated_reasoning += chunk.content
+                        if chunk.content:
+                            segment["content"] += chunk.content
                             # Official OpenAI event: response.reasoning_summary_text.delta
                             yield _format_sse_event(
                                 {
                                     "content_index": 0,
                                     "delta": chunk.content,
-                                    "item_id": message_id,
-                                    "output_index": reasoning_output_index,
+                                    "item_id": segment["item_id"],
+                                    "output_index": segment["output_index"],
                                     "sequence_number": sequence_number,
                                     "type": "response.reasoning_summary_text.delta",
                                 }
@@ -301,11 +314,7 @@ class OpenAPIStreamingService:
                     elif chunk.type == "text":
                         # Handle text content
                         if chunk.content:
-                            # If we had reasoning before, close it first
-                            if reasoning_started and not reasoning_complete:
-                                reasoning_complete = True
-                                # Note: OpenAI doesn't have explicit reasoning "done" event
-                                # We transition directly to text output
+                            close_reasoning_segment()
 
                             accumulated_text += chunk.content
 
@@ -360,6 +369,7 @@ class OpenAPIStreamingService:
                             )
                             sequence_number += 1
                     elif chunk.type == "function_call_added":
+                        close_reasoning_segment()
                         call_id = chunk.data["call_id"]
                         name = chunk.data["name"]
                         arguments = chunk.data.get("arguments") or ""
@@ -381,6 +391,7 @@ class OpenAPIStreamingService:
                         )
                         sequence_number += 1
                     elif chunk.type == "function_call_done":
+                        close_reasoning_segment()
                         call_id = chunk.data["call_id"]
                         name = chunk.data["name"]
                         arguments = chunk.data.get("arguments") or ""
@@ -422,6 +433,7 @@ class OpenAPIStreamingService:
                         )
                         sequence_number += 1
                     elif chunk.type == "shell_call_added":
+                        close_reasoning_segment()
                         call_id = chunk.data["call_id"]
                         name = chunk.data["name"]
                         arguments = chunk.data.get("arguments") or {}
@@ -442,6 +454,7 @@ class OpenAPIStreamingService:
                         )
                         sequence_number += 1
                     elif chunk.type == "shell_call_done":
+                        close_reasoning_segment()
                         call_id = chunk.data["call_id"]
                         name = chunk.data["name"]
                         arguments = chunk.data.get("arguments") or {}
@@ -472,6 +485,7 @@ class OpenAPIStreamingService:
                         )
                         sequence_number += 1
                     elif chunk.type == "mcp_call_added":
+                        close_reasoning_segment()
                         item_id = chunk.data["item_id"]
                         name = chunk.data["name"]
                         server_label = chunk.data["server_label"]
@@ -503,6 +517,7 @@ class OpenAPIStreamingService:
                         )
                         sequence_number += 1
                     elif chunk.type == "mcp_call_done":
+                        close_reasoning_segment()
                         item_id = chunk.data["item_id"]
                         name = chunk.data["name"]
                         server_label = chunk.data["server_label"]
@@ -650,12 +665,20 @@ class OpenAPIStreamingService:
                 sequence_number += 1
 
             # Build final output items
-            if accumulated_reasoning and reasoning_output_index is not None:
-                completed_output_items[reasoning_output_index] = OutputMessage(
-                    id=_generate_message_id(),
+            for segment in reasoning_segments:
+                if not segment["content"]:
+                    continue
+                completed_output_items[segment["output_index"]] = OutputMessage(
+                    id=segment["item_id"],
                     status="completed",
                     role="assistant",
-                    content=[{"type": "reasoning", "text": accumulated_reasoning}],
+                    content=[
+                        OutputTextContent(
+                            type="reasoning",
+                            text=segment["content"],
+                            annotations=[],
+                        )
+                    ],
                 )
             if accumulated_text and message_output_index is not None:
                 completed_output_items[message_output_index] = OutputMessage(

--- a/backend/tests/services/chat/storage/test_session_blocks.py
+++ b/backend/tests/services/chat/storage/test_session_blocks.py
@@ -23,6 +23,10 @@ class FakeRedisClient:
         self.values[key] = value
         return True
 
+    async def append(self, key, value):
+        self.values[key] = self.values.get(key, "") + value
+        return len(self.values[key])
+
     async def delete(self, *keys):
         for key in keys:
             self.values.pop(key, None)
@@ -87,3 +91,23 @@ async def test_add_tool_block_is_idempotent_by_tool_use_id():
     assert blocks[0]["tool_input"] == {"command": "pwd"}
     assert blocks[0]["tool_protocol"] == "function_call"
     assert json.loads(redis_client.lists["chat:streaming:blocks:202"][0]) == blocks[0]
+
+
+@pytest.mark.asyncio
+async def test_thinking_blocks_are_split_by_text_boundaries():
+    manager = SessionManager()
+    redis_client = FakeRedisClient()
+    manager._cache = FakeCache(redis_client)
+
+    await manager.add_thinking_content(subtask_id=303, content="First ")
+    await manager.add_thinking_content(subtask_id=303, content="thought.")
+    await manager.add_text_content(subtask_id=303, content="Answer.")
+    await manager.add_thinking_content(subtask_id=303, content="Second thought.")
+
+    blocks = await manager.finalize_and_get_blocks(303)
+
+    assert [block["type"] for block in blocks] == ["thinking", "text", "thinking"]
+    assert blocks[0]["content"] == "First thought."
+    assert blocks[1]["content"] == "Answer."
+    assert blocks[2]["content"] == "Second thought."
+    assert [block["status"] for block in blocks] == ["done", "done", "done"]

--- a/backend/tests/services/execution/test_extract_completed_result.py
+++ b/backend/tests/services/execution/test_extract_completed_result.py
@@ -100,3 +100,24 @@ class TestExtractCompletedResult:
         }
         result = extract_completed_result(response_data)
         assert result["value"] == "hello"
+
+    def test_reasoning_output_is_not_merged_into_value(self):
+        response_data = {
+            "output": [
+                {
+                    "content": [
+                        {"type": "reasoning", "text": "Before tool."},
+                    ]
+                },
+                {
+                    "content": [
+                        {"type": "output_text", "text": "Final answer."},
+                    ]
+                },
+            ]
+        }
+
+        result = extract_completed_result(response_data)
+
+        assert result["value"] == "Final answer."
+        assert result["reasoning_content"] == "Before tool."

--- a/backend/tests/services/execution/test_responses_api_event_parser.py
+++ b/backend/tests/services/execution/test_responses_api_event_parser.py
@@ -13,10 +13,26 @@ from app.services.execution.dispatcher import (
     ResponsesAPIEventParser,
 )
 from app.services.execution.inprocess_executor import EmitterBridgeTransport
+from shared.models import EventType
 from shared.models.responses_api import ResponsesAPIStreamEvents
 
 
 class TestResponsesAPIEventParserToolIds:
+    def test_reasoning_summary_text_delta_emits_thinking_event(self):
+        parser = ResponsesAPIEventParser()
+
+        result = parser.parse(
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+            event_type=ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+            data={"delta": "Reasoning chunk."},
+        )
+
+        assert result is not None
+        assert result.type == EventType.THINKING
+        assert result.content == "Reasoning chunk."
+
     def test_tool_start_requires_non_empty_id(self):
         parser = ResponsesAPIEventParser()
 
@@ -556,6 +572,24 @@ class TestResponsesAPIEventParserToolIds:
                 },
                 message_id=3,
             )
+
+    def test_inprocess_bridge_reasoning_summary_text_delta_emits_thinking_event(self):
+        transport = EmitterBridgeTransport(
+            emitter=AsyncMock(),
+            task_id=1,
+            subtask_id=2,
+            message_id=3,
+        )
+
+        result = transport._convert_event(
+            ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+            {"delta": "Reasoning chunk."},
+            message_id=3,
+        )
+
+        assert result is not None
+        assert result.type == EventType.THINKING.value
+        assert result.content == "Reasoning chunk."
 
     def test_inprocess_bridge_raises_for_unknown_tool_completion(self):
         transport = EmitterBridgeTransport(

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -158,3 +158,27 @@ async def test_tool_events_persist_mcp_protocol_metadata():
         tool_protocol="mcp_call",
         server_label="wegent-knowledge",
     )
+
+
+@pytest.mark.asyncio
+async def test_thinking_events_persist_thinking_blocks():
+    from app.services.execution.emitters import StatusUpdatingEmitter
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    mock_session_manager = AsyncMock()
+
+    thinking_event = ExecutionEvent(
+        type=EventType.THINKING.value,
+        task_id=101,
+        subtask_id=202,
+        content="Reasoning chunk.",
+    )
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit(thinking_event)
+
+    mock_session_manager.add_thinking_content.assert_awaited_once_with(
+        subtask_id=202,
+        content="Reasoning chunk.",
+    )

--- a/backend/tests/services/openapi/test_output_builder.py
+++ b/backend/tests/services/openapi/test_output_builder.py
@@ -91,6 +91,59 @@ def test_build_response_output_includes_reasoning_content():
     assert output[0].status == "completed"
 
 
+def test_build_response_output_preserves_thinking_block_order():
+    subtask = _assistant_subtask(
+        subtask_id=109,
+        result={
+            "value": "Final answer",
+            "reasoning_content": "Before tool.After tool.",
+            "blocks": [
+                {
+                    "id": "thinking-1",
+                    "type": "thinking",
+                    "content": "Before tool.",
+                    "status": "done",
+                },
+                {
+                    "id": "shell_1",
+                    "type": "tool",
+                    "tool_use_id": "shell_1",
+                    "tool_name": "exec",
+                    "tool_input": {"command": "cat /etc/os-release"},
+                    "status": "done",
+                },
+                {
+                    "id": "thinking-2",
+                    "type": "thinking",
+                    "content": "After tool.",
+                    "status": "done",
+                },
+                {
+                    "id": "text-1",
+                    "type": "text",
+                    "content": "Final answer",
+                    "status": "done",
+                },
+            ],
+        },
+    )
+
+    output = build_response_output([subtask])
+
+    assert [item.type for item in output] == [
+        "message",
+        "shell_call",
+        "message",
+        "message",
+    ]
+    assert output[0].content[0].type == "reasoning"
+    assert output[0].content[0].text == "Before tool."
+    assert output[2].content[0].type == "reasoning"
+    assert output[2].content[0].text == "After tool."
+    assert output[3].content[0].type == "output_text"
+    assert output[3].content[0].text == "Final answer"
+
+
 def test_build_response_output_matches_tool_block_by_id():
     subtask = _assistant_subtask(
         subtask_id=103,

--- a/backend/tests/services/openapi/test_streaming_reasoning.py
+++ b/backend/tests/services/openapi/test_streaming_reasoning.py
@@ -451,3 +451,75 @@ class TestStreamingServiceReasoning:
             message_added["output_index"],
         }
         assert len(indexes) == 3
+
+    @pytest.mark.asyncio
+    async def test_reasoning_segments_stay_split_around_tool_calls(
+        self, streaming_service
+    ):
+        async def mixed_stream():
+            yield StreamingChunk(type="reasoning", content="Before tool.")
+            yield StreamingChunk(
+                type="shell_call_added",
+                data={
+                    "call_id": "shell_123",
+                    "name": "exec",
+                    "arguments": {"command": "cat /etc/os-release"},
+                },
+            )
+            yield StreamingChunk(
+                type="shell_call_done",
+                data={
+                    "call_id": "shell_123",
+                    "name": "exec",
+                    "arguments": {"command": "cat /etc/os-release"},
+                    "status": "completed",
+                },
+            )
+            yield StreamingChunk(type="reasoning", content="After tool.")
+            yield StreamingChunk(type="text", content="Final answer.")
+
+        events = []
+        async for event in streaming_service.create_streaming_response(
+            response_id="resp_123",
+            model_string="gpt-4",
+            chat_stream=mixed_stream(),
+            created_at=1234567890,
+        ):
+            events.append(json.loads(event.replace("data: ", "").strip()))
+
+        reasoning_parts = [
+            e for e in events if e["type"] == "response.reasoning_summary_part.added"
+        ]
+        reasoning_deltas = [
+            e for e in events if e["type"] == "response.reasoning_summary_text.delta"
+        ]
+        assert len(reasoning_parts) == 2
+        assert [e["delta"] for e in reasoning_deltas] == [
+            "Before tool.",
+            "After tool.",
+        ]
+        assert reasoning_deltas[0]["item_id"] == reasoning_parts[0]["item"]["id"]
+        assert reasoning_deltas[1]["item_id"] == reasoning_parts[1]["item"]["id"]
+        assert reasoning_deltas[0]["output_index"] == reasoning_parts[0]["output_index"]
+        assert reasoning_deltas[1]["output_index"] == reasoning_parts[1]["output_index"]
+
+        completed = next(e for e in events if e["type"] == "response.completed")
+        output = completed["response"]["output"]
+        assert [item["type"] for item in output] == [
+            "message",
+            "shell_call",
+            "message",
+            "message",
+        ]
+        assert output[0]["content"][0] == {
+            "type": "reasoning",
+            "text": "Before tool.",
+            "annotations": [],
+        }
+        assert output[2]["content"][0] == {
+            "type": "reasoning",
+            "text": "After tool.",
+            "annotations": [],
+        }
+        assert output[3]["content"][0]["type"] == "output_text"
+        assert output[3]["content"][0]["text"] == "Final answer."

--- a/docs/en/reference/openapi-responses-api.md
+++ b/docs/en/reference/openapi-responses-api.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # OpenAPI v1/responses API
 
 This document describes the OpenAPI v1/responses endpoint, which provides an OpenAI Responses API compatible interface for interacting with Wegent agents (Teams).
@@ -308,11 +312,19 @@ When `stream=true` is set (Chat Shell type only), the API returns Server-Sent Ev
 | `response.output_item.added` | New output item (message) added |
 | `response.content_part.added` | New content part added to message |
 | `response.output_text.delta` | Text chunk received |
+| `response.reasoning_summary_part.added` | New reasoning summary output item added |
+| `response.reasoning_summary_text.delta` | Reasoning summary text chunk received |
 | `response.output_text.done` | Text output completed |
 | `response.content_part.done` | Content part completed |
 | `response.output_item.done` | Output item completed |
 | `response.completed` | Response fully completed |
 | `response.failed` | Response failed with error |
+
+### Reasoning Output Order
+
+When deep thinking is enabled or the model returns reasoning summaries, the stream may contain multiple independent `reasoning` output items. Tool calls or regular text output close the current reasoning block; later reasoning content creates a new `reasoning` output item.
+
+The final `response.completed.response.output` preserves the chronological order of these items, for example `reasoning -> shell_call -> reasoning -> message`. Clients should render the `output` array in order and should not merge multiple `reasoning` items into one block.
 
 ### Example SSE Stream
 

--- a/docs/zh/reference/openapi-responses-api.md
+++ b/docs/zh/reference/openapi-responses-api.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # OpenAPI v1/responses API
 
 本文档描述 OpenAPI v1/responses 端点，该端点提供与 OpenAI Responses API 兼容的接口，用于与 Wegent 智能体（Team）进行交互。
@@ -308,11 +312,19 @@ curl -X DELETE "https://your-domain/api/v1/responses/resp_123" \
 | `response.output_item.added` | 添加了新的输出项（消息） |
 | `response.content_part.added` | 向消息添加了新的内容部分 |
 | `response.output_text.delta` | 收到文本块 |
+| `response.reasoning_summary_part.added` | 添加了新的推理摘要输出项 |
+| `response.reasoning_summary_text.delta` | 收到推理摘要文本块 |
 | `response.output_text.done` | 文本输出完成 |
 | `response.content_part.done` | 内容部分完成 |
 | `response.output_item.done` | 输出项完成 |
 | `response.completed` | 响应完全完成 |
 | `response.failed` | 响应失败并带有错误 |
+
+### 推理输出顺序
+
+启用深度思考或模型返回推理摘要时，流式输出可能包含多个独立的 `reasoning` 输出项。工具调用或普通文本输出会结束当前推理块；之后如果继续产生推理内容，会创建新的 `reasoning` 输出项。
+
+最终的 `response.completed.response.output` 会保留这些输出项的时间顺序，例如 `reasoning -> shell_call -> reasoning -> message`。客户端应按 `output` 数组顺序渲染，不应把多个 `reasoning` 内容合并成一个块。
 
 ### SSE 流示例
 

--- a/shared/models/responses_api.py
+++ b/shared/models/responses_api.py
@@ -54,6 +54,7 @@ class ReasoningContent(TypedDict):
 
     type: Literal["reasoning"]
     text: str
+    annotations: NotRequired[List[Any]]
 
 
 class MessageItem(TypedDict, total=False):
@@ -63,7 +64,7 @@ class MessageItem(TypedDict, total=False):
     id: str
     status: str
     role: Literal["assistant"]
-    content: List[OutputTextContent]
+    content: List[Union[OutputTextContent, ReasoningContent]]
 
 
 class FunctionCallItem(TypedDict, total=False):
@@ -263,6 +264,16 @@ class ResponsePartAddedEvent(TypedDict):
     part: ReasoningContent
 
 
+class ReasoningSummaryTextDeltaEvent(TypedDict):
+    """response.reasoning_summary_text.delta event."""
+
+    type: Literal["response.reasoning_summary_text.delta"]
+    item_id: str
+    output_index: int
+    content_index: int
+    delta: str
+
+
 class BlockCreatedEvent(TypedDict):
     """response.block.created event."""
 
@@ -296,6 +307,7 @@ ResponsesAPIStreamingResponse = Union[
     FunctionCallArgumentsDeltaEvent,
     FunctionCallArgumentsDoneEvent,
     ResponsePartAddedEvent,
+    ReasoningSummaryTextDeltaEvent,
     BlockCreatedEvent,
     ErrorEvent,
 ]


### PR DESCRIPTION
## Summary
- Preserve separate reasoning/thinking segments across streaming and final Responses API output.
- Persist thinking blocks into task result blocks so completion/history rendering keeps the same structure as streaming.
- Document reasoning output ordering for the OpenAPI v1/responses reference.

## Test Plan
- [x] cd backend && uv run pytest tests/services/openapi/test_streaming_reasoning.py tests/services/openapi/test_output_builder.py tests/services/chat/storage/test_session_blocks.py tests/services/execution/test_status_updating_emitter.py tests/services/execution/test_extract_completed_result.py tests/services/execution/test_responses_api_event_parser.py
- [x] cd frontend && npm test -- TaskStateMachine.test.ts --runInBand
- [x] git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming and persisting model thinking/reasoning content alongside regular text output
  * Thinking blocks now display separately while maintaining chronological order in responses

* **Documentation**
  * Updated API reference documentation to include reasoning event types and client guidance for handling reasoning outputs

* **Tests**
  * Added comprehensive tests for thinking block streaming, persistence, and proper ordering across tool calls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->