### PR TITLE
fix(frontend): trigger runtime check on socket reconnect

### DIFF
--- a/frontend/e2e/config/environment.ts
+++ b/frontend/e2e/config/environment.ts
@@ -20,7 +20,7 @@ export function getEnvironment(): E2EEnvironment {
     baseUrl: process.env.E2E_BASE_URL || 'http://localhost:3000',
     apiUrl: process.env.E2E_API_URL || 'http://localhost:8000',
     timeout: parseInt(process.env.E2E_TIMEOUT || '30000', 10),
-    retries: isCI ? 2 : 0,
+    retries: 0,
     isCI,
   }
 }

--- a/frontend/e2e/tests/auth.spec.ts
+++ b/frontend/e2e/tests/auth.spec.ts
@@ -33,8 +33,8 @@ test.describe('Authentication', () => {
     // Submit form
     await page.locator('button[type="submit"]').click()
 
-    // Should redirect to chat or home
-    await page.waitForURL(/\/(chat|$)/, { timeout: 15000 })
+    // Should leave login page after successful authentication.
+    await page.waitForURL(url => !url.pathname.includes('/login'), { timeout: 30000 })
     await expect(page).not.toHaveURL(/\/login/)
   })
 

--- a/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
+++ b/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
@@ -863,19 +863,18 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
 
     await sendButton.click()
 
-    // Wait for response to appear
-    await page.waitForTimeout(8000)
+    // Check if response is displayed. Use an assertion so Playwright waits for streamed text.
+    const responseText = page
+      .getByTestId('messages-container')
+      .getByText(/I can see the image you uploaded/i)
+      .first()
 
-    // Check if response is displayed
-    // The mock server returns: "I can see the image you uploaded. It appears to be a small red test image."
-    const responseText = page.locator('text=I can see the image')
-    const hasResponse = await responseText.isVisible({ timeout: 10000 }).catch(() => false)
-
-    if (hasResponse) {
+    try {
+      await expect(responseText).toBeVisible({ timeout: 30000 })
       console.log('✅ Model response displayed successfully!')
-    } else {
+    } catch (error) {
       await page.screenshot({ path: 'test-results/chat-response-not-found.png' })
+      throw error
     }
-    expect(hasResponse).toBe(true)
   })
 })

