### PR TITLE
fix(executor): gate standalone chats by task_type, drop env var

### DIFF
--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -386,6 +386,10 @@ class TaskRequestBuilder:
             git_repo=git_repo,
             git_repo_id=git_repo_id,
             branch_name=branch_name,
+            # Task type (e.g. "chat", "code", "knowledge") used by the executor
+            # to decide between the legacy task-id workspace and the dated
+            # chats workspace tree.
+            type=self._derive_task_mode(task),
             message_id=subtask.message_id,
             user_message_id=None,
             is_group_chat=is_group_chat,

--- a/docs/en/user-guide/ai-devices/local-device-support.md
+++ b/docs/en/user-guide/ai-devices/local-device-support.md
@@ -138,9 +138,11 @@ When a project configures `workspace.localPath` or `workspace.checkoutPath`, the
 
 ### Standalone Chat Workspaces
 
-When a chat has no selected project but is bound to an online device, executor-side independent Chats workspaces are currently disabled by default. To enable them, set `WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED=true` in the device runtime environment.
+When a chat has no selected project but is bound to an online device, the executor routes the task into a dated `chats/YYYY-MM-DD/<slug>` directory instead of the legacy `workspace/<task_id>` path. The slug is derived from the user prompt, and a numeric suffix is appended on collisions.
 
-Once enabled, the first task runs in a temporary task directory. After the response finishes, the Executor generates a dated directory name from the response summary and moves the temporary directory into the Chats workspace tree. The default root is `~/.wecode/wegent-executor/workspace/chats`. To use another location, set `WEGENT_EXECUTOR_CHATS_DIR` in the device runtime environment. Backend stores the final path in the task metadata label `standaloneChatWorkspacePath`, so continuing the conversation or opening it from history reuses the same directory.
+The first task runs in a temporary task directory. After the response finishes, the executor moves the temporary directory into the chats workspace tree. The default root is `~/.wecode/wegent-executor/workspace/chats`. To use another location, set `WEGENT_EXECUTOR_CHATS_DIR` in the device runtime environment. Backend stores the final path in the task metadata label `standaloneChatWorkspacePath`, so continuing the conversation or opening it from history reuses the same directory.
+
+This routing is task-type aware: only tasks whose backend `taskType` label is `chat` ever use the dated chats tree. `code` and other task types always keep the legacy `workspace/<task_id>` path, so the feature is safe to leave on even when a device also serves the main Wegent web UI. No device-side environment toggle is required.
 
 Project chats do not use this path. They continue to use the project's configured `workspace.localPath` or `workspace.checkoutPath`.
 

--- a/docs/zh/user-guide/ai-devices/local-device-support.md
+++ b/docs/zh/user-guide/ai-devices/local-device-support.md
@@ -140,9 +140,11 @@ docker run -d --platform linux/amd64 \
 
 ### 非项目会话工作区
 
-当聊天未选择项目但绑定到在线设备时，Executor 侧的独立 Chats 工作区功能当前默认关闭。如需启用，可在设备运行环境中设置 `WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED=true`。
+当聊天未选择项目但绑定到在线设备时，Executor 会把任务路由到按日期命名的 `chats/YYYY-MM-DD/<slug>` 目录，而不是使用传统的 `workspace/<task_id>` 路径。slug 由用户输入派生，冲突时会附加数字后缀。
 
-启用后，首轮任务先在临时任务目录中执行；回复完成后，Executor 会根据日期和回复摘要生成目录名，并把临时目录移动到 Chats 工作区树中。默认根目录为 `~/.wecode/wegent-executor/workspace/chats`。如需自定义位置，可在设备运行环境中设置 `WEGENT_EXECUTOR_CHATS_DIR`。Backend 会把最终路径写入任务元数据标签 `standaloneChatWorkspacePath`，后续继续该会话或打开历史会话时会复用同一目录。
+首轮任务先在临时任务目录中执行；回复完成后，Executor 会把临时目录移动到 Chats 工作区树中。默认根目录为 `~/.wecode/wegent-executor/workspace/chats`。如需自定义位置，可在设备运行环境中设置 `WEGENT_EXECUTOR_CHATS_DIR`。Backend 会把最终路径写入任务元数据标签 `standaloneChatWorkspacePath`，后续继续该会话或打开历史会话时会复用同一目录。
+
+该路由按任务类型区分：只有后端 `taskType` 标签为 `chat` 的任务才会进入 chats 目录树。`code` 等其他任务类型始终走传统的 `workspace/<task_id>` 路径，因此即使该设备同时为 Wegent Web 主前端提供服务，也无需额外开关。设备侧无需配置任何环境变量。
 
 项目会话不使用此路径；项目会话仍然使用项目配置中的 `workspace.localPath` 或 `workspace.checkoutPath`。
 

