### PR TITLE
fix(executor-manager): map upstream errors properly for archive/restore

### DIFF
--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -1502,9 +1502,28 @@ async def archive_executor_workspace(
 
     except HTTPException:
         raise
+    except httpx.TimeoutException:
+        logger.error(f"[Archive] Upstream timeout for task {request.task_id}")
+        raise HTTPException(
+            status_code=504, detail="Executor archive service timed out"
+        )
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"[Archive] Upstream status error for task {request.task_id}: {e.response.status_code}"
+        )
+        raise HTTPException(
+            status_code=502, detail="Executor archive service returned an error"
+        )
+    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError):
+        logger.error(f"[Archive] Upstream connection error for task {request.task_id}")
+        raise HTTPException(
+            status_code=502, detail="Executor archive service is unavailable"
+        )
     except httpx.HTTPError as e:
         logger.error(f"[Archive] HTTP error for task {request.task_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"HTTP error: {str(e)}")
+        raise HTTPException(
+            status_code=502, detail="Executor archive service returned an error"
+        )
     except Exception as e:
         logger.error(f"[Archive] Error archiving task {request.task_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -1576,9 +1595,28 @@ async def restore_executor_workspace(
 
     except HTTPException:
         raise
+    except httpx.TimeoutException:
+        logger.error(f"[Restore] Upstream timeout for task {request.task_id}")
+        raise HTTPException(
+            status_code=504, detail="Executor restore service timed out"
+        )
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            f"[Restore] Upstream status error for task {request.task_id}: {e.response.status_code}"
+        )
+        raise HTTPException(
+            status_code=502, detail="Executor restore service returned an error"
+        )
+    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError):
+        logger.error(f"[Restore] Upstream connection error for task {request.task_id}")
+        raise HTTPException(
+            status_code=502, detail="Executor restore service is unavailable"
+        )
     except httpx.HTTPError as e:
         logger.error(f"[Restore] HTTP error for task {request.task_id}: {e}")
