### PR TITLE
fix(backend): handle chat SSE streams without terminal events

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -1361,6 +1361,25 @@ class ChatNamespace(socketio.AsyncNamespace):
                 f"[WS] chat:retry found user_subtask: id={user_subtask.id}, prompt={user_subtask.prompt[:50] if user_subtask.prompt else ''}..."
             )
 
+            retryable_statuses = {
+                SubtaskStatus.FAILED.value,
+                SubtaskStatus.CANCELLED.value,
+            }
+            current_status = (
+                failed_ai_subtask.status.value
+                if hasattr(failed_ai_subtask.status, "value")
+                else str(failed_ai_subtask.status)
+            )
+            if current_status not in retryable_statuses:
+                logger.warning(
+                    "[WS] chat:retry rejected non-terminal failed subtask: "
+                    "task_id=%s, subtask_id=%s, status=%s",
+                    payload.task_id,
+                    failed_ai_subtask.id,
+                    current_status,
+                )
+                return {"error": f"Cannot retry subtask in {current_status} state"}
+
             # Reset the failed AI subtask to PENDING status using service module
             # Also pass task to reset Task status (required for executor_manager to pick up the task)
             reset_subtask_for_retry(db, failed_ai_subtask, task)

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -1295,6 +1295,10 @@ class ExecutionDispatcher:
                     )
 
                 if not cancelled and not terminal_event_type:
+                    error_message = (
+                        "Chat Shell SSE stream ended without terminal event "
+                        f"after {event_count} events"
+                    )
                     logger.warning(
                         "[ExecutionDispatcher] SSE stream ended without terminal event: "
                         "task_id=%d, subtask_id=%d, request_id=%s, total_events=%d",
@@ -1311,6 +1315,16 @@ class ExecutionDispatcher:
                             "task_id": str(request.task_id),
                             "subtask_id": str(request.subtask_id),
                         },
+                    )
+                    await emitter.emit(
+                        ExecutionEvent(
+                            type=EventType.ERROR,
+                            task_id=request.task_id,
+                            subtask_id=request.subtask_id,
+                            message_id=request.message_id,
+                            error=error_message,
+                            error_code="sse_stream_no_terminal",
+                        )
                     )
 
                 # Log when stream iteration completes

--- a/backend/tests/api/ws/test_chat_namespace_retry.py
+++ b/backend/tests/api/ws/test_chat_namespace_retry.py
@@ -154,3 +154,54 @@ async def test_chat_retry_new_model_without_type_clears_stale_override_model_typ
         mock_trigger.await_args.kwargs["payload"].force_override_bot_model
         == "new-model"
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_retry_rejects_running_subtask_without_dispatching():
+    """Retry should not re-dispatch a subtask that is still marked RUNNING."""
+
+    namespace = ChatNamespace()
+    namespace.get_session = AsyncMock(return_value={"user_id": 1})
+    namespace._check_token_expiry = AsyncMock(return_value=False)
+
+    task = SimpleNamespace(id=100, json={"metadata": {"labels": {}}})
+    running_ai_subtask = SimpleNamespace(
+        id=42,
+        team_id=10,
+        message_id=7,
+        parent_id=41,
+        status=SimpleNamespace(value="RUNNING"),
+    )
+    team = SimpleNamespace(id=10)
+    user_subtask = SimpleNamespace(id=41, prompt="Hello", contexts=[])
+
+    db = Mock()
+
+    with (
+        patch("app.api.ws.chat_namespace.SessionLocal", return_value=db),
+        patch(
+            "app.api.ws.chat_namespace.can_access_task", AsyncMock(return_value=True)
+        ),
+        patch(
+            "app.api.ws.chat_namespace.fetch_retry_context",
+            return_value=(running_ai_subtask, task, team, user_subtask),
+        ),
+        patch("app.api.ws.chat_namespace.reset_subtask_for_retry") as mock_reset,
+        patch(
+            "app.services.chat.trigger.trigger_ai_response_unified", AsyncMock()
+        ) as mock_trigger,
+    ):
+        result = await namespace.on_chat_retry(
+            "sid-123",
+            {
+                "task_id": 100,
+                "subtask_id": 42,
+                "force_override_bot_model": None,
+                "force_override_bot_model_type": None,
+                "use_model_override": False,
+            },
+        )
+
+    assert result == {"error": "Cannot retry subtask in RUNNING state"}
+    mock_reset.assert_not_called()
+    mock_trigger.assert_not_awaited()

