### PR TITLE
Enforce internal service token configuration across services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,12 @@ EXECUTOR_IMAGE=ghcr.io/wecode-ai/wegent-executor:latest
 # These URLs configure how services communicate with each other in local dev mode
 # For docker-compose, these are overridden with container names (e.g., http://backend:8000)
 
+# Required shared secret for Backend internal API authentication.
+# start.sh generates this automatically for local development if it is empty.
+# docker-compose requires you to set it explicitly before startup.
+# Generate with: openssl rand -hex 32
+INTERNAL_SERVICE_TOKEN=
+
 # TASK_API_DOMAIN: URL for executor_manager to call backend
 # In local dev, this should use your machine's IP (not localhost) so docker containers can access it
 # Example: http://192.168.1.100:8000

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,9 +15,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  E2E_INTERNAL_SERVICE_TOKEN: e2e-internal-service-token
-
 jobs:
   # Runs browser and API tests with sharding. Executor-heavy coverage runs separately.
   e2e-tests:
@@ -55,6 +52,17 @@ jobs:
           --health-retries=3
 
     steps:
+      - name: Generate internal service token
+        run: |
+          token=$(openssl rand -hex 32)
+          echo "::add-mask::$token"
+          {
+            echo "E2E_INTERNAL_SERVICE_TOKEN=$token"
+            echo "INTERNAL_SERVICE_TOKEN=$token"
+            echo "CHAT_SHELL_REMOTE_STORAGE_TOKEN=$token"
+            echo "CHAT_SHELL_INTERNAL_SERVICE_TOKEN=$token"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -166,7 +174,6 @@ jobs:
           ENVIRONMENT: development
           DB_AUTO_MIGRATE: "false"
           INIT_DATA_ENABLED: "true"
-          INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
         run: |
           source .venv/bin/activate
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
@@ -178,8 +185,6 @@ jobs:
           CHAT_SHELL_MODE: http
           CHAT_SHELL_STORAGE_TYPE: remote
           CHAT_SHELL_REMOTE_STORAGE_URL: http://localhost:8000/api/internal
-          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
-          CHAT_SHELL_INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
           EXECUTOR_MANAGER_URL: http://localhost:8001
         run: |
           source .venv/bin/activate
@@ -327,6 +332,17 @@ jobs:
           --health-retries=3
 
     steps:
+      - name: Generate internal service token
+        run: |
+          token=$(openssl rand -hex 32)
+          echo "::add-mask::$token"
+          {
+            echo "E2E_INTERNAL_SERVICE_TOKEN=$token"
+            echo "INTERNAL_SERVICE_TOKEN=$token"
+            echo "CHAT_SHELL_REMOTE_STORAGE_TOKEN=$token"
+            echo "CHAT_SHELL_INTERNAL_SERVICE_TOKEN=$token"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -482,7 +498,6 @@ jobs:
           ENVIRONMENT: development
           DB_AUTO_MIGRATE: "false"
           INIT_DATA_ENABLED: "true"
-          INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
         run: |
           source .venv/bin/activate
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
@@ -494,8 +509,6 @@ jobs:
           CHAT_SHELL_MODE: http
           CHAT_SHELL_STORAGE_TYPE: remote
           CHAT_SHELL_REMOTE_STORAGE_URL: http://localhost:8000/api/internal
-          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
-          CHAT_SHELL_INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
           EXECUTOR_MANAGER_URL: http://localhost:8001
         run: |
           source .venv/bin/activate

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  E2E_INTERNAL_SERVICE_TOKEN: e2e-internal-service-token
+
 jobs:
   # Runs browser and API tests with sharding. Executor-heavy coverage runs separately.
   e2e-tests:
@@ -163,6 +166,7 @@ jobs:
           ENVIRONMENT: development
           DB_AUTO_MIGRATE: "false"
           INIT_DATA_ENABLED: "true"
+          INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
         run: |
           source .venv/bin/activate
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
@@ -174,7 +178,8 @@ jobs:
           CHAT_SHELL_MODE: http
           CHAT_SHELL_STORAGE_TYPE: remote
           CHAT_SHELL_REMOTE_STORAGE_URL: http://localhost:8000/api/internal
-          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ""
+          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
+          CHAT_SHELL_INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
           EXECUTOR_MANAGER_URL: http://localhost:8001
         run: |
           source .venv/bin/activate
@@ -477,6 +482,7 @@ jobs:
           ENVIRONMENT: development
           DB_AUTO_MIGRATE: "false"
           INIT_DATA_ENABLED: "true"
+          INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
         run: |
           source .venv/bin/activate
           nohup uvicorn app.main:app --host 0.0.0.0 --port 8000 > backend.log 2>&1 &
@@ -488,7 +494,8 @@ jobs:
           CHAT_SHELL_MODE: http
           CHAT_SHELL_STORAGE_TYPE: remote
           CHAT_SHELL_REMOTE_STORAGE_URL: http://localhost:8000/api/internal
-          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ""
+          CHAT_SHELL_REMOTE_STORAGE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
+          CHAT_SHELL_INTERNAL_SERVICE_TOKEN: ${{ env.E2E_INTERNAL_SERVICE_TOKEN }}
           EXECUTOR_MANAGER_URL: http://localhost:8001
         run: |
           source .venv/bin/activate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -397,6 +397,7 @@ jobs:
           ACCESS_TOKEN_EXPIRE_MINUTES: 1440
           REDIS_URL: redis://localhost:6379/0
           INIT_DATA_ENABLED: "False"
+          INTERNAL_SERVICE_TOKEN: test-internal-service-token
           PYTHONPATH: ${{ github.workspace }}
         run: |
           uvicorn app.main:app --host 0.0.0.0 --port 8000 &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -367,6 +367,12 @@ jobs:
           --health-retries=5
 
     steps:
+      - name: Generate internal service token
+        run: |
+          token=$(openssl rand -hex 32)
+          echo "::add-mask::$token"
+          echo "INTERNAL_SERVICE_TOKEN=$token" >> "$GITHUB_ENV"
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -397,7 +403,6 @@ jobs:
           ACCESS_TOKEN_EXPIRE_MINUTES: 1440
           REDIS_URL: redis://localhost:6379/0
           INIT_DATA_ENABLED: "False"
-          INTERNAL_SERVICE_TOKEN: test-internal-service-token
           PYTHONPATH: ${{ github.workspace }}
         run: |
           uvicorn app.main:app --host 0.0.0.0 --port 8000 &

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -245,8 +245,9 @@ EXECUTOR_LATEST_VERSION=1.0.0
 # Internal Service Token for service-to-service authentication
 # Used by: Backend -> knowledge_runtime, Backend -> chat_shell,
 #          chat_shell/knowledge_runtime -> Backend internal API
+# Required. Must match Chat Shell, Knowledge Runtime, and Converter settings.
 # Generate using: openssl rand -hex 32
-# INTERNAL_SERVICE_TOKEN=your-secure-token-here
+INTERNAL_SERVICE_TOKEN=
 
 # ========================================
 # Document Conversion (PDF/Office -> Markdown)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,9 @@ from app.core.yaml_init import run_yaml_initialization
 from app.db.base import Base
 from app.db.session import SessionLocal, engine
 from app.models import *  # noqa: F401,F403
+from app.services.auth.internal_service_token import (
+    require_internal_service_token_configured,
+)
 from app.services.jobs import start_background_jobs, stop_background_jobs
 from shared.telemetry.context.large_data import log_json_body
 
@@ -91,6 +94,8 @@ async def lifespan(app: FastAPI):
     logger = _logger
 
     # ==================== STARTUP ====================
+    require_internal_service_token_configured()
+
     # Try to get Redis client for distributed locking
     redis_client = None
     try:

--- a/backend/app/services/auth/internal_service_token.py
+++ b/backend/app/services/auth/internal_service_token.py
@@ -23,14 +23,26 @@ from app.core.config import settings
 security = HTTPBearer(auto_error=False)
 
 
+def require_internal_service_token_configured() -> None:
+    """Fail startup when protected internal endpoints cannot authenticate."""
+    if settings.INTERNAL_SERVICE_TOKEN:
+        return
+
+    raise RuntimeError(
+        "INTERNAL_SERVICE_TOKEN is required for Backend internal API authentication. "
+        "Generate one with `openssl rand -hex 32` and configure the same value for "
+        "Backend, Chat Shell, Knowledge Runtime, and Knowledge Doc Converter."
+    )
+
+
 def verify_internal_service_token(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> None:
     """Verify internal service authentication token.
 
     This dependency checks for a valid Bearer token in the Authorization header.
-    If INTERNAL_SERVICE_TOKEN is not configured (empty string), authentication is
-    skipped (dev mode).
+    If INTERNAL_SERVICE_TOKEN is not configured (empty string), requests are
+    rejected so internal endpoints fail closed.
 
     Args:
         credentials: The Bearer token credentials from the Authorization header.
@@ -40,9 +52,12 @@ def verify_internal_service_token(
     """
     expected_token = settings.INTERNAL_SERVICE_TOKEN
 
-    # Skip authentication if token is not configured (development mode)
     if not expected_token:
-        return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Internal service token is not configured",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     # Check if credentials are provided
     if credentials is None:

--- a/backend/app/services/auth/internal_service_token.py
+++ b/backend/app/services/auth/internal_service_token.py
@@ -18,14 +18,20 @@ from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.core.config import settings
+from shared.telemetry.decorators import trace_sync
 
 # HTTPBearer security scheme for OpenAPI documentation
 security = HTTPBearer(auto_error=False)
 
 
+def _normalized_internal_service_token() -> str:
+    return (settings.INTERNAL_SERVICE_TOKEN or "").strip()
+
+
+@trace_sync()
 def require_internal_service_token_configured() -> None:
     """Fail startup when protected internal endpoints cannot authenticate."""
-    if settings.INTERNAL_SERVICE_TOKEN:
+    if _normalized_internal_service_token():
         return
 
     raise RuntimeError(
@@ -50,7 +56,7 @@ def verify_internal_service_token(
     Raises:
         HTTPException: 401 Unauthorized if token is missing or invalid.
     """
-    expected_token = settings.INTERNAL_SERVICE_TOKEN
+    expected_token = _normalized_internal_service_token()
 
     if not expected_token:
         raise HTTPException(

--- a/backend/tests/api/endpoints/internal/test_rag_retrieve_endpoint.py
+++ b/backend/tests/api/endpoints/internal/test_rag_retrieve_endpoint.py
@@ -4,6 +4,8 @@
 
 from unittest.mock import ANY, AsyncMock, patch
 
+import pytest
+
 from app.core.config import settings
 from app.services.rag.remote_gateway import RemoteRagGatewayError
 from app.services.rag.runtime_specs import (
@@ -16,6 +18,11 @@ from shared.models import (
     RuntimeRetrievalConfig,
     RuntimeRetrieverConfig,
 )
+
+
+@pytest.fixture(autouse=True)
+def configure_internal_service_token(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
 
 
 def _internal_headers() -> dict[str, str]:

--- a/backend/tests/integration/test_rag_remote_mode.py
+++ b/backend/tests/integration/test_rag_remote_mode.py
@@ -58,6 +58,11 @@ EXPECTED_QUERY_RESPONSE = {
 }
 
 
+@pytest.fixture(autouse=True)
+def configure_internal_service_token(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+
+
 def _internal_headers() -> dict[str, str]:
     token = settings.INTERNAL_SERVICE_TOKEN
     return {"Authorization": f"Bearer {token}"} if token else {}

--- a/backend/tests/services/auth/test_internal_service_token.py
+++ b/backend/tests/services/auth/test_internal_service_token.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.core.config import settings
+from app.services.auth.internal_service_token import (
+    require_internal_service_token_configured,
+    verify_internal_service_token,
+)
+
+
+def _credentials(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+def test_missing_authorization_is_rejected_when_token_is_configured(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_internal_service_token(credentials=None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Missing authentication token"
+
+
+def test_invalid_authorization_is_rejected_when_token_is_configured(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_internal_service_token(credentials=_credentials("invalid-token"))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid authentication token"
+
+
+def test_valid_authorization_is_accepted_when_token_is_configured(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+
+    verify_internal_service_token(credentials=_credentials("test-internal-token"))
+
+
+def test_unconfigured_internal_service_token_rejects_missing_authorization(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "")
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_internal_service_token(credentials=None)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Internal service token is not configured"
+
+
+def test_unconfigured_internal_service_token_rejects_present_authorization(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "")
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_internal_service_token(credentials=_credentials("any-token"))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Internal service token is not configured"
+
+
+def test_startup_config_check_rejects_unconfigured_token(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        require_internal_service_token_configured()
+
+    assert "INTERNAL_SERVICE_TOKEN is required" in str(exc_info.value)
+
+
+def test_startup_config_check_accepts_configured_token(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "test-internal-token")
+
+    require_internal_service_token_configured()

--- a/backend/tests/services/auth/test_internal_service_token.py
+++ b/backend/tests/services/auth/test_internal_service_token.py
@@ -63,8 +63,27 @@ def test_unconfigured_internal_service_token_rejects_present_authorization(monke
     assert exc_info.value.detail == "Internal service token is not configured"
 
 
+def test_whitespace_internal_service_token_is_unconfigured(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "   ")
+
+    with pytest.raises(HTTPException) as exc_info:
+        verify_internal_service_token(credentials=_credentials("any-token"))
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Internal service token is not configured"
+
+
 def test_startup_config_check_rejects_unconfigured_token(monkeypatch):
     monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        require_internal_service_token_configured()
+
+    assert "INTERNAL_SERVICE_TOKEN is required" in str(exc_info.value)
+
+
+def test_startup_config_check_rejects_whitespace_token(monkeypatch):
+    monkeypatch.setattr(settings, "INTERNAL_SERVICE_TOKEN", "   ")
 
     with pytest.raises(RuntimeError) as exc_info:
         require_internal_service_token_configured()

--- a/chat_shell/.env.example
+++ b/chat_shell/.env.example
@@ -37,6 +37,7 @@ CHAT_SHELL_SQLITE_DB_PATH=~/.chat_shell/history.db
 # Remote storage configuration (calls Backend API)
 # Default: http://backend:8000/api/internal (Docker) or http://localhost:8000/api/internal (local)
 CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:8000/api/internal
+# Must match Backend's INTERNAL_SERVICE_TOKEN
 CHAT_SHELL_REMOTE_STORAGE_TOKEN=
 
 # =============================================================================
@@ -45,7 +46,7 @@ CHAT_SHELL_REMOTE_STORAGE_TOKEN=
 CHAT_SHELL_HTTP_HOST=0.0.0.0
 CHAT_SHELL_HTTP_PORT=8001
 
-# Internal service authentication token
+# Internal service authentication token. Must match Backend's INTERNAL_SERVICE_TOKEN
 CHAT_SHELL_INTERNAL_SERVICE_TOKEN=
 
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,8 +109,7 @@ services:
       # Chat Shell Configuration (uncomment to use HTTP mode)
       CHAT_SHELL_MODE: ${CHAT_SHELL_MODE:-http}
       CHAT_SHELL_URL: ${CHAT_SHELL_URL:-http://chat_shell:8100}
-      # CHAT_SHELL_TOKEN: ${INTERNAL_SERVICE_TOKEN:-chat-shell-token}
-      # INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-chat-shell-token}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env. Generate one with `openssl rand -hex 32`.}
       # Internal URL for MCP and other internal service calls (use container name in Docker)
       BACKEND_INTERNAL_URL: http://backend:8000
       # Knowledge Runtime URL for RAG operations
@@ -183,8 +182,9 @@ services:
       - CHAT_SHELL_MODE=${CHAT_SHELL_MODE:-http}
       - CHAT_SHELL_STORAGE_TYPE=${CHAT_SHELL_STORAGE_TYPE:-remote}
       - CHAT_SHELL_REMOTE_STORAGE_URL=${CHAT_SHELL_REMOTE_STORAGE_URL:-http://backend:8000/api/internal}
+      - CHAT_SHELL_REMOTE_STORAGE_TOKEN=${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env. Generate one with `openssl rand -hex 32`.}
+      - CHAT_SHELL_INTERNAL_SERVICE_TOKEN=${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env. Generate one with `openssl rand -hex 32`.}
       - EXECUTOR_MANAGER_URL=${EXECUTOR_MANAGER_URL:-http://executor_manager:8001}
-      # - CHAT_SHELL_REMOTE_STORAGE_TOKEN=${INTERNAL_SERVICE_TOKEN:-chat-shell-token}
       # OpenTelemetry Configuration (uncomment to enable)
       # - OTEL_ENABLED=true
       # - OTEL_SERVICE_NAME=wegent-chat-shell
@@ -284,8 +284,8 @@ services:
       - LOG_FILE_ENABLED=${LOG_FILE_ENABLED:-true}
       - LOG_DIR=${LOG_DIR:-/app/logs}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
-      # Internal service token (uncomment to enable, must match Backend's INTERNAL_SERVICE_TOKEN)
-      # - INTERNAL_SERVICE_TOKEN=${INTERNAL_SERVICE_TOKEN:-your-secure-token-here}
+      # Internal service token. Must match Backend's INTERNAL_SERVICE_TOKEN.
+      - INTERNAL_SERVICE_TOKEN=${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env. Generate one with `openssl rand -hex 32`.}
       # Database connection for config resolution (reference-mode)
       - DATABASE_URL=mysql+pymysql://${MYSQL_USER:-task_user}:${MYSQL_PASSWORD:-task_password}@mysql:3306/${MYSQL_DATABASE:-task_manager}
       # OpenTelemetry Configuration (uncomment to enable)
@@ -317,7 +317,7 @@ services:
     environment:
       TZ: ${TZ:-Asia/Shanghai}
       BACKEND_BASE_URL: ${BACKEND_BASE_URL:-http://backend:8000}
-      BACKEND_INTERNAL_TOKEN: ${INTERNAL_SERVICE_TOKEN:-}
+      BACKEND_INTERNAL_TOKEN: ${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env. Generate one with `openssl rand -hex 32`.}
       REDIS_PASSWORD: ${REDIS_PASSWORD:-}
       CELERY_BROKER_URL: ${REDIS_URL:-redis://redis:6379/0}
       CELERY_RESULT_BACKEND: ${REDIS_URL:-redis://redis:6379/1}

--- a/docker/standalone/start.sh
+++ b/docker/standalone/start.sh
@@ -26,6 +26,40 @@ FRONTEND_PORT=${FRONTEND_PORT:-3000}
 # Set Redis URL to localhost (embedded Redis)
 export REDIS_URL="${REDIS_URL:-redis://localhost:6379/0}"
 
+generate_internal_service_token() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 32
+        return
+    fi
+
+    python3 - << 'PY'
+import secrets
+
+print(secrets.token_hex(32))
+PY
+}
+
+ensure_internal_service_token() {
+    if [ -n "${INTERNAL_SERVICE_TOKEN:-}" ]; then
+        return
+    fi
+
+    local token_file="/app/data/internal_service_token"
+    if [ -f "$token_file" ]; then
+        export INTERNAL_SERVICE_TOKEN
+        INTERNAL_SERVICE_TOKEN=$(cat "$token_file")
+        return
+    fi
+
+    export INTERNAL_SERVICE_TOKEN
+    INTERNAL_SERVICE_TOKEN=$(generate_internal_service_token)
+    umask 077
+    printf '%s\n' "$INTERNAL_SERVICE_TOKEN" > "$token_file"
+    echo "      Generated internal service token for standalone mode"
+}
+
+ensure_internal_service_token
+
 # ========================================
 # Step 1: Start Redis
 # ========================================

--- a/docker/standalone/start.sh
+++ b/docker/standalone/start.sh
@@ -45,14 +45,21 @@ ensure_internal_service_token() {
     fi
 
     local token_file="/app/data/internal_service_token"
-    if [ -f "$token_file" ]; then
-        export INTERNAL_SERVICE_TOKEN
-        INTERNAL_SERVICE_TOKEN=$(cat "$token_file")
-        return
+    if [ -s "$token_file" ]; then
+        local token_value
+        token_value=$(tr -d '[:space:]' < "$token_file")
+        if [ -n "$token_value" ]; then
+            export INTERNAL_SERVICE_TOKEN="$token_value"
+            return
+        fi
     fi
 
     export INTERNAL_SERVICE_TOKEN
     INTERNAL_SERVICE_TOKEN=$(generate_internal_service_token)
+    if [ -z "$INTERNAL_SERVICE_TOKEN" ]; then
+        echo "      ERROR: Failed to generate INTERNAL_SERVICE_TOKEN"
+        exit 1
+    fi
     umask 077
     printf '%s\n' "$INTERNAL_SERVICE_TOKEN" > "$token_file"
     echo "      Generated internal service token for standalone mode"

--- a/knowledge_doc_converter/.env.example
+++ b/knowledge_doc_converter/.env.example
@@ -1,5 +1,6 @@
 # Backend callback
 BACKEND_BASE_URL=http://backend:8000
+# Required. Must match Backend's INTERNAL_SERVICE_TOKEN.
 BACKEND_INTERNAL_TOKEN=
 
 # Redis Password (applied to all Redis URLs when set; empty = no password authentication)

--- a/knowledge_runtime/.env.example
+++ b/knowledge_runtime/.env.example
@@ -21,10 +21,10 @@ LOG_DIR=./logs
 LOG_LEVEL=INFO
 
 # Internal Service Token for authentication
-# When set, all /internal/rag/* endpoints (except health) require this token
-# Must match Backend's INTERNAL_SERVICE_TOKEN when enabled
+# Required. All /internal/rag/* endpoints (except health) require this token.
+# Must match Backend's INTERNAL_SERVICE_TOKEN.
 # Generate using: openssl rand -hex 32
-# INTERNAL_SERVICE_TOKEN=your-secure-token-here
+INTERNAL_SERVICE_TOKEN=
 
 # Attachment encryption configuration
 # When ATTACHMENT_ENCRYPTION_ENABLED=true in Backend, attachments are encrypted

--- a/knowledge_runtime/knowledge_runtime/main.py
+++ b/knowledge_runtime/knowledge_runtime/main.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse
 from knowledge_runtime.api.router import router
 from knowledge_runtime.config import get_settings
 from knowledge_runtime.core.logging import setup_logging
+from knowledge_runtime.middleware.auth import require_internal_service_token_configured
 from shared.models import RemoteRagError
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,7 @@ async def lifespan(app: FastAPI):
         log_dir=settings.log_dir,
         log_level=settings.log_level,
     )
+    require_internal_service_token_configured()
 
     # Initialize database connection for config resolution
     if settings.database_url:

--- a/knowledge_runtime/knowledge_runtime/middleware/auth.py
+++ b/knowledge_runtime/knowledge_runtime/middleware/auth.py
@@ -18,10 +18,14 @@ from knowledge_runtime.config import get_settings
 security = HTTPBearer(auto_error=False)
 
 
+def _normalized_internal_service_token() -> str:
+    settings = get_settings()
+    return (settings.internal_service_token or "").strip()
+
+
 def require_internal_service_token_configured() -> None:
     """Fail startup when protected internal endpoints cannot authenticate."""
-    settings = get_settings()
-    if settings.internal_service_token:
+    if _normalized_internal_service_token():
         return
 
     raise RuntimeError(
@@ -46,8 +50,7 @@ def verify_internal_token(
     Raises:
         HTTPException: 401 Unauthorized if token is missing or invalid.
     """
-    settings = get_settings()
-    expected_token = settings.internal_service_token
+    expected_token = _normalized_internal_service_token()
 
     if not expected_token:
         raise HTTPException(

--- a/knowledge_runtime/knowledge_runtime/middleware/auth.py
+++ b/knowledge_runtime/knowledge_runtime/middleware/auth.py
@@ -18,13 +18,27 @@ from knowledge_runtime.config import get_settings
 security = HTTPBearer(auto_error=False)
 
 
+def require_internal_service_token_configured() -> None:
+    """Fail startup when protected internal endpoints cannot authenticate."""
+    settings = get_settings()
+    if settings.internal_service_token:
+        return
+
+    raise RuntimeError(
+        "INTERNAL_SERVICE_TOKEN is required for Knowledge Runtime internal API "
+        "authentication. Generate one with `openssl rand -hex 32` and configure "
+        "the same value for Backend and Knowledge Runtime."
+    )
+
+
 def verify_internal_token(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
 ) -> None:
     """Verify internal service authentication token.
 
     This dependency checks for a valid Bearer token in the Authorization header.
-    If INTERNAL_SERVICE_TOKEN is not configured, authentication is skipped (dev mode).
+    If INTERNAL_SERVICE_TOKEN is not configured, requests are rejected so internal
+    endpoints fail closed.
 
     Args:
         credentials: The Bearer token credentials from the Authorization header.
@@ -35,9 +49,12 @@ def verify_internal_token(
     settings = get_settings()
     expected_token = settings.internal_service_token
 
-    # Skip authentication if token is not configured (development mode)
     if not expected_token:
-        return
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Internal service token is not configured",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     # Check if credentials are provided
     if credentials is None:

--- a/knowledge_runtime/tests/test_auth.py
+++ b/knowledge_runtime/tests/test_auth.py
@@ -11,7 +11,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from knowledge_runtime.config import reset_settings
-from knowledge_runtime.middleware.auth import verify_internal_token
+from knowledge_runtime.middleware.auth import (
+    require_internal_service_token_configured,
+    verify_internal_token,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -36,17 +39,36 @@ def test_app():
     return app
 
 
-def test_auth_disabled_when_token_empty(test_app, monkeypatch):
-    """Test that authentication is skipped when token is not configured."""
+def test_protected_endpoint_rejects_when_token_empty(test_app, monkeypatch):
+    """Test that authentication fails closed when token is not configured."""
     monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "")
     reset_settings()
 
     client = TestClient(test_app)
 
-    # Should work without any auth header
     response = client.get("/protected")
-    assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Internal service token is not configured"}
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+def test_startup_config_check_rejects_unconfigured_token(monkeypatch):
+    """Test that startup fails when protected internal endpoints cannot authenticate."""
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "")
+    reset_settings()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        require_internal_service_token_configured()
+
+    assert "INTERNAL_SERVICE_TOKEN is required" in str(exc_info.value)
+
+
+def test_startup_config_check_accepts_configured_token(monkeypatch):
+    """Test that startup allows a configured internal service token."""
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "test-token-123")
+    reset_settings()
+
+    require_internal_service_token_configured()
 
 
 def test_protected_endpoint_missing_token(test_app, monkeypatch):

--- a/knowledge_runtime/tests/test_auth.py
+++ b/knowledge_runtime/tests/test_auth.py
@@ -52,9 +52,36 @@ def test_protected_endpoint_rejects_when_token_empty(test_app, monkeypatch):
     assert response.headers.get("WWW-Authenticate") == "Bearer"
 
 
+def test_protected_endpoint_rejects_when_token_whitespace(test_app, monkeypatch):
+    """Test that whitespace-only tokens are treated as unconfigured."""
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "   ")
+    reset_settings()
+
+    client = TestClient(test_app)
+
+    response = client.get(
+        "/protected",
+        headers={"Authorization": "Bearer any-token"},
+    )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Internal service token is not configured"}
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
 def test_startup_config_check_rejects_unconfigured_token(monkeypatch):
     """Test that startup fails when protected internal endpoints cannot authenticate."""
     monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "")
+    reset_settings()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        require_internal_service_token_configured()
+
+    assert "INTERNAL_SERVICE_TOKEN is required" in str(exc_info.value)
+
+
+def test_startup_config_check_rejects_whitespace_token(monkeypatch):
+    """Test that startup rejects whitespace-only internal service tokens."""
+    monkeypatch.setenv("INTERNAL_SERVICE_TOKEN", "   ")
     reset_settings()
 
     with pytest.raises(RuntimeError) as exc_info:

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -35,6 +35,8 @@ echo -e "${GREEN}  Wegent E2E Test Local Runner${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo -e "${YELLOW}Logs will be saved to: $LOG_DIR${NC}"
 
+export INTERNAL_SERVICE_TOKEN="${INTERNAL_SERVICE_TOKEN:-e2e-internal-service-token}"
+
 # Function to cleanup on exit
 cleanup() {
     echo -e "\n${YELLOW}Cleaning up...${NC}"

--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -35,7 +35,38 @@ echo -e "${GREEN}  Wegent E2E Test Local Runner${NC}"
 echo -e "${GREEN}========================================${NC}"
 echo -e "${YELLOW}Logs will be saved to: $LOG_DIR${NC}"
 
-export INTERNAL_SERVICE_TOKEN="${INTERNAL_SERVICE_TOKEN:-e2e-internal-service-token}"
+generate_internal_service_token() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 32
+        return
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - << 'PY'
+import secrets
+
+print(secrets.token_hex(32))
+PY
+        return
+    fi
+
+    return 1
+}
+
+ensure_internal_service_token() {
+    if [ -n "${INTERNAL_SERVICE_TOKEN:-}" ]; then
+        export INTERNAL_SERVICE_TOKEN
+        return
+    fi
+
+    INTERNAL_SERVICE_TOKEN=$(generate_internal_service_token) || {
+        echo -e "${RED}Error: Unable to generate INTERNAL_SERVICE_TOKEN. Install openssl or python3.${NC}"
+        exit 1
+    }
+    export INTERNAL_SERVICE_TOKEN
+}
+
+ensure_internal_service_token
 
 # Function to cleanup on exit
 cleanup() {
@@ -245,6 +276,7 @@ export E2E_BASE_URL="http://localhost:3000"
 # Parse command line arguments
 E2E_MODE="${1:-run}"
 
+set +e
 case "$E2E_MODE" in
     "ui")
         echo "Running E2E tests in UI mode..."
@@ -269,6 +301,7 @@ case "$E2E_MODE" in
 esac
 
 E2E_EXIT_CODE=$?
+set -e
 
 echo -e "\n${GREEN}========================================${NC}"
 if [ $E2E_EXIT_CODE -eq 0 ]; then

--- a/start.sh
+++ b/start.sh
@@ -60,6 +60,67 @@ load_config() {
     fi
 }
 
+persist_internal_service_token() {
+    local token="$1"
+    local temp_file
+    temp_file=$(mktemp)
+
+    if [ -f "$CONFIG_FILE" ]; then
+        grep -v "^INTERNAL_SERVICE_TOKEN=" "$CONFIG_FILE" > "$temp_file" || true
+    else
+        cat > "$temp_file" << 'EOF'
+# Wegent Configuration
+# This file is used by both docker-compose and start.sh
+# Copy from .env.example and customize as needed
+
+EOF
+    fi
+
+    cat >> "$temp_file" << EOF
+
+# Internal service authentication token shared by Backend, Chat Shell, and Knowledge Runtime.
+# Generated automatically by start.sh for local development.
+INTERNAL_SERVICE_TOKEN=$token
+EOF
+
+    mv "$temp_file" "$CONFIG_FILE"
+}
+
+generate_internal_service_token() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 32
+        return
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        python3 - << 'PY'
+import secrets
+
+print(secrets.token_hex(32))
+PY
+        return
+    fi
+
+    echo ""
+}
+
+ensure_internal_service_token() {
+    if [ -n "${INTERNAL_SERVICE_TOKEN:-}" ]; then
+        return
+    fi
+
+    local generated_token
+    generated_token=$(generate_internal_service_token)
+    if [ -z "$generated_token" ]; then
+        echo -e "${RED}Unable to generate INTERNAL_SERVICE_TOKEN. Install openssl or python3, or set INTERNAL_SERVICE_TOKEN manually.${NC}"
+        exit 1
+    fi
+
+    export INTERNAL_SERVICE_TOKEN="$generated_token"
+    persist_internal_service_token "$generated_token"
+    echo -e "${GREEN}✓ Generated INTERNAL_SERVICE_TOKEN for local development and saved it to .env${NC}"
+}
+
 # Save configuration to .env file
 # Only saves start.sh specific variables, preserves existing content
 save_config() {
@@ -1943,6 +2004,10 @@ start_services() {
         exit 1
     fi
 
+    if [ "$start_backend" = true ] || [ "$start_chat_shell" = true ] || [ "$start_knowledge_runtime" = true ]; then
+        ensure_internal_service_token
+    fi
+
     compute_derived_urls "$previous_backend_port" "$previous_executor_manager_port" "$previous_knowledge_runtime_port"
     echo -e "${GREEN}✓ Required ports resolved${NC}"
     echo ""
@@ -2040,7 +2105,7 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "backend" "backend" \
-            "export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=$TASK_API_DOMAIN && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug" \
+            "export INTERNAL_SERVICE_TOKEN=$INTERNAL_SERVICE_TOKEN && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=$TASK_API_DOMAIN && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug" \
             "$BACKEND_PORT"
     fi
 
@@ -2050,7 +2115,7 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "chat_shell" "chat_shell" \
-            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug" \
+            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export CHAT_SHELL_REMOTE_STORAGE_TOKEN=$INTERNAL_SERVICE_TOKEN && export CHAT_SHELL_INTERNAL_SERVICE_TOKEN=$INTERNAL_SERVICE_TOKEN && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug" \
             "$CHAT_SHELL_PORT"
     fi
 

--- a/start.sh
+++ b/start.sh
@@ -2105,7 +2105,7 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "backend" "backend" \
-            "export INTERNAL_SERVICE_TOKEN=$INTERNAL_SERVICE_TOKEN && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=$TASK_API_DOMAIN && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug" \
+            "export INTERNAL_SERVICE_TOKEN=\"\$INTERNAL_SERVICE_TOKEN\" && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && export CHAT_SHELL_URL=http://localhost:$CHAT_SHELL_PORT && export BACKEND_INTERNAL_URL=$TASK_API_DOMAIN && export LOG_LEVEL=DEBUG && source .venv/bin/activate && uvicorn app.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $BACKEND_PORT --log-level debug" \
             "$BACKEND_PORT"
     fi
 
@@ -2115,7 +2115,7 @@ start_services() {
         # --reload-dir: Watch shared module for changes (editable dependency)
         # --reload-exclude: Exclude .venv and __pycache__ to reduce CPU usage
         start_service "chat_shell" "chat_shell" \
-            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export CHAT_SHELL_REMOTE_STORAGE_TOKEN=$INTERNAL_SERVICE_TOKEN && export CHAT_SHELL_INTERNAL_SERVICE_TOKEN=$INTERNAL_SERVICE_TOKEN && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug" \
+            "export CHAT_SHELL_MODE=http && export CHAT_SHELL_STORAGE_TYPE=remote && export CHAT_SHELL_REMOTE_STORAGE_URL=http://localhost:$BACKEND_PORT/api/internal && export CHAT_SHELL_REMOTE_STORAGE_TOKEN=\"\$INTERNAL_SERVICE_TOKEN\" && export CHAT_SHELL_INTERNAL_SERVICE_TOKEN=\"\$INTERNAL_SERVICE_TOKEN\" && export EXECUTOR_MANAGER_URL=$EXECUTOR_MANAGER_URL && source .venv/bin/activate && .venv/bin/python -m uvicorn chat_shell.main:app --reload --reload-dir . --reload-dir ../shared $RELOAD_EXCLUDE --host 0.0.0.0 --port $CHAT_SHELL_PORT --log-level debug" \
             "$CHAT_SHELL_PORT"
     fi
 


### PR DESCRIPTION
## Summary
- Require `INTERNAL_SERVICE_TOKEN` to be set for backend and knowledge runtime startup
- Fail closed on internal auth when the token is missing
- Update docker, standalone startup, and example env files to share the same secret
- Add tests covering token validation and startup configuration checks

## Testing
- Unit tests added for internal service token validation and startup checks
- Integration test fixtures updated to use a configured internal token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced service-to-service token authentication across services.
  * Automatic generation and local persistence of an internal service token for development and standalone modes.

* **Chores**
  * Made the internal token required in runtime, container, startup scripts, and compose/CI workflows.
  * CI/workflows and compose updated to provide a consistent internal token to all services.

* **Tests**
  * Added/updated tests to validate token verification and startup enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->