-        raise HTTPException(status_code=500, detail=f"HTTP error: {str(e)}")
+        raise HTTPException(
+            status_code=502, detail="Executor restore service returned an error"
+        )
     except Exception as e:
         logger.error(f"[Restore] Error restoring task {request.task_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/executor_manager/routers/routers.py
+++ b/executor_manager/routers/routers.py
@@ -1502,28 +1502,28 @@ async def archive_executor_workspace(
 
     except HTTPException:
         raise
-    except httpx.TimeoutException:
+    except httpx.TimeoutException as e:
         logger.error(f"[Archive] Upstream timeout for task {request.task_id}")
         raise HTTPException(
             status_code=504, detail="Executor archive service timed out"
-        )
+        ) from e
     except httpx.HTTPStatusError as e:
         logger.error(
             f"[Archive] Upstream status error for task {request.task_id}: {e.response.status_code}"
         )
         raise HTTPException(
             status_code=502, detail="Executor archive service returned an error"
-        )
-    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError):
+        ) from e
+    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError) as e:
         logger.error(f"[Archive] Upstream connection error for task {request.task_id}")
         raise HTTPException(
             status_code=502, detail="Executor archive service is unavailable"
-        )
+        ) from None
     except httpx.HTTPError as e:
         logger.error(f"[Archive] HTTP error for task {request.task_id}: {e}")
         raise HTTPException(
             status_code=502, detail="Executor archive service returned an error"
-        )
+        ) from e
     except Exception as e:
         logger.error(f"[Archive] Error archiving task {request.task_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -1595,28 +1595,28 @@ async def restore_executor_workspace(
 
     except HTTPException:
         raise
-    except httpx.TimeoutException:
+    except httpx.TimeoutException as e:
         logger.error(f"[Restore] Upstream timeout for task {request.task_id}")
         raise HTTPException(
             status_code=504, detail="Executor restore service timed out"
-        )
+        ) from e
     except httpx.HTTPStatusError as e:
         logger.error(
             f"[Restore] Upstream status error for task {request.task_id}: {e.response.status_code}"
         )
         raise HTTPException(
             status_code=502, detail="Executor restore service returned an error"
-        )
-    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError):
+        ) from e
+    except (httpx.ConnectError, httpx.RemoteProtocolError, httpx.NetworkError) as e:
         logger.error(f"[Restore] Upstream connection error for task {request.task_id}")
         raise HTTPException(
             status_code=502, detail="Executor restore service is unavailable"
-        )
+        ) from None
     except httpx.HTTPError as e:
         logger.error(f"[Restore] HTTP error for task {request.task_id}: {e}")
         raise HTTPException(
             status_code=502, detail="Executor restore service returned an error"
-        )
+        ) from e
     except Exception as e:
         logger.error(f"[Restore] Error restoring task {request.task_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/executor_manager/tests/routers/test_workspace_archive_routes.py
+++ b/executor_manager/tests/routers/test_workspace_archive_routes.py
@@ -9,16 +9,43 @@ import pytest
 
 from executor_manager.routers import routers
 
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _mock_request(task_id=1385, max_size_mb=500):
+    return routers.ArchiveExecutorRequest(
+        task_id=task_id,
+        upload_url="https://minio.local/upload/archive",
+        executor_name="executor-1",
+        executor_namespace="default",
+        max_size_mb=max_size_mb,
+    )
+
+
+def _mock_restore_request(task_id=1385):
+    return routers.RestoreExecutorRequest(
+        task_id=task_id,
+        download_url="https://minio.local/download/archive",
+        executor_name="executor-1",
+        executor_namespace="default",
+    )
+
+
+def _mock_http_request():
+    return SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+
+# =============================================================================
+# Archive existing tests
+# =============================================================================
+
 
 @pytest.mark.asyncio
 async def test_archive_executor_workspace_returns_404_when_runtime_unavailable(mocker):
-    request = routers.ArchiveExecutorRequest(
-        task_id=1385,
-        upload_url="https://minio.local/upload/archive",
-        executor_name="missing-executor",
-        executor_namespace="default",
-    )
-    http_request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    request = _mock_request()
+    http_request = _mock_http_request()
     mock_executor = mocker.MagicMock()
     mock_executor.get_container_address.return_value = {
         "status": "failed",
@@ -36,14 +63,8 @@ async def test_archive_executor_workspace_returns_404_when_runtime_unavailable(m
 
 @pytest.mark.asyncio
 async def test_archive_executor_workspace_forwards_payload(mocker):
-    request = routers.ArchiveExecutorRequest(
-        task_id=1385,
-        upload_url="https://minio.local/upload/archive",
-        executor_name="executor-1",
-        executor_namespace="default",
-        max_size_mb=321,
-    )
-    http_request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+    request = _mock_request(max_size_mb=321)
+    http_request = _mock_http_request()
     mock_executor = mocker.MagicMock()
     mock_executor.get_container_address.return_value = {
         "status": "success",
@@ -76,15 +97,79 @@ async def test_archive_executor_workspace_forwards_payload(mocker):
     )
 
 
+# =============================================================================
+# Archive upstream error mapping tests
+# =============================================================================
+
+
 @pytest.mark.asyncio
-async def test_restore_executor_workspace_wraps_http_errors(mocker):
-    request = routers.RestoreExecutorRequest(
-        task_id=1385,
-        download_url="https://minio.local/download/archive",
-        executor_name="executor-1",
-        executor_namespace="default",
+async def test_archive_upstream_404_returns_502(mocker):
+    request = _mock_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
     )
-    http_request = SimpleNamespace(client=SimpleNamespace(host="127.0.0.1"))
+
+    response = mocker.MagicMock()
+    response.status_code = 404
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=mocker.MagicMock(), response=response
+    )
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(return_value=response)
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.archive_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+    assert "executor.local" not in exc_info.value.detail
+    assert "minio.local" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_archive_upstream_500_returns_502(mocker):
+    request = _mock_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    response = mocker.MagicMock()
+    response.status_code = 500
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Internal Server Error", request=mocker.MagicMock(), response=response
+    )
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(return_value=response)
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.archive_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_archive_upstream_timeout_returns_504(mocker):
+    request = _mock_request()
+    http_request = _mock_http_request()
     mock_executor = mocker.MagicMock()
     mock_executor.get_container_address.return_value = {
         "status": "success",
@@ -97,11 +182,224 @@ async def test_restore_executor_workspace_wraps_http_errors(mocker):
     client = mocker.MagicMock()
     client.__aenter__ = mocker.AsyncMock(return_value=client)
     client.__aexit__ = mocker.AsyncMock(return_value=None)
-    client.post = mocker.AsyncMock(side_effect=httpx.HTTPError("boom"))
+    client.post = mocker.AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.archive_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 504
+    assert "host.docker.internal" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_archive_upstream_connection_error_returns_502(mocker):
+    request = _mock_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.archive_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_archive_generic_http_error_returns_502_without_url_leak(mocker):
+    request = _mock_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(
+        side_effect=httpx.HTTPError(
+            "boom http://host.docker.internal:8001/api/archive https://minio.local/upload"
+        )
+    )
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.archive_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+    assert "minio.local" not in exc_info.value.detail
+    assert "executor.local" not in exc_info.value.detail
+    assert "HTTP error:" not in exc_info.value.detail
+
+
+# =============================================================================
+# Restore existing + upstream error mapping tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_restore_upstream_404_returns_502(mocker):
+    request = _mock_restore_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    response = mocker.MagicMock()
+    response.status_code = 404
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Not Found", request=mocker.MagicMock(), response=response
+    )
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(return_value=response)
     mocker.patch.object(routers, "traced_async_client", return_value=client)
 
     with pytest.raises(routers.HTTPException) as exc_info:
         await routers.restore_executor_workspace(request, http_request)
 
-    assert exc_info.value.status_code == 500
-    assert "HTTP error" in exc_info.value.detail
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+    assert "executor.local" not in exc_info.value.detail
+    assert "minio.local" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_restore_upstream_timeout_returns_504(mocker):
+    request = _mock_restore_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.restore_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 504
+    assert "host.docker.internal" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_restore_generic_http_error_returns_502_without_url_leak(mocker):
+    request = _mock_restore_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(
+        side_effect=httpx.HTTPError(
+            "boom http://host.docker.internal:8001/api/restore https://minio.local/download"
+        )
+    )
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.restore_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+    assert "minio.local" not in exc_info.value.detail
+    assert "executor.local" not in exc_info.value.detail
+    assert "HTTP error:" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_restore_upstream_connection_error_returns_502(mocker):
+    request = _mock_restore_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.restore_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_restore_upstream_500_returns_502(mocker):
+    request = _mock_restore_request()
+    http_request = _mock_http_request()
+    mock_executor = mocker.MagicMock()
+    mock_executor.get_container_address.return_value = {
+        "status": "success",
+        "base_url": "http://executor.local:8000",
+    }
+    mocker.patch.object(
+        routers.ExecutorDispatcher, "get_executor", return_value=mock_executor
+    )
+
+    response = mocker.MagicMock()
+    response.status_code = 500
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "Internal Server Error", request=mocker.MagicMock(), response=response
+    )
+    client = mocker.MagicMock()
+    client.__aenter__ = mocker.AsyncMock(return_value=client)
+    client.__aexit__ = mocker.AsyncMock(return_value=None)
+    client.post = mocker.AsyncMock(return_value=response)
+    mocker.patch.object(routers, "traced_async_client", return_value=client)
+
+    with pytest.raises(routers.HTTPException) as exc_info:
+        await routers.restore_executor_workspace(request, http_request)
+
+    assert exc_info.value.status_code == 502
+    assert "host.docker.internal" not in exc_info.value.detail


