### PR TITLE
fix(wework): correct processing duration timer and header interactivity

### DIFF
--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -884,12 +884,16 @@ class SessionManager:
             # Ensure block has id
             block_id = block.get("id")
             if not block_id:
-                block_id = f"block-{int(asyncio.get_event_loop().time() * 1000)}"
+                block_id = f"block-{int(time.time() * 1000)}"
                 block["id"] = block_id
 
-            # Ensure block has timestamp
+            # Ensure block has timestamp.
+            # Use wall-clock epoch milliseconds (time.time) rather than the
+            # event loop's monotonic clock: the latter is a small non-epoch
+            # number that clients reject as invalid, which collapses the
+            # rendered turn duration to 0s after a page refresh.
             if "timestamp" not in block:
-                block["timestamp"] = int(asyncio.get_event_loop().time() * 1000)
+                block["timestamp"] = int(time.time() * 1000)
 
             blocks_key = self._get_blocks_key(subtask_id)
             redis_client = await self._cache._get_client()

--- a/backend/tests/services/chat/storage/test_session_blocks.py
+++ b/backend/tests/services/chat/storage/test_session_blocks.py
@@ -113,3 +113,30 @@ async def test_thinking_blocks_are_split_by_text_boundaries():
     assert [block["status"] for block in blocks] == ["done", "done", "done"]
     assert blocks[0]["timestamp"] > 1_000_000_000_000
     assert blocks[2]["timestamp"] > 1_000_000_000_000
+
+
+@pytest.mark.asyncio
+async def test_add_block_fills_wall_clock_epoch_timestamp():
+    """Blocks without a timestamp must get a valid epoch-ms value.
+
+    Regression: the fallback previously used the event loop's monotonic clock,
+    producing a small non-epoch number that clients reject as invalid, which
+    collapsed the rendered turn duration to 0s after a refresh.
+    """
+    manager = SessionManager()
+    redis_client = FakeRedisClient()
+    manager._cache = FakeCache(redis_client)
+
+    await manager.add_block(
+        subtask_id=404,
+        block={"type": "tool", "tool_name": "Bash"},
+    )
+
+    blocks = await manager.get_blocks(404)
+
+    assert len(blocks) == 1
+    # A real wall-clock epoch in milliseconds is always greater than 1e12.
+    assert blocks[0]["timestamp"] > 1_000_000_000_000
+    # An auto-generated id must also be derived from wall-clock time.
+    assert blocks[0]["id"].startswith("block-")
+    assert int(blocks[0]["id"].removeprefix("block-")) > 1_000_000_000_000

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -43,6 +43,11 @@ export function MessageList({ messages }: MessageListProps) {
   )
 }
 
+function getTurnStartMs(createdAt: string): number | undefined {
+  const ms = new Date(createdAt).getTime()
+  return Number.isFinite(ms) ? ms : undefined
+}
+
 function formatMessageTime(createdAt: string) {
   const date = new Date(createdAt)
   if (Number.isNaN(date.getTime())) return ''
@@ -298,6 +303,7 @@ function AssistantMessage({ message }: { message: WorkbenchMessage }) {
         <ToolBlocksDisplay
           blocks={message.blocks ?? []}
           isStreaming={isStreaming}
+          startedAt={getTurnStartMs(message.createdAt)}
         />
       )}
       {hasContent && (

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -81,6 +81,36 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('已处理 5s 时间了')).toBeInTheDocument()
   })
 
