### PR TITLE
fix(wework): normalize visible app title casing

### DIFF
--- a/wework/index.html
+++ b/wework/index.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
     />
-    <title>wework</title>
+    <title>WeWork</title>
   </head>
   <body>
     <div id="root"></div>

--- a/wework/src-tauri/tauri.conf.json
+++ b/wework/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "wework",
+  "productName": "WeWork",
   "version": "0.1.0",
   "identifier": "io.wecode.wework",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "wework",
+        "title": "WeWork",
         "width": 1280,
         "height": 720,
         "titleBarStyle": "Overlay",


### PR DESCRIPTION
## Summary
- Normalize visible WeWork title casing in browser title and Tauri app config

## Tests
- Not run; copy/config-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application branding to display "WeWork" with proper capitalization in the product name and window title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->