### PR TITLE
fix(wework): restrict project tools to ClaudeCode devices

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1624,6 +1624,15 @@ describe('ChatInput', () => {
         is_default: false,
         device_type: 'local',
       },
+      {
+        id: 4,
+        device_id: 'openclaw-online',
+        name: 'OpenClaw Online',
+        status: 'online',
+        is_default: false,
+        device_type: 'cloud',
+        bind_shell: 'openclaw',
+      },
     ]
 
     render(
@@ -1647,6 +1656,7 @@ describe('ChatInput', () => {
     expect(screen.getByTestId('standalone-device-list')).toBeInTheDocument()
     expect(screen.getByText('Cloud Online')).toBeInTheDocument()
     expect(screen.getByText('Local Online')).toBeInTheDocument()
+    expect(screen.queryByText('OpenClaw Online')).not.toBeInTheDocument()
     expect(screen.getByTestId('standalone-device-option-local-offline')).toBeDisabled()
 
     await userEvent.click(screen.getByTestId('no-project-option'))

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -67,6 +67,18 @@ const localDevices: DeviceInfo[] = [
   },
 ]
 
+const openClawCloudDevices: DeviceInfo[] = [
+  {
+    id: 3,
+    device_id: 'device-1',
+    name: 'OpenClaw Device',
+    status: 'online',
+    is_default: false,
+    device_type: 'cloud',
+    bind_shell: 'openclaw',
+  },
+]
+
 describe('WorkspacePanelCards', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -120,20 +132,20 @@ describe('WorkspacePanelCards', () => {
     )
     expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
       'src',
-      'http://localhost/terminal-1?embed=1',
+      'http://localhost/terminal-1',
     )
     expect(screen.getByTestId('workspace-terminal-window')).toHaveClass(
       'bg-white',
     )
     expect(screen.getByTestId('workspace-terminal-tab')).toHaveTextContent(
-      'device-1',
+      'project38',
     )
     expect(screen.getByTestId('workspace-terminal-new-tab-button')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-terminal-close-button')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/projects/project38')).not.toBeInTheDocument()
   })
 
