### PR TITLE
fix(groups): log batch entity member addition results

### DIFF
--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -624,6 +624,12 @@ def add_entity_members_batch_endpoint(
             detail=str(e),
         )
 
+    logger.info(
+        f"Entity members batch added: group={group_name}, "
+        f"succeeded={len(succeeded_members)}, failed={len(failed_items)}, "
+        f"by_user={current_user.id}"
+    )
+
     return GroupEntityMemberBatchResponse(
         succeeded=[
             GroupEntityMemberResponse(
@@ -640,12 +646,6 @@ def add_entity_members_batch_endpoint(
         total=len(batch_create.members),
         success_count=len(succeeded_members),
         failed_count=len(failed_items),
-    )
-
-    logger.info(
-        f"Entity members batch added: group={group_name}, "
-        f"succeeded={len(succeeded_members)}, failed={len(failed_items)}, "
-        f"by_user={current_user.id}"
     )
 
 


### PR DESCRIPTION
## Summary

Move the batch entity member success log before the response is returned in `add_entity_members_batch_endpoint`.

The existing `logger.info(...)` statement was placed after an unconditional `return`, so it was unreachable and never executed. This change restores the intended success logging after `create_group_entity_members_batch(...)` completes and before returning `GroupEntityMemberBatchResponse`.

## Scope

This PR only changes the position of the existing log statement.

It does not change:

* permission checks
* entity validation
* batch creation behavior
* response schema
* error handling

## Testing

* Ran `python -m compileall backend/app/api/endpoints/groups.py`
* Ran `cd backend && uv run pytest tests/ -x -q`

  * `2276 passed, 1 skipped, 715 warnings in 190.93s`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging timing for batch operations to provide clearer operational insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->