--- a/executor/agents/claude_code/standalone_chat_workspace.py
+++ b/executor/agents/claude_code/standalone_chat_workspace.py
@@ -19,18 +19,9 @@ from shared.logger import setup_logger
 logger = setup_logger("standalone_chat_workspace")
 
 CHAT_WORKSPACE_ENV = "WEGENT_EXECUTOR_CHATS_DIR"
-STANDALONE_CHATS_ENABLED_ENV = "WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED"
 DEFAULT_CHAT_SLUG = "new-chat"
 MAX_CHAT_DIR_NAME_LENGTH = 20
 WORKSPACE_INTERNAL_DIRS = {".claude"}
-TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
-
-
-def is_standalone_chat_workspace_enabled() -> bool:
-    """Return whether executor-side standalone Chats workspaces are enabled."""
-
-    value = os.environ.get(STANDALONE_CHATS_ENABLED_ENV, "")
-    return value.strip().lower() in TRUTHY_ENV_VALUES
 
 
 def get_chats_root() -> Path:
@@ -137,12 +128,27 @@ def _move_user_workspace(source: Path, target: Path) -> None:
         shutil.move(str(item), str(target / item.name))
 
 
+def _task_type(task_data) -> Optional[str]:
+    """Return the task kind for the request, accepting both field names.
+
+    `ExecutionRequest.type` carries the task kind ("chat", "code", ...) and
+    `BaseAgent` aliases it as `task_type`. Standalone workspace routing
+    runs before the agent is fully constructed, so we read both spellings
+    to stay agnostic of the wrapper.
+    """
+
+    return getattr(task_data, "task_type", None) or getattr(task_data, "type", None)
+
+
 def is_initial_standalone_chat(task_data) -> bool:
     """Return true when this request should create a standalone chat workspace."""
 
-    if not is_standalone_chat_workspace_enabled():
-        return False
     if not task_data:
+        return False
+    # Only chat-type tasks may use the dated chats workspace. Code and
+    # knowledge tasks must keep the legacy `workspace/<task_id>` path
+    # even when they happen to arrive without project/git metadata.
+    if _task_type(task_data) != "chat":
         return False
     if getattr(task_data, "project_id", None):
         return False
@@ -156,9 +162,9 @@ def is_initial_standalone_chat(task_data) -> bool:
 def prepared_standalone_chat_workspace_path(task_data) -> Optional[str]:
     """Return an already resolved standalone chat workspace path."""
 
-    if not is_standalone_chat_workspace_enabled():
-        return None
     if not task_data:
+        return None
+    if _task_type(task_data) != "chat":
         return None
     if getattr(task_data, "project_id", None):
         return None

--- a/executor/tests/agents/test_project_workspace_paths.py
+++ b/executor/tests/agents/test_project_workspace_paths.py
@@ -13,10 +13,6 @@ from executor.agents.codex.codex_agent import CodeXAgent
 from shared.models.execution import ExecutionRequest
 
 