-  test('creates and switches to a new project terminal tab', async () => {
+  test('shows project tool cards from the terminal plus button', async () => {
     const api = createProjectApiMock()
     render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
@@ -141,32 +153,54 @@ describe('WorkspacePanelCards', () => {
     await waitFor(() =>
       expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
         'src',
-        'http://localhost/terminal-1?embed=1',
+        'http://localhost/terminal-1',
       ),
     )
 
     await userEvent.click(screen.getByTestId('workspace-terminal-new-tab-button'))
+
+    expect(screen.getByTestId('workspace-terminal-window')).not.toHaveAttribute('hidden')
+    expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
+      'src',
+      'http://localhost/terminal-1',
+    )
+    expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-desktop-card')).toBeInTheDocument()
+    expect(api.startTerminalSession).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
     await waitFor(() =>
       expect(api.startTerminalSession).toHaveBeenCalledTimes(2),
     )
     expect(screen.getAllByTestId('workspace-terminal-tab')).toHaveLength(2)
     expect(screen.getAllByTestId('workspace-terminal-close-button')).toHaveLength(2)
-    expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
+    const frames = screen.getAllByTestId('workspace-terminal-frame')
+    expect(frames).toHaveLength(2)
+    expect(frames[0]).toHaveAttribute(
       'src',
-      'http://localhost/terminal-2?embed=1',
+      'http://localhost/terminal-1',
     )
+    expect(frames[0]).toHaveAttribute('hidden')
+    expect(frames[1]).toHaveAttribute(
+      'src',
+      'http://localhost/terminal-2',
+    )
+    expect(frames[1]).not.toHaveAttribute('hidden')
 
     await userEvent.click(screen.getAllByTestId('workspace-terminal-close-button')[1])
 
     expect(screen.getAllByTestId('workspace-terminal-tab')).toHaveLength(1)
     expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
       'src',
-      'http://localhost/terminal-1?embed=1',
+      'http://localhost/terminal-1',
     )
+    expect(screen.getByTestId('workspace-terminal-frame')).not.toHaveAttribute('hidden')
   })
 
-  test('opens the project IDE in a new page', async () => {
+  test('opens the project IDE in a new page without a preflight probe', async () => {
     const api = createProjectApiMock()
     const onRequestClose = vi.fn()
     render(
@@ -182,13 +216,7 @@ describe('WorkspacePanelCards', () => {
     await waitFor(() =>
       expect(api.startCodeServerSession).toHaveBeenCalledWith(7),
     )
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://localhost/ide?__wegent_probe=1',
-      expect.objectContaining({
-        credentials: 'omit',
-        method: 'GET',
-      }),
-    )
+    expect(fetchMock).not.toHaveBeenCalled()
     expect(window.open).toHaveBeenCalledWith(
       'http://localhost/ide',
       '_blank',
@@ -236,12 +264,30 @@ describe('WorkspacePanelCards', () => {
     )
   })
 
+  test('does not show ClaudeCode-only project tools for OpenClaw devices', () => {
+    render(<WorkspacePanelCards currentProject={project} devices={openClawCloudDevices} />)
+
+    expect(screen.queryByTestId('workspace-terminal-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workspace-local-device-limited-tools')).toBeInTheDocument()
+  })
+
+  test('does not show cloud-only project tools before the bound device type is known', () => {
+    render(<WorkspacePanelCards currentProject={project} devices={[]} />)
+
+    expect(screen.queryByTestId('workspace-terminal-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workspace-local-device-limited-tools')).toBeInTheDocument()
+  })
+
   test('marks terminal as unavailable when session probing fails', async () => {
     const api = createProjectApiMock()
     vi.mocked(api.startTerminalSession).mockRejectedValueOnce(
       new Error('terminal unavailable'),
     )
-    render(<WorkspacePanelCards currentProject={project} />)
+    render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
@@ -257,34 +303,36 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getByTestId('workspace-desktop-card')).not.toBeDisabled()
   })
 
-  test('marks IDE as unavailable when session probing fails', async () => {
+  test('opens IDE even when browser preflight probing would be blocked', async () => {
     const api = createProjectApiMock()
-    vi.mocked(api.startCodeServerSession).mockRejectedValueOnce(
-      new Error('code-server unavailable'),
-    )
-    render(<WorkspacePanelCards currentProject={project} />)
+    fetchMock.mockRejectedValueOnce(new TypeError('Mixed content blocked'))
+    render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
     await userEvent.click(screen.getByTestId('workspace-ide-card'))
 
     await waitFor(() =>
-      expect(screen.getByTestId('workspace-ide-card')).toBeDisabled(),
+      expect(api.startCodeServerSession).toHaveBeenCalledWith(7),
     )
-    expect(screen.getByTestId('workspace-ide-card')).toHaveTextContent('暂不可用')
-    expect(window.open).not.toHaveBeenCalled()
-
-    await userEvent.click(screen.getByTestId('workspace-ide-card'))
-
+    expect(fetchMock).not.toHaveBeenCalled()
     expect(api.startCodeServerSession).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('workspace-terminal-card')).not.toBeDisabled()
-    expect(screen.getByTestId('workspace-desktop-card')).not.toBeDisabled()
+    expect(window.open).toHaveBeenCalledWith(
+      'http://localhost/ide',
+      '_blank',
+      'noopener',
+    )
   })
 
   test('marks IDE as unavailable when the returned session URL is missing', async () => {
     const api = createProjectApiMock()
-    fetchMock.mockResolvedValueOnce(
-      new Response('Session not found', { status: 404 }),
-    )
-    render(<WorkspacePanelCards currentProject={project} />)
+    vi.mocked(api.startCodeServerSession).mockResolvedValueOnce({
+      session_id: 'ide-1',
+      project_id: 7,
+      device_id: 'device-1',
+      type: 'code_server',
+      path: '/workspace/projects/project38',
+      url: '',
+    })
+    render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
     await userEvent.click(screen.getByTestId('workspace-ide-card'))
 
@@ -293,12 +341,12 @@ describe('WorkspacePanelCards', () => {
     )
     expect(window.open).not.toHaveBeenCalled()
     expect(api.startCodeServerSession).toHaveBeenCalledTimes(1)
-    expect(screen.getByRole('alert')).toHaveTextContent('会话已失效，请重新打开工具')
+    expect(screen.getByRole('alert')).toHaveTextContent('启动失败')
   })
 
   test('marks desktop as unavailable when VNC probing fails', async () => {
     getVncConfigMock.mockRejectedValueOnce(new Error('vnc unavailable'))
-    render(<WorkspacePanelCards currentProject={project} />)
+    render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
     await userEvent.click(screen.getByTestId('workspace-desktop-card'))
 
@@ -325,7 +373,9 @@ describe('WorkspacePanelCards', () => {
       id: 8,
       name: 'project39',
     }
-    const { rerender } = render(<WorkspacePanelCards currentProject={project} />)
+    const { rerender } = render(
+      <WorkspacePanelCards currentProject={project} devices={cloudDevices} />,
+    )
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
@@ -333,7 +383,7 @@ describe('WorkspacePanelCards', () => {
       expect(screen.getByTestId('workspace-terminal-card')).toBeDisabled(),
     )
 
-    rerender(<WorkspacePanelCards currentProject={nextProject} />)
+    rerender(<WorkspacePanelCards currentProject={nextProject} devices={cloudDevices} />)
 
     expect(screen.getByTestId('workspace-terminal-card')).not.toBeDisabled()
     expect(screen.getByTestId('workspace-terminal-card')).not.toHaveTextContent(

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -17,8 +17,6 @@ interface WorkspacePanelCardsProps {
 
 type WorkspaceTool = 'terminal' | 'ide' | 'desktop'
 
-const SESSION_PROBE_QUERY_KEY = '__wegent_probe'
-
 type WorkspaceToolAvailability = Record<WorkspaceTool, boolean>
 
 interface WorkspaceToolAvailabilityState {
@@ -29,13 +27,6 @@ interface WorkspaceToolAvailabilityState {
 interface WorkspaceToolErrorState {
   projectKey: string
   message: string | null
-}
-
-class SessionUrlUnavailableError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = 'SessionUrlUnavailableError'
-  }
 }
 
 function createAvailableTools(): WorkspaceToolAvailability {
@@ -60,38 +51,6 @@ function createDeviceSessionApi() {
   return createDeviceApi(createHttpClient({ baseUrl: apiBaseUrl }))
 }
 
-function toEmbeddedSessionUrl(url: string): string {
-  try {
-    const parsed = new URL(url)
-    parsed.searchParams.set('embed', '1')
-    return parsed.toString()
-  } catch {
-    return url
-  }
-}
-
-function toSessionProbeUrl(url: string): string {
-  try {
-    const parsed = new URL(url)
-    parsed.searchParams.set(SESSION_PROBE_QUERY_KEY, '1')
-    return parsed.toString()
-  } catch {
-    const separator = url.includes('?') ? '&' : '?'
-    return `${url}${separator}${SESSION_PROBE_QUERY_KEY}=1`
-  }
-}
-
-async function probeSessionUrl(url: string): Promise<void> {
-  const response = await fetch(toSessionProbeUrl(url), {
-    cache: 'no-store',
-    credentials: 'omit',
-    method: 'GET',
-  })
-  if (!response.ok) {
-    throw new SessionUrlUnavailableError(await response.text())
-  }
-}
-
 export function WorkspacePanelCards({
   currentProject,
   devices = [],
@@ -100,6 +59,7 @@ export function WorkspacePanelCards({
   const { t } = useTranslation('common')
   const [terminalSessions, setTerminalSessions] = useState<ProjectDeviceSessionResponse[]>([])
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null)
+  const [showToolLauncher, setShowToolLauncher] = useState(false)
   const [loadingTool, setLoadingTool] = useState<WorkspaceTool | null>(null)
   const [toolAvailability, setToolAvailability] = useState<WorkspaceToolAvailabilityState>(
     () => ({
@@ -115,8 +75,8 @@ export function WorkspacePanelCards({
   const projectDevice = projectDeviceId
     ? devices.find(device => device.device_id === projectDeviceId)
     : undefined
-  const hasExplicitLocalDevice = Boolean(projectDevice && !supportsCloudSessions(projectDevice))
-  const cloudToolsAvailable = !hasExplicitLocalDevice
+  const cloudToolsAvailable = Boolean(projectDevice && supportsCloudSessions(projectDevice))
+  const hasExplicitLocalDevice = Boolean(currentProject && projectDeviceId && !cloudToolsAvailable)
   const projectKey = currentProject ? `${currentProject.id}:${projectDeviceId ?? ''}` : ''
   const availableTools =
     toolAvailability.projectKey === projectKey
@@ -128,6 +88,7 @@ export function WorkspacePanelCards({
     terminalSessions.find(session => session.session_id === activeTerminalSessionId) ??
     terminalSessions[0] ??
     null
+  const terminalTabLabel = currentProject?.name ?? activeTerminalSession?.device_id ?? ''
 
   const markToolUnavailable = (tool: WorkspaceTool) => {
     setToolAvailability(state => {
@@ -146,12 +107,7 @@ export function WorkspacePanelCards({
     setToolError({ projectKey, message })
   }
 
-  const getSessionStartErrorMessage = (errorValue: unknown): string => {
-    if (errorValue instanceof SessionUrlUnavailableError) {
-      return t('workbench.project_session_unavailable', '会话已失效，请重新打开工具')
-    }
-    return t('workbench.project_tool_start_failed', '启动失败')
-  }
+  const getSessionStartErrorMessage = () => t('workbench.project_tool_start_failed', '启动失败')
 
   const startTerminalSession = async () => {
     if (!currentProject || loadingTool || !availableTools.terminal) return
@@ -160,11 +116,11 @@ export function WorkspacePanelCards({
     try {
       const session = await createProjectSessionApi().startTerminalSession(currentProject.id)
       if (!session.url) {
-        throw new SessionUrlUnavailableError('Terminal session URL is missing')
+        throw new Error('Terminal session URL is missing')
       }
-      await probeSessionUrl(session.url)
       setTerminalSessions(sessions => [...sessions, session])
       setActiveTerminalSessionId(session.session_id)
+      setShowToolLauncher(false)
     } catch (e) {
       console.error('Failed to start project terminal:', e)
       markToolUnavailable('terminal')
@@ -203,9 +159,8 @@ export function WorkspacePanelCards({
     try {
       const session = await createProjectSessionApi().startCodeServerSession(currentProject.id)
       if (!session.url) {
-        throw new SessionUrlUnavailableError('IDE session URL is missing')
+        throw new Error('IDE session URL is missing')
       }
-      await probeSessionUrl(session.url)
       window.open(session.url, '_blank', 'noopener')
       shouldClosePanel = true
     } catch (e) {
@@ -244,8 +199,7 @@ export function WorkspacePanelCards({
     }
   }
 
-  if (activeTerminalSession) {
-    return (
+  const terminalWindow = activeTerminalSession ? (
       <div
         data-testid="workspace-terminal-window"
         className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-white"
@@ -258,25 +212,30 @@ export function WorkspacePanelCards({
               return (
                 <div
                   key={session.session_id}
-                  className={`flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-md ${
-                    isActive ? 'bg-surface text-text-primary' : 'text-text-secondary hover:bg-muted'
+                  className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-md border border-transparent transition-colors ${
+                    isActive
+                      ? 'border-border bg-white text-text-primary shadow-sm after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+                      : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
                   }`}
-                  title={session.device_id}
+                  title={terminalTabLabel || session.device_id}
                 >
                   <button
                     type="button"
                     data-testid="workspace-terminal-tab"
-                    onClick={() => setActiveTerminalSessionId(session.session_id)}
+                    onClick={() => {
+                      setActiveTerminalSessionId(session.session_id)
+                      setShowToolLauncher(false)
+                    }}
                     className="flex min-w-0 flex-1 items-center gap-2 px-2.5 text-left text-[13px] leading-[18px]"
                   >
                     <SquareTerminal className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
-                    <span className="truncate">{session.device_id}</span>
+                    <span className="truncate">{terminalTabLabel || session.device_id}</span>
                   </button>
                   <button
                     type="button"
                     data-testid="workspace-terminal-close-button"
                     onClick={() => handleCloseTerminalSession(session.session_id)}
-                    className="flex h-8 w-7 shrink-0 items-center justify-center text-text-secondary hover:bg-muted"
+                    className="flex h-8 w-7 shrink-0 items-center justify-center text-text-secondary transition-colors group-hover:text-text-primary"
                     aria-label={t('workbench.close_terminal', '关闭终端')}
                   >
                     <X className="h-3.5 w-3.5" />
@@ -288,118 +247,130 @@ export function WorkspacePanelCards({
           <button
             type="button"
             data-testid="workspace-terminal-new-tab-button"
-            onClick={() => void startTerminalSession()}
-            disabled={loadingTool === 'terminal'}
+            onClick={() => setShowToolLauncher(true)}
             className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-secondary hover:bg-muted disabled:cursor-wait disabled:opacity-50"
-            aria-label={t('workbench.new_terminal_tab', '新建终端标签')}
+            aria-label={t('workbench.show_project_tools', '显示项目工具')}
           >
-            {loadingTool === 'terminal' ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4" />
-            )}
+            <Plus className="h-4 w-4" />
           </button>
         </div>
-        <iframe
-          data-testid="workspace-terminal-frame"
-          title={t('workbench.project_terminal_frame_title', '项目终端')}
-          src={toEmbeddedSessionUrl(activeTerminalSession.url)}
-          className="min-h-0 flex-1 border-0"
-        />
+        {terminalSessions.map(session => {
+          const isActive = session.session_id === activeTerminalSession.session_id
+
+          return (
+            <iframe
+              key={session.session_id}
+              data-testid="workspace-terminal-frame"
+              title={t('workbench.project_terminal_frame_title', '项目终端')}
+              src={session.url}
+              hidden={!isActive}
+              className="min-h-0 flex-1 border-0"
+            />
+          )
+        })}
       </div>
-    )
-  }
+  ) : null
+  const launcherClassName = activeTerminalSession
+    ? 'absolute inset-0 z-10 flex w-full flex-col bg-white'
+    : 'flex h-full min-h-0 w-full flex-col'
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-8 py-6">
-      {!currentProject && (
-        <p className="text-center text-[13px] leading-[18px] text-text-secondary">
-          {t('workbench.project_tool_requires_project', '请选择项目后使用')}
-        </p>
-      )}
-      {error && (
-        <p className="text-center text-[13px] leading-[18px] text-red-500" role="alert">
-          {error}
-        </p>
-      )}
-      {hasExplicitLocalDevice && (
-        <div
-          data-testid="workspace-local-device-limited-tools"
-          className="rounded-lg border border-border bg-surface px-4 py-5 text-center"
-        >
-          <p className="text-sm font-semibold text-text-primary">
-            {t('workbench.local_device_limited_tools_title')}
-          </p>
-          <p className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-            {t('workbench.local_device_limited_tools_desc')}
-          </p>
+    <div className="relative h-full min-h-0 w-full">
+      {terminalWindow}
+      {(!activeTerminalSession || showToolLauncher) && (
+        <div data-testid="workspace-tool-launcher" className={launcherClassName}>
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-8 py-6">
+          {!currentProject && (
+            <p className="text-center text-[13px] leading-[18px] text-text-secondary">
+              {t('workbench.project_tool_requires_project', '请选择项目后使用')}
+            </p>
+          )}
+          {error && (
+            <p className="text-center text-[13px] leading-[18px] text-red-500" role="alert">
+              {error}
+            </p>
+          )}
+          {hasExplicitLocalDevice && (
+            <div
+              data-testid="workspace-local-device-limited-tools"
+              className="rounded-lg border border-border bg-surface px-4 py-5 text-center"
+            >
+              <p className="text-sm font-semibold text-text-primary">
+                {t('workbench.local_device_limited_tools_title')}
+              </p>
+              <p className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                {t('workbench.local_device_limited_tools_desc')}
+              </p>
+            </div>
+          )}
+          {cloudToolsAvailable && (
+            <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-4">
+              <button
+                type="button"
+                data-testid="workspace-terminal-card"
+                onClick={handleTerminalClick}
+                disabled={toolsDisabled || !availableTools.terminal}
+                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loadingTool === 'terminal' ? (
+                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                ) : (
+                  <SquareTerminal className="mb-5 h-7 w-7 text-text-secondary" />
+                )}
+                <span className="text-sm font-semibold text-text-primary">
+                  {t('workbench.terminal', '终端')}
+                </span>
+                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                  {availableTools.terminal
+                    ? t('workbench.start_shell', '启动交互式 shell')
+                    : t('workbench.project_tool_unavailable', '暂不可用')}
+                </span>
+              </button>
+              <button
+                type="button"
+                data-testid="workspace-ide-card"
+                onClick={handleIdeClick}
+                disabled={toolsDisabled || !availableTools.ide}
+                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loadingTool === 'ide' ? (
+                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                ) : (
+                  <Code2 className="mb-5 h-7 w-7 text-text-secondary" />
+                )}
+                <span className="text-sm font-semibold text-text-primary">
+                  {t('workbench.ide', 'IDE')}
+                </span>
+                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                  {availableTools.ide
+                    ? t('workbench.open_project_ide', '打开项目 IDE')
+                    : t('workbench.project_tool_unavailable', '暂不可用')}
+                </span>
+              </button>
+              <button
+                type="button"
+                data-testid="workspace-desktop-card"
+                onClick={handleDesktopClick}
+                disabled={toolsDisabled || !projectDeviceId || !availableTools.desktop}
+                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {loadingTool === 'desktop' ? (
+                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                ) : (
+                  <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
+                )}
+                <span className="text-sm font-semibold text-text-primary">
+                  {t('workbench.desktop', '桌面')}
+                </span>
+                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                  {availableTools.desktop
+                    ? t('workbench.open_project_desktop', '打开项目桌面')
+                    : t('workbench.project_tool_unavailable', '暂不可用')}
+                </span>
+              </button>
+            </div>
+          )}
         </div>
-      )}
-      {cloudToolsAvailable && (
-        <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-4">
-          <button
-            type="button"
-            data-testid="workspace-terminal-card"
-            onClick={handleTerminalClick}
-            disabled={toolsDisabled || !availableTools.terminal}
-            className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loadingTool === 'terminal' ? (
-              <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-            ) : (
-              <SquareTerminal className="mb-5 h-7 w-7 text-text-secondary" />
-            )}
-            <span className="text-sm font-semibold text-text-primary">
-              {t('workbench.terminal', '终端')}
-            </span>
-            <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-              {availableTools.terminal
-                ? t('workbench.start_shell', '启动交互式 shell')
-                : t('workbench.project_tool_unavailable', '暂不可用')}
-            </span>
-          </button>
-          <button
-            type="button"
-            data-testid="workspace-ide-card"
-            onClick={handleIdeClick}
-            disabled={toolsDisabled || !availableTools.ide}
-            className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loadingTool === 'ide' ? (
-              <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-            ) : (
-              <Code2 className="mb-5 h-7 w-7 text-text-secondary" />
-            )}
-            <span className="text-sm font-semibold text-text-primary">
-              {t('workbench.ide', 'IDE')}
-            </span>
-            <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-              {availableTools.ide
-                ? t('workbench.open_project_ide', '打开项目 IDE')
-                : t('workbench.project_tool_unavailable', '暂不可用')}
-            </span>
-          </button>
-          <button
-            type="button"
-            data-testid="workspace-desktop-card"
-            onClick={handleDesktopClick}
-            disabled={toolsDisabled || !projectDeviceId || !availableTools.desktop}
-            className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loadingTool === 'desktop' ? (
-              <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-            ) : (
-              <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
-            )}
-            <span className="text-sm font-semibold text-text-primary">
-              {t('workbench.desktop', '桌面')}
-            </span>
-            <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-              {availableTools.desktop
-                ? t('workbench.open_project_desktop', '打开项目桌面')
-                : t('workbench.project_tool_unavailable', '暂不可用')}
-            </span>
-          </button>
         </div>
       )}
     </div>

--- a/wework/src/components/projects/ProjectCreateDialog.test.tsx
+++ b/wework/src/components/projects/ProjectCreateDialog.test.tsx
@@ -25,6 +25,36 @@ const devices: DeviceInfo[] = [
 ]
 
 describe('ProjectCreateDialog', () => {
+  test('hides OpenClaw devices from the project device selector', () => {
+    render(
+      <ProjectCreateDialog
+        open
+        mode="scratch"
+        devices={[
+          ...devices,
+          {
+            id: 3,
+            device_id: 'openclaw-device',
+            name: 'OpenClaw Device',
+            status: 'online',
+            is_default: false,
+            device_type: 'cloud',
+            bind_shell: 'openclaw',
+          },
+        ]}
+        onClose={vi.fn()}
+        onCreateProject={vi.fn()}
+        onGetDeviceHomeDirectory={vi.fn().mockResolvedValue('/home/user')}
+        onGetProjectWorkspaceRoot={vi.fn().mockResolvedValue('/workspace/projects')}
+        onListDeviceDirectories={vi.fn().mockResolvedValue([])}
+        onCreateDeviceDirectory={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('project-device-select')).toHaveTextContent('Cloud Device')
+    expect(screen.queryByText(/OpenClaw Device/)).not.toBeInTheDocument()
+  })
+
   test('uses the preferred device and keeps form state when device preference changes', async () => {
     const onSelectDevicePreference = vi.fn()
 

--- a/wework/src/components/projects/ProjectCreateDialog.tsx
+++ b/wework/src/components/projects/ProjectCreateDialog.tsx
@@ -64,6 +64,10 @@ function sortDevicesForProjectCreation(devices: DeviceInfo[]): DeviceInfo[] {
   })
 }
 
+function getProjectCreationDevices(devices: DeviceInfo[]): DeviceInfo[] {
+  return sortDevicesForProjectCreation(devices.filter(canUseForProjectCreation))
+}
+
 function getDefaultDeviceId(
   devices: DeviceInfo[],
   preferredDeviceId?: string | null
@@ -75,7 +79,7 @@ function getDefaultDeviceId(
     return preferredDevice.device_id
   }
 
-  return sortDevicesForProjectCreation(devices).find(canUseForProjectCreation)?.device_id ?? ''
+  return getProjectCreationDevices(devices)[0]?.device_id ?? ''
 }
 
 function getParentPath(path: string): string {
@@ -162,7 +166,7 @@ function ProjectCreateDialogContent({
   onCreateDeviceDirectory,
 }: Omit<ProjectCreateDialogProps, 'open'>) {
   const { t } = useTranslation('common')
-  const sortedDevices = useMemo(() => sortDevicesForProjectCreation(devices), [devices])
+  const sortedDevices = useMemo(() => getProjectCreationDevices(devices), [devices])
   const firstDeviceId = useMemo(
     () => getDefaultDeviceId(sortedDevices, preferredDeviceId),
     [preferredDeviceId, sortedDevices]

--- a/wework/src/lib/device-capabilities.ts
+++ b/wework/src/lib/device-capabilities.ts
@@ -3,7 +3,7 @@ import type { DeviceInfo } from '@/types/api'
 type DeviceLike = Pick<DeviceInfo, 'device_type' | 'bind_shell' | 'status'>
 
 export function isClaudeCodeDevice(device: DeviceLike): boolean {
-  return (device.bind_shell ?? 'claudecode') === 'claudecode'
+  return (device.bind_shell ?? 'claudecode').toLowerCase() === 'claudecode'
 }
 
 export function isCloudDevice(device: Pick<DeviceInfo, 'device_type'>): boolean {
@@ -18,8 +18,8 @@ export function canUseForProjectCreation(device: DeviceLike): boolean {
   return isClaudeCodeDevice(device) && isUsableDevice(device)
 }
 
-export function supportsCloudSessions(device: Pick<DeviceInfo, 'device_type'>): boolean {
-  return isCloudDevice(device)
+export function supportsCloudSessions(device: DeviceLike): boolean {
+  return isCloudDevice(device) && isClaudeCodeDevice(device)
 }
 
 export function supportsDeviceMetrics(device: Pick<DeviceInfo, 'device_type'>): boolean {

--- a/wework/src/lib/device-selection.ts
+++ b/wework/src/lib/device-selection.ts
@@ -3,6 +3,11 @@ export interface SelectableDevice {
   name?: string | null
   status?: string | null
   device_type?: string | null
+  bind_shell?: string | null
+}
+
+export function isClaudeCodeDevice(device: SelectableDevice): boolean {
+  return (device.bind_shell ?? 'claudecode').toLowerCase() === 'claudecode'
 }
 
 export function isOnlineDevice(device: SelectableDevice): boolean {
@@ -14,7 +19,7 @@ export function isCloudDevice(device: SelectableDevice): boolean {
 }
 
 export function sortStandaloneDevices<T extends SelectableDevice>(devices: T[]): T[] {
-  return [...devices].sort((left, right) => {
+  return devices.filter(isClaudeCodeDevice).sort((left, right) => {
     const leftOnline = isOnlineDevice(left) ? 0 : 1
     const rightOnline = isOnlineDevice(right) ? 0 : 1
     if (leftOnline !== rightOnline) return leftOnline - rightOnline
@@ -35,7 +40,7 @@ export function getPreferredStandaloneDeviceId(
     ? devices.find(device => device.device_id === currentDeviceId)
     : undefined
 
-  if (currentDevice && isOnlineDevice(currentDevice)) {
+  if (currentDevice && isClaudeCodeDevice(currentDevice) && isOnlineDevice(currentDevice)) {
     return currentDevice.device_id
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an overlay-style tool launcher and an always-present “new tab” control for terminal sessions.

* **Improvements**
  * Better device filtering and selection to prefer compatible cloud devices and handle bind-shell variations case-insensitively.
  * Simplified session startup behavior to avoid pre-opening probes and provide clearer failure handling.
  * Improved terminal tab/window behavior and multi-frame handling.

* **Bug Fixes**
  * Fixed UI to hide incompatible cloud devices from standalone and project device selectors; IDE opening now succeeds when probing is blocked.

* **Tests**
  * Expanded test coverage for device availability, terminal tabs, and IDE startup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->