### PR TITLE
fix(frontend): refine local skill display

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -43,9 +43,21 @@ import re
 from pathlib import Path
 
 FRONTMATTER_PATTERN = re.compile(r"^---\\n(.*?)\\n---", re.S)
-ROOTS = (
-    (Path.home() / ".claude" / "skills", "claude"),
-    (Path.home() / ".codex" / "skills", "codex"),
+SKILL_SOURCES = (
+    (Path.home() / ".claude" / "skills", "claude", "**/SKILL.md", "skill"),
+    (Path.home() / ".codex" / "skills", "codex", "**/SKILL.md", "skill"),
+    (
+        Path.home() / ".claude" / "plugins" / "cache",
+        "claude-plugin",
+        "**/skills/**/SKILL.md",
+        "plugin",
+    ),
+    (
+        Path.home() / ".codex" / "plugins" / "cache",
+        "codex-plugin",
+        "**/skills/**/SKILL.md",
+        "plugin",
+    ),
 )
 
 
@@ -53,6 +65,13 @@ def read_frontmatter(path):
     text = path.read_text(encoding="utf-8", errors="replace")
     match = FRONTMATTER_PATTERN.match(text)
     return match.group(1) if match else ""
+
+
+def read_json_file(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
 
 
 def line_indent(line):
@@ -117,32 +136,64 @@ def nested_metadata_field(frontmatter, field_name):
     return None
 
 
-def skill_metadata(skill_file, source):
+def plugin_info(skill_file):
+    parts = skill_file.parts
+    try:
+        cache_index = parts.index("cache")
+        skills_index = parts.index("skills", cache_index + 1)
+    except ValueError:
+        return None, None
+    if skills_index <= cache_index + 2:
+        return None, None
+    marketplace = parts[cache_index + 1]
+    plugin_name = parts[cache_index + 2]
+    return plugin_name, f"{plugin_name}@{marketplace}"
+
+
+def is_managed(record):
+    return isinstance(record, dict) and record.get("managed", True) is not False
+
+
+def skill_origin(name, plugin_key, manifest):
+    if plugin_key:
+        return "wegent" if is_managed(manifest.get("plugins", {}).get(plugin_key)) else "local"
+    return "wegent" if is_managed(manifest.get("skills", {}).get(name)) else "local"
+
+
+def skill_metadata(skill_file, source, source_kind, manifest):
     stat = skill_file.stat()
     frontmatter = read_frontmatter(skill_file)
     name = frontmatter_field(frontmatter, "name") or skill_file.parent.name
-    return {
+    plugin_name, plugin_key = (
+        plugin_info(skill_file) if source_kind == "plugin" else (None, None)
+    )
+    metadata = {
         "name": name,
         "description": frontmatter_field(frontmatter, "description") or "",
         "short_description": nested_metadata_field(frontmatter, "short-description")
         or frontmatter_field(frontmatter, "short-description"),
         "path": str(skill_file),
         "source": source,
+        "origin": skill_origin(name, plugin_key, manifest),
         "mtime": stat.st_mtime,
     }
+    if plugin_name:
+        metadata["plugin_name"] = plugin_name
+    return metadata
 
 
+manifest = read_json_file(Path.home() / ".wegent-executor" / "capabilities.json")
 skills = []
 seen_paths = set()
-for root, source in ROOTS:
+for root, source, pattern, source_kind in SKILL_SOURCES:
     if not root.is_dir():
         continue
-    for skill_file in sorted(root.glob("**/SKILL.md")):
+    for skill_file in sorted(root.glob(pattern)):
         key = str(skill_file)
         if key in seen_paths:
             continue
         try:
-            skills.append(skill_metadata(skill_file, source))
+            skills.append(skill_metadata(skill_file, source, source_kind, manifest))
             seen_paths.add(key)
         except OSError:
             continue

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -101,6 +101,7 @@ def test_local_device_command_registry_default_includes_diagnostic_commands():
     assert "python3 -c" in ls_skills_definition.command
     assert ".claude" in ls_skills_definition.command
     assert ".codex" in ls_skills_definition.command
+    assert "plugins" in ls_skills_definition.command
     assert ls_skills_definition.post_processor == "json"
 
 
@@ -272,10 +273,125 @@ metadata:
             "short_description": "Screen history context.",
             "path": str(skill_dir / "SKILL.md"),
             "source": "codex",
+            "origin": "local",
             "mtime": skills[0]["mtime"],
         }
     ]
     assert "|" not in skills[0]["description"]
+
+
+def test_ls_skills_command_includes_plugin_skills(tmp_path):
+    """ls_skills should include skills bundled by installed Claude and Codex plugins."""
+    from app.services.device.command_registry import LS_SKILLS_SCRIPT
+
+    claude_skill_dir = (
+        tmp_path
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "claude-plugins-official"
+        / "superpowers"
+        / "5.0.7"
+        / "skills"
+        / "test-driven-development"
+    )
+    codex_skill_dir = (
+        tmp_path
+        / ".codex"
+        / "plugins"
+        / "cache"
+        / "openai-curated"
+        / "github"
+        / "83d1f0d2"
+        / "skills"
+        / "github"
+    )
+    claude_skill_dir.mkdir(parents=True)
+    codex_skill_dir.mkdir(parents=True)
+    manifest_path = tmp_path / ".wegent-executor" / "capabilities.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "revision": 1,
+                "skills": {},
+                "plugins": {
+                    "superpowers@claude-plugins-official": {
+                        "installed_plugin_id": 9,
+                        "managed": True,
+                    }
+                },
+                "mcps": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (claude_skill_dir / "SKILL.md").write_text(
+        """---
+name: test-driven-development
+description: Use when implementing features.
+---
+
+# TDD
+""",
+        encoding="utf-8",
+    )
+    (codex_skill_dir / "SKILL.md").write_text(
+        """---
+name: github
+description: Inspect repositories and pull requests.
+metadata:
+  short-description: GitHub workflow support.
+---
+
+# GitHub
+""",
+        encoding="utf-8",
+    )
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+    result = subprocess.run(
+        ["python3", "-c", LS_SKILLS_SCRIPT],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    skills = json.loads(result.stdout)
+
+    assert {
+        (
+            skill["name"],
+            skill["source"],
+            skill["origin"],
+            skill["plugin_name"],
+            skill["path"],
+        )
+        for skill in skills
+    } == {
+        (
+            "test-driven-development",
+            "claude-plugin",
+            "wegent",
+            "superpowers",
+            str(claude_skill_dir / "SKILL.md"),
+        ),
+        (
+            "github",
+            "codex-plugin",
+            "local",
+            "github",
+            str(codex_skill_dir / "SKILL.md"),
+        ),
+    }
+    assert (
+        next(skill for skill in skills if skill["name"] == "github")[
+            "short_description"
+        ]
+        == "GitHub workflow support."
+    )
 
 
 @pytest.mark.asyncio

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StrictMode, useState } from 'react'
 import { describe, expect, test, vi } from 'vitest'
@@ -319,6 +319,108 @@ describe('ChatInput', () => {
     })
   })
 
