### PR TITLE
fix(frontend): preserve device chat task id

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/useChatStreamHandlers.queue.test.tsx
@@ -16,7 +16,8 @@ const mockCheckHealth = jest.fn().mockResolvedValue(undefined)
 let isMachineStreamingMock = true
 let activeStreamSubtaskIdMock: number | undefined = 77
 let taskInputMessageMock = 'next question'
-let selectedTaskDetailMock = {
+let sessionTaskIdMock = 42
+let selectedTaskDetailMock: TaskDetail | null = {
   id: 42,
   status: 'RUNNING',
   is_group_chat: false,
@@ -30,44 +31,40 @@ jest.mock('next/navigation', () => ({
 }))
 
 jest.mock('@/features/tasks/session/TaskSession', () => ({
-  useTaskSession: () => ({
-    selectedTaskDetail: selectedTaskDetailMock,
-    refreshTasks: jest.fn(),
-    refreshSelectedTaskDetail: mockRefreshSelectedTaskDetail,
-    markTaskAsViewed: jest.fn(),
-    sendMessage: mockContextSendMessage,
-    stopStream: jest.fn(),
-    recoverCurrentTask: mockCheckHealth,
-    taskState: {
-      taskId: selectedTaskDetailMock.id,
-      phase: isMachineStreamingMock ? 'streaming' : 'ready',
-      messages: new Map(),
-      isStopping: false,
-      runtime: {
-        taskStatus: selectedTaskDetailMock.status,
-        activeStreamSubtaskId: activeStreamSubtaskIdMock,
+  useTaskSession: () => {
+    const taskStatus = selectedTaskDetailMock?.status ?? 'COMPLETED'
+
+    return {
+      selectedTaskDetail: selectedTaskDetailMock,
+      refreshTasks: jest.fn(),
+      refreshSelectedTaskDetail: mockRefreshSelectedTaskDetail,
+      markTaskAsViewed: jest.fn(),
+      sendMessage: mockContextSendMessage,
+      stopStream: jest.fn(),
+      recoverCurrentTask: mockCheckHealth,
+      taskState: {
+        taskId: sessionTaskIdMock,
+        phase: isMachineStreamingMock ? 'streaming' : 'ready',
+        messages: new Map(),
+        isStopping: false,
+        runtime: {
+          taskStatus,
+          activeStreamSubtaskId: activeStreamSubtaskIdMock,
+        },
+        derived: {
+          isExecutionActive: taskStatus === 'RUNNING' || taskStatus === 'PENDING',
+          isTerminal:
+            taskStatus === 'COMPLETED' || taskStatus === 'FAILED' || taskStatus === 'CANCELLED',
+          isStreaming: isMachineStreamingMock,
+          shouldJoinRoom: false,
+          canSendMessage: taskStatus === 'COMPLETED',
+          canQueueMessage: isMachineStreamingMock,
+          canCancelTask: taskStatus === 'RUNNING' || taskStatus === 'PENDING',
+          blocksQueuedDispatch: taskStatus === 'RUNNING' || taskStatus === 'PENDING',
+        },
       },
-      derived: {
-        isExecutionActive:
-          selectedTaskDetailMock.status === 'RUNNING' ||
-          selectedTaskDetailMock.status === 'PENDING',
-        isTerminal:
-          selectedTaskDetailMock.status === 'COMPLETED' ||
-          selectedTaskDetailMock.status === 'FAILED' ||
-          selectedTaskDetailMock.status === 'CANCELLED',
-        isStreaming: isMachineStreamingMock,
-        shouldJoinRoom: false,
-        canSendMessage: selectedTaskDetailMock.status === 'COMPLETED',
-        canQueueMessage: isMachineStreamingMock,
-        canCancelTask:
-          selectedTaskDetailMock.status === 'RUNNING' ||
-          selectedTaskDetailMock.status === 'PENDING',
-        blocksQueuedDispatch:
-          selectedTaskDetailMock.status === 'RUNNING' ||
-          selectedTaskDetailMock.status === 'PENDING',
-      },
-    },
-  }),
+    }
+  },
 }))
 
 jest.mock('@/features/projects/contexts/projectContext', () => ({
@@ -154,6 +151,7 @@ describe('useChatStreamHandlers queue integration', () => {
     jest.clearAllMocks()
     isMachineStreamingMock = true
     activeStreamSubtaskIdMock = 77
+    sessionTaskIdMock = 42
     taskInputMessageMock = 'next question'
     selectedTaskDetailMock = {
       id: 42,
@@ -372,6 +370,29 @@ describe('useChatStreamHandlers queue integration', () => {
     expect(mockSetTaskInputMessage).toHaveBeenCalledWith('')
     expect(mockResetAttachment).toHaveBeenCalled()
     expect(mockResetContexts).toHaveBeenCalled()
+  })
+
+  it('continues on the resolved task when task detail has not refreshed yet', async () => {
+    isMachineStreamingMock = false
+    sessionTaskIdMock = 42
+    selectedTaskDetailMock = null
+    taskInputMessageMock = 'follow up'
+
+    const { result } = renderQueueableHook()
+
+    await act(async () => {
+      await result.current.handleSendMessage()
+    })
+
+    expect(mockContextSendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task_id: 42,
+        message: 'follow up',
+      }),
+      expect.objectContaining({
+        immediateTaskId: 42,
+      })
+    )
   })
 
   it('shows a retry action that resends a failed queued message', async () => {

--- a/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
+++ b/frontend/src/features/tasks/components/chat/useChatStreamHandlers.tsx
@@ -46,6 +46,10 @@ function isVirtualKnowledgeBasePath(path: string): boolean {
   return path.startsWith('/knowledge/') && !path.startsWith('/knowledge/document/')
 }
 
+function toPositiveTaskId(taskId?: number | null): number | null {
+  return taskId && taskId > 0 ? taskId : null
+}
+
 export interface UseChatStreamHandlersOptions {
   // Team and model
   selectedTeam: Team | null
@@ -319,10 +323,14 @@ export function useChatStreamHandlers({
       selectedTaskId: currentDisplayTaskId,
     })
 
+  const stateTaskId =
+    toPositiveTaskId(selectedTaskDetail?.id) ??
+    toPositiveTaskId(pendingTaskId) ??
+    toPositiveTaskId(sessionTaskState?.taskId) ??
+    effectiveTaskIdForState
   const taskState =
-    sessionTaskState && sessionTaskState.taskId === effectiveTaskIdForState
-      ? sessionTaskState
-      : null
+    sessionTaskState && sessionTaskState.taskId === stateTaskId ? sessionTaskState : null
+  const resolvedTaskId = toPositiveTaskId(stateTaskId)
   const isMachineStreaming = taskState?.phase === 'streaming'
   const runtimeDerived = taskState?.derived
   const activeStreamSubtaskId = taskState?.runtime.activeStreamSubtaskId
@@ -578,7 +586,7 @@ export function useChatStreamHandlers({
       const request: ContextSendRequest = {
         message: messageWithQueueContent,
         team_id: selectedTeam?.id ?? 0,
-        task_id: selectedTaskDetail?.id,
+        task_id: resolvedTaskId ?? undefined,
         model_id: modelId,
         force_override_bot_model: Boolean(modelId),
         force_override_bot_model_type: selectedModel?.type,
@@ -598,7 +606,7 @@ export function useChatStreamHandlers({
         contexts: contextItems.length > 0 ? contextItems : undefined,
         device_id: effectiveDeviceId,
         // Project association for workspace project conversations
-        project_id: selectedTaskDetail?.id ? undefined : projectId,
+        project_id: resolvedTaskId ? undefined : projectId,
         additional_skills:
           snapshotAdditionalSkills && snapshotAdditionalSkills.length > 0
             ? snapshotAdditionalSkills
@@ -617,11 +625,11 @@ export function useChatStreamHandlers({
             setPendingTaskId(completedTaskId)
           }
 
-          if (completedTaskId && !selectedTaskDetail?.id && onTaskCreated) {
+          if (completedTaskId && !resolvedTaskId && onTaskCreated) {
             onTaskCreated(completedTaskId)
           }
 
-          if (completedTaskId && !selectedTaskDetail?.id) {
+          if (completedTaskId && !resolvedTaskId) {
             if (taskType === 'knowledge' && knowledgeBaseId) {
               navigateToKnowledgeTask(completedTaskId, knowledgeBaseId)
             } else if (taskType === 'task' && !pathname?.startsWith('/devices')) {
@@ -675,6 +683,7 @@ export function useChatStreamHandlers({
       t,
       selectedTeam?.id,
       selectedTaskDetail,
+      resolvedTaskId,
       enableDeepThinking,
       enableClarification,
       showRepositorySelector,
@@ -724,8 +733,7 @@ export function useChatStreamHandlers({
     ]
   )
 
-  const activeTaskId =
-    selectedTaskDetail?.id && selectedTaskDetail.id > 0 ? selectedTaskDetail.id : null
+  const activeTaskId = resolvedTaskId
   const isRuntimeBlockingQueue = runtimeDerived?.blocksQueuedDispatch ?? false
   const isActiveTaskBlocked = isMachineStreaming || hasPendingUserMessage || isRuntimeBlockingQueue
   const canQueueMessage = Boolean(
@@ -971,7 +979,7 @@ export function useChatStreamHandlers({
         return
       }
 
-      const immediateTaskId = selectedTaskDetail?.id || -Date.now()
+      const immediateTaskId = resolvedTaskId || -Date.now()
       const localMessageId = generateMessageId('user')
       const prepared = prepareChatSend(message, localMessageId, immediateTaskId, effectiveRepo)
 
@@ -1008,7 +1016,7 @@ export function useChatStreamHandlers({
       resetAttachment()
       resetContexts?.()
 
-      if (!selectedTaskDetail?.id) {
+      if (!resolvedTaskId) {
         setPendingTaskId(immediateTaskId)
       }
 
@@ -1026,6 +1034,7 @@ export function useChatStreamHandlers({
       toast,
       selectedRepo,
       selectedTaskDetail,
+      resolvedTaskId,
       taskType,
       showRepositorySelector,
       effectiveRequiresWorkspace,
@@ -1206,7 +1215,7 @@ export function useChatStreamHandlers({
       }
 
       try {
-        const immediateTaskId = selectedTaskDetail?.id || -Date.now()
+        const immediateTaskId = resolvedTaskId || -Date.now()
 
         // Extract attachment IDs from existing contexts (for regeneration)
         const attachmentIds =
@@ -1277,7 +1286,7 @@ export function useChatStreamHandlers({
           {
             message: finalMessage,
             team_id: selectedTeam?.id ?? 0,
-            task_id: selectedTaskDetail?.id,
+            task_id: resolvedTaskId ?? undefined,
             model_id: modelId,
             force_override_bot_model: true, // Always force override when using model override
             force_override_bot_model_type: modelOverride.type,
@@ -1312,11 +1321,11 @@ export function useChatStreamHandlers({
               }
 
               // Call onTaskCreated callback when a new task is created
-              if (completedTaskId && !selectedTaskDetail?.id && onTaskCreated) {
+              if (completedTaskId && !resolvedTaskId && onTaskCreated) {
                 onTaskCreated(completedTaskId)
               }
 
-              if (completedTaskId && !selectedTaskDetail?.id) {
+              if (completedTaskId && !resolvedTaskId) {
                 if (taskType === 'knowledge' && knowledgeBaseId) {
                   navigateToKnowledgeTask(completedTaskId, knowledgeBaseId)
                 } else {
@@ -1363,6 +1372,7 @@ export function useChatStreamHandlers({
       toast,
       selectedTeam,
       selectedTaskDetail,
+      resolvedTaskId,
       contextSendMessage,
       enableDeepThinking,
       enableClarification,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved task ID normalization and unified task-id handling across chat messaging. Outgoing requests now include the resolved task ID when available (and omit project ID in that case), and message send/create flows more reliably choose between creating or attaching to existing tasks.

* **Tests**
  * Added coverage for message handling when task details are not yet loaded, ensuring sends proceed with the correct task identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->