### PR TITLE
fix(executor-manager): validate restore request payload

### DIFF
--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -1430,10 +1430,10 @@ class ArchiveExecutorRequest(BaseModel):
 class RestoreExecutorRequest(BaseModel):
     """Request model for /executor/restore endpoint."""
 
-    task_id: int
-    download_url: str  # Presigned MinIO download URL
-    executor_name: str
-    executor_namespace: str
+    task_id: int = Field(..., ge=1, strict=True)
+    download_url: str = Field(..., min_length=1)
+    executor_name: str = Field(..., min_length=1)
+    executor_namespace: str = Field(..., min_length=1)
 
 
 @api_router.post("/executor/archive")

--- a/executor_manager/tests/routers/test_workspace_archive_routes.py
+++ b/executor_manager/tests/routers/test_workspace_archive_routes.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import httpx
 import pytest
+from pydantic import ValidationError
 
 from executor_manager.routers import routers
 
@@ -105,3 +106,76 @@ async def test_restore_executor_workspace_wraps_http_errors(mocker):
 
     assert exc_info.value.status_code == 500
     assert "HTTP error" in exc_info.value.detail
+
+
+# =============================================================================
+# Restore Request Validation Regression Tests
+# =============================================================================
+
+
+class TestRestoreRequestValidation:
+    def test_all_invalid_fields_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="",
+                executor_namespace="",
+                task_id=0,
+                download_url="",
+            )
+        errors = exc_info.value.errors()
+        assert len(errors) == 4
+
+    def test_empty_executor_name_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="",
+                executor_namespace="default",
+                task_id=1,
+                download_url="http://example.com/download",
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "executor_name" in field_names
+
+    def test_empty_download_url_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=1,
+                download_url="",
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "download_url" in field_names
+
+    def test_empty_executor_namespace_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="x",
+                executor_namespace="",
+                task_id=1,
+                download_url="http://example.com/download",
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "executor_namespace" in field_names
+
+    def test_task_id_zero_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=0,
+                download_url="http://example.com/download",
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "task_id" in field_names
+
+    def test_task_id_true_returns_422(self):
+        with pytest.raises(ValidationError) as exc_info:
+            routers.RestoreExecutorRequest(
+                executor_name="x",
+                executor_namespace="default",
+                task_id=True,
+                download_url="http://example.com/download",
+            )
+        field_names = [e["loc"][-1] for e in exc_info.value.errors()]
+        assert "task_id" in field_names

--- a/executor_manager/tests/routers/test_workspace_archive_routes.py
+++ b/executor_manager/tests/routers/test_workspace_archive_routes.py
@@ -113,8 +113,8 @@ async def test_restore_executor_workspace_wraps_http_errors(mocker):
 # =============================================================================
 
 
-class TestRestoreRequestValidation:
-    def test_all_invalid_fields_returns_422(self):
+class TestRestoreExecutorRequestModelValidation:
+    def test_all_invalid_fields_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="",
@@ -125,7 +125,7 @@ class TestRestoreRequestValidation:
         errors = exc_info.value.errors()
         assert len(errors) == 4
 
-    def test_empty_executor_name_returns_422(self):
+    def test_empty_executor_name_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="",
@@ -136,7 +136,7 @@ class TestRestoreRequestValidation:
         field_names = [e["loc"][-1] for e in exc_info.value.errors()]
         assert "executor_name" in field_names
 
-    def test_empty_download_url_returns_422(self):
+    def test_empty_download_url_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="x",
@@ -147,7 +147,7 @@ class TestRestoreRequestValidation:
         field_names = [e["loc"][-1] for e in exc_info.value.errors()]
         assert "download_url" in field_names
 
-    def test_empty_executor_namespace_returns_422(self):
+    def test_empty_executor_namespace_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="x",
@@ -158,7 +158,7 @@ class TestRestoreRequestValidation:
         field_names = [e["loc"][-1] for e in exc_info.value.errors()]
         assert "executor_namespace" in field_names
 
-    def test_task_id_zero_returns_422(self):
+    def test_task_id_zero_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="x",
@@ -169,7 +169,7 @@ class TestRestoreRequestValidation:
         field_names = [e["loc"][-1] for e in exc_info.value.errors()]
         assert "task_id" in field_names
 
-    def test_task_id_true_returns_422(self):
+    def test_task_id_true_raises_validation_error(self):
         with pytest.raises(ValidationError) as exc_info:
             routers.RestoreExecutorRequest(
                 executor_name="x",


### PR DESCRIPTION
## Problem

`RestoreExecutorRequest` had no field constraints — all fields were bare types (`int`, `str`). This allowed invalid payloads to pass request validation and enter business logic, producing misleading 404/500 errors instead of proper 422 responses.

**Reproduction (all return 404 or 500 before this fix):**

| Payload | Before | After |
|---------|--------|-------|
| `executor_name=""` | 504 (upstream HTTP error) | 422 |
| `executor_namespace=""` | 404 (container not found) | 422 |
| `download_url=""` | 404 (container not found) | 422 |
| `task_id=0` | 404 (container not found) | 422 |
| `task_id=true` | accepted (bool→int coercion) | 422 |

## Root Cause

Pydantic v2 accepts `bool` values for `int` fields (coerces `False→0`, `True→1`) and empty strings for `str` fields when no `min_length` is set. The `RestoreExecutorRequest` model lacked `Field(...)` constraints on all four fields, so invalid data passed validation and reached the container lookup / upstream restore call, where it failed with non-422 errors.

## Fix

Add Pydantic v2 `Field` constraints to `RestoreExecutorRequest`:

| Field | Constraint | Reason |
|-------|-----------|--------|
| `executor_name` | `min_length=1` | Must be non-empty |
| `executor_namespace` | `min_length=1` | Must be non-empty |
| `download_url` | `min_length=1` | Must be non-empty |
| `task_id` | `ge=1, strict=True` | Must be positive int; reject bool coercion |

Invalid requests now return `422 Unprocessable Entity` at the validation layer, before any container lookup or upstream call.

## Files Changed

- `executor_manager/routers/routers.py` — Added `Field(...)` constraints to `RestoreExecutorRequest`
- `executor_manager/tests/routers/test_workspace_archive_routes.py` — Added 6 regression tests

## Regression Tests

6 new tests in `TestRestoreRequestValidation`:

1. All 4 fields invalid → 4 validation errors
2. `executor_name=""` → 422
3. `download_url=""` → 422
4. `executor_namespace=""` → 422
5. `task_id=0` → 422
6. `task_id=true` → 422 (strict=True rejects bool)

All tests are pure Pydantic model-layer unit tests — no Docker, network, or API dependencies.

## PR Scope

**This PR only fixes restore request validation.** It does NOT modify:
- Archive endpoint (covered by #1359)
- Prepare endpoint
- Sandbox endpoint
- Docker executor lifecycle
- Upstream 404 error mapping
- OpenAPI documentation
- Any other request models

## Verification

```
uv run pytest tests/routers -k "restore" -v
# 9 passed (6 new + 3 existing)
```

Manual curl verification confirms all invalid payloads now return 422.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request validation tightened: task IDs must be positive integers and string fields cannot be empty, reducing invalid API requests.

* **Tests**
  * Added thorough tests covering validation failures and edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->