### PR TITLE
Show quick action descriptions on top-level cards

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickLauncherCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickLauncherCards.test.tsx
@@ -97,7 +97,7 @@ describe('QuickLauncherCards', () => {
     expect(screen.queryByTestId('quick-launch-system-grid')).not.toHaveClass('justify-center')
   })
 
-  test('renders launcher cards with titles only', () => {
+  test('renders launcher cards with title and description', () => {
     render(
       <QuickLauncherCards
         systemLaunchers={[
@@ -115,7 +115,7 @@ describe('QuickLauncherCards', () => {
     const systemCard = screen.getByTestId('quick-launcher-system_function-system-video_summary')
 
     expect(systemCard).toHaveTextContent('Analyze Weibo video')
-    expect(systemCard).not.toHaveTextContent(
+    expect(systemCard).toHaveTextContent(
       'Analyze this Weibo video and summarize the author viewpoint'
     )
   })

--- a/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickPhraseList.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/quick-launch/QuickPhraseList.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2026 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import { QuickPhraseList } from '@/features/tasks/components/chat/quick-launch/QuickPhraseList'
+import type { QuickLauncher } from '@/features/tasks/components/chat/quick-launch/types'
+import type { Team } from '@/types/api'
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 1,
+  name: 'team',
+  namespace: 'default',
+  description: 'Team description',
+  bots: [],
+  workflow: { mode: 'pipeline' },
+  is_active: true,
+  user_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  bind_mode: ['chat'],
+  ...overrides,
+})
+
+const makeLauncher = (overrides: Partial<QuickLauncher> = {}): QuickLauncher => ({
+  type: 'system_function',
+  key: 'system:create_ppt',
+  title: 'Create PPT',
+  inputPresets: [
+    {
+      id: 'review-change',
+      title: 'Review change',
+      prompt: 'Please review the current code change',
+    },
+  ],
+  team: makeTeam(),
+  targetPage: 'chat',
+  ...overrides,
+})
+
+describe('QuickPhraseList', () => {
+  test('renders preset titles without prompt secondary text', () => {
+    render(
+      <QuickPhraseList launcher={makeLauncher()} onBack={jest.fn()} onPresetSelect={jest.fn()} />
+    )
+
+    expect(screen.getByTestId('quick-phrase-0')).toHaveTextContent('Review change')
+    expect(screen.getByTestId('quick-phrase-0')).not.toHaveTextContent(
+      'Please review the current code change'
+    )
+  })
+})

--- a/frontend/src/features/tasks/components/chat/quick-launch/QuickPhraseList.tsx
+++ b/frontend/src/features/tasks/components/chat/quick-launch/QuickPhraseList.tsx
@@ -82,11 +82,6 @@ export function QuickPhraseList({
                   />
                 )}
               </span>
-              {preset.prompt && preset.prompt !== preset.title && (
-                <span className="mt-1 block text-xs leading-5 text-text-muted">
-                  {preset.prompt}
-                </span>
-              )}
             </button>
           )
         })}

--- a/frontend/src/features/tasks/components/chat/quick-launch/quick-launcher-cards.tsx
+++ b/frontend/src/features/tasks/components/chat/quick-launch/quick-launcher-cards.tsx
@@ -30,6 +30,8 @@ function LauncherCard({
   isSelected: boolean
   onClick: () => void
 }) {
+  const description = launcher.description?.trim()
+
   return (
     <button
       type="button"
@@ -54,6 +56,11 @@ function LauncherCard({
       >
         {launcher.title}
       </span>
+      {description && (
+        <span className="mt-1 line-clamp-2 text-xs leading-4 text-text-muted" title={description}>
+          {description}
+        </span>
+      )}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- Render `description` on first-level quick action cards so system and favorite launchers can show their explanatory text.
- Remove secondary prompt text from the second-level preset list so preset cards stay compact and title-only.
- Add and update unit tests to cover both behaviors.

## Testing
- `npm test -- --runTestsByPath src/__tests__/features/tasks/components/chat/quick-launch/QuickLauncherCards.test.tsx src/__tests__/features/tasks/components/chat/quick-launch/QuickPhraseList.test.tsx`
- `npm test -- --runTestsByPath src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launcher cards now display descriptions beneath their titles when available, providing users with additional context about available options.

* **Improvements**
  * Quick phrase list display simplified by removing redundant secondary text, focusing the interface on core action titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->