### PR TITLE
fix(frontend): preserve advanced model selection

### DIFF
--- a/frontend/src/__tests__/components/model-select/model-cascade-content.test.tsx
+++ b/frontend/src/__tests__/components/model-select/model-cascade-content.test.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import {
   ModelCascadeContent,
   type ModelCascadeLabels,
@@ -55,6 +55,10 @@ const models: GroupableModel[] = [
 ]
 
 describe('ModelCascadeContent', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('shows primary and secondary groups before choosing a model', () => {
     render(
       <ModelCascadeContent
@@ -144,5 +148,38 @@ describe('ModelCascadeContent', () => {
     expect(results).toHaveClass('min-h-0')
     expect(results.className).toContain('h-[clamp(')
     expect(footer).toHaveClass('shrink-0')
+  })
+
+  it('scrolls the selected model into view when the active subgroup contains many models', async () => {
+    const scrollIntoView = jest.fn()
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    })
+
+    const longModelList = Array.from({ length: 32 }, (_, index) => ({
+      name: `model-${String(index).padStart(2, '0')}`,
+      displayName: `Model ${String(index).padStart(2, '0')}`,
+      provider: 'provider-one',
+      modelId: `provider-one-model-${index}`,
+      modelGroup: 'Primary One',
+      modelSubGroup: 'Secondary One',
+    }))
+    const selectedModel = longModelList[31]
+
+    render(
+      <ModelCascadeContent
+        models={longModelList}
+        selectedModel={selectedModel}
+        labels={labels}
+        searchValue=""
+        onSearchValueChange={jest.fn()}
+        onSelectModel={jest.fn()}
+      />
+    )
+
+    await waitFor(() => {
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+    })
   })
 })

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -16,6 +16,7 @@ import {
   getModelNamespaceFromConfig,
   getModelTypeFromConfig,
 } from '@/features/settings/services/bots'
+import { getGlobalModelPreference } from '@/utils/modelPreferences'
 
 const mockTranslate = (_key: string, fallback?: string) => fallback ?? _key
 
@@ -118,6 +119,22 @@ async function renderModelSelectionHook() {
   return hook
 }
 
+function mockDeferredModelsLoad(models: Model[]) {
+  let resolveModels!: (value: { data: Model[] }) => void
+  const promise = new Promise<{ data: Model[] }>(resolve => {
+    resolveModels = resolve
+  })
+  ;(modelApis.getUnifiedModels as jest.Mock).mockReturnValue(promise)
+  return {
+    async resolve() {
+      await act(async () => {
+        resolveModels({ data: models })
+        await promise
+      })
+    },
+  }
+}
+
 describe('useModelSelection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -188,5 +205,58 @@ describe('useModelSelection', () => {
     await waitFor(() => {
       expect(result.current.boundDefaultModel).toEqual(mockAdvancedModel)
     })
+  })
+
+  it('restores advanced model from team preference even when advanced models are hidden', async () => {
+    ;(getGlobalModelPreference as jest.Mock).mockReturnValue({
+      modelName: mockAdvancedModel.name,
+      modelType: mockAdvancedModel.type,
+      forceOverride: true,
+      updatedAt: Date.now(),
+    })
+    ;(modelApis.getUnifiedModels as jest.Mock).mockReset()
+    const modelLoad = mockDeferredModelsLoad([mockModel, mockAdvancedModel])
+
+    const { result } = renderHook(() =>
+      useModelSelection({
+        teamId: 1,
+        taskId: null,
+        selectedTeam: mockTeam,
+      })
+    )
+
+    await modelLoad.resolve()
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
+    })
+    expect(result.current.showAdvancedModels).toBe(false)
+    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
+  })
+
+  it('keeps advanced task model selection when advanced models are hidden', async () => {
+    ;(modelApis.getUnifiedModels as jest.Mock).mockReset()
+    const modelLoad = mockDeferredModelsLoad([mockModel, mockAdvancedModel])
+
+    const { result } = renderHook(() =>
+      useModelSelection({
+        teamId: 1,
+        taskId: 100,
+        taskModelId: mockAdvancedModel.name,
+        selectedTeam: mockTeam,
+      })
+    )
+
+    await modelLoad.resolve()
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
+    })
+
+    await act(async () => {})
+
+    expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
+    expect(result.current.showAdvancedModels).toBe(false)
+    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
   })
 })

