### PR TITLE
docs(readme): polish project positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Wegent
 
-> 🚀 An open-source AI-native operating system to define, organize, and run intelligent agent teams
+> A self-hostable AI workspace for chat, coding, knowledge bases, automation, and local execution.
 
 English | [简体中文](README_zh.md)
 
-[![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.68+-green.svg)](https://fastapi.tiangolo.com)
+[![Python](https://img.shields.io/badge/python-3.10--3.13-blue.svg)](https://python.org)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.109+-green.svg)](https://fastapi.tiangolo.com)
 [![Next.js](https://img.shields.io/badge/Next.js-15+-black.svg)](https://nextjs.org)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://docker.com)
 [![Claude](https://img.shields.io/badge/Claude-Code-orange.svg)](https://claude.ai)
@@ -14,146 +14,26 @@ English | [简体中文](README_zh.md)
 
 <div align="center">
 
-
-
-
-[Quick Start](#-quick-start) · [Documentation](https://wecode-ai.github.io/wegent-docs/) · [Development Guide](https://wecode-ai.github.io/wegent-docs/docs/category/developer-guide)
+[Quick Start](#-quick-start) · [Core Scenarios](#core-scenarios) · [How It Grows](#how-it-grows) · [Documentation](https://wecode-ai.github.io/wegent-docs/) · [Development Guide](https://wecode-ai.github.io/wegent-docs/docs/category/developer-guide)
 
 </div>
 
 ---
 
-## 🏗️ Architecture Overview
+## Why Wegent
 
-```mermaid
-graph TB
-    subgraph Access["Entry Layer"]
-        direction TB
-        Web["🌐 Web"]
-        IM["💬 IM Tools"]
-        API["🔌 API"]
-    end
+Wegent is a self-hostable AI workspace for managing chat, coding tasks, knowledge bases, automation, and local execution in one place. You can ask questions over your own materials, hand code repositories to AI, turn recurring information checks into automated feeds, and let your team use the same assistants from DingTalk, Telegram, or other tools. When a task needs local repositories or intranet access, it can run on your own machine.
 
-    subgraph Features["Feature Layer"]
-        direction TB
-        Chat["💬 Chat"]
-        Code["💻 Coding"]
-        Feed["📡 Feed"]
-        Knowledge["📚 Knowledge"]
-    end
-
-    subgraph Agents["Agent Layer"]
-        direction TB
-        ChatShell["🗣️ Wegent Chat"]
-        ClaudeCode["🧠 Claude Code"]
-        Agno["🤝 Agno"]
-        Dify["✨ Dify"]
-    end
-
-    subgraph Execution["Execution Environment"]
-        direction TB
-        Docker["🐳 Agent Sandbox"]
-        Cloud["☁️ Cloud Device"]
-        Local["💻 Local Device"]
-    end
-
-    Access --> Features
-    Features --> Agents
-    Agents --> Execution
-```
-
----
-
-## ✨ Core Features
-
-### 💬 Chat Agent
-<img src="https://github.com/user-attachments/assets/677abce3-bd3f-4064-bdab-e247b142c22f" width="100%" alt="Chat Mode Demo"/>
-A fully open-source chat agent with powerful capabilities:
-
-- **Multi-Model Support**: Compatible with Claude, OpenAI, Gemini, DeepSeek, GLM and other mainstream models
-- **Conversation History**: Create new conversations, multi-turn dialogues, save and share chat history
-- **Group Chat**: AI group chat where AI responds based on conversation context with @mentions
-- **Attachment Parsing**: Send txt, pdf, ppt, doc, images and other file formats in single/group chats
-- **Follow-up Mode**: AI asks clarifying questions to help refine your requirements
-- **Error Correction Mode**: Multiple AI models automatically detect and correct response errors
-- **Long-term Memory**: Supports mem0 integration for conversation memory persistence
-- **Sandbox Execution**: Execute commands or modify files via sandbox, E2B protocol compatible
-- **Extensions**: Customize prompts, MCP tools and Skills (includes chart drawing skill)
-
-### 💻 Code Agent
-<img src="https://github.com/user-attachments/assets/cc25c415-d3f1-4e9f-a64c-1d2614d69c7d" width="100%" alt="Code Mode Demo"/>
-
-A cloud-based Claude Code execution engine:
-
-- **Multi-Model Configuration**: Configure various Claude-compatible models
-- **Concurrent Execution**: Run multiple coding tasks simultaneously in the cloud
-- **Requirement Clarification**: AI analyzes code and asks questions to generate specification documents
-- **Git Integration**: Integrate with GitHub/GitLab/Gitea/Gerrit to clone, modify and create PRs
-- **MCP/Skill Support**: Configure MCP tools and Skills for agents
-- **Multi-turn Conversations**: Continue conversations with follow-up questions
-
-### 📡 AI Feed
-<img src="https://github.com/user-attachments/assets/6680c33a-f4ba-4ef2-aa8c-e7a53bd003dc" width="100%" alt="Feed Demo"/>
-
-A cloud-based AI task trigger system:
-
-- **Full Capability Access**: Tasks can use all Chat and Code mode capabilities
-- **Scheduled/Event Triggers**: Set up cron schedules or event-based AI task execution
-- **Information Feed**: Display AI-generated content as an information stream
-- **Event Filtering**: Filter conditions like "only notify me if it will rain tomorrow"
-
-### 📚 AI Knowledge
-<img src="https://github.com/user-attachments/assets/2b210d33-2569-4bc9-acac-e163de4e12a5" width="100%" alt="Knowledge Demo"/>
-
-A cloud-based AI document repository:
-
-- **Document Management**: Upload and manage txt/doc/ppt/xls and other document formats
-- **Web Import**: Import web pages and DingTalk multi-dimensional tables
-- **NotebookLM Mode**: Select documents directly in notebooks for Q&A
-- **Online Editing**: Edit text files directly in notebook mode
-- **Chat Integration**: Reference knowledge bases in single/group chats for AI responses
-
-### 🖥️ AI Device
-<img src="https://github.com/user-attachments/assets/ead0cc30-b3a4-4eb6-a6dd-77ffcbd72238" width="100%" alt="AI Device Demo"/>
-
-Run AI tasks on your local machine with full control:
-
-- **Local Executor**: Install and run the Wegent executor on your own device
-- **Multi-Device Management**: Register and manage multiple local devices
-- **Default Device**: Set a preferred device for quick task execution
-- **Secure Connection**: Connect to Wegent backend via authenticated WebSocket
-
-### 💬 IM Integration
-
-Integrate AI agents into your favorite IM tools:
-
-- **DingTalk Bot**: Deploy agents as DingTalk bots for team collaboration
-- **Telegram Bot**: Connect agents to Telegram for personal or group chats
-
-### 🔧 Customization
-
-All features above are fully customizable:
-
-- **Custom Agents**: Create custom agents in the web UI, configure prompts, MCP, Skills and multi-agent collaboration
-- **Agent Creation Wizard**: 4-step creation: Describe requirements → AI asks questions → Real-time fine-tuning → One-click create
-- **Organization Management**: Create and join groups, share agents, models, Skills within groups
-
----
-
-## 🔧 Extensibility
-- **Agent Creation Wizard**: 4-step creation: Describe requirements → AI asks questions → Real-time fine-tuning → One-click create
-- **Collaboration Modes**: 4 out-of-the-box multi-Agent collaboration modes (Sequential/Parallel/Router/Loop)
-- **Skill Support**: Dynamically load skill packages to improve Token efficiency
-- **MCP Tools**: Model Context Protocol for calling external tools and services
-- **Execution Engines**: ClaudeCode / Agno sandboxed isolation, Dify API proxy, Chat direct mode
-- **YAML Config**: Kubernetes-style CRD for defining Ghost / Bot / Team / Skill
-- **API**: OpenAI-compatible interface for easy integration with other systems
+- **Start privately**: Launch a self-hosted workspace with one command and begin with chat and knowledge Q&A.
+- **Grow into team workflows**: Share common assistants, models, tools, and knowledge bases instead of configuring them repeatedly.
+- **Choose where work runs**: Run coding tasks, automation, and local-device jobs in the environment that fits the job.
+- **Fit existing tools**: Bring AI into your current workflow through APIs or IM bots.
 
 ---
 
 ## 🚀 Quick Start
 
-**One command to start:**
+Prerequisite: Docker and Docker Compose.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash
@@ -161,70 +41,196 @@ curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | 
 
 Then open http://localhost:3000 in your browser.
 
-### Other Deployment Options
+### Deployment Modes
 
-| Mode | Description |
-|------|-------------|
-| **Standalone** (default) | Single container, SQLite, recommended for most users |
-| **Standard** | Multi-container, MySQL, for production |
-| **Development** | Hot reload, for developers |
+| Mode | Best For |
+|------|----------|
+| **Standalone** (default) | Single container + SQLite, best for personal trials and lightweight deployments |
+| **Standard** | Multi-container + MySQL + Redis, best for teams and production |
+| **Development** | Source startup + hot reload, best for development and extensions |
 
 ```bash
-# Standard mode (multi-container with MySQL)
+# Standard mode
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard
 
-# Development mode (from source, with hot reload)
+# Development mode
 git clone https://github.com/wecode-ai/Wegent.git && cd Wegent && ./start.sh
 ```
 
 <details>
-<summary><b>🔧 Common Commands</b></summary>
+<summary><b>Common Commands</b></summary>
 
 ```bash
-# Standalone mode (single container)
-docker logs -f wegent-standalone      # View logs
-docker stop wegent-standalone         # Stop
-docker start wegent-standalone        # Start
-docker restart wegent-standalone      # Restart
+# Standalone mode
+docker logs -f wegent-standalone
+docker restart wegent-standalone
 
-# Standard mode (multi-container)
-docker compose logs -f   # View logs
-docker compose down      # Stop
-docker compose up -d     # Start
+# Standard mode
+docker compose logs -f
+docker compose down
+docker compose up -d
 
 # Development mode
-./start.sh --status      # Check status
-./start.sh --stop        # Stop
-./start.sh --restart     # Restart
+./start.sh --status
+./start.sh --restart
+./start.sh --stop
 ```
 
 </details>
 
-> 📖 See [Standalone Mode Documentation](docs/en/deployment/standalone-mode.md) for details.
+See [Standalone Mode](docs/en/deployment/standalone-mode.md) and [Quick Start](docs/en/getting-started/quick-start.md) for details.
 
 ---
 
-## 📦 Built-in Agents
+## Core Scenarios
 
-| Team | Purpose |
-|------|---------|
-| chat-team | General AI assistant + Mermaid diagrams |
-| translator | Multi-language translation |
-| dev-team | Git workflow: branch → code → commit → PR |
-| wiki-team | Codebase Wiki documentation generation |
+### Chat, Group Chat, and File Handling
+
+<img src="https://github.com/user-attachments/assets/677abce3-bd3f-4064-bdab-e247b142c22f" width="100%" alt="Chat Mode Demo"/>
+
+Set up a private AI chat entrypoint. Wegent supports multiple models, multi-turn history, group chat with @mentions, file parsing, clarifying questions, answer checking, and long-term memory. When needed, AI can also read files, run commands, or generate diagrams.
+
+### Let AI Work on Code Repositories
+
+<img src="https://github.com/user-attachments/assets/cc25c415-d3f1-4e9f-a64c-1d2614d69c7d" width="100%" alt="Code Mode Demo"/>
+
+Let AI work on code in isolated environments. Wegent connects to GitHub, GitLab, Gitea, and Gerrit so agents can clarify requirements, create branches, modify code, run tests, commit changes, and open pull requests.
+
+### Track Information and Publish Feeds
+
+<img src="https://github.com/user-attachments/assets/6680c33a-f4ba-4ef2-aa8c-e7a53bd003dc" width="100%" alt="Feed Demo"/>
+
+Turn AI into a continuously running task trigger. Set schedules or event triggers so AI can summarize information, analyze webpages, filter notifications, and publish results as a feed.
+
+### Knowledge Q&A
+
+<img src="https://github.com/user-attachments/assets/2b210d33-2569-4bc9-acac-e163de4e12a5" width="100%" alt="Knowledge Demo"/>
+
+Upload documents, import webpages, or sync DingTalk multi-dimensional tables to build team knowledge bases. Wegent handles parsing, conversion, indexing, and retrieval so AI can answer with your own materials.
+
+### Local Device Execution
+
+<img src="https://github.com/user-attachments/assets/ead0cc30-b3a4-4eb6-a6dd-77ffcbd72238" width="100%" alt="AI Device Demo"/>
+
+Install a local runner on your own machine and connect it securely to Wegent. Tasks can switch between cloud environments and local devices, which is useful when AI needs access to local repositories, intranet resources, or dedicated development environments.
+
+### Team Tools and Existing Systems
+
+Connect Wegent agents to DingTalk, Telegram, and other IM tools, or call them from existing applications through an API.
 
 ---
 
-## 🤝 Contributing
+## How It Grows
+
+You do not need to learn every concept upfront. Wegent can start as a private AI workspace: choose a model, create an assistant, upload materials, and chat. As your team starts reusing these capabilities, you can turn common assistants, knowledge bases, coding tasks, and IM entrypoints into shared workflows.
+
+| Stage | How You Can Use Wegent |
+|-------|------------------------|
+| **Personal use** | Start the service and create your own AI assistants and knowledge bases |
+| **Team collaboration** | Share common assistants, model settings, knowledge bases, and coding tasks |
+| **Automated workflows** | Let AI handle work through schedules, event triggers, or IM bots |
+| **Deep integration** | Connect Wegent to existing systems through APIs, tools, and configuration files |
+
+<details>
+<summary><b>Core concepts for customization and extension</b></summary>
+
+Internally, Wegent splits an AI assistant into reusable pieces:
+
+```text
+Ghost (prompt + MCP + Skills)
+  + Shell (Chat / ClaudeCode / Agno / Dify)
+  + Model (Claude / OpenAI / Gemini / DeepSeek / GLM, etc.)
+  = Bot
+
+Multiple Bots + collaboration mode = Team (the user-facing Agent)
+Team + Workspace = Task (a traceable execution)
+```
+
+These relationships can be created in the web UI or managed with YAML. The web wizard supports "describe requirements → AI follow-up questions → live prompt tuning → one-click creation."
+
+</details>
+
+---
+
+## Deployment and Integration
+
+Wegent can grow from a personal trial to a team deployment:
+
+- **Personal trial**: Standalone mode starts one container, suitable for a laptop or lightweight server.
+- **Team deployment**: Standard mode uses dedicated database, cache, and execution services for long-running use.
+- **Local devices**: Connect your own machine as a place to run tasks that need local repositories or intranet access.
+- **Existing systems**: Connect Wegent to team tools through APIs or IM bots.
+
+<details>
+<summary><b>Technical component overview</b></summary>
+
+```mermaid
+graph TB
+    User["User / API / IM"] --> Frontend["Next.js Web"]
+    User --> Backend["FastAPI Backend"]
+    Frontend --> Backend
+
+    Backend --> MySQL[("MySQL / SQLite")]
+    Backend --> Redis[("Redis")]
+    Backend --> ChatShell["Chat Shell<br/>LangGraph + Multi-LLM"]
+    Backend --> ExecutorManager["Executor Manager"]
+    Backend --> KnowledgeRuntime["Knowledge Runtime"]
+
+    ExecutorManager --> CloudExecutor["Cloud Executor<br/>ClaudeCode / Agno / Dify"]
+    Backend <--> LocalExecutor["Local Executor<br/>WebSocket"]
+    KnowledgeRuntime --> VectorStore["Elasticsearch / Qdrant / Milvus"]
+    Backend --> DocConverter["Knowledge Doc Converter<br/>MinerU OCR"]
+```
+
+</details>
+
+---
+
+## For Developers and Team Admins
+
+- **Application integration**: Call Wegent agents from your own apps through `/api/v1/responses`.
+- **External tools**: Use MCP to let AI call existing tools and services.
+- **Reusable capabilities**: Package specialized abilities as Skills and load them only when needed.
+- **Flexible runtimes**: Use different runtime engines for chat, coding tasks, multi-agent work, and external app proxying.
+- **Central model management**: OpenAI, Claude, Gemini, DeepSeek, GLM, and protocol-compatible model services.
+- **Team sharing and permissions**: Groups, shared agents, shared models, shared Skills, and admin management.
+- **Observability**: OpenTelemetry support across backend, frontend, and execution services.
+
+---
+
+## Built-in Assistants
+
+| Assistant | Purpose |
+|-----------|---------|
+| `chat-team` | General AI assistant with Mermaid diagram support |
+| `translator` | Multi-language translation |
+| `dev-team` | Git workflow: branch, code, commit, PR |
+| `wiki-team` | Codebase Wiki documentation generation |
+
+---
+
+## Documentation
+
+- [Quick Start](docs/en/getting-started/quick-start.md)
+- [Installation Guide](docs/en/getting-started/installation.md)
+- [Core Concepts](docs/en/concepts/core-concepts.md)
+- [Skill System](docs/en/concepts/skill-system.md)
+- [YAML Specification](docs/en/reference/yaml-specification.md)
+- [OpenAPI Responses API](docs/en/reference/openapi-responses-api.md)
+- [Developer Guide](docs/en/developer-guide/README.md)
+
+---
+
+## Contributing
 
 We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
 
-## 📞 Support
+## Support
 
 - 🐛 Issues: [GitHub Issues](https://github.com/wecode-ai/wegent/issues)
 - 💬 Discord: [Join our community](https://discord.gg/MVzJzyqEUp)
 
-## 👥 Contributors
+## Contributors
 
 Thanks to the following developers for their contributions and efforts to make this project better. 💪
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,11 +1,11 @@
 # Wegent
 
-> 🚀 一个开源的 AI 原生操作系统，用于定义、组织和运行智能体团队
+> 可自部署的 AI 工作台：把对话、代码、知识库、自动化和本地执行放到一个入口里。
 
 [English](README.md) | 简体中文
 
-[![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://python.org)
-[![FastAPI](https://img.shields.io/badge/FastAPI-0.68+-green.svg)](https://fastapi.tiangolo.com)
+[![Python](https://img.shields.io/badge/python-3.10--3.13-blue.svg)](https://python.org)
+[![FastAPI](https://img.shields.io/badge/FastAPI-0.109+-green.svg)](https://fastapi.tiangolo.com)
 [![Next.js](https://img.shields.io/badge/Next.js-15+-black.svg)](https://nextjs.org)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg)](https://docker.com)
 [![Claude](https://img.shields.io/badge/Claude-Code-orange.svg)](https://claude.ai)
@@ -14,218 +14,223 @@
 
 <div align="center">
 
-
-
-
-[快速开始](#-快速开始) · [文档](https://wecode-ai.github.io/wegent-docs/zh/) · [开发指南](https://wecode-ai.github.io/wegent-docs/zh/docs/category/developer-guide)
+[快速开始](#-快速开始) · [核心场景](#核心场景) · [工作方式](#工作方式) · [文档](https://wecode-ai.github.io/wegent-docs/zh/) · [开发指南](https://wecode-ai.github.io/wegent-docs/zh/docs/category/developer-guide)
 
 </div>
 
 ---
 
-## 🏗️ 架构概览
+## 为什么选择 Wegent
 
-```mermaid
-graph TB
-    subgraph Access["入口层"]
-        direction TB
-        Web["🌐 网页"]
-        IM["💬 IM 工具"]
-        API["🔌 API"]
-    end
+Wegent 是一个可自部署的 AI 工作台，用来统一管理对话、代码任务、知识库、自动化和本地执行。你可以把资料放进知识库直接提问，把代码仓库交给 AI 处理，把每天要关注的信息做成自动追踪，也可以让团队在钉钉、Telegram 里调用同一批助手。需要访问本机仓库或内网资源时，任务还能跑在自己的电脑上。
 
-    subgraph Features["功能层"]
-        direction TB
-        Chat["💬 对话"]
-        Code["💻 编码"]
-        Feed["📡 定时任务"]
-        Knowledge["📚 知识库"]
-    end
-
-    subgraph Agents["Agent 层"]
-        direction TB
-        ChatShell["🗣️ Wegent Chat"]
-        ClaudeCode["🧠 Claude Code"]
-        Agno["🤝 Agno"]
-        Dify["✨ Dify"]
-    end
-
-    subgraph Execution["执行环境"]
-        direction TB
-        Docker["🐳 Agent 沙箱"]
-        Cloud["☁️ 云端设备"]
-        Local["💻 本地设备"]
-    end
-
-    Access --> Features
-    Features --> Agents
-    Agents --> Execution
-```
-
----
-
-## ✨ 核心功能
-
-### 💬 对话模式
-
-<img src="https://github.com/user-attachments/assets/677abce3-bd3f-4064-bdab-e247b142c22f" width="100%" alt="Chat Mode Demo"/>
-一个完全开源的聊天 Agent，具备以下能力：
-
-- **多模型支持**：兼容 Claude、OpenAI、Gemini、DeepSeek、GLM 等主流模型
-- **对话历史**：支持新建对话和多轮对话，支持对话历史的保存和分享
-- **多人对话**：支持 AI 群聊，AI 可以根据群聊历史通过 @提及 进行回复
-- **附件解析**：可在单聊、群聊中给 AI 发送 txt、pdf、ppt、doc、图片格式的附件
-- **追问模式**：模型通过启发式问题帮你澄清思路
-- **纠错模式**：自动调用多个模型矫正回答
-- **长期记忆**：支持集成 mem0 实现对话的长期记忆
-- **运行沙箱**：支持通过沙箱执行命令或修改文件，兼容 E2B 协议
-- **扩展能力**：可通过配置的方式自定义提示词、MCP 和 Skill（自带绘制图表技能）
-
-### 💻 编码模式
-
-<img src="https://github.com/user-attachments/assets/cc25c415-d3f1-4e9f-a64c-1d2614d69c7d" width="100%" alt="Code Mode Demo"/>
-一个云端的 Claude Code 编码执行引擎：
-
-- **多模型配置**：配置各种兼容 Claude 协议的模型
-- **并发执行**：可在云端同时执行多个编码任务
-- **需求澄清**：AI 会结合代码和提问，帮你梳理需求后生成规格文档
-- **Git 集成**：支持与 GitHub/GitLab/Gitea/Gerrit 进行集成，直接从代码仓库克隆、修改后创建 PR
-- **MCP/Skill 支持**：支持通过配置为 Agent 集成 MCP/Skill
-- **多轮对话**：支持多轮对话追问
-
-### 📡 关注模式
-<img src="https://github.com/user-attachments/assets/6680c33a-f4ba-4ef2-aa8c-e7a53bd003dc" width="100%" alt="Feed Demo"/>
-
-一个云端的 AI 任务触发器：
-
-- **全能力访问**：任务可以使用对话和编码的全部能力
-- **定时/事件触发**：设定定时或基于事件执行 AI 任务，如每天 9 点汇总今天的 AI 新闻
-- **信息流展示**：展示基于 AI 任务生成的信息流
-- **事件过滤**：支持事件过滤，如"只有明天要下雨了才通知我"
-
-### 📚 知识模式
-
-<img src="https://github.com/user-attachments/assets/2b210d33-2569-4bc9-acac-e163de4e12a5" width="100%" alt="Knowledge Demo"/>
-一个云端 AI 文档仓库：
-
-- **文档管理**：上传、管理 txt/doc/ppt/xls 等等格式的文档到知识库
-- **网页导入**：支持导入网页、钉钉多维表到知识库
-- **NotebookLM 模式**：支持在笔记本里直接选择文档进行提问
-- **在线编辑**：笔记本模式支持在线编辑文本文件
-- **对话集成**：支持在单聊、群聊中让 AI 引用知识库进行回答
-
-### 🖥️ 设备模式
-
-<img src="https://github.com/user-attachments/assets/ead0cc30-b3a4-4eb6-a6dd-77ffcbd72238" width="100%" alt="AI Device Demo"/>>
-在本地设备上运行 AI 任务，完全掌控：
-
-- **本地执行器**：在自己的设备上安装并运行 Wegent 执行器
-- **多设备管理**：注册和管理多个本地设备
-- **槽位调度**：为每个设备配置并发任务槽位数
-- **安全连接**：通过认证的 WebSocket 连接到 Wegent 后端
-
-### 💬 IM 集成
-
-将 AI 智能体集成到你常用的 IM 工具中：
-
-- **钉钉机器人**：将智能体部署为钉钉机器人，支持团队协作
-- **Telegram 机器人**：连接智能体到 Telegram，支持个人或群组对话
-
-### 🔧 定制化
-
-上面的所有功能都是可定制的：
-
-- **自定义智能体**：支持在网页中创建自定义智能体，可直接在页面上配置提示词、MCP、Skill 和多智能体协作
-- **智能体创建向导**：4 步创建：描述需求 → AI 追问 → 实时微调 → 一键创建
-- **组织管理**：支持人员创建和加入组，组内可共享智能体、模型、Skill 等等
-
----
-
-## 🔧 扩展能力
-- **智能体生成向导**: 4 步创建: 描述需求 → AI 追问 → 实时微调 → 一键创建
-- **协作模式**：支持开箱即用的 4 种多 Agent 协作模式（顺序/并行/路由/循环）
-- **支持 Skill**：动态加载技能包，提升 Token 效率
-- **MCP 工具**：Model Context Protocol，调用外部工具和服务
-- **执行引擎**：支持 ClaudeCode / Agno 沙箱隔离执行，Dify API 代理，Chat 直连模式
-- **YAML 配置**：Kubernetes 风格 CRD，定义 Ghost / Bot / Team / Skill
-- **API**：对外提供 OpenAI 兼容接口，方便与其他系统集成
+- **个人可快速开始**：一条命令启动私有工作台，先用对话和知识库解决日常问题。
+- **团队可逐步沉淀**：常用助手、模型、工具和知识库可以共享，避免每个人重复配置。
+- **任务不被限制在云端**：代码任务、自动化任务和本地执行可以按场景选择运行位置。
+- **容易接进现有流程**：通过 API 或 IM 机器人，把 AI 放到已经在用的工具里。
 
 ---
 
 ## 🚀 快速开始
 
-**一条命令启动：**
+前置要求：已安装 Docker 和 Docker Compose。
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash
 ```
 
-然后在浏览器中访问 http://localhost:3000
+启动后访问 http://localhost:3000。
 
-### 其他部署方式
+### 部署模式
 
-| 模式 | 说明 |
-|------|------|
-| **Standalone**（默认） | 单容器，SQLite，推荐大多数用户使用 |
-| **Standard** | 多容器，MySQL，适合生产环境 |
-| **Development** | 热重载，适合开发者 |
+| 模式 | 适合场景 |
+|------|----------|
+| **Standalone**（默认） | 单容器 + SQLite，适合个人试用和轻量部署 |
+| **Standard** | 多容器 + MySQL + Redis，适合团队和生产环境 |
+| **Development** | 源码启动 + 热重载，适合开发和二次扩展 |
 
 ```bash
-# Standard 模式（多容器 + MySQL）
+# Standard 模式
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard
 
-# 开发模式（从源码安装，支持热重载）
+# 开发模式
 git clone https://github.com/wecode-ai/Wegent.git && cd Wegent && ./start.sh
 ```
 
 <details>
-<summary><b>🔧 常用命令</b></summary>
+<summary><b>常用命令</b></summary>
 
 ```bash
-# Standalone 模式（单容器）
-docker logs -f wegent-standalone      # 查看日志
-docker stop wegent-standalone         # 停止
-docker start wegent-standalone        # 启动
-docker restart wegent-standalone      # 重启
+# Standalone 模式
+docker logs -f wegent-standalone
+docker restart wegent-standalone
 
-# Standard 模式（多容器）
-docker compose logs -f   # 查看日志
-docker compose down      # 停止
-docker compose up -d     # 启动
+# Standard 模式
+docker compose logs -f
+docker compose down
+docker compose up -d
 
 # 开发模式
-./start.sh --status      # 查看状态
-./start.sh --stop        # 停止
-./start.sh --restart     # 重启
+./start.sh --status
+./start.sh --restart
+./start.sh --stop
 ```
 
 </details>
 
-> 📖 详情请参阅 [Standalone 模式文档](docs/zh/deployment/standalone-mode.md)。
+> 详细部署说明见 [Standalone 模式文档](docs/zh/deployment/standalone-mode.md) 和 [快速开始文档](docs/zh/getting-started/quick-start.md)。
 
 ---
 
-## 📦 预置智能体
+## 核心场景
 
-| 团队 | 用途 |
+### 对话、群聊与文件处理
+
+<img src="https://github.com/user-attachments/assets/677abce3-bd3f-4064-bdab-e247b142c22f" width="100%" alt="Chat Mode Demo"/>
+
+搭建一个可私有化的 AI 对话入口。它支持多模型、多轮历史、群聊 @ 提及、文件解析、追问澄清、回答校验和长期记忆。需要时，AI 也可以读取文件、执行命令或生成图表。
+
+### 让 AI 处理代码仓库
+
+<img src="https://github.com/user-attachments/assets/cc25c415-d3f1-4e9f-a64c-1d2614d69c7d" width="100%" alt="Code Mode Demo"/>
+
+让 AI 在隔离环境中处理代码任务。Wegent 可以连接 GitHub、GitLab、Gitea、Gerrit，完成需求澄清、分支创建、代码修改、测试、提交和 PR 创建等流程。
+
+### 自动追踪信息并生成信息流
+
+<img src="https://github.com/user-attachments/assets/6680c33a-f4ba-4ef2-aa8c-e7a53bd003dc" width="100%" alt="Feed Demo"/>
+
+把 AI 变成持续运行的任务触发器。你可以设置定时规则或事件触发，让 AI 定期汇总信息、分析网页、筛选通知，并把结果沉淀为信息流。
+
+### 知识库问答
+
+<img src="https://github.com/user-attachments/assets/2b210d33-2569-4bc9-acac-e163de4e12a5" width="100%" alt="Knowledge Demo"/>
+
+上传文档、导入网页或同步钉钉多维表，构建团队知识库。Wegent 会负责解析、转换、索引和检索，让 AI 在回答时引用你的资料。
+
+### 本地设备执行
+
+<img src="https://github.com/user-attachments/assets/ead0cc30-b3a4-4eb6-a6dd-77ffcbd72238" width="100%" alt="AI Device Demo"/>
+
+在自己的电脑上安装本地执行程序，并安全连接到 Wegent。任务可以在云端隔离环境和本地设备之间切换，适合需要访问本机仓库、内网资源或专属开发环境的场景。
+
+### 接入团队沟通工具和已有系统
+
+把 Wegent 智能体接入钉钉、Telegram 等 IM 工具，也可以通过 API 接入已有应用，让团队在原来的工作流里直接调用 AI。
+
+---
+
+## 从简单开始，再逐步扩展
+
+你不需要一开始就理解所有概念。Wegent 可以先当作一个私有 AI 工作台使用：选模型、创建助手、上传资料、开始对话。等团队开始复用这些能力时，再逐步把常用助手、知识库、代码任务和 IM 入口沉淀下来。
+
+| 阶段 | 你可以怎么用 |
+|------|--------------|
+| **个人使用** | 快速启动服务，创建自己的 AI 助手和知识库 |
+| **团队协作** | 共享常用助手、模型配置、知识库和代码任务 |
+| **自动化工作流** | 用定时任务、事件触发或 IM 机器人让 AI 主动处理工作 |
+| **深度集成** | 通过 API、工具扩展和配置文件接入已有系统 |
+
+<details>
+<summary><b>核心概念（给需要自定义和扩展的人）</b></summary>
+
+Wegent 内部把一个 AI 助手拆成几块可复用配置：
+
+```text
+Ghost（提示词 + MCP + Skills）
+  + Shell（Chat / ClaudeCode / Agno / Dify）
+  + Model（Claude / OpenAI / Gemini / DeepSeek / GLM 等）
+  = Bot（机器人）
+
+多个 Bot + 协作模式 = Team（用户看到的智能体）
+Team + Workspace = Task（一次可追踪的执行）
+```
+
+这些关系可以通过 Web UI 创建，也可以用 YAML 管理。Web UI 里的创建向导支持“描述需求 → AI 追问 → 实时微调 → 一键创建”。
+
+</details>
+
+---
+
+## 部署和接入
+
+Wegent 可以从个人试用逐步扩展到团队部署：
+
+- **个人试用**：Standalone 模式单容器启动，适合本机或轻量服务器。
+- **团队部署**：Standard 模式使用独立数据库、缓存和执行服务，适合长期运行。
+- **本地设备**：把自己的电脑接入为执行环境，处理需要本机仓库或内网资源的任务。
+- **已有系统**：通过 API 或 IM 机器人，把 Wegent 接到团队现有工具里。
+
+<details>
+<summary><b>技术组件概览</b></summary>
+
+```mermaid
+graph TB
+    User["用户 / API / IM"] --> Frontend["Next.js Web"]
+    User --> Backend["FastAPI Backend"]
+    Frontend --> Backend
+
+    Backend --> MySQL[("MySQL / SQLite")]
+    Backend --> Redis[("Redis")]
+    Backend --> ChatShell["Chat Shell<br/>LangGraph + Multi-LLM"]
+    Backend --> ExecutorManager["Executor Manager"]
+    Backend --> KnowledgeRuntime["Knowledge Runtime"]
+
+    ExecutorManager --> CloudExecutor["云端 Executor<br/>ClaudeCode / Agno / Dify"]
+    Backend <--> LocalExecutor["本地 Executor<br/>WebSocket"]
+    KnowledgeRuntime --> VectorStore["Elasticsearch / Qdrant / Milvus"]
+    Backend --> DocConverter["Knowledge Doc Converter<br/>MinerU OCR"]
+```
+
+</details>
+
+---
+
+## 给开发者和团队管理员
+
+- **接入自己的应用**：通过 `/api/v1/responses` 调用 Wegent 中的智能体。
+- **连接外部工具**：通过 MCP 让 AI 调用已有工具和服务。
+- **复用复杂能力**：把特定能力打包成 Skill，需要时再加载。
+- **选择适合的运行方式**：对话、代码任务、多智能体协作和外部应用代理可以分别使用不同运行引擎。
+- **统一管理模型**：支持 OpenAI、Claude、Gemini、DeepSeek、GLM 以及兼容协议的模型服务。
+- **团队共享和权限**：支持组织、共享智能体、共享模型、共享 Skills 和管理后台。
+- **可观测性**：后端、前端和执行服务支持 OpenTelemetry 配置。
+
+---
+
+## 预置助手
+
+| 助手 | 用途 |
 |------|------|
-| chat-team | 通用 AI 助手 + Mermaid 图表 |
-| translator | 多语言翻译 |
-| dev-team | Git 工作流：分支 → 编码 → 提交 → PR |
-| wiki-team | 代码库 Wiki 文档生成 |
+| `chat-team` | 通用 AI 助手，支持 Mermaid 图表 |
+| `translator` | 多语言翻译 |
+| `dev-team` | Git 工作流：分支、编码、提交、PR |
+| `wiki-team` | 代码库 Wiki 文档生成 |
 
 ---
 
-## 🤝 贡献
+## 文档
+
+- [快速开始](docs/zh/getting-started/quick-start.md)
+- [安装指南](docs/zh/getting-started/installation.md)
+- [核心概念](docs/zh/concepts/core-concepts.md)
+- [Skill 系统](docs/zh/concepts/skill-system.md)
+- [YAML 规范](docs/zh/reference/yaml-specification.md)
+- [OpenAPI Responses API](docs/zh/reference/openapi-responses-api.md)
+- [开发指南](docs/zh/developer-guide/README.md)
+
+---
+
+## 贡献
 
 我们欢迎贡献！详情请参阅 [贡献指南](CONTRIBUTING.md)。
 
-## 📞 支持
+## 支持
 
 - 🐛 问题反馈：[GitHub Issues](https://github.com/wecode-ai/wegent/issues)
 - 💬 Discord：[加入社区](https://discord.gg/MVzJzyqEUp)
 
-## 👥 贡献者
+## 贡献者
 
 感谢以下开发者的贡献，让这个项目变得更好 💪
 


### PR DESCRIPTION
## Summary
- Rewrite Chinese README first to focus on user value instead of technical term lists
- Sync the English README with the updated positioning and structure
- Move deeper technical details into expandable sections while preserving setup and contributor information

## Test Plan
- git diff --cached --check
- git diff --check -- README_zh.md README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and restructured documentation for improved clarity and navigation
  * Updated Python and FastAPI version requirements in badges
  * Added new sections: Quick Start with deployment modes, Core Scenarios, How It Grows, Deployment and Integration, and built-in Assistants overview
  * Enhanced documentation with visual diagrams and tables
  * Updated both English and Chinese documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->