### PR TITLE
test(e2e): isolate sharded test users

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2, 3]
-        shardTotal: [3]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
 
     services:
       mysql:
@@ -330,6 +330,7 @@ jobs:
           MOCK_MODEL_SERVER_URL: http://localhost:9999
           E2E_LOCAL_CLAUDE_MODEL_SERVER_URL: http://localhost:9999
           E2E_DEVICE_ID: e2e-claudecode-device
+          E2E_SHARD_INDEX: ${{ matrix.shardIndex }}
           CI: true
         run: |
           npx playwright test --project=chromium --project=api \

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -196,6 +196,20 @@ E2E tests run automatically in GitHub Actions:
 
 See [`.github/workflows/e2e-tests.yml`](../../.github/workflows/e2e-tests.yml) for configuration.
 
+### Sharded CI Users
+
+The CI workflow runs Playwright tests across multiple shards. Each shard uses an
+isolated E2E admin and regular user to reduce cross-shard data interference:
+
+- `E2E_SHARD_INDEX=1` uses `e2e-admin-shard-1` and `e2e-user-shard-1`
+- `E2E_SHARD_INDEX=2` uses `e2e-admin-shard-2` and `e2e-user-shard-2`
+- Local runs without `E2E_SHARD_INDEX` use `e2e-admin-local` and `e2e-user-local`
+
+`global-setup.ts` provisions these users with the bootstrap admin account, logs in
+through the backend API, and writes Playwright `storageState` for browser tests.
+Set `E2E_USE_ISOLATED_USERS=false` to fall back to the bootstrap admin user when
+debugging against an environment where creating users is not desirable.
+
 ## Troubleshooting
 
 ### Tests Timing Out

--- a/frontend/e2e/config/test-users.ts
+++ b/frontend/e2e/config/test-users.ts
@@ -1,6 +1,11 @@
 /**
  * Test users configuration
  */
