### PR TITLE
fix(wework): restore streaming content after refresh

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -193,7 +193,7 @@ describe('ChatInput', () => {
       'box-border',
       'py-[14px]',
       'pl-5',
-      'pr-[104px]',
+      'pr-16',
       'scrollbar-none',
     )
     expect(screen.getByTestId('send-message-button')).toHaveClass(
@@ -240,10 +240,12 @@ describe('ChatInput', () => {
     expect(onPause).toHaveBeenCalledTimes(1)
   })
 
-  test('hides voice input after typing in the compact composer', async () => {
+  test('does not render voice input in the compact composer', async () => {
     render(<ControlledChatInput />)
 
-    expect(screen.getByTestId('voice-input-button')).toBeInTheDocument()
+    expect(screen.queryByTestId('voice-input-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('chat-message-input')).toHaveClass('pr-16')
+
     await userEvent.type(screen.getByTestId('chat-message-input'), 'hello')
 
     expect(screen.queryByTestId('voice-input-button')).not.toBeInTheDocument()

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Camera, Image, Maximize2, Mic, Minimize2, Plus, Square } from 'lucide-react'
+import { ArrowUp, Camera, Image, Maximize2, Minimize2, Plus, Square } from 'lucide-react'
 import type { ChangeEvent, ClipboardEventHandler } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -48,9 +48,7 @@ export function CompactChatComposer({
   const [fullscreenInputOpen, setFullscreenInputOpen] = useState(false)
   const [canExpandInput, setCanExpandInput] = useState(false)
   const canSend = (value.trim().length > 0 || attachments.length > 0) && !disabled
-  const hasText = value.trim().length > 0
   const explicitLineCount = value.split('\n').length
-  const textareaRightPaddingClass = hasText ? 'pr-16' : 'pr-[104px]'
 
   const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files
@@ -148,7 +146,7 @@ export function CompactChatComposer({
             onPasteFiles={files => onFileSelect?.(files)}
             className={[
               'scrollbar-none m-0 block h-[52px] max-h-32 w-full min-w-0 flex-1 box-border resize-none overflow-y-auto bg-transparent py-[14px] pl-5 text-base leading-6 text-text-primary outline-none placeholder:text-text-muted',
-              textareaRightPaddingClass,
+              'pr-16',
             ].join(' ')}
             skillMenuClassName="left-[-1rem] right-[-3.5rem]"
             onListLocalSkills={onListLocalSkills}
@@ -163,17 +161,6 @@ export function CompactChatComposer({
               aria-label={t('workbench.expand_input', '展开输入框')}
             >
               <Maximize2 className="h-4 w-4" />
-            </button>
-          )}
-          {!hasText && (
-            <button
-              type="button"
-              data-testid="voice-input-button"
-              disabled={disabled}
-              className="absolute bottom-[6px] right-14 z-popover flex h-11 w-11 items-center justify-center rounded-full p-0 text-text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-              aria-label={t('workbench.voice_input', '语音输入')}
-            >
-              <Mic className="h-5 w-5" />
             </button>
           )}
           {isStreaming ? (

--- a/wework/src/components/chat/composer/ComposerToolbar.tsx
+++ b/wework/src/components/chat/composer/ComposerToolbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, Mic, Square } from 'lucide-react'
+import { ArrowUp, Square } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ModelOptions, UnifiedModel } from '@/types/api'
 import { AddContextMenu } from './AddContextMenu'
@@ -54,15 +54,6 @@ export function ComposerToolbar({
             data-testid="model-selector-loading"
           />
         )}
-        <button
-          type="button"
-          data-testid="voice-input-button"
-          disabled={disabled}
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full p-0 text-text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          aria-label={t('workbench.voice_input', '语音输入')}
-        >
-          <Mic className="h-4 w-4" />
-        </button>
         {isStreaming ? (
           <button
             type="button"

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -439,7 +439,7 @@ function ProjectTaskRow({
       onClick={handleOpen}
       onKeyDown={(event) => handleSidebarRowKeyDown(event, handleOpen)}
       className={[
-        'group/task flex h-8 cursor-default items-center rounded-md pl-10 pr-0.5 text-[13px] leading-[18px]',
+        'group/task flex h-8 cursor-default items-center rounded-md pl-9 pr-1 text-[13px] leading-[18px]',
         selected
           ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
           : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]',
@@ -621,7 +621,7 @@ function ProjectItem({
       {expanded && (
         <div className="space-y-0.5">
           {tasks.length === 0 ? (
-            <div className="ml-10 rounded-md px-2 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]">
+            <div className="ml-6 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]">
               {t('workbench.no_chats', '暂无会话')}
             </div>
           ) : (
@@ -643,7 +643,7 @@ function ProjectItem({
               type="button"
               data-testid={`project-task-limit-toggle-${project.id}`}
               onClick={() => onToggleTaskLimit(project.id)}
-              className="ml-10 h-8 rounded-md px-2 text-left text-xs font-medium text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
+              className="ml-6 h-8 rounded-md px-3 text-left text-xs font-medium text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
             >
               {showAllTasks
                 ? t('workbench.show_less', '收起')

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1333,6 +1333,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
     expect(screen.getByTestId('project-chat-row-11')).toHaveClass(
       'bg-[rgb(var(--color-sidebar-active))]',
+      'pl-9',
     )
     await userEvent.click(screen.getByTestId('project-chat-button'))
     expect(baseProps.onOpenTask).toHaveBeenCalledWith(11, 1)

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -122,6 +122,23 @@ function ArchiveProbe() {
   )
 }
 
+function TaskMessagesProbe() {
+  const workbench = useWorkbench()
+
+  return (
+    <div>
+      <span data-testid="message-contents">
+        {workbench.messages
+          .map(message => `${message.role}:${message.status}:${message.content}`)
+          .join('|')}
+      </span>
+      <button type="button" onClick={() => void workbench.openTask(8)}>
+        open task
+      </button>
+    </div>
+  )
+}
+
 function DeviceListProbe() {
   const workbench = useWorkbench()
 
@@ -414,6 +431,117 @@ describe('WorkbenchProvider', () => {
       'Restored task',
     )
     expect(joinTask).toHaveBeenCalledWith(8)
+  })
+
+  test('restores cached streaming content when opening a running task after refresh', async () => {
+    const getTaskDetail = vi.fn().mockResolvedValue({
+      id: 8,
+      title: 'Running task',
+      status: 'RUNNING',
+      task_type: 'code',
+      project_id: 0,
+      device_id: 'local-online',
+      created_at: '2026-06-04T00:00:00.000Z',
+      updated_at: '2026-06-04T00:01:00.000Z',
+      subtasks: [
+        {
+          id: 20,
+          task_id: 8,
+          role: 'user',
+          prompt: '写个故事',
+          status: 'COMPLETED',
+          created_at: '2026-06-04T00:00:00.000Z',
+        },
+        {
+          id: 21,
+          task_id: 8,
+          role: 'assistant',
+          result: { value: '' },
+          status: 'RUNNING',
+          created_at: '2026-06-04T00:00:01.000Z',
+        },
+      ],
+    })
+    const joinTask = vi.fn().mockResolvedValue({
+      streaming: {
+        subtask_id: 21,
+        offset: 9,
+        cached_content: '已经输出的内容',
+      },
+    })
+
+    render(
+      <WorkbenchProvider
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={{
+          teamApi: {
+            getDefaultWorkbenchTeam: vi
+              .fn()
+              .mockResolvedValue({ id: 2, name: 'coder', is_active: true }),
+          },
+          modelApi: { listModels: vi.fn().mockResolvedValue({ data: [] }) },
+          skillApi: {
+            listSkills: vi.fn().mockResolvedValue([]),
+            getTeamSkills: vi.fn().mockResolvedValue({ skills: [], preload_skills: [] }),
+          },
+          projectApi: {
+            listProjects: vi.fn().mockResolvedValue({ items: [] }),
+            getProject: vi.fn(),
+            createProject: vi.fn(),
+            updateProject: vi.fn(),
+            deleteProject: vi.fn(),
+            archiveProjectChats: vi.fn(),
+            archiveAllProjectChats: vi.fn(),
+            createConversation: vi.fn(),
+          },
+          taskApi: {
+            listRecentTasks: vi.fn().mockResolvedValue({ total: 0, items: [] }),
+            getTaskDetail,
+            renameTask: vi.fn(),
+            archiveTask: vi.fn(),
+            archiveAllChats: vi.fn(),
+            listArchivedTasks: vi.fn(),
+            unarchiveTask: vi.fn(),
+            deleteTask: vi.fn(),
+            deleteArchivedTasks: vi.fn(),
+          },
+          deviceApi: {
+            listDevices: vi.fn().mockResolvedValue([
+              {
+                id: 1,
+                device_id: 'local-online',
+                name: 'Local Device',
+                status: 'online',
+                is_default: false,
+                device_type: 'local',
+                bind_shell: 'claudecode',
+              },
+            ]),
+            getHomeDirectory: vi.fn(),
+            getProjectWorkspaceRoot: vi.fn(),
+            listDirectories: vi.fn(),
+            listSkills: vi.fn().mockResolvedValue([]),
+          },
+          chatStream: {
+            joinTask,
+            leaveTask: vi.fn(),
+            sendMessage: vi.fn(),
+            sendGuidance: vi.fn(),
+            cancelStream: vi.fn(),
+            subscribe: vi.fn(() => vi.fn()),
+          },
+        }}
+      >
+        <TaskMessagesProbe />
+      </WorkbenchProvider>
+    )
+
+    await userEvent.click(await screen.findByText('open task'))
+
+    await waitFor(() => expect(joinTask).toHaveBeenCalledWith(8))
+    expect(screen.getByTestId('message-contents')).toHaveTextContent(
+      'assistant:streaming:已经输出的内容'
+    )
   })
 
   test('uses the opened task model as the runtime compatibility anchor', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -995,7 +995,15 @@ export function WorkbenchProvider({
       setQueuedSends([])
       setGuidanceMessages([])
       writeTaskIdToUrl(taskId)
-      await resolvedServices.chatStream.joinTask(taskId)
+      const joinResponse = await resolvedServices.chatStream.joinTask(taskId)
+      if (joinResponse?.streaming) {
+        dispatchMessages({
+          type: 'assistant_cached',
+          taskId,
+          subtaskId: joinResponse.streaming.subtask_id,
+          content: joinResponse.streaming.cached_content,
+        })
+      }
       const routeProjectId =
         resolvedProjectId && resolvedProjectId > 0 ? resolvedProjectId : undefined
       handledTaskRouteRef.current = getTaskRouteKey(taskId, routeProjectId)

--- a/wework/src/features/workbench/messageReducer.ts
+++ b/wework/src/features/workbench/messageReducer.ts
@@ -15,6 +15,7 @@ export type MessageAction =
   | { type: 'reset'; messages: WorkbenchMessage[] }
   | { type: 'user_added'; message: WorkbenchMessage }
   | { type: 'assistant_started'; taskId?: number; subtaskId: number; shellType?: string }
+  | { type: 'assistant_cached'; taskId?: number; subtaskId: number; content: string }
   | {
       type: 'assistant_chunk'
       subtaskId: number
@@ -63,6 +64,32 @@ export function messageReducer(
           shellType: action.shellType,
           role: 'assistant',
           content: '',
+          status: 'streaming',
+          blocks: [],
+          createdAt: new Date().toISOString(),
+        },
+      ]
+    case 'assistant_cached':
+      if (state.some(message => message.subtaskId === action.subtaskId)) {
+        return state.map(message =>
+          message.subtaskId === action.subtaskId
+            ? {
+                ...message,
+                taskId: action.taskId ?? message.taskId,
+                content: action.content,
+                status: 'streaming' as const,
+              }
+            : message
+        )
+      }
+      return [
+        ...state,
+        {
+          id: `assistant-${action.subtaskId}`,
+          taskId: action.taskId,
+          subtaskId: action.subtaskId,
+          role: 'assistant',
+          content: action.content,
           status: 'streaming',
           blocks: [],
           createdAt: new Date().toISOString(),

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -115,7 +115,6 @@
     "expand_input": "Expand input",
     "collapse_input": "Collapse input",
     "fullscreen_input_title": "Edit message",
-    "voice_input": "Voice input",
     "send_message": "Send message",
     "custom_mode": "Custom",
     "model_selector": "Model selector",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -115,7 +115,6 @@
     "expand_input": "展开输入框",
     "collapse_input": "折叠输入框",
     "fullscreen_input_title": "编辑消息",
-    "voice_input": "语音输入",
     "send_message": "发送消息",
     "custom_mode": "自定义",
     "model_selector": "模型选择",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Running tasks now restore cached streaming content when reopened after refresh.

* **Improvements**
  * Removed voice input functionality from the chat composer.
  * Adjusted sidebar spacing and layout for task rows and project sections.
  * Updated chat composer padding and styling adjustments.

* **Tests**
  * Added test coverage for cached streaming content restoration.
  * Updated assertions for sidebar and composer styling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->