### PR TITLE
fix(frontend): translate empty tool output detail

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx
@@ -9,7 +9,10 @@ import type { ToolPair } from '@/features/tasks/components/message/thinking/type
 
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) =>
+      ({
+        'thinking.no_output': 'No output',
+      })[key] ?? key,
   }),
 }))
 
@@ -48,5 +51,20 @@ describe('ToolBlock', () => {
     render(<ToolBlock tool={createTool({})} />)
 
     expect(screen.queryByText(/\{\}/)).not.toBeInTheDocument()
+  })
+
+  it('does not expose missing translation keys for completed tools without output', () => {
+    const emptyTool = createTool({})
+    render(
+      <ToolBlock
+        tool={emptyTool}
+        defaultExpanded
+        count={2}
+        mergedTools={[emptyTool, { ...emptyTool, toolUseId: 'tool_write_2' }]}
+      />
+    )
+
+    expect(screen.queryByText('thinking.no_output')).not.toBeInTheDocument()
+    expect(screen.getAllByText('No output')).toHaveLength(2)
   })
 })

--- a/frontend/src/__tests__/i18n/missing-console-keys.test.ts
+++ b/frontend/src/__tests__/i18n/missing-console-keys.test.ts
@@ -22,6 +22,11 @@ describe('i18n console warning keys', () => {
     expect(zhCommon.noData).toBeTruthy()
   })
 
+  test('has tool detail empty output translations in zh-CN and en', () => {
+    expect(enChat.thinking.no_output).toBe('No output')
+    expect(zhChat.thinking.no_output).toBe('无输出')
+  })
+
   test('uses automation as the feed module title in zh-CN and en', () => {
     expect(zhCommon.navigation.flow).toBe('自动化')
     expect(zhFeed.title).toBe('自动化')

--- a/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
+++ b/frontend/src/features/tasks/components/message/thinking/components/ToolBlock.tsx
@@ -324,14 +324,14 @@ export const ToolBlock = memo(function ToolBlock({
                 {!toolHasContent && toolIsRunning ? (
                   <div className="flex items-center gap-2 text-xs text-[#888] dark:text-[#777]">
                     <Loader2 className="w-3 h-3 animate-spin" />
-                    <span>{t('thinking.tool_executing') || 'Executing...'}</span>
+                    <span>{t('thinking.tool_executing')}</span>
                   </div>
                 ) : toolHasContent ? (
                   <CurrentToolRenderer tool={toolItem} />
                 ) : (
                   // Tool completed but no content (edge case)
                   <div className="text-xs text-[#888] dark:text-[#777] italic">
-                    {t('thinking.no_output') || 'No output'}
+                    {t('thinking.no_output')}
                   </div>
                 )}
               </div>

--- a/frontend/src/i18n/locales/en/chat.json
+++ b/frontend/src/i18n/locales/en/chat.json
@@ -142,28 +142,6 @@
     "video_generation": "Video Generation"
   },
   "message_count": "messages",
-  "thinking": {
-    "tool_group": "Tool Group",
-    "tools": "tools",
-    "completed": "Completed",
-    "running": "Running",
-    "has_errors": "Has Errors",
-    "tool_input": "Input",
-    "tool_output": "Output",
-    "tool_error": "Error",
-    "tool_executing": "Executing...",
-    "tools": {
-      "bash": "Execute Command",
-      "read": "Read File",
-      "edit": "Edit File",
-      "write": "Write File",
-      "grep": "Search Code",
-      "glob": "Find Files",
-      "todo": "Update Tasks",
-      "kb_search": "Search Knowledge Base",
-      "web_search": "Web Search"
-    }
-  },
   "shared_task": {
     "share_task": "Share",
     "sharing": "Sharing...",
@@ -256,6 +234,7 @@
     "tool_input": "Input",
     "tool_output": "Output",
     "tool_executing": "Executing...",
+    "no_output": "No output",
     "downloadable": "Downloadable",
     "processing": "Processing...",
     "tools": {

--- a/frontend/src/i18n/locales/zh-CN/chat.json
+++ b/frontend/src/i18n/locales/zh-CN/chat.json
@@ -234,6 +234,7 @@
     "tool_input": "输入",
     "tool_output": "输出",
     "tool_executing": "执行中...",
+    "no_output": "无输出",
     "downloadable": "可下载",
     "processing": "正在处理...",
     "tools": {


### PR DESCRIPTION
## Summary
- Add the missing chat i18n key for empty tool output details in English and Chinese.
- Render the empty tool output state through the normal translation path.
- Remove a duplicate English chat `thinking` block that was being overwritten at JSON parse time.

## Test Plan
- npm test -- --runTestsByPath src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx src/__tests__/i18n/missing-console-keys.test.ts
- npx prettier --check src/features/tasks/components/message/thinking/components/ToolBlock.tsx src/__tests__/features/tasks/components/message/thinking/ToolBlock.test.tsx src/__tests__/i18n/missing-console-keys.test.ts src/i18n/locales/en/chat.json src/i18n/locales/zh-CN/chat.json
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added translation support for "no output" tool status in English and Chinese locales.

* **Tests**
  * Enhanced test coverage for tool output translation handling and internationalization validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->