### PR TITLE
fix(backend): avoid api key last_used_at writes on device websocket auth

### DIFF
--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -379,7 +379,7 @@ def _verify_api_key_sync(token: str) -> Optional[tuple[int, str]]:
         Tuple of (user_id, user_name) if valid, None otherwise.
     """
     with get_db_session() as db:
-        user = verify_api_key(db, token)
+        user = verify_api_key(db, token, update_last_used_at=False)
         if user:
             return (user.id, user.user_name)
     return None

--- a/backend/tests/api/ws/test_device_namespace_static.py
+++ b/backend/tests/api/ws/test_device_namespace_static.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+DEVICE_NAMESPACE_PATH = (
+    Path(__file__).resolve().parents[3] / "app" / "api" / "ws" / "device_namespace.py"
+)
+
+
+def test_device_ws_api_key_auth_does_not_update_last_used_at():
+    tree = ast.parse(DEVICE_NAMESPACE_PATH.read_text())
+    verify_function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_verify_api_key_sync"
+    )
+    verify_calls = [
+        node
+        for node in ast.walk(verify_function)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", "") == "verify_api_key"
+    ]
+
+    assert len(verify_calls) == 1
+    update_keyword = next(
+        (
+            keyword
+            for keyword in verify_calls[0].keywords
+            if keyword.arg == "update_last_used_at"
+        ),
+        None,
+    )
+    assert update_keyword is not None
+    assert isinstance(update_keyword.value, ast.Constant)
+    assert update_keyword.value.value is False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API key "last used at" timestamp behavior for WebSocket device connections to prevent unnecessary timestamp updates during authentication.

* **Tests**
  * Added test to verify API key authentication handling for WebSocket device connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->