### PR TITLE
fix(wework): respect base path for vnc page

### DIFF
--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -7,7 +7,15 @@ import { WorkspacePanelCards } from './WorkspacePanelCards'
 import type { DeviceInfo } from '@/types/api'
 
 vi.mock('@/config/runtime', () => ({
-  getRuntimeConfig: () => ({ apiBaseUrl: '/api' }),
+  getRuntimeConfig: () => ({ appBasePath: '', apiBaseUrl: '/api' }),
+  joinAppPath: (basePath: string, path: string) => {
+    const normalizedBasePath = !basePath || basePath === '/' ? '' : basePath.replace(/\/+$/, '')
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`
+
+    if (!normalizedBasePath) return normalizedPath
+    if (normalizedPath === '/') return `${normalizedBasePath}/`
+    return `${normalizedBasePath}${normalizedPath}`
+  },
 }))
 
 vi.mock('@/api/http', () => ({

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -124,7 +124,7 @@ export function WorkspacePanelCards({
     } catch (e) {
       console.error('Failed to start project terminal:', e)
       markToolUnavailable('terminal')
-      setProjectError(getSessionStartErrorMessage(e))
+      setProjectError(getSessionStartErrorMessage())
     } finally {
       setLoadingTool(null)
     }
@@ -166,7 +166,7 @@ export function WorkspacePanelCards({
     } catch (e) {
       console.error('Failed to start project IDE:', e)
       markToolUnavailable('ide')
-      setProjectError(getSessionStartErrorMessage(e))
+      setProjectError(getSessionStartErrorMessage())
     } finally {
       setLoadingTool(null)
       if (shouldClosePanel) {

--- a/wework/src/lib/vnc.test.ts
+++ b/wework/src/lib/vnc.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { buildVncPageUrl } from './vnc'
+
+describe('buildVncPageUrl', () => {
+  afterEach(() => {
+    localStorage.clear()
+    vi.unstubAllEnvs()
+  })
+
+  test('uses the configured app base path for the VNC page', () => {
+    vi.stubEnv('VITE_APP_BASE_PATH', '/wework')
+    localStorage.setItem('auth_token', 'token value')
+
+    const url = buildVncPageUrl('device/1', 'sandbox-1')
+    const parsedUrl = new URL(url)
+
+    expect(parsedUrl.pathname).toBe('/wework/vnc.html')
+    expect(parsedUrl.searchParams.get('sandboxId')).toBe('sandbox-1')
+    expect(parsedUrl.searchParams.get('wsUrl')).toBe(
+      'ws://localhost:3000/api/cloud-devices/device%2F1/vnc-ws?token=token%20value',
+    )
+  })
+})

--- a/wework/src/lib/vnc.ts
+++ b/wework/src/lib/vnc.ts
@@ -1,9 +1,13 @@
+import { getRuntimeConfig, joinAppPath } from '@/config/runtime'
+
 export function buildVncPageUrl(deviceId: string, sandboxId: string): string {
   const token = localStorage.getItem('auth_token') || ''
+  const { appBasePath } = getRuntimeConfig()
   const origin = window.location.origin
   const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
   const host = window.location.host
   const vncWsUrl = `${protocol}//${host}/api/cloud-devices/${encodeURIComponent(deviceId)}/vnc-ws?token=${encodeURIComponent(token)}`
+  const vncPagePath = joinAppPath(appBasePath, '/vnc.html')
 
-  return `${origin}/vnc.html?wsUrl=${encodeURIComponent(vncWsUrl)}&sandboxId=${encodeURIComponent(sandboxId)}`
+  return `${origin}${vncPagePath}?wsUrl=${encodeURIComponent(vncWsUrl)}&sandboxId=${encodeURIComponent(sandboxId)}`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error message handling when terminal and IDE session initialization fails.

* **Tests**
  * Added test coverage for VNC page URL generation.
  * Updated test configuration for workspace panel component validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->