### PR TITLE
fix(executor-manager): force Redis RESP2 protocol

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,11 @@ MYSQL_PASSWORD=task_password
 # Redis port (default: 6379)
 # REDIS_PORT=6379
 
+# Redis wire protocol for executor_manager clients.
+# Keep RESP2 for compatibility with older Redis-compatible servers that do not support HELLO.
+# Set to 3 only when your Redis server supports RESP3.
+# REDIS_PROTOCOL=2
+
 # =============================================================================
 # ELASTICSEARCH (RAG feature)
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,6 +228,7 @@ services:
       - TASK_API_DOMAIN=${TASK_API_DOMAIN:-http://backend:8000}
       - EXECUTOR_MANAGER_EXTERNAL_URL=${EXECUTOR_MANAGER_EXTERNAL_URL:-http://executor_manager:8001}
       - REDIS_URL=${REDIS_URL:-redis://redis:6379/0}
+      - REDIS_PROTOCOL=${REDIS_PROTOCOL:-2}
       - MAX_CONCURRENT_TASKS=${EXECUTOR_MAX_CONCURRENT_TASKS:-30}
       - CALLBACK_HOST=${EXECUTOR_CALLBACK_HOST:-http://executor_manager:8001}
       - NETWORK=${EXECUTOR_NETWORK:-wegent-network}

--- a/docs/en/getting-started/installation.md
+++ b/docs/en/getting-started/installation.md
@@ -83,6 +83,7 @@ MYSQL_PASSWORD=your_password
 
 # Redis Configuration
 REDIS_PASSWORD=your_redis_password  # Optional
+REDIS_PROTOCOL=2  # Default RESP2, compatible with Redis-compatible servers without HELLO support
 
 # Backend Configuration
 PASSWORD_KEY=your-password-key-here

--- a/docs/zh/getting-started/installation.md
+++ b/docs/zh/getting-started/installation.md
@@ -83,6 +83,7 @@ MYSQL_PASSWORD=your_password
 
 # Redis 配置
 REDIS_PASSWORD=your_redis_password  # 可选
+REDIS_PROTOCOL=2  # 默认使用 RESP2，兼容不支持 HELLO 的 Redis 兼容服务
 
 # 后端配置
 PASSWORD_KEY=your-password-key-here

--- a/executor_manager/common/config.py
+++ b/executor_manager/common/config.py
@@ -18,6 +18,20 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 
+def _get_redis_protocol() -> int:
+    """Read and validate Redis wire protocol version."""
+    value = os.getenv("REDIS_PROTOCOL", "2")
+    try:
+        protocol = int(value)
+    except ValueError as exc:
+        raise ValueError("REDIS_PROTOCOL must be 2 or 3") from exc
+
+    if protocol not in (2, 3):
+        raise ValueError("REDIS_PROTOCOL must be 2 or 3")
+
+    return protocol
+
+
 @dataclass(frozen=True)
 class RedisConfig:
     """Redis connection configuration."""
@@ -32,6 +46,9 @@ class RedisConfig:
     connect_timeout: float = 5.0
     encoding: str = "utf-8"
     decode_responses: bool = True
+    # RESP2 avoids the HELLO handshake and remains compatible with older
+    # Redis-compatible servers.
+    protocol: int = field(default_factory=_get_redis_protocol)
     # Retry configuration for connection failures
     max_retries: int = field(
         default_factory=lambda: int(os.getenv("REDIS_MAX_RETRIES", "3"))

--- a/executor_manager/common/redis_factory.py
+++ b/executor_manager/common/redis_factory.py
@@ -55,6 +55,7 @@ class RedisClientFactory:
             decode_responses=config.decode_responses,
             socket_timeout=config.socket_timeout,
             socket_connect_timeout=config.connect_timeout,
+            protocol=config.protocol,
         )
 
     @classmethod
@@ -64,6 +65,7 @@ class RedisClientFactory:
             config.url,
             encoding=config.encoding,
             decode_responses=config.decode_responses,
+            protocol=config.protocol,
         )
 
     @classmethod

--- a/executor_manager/tests/common/test_redis_factory.py
+++ b/executor_manager/tests/common/test_redis_factory.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from executor_manager.common.config import RedisConfig
+from executor_manager.common.redis_factory import RedisClientFactory
+
+
+def test_create_sync_client_uses_resp2_protocol_by_default(mocker):
+    """Redis clients must remain compatible with Redis servers without HELLO."""
+    from_url = mocker.patch("executor_manager.common.redis_factory.redis.from_url")
+    config = RedisConfig(url="redis://redis:6379/0")
+
+    RedisClientFactory._create_sync_client(config)
+
+    assert from_url.call_args.kwargs["protocol"] == 2
+
+
+def test_create_async_client_uses_resp2_protocol_by_default(mocker):
+    """Async Redis clients must use the same protocol as sync clients."""
+    from_url = mocker.patch("executor_manager.common.redis_factory.aioredis.from_url")
+    config = RedisConfig(url="redis://redis:6379/0")
+
+    RedisClientFactory._create_async_client(config)
+
+    assert from_url.call_args.kwargs["protocol"] == 2

--- a/shared/logger.py
+++ b/shared/logger.py
@@ -73,6 +73,19 @@ class NonBlockingStreamHandler(logging.StreamHandler):
             pass
 
 
+def _stop_queue_listener_safely(listener: QueueListener) -> None:
+    """Stop a QueueListener once, ignoring duplicate shutdown calls."""
+    if getattr(listener, "_thread", None) is None:
+        return
+
+    try:
+        listener.stop()
+    except AttributeError as exc:
+        if getattr(listener, "_thread", None) is None:
+            return
+        raise
+
+
 def setup_logger(
     name,
     level=logging.INFO,
@@ -144,7 +157,7 @@ def setup_logger(
 
             listener = QueueListener(log_queue, listener_handler)
             listener.start()
-            atexit.register(listener.stop)
+            atexit.register(_stop_queue_listener_safely, listener)
 
             logger.addHandler(queue_handler)
             logger._queue_listener = listener

--- a/shared/tests/test_logger.py
+++ b/shared/tests/test_logger.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 WeCode, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+from shared import logger as logger_module
+from shared.logger import setup_logger
+
+
+class QueueListenerThatRaisesOnSecondStop:
+    def __init__(self):
+        self._thread = object()
+        self.stop_count = 0
+
+    def stop(self):
+        self.stop_count += 1
+        if self.stop_count > 1:
+            raise AttributeError("'NoneType' object has no attribute 'join'")
+        self._thread = None
+
+
+class FakeQueueListener(QueueListenerThatRaisesOnSecondStop):
+    def __init__(self, log_queue, handler):
+        super().__init__()
+        self.log_queue = log_queue
+        self.handler = handler
+        self._thread = None
+
+    def start(self):
+        self._thread = object()
+
+
+def test_stop_queue_listener_safely_ignores_duplicate_stop():
+    """Duplicate QueueListener cleanup should not leak atexit exceptions."""
+    listener = QueueListenerThatRaisesOnSecondStop()
+
+    logger_module._stop_queue_listener_safely(listener)
+    logger_module._stop_queue_listener_safely(listener)
+
+    assert listener.stop_count == 1
+
+
+def test_queue_listener_shutdown_callback_is_idempotent(mocker):
+    """The atexit shutdown callback may run after explicit test cleanup."""
+    registered_callbacks = []
+    mocker.patch("shared.logger.os.getppid", return_value=2)
+    mocker.patch("shared.logger.multiprocessing.Queue", return_value=object())
+    mocker.patch("shared.logger.QueueListener", FakeQueueListener)
+    mocker.patch(
+        "shared.logger.atexit.register",
+        side_effect=lambda *args: registered_callbacks.append(args),
+    )
+
+    logger = setup_logger("test-idempotent-queue-listener-shutdown")
+
+    try:
+        assert registered_callbacks
+        callback, listener = registered_callbacks[0]
+        callback(listener)
+        callback(listener)
+        assert listener.stop_count == 1
+    finally:
+        for handler in list(logger.handlers):
+            logger.removeHandler(handler)
+            handler.close()
+        logging.Logger.manager.loggerDict.pop(logger.name, None)


### PR DESCRIPTION
## Summary
- Default executor_manager Redis clients to RESP2 via `REDIS_PROTOCOL=2` to avoid `HELLO` on older Redis-compatible servers.
- Pass `REDIS_PROTOCOL` through Docker Compose and document it in `.env.example` plus zh/en installation guides.
- Make shared QueueListener shutdown idempotent to avoid duplicate atexit stop errors surfaced during tests.

## Test Plan
- `cd executor_manager && uv run pytest tests/ -q`
- `cd shared && uv run pytest tests/ -q`
- `git diff --check`
- `docker compose config --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Redis protocol version support (RESP2/RESP3) via the `REDIS_PROTOCOL` environment variable for improved compatibility with Redis-compatible servers.

* **Improvements**
  * Enhanced logger shutdown stability in multiprocessing environments to prevent exceptions during cleanup.

* **Documentation**
  * Updated installation guides with Redis protocol configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->