### PR TITLE
fix(wework): hide project tasks from conversation lists

### DIFF
--- a/backend/app/api/ws/events.py
+++ b/backend/app/api/ws/events.py
@@ -493,6 +493,7 @@ class TaskCreatedPayload(BaseModel):
     team_name: str
     created_at: str
     is_group_chat: bool = False
+    project_id: Optional[int] = None
 
 
 class TaskDeletedPayload(BaseModel):

--- a/backend/app/services/adapters/task_kinds/query_utils.py
+++ b/backend/app/services/adapters/task_kinds/query_utils.py
@@ -82,6 +82,7 @@ _PERSONAL_COUNT_SQL = text(
     AND k.namespace != 'system'
     AND k.user_id = :user_id
     AND k.is_group_chat = 0
+    AND k.project_id = 0
 """
 )
 
@@ -95,6 +96,7 @@ _PERSONAL_COUNT_BY_ORIGIN_SQL = text(
     AND k.user_id = :user_id
     AND k.is_group_chat = 0
     AND k.client_origin = :client_origin
+    AND k.project_id = 0
 """
 )
 
@@ -107,6 +109,7 @@ _PERSONAL_IDS_SQL = text(
     AND k.namespace != 'system'
     AND k.user_id = :user_id
     AND k.is_group_chat = 0
+    AND k.project_id = 0
     ORDER BY k.created_at DESC
     LIMIT :limit OFFSET :skip
 """
@@ -122,6 +125,7 @@ _PERSONAL_IDS_BY_ORIGIN_SQL = text(
     AND k.user_id = :user_id
     AND k.is_group_chat = 0
     AND k.client_origin = :client_origin
+    AND k.project_id = 0
     ORDER BY k.created_at DESC
     LIMIT :limit OFFSET :skip
 """

--- a/backend/app/services/adapters/wework_conversation_search.py
+++ b/backend/app/services/adapters/wework_conversation_search.py
@@ -130,6 +130,7 @@ def _load_visible_wework_tasks(
             TaskResource.namespace != "system",
             TaskResource.user_id == user_id,
             TaskResource.client_origin == client_origin,
+            TaskResource.project_id == 0,
         )
         .order_by(TaskResource.updated_at.desc())
         .all()

--- a/backend/app/services/chat/webpage_websocket_chat_emitter.py
+++ b/backend/app/services/chat/webpage_websocket_chat_emitter.py
@@ -489,6 +489,7 @@ class WebSocketEmitter:
         team_id: int,
         team_name: str,
         is_group_chat: bool = False,
+        project_id: int | None = None,
     ) -> None:
         """
         Emit task:created event to user room.
@@ -500,6 +501,7 @@ class WebSocketEmitter:
             team_id: Team ID
             team_name: Team name
             is_group_chat: Whether this is a group chat task
+            project_id: Optional project ID for project-owned tasks
         """
         await self.sio.emit(
             ServerEvents.TASK_CREATED,
@@ -510,6 +512,7 @@ class WebSocketEmitter:
                 "team_name": team_name,
                 "created_at": datetime.now().isoformat(),
                 "is_group_chat": is_group_chat,
+                "project_id": project_id,
             },
             room=f"user:{user_id}",
             namespace=self.namespace,

--- a/backend/app/services/chat/webpage_ws_chat_emitter.py
+++ b/backend/app/services/chat/webpage_ws_chat_emitter.py
@@ -489,6 +489,7 @@ class WebPageSocketEmitter:
         team_id: int,
         team_name: str,
         is_group_chat: bool = False,
+        project_id: int | None = None,
     ) -> None:
         """
         Emit task:created event to user room.
@@ -500,6 +501,7 @@ class WebPageSocketEmitter:
             team_id: Team ID
             team_name: Team name
             is_group_chat: Whether this is a group chat task
+            project_id: Optional project ID for project-owned tasks
         """
         await self.sio.emit(
             ServerEvents.TASK_CREATED,
@@ -510,6 +512,7 @@ class WebPageSocketEmitter:
                 "team_name": team_name,
                 "created_at": datetime.now().isoformat(),
                 "is_group_chat": is_group_chat,
+                "project_id": project_id,
             },
             room=f"user:{user_id}",
             namespace=self.namespace,

--- a/backend/app/services/chat/ws_emitter.py
+++ b/backend/app/services/chat/ws_emitter.py
@@ -489,6 +489,7 @@ class WebSocketEmitter:
         team_id: int,
         team_name: str,
         is_group_chat: bool = False,