--- a/frontend/src/components/model-select/ModelCascadeSelect.tsx
+++ b/frontend/src/components/model-select/ModelCascadeSelect.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Check, ChevronsUpDown, Search } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -124,6 +124,8 @@ export function ModelCascadeContent<T extends GroupableModel>({
   )
   const [activeGroupName, setActiveGroupName] = useState<string>('')
   const [activeSubGroupName, setActiveSubGroupName] = useState<string>('')
+  const selectedModelOptionRef = useRef<HTMLButtonElement | null>(null)
+  const selectedModelKey = selectedModel ? getModelKey(selectedModel) : null
 
   useEffect(() => {
     if (groups.length === 0) {
@@ -163,6 +165,11 @@ export function ModelCascadeContent<T extends GroupableModel>({
     return specialOptions.filter(option => getSpecialOptionSearchText(option).includes(query))
   }, [normalizedSearchValue, specialOptions])
 
+  useEffect(() => {
+    if (!selectedModelKey || isSearching) return
+    selectedModelOptionRef.current?.scrollIntoView({ block: 'nearest' })
+  }, [activeGroup?.name, activeSubGroup?.name, isSearching, selectedModelKey])
+
   const renderSpecialOption = (option: SpecialModelOption) => {
     const isSelected = selectedSpecialKey === option.key
 
@@ -193,12 +200,12 @@ export function ModelCascadeContent<T extends GroupableModel>({
 
   const renderModelOption = (model: T, showPath: boolean) => {
     const modelKey = getModelKey(model)
-    const selectedModelKey = selectedModel ? getModelKey(selectedModel) : null
     const isSelected = selectedModelKey === modelKey
     const groupPath = `${getModelGroupName(model, labels)} / ${getModelSubGroupName(model, labels)}`
 
     return (
       <button
+        ref={isSelected ? selectedModelOptionRef : undefined}
         key={modelKey}
         type="button"
         data-model-key={modelKey}

--- a/frontend/src/features/tasks/hooks/useModelSelection.ts
+++ b/frontend/src/features/tasks/hooks/useModelSelection.ts
@@ -258,23 +258,15 @@ export function useModelSelection({
     return configuredModels[0] ?? null
   }, [selectedTeam?.bots, models])
 
-  /** Check if there are any advanced models (after provider filtering) */
-  const hasAdvancedModels = useMemo(() => {
+  /**
+   * Models that are valid for the current team.
+   * This intentionally ignores showAdvancedModels: advanced visibility is a UI filter,
+   * not a compatibility rule for persisted or already-selected models.
+   */
+  const selectableModels = useMemo(() => {
     let result = models
     if (compatibleProvider) {
       result = result.filter(model => model.provider === compatibleProvider)
-    }
-    return result.some(model => model.isAdvanced === true)
-  }, [models, compatibleProvider])
-
-  /** Filter models by compatible provider, advanced flag, allowed_models whitelist, and sort by display name */
-  const filteredModels = useMemo(() => {
-    let result = models
-    if (compatibleProvider) {
-      result = result.filter(model => model.provider === compatibleProvider)
-    }
-    if (!showAdvancedModels) {
-      result = result.filter(model => !model.isAdvanced)
     }
     // Apply allowed_models whitelist filter if configured
     if (allowedModels.length > 0) {
@@ -286,7 +278,20 @@ export function useModelSelection({
       const displayB = getModelDisplayTextHelper(b).toLowerCase()
       return displayA.localeCompare(displayB)
     })
-  }, [models, compatibleProvider, showAdvancedModels, allowedModels])
+  }, [models, compatibleProvider, allowedModels])
+
+  /** Check if there are any advanced models (after provider filtering) */
+  const hasAdvancedModels = useMemo(() => {
+    return selectableModels.some(model => model.isAdvanced === true)
+  }, [selectableModels])
+
+  /** Filter models by advanced visibility for dropdown display */
+  const filteredModels = useMemo(() => {
+    if (showAdvancedModels) {
+      return selectableModels
+    }
+    return selectableModels.filter(model => !model.isAdvanced)
+  }, [selectableModels, showAdvancedModels])
 
   /** Check if model selection is required */
   const isModelRequired = !showDefaultOption && !selectedModel
@@ -303,14 +308,14 @@ export function useModelSelection({
     if (botConfig) {
       const bindModel = getModelFromConfig(botConfig)
       if (bindModel) {
-        const foundModel = filteredModels.find(
+        const foundModel = selectableModels.find(
           m => m.name === bindModel || m.displayName === bindModel
         )
         return foundModel || null
       }
     }
     return null
-  }, [selectedTeam?.bots, filteredModels])
+  }, [selectedTeam?.bots, selectableModels])
 
   // -------------------------------------------------------------------------
   // Model Fetching
@@ -345,7 +350,7 @@ export function useModelSelection({
 
   // -------------------------------------------------------------------------
   // Model Selection Logic (Simplified)
-  // Priority: 1. taskModelId (from API) -> 2. team's bind_model -> 3. global preference
+  // Priority: 1. taskModelId (from API) -> 2. global preference -> 3. team's bind_model -> 4. default
   // -------------------------------------------------------------------------
   useEffect(() => {
     const currentTeamId = selectedTeam?.id ?? null
@@ -380,12 +385,12 @@ export function useModelSelection({
       }
 
       // Priority 2: Use global preference (for new chat only, i.e. no taskId)
-      // NOTE: Must search in filteredModels to ensure model is compatible with current team's agent_type
+      // NOTE: Must search in selectableModels to ensure model is compatible with current team's agent_type
+      // while still allowing persisted advanced models even when they are hidden from the dropdown.
       if (!restoredModel && teamId && !taskId) {
         const preference = getGlobalModelPreference(teamId)
         if (preference && preference.modelName !== DEFAULT_MODEL_NAME) {
-          // Search in filteredModels (not models) to ensure compatibility with team's agent_type
-          const foundModel = filteredModels.find(m => {
+          const foundModel = selectableModels.find(m => {
             if (preference.modelType) {
               return m.name === preference.modelName && m.type === preference.modelType
             }
@@ -437,7 +442,7 @@ export function useModelSelection({
 
     // Case 2: Model list changed - check compatibility
     if (selectedModel && selectedModel.name !== DEFAULT_MODEL_NAME) {
-      const isStillCompatible = filteredModels.some(m => {
+      const isStillCompatible = selectableModels.some(m => {
         if (selectedModel.type) {
           return m.name === selectedModel.name && m.type === selectedModel.type
         }
@@ -452,7 +457,7 @@ export function useModelSelection({
     selectedTeam?.id,
     showDefaultOption,
     models,
-    filteredModels,
+    selectableModels,
     teamId,
     taskId,
     taskModelId,


### PR DESCRIPTION
## Summary
- Preserve selected advanced models when a new chat task is created and the page restores task state.
- Keep advanced models selectable internally while only hiding them from the dropdown display by default.
- Scroll the selected model row into view when opening the desktop model cascade selector.

## Test Plan
- npm test -- useModelSelection.test.tsx model-cascade-content.test.tsx --runInBand
- npm run lint -- --file src/components/model-select/ModelCascadeSelect.tsx --file src/__tests__/components/model-select/model-cascade-content.test.tsx --file src/features/tasks/hooks/useModelSelection.ts --file src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
- Pre-push quality gate: ESLint, TypeScript, and unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Improved model selection experience with automatic scrolling that brings the selected model into view when navigating between category groups.

**Bug Fixes**
- Fixed an issue where advanced model selections were lost when advanced models were hidden from the interface, ensuring model preferences are preserved consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->