### PR TITLE
fix(frontend): show attachment icon on quick presets

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
@@ -111,6 +111,7 @@ const makeInputPreset = (
   title: overrides.title ?? prompt,
   prompt,
   options: overrides.options,
+  source_attachment_ids: overrides.source_attachment_ids,
 })
 
 const renderQuickAccessCards = (
@@ -318,6 +319,42 @@ describe('QuickAccessCards', () => {
 
     expect(onTeamSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }))
     expect(onPhraseSelect).toHaveBeenCalledWith('帮我创建一个 xxx 的 PPT')
+  })
+
+  test('shows an attachment icon on quick presets that include attachments', async () => {
+    mockGetQuickLaunch.mockResolvedValueOnce({
+      system_functions: [
+        {
+          type: 'system_function',
+          id: 'create_ppt',
+          title: 'Create PPT',
+          team_id: 2,
+          name: 'system-team',
+          enabled: true,
+          order: 10,
+          input_presets: [
+            makeInputPreset('把附件整理成 PPT', { source_attachment_ids: [10] }),
+            makeInputPreset('空白创建 PPT'),
+          ],
+        },
+      ],
+      favorite_agents: [],
+    } satisfies QuickLaunchResponse)
+
+    render(
+      <QuickAccessCards
+        teams={[makeTeam({ id: 2, name: 'system-team', description: 'System description' })]}
+        selectedTeam={null}
+        onTeamSelect={jest.fn()}
+        onPhraseSelect={jest.fn()}
+        currentMode="chat"
+      />
+    )
+
+    fireEvent.click(await screen.findByText('Create PPT'))
+
+    expect(screen.getByTestId('quick-phrase-attachment-icon-0')).toBeInTheDocument()
+    expect(screen.queryByTestId('quick-phrase-attachment-icon-1')).not.toBeInTheDocument()
   })
 
   test('animates quick phrase panel in and out before restoring quick cards', async () => {

--- a/frontend/src/features/tasks/components/chat/quick-launch/QuickPhraseList.tsx
+++ b/frontend/src/features/tasks/components/chat/quick-launch/QuickPhraseList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Paperclip } from 'lucide-react'
 
 import type { QuickInputPreset, QuickLauncher } from './types'
 
@@ -49,6 +49,7 @@ export function QuickPhraseList({
             index * QUICK_PHRASE_STAGGER_MS,
             QUICK_PHRASE_MAX_STAGGER_MS
           )
+          const hasAttachments = (preset.source_attachment_ids?.length ?? 0) > 0
 
           return (
             <button
@@ -70,7 +71,17 @@ export function QuickPhraseList({
               }
               data-testid={`quick-phrase-${index}`}
             >
-              <span className="block text-sm font-medium text-text-primary">{preset.title}</span>
+              <span className="flex items-center gap-1.5">
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-text-primary">
+                  {preset.title}
+                </span>
+                {hasAttachments && (
+                  <Paperclip
+                    className="h-3.5 w-3.5 flex-shrink-0 text-text-muted"
+                    data-testid={`quick-phrase-attachment-icon-${index}`}
+                  />
+                )}
+              </span>
               {preset.prompt && preset.prompt !== preset.title && (
                 <span className="mt-1 block text-xs leading-5 text-text-muted">
                   {preset.prompt}


### PR DESCRIPTION
## Summary
- Show a paperclip icon on QuickAction preset rows that have source attachments.
- Keep presets without attachments visually unchanged.
- Add regression coverage for the attachment icon state.

## Test Plan
- npm test -- QuickAccessCards.test.tsx --runInBand
- Pre-push hook: ESLint, TypeScript, frontend unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick preset entries now display a visual attachment icon when they include source attachments, making it easier to identify presets with attached files.

* **Tests**
  * Added test coverage to verify the attachment icon displays correctly for quick presets with attachments and is absent for those without.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->