### PR TITLE
Hide quick action descriptions in launcher cards

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickLauncherCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickLauncherCards.test.tsx
@@ -97,6 +97,29 @@ describe('QuickLauncherCards', () => {
     expect(screen.queryByTestId('quick-launch-system-grid')).not.toHaveClass('justify-center')
   })
 
+  test('renders launcher cards with titles only', () => {
+    render(
+      <QuickLauncherCards
+        systemLaunchers={[
+          makeLauncher({
+            key: 'system:video_summary',
+            title: 'Analyze Weibo video',
+            description: 'Analyze this Weibo video and summarize the author viewpoint',
+          }),
+        ]}
+        favoriteLaunchers={[]}
+        onSelectLauncher={jest.fn()}
+      />
+    )
+
+    const systemCard = screen.getByTestId('quick-launcher-system_function-system-video_summary')
+
+    expect(systemCard).toHaveTextContent('Analyze Weibo video')
+    expect(systemCard).not.toHaveTextContent(
+      'Analyze this Weibo video and summarize the author viewpoint'
+    )
+  })
+
   test('supports horizontal scrolling for both launcher rows without inline arrow slots', () => {
     render(
       <QuickLauncherCards

--- a/frontend/src/features/tasks/components/chat/quick-launch/quick-launcher-cards.tsx
+++ b/frontend/src/features/tasks/components/chat/quick-launch/quick-launcher-cards.tsx
@@ -54,14 +54,6 @@ function LauncherCard({
       >
         {launcher.title}
       </span>
-      {launcher.description && (
-        <span
-          className="mt-1 block truncate text-xs leading-[18px] text-text-muted"
-          title={launcher.description}
-        >
-          {launcher.description}
-        </span>
-      )}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the description preview from quick launch cards so they show only the title
- Add a regression test covering title-only rendering

## Testing
- Unit tests: `QuickLauncherCards.test.tsx` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quick launch launcher cards now display titles only, with descriptions removed from the card interface.

* **Tests**
  * Added test verification for launcher card rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->