### PR TITLE
feat(frontend): add automation page hint

### DIFF
--- a/frontend/src/__tests__/features/feed/SubscriptionPage.hint.test.tsx
+++ b/frontend/src/__tests__/features/feed/SubscriptionPage.hint.test.tsx
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { SubscriptionPage } from '@/features/feed/components/SubscriptionPage'
+
+jest.mock('next/dynamic', () => () => {
+  const MockDynamicComponent = () => <div data-testid="dynamic-content" />
+  MockDynamicComponent.displayName = 'MockDynamicComponent'
+  return MockDynamicComponent
+})
+
+jest.mock('@/features/feed/contexts/subscriptionContext', () => ({
+  SubscriptionProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useSubscriptionContext: () => ({
+    refreshSubscriptions: jest.fn(),
+    refreshExecutions: jest.fn(),
+    showSilentExecutions: false,
+    setShowSilentExecutions: jest.fn(),
+  }),
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        automation_hint:
+          'Create scheduled tasks, event-triggered tasks, or automation subscriptions for agents to run on plan.',
+        'tabs.all': 'All',
+        discover: 'Discover',
+        'market.tab': 'Market',
+        'tabs.mine': 'Mine',
+        'feed.show_silent': 'Show silent executions',
+        'feed.silent_executions': 'Silent executions',
+      }
+
+      return translations[key] ?? key
+    },
+  }),
+}))
+
+describe('SubscriptionPage automation hint', () => {
+  test('explains that automation can create scheduled tasks', () => {
+    render(<SubscriptionPage />)
+
+    expect(
+      screen.getByText(
+        'Create scheduled tasks, event-triggered tasks, or automation subscriptions for agents to run on plan.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/feed/components/SubscriptionPage.tsx
+++ b/frontend/src/features/feed/components/SubscriptionPage.tsx
@@ -231,6 +231,10 @@ function SubscriptionPageContent() {
         )}
       </div>
 
+      <div className="border-b border-border bg-base px-4 py-2">
+        <p className="text-sm text-text-secondary">{t('automation_hint')}</p>
+      </div>
+
       {/* Tab content */}
       <div className="flex-1 overflow-hidden flex flex-col">
         {activeTab === 'all' && (

--- a/frontend/src/i18n/locales/en/feed.json
+++ b/frontend/src/i18n/locales/en/feed.json
@@ -1,6 +1,7 @@
 {
   "title": "Automation",
   "subtitle": "AI-powered information tracking and updates",
+  "automation_hint": "Create scheduled tasks, event-triggered tasks, or automation subscriptions for agents to run on plan.",
   "tab_timeline": "Feed",
   "notification_level": {
     "silent": "Silent",

--- a/frontend/src/i18n/locales/zh-CN/feed.json
+++ b/frontend/src/i18n/locales/zh-CN/feed.json
@@ -1,6 +1,7 @@
 {
   "title": "自动化",
   "subtitle": "AI 智能体的动态与执行记录",
+  "automation_hint": "在这里创建定时任务、事件触发任务或自动化订阅，让智能体按计划执行工作。",
   "tab_timeline": "动态",
   "notification_level": {
     "silent": "静默",


### PR DESCRIPTION
## Summary
- Add a short automation-page hint below the tab navigation.
- Add zh-CN and en feed translations for the hint.
- Add a focused page test covering the new hint copy.

## Test Plan
- npx prettier --check src/features/feed/components/SubscriptionPage.tsx src/i18n/locales/en/feed.json src/i18n/locales/zh-CN/feed.json src/__tests__/features/feed/SubscriptionPage.hint.test.tsx
- npm test -- SubscriptionPage.hint.test.tsx missing-console-keys.test.ts --runInBand
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational banner to the Subscription page with guidance on creating scheduled, event-triggered, and automation-based subscriptions for agents.
  * Support for English and Chinese translations.

* **Tests**
  * Added test coverage for the new automation hint feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->