### PR TITLE
允许 Chat 任务在 ClaudeCode 执行器下使用知识库上下文

### DIFF
--- a/frontend/src/__tests__/features/tasks/service/messageService.test.ts
+++ b/frontend/src/__tests__/features/tasks/service/messageService.test.ts
@@ -40,6 +40,10 @@ describe('messageService canUseChatContexts', () => {
     expect(canUseChatContexts('code', null)).toBe(false)
   })
 
+  it('returns true for ClaudeCode shell teams in chat mode', () => {
+    expect(canUseChatContexts('chat', createTeam('ClaudeCode'))).toBe(true)
+  })
+
   it('returns true for chat shell teams in chat mode', () => {
     const team = {
       id: 1,

--- a/frontend/src/features/tasks/service/messageService.ts
+++ b/frontend/src/features/tasks/service/messageService.ts
@@ -47,7 +47,7 @@ export function canUseChatContexts(taskType: TaskType | undefined, team: Team | 
     return true
   }
 
-  return isChatShell(team)
+  return isChatShell(team) || isClaudeCode(team)
 }
 
 /**


### PR DESCRIPTION
## Summary
- 放开 `chat` 任务下的上下文入口，ClaudeCode 执行器也可以使用知识库/上下文选择器
- 保持 `code` 任务现有行为不变
- 补充回归测试，覆盖 `chat + ClaudeCode` 场景

## Testing
- `frontend/src/__tests__/features/tasks/service/messageService.test.ts` 单测通过，新增用例验证 ClaudeCode team 在 chat mode 下可用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* ClaudeCode teams can now access chat context functionality for tasks, matching the capability previously available to Chat Shell teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->