### PR TITLE
[codex] Support Wework image attachments in Codex

### DIFF
--- a/executor/agents/claude_code/attachment_handler.py
+++ b/executor/agents/claude_code/attachment_handler.py
@@ -75,37 +75,24 @@ def download_attachments(
         )
 
     try:
-        from executor.config import config
         from executor.services.attachment_downloader import AttachmentDownloader
         from executor.services.attachment_prompt_processor import (
             AttachmentPromptProcessor,
         )
 
-        # Determine workspace path for attachments. Project workspace mode keeps
-        # attachments under the shared project directory but still scoped by
-        # task_id/subtask_id.
-        project_workspace = task_data.project_workspace_path
-        if not project_workspace and task_data.project_id and task_data.git_url:
-            repo_name = git_util.get_repo_name_from_url(task_data.git_url)
-            safe_repo_name = repo_name.replace("/", "_").replace("\\", "_")
-            project_workspace = os.path.join(
-                "projects", str(task_data.project_id), safe_repo_name
-            )
-        project_layout = bool(task_data.project_id and project_workspace)
-        if project_layout:
-            project_workspace = os.path.expanduser(str(project_workspace))
-            if not os.path.isabs(project_workspace):
-                project_workspace = os.path.join(
-                    config.get_workspace_root(), project_workspace
-                )
-            workspace = os.path.join(project_workspace, ".wegent", "attachments")
-        else:
-            workspace = os.path.join(config.get_workspace_root(), str(task_id))
+        workspace, project_layout = _resolve_attachment_workspace(
+            task_data,
+            task_id,
+        )
+        attachment_subtask_id = _resolve_attachment_subtask_id(
+            attachments,
+            fallback=getattr(task_data, "user_subtask_id", None) or subtask_id,
+        )
 
         downloader = AttachmentDownloader(
             workspace=workspace,
             task_id=str(task_id),
-            subtask_id=str(subtask_id),
+            subtask_id=str(attachment_subtask_id),
             auth_token=auth_token,
             project_layout=project_layout,
         )
@@ -124,7 +111,7 @@ def download_attachments(
                 result.success,
                 result.failed,
                 task_id=task_id,
-                subtask_id=subtask_id,
+                subtask_id=attachment_subtask_id,
             )
 
             # String prompts may still rely on explicit attachment context. For
@@ -171,6 +158,46 @@ def download_attachments(
             success_count=0,
             failed_count=len(attachments),
         )
