### PR TITLE
fix(executor): preserve standalone chat session

### DIFF
--- a/executor/agents/claude_code/standalone_chat_workspace.py
+++ b/executor/agents/claude_code/standalone_chat_workspace.py
@@ -103,8 +103,16 @@ def _copy_session_files(task_id: int, workspace_path: Path) -> None:
     for session_file in workspace_path.glob(".claude_session_id*"):
         if not session_file.is_file():
             continue
+        target_file = session_dir / session_file.name
+        if target_file.exists():
+            logger.info(
+                "Skipped standalone chat session migration for task %s because %s already exists",
+                task_id,
+                target_file,
+            )
+            continue
         session_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(session_file, session_dir / session_file.name)
+        shutil.copy2(session_file, target_file)
 
 
 def _move_user_workspace(source: Path, target: Path) -> None:

--- a/executor/tests/agents/test_standalone_chat_workspace.py
+++ b/executor/tests/agents/test_standalone_chat_workspace.py
@@ -120,6 +120,37 @@ def test_finalize_standalone_chat_workspace_moves_initial_task_workspace(
     ) == "session-id"
 
 
+def test_finalize_standalone_chat_workspace_keeps_existing_session_root(
+    tmp_path,
+    monkeypatch,
+):
+    workspace_root = tmp_path / "workspace"
+    source = workspace_root / "126"
+    source.mkdir(parents=True)
+    (source / ".claude_session_id").write_text("stale-session-id", encoding="utf-8")
+    chats_root = tmp_path / "chats"
+    executor_home = tmp_path / ".wegent-executor"
+    session_file = executor_home / "sessions" / "126" / ".claude_session_id"
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text("current-session-id", encoding="utf-8")
+    task_data = SimpleNamespace(
+        task_id=126,
+        project_id=None,
+        project_workspace_path=None,
+        git_url=None,
+    )
+
+    monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
+    monkeypatch.setattr(
+        workspace.config, "get_workspace_root", lambda: str(workspace_root)
+    )
+    monkeypatch.setattr(workspace.config, "WEGENT_EXECUTOR_HOME", str(executor_home))
+
+    workspace.finalize_standalone_chat_workspace(task_data, "Hello")
+
+    assert session_file.read_text(encoding="utf-8") == "current-session-id"
+
+
 def test_finalize_standalone_chat_workspace_adds_duplicate_suffix(
     tmp_path,
     monkeypatch,

--- a/frontend/src/__tests__/features/tasks/components/chat/useChatTransientState.test.ts
+++ b/frontend/src/__tests__/features/tasks/components/chat/useChatTransientState.test.ts
@@ -1,13 +1,19 @@
 import { act, renderHook } from '@testing-library/react'
 import { useChatTransientState } from '@/features/tasks/components/chat/useChatTransientState'
 
+type UseChatTransientStateTestProps = {
+  selectedTaskId?: number | null
+}
+
 describe('useChatTransientState', () => {
   it('clears a resolved pending task id when no task is selected', () => {
+    const initialProps: UseChatTransientStateTestProps = { selectedTaskId: 42 }
+
     const { result, rerender } = renderHook(
-      ({ selectedTaskId }: { selectedTaskId?: number | null }) =>
+      ({ selectedTaskId }: UseChatTransientStateTestProps) =>
         useChatTransientState({ selectedTaskId }),
       {
-        initialProps: { selectedTaskId: 42 },
+        initialProps,
       }
     )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental overwrites of existing session files by detecting and preserving pre-existing session data.

* **Tests**
  * Added a test verifying existing session data is preserved during workspace finalization.
  * Refactored a chat transient state test for clearer typing (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->