### PR TITLE
Fix processing indicator ghosting and socket URL startup handling

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/message/StreamingWaitIndicator.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/StreamingWaitIndicator.test.tsx
@@ -22,7 +22,7 @@ const getCssRule = (css: string, selector: string) => {
   const matches = Array.from(
     css.matchAll(new RegExp(`${escapedSelector} \\{([\\s\\S]*?)\\n\\}`, 'g'))
   )
-  return matches.at(-1)?.[1] ?? ''
+  return matches[0]?.[1] ?? ''
 }
 
 describe('StreamingWaitIndicator', () => {
@@ -47,7 +47,7 @@ describe('StreamingWaitIndicator', () => {
 
     expect(screen.getByTestId('streaming-wait-runner-dot')).toBeInTheDocument()
     expect(indicator.querySelectorAll('.animate-pulse')).toHaveLength(0)
-    expect(screen.getAllByText('thinking.processing')).toHaveLength(2)
+    expect(screen.getAllByText('thinking.processing')).toHaveLength(1)
   })
 
   it('keeps the runner dot as one continuous shape instead of split top and bottom pieces', () => {
@@ -64,21 +64,18 @@ describe('StreamingWaitIndicator', () => {
     expect(css).not.toContain('left: 68%')
   })
 
-  it('clips the moving runner highlight to text glyphs while it crosses the message', () => {
+  it('renders a single text layer so the runner cannot create ghosted glyphs', () => {
     render(<StreamingWaitIndicator isWaiting={true} />)
 
     const css = readGlobalCss()
     const trackRule = getCssRule(css, '.streaming-wait-runner-track')
-    const textMask = screen.getByTestId('streaming-wait-runner-text-mask')
-    const maskRule = css.slice(
-      css.indexOf('.streaming-wait-runner-text-mask {\n  position: absolute')
-    )
 
-    expect(textMask).toHaveAttribute('aria-hidden', 'true')
-    expect(textMask).toHaveTextContent('tasks:streaming_wait.thinking')
     expect(trackRule).toContain('--runner-dot-size: 0.75rem')
-    expect(maskRule).toContain('background-clip: text')
-    expect(maskRule).toContain('-webkit-text-fill-color: transparent')
+    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(1)
+    expect(screen.queryByTestId('streaming-wait-runner-text-mask')).not.toBeInTheDocument()
+    expect(css).not.toContain('.streaming-wait-runner-text-mask')
+    expect(css).not.toContain('--runner-text-spot-size')
+    expect(css).not.toContain('@keyframes streaming-wait-runner-text-mask')
   })
 
   it('changes progressive text only after a full runner animation lap completes', () => {
@@ -87,19 +84,19 @@ describe('StreamingWaitIndicator', () => {
 
     render(<StreamingWaitIndicator isWaiting={true} />)
 
-    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(2)
+    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(1)
 
     act(() => {
       jest.advanceTimersByTime(5300)
     })
 
-    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(2)
+    expect(screen.getAllByText('tasks:streaming_wait.thinking')).toHaveLength(1)
 
     act(() => {
       jest.advanceTimersByTime(100)
     })
 
-    expect(screen.getAllByText('tasks:streaming_wait.analyzing')).toHaveLength(2)
+    expect(screen.getAllByText('tasks:streaming_wait.analyzing')).toHaveLength(1)
 
     jest.useRealTimers()
   })
@@ -127,12 +124,8 @@ describe('StreamingWaitIndicator', () => {
   it('waits about 0.5 seconds on the right side before hopping', () => {
     const css = readGlobalCss()
     const dotRule = getCssRule(css, '.streaming-wait-runner-dot')
-    const maskRule = css.slice(
-      css.indexOf('.streaming-wait-runner-text-mask {\n  position: absolute')
-    )
 
     expect(dotRule).toContain('animation: streaming-wait-runner-travel 5.4s linear infinite')
-    expect(maskRule).toContain('animation: streaming-wait-runner-text-mask 5.4s linear infinite')
     expect(css).toMatch(
       /26%,\s+35% \{[\s\S]*left: calc\(100% - var\(--runner-dot-size\)\);[\s\S]*transform: translateY\(-50%\) scale\(1\);/
     )

--- a/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/MixedContentView.test.tsx
@@ -264,7 +264,7 @@ describe('MixedContentView', () => {
     expect(screen.getByText('雨后的清晨')).toBeInTheDocument()
     const indicator = screen.getByTestId('streaming-wait-indicator')
 
-    expect(screen.getAllByText('thinking.processing')).toHaveLength(2)
+    expect(screen.getAllByText('thinking.processing')).toHaveLength(1)
     expect(screen.getByTestId('streaming-wait-runner-dot')).toBeInTheDocument()
     expect(indicator.querySelectorAll('.animate-pulse')).toHaveLength(0)
   })

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -573,7 +573,6 @@ button:focus-visible {
 /* Single runner dot used while an AI message is waiting or still processing */
 .streaming-wait-runner-track {
   --runner-dot-size: 0.75rem;
-  --runner-text-spot-size: 1.15rem;
   --runner-y-offset: 1px;
 
   position: relative;
@@ -591,33 +590,10 @@ button:focus-visible {
   display: inline-block;
 }
 
-.streaming-wait-runner-text,
-.streaming-wait-runner-text-mask {
+.streaming-wait-runner-text {
   font-size: 0.875rem;
   line-height: 1.25rem;
   white-space: nowrap;
-}
-
-.streaming-wait-runner-text-mask {
-  position: absolute;
-  inset: 0;
-  z-index: 3;
-  color: transparent;
-  background-image: radial-gradient(
-    circle,
-    rgb(var(--color-primary)) 0 38%,
-    rgb(var(--color-primary) / 0.9) 48%,
-    transparent 70%
-  );
-  background-repeat: no-repeat;
-  background-size: var(--runner-text-spot-size) var(--runner-text-spot-size);
-  background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  pointer-events: none;
-  will-change: background-position, opacity;
-  animation: streaming-wait-runner-text-mask 5.4s linear infinite;
 }
 
 .streaming-wait-runner-dot {
@@ -716,51 +692,8 @@ button:focus-visible {
   }
 }
 
-@keyframes streaming-wait-runner-text-mask {
-  0%,
-  10% {
-    opacity: 0;
-    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
-  }
-
-  13% {
-    opacity: 1;
-  }
-
-  26% {
-    opacity: 1;
-    background-position: calc(100% + var(--runner-text-spot-size))
-      calc(50% + var(--runner-y-offset));
-  }
-
-  30%,
-  50% {
-    opacity: 0;
-    background-position: calc(100% + var(--runner-text-spot-size))
-      calc(50% + var(--runner-y-offset));
-  }
-
-  52% {
-    opacity: 1;
-    background-position: calc(100% + var(--runner-text-spot-size))
-      calc(50% + var(--runner-y-offset));
-  }
-
-  72% {
-    opacity: 1;
-    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
-  }
-
-  76%,
-  100% {
-    opacity: 0;
-    background-position: calc(var(--runner-text-spot-size) * -1) calc(50% + var(--runner-y-offset));
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .streaming-wait-runner-dot,
-  .streaming-wait-runner-text-mask {
+  .streaming-wait-runner-dot {
     animation: none;
   }
 }

--- a/frontend/src/features/tasks/components/message/StreamingWaitIndicator.tsx
+++ b/frontend/src/features/tasks/components/message/StreamingWaitIndicator.tsx
@@ -118,13 +118,6 @@ export default function StreamingWaitIndicator({
       <span className="streaming-wait-runner-track" data-testid="streaming-wait-runner-track">
         <span className="streaming-wait-runner-text-wrap">
           <span className="streaming-wait-runner-text">{stageMessage}</span>
-          <span
-            className="streaming-wait-runner-text-mask"
-            aria-hidden="true"
-            data-testid="streaming-wait-runner-text-mask"
-          >
-            {stageMessage}
-          </span>
         </span>
         <span
           className="streaming-wait-runner-dot"

--- a/start.sh
+++ b/start.sh
@@ -1199,6 +1199,20 @@ replace_url_port() {
     echo "$url" | sed -E "s#(^[a-zA-Z][a-zA-Z0-9+.-]*://[^/:]+):[0-9]+#\1:$port#"
 }
 
+extract_url_host() {
+    local url=$1
+
+    echo "$url" | sed -E 's#^[a-zA-Z][a-zA-Z0-9+.-]*://##' | cut -d/ -f1 | cut -d: -f1
+}
+
+replace_url_host_and_port() {
+    local url=$1
+    local host=$2
+    local port=$3
+
+    echo "$url" | sed -E "s#(^[a-zA-Z][a-zA-Z0-9+.-]*://)[^/:]+(:[0-9]+)?#\1$host:$port#"
+}
+
 update_url_port_if_matches() {
     local url=$1
     local old_port=$2
@@ -1216,13 +1230,19 @@ compute_derived_urls() {
     local previous_executor_manager_port="${2:-}"
     local previous_knowledge_runtime_port="${3:-}"
     local previous_socket_url="$WEGENT_SOCKET_URL"
+    local socket_host=""
 
     LOCAL_IP=$(get_local_ip)
 
     if [ -z "$WEGENT_SOCKET_URL" ]; then
         WEGENT_SOCKET_URL="http://$LOCAL_IP:$BACKEND_PORT"
-    elif [ -n "$previous_backend_port" ] && [ "$BACKEND_PORT" != "$previous_backend_port" ] && [ -z "$CLI_WEGENT_SOCKET_URL" ]; then
-        WEGENT_SOCKET_URL=$(update_url_port_if_matches "$WEGENT_SOCKET_URL" "$previous_backend_port" "$BACKEND_PORT")
+    elif [ -z "$CLI_WEGENT_SOCKET_URL" ]; then
+        socket_host=$(extract_url_host "$WEGENT_SOCKET_URL")
+        if [ -n "$socket_host" ] && [ "$socket_host" != "localhost" ] && [ "$socket_host" != "127.0.0.1" ] && [ "$socket_host" != "$LOCAL_IP" ]; then
+            WEGENT_SOCKET_URL=$(replace_url_host_and_port "$WEGENT_SOCKET_URL" "$LOCAL_IP" "$BACKEND_PORT")
+        elif [ -n "$previous_backend_port" ] && [ "$BACKEND_PORT" != "$previous_backend_port" ]; then
+            WEGENT_SOCKET_URL=$(update_url_port_if_matches "$WEGENT_SOCKET_URL" "$previous_backend_port" "$BACKEND_PORT")
+        fi
     fi
 
     if [ -z "$TASK_API_DOMAIN" ] || [ "$TASK_API_DOMAIN" = "$previous_socket_url" ]; then
@@ -1403,17 +1423,8 @@ check_socket_url_ip() {
         echo -e "  • Connection failure or timeout on the page"
         echo -e "  • Real-time messages cannot be pushed"
         echo ""
-        echo -e "${YELLOW}Recommended actions:${NC}"
-        echo -e "  1. Update WEGENT_SOCKET_URL in .env file to:"
-        echo -e "     ${GREEN}http://$local_ip:$BACKEND_PORT${NC}"
-        echo -e "  2. Or re-run configuration: ${BLUE}./start.sh --init${NC}"
-        echo ""
-        echo -e "${YELLOW}Continue startup? [y/N]:${NC} \c"
-        read -r confirm
-        if [[ "$confirm" =~ ^[Nn]$ ]]; then
-            echo -e "${YELLOW}Startup cancelled${NC}"
-            exit 1
-        fi
+        echo -e "${YELLOW}If this was not intentional, update WEGENT_SOCKET_URL in .env to:${NC}"
+        echo -e "  ${GREEN}http://$local_ip:$BACKEND_PORT${NC}"
         echo ""
     fi
 }

--- a/tests/test_start_sh.sh
+++ b/tests/test_start_sh.sh
@@ -87,6 +87,22 @@ done
 exit 1
 EOF
 
+cat > "$STUB_DIR/route" <<'EOF'
+#!/bin/bash
+if [ "$1" = "-n" ] && [ "$2" = "get" ] && [ "$3" = "default" ]; then
+    echo "   route to: default"
+    echo "interface: en0"
+fi
+EOF
+
+cat > "$STUB_DIR/ifconfig" <<'EOF'
+#!/bin/bash
+if [ "$1" = "en0" ] || [ $# -eq 0 ]; then
+    echo "en0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500"
+    echo "        inet 192.0.2.10 netmask 0xffffff00 broadcast 192.0.2.255"
+fi
+EOF
+
 cat > "$STUB_DIR/docker" <<'EOF'
 #!/bin/bash
 case "$1" in
@@ -243,6 +259,40 @@ if [ "$(cat "$REPO_ROOT/.pids/frontend.port")" != "3001" ]; then
 fi
 
 echo "start.sh service selection and auto port test passed"
+
+reset_runtime_files
+cat > "$ROOT_ENV" <<'EOF'
+BACKEND_PORT=8000
+CHAT_SHELL_PORT=8100
+EXECUTOR_MANAGER_PORT=8001
+KNOWLEDGE_RUNTIME_PORT=8200
+WEGENT_FRONTEND_PORT=3000
+WEWORK_PORT=1420
+EXECUTOR_IMAGE=test-executor:latest
+WEGENT_SOCKET_URL=http://10.0.0.99:8000
+EOF
+
+run_start_with_stubs "y\n" be fe
+
+if [ "$status" -ne 0 ]; then
+    echo "Expected start.sh be fe with stale socket IP to succeed"
+    echo "$output"
+    exit 1
+fi
+
+if grep -q "IP Address Mismatch Warning" <<< "$output"; then
+    echo "Expected stale socket IP to auto-refresh without warning"
+    echo "$output"
+    exit 1
+fi
+
+if ! grep -q "Socket URL:          http://192.0.2.10:8002" <<< "$output"; then
+    echo "Expected Socket URL to use current machine IP and resolved backend port"
+    echo "$output"
+    exit 1
+fi
+
+echo "start.sh stale socket IP auto-refresh test passed"
 
 reset_runtime_files
 rm -f "$ROOT_ENV"


### PR DESCRIPTION
## Summary
- Remove the duplicate masked text layer from the streaming wait indicator to prevent ghosted glyphs while the runner dot crosses text.
- Auto-refresh stale configured socket URL hosts to the current machine IP when `start.sh` derives runtime URLs.
- Make socket IP mismatch warnings non-blocking and cover the stale-IP behavior in `start.sh` tests.

## Test Plan
- [x] `npm test -- StreamingWaitIndicator.test.tsx MixedContentView.test.tsx --runInBand`
- [x] `bash tests/test_start_sh.sh`
- [x] `bash -n start.sh && bash -n tests/test_start_sh.sh`
- [x] pre-push hook: ESLint, TypeScript check, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic socket URL detection and refresh to maintain correct backend IP during startup.

* **Style**
  * Simplified streaming indicator text rendering and refactored CSS animation styling.

* **Tests**
  * Updated tests to reflect streaming indicator behavior and socket URL auto-refresh functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->