### PR TITLE
Add resource library sorting and stop-port cleanup

### DIFF
--- a/backend/app/api/endpoints/adapter/shells.py
+++ b/backend/app/api/endpoints/adapter/shells.py
@@ -59,6 +59,8 @@ class UnifiedShell(BaseModel):
     requiresWorkspace: Optional[bool] = (
         None  # Whether this shell requires a workspace. Defaults based on executionType.
     )
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
 
 class ShellCreateRequest(BaseModel):
@@ -148,6 +150,8 @@ def _public_shell_to_unified(shell: Kind) -> UnifiedShell:
         executionType=labels.get("type"),
         namespace=shell.namespace,
         requiresWorkspace=shell_crd.spec.requiresWorkspace,
+        created_at=shell.created_at,
+        updated_at=shell.updated_at,
     )
 
 
@@ -170,6 +174,8 @@ def _user_shell_to_unified(kind: Kind) -> UnifiedShell:
         executionType=labels.get("type"),
         namespace=kind.namespace,
         requiresWorkspace=shell_crd.spec.requiresWorkspace,
+        created_at=kind.created_at,
+        updated_at=kind.updated_at,
     )
 
 

--- a/backend/app/services/adapters/retriever_kinds.py
+++ b/backend/app/services/adapters/retriever_kinds.py
@@ -606,6 +606,8 @@ class RetrieverKindsService(BaseService[Kind, Dict, Dict]):
                 "storageType": retriever.spec.storageConfig.type,
                 "namespace": kind.namespace,
                 "description": retriever.spec.description,
+                "created_at": kind.created_at,
+                "updated_at": kind.updated_at,
             }
         except Exception as e:
             logger.warning(f"Failed to parse retriever {kind.name}: {e}")
@@ -623,6 +625,8 @@ class RetrieverKindsService(BaseService[Kind, Dict, Dict]):
                 "storageType": "unknown",
                 "namespace": kind.namespace,
                 "description": None,
+                "created_at": kind.created_at,
+                "updated_at": kind.updated_at,
             }
 
 

--- a/backend/app/services/model_aggregation_service.py
+++ b/backend/app/services/model_aggregation_service.py
@@ -91,6 +91,8 @@ class UnifiedModel:
         model_group: Optional[str] = None,
         model_sub_group: Optional[str] = None,
         runtime_family: Optional[str] = None,
+        created_at: Optional[Any] = None,
+        updated_at: Optional[Any] = None,
     ):
         self.name = name
         self.type = (
@@ -108,6 +110,8 @@ class UnifiedModel:
         self.is_advanced = is_advanced
         self.model_group = model_group
         self.model_sub_group = model_sub_group
+        self.created_at = created_at
+        self.updated_at = updated_at
         self.runtime_family = runtime_family or build_model_runtime_family(
             provider, self.config
         )
@@ -138,6 +142,8 @@ class UnifiedModel:
             "modelSubGroup": self.model_sub_group,
             "runtime": self.runtime,
             "config": safe_config,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
 
     def to_full_dict(self) -> Dict[str, Any]:
@@ -501,6 +507,8 @@ class ModelAggregationService:
                     is_advanced=info.get("is_advanced", False),
                     model_group=info.get("model_group"),
                     model_sub_group=info.get("model_sub_group"),
+                    created_at=resource.created_at,
+                    updated_at=resource.updated_at,
                 )
                 result.append(unified)
                 seen_names[resource.name] = resource_type
@@ -553,6 +561,8 @@ class ModelAggregationService:
                 or model_dict.get("model_group"),
                 model_sub_group=model_dict.get("modelSubGroup")
                 or model_dict.get("model_sub_group"),
+                created_at=model_dict.get("created_at"),
+                updated_at=model_dict.get("updated_at"),
             )
 
             # If name already exists as user model, we still add public model
@@ -612,6 +622,8 @@ class ModelAggregationService:
                     is_active=resource.is_active,
                     model_group=info.get("model_group"),
                     model_sub_group=info.get("model_sub_group"),
+                    created_at=resource.created_at,
+                    updated_at=resource.updated_at,
                 ).to_full_dict()
 
         elif model_type == ModelType.PUBLIC:
@@ -638,6 +650,8 @@ class ModelAggregationService:
                         or model_dict.get("model_group"),
                         model_sub_group=model_dict.get("modelSubGroup")
                         or model_dict.get("model_sub_group"),
+                        created_at=model_dict.get("created_at"),
+                        updated_at=model_dict.get("updated_at"),
                     ).to_full_dict()
 
         return None

--- a/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
+++ b/frontend/src/__tests__/features/resource-library/MyResources.test.tsx
@@ -28,13 +28,23 @@ jest.mock('@/features/settings/components/TeamListWithScope', () => ({
     scope,
     selectedGroup,
     sourceControls,
+    sortControls,
+    sortMode,
   }: {
     scope: string
     selectedGroup?: string | null
     sourceControls?: React.ReactNode
+    sortControls?: React.ReactNode
+    sortMode?: string
   }) => (
-    <div data-testid="agent-resource-manager" data-scope={scope} data-group={selectedGroup ?? ''}>
+    <div
+      data-testid="agent-resource-manager"
+      data-scope={scope}
+      data-group={selectedGroup ?? ''}
+      data-sort={sortMode ?? ''}
+    >
       {sourceControls}
+      {sortControls}
     </div>
   ),
 }))
@@ -44,13 +54,23 @@ jest.mock('@/features/settings/components/ModelListWithScope', () => ({
     scope,
     selectedGroup,
     sourceControls,
+    sortControls,
+    sortMode,
   }: {
     scope: string
     selectedGroup?: string | null
     sourceControls?: React.ReactNode
+    sortControls?: React.ReactNode
+    sortMode?: string
   }) => (
-    <div data-testid="model-resource-manager" data-scope={scope} data-group={selectedGroup ?? ''}>
+    <div
+      data-testid="model-resource-manager"
+      data-scope={scope}
+      data-group={selectedGroup ?? ''}
+      data-sort={sortMode ?? ''}
+    >
       {sourceControls}
+      {sortControls}
     </div>
   ),
 }))
@@ -60,13 +80,23 @@ jest.mock('@/features/settings/components/ShellListWithScope', () => ({
     scope,
     selectedGroup,
     sourceControls,
+    sortControls,
+    sortMode,
   }: {
     scope: string
     selectedGroup?: string | null
     sourceControls?: React.ReactNode
+    sortControls?: React.ReactNode
+    sortMode?: string
   }) => (
-    <div data-testid="shell-resource-manager" data-scope={scope} data-group={selectedGroup ?? ''}>
+    <div
+      data-testid="shell-resource-manager"
+      data-scope={scope}
+      data-group={selectedGroup ?? ''}
+      data-sort={sortMode ?? ''}
+    >
       {sourceControls}
+      {sortControls}
     </div>
   ),
 }))
@@ -76,13 +106,23 @@ jest.mock('@/features/settings/components/SkillListWithScope', () => ({
     scope,
     selectedGroup,
     sourceControls,
+    sortControls,
+    sortMode,
   }: {
     scope: string
     selectedGroup?: string | null
     sourceControls?: React.ReactNode
+    sortControls?: React.ReactNode
+    sortMode?: string
   }) => (
-    <div data-testid="skill-resource-manager" data-scope={scope} data-group={selectedGroup ?? ''}>
+    <div
+      data-testid="skill-resource-manager"
+      data-scope={scope}
+      data-group={selectedGroup ?? ''}
+      data-sort={sortMode ?? ''}
+    >
       {sourceControls}
+      {sortControls}
     </div>
   ),
 }))
@@ -92,17 +132,23 @@ jest.mock('@/features/settings/components/RetrieverListWithScope', () => ({
     scope,
     selectedGroup,
     sourceControls,
+    sortControls,
+    sortMode,
   }: {
     scope: string
     selectedGroup?: string | null
     sourceControls?: React.ReactNode
+    sortControls?: React.ReactNode
+    sortMode?: string
   }) => (
     <div
       data-testid="retriever-resource-manager"
       data-scope={scope}
       data-group={selectedGroup ?? ''}
+      data-sort={sortMode ?? ''}
     >
       {sourceControls}
+      {sortControls}
     </div>
   ),
 }))
@@ -123,6 +169,9 @@ jest.mock('@/hooks/useTranslation', () => ({
         'sources.all_groups': '全部团队',
         'actions.manage_groups': '管理...',
         'fields.source': '来源',
+        'fields.sort': '排序',
+        'sort.default': '默认',
+        'sort.latest': '最新',
         'states.no_groups': '暂无组资源',
         'search.groups_placeholder': '搜索团队',
         'search.groups_empty': '没有匹配的团队',
@@ -181,6 +230,7 @@ describe('MyResources', () => {
     render(<MyResources title="资源库" />)
 
     expect(await screen.findByTestId('agent-resource-manager')).toHaveAttribute('data-scope', 'all')
+    expect(screen.getByTestId('agent-resource-manager')).toHaveAttribute('data-sort', 'default')
     const header = screen.getByTestId('managed-resource-header')
     expect(within(header).getByRole('heading', { name: '资源库' })).toBeInTheDocument()
     expect(within(header).getByTestId('managed-resource-type-tabs')).toBeInTheDocument()
@@ -205,6 +255,17 @@ describe('MyResources', () => {
     expect(within(sourceFilter).getByTestId('resource-source-group-button')).toBeInTheDocument()
     expect(within(sourceFilter).getByTestId('resource-source-system-button')).toBeInTheDocument()
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument()
+
+    const sortControl = screen.getByTestId('managed-resource-sort-control')
+    expect(within(sortControl).getByText('排序')).toBeInTheDocument()
+    expect(within(sortControl).getByTestId('resource-sort-default-button')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(within(sortControl).getByTestId('resource-sort-latest-button')).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    )
 
     await openGroupMenu()
     expect(await screen.findByRole('menuitem', { name: '全部团队' })).toBeInTheDocument()
@@ -301,7 +362,11 @@ describe('MyResources', () => {
   })
 
   it('opens the managed resource type from the URL query', async () => {
-    window.history.replaceState({}, '', '/resource-library?tab=mine&type=skill&scope=personal')
+    window.history.replaceState(
+      {},
+      '',
+      '/resource-library?tab=mine&type=skill&scope=personal&sort=latest'
+    )
 
     render(<MyResources />)
 
@@ -309,7 +374,12 @@ describe('MyResources', () => {
       'data-scope',
       'personal'
     )
+    expect(screen.getByTestId('skill-resource-manager')).toHaveAttribute('data-sort', 'latest')
     expect(screen.getByTestId('managed-resource-skill-tab')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('resource-sort-latest-button')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
   })
 
   it('updates the URL query when switching managed resource types', async () => {
@@ -322,6 +392,26 @@ describe('MyResources', () => {
       '/resource-library?tab=mine&type=skill&scope=personal',
       { scroll: false }
     )
+  })
+
+  it('updates the URL query when switching resource sort modes', async () => {
+    window.history.replaceState({}, '', '/resource-library?tab=mine&type=agent&source=all')
+    render(<MyResources />)
+
+    fireEvent.click(await screen.findByTestId('resource-sort-latest-button'))
+
+    expect(screen.getByTestId('agent-resource-manager')).toHaveAttribute('data-sort', 'latest')
+    expect(mockReplace).toHaveBeenCalledWith(
+      '/resource-library?tab=mine&type=agent&source=all&sort=latest',
+      { scroll: false }
+    )
+
+    fireEvent.click(screen.getByTestId('resource-sort-default-button'))
+
+    expect(screen.getByTestId('agent-resource-manager')).toHaveAttribute('data-sort', 'default')
+    expect(mockReplace).toHaveBeenCalledWith('/resource-library?tab=mine&type=agent&source=all', {
+      scroll: false,
+    })
   })
 
   it('filters to all groups or a selected group from the team source dropdown', async () => {

--- a/frontend/src/__tests__/features/resource-library/resourceSorting.test.ts
+++ b/frontend/src/__tests__/features/resource-library/resourceSorting.test.ts
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getResourceLibrarySortMode,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
+
+interface TestResource {
+  id: number
+  name: string
+  displayName?: string
+  namespace?: string
+  source: ResourceLibrarySortSource
+  created_at?: string
+  updated_at?: string
+}
+
+const groupDisplayNames = new Map([
+  ['team-a', 'Alpha Team'],
+  ['team-z', 'Zeta Team'],
+])
+
+function sortResources(items: TestResource[], sortMode: 'default' | 'latest') {
+  return sortResourceLibraryItems(items, {
+    sortMode,
+    groupDisplayNames,
+    getSource: item => item.source,
+    getName: item => item.name,
+    getDisplayName: item => item.displayName,
+    getNamespace: item => item.namespace,
+    getCreatedAt: item => item.created_at,
+    getUpdatedAt: item => item.updated_at,
+    getStableId: item => item.id,
+  })
+}
+
+describe('resource library sorting', () => {
+  it('normalizes invalid sort modes to the default mode', () => {
+    expect(getResourceLibrarySortMode(null)).toBe('default')
+    expect(getResourceLibrarySortMode('latest')).toBe('latest')
+    expect(getResourceLibrarySortMode('created')).toBe('default')
+  })
+
+  it('sorts default mode by source group, team name, then resource display name', () => {
+    const sorted = sortResources(
+      [
+        { id: 1, name: 'system-alpha', displayName: 'Alpha', source: 'system' },
+        {
+          id: 2,
+          name: 'group-z-beta',
+          displayName: 'Beta',
+          namespace: 'team-z',
+          source: 'group',
+        },
+        { id: 3, name: 'personal-zeta', displayName: 'Zeta', source: 'personal' },
+        {
+          id: 4,
+          name: 'group-a-zoo',
+          displayName: 'Zoo',
+          namespace: 'team-a',
+          source: 'group',
+        },
+        {
+          id: 5,
+          name: 'group-a-alpha',
+          displayName: 'Alpha',
+          namespace: 'team-a',
+          source: 'group',
+        },
+        { id: 6, name: 'personal-alpha', displayName: 'Alpha', source: 'personal' },
+      ],
+      'default'
+    )
+
+    expect(sorted.map(item => item.name)).toEqual([
+      'personal-alpha',
+      'personal-zeta',
+      'group-a-alpha',
+      'group-a-zoo',
+      'group-z-beta',
+      'system-alpha',
+    ])
+  })
+
+  it('sorts latest mode by updated time and falls back to default ordering for ties', () => {
+    const sorted = sortResources(
+      [
+        {
+          id: 1,
+          name: 'system-old',
+          displayName: 'Old',
+          source: 'system',
+          updated_at: '2026-05-01T00:00:00Z',
+        },
+        {
+          id: 2,
+          name: 'personal-mid',
+          displayName: 'Mid',
+          source: 'personal',
+          updated_at: '2026-05-02T00:00:00Z',
+        },
+        {
+          id: 3,
+          name: 'group-new',
+          displayName: 'New',
+          namespace: 'team-a',
+          source: 'group',
+          updated_at: '2026-05-03T00:00:00Z',
+        },
+        {
+          id: 4,
+          name: 'personal-alpha-tie',
+          displayName: 'Alpha',
+          source: 'personal',
+          updated_at: '2026-05-03T00:00:00Z',
+        },
+      ],
+      'latest'
+    )
+
+    expect(sorted.map(item => item.name)).toEqual([
+      'personal-alpha-tie',
+      'group-new',
+      'personal-mid',
+      'system-old',
+    ])
+  })
+})

--- a/frontend/src/apis/models.ts
+++ b/frontend/src/apis/models.ts
@@ -169,6 +169,8 @@ export interface UnifiedModel {
   isAdvanced?: boolean
   modelGroup?: string | null
   modelSubGroup?: string | null
+  created_at?: string | null
+  updated_at?: string | null
 }
 
 export interface UnifiedModelListResponse {

--- a/frontend/src/apis/retrievers.ts
+++ b/frontend/src/apis/retrievers.ts
@@ -59,6 +59,8 @@ export interface UnifiedRetriever {
   storageType: string // 'elasticsearch' | 'qdrant'
   namespace: string
   description?: string
+  created_at?: string | null
+  updated_at?: string | null
 }
 
 // Test Connection Types

--- a/frontend/src/apis/shells.ts
+++ b/frontend/src/apis/shells.ts
@@ -18,6 +18,8 @@ export interface UnifiedShell {
   executionType?: 'local_engine' | 'external_api' | null // Shell execution type
   namespace?: string // Resource namespace (group name or 'default')
   requiresWorkspace?: boolean // Whether this shell requires a workspace (default: true for local_engine)
+  created_at?: string | null
+  updated_at?: string | null
 }
 
 export interface UnifiedShellListResponse {

--- a/frontend/src/features/resource-library/components/MyResources.tsx
+++ b/frontend/src/features/resource-library/components/MyResources.tsx
@@ -21,6 +21,7 @@ import { Input } from '@/components/ui/input'
 import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import type { Group } from '@/types/group'
+import { getResourceLibrarySortMode, type ResourceLibrarySortMode } from '../resourceSorting'
 import type { ManagedResourceSourceFilter, ManagedResourceType } from '../types'
 
 const managedResourceTypes: ManagedResourceType[] = [
@@ -38,6 +39,7 @@ const resourceLibraryUrlParams = {
   source: 'source',
   legacyScope: 'scope',
   group: 'group',
+  sort: 'sort',
 } as const
 
 const TeamListWithScope = dynamic(
@@ -117,6 +119,10 @@ function getGroupNameFromSearchParams(params: SearchParamReader): string | null 
   return params.get(resourceLibraryUrlParams.group)
 }
 
+function getSortModeFromSearchParams(params: SearchParamReader): ResourceLibrarySortMode {
+  return getResourceLibrarySortMode(params.get(resourceLibraryUrlParams.sort))
+}
+
 function getInitialResourceType(): ManagedResourceType {
   return getResourceTypeFromSearchParams(getInitialSearchParams())
 }
@@ -127,6 +133,10 @@ function getInitialSourceFilter(): ManagedResourceSourceFilter {
 
 function getInitialGroupName(): string | null {
   return getGroupNameFromSearchParams(getInitialSearchParams())
+}
+
+function getInitialSortMode(): ResourceLibrarySortMode {
+  return getSortModeFromSearchParams(getInitialSearchParams())
 }
 
 function getGroupDisplayName(group: Group): string {
@@ -392,6 +402,45 @@ function ResourceSourceFilterControls({
   )
 }
 
+function ResourceSortControls({
+  value,
+  onValueChange,
+}: {
+  value: ResourceLibrarySortMode
+  onValueChange: (value: ResourceLibrarySortMode) => void
+}) {
+  const t = useResourceLibraryTranslation()
+  const options: ResourceLibrarySortMode[] = ['default', 'latest']
+
+  return (
+    <div
+      className="flex flex-col gap-2 sm:flex-row sm:items-center lg:flex-shrink-0 lg:justify-end"
+      data-testid="managed-resource-sort-control"
+    >
+      <span className="text-xs font-medium text-text-muted">{t('fields.sort')}</span>
+      <div className="flex flex-wrap items-center gap-2">
+        {options.map(option => {
+          const isActive = value === option
+
+          return (
+            <Button
+              key={option}
+              type="button"
+              variant={isActive ? 'primary' : 'outline'}
+              aria-pressed={isActive}
+              className="h-11 min-w-[44px] px-4 lg:h-9"
+              onClick={() => onValueChange(option)}
+              data-testid={`resource-sort-${option}-button`}
+            >
+              {t(`sort.${option}`)}
+            </Button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
 function sourceFilterToScope(
   sourceFilter: ManagedResourceSourceFilter
 ): 'personal' | 'group' | 'all' {
@@ -416,16 +465,19 @@ export function MyResources({ title }: MyResourcesProps = {}) {
     useState<ManagedResourceSourceFilter>(getInitialSourceFilter)
   const [groups, setGroups] = useState<Group[]>([])
   const [selectedGroup, setSelectedGroup] = useState<string | null>(getInitialGroupName)
+  const [sortMode, setSortMode] = useState<ResourceLibrarySortMode>(getInitialSortMode)
 
   const replaceResourceLibraryUrl = useCallback(
     ({
       type,
       source,
       group,
+      sort,
     }: {
       type?: ManagedResourceType
       source?: ManagedResourceSourceFilter
       group?: string | null
+      sort?: ResourceLibrarySortMode
     }) => {
       const params = new URLSearchParams(searchParamsSnapshot)
 
@@ -443,6 +495,14 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           params.set(resourceLibraryUrlParams.group, group)
         } else {
           params.delete(resourceLibraryUrlParams.group)
+        }
+      }
+
+      if (sort) {
+        if (sort === 'latest') {
+          params.set(resourceLibraryUrlParams.sort, sort)
+        } else {
+          params.delete(resourceLibraryUrlParams.sort)
         }
       }
 
@@ -485,11 +545,20 @@ export function MyResources({ title }: MyResourcesProps = {}) {
     [replaceResourceLibraryUrl]
   )
 
+  const handleSortModeChange = useCallback(
+    (nextSortMode: ResourceLibrarySortMode) => {
+      setSortMode(nextSortMode)
+      replaceResourceLibraryUrl({ sort: nextSortMode })
+    },
+    [replaceResourceLibraryUrl]
+  )
+
   useEffect(() => {
     const params = new URLSearchParams(searchParamsSnapshot)
     setResourceType(getResourceTypeFromSearchParams(params))
     setSourceFilter(getSourceFilterFromSearchParams(params))
     setSelectedGroup(getGroupNameFromSearchParams(params))
+    setSortMode(getSortModeFromSearchParams(params))
   }, [searchParamsSnapshot])
 
   useEffect(() => {
@@ -521,6 +590,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
         onGroupSourceChange={handleGroupSourceChange}
       />
     )
+    const sortControls = (
+      <ResourceSortControls value={sortMode} onValueChange={handleSortModeChange} />
+    )
     const groupName = sourceFilter === 'group' ? selectedGroup : null
 
     if (resourceType === 'agent') {
@@ -530,7 +602,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           selectedGroup={groupName}
           sourceFilter={sourceFilter}
           sourceControls={sourceControls}
+          sortControls={sortControls}
           groups={groups}
+          sortMode={sortMode}
         />
       )
     }
@@ -541,7 +615,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           selectedGroup={groupName}
           sourceFilter={sourceFilter}
           sourceControls={sourceControls}
+          sortControls={sortControls}
           groups={groups}
+          sortMode={sortMode}
         />
       )
     }
@@ -552,7 +628,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           selectedGroup={groupName}
           sourceFilter={sourceFilter}
           sourceControls={sourceControls}
+          sortControls={sortControls}
           groups={groups}
+          sortMode={sortMode}
         />
       )
     }
@@ -563,7 +641,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           selectedGroup={groupName}
           sourceFilter={sourceFilter}
           sourceControls={sourceControls}
+          sortControls={sortControls}
           groups={groups}
+          sortMode={sortMode}
         />
       )
     }
@@ -574,7 +654,9 @@ export function MyResources({ title }: MyResourcesProps = {}) {
           selectedGroup={groupName}
           sourceFilter={sourceFilter}
           sourceControls={sourceControls}
+          sortControls={sortControls}
           groups={groups}
+          sortMode={sortMode}
         />
       )
     }

--- a/frontend/src/features/resource-library/resourceSorting.ts
+++ b/frontend/src/features/resource-library/resourceSorting.ts
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Group } from '@/types/group'
+
+export type ResourceLibrarySortMode = 'default' | 'latest'
+
+export type ResourceLibrarySortSource = 'personal' | 'group' | 'system'
+
+type ResourceTimestamp = string | number | Date | null | undefined
+
+interface ResourceLibrarySortOptions<T> {
+  sortMode: ResourceLibrarySortMode
+  groupDisplayNames?: Map<string, string>
+  getSource: (item: T) => ResourceLibrarySortSource
+  getName: (item: T) => string | null | undefined
+  getDisplayName?: (item: T) => string | null | undefined
+  getNamespace?: (item: T) => string | null | undefined
+  getCreatedAt?: (item: T) => ResourceTimestamp
+  getUpdatedAt?: (item: T) => ResourceTimestamp
+  getStableId?: (item: T) => string | number | null | undefined
+}
+
+const sourceRanks: Record<ResourceLibrarySortSource, number> = {
+  personal: 0,
+  group: 1,
+  system: 2,
+}
+
+const nameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+})
+
+export function getResourceLibrarySortMode(
+  value: string | null | undefined
+): ResourceLibrarySortMode {
+  return value === 'latest' ? 'latest' : 'default'
+}
+
+export function buildGroupDisplayNameMap(groups: Group[]): Map<string, string> {
+  return new Map(groups.map(group => [group.name, group.display_name || group.name]))
+}
+
+function compareText(left: string | null | undefined, right: string | null | undefined): number {
+  return nameCollator.compare(left || '', right || '')
+}
+
+function getTimestamp(value: ResourceTimestamp): number | null {
+  if (!value) {
+    return null
+  }
+
+  if (value instanceof Date) {
+    const time = value.getTime()
+    return Number.isNaN(time) ? null : time
+  }
+
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? null : value
+  }
+
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function getSortTimestamp<T>(item: T, options: ResourceLibrarySortOptions<T>): number | null {
+  return getTimestamp(options.getUpdatedAt?.(item)) ?? getTimestamp(options.getCreatedAt?.(item))
+}
+
+function compareByDefault<T>(left: T, right: T, options: ResourceLibrarySortOptions<T>): number {
+  const leftSource = options.getSource(left)
+  const rightSource = options.getSource(right)
+  const sourceResult = sourceRanks[leftSource] - sourceRanks[rightSource]
+
+  if (sourceResult !== 0) {
+    return sourceResult
+  }
+
+  if (leftSource === 'group') {
+    const leftNamespace = options.getNamespace?.(left)
+    const rightNamespace = options.getNamespace?.(right)
+    const leftGroupName =
+      (leftNamespace && options.groupDisplayNames?.get(leftNamespace)) || leftNamespace
+    const rightGroupName =
+      (rightNamespace && options.groupDisplayNames?.get(rightNamespace)) || rightNamespace
+    const groupResult = compareText(leftGroupName, rightGroupName)
+
+    if (groupResult !== 0) {
+      return groupResult
+    }
+  }
+
+  const nameResult = compareText(
+    options.getDisplayName?.(left) || options.getName(left),
+    options.getDisplayName?.(right) || options.getName(right)
+  )
+
+  if (nameResult !== 0) {
+    return nameResult
+  }
+
+  const namespaceResult = compareText(options.getNamespace?.(left), options.getNamespace?.(right))
+
+  if (namespaceResult !== 0) {
+    return namespaceResult
+  }
+
+  return compareText(
+    String(options.getStableId?.(left) ?? ''),
+    String(options.getStableId?.(right) ?? '')
+  )
+}
+
+export function sortResourceLibraryItems<T>(
+  items: T[],
+  options: ResourceLibrarySortOptions<T>
+): T[] {
+  return [...items].sort((left, right) => {
+    if (options.sortMode === 'latest') {
+      const leftTimestamp = getSortTimestamp(left, options)
+      const rightTimestamp = getSortTimestamp(right, options)
+
+      if (leftTimestamp !== rightTimestamp) {
+        if (leftTimestamp === null) {
+          return 1
+        }
+
+        if (rightTimestamp === null) {
+          return -1
+        }
+
+        return rightTimestamp - leftTimestamp
+      }
+    }
+
+    return compareByDefault(left, right, options)
+  })
+}

--- a/frontend/src/features/settings/components/ModelList.tsx
+++ b/frontend/src/features/settings/components/ModelList.tsx
@@ -35,6 +35,12 @@ import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
 import {
+  buildGroupDisplayNameMap,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortMode,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
+import {
   hasResourceCreateTargets,
   ResourceCreateButton,
   type ResourceCreateTarget,
@@ -76,6 +82,8 @@ interface DisplayModel {
   namespace: string // Resource namespace (group name or 'default')
   config: Record<string, unknown> // Full config from unified API
   modelCategoryType: ModelCategoryType // Model category type: llm, tts, stt, embedding, rerank
+  created_at?: string | null
+  updated_at?: string | null
 }
 
 interface ModelListProps {
@@ -84,8 +92,10 @@ interface ModelListProps {
   groupRoleMap?: Map<string, BaseRole>
   onEditResource?: (namespace: string) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 const ModelList: React.FC<ModelListProps> = ({
@@ -94,8 +104,10 @@ const ModelList: React.FC<ModelListProps> = ({
   groupRoleMap,
   onEditResource,
   sourceControls,
+  sortControls,
   sourceFilter = 'all',
   groups = [],
+  sortMode = 'default',
 }) => {
   const { t } = useTranslation()
   const { toast } = useToast()
@@ -153,8 +165,16 @@ const ModelList: React.FC<ModelListProps> = ({
     return unifiedModels
   }, [unifiedModels, sourceFilter])
 
+  const groupDisplayNames = React.useMemo(() => buildGroupDisplayNameMap(groups), [groups])
+
+  const getModelSource = React.useCallback((model: DisplayModel): ResourceLibrarySortSource => {
+    if (model.sourceType === 'public') return 'system'
+    if (model.sourceType === 'group') return 'group'
+    return 'personal'
+  }, [])
+
   const displayModels = React.useMemo(() => {
-    return sourceFilteredModels.map(model => {
+    const mappedModels = sourceFilteredModels.map(model => {
       const config = (model.config as Record<string, unknown>) || {}
       const env = (config?.env as Record<string, unknown>) || {}
       const isPublic = model.type === 'public'
@@ -171,9 +191,23 @@ const ModelList: React.FC<ModelListProps> = ({
         namespace: model.namespace || 'default',
         config,
         modelCategoryType: (model.modelCategoryType as ModelCategoryType) || 'llm',
+        created_at: model.created_at,
+        updated_at: model.updated_at,
       }
     })
-  }, [sourceFilteredModels])
+
+    return sortResourceLibraryItems(mappedModels, {
+      sortMode,
+      groupDisplayNames,
+      getSource: getModelSource,
+      getName: model => model.name,
+      getDisplayName: model => model.displayName,
+      getNamespace: model => model.namespace,
+      getCreatedAt: model => model.created_at,
+      getUpdatedAt: model => model.updated_at,
+      getStableId: model => `${model.sourceType}-${model.namespace}-${model.name}`,
+    })
+  }, [sourceFilteredModels, sortMode, groupDisplayNames, getModelSource])
 
   const totalModels = displayModels.length
 
@@ -401,10 +435,13 @@ const ModelList: React.FC<ModelListProps> = ({
   )
 
   const filters = (
-    <>
-      {sourceControls}
-      {categoryFilterControls}
-    </>
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+      <div className="flex min-w-0 flex-col gap-3">
+        {sourceControls}
+        {categoryFilterControls}
+      </div>
+      {sortControls}
+    </div>
   )
 
   return (

--- a/frontend/src/features/settings/components/ModelListWithScope.tsx
+++ b/frontend/src/features/settings/components/ModelListWithScope.tsx
@@ -11,14 +11,17 @@ import { listGroups } from '@/apis/groups'
 import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
+import type { ResourceLibrarySortMode } from '@/features/resource-library/resourceSorting'
 
 interface ModelListWithScopeProps {
   scope: 'personal' | 'group' | 'all'
   selectedGroup?: string | null
   onGroupChange?: (groupName: string | null) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export function ModelListWithScope({
@@ -26,8 +29,10 @@ export function ModelListWithScope({
   selectedGroup: externalSelectedGroup,
   onGroupChange,
   sourceControls,
+  sortControls,
   sourceFilter,
   groups: externalGroups,
+  sortMode = 'default',
 }: ModelListWithScopeProps) {
   // Use external state if provided, otherwise use internal state
   const [internalSelectedGroup, setInternalSelectedGroup] = useState<string | null>(null)
@@ -76,8 +81,10 @@ export function ModelListWithScope({
       <ModelList
         scope="personal"
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -88,8 +95,10 @@ export function ModelListWithScope({
         scope="all"
         groupRoleMap={groupRoleMap}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -110,8 +119,10 @@ export function ModelListWithScope({
         groupRoleMap={groupRoleMap}
         onEditResource={handleEditResource}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     </div>
   )

--- a/frontend/src/features/settings/components/RetrieverList.tsx
+++ b/frontend/src/features/settings/components/RetrieverList.tsx
@@ -35,6 +35,12 @@ import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
 import {
+  buildGroupDisplayNameMap,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortMode,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
+import {
   hasResourceCreateTargets,
   ResourceCreateButton,
   type ResourceCreateTarget,
@@ -47,8 +53,10 @@ interface RetrieverListProps {
   groupRoleMap?: Map<string, BaseRole>
   onEditResource?: (namespace: string) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 const RetrieverList: React.FC<RetrieverListProps> = ({
@@ -57,8 +65,10 @@ const RetrieverList: React.FC<RetrieverListProps> = ({
   groupRoleMap,
   onEditResource,
   sourceControls,
+  sortControls,
   sourceFilter = 'all',
   groups = [],
+  sortMode = 'default',
 }) => {
   const { t } = useTranslation()
   const { toast } = useToast()
@@ -107,7 +117,34 @@ const RetrieverList: React.FC<RetrieverListProps> = ({
     return retrievers
   }, [retrievers, sourceFilter])
 
-  const totalRetrievers = sourceFilteredRetrievers.length
+  const groupDisplayNames = React.useMemo(() => buildGroupDisplayNameMap(groups), [groups])
+
+  const getRetrieverSource = React.useCallback(
+    (retriever: UnifiedRetriever): ResourceLibrarySortSource => {
+      if (retriever.type === 'public') return 'system'
+      if (retriever.type === 'group') return 'group'
+      return 'personal'
+    },
+    []
+  )
+
+  const sortedRetrievers = React.useMemo(
+    () =>
+      sortResourceLibraryItems(sourceFilteredRetrievers, {
+        sortMode,
+        groupDisplayNames,
+        getSource: getRetrieverSource,
+        getName: retriever => retriever.name,
+        getDisplayName: retriever => retriever.displayName,
+        getNamespace: retriever => retriever.namespace,
+        getCreatedAt: retriever => retriever.created_at,
+        getUpdatedAt: retriever => retriever.updated_at,
+        getStableId: retriever => `${retriever.type}-${retriever.namespace}-${retriever.name}`,
+      }),
+    [sourceFilteredRetrievers, sortMode, groupDisplayNames, getRetrieverSource]
+  )
+
+  const totalRetrievers = sortedRetrievers.length
 
   // Helper function to check permissions for a specific group resource
   const canEditGroupResource = (namespace: string) => {
@@ -249,13 +286,21 @@ const RetrieverList: React.FC<RetrieverListProps> = ({
     />
   ) : null
 
+  const filters =
+    sourceControls || sortControls ? (
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">{sourceControls}</div>
+        {sortControls}
+      </div>
+    ) : null
+
   return (
     <>
       <ResourceManagementLayout
         title={t('common:retrievers.title')}
         description={t('common:retrievers.description')}
         actions={createAction}
-        filters={sourceControls}
+        filters={filters}
       >
         {loading && (
           <div className="flex items-center justify-center py-12">
@@ -275,7 +320,7 @@ const RetrieverList: React.FC<RetrieverListProps> = ({
 
         {!loading && totalRetrievers > 0 && (
           <div className="space-y-3" data-testid="retriever-list-items">
-            {sourceFilteredRetrievers.map(retriever => (
+            {sortedRetrievers.map(retriever => (
               <Card
                 key={`${retriever.type}-${retriever.namespace}-${retriever.name}`}
                 className="overflow-hidden bg-base p-3 transition-colors hover:bg-hover sm:p-4"

--- a/frontend/src/features/settings/components/RetrieverListWithScope.tsx
+++ b/frontend/src/features/settings/components/RetrieverListWithScope.tsx
@@ -11,14 +11,17 @@ import { listGroups } from '@/apis/groups'
 import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
+import type { ResourceLibrarySortMode } from '@/features/resource-library/resourceSorting'
 
 interface RetrieverListWithScopeProps {
   scope: 'personal' | 'group' | 'all'
   selectedGroup?: string | null
   onGroupChange?: (groupName: string | null) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export function RetrieverListWithScope({
@@ -26,8 +29,10 @@ export function RetrieverListWithScope({
   selectedGroup: externalSelectedGroup,
   onGroupChange,
   sourceControls,
+  sortControls,
   sourceFilter,
   groups: externalGroups,
+  sortMode = 'default',
 }: RetrieverListWithScopeProps) {
   // Use external state if provided, otherwise use internal state
   const [internalSelectedGroup, setInternalSelectedGroup] = useState<string | null>(null)
@@ -76,8 +81,10 @@ export function RetrieverListWithScope({
       <RetrieverList
         scope="personal"
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -88,8 +95,10 @@ export function RetrieverListWithScope({
         scope="all"
         groupRoleMap={groupRoleMap}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -110,8 +119,10 @@ export function RetrieverListWithScope({
         groupRoleMap={groupRoleMap}
         onEditResource={handleEditResource}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     </div>
   )

--- a/frontend/src/features/settings/components/ShellList.tsx
+++ b/frontend/src/features/settings/components/ShellList.tsx
@@ -29,6 +29,12 @@ import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
 import {
+  buildGroupDisplayNameMap,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortMode,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
+import {
   hasResourceCreateTargets,
   ResourceCreateButton,
   type ResourceCreateTarget,
@@ -41,8 +47,10 @@ interface ShellListProps {
   groupRoleMap?: Map<string, BaseRole>
   onEditResource?: (namespace: string) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 const ShellList: React.FC<ShellListProps> = ({
@@ -51,8 +59,10 @@ const ShellList: React.FC<ShellListProps> = ({
   groupRoleMap,
   onEditResource,
   sourceControls,
+  sortControls,
   sourceFilter = 'all',
   groups = [],
+  sortMode = 'default',
 }) => {
   const { t } = useTranslation()
   const { toast } = useToast()
@@ -98,7 +108,31 @@ const ShellList: React.FC<ShellListProps> = ({
     return shells
   }, [shells, sourceFilter])
 
-  const totalShells = sourceFilteredShells.length
+  const groupDisplayNames = React.useMemo(() => buildGroupDisplayNameMap(groups), [groups])
+
+  const getShellSource = React.useCallback((shell: UnifiedShell): ResourceLibrarySortSource => {
+    if (shell.type === 'public') return 'system'
+    if (shell.type === 'group') return 'group'
+    return 'personal'
+  }, [])
+
+  const sortedShells = React.useMemo(
+    () =>
+      sortResourceLibraryItems(sourceFilteredShells, {
+        sortMode,
+        groupDisplayNames,
+        getSource: getShellSource,
+        getName: shell => shell.name,
+        getDisplayName: shell => shell.displayName,
+        getNamespace: shell => shell.namespace || 'default',
+        getCreatedAt: shell => shell.created_at,
+        getUpdatedAt: shell => shell.updated_at,
+        getStableId: shell => `${shell.type}-${shell.namespace || 'default'}-${shell.name}`,
+      }),
+    [sourceFilteredShells, sortMode, groupDisplayNames, getShellSource]
+  )
+
+  const totalShells = sortedShells.length
 
   // Helper function to check permissions for a specific group resource
   const canEditGroupResource = (namespace: string) => {
@@ -196,13 +230,21 @@ const ShellList: React.FC<ShellListProps> = ({
     />
   ) : null
 
+  const filters =
+    sourceControls || sortControls ? (
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">{sourceControls}</div>
+        {sortControls}
+      </div>
+    ) : null
+
   return (
     <>
       <ResourceManagementLayout
         title={t('common:shells.title')}
         description={t('common:shells.description')}
         actions={createAction}
-        filters={sourceControls}
+        filters={filters}
       >
         {loading && (
           <div className="flex items-center justify-center py-12">
@@ -220,7 +262,7 @@ const ShellList: React.FC<ShellListProps> = ({
 
         {!loading && totalShells > 0 && (
           <div className="space-y-3" data-testid="shell-list-items">
-            {sourceFilteredShells.map(shell => (
+            {sortedShells.map(shell => (
               <Card
                 key={`${shell.type}-${shell.namespace || 'default'}-${shell.name}`}
                 className="overflow-hidden bg-base p-3 transition-colors hover:bg-hover sm:p-4"

--- a/frontend/src/features/settings/components/ShellListWithScope.tsx
+++ b/frontend/src/features/settings/components/ShellListWithScope.tsx
@@ -11,14 +11,17 @@ import { listGroups } from '@/apis/groups'
 import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
+import type { ResourceLibrarySortMode } from '@/features/resource-library/resourceSorting'
 
 interface ShellListWithScopeProps {
   scope: 'personal' | 'group' | 'all'
   selectedGroup?: string | null
   onGroupChange?: (groupName: string | null) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export function ShellListWithScope({
@@ -26,8 +29,10 @@ export function ShellListWithScope({
   selectedGroup: externalSelectedGroup,
   onGroupChange,
   sourceControls,
+  sortControls,
   sourceFilter,
   groups: externalGroups,
+  sortMode = 'default',
 }: ShellListWithScopeProps) {
   // Use external state if provided, otherwise use internal state
   const [internalSelectedGroup, setInternalSelectedGroup] = useState<string | null>(null)
@@ -76,8 +81,10 @@ export function ShellListWithScope({
       <ShellList
         scope="personal"
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -88,8 +95,10 @@ export function ShellListWithScope({
         scope="all"
         groupRoleMap={groupRoleMap}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -110,8 +119,10 @@ export function ShellListWithScope({
         groupRoleMap={groupRoleMap}
         onEditResource={handleEditResource}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     </div>
   )

--- a/frontend/src/features/settings/components/SkillListWithScope.tsx
+++ b/frontend/src/features/settings/components/SkillListWithScope.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback, type ReactNode } from 'react'
+import { useState, useEffect, useCallback, useMemo, type ReactNode } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
 import {
   fetchUnifiedSkillsList,
@@ -62,6 +62,12 @@ import { AutoEnabledSkillSettingsView } from './skills/AutoEnabledSkillSettingsV
 import { useUser } from '@/features/common/UserContext'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
 import {
+  buildGroupDisplayNameMap,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortMode,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
+import {
   hasResourceCreateTargets,
   ResourceCreateButton,
   type ResourceCreateTarget,
@@ -73,16 +79,20 @@ interface SkillListWithScopeProps {
   selectedGroup?: string | null
   onGroupChange?: (groupName: string | null) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export function SkillListWithScope({
   scope,
   selectedGroup,
   sourceControls,
+  sortControls,
   sourceFilter = 'all',
   groups = [],
+  sortMode = 'default',
 }: SkillListWithScopeProps) {
   const { t } = useTranslation('common')
   const { t: tSettingsBase } = useTranslation('settings')
@@ -216,21 +226,64 @@ export function SkillListWithScope({
     return tSettings('skills.source.library')
   }
 
-  const isGroupSkill = (skill: UnifiedSkill) =>
-    !skill.is_public && Boolean(skill.namespace && skill.namespace !== 'default')
+  const isGroupSkill = useCallback(
+    (skill: UnifiedSkill) =>
+      !skill.is_public && Boolean(skill.namespace && skill.namespace !== 'default'),
+    []
+  )
 
-  const matchesSourceFilter = (skill: UnifiedSkill): boolean => {
-    if (sourceFilter === 'personal') {
-      return !skill.is_public && skill.namespace === 'default'
-    }
-    if (sourceFilter === 'group') {
-      return isGroupSkill(skill)
-    }
-    if (sourceFilter === 'system') {
-      return skill.is_public
-    }
-    return true
-  }
+  const matchesSourceFilter = useCallback(
+    (skill: UnifiedSkill): boolean => {
+      if (sourceFilter === 'personal') {
+        return !skill.is_public && skill.namespace === 'default'
+      }
+      if (sourceFilter === 'group') {
+        return isGroupSkill(skill)
+      }
+      if (sourceFilter === 'system') {
+        return skill.is_public
+      }
+      return true
+    },
+    [isGroupSkill, sourceFilter]
+  )
+
+  const groupDisplayNames = useMemo(() => buildGroupDisplayNameMap(groups), [groups])
+
+  const getSkillSource = useCallback(
+    (skill: UnifiedSkill): ResourceLibrarySortSource => {
+      if (skill.is_public) return 'system'
+      if (isGroupSkill(skill)) return 'group'
+      return 'personal'
+    },
+    [isGroupSkill]
+  )
+
+  const sortedLibrarySkills = useMemo(() => {
+    const visibleSkills = librarySkills.filter(skill => {
+      if (!matchesSourceFilter(skill)) {
+        return false
+      }
+
+      if (scope === 'personal') {
+        return !skill.is_public
+      }
+
+      return true
+    })
+
+    return sortResourceLibraryItems(visibleSkills, {
+      sortMode,
+      groupDisplayNames,
+      getSource: getSkillSource,
+      getName: skill => skill.name,
+      getDisplayName: skill => skill.displayName,
+      getNamespace: skill => skill.namespace,
+      getCreatedAt: skill => skill.created_at,
+      getUpdatedAt: skill => skill.updated_at,
+      getStableId: skill => skill.id,
+    })
+  }, [librarySkills, matchesSourceFilter, scope, sortMode, groupDisplayNames, getSkillSource])
 
   const updateSkillDefaultAvailability = (skillId: number, inMyDefault: boolean) => {
     const updateSkill = (item: UnifiedSkill): UnifiedSkill =>
@@ -399,7 +452,7 @@ export function SkillListWithScope({
 
   // Get git skills for update all
   const getGitSkills = () => {
-    return filteredSkills.filter(skill => !skill.is_public && skill.source?.type === 'git')
+    return sortedLibrarySkills.filter(skill => !skill.is_public && skill.source?.type === 'git')
   }
 
   // Open confirm dialog for update all
@@ -467,18 +520,6 @@ export function SkillListWithScope({
     }
   }
 
-  // Filter skills based on scope
-  const filteredSkills = librarySkills.filter(skill => {
-    if (!matchesSourceFilter(skill)) {
-      return false
-    }
-
-    if (scope === 'personal') {
-      return !skill.is_public
-    }
-    // For 'all' scope, show all skills
-    return true
-  })
   const defaultEnabledSkills = allAvailableSkills.filter(skill => skill.availability?.inMyDefault)
   const defaultEnabledCandidates = allAvailableSkills.filter(
     skill => !skill.availability?.inMyDefault
@@ -519,7 +560,7 @@ export function SkillListWithScope({
   }
 
   // Check if there are any git-imported skills
-  const hasGitSkills = filteredSkills.some(
+  const hasGitSkills = sortedLibrarySkills.some(
     skill => !skill.is_public && skill.source?.type === 'git'
   )
 
@@ -571,6 +612,18 @@ export function SkillListWithScope({
     </>
   )
 
+  const libraryFilters =
+    sourceControls || sortControls ? (
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        {sourceControls ? (
+          <div className="min-w-0" data-testid="skill-library-source-filter">
+            {sourceControls}
+          </div>
+        ) : null}
+        {sortControls}
+      </div>
+    ) : null
+
   if (autoEnabledSettingsOpen) {
     return (
       <AutoEnabledSkillSettingsView
@@ -600,15 +653,11 @@ export function SkillListWithScope({
         title={tSettings('skills.libraryTitle')}
         description={tSettings('skills.libraryDescription')}
         actions={libraryActions}
-        filters={
-          sourceControls ? (
-            <div data-testid="skill-library-source-filter">{sourceControls}</div>
-          ) : null
-        }
+        filters={libraryFilters}
         data-testid="skill-library-section"
       >
         {/* Skills list */}
-        {filteredSkills.length === 0 ? (
+        {sortedLibrarySkills.length === 0 ? (
           <div className="text-center py-12 text-text-secondary">
             <Sparkles className="w-12 h-12 mx-auto mb-4 opacity-50" />
             <p>{t('skills.no_skills')}</p>
@@ -634,7 +683,7 @@ export function SkillListWithScope({
           </div>
         ) : (
           <div className="space-y-3" data-testid="skill-library-list">
-            {filteredSkills.map(skill => (
+            {sortedLibrarySkills.map(skill => (
               <Card
                 key={skill.id}
                 className="overflow-hidden bg-base p-3 transition-colors hover:bg-hover sm:p-4"

--- a/frontend/src/features/settings/components/TeamList.tsx
+++ b/frontend/src/features/settings/components/TeamList.tsx
@@ -36,7 +36,7 @@ import TeamCreationWizard from './wizard/TeamCreationWizard'
 import { TeamApiCallButton } from './TeamApiCallButton'
 import { useTranslation } from '@/hooks/useTranslation'
 import { useToast } from '@/hooks/use-toast'
-import { getTeamDisplayName, sortTeamsByUpdatedAt } from '@/utils/team'
+import { getTeamDisplayName } from '@/utils/team'
 import { isGroupTeam, isPublicTeam, isSharedTeam } from '@/utils/team-permissions'
 import type { BaseRole } from '@/types/base-role'
 import { sortBotsByUpdatedAt } from '@/utils/bot'
@@ -74,6 +74,12 @@ import {
   type TeamTargetPage,
 } from '@/features/tasks/components/selector/team-selector-utils'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
+import {
+  buildGroupDisplayNameMap,
+  sortResourceLibraryItems,
+  type ResourceLibrarySortMode,
+  type ResourceLibrarySortSource,
+} from '@/features/resource-library/resourceSorting'
 import { ResourceManagementLayout } from './resource-management/ResourceManagementLayout'
 
 interface TeamListProps {
@@ -82,8 +88,10 @@ interface TeamListProps {
   groupRoleMap?: Map<string, BaseRole>
   onEditResource?: (namespace: string) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export default function TeamList({
@@ -92,8 +100,10 @@ export default function TeamList({
   groupRoleMap,
   onEditResource,
   sourceControls,
+  sortControls,
   sourceFilter = 'all',
   groups = [],
+  sortMode = 'default',
 }: TeamListProps) {
   const { t } = useTranslation(['common', 'wizard'])
   const { toast } = useToast()
@@ -128,17 +138,6 @@ export default function TeamList({
   const [writableGroups, setWritableGroups] = useState<Group[]>([])
   const router = useRouter()
 
-  const setTeamsSorted = useCallback<React.Dispatch<React.SetStateAction<Team[]>>>(
-    updater => {
-      setTeams(prev => {
-        const next =
-          typeof updater === 'function' ? (updater as (value: Team[]) => Team[])(prev) : updater
-        return sortTeamsByUpdatedAt(next)
-      })
-    },
-    [setTeams]
-  )
-
   const setBotsSorted = useCallback<React.Dispatch<React.SetStateAction<Bot[]>>>(
     updater => {
       setBots(prev => {
@@ -158,7 +157,7 @@ export default function TeamList({
           fetchTeamsList(scope, groupName),
           fetchBotsList(scope, groupName),
         ])
-        setTeamsSorted(teamsData)
+        setTeams(teamsData)
         setBotsSorted(botsData)
       } catch {
         toast({
@@ -170,7 +169,7 @@ export default function TeamList({
       }
     }
     loadData()
-  }, [toast, setBotsSorted, setTeamsSorted, t, scope, groupName])
+  }, [toast, setBotsSorted, t, scope, groupName])
 
   // Load groups where user has at least Developer role (for copy target selection)
   useEffect(() => {
@@ -224,7 +223,7 @@ export default function TeamList({
       const currentNamespace = scope === 'group' ? groupName : 'default'
       const copiedNamespace = copied.namespace || 'default'
       if (copiedNamespace === currentNamespace) {
-        setTeamsSorted(prev => [copied, ...prev])
+        setTeams(prev => [copied, ...prev])
       }
       // Refresh bots so the cloned bot (solo mode) is available in edit dialog
       fetchBotsList(scope, groupName)
@@ -289,7 +288,7 @@ export default function TeamList({
     })
     // Reload teams list
     const teamsData = await fetchTeamsList(scope, groupName)
-    setTeamsSorted(teamsData)
+    setTeams(teamsData)
     setWizardOpen(false)
   }
 
@@ -342,6 +341,30 @@ export default function TeamList({
   const filteredTeams = useMemo(() => {
     return filterTeamsByMode(sourceFilteredTeams, modeFilter)
   }, [sourceFilteredTeams, modeFilter])
+
+  const groupDisplayNames = useMemo(() => buildGroupDisplayNameMap(groups), [groups])
+
+  const getTeamSource = useCallback((team: Team): ResourceLibrarySortSource => {
+    if (isPublicTeam(team)) return 'system'
+    if (isGroupTeam(team) || isSharedTeam(team)) return 'group'
+    return 'personal'
+  }, [])
+
+  const sortedTeams = useMemo(
+    () =>
+      sortResourceLibraryItems(filteredTeams, {
+        sortMode,
+        groupDisplayNames,
+        getSource: getTeamSource,
+        getName: team => team.name,
+        getDisplayName: getTeamDisplayName,
+        getNamespace: team => team.namespace || 'default',
+        getCreatedAt: team => team.created_at,
+        getUpdatedAt: team => team.updated_at,
+        getStableId: team => team.id,
+      }),
+    [filteredTeams, sortMode, groupDisplayNames, getTeamSource]
+  )
 
   // Helper function to check permissions for a specific group resource
   const canEditGroupResource = (namespace: string) => {
@@ -399,7 +422,7 @@ export default function TeamList({
     setIsDeleting(true)
     try {
       await deleteTeam(teamToDelete)
-      setTeamsSorted(prev => prev.filter(team => team.id !== teamToDelete))
+      setTeams(prev => prev.filter(team => team.id !== teamToDelete))
       setDeleteConfirmVisible(false)
       setTeamToDelete(null)
       setRunningTasksInfo(null)
@@ -419,7 +442,7 @@ export default function TeamList({
     setIsDeleting(true)
     try {
       await deleteTeam(teamToDelete, true)
-      setTeamsSorted(prev => prev.filter(team => team.id !== teamToDelete))
+      setTeams(prev => prev.filter(team => team.id !== teamToDelete))
       setForceDeleteConfirmVisible(false)
       setTeamToDelete(null)
       setRunningTasksInfo(null)
@@ -451,7 +474,7 @@ export default function TeamList({
       })
       setShareModalVisible(true)
       // Update team status to sharing
-      setTeamsSorted(prev => prev.map(t => (t.id === team.id ? { ...t, share_status: 1 } : t)))
+      setTeams(prev => prev.map(t => (t.id === team.id ? { ...t, share_status: 1 } : t)))
     } catch {
       toast({
         variant: 'destructive',
@@ -576,34 +599,37 @@ export default function TeamList({
   ) : null
 
   const filters = (
-    <>
-      {sourceControls}
-      <div
-        className="flex flex-col gap-2 sm:flex-row sm:items-center"
-        data-testid="team-mode-filter"
-      >
-        <span className="text-xs font-medium text-text-muted">{t('teams.filter_mode')}</span>
-        <div className="flex flex-wrap items-center gap-2">
-          {modeFilterOptions.map(option => {
-            const Icon = option.icon
-            return (
-              <Button
-                key={option.value}
-                type="button"
-                variant={modeFilter === option.value ? 'primary' : 'outline'}
-                aria-pressed={modeFilter === option.value}
-                onClick={() => setModeFilter(option.value)}
-                data-testid={option.testId}
-                className="h-11 min-w-[44px] px-4 lg:h-9"
-              >
-                {Icon && <Icon className="h-4 w-4" aria-hidden />}
-                {option.label}
-              </Button>
-            )
-          })}
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+      <div className="flex min-w-0 flex-col gap-3">
+        {sourceControls}
+        <div
+          className="flex flex-col gap-2 sm:flex-row sm:items-center"
+          data-testid="team-mode-filter"
+        >
+          <span className="text-xs font-medium text-text-muted">{t('teams.filter_mode')}</span>
+          <div className="flex flex-wrap items-center gap-2">
+            {modeFilterOptions.map(option => {
+              const Icon = option.icon
+              return (
+                <Button
+                  key={option.value}
+                  type="button"
+                  variant={modeFilter === option.value ? 'primary' : 'outline'}
+                  aria-pressed={modeFilter === option.value}
+                  onClick={() => setModeFilter(option.value)}
+                  data-testid={option.testId}
+                  className="h-11 min-w-[44px] px-4 lg:h-9"
+                >
+                  {Icon && <Icon className="h-4 w-4" aria-hidden />}
+                  {option.label}
+                </Button>
+              )
+            })}
+          </div>
         </div>
       </div>
-    </>
+      {sortControls}
+    </div>
   )
 
   return (
@@ -625,8 +651,8 @@ export default function TeamList({
               className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden custom-scrollbar space-y-3 pr-1"
               data-testid="team-list-items"
             >
-              {filteredTeams.length > 0 ? (
-                filteredTeams.map(team => (
+              {sortedTeams.length > 0 ? (
+                sortedTeams.map(team => (
                   <Card
                     key={team.id}
                     className="p-3 sm:p-4 bg-base hover:bg-hover transition-colors overflow-hidden"
@@ -866,7 +892,7 @@ export default function TeamList({
         open={editDialogOpen}
         onClose={handleCloseEditDialog}
         teams={teams}
-        setTeams={setTeamsSorted}
+        setTeams={setTeams}
         editingTeamId={editingTeamId}
         initialTeam={prefillTeam}
         bots={bots}

--- a/frontend/src/features/settings/components/TeamListWithScope.tsx
+++ b/frontend/src/features/settings/components/TeamListWithScope.tsx
@@ -11,14 +11,17 @@ import { listGroups } from '@/apis/groups'
 import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
+import type { ResourceLibrarySortMode } from '@/features/resource-library/resourceSorting'
 
 interface TeamListWithScopeProps {
   scope: 'personal' | 'group' | 'all'
   selectedGroup?: string | null
   onGroupChange?: (groupName: string | null) => void
   sourceControls?: ReactNode
+  sortControls?: ReactNode
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
+  sortMode?: ResourceLibrarySortMode
 }
 
 export function TeamListWithScope({
@@ -26,8 +29,10 @@ export function TeamListWithScope({
   selectedGroup: externalSelectedGroup,
   onGroupChange,
   sourceControls,
+  sortControls,
   sourceFilter,
   groups: externalGroups,
+  sortMode = 'default',
 }: TeamListWithScopeProps) {
   // Use external state if provided, otherwise use internal state
   const [internalSelectedGroup, setInternalSelectedGroup] = useState<string | null>(null)
@@ -76,8 +81,10 @@ export function TeamListWithScope({
       <TeamList
         scope="personal"
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -88,8 +95,10 @@ export function TeamListWithScope({
         scope="all"
         groupRoleMap={groupRoleMap}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     )
   }
@@ -110,8 +119,10 @@ export function TeamListWithScope({
         groupRoleMap={groupRoleMap}
         onEditResource={handleEditResource}
         sourceControls={sourceControls}
+        sortControls={sortControls}
         sourceFilter={sourceFilter}
         groups={groups}
+        sortMode={sortMode}
       />
     </div>
   )

--- a/frontend/src/i18n/locales/en/resource-library.json
+++ b/frontend/src/i18n/locales/en/resource-library.json
@@ -66,12 +66,17 @@
     "description": "Description",
     "tags": "Tags",
     "type": "Resource type",
+    "sort": "Sort",
     "source": "Source",
     "source_id": "Source resource ID",
     "version": "Version",
     "publisher": "Publisher",
     "install_count": "Installs",
     "updated_at": "Updated"
+  },
+  "sort": {
+    "default": "Default",
+    "latest": "Latest"
   },
   "empty": {
     "discover": "No resources to discover",

--- a/frontend/src/i18n/locales/zh-CN/resource-library.json
+++ b/frontend/src/i18n/locales/zh-CN/resource-library.json
@@ -66,12 +66,17 @@
     "description": "描述",
     "tags": "标签",
     "type": "资源类型",
+    "sort": "排序",
     "source": "来源",
     "source_id": "源资源 ID",
     "version": "版本",
     "publisher": "发布者",
     "install_count": "安装次数",
     "updated_at": "更新时间"
+  },
+  "sort": {
+    "default": "默认",
+    "latest": "最新"
   },
   "empty": {
     "discover": "暂无可发现资源",

--- a/start.sh
+++ b/start.sh
@@ -1000,7 +1000,7 @@ Options:
   --socket-url URL              Socket direct url (auto-computed from BACKEND_PORT)
   --clean-frontend-cache        Remove frontend .next cache before starting frontend
   --init                        Interactive configuration initialization
-  --stop [services...]          Stop tracked services by default. Can specify multiple:
+  --stop [services...]          Stop all known service ports by default. Can specify multiple:
                                 $(valid_service_names)
   -g, --graceful                Use graceful shutdown with stop/restart (SIGTERM, wait 30s, then SIGKILL)
   --restart [services...]       Restart services (default: all)
@@ -1045,7 +1045,7 @@ Examples:
   $0 -p 8080                            # Specify frontend port as 8080
   $0 -e my-executor:latest              # Specify custom executor image
   $0 --socket-url http://192.168.1.100:8000  # Specify socket URL with your IP
-  $0 --stop                             # Stop services tracked by .pids (force kill)
+  $0 --stop                             # Stop all known service ports (force kill)
   $0 --stop all                         # Stop all known services (force kill)
   $0 --stop backend frontend            # Stop only backend and frontend
   $0 --stop be cs kr                    # Stop backend, chat_shell, knowledge_runtime (short names)
@@ -1466,23 +1466,16 @@ stop_services() {
         all_ports+=("$(get_runtime_service_port "$service")")
     done
 
-    local tracked_services=()
-    local tracked_service
-    for tracked_service in $(get_tracked_services); do
-        [ -n "$tracked_service" ] || continue
-        tracked_services+=("$tracked_service")
-    done
-
     # Determine which services to stop
     local services=()
     local service_ports=()
 
     if [ $# -eq 0 ]; then
-        # No specific services provided, stop only services this script tracks.
-        services=("${tracked_services[@]}")
-        for service in "${services[@]}"; do
-            service_ports+=("$(get_runtime_service_port "$service")")
-        done
+        # No specific services provided: stop every known service port.
+        # PID files can be missing when a process was orphaned or started by a
+        # previous shell, so default stop must not depend on .pids alone.
+        services=("${all_services[@]}")
+        service_ports=("${all_ports[@]}")
     else
         # Parse specified services
         for svc in "$@"; do


### PR DESCRIPTION
## Summary
- add resource library sorting with `default` and `latest` modes, including URL sync and tests
- use a unified default ordering by source/group/name across agents, models, shells, skills, and retrievers
- propagate `created_at` and `updated_at` through unified shell, retriever, and model APIs for latest sorting
- update `start.sh --stop` so the default stop path cleans all known service ports

## Testing
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- --runTestsByPath src/__tests__/features/resource-library/resourceSorting.test.ts src/__tests__/features/resource-library/MyResources.test.tsx`
- `cd backend && uv run pytest tests/services/test_model_aggregation_service.py`