+
+
+def _resolve_attachment_workspace(
+    task_data: ExecutionRequest,
+    task_id: int,
+) -> tuple[str, bool]:
+    """Resolve attachment root and layout for Claude Code downloads."""
+
+    from executor.config import config
+
+    project_workspace = getattr(task_data, "project_workspace_path", None)
+    if not project_workspace and task_data.project_id and task_data.git_url:
+        repo_name = git_util.get_repo_name_from_url(task_data.git_url)
+        safe_repo_name = repo_name.replace("/", "_").replace("\\", "_")
+        project_workspace = os.path.join(
+            "projects", str(task_data.project_id), safe_repo_name
+        )
+
+    if project_workspace:
+        project_workspace = os.path.expanduser(str(project_workspace))
+        if not os.path.isabs(project_workspace):
+            project_workspace = os.path.join(
+                config.get_workspace_root(), project_workspace
+            )
+        return os.path.join(project_workspace, ".wegent", "attachments"), True
+
+    return os.path.join(config.get_workspace_root(), str(task_id)), False
+
+
+def _resolve_attachment_subtask_id(
+    attachments: list[dict[str, Any]],
+    fallback: int,
+) -> int:
+    """Prefer the source user-message subtask id embedded in attachment metadata."""
+
+    for attachment in attachments:
+        subtask_id = attachment.get("subtask_id")
+        if subtask_id is not None:
+            return int(subtask_id)
+    return int(fallback)
 
 
 def get_attachment_thinking_step_details(

--- a/executor/agents/codex/attachment_handler.py
+++ b/executor/agents/codex/attachment_handler.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Attachment handling for the Codex agent."""
+
+import os
+from dataclasses import dataclass
+from typing import Any, Union
+
+from executor.config import config
+from executor.services.attachment_downloader import AttachmentDownloader
+from executor.services.attachment_prompt_processor import (
+    IMAGE_MIME_TYPES,
+    AttachmentPromptProcessor,
+)
+from shared.logger import setup_logger
+from shared.models.execution import ExecutionRequest
+
+logger = setup_logger("codex_attachment_handler")
+
+
+@dataclass
+class CodexAttachmentProcessResult:
+    """Result of preparing attachments for a Codex turn."""
+
+    prompt: Union[str, list[dict[str, Any]]]
+    local_image_paths: list[str | None]
+    success_count: int
+    failed_count: int
+
+
+def process_codex_attachments(
+    task_data: ExecutionRequest,
+    task_id: int,
+    subtask_id: int,
+    prompt: Union[str, list[dict[str, Any]]],
+) -> CodexAttachmentProcessResult:
+    """Download attachments and rewrite backend sandbox paths for Codex."""
+
+    attachments = task_data.attachments
+    if not attachments:
+        return CodexAttachmentProcessResult(
+            prompt=prompt,
+            local_image_paths=[],
+            success_count=0,
+            failed_count=0,
+        )
+
+    auth_token = task_data.auth_token
+    if not auth_token:
+        logger.warning("No auth token available, cannot download Codex attachments")
+        return CodexAttachmentProcessResult(
+            prompt=prompt,
+            local_image_paths=[],
+            success_count=0,
+            failed_count=len(attachments),
+        )
+
+    try:
+        workspace, project_layout = _resolve_attachment_workspace()
+        attachment_subtask_id = _resolve_attachment_subtask_id(
+            attachments,
+            fallback=getattr(task_data, "user_subtask_id", None) or subtask_id,
+        )
+        downloader = AttachmentDownloader(
+            workspace=workspace,
+            task_id=str(task_id),
+            subtask_id=str(attachment_subtask_id),
+            auth_token=auth_token,
+            project_layout=project_layout,
+        )
+        result = downloader.download_all(attachments)
+
+        modified_prompt = prompt
+        if result.success or result.failed:
+            modified_prompt = AttachmentPromptProcessor.process_prompt(
+                prompt,
+                result.success,
+                result.failed,
+                task_id=task_id,
+                subtask_id=attachment_subtask_id,
+            )
+            if isinstance(modified_prompt, str):
+                attachment_context = AttachmentPromptProcessor.build_attachment_context(
+                    result.success,
+                )
+                if attachment_context:
+                    modified_prompt += attachment_context
+
+        success_by_id = {att.get("id"): att for att in result.success}
+        local_image_paths = []
+        for attachment in attachments:
+            if attachment.get("mime_type") not in IMAGE_MIME_TYPES:
+                continue
+            success_attachment = success_by_id.get(attachment.get("id"))
+            local_path = (
+                str(success_attachment["local_path"])
+                if success_attachment and success_attachment.get("local_path")
+                else None
+            )
+            local_image_paths.append(local_path)
+        logger.info(
+            "Prepared Codex attachments: %s success, %s failed, %s local images",
+            len(result.success),
+            len(result.failed),
+            len([path for path in local_image_paths if path]),
+        )
+        return CodexAttachmentProcessResult(
+            prompt=modified_prompt,
+            local_image_paths=local_image_paths,
+            success_count=len(result.success),
+            failed_count=len(result.failed),
+        )
+    except Exception as exc:
+        logger.error("Error preparing Codex attachments: %s", exc)
+        return CodexAttachmentProcessResult(
+            prompt=prompt,
+            local_image_paths=[],
+            success_count=0,
+            failed_count=len(attachments),
+        )
+
+
+def _resolve_attachment_workspace() -> tuple[str, bool]:
+    return os.path.join(config.get_workspace_root(), "attachments"), True
+
+
+def _resolve_attachment_subtask_id(
+    attachments: list[dict[str, Any]],
+    fallback: int,
+) -> int:
+    for attachment in attachments:
+        subtask_id = attachment.get("subtask_id")
+        if subtask_id is not None:
+            return int(subtask_id)
+    return int(fallback)

--- a/executor/agents/codex/codex_agent.py
+++ b/executor/agents/codex/codex_agent.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional, Tuple
 
 from executor.agents.base import Agent
+from executor.agents.codex.attachment_handler import process_codex_attachments
 from executor.agents.codex.config_builder import CodeXConfig, build_codex_config
 from executor.agents.codex.event_mapper import CodeXEventMapper
 from executor.agents.codex.session_store import CodeXSessionStore
@@ -69,6 +70,7 @@ class CodeXAgent(Agent):
         self._turn = None
         self._bot_id = self._resolve_bot_id(task_data)
         self._session_store = CodeXSessionStore()
+        self._local_image_paths: list[str | None] = []
         self.on_client_created_callback: Optional[Callable[[], Any]] = None
 
     def initialize(self) -> TaskStatus:
@@ -140,12 +142,13 @@ class CodeXAgent(Agent):
             await self._start_codex_client()
             await self._open_thread()
             await self._notify_client_created()
+            self._process_attachments_for_codex()
 
-            input_text = self._build_turn_input()
+            turn_input = self._build_turn_input()
             effort, summary = self._build_reasoning_params()
             await self.start_turn_file_change_tracking()
             self._turn = await self._thread.turn(
-                input_text,
+                turn_input,
                 cwd=self.project_path,
                 effort=effort,
                 model=self.codex_config.model,
@@ -263,14 +266,34 @@ class CodeXAgent(Agent):
         except Exception as exc:
             logger.warning("CodeXAgent client-created callback failed: %s", exc)
 
-    def _build_turn_input(self) -> str:
+    def _process_attachments_for_codex(self) -> None:
+        result = process_codex_attachments(
+            task_data=self.task_data,
+            task_id=self.task_id,
+            subtask_id=self.subtask_id,
+            prompt=self.prompt,
+        )
+        self.prompt = result.prompt
+        self._local_image_paths = result.local_image_paths
+
+    def _build_turn_input(self) -> Any:
+        from openai_codex import ImageInput, LocalImageInput, TextInput
+
         prompt = self.prompt
         if isinstance(prompt, str):
-            return prompt
+            if not self._local_image_paths:
+                return prompt
+            items: list[Any] = [TextInput(self._build_files_mentioned_text([prompt]))]
+            items.extend(
+                LocalImageInput(path) for path in self._local_image_paths if path
+            )
+            return items
         if not isinstance(prompt, list):
             return str(prompt)
 
-        parts: list[str] = []
+        text_parts: list[str] = []
+        image_items: list[Any] = []
+        local_image_index = 0
         for block in prompt:
             if not isinstance(block, dict):
                 continue
@@ -278,10 +301,90 @@ class CodeXAgent(Agent):
             if block_type in {"input_text", "text"}:
                 text = block.get("text")
                 if text:
-                    parts.append(str(text))
+                    text_parts.append(str(text))
             elif block_type in {"input_image", "image_url"}:
-                parts.append("[Image input omitted by CodeXAgent]")
-        return "\n\n".join(parts)
+                local_path = None
+                if local_image_index < len(self._local_image_paths):
+                    local_path = self._next_local_image_path(local_image_index)
+                    local_image_index += 1
+                if local_path:
+                    image_items.append(LocalImageInput(local_path))
+                    continue
+
+                image_url = self._extract_image_url(block)
+                if image_url:
+                    image_items.append(ImageInput(image_url))
+
+        items: list[Any] = []
+        if self._has_local_images():
+            items.append(TextInput(self._build_files_mentioned_text(text_parts)))
+        elif text_parts:
+            items.append(TextInput("\n\n".join(text_parts)))
+        items.extend(image_items)
+        return items or ""
+
+    def _next_local_image_path(self, index: int) -> Optional[str]:
+        if index >= len(self._local_image_paths):
+            return None
+        return self._local_image_paths[index]
+
+    def _has_local_images(self) -> bool:
+        return any(self._local_image_paths)
+
+    def _build_files_mentioned_text(self, text_parts: list[str]) -> str:
+        file_lines = "\n".join(
+            f"## {os.path.basename(path)}: {path}"
+            for path in self._local_image_paths
+            if path
+        )
+        request_text = self._extract_user_request_text(text_parts)
+        return (
+            "\n# Files mentioned by the user:\n\n"
+            f"{file_lines}\n\n"
+            "## My request for Codex:\n"
+            f"{request_text}\n"
+        )
+
+    @classmethod
+    def _extract_user_request_text(cls, text_parts: list[str]) -> str:
+        request_parts = []
+        for text in text_parts:
+            user_text = cls._strip_attachment_warnings(
+                cls._strip_attachment_blocks(str(text))
+            ).strip()
+            if user_text:
+                request_parts.append(user_text)
+        return "\n\n".join(request_parts)
+
+    @staticmethod
+    def _strip_attachment_blocks(text: str) -> str:
+        remaining = text
+        while True:
+            start = remaining.find("<attachment>")
+            if start < 0:
+                return remaining
+            end = remaining.find("</attachment>", start)
+            if end < 0:
+                return remaining
+            remaining = remaining[:start] + remaining[end + len("</attachment>") :]
+
+    @staticmethod
+    def _strip_attachment_warnings(text: str) -> str:
+        warning_marker = "\n\n⚠️ The following attachments failed to download"
+        marker_index = text.find(warning_marker)
+        if marker_index < 0:
+            return text
+        return text[:marker_index]
+
+    @staticmethod
+    def _extract_image_url(block: dict[str, Any]) -> Optional[str]:
+        image_url = block.get("image_url")
+        if isinstance(image_url, str):
+            return image_url
+        if isinstance(image_url, dict):
+            url = image_url.get("url")
+            return str(url) if url else None
+        return None
 
     def _build_developer_instructions(self) -> Optional[str]:
         parts = [

--- a/executor/tests/agents/test_codex_attachment_input.py
+++ b/executor/tests/agents/test_codex_attachment_input.py
@@ -2,7 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+from dataclasses import dataclass
+from types import ModuleType
 from unittest.mock import MagicMock
+
+
+@dataclass
+class TextInput:
+    text: str
+
+
+@dataclass
+class ImageInput:
+    url: str
+
+
+@dataclass
+class LocalImageInput:
+    path: str
+
+
+openai_codex_stub = ModuleType("openai_codex")
+openai_codex_stub.TextInput = TextInput
+openai_codex_stub.ImageInput = ImageInput
+openai_codex_stub.LocalImageInput = LocalImageInput
+sys.modules.setdefault("openai_codex", openai_codex_stub)
 
 from executor.agents.codex.codex_agent import CodeXAgent
 from executor.services.attachment_downloader import AttachmentDownloadResult

--- a/executor/tests/agents/test_codex_attachment_input.py
+++ b/executor/tests/agents/test_codex_attachment_input.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+from executor.agents.codex.codex_agent import CodeXAgent
+from executor.services.attachment_downloader import AttachmentDownloadResult
+from shared.models.execution import ExecutionRequest
+
+
+def _codex_request(**overrides):
+    data = {
+        "task_id": 29,
+        "subtask_id": 44,
+        "model_config": {
+            "model": "openai",
+            "model_id": "gpt-5.5",
+            "api_format": "responses",
+        },
+    }
+    data.update(overrides)
+    return ExecutionRequest(**data)
+
+
+def test_codex_build_turn_input_preserves_inline_image_blocks():
+    request = _codex_request(
+        prompt=[
+            {"type": "input_text", "text": "Analyze this image"},
+            {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+        ],
+    )
+    agent = CodeXAgent(request, MagicMock())
+
+    turn_input = agent._build_turn_input()
+
+    assert [type(item).__name__ for item in turn_input] == ["TextInput", "ImageInput"]
+    assert turn_input[0].text == "Analyze this image"
+    assert turn_input[1].url == "data:image/png;base64,abc"
+
+
+def test_codex_attachment_processing_rewrites_sandbox_path_to_local_image(
+    tmp_path,
+    monkeypatch,
+):
+    workspace_root = tmp_path / "workspace"
+    local_image = workspace_root / "attachments" / "29" / "43" / "image.png"
+    local_image.parent.mkdir(parents=True)
+    local_image.write_bytes(b"png")
+    sandbox_path = "/home/user/29:executor:attachments/43/image.png"
+    request = _codex_request(
+        auth_token="token",
+        prompt=[
+            {
+                "type": "input_text",
+                "text": (
+                    "<attachment>[Image Attachment: image.png | ID: 15 | "
+                    "File Path(already in sandbox): "
+                    f"{sandbox_path}]</attachment>"
+                ),
+            },
+            {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+            {"type": "input_text", "text": "分析一下这张图片"},
+        ],
+        attachments=[
+            {
+                "id": 15,
+                "original_filename": "image.png",
+                "mime_type": "image/png",
+                "file_size": 3,
+                "subtask_id": 43,
+            }
+        ],
+    )
+    agent = CodeXAgent(request, MagicMock())
+    monkeypatch.setattr(
+        "executor.agents.codex.attachment_handler.config.get_workspace_root",
+        lambda: str(workspace_root),
+    )
+
+    def fake_download_all(self, attachments):
+        assert self.workspace == str(workspace_root / "attachments")
+        assert self.project_layout is True
+        assert self.get_attachment_path("image.png") == str(local_image)
+        return AttachmentDownloadResult(
+            success=[{**attachments[0], "local_path": str(local_image)}],
+            failed=[],
+        )
+
+    monkeypatch.setattr(
+        "executor.services.attachment_downloader.AttachmentDownloader.download_all",
+        fake_download_all,
+    )
+
+    agent._process_attachments_for_codex()
+    turn_input = agent._build_turn_input()
+
+    text = turn_input[0].text
+    assert sandbox_path not in text
+    assert text == (
+        "\n# Files mentioned by the user:\n\n"
+        f"## image.png: {local_image}\n\n"
+        "## My request for Codex:\n"
+        "分析一下这张图片\n"
+    )
+    assert [type(item).__name__ for item in turn_input] == [
+        "TextInput",
+        "LocalImageInput",
+    ]
+    assert turn_input[1].path == str(local_image)
+
+
+def test_codex_attachment_only_empty_text_leaves_request_empty(tmp_path, monkeypatch):
+    local_image = tmp_path / "image.png"
+    local_image.write_bytes(b"png")
+    request = _codex_request(
+        auth_token="token",
+        prompt=[
+            {
+                "type": "input_text",
+                "text": "<attachment>[Image Attachment: image.png]</attachment>",
+            },
+            {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+            {"type": "input_text", "text": ""},
+        ],
+        attachments=[
+            {
+                "id": 15,
+                "original_filename": "image.png",
+                "mime_type": "image/png",
+                "file_size": 3,
+                "subtask_id": 43,
+            }
+        ],
+    )
+    agent = CodeXAgent(request, MagicMock())
+
+    def fake_download_all(self, attachments):
+        return AttachmentDownloadResult(
+            success=[{**attachments[0], "local_path": str(local_image)}],
+            failed=[],
+        )
+
+    monkeypatch.setattr(
+        "executor.services.attachment_downloader.AttachmentDownloader.download_all",
+        fake_download_all,
+    )
+
+    agent._process_attachments_for_codex()
+    turn_input = agent._build_turn_input()
+
+    assert turn_input[0].text == (
+        "\n# Files mentioned by the user:\n\n"
+        f"## image.png: {local_image}\n\n"
+        "## My request for Codex:\n"
+        "\n"
+    )
+
+
+def test_codex_preserves_literal_attachment_reference_request(tmp_path, monkeypatch):
+    local_image = tmp_path / "image.png"
+    local_image.write_bytes(b"png")
+    request = _codex_request(
+        auth_token="token",
+        prompt=[
+            {
+                "type": "input_text",
+                "text": "<attachment>[Image Attachment: image.png]</attachment>",
+            },
+            {"type": "input_image", "image_url": "data:image/png;base64,abc"},
+            {"type": "input_text", "text": "请参考附件"},
+        ],
+        attachments=[
+            {
+                "id": 15,
+                "original_filename": "image.png",
+                "mime_type": "image/png",
+                "file_size": 3,
+                "subtask_id": 43,
+            }
+        ],
+    )
+    agent = CodeXAgent(request, MagicMock())
+
+    def fake_download_all(self, attachments):
+        return AttachmentDownloadResult(
+            success=[{**attachments[0], "local_path": str(local_image)}],
+            failed=[],
+        )
+
+    monkeypatch.setattr(
+        "executor.services.attachment_downloader.AttachmentDownloader.download_all",
+        fake_download_all,
+    )
+
+    agent._process_attachments_for_codex()
+    turn_input = agent._build_turn_input()
+
+    assert turn_input[0].text == (
+        "\n# Files mentioned by the user:\n\n"
+        f"## image.png: {local_image}\n\n"
+        "## My request for Codex:\n"
+        "请参考附件\n"
+    )
+
+
+def test_codex_attachment_processing_keeps_image_order_when_download_fails(
+    tmp_path,
+    monkeypatch,
+):
+    second_image = tmp_path / "second.png"
+    second_image.write_bytes(b"png")
+    request = _codex_request(
+        auth_token="token",
+        prompt=[
+            {"type": "input_text", "text": "Compare these images"},
+            {"type": "input_image", "image_url": "data:image/png;base64,first"},
+            {"type": "input_image", "image_url": "data:image/png;base64,second"},
+        ],
+        attachments=[
+            {
+                "id": 15,
+                "original_filename": "first.png",
+                "mime_type": "image/png",
+                "file_size": 3,
+                "subtask_id": 43,
+            },
+            {
+                "id": 16,
+                "original_filename": "second.png",
+                "mime_type": "image/png",
+                "file_size": 3,
+                "subtask_id": 43,
+            },
+        ],
+    )
+    agent = CodeXAgent(request, MagicMock())
+
+    def fake_download_all(self, attachments):
+        return AttachmentDownloadResult(
+            success=[{**attachments[1], "local_path": str(second_image)}],
+            failed=[{**attachments[0], "error": "HTTP 404"}],
+        )
+
+    monkeypatch.setattr(
+        "executor.services.attachment_downloader.AttachmentDownloader.download_all",
+        fake_download_all,
+    )
+
+    agent._process_attachments_for_codex()
+    turn_input = agent._build_turn_input()
+
+    assert [type(item).__name__ for item in turn_input] == [
+        "TextInput",
+        "ImageInput",
+        "LocalImageInput",
+    ]
+    assert turn_input[0].text == (
+        "\n# Files mentioned by the user:\n\n"
+        f"## second.png: {second_image}\n\n"
+        "## My request for Codex:\n"
+        "Compare these images\n"
+    )
+    assert turn_input[1].url == "data:image/png;base64,first"
+    assert turn_input[2].path == str(second_image)

--- a/executor/tests/services/test_attachment_handler.py
+++ b/executor/tests/services/test_attachment_handler.py
@@ -5,6 +5,7 @@
 from unittest.mock import MagicMock, patch
 
 from executor.agents.claude_code.attachment_handler import download_attachments
+from executor.services.attachment_downloader import AttachmentDownloadResult
 from shared.models.execution import ExecutionRequest
 
 
@@ -99,3 +100,73 @@ class TestDownloadAttachments:
             "Do not assume a workspace/<task_id>/attachments/ directory."
             not in result.prompt
         )
+
+    def test_project_zero_workspace_downloads_to_project_attachment_layout(
+        self, tmp_path
+    ):
+        """Wework standalone chats should keep attachments under the chat workspace."""
+        project_workspace = tmp_path / "chats" / "2026-06-12" / "hello"
+        local_image = (
+            project_workspace / ".wegent" / "attachments" / "31" / "45" / "image.png"
+        )
+        local_image.parent.mkdir(parents=True)
+        local_image.write_bytes(b"png")
+        sandbox_path = "/home/user/31:executor:attachments/45/image.png"
+        task_data = ExecutionRequest(
+            task_id=31,
+            subtask_id=46,
+            auth_token="test-token",  # noqa: S106
+            project_id=0,
+            standalone_chat_workspace=True,
+            workspace_source="local_path",
+            project_workspace_path=str(project_workspace),
+            user_subtask_id=45,
+            attachments=[
+                {
+                    "id": 16,
+                    "original_filename": "image.png",
+                    "mime_type": "image/png",
+                    "file_size": 3,
+                    "subtask_id": 45,
+                }
+            ],
+        )
+        prompt = [
+            {
+                "type": "input_text",
+                "text": (
+                    "<attachment>[Image Attachment: image.png | ID: 16 | "
+                    "File Path(already in sandbox): "
+                    f"{sandbox_path}]</attachment>"
+                ),
+            }
+        ]
+
+        download_calls = []
+
+        def fake_download_all(self, attachments):
+            download_calls.append(attachments)
+            assert self.workspace == str(project_workspace / ".wegent" / "attachments")
+            assert self.project_layout is True
+            assert self.subtask_id == "45"
+            assert self.get_attachment_path("image.png") == str(local_image)
+            return AttachmentDownloadResult(
+                success=[{**attachments[0], "local_path": str(local_image)}],
+                failed=[],
+            )
+
+        with patch(
+            "executor.services.attachment_downloader.AttachmentDownloader.download_all",
+            fake_download_all,
+        ):
+            result = download_attachments(
+                task_data=task_data,
+                task_id=31,
+                subtask_id=46,
+                prompt=prompt,
+            )
+
+        assert len(download_calls) == 1
+        assert result.success_count == 1
+        assert sandbox_path not in result.prompt[0]["text"]
+        assert f"Local File Path: {local_image}" in result.prompt[0]["text"]

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -179,6 +179,61 @@ describe('MessageList', () => {
     )
   })
 
+  test('lays out multiple image attachments horizontally in user messages', async () => {
+    URL.createObjectURL = vi.fn(() => 'blob:message-image-preview')
+    URL.revokeObjectURL = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: vi.fn().mockResolvedValue(new Blob(['image'], { type: 'image/png' })),
+      })
+    )
+
+    const attachments: Attachment[] = [
+      {
+        id: 43,
+        filename: 'first.png',
+        file_size: 1024,
+        mime_type: 'image/png',
+        status: 'ready',
+        file_extension: '.png',
+        created_at: '2026-05-25T15:08:00.000+08:00',
+      },
+      {
+        id: 44,
+        filename: 'second.png',
+        file_size: 1024,
+        mime_type: 'image/png',
+        status: 'ready',
+        file_extension: '.png',
+        created_at: '2026-05-25T15:08:00.000+08:00',
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '1',
+            role: 'user',
+            content: '',
+            status: 'done',
+            attachments,
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    expect(await screen.findAllByTestId('message-image-preview')).toHaveLength(2)
+    expect(screen.getByTestId('message-image-attachments')).toHaveClass(
+      'flex-row',
+      'flex-wrap',
+      'justify-end',
+    )
+  })
+
   test('renders document attachments in user messages', () => {
     const attachment: Attachment = {
       id: 44,

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -125,12 +125,19 @@ function UserMessage({ message }: { message: WorkbenchMessage }) {
     <div className="group flex max-w-[80%] flex-col items-end gap-1.5">
       {(imageAttachments.length > 0 || documentAttachments.length > 0) && (
         <div className="flex max-w-full flex-col items-end gap-2">
-          {imageAttachments.map(attachment => (
-            <MessageImageAttachmentPreview
-              key={attachment.id}
-              attachment={attachment}
-            />
-          ))}
+          {imageAttachments.length > 0 && (
+            <div
+              data-testid="message-image-attachments"
+              className="flex max-w-full flex-row flex-wrap justify-end gap-2"
+            >
+              {imageAttachments.map(attachment => (
+                <MessageImageAttachmentPreview
+                  key={attachment.id}
+                  attachment={attachment}
+                />
+              ))}
+            </div>
+          )}
           {documentAttachments.map(attachment => (
             <MessageDocumentAttachment
               key={attachment.id}

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -2725,7 +2725,7 @@ describe('WorkbenchProvider', () => {
     expect(updateCurrentUser).not.toHaveBeenCalled()
   })
 
-  test('sends an attachment-only project message with fallback text', async () => {
+  test('sends an attachment-only project message without echoing fallback text', async () => {
     const sendMessage = vi.fn().mockResolvedValue({ success: true, task_id: 100 })
 
     function AttachmentOnlyProbe() {
@@ -2744,6 +2744,14 @@ describe('WorkbenchProvider', () => {
         <div>
           <span data-testid="attachment-probe-ready">
             {workbench.state.defaultTeam ? 'ready' : 'loading'}
+          </span>
+          <span data-testid="attachment-message-contents">
+            {workbench.messages
+              .map(message => `${message.role}:${message.status}:${message.content}`)
+              .join('|')}
+          </span>
+          <span data-testid="attachment-current-task-title">
+            {workbench.state.currentTask?.title ?? ''}
           </span>
           <button type="button" onClick={() => workbench.projectChat.addExistingAttachment(attachment)}>
             add attachment
@@ -2829,10 +2837,20 @@ describe('WorkbenchProvider', () => {
     await waitFor(() =>
       expect(sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: '请参考附件',
+          message: '',
+          title: '新对话',
           attachment_ids: [55],
         })
       )
+    )
+    expect(screen.getByTestId('attachment-message-contents')).not.toHaveTextContent(
+      '请参考附件'
+    )
+    expect(screen.getByTestId('attachment-message-contents')).toHaveTextContent(
+      'user:done:'
+    )
+    expect(screen.getByTestId('attachment-current-task-title')).toHaveTextContent(
+      '新对话'
     )
   })
 

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -85,6 +85,7 @@ import { WorkbenchContext } from './useWorkbench'
 const WEWORK_CLIENT_ORIGIN = 'wework'
 const LOCAL_SKILLS_CACHE_TTL_MS = 60_000
 const STANDALONE_PROJECT_ID = 0
+const EMPTY_MESSAGE_TASK_TITLE = '新对话'
 const DEVICE_STATUS_LABELS: Record<string, string> = {
   online: '在线',
   busy: '忙碌',
@@ -1544,6 +1545,9 @@ export function WorkbenchProvider({
 
       if (attachmentSelection.attachments.length > 0) {
         payload.attachment_ids = attachmentSelection.attachments.map(attachment => attachment.id)
+        if (!message && !state.currentTask) {
+          payload.title = EMPTY_MESSAGE_TASK_TITLE
+        }
       }
 
       return { payload, activeDeviceId }
@@ -1615,14 +1619,14 @@ export function WorkbenchProvider({
 
       if (!state.currentTask && ack.task_id) {
         const projectId = payload.project_id ?? state.currentProject?.id ?? 0
-        const routeProjectId = projectId > 0 ? projectId : undefined
+        const routeProjectId = projectId
         // Navigate to the canonical task route so a freshly created chat shares
         // the same URL shape as opening an existing one (path, not ?taskId=).
         handledTaskRouteRef.current = getTaskRouteKey(ack.task_id, routeProjectId)
         navigateTo(buildTaskRoute({ taskId: ack.task_id, projectId: routeProjectId }))
         const openedTask: Task = {
           id: ack.task_id,
-          title: message.substring(0, 100),
+          title: (payload.title ?? message).substring(0, 100),
           status: 'RUNNING',
           task_type: 'code',
           team_id: payload.team_id,
@@ -1647,6 +1651,7 @@ export function WorkbenchProvider({
     [
       refreshWorkLists,
       resolvedServices.chatStream,
+      state.currentProject?.id,
       state.currentTask,
     ]
   )
@@ -1655,8 +1660,8 @@ export function WorkbenchProvider({
     const trimmedMessage = state.input.trim()
     const hasAttachments = attachmentSelection.attachments.length > 0
     if (!trimmedMessage && !hasAttachments) return
-    const message = trimmedMessage || '请参考附件'
-    const prepared = buildSendPayload(message)
+    const payloadMessage = trimmedMessage
+    const prepared = buildSendPayload(payloadMessage)
     if (!prepared) return
     if (prepared.activeDeviceId) {
       const activeDevice = findWorkbenchDevice(state.devices, prepared.activeDeviceId)
@@ -1708,7 +1713,7 @@ export function WorkbenchProvider({
         ...items,
         {
           id: `queued-${state.currentTask?.id}-${Date.now()}`,
-          content: message,
+          content: payloadMessage,
           status: 'queued',
           createdAt: new Date().toISOString(),
           payload: prepared.payload,
@@ -1721,7 +1726,7 @@ export function WorkbenchProvider({
     }
 
     const sent = await sendPreparedMessage(
-      message,
+      payloadMessage,
       prepared.payload,
       prepared.activeDeviceId,
       attachmentsSnapshot


### PR DESCRIPTION
## Summary

- Download and rewrite Codex attachments from Wework before starting a turn.
- Preserve image inputs for Codex using local image paths or inline data URLs instead of replacing them with an omitted marker.
- Match Codex app-style file mention formatting for local images.
- Keep Wework attachment-only sends as an empty message, use "新对话" only as the new task title, and avoid echoing placeholder text.

## Root Cause

Wework image uploads reached the Codex path as text-only prompts with stale sandbox paths such as `/home/user/...`, while CodeXAgent collapsed image content blocks into `[Image input omitted by CodeXAgent]`. This caused Codex to try opening a non-existent path instead of receiving an image input.

## Validation

- `PYTHONPATH=/home/ubuntu/workspace/Wegent executor/.venv/bin/pytest -c executor/pytest.ini -o addopts="" executor/tests/agents/test_codex_attachment_input.py -vv`
- `npm test -- WorkbenchProvider.test.tsx`
- `npx eslint src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx`
- `git diff --check --cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal attachment support: agents now process image attachments and include local images alongside text inputs.
  * Use a default chat title when creating a new conversation from an empty input.
  * Message image rendering groups images in a horizontal, wrapping container.

* **Bug Fixes**
  * Removed fallback text for attachment-only messages.

* **Tests**
  * Added tests covering attachment processing, Codex input construction, and message image layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->