--- a/backend/tests/services/execution/test_dispatcher_sse_request_id.py
+++ b/backend/tests/services/execution/test_dispatcher_sse_request_id.py
@@ -12,6 +12,7 @@ import pytest
 
 from app.services.execution.dispatcher import ExecutionDispatcher
 from app.services.execution.router import CommunicationMode, ExecutionTarget
+from shared.models import EventType
 
 
 class _FakeEvent:
@@ -44,7 +45,10 @@ class _FakeStream:
         return self._events.pop(0)
 
 
-def _build_fake_openai_module(calls: dict):
+def _build_fake_openai_module(calls: dict, events=None):
+    if events is None:
+        events = [_FakeEvent("response.completed")]
+
     class _FakeResponses:
         async def create(
             self,
@@ -61,7 +65,7 @@ def _build_fake_openai_module(calls: dict):
             calls["tools"] = tools
             calls["stream"] = stream
             calls["extra_body"] = extra_body
-            return _FakeStream([_FakeEvent("response.completed")])
+            return _FakeStream(events)
 
     class _FakeAsyncOpenAI:
         def __init__(self, **kwargs):
@@ -185,3 +189,45 @@ async def test_dispatch_sse_generates_request_id_when_missing():
         await dispatcher._dispatch_sse(request, target, emitter)
 
     assert calls["extra_body"]["metadata"]["request_id"] == "req_77"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sse_emits_error_when_stream_ends_without_terminal_event():
+    dispatcher = ExecutionDispatcher()
+    request = _make_request(subtask_id=88, request_id="backend-request-id")
+    target = ExecutionTarget(
+        mode=CommunicationMode.SSE,
+        url="http://chat-shell",
+        namespace=None,
+        event="task:execute",
+        room=None,
+    )
+    emitter = AsyncMock()
+    calls = {}
+    session_manager = AsyncMock()
+    session_manager.register_stream.return_value = asyncio.Event()
+    session_manager.is_cancelled.return_value = False
+
+    with (
+        patch.dict("sys.modules", {"openai": _build_fake_openai_module(calls, [])}),
+        patch(
+            "app.services.execution.dispatcher.OpenAIRequestConverter.from_execution_request",
+            return_value={
+                "model": "test-model",
+                "input": "hello",
+                "metadata": {},
+                "model_config": {},
+            },
+        ),
+        patch("app.services.chat.storage.session.session_manager", session_manager),
+    ):
+        await dispatcher._dispatch_sse(request, target, emitter)
+
+    emitted_events = [call.args[0] for call in emitter.emit.call_args_list]
+    assert len(emitted_events) == 1
+    error_event = emitted_events[0]
+    assert error_event.type == EventType.ERROR.value
+    assert error_event.task_id == request.task_id
+    assert error_event.subtask_id == request.subtask_id
+    assert error_event.message_id == request.message_id
+    assert "ended without terminal event" in error_event.error


### PR DESCRIPTION
## Summary
- Emit a terminal error when a Chat Shell SSE stream ends without a completed/error/incomplete event.
- Reject chat:retry for non-retryable subtask states so stale RUNNING subtasks cannot be re-dispatched.
- Add regression coverage for no-terminal SSE streams and RUNNING retry rejection.

## Test Plan
- uv run pytest tests/services/execution/test_dispatcher_sse_request_id.py tests/api/ws/test_chat_namespace_retry.py
- uv run black --check app/services/execution/dispatcher.py app/api/ws/chat_namespace.py tests/services/execution/test_dispatcher_sse_request_id.py tests/api/ws/test_chat_namespace_retry.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent retrying subtasks in invalid states; requests return an error when subtask state is not retryable.
  * Improved error handling for interrupted streams; errors now emit proper notifications instead of being silently logged.

* **Tests**
  * Added test coverage for retry state validation and stream error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->