### PR TITLE
fix(wework): prevent IME enter from submitting chat

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StrictMode, useState } from 'react'
 import { describe, expect, test, vi } from 'vitest'
@@ -88,6 +88,7 @@ describe('ChatInput', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    vi.useRealTimers()
     localStorage.clear()
     URL.createObjectURL = originalCreateObjectUrl
   })
@@ -2794,6 +2795,28 @@ describe('ChatInput', () => {
     render(<ControlledChatInput onSubmit={onSubmit} />)
 
     await userEvent.type(screen.getByTestId('chat-message-input'), 'hello{enter}')
+
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not submit when Enter confirms IME composition', () => {
+    vi.useFakeTimers()
+    const onSubmit = vi.fn()
+    render(<ControlledChatInput onSubmit={onSubmit} />)
+
+    const input = screen.getByTestId('chat-message-input')
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(101)
+    })
+    fireEvent.keyDown(input, { key: 'Enter' })
 
     expect(onSubmit).toHaveBeenCalledTimes(1)
   })

--- a/wework/src/components/chat/composer/ComposerTextarea.tsx
+++ b/wework/src/components/chat/composer/ComposerTextarea.tsx
@@ -275,6 +275,11 @@ export function ComposerTextarea({
     end: 0,
     focused: false,
   })
+  const [isComposing, setIsComposing] = useState(false)
+  const compositionJustEndedRef = useRef(false)
+  const compositionResetTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  )
   const [trigger, setTrigger] = useState<SkillTrigger | null>(null)
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [loading, setLoading] = useState(false)
@@ -454,6 +459,37 @@ export function ComposerTextarea({
     }
   }, [closeSkillMenu, showSkillMenu, textareaRef])
 
+  useEffect(() => {
+    return () => {
+      if (compositionResetTimerRef.current) {
+        window.clearTimeout(compositionResetTimerRef.current)
+      }
+    }
+  }, [])
+
+  const clearCompositionResetTimer = () => {
+    if (!compositionResetTimerRef.current) return
+
+    window.clearTimeout(compositionResetTimerRef.current)
+    compositionResetTimerRef.current = null
+  }
+
+  const handleCompositionStart = () => {
+    clearCompositionResetTimer()
+    setIsComposing(true)
+    compositionJustEndedRef.current = false
+  }
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false)
+    compositionJustEndedRef.current = true
+    clearCompositionResetTimer()
+    compositionResetTimerRef.current = window.setTimeout(() => {
+      compositionJustEndedRef.current = false
+      compositionResetTimerRef.current = null
+    }, 100)
+  }
+
   const selectSkill = useCallback(
     (skill: LocalDeviceSkill) => {
       const textarea = textareaRef.current
@@ -502,6 +538,14 @@ export function ComposerTextarea({
   )
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = event => {
+    if (
+      isComposing ||
+      event.nativeEvent.isComposing ||
+      compositionJustEndedRef.current
+    ) {
+      return
+    }
+
     if (event.key === 'Backspace' || event.key === 'Delete') {
       const selectionStart = event.currentTarget.selectionStart
       const selectionEnd = event.currentTarget.selectionEnd
@@ -566,7 +610,7 @@ export function ComposerTextarea({
       }
     }
 
-    if (event.key !== 'Enter' || event.shiftKey || event.nativeEvent.isComposing) return
+    if (event.key !== 'Enter' || event.shiftKey) return
 
     event.preventDefault()
     if (canSend) onSubmit()
@@ -622,6 +666,8 @@ export function ComposerTextarea({
         }}
         onKeyDown={handleKeyDown}
         onKeyUp={syncSelection}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
         onSelect={() => {
           updateSkillTrigger()
           syncSelection()


### PR DESCRIPTION
## Summary
- track IME composition state in the WeWork composer textarea
- ignore Enter during composition and immediately after compositionend to avoid accidental send
- add regression coverage for IME Enter behavior

## Verification
- cd wework && npm test -- ChatInput.test.tsx
- cd wework && npm run build
- cd wework && npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IME (Input Method Editor) text composition in the chat input. Messages will no longer be submitted during active text composition, preventing accidental sends when using input methods for languages like Chinese, Japanese, or Korean.

* **Tests**
  * Added test coverage for IME composition behavior during message submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->