### PR TITLE
fix(frontend): load task detail after device chat creation

### DIFF
--- a/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
+++ b/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
@@ -189,6 +189,43 @@ describe('TaskSessionProvider', () => {
     expect(mockedTaskApis.getTaskRuntimeCheck).not.toHaveBeenCalled()
   })
 
+  it('loads task detail after a new chat message resolves to a real task id', async () => {
+    mockSocketContext.sendChatMessage.mockResolvedValue({
+      task_id: 713,
+      subtask_id: 714,
+      message_id: 1,
+    })
+
+    render(
+      <TaskSessionProvider>
+        <SessionProbe />
+      </TaskSessionProvider>
+    )
+
+    await waitFor(() => {
+      expect(sessionProbe.current).not.toBeNull()
+    })
+
+    mockedTaskApis.getTaskDetail.mockClear()
+
+    await act(async () => {
+      await sessionProbe.current?.sendMessage(
+        {
+          message: 'hello',
+          team_id: 1,
+          task_type: 'task',
+        },
+        {
+          immediateTaskId: -1,
+        }
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockedTaskApis.getTaskDetail).toHaveBeenCalledWith(713)
+    })
+  })
+
   it('uses runtime check only for later consistency recovery', async () => {
     render(
       <TaskSessionProvider>

--- a/frontend/src/features/tasks/session/TaskSession.tsx
+++ b/frontend/src/features/tasks/session/TaskSession.tsx
@@ -133,9 +133,10 @@ export function TaskSessionProvider({ children }: { children: ReactNode }) {
     (realTaskId: number, previousTaskId: number) => {
       if (realTaskId === previousTaskId) return
       writeSelectedTask({ id: realTaskId } as Task)
+      void pullTaskDetail(realTaskId)
       setTaskState(machineRef.current?.getState() ?? null)
     },
-    [writeSelectedTask]
+    [pullTaskDetail, writeSelectedTask]
   )
 
   const messageSyncer = useMessageSyncer({


### PR DESCRIPTION
## Summary
- Load full task detail immediately after a new chat message resolves from a temporary task id to the real task id.
- Prevent device chat follow-up sends from losing selected team context before page refresh.
- Add a TaskSession regression test for real task id resolution.

## Test Plan
- npm test -- --runInBand src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx