### PR TITLE
Preserve forwarded message selection across rerenders

### DIFF
--- a/frontend/src/__tests__/features/inbox/ForwardMessageDialog.test.tsx
+++ b/frontend/src/__tests__/features/inbox/ForwardMessageDialog.test.tsx
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import {
+  ForwardMessageDialog,
+  type ForwardableMessage,
+} from '@/features/inbox/components/ForwardMessageDialog'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}))
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/features/common/UserContext', () => ({
+  useUser: () => ({
+    user: { id: 1 },
+  }),
+}))
+
+jest.mock('sonner', () => ({
+  toast: {
+    error: jest.fn(),
+    success: jest.fn(),
+  },
+}))
+
+jest.mock('@/apis/work-queue', () => ({
+  forwardMessages: jest.fn(),
+  getRecentContacts: jest.fn().mockResolvedValue({ items: [] }),
+  getUserPublicQueues: jest.fn().mockResolvedValue({ queues: [] }),
+  listWorkQueues: jest.fn().mockResolvedValue({ items: [] }),
+}))
+
+jest.mock('@/utils/dateTime', () => ({
+  formatDateTime: () => '2026-06-05 12:00:00',
+}))
+
+jest.mock('@/components/common/UserSearchSelect', () => ({
+  UserSearchSelect: () => <div data-testid="user-search-select" />,
+}))
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsTrigger: ({
+    children,
+    ...props
+  }: {
+    children: React.ReactNode
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@/components/ui/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+}))
+
+jest.mock('@/components/ui/checkbox', () => ({
+  Checkbox: ({
+    checked,
+    onCheckedChange,
+    onClick,
+  }: {
+    checked?: boolean
+    onCheckedChange?: () => void
+    onClick?: React.MouseEventHandler<HTMLInputElement>
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      readOnly
+      onChange={onCheckedChange}
+      onClick={onClick}
+    />
+  ),
+}))
+
+const messages: ForwardableMessage[] = [
+  {
+    subtaskId: 1,
+    type: 'user',
+    content: 'First message',
+    timestamp: 1,
+  },
+  {
+    subtaskId: 2,
+    type: 'ai',
+    content: 'Second message',
+    timestamp: 2,
+    botName: 'Bot',
+  },
+  {
+    subtaskId: 3,
+    type: 'user',
+    content: 'Third message',
+    timestamp: 3,
+  },
+]
+
+describe('ForwardMessageDialog', () => {
+  it('preserves manual select-all state across parent rerenders with the same initial subtask ids', async () => {
+    const user = userEvent.setup()
+    const onOpenChange = jest.fn()
+
+    const { rerender } = render(
+      <ForwardMessageDialog
+        taskId={42}
+        subtaskIds={[1]}
+        allMessages={messages}
+        open
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    await user.click(screen.getByTestId('forward-select-all'))
+    expect(screen.getByText('(3/3)')).toBeInTheDocument()
+
+    rerender(
+      <ForwardMessageDialog
+        taskId={42}
+        subtaskIds={[1]}
+        allMessages={messages}
+        open
+        onOpenChange={onOpenChange}
+      />
+    )
+
+    expect(screen.getByText('(3/3)')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/features/inbox/components/ForwardMessageDialog.tsx
+++ b/frontend/src/features/inbox/components/ForwardMessageDialog.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { X, User, Users, Inbox, Clock, Send, Loader2, MessageSquare, Bot } from 'lucide-react'
 import { useRouter } from 'next/navigation'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -111,6 +111,8 @@ export function ForwardMessageDialog({
 
   // Message selection state
   const [selectedMessageIds, setSelectedMessageIds] = useState<Set<number>>(new Set())
+  const wasOpenRef = useRef(false)
+  const initializedSelectionKeyRef = useRef<string | null>(null)
 
   // Recent contacts
   const [recentContacts, setRecentContacts] = useState<RecentContact[]>([])
@@ -124,30 +126,9 @@ export function ForwardMessageDialog({
   const [selfQueues, setSelfQueues] = useState<WorkQueue[]>([])
   const [selfQueuesLoading, setSelfQueuesLoading] = useState(false)
   const [selectedSelfQueueId, setSelectedSelfQueueId] = useState<number | undefined>(undefined)
+  const initialSelectionKey = subtaskIds?.join(',') ?? ''
 
-  // Initialize selected messages when dialog opens
-  useEffect(() => {
-    if (open) {
-      loadRecentContacts()
-      loadSelfQueues()
-      // Initialize selected messages with the provided subtaskIds
-      if (subtaskIds && subtaskIds.length > 0) {
-        setSelectedMessageIds(new Set(subtaskIds))
-      } else {
-        setSelectedMessageIds(new Set())
-      }
-    } else {
-      // Reset form when dialog closes
-      setRecipients([])
-      setNote('')
-      setPriority('normal')
-      setForwardMode('others')
-      setSelectedSelfQueueId(undefined)
-      setSelectedMessageIds(new Set())
-    }
-  }, [open, subtaskIds])
-
-  const loadRecentContacts = async () => {
+  const loadRecentContacts = useCallback(async () => {
     setRecentLoading(true)
     try {
       const response = await getRecentContacts(10)
@@ -157,9 +138,9 @@ export function ForwardMessageDialog({
     } finally {
       setRecentLoading(false)
     }
-  }
+  }, [])
 
-  const loadSelfQueues = async () => {
+  const loadSelfQueues = useCallback(async () => {
     setSelfQueuesLoading(true)
     try {
       const response = await listWorkQueues()
@@ -176,7 +157,55 @@ export function ForwardMessageDialog({
     } finally {
       setSelfQueuesLoading(false)
     }
-  }
+  }, [])
+
+  const buildInitialSelectedMessageIds = useCallback(() => {
+    if (!initialSelectionKey) {
+      return new Set<number>()
+    }
+
+    const ids = initialSelectionKey
+      .split(',')
+      .map(id => Number(id))
+      .filter(Number.isFinite)
+    return new Set(ids)
+  }, [initialSelectionKey])
+
+  // Initialize selected messages when dialog opens or when a genuinely different
+  // initial selection is provided while open.
+  useEffect(() => {
+    if (open) {
+      const isNewOpen = !wasOpenRef.current
+      if (isNewOpen) {
+        loadRecentContacts()
+        loadSelfQueues()
+      }
+
+      if (isNewOpen || initializedSelectionKeyRef.current !== initialSelectionKey) {
+        setSelectedMessageIds(buildInitialSelectedMessageIds())
+        initializedSelectionKeyRef.current = initialSelectionKey
+      }
+
+      wasOpenRef.current = true
+      return
+    }
+
+    // Reset form when dialog closes
+    wasOpenRef.current = false
+    initializedSelectionKeyRef.current = null
+    setRecipients([])
+    setNote('')
+    setPriority('normal')
+    setForwardMode('others')
+    setSelectedSelfQueueId(undefined)
+    setSelectedMessageIds(new Set())
+  }, [
+    buildInitialSelectedMessageIds,
+    initialSelectionKey,
+    loadRecentContacts,
+    loadSelfQueues,
+    open,
+  ])
 
   // Load user's public queues when a user is selected
   const loadUserQueues = useCallback(


### PR DESCRIPTION
## Summary
- Keep the forward dialog’s message selection stable across parent rerenders when the initial subtask ids have not changed.
- Initialize the selection only on first open or when the initial selection content actually changes, instead of reapplying it on every rerender.
- Add a regression test covering the select-all case.

## Testing
- `npm test -- ForwardMessageDialog.test.tsx --runInBand`
- `npm test -- QueueMessageHandler.test.tsx MessageDetailDialog.test.tsx FinalPromptMessage.test.tsx --runInBand`
- `npx tsc --noEmit --pretty false`
- `npx prettier --check frontend/src/features/inbox/components/ForwardMessageDialog.tsx frontend/src/__tests__/features/inbox/ForwardMessageDialog.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the forward message dialog to correctly maintain selected items when reopening with unchanged context.

* **Tests**
  * Added test coverage for forward message dialog selection state persistence across dialog reopens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->