### PR TITLE
fix(frontend): sync resource library tabs with URL

### DIFF
--- a/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
@@ -9,6 +9,16 @@ import userEvent from '@testing-library/user-event'
 import { listGroups } from '@/apis/groups'
 import { MyResources } from '@/features/resource-library/components/MyResources'
 
+const mockReplace = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/resource-library',
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}))
+
 jest.mock('@/apis/groups', () => ({
   listGroups: jest.fn(),
 }))
@@ -133,6 +143,7 @@ async function openGroupMenu() {
 describe('MyResources', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    window.history.replaceState({}, '', '/resource-library')
     mockListGroups.mockResolvedValue({
       items: [
         {
@@ -223,6 +234,33 @@ describe('MyResources', () => {
     expect(await screen.findByTestId('retriever-resource-manager')).toHaveAttribute(
       'data-scope',
       'all'
+    )
+  })
+
+  it('opens the managed resource type from the URL query', async () => {
+    window.history.replaceState({}, '', '/resource-library?tab=mine&type=skill&scope=personal')
+
+    render(<MyResources />)
+
+    expect(await screen.findByTestId('skill-resource-manager')).toHaveAttribute(
+      'data-scope',
+      'personal'
+    )
+    expect(screen.getByTestId('managed-resource-skill-tab')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+
+  it('updates the URL query when switching managed resource types', async () => {
+    window.history.replaceState({}, '', '/resource-library?tab=mine&type=agent&scope=personal')
+    render(<MyResources />)
+
+    fireEvent.click(await screen.findByTestId('managed-resource-skill-tab'))
+
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/resource-library?tab=mine&type=skill&scope=personal',
+      { scroll: false }
     )
   })
 

--- a/frontend/src/app/(tasks)/resource-library/page.tsx
+++ b/frontend/src/app/(tasks)/resource-library/page.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 import '@/app/tasks/tasks.css'
@@ -73,7 +73,9 @@ export default function Page() {
           isSidebarCollapsed={isCollapsed}
         />
         <div className="min-h-0 flex-1 overflow-hidden">
-          <ResourceLibraryPage />
+          <Suspense fallback={null}>
+            <ResourceLibraryPage />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/frontend/src/features/resource-library/components/MyResources.tsx
+++ b/frontend/src/features/resource-library/components/MyResources.tsx
@@ -4,8 +4,9 @@
 
 'use client'
 
-import { useEffect, useState, type ComponentType } from 'react'
+import { useCallback, useEffect, useState, type ComponentType } from 'react'
 import dynamic from 'next/dynamic'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Building2, Check, ChevronDown, Globe2, Layers3, UserRound } from 'lucide-react'
 
 import { listGroups } from '@/apis/groups'
@@ -28,6 +29,15 @@ const managedResourceTypes: ManagedResourceType[] = [
   'shell',
   'retriever',
 ]
+
+const sourceFilters: ManagedResourceSourceFilter[] = ['all', 'personal', 'group', 'system']
+
+const resourceLibraryUrlParams = {
+  type: 'type',
+  source: 'source',
+  legacyScope: 'scope',
+  group: 'group',
+} as const
 
 const TeamListWithScope = dynamic(
   () =>
@@ -65,27 +75,36 @@ const RetrieverListWithScope = dynamic(
   { ssr: false }
 )
 
-function getInitialSearchParam(name: string): string | null {
+type SearchParamReader = Pick<URLSearchParams, 'get'>
+
+function getInitialSearchParams(): URLSearchParams {
   if (typeof window === 'undefined') {
-    return null
+    return new URLSearchParams()
   }
-  return new URLSearchParams(window.location.search).get(name)
+
+  return new URLSearchParams(window.location.search)
 }
 
-function getInitialResourceType(): ManagedResourceType {
-  const type = getInitialSearchParam('type')
-  return managedResourceTypes.includes(type as ManagedResourceType)
-    ? (type as ManagedResourceType)
-    : 'agent'
+function isManagedResourceType(value: string | null): value is ManagedResourceType {
+  return managedResourceTypes.includes(value as ManagedResourceType)
 }
 
-function getInitialSourceFilter(): ManagedResourceSourceFilter {
-  const source = getInitialSearchParam('source')
-  if (source === 'all' || source === 'personal' || source === 'group' || source === 'system') {
+function isSourceFilter(value: string | null): value is ManagedResourceSourceFilter {
+  return sourceFilters.includes(value as ManagedResourceSourceFilter)
+}
+
+function getResourceTypeFromSearchParams(params: SearchParamReader): ManagedResourceType {
+  const type = params.get(resourceLibraryUrlParams.type)
+  return isManagedResourceType(type) ? type : 'agent'
+}
+
+function getSourceFilterFromSearchParams(params: SearchParamReader): ManagedResourceSourceFilter {
+  const source = params.get(resourceLibraryUrlParams.source)
+  if (isSourceFilter(source)) {
     return source
   }
 
-  const legacyScope = getInitialSearchParam('scope')
+  const legacyScope = params.get(resourceLibraryUrlParams.legacyScope)
   if (legacyScope === 'personal' || legacyScope === 'group') {
     return legacyScope
   }
@@ -93,8 +112,20 @@ function getInitialSourceFilter(): ManagedResourceSourceFilter {
   return 'all'
 }
 
+function getGroupNameFromSearchParams(params: SearchParamReader): string | null {
+  return params.get(resourceLibraryUrlParams.group)
+}
+
+function getInitialResourceType(): ManagedResourceType {
+  return getResourceTypeFromSearchParams(getInitialSearchParams())
+}
+
+function getInitialSourceFilter(): ManagedResourceSourceFilter {
+  return getSourceFilterFromSearchParams(getInitialSearchParams())
+}
+
 function getInitialGroupName(): string | null {
-  return getInitialSearchParam('group')
+  return getGroupNameFromSearchParams(getInitialSearchParams())
 }
 
 function getGroupDisplayName(group: Group): string {
@@ -149,13 +180,13 @@ function ResourceSourceFilterControls({
   onValueChange,
   groups,
   selectedGroup,
-  onGroupChange,
+  onGroupSourceChange,
 }: {
   value: ManagedResourceSourceFilter
   onValueChange: (value: ManagedResourceSourceFilter) => void
   groups: Group[]
   selectedGroup: string | null
-  onGroupChange: (groupName: string | null) => void
+  onGroupSourceChange: (groupName: string | null) => void
 }) {
   const t = useResourceLibraryTranslation()
   const regularOptions: Array<{
@@ -231,10 +262,7 @@ function ResourceSourceFilterControls({
                   'bg-primary/10 text-primary focus:text-primary'
               )}
               data-testid="resource-source-all-groups-option"
-              onClick={() => {
-                onGroupChange(null)
-                onValueChange('group')
-              }}
+              onClick={() => onGroupSourceChange(null)}
             >
               <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
                 {value === 'group' && !selectedGroup && <Check className="h-4 w-4" aria-hidden />}
@@ -262,10 +290,7 @@ function ResourceSourceFilterControls({
                       isSelected && 'bg-primary/10 text-primary focus:text-primary'
                     )}
                     data-testid={`resource-source-group-option-${group.id}`}
-                    onClick={() => {
-                      onGroupChange(group.name)
-                      onValueChange('group')
-                    }}
+                    onClick={() => onGroupSourceChange(group.name)}
                   >
                     <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
                       {isSelected && <Check className="h-4 w-4" aria-hidden />}
@@ -310,11 +335,90 @@ interface MyResourcesProps {
 }
 
 export function MyResources({ title }: MyResourcesProps = {}) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const searchParamsSnapshot = searchParams.toString()
   const [resourceType, setResourceType] = useState<ManagedResourceType>(getInitialResourceType)
   const [sourceFilter, setSourceFilter] =
     useState<ManagedResourceSourceFilter>(getInitialSourceFilter)
   const [groups, setGroups] = useState<Group[]>([])
   const [selectedGroup, setSelectedGroup] = useState<string | null>(getInitialGroupName)
+
+  const replaceResourceLibraryUrl = useCallback(
+    ({
+      type,
+      source,
+      group,
+    }: {
+      type?: ManagedResourceType
+      source?: ManagedResourceSourceFilter
+      group?: string | null
+    }) => {
+      const params = new URLSearchParams(searchParamsSnapshot)
+
+      if (type) {
+        params.set(resourceLibraryUrlParams.type, type)
+      }
+
+      if (source) {
+        params.set(resourceLibraryUrlParams.source, source)
+        params.delete(resourceLibraryUrlParams.legacyScope)
+      }
+
+      if (group !== undefined) {
+        if (group) {
+          params.set(resourceLibraryUrlParams.group, group)
+        } else {
+          params.delete(resourceLibraryUrlParams.group)
+        }
+      }
+
+      if (source && source !== 'group') {
+        params.delete(resourceLibraryUrlParams.group)
+      }
+
+      const queryString = params.toString()
+      const nextUrl = queryString ? `${pathname}?${queryString}` : pathname
+      router.replace(nextUrl, { scroll: false })
+    },
+    [pathname, router, searchParamsSnapshot]
+  )
+
+  const handleResourceTypeChange = useCallback(
+    (nextType: ManagedResourceType) => {
+      setResourceType(nextType)
+      replaceResourceLibraryUrl({ type: nextType })
+    },
+    [replaceResourceLibraryUrl]
+  )
+
+  const handleSourceFilterChange = useCallback(
+    (nextSource: ManagedResourceSourceFilter) => {
+      setSourceFilter(nextSource)
+      replaceResourceLibraryUrl({
+        source: nextSource,
+        group: nextSource === 'group' ? selectedGroup : null,
+      })
+    },
+    [replaceResourceLibraryUrl, selectedGroup]
+  )
+
+  const handleGroupSourceChange = useCallback(
+    (groupName: string | null) => {
+      setSelectedGroup(groupName)
+      setSourceFilter('group')
+      replaceResourceLibraryUrl({ source: 'group', group: groupName })
+    },
+    [replaceResourceLibraryUrl]
+  )
+
+  useEffect(() => {
+    const params = new URLSearchParams(searchParamsSnapshot)
+    setResourceType(getResourceTypeFromSearchParams(params))
+    setSourceFilter(getSourceFilterFromSearchParams(params))
+    setSelectedGroup(getGroupNameFromSearchParams(params))
+  }, [searchParamsSnapshot])
 
   useEffect(() => {
     let isMounted = true
@@ -339,10 +443,10 @@ export function MyResources({ title }: MyResourcesProps = {}) {
     const sourceControls = (
       <ResourceSourceFilterControls
         value={sourceFilter}
-        onValueChange={setSourceFilter}
+        onValueChange={handleSourceFilterChange}
         groups={groups}
         selectedGroup={selectedGroup}
-        onGroupChange={setSelectedGroup}
+        onGroupSourceChange={handleGroupSourceChange}
       />
     )
     const groupName = sourceFilter === 'group' ? selectedGroup : null
@@ -413,7 +517,7 @@ export function MyResources({ title }: MyResourcesProps = {}) {
         data-testid="managed-resource-header"
       >
         {title && <h1 className="shrink-0 text-xl font-semibold text-text-primary">{title}</h1>}
-        <ManagedResourceTabs value={resourceType} onValueChange={setResourceType} />
+        <ManagedResourceTabs value={resourceType} onValueChange={handleResourceTypeChange} />
       </div>
 
       <div>{renderManager()}</div>


### PR DESCRIPTION
## Summary
- Sync resource library managed-resource tabs with URL query params.
- Restore the selected tab/source/group from direct `/resource-library` visits.
- Add a Suspense boundary for the search params reader and cover URL behavior in tests.

## Test Plan
- npm test -- --runInBand src/__tests__/features/resource-library/MyResources.test.tsx src/__tests__/features/resource-library/ResourceLibraryPage.test.tsx src/__tests__/features/resource-library/ResourceLibraryRoute.test.tsx
- npx tsc --noEmit
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource library filters now sync with URL parameters, enabling better navigation and bookmarkable filter states.
  * Added improved loading states during page transitions.

* **Tests**
  * Enhanced test coverage for URL-based filter parameter handling in the resource library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->