### PR TITLE
fix(backend): reduce large attachment prompt preview

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -444,6 +444,8 @@ class Settings(BaseSettings):
     # File upload configuration
     MAX_UPLOAD_FILE_SIZE_MB: int = 100  # Maximum file size in MB
     MAX_EXTRACTED_TEXT_LENGTH: int = 500000  # Maximum extracted text length
+    LARGE_ATTACHMENT_PREVIEW_THRESHOLD: int = 12000
+    LARGE_ATTACHMENT_PREVIEW_LENGTH: int = 2000
 
     # Attachment storage backend configuration
     # Supported backends: "mysql" (default), "s3", "minio"

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.models.subtask_context import (
     ContextStatus,
     ContextType,
@@ -716,10 +717,45 @@ class ContextService:
                 f"{max_text_length} characters. The following is only partial content.)\n"
             )
 
-        prefix += f"{context.extracted_text}\n\n"
+        prefix += self._build_document_prompt_content(
+            extracted_text=context.extracted_text,
+            sandbox_path=sandbox_path,
+        )
 
         # Wrap in <attachment> XML tags
         return prefix
+
+    @staticmethod
+    def _build_document_prompt_content(
+        extracted_text: str,
+        sandbox_path: Optional[str],
+    ) -> str:
+        """Build prompt-safe document text, using a short preview for large files."""
+        preview_threshold = settings.LARGE_ATTACHMENT_PREVIEW_THRESHOLD
+        preview_length = settings.LARGE_ATTACHMENT_PREVIEW_LENGTH
+
+        if len(extracted_text) <= preview_threshold:
+            return f"{extracted_text}\n\n"
+
+        preview = extracted_text[: max(preview_length, 0)]
+        if sandbox_path:
+            guidance = (
+                "Note: This attachment is large. Only a short content preview is "
+                "included here to protect the model context. To inspect the full "
+                "content, read the full file from the sandbox path above.\n"
+            )
+        else:
+            guidance = (
+                "Note: This attachment is large. Only a short content preview is "
+                "included here to protect the model context. Use the attachment "
+                "download URL if the full content is required.\n"
+            )
+
+        return (
+            guidance
+            + f"Content preview ({len(preview)} of {len(extracted_text)} characters):\n"
+            + f"{preview}\n\n"
+        )
 
     # ==================== Knowledge Base Operations ====================
 

--- a/backend/tests/services/chat/test_selected_documents.py
+++ b/backend/tests/services/chat/test_selected_documents.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for notebook selected document context injection."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestSelectedDocumentsContext:
+    def test_selected_documents_direct_injection_keeps_full_content_when_attachment_preview_is_small(
+        self, monkeypatch
+    ):
+        """Notebook selected documents should not use large attachment prompt previews."""
+        from app.services.chat.preprocessing.selected_documents import (
+            process_selected_documents_contexts,
+        )
+        from app.services.context.context_service import settings
+
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_THRESHOLD", 20)
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_LENGTH", 5)
+
+        long_content = "A" * 30 + "FULL_DOCUMENT_TAIL"
+        selected_context = MagicMock(
+            type_data={"knowledge_base_id": 101, "document_ids": [501]}
+        )
+
+        with (
+            patch(
+                "app.services.chat.preprocessing.selected_documents."
+                "_check_user_kb_access_for_selected_docs",
+                return_value=(True, ""),
+            ),
+            patch(
+                "app.services.chat.preprocessing.selected_documents."
+                "_load_documents_content",
+                return_value=[
+                    {
+                        "id": 501,
+                        "name": "notebook.md",
+                        "content": long_content,
+                        "file_extension": ".md",
+                    }
+                ],
+            ),
+        ):
+            final_message, system_prompt, extra_tools = (
+                process_selected_documents_contexts(
+                    db=MagicMock(),
+                    selected_docs_contexts=[selected_context],
+                    user_id=1,
+                    message="Summarize it",
+                    base_system_prompt="base system",
+                    extra_tools=[],
+                    context_window=128000,
+                )
+            )
+
+        assert system_prompt == "base system"
+        assert extra_tools == []
+        assert isinstance(final_message, list)
+        selected_docs_block = final_message[0]["text"]
+        assert "<selected_documents>" in selected_docs_block
+        assert "notebook.md" in selected_docs_block
+        assert "FULL_DOCUMENT_TAIL" in selected_docs_block
+        assert "Content preview" not in selected_docs_block
+        assert final_message[-1]["text"] == "Summarize it"

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -1284,6 +1284,97 @@ class TestContextServiceFormatting:
         assert "URL: /api/attachments/100/download" in prefix
         assert "truncated" in prefix.lower()
 
