### PR TITLE
fix(executor): add wecode-user to local Claude headers

### DIFF
--- a/docs/en/developer-guide/local-device-architecture.md
+++ b/docs/en/developer-guide/local-device-architecture.md
@@ -202,6 +202,20 @@ In `replace` mode, the executor only removes capabilities marked as `managed` in
 
 When a project task runs through the local executor, its task-level `CLAUDE_CONFIG_DIR` exposes both global `skills` and `plugins` directories and inherits non-sensitive plugin settings such as `enabledPlugins` and `extraKnownMarketplaces` from the local `~/.claude/settings.json`. This lets Claude Code load global Skills and Skills provided by Plugins. Sensitive model and token configuration is still injected through runtime environment variables and is not copied from global settings into the task directory.
 
+### Claude Custom Request Headers
+
+When the local executor calls Claude Code, it merges `agent_config.env.ANTHROPIC_CUSTOM_HEADERS` from the Model/Bot configuration with `ANTHROPIC_CUSTOM_HEADERS` from the local executor process environment before passing the result to the Claude Code SDK. The header format is one `name: value` entry per line. If the same header appears more than once, the later value wins, so the local executor process configuration takes precedence over Model/Bot configuration.
+
+Local mode also appends these Wegent headers to identify Claude model request provenance:
+
+| Header | Value |
+|--------|-------|
+| `wecode-action` | `wegent` |
+| `wecode-executor` | `claudecode` |
+| `wecode-source` | `wegent-local` |
+
+The executor also appends `wecode-user: <user_name>` from the current task identity. If earlier configuration already contains these Wegent headers, the local-mode standard values replace them so Claude model requests carry the current Wegent user identity and local execution source.
+
 ---
 
 ## 🔄 Task Execution Flow

--- a/docs/zh/developer-guide/local-device-architecture.md
+++ b/docs/zh/developer-guide/local-device-architecture.md
@@ -202,6 +202,20 @@ Plugin 上报必须包含其内部 Skill 列表。Executor 会扫描每个 Plugi
 
 项目任务使用本地 executor 执行时，任务级 `CLAUDE_CONFIG_DIR` 会同时暴露全局 `skills` 和 `plugins` 目录，并从本机 `~/.claude/settings.json` 继承 `enabledPlugins`、`extraKnownMarketplaces` 等非敏感插件配置，使 Claude Code 能加载全局 Skill 以及 Plugin 内部提供的 Skill。模型、Token 等敏感配置仍通过运行时环境变量注入，不会从全局 settings 写入任务目录。
 
+### Claude 自定义请求头
+
+本地 executor 调用 Claude Code 时，会把 Model/Bot 的 `agent_config.env.ANTHROPIC_CUSTOM_HEADERS` 与本机 executor 进程的 `ANTHROPIC_CUSTOM_HEADERS` 合并后传给 Claude Code SDK。请求头格式为每行一个 `name: value`；同名请求头按后写入者覆盖先写入者，本机 executor 进程配置优先于 Model/Bot 配置。
+
+本地模式还会追加以下 Wegent 请求头，用于标识 Claude 模型请求来源：
+
+| 请求头 | 值 |
+|--------|----|
+| `wecode-action` | `wegent` |
+| `wecode-executor` | `claudecode` |
+| `wecode-source` | `wegent-local` |
+
+Executor 会根据当前任务身份追加 `wecode-user: <user_name>`。如果前面的配置中已经包含上述 Wegent 请求头，local 模式的标准值会覆盖对应字段，确保 Claude 模型请求携带当前 Wegent 用户身份和本地执行来源。
+
 ---
 
 ## 🔄 任务执行流程

--- a/executor/agents/claude_code/local_mode_strategy.py
+++ b/executor/agents/claude_code/local_mode_strategy.py
@@ -35,6 +35,53 @@ from shared.logger import setup_logger
 logger = setup_logger("local_mode_strategy")
 
 GLOBAL_PLUGIN_SETTINGS_KEYS = ("enabledPlugins", "extraKnownMarketplaces")
+LOCAL_CLAUDE_REQUEST_HEADERS = {
+    "wecode-action": "wegent",
+    "wecode-executor": "claudecode",
+    "wecode-source": "wegent-local",
+}
+
+
+def _merge_anthropic_custom_headers(*header_values: str) -> str:
+    """Merge newline-delimited Anthropic custom headers by header name."""
+    merged: dict[str, tuple[str, str]] = {}
+    order: list[str] = []
+
+    for header_value in header_values:
+        if not header_value:
+            continue
+        for raw_line in str(header_value).splitlines():
+            line = raw_line.strip()
+            if not line or ":" not in line:
+                continue
+            name, value = line.split(":", 1)
+            header_name = name.strip()
+            normalized_name = header_name.lower()
+            if not header_name:
+                continue
+            if normalized_name not in merged:
+                order.append(normalized_name)
+            merged[normalized_name] = (header_name, value.strip())
+
+    return "\n".join(
+        f"{merged[normalized_name][0]}: {merged[normalized_name][1]}"
+        for normalized_name in order
+    )
+
+
+def _ensure_wecode_user_header(headers: str, user_name: str | None) -> str:
+    """Ensure ANTHROPIC_CUSTOM_HEADERS contains the task user header."""
+    if not user_name:
+        return headers
+
+    return _merge_anthropic_custom_headers(headers, f"wecode-user: {user_name}")
+
+
+def _build_local_claude_request_headers() -> str:
+    """Build local-mode default Claude request headers."""
+    return "\n".join(
+        f"{name}: {value}" for name, value in LOCAL_CLAUDE_REQUEST_HEADERS.items()
+    )
 
 
 class LocalModeStrategy(ExecutionModeStrategy):
