### PR TITLE
fix(security): block unspecified IPs in URL metadata validation

### DIFF
--- a/backend/app/services/url_metadata.py
+++ b/backend/app/services/url_metadata.py
@@ -47,6 +47,10 @@ BLOCKED_IP_NETWORKS = [
     ipaddress.ip_network("169.254.0.0/16"),
     # IPv4 shared address space (RFC6598)
     ipaddress.ip_network("100.64.0.0/10"),
+    # IPv4 unspecified addresses. These should never be valid remote
+    # metadata fetch targets and may route to local services depending
+    # on the runtime environment.
+    ipaddress.ip_network("0.0.0.0/8"),
     # IPv6 loopback
     ipaddress.ip_network("::1/128"),
     # IPv6 link-local
@@ -55,6 +59,8 @@ BLOCKED_IP_NETWORKS = [
     ipaddress.ip_network("fc00::/7"),
     # IPv4-mapped IPv6
     ipaddress.ip_network("::ffff:0:0/96"),
+    # IPv6 unspecified address.
+    ipaddress.ip_network("::/128"),
 ]
 
 # Cloud metadata endpoints that should be blocked

--- a/backend/tests/services/test_url_metadata_ssrf.py
+++ b/backend/tests/services/test_url_metadata_ssrf.py
@@ -1,0 +1,23 @@
+import pytest
+
+from app.services.url_metadata import _is_ip_blocked, _validate_url_for_ssrf
+
+
+@pytest.mark.parametrize("ip", ["0.0.0.0", "::"])
+def test_unspecified_ip_is_blocked(ip):
+    assert _is_ip_blocked(ip) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://0.0.0.0",
+        "http://0.0.0.0/",
+        "http://0.0.0.0:8080",
+        "http://[::]",
+        "http://[::]/",
+        "http://[::]:8080",
+    ],
+)
+def test_unspecified_url_is_blocked(url):
+    assert _validate_url_for_ssrf(url) is False


### PR DESCRIPTION
## Summary

Block IPv4 and IPv6 unspecified addresses in URL metadata SSRF validation.

## Problem

The URL metadata validation already blocks private, loopback, link-local, and IPv4-mapped IPv6 addresses, but it did not block unspecified addresses:

* `0.0.0.0/8`
* `::/128`

These addresses should not be accepted as remote metadata fetch targets. Allowing them creates ambiguous local-network behavior and may allow access to services bound to all interfaces in some runtime environments.

## Fix

Added the following networks to `BLOCKED_IP_NETWORKS`:

* `0.0.0.0/8`
* `::/128`

## Tests

Added regression tests covering:

* direct `_is_ip_blocked()` checks for unspecified IPv4 and IPv6 addresses
* URL-level validation for:

  * `http://0.0.0.0`
  * `http://0.0.0.0/`
  * `http://0.0.0.0:8080`
  * `http://[::]`
  * `http://[::]/`
  * `http://[::]:8080`

## Validation

```bash
uv run pytest backend/tests/services/test_url_metadata_ssrf.py -v
```

Result:

```text
8 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to block requests to unspecified IPv4 (0.0.0.0/8) and IPv6 (::) address ranges.

* **Tests**
  * Added test coverage for URL validation against unspecified IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->