### PR TITLE
去重首页 quick-access 并发请求

### DIFF
--- a/frontend/src/__tests__/apis/user.quick-access.test.ts
+++ b/frontend/src/__tests__/apis/user.quick-access.test.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { apiClient } from '@/apis/client'
+import { userApis } from '@/apis/user'
+import type { QuickAccessResponse } from '@/types/api'
+
+jest.mock('@/apis/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+  },
+}))
+
+const quickAccessResponse: QuickAccessResponse = {
+  system_version: 1,
+  system_team_ids: [101],
+  user_version: null,
+  show_system_recommended: true,
+  teams: [],
+}
+
+describe('userApis.getQuickAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('deduplicates concurrent quick access requests', async () => {
+    let resolveRequest: (value: QuickAccessResponse) => void = () => {}
+    ;(apiClient.get as jest.Mock).mockReturnValue(
+      new Promise<QuickAccessResponse>(resolve => {
+        resolveRequest = resolve
+      })
+    )
+
+    const firstRequest = userApis.getQuickAccess()
+    const secondRequest = userApis.getQuickAccess()
+
+    expect(apiClient.get).toHaveBeenCalledTimes(1)
+    expect(apiClient.get).toHaveBeenCalledWith('/users/quick-access')
+
+    resolveRequest(quickAccessResponse)
+
+    await expect(firstRequest).resolves.toBe(quickAccessResponse)
+    await expect(secondRequest).resolves.toBe(quickAccessResponse)
+  })
+
+  test('starts a fresh quick access request after the previous one settles', async () => {
+    ;(apiClient.get as jest.Mock)
+      .mockResolvedValueOnce(quickAccessResponse)
+      .mockResolvedValueOnce({
+        ...quickAccessResponse,
+        system_version: 2,
+      })
+
+    await userApis.getQuickAccess()
+    await userApis.getQuickAccess()
+
+    expect(apiClient.get).toHaveBeenCalledTimes(2)
+    expect(apiClient.get).toHaveBeenNthCalledWith(1, '/users/quick-access')
+    expect(apiClient.get).toHaveBeenNthCalledWith(2, '/users/quick-access')
+  })
+})

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -151,6 +151,8 @@ function isAuthenticated(): boolean {
 import { apiClient } from './client'
 import { paths } from '@/config/paths'
 
+let quickAccessRequest: Promise<QuickAccessResponse> | null = null
+
 export const userApis = {
   async login(data: LoginRequest): Promise<User> {
     const res: LoginResponse = await apiClient.post('/auth/login', data)
@@ -180,7 +182,15 @@ export const userApis = {
   },
 
   async getQuickAccess(): Promise<QuickAccessResponse> {
-    return apiClient.get('/users/quick-access')
+    if (!quickAccessRequest) {
+      quickAccessRequest = apiClient
+        .get('/users/quick-access')
+        .finally(() => {
+          quickAccessRequest = null
+        })
+    }
+
+    return quickAccessRequest
   },
 
   async getQuickLaunch(): Promise<QuickLaunchResponse> {


### PR DESCRIPTION
## Summary
- 为 `userApis.getQuickAccess()` 增加 in-flight 去重，避免首页多个组件同时触发时重复请求 `/users/quick-access`
- 保持请求完成后自动清空状态，后续刷新仍会重新拉取最新数据
- 补充回归测试，覆盖并发复用和后续重新请求两种场景

## Testing
- `npm test -- QuickAccessCards.test.tsx TeamSelectorButton.test.tsx user.quick-access.test.ts`
- 相关前端测试已通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized quick access feature to prevent duplicate concurrent API requests, reducing unnecessary network calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->