+import {
+  buildBootstrapAdminUser,
+  buildE2EAdminUser,
+  buildE2ERegularUser,
+} from '../utils/auth-state'
 
 export interface TestUser {
   username: string
@@ -10,25 +15,20 @@ export interface TestUser {
 }
 
 /**
+ * Bootstrap admin user for provisioning isolated E2E users.
+ */
+export const BOOTSTRAP_ADMIN_USER: TestUser = buildBootstrapAdminUser()
+
+/**
  * Default admin user for E2E tests
  */
-export const ADMIN_USER: TestUser = {
-  username: 'admin',
-  password: 'Wegent2025!',
-  role: 'admin',
-  description: 'Default admin user with full access',
-}
+export const ADMIN_USER: TestUser = buildE2EAdminUser()
 
 /**
  * Default regular user for E2E tests
  * Note: This user should be created during test setup if it does not exist
  */
-export const REGULAR_USER: TestUser = {
-  username: 'e2e-user',
-  password: 'Test@12345',
-  role: 'user',
-  description: 'Regular user with limited access',
-}
+export const REGULAR_USER: TestUser = buildE2ERegularUser()
 
 /**
  * Get test user by role

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -1,15 +1,132 @@
-import { test as setup, expect } from '@playwright/test'
-import { login, TEST_USER } from '../utils/auth'
+import { APIRequestContext, expect, test as setup } from '@playwright/test'
 import * as path from 'path'
 import { promises as fsPromises } from 'fs'
+import { ADMIN_USER, BOOTSTRAP_ADMIN_USER, REGULAR_USER } from '../config/test-users'
+import type { TestUser } from '../config/test-users'
+import { buildStorageState, getJwtExpiryMs } from '../utils/auth-state'
 
 const authFile = path.join(__dirname, '../.auth/user.json')
+const apiBaseUrl = process.env.E2E_API_URL || 'http://localhost:8000'
+const appBaseUrl = process.env.E2E_BASE_URL || 'http://localhost:3000'
+
+async function loginViaApi(request: APIRequestContext, user: TestUser): Promise<string> {
+  const response = await request.post(`${apiBaseUrl}/api/auth/login`, {
+    data: {
+      user_name: user.username,
+      password: user.password,
+    },
+  })
+
+  expect(response.ok(), `Login failed for ${user.username}: ${await response.text()}`).toBe(true)
+
+  const body = (await response.json()) as { access_token?: string }
+  expect(
+    body.access_token,
+    `Login response did not include access_token for ${user.username}`
+  ).toEqual(expect.any(String))
+
+  return body.access_token!
+}
+
+async function ensureUser(
+  request: APIRequestContext,
+  bootstrapToken: string,
+  user: TestUser
+): Promise<void> {
+  if (user.username === BOOTSTRAP_ADMIN_USER.username) {
+    return
+  }
+
+  const headers = {
+    Authorization: `Bearer ${bootstrapToken}`,
+    'Content-Type': 'application/json',
+  }
+
+  const listResponse = await request.get(
+    `${apiBaseUrl}/api/admin/users?page=1&limit=100&include_inactive=true&search=${encodeURIComponent(
+      user.username
+    )}`,
+    {
+      headers,
+    }
+  )
+  expect(
+    listResponse.ok(),
+    `Failed to list users while provisioning ${user.username}: ${await listResponse.text()}`
+  ).toBe(true)
+
+  const listBody = (await listResponse.json()) as {
+    items?: Array<{ id: number; user_name: string; role: string; is_active: boolean }>
+  }
+  const existingUser = listBody.items?.find(item => item.user_name === user.username)
+
+  if (!existingUser) {
+    const createResponse = await request.post(`${apiBaseUrl}/api/admin/users`, {
+      headers,
+      data: {
+        user_name: user.username,
+        password: user.password,
+        role: user.role,
+        auth_source: 'password',
+      },
+    })
+    expect(
+      createResponse.ok(),
+      `Failed to create E2E user ${user.username}: ${await createResponse.text()}`
+    ).toBe(true)
+    return
+  }
+
+  if (existingUser.role !== user.role || !existingUser.is_active) {
+    const updateResponse = await request.put(`${apiBaseUrl}/api/admin/users/${existingUser.id}`, {
+      headers,
+      data: {
+        role: user.role,
+        is_active: true,
+      },
+    })
+    expect(
+      updateResponse.ok(),
+      `Failed to update E2E user ${user.username}: ${await updateResponse.text()}`
+    ).toBe(true)
+  }
+
+  const resetResponse = await request.post(
+    `${apiBaseUrl}/api/admin/users/${existingUser.id}/reset-password`,
+    {
+      headers,
+      data: {
+        new_password: user.password,
+      },
+    }
+  )
+  expect(
+    resetResponse.ok(),
+    `Failed to reset password for E2E user ${user.username}: ${await resetResponse.text()}`
+  ).toBe(true)
+}
+
+async function markAdminSetupComplete(request: APIRequestContext, token: string): Promise<void> {
+  const response = await request.post(`${apiBaseUrl}/api/admin/setup-complete`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  })
+
+  if (response.ok()) {
+    console.log('Admin setup marked as complete')
+    return
+  }
+
+  console.log(`Admin setup API returned ${response.status()} - may already be complete`)
+}
 
 /**
  * Global setup - run once before all tests
  * Authenticates and saves storage state for reuse
  */
-setup('authenticate', async ({ page, request }) => {
+setup('authenticate', async ({ request }) => {
   // Ensure .auth directory exists using async operations
   const authDir = path.dirname(authFile)
   try {
@@ -18,66 +135,20 @@ setup('authenticate', async ({ page, request }) => {
     await fsPromises.mkdir(authDir, { recursive: true })
   }
 
-  // Perform login
-  await login(page, TEST_USER.username, TEST_USER.password)
+  const bootstrapToken = await loginViaApi(request, BOOTSTRAP_ADMIN_USER)
+  await ensureUser(request, bootstrapToken, ADMIN_USER)
+  await ensureUser(request, bootstrapToken, REGULAR_USER)
 
-  // Verify login was successful by checking we're on a protected page
-  await expect(page).not.toHaveURL(/\/login/)
+  const authToken = await loginViaApi(request, ADMIN_USER)
+  const tokenExpiryMs = getJwtExpiryMs(authToken)
+  expect(tokenExpiryMs, `E2E auth token for ${ADMIN_USER.username} must include exp`).toEqual(
+    expect.any(Number)
+  )
 
-  // Mark admin setup as complete to prevent the setup wizard dialog from blocking tests
-  // This is necessary because the GlobalAdminSetupWizard component shows a modal dialog
-  // for admin users when admin_setup_completed is false, which intercepts all pointer events
-  const apiBaseUrl = process.env.E2E_API_URL || 'http://localhost:8000'
-  try {
-    // Get auth token from localStorage
-    const token = await page.evaluate(() => localStorage.getItem('auth_token'))
-    if (token) {
-      const response = await page.request.post(`${apiBaseUrl}/api/admin/setup-complete`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
-      })
-      if (response.ok()) {
-        console.log('Admin setup marked as complete')
-      } else {
-        console.warn(`Failed to mark admin setup as complete: ${response.status()}`)
-      }
-    }
-  } catch (error) {
-    console.warn('Warning: Could not mark admin setup as complete:', error)
-    // Continue anyway - this is not critical for all tests
-  }
+  await markAdminSetupComplete(request, authToken)
 
-  // Save storage state (cookies, localStorage)
-  await page.context().storageState({ path: authFile })
+  const storageState = buildStorageState(appBaseUrl, authToken, tokenExpiryMs)
+  await fsPromises.writeFile(authFile, JSON.stringify(storageState, null, 2))
 
-  console.log('Authentication successful, storage state saved')
-
-  // Mark admin setup as complete to prevent GlobalAdminSetupWizard from showing
-  // This is done via API to ensure it's completed before any tests run
-  try {
-    // Get auth token from localStorage
-    const authToken = await page.evaluate(() => {
-      return localStorage.getItem('auth_token')
-    })
-
-    if (authToken) {
-      const baseURL = process.env.E2E_API_URL || 'http://localhost:8000'
-      const response = await request.post(`${baseURL}/api/admin/setup-complete`, {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-          'Content-Type': 'application/json',
-        },
-      })
-      if (response.ok()) {
-        console.log('Admin setup marked as complete')
-      } else {
-        console.log('Admin setup API returned:', response.status(), '- may already be complete')
-      }
-    }
-  } catch (error) {
-    // Ignore errors - setup may already be complete or user may not be admin
-    console.log('Note: Could not mark admin setup as complete:', error)
-  }
+  console.log(`Authentication successful for ${ADMIN_USER.username}, storage state saved`)
 })

--- a/frontend/e2e/utils/api-client.ts
+++ b/frontend/e2e/utils/api-client.ts
@@ -409,7 +409,7 @@ export class ApiClient {
    * List all users (admin only)
    */
   async adminListUsers(page: number = 1, pageSize: number = 20): Promise<ApiResponse> {
-    return this.call('GET', `/api/admin/users?page=${page}&page_size=${pageSize}`)
+    return this.call('GET', `/api/admin/users?page=${page}&limit=${pageSize}`)
   }
 
   /**

--- a/frontend/e2e/utils/auth-state.ts
+++ b/frontend/e2e/utils/auth-state.ts
@@ -1,0 +1,140 @@
+import type { TestUser } from '../config/test-users'
+
+const DEFAULT_ADMIN_PASSWORD = 'Wegent2025!'
+const TOKEN_KEY = 'auth_token'
+const TOKEN_EXPIRE_KEY = 'auth_token_expire'
+const TOKEN_COOKIE_NAME = 'auth_token'
+
+type EnvMap = Partial<Record<string, string | undefined>>
+type StorageState = {
+  cookies: Array<{
+    name: string
+    value: string
+    domain: string
+    path: string
+    expires: number
+    httpOnly: boolean
+    secure: boolean
+    sameSite: 'Strict' | 'Lax' | 'None'
+  }>
+  origins: Array<{
+    origin: string
+    localStorage: Array<{ name: string; value: string }>
+  }>
+}
+
+function sanitizeSuffix(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+
+  return normalized || 'local'
+}
+
+function getShardSuffix(env: EnvMap = process.env): string {
+  if (env.E2E_USER_SUFFIX) {
+    return sanitizeSuffix(env.E2E_USER_SUFFIX)
+  }
+
+  if (env.E2E_SHARD_INDEX) {
+    return `shard-${sanitizeSuffix(env.E2E_SHARD_INDEX)}`
+  }
+
+  return 'local'
+}
+
+function shouldUseIsolatedUsers(env: EnvMap = process.env): boolean {
+  return env.E2E_USE_ISOLATED_USERS !== 'false'
+}
+
+export function buildBootstrapAdminUser(env: EnvMap = process.env): TestUser {
+  return {
+    username: env.E2E_BOOTSTRAP_ADMIN_USER || 'admin',
+    password: env.E2E_BOOTSTRAP_ADMIN_PASSWORD || DEFAULT_ADMIN_PASSWORD,
+    role: 'admin',
+    description: 'Bootstrap admin user for E2E account provisioning',
+  }
+}
+
+export function buildE2EAdminUser(env: EnvMap = process.env): TestUser {
+  if (!shouldUseIsolatedUsers(env)) {
+    return buildBootstrapAdminUser(env)
+  }
+
+  const suffix = getShardSuffix(env)
+  const descriptionSuffix = suffix.replace(/-/g, ' ')
+  return {
+    username: env.E2E_ADMIN_USER || `e2e-admin-${suffix}`,
+    password: env.E2E_ADMIN_PASSWORD || DEFAULT_ADMIN_PASSWORD,
+    role: 'admin',
+    description: `Isolated admin user for E2E ${descriptionSuffix}`,
+  }
+}
+
+export function buildE2ERegularUser(env: EnvMap = process.env): TestUser {
+  if (!shouldUseIsolatedUsers(env)) {
+    return {
+      username: env.E2E_REGULAR_USER || 'e2e-user',
+      password: env.E2E_REGULAR_PASSWORD || 'Test@12345',
+      role: 'user',
+      description: 'Regular user with limited access',
+    }
+  }
+
+  const suffix = getShardSuffix(env)
+  return {
+    username: env.E2E_REGULAR_USER || `e2e-user-${suffix}`,
+    password: env.E2E_REGULAR_PASSWORD || 'Test@12345',
+    role: 'user',
+    description: `Isolated regular user for E2E ${suffix}`,
+  }
+}
+
+export function getJwtExpiryMs(token: string): number | null {
+  const payload = token.split('.')[1]
+  if (!payload) return null
+
+  try {
+    const decoded = Buffer.from(payload, 'base64url').toString('utf8')
+    const parsed = JSON.parse(decoded) as { exp?: unknown }
+    return typeof parsed.exp === 'number' ? parsed.exp * 1000 : null
+  } catch {
+    return null
+  }
+}
+
+export function buildStorageState(
+  appBaseUrl: string,
+  token: string,
+  expiryMs: number | null
+): StorageState {
+  const appUrl = new URL(appBaseUrl)
+  const localStorage = [{ name: TOKEN_KEY, value: token }]
+
+  if (expiryMs) {
+    localStorage.push({ name: TOKEN_EXPIRE_KEY, value: String(expiryMs) })
+  }
+
+  return {
+    cookies: [
+      {
+        name: TOKEN_COOKIE_NAME,
+        value: token,
+        domain: appUrl.hostname,
+        path: '/',
+        expires: expiryMs ? Math.floor(expiryMs / 1000) : -1,
+        httpOnly: false,
+        secure: appUrl.protocol === 'https:',
+        sameSite: 'Lax',
+      },
+    ],
+    origins: [
+      {
+        origin: appUrl.origin,
+        localStorage,
+      },
+    ],
+  }
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
-    /* API tests - no browser needed, no setup dependency */
+    /* API tests - no browser needed, but setup provisions isolated E2E users */
     {
       name: 'api',
       testMatch: /api\/.*\.spec\.ts/,
@@ -83,6 +83,7 @@ export default defineConfig({
         // API tests don't need a browser
         baseURL: process.env.E2E_API_URL || 'http://localhost:8000',
       },
+      dependencies: ['setup'],
     },
     /* Performance tests */
     {

--- a/frontend/src/__tests__/e2e/auth-state.test.ts
+++ b/frontend/src/__tests__/e2e/auth-state.test.ts
@@ -1,0 +1,57 @@
+import { buildE2EAdminUser, buildStorageState, getJwtExpiryMs } from '../../../e2e/utils/auth-state'
+
+function createJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url')
+  return `${header}.${payload}.signature`
+}
+
+describe('E2E auth state helpers', () => {
+  it('builds an isolated admin user from the shard index', () => {
+    const user = buildE2EAdminUser({
+      E2E_SHARD_INDEX: '4',
+    })
+
+    expect(user).toEqual({
+      username: 'e2e-admin-shard-4',
+      password: 'Wegent2025!',
+      role: 'admin',
+      description: 'Isolated admin user for E2E shard 4',
+    })
+  })
+
+  it('falls back to the bootstrap admin when isolated users are disabled', () => {
+    const user = buildE2EAdminUser({
+      E2E_USE_ISOLATED_USERS: 'false',
+      E2E_SHARD_INDEX: '2',
+    })
+
+    expect(user.username).toBe('admin')
+    expect(user.role).toBe('admin')
+  })
+
+  it('writes auth token, expiry, and cookie into Playwright storage state', () => {
+    const token = createJwt(1_700_000_000)
+    const expiryMs = getJwtExpiryMs(token)
+    const storageState = buildStorageState('http://localhost:3000', token, expiryMs)
+
+    expect(storageState.origins).toEqual([
+      {
+        origin: 'http://localhost:3000',
+        localStorage: [
+          { name: 'auth_token', value: token },
+          { name: 'auth_token_expire', value: '1700000000000' },
+        ],
+      },
+    ])
+    expect(storageState.cookies).toEqual([
+      expect.objectContaining({
+        name: 'auth_token',
+        value: token,
+        domain: 'localhost',
+        path: '/',
+        sameSite: 'Lax',
+      }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- Increase CI E2E sharding from 3 to 4 shards and pass `E2E_SHARD_INDEX` into Playwright runs.
- Provision shard-isolated E2E admin and regular users via API-based global setup, then write Playwright storage state directly.
- Document the sharded CI user strategy and fix the E2E admin user list helper to use the backend's `limit` parameter.

## Test Plan
- `cd frontend && npx tsc --noEmit --pretty false`
- `cd frontend && npm test -- --runInBand src/__tests__/e2e/auth-state.test.ts`
- `cd frontend && npx prettier --check e2e/utils/auth-state.ts e2e/config/test-users.ts e2e/tests/global-setup.ts e2e/utils/api-client.ts playwright.config.ts src/__tests__/e2e/auth-state.test.ts ../.github/workflows/e2e-tests.yml e2e/README.md`
- `cd frontend && E2E_SHARD_INDEX=2 npx playwright test --project=api --list`
- `cd frontend && E2E_SHARD_INDEX=2 npx playwright test --project=chromium --list`
- `cd frontend && npm run lint`
- `git diff --check`
- Pre-push hook: ESLint, TypeScript, unit tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased E2E test parallelization from 3 to 4 shards for faster test execution.
  * Refactored test setup to use API-based authentication for improved reliability and determinism.
  * Enhanced test user provisioning with per-shard isolation and configurable fallback behavior.
  * Added comprehensive documentation for sharded CI user management.

* **Tests**
  * Added validation tests for authentication state helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->