### PR DESCRIPTION
## Problem

Archive/restore endpoints returned bare `500 Internal Server Error` with internal URLs leaked in error detail when the upstream executor runtime API returned 404, timeout, or connection error.

**Before fix:**

```http
HTTP/1.1 500 Internal Server Error
{"detail":"HTTP error: Client error '404 Not Found' for url 'http://host.docker.internal:8001/api/archive'"}
```

This exposed infrastructure details (`host.docker.internal`, internal API paths) to clients.

## Root Cause

Both `archive_executor_workspace` and `restore_executor_workspace` caught all `httpx.HTTPError` exceptions and returned a generic 500 with the raw exception string, which includes the full upstream URL.

## Fix

Add specific error mapping for different upstream failure modes:

| Upstream Error | Before | After | Detail |
|---------------|--------|-------|--------|
| 4xx/5xx (HTTPStatusError) | 500 + raw URL | **502** | "service returned an error" |
| Timeout (TimeoutException) | 500 + raw URL | **504** | "service timed out" |
| Connection error (ConnectError, RemoteProtocolError, NetworkError) | 500 + raw URL | **502** | "service is unavailable" |
| Other HTTPError (fallback) | 500 + raw URL | **502** | "service returned an error" |

Internal URLs are logged but never exposed in error detail.

## Files Changed

- `executor_manager/routers/routers.py` — Add httpx exception mapping for archive and restore
- `executor_manager/tests/routers/test_workspace_archive_routes.py` — 10 new upstream error mapping tests

## Tests

12 tests total (2 existing + 10 new). All upstream error tests verify:

1. Correct HTTP status code (502 or 504)
2. No internal URL leak in response detail (`host.docker.internal`, `executor.local`, `minio.local`, `HTTP error:`)

| Test | Scenario | Assert |
|------|----------|--------|
| `test_archive_upstream_404_returns_502` | HTTPStatusError 404 | 502 + no URL |
| `test_archive_upstream_500_returns_502` | HTTPStatusError 500 | 502 + no URL |
| `test_archive_upstream_timeout_returns_504` | TimeoutException | 504 + no URL |
| `test_archive_upstream_connection_error_returns_502` | ConnectError | 502 + no URL |
| `test_archive_generic_http_error_returns_502_without_url_leak` | HTTPError with URL in message | 502 + no URL |
| `test_restore_upstream_404_returns_502` | HTTPStatusError 404 | 502 + no URL |
| `test_restore_upstream_timeout_returns_504` | TimeoutException | 504 + no URL |
| `test_restore_upstream_connection_error_returns_502` | ConnectError | 502 + no URL |
| `test_restore_upstream_500_returns_502` | HTTPStatusError 500 | 502 + no URL |
| `test_restore_generic_http_error_returns_502_without_url_leak` | HTTPError with URL in message | 502 + no URL |

## PR Scope

**This PR only fixes upstream error mapping.** It does NOT modify:
- Archive/restore request validation (#1359, #1360)
- Prepare endpoint / skip_git_clone (#1361)
- Docker executor lifecycle
- OpenAPI docs

## Verification

```
uv run pytest tests/routers/test_workspace_archive_routes.py -v
# 12 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined upstream error handling for archive/restore flows: timeouts → HTTP 504; connection/protocol/status failures and generic upstream errors → HTTP 502
  * Error responses and logging adjusted to avoid exposing internal URLs/hosts or raw upstream details

* **Tests**
  * Added/updated tests to validate status mappings and that internal hostnames/URLs are not leaked in error responses
<!-- end of auto-generated comment: release notes by coderabbit.ai -->