### PR TITLE
fix(backend): validate internal chat sessions pagination

### DIFF
--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -1180,8 +1180,10 @@ async def clear_history(
 
 @router.get("/sessions", response_model=SessionListResponse)
 async def list_sessions(
-    limit: int = Query(100, description="Max number of sessions to return"),
-    offset: int = Query(0, description="Offset for pagination"),
+    limit: int = Query(
+        100, ge=1, le=1000, description="Max number of sessions to return"
+    ),
+    offset: int = Query(0, ge=0, description="Offset for pagination"),
     db: Session = Depends(get_db),
 ):
     """

--- a/backend/tests/api/endpoints/internal/test_chat_storage_sessions.py
+++ b/backend/tests/api/endpoints/internal/test_chat_storage_sessions.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi.testclient import TestClient
+
+
+def test_internal_chat_sessions_invalid_offset_negative(test_client: TestClient):
+    response = test_client.get("/api/internal/chat/sessions?offset=-1&limit=100")
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["error_code"] == 422
+    assert payload["detail"] == "Request parameter validation failed"
+    errors = payload["errors"]
+    assert any(
+        e["loc"] == ["query", "offset"]
+        and e["type"] == "greater_than_equal"
+        and e["msg"] == "Input should be greater than or equal to 0"
+        for e in errors
+    )
+
+
+def test_internal_chat_sessions_invalid_limit_too_large(test_client: TestClient):
+    response = test_client.get("/api/internal/chat/sessions?offset=0&limit=1001")
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["error_code"] == 422
+    assert payload["detail"] == "Request parameter validation failed"
+    errors = payload["errors"]
+    assert any(
+        e["loc"] == ["query", "limit"]
+        and e["type"] == "less_than_equal"
+        and e["msg"] == "Input should be less than or equal to 1000"
+        for e in errors
+    )
+
+
+def test_internal_chat_sessions_invalid_limit_zero(test_client: TestClient):
+    response = test_client.get("/api/internal/chat/sessions?offset=0&limit=0")
+    assert response.status_code == 422
+    payload = response.json()
+    assert payload["error_code"] == 422
+    errors = payload["errors"]
+    assert any(
+        e["loc"] == ["query", "limit"]
+        and e["type"] == "greater_than_equal"
+        and e["msg"] == "Input should be greater than or equal to 1"
+        for e in errors
+    )
+
+
+def test_internal_chat_sessions_valid_boundary_values(test_client: TestClient):
+    response = test_client.get("/api/internal/chat/sessions?offset=0&limit=1000")
+    assert response.status_code == 200
+    payload = response.json()
+    assert "sessions" in payload
+    assert isinstance(payload["sessions"], list)


### PR DESCRIPTION
## Summary

Fixes a fuzz-discovered validation bug in:

`GET /api/internal/chat/sessions`

Before this change, invalid pagination values could reach the business/database layer and produce a 500 response.

Example:

```bash
curl -i -X GET \
  'http://localhost:8000/api/internal/chat/sessions?offset=-14196370325633274&limit=7256'

Previously returned:

HTTP/1.1 500 Internal Server Error
{"error_code":500,"detail":"Internal server error"}
```

After this change, FastAPI validates the query parameters and returns 422.

### Root Cause

The endpoint accepted `limit` and `offset` as plain integers without explicit bounds:

- `offset` allowed negative values
- `limit` allowed excessive values

These invalid values were schema-acceptable enough to reach runtime logic and trigger an internal error.

### Fix

Updated `backend/app/api/endpoints/internal/chat_storage.py`:

```python
limit: int = Query(100, ge=1, le=1000, ...)
offset: int = Query(0, ge=0, ...)
```

### Tests

Added regression tests in `backend/tests/api/endpoints/internal/test_chat_storage_sessions.py`:

- `test_internal_chat_sessions_invalid_offset_negative` — `offset=-1` returns 422
- `test_internal_chat_sessions_invalid_limit_too_large` — `limit=1001` returns 422
- `test_internal_chat_sessions_invalid_limit_zero` — `limit=0` returns 422
- `test_internal_chat_sessions_valid_boundary_values` — `offset=0, limit=1000` returns 200

All 4 tests pass.

### Verification

Manual verification:

```bash
curl -i -X GET \
  'http://localhost:8000/api/internal/chat/sessions?offset=-14196370325633274&limit=7256'
```

Now returns 422 validation errors instead of 500.

### Scope

This PR only changes pagination validation for the internal chat sessions endpoint.
It does not modify chat storage business logic, database queries, or response format for valid requests.