### PR TITLE
fix(backend): keep skill router paths concrete

### DIFF
--- a/backend/app/api/endpoints/kind/__init__.py
+++ b/backend/app/api/endpoints/kind/__init__.py
@@ -18,6 +18,6 @@ k_router = APIRouter(prefix="/v1")
 # Include batch router first to avoid path conflicts
 k_router.include_router(batch_router, tags=["kinds-batch"])
 # Include skills router
-k_router.include_router(skills_router, prefix="/kinds/skills", tags=["skills"])
+k_router.include_router(skills_router, tags=["skills"])
 # Include unified kinds router after batch router
 k_router.include_router(kinds_router, tags=["kinds"])

--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -56,7 +56,7 @@ from app.services.git_skill import git_skill_service
 from app.services.group_permission import check_group_permission
 from app.services.skill_binding_service import skill_binding_service
 
-router = APIRouter()
+router = APIRouter(prefix="/kinds/skills")
 
 
 def _extract_bearer_token(authorization: str, oauth2_token: Optional[str]) -> str:

--- a/backend/tests/api/test_kind_skill_router.py
+++ b/backend/tests/api/test_kind_skill_router.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from fastapi import APIRouter
+
+from app.api.endpoints.kind.skills import router as skills_router
+
+
+def test_skill_router_has_concrete_paths_when_included_without_prefix():
+    """Skill routes must not depend on caller-provided prefixes to be valid."""
+    parent_router = APIRouter()
+
+    parent_router.include_router(skills_router)
+
+    route_paths = {route.path for route in parent_router.routes}
+    assert "/kinds/skills" in route_paths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the API router configuration to ensure skills endpoints register with the proper path structure.

* **Tests**
  * Added test coverage to validate API route path registration when routers are nested without explicit path prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->