### PR TITLE
fix(executor-manager): validate archive request payload

### DIFF
--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -1420,11 +1420,11 @@ async def task_heartbeat(task_id: str, http_request: Request):
 class ArchiveExecutorRequest(BaseModel):
     """Request model for /executor/archive endpoint."""
 
-    task_id: int
-    upload_url: str  # Presigned MinIO upload URL
-    executor_name: str
-    executor_namespace: str
-    max_size_mb: int = 500
+    task_id: int = Field(..., ge=1)
+    upload_url: str = Field(..., min_length=1)
+    executor_name: str = Field(..., min_length=1)
+    executor_namespace: str = Field(..., min_length=1)
+    max_size_mb: int = Field(500, ge=1)
 
 
 class RestoreExecutorRequest(BaseModel):

--- a/executor_manager/tests/routers/test_workspace_archive_routes.py
+++ b/executor_manager/tests/routers/test_workspace_archive_routes.py
@@ -6,8 +6,92 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from executor_manager.routers import routers
+
+# =============================================================================
+# Request Validation Regression Tests
+# =============================================================================
+
+
+class TestArchiveRequestValidation:
+    def test_all_invalid_fields_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="",
+                executor_namespace="",
+                task_id=0,
+                upload_url="",
+                max_size_mb=False,
+            )
+        errors = exc_info.value.errors()
+        assert len(errors) == 5
+
+    def test_empty_executor_name_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="",
+                executor_namespace="default",
+                task_id=1,
+                upload_url="http://example.com/upload",
+                max_size_mb=100,
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "executor_name" in field_names
+
+    def test_empty_upload_url_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=1,
+                upload_url="",
+                max_size_mb=100,
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "upload_url" in field_names
+
+    def test_max_size_mb_false_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=1,
+                upload_url="http://example.com/upload",
+                max_size_mb=False,
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "max_size_mb" in field_names
+
+    def test_empty_executor_namespace_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="x",
+                executor_namespace="",
+                task_id=1,
+                upload_url="http://example.com/upload",
+                max_size_mb=100,
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "executor_namespace" in field_names
+
+    def test_task_id_zero_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.ArchiveExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=0,
+                upload_url="http://example.com/upload",
+                max_size_mb=100,
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "task_id" in field_names
+
+
+# =============================================================================
+# Existing Tests
+# =============================================================================
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`ArchiveExecutorRequest` Pydantic model had no field constraints — all fields were bare types (`int`, `str`). This allowed invalid payloads to pass request validation and enter business logic, producing misleading 404/500 errors instead of proper 422 responses.

**Reproduction (all return 404 or 500 before this fix):**

| Payload | Before | After |
|---------|--------|-------|
| `executor_name=""` | 500 (upstream HTTP error) | 422 |
| `executor_namespace=""` | 404 (container not found) | 422 |
| `upload_url=""` | 404 (container not found) | 422 |
| `max_size_mb=false` | 404 (container not found) | 422 |
| All fields invalid | 404/500 | 422 (5 errors) |

## Root Cause

Pydantic v2 accepts `bool` values for `int` fields (coerces `False→0`) and empty strings for `str` fields when no `min_length` is set. The `ArchiveExecutorRequest` model lacked `Field(...)` constraints on all five fields, so invalid data passed validation and reached the container lookup / upstream archive call, where it failed with non-422 errors.

## Fix

Add Pydantic v2 `Field` constraints to `ArchiveExecutorRequest`:

| Field | Constraint | Reason |
|-------|-----------|--------|
| `executor_name` | `min_length=1` | Must be non-empty |
| `executor_namespace` | `min_length=1` | Must be non-empty |
| `upload_url` | `min_length=1` | Must be non-empty |
| `task_id` | `ge=1` | Must be positive |
| `max_size_mb` | `ge=1` | Must be positive (was unbounded) |

Invalid requests now return `422 Unprocessable Entity` at the validation layer, before any container lookup or upstream call.

## Files Changed

- `executor_manager/routers/routers.py` — Added `Field(...)` constraints to `ArchiveExecutorRequest`
- `executor_manager/tests/routers/test_workspace_archive_routes.py` — Added 6 regression tests

## Regression Tests

6 new tests in `TestArchiveRequestValidation`:

1. All 5 fields invalid (fuzz payload) → 5 validation errors
2. `executor_name=""` → 422
3. `upload_url=""` → 422
4. `max_size_mb=false` → 422
5. `executor_namespace=""` → 422
6. `task_id=0` → 422

All tests are pure Pydantic model-layer unit tests — no Docker, network, or API dependencies.

## PR Scope

**This PR only fixes archive request validation.** It does NOT modify:
- Restore endpoint
- Prepare endpoint
- Sandbox endpoint
- Docker executor lifecycle
- Upstream 404 error mapping
- OpenAPI documentation
- Any other request models

## Verification

```
uv run pytest tests/routers -k "archive" -v
# 9 passed (6 new + 3 existing)
```

Manual curl verification confirms all invalid payloads now return 422.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added input validation to the executor archive endpoint, enforcing positive task IDs, non-empty names and URLs, and minimum file size requirements. Invalid inputs now return validation errors.

* **Tests**
  * Added validation regression tests for archive request parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->