### PR TITLE
[codex] fix startup internal service token bootstrap

### DIFF
--- a/scripts/test-start-internal-token.sh
+++ b/scripts/test-start-internal-token.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression test for start.sh internal service token bootstrapping.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+START_SH="$PROJECT_ROOT/start.sh"
+
+start_services_body=$(awk '
+    /^start_services\(\) \{/ {
+        in_function = 1
+        depth = 1
+        print
+        next
+    }
+    in_function {
+        print
+        opens = gsub(/\{/, "{")
+        closes = gsub(/\}/, "}")
+        depth += opens - closes
+        if (depth == 0) {
+            exit
+        }
+    }
+' "$START_SH")
+
+ensure_line=$(printf '%s\n' "$start_services_body" | awk '/ensure_internal_service_token/ { print NR; exit }')
+compose_line=$(printf '%s\n' "$start_services_body" | awk '/check_mysql_redis/ { print NR; exit }')
+
+if [ -z "$ensure_line" ]; then
+    echo "Expected start_services to call ensure_internal_service_token."
+    exit 1
+fi
+
+if [ -z "$compose_line" ]; then
+    echo "Expected start_services to call check_mysql_redis."
+    exit 1
+fi
+
+if [ "$ensure_line" -ge "$compose_line" ]; then
+    echo "Expected INTERNAL_SERVICE_TOKEN to be ensured before Docker Compose is used."
+    echo "ensure_internal_service_token line in start_services: $ensure_line"
+    echo "check_mysql_redis line in start_services: $compose_line"
+    exit 1
+fi
+
+echo "start.sh internal token bootstrap regression test passed"

--- a/start.sh
+++ b/start.sh
@@ -2052,6 +2052,10 @@ start_services() {
     local compose_version=$($DOCKER_COMPOSE_CMD version 2>&1 | head -n 1)
     echo -e "  ${GREEN}✓${NC} Docker Compose detected: $compose_version"
 
+    # Docker Compose validates the whole compose file before starting selected
+    # services, so the internal token must exist before any compose command runs.
+    ensure_internal_service_token
+
     # Check and start MySQL and Redis if needed
     check_mysql_redis
 
@@ -2094,10 +2098,6 @@ start_services() {
 
     if [ "$port_resolution_failed" = true ]; then
         exit 1
-    fi
-
-    if [ "$start_backend" = true ] || [ "$start_chat_shell" = true ] || [ "$start_knowledge_runtime" = true ]; then
-        ensure_internal_service_token
     fi
 
     compute_derived_urls "$previous_backend_port" "$previous_executor_manager_port" "$previous_knowledge_runtime_port"


### PR DESCRIPTION
## Summary
- Ensure `start.sh` generates and persists `INTERNAL_SERVICE_TOKEN` before any Docker Compose command runs.
- Remove the later conditional token generation call because the token is now guaranteed during prerequisite checks.
- Add a lightweight shell regression test that verifies token bootstrapping happens before `check_mysql_redis`.

## Root Cause
Docker Compose validates the full `docker-compose.yml` before starting selected services. Because `check_mysql_redis` can call Compose before `INTERNAL_SERVICE_TOKEN` was generated, first-time local startup could fail while resolving `${INTERNAL_SERVICE_TOKEN:?Set INTERNAL_SERVICE_TOKEN in .env...}`.

## Validation
- `bash scripts/test-start-internal-token.sh`
- `bash -n start.sh scripts/test-start-internal-token.sh`
- `git diff --check`

Note: `shellcheck` is not installed in this local environment, so it was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test for service token initialization during startup.

* **Bug Fixes**
  * Adjusted startup sequence to generate service token earlier in the initialization process, ensuring proper token availability before dependent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->