+  test('shows plugin skill names with plugin prefix and origin labels', async () => {
+    const wegentPluginSkill: LocalDeviceSkill = {
+      name: 'brainstorming',
+      description: 'Use before creative work',
+      short_description: 'Use before creative work',
+      path: '/Users/crystal/.claude/plugins/cache/claude-plugins-official/superpowers/5.0.7/skills/brainstorming/SKILL.md',
+      source: 'claude-plugin',
+      origin: 'wegent',
+      plugin_name: 'superpowers',
+    }
+    const localPluginSkill: LocalDeviceSkill = {
+      name: 'github',
+      description: 'Inspect repositories and pull requests',
+      short_description: 'GitHub workflow support',
+      path: '/Users/crystal/.codex/plugins/cache/openai-curated/github/83d1f0d2/skills/github/SKILL.md',
+      source: 'codex-plugin',
+      origin: 'local',
+      plugin_name: 'github',
+    }
+    const listLocalSkills = vi
+      .fn()
+      .mockResolvedValue([wegentPluginSkill, localPluginSkill])
+
+    render(
+      <ControlledChatInput
+        projectChat={projectChatControls({ listLocalSkills })}
+      />,
+    )
+
+    await userEvent.type(screen.getByTestId('chat-message-input'), '$')
+
+    const wegentOption = await screen.findByTestId('local-skill-option-brainstorming')
+    const localOption = screen.getByTestId('local-skill-option-github')
+
+    expect(screen.getByText('Superpowers: Brainstorming')).toBeInTheDocument()
+    expect(screen.getByText('Github: Github')).toBeInTheDocument()
+    expect(wegentOption).toHaveClass('min-h-8', 'py-1.5')
+    expect(wegentOption.querySelector('.lucide-package')).toBeInTheDocument()
+    expect(wegentOption).toHaveTextContent(
+      'workbench.local_skill_origin_wegent',
+    )
+    expect(localOption).toHaveTextContent(
+      'workbench.local_skill_origin_local',
+    )
+
+    await userEvent.click(wegentOption)
+
+    const selectedChip = screen.getByTestId('local-skill-chip-brainstorming')
+    expect(selectedChip).toHaveTextContent('Superpowers: Brainstorming')
+    expect(selectedChip).toHaveClass('text-blue-600')
+    expect(selectedChip).not.toHaveClass('bg-[#FFF8EA]', 'border-[#E6D5AF]')
+    expect(selectedChip.querySelector('.lucide-package')).toBeInTheDocument()
+  })
+
+  test('sorts local skill suggestions by display name', async () => {
+    const listLocalSkills = vi.fn().mockResolvedValue([
+      {
+        name: 'zeta-helper',
+        description: 'Last plugin skill',
+        short_description: 'Last plugin skill',
+        path: '/Users/crystal/.codex/plugins/cache/openai-curated/zeta/83d1f0d2/skills/zeta-helper/SKILL.md',
+        source: 'codex-plugin',
+        origin: 'local',
+        plugin_name: 'zeta',
+      },
+      {
+        name: 'alpha-helper',
+        description: 'First local skill',
+        short_description: 'First local skill',
+        path: '/Users/crystal/.codex/skills/alpha-helper/SKILL.md',
+        source: 'codex',
+        origin: 'local',
+      },
+      {
+        name: 'beta-helper',
+        description: 'Middle plugin skill',
+        short_description: 'Middle plugin skill',
+        path: '/Users/crystal/.claude/plugins/cache/claude-plugins-official/beta/5.0.7/skills/beta-helper/SKILL.md',
+        source: 'claude-plugin',
+        origin: 'wegent',
+        plugin_name: 'beta',
+      },
+    ])
+
+    render(
+      <ControlledChatInput
+        projectChat={projectChatControls({ listLocalSkills })}
+      />,
+    )
+
+    await userEvent.type(screen.getByTestId('chat-message-input'), '$')
+
+    const listbox = await screen.findByTestId('local-skill-autocomplete')
+    const options = within(listbox).getAllByRole('option')
+
+    expect(options.map(option => option.dataset.testid)).toEqual([
+      'local-skill-option-alpha-helper',
+      'local-skill-option-beta-helper',
+      'local-skill-option-zeta-helper',
+    ])
+  })
+
   test('keeps the composer editable after selecting a local skill', async () => {
     const skill: LocalDeviceSkill = {
       name: 'env-context',
@@ -349,7 +451,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('local-skill-chip-env-context')).toHaveTextContent('Env Context')
   })
 
