### PR TITLE
fix(frontend): allow attachment-only chat sends

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
@@ -283,6 +283,42 @@ describe('useChatStreamHandlers queue integration', () => {
     expect(mockRefreshSelectedTaskDetail).toHaveBeenCalledWith(false)
   })
 
+  it('sends a ready attachment even when the text input is empty', async () => {
+    isMachineStreamingMock = false
+    taskInputMessageMock = ''
+    selectedTaskDetailMock = {
+      id: 42,
+      status: 'COMPLETED',
+      is_group_chat: false,
+      subtasks: [],
+    } as unknown as TaskDetail
+
+    const { result } = renderQueueableHook()
+
+    await act(async () => {
+      await result.current.handleSendMessage()
+    })
+
+    expect(mockContextSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: '',
+        attachment_ids: [11],
+      }),
+      expect.objectContaining({
+        pendingUserMessage: '',
+        pendingAttachments: [
+          expect.objectContaining({
+            id: 11,
+            filename: 'ready.txt',
+          }),
+        ],
+      })
+    )
+    expect(mockSetTaskInputMessage).toHaveBeenCalledWith('')
+    expect(mockResetAttachment).toHaveBeenCalled()
+    expect(mockResetContexts).toHaveBeenCalled()
+  })
+
   it('shows a retry action that resends a failed queued message', async () => {
     mockContextSendMessage.mockImplementationOnce(async (_request, options) => {
       options?.onError?.(new Error('network down'))

--- a/frontend/src/__tests__/features/tasks/components/input/chat-send-state.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/chat-send-state.test.tsx
@@ -280,6 +280,32 @@ describe('getChatSendState', () => {
     })
   })
 
+  it('allows normal send when the input only has ready attachments', () => {
+    expect(
+      getChatSendState({
+        isLoading: false,
+        isStreaming: false,
+        isAwaitingResponseStart: false,
+        isStopping: false,
+        isModelSelectionRequired: false,
+        isAttachmentReadyToSend: true,
+        hasNoTeams: false,
+        shouldHideChatInput: false,
+        taskInputMessage: '',
+        hasAttachments: true,
+        selectedTaskStatus: undefined,
+        isSubtaskStreaming: false,
+        isGroupChat: false,
+        canQueueMessage: false,
+      })
+    ).toEqual({
+      primaryAction: 'send',
+      isPrimaryDisabled: false,
+      showStopAction: false,
+      showPendingAction: false,
+    })
+  })
+
   it('uses cancel as the primary action for non-group pending task', () => {
     expect(
       getChatSendState({

--- a/frontend/src/features/tasks/components/chat/ChatArea.tsx
+++ b/frontend/src/features/tasks/components/chat/ChatArea.tsx
@@ -774,7 +774,8 @@ function ChatAreaContent({
   const sendOrConfirmPendingReplacement = useCallback(
     async (message: string) => {
       const trimmedMessage = message.trim()
-      if (!trimmedMessage && !chatState.shouldHideChatInput) return
+      const hasAttachments = chatState.attachmentState.attachments.length > 0
+      if (!trimmedMessage && !hasAttachments && !chatState.shouldHideChatInput) return
 
       if (shouldConfirmPendingReplacement) {
         setPendingReplacementMessage(trimmedMessage)
@@ -784,11 +785,16 @@ function ChatAreaContent({
 
       await streamHandlers.handleSendMessage(trimmedMessage)
     },
-    [chatState.shouldHideChatInput, shouldConfirmPendingReplacement, streamHandlers]
+    [
+      chatState.attachmentState.attachments.length,
+      chatState.shouldHideChatInput,
+      shouldConfirmPendingReplacement,
+      streamHandlers,
+    ]
   )
 
   const handleConfirmPendingReplacement = useCallback(async () => {
-    if (!pendingReplacementMessage || isPendingReplacementConfirming) return
+    if (pendingReplacementMessage === null || isPendingReplacementConfirming) return
 
     setIsPendingReplacementConfirming(true)
     try {

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -1033,8 +1033,10 @@ export function useChatStreamHandlers({
   // Core message sending logic
   const handleSendMessage = useCallback(
     async (overrideMessage?: string) => {
-      const message = overrideMessage?.trim() || taskInputMessage.trim()
-      if (!message && !shouldHideChatInput) return
+      const message =
+        overrideMessage !== undefined ? overrideMessage.trim() : taskInputMessage.trim()
+      const hasAttachments = attachments.length > 0
+      if (!message && !hasAttachments && !shouldHideChatInput) return
 
       if (!isAttachmentReadyToSend) {
         toast({
@@ -1122,6 +1124,7 @@ export function useChatStreamHandlers({
     },
     [
       taskInputMessage,
+      attachments.length,
       shouldHideChatInput,
       isAttachmentReadyToSend,
       toast,

--- a/frontend/src/features/tasks/components/input/ChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/ChatInputControls.tsx
@@ -214,7 +214,7 @@ export function ChatInputControls({
   onCorrectionModeToggle,
   selectedContexts,
   setSelectedContexts,
-  attachmentState: _attachmentState,
+  attachmentState,
   onFileSelect,
   onAttachmentRemove: _onAttachmentRemove,
   isLoading,
@@ -292,6 +292,7 @@ export function ChatInputControls({
       hasNoTeams,
       shouldHideChatInput,
       taskInputMessage,
+      hasAttachments: attachmentState.attachments.length > 0,
       selectedTaskStatus: selectedTaskDetail?.status,
       isSubtaskStreaming,
       isGroupChat: selectedTaskDetail?.is_group_chat,
@@ -419,6 +420,7 @@ export function ChatInputControls({
         isModelSelectionRequired={isModelSelectionRequired}
         isAttachmentReadyToSend={isAttachmentReadyToSend}
         taskInputMessage={taskInputMessage}
+        hasAttachments={attachmentState.attachments.length > 0}
         isSubtaskStreaming={isSubtaskStreaming}
         canQueueMessage={canQueueMessage}
         canSendGuidance={canSendGuidance}

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -93,6 +93,7 @@ export interface MobileChatInputControlsProps {
   isModelSelectionRequired: boolean
   isAttachmentReadyToSend: boolean
   taskInputMessage: string
+  hasAttachments?: boolean
   isSubtaskStreaming: boolean
   canQueueMessage?: boolean
   canSendGuidance?: boolean
@@ -160,6 +161,7 @@ export function MobileChatInputControls({
   isModelSelectionRequired,
   isAttachmentReadyToSend,
   taskInputMessage,
+  hasAttachments = false,
   isSubtaskStreaming,
   canQueueMessage = false,
   canSendGuidance = false,
@@ -220,6 +222,7 @@ export function MobileChatInputControls({
       hasNoTeams,
       shouldHideChatInput,
       taskInputMessage,
+      hasAttachments,
       selectedTaskStatus: selectedTaskDetail?.status,
       isSubtaskStreaming,
       isGroupChat: selectedTaskDetail?.is_group_chat,

--- a/frontend/src/features/tasks/components/input/chatSendState.ts
+++ b/frontend/src/features/tasks/components/input/chatSendState.ts
@@ -14,6 +14,7 @@ interface ChatSendStateInput {
   hasNoTeams: boolean
   shouldHideChatInput: boolean
   taskInputMessage: string
+  hasAttachments?: boolean
   selectedTaskStatus?: string | null
   isSubtaskStreaming: boolean
   isGroupChat?: boolean
@@ -29,13 +30,14 @@ export interface ChatSendState {
 
 export function getChatSendState(input: ChatSendStateInput): ChatSendState {
   const hasTextContent = input.taskInputMessage.trim().length > 0
-  const hasMessage = input.shouldHideChatInput || hasTextContent
+  const hasUserProvidedContent = hasTextContent || Boolean(input.hasAttachments)
+  const hasSendableContent = input.shouldHideChatInput || hasUserProvidedContent
   const baseDisabled =
     input.isLoading ||
     input.isModelSelectionRequired ||
     !input.isAttachmentReadyToSend ||
     input.hasNoTeams ||
-    !hasMessage
+    !hasSendableContent
   const isActiveStream = input.isStreaming || input.isAwaitingResponseStart || input.isStopping
 
   if (input.isStopping) {
@@ -47,7 +49,7 @@ export function getChatSendState(input: ChatSendStateInput): ChatSendState {
     }
   }
 
-  if (isActiveStream && input.canQueueMessage && hasTextContent && !baseDisabled) {
+  if (isActiveStream && input.canQueueMessage && hasUserProvidedContent && !baseDisabled) {
     return {
       primaryAction: 'queue',
       isPrimaryDisabled: false,


### PR DESCRIPTION
## Summary
- Treat ready attachments as sendable chat input content so the send button enables without typed text.
- Apply the same sendability state to desktop and mobile chat controls.
- Update the send handler and pending replacement flow to allow attachment-only submissions.

## Test Plan
- [x] `npm test -- --runTestsByPath src/__tests__/features/tasks/components/input/chat-send-state.test.tsx src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now send attachments without requiring accompanying text input.
  * Send button properly enables when attachments are present, even with empty messages.

* **Tests**
  * Added test coverage for sending attachments independently of text.
  * Added test coverage for send state behavior when attachments are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->