### PR TITLE
[codex] Hide system recommendations from quick access favorites

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx
@@ -677,7 +677,38 @@ describe('QuickAccessCards', () => {
     expect(screen.queryByText('regular-team')).not.toBeInTheDocument()
   })
 
-  test('opens quick access teams from the more popover', async () => {
+  test('shows no quick access teams when only system recommendations are returned', async () => {
+    renderQuickAccessCards(
+      [
+        makeTeam({ id: 2, name: 'system-team', description: 'System description' }),
+        makeTeam({ id: 3, name: 'regular-team', description: 'Regular description' }),
+      ],
+      {
+        system_version: 2,
+        system_team_ids: [2],
+        user_version: null,
+        show_system_recommended: true,
+        teams: [
+          {
+            id: 2,
+            name: 'system-team',
+            display_name: 'System Team Display',
+            is_system: true,
+            recommended_mode: 'chat',
+          },
+        ],
+      }
+    )
+
+    expect(await screen.findByTestId('quick-launch-cards')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('More'))
+
+    expect(await screen.findByText('common:teams.quick_access_empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('quick-access-more-team-system-team')).not.toBeInTheDocument()
+  })
+
+  test('opens favorite teams from the more popover and keeps system recommendations in all agents', async () => {
     renderQuickAccessCards(
       [
         makeTeam({ id: 2, name: 'system-team', description: 'System description' }),
@@ -711,11 +742,15 @@ describe('QuickAccessCards', () => {
 
     fireEvent.click(screen.getByText('More'))
 
+    expect(await screen.findByTestId('quick-access-more-team-favorite-team')).toHaveTextContent(
+      'Favorite Team Display'
+    )
+    expect(screen.queryByTestId('quick-access-more-team-system-team')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('quick-access-view-all-agents'))
+
     expect(await screen.findByTestId('quick-access-more-team-system-team')).toHaveTextContent(
       'System Team Display'
-    )
-    expect(screen.getByTestId('quick-access-more-team-favorite-team')).toHaveTextContent(
-      'Favorite Team Display'
     )
   })
 

--- a/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
+++ b/frontend/src/features/tasks/components/chat/QuickAccessCards.tsx
@@ -112,6 +112,8 @@ export function QuickAccessCards({
   }, [teams])
 
   const filteredTeams = filterTeamsByMode(teams, currentMode)
+  const systemRecommendedQuickAccessIds = quickAccessResponse?.system_team_ids ?? []
+  const systemRecommendedQuickAccessIdSet = new Set(systemRecommendedQuickAccessIds)
 
   // Get all quick access teams matched with full team data
   const allDisplayTeams: DisplayTeam[] = quickAccessTeams
@@ -129,8 +131,12 @@ export function QuickAccessCards({
     })
     .filter((t): t is DisplayTeam => t !== null)
 
+  const favoriteDisplayTeams = allDisplayTeams.filter(
+    team => !team.is_system && !systemRecommendedQuickAccessIdSet.has(team.id)
+  )
+
   // Filter out default team only (keep selected team visible with selection state)
-  const displayTeams = allDisplayTeams.filter(t => {
+  const displayTeams = favoriteDisplayTeams.filter(t => {
     if (defaultTeam && t.id === defaultTeam.id) return false
     return true
   })
@@ -150,10 +156,8 @@ export function QuickAccessCards({
     team => !quickAccessTeamIds.has(team.id)
   )
   const morePopoverTeams = showAllTeamsInMore ? allSelectableTeams : displayTeams
-  const systemRecommendedQuickAccessIds = quickAccessResponse?.system_team_ids ?? []
-  const systemRecommendedQuickAccessIdSet = new Set(systemRecommendedQuickAccessIds)
   const favoriteQuickAccessTeamIds = quickAccessTeams
-    .filter(team => !systemRecommendedQuickAccessIdSet.has(team.id))
+    .filter(team => !team.is_system && !systemRecommendedQuickAccessIdSet.has(team.id))
     .map(team => team.id)
   const {
     favoriteTeamIdSet,
@@ -465,7 +469,7 @@ export function QuickAccessCards({
               onToggleFavorite={handleToggleFavorite}
               optionTestIdPrefix="quick-access-more-team"
               showReorderHandle={!showAllTeamsInMore}
-              canReorder={quickAccessTeams.length > 1}
+              canReorder={displayTeams.length > 1}
               dragOverTeamId={dragOverTeamId}
               onTeamDragStart={handleQuickAccessDragStart}
               onTeamDragOver={handleQuickAccessDragOver}

--- a/frontend/src/i18n/locales/en/common.json
+++ b/frontend/src/i18n/locales/en/common.json
@@ -315,7 +315,7 @@
     "create_first_team": "Create Agent",
     "system_recommended": "Recommended",
     "quick_access_title": "Favorite agents",
-    "quick_access_description": "This list shows your favorites and system-recommended agents by default.",
+    "quick_access_description": "This list shows your favorite agents.",
     "quick_access_empty": "No favorite agents yet",
     "quick_access_view_all": "View all agents",
     "quick_access_back": "Back to favorites",

--- a/frontend/src/i18n/locales/zh-CN/common.json
+++ b/frontend/src/i18n/locales/zh-CN/common.json
@@ -315,7 +315,7 @@
     "create_first_team": "创建智能体",
     "system_recommended": "系统推荐",
     "quick_access_title": "常用智能体",
-    "quick_access_description": "这里默认展示已收藏和系统推荐的智能体。",
+    "quick_access_description": "这里展示你已收藏的智能体。",
     "quick_access_empty": "暂无常用智能体",
     "quick_access_view_all": "查看全部智能体",
     "quick_access_back": "返回常用智能体",


### PR DESCRIPTION
## Summary
- Filter system-recommended teams out of the default Favorite agents / 常用智能体 popover.
- Keep system-recommended teams available after switching to the all-agents view.
- Update Chinese and English helper copy so the popover describes favorites only.

## Root Cause
The quick access API can return system recommendations in `teams`, and `QuickAccessCards` used that merged list directly for the default favorites popover.

## Test Plan
- `pnpm --dir frontend test -- src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx --runInBand`
- `pnpm --dir frontend exec eslint src/features/tasks/components/chat/QuickAccessCards.tsx src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx`
- `pnpm --dir frontend exec prettier --check src/features/tasks/components/chat/QuickAccessCards.tsx src/__tests__/features/tasks/components/chat/QuickAccessCards.test.tsx src/i18n/locales/en/common.json src/i18n/locales/zh-CN/common.json`
- `git diff --check`
- pre-push hook: ESLint, TypeScript, unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Quick-access cards now display only favorite agents by default; system recommendations are available in the expanded view.

* **Documentation**
  * Updated quick-access descriptions to clarify which agents are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->