-  test('deletes a selected local skill mention as one unit', async () => {
+  test('does not delete a selected local skill mention as one unit', async () => {
     const skill: LocalDeviceSkill = {
       name: 'env-context',
       description: 'Use when environment facts are needed',
@@ -372,8 +474,42 @@ describe('ChatInput', () => {
     })
     await userEvent.keyboard('{Backspace}')
 
-    expect(screen.getByTestId('chat-message-input')).toHaveValue('')
-    expect(screen.queryByTestId('local-skill-chip-env-context')).not.toBeInTheDocument()
+    expect(screen.getByTestId('chat-message-input')).toHaveValue(
+      '[$env-context](skill:///Users/crystal/.codex/skills/env-context/SKILL.md)',
+    )
+    expect(screen.getByTestId('local-skill-chip-env-context')).toBeInTheDocument()
+  })
+
+  test('converts a selected local skill mention to visible text before deleting inside it', async () => {
+    const skill: LocalDeviceSkill = {
+      name: 'brainstorming',
+      description: 'Use before creative work',
+      short_description: 'Use before creative work',
+      path: '/home/ubuntu/.claude/plugins/cache/superpowers-marketplace/superpowers/5.1.0/skills/brainstorming/SKILL.md',
+      source: 'claude-plugin',
+      origin: 'local',
+      plugin_name: 'superpowers',
+    }
+    const listLocalSkills = vi.fn().mockResolvedValue([skill])
+
+    render(
+      <ControlledChatInput
+        projectChat={projectChatControls({ listLocalSkills })}
+      />,
+    )
+
+    const input = screen.getByTestId('chat-message-input')
+    await userEvent.type(input, '$')
+    await userEvent.click(await screen.findByTestId('local-skill-option-brainstorming'))
+    await waitFor(() => {
+      expect(input).toHaveFocus()
+    })
+
+    await userEvent.keyboard('{Backspace}{Backspace}')
+
+    expect(input).toHaveValue('Superpowers: Brainstormin')
+    expect(screen.queryByText(/\[\$brainstorming]/)).not.toBeInTheDocument()
+    expect(screen.queryByTestId('local-skill-chip-brainstorming')).not.toBeInTheDocument()
   })
 
   test('sizes desktop local skill autocomplete to the composer width', async () => {
@@ -1544,7 +1680,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('project-work-menu')).not.toHaveTextContent('进入项目工作')
   })
 
-  test('renders online project devices with neutral secondary text', async () => {
+  test('renders online project and standalone devices with neutral secondary text', async () => {
     const projects: ProjectWithTasks[] = [
       {
         id: 7,
@@ -1593,8 +1729,13 @@ describe('ChatInput', () => {
 
     const projectDeviceLabel = screen.getAllByText('online-executor')[0]
     const offlineProjectDeviceLabel = screen.getAllByText('offline-executor')[0]
+    const standaloneDeviceStatus = screen
+      .getByTestId('standalone-device-option-device-online')
+      .querySelector('span:last-of-type')
     expect(projectDeviceLabel).toHaveClass('text-text-secondary')
     expect(projectDeviceLabel).not.toHaveClass('text-primary')
+    expect(standaloneDeviceStatus).toHaveClass('text-text-secondary')
+    expect(standaloneDeviceStatus).not.toHaveClass('text-primary')
     expect(offlineProjectDeviceLabel).toHaveClass('text-text-muted')
   })
 

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -68,7 +68,35 @@ function displaySkillNameFromName(name: string): string {
 }
 
 function displaySkillName(skill: LocalDeviceSkill): string {
+  if (skill.plugin_name && skill.source.includes('plugin')) {
+    return `${displaySkillNameFromName(skill.plugin_name)}: ${displaySkillNameFromName(skill.name)}`
+  }
   return displaySkillNameFromName(skill.name)
+}
+
+function isPluginSkill(skill: LocalDeviceSkill): boolean {
+  return Boolean(skill.plugin_name && skill.source.includes('plugin'))
+}
+
+function compareSkillDisplayName(
+  left: LocalDeviceSkill,
+  right: LocalDeviceSkill,
+): number {
+  const leftName = displaySkillName(left).toLowerCase()
+  const rightName = displaySkillName(right).toLowerCase()
+  const nameResult = leftName.localeCompare(rightName)
+  if (nameResult !== 0) return nameResult
+
+  return left.path.localeCompare(right.path)
+}
+
+function displaySkillOrigin(
+  skill: LocalDeviceSkill,
+  t: (key: string) => string,
+): string {
+  return skill.origin === 'wegent'
+    ? t('workbench.local_skill_origin_wegent')
+    : t('workbench.local_skill_origin_local')
 }
 
 function localSkillTestId(name: string): string {
@@ -95,19 +123,11 @@ function parseSkillMentions(value: string): SkillMention[] {
   })
 }
 
-function findSkillMentionBeforeCursor(
-  value: string,
+function findSkillMentionEndingAtCursor(
   cursor: number,
   mentions: SkillMention[],
-): { start: number; end: number } | null {
-  const mention = mentions.find(item => {
-    if (item.end === cursor) return true
-    return cursor > item.end && value.slice(item.end, cursor) === ' '
-  })
-
-  if (mention) return { start: mention.start, end: cursor }
-
-  return null
+): SkillMention | null {
+  return mentions.find(mention => mention.end === cursor) ?? null
 }
 
 function renderCaret(key: string) {
@@ -161,7 +181,7 @@ function renderTextWithSkillMentions(
       <span
         key={mention.id}
         data-testid={`local-skill-chip-${localSkillTestId(mention.name)}`}
-        className="inline-flex h-6 max-w-full items-center gap-1.5 rounded-md border border-[#E6D5AF] bg-[#FFF8EA] px-2 align-middle text-xs font-medium text-[#6F4D13]"
+        className="inline-flex max-w-full items-center gap-1 align-baseline text-sm font-medium leading-5 text-blue-600"
       >
         <Package className="h-3.5 w-3.5 shrink-0" />
         <span className="truncate">{mention.label}</span>
@@ -229,16 +249,18 @@ export function ComposerTextarea({
 
   const filteredSkills = useMemo(() => {
     const query = trigger?.query.trim().toLowerCase() ?? ''
-    if (!query) return skills
+    const matchingSkills = query
+      ? skills.filter(skill => {
+          const description = skill.short_description || skill.description || ''
+          return (
+            skill.name.toLowerCase().includes(query) ||
+            displaySkillName(skill).toLowerCase().includes(query) ||
+            description.toLowerCase().includes(query)
+          )
+        })
+      : skills
 
-    return skills.filter(skill => {
-      const description = skill.short_description || skill.description || ''
-      return (
-        skill.name.toLowerCase().includes(query) ||
-        displaySkillName(skill).toLowerCase().includes(query) ||
-        description.toLowerCase().includes(query)
-      )
-    })
+    return [...matchingSkills].sort(compareSkillDisplayName)
   }, [skills, trigger?.query])
 
   const showSkillMenu = trigger !== null && Boolean(onListLocalSkills)
@@ -300,7 +322,7 @@ export function ComposerTextarea({
             return null
           })
           .filter((mention): mention is SkillMention =>
-            Boolean(mention && nextValue.slice(mention.start, mention.end) === mention.label),
+            Boolean(mention && nextValue.slice(mention.start, mention.end) === mention.reference),
           ),
       )
       onChange(nextValue)
@@ -436,19 +458,19 @@ export function ComposerTextarea({
       event.key === 'Backspace' &&
       event.currentTarget.selectionStart === event.currentTarget.selectionEnd
     ) {
-      const mention = findSkillMentionBeforeCursor(
-        value,
-        event.currentTarget.selectionStart,
-        validSkillMentions,
-      )
+      const cursor = event.currentTarget.selectionStart
+      const mention = findSkillMentionEndingAtCursor(cursor, validSkillMentions)
       if (mention) {
         event.preventDefault()
-        const nextValue = value.slice(0, mention.start) + value.slice(mention.end)
+        const replacement = mention.label.slice(0, -1)
+        const nextValue =
+          value.slice(0, mention.start) + replacement + value.slice(mention.end)
+        const nextCursor = mention.start + replacement.length
         handleValueChange(nextValue)
         window.requestAnimationFrame(() => {
           const textarea = textareaRef.current
-          textarea?.setSelectionRange(mention.start, mention.start)
-          setSelection({ start: mention.start, end: mention.start, focused: true })
+          textarea?.setSelectionRange(nextCursor, nextCursor)
+          setSelection({ start: nextCursor, end: nextCursor, focused: true })
         })
         return
       }
@@ -586,35 +608,41 @@ export function ComposerTextarea({
               {t('workbench.no_local_skills')}
             </div>
           ) : (
-            filteredSkills.map((skill, index) => (
-              <button
-                key={`${skill.source}:${skill.path}`}
-                type="button"
-                data-testid={`local-skill-option-${skill.name}`}
-                aria-selected={index === selectedIndex}
-                role="option"
-                onMouseEnter={() => setSelectedIndex(index)}
-                onPointerEnter={() => setSelectedIndex(index)}
-                onClick={() => selectSkill(skill)}
-                className={[
-                  'flex min-h-11 w-full items-center gap-3 rounded-xl px-3 py-2 text-left',
-                  index === selectedIndex ? 'bg-muted' : '',
-                ].join(' ')}
-              >
-                <Sparkles className="h-4 w-4 shrink-0 text-primary" />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-sm font-medium text-text-primary">
-                    {displaySkillName(skill)}
-                  </span>
-                  {(skill.short_description || skill.description) && (
-                    <span className="line-clamp-1 text-xs text-text-muted">
-                      {skill.short_description || skill.description}
+            filteredSkills.map((skill, index) => {
+              const SkillIcon = isPluginSkill(skill) ? Package : Sparkles
+
+              return (
+                <button
+                  key={`${skill.source}:${skill.path}`}
+                  type="button"
+                  data-testid={`local-skill-option-${skill.name}`}
+                  aria-selected={index === selectedIndex}
+                  role="option"
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  onPointerEnter={() => setSelectedIndex(index)}
+                  onClick={() => selectSkill(skill)}
+                  className={[
+                    'flex min-h-8 w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left',
+                    index === selectedIndex ? 'bg-muted' : '',
+                  ].join(' ')}
+                >
+                  <SkillIcon className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
+                  <span className="flex min-w-0 flex-1 items-baseline gap-2">
+                    <span className="max-w-[48%] shrink-0 truncate text-[13px] font-medium leading-[18px] text-text-primary">
+                      {displaySkillName(skill)}
                     </span>
-                  )}
-                </span>
-                <span className="shrink-0 text-xs text-text-muted">{skill.source}</span>
-              </button>
-            ))
+                    {(skill.short_description || skill.description) && (
+                      <span className="min-w-0 flex-1 truncate text-[13px] leading-[18px] text-text-muted">
+                        {skill.short_description || skill.description}
+                      </span>
+                    )}
+                  </span>
+                  <span className="shrink-0 text-xs text-text-muted">
+                    {displaySkillOrigin(skill, t)}
+                  </span>
+                </button>
+              )
+            })
           )}
         </div>
       )}

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -208,7 +208,7 @@ export function ProjectWorkBar({
                       <span className="min-w-0 flex-1 truncate">
                         {device.name || device.device_id}
                       </span>
-                      <span className={online ? 'text-primary' : 'text-text-muted'}>
+                      <span className={online ? 'text-text-secondary' : 'text-text-muted'}>
                         {getDeviceStatusLabel(device)}
                       </span>
                       {selected && online && (

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -308,6 +308,8 @@
     "local_skills_error": "Unable to load local skills",
     "retry_local_skills": "Retry",
     "no_local_skills": "No matching skills",
+    "local_skill_origin_local": "Local",
+    "local_skill_origin_wegent": "Wegent",
     "login_title": "Log in to Wework",
     "login_subtitle": "Continue with your Wegent account",
     "login_username": "Username",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -308,6 +308,8 @@
     "local_skills_error": "无法加载本地技能",
     "retry_local_skills": "重试",
     "no_local_skills": "暂无匹配技能",
+    "local_skill_origin_local": "本地",
+    "local_skill_origin_wegent": "Wegent",
     "login_title": "登录 Wework",
     "login_subtitle": "使用 Wegent 账号继续",
     "login_username": "用户名",

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -176,6 +176,8 @@ export interface LocalDeviceSkill {
   short_description?: string | null
   path: string
   source: 'claude' | 'codex' | string
+  origin?: 'local' | 'wegent' | string
+  plugin_name?: string | null
   mtime?: number
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended skill discovery to scan additional plugin directories; skills now display origin labels (Local or Wegent) for clearer identification.
  * Plugin-origin skills in autocomplete now show plugin name and source information.

* **Improvements**
  * Skill autocomplete suggestions are now sorted alphabetically by display name for better usability.
  * Refined device status indicator styling for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->