+    def test_build_document_text_prefix_uses_short_preview_for_large_attachment(
+        self, monkeypatch
+    ):
+        """Large attachments should not inject the full extracted text."""
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.context import context_service
+        from app.services.context.context_service import settings
+
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_THRESHOLD", 100)
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_LENGTH", 20)
+
+        preview_text = "A" * 20
+        omitted_text = "B" * 200
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="large.md",
+            status=ContextStatus.READY.value,
+            extracted_text=preview_text + omitted_text,
+            text_length=220,
+            type_data={
+                "original_filename": "large.md",
+                "mime_type": "text/markdown",
+                "file_size": 220,
+            },
+        )
+        context.id = 100
+
+        prefix = context_service.build_document_text_prefix(
+            context,
+            task_id=12,
+            subtask_id=34,
+        )
+
+        assert prefix is not None
+        assert (
+            "File Path(already in sandbox): "
+            "/home/user/12:executor:attachments/34/large.md"
+        ) in prefix
+        assert "Content preview" in prefix
+        assert "read the full file from the sandbox path" in prefix
+        assert preview_text in prefix
+        assert omitted_text not in prefix
+
+    def test_build_document_text_prefix_keeps_full_text_below_large_threshold(
+        self, monkeypatch
+    ):
+        """Small attachments should keep the existing full-text injection behavior."""
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.context import context_service
+        from app.services.context.context_service import settings
+
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_THRESHOLD", 100)
+        monkeypatch.setattr(settings, "LARGE_ATTACHMENT_PREVIEW_LENGTH", 20)
+
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="small.md",
+            status=ContextStatus.READY.value,
+            extracted_text="Short complete content.",
+            text_length=23,
+            type_data={
+                "original_filename": "small.md",
+                "mime_type": "text/markdown",
+                "file_size": 23,
+            },
+        )
+        context.id = 101
+
+        prefix = context_service.build_document_text_prefix(
+            context,
+            task_id=12,
+            subtask_id=34,
+        )
+
+        assert prefix is not None
+        assert "Short complete content." in prefix
+        assert "Content preview" not in prefix
+        assert "read the full file from the sandbox path" not in prefix
+
 
 class TestContextServiceOverwrite:
     """Test attachment overwrite functionality"""


### PR DESCRIPTION
## Summary
- Add backend settings for large attachment prompt preview threshold and preview length.
- Keep full prompt injection for small attachments, but inject only a short preview for large attachments.
- Preserve attachment metadata and sandbox path so executors can rewrite and models can read the full file in the sandbox.

## Test Plan
- cd backend && uv run pytest tests/services/test_context_service.py tests/services/chat/test_vision_structure.py -q
- cd executor && uv run pytest tests/services/test_attachment_prompt_processor.py tests/services/test_attachment_handler.py -q
- git diff --check

Note: executor tests exit 0 but still print existing QueueListener atexit warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large attachments now show a truncated content preview with guidance on how to access the full file when applicable; small attachments continue to include full content.

* **Tests**
  * Added unit tests validating preview vs full-content behavior for large and small attachments and ensuring selected-document injection preserves expected content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->