### PR TITLE
fix(executor): include Codex SDK in local builds

### DIFF
--- a/docker/device/Dockerfile
+++ b/docker/device/Dockerfile
@@ -63,7 +63,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get update && apt-get install -y --no-install-recommends \
     nodejs \
     ttyd \
-    && npm install -g @anthropic-ai/claude-code@2.1.142 \
+    && npm install -g @anthropic-ai/claude-code@2.1.142 @openai/codex@0.137.0 \
     && curl -fsSL https://code-server.dev/install.sh | sh \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && apt-get purge -y --auto-remove software-properties-common \

--- a/docker/executor/Dockerfile
+++ b/docker/executor/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app
 COPY executor/pyproject.toml /app/executor/pyproject.toml
 
 RUN cd /app/executor && uv pip install --system --no-cache -r pyproject.toml
-RUN uv pip install --system --no-cache --no-deps openai-codex==0.1.0b2
+RUN uv pip install --system --no-cache --no-deps openai-codex==0.1.0b3
 
 # Install PyInstaller for building standalone binary (using uv for speed)
 RUN uv pip install --system pyinstaller
@@ -38,7 +38,7 @@ RUN dnf install -y \
     atk at-spi2-atk libXcomposite libXdamage libXfixes libXrandr libxkbcommon \
     # Skill-creator dependencies (JSON parsing and packaging)
     jq zip \
