### PR TITLE
feat(backend): add web runtime guidance prompt

### DIFF
--- a/backend/app/services/chat/trigger/unified.py
+++ b/backend/app/services/chat/trigger/unified.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from fastapi import HTTPException
 
+from app.core.constants import CLIENT_ORIGIN_FRONTEND
 from app.db.session import SessionLocal
 from app.models.kind import Kind
 from app.models.subtask import Subtask
@@ -293,6 +294,10 @@ async def build_execution_request(
             additional_skills = getattr(payload, "additional_skills", None)
             if additional_skills:
                 preload_skills = list(preload_skills or []) + list(additional_skills)
+        web_runtime_guidance = (
+            payload is not None
+            and getattr(payload, "client_origin", None) == CLIENT_ORIGIN_FRONTEND
+        )
 
         # Extract model override from task metadata labels
         # This is where force_override_bot_model is stored when task is created
@@ -326,6 +331,7 @@ async def build_execution_request(
             override_model_name=override_model_name,
             force_override=force_override,
             previous_bot_id=previous_bot_id,
+            web_runtime_guidance=web_runtime_guidance,
         )
 
         # Merge reasoning config from API/model selection into model_config.

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -42,6 +42,8 @@ from shared.utils.url_util import domains_match
 
 logger = logging.getLogger(__name__)
 SELECTED_KB_PRELOAD_SKILL = "wegent-knowledge"
+WEB_RUNTIME_GUIDANCE_MARKER = "<wegent_runtime_guidance>"
+WEB_RUNTIME_GUIDANCE_CLOSE = "</wegent_runtime_guidance>"
 
 
 class TaskRequestBuilder:
@@ -110,6 +112,7 @@ class TaskRequestBuilder:
         override_model_name: Optional[str] = None,
         force_override: bool = False,
         team_member_prompt: Optional[str] = None,
+        web_runtime_guidance: bool = False,
     ) -> ExecutionRequest:
         """Build ExecutionRequest from database models.
 
@@ -138,6 +141,7 @@ class TaskRequestBuilder:
             override_model_name: Optional model name to override bot's model
             force_override: If True, override takes highest priority
             team_member_prompt: Optional additional prompt from team member
+            web_runtime_guidance: Whether to inject Wegent web UI runtime guidance
 
         Returns:
             ExecutionRequest ready for dispatch
@@ -325,6 +329,23 @@ class TaskRequestBuilder:
                     previous_bot_id,
                     current_bot_id,
                 )
+
+        if web_runtime_guidance:
+            project_workspace = workspace.get("project") or {}
+            task_device_id = self._extract_task_device_id(
+                task
+            ) or project_workspace.get("device_id")
+            device_type = self._get_device_type(user.id, task_device_id)
+            shell_type = bot_config[0].get("shell_type", "") if bot_config else ""
+            system_prompt = self._append_web_runtime_guidance(
+                system_prompt,
+                shell_type=shell_type,
+                device_type=device_type,
+                has_device_id=bool(task_device_id),
+                execution_target_type=project_workspace.get("execution_target_type"),
+                workspace_source=project_workspace.get("workspace_source"),
+                workspace_path=project_workspace.get("project_workspace_path"),
+            )
 
         return ExecutionRequest(
             task_id=task.id,
@@ -514,6 +535,134 @@ class TaskRequestBuilder:
         metadata = payload.get("metadata", {})
         labels = metadata.get("labels", {}) if isinstance(metadata, dict) else {}
         return str(labels.get("taskType") or labels.get("type") or "chat")
+
+    @staticmethod
+    def _append_web_runtime_guidance(
+        system_prompt: str,
+        *,
+        shell_type: str | None,
+        device_type: str | None,
+        has_device_id: bool,
+        execution_target_type: str | None,
+        workspace_source: str | None,
+        workspace_path: str | None,
+    ) -> str:
+        """Append Wegent web UI runtime guidance to the system prompt."""
+        if WEB_RUNTIME_GUIDANCE_MARKER in (system_prompt or ""):
+            return system_prompt
+
+        environment = TaskRequestBuilder._describe_web_runtime_environment(
+            shell_type=shell_type,
+            device_type=device_type,
+            has_device_id=has_device_id,
+            execution_target_type=execution_target_type,
+        )
+        workspace_details = []
+        if workspace_source:
+            workspace_details.append(f"- workspace source: {workspace_source}")
+        if workspace_path:
+            workspace_details.append(f"- workspace path: {workspace_path}")
+
+        guidance_lines = [
+            WEB_RUNTIME_GUIDANCE_MARKER,
+            "This request was started from the Wegent web UI.",
+            "Runtime environment:",
+            f"- You are running in: {environment}.",
+            *workspace_details,
+            "",
+            "User-facing file access:",
+            "- Do not assume the user can access local paths, container paths, "
+            "terminal sessions, or files you create directly.",
+            "- If you create, edit, or download files for the user, tell the user "
+            'to click "View the task files" / "查看任务文件" in the Wegent task '
+            "page to browse, preview, or download them.",
+            "- Keep paths in your answer as useful context when relevant, but do "
+            "not present a runtime path as the only way for the user to get a file.",
+            "",
+            "Interaction rules:",
+            "- Match Wegent's web interaction model instead of giving generic "
+            "sandbox or local-terminal instructions.",
+            "- If the task runs on a selected device, remember that generated "
+            "files may live on that device or be exposed through Wegent task files.",
+            WEB_RUNTIME_GUIDANCE_CLOSE,
+        ]
+        guidance = "\n".join(guidance_lines)
+        base_prompt = (system_prompt or "").rstrip()
+        if not base_prompt:
+            return guidance
+        return f"{base_prompt}\n\n{guidance}"
+
+    @staticmethod
+    def _describe_web_runtime_environment(
+        *,
+        shell_type: str | None,
+        device_type: str | None,
+        has_device_id: bool,
+        execution_target_type: str | None,
+    ) -> str:
+        """Build a concise execution environment label for web guidance."""
+        if has_device_id:
+            if device_type == "local":
+                return "local device selected in Wegent"
+            if device_type == "cloud":
+                return "cloud device or remote sandbox selected in Wegent"
+            return "selected Wegent device"
+
+        if execution_target_type == "cloud":
+            return "Wegent-managed cloud sandbox"
+        if execution_target_type == "local":
+            return "local device configured for this workspace project"
+
+        if shell_type in {"ClaudeCode", "Agno", "Codex"}:
+            return "Wegent-managed disposable execution sandbox"
+        if shell_type == "Dify":
+            return "external service configured by the selected bot"
+        if shell_type == "Chat":
+            return "Wegent web chat runtime"
+
+        return "Wegent-managed execution runtime"
+
+    @staticmethod
+    def _extract_task_device_id(task: TaskResource) -> str | None:
+        """Extract the selected device ID from task CRD JSON if present."""
+        task_json = task.json if isinstance(task.json, dict) else {}
+        spec = task_json.get("spec", {})
+        if not isinstance(spec, dict):
+            return None
+        device_id = spec.get("device_id")
+        if isinstance(device_id, str) and device_id.strip():
+            return device_id.strip()
+        return None
+
+    def _get_device_type(self, user_id: int, device_id: str | None) -> str | None:
+        """Resolve a Device CRD type without making request building depend on it."""
+        if not device_id:
+            return None
+
+        try:
+            device = (
+                self.db.query(Kind)
+                .filter(
+                    Kind.user_id == user_id,
+                    Kind.kind == "Device",
+                    Kind.namespace == "default",
+                    Kind.name == device_id,
+                    Kind.is_active,
+                )
+                .first()
+            )
+        except Exception as e:
+            logger.warning(
+                "[TaskRequestBuilder] Failed to resolve device type for %s: %s",
+                device_id,
+                e,
+            )
+            return None
+
+        device_json = device.json if device and isinstance(device.json, dict) else {}
+        spec = device_json.get("spec", {}) if isinstance(device_json, dict) else {}
+        device_type = spec.get("deviceType") if isinstance(spec, dict) else None
+        return device_type if isinstance(device_type, str) else None
 
     # =========================================================================
     # Bot Resolution (from ChatConfigBuilder)

--- a/backend/tests/services/chat/test_trigger_unified.py
+++ b/backend/tests/services/chat/test_trigger_unified.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core.constants import CLIENT_ORIGIN_FRONTEND
 from shared.models import ExecutionRequest
 from shared.models.knowledge import ChatContextsResult, KnowledgeBaseToolsResult
 
@@ -120,6 +121,48 @@ class TestBuildExecutionRequestUserSubtaskId:
                     "answers": {"language": "python"},
                     "message": "selected python",
                 }
+
+    async def test_frontend_payload_enables_web_runtime_guidance(self):
+        """Web chat requests should ask the request builder to add UI guidance."""
+        from app.services.chat.trigger import unified as trigger_unified
+
+        mock_db = MagicMock()
+        request_from_builder = ExecutionRequest(task_id=1, subtask_id=2)
+        mock_builder = MagicMock()
+        mock_builder.build.return_value = request_from_builder
+        payload = SimpleNamespace(
+            enable_web_search=False,
+            enable_clarification=False,
+            additional_skills=None,
+            client_origin=CLIENT_ORIGIN_FRONTEND,
+        )
+
+        with patch.object(trigger_unified, "SessionLocal", return_value=mock_db):
+            with patch(
+                "app.services.execution.TaskRequestBuilder", return_value=mock_builder
+            ):
+                task = MagicMock()
+                task.id = 1
+                task.json = {}
+
+                assistant_subtask = MagicMock()
+                assistant_subtask.id = 2
+
+                team = MagicMock()
+                user = MagicMock()
+                user.id = 7
+
+                await trigger_unified.build_execution_request(
+                    task=task,
+                    assistant_subtask=assistant_subtask,
+                    team=team,
+                    user=user,
+                    message="hello",
+                    payload=payload,
+                    user_subtask_id=None,
+                )
+
+        assert mock_builder.build.call_args.kwargs["web_runtime_guidance"] is True
 
     async def test_device_execution_keeps_sandbox_path_in_context_processing(self):
         """Device-routed tasks should keep sandbox path placeholders for executor rewrite."""

--- a/backend/tests/services/execution/test_web_runtime_guidance.py
+++ b/backend/tests/services/execution/test_web_runtime_guidance.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from app.services.execution.request_builder import TaskRequestBuilder
+
+
+def test_web_runtime_guidance_describes_local_device_and_file_access():
+    system_prompt = TaskRequestBuilder._append_web_runtime_guidance(
+        "Base prompt",
+        shell_type="ClaudeCode",
+        device_type="local",
+        has_device_id=True,
+        execution_target_type=None,
+        workspace_source=None,
+        workspace_path=None,
+    )
+
+    assert "Base prompt" in system_prompt
+    assert "local device" in system_prompt
+    assert "View the task files" in system_prompt
+    assert "查看任务文件" in system_prompt
+    assert "Do not assume the user can access local paths" in system_prompt
+
+
+def test_web_runtime_guidance_describes_disposable_managed_sandbox():
+    system_prompt = TaskRequestBuilder._append_web_runtime_guidance(
+        "Base prompt",
+        shell_type="ClaudeCode",
+        device_type=None,
+        has_device_id=False,
+        execution_target_type=None,
+        workspace_source=None,
+        workspace_path=None,
+    )
+
+    assert "Wegent-managed disposable execution sandbox" in system_prompt
+    assert "View the task files" in system_prompt
+
+
+def test_web_runtime_guidance_describes_cloud_project_workspace():
+    system_prompt = TaskRequestBuilder._append_web_runtime_guidance(
+        "Base prompt",
+        shell_type="ClaudeCode",
+        device_type=None,
+        has_device_id=False,
+        execution_target_type="cloud",
+        workspace_source="git",
+        workspace_path="repo-checkout",
+    )
+
+    assert "Wegent-managed cloud sandbox" in system_prompt
+    assert "workspace source: git" in system_prompt
+    assert "workspace path: repo-checkout" in system_prompt
+
+
+def test_web_runtime_guidance_is_idempotent():
+    first = TaskRequestBuilder._append_web_runtime_guidance(
+        "Base prompt",
+        shell_type="Chat",
+        device_type=None,
+        has_device_id=False,
+        execution_target_type=None,
+        workspace_source=None,
+        workspace_path=None,
+    )
+    second = TaskRequestBuilder._append_web_runtime_guidance(
+        first,
+        shell_type="Chat",
+        device_type=None,
+        has_device_id=False,
+        execution_target_type=None,
+        workspace_source=None,
+        workspace_path=None,
+    )
+
+    assert first == second

--- a/docs/en/developer-guide/dynamic-context.md
+++ b/docs/en/developer-guide/dynamic-context.md
@@ -91,6 +91,17 @@ Suggested approach:
 - Build dynamic blocks independently, then join with `\n\n`.
 - Avoid putting any request-scoped data into system prompt templates.
 
+### Controlled Exception: Web UI Runtime Guidance
+
+Tasks started from the Wegent Web UI append a small `<wegent_runtime_guidance>` system prompt block while Backend builds the `ExecutionRequest`. This block is not KB metadata or business data context. It is interaction policy: it tells the model that the request came from the Web UI, describes whether execution is on a local device, cloud sandbox, or managed runtime, and asks the model to tell users to use the task page's "View the task files" entry when previewing or downloading generated files.
+
+Keep this exception tightly scoped:
+
+- Apply it only to tasks started from the Web UI, not API or other entry points.
+- Describe only runtime and user interaction behavior; do not include KB content, business data, or large request context.
+- Keep the block short, idempotent, and guarded by the `<wegent_runtime_guidance>` marker.
+- If the new content is factual request context, prefer `dynamic_context` instead of extending the system prompt.
+
 ## Responsibilities
 
 - [`shared/prompts/knowledge_base.py`](shared/prompts/knowledge_base.py):
@@ -99,6 +110,7 @@ Suggested approach:
 - Backend:
   - Generates `kb_meta_prompt` and stores it in [`ExecutionRequest.kb_meta_prompt`](shared/models/execution.py:46).
   - Transports it to Chat Shell via [`OpenAIRequestConverter`](shared/models/openai_converter.py:55) `metadata`.
+  - Appends controlled runtime guidance in [`TaskRequestBuilder`](backend/app/services/execution/request_builder.py:49) for Web UI tasks.
 
 - Chat Shell:
   - Injects `dynamic_context` as a human message.

--- a/docs/zh/developer-guide/dynamic-context.md
+++ b/docs/zh/developer-guide/dynamic-context.md
@@ -89,6 +89,17 @@ messages.append(current_user_message_with_datetime_suffix)
 - 动态内容分块构建，最后使用 `\n\n` 拼接。
 - 避免在 system prompt 中引入任何请求级变化内容。
 
+### 受控例外：Web UI runtime guidance
+
+从 Wegent Web UI 发起的任务会在 Backend 构建 `ExecutionRequest` 时追加一个很小的 `<wegent_runtime_guidance>` system prompt 块。这个块不是知识库或业务数据上下文，而是交互策略：它告诉模型当前请求来自 Web UI、运行在本地设备/云沙箱/托管运行时等环境，并要求模型在产出文件时提示用户通过任务页的“查看任务文件”入口预览或下载。
+
+这个例外应保持严格受控：
+
+- 只用于 Web UI 发起的任务，不应影响 API 或其它入口。
+- 只描述运行时与用户交互方式，不放入知识库内容、业务数据或大段请求上下文。
+- 注入内容必须保持简短、幂等，并用 `<wegent_runtime_guidance>` 标记避免重复追加。
+- 如果新增的是事实型请求上下文，仍应优先走 `dynamic_context`，而不是继续扩展 system prompt。
+
 ## 模块职责划分
 
 - [`shared/prompts/knowledge_base.py`](shared/prompts/knowledge_base.py):
@@ -97,6 +108,7 @@ messages.append(current_user_message_with_datetime_suffix)
 - Backend：
   - 生成 `kb_meta_prompt` 并写入 [`ExecutionRequest.kb_meta_prompt`](shared/models/execution.py:46)。
   - 通过 [`OpenAIRequestConverter`](shared/models/openai_converter.py:55) 的 `metadata` 字段透传给 Chat Shell。
+  - 对 Web UI 发起的任务，在 [`TaskRequestBuilder`](backend/app/services/execution/request_builder.py:49) 中追加受控的 runtime guidance。
 
 - Chat Shell：
   - messages 构建时注入 `dynamic_context`（human message）。

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -467,6 +467,10 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
             if key in bot_config and bot_config[key] is not None:
                 options[key] = bot_config[key]
 
+    if task_data.system_prompt:
+        options["system_prompt"] = task_data.system_prompt
+        logger.info("[ClaudeOptions] Using top-level ExecutionRequest system_prompt")
+
     # Final summary log
     final_mcp = options.get("mcp_servers", options.get("mcpServers"))
     if final_mcp and isinstance(final_mcp, dict):

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -67,6 +67,57 @@ class TestExtractClaudeOptionsWithMcp:
         options = extract_claude_options(task_data)
         assert "mcp_servers" not in options
 
+    def test_request_system_prompt_overrides_bot_system_prompt(self):
+        """Top-level request prompt contains dynamic context added by backend."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            system_prompt=(
+                "You are helpful.\n\n"
+                "<wegent_runtime_guidance>\n"
+                "Tell users to click View the task files.\n"
+                "</wegent_runtime_guidance>"
+            ),
+            bot=[{"system_prompt": "You are helpful."}],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert options["system_prompt"] == task_data.system_prompt
+        assert "<wegent_runtime_guidance>" in options["system_prompt"]
+
+    def test_bot_system_prompt_used_when_request_system_prompt_absent(self):
+        """Bot prompt remains the fallback when backend has no dynamic prompt."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            bot=[{"system_prompt": "You are helpful."}],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert options["system_prompt"] == "You are helpful."
+
+    def test_pipeline_uses_current_request_system_prompt(self):
+        """Pipeline stages pass the stage-specific top-level prompt to Claude."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            collaboration_model="pipeline",
+            new_session=True,
+            system_prompt=(
+                "Current stage prompt.\n\n"
+                "<wegent_runtime_guidance>\n"
+                "Use Wegent task files for downloads.\n"
+                "</wegent_runtime_guidance>"
+            ),
+            bot=[
+                {"id": 2, "system_prompt": "First raw bot prompt."},
+                {"id": 3, "system_prompt": "Second raw bot prompt."},
+            ],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert options["system_prompt"] == task_data.system_prompt
+
     def test_empty_bot_list(self):
         """Empty bot list should not crash."""
         task_data = ExecutionRequest(task_id=1, bot=[])


