### PR TITLE
[codex] Fix Codex cancellation recovery

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -1189,12 +1189,28 @@ class ChatNamespace(socketio.AsyncNamespace):
                 # Even if cancel request failed, we should still return success
                 # The executor may have already completed or the connection may be lost
 
+            from app.services.chat.trigger.lifecycle import collect_completed_result
+
+            cancel_result = await collect_completed_result(
+                payload.subtask_id,
+                status="CANCELLED",
+            )
+            if payload.partial_content:
+                if cancel_result is None:
+                    cancel_result = {"value": payload.partial_content}
+                elif not cancel_result.get("value"):
+                    cancel_result["value"] = payload.partial_content
+
             # Force update database state immediately after sending cancel request.
             # Keep this simple and deterministic even if no event consumer is available.
             await run_sync_in_executor(
                 _mark_subtask_and_task_cancelled,
                 payload.subtask_id,
-                payload.partial_content,
+                cancel_result,
+            )
+            await session_manager.cleanup_streaming_state(
+                payload.subtask_id,
+                task_id=subtask_info["task_id"],
             )
             logger.info(
                 f"[WS] chat:cancel Cancel request sent and status force-updated to CANCELLED "
@@ -1887,7 +1903,7 @@ def _subtask_belongs_to_task(subtask_id: int, task_id: int) -> bool:
 
 
 def _mark_subtask_and_task_cancelled(
-    subtask_id: int, partial_content: Optional[str] = None
+    subtask_id: int, result: Optional[dict] = None
 ) -> None:
     """Force mark subtask and task as CANCELLED."""
     with get_db_session() as db:
@@ -1896,7 +1912,7 @@ def _mark_subtask_and_task_cancelled(
             return
 
         # Force subtask to CANCELLED
-        update_subtask_on_cancel(db, subtask, partial_content)
+        update_subtask_on_cancel(db, subtask, result=result)
 
         # Force task to CANCELLED
         task = task_store.get_regular_active_task(db, task_id=subtask.task_id)

--- a/backend/app/services/chat/access/permissions.py
+++ b/backend/app/services/chat/access/permissions.py
@@ -17,10 +17,19 @@ from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
+from app.models.subtask import SubtaskStatus
 from app.services.chat.storage.db import with_session_in_executor
 from app.stores.tasks import subtask_store, task_access_store
 
 logger = logging.getLogger(__name__)
+
+_ACTIVE_STREAMING_SUBTASK_STATUSES = {
+    SubtaskStatus.PENDING,
+    SubtaskStatus.RUNNING,
+}
+_ACTIVE_STREAMING_STATUS_VALUES = {
+    status.value for status in _ACTIVE_STREAMING_SUBTASK_STATUSES
+}
 
 
 @with_session_in_executor
@@ -80,6 +89,31 @@ async def get_active_streaming(task_id: int) -> Optional[Dict[str, Any]]:
 
     if redis_status:
         subtask_id = redis_status.get("subtask_id")
+        try:
+            subtask_id = int(subtask_id)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[get_active_streaming] Invalid Redis streaming status for task %s: %s",
+                task_id,
+                redis_status,
+            )
+            await session_manager.clear_task_streaming_status(task_id)
+            return await _get_active_streaming_from_db(task_id)
+
+        if not await _is_streaming_subtask_active(task_id, subtask_id):
+            logger.info(
+                "[get_active_streaming] Ignoring stale Redis streaming status for "
+                "task_id=%s subtask_id=%s",
+                task_id,
+                subtask_id,
+            )
+            await session_manager.cleanup_streaming_state(
+                subtask_id,
+                task_id=task_id,
+            )
+            return await _get_active_streaming_from_db(task_id)
+
+        redis_status["subtask_id"] = subtask_id
         # Also get cached content to verify stream is active
         cached_content = await session_manager.get_streaming_content(subtask_id)
         logger.info(
@@ -95,6 +129,19 @@ async def get_active_streaming(task_id: int) -> Optional[Dict[str, Any]]:
         f"[get_active_streaming] No Redis status, falling back to DB query for task_id={task_id}"
     )
     return await _get_active_streaming_from_db(task_id)
+
+
+@with_session_in_executor
+def _is_streaming_subtask_active(db: Session, task_id: int, subtask_id: int) -> bool:
+    """Return True only when the cached streaming subtask is still active."""
+    subtask = subtask_store.get_basic_by_id(db, subtask_id=subtask_id)
+    if not subtask or subtask.task_id != task_id:
+        return False
+
+    if isinstance(subtask.status, str):
+        return subtask.status.upper() in _ACTIVE_STREAMING_STATUS_VALUES
+
+    return subtask.status in _ACTIVE_STREAMING_SUBTASK_STATUSES
 
 
 @with_session_in_executor

--- a/backend/app/services/chat/operations/cancel.py
+++ b/backend/app/services/chat/operations/cancel.py
@@ -10,7 +10,7 @@ subtask status on cancellation.
 
 import logging
 from datetime import datetime
-from typing import Optional
+from typing import Any, Optional
 
 from sqlalchemy.orm import Session
 
@@ -75,6 +75,7 @@ def update_subtask_on_cancel(
     db: Session,
     subtask: Subtask,
     partial_content: Optional[str] = None,
+    result: Optional[dict[str, Any]] = None,
 ) -> None:
     """
     Update subtask status and result on cancellation.
@@ -83,8 +84,10 @@ def update_subtask_on_cancel(
         db: Database session
         subtask: Subtask to update
         partial_content: Optional partial content to save
+        result: Optional full result payload collected from streaming state
     """
     now = datetime.now()
+    result_payload = result if result is not None else {"value": partial_content or ""}
     subtask_store.update_fields(
         db,
         subtask=subtask,
@@ -92,7 +95,7 @@ def update_subtask_on_cancel(
         progress=100,
         completed_at=now,
         updated_at=now,
-        result={"value": partial_content or ""},
+        result=result_payload,
     )
 
 

--- a/backend/app/services/execution/inprocess_executor.py
+++ b/backend/app/services/execution/inprocess_executor.py
@@ -675,8 +675,8 @@ class InprocessExecutor:
             from executor.services.agent_service import AgentService
 
             agent_service = AgentService()
-            status, _ = agent_service.cancel_task(task_id)
-            return status.value == "success"
+            status, _ = await agent_service.cancel_task_async(task_id)
+            return status == TaskStatus.SUCCESS
         except Exception as e:
             logger.error(
                 f"[InprocessExecutor] Cancel error: task_id={task_id}, error={e}"

--- a/backend/tests/api/ws/test_chat_namespace_task_join.py
+++ b/backend/tests/api/ws/test_chat_namespace_task_join.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.api.ws.chat_namespace import ChatNamespace
 from app.api.ws.events import ServerEvents
+from app.models.subtask import SubtaskStatus
 
 
 @pytest.mark.asyncio
@@ -65,6 +66,73 @@ async def test_task_join_replays_cached_context_metrics_for_active_stream() -> N
         cached_metrics,
         to="sid-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_cancel_cleans_cached_streaming_state() -> None:
+    """Cancelling a stream should remove refresh recovery cache immediately."""
+
+    namespace = ChatNamespace()
+    namespace.get_session = AsyncMock(return_value={"user_id": 1})
+    namespace._check_token_expiry = AsyncMock(return_value=False)
+    mark_cancelled_calls = []
+
+    async def run_sync_side_effect(func, *args):
+        if func.__name__ == "_get_subtask_for_cancel":
+            return {
+                "task_id": 101,
+                "status": SubtaskStatus.RUNNING,
+                "executor_name": "device-local-device",
+            }
+        if func.__name__ == "_mark_subtask_and_task_cancelled":
+            mark_cancelled_calls.append(args)
+            return None
+        raise AssertionError(f"Unexpected sync function: {func.__name__}")
+
+    with (
+        patch(
+            "app.api.ws.chat_namespace.run_sync_in_executor",
+            AsyncMock(side_effect=run_sync_side_effect),
+        ),
+        patch(
+            "app.services.execution.dispatcher.execution_dispatcher.cancel",
+            AsyncMock(return_value=True),
+        ),
+        patch(
+            "app.services.chat.trigger.lifecycle.collect_completed_result",
+            AsyncMock(
+                return_value={
+                    "value": "collected output",
+                    "blocks": [{"type": "thinking", "content": "collected thought"}],
+                }
+            ),
+        ) as collect_completed_result,
+        patch(
+            "app.api.ws.chat_namespace.session_manager.cleanup_streaming_state",
+            AsyncMock(),
+        ) as cleanup_streaming_state,
+    ):
+        result = await namespace.on_chat_cancel(
+            "sid-1",
+            {
+                "subtask_id": 55,
+                "partial_content": "partial",
+                "shell_type": "ClaudeCode",
+            },
+        )
+
+    assert result == {"success": True}
+    collect_completed_result.assert_awaited_once_with(55, status="CANCELLED")
+    assert mark_cancelled_calls == [
+        (
+            55,
+            {
+                "value": "collected output",
+                "blocks": [{"type": "thinking", "content": "collected thought"}],
+            },
+        )
+    ]
+    cleanup_streaming_state.assert_awaited_once_with(55, task_id=101)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/chat/test_store_boundaries.py
+++ b/backend/tests/services/chat/test_store_boundaries.py
@@ -113,6 +113,96 @@ def test_active_streaming_db_fallback_uses_subtask_store(monkeypatch):
     assert result["subtask_id"] == 10
 
 
+def test_active_streaming_subtask_validation_rejects_terminal_subtask(monkeypatch):
+    store = SimpleNamespace(
+        get_basic_by_id=lambda db, subtask_id: _subtask(status=SubtaskStatus.CANCELLED)
+    )
+    monkeypatch.setattr(permissions, "subtask_store", store, raising=False)
+
+    result = permissions._is_streaming_subtask_active.__wrapped__(
+        _NoModelCrudDb(),
+        100,
+        10,
+    )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_active_streaming_ignores_stale_redis_status(monkeypatch):
+    mock_session_manager = SimpleNamespace(
+        get_task_streaming_status=AsyncMock(
+            return_value={
+                "subtask_id": 10,
+                "user_id": 7,
+            }
+        ),
+        cleanup_streaming_state=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.services.chat.storage.session_manager",
+        mock_session_manager,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        permissions,
+        "_is_streaming_subtask_active",
+        AsyncMock(return_value=False),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        permissions,
+        "_get_active_streaming_from_db",
+        AsyncMock(return_value=None),
+        raising=False,
+    )
+
+    result = await permissions.get_active_streaming(100)
+
+    assert result is None
+    mock_session_manager.cleanup_streaming_state.assert_awaited_once_with(
+        10,
+        task_id=100,
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_streaming_keeps_valid_redis_status(monkeypatch):
+    mock_session_manager = SimpleNamespace(
+        get_task_streaming_status=AsyncMock(
+            return_value={
+                "subtask_id": "10",
+                "user_id": 7,
+            }
+        ),
+        get_streaming_content=AsyncMock(return_value="hello"),
+        cleanup_streaming_state=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.services.chat.storage.session_manager",
+        mock_session_manager,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        permissions,
+        "_is_streaming_subtask_active",
+        AsyncMock(return_value=True),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        permissions,
+        "_get_active_streaming_from_db",
+        AsyncMock(return_value=None),
+        raising=False,
+    )
+
+    result = await permissions.get_active_streaming(100)
+
+    assert result == {"subtask_id": 10, "user_id": 7}
+    mock_session_manager.get_streaming_content.assert_awaited_once_with(10)
+    mock_session_manager.cleanup_streaming_state.assert_not_awaited()
+
+
 def test_correction_history_reads_subtasks_through_store(monkeypatch):
     store = SimpleNamespace(
         list_completed_before_message_id=lambda db, task_id, before_message_id: [

--- a/backend/tests/services/execution/test_inprocess_executor.py
+++ b/backend/tests/services/execution/test_inprocess_executor.py
@@ -123,3 +123,21 @@ async def test_execute_raises_and_emits_error_when_agent_lifecycle_returns_faile
 
     emitter.emit_error.assert_awaited_once()
     mock_cleanup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancel_awaits_agent_service_async_cancel() -> None:
+    """In-process cancellation should not call the sync asyncio.run wrapper."""
+    executor = InprocessExecutor()
+    agent_service = MagicMock()
+    agent_service.cancel_task_async = AsyncMock(return_value=(TaskStatus.SUCCESS, None))
+    agent_service.cancel_task = MagicMock()
+    fake_module = types.ModuleType("executor.services.agent_service")
+    fake_module.AgentService = MagicMock(return_value=agent_service)
+
+    with patch.dict(sys.modules, {"executor.services.agent_service": fake_module}):
+        success = await executor.cancel(33)
+
+    assert success is True
+    agent_service.cancel_task_async.assert_awaited_once_with(33)
+    agent_service.cancel_task.assert_not_called()

--- a/executor/agents/codex/codex_agent.py
+++ b/executor/agents/codex/codex_agent.py
@@ -71,6 +71,8 @@ class CodeXAgent(Agent):
         self._bot_id = self._resolve_bot_id(task_data)
         self._session_store = CodeXSessionStore()
         self._local_image_paths: list[str | None] = []
+        self._cancel_requested = False
+        self._turn_interrupt_requested = False
         self.on_client_created_callback: Optional[Callable[[], Any]] = None
 
     def initialize(self) -> TaskStatus:
@@ -146,6 +148,9 @@ class CodeXAgent(Agent):
 
             turn_input = self._build_turn_input()
             effort, summary = self._build_reasoning_params()
+            if self._cancel_requested:
+                await self.emitter.incomplete(reason="cancelled")
+                return TaskStatus.CANCELLED
             await self.start_turn_file_change_tracking()
             self._turn = await self._thread.turn(
                 turn_input,
@@ -155,6 +160,8 @@ class CodeXAgent(Agent):
                 sandbox=self._sandbox_full_access(),
                 summary=summary,
             )
+            if self._cancel_requested:
+                await self._interrupt_active_turn()
 
             async for event in self._turn.stream():
                 status = await mapper.handle(event)
@@ -172,16 +179,45 @@ class CodeXAgent(Agent):
         finally:
             await self.cleanup_async()
 
-    def cancel_run(self) -> bool:
+    async def cancel_run_async(self) -> bool:
+        self._cancel_requested = True
         if self._turn is None:
-            logger.warning("CodeXAgent has no active turn to cancel: %s", self.task_id)
+            logger.info(
+                "CodeXAgent cancel requested before turn start: %s", self.task_id
+            )
+            return True
+        return await self._interrupt_active_turn()
+
+    async def _interrupt_active_turn(self) -> bool:
+        if getattr(self, "_turn_interrupt_requested", False):
+            return True
+        if self._turn is None:
             return False
+
+        self._turn_interrupt_requested = True
         try:
-            loop = asyncio.get_running_loop()
-            loop.create_task(self._turn.interrupt())
+            await self._turn.interrupt()
+            logger.info("CodeXAgent turn interrupt requested: %s", self.task_id)
+            return True
+        except Exception as exc:
+            logger.exception(
+                "Failed to interrupt CodeXAgent turn: task_id=%s error=%s",
+                self.task_id,
+                exc,
+            )
+            return False
+
+    def cancel_run(self) -> bool:
+        try:
+            asyncio.get_running_loop()
         except RuntimeError:
-            asyncio.run(self._turn.interrupt())
-        return True
+            return asyncio.run(self.cancel_run_async())
+        logger.warning(
+            "CodeXAgent.cancel_run() called inside a running event loop; "
+            "use cancel_run_async() for task_id=%s",
+            self.task_id,
+        )
+        return False
 
     async def cleanup_async(self) -> None:
         if self._codex is not None:

--- a/executor/modes/local/handlers.py
+++ b/executor/modes/local/handlers.py
@@ -64,9 +64,10 @@ class TaskHandler:
             data: Cancel data containing task_id.
         """
         task_id = data.get("task_id")
+        subtask_id = data.get("subtask_id")
         if task_id is not None:
             logger.info(f"Received task cancel request: task_id={task_id}")
-            await self.runner.cancel_task(task_id)
+            await self.runner.cancel_task(task_id, subtask_id=subtask_id)
         else:
             logger.warning("Received cancel request without task_id")
 

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -51,6 +51,7 @@ class RunningTaskInfo:
     task_data: ExecutionRequest
     agent: Optional[Any] = None
     asyncio_task: Optional[asyncio.Task] = None
+    cancel_requested: bool = False
 
 
 class LocalRunner:
@@ -95,6 +96,8 @@ class LocalRunner:
 
         # Running tasks tracking (task_id -> RunningTaskInfo)
         self._running_tasks: Dict[int, RunningTaskInfo] = {}
+        self._pending_cancel_task_ids: set[int] = set()
+        self._pending_cancel_subtask_ids: set[int] = set()
 
         # Runner state
         self._running = False
@@ -306,7 +309,7 @@ class LocalRunner:
         logger.info(f"Enqueuing task: task_id={task_id}")
         await self.task_queue.put(task_data)
 
-    async def cancel_task(self, task_id: int) -> None:
+    async def cancel_task(self, task_id: int, subtask_id: Optional[int] = None) -> None:
         """Cancel a running task.
 
         Note: Cancel callback will be sent by response_processor after SDK interrupt
@@ -314,6 +317,7 @@ class LocalRunner:
         """
         info = self._running_tasks.get(task_id)
         if info:
+            info.cancel_requested = True
             if info.agent and hasattr(info.agent, "cancel_run_async"):
                 cancelled = await info.agent.cancel_run_async()
                 if cancelled:
@@ -325,10 +329,20 @@ class LocalRunner:
                 # after SDK interrupt messages are fully processed, avoiding duplicate callbacks
             else:
                 logger.warning(
-                    f"Cannot cancel task {task_id}: agent doesn't support cancellation"
+                    "Cancel requested before agent is ready: task_id=%s subtask_id=%s",
+                    task_id,
+                    subtask_id,
                 )
         else:
-            logger.warning(f"Cannot cancel task {task_id}: not currently running")
+            if subtask_id is not None:
+                self._pending_cancel_subtask_ids.add(int(subtask_id))
+            else:
+                self._pending_cancel_task_ids.add(int(task_id))
+            logger.info(
+                "Stored pending cancel request: task_id=%s subtask_id=%s",
+                task_id,
+                subtask_id,
+            )
 
     async def close_task_session(self, task_id: int) -> None:
         """Close a task session completely, freeing up the slot.
@@ -448,7 +462,10 @@ class LocalRunner:
                 logger.info(f"Dispatching task in parallel: task_id={task_id}")
 
                 # Register the task and dispatch it concurrently
-                info = RunningTaskInfo(task_data=task_data)
+                info = RunningTaskInfo(
+                    task_data=task_data,
+                    cancel_requested=self._consume_pending_cancel(task_data),
+                )
                 self._running_tasks[task_id] = info
                 info.asyncio_task = asyncio.create_task(
                     self._run_task_wrapper(task_data)
@@ -460,6 +477,15 @@ class LocalRunner:
                 break
 
         logger.info("Task processing loop ended")
+
+    def _consume_pending_cancel(self, task_data: ExecutionRequest) -> bool:
+        task_cancelled = task_data.task_id in self._pending_cancel_task_ids
+        subtask_cancelled = task_data.subtask_id in self._pending_cancel_subtask_ids
+        if task_cancelled:
+            self._pending_cancel_task_ids.discard(task_data.task_id)
+        if subtask_cancelled:
+            self._pending_cancel_subtask_ids.discard(task_data.subtask_id)
+        return task_cancelled or subtask_cancelled
 
     async def _run_task_wrapper(self, task_data: ExecutionRequest) -> None:
         """Wrapper that executes a task and handles cleanup on completion."""
@@ -544,12 +570,22 @@ class LocalRunner:
         # Create WebSocket emitter for local mode
         ws_emitter = self._create_emitter(task_id, subtask_id)
 
+        info = self._running_tasks.get(task_id)
+        if info and info.cancel_requested:
+            logger.info(
+                "Task was cancelled before execution started: task_id=%s subtask_id=%s",
+                task_id,
+                subtask_id,
+            )
+            await ws_emitter.incomplete(reason="cancelled")
+            return
+
         # Create and initialize agent with WebSocket emitter
         agent = AgentFactory.get_code_agent(task_data, emitter=ws_emitter)
 
         # Register agent in running tasks
-        if task_id in self._running_tasks:
-            self._running_tasks[task_id].agent = agent
+        if info:
+            info.agent = agent
 
         agent.on_client_created_callback = lambda: self._on_client_created(task_id)
         agent.report_progress = self._make_emitter_report_progress(ws_emitter)
@@ -563,6 +599,9 @@ class LocalRunner:
             logger.error(f"Agent initialization failed: {init_status}")
             await ws_emitter.error("Agent initialization failed", "init_error")
             return
+        if info and info.cancel_requested:
+            await ws_emitter.incomplete(reason="cancelled")
+            return
 
         # Pre-execute
         pre_status, pre_error = await agent.pre_execute()
@@ -570,6 +609,9 @@ class LocalRunner:
             error_msg = pre_error or "Agent pre-execution failed"
             logger.error(f"Agent pre-execution failed: {error_msg}")
             await ws_emitter.error(error_msg, "pre_execute_error")
+            return
+        if info and info.cancel_requested:
+            await ws_emitter.incomplete(reason="cancelled")
             return
 
         # Execute the task (agent client creation triggers heartbeat callback)

--- a/executor/tests/agents/test_codex_cancellation.py
+++ b/executor/tests/agents/test_codex_cancellation.py
@@ -1,0 +1,31 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from executor.agents.codex.codex_agent import CodeXAgent
+
+
+@pytest.mark.asyncio
+async def test_codex_cancel_run_async_interrupts_active_turn():
+    """Codex cancellation should await the SDK turn interrupt."""
+    agent = object.__new__(CodeXAgent)
+    agent.task_id = 1
+    agent._turn = AsyncMock()
+
+    cancelled = await agent.cancel_run_async()
+
+    assert cancelled is True
+    agent._turn.interrupt.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_codex_cancel_run_async_records_pending_cancel_without_active_turn():
+    """Cancellation before turn startup should be consumed by execute_async."""
+    agent = object.__new__(CodeXAgent)
+    agent.task_id = 1
+    agent._turn = None
+
+    cancelled = await agent.cancel_run_async()
+
+    assert cancelled is True
+    assert agent._cancel_requested is True

--- a/executor/tests/test_local_task_dispatch_handler.py
+++ b/executor/tests/test_local_task_dispatch_handler.py
@@ -37,8 +37,35 @@ async def test_cancel_task_awaits_agent_async_cancellation():
     runner = object.__new__(LocalRunner)
     agent = MagicMock()
     agent.cancel_run_async = AsyncMock(return_value=True)
-    runner._running_tasks = {1: SimpleNamespace(agent=agent)}
+    runner._running_tasks = {1: SimpleNamespace(agent=agent, cancel_requested=False)}
 
     await runner.cancel_task(1)
 
     agent.cancel_run_async.assert_awaited_once_with()
+    assert runner._running_tasks[1].cancel_requested is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_marks_request_pending_before_agent_is_ready():
+    """Local cancellation should survive the gap before agent creation."""
+    runner = object.__new__(LocalRunner)
+    info = SimpleNamespace(agent=None, cancel_requested=False)
+    runner._running_tasks = {1: info}
+
+    await runner.cancel_task(1, subtask_id=2)
+
+    assert info.cancel_requested is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_stores_pending_subtask_when_task_not_registered():
+    """Cancel can arrive before task:execute is consumed by the local runner."""
+    runner = object.__new__(LocalRunner)
+    runner._running_tasks = {}
+    runner._pending_cancel_task_ids = set()
+    runner._pending_cancel_subtask_ids = set()
+
+    await runner.cancel_task(1, subtask_id=2)
+
+    assert runner._pending_cancel_subtask_ids == {2}
+    assert runner._pending_cancel_task_ids == set()

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { StrictMode, useState } from 'react'
 import { describe, expect, test, vi } from 'vitest'

--- a/wework/src/components/layout/DeviceStatusPrompt.tsx
+++ b/wework/src/components/layout/DeviceStatusPrompt.tsx
@@ -1,5 +1,5 @@
 import { AlertCircle, ArrowUpCircle, Loader2, PlusCircle } from 'lucide-react'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from '@/hooks/useTranslation'
 import {
@@ -59,6 +59,13 @@ function readSidebarDeviceCache() {
   }
 }
 
+function readFreshSidebarDeviceCache(maxAgeMs: number) {
+  const cached = readSidebarDeviceCache()
+  if (!cached) return null
+
+  return Date.now() - cached.updatedAt < maxAgeMs ? cached : null
+}
+
 function writeSidebarDeviceCache(devices: DeviceInfo[], updatedAt: number) {
   sidebarDeviceMemoryCache = { devices, updatedAt }
   try {
@@ -114,16 +121,21 @@ export function DeviceStatusPrompt({
   const [sidebarTooltipOpen, setSidebarTooltipOpen] = useState(false)
   const sidebarActionRef = useRef<HTMLDivElement>(null)
   const sidebarTooltipRef = useRef<HTMLDivElement>(null)
-  const now = Date.now()
-  const sidebarDeviceCache = readSidebarDeviceCache()
+
+  useEffect(() => {
+    if (presentation === 'sidebar-action' && devices.length > 0) {
+      writeSidebarDeviceCache(devices, Date.now())
+    }
+  }, [devices, presentation])
+
+  const sidebarDeviceCache =
+    presentation === 'sidebar-action'
+      ? readFreshSidebarDeviceCache(SIDEBAR_EMPTY_DEVICE_FALLBACK_MS)
+      : null
   const canUseSidebarDeviceFallback =
     presentation === 'sidebar-action' &&
     devices.length === 0 &&
-    sidebarDeviceCache !== null &&
-    now - sidebarDeviceCache.updatedAt < SIDEBAR_EMPTY_DEVICE_FALLBACK_MS
-  if (presentation === 'sidebar-action' && devices.length > 0) {
-    writeSidebarDeviceCache(devices, now)
-  }
+    sidebarDeviceCache !== null
   const effectiveDevices = canUseSidebarDeviceFallback
     ? sidebarDeviceCache?.devices ?? devices
     : devices

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -622,6 +622,120 @@ describe('WorkbenchProvider', () => {
     )
   })
 
+  test('ignores stale cached streaming when opening a cancelled task', async () => {
+    const getTaskDetail = vi.fn().mockResolvedValue({
+      id: 8,
+      title: 'Cancelled task',
+      status: 'CANCELLED',
+      task_type: 'code',
+      project_id: 0,
+      device_id: 'local-online',
+      created_at: '2026-06-04T00:00:00.000Z',
+      updated_at: '2026-06-04T00:01:00.000Z',
+      subtasks: [
+        {
+          id: 20,
+          task_id: 8,
+          role: 'user',
+          prompt: '写个故事',
+          status: 'COMPLETED',
+          created_at: '2026-06-04T00:00:00.000Z',
+        },
+        {
+          id: 21,
+          task_id: 8,
+          role: 'assistant',
+          result: { value: '' },
+          status: 'CANCELLED',
+          created_at: '2026-06-04T00:00:01.000Z',
+        },
+      ],
+    })
+    const joinTask = vi.fn().mockResolvedValue({
+      streaming: {
+        subtask_id: 21,
+        offset: 9,
+        cached_content: '旧的缓存内容',
+      },
+    })
+
+    render(
+      <WorkbenchProvider
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={{
+          teamApi: {
+            getDefaultWorkbenchTeam: vi
+              .fn()
+              .mockResolvedValue({ id: 2, name: 'coder', is_active: true }),
+          },
+          modelApi: { listModels: vi.fn().mockResolvedValue({ data: [] }) },
+          skillApi: {
+            listSkills: vi.fn().mockResolvedValue([]),
+            getTeamSkills: vi.fn().mockResolvedValue({ skills: [], preload_skills: [] }),
+          },
+          projectApi: {
+            listProjects: vi.fn().mockResolvedValue({ items: [] }),
+            getProject: vi.fn(),
+            createProject: vi.fn(),
+            updateProject: vi.fn(),
+            deleteProject: vi.fn(),
+            archiveProjectChats: vi.fn(),
+            archiveAllProjectChats: vi.fn(),
+            createConversation: vi.fn(),
+          },
+          taskApi: {
+            listRecentTasks: vi.fn().mockResolvedValue({ total: 0, items: [] }),
+            getTaskDetail,
+            renameTask: vi.fn(),
+            archiveTask: vi.fn(),
+            archiveAllChats: vi.fn(),
+            listArchivedTasks: vi.fn(),
+            unarchiveTask: vi.fn(),
+            deleteTask: vi.fn(),
+            deleteArchivedTasks: vi.fn(),
+          },
+          deviceApi: {
+            listDevices: vi.fn().mockResolvedValue([
+              {
+                id: 1,
+                device_id: 'local-online',
+                name: 'Local Device',
+                status: 'online',
+                is_default: false,
+                device_type: 'local',
+                bind_shell: 'claudecode',
+              },
+            ]),
+            getHomeDirectory: vi.fn(),
+            getProjectWorkspaceRoot: vi.fn(),
+            listDirectories: vi.fn(),
+            listSkills: vi.fn().mockResolvedValue([]),
+          },
+          chatStream: {
+            joinTask,
+            leaveTask: vi.fn(),
+            sendMessage: vi.fn(),
+            sendGuidance: vi.fn(),
+            cancelStream: vi.fn(),
+            subscribe: vi.fn(() => vi.fn()),
+          },
+        }}
+      >
+        <TaskMessagesProbe />
+      </WorkbenchProvider>
+    )
+
+    await userEvent.click(await screen.findByText('open task'))
+
+    await waitFor(() => expect(joinTask).toHaveBeenCalledWith(8))
+    expect(screen.getByTestId('message-contents')).toHaveTextContent(
+      'assistant:done:'
+    )
+    expect(screen.getByTestId('message-contents')).not.toHaveTextContent(
+      'assistant:streaming'
+    )
+  })
+
   test('uses the opened task model as the runtime compatibility anchor', async () => {
     const models: UnifiedModel[] = [
       {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -561,6 +561,17 @@ function isRunningTaskStatus(status?: string) {
   )
 }
 
+function shouldRestoreCachedStreaming(
+  task: Task,
+  subtasks: Subtask[] | undefined,
+  subtaskId: number
+) {
+  if (!isRunningTaskStatus(task.status)) return false
+
+  const subtask = subtasks?.find(item => item.id === subtaskId)
+  return subtask ? isRunningTaskStatus(subtask.status) : true
+}
+
 function normalizeGuidanceError(error?: string) {
   if (!error) return '引导发送失败'
   if (error.includes('Chat Shell')) {
@@ -1253,7 +1264,14 @@ export function WorkbenchProvider({
       setQueuedSends([])
       setGuidanceMessages([])
       const joinResponse = await resolvedServices.chatStream.joinTask(taskId)
-      if (joinResponse?.streaming) {
+      if (
+        joinResponse?.streaming &&
+        shouldRestoreCachedStreaming(
+          detailTask,
+          detail.subtasks,
+          joinResponse.streaming.subtask_id
+        )
+      ) {
         dispatchMessages({
           type: 'assistant_cached',
           taskId,


### PR DESCRIPTION
## Summary

- Make Codex cancellation await the SDK turn interrupt and preserve early cancel requests before the turn or agent is ready.
- Clear stale streaming recovery state on cancel and validate Redis streaming status against the DB before restoring a refreshed task.
- Preserve partial output, thinking blocks, and tool blocks when a cancelled stream is force-marked as CANCELLED.
- Add Wework-side protection so terminal tasks do not restore cached streaming after refresh.

## Root Cause

Cancel requests could arrive before the Codex turn or local agent was ready, and the backend trusted task-level Redis streaming markers during task:join without checking whether the subtask had already reached a terminal state. The forced cancel path also cleaned streaming state before persisting accumulated output and blocks.

## Validation

- cd backend && uv run pytest tests/api/ws/test_chat_namespace_task_join.py tests/services/chat/test_store_boundaries.py tests/services/execution/test_inprocess_executor.py -vv
- cd executor && PYTHONPATH=.. timeout 60s uv run pytest tests/agents/test_codex_cancellation.py tests/test_local_task_dispatch_handler.py -vv --no-cov
- cd wework && npm test -- WorkbenchProvider.test.tsx messageReducer.test.ts DeviceStatusPrompt.test.tsx
- cd wework && npm run lint
- cd wework && npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task cancellation handling with proper cleanup of streaming cache state
  * Fixed UI to prevent restoring streaming content for cancelled tasks
  * Enhanced device status sidebar cache management to write only when needed
  * Corrected submenu placement invocation in project work area

* **New Features**
  * Added asynchronous cancellation support for better responsiveness to cancellation requests
  * Improved handling of cancellations arriving before agents are fully initialized
<!-- end of auto-generated comment: release notes by coderabbit.ai -->