### PR TITLE
[codex] stabilize websocket connect handling

### DIFF
--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Optional
 import socketio
 from sqlalchemy.orm import Session
 
+from app.api.ws.connection_utils import enter_connect_room, save_connect_session
 from app.api.ws.context_decorators import auto_task_context
 from app.api.ws.decorators import trace_websocket_event
 from app.api.ws.events import (
@@ -318,24 +319,36 @@ class ChatNamespace(socketio.AsyncNamespace):
         # Extract token expiry for later validation
         token_exp = get_token_expiry(token)
 
-        # Save user info to session
-        await self.save_session(
+        session_saved = await save_connect_session(
+            self,
             sid,
-            {
+            session_data={
                 "user_id": user.id,
                 "user_name": user.user_name,
                 "request_id": request_id,
-                "token_exp": token_exp,  # Store token expiry for later checks
-                "auth_token": token,  # Store original token for downstream services
+                "token_exp": token_exp,
+                "auth_token": token,
             },
+            logger=logger,
+            log_prefix="[WS]",
         )
+        if not session_saved:
+            return False
 
         # Set user context for trace logging
         set_user_context(user_id=str(user.id), user_name=user.user_name)
 
         # Join user room
         user_room = f"user:{user.id}"
-        await self.enter_room(sid, user_room)
+        room_entered = await enter_connect_room(
+            self,
+            sid,
+            user_room,
+            logger=logger,
+            log_prefix="[WS]",
+        )
+        if not room_entered:
+            return False
 
         logger.info(f"[WS] Connected user={user.id} ({user.user_name}) sid={sid}")
 

--- a/backend/app/api/ws/connection_utils.py
+++ b/backend/app/api/ws/connection_utils.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for Socket.IO connection setup."""
+
+import logging
+from typing import Any
+
+
+async def save_connect_session(
+    namespace: Any,
+    sid: str,
+    session_data: dict[str, Any],
+    *,
+    logger: logging.Logger,
+    log_prefix: str,
+) -> bool:
+    """Save a Socket.IO session if the connection is still present."""
+    try:
+        await namespace.save_session(sid, session_data)
+    except KeyError as exc:
+        logger.info(
+            "%s Connection disappeared before session save; sid=%s, error=%s",
+            log_prefix,
+            sid,
+            exc,
+        )
+        return False
+
+    return True
+
+
+async def enter_connect_room(
+    namespace: Any,
+    sid: str,
+    room: str,
+    *,
+    logger: logging.Logger,
+    log_prefix: str,
+) -> bool:
+    """Join a Socket.IO room if the connection is still present."""
+    try:
+        await namespace.enter_room(sid, room)
+    except (KeyError, ValueError) as exc:
+        logger.info(
+            "%s Connection disappeared before room join; sid=%s, room=%s, error=%s",
+            log_prefix,
+            sid,
+            room,
+            exc,
+        )
+        return False
+
+    return True

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, Generator, Optional
 import socketio
 from sqlalchemy.orm import Session
 
+from app.api.ws.connection_utils import enter_connect_room, save_connect_session
 from app.api.ws.decorators import trace_websocket_event
 from app.core.auth_utils import is_api_key, verify_api_key
 from app.core.events import TaskCompletedEvent, get_event_bus
@@ -553,6 +554,16 @@ class DeviceNamespace(socketio.AsyncNamespace):
         # Fall back to REMOTE_ADDR
         return environ.get("REMOTE_ADDR")
 
+    def _get_client_ip_log_context(self, environ: dict) -> tuple[Optional[str], str]:
+        """Build log context for WebSocket client IP attribution."""
+        client_ip = self._get_client_ip(environ)
+        return client_ip, (
+            f"client_ip={client_ip} "
+            f"remote_addr={environ.get('REMOTE_ADDR')} "
+            f"x_forwarded_for={environ.get('HTTP_X_FORWARDED_FOR')} "
+            f"x_real_ip={environ.get('HTTP_X_REAL_IP')}"
+        )
+
     async def _match_cloud_device(
         self, user_id: int, client_ip: str, executor_device_id: str
     ) -> Optional[str]:
@@ -624,8 +635,9 @@ class DeviceNamespace(socketio.AsyncNamespace):
 
         request_id = str(uuid.uuid4())[:8]
         set_request_context(request_id)
+        client_ip, ip_log_context = self._get_client_ip_log_context(environ)
 
-        logger.info(f"[Device WS] Connection attempt sid={sid}")
+        logger.info(f"[Device WS] Connection attempt sid={sid} {ip_log_context}")
 
         # Reject new connections during graceful shutdown
         if shutdown_manager.is_shutting_down:
@@ -674,34 +686,43 @@ class DeviceNamespace(socketio.AsyncNamespace):
             # Extract token expiry for JWT
             token_exp = get_token_expiry(token)
 
-        # Get client IP from environ
-        client_ip = self._get_client_ip(environ)
-
-        # Save user info to session (device_id will be added on register)
-        await self.save_session(
+        session_saved = await save_connect_session(
+            self,
             sid,
-            {
+            session_data={
                 "user_id": user_id,
                 "user_name": user_name,
                 "request_id": request_id,
                 "token_exp": token_exp,
                 "auth_token": token,
                 "auth_type": auth_type,
-                "device_id": None,  # Set on device:register
+                "device_id": None,
                 "registered": False,
-                "client_ip": client_ip,  # For cloud device matching
+                "client_ip": client_ip,
             },
+            logger=logger,
+            log_prefix="[Device WS]",
         )
+        if not session_saved:
+            return False
 
         set_user_context(user_id=str(user_id), user_name=user_name)
 
         # Join user room for device-related notifications
         user_room = f"user:{user_id}"
-        await self.enter_room(sid, user_room)
+        room_entered = await enter_connect_room(
+            self,
+            sid,
+            user_room,
+            logger=logger,
+            log_prefix="[Device WS]",
+        )
+        if not room_entered:
+            return False
 
         logger.info(
             f"[Device WS] Connected user={user_id} ({user_name}) via {auth_type} "
-            f"sid={sid}, awaiting registration"
+            f"sid={sid} {ip_log_context}, awaiting registration"
         )
 
     async def on_disconnect(self, sid: str):

--- a/backend/tests/api/ws/test_chat_namespace_connect.py
+++ b/backend/tests/api/ws/test_chat_namespace_connect.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.ws import chat_namespace
+from app.core.shutdown import shutdown_manager
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_manager():
+    shutdown_manager.reset()
+    yield
+    shutdown_manager.reset()
+
+
+@pytest.fixture
+def valid_jwt_auth(monkeypatch):
+    monkeypatch.setattr(
+        chat_namespace,
+        "verify_jwt_token",
+        lambda token: SimpleNamespace(id=7, user_name="alice"),
+    )
+    monkeypatch.setattr(chat_namespace, "get_token_expiry", lambda token: 123456)
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_false_when_session_disappears_before_save(
+    valid_jwt_auth,
+    monkeypatch,
+):
+    namespace = chat_namespace.ChatNamespace()
+    save_session = AsyncMock(side_effect=KeyError("Session not found"))
+    enter_room = AsyncMock()
+    monkeypatch.setattr(namespace, "save_session", save_session)
+    monkeypatch.setattr(namespace, "enter_room", enter_room)
+
+    result = await namespace.on_connect(
+        "sid-1",
+        {"REMOTE_ADDR": "127.0.0.1"},
+        {"token": "jwt-token"},
+    )
+
+    assert result is False
+    save_session.assert_awaited_once()
+    enter_room.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_false_when_session_disappears_before_room_join(
+    valid_jwt_auth,
+    monkeypatch,
+):
+    namespace = chat_namespace.ChatNamespace()
+    save_session = AsyncMock()
+    enter_room = AsyncMock(side_effect=KeyError("sid-1"))
+    monkeypatch.setattr(namespace, "save_session", save_session)
+    monkeypatch.setattr(namespace, "enter_room", enter_room)
+
+    result = await namespace.on_connect(
+        "sid-1",
+        {"REMOTE_ADDR": "127.0.0.1"},
+        {"token": "jwt-token"},
+    )
+
+    assert result is False
+    save_session.assert_awaited_once()
+    enter_room.assert_awaited_once_with("sid-1", "user:7")

--- a/backend/tests/api/ws/test_connection_utils.py
+++ b/backend/tests/api/ws/test_connection_utils.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.api.ws.connection_utils import enter_connect_room, save_connect_session
+
+
+@pytest.mark.asyncio
+async def test_save_connect_session_logs_stale_connection_at_info_level():
+    namespace = Mock()
+    namespace.save_session = AsyncMock(side_effect=KeyError("Session not found"))
+    logger = Mock()
+
+    result = await save_connect_session(
+        namespace,
+        "sid-1",
+        {"user_id": 7},
+        logger=logger,
+        log_prefix="[WS]",
+    )
+
+    assert result is False
+    logger.info.assert_called_once()
+    logger.warning.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enter_connect_room_logs_stale_connection_at_info_level():
+    namespace = Mock()
+    namespace.enter_room = AsyncMock(side_effect=KeyError("sid-1"))
+    logger = Mock()
+
+    result = await enter_connect_room(
+        namespace,
+        "sid-1",
+        "user:7",
+        logger=logger,
+        log_prefix="[WS]",
+    )
+
+    assert result is False
+    logger.info.assert_called_once()
+    logger.warning.assert_not_called()

--- a/backend/tests/api/ws/test_device_namespace_connect.py
+++ b/backend/tests/api/ws/test_device_namespace_connect.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.api.ws import device_namespace
+from app.core.shutdown import shutdown_manager
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_manager():
+    shutdown_manager.reset()
+    yield
+    shutdown_manager.reset()
+
+
+@pytest.fixture
+def valid_jwt_auth(monkeypatch):
+    monkeypatch.setattr(device_namespace, "is_api_key", lambda token: False)
+    monkeypatch.setattr(
+        device_namespace,
+        "verify_jwt_token",
+        lambda token: SimpleNamespace(id=7, user_name="alice"),
+    )
+    monkeypatch.setattr(device_namespace, "get_token_expiry", lambda token: 123456)
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_false_when_session_disappears_before_save(
+    valid_jwt_auth,
+    monkeypatch,
+):
+    namespace = device_namespace.DeviceNamespace()
+    save_session = AsyncMock(side_effect=KeyError("Session not found"))
+    enter_room = AsyncMock()
+    monkeypatch.setattr(namespace, "save_session", save_session)
+    monkeypatch.setattr(namespace, "enter_room", enter_room)
+
+    result = await namespace.on_connect(
+        "sid-1",
+        {"REMOTE_ADDR": "127.0.0.1"},
+        {"token": "jwt-token"},
+    )
+
+    assert result is False
+    save_session.assert_awaited_once()
+    enter_room.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_returns_false_when_session_disappears_before_room_join(
+    valid_jwt_auth,
+    monkeypatch,
+):
+    namespace = device_namespace.DeviceNamespace()
+    save_session = AsyncMock()
+    enter_room = AsyncMock(side_effect=KeyError("sid-1"))
+    monkeypatch.setattr(namespace, "save_session", save_session)
+    monkeypatch.setattr(namespace, "enter_room", enter_room)
+
+    result = await namespace.on_connect(
+        "sid-1",
+        {"REMOTE_ADDR": "127.0.0.1"},
+        {"token": "jwt-token"},
+    )
+
+    assert result is False
+    save_session.assert_awaited_once()
+    enter_room.assert_awaited_once_with("sid-1", "user:7")
+
+
+@pytest.mark.asyncio
+async def test_connect_logs_resolved_client_ip_and_forwarding_context(
+    valid_jwt_auth,
+    monkeypatch,
+    caplog,
+):
+    namespace = device_namespace.DeviceNamespace()
+    monkeypatch.setattr(namespace, "save_session", AsyncMock())
+    monkeypatch.setattr(namespace, "enter_room", AsyncMock())
+
+    environ = {
+        "HTTP_X_FORWARDED_FOR": "203.0.113.9, 10.0.0.2",
+        "HTTP_X_REAL_IP": "198.51.100.10",
+        "REMOTE_ADDR": "10.2.0.5",
+    }
+
+    with caplog.at_level(logging.INFO, logger=device_namespace.logger.name):
+        await namespace.on_connect("sid-1", environ, {"token": "jwt-token"})
+
+    assert (
+        "[Device WS] Connection attempt sid=sid-1 client_ip=203.0.113.9 "
+        "remote_addr=10.2.0.5 x_forwarded_for=203.0.113.9, 10.0.0.2 "
+        "x_real_ip=198.51.100.10"
+    ) in caplog.messages
+    assert (
+        "[Device WS] Connected user=7 (alice) via jwt sid=sid-1 "
+        "client_ip=203.0.113.9 remote_addr=10.2.0.5 "
+        "x_forwarded_for=203.0.113.9, 10.0.0.2 x_real_ip=198.51.100.10, "
+        "awaiting registration"
+    ) in caplog.messages


### PR DESCRIPTION
## Summary
- Treat Socket.IO connections that disappear during `save_session` or `enter_room` as stale connects instead of surfacing `Session not found` errors.
- Reuse the stale-connect handling in both chat and device namespaces.
- Add Device WS connect IP attribution to `Connection attempt` and `Connected user` logs, including resolved `client_ip`, `REMOTE_ADDR`, `X-Forwarded-For`, and `X-Real-IP`.
- Cover stale connect behavior and IP logging with focused WebSocket tests.

## Root Cause
During rolling restarts and reconnect storms, a Socket.IO client can disconnect while the async `on_connect` handler is still awaiting auth or setup work. In that case python-socketio no longer has a live Engine.IO session for the Socket.IO sid, so `save_session`/`enter_room` can raise a stale-session error. Existing logs also did not attach client IP context to the authenticated Device WS connect line, which made later attribution rely on uvicorn log ordering.

## Validation
- `cd backend && uv run pytest tests/api/ws tests/test_ws_decorators.py -q`
- `cd backend && uv run black --check app/api/ws/chat_namespace.py app/api/ws/device_namespace.py app/api/ws/connection_utils.py tests/api/ws/test_chat_namespace_connect.py tests/api/ws/test_connection_utils.py tests/api/ws/test_device_namespace_connect.py`
- `cd backend && uv run isort --check-only app/api/ws/chat_namespace.py app/api/ws/device_namespace.py app/api/ws/connection_utils.py tests/api/ws/test_chat_namespace_connect.py tests/api/ws/test_connection_utils.py tests/api/ws/test_device_namespace_connect.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Enhanced WebSocket connection handling with improved error detection and graceful recovery for stale connections, ensuring more robust session management and reduced connection failures.

* **Tests**
  * Added comprehensive test coverage for WebSocket connection utilities and related integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->