@@ -169,12 +216,18 @@ class LocalModeStrategy(ExecutionModeStrategy):
         env["CLAUDE_CONFIG_DIR"] = config_dir
         env["SKILLS_DIR"] = self.get_skills_directory(config_dir)
 
-        # Add ANTHROPIC_CUSTOM_HEADERS if configured via environment variable
-        if config.ANTHROPIC_CUSTOM_HEADERS:
-            env["ANTHROPIC_CUSTOM_HEADERS"] = config.ANTHROPIC_CUSTOM_HEADERS
-            logger.info(
-                f"Local mode: ANTHROPIC_CUSTOM_HEADERS={config.ANTHROPIC_CUSTOM_HEADERS}"
-            )
+        custom_headers = _merge_anthropic_custom_headers(
+            env.get("ANTHROPIC_CUSTOM_HEADERS", ""),
+            config.ANTHROPIC_CUSTOM_HEADERS,
+            _build_local_claude_request_headers(),
+        )
+        custom_headers = _ensure_wecode_user_header(
+            custom_headers,
+            task_identity_env.get("WEGENT_SKILL_USER_NAME"),
+        )
+        if custom_headers:
+            env["ANTHROPIC_CUSTOM_HEADERS"] = custom_headers
+            logger.info("Local mode: ANTHROPIC_CUSTOM_HEADERS configured")
 
         updated_options["env"] = env
 

--- a/executor/tests/agents/test_mode_strategy.py
+++ b/executor/tests/agents/test_mode_strategy.py
@@ -25,6 +25,14 @@ from executor.agents.claude_code.mode_strategy import (
 from shared.models.execution import ExecutionRequest
 
 
+def _parse_header_lines(headers: str) -> dict[str, str]:
+    return {
+        name.strip(): value.strip()
+        for line in headers.splitlines()
+        for name, value in [line.split(":", 1)]
+    }
+
+
 class TestModeStrategyFactory:
     """Tests for ModeStrategyFactory."""
 
@@ -285,17 +293,53 @@ class TestLocalModeStrategy:
         with patch("executor.config.config.ANTHROPIC_CUSTOM_HEADERS", custom_headers):
             result = strategy.configure_client_options(options, config_dir, {}, {})
 
-        assert result["env"]["ANTHROPIC_CUSTOM_HEADERS"] == custom_headers
+        headers = _parse_header_lines(result["env"]["ANTHROPIC_CUSTOM_HEADERS"])
+        assert headers["x-custom-user"] == "test"
+        assert headers["x-custom-source"] == "executor"
+        assert headers["wecode-action"] == "wegent"
+        assert headers["wecode-executor"] == "claudecode"
+        assert headers["wecode-source"] == "wegent-local"
 
-    def test_configure_client_options_no_custom_headers_when_empty(self, strategy):
-        """Test that ANTHROPIC_CUSTOM_HEADERS is not added when empty."""
+    def test_configure_client_options_merges_local_headers_with_wecode_user(
+        self, strategy
+    ):
+        """Local headers should preserve model headers and include the task user."""
+        options = {"cwd": "/workspace"}
+        config_dir = "/workspace/12345/.claude"
+        env_config = {
+            "ANTHROPIC_CUSTOM_HEADERS": "x-model-source: model\nx-shared: model"
+        }
+        task_identity_env = {"WEGENT_SKILL_USER_NAME": "alice"}
+        local_headers = "x-local-source: executor\nx-shared: local"
+
+        with patch("executor.config.config.ANTHROPIC_CUSTOM_HEADERS", local_headers):
+            result = strategy.configure_client_options(
+                options, config_dir, env_config, task_identity_env
+            )
+
+        headers = _parse_header_lines(result["env"]["ANTHROPIC_CUSTOM_HEADERS"])
+        assert headers["x-model-source"] == "model"
+        assert headers["x-local-source"] == "executor"
+        assert headers["x-shared"] == "local"
+        assert headers["wecode-action"] == "wegent"
+        assert headers["wecode-executor"] == "claudecode"
+        assert headers["wecode-source"] == "wegent-local"
+        assert headers["wecode-user"] == "alice"
+
+    def test_configure_client_options_adds_default_wecode_headers(self, strategy):
+        """Local mode should always add Wegent Claude request headers."""
         options = {"cwd": "/workspace"}
         config_dir = "/workspace/12345/.claude"
 
         with patch("executor.config.config.ANTHROPIC_CUSTOM_HEADERS", ""):
             result = strategy.configure_client_options(options, config_dir, {}, {})
 
-        assert "ANTHROPIC_CUSTOM_HEADERS" not in result["env"]
+        headers = _parse_header_lines(result["env"]["ANTHROPIC_CUSTOM_HEADERS"])
+        assert headers == {
+            "wecode-action": "wegent",
+            "wecode-executor": "claudecode",
+            "wecode-source": "wegent-local",
+        }
 
     def test_configure_client_options_refreshes_task_identity_without_mutating_input(
         self, strategy


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on how custom request headers for Claude are composed, merged, and which headers take precedence; documents automatic inclusion of execution-source and user-identification headers.

* **New Features**
  * Requests now automatically merge custom headers from multiple sources with clear precedence and inject execution-context and current-user headers.

* **Tests**
  * Expanded tests to cover header parsing, merging behavior, and automatic injection of execution and user headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->