### PR TITLE
fix(wework): improve processing duration copy

### DIFF
--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -21,7 +21,7 @@ describe('ToolBlocksDisplay', () => {
   test('groups completed tools into an activity summary', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={false} />)
 
-    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    fireEvent.click(screen.getByRole('button', { name: /用时/ }))
 
     expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
     expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
@@ -56,7 +56,28 @@ describe('ToolBlocksDisplay', () => {
     })
 
     expect(
-      screen.getByRole('button', { name: /已处理 3s 时间了/ })
+      screen.getByRole('button', { name: /用时 3 秒/ })
+    ).toBeInTheDocument()
+  })
+
+  test('formats live duration with natural Chinese units', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))
+
+    const runningBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'streaming',
+      createdAt: Date.now(),
+    }
+
+    render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} />)
+
+    act(() => {
+      vi.advanceTimersByTime(62000)
+    })
+
+    expect(
+      screen.getByRole('button', { name: /已处理 1 分 2 秒/ })
     ).toBeInTheDocument()
   })
 })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -44,7 +44,7 @@ export function ToolBlocksDisplay({ blocks, isStreaming }: ToolBlocksDisplayProp
 
   if (blocks.length === 0 && !isStreaming) return null
 
-  const duration = getDuration(blocks, startedAt, now, completedAt)
+  const duration = getDurationText(blocks, startedAt, now, completedAt, isRunning)
   const rows = buildProcessingDisplayRows(blocks)
   const expanded = isRunning || userExpanded
 
@@ -58,7 +58,7 @@ export function ToolBlocksDisplay({ blocks, isStreaming }: ToolBlocksDisplayProp
           if (!isRunning) setUserExpanded(value => !value)
         }}
       >
-        <span>已处理 {duration} 时间了</span>
+        <span>{duration}</span>
         <svg
           className={`h-3 w-3 transition-transform ${expanded || isRunning ? '' : '-rotate-90'}`}
           fill="none"
@@ -143,11 +143,12 @@ function ThinkingIndicator() {
   )
 }
 
-function getDuration(
+function getDurationText(
   blocks: ProcessingBlock[],
   fallbackStart: number,
   now: number,
-  completedAt: number | null
+  completedAt: number | null,
+  isRunning: boolean
 ): string {
   const first = blocks[0]?.createdAt ?? fallbackStart
   const last = blocks[blocks.length - 1]?.createdAt ?? first
@@ -155,9 +156,26 @@ function getDuration(
     blocks.length > 0 && blocks.every(b => b.status === 'done' || b.status === 'error')
   const endTime = isComplete ? (completedAt ?? last) : now
   const durationMs = Math.max(0, endTime - first)
+  const duration = formatDuration(durationMs)
+
+  if (isRunning) return `已处理 ${duration}`
+  return `用时 ${duration}`
+}
+
+function formatDuration(durationMs: number): string {
   const seconds = Math.floor(durationMs / 1000)
-  if (seconds < 60) return `${seconds}s`
+  if (seconds < 60) return `${seconds} 秒`
+
   const minutes = Math.floor(seconds / 60)
   const remainingSeconds = seconds % 60
-  return `${minutes}m ${remainingSeconds}s`
+  if (minutes < 60) {
+    return remainingSeconds > 0
+      ? `${minutes} 分 ${remainingSeconds} 秒`
+      : `${minutes} 分钟`
+  }
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  if (remainingMinutes === 0) return `${hours} 小时`
+  return `${hours} 小时 ${remainingMinutes} 分钟`
 }


### PR DESCRIPTION
## Summary
- improve wework processing duration copy in Chinese
- format durations with natural Chinese units
- add coverage for completed and live duration states

## Tests
- cd wework && npm test -- ToolBlocksDisplay.test.tsx
- cd wework && npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duration display formatting to use natural Chinese time units (seconds, minutes, hours) instead of abbreviated notation
  * Updated button labels for tool duration and completion status indicators with clearer, more readable formatting
  * Duration text now displays with full descriptive labels (e.g., "用时 3 秒" and "已处理 1 分 2 秒") for improved user comprehension

<!-- end of auto-generated comment: release notes by coderabbit.ai -->