### PR TITLE
[codex] Log forwarded headers in access logs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,11 +51,42 @@ from shared.telemetry.context.large_data import log_json_body
 # Only used to prevent concurrent initialization, not to skip initialization
 STARTUP_LOCK_KEY = "wegent:startup_lock"
 STARTUP_LOCK_TIMEOUT = 120  # 120 seconds timeout for migrations + YAML init
+FORWARDED_LOG_HEADER_NAMES = (
+    "x-forwarded-for",
+    "x-forwarded-proto",
+    "x-forwarded-host",
+    "x-forwarded-port",
+    "x-forwarded-prefix",
+    "x-real-ip",
+    "forwarded",
+)
+MAX_LOGGED_HEADER_VALUE_LENGTH = 512
 
 
 # Initialize logging at module level for use in lifespan
 setup_logging()
 _logger = logging.getLogger(__name__)
+
+
+def _truncate_logged_header_value(value: str) -> str:
+    if len(value) <= MAX_LOGGED_HEADER_VALUE_LENGTH:
+        return value
+    return f"{value[:MAX_LOGGED_HEADER_VALUE_LENGTH]}... [truncated]"
+
+
+def _format_forwarded_headers_for_log(headers) -> str:
+    forwarded_headers = []
+    for header_name in FORWARDED_LOG_HEADER_NAMES:
+        header_value = headers.get(header_name)
+        if header_value:
+            forwarded_headers.append(
+                f"{header_name}={_truncate_logged_header_value(header_value)}"
+            )
+
+    if not forwarded_headers:
+        return ""
+
+    return f" headers={{{', '.join(forwarded_headers)}}}"
 
 
 def _get_mcp_lifespan_servers():
@@ -501,6 +532,7 @@ def create_app():
         username = get_username_from_request(request)
 
         client_ip = request.client.host if request.client else "Unknown"
+        forwarded_headers_log = _format_forwarded_headers_for_log(request.headers)
 
         # Always set request context for logging (works even without OTEL)
         from shared.telemetry.context import (
@@ -567,9 +599,11 @@ def create_app():
                         log_json_body("http.request.body", request_body)
 
         # Pre-request logging with request ID
-        logger.info(
-            f"request : {request.method} {request.url.path} {request.query_params} {request_id} {client_ip} [{username}]"
+        request_log_message = (
+            f"request : {request.method} {request.url.path} {request.query_params} "
+            f"{request_id} {client_ip} [{username}]{forwarded_headers_log}"
         )
+        logger.info(request_log_message)
 
         # Process request
         response = await call_next(request)
@@ -640,9 +674,12 @@ def create_app():
                                 logger.debug(f"Failed to capture response body: {e}")
 
         # Post-request logging with request ID
-        logger.info(
-            f"response: {request.method} {request.url.path} {request.query_params} {request_id} {client_ip} [{username}] {response.status_code} {process_time:.2f}ms"
+        response_log_message = (
+            f"response: {request.method} {request.url.path} {request.query_params} "
+            f"{request_id} {client_ip} [{username}]{forwarded_headers_log} "
+            f"{response.status_code} {process_time:.2f}ms"
         )
+        logger.info(response_log_message)
 
         # Add request ID to response headers for client-side tracking
         response.headers["X-Request-ID"] = request_id

--- a/backend/tests/test_request_logging.py
+++ b/backend/tests/test_request_logging.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+
+
+def test_access_logs_include_forwarded_headers(test_client, caplog):
+    headers = {
+        "X-Request-ID": "req-forwarded",
+        "X-Forwarded-For": "203.0.113.9, 10.0.0.2",
+        "X-Forwarded-Proto": "https",
+        "X-Forwarded-Host": "api.example.com",
+        "X-Real-IP": "203.0.113.9",
+        "Forwarded": "for=203.0.113.9;proto=https;host=api.example.com",
+    }
+
+    with caplog.at_level(logging.INFO, logger="app.main"):
+        response = test_client.get("/api/health", headers=headers)
+
+    assert response.status_code == 200
+
+    request_logs = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("request : GET /api/health")
+    ]
+    response_logs = [
+        record.message
+        for record in caplog.records
+        if record.message.startswith("response: GET /api/health")
+    ]
+
+    assert request_logs
+    assert response_logs
+    for log_message in (request_logs[-1], response_logs[-1]):
+        assert (
+            "headers={x-forwarded-for=203.0.113.9, 10.0.0.2, "
+            "x-forwarded-proto=https, x-forwarded-host=api.example.com, "
+            "x-real-ip=203.0.113.9, "
+            "forwarded=for=203.0.113.9;proto=https;host=api.example.com}"
+        ) in log_message


### PR DESCRIPTION
## Summary

- Add a constrained forwarded-header block to backend access logs.
- Include the same proxy header context in both request and response log lines.
- Add a regression test covering `X-Forwarded-*`, `X-Real-IP`, and `Forwarded` header logging.

## Why

Request diagnostics behind proxies need the original forwarded header context. The existing access logs only showed the ASGI client host, which can be the proxy/test client rather than the original requester.

## Validation

- `cd backend && uv run pytest tests/test_request_logging.py -q`

Note: the targeted test passes. The run still emits existing deprecation warnings from Pydantic/passlib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced HTTP middleware logging to capture and include forwarded client IP headers in both request and response logs.
  * Implemented automatic truncation of lengthy header values in log output.

* **Tests**
  * Added test coverage to verify forwarded headers are correctly captured in request and response logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->