### PR TITLE
fix(executor-manager,chat-shell): strict int validation on cancel request ID fields

### DIFF
--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -110,7 +110,7 @@ class OpenAIResponsesRequest(BaseModel):
 class CancelRequest(BaseModel):
     """Cancel request schema."""
 
-    subtask_id: int = Field(..., description="Subtask ID to cancel")
+    subtask_id: int = Field(..., strict=True, description="Subtask ID to cancel")
 
 
 class CancelResponse(BaseModel):

--- a/chat_shell/tests/api/v1/test_cancel_request_validation.py
+++ b/chat_shell/tests/api/v1/test_cancel_request_validation.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Schemathesis fuzz discovered issues.
+
+Issue: cancel request ID fields using regular int caused Pydantic to loosely
+convert JSON boolean to int, allowing invalid requests into business logic
+instead of returning 422.
+
+Reproduction (chat_shell 8100):
+```bash
+curl -i -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"subtask_id": false}' \
+  http://localhost:8100/v1/responses/cancel
+```
+Current behavior: returns 404
+Expected behavior: returns 422
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    from chat_shell.main import app
+
+    return TestClient(app)
+
+
+class TestCancelRequestStrictIntValidation:
+    """Regression tests for /v1/responses/cancel strict int validation.
+
+    Schemathesis fuzz discovered that boolean values were being coerced to
+    integers (false→0, true→1), bypassing proper validation.
+    """
+
+    def test_subtask_id_boolean_false_returns_422_regression(self, client):
+        """REGRESSION: subtask_id=false should return 422, not 404.
+
+        Directly reproduces the Schemathesis fuzz finding where
+        JSON boolean 'false' was coerced to integer 0, causing
+        the request to reach business logic instead of being
+        rejected at schema validation.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": False},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_boolean_true_returns_422(self, client):
+        """REGRESSION: subtask_id=true should return 422.
+
+        Ensures that boolean 'true' is also rejected (would be coerced to 1).
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": True},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_string_returns_422(self, client):
+        """REGRESSION: subtask_id="1" should return 422.
+
+        Ensures string representations of numbers are also rejected.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": "1"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_float_returns_422(self, client):
+        """REGRESSION: subtask_id=1.0 should return 422.
+
+        Ensures float values are rejected even if they represent integers.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": 1.0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_integer_zero_passes_validation(self, client):
+        """Verify that subtask_id=0 passes schema validation.
+
+        Integer 0 should NOT be rejected with 422 by strict int validation.
+        It may return 404 or other status codes from business logic, but
+        the schema layer must accept it.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": 0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_subtask_id_positive_integer_passes_validation(self, client):
+        """Verify that subtask_id=1 passes schema validation.
+
+        Positive integers should NOT be rejected with 422.
+        They may return 404 or other status codes from business logic.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": 1},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_subtask_id_large_integer_passes_validation(self, client):
+        """Verify that subtask_id=999999 passes schema validation.
+
+        Large integers should also pass schema validation.
+        """
+        response = client.post(
+            "/v1/responses/cancel",
+            json={"subtask_id": 999999},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422

--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -23,7 +23,7 @@ from urllib.parse import urlparse
 import httpx
 from fastapi import APIRouter, Body, FastAPI, HTTPException, Request, Response
 from fastapi.responses import PlainTextResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from executor_manager.common.config import ROUTE_PREFIX
 from executor_manager.config.config import EXECUTOR_DISPATCHER_MODE
@@ -688,7 +688,7 @@ async def get_executor_workspace_file(
 
 
 class CancelTaskRequest(BaseModel):
-    task_id: int
+    task_id: int = Field(..., strict=True)
 
 
 class ValidateImageRequest(BaseModel):
@@ -1110,8 +1110,8 @@ class OpenAIResponsesRequest(BaseModel):
 class CancelRequest(BaseModel):
     """Request model for /v1/cancel endpoint."""
 
-    task_id: int
-    subtask_id: Optional[int] = None
+    task_id: int = Field(..., strict=True)
+    subtask_id: Optional[int] = Field(None, strict=True)
     executor_name: Optional[str] = None
 
 

--- a/executor_manager/tests/routers/test_cancel_request_validation.py
+++ b/executor_manager/tests/routers/test_cancel_request_validation.py
@@ -1,0 +1,334 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for Schemathesis fuzz discovered issues.
+
+Issue: cancel request ID fields using regular int caused Pydantic to loosely
+convert JSON boolean to int, allowing invalid requests into business logic
+instead of returning 422.
+
+Reproduction (executor_manager 8001):
+```bash
+# /executor-manager/tasks/cancel
+curl -i -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"task_id": false}' \
+  http://localhost:8001/executor-manager/tasks/cancel
+
+# /executor-manager/v1/cancel
+curl -i -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"task_id": 0, "subtask_id": false}' \
+  http://localhost:8001/executor-manager/v1/cancel
+```
+Current behavior: boolean values enter business logic (false→0)
+Expected behavior: returns 422
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    from executor_manager.main import app
+
+    return TestClient(app)
+
+
+class TestCancelTaskRequestStrictIntValidation:
+    """Regression tests for /executor-manager/tasks/cancel strict int validation.
+
+    Schemathesis fuzz discovered that boolean task_id was being coerced to
+    integers (false→0, true→1), bypassing proper validation.
+    """
+
+    def test_task_id_boolean_false_returns_422_regression(self, client):
+        """REGRESSION: task_id=false should return 422.
+
+        Directly reproduces the Schemathesis fuzz finding where
+        JSON boolean 'false' was coerced to integer 0, causing
+        the request to reach business logic instead of being
+        rejected at schema validation.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": False},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_boolean_true_returns_422(self, client):
+        """REGRESSION: task_id=true should return 422.
+
+        Ensures that boolean 'true' is also rejected (would be coerced to 1).
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": True},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_string_returns_422(self, client):
+        """REGRESSION: task_id="1" should return 422.
+
+        Ensures string representations of numbers are also rejected.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": "1"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_float_returns_422(self, client):
+        """REGRESSION: task_id=1.0 should return 422.
+
+        Ensures float values are rejected even if they represent integers.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": 1.0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_integer_zero_passes_validation(self, client):
+        """Verify that task_id=0 passes schema validation.
+
+        Integer 0 should NOT be rejected with 422 by strict int validation.
+        It may return other status codes from business logic, but
+        the schema layer must accept it.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": 0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Critical: must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_task_id_positive_integer_passes_validation(self, client):
+        """Verify that task_id=1 passes schema validation.
+
+        Positive integers should NOT be rejected with 422.
+        They may return other status codes from business logic.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": 1},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Critical: must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_task_id_large_integer_passes_validation(self, client):
+        """Verify that task_id=999999 passes schema validation.
+
+        Large integers should also pass schema validation.
+        """
+        response = client.post(
+            "/executor-manager/tasks/cancel",
+            json={"task_id": 999999},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Critical: must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+
+class TestCancelRequestV1StrictIntValidation:
+    """Regression tests for /executor-manager/v1/cancel strict int validation.
+
+    Schemathesis fuzz discovered that boolean task_id/subtask_id were being
+    coerced to integers (false→0, true→1), bypassing proper validation.
+    """
+
+    def test_task_id_boolean_false_returns_422_regression(self, client):
+        """REGRESSION: task_id=false should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": False},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_boolean_true_returns_422(self, client):
+        """REGRESSION: task_id=true should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": True},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_boolean_false_returns_422_regression(self, client):
+        """REGRESSION: subtask_id=false should return 422.
+
+        Directly reproduces the Schemathesis fuzz finding where
+        JSON boolean 'false' in subtask_id was coerced to integer 0,
+        causing the request to reach business logic instead of being
+        rejected at schema validation.
+        """
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": False},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_boolean_true_returns_422(self, client):
+        """REGRESSION: subtask_id=true should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": True},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_string_returns_422(self, client):
+        """REGRESSION: task_id="1" should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": "1"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_string_returns_422(self, client):
+        """REGRESSION: subtask_id="1" should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": "1"},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_task_id_float_returns_422(self, client):
+        """REGRESSION: task_id=1.0 should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 1.0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_float_returns_422(self, client):
+        """REGRESSION: subtask_id=1.0 should return 422."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": 1.0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        assert response.status_code == 422
+        error_detail = response.json()
+        assert "detail" in error_detail
+
+    def test_subtask_id_null_passes_validation(self, client):
+        """Verify that subtask_id=null passes schema validation.
+
+        Confirms subtask_id retains Optional semantics — null should be
+        accepted without 422, only non-integer types should be rejected.
+        """
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": None},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_task_id_integer_zero_passes_validation(self, client):
+        """Verify that task_id=0 passes schema validation."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_task_id_positive_integer_passes_validation(self, client):
+        """Verify that task_id=1 passes schema validation."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 1},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_subtask_id_positive_integer_passes_validation(self, client):
+        """Verify that subtask_id=1 passes schema validation."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": 1},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_task_id_large_integer_passes_validation(self, client):
+        """Verify that task_id=999999 passes schema validation."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 999999},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422
+
+    def test_subtask_id_large_integer_passes_validation(self, client):
+        """Verify that subtask_id=999999 passes schema validation."""
+        response = client.post(
+            "/executor-manager/v1/cancel",
+            json={"task_id": 0, "subtask_id": 999999},
+            headers={"Content-Type": "application/json"},
+        )
+
+        # Must NOT be 422 (schema validation error)
+        assert response.status_code != 422

--- a/executor_manager/tests/routers/test_cancel_request_validation.py
+++ b/executor_manager/tests/routers/test_cancel_request_validation.py
@@ -26,16 +26,27 @@ Current behavior: boolean values enter business logic (false→0)
 Expected behavior: returns 422
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
+
+_app = None
 
 
 @pytest.fixture
 def client():
     """Create test client."""
-    from executor_manager.main import app
+    global _app
+    if _app is None:
+        with patch(
+            "executor_manager.executors.docker.executor.subprocess.run",
+            return_value=MagicMock(stdout="Docker version 27.0.0", returncode=0),
+        ):
+            from executor_manager.routers.routers import app
 
-    return TestClient(app)
+            _app = app
+    return TestClient(_app)
 
 
 class TestCancelTaskRequestStrictIntValidation:


### PR DESCRIPTION
## Summary

Schemathesis fuzz discovered that cancel request ID fields using regular `int` caused Pydantic to loosely convert JSON boolean values to int (`false`→`0`, `true`→`1`), allowing invalid requests to pass schema validation and enter business logic instead of returning 422.

Added `strict=True` to `Field()` on all cancel request integer ID fields to reject boolean, float, and string inputs at the schema layer.

## Schema Fix

### Affected Endpoints

| Service | Endpoint | Field | Fix |
|---------|----------|-------|-----|
| chat_shell (8100) | `POST /v1/responses/cancel` | `subtask_id` | `Field(..., strict=True)` |
| executor_manager (8001) | `POST /tasks/cancel` | `task_id` | `Field(..., strict=True)` |
| executor_manager (8001) | `POST /v1/cancel` | `task_id` | `Field(..., strict=True)` |
| executor_manager (8001) | `POST /v1/cancel` | `subtask_id` | `Field(None, strict=True)` |

### Files Changed

- `chat_shell/chat_shell/api/v1/response.py` — `CancelRequest.subtask_id`
- `executor_manager/routers/routers.py` — `CancelTaskRequest.task_id`, `CancelRequest.task_id`, `CancelRequest.subtask_id`

## Regression Tests

Added 27 regression tests to ensure boolean values are rejected for integer ID fields in cancel requests.

**chat_shell** — `tests/api/v1/test_cancel_request_validation.py` (7 tests)
- `subtask_id=false` → 422
- `subtask_id=true` → 422
- `subtask_id="1"` → 422
- `subtask_id=1.0` → 422
- `subtask_id=0` → passes schema validation (not 422)
- `subtask_id=1` → passes schema validation (not 422)
- `subtask_id=999999` → passes schema validation (not 422)

**executor_manager** — `tests/routers/test_cancel_request_validation.py` (20 tests)
- `/tasks/cancel`: `task_id` boolean/string/float → 422, valid ints pass
- `/v1/cancel`: `task_id` and `subtask_id` boolean/string/float → 422, valid ints pass

### Test Commands and Results

```bash
cd chat_shell && uv run pytest tests/api/v1/test_cancel_request_validation.py -v
# 7 passed

cd executor_manager && uv run pytest tests/routers/test_cancel_request_validation.py -v
# 20 passed
```

## Manual curl Results

### Before Fix (Bug)

```bash
# chat_shell 8100 — subtask_id=false returned 404, should be 422
curl -i -X POST -H "Content-Type: application/json" \
  -d '{"subtask_id": false}' \
  http://localhost:8100/v1/responses/cancel
# → HTTP 404 (false coerced to 0, entered business logic)

# executor_manager 8001 — task_id=false entered business logic
curl -i -X POST -H "Content-Type: application/json" \
  -d '{"task_id": false}' \
  http://localhost:8001/executor-manager/tasks/cancel
# → false treated as 0, entered business logic

# executor_manager 8001 — subtask_id=false entered business logic
curl -i -X POST -H "Content-Type: application/json" \
  -d '{"task_id": 0, "subtask_id": false}' \
  http://localhost:8001/executor-manager/v1/cancel
# → false treated as 0, entered business logic
```

### After Fix

```bash
# All three return 422 as expected
curl -i -X POST -H "Content-Type: application/json" \
  -d '{"subtask_id": false}' \
  http://localhost:8100/v1/responses/cancel
# → HTTP 422 Unprocessable Entity

curl -i -X POST -H "Content-Type: application/json" \
  -d '{"task_id": false}' \
  http://localhost:8001/executor-manager/tasks/cancel
# → HTTP 422 Unprocessable Entity

curl -i -X POST -H "Content-Type: application/json" \
  -d '{"task_id": 0, "subtask_id": false}' \
  http://localhost:8001/executor-manager/v1/cancel
# → HTTP 422 Unprocessable Entity

# Valid integers are NOT blocked
curl -i -X POST -H "Content-Type: application/json" \
  -d '{"task_id": 1}' \
  http://localhost:8001/executor-manager/tasks/cancel
# → NOT 422 (passes schema validation)
```

## PR Scope

Only cancel request strict int validation. Does **not** touch:
- `/executor-manager/executors/prepare`
- `/executor-manager/executor/archive` / `restore`
- RAG auth
- OpenAPI 401/403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced strict integer validation for task and subtask ID parameters across cancel endpoints (including v1 responses); non-integer booleans, strings, and floats are now rejected with HTTP 422 while integer inputs remain accepted.

* **Tests**
  * Added regression tests asserting strict validation and correct 422 rejection/acceptance behavior for cancel endpoints, covering booleans, strings, floats, null, and various integer values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->