### PR TITLE
fix(wework): keep project tasks under their project when opened via /tasks/{id}

### DIFF
--- a/backend/app/services/adapters/task_kinds/converters.py
+++ b/backend/app/services/adapters/task_kinds/converters.py
@@ -211,6 +211,7 @@ def convert_to_task_dict(task: Kind, db: Session, user_id: int) -> Dict[str, Any
         "created_at": created_at or task.created_at,
         "updated_at": updated_at or task.updated_at,
         "completed_at": completed_at,
+        "project_id": task.project_id or 0,
         **model_selection,
         "is_group_chat": is_group_chat,
         "app": app_data,
@@ -277,6 +278,7 @@ def convert_to_task_dict_optimized(
         "created_at": related_data.get("created_at", task.created_at),
         "updated_at": related_data.get("updated_at", task.updated_at),
         "completed_at": related_data.get("completed_at"),
+        "project_id": task.project_id or 0,
         **model_selection,
         "is_group_chat": related_data.get("is_group_chat", False),
         "app": (

--- a/backend/tests/services/adapters/test_task_detail_converter_project_id.py
+++ b/backend/tests/services/adapters/test_task_detail_converter_project_id.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression tests for task detail converters exposing ``project_id``.
+
+Both ``convert_to_task_dict`` and ``convert_to_task_dict_optimized`` must
+include ``project_id`` in the returned payload so the frontend can correctly
+classify opened tasks into projects vs. standalone conversations.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.models.task import TaskResource
+from app.schemas.kind import Task as TaskCrd
+from app.services.adapters.task_kinds.converters import (
+    convert_to_task_dict,
+    convert_to_task_dict_optimized,
+)
+
+
+def _task_crd() -> dict:
+    return {
+        "apiVersion": "agent.wecode.io/v1",
+        "kind": "Task",
+        "metadata": {
+            "name": "demo",
+            "namespace": "default",
+            "labels": {"taskType": "chat", "type": "online"},
+        },
+        "spec": {
+            "title": "Demo",
+            "prompt": "hello",
+            "teamRef": {"name": "team-a", "namespace": "default"},
+            "workspaceRef": {"name": "workspace-a", "namespace": "default"},
+            "knowledgeBaseRefs": [],
+        },
+        "status": {"status": "RUNNING", "progress": 0},
+    }
+
+
+def _build_kind_task(project_id):
+    task = Mock(spec=TaskResource)
+    task.id = 42
+    task.user_id = 1
+    task.project_id = project_id
+    task.client_origin = "wework"
+    task.json = _task_crd()
+    return task
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_includes_project_id_for_project_task():
+    db = Mock(spec=Session)
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    task = _build_kind_task(project_id=1821)
+
+    with (
+        patch(
+            "app.services.readers.kinds.kindReader.get_by_name_and_namespace",
+            return_value=None,
+        ),
+        patch(
+            "app.services.readers.users.userReader.get_by_id",
+            return_value=SimpleNamespace(user_name="alice"),
+        ),
+    ):
+        result = convert_to_task_dict(task, db, user_id=1)
+
+    assert result["project_id"] == 1821
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_includes_project_id_zero_for_standalone_task():
+    db = Mock(spec=Session)
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    task = _build_kind_task(project_id=0)
+
+    with (
+        patch(
+            "app.services.readers.kinds.kindReader.get_by_name_and_namespace",
+            return_value=None,
+        ),
+        patch(
+            "app.services.readers.users.userReader.get_by_id",
+            return_value=SimpleNamespace(user_name="alice"),
+        ),
+    ):
+        result = convert_to_task_dict(task, db, user_id=1)
+
+    assert result["project_id"] == 0
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_normalizes_none_project_id_to_zero():
+    db = Mock(spec=Session)
+    db.query.return_value.filter.return_value.first.return_value = None
+
+    task = _build_kind_task(project_id=None)
+
+    with (
+        patch(
+            "app.services.readers.kinds.kindReader.get_by_name_and_namespace",
+            return_value=None,
+        ),
+        patch(
+            "app.services.readers.users.userReader.get_by_id",
+            return_value=SimpleNamespace(user_name="alice"),
+        ),
+    ):
+        result = convert_to_task_dict(task, db, user_id=1)
+
+    assert result["project_id"] == 0
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_optimized_includes_project_id_for_project_task():
+    task = _build_kind_task(project_id=1821)
+    task_crd = TaskCrd.model_validate(task.json)
+    related_data = {
+        "workspace_data": {},
+        "created_at": None,
+        "updated_at": None,
+        "completed_at": None,
+        "is_group_chat": False,
+    }
+
+    result = convert_to_task_dict_optimized(task, related_data, task_crd)
+
+    assert result["project_id"] == 1821
+
+
+@pytest.mark.unit
+def test_convert_to_task_dict_optimized_includes_project_id_zero_for_standalone_task():
+    task = _build_kind_task(project_id=0)
+    task_crd = TaskCrd.model_validate(task.json)
+    related_data = {
+        "workspace_data": {},
+        "created_at": None,
+        "updated_at": None,
+        "completed_at": None,
+        "is_group_chat": False,
+    }
+
+    result = convert_to_task_dict_optimized(task, related_data, task_crd)
+
+    assert result["project_id"] == 0

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -515,7 +515,7 @@ function resolveOpenedTaskProjectId(
 ): number | undefined {
   if (explicitProjectId !== undefined) return explicitProjectId
   if (task.project_id !== undefined) return task.project_id
-  if (listTask && !listTask.project_id) return 0
+  if (listTask?.project_id !== undefined) return listTask.project_id
   return undefined
 }
 


### PR DESCRIPTION
## Summary

When a wework user opens a task via the URL `/wework/tasks/{taskId}` (without
the `/projects/{projectId}/` prefix), the task was being misclassified as a
standalone conversation and ended up under the **对话 (Conversations)**
section of the sidebar — even when the task actually belonged to a project.

The URL was also never auto-corrected to
`/projects/{projectId}/tasks/{taskId}`.

## Root Cause

Two collaborating bugs:

1. **Backend** — `convert_to_task_dict` and `convert_to_task_dict_optimized`
   in `backend/app/services/adapters/task_kinds/converters.py` did not
   include `project_id` in the response, even though the
   `TaskDetail` Pydantic schema already declares
   `project_id: int = 0` and the lite list endpoints do return it.

2. **Frontend** — `resolveOpenedTaskProjectId` in
   `wework/src/features/workbench/WorkbenchProvider.tsx` only consulted
   `listTask.project_id` for the falsy case (`!listTask.project_id`),
   falling through to `undefined` for project tasks — so even with the
   listTask's `project_id` available, the resolver returned `undefined`
   for `project_id > 0` and the task was treated as standalone.

Together these caused `upsertOpenedTask` to place the task in
`state.recentTasks` (the standalone list) and remove it from
`state.projects[...].tasks` if it was already there.

## Changes

- **`backend/app/services/adapters/task_kinds/converters.py`**: add
  `"project_id": task.project_id or 0` to both converters so the task
  detail response matches the list endpoints.
- **`wework/src/features/workbench/WorkbenchProvider.tsx`**: change
  `if (listTask && !listTask.project_id) return 0` to
  `if (listTask?.project_id !== undefined) return listTask.project_id`,
  so a known `project_id` (including 0 for standalone) is forwarded
  correctly.
- **`backend/tests/services/adapters/test_task_detail_converter_project_id.py`**:
  new regression tests covering project / standalone / `None` cases for
  both converters.

## Test Plan

- [x] Backend unit tests for the converter project_id field
  (`test_task_detail_converter_project_id.py`, 5 cases)
- [x] Backend related suites:
  `test_task_access_control`, `test_task_lite_batch_loading`,
  `test_task_manager`, `test_task_skills_batch_resolution`,
  `test_task_kinds_delete_runtime` — all pass
- [x] wework `WorkbenchProvider.test.tsx` (24 tests) — all pass
- [x] Manual verification with a task that belongs to a project:
  opening `/wework/tasks/{id}` now resolves the project, places the task
  under the project, and corrects the URL to
  `/projects/{projectId}/tasks/{taskId}`

## Risk & Rollback

- Backend change only **adds** a field to the response; existing clients
  ignore the extra field.
- Frontend change is a one-line logic fix with a wider correctness net
  (the previous check was already wrong for project tasks).
- Revert by reverting this single commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tasks now correctly include project association data in all contexts. Previously, project identification information could be missing; this has been corrected to ensure accurate project tracking throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->