### PR TITLE
fix(workspace): prepend projects/ prefix for git workspace checkout path

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -2503,7 +2503,10 @@ Response template:
 
         workspace = config.workspace
         if workspace:
-            project_workspace_path = workspace.localPath or workspace.checkoutPath
+            if workspace.source == "git" and workspace.checkoutPath:
+                project_workspace_path = f"projects/{workspace.checkoutPath}"
+            else:
+                project_workspace_path = workspace.localPath or workspace.checkoutPath
             workspace_data["project"] = {
                 "project_id": project_id,
                 "workspace_source": workspace.source,

--- a/backend/app/services/project_device_session_service.py
+++ b/backend/app/services/project_device_session_service.py
@@ -157,7 +157,10 @@ def _get_project_path(
 ) -> tuple[str, bool]:
     workspace = config.workspace
     if workspace:
-        path = workspace.localPath or workspace.checkoutPath
+        if workspace.source == "git" and workspace.checkoutPath:
+            path = f"projects/{workspace.checkoutPath}"
+        else:
+            path = workspace.localPath or workspace.checkoutPath
         if path:
             return path, True
 

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -24,6 +24,9 @@ function outputAsString(output: DeviceCommandResponse['stdout']): string {
 
 function workspacePath(project: ProjectWithTasks): string | undefined {
   const config = project.config
+  if (config?.workspace?.source === 'git' && config.workspace.checkoutPath) {
+    return `projects/${config.workspace.checkoutPath}`
+  }
   return config?.workspace?.localPath || config?.workspace?.checkoutPath || config?.path
 }
 


### PR DESCRIPTION
For git-type workspaces, use `projects/{checkoutPath}` as the resolved path instead of raw checkoutPath, ensuring the executor finds the cloned repo under the correct directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed path resolution for Git-based workspace projects. When a project workspace is sourced from Git with a checkout path available, the system now correctly computes and applies the project workspace path, ensuring consistent behavior across project execution, device sessions, and environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->