### PR TITLE
style: emoji延迟三秒出现

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/MessagesArea.memo.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import MessagesArea from '@/features/tasks/components/message/MessagesArea'
 import type { DisplayMessage } from '@/features/tasks/presentation/useMessagePresenter'
 
@@ -217,6 +217,7 @@ describe('MessagesArea memoization', () => {
   })
 
   it('shows runtime glyph only for an empty non-loading message area', () => {
+    jest.useFakeTimers()
     mockMessages = []
     mockTaskSession = {
       ...mockTaskSession,
@@ -244,6 +245,12 @@ describe('MessagesArea memoization', () => {
     )
 
     expect(screen.queryByTestId('messages-syncing-indicator')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+
     const watermark = screen.getByTestId('task-runtime-watermark')
     expect(watermark).toHaveTextContent('✅')
     expect(watermark).toHaveTextContent('🏁')
@@ -254,5 +261,6 @@ describe('MessagesArea memoization', () => {
     expect(watermark).toHaveAttribute('data-task-id', '707')
     expect(watermark).toHaveAttribute('data-runtime-code', 's4-p5-r0-q1-e0-m0')
     expect(watermark.querySelectorAll('[data-runtime-symbol]')).toHaveLength(6)
+    jest.useRealTimers()
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/message/TaskRuntimeGlyph.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/TaskRuntimeGlyph.test.tsx
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { act, render, screen } from '@testing-library/react'
+
+import { TaskRuntimeGlyph } from '@/features/tasks/components/message/TaskRuntimeGlyph'
+import type { TaskStateData } from '@/features/tasks/state'
+
+function createTaskState(taskId: number): TaskStateData {
+  return {
+    taskId,
+    status: 'ready',
+    messages: new Map(),
+    streamingSubtaskId: null,
+    streamingInfo: null,
+    error: null,
+    isStopping: false,
+    runtime: {
+      taskId,
+      phase: 'terminal',
+      joinedRoom: false,
+      localStreamCursor: 0,
+    },
+    derived: {
+      isExecutionActive: false,
+      isTerminal: true,
+      isStreaming: false,
+      shouldJoinRoom: false,
+      canSendMessage: true,
+      canQueueMessage: false,
+      canCancelTask: false,
+      blocksQueuedDispatch: false,
+    },
+  }
+}
+
+describe('TaskRuntimeGlyph', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('shows the runtime glyph only after it remains visible for three seconds', () => {
+    render(<TaskRuntimeGlyph taskState={createTaskState(713)} visible />)
+
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(2999)
+    })
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+    expect(screen.getByTestId('task-runtime-watermark')).toHaveAttribute('data-task-id', '713')
+  })
+
+  it('restarts the delay when the task changes', () => {
+    const { rerender } = render(<TaskRuntimeGlyph taskState={createTaskState(713)} visible />)
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+    expect(screen.getByTestId('task-runtime-watermark')).toHaveAttribute('data-task-id', '713')
+
+    rerender(<TaskRuntimeGlyph taskState={createTaskState(714)} visible />)
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+    expect(screen.getByTestId('task-runtime-watermark')).toHaveAttribute('data-task-id', '714')
+  })
+
+  it('does not show a stale delayed glyph when the task changes again at the timeout boundary', () => {
+    const { rerender } = render(<TaskRuntimeGlyph taskState={createTaskState(713)} visible />)
+
+    act(() => {
+      jest.advanceTimersByTime(3000)
+    })
+    expect(screen.getByTestId('task-runtime-watermark')).toHaveAttribute('data-task-id', '713')
+
+    rerender(<TaskRuntimeGlyph taskState={createTaskState(714)} visible />)
+    act(() => {
+      jest.advanceTimersByTime(2999)
+    })
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    rerender(<TaskRuntimeGlyph taskState={createTaskState(715)} visible />)
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+    expect(screen.queryByTestId('task-runtime-watermark')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(2999)
+    })
+    expect(screen.getByTestId('task-runtime-watermark')).toHaveAttribute('data-task-id', '715')
+  })
+})

--- a/frontend/src/features/tasks/components/message/TaskRuntimeGlyph.tsx
+++ b/frontend/src/features/tasks/components/message/TaskRuntimeGlyph.tsx
@@ -4,8 +4,10 @@
 
 'use client'
 
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { TaskStateData } from '@/features/tasks/state'
+
+const GLYPH_VISIBLE_DELAY_MS = 3000
 
 const TASK_MACHINE_STATUS_CODES = {
   idle: 0,
@@ -72,8 +74,24 @@ export function TaskRuntimeGlyph({ taskState, visible }: TaskRuntimeGlyphProps) 
     if (!taskState) return null
     return buildRuntimeGlyphState(taskState)
   }, [taskState])
+  const glyphKey = visible && glyph ? `${glyph.taskId}:${glyph.code}` : null
+  const [visibleGlyphKey, setVisibleGlyphKey] = useState<string | null>(null)
 
-  if (!visible || !glyph) return null
+  useEffect(() => {
+    setVisibleGlyphKey(null)
+
+    if (!glyphKey) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setVisibleGlyphKey(glyphKey)
+    }, GLYPH_VISIBLE_DELAY_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [glyphKey])
+
+  if (!glyph || !glyphKey || visibleGlyphKey !== glyphKey) return null
 
   return (
     <div


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task runtime watermark now appears with a 3-second delay after a task becomes visible.

* **Tests**
  * Added comprehensive test suite for task runtime watermark behavior, including timing scenarios and task transitions.
  * Updated existing test setup to support time-based UI behavior with fake timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->