### PR DESCRIPTION
## Summary
- Pass Web UI origin through chat execution request building.
- Append a bounded `<wegent_runtime_guidance>` prompt block for Wegent web tasks so models understand the execution environment and tell users to use "View the task files" / "查看任务文件" for generated files.
- Cover local device, managed sandbox, cloud workspace, and idempotency behavior with tests, and document the controlled system-prompt exception in dynamic context docs.

## Tests
- `cd backend && uv run black --check app/services/execution/request_builder.py app/services/chat/trigger/unified.py tests/services/execution/test_web_runtime_guidance.py tests/services/chat/test_trigger_unified.py`
- `cd backend && uv run isort --check-only app/services/execution/request_builder.py app/services/chat/trigger/unified.py tests/services/execution/test_web_runtime_guidance.py tests/services/chat/test_trigger_unified.py`
- `cd backend && uv run pytest tests/services/execution/test_web_runtime_guidance.py tests/services/chat/test_trigger_unified.py tests/services/execution/test_request_builder_standalone_workspace.py tests/services/execution/test_request_builder_user_mcp.py` (30 passed)
- `git diff --check`
- Pre-push hook passed with `AI_VERIFIED=1` after documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Web UI runtime guidance for tasks started from the frontend, injecting concise environment, device and workspace hints into execution requests.
  * Backend now ensures this guidance is passed through agent invocation where applicable.

* **Documentation**
  * Developer guides updated to describe the guidance block, its constraints, and idempotency.

* **Tests**
  * New and expanded tests validate guidance injection, idempotency, and downstream propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->