### PR TITLE
fix(frontend): preserve task socket recovery

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -443,7 +443,6 @@ class ChatNamespace(socketio.AsyncNamespace):
                 )
         except Exception as e:
             logger.exception(f"[WS] task:join error fetching subtasks: {e}")
-            # Continue without subtasks - frontend can fall back to API call
 
         # Check for active streaming
         logger.info(

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -157,6 +157,36 @@ describe('TaskStateMachine', () => {
     consoleInfoSpy.mockRestore()
   })
 
+  it('keeps pending socket recovery when terminal task detail arrives before socket connect', async () => {
+    const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
+    let connected = false
+
+    const machine = new TaskStateMachine(100, {
+      joinTask,
+      isConnected: () => connected,
+    })
+
+    await machine.recover({ force: true, reason: 'task-selected' })
+    expect(machine.getState().phase).toBe('waiting_socket')
+
+    machine.loadTask({
+      id: 100,
+      status: 'COMPLETED',
+      updated_at: '2026-06-01T10:00:00.000Z',
+    })
+
+    expect(machine.getState().phase).toBe('waiting_socket')
+    expect(joinTask).not.toHaveBeenCalled()
+
+    connected = true
+    await machine.handleSocketConnected('websocket-reconnect')
+
+    expect(joinTask).toHaveBeenCalledWith(100, {
+      forceRefresh: true,
+      afterMessageId: undefined,
+    })
+  })
+
   it('refreshes timestamp when the same AI message receives a new chat:error event', () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000)
 

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -886,9 +886,15 @@ export class TaskStateMachine {
       this.pendingChunks = []
     }
 
+    const shouldPreserveMessageRecoveryPhase =
+      isTerminal &&
+      (this.state.status === 'waiting_socket' ||
+        this.state.status === 'joining' ||
+        this.state.status === 'syncing')
+
     this.state = {
       ...this.state,
-      status: isTerminal ? 'ready' : this.state.status,
+      status: isTerminal && !shouldPreserveMessageRecoveryPhase ? 'ready' : this.state.status,
       isStopping: isTerminal ? false : this.state.isStopping,
       messages,
       runtime,


### PR DESCRIPTION
## Summary
- Preserve pending `waiting_socket` / join / sync recovery when terminal task detail arrives before the socket connects.
- Add a regression test for the blank task page state where message sync never re-ran after socket reconnect.
- Remove the stale backend comment that suggested an HTTP fallback for task messages.

## Test Plan
- `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/state/TaskStateMachine.test.ts --runInBand`
- `cd backend && uv run python -m py_compile app/api/ws/chat_namespace.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task state machine now correctly preserves recovery-oriented states during socket reconnection when a terminal task status is loaded, preventing premature state transitions.

* **Tests**
  * Added test case verifying socket recovery behavior and proper task state machine transitions during socket reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->