### PR TITLE
fix(shared): preserve stream event ordering

### DIFF
--- a/shared/models/throttled_transport.py
+++ b/shared/models/throttled_transport.py
@@ -193,7 +193,10 @@ class ThrottledTransport(EventTransport):
 
         # Check if throttling is needed
         if not self._config.should_throttle(event_type):
-            # No throttling, send directly
+            # No throttling, but preserve ordering with any buffered deltas for
+            # the same response before sending the higher-priority event.
+            async with self._lock:
+                await self._flush_task_buffers(task_id, subtask_id)
             return await self._transport.send(
                 event_type,
                 task_id,
@@ -219,6 +222,12 @@ class ThrottledTransport(EventTransport):
         key = (event["task_id"], event["subtask_id"], event["event_type"])
 
         async with self._lock:
+            await self._flush_task_buffers(
+                event["task_id"],
+                event["subtask_id"],
+                exclude_event_type=event["event_type"],
+            )
+
             interval = self._config.get_interval(event["event_type"])
 
             # Initialize buffer
@@ -292,6 +301,27 @@ class ThrottledTransport(EventTransport):
             # Check if this buffer has expired
             time_since_last = current_time - self._last_send_times.get(buffer_key, 0)
             if time_since_last >= interval:
+                await self._flush_buffer(buffer_key)
+
+    async def _flush_task_buffers(
+        self,
+        task_id: int,
+        subtask_id: int,
+        exclude_event_type: Optional[str] = None,
+    ) -> None:
+        """Flush pending buffers for a response before a different event type.
+
+        Per-event-type throttling must not reorder semantically adjacent stream
+        segments. For example, reasoning deltas buffered just before output text
+        must reach the frontend before that output text.
+        """
+        for buffer_key in list(self._buffers.keys()):
+            buffer_task_id, buffer_subtask_id, buffer_event_type = buffer_key
+            if buffer_task_id != task_id or buffer_subtask_id != subtask_id:
+                continue
+            if exclude_event_type and buffer_event_type == exclude_event_type:
+                continue
+            if self._buffers[buffer_key]:
                 await self._flush_buffer(buffer_key)
 
     def _calculate_buffer_size(self, events: List[dict]) -> int:

--- a/shared/tests/test_emitter_factory.py
+++ b/shared/tests/test_emitter_factory.py
@@ -272,6 +272,32 @@ class TestThrottledTransport:
         assert call_args[0][3]["delta"] == " world!"
 
     @pytest.mark.asyncio
+    async def test_cross_type_events_flush_pending_buffer_in_order(self):
+        """Test that reasoning buffered before text is sent before that text."""
+        mock_transport = AsyncMock(spec=EventTransport)
+        config = ThrottleConfig(default_interval=10.0)
+        throttled = ThrottledTransport(mock_transport, config)
+
+        await throttled.send(
+            "response.reasoning_summary_text.delta", 1, 2, {"delta": "Good"}
+        )
+        mock_transport.reset_mock()
+
+        await throttled.send(
+            "response.reasoning_summary_text.delta", 1, 2, {"delta": "思考"}
+        )
+        mock_transport.send.assert_not_called()
+
+        await throttled.send("response.output_text.delta", 1, 2, {"delta": "数据"})
+
+        calls = mock_transport.send.call_args_list
+        assert [call.args[0] for call in calls] == [
+            "response.reasoning_summary_text.delta",
+            "response.output_text.delta",
+        ]
+        assert [call.args[3]["delta"] for call in calls] == ["思考", "数据"]
+
+    @pytest.mark.asyncio
     async def test_flush_all(self):
         """Test flushing all buffers."""
         mock_transport = AsyncMock(spec=EventTransport)


### PR DESCRIPTION
## Summary
- Flush pending throttled stream buffers before emitting a different event type for the same task/subtask.
- Preserve ordering between reasoning deltas and output text deltas so Claude Code thinking and normal content do not interleave incorrectly.
- Add a regression test for reasoning buffered before output text.

## Test Plan
- cd shared && uv run pytest

## Deployment Note
- Rebuild/repackage the executor service/local executor artifact that runs Claude Code so it includes the updated shared transport code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event ordering to prevent reordering of adjacent events across different event types when using throttled transport.
  * Enhanced buffer flushing logic to maintain proper event sequence when high-priority events are sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->