+        project_id: int | None = None,
     ) -> None:
         """
         Emit task:created event to user room.
@@ -500,6 +501,7 @@ class WebSocketEmitter:
             team_id: Team ID
             team_name: Team name
             is_group_chat: Whether this is a group chat task
+            project_id: Optional project ID for project-owned tasks
         """
         await self.sio.emit(
             ServerEvents.TASK_CREATED,
@@ -510,6 +512,7 @@ class WebSocketEmitter:
                 "team_name": team_name,
                 "created_at": datetime.now().isoformat(),
                 "is_group_chat": is_group_chat,
+                "project_id": project_id,
             },
             room=f"user:{user_id}",
             namespace=self.namespace,

--- a/backend/app/services/execution/dispatcher.py
+++ b/backend/app/services/execution/dispatcher.py
@@ -750,6 +750,7 @@ class ExecutionDispatcher:
                     team_name=team_name,
                     task_title=task_title,
                     is_group_chat=is_group_chat,
+                    project_id=request.project_id,
                 )
 
             # Wrap emitter with StatusUpdatingEmitter for unified status updates

--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -43,6 +43,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
         team_name: Optional[str] = None,
         task_title: Optional[str] = None,
         is_group_chat: bool = False,
+        project_id: Optional[int] = None,
     ):
         """Initialize the WebSocket emitter.
 
@@ -54,6 +55,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
             team_name: Optional team name for task:created event
             task_title: Optional task title for task:created event
             is_group_chat: Whether this is a group chat task
+            project_id: Optional project ID for project-owned tasks
         """
         super().__init__(task_id, subtask_id)
         self.user_id = user_id
@@ -61,6 +63,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
         self.team_name = team_name
         self.task_title = task_title
         self.is_group_chat = is_group_chat