--- a/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
+++ b/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
@@ -102,6 +102,9 @@ async function waitForChatCompletionRequest(
 }
 
 test.describe('Chat Image Browser E2E with Mock Model Server', () => {
+  // Tests in this spec use the same shard user and mutate that user's selected team state.
+  test.describe.configure({ mode: 'default' })
+
   let apiClient: ApiClient
   let token: string
   const testImagePath = path.join(__dirname, '../../fixtures/test-image.png')

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,8 +18,8 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code */
   forbidOnly: !!process.env.CI,
 
-  /* Retry once on CI to handle flaky tests, reduce from 2 to 1 for speed */
-  retries: process.env.CI ? 1 : 0,
+  /* Do not retry E2E tests. Flaky tests should fail so they can be fixed. */
+  retries: 0,
 
   /* Reporter to use - use blob reporter for sharded runs */
   reporter: process.env.CI
@@ -34,8 +34,8 @@ export default defineConfig({
     /* Base URL to use in actions like `await page.goto('/')` */
     baseURL: process.env.E2E_BASE_URL || 'http://localhost:3000',
 
-    /* Collect trace only on first retry to save time */
-    trace: 'on-first-retry',
+    /* Collect trace for failed CI runs without requiring retries. */
+    trace: process.env.CI ? 'retain-on-failure' : 'on-first-retry',
 
     /* Capture screenshot only on failure */
     screenshot: 'only-on-failure',

--- a/frontend/src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx
+++ b/frontend/src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx
@@ -12,6 +12,7 @@ import type { TaskStatusPayload } from '@/types/socket'
 
 let mockTaskHandlers: { onTaskStatus?: (payload: TaskStatusPayload) => void } | null = null
 let mockVisibleHandler: ((wasHiddenFor: number) => void) | null = null
+let mockReconnectHandler: (() => void) | null = null
 let mockIsConnected = true
 
 const mockJoinTask = jest.fn()
@@ -31,6 +32,10 @@ const mockSocketContext = {
   registerChatHandlers: jest.fn(() => jest.fn()),
   registerSkillHandlers: jest.fn(() => jest.fn()),
   sendSkillResponse: jest.fn(),
+  onReconnect: jest.fn((callback: () => void) => {
+    mockReconnectHandler = callback
+    return jest.fn()
+  }),
 }
 
 jest.mock('@/contexts/SocketContext', () => ({
@@ -147,6 +152,7 @@ describe('TaskSessionContext runtime state machine sync', () => {
     contextProbe.current = null
     mockTaskHandlers = null
     mockVisibleHandler = null
+    mockReconnectHandler = null
     mockIsConnected = true
     mockJoinTask.mockResolvedValue({ subtasks: [] })
 
@@ -289,6 +295,38 @@ describe('TaskSessionContext runtime state machine sync', () => {
     act(() => {
       mockIsConnected = true
       rerender(renderTree())
+    })
+
+    await waitFor(() => {
+      expect(mockedTaskApis.getTaskRuntimeCheck).toHaveBeenCalledWith(42)
+    })
+    expect(mockedTaskApis.getPersonalTasksLite).toHaveBeenCalledWith({ page: 1, limit: 50 })
+  })
+
+  it('checks runtime health when the socket reconnect callback fires', async () => {
+    render(
+      <TaskSessionProvider>
+        <ContextProbe />
+      </TaskSessionProvider>
+    )
+
+    await waitFor(() => {
+      expect(contextProbe.current).not.toBeNull()
+    })
+
+    act(() => {
+      contextProbe.current?.selectTask(createTask())
+    })
+
+    await waitFor(() => {
+      expect(mockedTaskApis.getTaskDetail).toHaveBeenCalledWith(42)
+    })
+
+    mockedTaskApis.getTaskRuntimeCheck.mockClear()
+    mockedTaskApis.getPersonalTasksLite.mockClear()
+
+    act(() => {
+      mockReconnectHandler?.()
     })
 
     await waitFor(() => {

--- a/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
+++ b/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
@@ -28,6 +28,7 @@ const mockSocketContext = {
   registerSkillHandlers: jest.fn(() => jest.fn()),
   registerTaskHandlers: jest.fn(() => jest.fn()),
   sendSkillResponse: jest.fn(),
+  onReconnect: jest.fn(() => jest.fn()),
 }
 
 jest.mock('@/contexts/SocketContext', () => ({

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -7,7 +7,7 @@ import { TaskStateMachine, type TaskStateMachineDeps } from '@/features/tasks/st
 function createRuntimeActions(overrides: Partial<TaskStateMachineDeps> = {}): TaskStateMachineDeps {
   return {
     joinTask: jest.fn().mockResolvedValue({ subtasks: [] }),
-    verifyRuntime: jest.fn().mockResolvedValue({
+    pullRuntime: jest.fn().mockResolvedValue({
       task_id: 42,
       task_status: 'COMPLETED',
       status_updated_at: '2026-06-01T10:00:00',
@@ -159,10 +159,17 @@ describe('TaskStateMachine', () => {
 
   it('keeps pending socket recovery when terminal task detail arrives before socket connect', async () => {
     const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
+    const pullRuntime = jest.fn().mockResolvedValue({
+      task_id: 100,
+      task_status: 'COMPLETED',
+      status_updated_at: '2026-06-01T10:00:00.000Z',
+      active_stream: null,
+    })
     let connected = false
 
     const machine = new TaskStateMachine(100, {
       joinTask,
+      pullRuntime,
       isConnected: () => connected,
     })
 
@@ -181,6 +188,7 @@ describe('TaskStateMachine', () => {
     connected = true
     await machine.handleSocketConnected('websocket-reconnect')
 
+    expect(pullRuntime).toHaveBeenCalledWith(100)
     expect(joinTask).toHaveBeenCalledWith(100, {
       forceRefresh: true,
       afterMessageId: undefined,
@@ -189,7 +197,7 @@ describe('TaskStateMachine', () => {
 
   it('checks runtime before resolving pending socket recovery on reconnect', async () => {
     const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
-    const verifyRuntime = jest.fn().mockResolvedValue({
+    const pullRuntime = jest.fn().mockResolvedValue({
       task_id: 100,
       task_status: 'RUNNING',
       active_stream: {
@@ -201,7 +209,7 @@ describe('TaskStateMachine', () => {
 
     const machine = new TaskStateMachine(100, {
       joinTask,
-      verifyRuntime,
+      pullRuntime,
       isConnected: () => connected,
     })
 
@@ -211,13 +219,33 @@ describe('TaskStateMachine', () => {
     connected = true
     await machine.handleSocketConnected('websocket-reconnect')
 
-    expect(verifyRuntime).toHaveBeenCalledWith(100)
+    expect(pullRuntime).toHaveBeenCalledWith(100)
     expect(joinTask).toHaveBeenCalledWith(100, {
       forceRefresh: true,
       afterMessageId: undefined,
       resumeFromCursor: 0,
       activeStreamSubtaskId: 77,
     })
+  })
+
+  it('requires pullRuntime when resolving pending socket recovery on reconnect', async () => {
+    const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
+    let connected = false
+
+    const machine = new TaskStateMachine(100, {
+      joinTask,
+      isConnected: () => connected,
+    })
+
+    await machine.recover({ force: true, reason: 'task-selected' })
+    expect(machine.getState().phase).toBe('waiting_socket')
+
+    connected = true
+
+    await expect(machine.handleSocketConnected('websocket-reconnect')).rejects.toThrow(
+      '[TaskStateMachine] pullRuntime action is required for checkHealth().'
+    )
+    expect(joinTask).not.toHaveBeenCalled()
   })
 
   it('refreshes timestamp when the same AI message receives a new chat:error event', () => {
@@ -1024,7 +1052,7 @@ describe('TaskStateMachine', () => {
 
   it('checkHealth joins when server has an active stream and local room is not joined', async () => {
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 42,
         task_status: 'RUNNING',
         status_updated_at: '2026-06-01T10:00:00',
@@ -1048,7 +1076,7 @@ describe('TaskStateMachine', () => {
     })
     await machine.checkHealth('page-visible')
 
-    expect(actions.verifyRuntime).toHaveBeenCalledTimes(1)
+    expect(actions.pullRuntime).toHaveBeenCalledTimes(1)
     expect(actions.joinTask).toHaveBeenCalledWith(42, {
       forceRefresh: true,
       afterMessageId: undefined,
@@ -1062,7 +1090,7 @@ describe('TaskStateMachine', () => {
   it('checkHealth syncs messages when the task updatedAt has not been message-synced', async () => {
     const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 42,
         task_status: 'COMPLETED',
         status_updated_at: '2026-06-01T10:00:10',
@@ -1120,7 +1148,7 @@ describe('TaskStateMachine', () => {
 
   it('does not synthesize interactive form blocks from messages_chain on refresh', async () => {
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 42,
         task_status: 'COMPLETED',
         status_updated_at: '2026-06-01T10:00:10',
@@ -1213,7 +1241,7 @@ describe('TaskStateMachine', () => {
     })
     const toolOutput = [{ type: 'text', text: deferredText, id: 'lc_1266' }]
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 793,
         task_status: 'COMPLETED',
         status_updated_at: '2026-06-03T20:34:56',
@@ -1359,7 +1387,7 @@ describe('TaskStateMachine', () => {
       bots: [],
     }
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 42,
         task_status: 'COMPLETED',
         status_updated_at: '2026-06-01T10:00:10',
@@ -1465,7 +1493,7 @@ describe('TaskStateMachine', () => {
 
   it('checkHealth clears local streaming when server is terminal with no active stream', async () => {
     const actions = createRuntimeActions({
-      verifyRuntime: jest.fn().mockResolvedValue({
+      pullRuntime: jest.fn().mockResolvedValue({
         task_id: 42,
         task_status: 'COMPLETED',
         status_updated_at: '2026-06-01T10:00:10',

--- a/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
+++ b/frontend/src/__tests__/features/tasks/state/TaskStateMachine.test.ts
@@ -187,6 +187,39 @@ describe('TaskStateMachine', () => {
     })
   })
 
+  it('checks runtime before resolving pending socket recovery on reconnect', async () => {
+    const joinTask = jest.fn().mockResolvedValue({ subtasks: [] })
+    const verifyRuntime = jest.fn().mockResolvedValue({
+      task_id: 100,
+      task_status: 'RUNNING',
+      active_stream: {
+        subtask_id: 77,
+        cursor: 12,
+      },
+    })
+    let connected = false
+
+    const machine = new TaskStateMachine(100, {
+      joinTask,
+      verifyRuntime,
+      isConnected: () => connected,
+    })
+
+    await machine.recover({ force: true, reason: 'task-selected' })
+    expect(machine.getState().phase).toBe('waiting_socket')
+
+    connected = true
+    await machine.handleSocketConnected('websocket-reconnect')
+
+    expect(verifyRuntime).toHaveBeenCalledWith(100)
+    expect(joinTask).toHaveBeenCalledWith(100, {
+      forceRefresh: true,
+      afterMessageId: undefined,
+      resumeFromCursor: 0,
+      activeStreamSubtaskId: 77,
+    })
+  })
+
   it('refreshes timestamp when the same AI message receives a new chat:error event', () => {
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValueOnce(1000).mockReturnValueOnce(2000)
 

--- a/frontend/src/features/tasks/session/consistencyWatcher.ts
+++ b/frontend/src/features/tasks/session/consistencyWatcher.ts
@@ -34,7 +34,7 @@ export function useConsistencyWatcher({
   getMachine,
   refreshTasks,
 }: ConsistencyWatcherOptions): void {
-  const { isConnected } = useSocket()
+  const { isConnected, onReconnect } = useSocket()
   const isCheckingRef = useRef(false)
   const hasConnectedOnceRef = useRef(false)
   const wasConnectedRef = useRef(false)
@@ -86,7 +86,13 @@ export function useConsistencyWatcher({
     }
 
     wasConnectedRef.current = isConnected
-  }, [isConnected, verifyCurrentTask])
+  }, [getMachine, isConnected, verifyCurrentTask])
+
+  useEffect(() => {
+    return onReconnect(() => {
+      void verifyCurrentTask('websocket-reconnect')
+    })
+  }, [onReconnect, verifyCurrentTask])
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -304,7 +304,6 @@ export interface TaskStateMachineDeps {
     error?: string
   }>
   leaveTask?: (taskId: number) => void
-  verifyRuntime?: (taskId: number) => Promise<TaskRuntimeVerifyResult>
   isConnected: () => boolean
 }
 
@@ -556,34 +555,16 @@ export class TaskStateMachine {
 
   async checkHealth(reason: TaskRecoveryReason): Promise<void> {
     if (!this.deps.isConnected()) return
-    const pullRuntime = this.deps.pullRuntime ?? this.deps.verifyRuntime
-    if (!pullRuntime) {
+    if (!this.deps.pullRuntime) {
       throw new Error('[TaskStateMachine] pullRuntime action is required for checkHealth().')
     }
 
-    const server = await pullRuntime(this.state.taskId)
+    const server = await this.deps.pullRuntime(this.state.taskId)
     if (!server) return
     await this.reconcileRuntime(server, reason)
   }
 
   async handleSocketConnected(reason: TaskRecoveryReason): Promise<void> {
-    if (this.state.status === 'waiting_socket') {
-      const pullRuntime = this.deps.pullRuntime ?? this.deps.verifyRuntime
-      if (pullRuntime) {
-        await this.checkHealth(reason)
-        return
-      }
-
-      const recoveryReason =
-        this.pendingRecoveryReason ?? this.state.runtime.recoveryReason ?? reason
-      const recoveryOptions = this.pendingRecoveryOptions
-      this.pendingRecovery = false
-      this.pendingRecoveryReason = undefined
-      this.pendingRecoveryOptions = undefined
-      await this.recover({ force: true, reason: recoveryReason, ...recoveryOptions })
-      return
-    }
-
     await this.checkHealth(reason)
   }
 

--- a/frontend/src/features/tasks/state/TaskStateMachine.ts
+++ b/frontend/src/features/tasks/state/TaskStateMachine.ts
@@ -568,6 +568,12 @@ export class TaskStateMachine {
 
   async handleSocketConnected(reason: TaskRecoveryReason): Promise<void> {
     if (this.state.status === 'waiting_socket') {
+      const pullRuntime = this.deps.pullRuntime ?? this.deps.verifyRuntime
+      if (pullRuntime) {
+        await this.checkHealth(reason)
+        return
+      }
+
       const recoveryReason =
         this.pendingRecoveryReason ?? this.state.runtime.recoveryReason ?? reason
       const recoveryOptions = this.pendingRecoveryOptions


### PR DESCRIPTION
## Summary
- Trigger task runtime verification from the SocketContext reconnect callback so recovery runs after the socket is actually connected.
- Route pending `waiting_socket` recovery through runtime-check using `pullRuntime`, and remove the legacy `verifyRuntime` fallback/direct recover path.
- Disable Playwright E2E retries in CI/local config so flaky tests fail immediately, while retaining traces on failed CI runs.
- Wait for the streamed image response with a Playwright visibility assertion instead of a fixed sleep plus one-shot `isVisible()` probe.
- Wait for successful auth to leave `/login` using the existing 30s redirect pattern, matching CI startup latency without adding retries.
- Keep the image browser E2E spec out of `fullyParallel` mode because tests in the same shard share the same shard user and mutate selected-team state.
- Add regression coverage for reconnect callback recovery and pending socket recovery runtime checks.

## Test Plan
- `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/state/TaskStateMachine.test.ts --runInBand`
- `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx src/__tests__/features/tasks/contexts/taskContext.group-loading.test.tsx --runInBand`
- `cd frontend && npm run lint`
- `cd frontend && npx prettier --check e2e/tests/auth.spec.ts e2e/tests/tasks/chat-image-browser-e2e.spec.ts`
- `git diff --check`

## Notes
- Latest cleanup validation was run manually in an isolated worktree; lint exits 0 with existing warnings.
- The full local E2E runner starts the complete service stack and all tests; the sharded browser scenarios are being revalidated by CI after this push.
- Documentation update was verified as not required because this is an internal recovery/config/test-stability bugfix with no user-facing API or workflow change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconnect recovery so task runtime is re-checked and pending task recovery resumes correctly on socket reconnection.

* **Tests**
  * Added and updated tests and mocks to cover reconnect and runtime-recovery scenarios; made E2E assertions for image-chat and auth flows more robust.

* **Chores**
  * Test runner retries disabled and CI traces retained on failure for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->