-def _enable_standalone_chats(monkeypatch):
-    monkeypatch.setenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", "true")
-
-
 def test_git_project_path_uses_project_workspace_root_when_project_id_present():
     request = ExecutionRequest(
         task_id=1001,
@@ -134,6 +130,7 @@ def test_initial_standalone_chat_prepares_request_named_cwd(tmp_path, monkeypatc
         task_id=1003,
         subtask_id=2003,
         prompt="hello-new-wework",
+        type="chat",
     )
     agent = ClaudeCodeAgent.__new__(ClaudeCodeAgent)
     agent.task_data = request
@@ -144,7 +141,6 @@ def test_initial_standalone_chat_prepares_request_named_cwd(tmp_path, monkeypatc
     agent._claude_config_dir = str(task_dir / ".claude")
 
     executor_home = tmp_path / ".wegent-executor"
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     with (
         patch(
@@ -177,6 +173,58 @@ def test_initial_standalone_chat_prepares_request_named_cwd(tmp_path, monkeypatc
     assert (task_dir / ".claude").exists()
     assert target.exists()
     set_session_root.assert_called_once_with(1003, str(executor_home / "sessions"))
+
+
+def test_code_task_is_not_moved_into_chats_workspace_by_prepare(
+    tmp_path,
+    monkeypatch,
+):
+    """A ClaudeCode task with no project_id/git_url must NOT be hijacked into
+    the dated chats tree just because it lacks project metadata. This is
+    the regression that the task_type gate replaces."""
+    workspace_root = tmp_path / "workspace"
+    task_dir = workspace_root / "1009"
+    (task_dir / ".claude").mkdir(parents=True)
+    chats_root = tmp_path / "chats"
+    request = ExecutionRequest(
+        task_id=1009,
+        subtask_id=2009,
+        prompt="plain-code-prompt",
+        type="code",
+    )
+    agent = ClaudeCodeAgent.__new__(ClaudeCodeAgent)
+    agent.task_data = request
+    agent.task_id = request.task_id
+    agent.prompt = request.prompt
+    agent.options = {}
+    agent.project_path = None
+    agent._claude_config_dir = str(task_dir / ".claude")
+
+    executor_home = tmp_path / ".wegent-executor"
+    monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
+    monkeypatch.delenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", raising=False)
+    with (
+        patch(
+            "executor.agents.claude_code.claude_code_agent.config.get_workspace_root",
+            return_value=str(workspace_root),
+        ),
+        patch(
+            "executor.agents.claude_code.standalone_chat_workspace.config.get_workspace_root",
+            return_value=str(workspace_root),
+        ),
+        patch(
+            "executor.agents.claude_code.claude_code_agent.config.WEGENT_EXECUTOR_HOME",
+            str(executor_home),
+        ),
+        patch.object(SessionManager, "set_task_session_root") as set_session_root,
+    ):
+        agent._prepare_project_workspace()
+
+    assert not chats_root.exists()
+    # project_workspace_path stays unset, so the executor falls back to
+    # the legacy workspace/<task_id> default in the client.
+    assert request.project_workspace_path is None
+    set_session_root.assert_not_called()
 
 
 async def test_codex_pre_execute_uses_project_workspace_path(tmp_path):
@@ -217,6 +265,7 @@ def test_initial_standalone_chat_coordinate_mode_keeps_claude_out_of_chat_dir(
         subtask_id=2004,
         prompt="coordinate-chat",
         mode="coordinate",
+        type="chat",
         bot=[
             {"id": 1, "name": "leader", "system_prompt": "Lead"},
             {"id": 2, "name": "worker", "system_prompt": "Work"},
@@ -231,7 +280,6 @@ def test_initial_standalone_chat_coordinate_mode_keeps_claude_out_of_chat_dir(
     agent._claude_config_dir = str(task_dir / ".claude")
 
     executor_home = tmp_path / ".wegent-executor"
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     with (
         patch(

--- a/executor/tests/agents/test_standalone_chat_workspace.py
+++ b/executor/tests/agents/test_standalone_chat_workspace.py
@@ -8,10 +8,6 @@ from types import SimpleNamespace
 from executor.agents.claude_code import standalone_chat_workspace as workspace
 
 
-def _enable_standalone_chats(monkeypatch):
-    monkeypatch.setenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", "true")
-
-
 def test_slugify_response_uses_alphanumeric_words():
     assert workspace.slugify_response("Hello, Codex 2026!") == "hello-codex-2026"
     assert workspace.slugify_response("只有中文") == "new-chat"
@@ -31,10 +27,42 @@ def test_prompt_text_for_workspace_extracts_text_blocks():
     assert workspace.prompt_text_for_workspace(prompt) == "hello-new-wework\nrun pwd"
 
 
-def test_standalone_chat_workspace_is_disabled_by_default(tmp_path, monkeypatch):
+def test_code_task_is_not_a_standalone_chat_even_without_project_or_git_url(
+    tmp_path,
+    monkeypatch,
+):
+    """A code task must never be moved into the dated chats tree, even when
+    project_id / git_url happen to be empty. This protects the main frontend
+    code path from being hijacked into the chats workspace by accident."""
     chats_root = tmp_path / "chats"
     task_data = SimpleNamespace(
         task_id=120,
+        task_type="code",
+        project_id=None,
+        project_workspace_path=None,
+        git_url=None,
+    )
+
+    # No env var must be set; the feature is always-on for chat tasks and
+    # always-off for everything else.
+    monkeypatch.delenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", raising=False)
+    monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
+
+    assert workspace.is_initial_standalone_chat(task_data) is False
+    assert workspace.prepare_standalone_chat_workspace(task_data, "hello") is None
+    assert not chats_root.exists()
+
+
+def test_chat_task_with_no_metadata_is_a_standalone_chat(tmp_path, monkeypatch):
+    """A chat task with no project/git metadata is the canonical standalone
+    chat case and must prepare the dated workspace without any env var."""
+    workspace_root = tmp_path / "workspace"
+    source = workspace_root / "121"
+    source.mkdir(parents=True)
+    chats_root = tmp_path / "chats"
+    task_data = SimpleNamespace(
+        task_id=121,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
@@ -42,21 +70,29 @@ def test_standalone_chat_workspace_is_disabled_by_default(tmp_path, monkeypatch)
 
     monkeypatch.delenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", raising=False)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
+    monkeypatch.setattr(
+        workspace.config, "get_workspace_root", lambda: str(workspace_root)
+    )
 
     result = workspace.prepare_standalone_chat_workspace(task_data, "hello")
 
-    assert result is None
-    assert not chats_root.exists()
+    target = chats_root / datetime.now().strftime("%Y-%m-%d") / "hello"
+    assert result == str(target)
+    assert target.exists()
 
 
-def test_disabled_standalone_chat_workspace_does_not_return_prepared_path(
+def test_code_task_with_existing_workspace_path_does_not_finalize_into_chats(
     tmp_path,
     monkeypatch,
 ):
+    """Even when a code task already has a `project_workspace_path` set (e.g.
+    resumed from a previous round), `finalize_standalone_chat_workspace`
+    must not move it into the chats tree."""
     workspace_path = tmp_path / "chats" / "2026-05-29" / "hello"
     workspace_path.mkdir(parents=True)
     task_data = SimpleNamespace(
         task_id=121,
+        task_type="code",
         project_id=None,
         project_workspace_path=str(workspace_path),
         git_url=None,
@@ -64,9 +100,8 @@ def test_disabled_standalone_chat_workspace_does_not_return_prepared_path(
 
     monkeypatch.delenv("WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED", raising=False)
 
-    result = workspace.finalize_standalone_chat_workspace(task_data, "response")
-
-    assert result is None
+    assert workspace.prepared_standalone_chat_workspace_path(task_data) is None
+    assert workspace.finalize_standalone_chat_workspace(task_data, "response") is None
 
 
 def test_prepare_standalone_chat_workspace_uses_request_text_before_execution(
@@ -82,12 +117,12 @@ def test_prepare_standalone_chat_workspace_uses_request_text_before_execution(
     chats_root = tmp_path / "chats"
     task_data = SimpleNamespace(
         task_id=122,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     monkeypatch.setattr(
         workspace.config, "get_workspace_root", lambda: str(workspace_root)
@@ -111,12 +146,12 @@ def test_finalize_returns_prepared_standalone_workspace_path(tmp_path, monkeypat
     executor_home = tmp_path / ".wegent-executor"
     task_data = SimpleNamespace(
         task_id=121,
+        task_type="chat",
         project_id=None,
         project_workspace_path=str(workspace_path),
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setattr(workspace.config, "WEGENT_EXECUTOR_HOME", str(executor_home))
 
     result = workspace.finalize_standalone_chat_workspace(
@@ -140,12 +175,12 @@ def test_finalize_standalone_chat_workspace_moves_initial_task_workspace(
     executor_home = tmp_path / ".wegent-executor"
     task_data = SimpleNamespace(
         task_id=123,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     monkeypatch.setattr(
         workspace.config, "get_workspace_root", lambda: str(workspace_root)
@@ -180,12 +215,12 @@ def test_finalize_standalone_chat_workspace_keeps_existing_session_root(
     session_file.write_text("current-session-id", encoding="utf-8")
     task_data = SimpleNamespace(
         task_id=126,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     monkeypatch.setattr(
         workspace.config, "get_workspace_root", lambda: str(workspace_root)
@@ -209,12 +244,12 @@ def test_finalize_standalone_chat_workspace_adds_duplicate_suffix(
     existing.mkdir(parents=True)
     task_data = SimpleNamespace(
         task_id=124,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     monkeypatch.setattr(
         workspace.config, "get_workspace_root", lambda: str(workspace_root)
@@ -238,12 +273,12 @@ def test_duplicate_suffix_counts_toward_twenty_character_limit(
     existing.mkdir(parents=True)
     task_data = SimpleNamespace(
         task_id=125,
+        task_type="chat",
         project_id=None,
         project_workspace_path=None,
         git_url=None,
     )
 
-    _enable_standalone_chats(monkeypatch)
     monkeypatch.setenv("WEGENT_EXECUTOR_CHATS_DIR", str(chats_root))
     monkeypatch.setattr(
         workspace.config, "get_workspace_root", lambda: str(workspace_root)

--- a/shared/models/execution.py
+++ b/shared/models/execution.py
@@ -184,7 +184,9 @@ class ExecutionRequest:
     # === Task Status (from Task) ===
     status: Optional[str] = None
     progress: Optional[int] = None
-    type: Optional[str] = None  # Task type: "online" or "offline"
+    type: Optional[str] = (
+        None  # Task kind: "chat" | "code" | "knowledge" | "validation"
+    )
 
     # === Executor Information (from Task) ===
     executor_name: Optional[str] = None

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1516,6 +1516,10 @@ describe('WorkbenchProvider', () => {
           project_id: 7,
           client_origin: 'wework',
           device_id: 'device-1',
+          // A conversation that's attached to a project is a code task — the
+          // executor keeps it in the project workspace and skips the chats
+          // directory tree. The complementary 'chat' path is asserted by
+          // `sends standalone chats to the preferred online cloud device`.
           task_type: 'code',
           message: 'build it',
           force_override_bot_model: 'gpt-5.5-medium',
@@ -1997,7 +2001,12 @@ describe('WorkbenchProvider', () => {
           project_id: undefined,
           client_origin: 'wework',
           device_id: 'cloud-online',
-          task_type: 'code',
+          // Standalone chats (no project_id) must declare task_type='chat' so
+          // the executor routes the workspace into chats/<YYYY-MM-DD>/<slug>
+          // instead of the legacy workspace/<task_id> directory. The previous
+          // behaviour of always sending 'code' silently disabled the chats
+          // workspace tree for every wework conversation.
+          task_type: 'chat',
           message: 'run pwd',
         })
       )

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1476,13 +1476,22 @@ export function WorkbenchProvider({
         standaloneDeviceId: state.standaloneDeviceId,
       })
 
+      // A WeWork task is "code" when it lives inside a project (which always
+      // has a git workspace) and "chat" when it's a standalone conversation.
+      // The backend records this on the Task and the executor uses it to
+      // decide between the legacy workspace/<task_id> directory and the dated
+      // chats/<YYYY-MM-DD>/<slug> tree. Hardcoding 'code' here would force
+      // every standalone chat into the code workspace and break the chats
+      // tree (see PR #1340).
+      const taskType: 'chat' | 'code' = state.currentProject ? 'code' : 'chat'
+
       const payload: ChatSendPayload = {
         task_id: state.currentTask?.id,
         team_id: state.defaultTeam.id,
         project_id: state.currentTask ? undefined : state.currentProject?.id,
         client_origin: WEWORK_CLIENT_ORIGIN,
         device_id: activeDeviceId,
-        task_type: 'code',
+        task_type: taskType,
         message,
       }
 
@@ -1593,7 +1602,10 @@ export function WorkbenchProvider({
           id: ack.task_id,
           title: message.substring(0, 100),
           status: 'RUNNING',
-          task_type: 'code',
+          // Mirror the task_type we just sent so the local task list matches
+          // the row the backend persisted (chat-only conversations vs. code
+          // tasks attached to a project).
+          task_type: payload.task_type === 'chat' ? 'chat' : 'code',
           team_id: payload.team_id,
           project_id: projectId,
           client_origin: WEWORK_CLIENT_ORIGIN,


### PR DESCRIPTION
## Summary
- **独立 Chats 工作区不再需要环境变量开关**：把原本全局的 `WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED` 开关替换为按任务类型的细粒度判别——只有 `task_type == "chat"` 的任务会进 `chats/YYYY-MM-DD/<slug>`，code / knowledge / validation 一律回退到 `workspace/<task_id>`。设备侧无需再设环境变量。
- **修复粗粒度判别带来的潜在劫持**：`is_initial_standalone_chat` 原本只看「无 project_id / 无 git_url / 无 project_workspace_path」，这会让任何「无项目也无 git」的 ClaudeCode 任务都被搬进 chats 目录（包括主前端的 code 任务）。`task_type` 已在后端任务创建时由 `taskType` 标签可靠写入，可作为权威判别维度。
- **后端补齐 `ExecutionRequest.type`**：request_builder 在构造 ExecutionRequest 时从 `task.json.metadata.labels.taskType` 读出任务类型写入 `type` 字段。修正 shared model 中 `type` 字段的注释（从过时的 "online/offline" 改为真正的任务类型语义）。
- **同步更新文档**：中英 `local-device-support.md` 删除 `WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED` 相关段落，改为「按任务类型自动路由」说明。

## Changes
| File | Change |
|------|--------|
| `executor/agents/claude_code/standalone_chat_workspace.py` | Remove `STANDALONE_CHATS_ENABLED_ENV` / `TRUTHY_ENV_VALUES` / `is_standalone_chat_workspace_enabled()`. Add `_task_type()` helper accepting both `task_type` and `type` field names. Gate `is_initial_standalone_chat` / `prepared_standalone_chat_workspace_path` on `_task_type() == "chat"`. |
| `backend/app/services/execution/request_builder.py` | Populate `ExecutionRequest.type` from `self._derive_task_mode(task)` so the executor can discriminate. |
| `shared/models/execution.py` | Fix stale docstring on `type` field (was "online/offline", now actual "chat/code/knowledge/validation" semantics). |
| `executor/tests/agents/test_standalone_chat_workspace.py` | Remove `_enable_standalone_chats` helper and `WEGENT_EXECUTOR_STANDALONE_CHATS_ENABLED` references. Add regression tests asserting code-type tasks are never hijacked into chats tree (both prepare and finalize paths). |
| `executor/tests/agents/test_project_workspace_paths.py` | Drop env-var setup; mark `task_type="chat"` on relevant fixtures; add `test_code_task_is_not_moved_into_chats_workspace_by_prepare` regression. |
| `docs/{en,zh}/user-guide/ai-devices/local-device-support.md` | Drop env var section; document automatic task-type-aware routing. |

## Test plan
- [x] `executor/tests/agents/test_standalone_chat_workspace.py` — 12 passed
- [x] `executor/tests/agents/test_project_workspace_paths.py` — 8 passed (incl. new `test_code_task_is_not_moved_into_chats_workspace_by_prepare` regression)
- [x] `executor/tests/` full suite — 460 passed; 8 failures are pre-existing on `main` (mode strategy, device config, updater — verified via `git stash` round-trip) and unrelated to this change
- [x] `backend/tests/services/execution/` + `backend/tests/services/chat/` — 293 passed (incl. `test_web_runtime_guidance`, `test_emitters`)
- [ ] Manual: create a wework standalone chat in wework → workspace lands at `~/.wecode/wegent-executor/workspace/chats/YYYY-MM-DD/<slug>` without any device env config
- [ ] Manual: trigger a code task from main frontend without project/git → workspace falls back to `workspace/<task_id>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic standalone chat workspace routing—chat tasks now use dated workspace paths without manual device config.

* **Improvements**
  * Requests now carry an explicit task kind (e.g., "chat"/"code") used to route workspaces.
  * UI now sends/reflects the correct task kind for project vs standalone chats.

* **Bug Fixes**
  * Code tasks are no longer redirected into the chats workspace.

* **Documentation**
  * Updated workspace routing guidance (en/zh).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->