+  test('anchors the running duration to the turn start, surviving a refresh', () => {
+    vi.useFakeTimers()
+    // The page was refreshed 10s into a still-running turn.
+    vi.setSystemTime(new Date('2026-06-05T00:00:10.000Z'))
+
+    // After a refresh the in-progress blocks are re-streamed with fresh client
+    // timestamps (createdAt === now), so anchoring to the first block would
+    // restart the timer. The turn actually started 10s ago.
+    const restreamedBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'streaming',
+      createdAt: Date.now(),
+    }
+    const turnStart = new Date('2026-06-05T00:00:00.000Z').getTime()
+
+    render(
+      <ToolBlocksDisplay
+        blocks={[restreamedBlock]}
+        isStreaming={true}
+        startedAt={turnStart}
+      />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(screen.getByText('已处理 10s 时间了')).toBeInTheDocument()
+  })
+
   test('renders the header as plain text (not a button) while running', () => {
     const runningBlock: ProcessingBlock = {
       ...completedCommandBlock,

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -59,4 +59,40 @@ describe('ToolBlocksDisplay', () => {
       screen.getByRole('button', { name: /已处理 3s 时间了/ })
     ).toBeInTheDocument()
   })
+
+  test('keeps ticking while streaming even when all tool blocks are done', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))
+
+    // All blocks are done but the model is still streaming (pure thinking
+    // phase with no new tool output). The timer must keep advancing.
+    const doneBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'done',
+      createdAt: Date.now(),
+    }
+
+    render(<ToolBlocksDisplay blocks={[doneBlock]} isStreaming={true} />)
+
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(screen.getByText('已处理 5s 时间了')).toBeInTheDocument()
+  })
+
+  test('renders the header as plain text (not a button) while running', () => {
+    const runningBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'streaming',
+    }
+
+    render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} />)
+
+    // While running the summary is informational only and must not be clickable.
+    expect(
+      screen.queryByRole('button', { name: /已处理/ })
+    ).not.toBeInTheDocument()
+    expect(screen.getByText(/已处理 .* 时间了/)).toBeInTheDocument()
+  })
 })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -44,31 +44,36 @@ export function ToolBlocksDisplay({ blocks, isStreaming }: ToolBlocksDisplayProp
 
   if (blocks.length === 0 && !isStreaming) return null
 
-  const duration = getDuration(blocks, startedAt, now, completedAt)
+  const duration = getDuration(blocks, startedAt, now, completedAt, isRunning)
   const rows = buildProcessingDisplayRows(blocks)
   const expanded = isRunning || userExpanded
 
   return (
     <div className="mb-3 min-w-0">
-      <button
-        type="button"
-        className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-left text-xs text-text-muted hover:text-text-secondary disabled:hover:text-text-muted"
-        disabled={isRunning}
-        onClick={() => {
-          if (!isRunning) setUserExpanded(value => !value)
-        }}
-      >
-        <span>已处理 {duration} 时间了</span>
-        <svg
-          className={`h-3 w-3 transition-transform ${expanded || isRunning ? '' : '-rotate-90'}`}
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
+      {isRunning ? (
+        // While the turn is still running the summary is informational only:
+        // render it as plain, non-interactive text so it does not look clickable.
+        <div className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-xs text-text-muted">
+          <span>已处理 {duration} 时间了</span>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-left text-xs text-text-muted hover:text-text-secondary"
+          onClick={() => setUserExpanded(value => !value)}
         >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
+          <span>已处理 {duration} 时间了</span>
+          <svg
+            className={`h-3 w-3 transition-transform ${expanded ? '' : '-rotate-90'}`}
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+      )}
       {expanded && (
         <div className="flex min-w-0 flex-col gap-3">
           {rows.map(row =>
@@ -147,13 +152,16 @@ function getDuration(
   blocks: ProcessingBlock[],
   fallbackStart: number,
   now: number,
-  completedAt: number | null
+  completedAt: number | null,
+  isRunning: boolean
 ): string {
   const first = blocks[0]?.createdAt ?? fallbackStart
   const last = blocks[blocks.length - 1]?.createdAt ?? first
-  const isComplete =
-    blocks.length > 0 && blocks.every(b => b.status === 'done' || b.status === 'error')
-  const endTime = isComplete ? (completedAt ?? last) : now
+  // While running, keep counting against the live clock so the timer advances
+  // every second even during pure thinking phases with no new tool output.
+  // Once finished, lock to the completion time (or the last block timestamp
+  // when the turn was restored from history after a refresh).
+  const endTime = isRunning ? now : (completedAt ?? last)
   const durationMs = Math.max(0, endTime - first)
   const seconds = Math.floor(durationMs / 1000)
   if (seconds < 60) return `${seconds}s`

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -10,12 +10,23 @@ import {
 interface ToolBlocksDisplayProps {
   blocks: ProcessingBlock[]
   isStreaming: boolean
+  // Wall-clock epoch ms when the turn started (the assistant subtask's
+  // created_at). Used as the duration anchor so the elapsed time survives a
+  // page refresh: after a refresh the in-progress blocks are re-streamed with
+  // fresh client timestamps, so anchoring to the first block would restart the
+  // timer from the refresh moment.
+  startedAt?: number
 }
 
-export function ToolBlocksDisplay({ blocks, isStreaming }: ToolBlocksDisplayProps) {
+export function ToolBlocksDisplay({
+  blocks,
+  isStreaming,
+  startedAt,
+}: ToolBlocksDisplayProps) {
   const isRunning = isStreaming || blocks.some(b => b.status !== 'done' && b.status !== 'error')
   const [userExpanded, setUserExpanded] = useState(false)
-  const [startedAt] = useState(() => Date.now())
+  const [mountedAt] = useState(() => Date.now())
+  const turnStartedAt = startedAt ?? mountedAt
   const [hasRenderedRunning, setHasRenderedRunning] = useState(isRunning)
   const [completedAt, setCompletedAt] = useState<number | null>(null)
   const [now, setNow] = useState(() => Date.now())
@@ -44,7 +55,7 @@ export function ToolBlocksDisplay({ blocks, isStreaming }: ToolBlocksDisplayProp
 
   if (blocks.length === 0 && !isStreaming) return null
 
-  const duration = getDuration(blocks, startedAt, now, completedAt, isRunning)
+  const duration = getDuration(blocks, turnStartedAt, now, completedAt, isRunning)
   const rows = buildProcessingDisplayRows(blocks)
   const expanded = isRunning || userExpanded
 
@@ -150,12 +161,16 @@ function ThinkingIndicator() {
 
 function getDuration(
   blocks: ProcessingBlock[],
-  fallbackStart: number,
+  turnStartedAt: number,
   now: number,
   completedAt: number | null,
   isRunning: boolean
 ): string {
-  const first = blocks[0]?.createdAt ?? fallbackStart
+  // Anchor the elapsed time to the turn's wall-clock start rather than the
+  // first block. After a page refresh the in-progress blocks are re-streamed
+  // with fresh client timestamps, so anchoring to blocks[0] would restart the
+  // timer from the refresh moment.
+  const first = turnStartedAt
   const last = blocks[blocks.length - 1]?.createdAt ?? first
   // While running, keep counting against the live clock so the timer advances
   // every second even during pure thinking phases with no new tool output.


### PR DESCRIPTION
## Summary

Fixes three issues with the chat "已处理 Xs 时间了" turn-duration display:

- **Timer froze during pure-thinking phases (no tool output).** `getDuration` now counts against the live clock while the turn `isRunning` instead of locking to the last block timestamp, so the elapsed time advances every second even when there is no new tool output.
- **A completed turn showed "已处理 0s 时间了" after page refresh.** The backend `add_block` fallback stamped blocks with the event loop's monotonic clock — a small non-epoch value the client rejects as invalid (`getBlockTimestamp` requires `> 1e12`), collapsing the rendered duration to 0s. It now uses wall-clock epoch milliseconds (`time.time`).
- **Running header showed a not-allowed cursor.** It was a `disabled` button. While running it now renders as plain, non-interactive text; the collapsible button only appears once the turn finishes.

## Changes

- `wework/src/components/chat/blocks/ToolBlocksDisplay.tsx` — live-clock duration while running; plain text vs. button header.
- `backend/app/services/chat/storage/session.py` — `add_block` uses `time.time()` for both the generated `id` and `timestamp` fallback.
- Tests added in both `ToolBlocksDisplay.test.tsx` and `test_session_blocks.py`.

## Test plan

- [x] wework: `ToolBlocksDisplay` tests pass (live tick while streaming with all blocks done; header renders as plain text while running)
- [x] wework: theme-token-guard, `tsc --noEmit`, eslint clean
- [x] backend: `black --check` / `isort --check-only` clean on changed files
- [ ] backend: `test_add_block_fills_wall_clock_epoch_timestamp` regression test (runs in CI; local run blocked by network/env)
- [ ] Manual: verify timer advances during thinking-only phase and a completed turn keeps its duration after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elapsed activity timer can be anchored to the original turn start (prop) so durations persist after refresh; timer keeps updating during active processing and shows a non-clickable running header.

* **Bug Fixes**
  * Block timestamps and auto-generated IDs now use wall-clock epoch milliseconds for accurate duration display after reloads.

* **Tests**
  * Added regression tests for timestamp/ID generation and streaming-duration display/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->