### PR TITLE
fix(wework): 修复无commit仓库环境信息显示错误，新增用户消息折叠功能

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -420,6 +420,9 @@ DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
     "git_branch_diff_shortstat": LocalDeviceCommandDefinition(
         command=GIT_BRANCH_DIFF_SHORTSTAT_COMMAND
     ),
+    "git_status_porcelain": LocalDeviceCommandDefinition(
+        command="git status --porcelain"
+    ),
     "git_remote_url": LocalDeviceCommandDefinition(command="git remote get-url origin"),
     "git_add_all": LocalDeviceCommandDefinition(command="git add --all"),
     "git_commit": LocalDeviceCommandDefinition(command="git commit"),

--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -20,6 +20,13 @@ describe('parseGitShortStat', () => {
   test('defaults missing additions and deletions to zero', () => {
     expect(parseGitShortStat('')).toEqual({ additions: '+0', deletions: '-0' })
   })
+
+  test('parses pending file count from no-commit repos', () => {
+    expect(parseGitShortStat(' 3 file(s) pending')).toEqual({
+      additions: '+3',
+      deletions: '-0',
+    })
+  })
 })
 
 describe('buildPullRequestUrl', () => {
@@ -62,6 +69,11 @@ describe('loadProjectEnvironment', () => {
       })
       .mockResolvedValueOnce({
         success: true,
+        stdout: '',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        success: true,
         stdout: 'https://github.com/wecode-ai/Wegent.git\n',
         stderr: '',
       })
@@ -95,7 +107,7 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
       command_key: 'git_diff_shortstat',
       path: '/workspace/projects/directmessage_single',
-      args: ['main...', '--'],
+      args: ['HEAD', '--'],
       timeout_seconds: 10,
       max_output_bytes: 4096,
     })
