### PR TITLE
fix(frontend): repair quick access CI failures

### DIFF
--- a/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
+++ b/frontend/e2e/tests/tasks/chat-image-browser-e2e.spec.ts
@@ -337,6 +337,22 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
     await page.waitForTimeout(1500)
   }
 
+  async function isTestTeamAlreadySelected(page: Page): Promise<boolean> {
+    const selectedBadge = page
+      .locator('[data-testid="selected-team-badge"]')
+      .filter({ hasText: TEST_TEAM_NAME })
+      .first()
+    if (await selectedBadge.isVisible({ timeout: 1000 }).catch(() => false)) {
+      return true
+    }
+
+    const chatInputTeamText = page
+      .locator('[data-testid="chat-input-card"]')
+      .getByText(TEST_TEAM_NAME, { exact: true })
+      .first()
+    return chatInputTeamText.isVisible({ timeout: 1000 }).catch(() => false)
+  }
+
   /**
    * Helper function to select the test team in the UI
    * Updated to work with the new QuickAccessCards pagination design (removed "More" button)
@@ -354,6 +370,11 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
       // Take a screenshot for debugging
       await page.screenshot({ path: 'test-results/chat-page-initial.png' })
       console.log('Saved initial page screenshot')
+
+      if (await isTestTeamAlreadySelected(page)) {
+        console.log('Test team is already selected')
+        return true
+      }
 
       // Strategy 0: Current input toolbar selector.
       // The trigger is icon-only and uses data-testid="agent-skill-selector-button".
@@ -382,6 +403,12 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
           console.log('Found test team in current selector, selecting...')
           await teamOption.click()
           await page.waitForTimeout(1000)
+          return true
+        }
+
+        if (await isTestTeamAlreadySelected(page)) {
+          console.log('Test team is already selected after opening current selector')
+          await page.keyboard.press('Escape').catch(() => {})
           return true
         }
 
@@ -459,29 +486,6 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
         }
       }
 
-      // Strategy 2b: Fallback - try button with text "智能体" or "Agent"
-      const teamSelectorByText = page
-        .locator('button:has-text("智能体"), button:has-text("Agent")')
-        .first()
-      if (await teamSelectorByText.isVisible({ timeout: 3000 }).catch(() => false)) {
-        console.log('Found TeamSelectorButton by text, clicking...')
-        await teamSelectorByText.click()
-        await page.waitForTimeout(500)
-
-        // Look for the test team in the popover
-        const teamOption = page
-          .locator(
-            `[data-testid="team-option-${TEST_TEAM_NAME}"], [role="button"]:has-text("${TEST_TEAM_NAME}")`
-          )
-          .first()
-        if (await teamOption.isVisible({ timeout: 3000 }).catch(() => false)) {
-          console.log('Found team in popover, selecting...')
-          await teamOption.click()
-          await page.waitForTimeout(1000)
-          return true
-        }
-      }
-
       // Strategy 3: Look for team selector with data-tour attribute (when a task is selected)
       const teamSelector = page.locator('[data-tour="team-selector"]')
       if (await teamSelector.isVisible({ timeout: 3000 }).catch(() => false)) {
@@ -503,12 +507,9 @@ test.describe('Chat Image Browser E2E with Mock Model Server', () => {
         }
       }
 
-      // Strategy 4: Direct click on team card if visible anywhere on page
-      const teamCard = page.locator(`text="${TEST_TEAM_NAME}"`).first()
-      if (await teamCard.isVisible({ timeout: 3000 }).catch(() => false)) {
-        await teamCard.click()
-        await page.waitForTimeout(1000)
-        console.log(`Selected team from direct card: ${TEST_TEAM_NAME}`)
+      // Strategy 4: Directly visible team text in the input means URL-based selection has applied.
+      if (await isTestTeamAlreadySelected(page)) {
+        console.log(`Selected team is visible in chat input: ${TEST_TEAM_NAME}`)
         return true
       }
 

--- a/frontend/src/__tests__/apis/user.quick-access.test.ts
+++ b/frontend/src/__tests__/apis/user.quick-access.test.ts
@@ -49,12 +49,10 @@ describe('userApis.getQuickAccess', () => {
   })
 
   test('starts a fresh quick access request after the previous one settles', async () => {
-    ;(apiClient.get as jest.Mock)
-      .mockResolvedValueOnce(quickAccessResponse)
-      .mockResolvedValueOnce({
-        ...quickAccessResponse,
-        system_version: 2,
-      })
+    ;(apiClient.get as jest.Mock).mockResolvedValueOnce(quickAccessResponse).mockResolvedValueOnce({
+      ...quickAccessResponse,
+      system_version: 2,
+    })
 
     await userApis.getQuickAccess()
     await userApis.getQuickAccess()

--- a/frontend/src/apis/user.ts
+++ b/frontend/src/apis/user.ts
@@ -182,15 +182,18 @@ export const userApis = {
   },
 
   async getQuickAccess(): Promise<QuickAccessResponse> {
-    if (!quickAccessRequest) {
-      quickAccessRequest = apiClient
-        .get('/users/quick-access')
-        .finally(() => {
-          quickAccessRequest = null
-        })
+    if (quickAccessRequest) {
+      return quickAccessRequest
     }
 
-    return quickAccessRequest
+    const request = apiClient.get<QuickAccessResponse>('/users/quick-access').finally(() => {
+      if (quickAccessRequest === request) {
+        quickAccessRequest = null
+      }
+    })
+    quickAccessRequest = request
+
+    return request
   },
 
   async getQuickLaunch(): Promise<QuickLaunchResponse> {


### PR DESCRIPTION
## Summary
- Fix quick-access response promise typing so frontend TypeScript checks pass.
- Avoid reopening the team selector in the chat image browser E2E when the target team is already selected by URL.
- Keep the quick-access concurrency test formatted by repo tooling.

## Test Plan
- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm test -- user.quick-access.test.ts`
- `cd frontend && npx prettier --check src/apis/user.ts src/__tests__/apis/user.quick-access.test.ts e2e/tests/tasks/chat-image-browser-e2e.spec.ts`
- `cd frontend && npx playwright test e2e/tests/tasks/chat-image-browser-e2e.spec.ts --list`
- `cd frontend && npm run lint`
- pre-push hook: ESLint, TypeScript, frontend unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added request de-duplication for quick access calls to reduce redundant network requests and improve responsiveness.

* **Tests**
  * Improved team-selection end-to-end tests with early checks to skip unnecessary interactions, making them faster and more reliable.
  * Reworked user API test mocks for clearer structure and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->