### PR TITLE
fix(frontend): update resource guide title

### DIFF
--- a/frontend/src/__tests__/app/settings/resource-guide.test.tsx
+++ b/frontend/src/__tests__/app/settings/resource-guide.test.tsx
@@ -84,7 +84,7 @@ jest.mock('@/hooks/useTranslation', () => ({
         'navigation.apiKeys': 'API 密钥',
         'navigation.groupManager': '组管理',
         'pet:title': '我的宠物',
-        'resourceGuide.title': '资源管理已移到资源库',
+        'resourceGuide.title': '智能体管理已移到资源库',
         'resourceGuide.description': '智能体、模型、执行器、技能和检索器现在在资源库管理。',
         'resourceGuide.action': '前往资源库',
       }
@@ -98,7 +98,7 @@ describe('Settings resource guide', () => {
   it('guides users from the old settings page to resource library management', async () => {
     render(<Page />)
 
-    expect(await screen.findByText('资源管理已移到资源库')).toBeInTheDocument()
+    expect(await screen.findByText('智能体管理已移到资源库')).toBeInTheDocument()
     expect(
       screen.getByText('智能体、模型、执行器、技能和检索器现在在资源库管理。')
     ).toBeInTheDocument()

--- a/frontend/src/features/settings/components/SettingsResourceGuide.tsx
+++ b/frontend/src/features/settings/components/SettingsResourceGuide.tsx
@@ -36,8 +36,8 @@ export function SettingsResourceGuide() {
             <h2 id="settings-resource-guide-title" className="text-sm font-semibold">
               {translateWithFallback(
                 'resourceGuide.title',
-                '资源管理已移到资源库',
-                'Resource management moved to Resource Library'
+                '智能体管理已移到资源库',
+                'Agent management moved to Resource Library'
               )}
             </h2>
             <p className="mt-1 text-sm text-text-secondary">

--- a/frontend/src/i18n/locales/en/settings.json
+++ b/frontend/src/i18n/locales/en/settings.json
@@ -55,7 +55,7 @@
     "reset_to_default": "Reset to Default"
   },
   "resourceGuide": {
-    "title": "Resource management moved to Resource Library",
+    "title": "Agent management moved to Resource Library",
     "description": "Agents, models, executors, skills, and retrievers are now managed in Resource Library.",
     "action": "Go to Resource Library"
   },

--- a/frontend/src/i18n/locales/zh-CN/settings.json
+++ b/frontend/src/i18n/locales/zh-CN/settings.json
@@ -55,7 +55,7 @@
     "reset_to_default": "恢复默认"
   },
   "resourceGuide": {
-    "title": "资源管理已移到资源库",
+    "title": "智能体管理已移到资源库",
     "description": "智能体、模型、执行器、技能和检索器现在在资源库管理。",
     "action": "前往资源库"
   },


### PR DESCRIPTION
## Summary
- Update the settings resource guide title from resource management to agent management in Chinese.
- Keep the English locale and component fallback aligned with the new wording.
- Update the focused settings resource-guide test expectation.

## Test Plan
- `npm test -- resource-guide.test.tsx --runInBand`
- Pre-commit hook: lint-staged and translation checker passed.
- Pre-push hook: ESLint, TypeScript, and full frontend unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the settings resource guide to clarify that "Agent management" has moved to the Resource Library, replacing previous "Resource management" terminology. This includes updates to both English and Chinese localization strings and corresponding component fallback text to ensure consistent messaging across all supported languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wecode-ai/Wegent/pull/1208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->