@@ -112,6 +124,11 @@ describe('loadProjectEnvironment', () => {
       .mockResolvedValueOnce({
         success: true,
         stdout: ' 2 files changed, 8 insertions(+), 3 deletions(-)',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        stdout: '',
         stderr: '',
       })
       .mockResolvedValueOnce({
@@ -157,7 +174,7 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
       command_key: 'git_diff_shortstat',
       path: '/workspace/Wegent',
-      args: ['main...', '--'],
+      args: ['HEAD', '--'],
       timeout_seconds: 10,
       max_output_bytes: 4096,
     })
@@ -174,6 +191,11 @@ describe('loadProjectEnvironment', () => {
       .mockResolvedValueOnce({
         success: true,
         stdout: ' 2 files changed, 8 insertions(+), 3 deletions(-)',
+        stderr: '',
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        stdout: '',
         stderr: '',
       })
       .mockResolvedValueOnce({
@@ -211,7 +233,8 @@ describe('loadProjectEnvironment', () => {
     const cachedInfo = await loadProjectEnvironment(api, project)
 
     expect(cachedInfo.branchName).toBe('human/narwhal-20260528-073440')
-    expect(executeCommand).toHaveBeenCalledTimes(3)
+    // 4 calls: git_branch, git_diff_shortstat, git_status_porcelain, git_remote_url
+    expect(executeCommand).toHaveBeenCalledTimes(4)
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
       command_key: 'git_branch',
       path: '/workspace/Wegent',
@@ -221,7 +244,13 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
       command_key: 'git_diff_shortstat',
       path: '/workspace/Wegent',
-      args: ['main...', '--'],
+      args: ['HEAD', '--'],
+      timeout_seconds: 10,
+      max_output_bytes: 4096,
+    })
+    expect(executeCommand).toHaveBeenCalledWith('device-123', {
+      command_key: 'git_status_porcelain',
+      path: '/workspace/Wegent',
       timeout_seconds: 10,
       max_output_bytes: 4096,
     })
@@ -233,7 +262,7 @@ describe('loadProjectEnvironment', () => {
     })
   })
 
-  test('falls back to origin main when local main is unavailable', async () => {
+  test('uses git diff against HEAD for tracked uncommitted changes', async () => {
     const executeCommand = vi.fn((_: string, data: { command_key: string; args?: string[] }) => {
       if (data.command_key === 'git_branch') {
         return Promise.resolve({
@@ -243,18 +272,18 @@ describe('loadProjectEnvironment', () => {
         })
       }
 
-      if (data.command_key === 'git_diff_shortstat' && data.args?.[0] === 'main...') {
-        return Promise.resolve({
-          success: false,
-          stdout: '',
-          stderr: "fatal: ambiguous argument 'main...'",
-        })
-      }
-
-      if (data.command_key === 'git_diff_shortstat' && data.args?.[0] === 'origin/main...') {
+      if (data.command_key === 'git_diff_shortstat') {
         return Promise.resolve({
           success: true,
           stdout: ' 1 file changed, 1 insertion(+), 1 deletion(-)',
+          stderr: '',
+        })
+      }
+
+      if (data.command_key === 'git_status_porcelain') {
+        return Promise.resolve({
+          success: true,
+          stdout: '',
           stderr: '',
         })
       }
@@ -298,41 +327,34 @@ describe('loadProjectEnvironment', () => {
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
       command_key: 'git_diff_shortstat',
       path: '/workspace/Wegent',
-      args: ['main...', '--'],
-      timeout_seconds: 10,
-      max_output_bytes: 4096,
-    })
-    expect(executeCommand).toHaveBeenCalledWith('device-123', {
-      command_key: 'git_diff_shortstat',
-      path: '/workspace/Wegent',
-      args: ['origin/main...', '--'],
+      args: ['HEAD', '--'],
       timeout_seconds: 10,
       max_output_bytes: 4096,
     })
   })
 
-  test('falls back to head when no main or master base exists', async () => {
+  test('adds untracked file count to diff additions', async () => {
     const executeCommand = vi.fn((_: string, data: { command_key: string; args?: string[] }) => {
       if (data.command_key === 'git_branch') {
         return Promise.resolve({
           success: true,
-          stdout: 'human/seal-20260529-104820\n',
+          stdout: 'main\n',
           stderr: '',
         })
       }
 
-      if (data.command_key === 'git_diff_shortstat' && data.args?.[0] !== 'HEAD') {
+      if (data.command_key === 'git_diff_shortstat') {
         return Promise.resolve({
-          success: false,
-          stdout: '',
-          stderr: `fatal: ambiguous argument '${data.args?.[0]}'`,
+          success: true,
+          stdout: ' 1 file changed, 5 insertions(+), 2 deletions(-)',
+          stderr: '',
         })
       }
 
-      if (data.command_key === 'git_diff_shortstat' && data.args?.[0] === 'HEAD') {
+      if (data.command_key === 'git_status_porcelain') {
         return Promise.resolve({
           success: true,
-          stdout: ' 1 file changed, 1 insertion(+), 1 deletion(-)',
+          stdout: '?? output.txt\n?? notes.md\n',
           stderr: '',
         })
       }
@@ -356,7 +378,7 @@ describe('loadProjectEnvironment', () => {
       { executeCommand },
       {
         id: 1,
-        name: 'sina-sso',
+        name: 'Wegent',
         config: {
           mode: 'workspace',
           execution: {
@@ -365,21 +387,153 @@ describe('loadProjectEnvironment', () => {
           },
           workspace: {
             source: 'local_path',
-            localPath: '/Users/hongyu9/Downloads/sina-sso',
+            localPath: '/workspace/Wegent',
+          },
+        },
+      },
+    )
+
+    // 5 tracked insertions + 2 untracked files = +7
+    expect(info.additions).toBe('+7')
+    expect(info.deletions).toBe('-2')
+    expect(info.branchName).toBe('main')
+  })
+
+  test('counts pending files from porcelain when repo has no commits', async () => {
+    const executeCommand = vi.fn((_: string, data: { command_key: string; args?: string[] }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'master\n',
+          stderr: '',
+        })
+      }
+
+      if (data.command_key === 'git_diff_shortstat') {
+        return Promise.resolve({
+          success: false,
+          stdout: '',
+          stderr: "fatal: bad revision 'HEAD'",
+        })
+      }
+
+      if (data.command_key === 'git_status_porcelain') {
+        return Promise.resolve({
+          success: true,
+          stdout: '?? output.txt\n',
+          stderr: '',
+        })
+      }
+
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: false,
+          stdout: '',
+          stderr: 'No such remote',
+        })
+      }
+
+      return Promise.resolve({
+        success: false,
+        stdout: '',
+        stderr: 'unknown command',
+      })
+    })
+
+    const info = await loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 2,
+        name: 'empty-repo',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'local',
+            deviceId: 'device-123',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/Volumes/OuterHD/Documents/test-porject',
           },
         },
       },
     )
 
     expect(info.additions).toBe('+1')
-    expect(info.deletions).toBe('-1')
+    expect(info.deletions).toBe('-0')
+    expect(info.branchName).toBe('master')
+    expect(info.error).toBeUndefined()
     expect(executeCommand).toHaveBeenCalledWith('device-123', {
-      command_key: 'git_diff_shortstat',
-      path: '/Users/hongyu9/Downloads/sina-sso',
-      args: ['HEAD', '--'],
+      command_key: 'git_status_porcelain',
+      path: '/Volumes/OuterHD/Documents/test-porject',
       timeout_seconds: 10,
       max_output_bytes: 4096,
     })
+  })
+
+  test('shows zero diff when repo is clean and has no untracked files', async () => {
+    const executeCommand = vi.fn((_: string, data: { command_key: string; args?: string[] }) => {
+      if (data.command_key === 'git_branch') {
+        return Promise.resolve({
+          success: true,
+          stdout: 'main\n',
+          stderr: '',
+        })
+      }
+
+      if (data.command_key === 'git_diff_shortstat') {
+        return Promise.resolve({
+          success: false,
+          stdout: '',
+          stderr: "fatal: bad revision 'HEAD'",
+        })
+      }
+
+      if (data.command_key === 'git_status_porcelain') {
+        return Promise.resolve({
+          success: true,
+          stdout: '',
+          stderr: '',
+        })
+      }
+
+      if (data.command_key === 'git_remote_url') {
+        return Promise.resolve({
+          success: false,
+          stdout: '',
+          stderr: 'No such remote',
+        })
+      }
+
+      return Promise.resolve({
+        success: false,
+        stdout: '',
+        stderr: 'unknown command',
+      })
+    })
+
+    const info = await loadProjectEnvironment(
+      { executeCommand },
+      {
+        id: 3,
+        name: 'clean-repo',
+        config: {
+          mode: 'workspace',
+          execution: {
+            targetType: 'local',
+            deviceId: 'device-123',
+          },
+          workspace: {
+            source: 'local_path',
+            localPath: '/tmp/clean-repo',
+          },
+        },
+      },
+    )
+
+    expect(info.additions).toBe('+0')
+    expect(info.deletions).toBe('-0')
+    expect(info.error).toBeUndefined()
   })
 })
 

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -15,7 +15,6 @@ const EMPTY_ENVIRONMENT_INFO: EnvironmentInfo = {
   deletions: '-0',
   executionTarget: 'local',
 }
-const DEFAULT_DIFF_BASE_REFS = ['main', 'origin/main', 'master', 'origin/master']
 const INVALID_BRANCH_CHARACTERS = new Set([' ', '~', '^', ':', '?', '*', '[', '\\', ']'])
 const ENVIRONMENT_INFO_CACHE_TTL_MS = 1500
 
@@ -152,6 +151,15 @@ function validateBranchName(branchName: string): void {
 }
 
 export function parseGitShortStat(value: string): Pick<EnvironmentInfo, 'additions' | 'deletions'> {
+  // Handle "N file(s) pending" format (no-commit repos with pending files)
+  const pendingMatch = value.match(/(\d+)\s+file\(s\)\s+pending/)
+  if (pendingMatch) {
+    return {
+      additions: `+${pendingMatch[1]}`,
+      deletions: '-0',
+    }
+  }
+
   const additionsMatch = value.match(/(\d+)\s+insertions?\(\+\)/)
   const deletionsMatch = value.match(/(\d+)\s+deletions?\(-\)/)
 
@@ -242,24 +250,15 @@ async function loadBranchDiffShortStat(
   deviceId: string,
   path: string,
 ): Promise<string> {
-  for (const baseRef of DEFAULT_DIFF_BASE_REFS) {
-    try {
-      return await runGitCommand(api, deviceId, 'git_diff_shortstat', path, {
-        args: [`${baseRef}...`, '--'],
-      })
-    } catch {
-      // Try the next common base ref when this repository does not have one.
-    }
-  }
-
+  // Use diff against HEAD for tracked uncommitted line changes.
+  // This captures staged + unstaged modifications to tracked files.
   try {
     return await runGitCommand(api, deviceId, 'git_diff_shortstat', path, {
       args: ['HEAD', '--'],
     })
-  } catch (error) {
-    throw error instanceof Error
-      ? error
-      : new Error('Failed to load branch diff stat')
+  } catch {
+    // HEAD may not exist (no commits yet).
+    return ''
   }
 }
 
@@ -305,14 +304,40 @@ async function loadProjectEnvironmentUncached(
     if (!path) {
       return baseInfo
     }
-    const [branchName, shortStat] = await Promise.all([
+    const [branchName, shortStat, porcelain] = await Promise.all([
       runGitCommand(api, deviceId, 'git_branch', path),
       loadBranchDiffShortStat(api, deviceId, path),
+      runGitCommand(api, deviceId, 'git_status_porcelain', path).catch(
+        () => '',
+      ),
     ])
     const remoteUrl = await runGitCommand(api, deviceId, 'git_remote_url', path).catch(
       () => '',
     )
     const diff = parseGitShortStat(shortStat)
+
+    // Count pending files from porcelain (untracked, staged, modified).
+    // git diff --shortstat only covers tracked files, so we merge
+    // porcelain data to include untracked and no-commit scenarios.
+    const porcelainLines = porcelain
+      .split('\n')
+      .filter(line => line.trim().length > 0)
+
+    if (shortStat) {
+      // Repo has commits — diff stat covers tracked changes.
+      // Add untracked file count on top.
+      const untrackedCount = porcelainLines.filter(line =>
+        line.startsWith('??'),
+      ).length
+      if (untrackedCount > 0) {
+        const trackedAdditions =
+          parseInt(diff.additions.replace(/^\+/, ''), 10) || 0
+        diff.additions = `+${trackedAdditions + untrackedCount}`
+      }
+    } else if (porcelainLines.length > 0) {
+      // Repo has no commits — every porcelain line is a pending change.
+      diff.additions = `+${porcelainLines.length}`
+    }
 
     return {
       ...baseInfo,

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -216,6 +216,66 @@ describe('MessageList', () => {
     expect(writeText).toHaveBeenCalledWith('对 bind_shell=openclaw 直接跳过')
   })
 
+  test('collapses long user messages without changing copied content', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    })
+    const content = Array.from(
+      { length: 12 },
+      (_, index) => `第 ${index + 1} 行内容`,
+    ).join('\n')
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '1',
+            role: 'user',
+            content,
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />,
+    )
+
+    const messageContent = screen.getByTestId('user-message-content')
+    const toggleButton = screen.getByTestId('toggle-user-message-button')
+
+    expect(messageContent).toHaveClass('max-h-44', 'overflow-hidden')
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false')
+    expect(toggleButton).toHaveTextContent('展开')
+
+    await userEvent.click(toggleButton)
+
+    expect(messageContent).not.toHaveClass('max-h-44')
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
+    expect(toggleButton).toHaveTextContent('收起')
+
+    await userEvent.click(screen.getByTestId('copy-message-button'))
+    expect(writeText).toHaveBeenCalledWith(content)
+  })
+
+  test('does not show a collapse control for short user messages', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '1',
+            role: 'user',
+            content: '短消息',
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />,
+    )
+
+    expect(screen.queryByTestId('toggle-user-message-button')).not.toBeInTheDocument()
+    expect(screen.getByTestId('user-message-content')).not.toHaveClass('max-h-44')
+  })
+
   test('shows only clock time for messages created today', () => {
     vi.useFakeTimers()
     try {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,6 +1,13 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
-import { Copy, CopyCheck, FileText, Loader2 } from 'lucide-react'
+import {
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  CopyCheck,
+  FileText,
+  Loader2,
+} from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { Attachment } from '@/types/api'
@@ -15,6 +22,9 @@ import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
 interface MessageListProps {
   messages: WorkbenchMessage[]
 }
+
+const USER_MESSAGE_COLLAPSE_LINES = 10
+const USER_MESSAGE_COLLAPSE_CHARACTERS = 600
 
 export function MessageList({ messages }: MessageListProps) {
   if (messages.length === 0) {
@@ -82,10 +92,14 @@ async function copyText(text: string) {
 }
 
 function UserMessage({ message }: { message: WorkbenchMessage }) {
+  const [isExpanded, setIsExpanded] = useState(false)
   const imageAttachments = (message.attachments ?? []).filter(isImageAttachment)
   const documentAttachments = (message.attachments ?? []).filter(
     attachment => !isImageAttachment(attachment)
   )
+  const shouldCollapse =
+    message.content.length > USER_MESSAGE_COLLAPSE_CHARACTERS ||
+    message.content.split('\n').length > USER_MESSAGE_COLLAPSE_LINES
 
   return (
     <div className="group flex max-w-[80%] flex-col items-end gap-1.5">
@@ -106,8 +120,35 @@ function UserMessage({ message }: { message: WorkbenchMessage }) {
         </div>
       )}
       {message.content && (
-        <div className="overflow-hidden break-words whitespace-pre-wrap rounded-2xl bg-muted px-4 py-3 text-[13px] leading-5 text-text-primary">
-          {renderUserContent(message.content)}
+        <div className="max-w-full overflow-hidden rounded-2xl bg-muted text-[13px] leading-5 text-text-primary">
+          <div
+            data-testid="user-message-content"
+            className={[
+              'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-3',
+              shouldCollapse && !isExpanded ? 'max-h-44' : '',
+            ].join(' ')}
+          >
+            {renderUserContent(message.content)}
+            {shouldCollapse && !isExpanded && (
+              <span className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-muted to-transparent" />
+            )}
+          </div>
+          {shouldCollapse && (
+            <button
+              type="button"
+              data-testid="toggle-user-message-button"
+              aria-expanded={isExpanded}
+              onClick={() => setIsExpanded(value => !value)}
+              className="flex h-9 w-full items-center justify-center gap-1 border-t border-border/60 text-xs font-medium text-text-secondary transition-colors hover:bg-surface"
+            >
+              {isExpanded ? (
+                <ChevronUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronDown className="h-3.5 w-3.5" />
+              )}
+              {isExpanded ? '收起' : '展开'}
+            </button>
+          )}
         </div>
       )}
       <MessageHoverActions message={message} align="right" />


### PR DESCRIPTION
- 环境信息栏：改用 git diff HEAD 替代原来的 main/master 分支对比链， 仅统计未提交的变更（已 commit 的不算）。新增 git_status_porcelain 命令，通过 git status --porcelain 检测未跟踪文件，无 commit 仓库也能正常显示待处理文件数。
- 用户消息：长消息自动折叠，超过 10 行或 600 字符时展示展开/收起按钮。
- 后端：新增 git_status_porcelain 设备命令。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapse/expand toggle for long user messages in chat, with a button to control visibility and preserve full content when copying.

* **Improvements**
  * Enhanced project environment detection with improved git status handling for better accuracy in tracking uncommitted changes and untracked files.
  * Better support for repositories with no commits yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->