### PR TITLE
fix(chat-shell): handle special tokens in tiktoken encode calls

### DIFF
--- a/chat_shell/chat_shell/compression/token_counter.py
+++ b/chat_shell/chat_shell/compression/token_counter.py
@@ -92,30 +92,32 @@ def _count_tokens_for_messages(model_id: str, messages: list[dict[str, Any]]) ->
         # Count role tokens
         role = message.get("role", "")
         if role:
-            total_tokens += len(encoding.encode(role))
+            total_tokens += len(encoding.encode(role, disallowed_special=()))
 
         # Count content tokens
         content = message.get("content", "")
         if isinstance(content, str):
-            total_tokens += len(encoding.encode(content))
+            total_tokens += len(encoding.encode(content, disallowed_special=()))
         elif isinstance(content, list):
             # Multimodal content (text + images)
             for item in content:
                 if isinstance(item, dict):
                     if item.get("type") == "text":
                         text = item.get("text", "")
-                        total_tokens += len(encoding.encode(text))
+                        total_tokens += len(
+                            encoding.encode(text, disallowed_special=())
+                        )
                     elif item.get("type") == "image_url":
                         # Approximate image tokens (varies by resolution)
                         # OpenAI uses ~85 tokens for low-res, ~170 for high-res
                         total_tokens += 170
                 elif isinstance(item, str):
-                    total_tokens += len(encoding.encode(item))
+                    total_tokens += len(encoding.encode(item, disallowed_special=()))
 
         # Count name tokens if present
         name = message.get("name", "")
         if name:
-            total_tokens += len(encoding.encode(name))
+            total_tokens += len(encoding.encode(name, disallowed_special=()))
             total_tokens += 1  # Extra token for name field
 
         # Count tool_calls tokens if present
@@ -125,15 +127,23 @@ def _count_tokens_for_messages(model_id: str, messages: list[dict[str, Any]]) ->
                 # Function name
                 func_name = tool_call.get("function", {}).get("name", "")
                 if func_name:
-                    total_tokens += len(encoding.encode(func_name))
+                    total_tokens += len(
+                        encoding.encode(func_name, disallowed_special=())
+                    )
 
                 # Function arguments (JSON)
                 func_args = tool_call.get("function", {}).get("arguments", "")
                 if func_args:
                     if isinstance(func_args, str):
-                        total_tokens += len(encoding.encode(func_args))
+                        total_tokens += len(
+                            encoding.encode(func_args, disallowed_special=())
+                        )
                     else:
-                        total_tokens += len(encoding.encode(json.dumps(func_args)))
+                        total_tokens += len(
+                            encoding.encode(
+                                json.dumps(func_args), disallowed_special=()
+                            )
+                        )
 
     # Add 3 tokens for assistant reply priming
     total_tokens += 3
@@ -203,7 +213,7 @@ class TokenCounter:
         if not text:
             return 0
 
-        return len(self.encoding.encode(text))
+        return len(self.encoding.encode(text, disallowed_special=()))
 
     def count_image(self, image_data: dict[str, Any] | str) -> int:
         """Count tokens for an image.

--- a/chat_shell/tests/test_compression.py
+++ b/chat_shell/tests/test_compression.py
@@ -116,6 +116,36 @@ class TestTokenCounter:
         assert not counter.is_over_limit(messages, 1000)
         assert counter.is_over_limit(messages, 1)
 
+    def test_count_text_with_special_token_literal(self):
+        """Text containing literal '<|endoftext|>' must not raise an error.
+
+        tiktoken treats '<|endoftext|>' as a special token and raises by default
+        when it appears as plain text.  disallowed_special=() disables this check
+        so that content fetched from external sources (e.g. the Qwen3 Embedding
+        paper) is counted without crashing the token counter.
+        """
+        counter = TokenCounter(model_id="gpt-4")
+        text = "Input format: {Instruction} {Query}<|endoftext|>"
+        count = counter.count_text(text)
+        assert count > 0
+
+    def test_count_messages_with_special_token_literal(self):
+        """Message history containing literal '<|endoftext|>' must not raise."""
+        counter = TokenCounter(model_id="gpt-4")
+        messages = [
+            {"role": "user", "content": "Tell me about Qwen3 Reranker."},
+            {
+                "role": "assistant",
+                "content": (
+                    "The input format is: {Instruction} {Query}<|endoftext|>\n"
+                    "This is used as a separator in the embedding model."
+                ),
+            },
+            {"role": "user", "content": "What loss function is used?"},
+        ]
+        count = counter.count_messages(messages)
+        assert count > 0
+
 
 class TestModelContextConfig:
     """Tests for model context configuration."""


### PR DESCRIPTION
## Problem

When a user's conversation history contains the literal string `<|endoftext|>` — which appears verbatim in the [Qwen3 Embedding technical report](https://arxiv.org/abs/2506.05176) as the model's input format separator:

```
The input format for queries is as follows:
{Instruction} {Query}<|endoftext|>
```

— the **web-tools skill** fetches this content and the assistant includes it in its response. On the very next turn, `TokenCounter.count_messages()` is called to check context window usage, and tiktoken raises:

```
Encountered text corresponding to disallowed special token '<|endoftext|>'.
If you want this text to be encoded as a special token, pass it to `allowed_special`, ...
If you want this text to be encoded as normal text, disable the check for this token by
passing `disallowed_special=(enc.special_tokens_set - {'<|endoftext|>'})`.
To disable this check for all special tokens, pass `disallowed_special=()`.
```

The user is then **permanently blocked** from continuing that chat session — every subsequent message fails with the same error regardless of how many times they retry or create new messages.

## Root Cause

All `encoding.encode(text)` calls in `token_counter.py` were missing the `disallowed_special=()` argument. By default tiktoken raises an error when it encounters special token strings in plain text. Since the token counter is only used for **counting** (not for actual model input), treating these strings as ordinary text is the correct behavior.

## Fix

Add `disallowed_special=()` to every `encoding.encode()` call in:

- `_count_tokens_for_messages()` — role, string content, multimodal text items, list items, name, tool_call function name, tool_call arguments
- `TokenCounter.count_text()` — direct text counting

## Tests

Two regression tests added to `TestTokenCounter`:

- `test_count_text_with_special_token_literal` — verifies `count_text()` handles `<|endoftext|>` in plain text
- `test_count_messages_with_special_token_literal` — verifies `count_messages()` handles `<|endoftext|>` inside conversation history

## Checklist

- [x] Bug reproduced and understood
- [x] Fix applied to all `encoding.encode()` call sites
- [x] Regression tests added and passing (`pytest tests/test_compression.py::TestTokenCounter` — 11/11 passed)
- [x] No behavior change for normal text (only affects text that happens to contain special token strings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token counting to properly handle content containing special token literals without errors, improving robustness when processing diverse text inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->