### PR TITLE
feat(frontend): filter resource library teams

### DIFF
--- a/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
@@ -114,6 +114,8 @@ jest.mock('@/hooks/useTranslation', () => ({
         'actions.manage_groups': '管理...',
         'fields.source': '来源',
         'states.no_groups': '暂无组资源',
+        'search.groups_placeholder': '搜索团队',
+        'search.groups_empty': '没有匹配的团队',
       }
 
       return translations[key] ?? translations[key.replace(/^resource-library:/, '')] ?? key
@@ -130,26 +132,35 @@ async function openGroupMenu() {
   return groupSelect
 }
 
+function makeGroup(overrides: Partial<Awaited<ReturnType<typeof listGroups>>['items'][number]>) {
+  return {
+    id: 1,
+    name: 'platform',
+    display_name: 'Platform',
+    parent_name: null,
+    owner_user_id: 1,
+    description: '',
+    visibility: 'private',
+    level: 'group',
+    is_active: true,
+    my_role: 'Owner',
+    member_count: 1,
+    created_at: '2026-05-28T00:00:00',
+    updated_at: '2026-05-28T00:00:00',
+    ...overrides,
+  } as Awaited<ReturnType<typeof listGroups>>['items'][number]
+}
+
 describe('MyResources', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockListGroups.mockResolvedValue({
       items: [
-        {
+        makeGroup({
           id: 1,
           name: 'platform',
           display_name: 'Platform',
-          parent_name: null,
-          owner_user_id: 1,
-          description: '',
-          visibility: 'private',
-          level: 'group',
-          is_active: true,
-          my_role: 'Owner',
-          member_count: 1,
-          created_at: '2026-05-28T00:00:00',
-          updated_at: '2026-05-28T00:00:00',
-        },
+        }),
       ],
       total: 1,
     })
@@ -187,6 +198,58 @@ describe('MyResources', () => {
     await openGroupMenu()
     expect(await screen.findByRole('menuitem', { name: '全部团队' })).toBeInTheDocument()
     expect(await screen.findByRole('menuitem', { name: 'Platform' })).toBeInTheDocument()
+  })
+
+  it('sorts team source options by display name', async () => {
+    mockListGroups.mockResolvedValue({
+      items: [
+        makeGroup({ id: 1, name: 'zeta', display_name: 'Zeta Team' }),
+        makeGroup({ id: 2, name: 'alpha', display_name: 'Alpha Team' }),
+        makeGroup({ id: 3, name: 'beta', display_name: 'Beta Team' }),
+      ],
+      total: 3,
+    })
+
+    render(<MyResources />)
+
+    await waitFor(() => expect(mockListGroups).toHaveBeenCalled())
+    await openGroupMenu()
+
+    const menu = await screen.findByRole('menu')
+    expect(
+      within(menu)
+        .getAllByRole('menuitem')
+        .map(item => item.textContent)
+    ).toEqual(['全部团队', 'Alpha Team', 'Beta Team', 'Zeta Team'])
+  })
+
+  it('filters team source options by entered text', async () => {
+    const user = userEvent.setup()
+    mockListGroups.mockResolvedValue({
+      items: [
+        makeGroup({ id: 1, name: 'zeta', display_name: 'Zeta Team' }),
+        makeGroup({ id: 2, name: 'ops-core', display_name: 'Core Team' }),
+        makeGroup({ id: 3, name: 'beta', display_name: 'Beta Team' }),
+      ],
+      total: 3,
+    })
+
+    render(<MyResources />)
+
+    await waitFor(() => expect(mockListGroups).toHaveBeenCalled())
+    await openGroupMenu()
+    await user.type(screen.getByTestId('resource-source-group-search-input'), 'ops')
+
+    expect(screen.getByRole('menuitem', { name: '全部团队' })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: 'Core Team' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Beta Team' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Zeta Team' })).not.toBeInTheDocument()
+
+    await user.clear(screen.getByTestId('resource-source-group-search-input'))
+    await user.type(screen.getByTestId('resource-source-group-search-input'), 'missing')
+
+    expect(screen.getByRole('menuitem', { name: '全部团队' })).toBeInTheDocument()
+    expect(screen.getByText('没有匹配的团队')).toBeInTheDocument()
   })
 
   it('keeps resource type as the primary navigation and source as a secondary filter', async () => {

--- a/frontend/src/features/resource-library/components/MyResources.tsx
+++ b/frontend/src/features/resource-library/components/MyResources.tsx
@@ -4,9 +4,9 @@
 
 'use client'
 
-import { useEffect, useState, type ComponentType } from 'react'
+import { useEffect, useMemo, useState, type ComponentType } from 'react'
 import dynamic from 'next/dynamic'
-import { Building2, Check, ChevronDown, Globe2, Layers3, UserRound } from 'lucide-react'
+import { Building2, Check, ChevronDown, Globe2, Layers3, Search, UserRound } from 'lucide-react'
 
 import { listGroups } from '@/apis/groups'
 import { Button } from '@/components/ui/button'
@@ -16,6 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown'
+import { Input } from '@/components/ui/input'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { Group } from '@/types/group'
@@ -101,6 +102,28 @@ function getGroupDisplayName(group: Group): string {
   return group.display_name || group.name
 }
 
+const groupNameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+function compareGroupsByDisplayName(left: Group, right: Group): number {
+  const displayNameResult = groupNameCollator.compare(
+    getGroupDisplayName(left),
+    getGroupDisplayName(right)
+  )
+
+  if (displayNameResult !== 0) {
+    return displayNameResult
+  }
+
+  return groupNameCollator.compare(left.name, right.name)
+}
+
+function getGroupSearchText(group: Group): string {
+  return `${getGroupDisplayName(group)} ${group.name}`.toLowerCase()
+}
+
 function useResourceLibraryTranslation() {
   const { t: tBase } = useTranslation('resource-library')
   return (key: string, options?: Record<string, unknown>) =>
@@ -158,6 +181,8 @@ function ResourceSourceFilterControls({
   onGroupChange: (groupName: string | null) => void
 }) {
   const t = useResourceLibraryTranslation()
+  const [isGroupMenuOpen, setIsGroupMenuOpen] = useState(false)
+  const [groupSearchQuery, setGroupSearchQuery] = useState('')
   const regularOptions: Array<{
     value: ManagedResourceSourceFilter
     label: string
@@ -170,6 +195,17 @@ function ResourceSourceFilterControls({
   const selectedGroupLabel = selectedGroupInfo ? getGroupDisplayName(selectedGroupInfo) : null
   const groupButtonLabel =
     value === 'group' ? selectedGroupLabel || t('sources.all_groups') : t('sources.group')
+  const sortedGroups = useMemo(() => [...groups].sort(compareGroupsByDisplayName), [groups])
+  const normalizedGroupSearchQuery = groupSearchQuery.trim().toLowerCase()
+  const filteredGroups = useMemo(() => {
+    if (!normalizedGroupSearchQuery) {
+      return sortedGroups
+    }
+
+    return sortedGroups.filter(group =>
+      getGroupSearchText(group).includes(normalizedGroupSearchQuery)
+    )
+  }, [normalizedGroupSearchQuery, sortedGroups])
 
   return (
     <div
@@ -197,7 +233,15 @@ function ResourceSourceFilterControls({
             </Button>
           )
         })}
-        <DropdownMenu>
+        <DropdownMenu
+          open={isGroupMenuOpen}
+          onOpenChange={open => {
+            setIsGroupMenuOpen(open)
+            if (!open) {
+              setGroupSearchQuery('')
+            }
+          }}
+        >
           <DropdownMenuTrigger asChild>
             <Button
               type="button"
@@ -221,62 +265,90 @@ function ResourceSourceFilterControls({
           <DropdownMenuContent
             align="start"
             sideOffset={6}
-            className="max-h-[320px] min-w-[220px] max-w-[min(320px,calc(100vw-2rem))] overflow-y-auto"
+            className="flex max-h-[320px] min-w-[220px] max-w-[min(320px,calc(100vw-2rem))] flex-col overflow-hidden"
           >
-            <DropdownMenuItem
-              className={cn(
-                'min-h-11 gap-2 lg:min-h-9',
-                value === 'group' &&
-                  !selectedGroup &&
-                  'bg-primary/10 text-primary focus:text-primary'
-              )}
-              data-testid="resource-source-all-groups-option"
-              onClick={() => {
-                onGroupChange(null)
-                onValueChange('group')
-              }}
+            <div
+              className="border-b border-border p-1 pb-2"
+              onKeyDown={event => event.stopPropagation()}
             >
-              <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
-                {value === 'group' && !selectedGroup && <Check className="h-4 w-4" aria-hidden />}
-              </span>
-              <span className="truncate">{t('sources.all_groups')}</span>
-            </DropdownMenuItem>
-            {groups.length === 0 ? (
+              <div className="relative">
+                <Search
+                  className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
+                  aria-hidden
+                />
+                <Input
+                  value={groupSearchQuery}
+                  onChange={event => setGroupSearchQuery(event.target.value)}
+                  placeholder={t('search.groups_placeholder')}
+                  data-testid="resource-source-group-search-input"
+                  className="h-9 bg-base pl-9"
+                />
+              </div>
+            </div>
+            <div className="min-h-0 overflow-y-auto pt-1">
               <DropdownMenuItem
-                disabled
-                className="min-h-11 text-text-muted lg:min-h-9"
-                data-testid="resource-source-group-empty-option"
+                className={cn(
+                  'min-h-11 gap-2 lg:min-h-9',
+                  value === 'group' &&
+                    !selectedGroup &&
+                    'bg-primary/10 text-primary focus:text-primary'
+                )}
+                data-testid="resource-source-all-groups-option"
+                onClick={() => {
+                  onGroupChange(null)
+                  onValueChange('group')
+                }}
               >
-                {t('states.no_groups')}
+                <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
+                  {value === 'group' && !selectedGroup && <Check className="h-4 w-4" aria-hidden />}
+                </span>
+                <span className="truncate">{t('sources.all_groups')}</span>
               </DropdownMenuItem>
-            ) : (
-              groups.map(group => {
-                const isSelected = value === 'group' && selectedGroup === group.name
-                const displayName = getGroupDisplayName(group)
+              {groups.length === 0 ? (
+                <DropdownMenuItem
+                  disabled
+                  className="min-h-11 text-text-muted lg:min-h-9"
+                  data-testid="resource-source-group-empty-option"
+                >
+                  {t('states.no_groups')}
+                </DropdownMenuItem>
+              ) : filteredGroups.length === 0 ? (
+                <DropdownMenuItem
+                  disabled
+                  className="min-h-11 text-text-muted lg:min-h-9"
+                  data-testid="resource-source-group-no-match-option"
+                >
+                  {t('search.groups_empty')}
+                </DropdownMenuItem>
+              ) : (
+                filteredGroups.map(group => {
+                  const isSelected = value === 'group' && selectedGroup === group.name
+                  const displayName = getGroupDisplayName(group)
 
-                return (
-                  <DropdownMenuItem
-                    key={group.id}
-                    className={cn(
-                      'min-h-11 gap-2 lg:min-h-9',
-                      isSelected && 'bg-primary/10 text-primary focus:text-primary'
-                    )}
-                    data-testid={`resource-source-group-option-${group.id}`}
-                    onClick={() => {
-                      onGroupChange(group.name)
-                      onValueChange('group')
-                    }}
-                  >
-                    <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
-                      {isSelected && <Check className="h-4 w-4" aria-hidden />}
-                    </span>
-                    <span className="truncate" title={displayName}>
-                      {displayName}
-                    </span>
-                  </DropdownMenuItem>
-                )
-              })
-            )}
+                  return (
+                    <DropdownMenuItem
+                      key={group.id}
+                      className={cn(
+                        'min-h-11 gap-2 lg:min-h-9',
+                        isSelected && 'bg-primary/10 text-primary focus:text-primary'
+                      )}
+                      data-testid={`resource-source-group-option-${group.id}`}
+                      onClick={() => {
+                        onGroupChange(group.name)
+                        onValueChange('group')
+                      }}
+                    >
+                      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
+                        {isSelected && <Check className="h-4 w-4" aria-hidden />}
+                      </span>
+                      <span className="truncate" title={displayName}>
+                        {displayName}
+                      </span>
+                    </DropdownMenuItem>
+                  )
+                })
+              )}
+            </div>
           </DropdownMenuContent>
         </DropdownMenu>
         <Button


### PR DESCRIPTION
## Summary
- Sort resource library team source options by display name.
- Add a searchable input to the team source dropdown while keeping "All teams" pinned at the top.
- Cover sorting and filtering behavior in `MyResources` tests.

## Test Plan
- `npm test -- MyResources.test.tsx --runInBand`
- `npm test -- --passWithNoTests`
- Pre-push gate: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group search and filtering inside the resource library dropdown, including a search input with placeholder and a “no matches” empty-search message.
  * Groups are now sorted by display name with numeric-aware ordering; filtered results show selection checkmarks.
  * Dropdown clears its search query when closed and displays contextual states: all groups, empty-groups, or no-match guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->