+        self.project_id = project_id
 
     async def emit(self, event: ExecutionEvent) -> None:
         """Emit event via WebSocket.
@@ -205,6 +208,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
             team_id=self.team_id,
             team_name=self.team_name,
             is_group_chat=self.is_group_chat,
+            project_id=self.project_id,
         )
         logger.debug(
             f"[WebSocketResultEmitter] task:created emitted: "

--- a/backend/tests/services/adapters/test_task_archive_operations.py
+++ b/backend/tests/services/adapters/test_task_archive_operations.py
@@ -212,6 +212,13 @@ def test_conversation_search_matches_subtask_content_and_client_origin(
     test_db: Session,
     test_user: User,
 ):
+    project = _create_project(
+        test_db,
+        test_user.id,
+        711,
+        "wework-project",
+        client_origin="wework",
+    )
     matched_task = _create_task(
         test_db,
         test_user.id,
@@ -227,6 +234,15 @@ def test_conversation_search_matches_subtask_content_and_client_origin(
         "hi",
         client_origin="frontend",
         updated_at=datetime(2026, 5, 30, 10, 0, 0),
+    )
+    project_task = _create_task(
+        test_db,
+        test_user.id,
+        7113,
+        "project hi",
+        project_id=project.id,
+        client_origin="wework",
+        updated_at=datetime(2026, 5, 30, 11, 0, 0),
     )
     test_db.add_all(
         [
@@ -249,6 +265,16 @@ def test_conversation_search_matches_subtask_content_and_client_origin(
                 prompt="胡云鹏",
                 result={"value": "wrong client"},
                 completed_at=datetime(2026, 5, 30, 10, 1, 0),
+            ),
+            Subtask(
+                user_id=test_user.id,
+                task_id=project_task.id,
+                team_id=1,
+                title="assistant reply",
+                bot_ids=[],
+                prompt="胡云鹏",
+                result={"value": "project task should stay under project"},
+                completed_at=datetime(2026, 5, 30, 11, 1, 0),
             ),
         ]
     )
@@ -400,6 +426,13 @@ def test_personal_task_list_filters_by_client_origin(
     test_db: Session,
     test_user: User,
 ):
+    project = _create_project(
+        test_db,
+        test_user.id,
+        707,
+        "wework-project",
+        client_origin="wework",
+    )
     frontend_task = _create_task(
         test_db,
         test_user.id,
@@ -414,6 +447,14 @@ def test_personal_task_list_filters_by_client_origin(
         "Wework standalone chat",
         client_origin="wework",
     )
+    project_task = _create_task(
+        test_db,
+        test_user.id,
+        7028,
+        "Wework project chat",
+        project_id=project.id,
+        client_origin="wework",
+    )
 
     items, total = task_kinds_service.get_user_personal_tasks_lite(
         test_db,
@@ -425,6 +466,7 @@ def test_personal_task_list_filters_by_client_origin(
     assert total == 1
     assert [item["id"] for item in items] == [wework_task.id]
     assert frontend_task.id not in [item["id"] for item in items]
+    assert project_task.id not in [item["id"] for item in items]
 
 
 def test_archive_standalone_chats_filters_by_client_origin(

--- a/frontend/src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx
+++ b/frontend/src/__tests__/features/tasks/contexts/taskContext.runtime-state-machine.test.tsx
@@ -8,9 +8,12 @@ import { act, render, waitFor } from '@testing-library/react'
 import { taskApis } from '@/apis/tasks'
 import { TaskSessionProvider, useTaskSession } from '@/features/tasks/session/TaskSession'
 import type { Task, TaskDetail } from '@/types/api'
-import type { TaskStatusPayload } from '@/types/socket'
+import type { TaskCreatedPayload, TaskStatusPayload } from '@/types/socket'
 
-let mockTaskHandlers: { onTaskStatus?: (payload: TaskStatusPayload) => void } | null = null
+let mockTaskHandlers: {
+  onTaskCreated?: (payload: TaskCreatedPayload) => void
+  onTaskStatus?: (payload: TaskStatusPayload) => void
+} | null = null
 let mockVisibleHandler: ((wasHiddenFor: number) => void) | null = null
 let mockReconnectHandler: (() => void) | null = null
 let mockIsConnected = true
@@ -203,6 +206,33 @@ describe('TaskSessionContext runtime state machine sync', () => {
     expect(contextProbe.current?.taskState?.runtime.lastStatusUpdatedAt).toBe(
       '2026-05-31T10:00:00.000Z'
     )
+  })
+
+  it('does not add project-owned task creation events to personal history', async () => {
+    render(
+      <TaskSessionProvider>
+        <ContextProbe />
+      </TaskSessionProvider>
+    )
+
+    await waitFor(() => {
+      expect(mockTaskHandlers?.onTaskCreated).toBeDefined()
+    })
+
+    act(() => {
+      mockTaskHandlers?.onTaskCreated?.({
+        task_id: 99,
+        title: 'Project task',
+        team_id: 1,
+        team_name: 'team',
+        created_at: '2026-05-31T10:00:00.000Z',
+        is_group_chat: false,
+        project_id: 12,
+      })
+    })
+
+    expect(contextProbe.current?.personalTasks.some(task => task.id === 99)).toBe(false)
+    expect(contextProbe.current?.tasks.some(task => task.id === 99)).toBe(false)
   })
 
   it('does not stamp active task runtime events with client time', async () => {

--- a/frontend/src/features/tasks/session/taskPuller.ts
+++ b/frontend/src/features/tasks/session/taskPuller.ts
@@ -427,6 +427,11 @@ export function useTaskPuller(): TaskPuller {
 
   // Handle new task created via WebSocket
   const handleTaskCreated = useCallback((data: TaskCreatedPayload) => {
+    const projectId = data.project_id ?? 0
+    if (projectId > 0) {
+      return
+    }
+
     // Use is_group_chat from WebSocket payload (defaults to false if not provided)
     const isGroupChat = data.is_group_chat ?? false
 
@@ -456,6 +461,7 @@ export function useTaskPuller(): TaskPuller {
       updated_at: data.created_at,
       completed_at: '',
       is_group_chat: isGroupChat,
+      project_id: projectId,
     }
 
     // Initialize view status for the new task

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -439,6 +439,7 @@ export interface Task {
   updated_at: string
   completed_at: string
   is_group_chat?: boolean // Whether this task is a group chat
+  project_id?: number // Project ID for project-owned tasks
   knowledge_base_id?: number // Knowledge base ID for knowledge type tasks
 }
 

--- a/frontend/src/types/socket.ts
+++ b/frontend/src/types/socket.ts
@@ -431,6 +431,7 @@ export interface TaskCreatedPayload {
   team_name: string
   created_at: string
   is_group_chat?: boolean
+  project_id?: number | null
 }
 
 export interface TaskDeletedPayload {


### PR DESCRIPTION
## Summary
- exclude project-owned tasks from personal conversation list queries
- exclude project-owned tasks from WeWork conversation search
- include project_id in task:created events and skip project tasks in frontend personal history updates
- add regression coverage for backend list/search behavior and frontend realtime task creation handling

## Verification
- git diff --check
- /usr/bin/python3 -m py_compile backend/app/api/ws/events.py backend/app/services/adapters/task_kinds/query_utils.py backend/app/services/adapters/wework_conversation_search.py backend/app/services/chat/webpage_ws_chat_emitter.py backend/app/services/chat/webpage_websocket_chat_emitter.py backend/app/services/chat/ws_emitter.py backend/app/services/execution/dispatcher.py backend/app/services/execution/emitters/websocket.py backend/tests/services/adapters/test_task_archive_operations.py

## Not run
- backend pytest: uv is not installed in this environment
- frontend jest: frontend dependencies are not installed, jest command is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now be associated with specific projects, with proper separation maintained from personal tasks.
  * Personal task lists now automatically exclude project-owned tasks.

* **Improvements**
  * Real-time task creation notifications now include project context information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->