### PR TITLE
fix(frontend): respect configured default model refs

### DIFF
--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -138,6 +138,10 @@ function mockDeferredModelsLoad(models: Model[]) {
 describe('useModelSelection', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    ;(getModelFromConfig as jest.Mock).mockReturnValue(null)
+    ;(getModelTypeFromConfig as jest.Mock).mockReturnValue(undefined)
+    ;(getModelNamespaceFromConfig as jest.Mock).mockReturnValue(undefined)
+    ;(getGlobalModelPreference as jest.Mock).mockReturnValue(null)
   })
 
   it('selects concrete models as force override without showing override text', async () => {
@@ -241,7 +245,13 @@ describe('useModelSelection', () => {
       expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
     })
     expect(result.current.forceOverride).toBe(false)
-    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
+    expect(result.current.showAdvancedModels).toBe(true)
+    expect(result.current.filteredModels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(mockAdvancedModel),
+        expect.objectContaining(mockModel),
+      ])
+    )
   })
 
   it('uses the configured model type when restoring an advanced bot preset model', async () => {
@@ -298,9 +308,11 @@ describe('useModelSelection', () => {
     await waitFor(() => {
       expect(result.current.selectedModel).toEqual(expect.objectContaining(advancedUserModel))
     })
+    expect(result.current.showAdvancedModels).toBe(true)
+    expect(result.current.filteredModels).toContainEqual(expect.objectContaining(advancedUserModel))
   })
 
-  it('restores advanced model from team preference even when advanced models are hidden', async () => {
+  it('restores advanced model from team preference and opens advanced model mode', async () => {
     ;(getGlobalModelPreference as jest.Mock).mockReturnValue({
       modelName: mockAdvancedModel.name,
       modelType: mockAdvancedModel.type,
@@ -323,11 +335,16 @@ describe('useModelSelection', () => {
     await waitFor(() => {
       expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
     })
-    expect(result.current.showAdvancedModels).toBe(false)
-    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
+    expect(result.current.showAdvancedModels).toBe(true)
+    expect(result.current.filteredModels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(mockAdvancedModel),
+        expect.objectContaining(mockModel),
+      ])
+    )
   })
 
-  it('keeps advanced task model selection when advanced models are hidden', async () => {
+  it('keeps advanced task model selection and opens advanced model mode', async () => {
     ;(modelApis.getUnifiedModels as jest.Mock).mockReset()
     const modelLoad = mockDeferredModelsLoad([mockModel, mockAdvancedModel])
 
@@ -349,7 +366,12 @@ describe('useModelSelection', () => {
     await act(async () => {})
 
     expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
-    expect(result.current.showAdvancedModels).toBe(false)
-    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
+    expect(result.current.showAdvancedModels).toBe(true)
+    expect(result.current.filteredModels).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining(mockAdvancedModel),
+        expect.objectContaining(mockModel),
+      ])
+    )
   })
 })

--- a/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
+++ b/frontend/src/__tests__/features/tasks/hooks/useModelSelection.test.tsx
@@ -207,6 +207,99 @@ describe('useModelSelection', () => {
     })
   })
 
+  it('selects an advanced bot preset model when restoring a new chat team', async () => {
+    ;(getModelFromConfig as jest.Mock).mockReturnValue(mockAdvancedModel.name)
+    ;(getModelTypeFromConfig as jest.Mock).mockReturnValue(mockAdvancedModel.type)
+    ;(getModelNamespaceFromConfig as jest.Mock).mockReturnValue(undefined)
+    const teamWithAdvancedBotModel: TeamWithBotDetails = {
+      ...mockTeam,
+      bots: [
+        {
+          bot_id: 1,
+          bot_prompt: '',
+          bot: {
+            agent_config: { bind_model: mockAdvancedModel.name },
+          },
+        },
+      ],
+    } satisfies TeamWithBotDetails
+
+    ;(modelApis.getUnifiedModels as jest.Mock).mockReset()
+    const modelLoad = mockDeferredModelsLoad([mockModel, mockAdvancedModel])
+
+    const { result } = renderHook(() =>
+      useModelSelection({
+        teamId: 1,
+        taskId: null,
+        selectedTeam: teamWithAdvancedBotModel,
+      })
+    )
+
+    await modelLoad.resolve()
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toEqual(expect.objectContaining(mockAdvancedModel))
+    })
+    expect(result.current.forceOverride).toBe(false)
+    expect(result.current.filteredModels).toEqual([expect.objectContaining(mockModel)])
+  })
+
+  it('uses the configured model type when restoring an advanced bot preset model', async () => {
+    const regularSharedModel: Model = {
+      name: 'same-model',
+      displayName: 'Same Model',
+      provider: 'anthropic',
+      modelId: 'same-model-regular',
+      type: 'public',
+      isAdvanced: false,
+    }
+    const advancedUserModel: Model = {
+      name: 'same-model',
+      displayName: 'Same Model',
+      provider: 'anthropic',
+      modelId: 'same-model-advanced',
+      type: 'user',
+      namespace: 'default',
+      isAdvanced: true,
+    }
+    ;(getModelFromConfig as jest.Mock).mockReturnValue(advancedUserModel.name)
+    ;(getModelTypeFromConfig as jest.Mock).mockReturnValue(advancedUserModel.type)
+    ;(getModelNamespaceFromConfig as jest.Mock).mockReturnValue(advancedUserModel.namespace)
+    const teamWithAdvancedBotModel: TeamWithBotDetails = {
+      ...mockTeam,
+      bots: [
+        {
+          bot_id: 1,
+          bot_prompt: '',
+          bot: {
+            agent_config: {
+              bind_model: advancedUserModel.name,
+              bind_model_type: advancedUserModel.type,
+              bind_model_namespace: advancedUserModel.namespace,
+            },
+          },
+        },
+      ],
+    } satisfies TeamWithBotDetails
+
+    ;(modelApis.getUnifiedModels as jest.Mock).mockReset()
+    const modelLoad = mockDeferredModelsLoad([regularSharedModel, advancedUserModel])
+
+    const { result } = renderHook(() =>
+      useModelSelection({
+        teamId: 1,
+        taskId: null,
+        selectedTeam: teamWithAdvancedBotModel,
+      })
+    )
+
+    await modelLoad.resolve()
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toEqual(expect.objectContaining(advancedUserModel))
+    })
+  })
+
   it('restores advanced model from team preference even when advanced models are hidden', async () => {
     ;(getGlobalModelPreference as jest.Mock).mockReturnValue({
       modelName: mockAdvancedModel.name,

--- a/frontend/src/features/tasks/hooks/useModelSelection.ts
+++ b/frontend/src/features/tasks/hooks/useModelSelection.ts
@@ -425,6 +425,9 @@ export function useModelSelection({
 
       if (restoredModel) {
         setSelectedModel(restoredModel)
+        if (restoredModel.isAdvanced) {
+          setShowAdvancedModelsState(true)
+        }
         if (restoredModel.name === DEFAULT_MODEL_NAME) {
           setForceOverrideState(false)
         } else if (restoredForceOverride !== undefined) {
@@ -505,6 +508,9 @@ export function useModelSelection({
   /** Select a model directly */
   const selectModel = useCallback((model: Model | null) => {
     setSelectedModel(model)
+    if (model?.isAdvanced) {
+      setShowAdvancedModelsState(true)
+    }
     setForceOverrideState(Boolean(model && model.name !== DEFAULT_MODEL_NAME))
   }, [])
 
@@ -522,6 +528,9 @@ export function useModelSelection({
       const model = filteredModels.find(m => m.name === modelName && m.type === modelType)
       if (model) {
         setSelectedModel(model)
+        if (model.isAdvanced) {
+          setShowAdvancedModelsState(true)
+        }
         setForceOverrideState(true)
       }
     },
@@ -532,8 +541,11 @@ export function useModelSelection({
   const selectDefaultModel = useCallback(() => {
     const defaultModel = { name: DEFAULT_MODEL_NAME, provider: '', modelId: '' }
     setSelectedModel(defaultModel)
+    if (boundDefaultModel?.isAdvanced) {
+      setShowAdvancedModelsState(true)
+    }
     setForceOverrideState(false)
-  }, [])
+  }, [boundDefaultModel?.isAdvanced])
 
   /** Set force override flag */
   const setForceOverride = useCallback((value: boolean) => {

--- a/frontend/src/features/tasks/hooks/useModelSelection.ts
+++ b/frontend/src/features/tasks/hooks/useModelSelection.ts
@@ -308,8 +308,13 @@ export function useModelSelection({
     if (botConfig) {
       const bindModel = getModelFromConfig(botConfig)
       if (bindModel) {
-        const foundModel = selectableModels.find(
-          m => m.name === bindModel || m.displayName === bindModel
+        const foundModel = selectableModels.find(model =>
+          modelMatchesConfiguredRef(
+            model,
+            bindModel,
+            getModelTypeFromConfig(botConfig),
+            getModelNamespaceFromConfig(botConfig)
+          )
         )
         return foundModel || null
       }


### PR DESCRIPTION
## Summary
- Match bot preset default models using configured name, type, and namespace.
- Add regression coverage for advanced default model restoration and same-name model refs.

## Test Plan
- [x] `cd frontend && npm test -- --runTestsByPath src/__tests__/features/tasks/hooks/useModelSelection.test.tsx src/__tests__/features/tasks/components/selector/ModelSelector.test.tsx --runInBand`
- [x] `cd frontend && npm test -- --passWithNoTests`
- [x] `AI_VERIFIED=1 git push -u origin codex/fix-quickaction-advanced-model` (pre-push ESLint, TypeScript, and unit tests passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model matching for restored team bot presets so configured advanced models are correctly recognized and applied; advanced model visibility is now enabled when a restored, selected, keyed, or default model is advanced.
* **Tests**
  * Expanded test coverage to validate restoring and selecting advanced bot preset models and the resulting visibility/filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->