### PR TITLE
fix(wework): keep worktree icon visible on sidebar hover

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -94,7 +94,9 @@ interface DesktopSidebarProps {
 type ProjectCreateMode = 'scratch' | 'existing' | 'git'
 
 const SIDEBAR_ROW_METADATA_CLASS =
-  'flex items-center gap-1 text-xs text-[rgb(var(--color-sidebar-text-muted))] group-hover/task:invisible group-focus-within/task:invisible'
+  'flex items-center gap-1 text-xs text-[rgb(var(--color-sidebar-text-muted))]'
+const SIDEBAR_ROW_HOVER_HIDE_CLASS =
+  'group-hover/task:invisible group-focus-within/task:invisible'
 const SIDEBAR_ROW_ACTIONS_CLASS =
   'absolute inset-0 invisible flex items-center justify-end opacity-0 transition-opacity group-hover/task:visible group-hover/task:opacity-100 group-focus-within/task:visible group-focus-within/task:opacity-100'
 
@@ -486,7 +488,10 @@ function ProjectTaskRow({
             )}
             <span
               data-testid={`project-chat-time-value-${task.task_id}`}
-              className="flex h-7 w-7 items-center justify-center"
+              className={cn(
+                'flex h-7 w-7 items-center justify-center',
+                SIDEBAR_ROW_HOVER_HIDE_CLASS,
+              )}
             >
               {formatRelativeSidebarTime(getProjectTaskTime(task))}
             </span>
@@ -752,11 +757,15 @@ function RecentTaskRow({
               <SidebarDeviceStatusIndicator
                 deviceState={visibleDeviceState}
                 testId={`history-task-device-status-${task.id}`}
+                className={SIDEBAR_ROW_HOVER_HIDE_CLASS}
               />
             )}
             <span
               data-testid={`history-task-time-value-${task.id}`}
-              className="flex h-7 w-7 items-center justify-center"
+              className={cn(
+                'flex h-7 w-7 items-center justify-center',
+                SIDEBAR_ROW_HOVER_HIDE_CLASS,
+              )}
             >
               {formatRelativeSidebarTime(task.updated_at || task.created_at)}
             </span>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1436,13 +1436,15 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(await screen.findByText('Implement archive')).toBeInTheDocument()
     expect(screen.getByText('2h')).toBeInTheDocument()
-    expect(screen.getByTestId('project-chat-time-11')).toHaveClass(
+    expect(screen.getByTestId('project-chat-time-11')).not.toHaveClass(
       'group-hover/task:invisible',
       'group-focus-within/task:invisible',
     )
     expect(screen.getByTestId('project-chat-time-value-11')).toHaveClass(
       'w-7',
       'justify-center',
+      'group-hover/task:invisible',
+      'group-focus-within/task:invisible',
     )
     expect(screen.getByTestId('project-chat-actions-11')).toHaveClass(
       'absolute',
@@ -1531,13 +1533,15 @@ describe('DesktopWorkbenchLayout', () => {
     expect(rows[1]).toHaveTextContent('Older session')
     expect(screen.queryByText('Project session')).not.toBeInTheDocument()
     expect(screen.getByText('1h')).toBeInTheDocument()
-    expect(screen.getByTestId('history-task-time-5')).toHaveClass(
+    expect(screen.getByTestId('history-task-time-5')).not.toHaveClass(
       'group-hover/task:invisible',
       'group-focus-within/task:invisible',
     )
     expect(screen.getByTestId('history-task-time-value-5')).toHaveClass(
       'w-7',
       'justify-center',
+      'group-hover/task:invisible',
+      'group-focus-within/task:invisible',
     )
     expect(screen.getByTestId('history-task-actions-5')).toHaveClass(
       'absolute',
@@ -1674,6 +1678,10 @@ describe('DesktopWorkbenchLayout', () => {
       'aria-label',
       'Git worktree',
     )
+    expect(screen.getByTestId('project-chat-git-worktree-icon-71')).not.toHaveClass(
+      'group-hover/task:invisible',
+      'group-focus-within/task:invisible',
+    )
 
     await userEvent.click(screen.getByTestId('project-chat-button'))
     expect(baseProps.onOpenTask).toHaveBeenCalledWith(71, 7)
@@ -1684,6 +1692,14 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('history-task-git-worktree-icon-81')).toHaveAttribute(
       'aria-label',
       'Git worktree',
+    )
+    expect(screen.getByTestId('history-task-git-worktree-icon-81')).not.toHaveClass(
+      'group-hover/task:invisible',
+      'group-focus-within/task:invisible',
+    )
+    expect(historyDeviceStatus).toHaveClass(
+      'group-hover/task:invisible',
+      'group-focus-within/task:invisible',
     )
 
     await userEvent.click(screen.getByTestId('history-task-button'))


### PR DESCRIPTION
## Summary
- Keep Git worktree sidebar icons visible when hovering task rows.
- Move hover-hidden behavior from the metadata container to time/device metadata only.
- Add regression assertions for project and recent task worktree icons.

## Tests
- `cd wework && npm test -- src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `cd wework && npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sidebar metadata visibility behavior on hover and focus interactions, ensuring timestamps and status icons remain properly visible when interacting with sidebar rows.

* **Tests**
  * Updated test assertions to verify sidebar metadata elements maintain correct visibility states during user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->