-    && npm install -g @anthropic-ai/claude-code@2.1.142 @openai/codex@0.132.0 \
+    && npm install -g @anthropic-ai/claude-code@2.1.142 @openai/codex@0.137.0 \
     && dnf clean all \
     && rm -rf /var/cache/dnf/*
 

--- a/executor/scripts/build_local.py
+++ b/executor/scripts/build_local.py
@@ -24,6 +24,7 @@ Output:
 """
 
 import argparse
+import importlib.util
 import os
 import platform
 import re
@@ -31,6 +32,10 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+OPENAI_CODEX_SDK_PACKAGE = "openai-codex"
+OPENAI_CODEX_SDK_IMPORT = "openai_codex"
+OPENAI_CODEX_SDK_VERSION = "0.1.0b3"
 
 
 def get_project_root() -> Path:
@@ -172,6 +177,57 @@ def restore_github_repo_source(original_content: str) -> None:
     )
     github_checker_py.write_text(original_content)
     print("Restored github_version_checker.py to original content")
+
+
+def ensure_linux_openai_codex_sdk(effective_platform: str) -> None:
+    """Install the Codex Python SDK for Linux PyInstaller builds.
+
+    Linux builds use the npm Codex CLI from the runtime image. The Python SDK's
+    default dependency chain includes a platform-specific CLI wheel that is not
+    available for Linux, so install the SDK without dependencies before
+    PyInstaller collects modules.
+    """
+    if effective_platform != "Linux":
+        return
+
+    if importlib.util.find_spec(OPENAI_CODEX_SDK_IMPORT) is not None:
+        print(f"Found {OPENAI_CODEX_SDK_IMPORT}; skipping SDK install")
+        return
+
+    uv_binary = shutil.which("uv")
+    if uv_binary is None:
+        raise RuntimeError(
+            "uv is required to install openai-codex for Linux executor builds"
+        )
+
+    package_spec = f"{OPENAI_CODEX_SDK_PACKAGE}=={OPENAI_CODEX_SDK_VERSION}"
+    print(f"Installing {package_spec} with --no-deps for Linux build...")
+    subprocess.run(
+        [
+            uv_binary,
+            "pip",
+            "install",
+            "--python",
+            sys.executable,
+            "--no-deps",
+            package_spec,
+        ],
+        check=True,
+    )
+
+
+def append_codex_pyinstaller_options(cmd: list[str]) -> None:
+    """Add CodeXAgent and openai_codex modules to a PyInstaller command."""
+    cmd += [
+        "--hidden-import=executor.agents.codex",
+        "--hidden-import=executor.agents.codex.codex_agent",
+        "--hidden-import=executor.agents.codex.config_builder",
+        "--hidden-import=executor.agents.codex.event_mapper",
+        "--hidden-import=executor.agents.codex.session_store",
+        "--hidden-import=openai_codex",
+        "--hidden-import=openai_codex.generated.v2_all",
+        "--collect-all=openai_codex",
+    ]
 
 
 def find_claude_agent_sdk_binary(
@@ -378,6 +434,7 @@ def build_executable(
     try:
         # Change to project root for correct imports
         os.chdir(project_root)
+        ensure_linux_openai_codex_sdk(effective_platform)
 
         # Determine output name based on platform
         if platform.system() == "Windows":
@@ -524,6 +581,7 @@ def build_executable(
             "--collect-data=tiktoken",
             "--collect-data=tiktoken_ext",
         ]
+        append_codex_pyinstaller_options(cmd)
 
         append_claude_cli_binary(
             cmd,

--- a/executor/scripts/local_executor_install.ps1
+++ b/executor/scripts/local_executor_install.ps1
@@ -24,6 +24,8 @@ $InstallDir = "$env:LOCALAPPDATA\Wegent\bin"
 $BinaryName = "wegent-executor.exe"
 $MinNodeVersion = 18
 $MinClaudeCodeVersion = "2.1.0"
+$MinCodexCliVersion = "0.137.0"
+$CodexCliPackage = "@openai/codex@0.137.0"
 
 # Print colored message
 function Write-ColorOutput {
@@ -85,7 +87,7 @@ function Test-NodeJS {
     }
     catch {
         Write-ColorOutput "Node.js is not installed." "ERROR"
-        Write-ColorOutput "Claude Code requires Node.js $MinNodeVersion+ to run." "ERROR"
+        Write-ColorOutput "CLI dependencies require Node.js $MinNodeVersion+ to run." "ERROR"
         Write-Host ""
         Write-ColorOutput "Please install Node.js from:" "INFO"
         Write-Host "  - https://nodejs.org/"
@@ -106,12 +108,81 @@ function Test-Npm {
     }
     catch {
         Write-ColorOutput "npm is not installed." "ERROR"
-        Write-ColorOutput "npm is required to install Claude Code." "ERROR"
+        Write-ColorOutput "npm is required to install CLI dependencies." "ERROR"
         Write-Host ""
         Write-ColorOutput "npm usually comes with Node.js. Please reinstall Node.js." "INFO"
         Write-Host ""
         exit 1
     }
+}
+
+# Install or upgrade Codex CLI
+function Install-CodexCli {
+    Write-ColorOutput "Checking Codex CLI installation..." "INFO"
+    Test-Npm
+
+    $codexInstalled = $false
+    $currentVersion = ""
+
+    try {
+        $codexOutput = & codex --version 2>$null
+        if ($codexOutput) {
+            $codexInstalled = $true
+            if ($codexOutput -match '\d+\.\d+\.\d+') {
+                $currentVersion = $Matches[0]
+            }
+        }
+    }
+    catch {
+        # Codex CLI not found
+    }
+
+    if ($codexInstalled -and $currentVersion -and (Compare-SemanticVersion $currentVersion $MinCodexCliVersion)) {
+        Write-ColorOutput "Codex CLI found: v$currentVersion" "SUCCESS"
+        return
+    }
+
+    if ($codexInstalled) {
+        Write-ColorOutput "Upgrading Codex CLI to $CodexCliPackage..." "INFO"
+    }
+    else {
+        Write-ColorOutput "Codex CLI not found, installing $CodexCliPackage..." "INFO"
+    }
+
+    try {
+        & npm install -g "$CodexCliPackage"
+        if ($LASTEXITCODE -ne 0) {
+            throw "npm install failed with exit code $LASTEXITCODE"
+        }
+    }
+    catch {
+        Write-ColorOutput "Failed to install Codex CLI via npm." "ERROR"
+        Write-Host ""
+        Write-ColorOutput "You can try installing manually:" "INFO"
+        Write-Host "  npm install -g $CodexCliPackage"
+        Write-Host ""
+        Write-ColorOutput "If you encounter permission issues, try running PowerShell as Administrator." "INFO"
+        Write-Host ""
+        exit 1
+    }
+
+    try {
+        $codexOutput = & codex --version 2>$null
+        if ($codexOutput -match '\d+\.\d+\.\d+') {
+            $currentVersion = $Matches[0]
+        }
+    }
+    catch {
+        Write-ColorOutput "Codex CLI installation failed - 'codex' command not found." "ERROR"
+        exit 1
+    }
+
+    if (-not $currentVersion -or -not (Compare-SemanticVersion $currentVersion $MinCodexCliVersion)) {
+        Write-ColorOutput "Codex CLI version $currentVersion is below required $MinCodexCliVersion" "ERROR"
+        exit 1
+    }
+
+    Write-ColorOutput "Codex CLI installed: v$currentVersion" "SUCCESS"
 }
 
 # Install or upgrade Claude Code
@@ -353,6 +424,7 @@ function Main {
 
     Test-NodeJS
     Install-ClaudeCode
+    Install-CodexCli
     Install-WegentExecutor -Platform $platform
     Add-ToPath
     Show-Usage

--- a/executor/scripts/local_executor_install.sh
+++ b/executor/scripts/local_executor_install.sh
@@ -31,7 +31,9 @@ VERSION=""
 # Claude Code minimum version requirement
 # Claude Code defer requires 2.1.89+.
 MIN_CLAUDE_CODE_VERSION="2.1.89"
+MIN_CODEX_CLI_VERSION="0.137.0"
 MIN_NODE_VERSION="18"
+CODEX_CLI_PACKAGE="@openai/codex@0.137.0"
 
 # Feature flags
 # Claude Code is bundled for Linux and Windows, but not for macOS
@@ -143,12 +145,64 @@ check_nodejs() {
 check_npm() {
     if ! command -v npm &> /dev/null; then
         print_error "npm is not installed."
-        print_error "npm is required to install Claude Code."
+        print_error "npm is required to install CLI dependencies."
         echo ""
         print_info "npm usually comes with Node.js. Please reinstall Node.js."
         echo ""
         exit 1
     fi
+}
+
+install_codex_cli() {
+    print_info "Checking Codex CLI installation..."
+    check_nodejs
+    check_npm
+
+    local codex_installed=false
+    local current_version=""
+
+    if command -v codex &> /dev/null; then
+        codex_installed=true
+        current_version="$(codex --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" || true
+    fi
+
+    if [[ "$codex_installed" == "true" ]] \
+        && [[ -n "$current_version" ]] \
+        && version_compare "$current_version" "$MIN_CODEX_CLI_VERSION"; then
+        print_success "Codex CLI found: v${current_version}"
+        return
+    fi
+
+    if [[ "$codex_installed" == "true" ]]; then
+        print_info "Upgrading Codex CLI to ${CODEX_CLI_PACKAGE}..."
+    else
+        print_info "Codex CLI not found, installing ${CODEX_CLI_PACKAGE}..."
+    fi
+
+    if ! npm install -g "$CODEX_CLI_PACKAGE"; then
+        print_error "Failed to install Codex CLI via npm."
+        echo ""
+        print_info "You can try installing manually:"
+        echo "  npm install -g ${CODEX_CLI_PACKAGE}"
+        echo ""
+        print_info "If you encounter permission issues, try:"
+        echo "  sudo npm install -g ${CODEX_CLI_PACKAGE}"
+        echo ""
+        exit 1
+    fi
+
+    if ! command -v codex &> /dev/null; then
+        print_error "Codex CLI installation failed - 'codex' command not found."
+        exit 1
+    fi
+
+    current_version="$(codex --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" || true
+    if [[ -z "$current_version" ]] || ! version_compare "$current_version" "$MIN_CODEX_CLI_VERSION"; then
+        print_error "Codex CLI version ${current_version:-unknown} is below required ${MIN_CODEX_CLI_VERSION}"
+        exit 1
+    fi
+
+    print_success "Codex CLI installed: v${current_version}"
 }
 
 # Install or upgrade Claude Code
@@ -575,6 +629,7 @@ main() {
         check_nodejs
         install_claude_code
     fi
+    install_codex_cli
 
     get_download_url
     create_install_dir

--- a/executor/tests/scripts/test_build_local.py
+++ b/executor/tests/scripts/test_build_local.py
@@ -50,3 +50,56 @@ def test_append_claude_cli_binary_adds_binary_when_enabled(monkeypatch):
     )
 
     assert "--add-binary=/tmp/claude:claude_agent_sdk/_bundled" in cmd
+
+
+def test_ensure_linux_openai_codex_sdk_skips_non_linux(monkeypatch):
+    build_local = load_build_local_module()
+
+    def fail_lookup(name):
+        raise AssertionError("SDK lookup should be skipped")
+
+    monkeypatch.setattr(build_local.importlib.util, "find_spec", fail_lookup)
+
+    build_local.ensure_linux_openai_codex_sdk("Darwin")
+
+
+def test_ensure_linux_openai_codex_sdk_installs_with_no_deps(monkeypatch):
+    build_local = load_build_local_module()
+    calls = []
+
+    monkeypatch.setattr(build_local.importlib.util, "find_spec", lambda name: None)
+    monkeypatch.setattr(build_local.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(
+        build_local.subprocess,
+        "run",
+        lambda cmd, check: calls.append((cmd, check)),
+    )
+
+    build_local.ensure_linux_openai_codex_sdk("Linux")
+
+    assert calls == [
+        (
+            [
+                "/usr/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                build_local.sys.executable,
+                "--no-deps",
+                "openai-codex==0.1.0b3",
+            ],
+            True,
+        )
+    ]
+
+
+def test_append_codex_pyinstaller_options_collects_sdk_modules():
+    build_local = load_build_local_module()
+    cmd = ["python", "-m", "PyInstaller"]
+
+    build_local.append_codex_pyinstaller_options(cmd)
+
+    assert "--hidden-import=executor.agents.codex.codex_agent" in cmd
+    assert "--hidden-import=openai_codex" in cmd
+    assert "--hidden-import=openai_codex.generated.v2_all" in cmd
+    assert "--collect-all=openai_codex" in cmd

--- a/scripts/install-device-tools-ubuntu.sh
+++ b/scripts/install-device-tools-ubuntu.sh
@@ -31,6 +31,8 @@ NODE_VERSION="${NODE_VERSION:-}"
 NODE_DIST_MIRROR="${NODE_DIST_MIRROR:-https://npmmirror.com/mirrors/node}"
 NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmmirror.com}"
 NPM_LOGLEVEL="${NPM_LOGLEVEL:-info}"
+INSTALL_CODEX_CLI="${INSTALL_CODEX_CLI:-true}"
+CODEX_CLI_PACKAGE="${CODEX_CLI_PACKAGE:-@openai/codex@0.137.0}"
 NODE_BIN="${NODE_BIN:-/usr/local/bin/node}"
 NPM_BIN="${NPM_BIN:-/usr/local/bin/npm}"
 NPX_BIN="${NPX_BIN:-/usr/local/bin/npx}"
@@ -297,6 +299,47 @@ install_nodejs_from_npmmirror() {
     hash -r
 
     success "Installed Node.js $("$NODE_BIN" --version)."
+}
+
+install_codex_cli() {
+    local node_cmd node_path_dir npm_cmd
+
+    if [ "$INSTALL_CODEX_CLI" != "true" ]; then
+        info "Skipping Codex CLI installation."
+        return
+    fi
+
+    ensure_nodejs_for_code_server
+    node_cmd="$(preferred_node_command || true)"
+    npm_cmd="$(preferred_npm_command || true)"
+    if [ -z "$node_cmd" ] || [ -z "$npm_cmd" ]; then
+        error "Node.js and npm are required to install Codex CLI."
+        exit 1
+    fi
+
+    node_path_dir="$(dirname "$node_cmd")"
+    info "Installing ${CODEX_CLI_PACKAGE} from npm registry ${NPM_REGISTRY}..."
+    if ! $SUDO env \
+        PATH="${node_path_dir}:/usr/local/bin:${PATH}" \
+        npm_config_fetch_retries=5 \
+        npm_config_fetch_retry_factor=2 \
+        npm_config_fetch_retry_maxtimeout=120000 \
+        npm_config_fetch_retry_mintimeout=10000 \
+        npm_config_loglevel="$NPM_LOGLEVEL" \
+        npm_config_registry="$NPM_REGISTRY" \
+        "$npm_cmd" install -g "$CODEX_CLI_PACKAGE" \
+            --loglevel="$NPM_LOGLEVEL" \
+            --unsafe-perm; then
+        error "Failed to install ${CODEX_CLI_PACKAGE}."
+        exit 1
+    fi
+
+    if ! env PATH="${node_path_dir}:/usr/local/bin:${PATH}" codex --version >/dev/null 2>&1; then
+        error "Codex CLI installation failed; 'codex' command is unavailable."
+        exit 1
+    fi
+
+    success "Installed Codex CLI $(env PATH="${node_path_dir}:/usr/local/bin:${PATH}" codex --version)."
 }
 
 install_ttyd() {
@@ -739,6 +782,9 @@ print_versions() {
     if command -v node >/dev/null 2>&1; then
         node --version || true
     fi
+    if command -v codex >/dev/null 2>&1; then
+        codex --version || true
+    fi
 }
 
 main() {
@@ -747,6 +793,7 @@ main() {
     apt_install_base_packages
     enable_universe_repository
     install_nodejs_if_requested
+    install_codex_cli
     install_ttyd
     install_code_server
     patch_code_server_vsda_assets


### PR DESCRIPTION
## Summary
- install openai-codex without dependencies before Linux local executor PyInstaller builds
- collect CodeXAgent and openai_codex modules in the local executor binary
- install a pinned Codex CLI in device/executor images and local device installers

## Tests
- git diff --check
- bash -n scripts/install-device-tools-ubuntu.sh && bash -n executor/scripts/local_executor_install.sh
- uvx black --check executor/scripts/build_local.py executor/tests/scripts/test_build_local.py
- cd executor && uv run pytest tests/scripts/test_build_local.py tests/agents/test_codex_config_builder.py tests/agents/test_factory.py

Note: PowerShell parser check was skipped locally because pwsh is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI Codex CLI support to device and executor environments.
  * Integrated Codex CLI installation across Windows, macOS, and Ubuntu platforms.
  * Added automatic Codex SDK dependency handling in build processes.

* **Chores**
  * Updated OpenAI Codex package versions in Docker configurations.

* **Tests**
  * Added unit tests for Codex SDK integration and build bundling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->