### PR TITLE
fix: remove unreachable statements

### DIFF
--- a/backend/app/services/chat/webpage_websocket_chat_emitter.py
+++ b/backend/app/services/chat/webpage_websocket_chat_emitter.py
@@ -1039,7 +1039,6 @@ def get_main_event_loop() -> Optional[asyncio.AbstractEventLoop]:
         The main event loop or None if not initialized
     """
     return _main_event_loop
-    return _main_event_loop
 
 
 def init_ws_emitter(sio: socketio.AsyncServer) -> WebSocketEmitter:

--- a/backend/app/services/chat/ws_emitter.py
+++ b/backend/app/services/chat/ws_emitter.py
@@ -1039,7 +1039,6 @@ def get_main_event_loop() -> Optional[asyncio.AbstractEventLoop]:
         The main event loop or None if not initialized
     """
     return _main_event_loop
-    return _main_event_loop
 
 
 def init_ws_emitter(sio: socketio.AsyncServer) -> WebSocketEmitter:

--- a/backend/app/services/kind_impl.py
+++ b/backend/app/services/kind_impl.py
@@ -115,7 +115,6 @@ class ModelKindService(KindBaseService):
         except ValueError as e:
             logger.exception("Failed to encrypt API key: %r", e)
             raise
-            raise
 
         return resource_data
 

--- a/backend/app/services/openapi/helpers.py
+++ b/backend/app/services/openapi/helpers.py
@@ -350,4 +350,3 @@ def get_team_shell_type(db: Session, team: Kind) -> str:
 
     shell_crd = Shell.model_validate(shell.json)
     return shell_crd.spec.shellType
-    return True

--- a/frontend/src/features/settings/components/wizard/TeamCreationWizard.tsx
+++ b/frontend/src/features/settings/components/wizard/TeamCreationWizard.tsx
@@ -444,7 +444,6 @@ export default function TeamCreationWizard({
             isLoading={false}
           />
         )
-        return null
     }
   }
 


### PR DESCRIPTION
## Summary

Remove unreachable statements reported by static analysis in backend and frontend code.

This PR only removes statements that appear after unconditional `raise` / `return` paths, plus one frontend `no-unreachable` violation. These statements were never executed at runtime.

Removed unreachable statements from:

* `backend/app/services/kind_impl.py`
* `backend/app/services/openapi/helpers.py`
* `backend/app/services/chat/webpage_websocket_chat_emitter.py`
* `backend/app/services/chat/ws_emitter.py`
* `frontend/src/features/settings/components/wizard/TeamCreationWizard.tsx`

## Changes

* Remove duplicate `raise` in `kind_impl.py`
* Remove unreachable `return True` in `openapi/helpers.py`
* Remove duplicate `return` statements in websocket chat emitters
* Remove unreachable `return null` in `TeamCreationWizard.tsx`

## Scope

This PR is intentionally limited to unreachable-code cleanup.

It does not change:

* API behavior
* response schemas
* exception handling semantics
* logging behavior
* frontend component logic

## Testing

* Backend: `2276 passed`
* Frontend: `813 passed`
* Ran frontend ESLint `no-unreachable` check; no output after the fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team creation wizard now displays a prompt preview in the final step.

* **Bug Fixes**
  * Adjusted chat event loop handling to avoid returning an outdated reference.
  * Improved logging when API key encryption fails to aid diagnostics.

* **Chores**
  * Removed a redundant return in OpenAPI helper code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->