### PR TITLE
fix(wework): preserve opened chat navigation state

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -499,7 +499,6 @@ export function DesktopSidebar({
   onCollapse,
   onNewChat,
   onStartStandaloneChat,
-  onSelectProject,
   onStartNewProjectChat,
   onOpenTask,
   onSearchTasks,
@@ -555,7 +554,6 @@ export function DesktopSidebar({
   }, [currentProjectWithTask, currentTaskId])
 
   const handleToggleProject = (projectId: number) => {
-    const shouldExpand = !expandedProjectIds.has(projectId)
     setExpandedProjectIds(previous => {
       const next = new Set(previous)
       if (next.has(projectId)) {
@@ -565,9 +563,6 @@ export function DesktopSidebar({
       }
       return next
     })
-    if (shouldExpand) {
-      onSelectProject(projectId)
-    }
   }
 
   const handleToggleProjectTaskLimit = (projectId: number) => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1156,7 +1156,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('settings-button')).toHaveClass('shrink-0')
   })
 
-  test('toggles an empty project chat list without persistent project highlight', async () => {
+  test('toggles an empty project chat list without selecting the project chat context', async () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
     expect(screen.queryByText('暂无会话')).not.toBeInTheDocument()
@@ -1164,14 +1164,14 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
-    expect(baseProps.onSelectProject).toHaveBeenCalledWith(1)
+    expect(baseProps.onSelectProject).not.toHaveBeenCalled()
     expect(screen.getByText('暂无会话')).toBeInTheDocument()
     expect(screen.getByTestId('project-row-1')).not.toHaveClass('bg-white')
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
     expect(screen.queryByText('暂无会话')).not.toBeInTheDocument()
-    expect(baseProps.onSelectProject).toHaveBeenCalledTimes(1)
+    expect(baseProps.onSelectProject).not.toHaveBeenCalled()
   })
 
   test('limits project chats to five and toggles show more and show less', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -217,6 +217,7 @@ function ProjectCreationProbe() {
 
 describe('WorkbenchProvider', () => {
   beforeEach(() => {
+    window.history.pushState({}, '', '/')
     localStorage.clear()
     vi.clearAllMocks()
   })
@@ -723,6 +724,117 @@ describe('WorkbenchProvider', () => {
     )
     expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('local-online')
     expect(joinTask).toHaveBeenCalledWith(8)
+    expect(window.location.search).toBe('?taskId=8')
+  })
+
+  test('restores an opened task from the taskId URL parameter after refresh', async () => {
+    window.history.pushState({}, '', '/?taskId=8')
+    const getTaskDetail = vi.fn().mockResolvedValue({
+      id: 8,
+      title: 'restored chat',
+      status: 'SUCCESS',
+      task_type: 'code',
+      project_id: 0,
+      device_id: 'local-online',
+      created_at: '2026-05-29T00:00:00.000Z',
+      subtasks: [],
+    })
+    const joinTask = vi.fn()
+
+    render(
+      <WorkbenchProvider
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={{
+          teamApi: {
+            getDefaultWorkbenchTeam: vi
+              .fn()
+              .mockResolvedValue({ id: 2, name: 'coder', is_active: true }),
+          },
+          modelApi: {
+            listModels: vi.fn().mockResolvedValue({
+              data: [
+                {
+                  name: 'gpt-5.5-medium',
+                  type: 'user',
+                  displayName: 'GPT 5.5 Medium',
+                },
+              ],
+            }),
+          },
+          skillApi: {
+            listSkills: vi.fn().mockResolvedValue([]),
+            getTeamSkills: vi.fn().mockResolvedValue({ skills: [], preload_skills: [] }),
+          },
+          projectApi: {
+            listProjects: vi.fn().mockResolvedValue({
+              items: [{ id: 7, name: 'Wegent', tasks: [] }],
+            }),
+            getProject: vi.fn(),
+            createProject: vi.fn(),
+            updateProject: vi.fn(),
+            deleteProject: vi.fn(),
+            archiveProjectChats: vi.fn(),
+            archiveAllProjectChats: vi.fn(),
+            createConversation: vi.fn(),
+          },
+          taskApi: {
+            listRecentTasks: vi.fn().mockResolvedValue({
+              total: 1,
+              items: [
+                {
+                  id: 8,
+                  title: 'restored chat',
+                  status: 'SUCCESS',
+                  task_type: 'code',
+                  project_id: 0,
+                  device_id: 'local-online',
+                  created_at: '2026-05-29T00:00:00.000Z',
+                },
+              ],
+            }),
+            getTaskDetail,
+            renameTask: vi.fn(),
+            archiveTask: vi.fn(),
+            archiveAllChats: vi.fn(),
+            listArchivedTasks: vi.fn(),
+            unarchiveTask: vi.fn(),
+            deleteTask: vi.fn(),
+            deleteArchivedTasks: vi.fn(),
+          },
+          deviceApi: {
+            listDevices: vi.fn().mockResolvedValue([
+              {
+                id: 2,
+                device_id: 'local-online',
+                name: 'Local Online',
+                status: 'online',
+                is_default: false,
+                device_type: 'local',
+              },
+            ]),
+            getHomeDirectory: vi.fn(),
+            getProjectWorkspaceRoot: vi.fn(),
+            listDirectories: vi.fn(),
+            listSkills: vi.fn().mockResolvedValue([]),
+          },
+          chatStream: {
+            joinTask,
+            leaveTask: vi.fn(),
+            sendMessage: vi.fn(),
+            subscribe: vi.fn(() => vi.fn()),
+          },
+        }}
+      >
+        <ArchiveProbe />
+      </WorkbenchProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-task-title')).toHaveTextContent('restored chat')
+    )
+    expect(getTaskDetail).toHaveBeenCalledWith(8)
+    expect(joinTask).toHaveBeenCalledWith(8)
+    expect(window.location.search).toBe('?taskId=8')
   })
 
   test('persists the project creation device as the default execution target', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -295,6 +295,28 @@ function getLastProjectStorageKey(userId: number) {
   return `wework.lastProjectId.${userId}`
 }
 
+function readTaskIdFromUrl(): number | null {
+  if (typeof window === 'undefined') return null
+  const params = new URLSearchParams(window.location.search)
+  const value = params.get('taskId') || params.get('task_id') || params.get('taskid')
+  if (!value) return null
+  const taskId = Number(value)
+  return Number.isFinite(taskId) && taskId > 0 ? taskId : null
+}
+
+function writeTaskIdToUrl(taskId: number | null) {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  url.searchParams.delete('task_id')
+  url.searchParams.delete('taskid')
+  if (taskId) {
+    url.searchParams.set('taskId', String(taskId))
+  } else {
+    url.searchParams.delete('taskId')
+  }
+  window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`)
+}
+
 function readLastProjectId(userId: number): number | null {
   try {
     const value = window.localStorage.getItem(getLastProjectStorageKey(userId))
@@ -401,6 +423,7 @@ export function WorkbenchProvider({
   const localSkillsCacheRef = useRef<
     Map<string, { expiresAt: number; skills: LocalDeviceSkill[] }>
   >(new Map())
+  const urlTaskOpenAttemptRef = useRef<number | null>(null)
   const isOptionsLocked = Boolean(state.currentTask)
   const currentUser = state.user ?? user
   const activeDeviceId =
@@ -666,6 +689,7 @@ export function WorkbenchProvider({
 
   const selectProject = useCallback(
     (projectId: number | null) => {
+      writeTaskIdToUrl(null)
       if (projectId === null) {
         dispatch({
           type: 'project_cleared',
@@ -694,6 +718,7 @@ export function WorkbenchProvider({
 
   const selectStandaloneDevice = useCallback(
     (deviceId: string | null) => {
+      writeTaskIdToUrl(null)
       const standaloneDeviceId = getPreferredStandaloneDeviceId(
         state.devices,
         deviceId ?? user.preferences?.default_execution_target ?? state.standaloneDeviceId
@@ -718,6 +743,7 @@ export function WorkbenchProvider({
   )
 
   const startNewChat = useCallback(() => {
+    writeTaskIdToUrl(null)
     const lastProjectId = readLastProjectId(user.id)
     const project = lastProjectId
       ? state.projects.find(item => item.id === lastProjectId)
@@ -740,6 +766,7 @@ export function WorkbenchProvider({
   }, [state.devices, state.projects, state.standaloneDeviceId, user])
 
   const startStandaloneChat = useCallback(() => {
+    writeTaskIdToUrl(null)
     dispatch({
       type: 'project_cleared',
       standaloneDeviceId: getRememberedStandaloneDeviceId(
@@ -798,6 +825,7 @@ export function WorkbenchProvider({
       })
       setQueuedSends([])
       setGuidanceMessages([])
+      writeTaskIdToUrl(taskId)
       await resolvedServices.chatStream.joinTask(taskId)
     },
     [
@@ -821,6 +849,25 @@ export function WorkbenchProvider({
       Promise.resolve({ total: 0, items: [] }),
     [resolvedServices]
   )
+
+  useEffect(() => {
+    if (state.isBootstrapping) return
+    const taskId = readTaskIdFromUrl()
+    if (!taskId || state.currentTask?.id === taskId) return
+    if (urlTaskOpenAttemptRef.current === taskId) return
+
+    urlTaskOpenAttemptRef.current = taskId
+    void openTask(taskId).catch(error => {
+      dispatch({
+        type: 'error_set',
+        error: error instanceof Error ? error.message : '会话加载失败',
+      })
+      writeTaskIdToUrl(null)
+      if (urlTaskOpenAttemptRef.current === taskId) {
+        urlTaskOpenAttemptRef.current = null
+      }
+    })
+  }, [openTask, state.currentTask?.id, state.isBootstrapping])
 
   const setInput = useCallback((input: string) => {
     dispatch({ type: 'input_changed', input })
@@ -863,6 +910,7 @@ export function WorkbenchProvider({
   const archiveAllChats = useCallback(async () => {
     await resolvedServices.taskApi.archiveAllChats()
     if (!state.currentProject && (!state.currentTask || !state.currentTask.project_id)) {
+      writeTaskIdToUrl(null)
       dispatch({ type: 'current_task_cleared' })
       dispatchMessages({ type: 'reset', messages: [] })
     }
@@ -872,6 +920,7 @@ export function WorkbenchProvider({
   const archiveAllProjectChats = useCallback(async () => {
     await resolvedServices.projectApi.archiveAllProjectChats()
     if (state.currentProject || (state.currentTask?.project_id ?? 0) > 0) {
+      writeTaskIdToUrl(null)
       dispatch({ type: 'current_task_cleared' })
       dispatchMessages({ type: 'reset', messages: [] })
     }
@@ -881,6 +930,7 @@ export function WorkbenchProvider({
   const archiveProjectChats = useCallback(
     async (projectId: number) => {
       await resolvedServices.projectApi.archiveProjectChats(projectId)
+      writeTaskIdToUrl(null)
       dispatch({ type: 'current_task_cleared' })
       dispatchMessages({ type: 'reset', messages: [] })
       await refreshWorkLists()
@@ -892,6 +942,7 @@ export function WorkbenchProvider({
     async (taskId: number) => {
       await resolvedServices.taskApi.archiveTask(taskId)
       if (state.currentTask?.id === taskId) {
+        writeTaskIdToUrl(null)
         dispatch({ type: 'current_task_cleared' })
         dispatchMessages({ type: 'reset', messages: [] })
       }
@@ -924,9 +975,14 @@ export function WorkbenchProvider({
   const deleteTask = useCallback(
     async (taskId: number) => {
       await resolvedServices.taskApi.deleteTask(taskId)
+      if (state.currentTask?.id === taskId) {
+        writeTaskIdToUrl(null)
+        dispatch({ type: 'current_task_cleared' })
+        dispatchMessages({ type: 'reset', messages: [] })
+      }
       await refreshWorkLists()
     },
-    [refreshWorkLists, resolvedServices]
+    [refreshWorkLists, resolvedServices, state.currentTask?.id]
   )
 
   const deleteArchivedTasks = useCallback(async () => {
@@ -1104,6 +1160,7 @@ export function WorkbenchProvider({
       }
 
       if (!state.currentTask && ack.task_id) {
+        writeTaskIdToUrl(ack.task_id)
         const projectId = state.currentProject?.id ?? 0
         const openedTask: Task = {
           id: ack.task_id,


### PR DESCRIPTION
## Summary
- Prevent expanding a WeWork project from switching the main chat area to a new project chat
- Persist opened WeWork task IDs in the URL so refresh restores the current chat
- Clear stale taskId parameters when starting/clearing/archiving/deleting chats

## Tests
- cd wework && npm test -- src/components/layout/DesktopWorkbenchLayout.test.tsx src/features/workbench/WorkbenchProvider.test.tsx
- cd wework && npm run lint
- cd wework && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks are now persisted in the URL, enabling deep-linking and allowing users to share direct links to specific tasks.
  * Previously opened tasks are automatically restored when refreshing or returning to the page.

* **Bug Fixes**
  * Fixed unintended project selection behavior when expanding projects in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->