### PR TITLE
fix(wework): stop completed Codex block timer

### DIFF
--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -75,6 +75,43 @@ describe('reduceWorkbenchMessages', () => {
     ])
   })
 
+  test('finalizes incoming processing blocks on done', () => {
+    const state = reduceWorkbenchMessages([], {
+      type: 'assistant_started',
+      taskId: 1,
+      subtaskId: 9,
+    })
+
+    const done = reduceWorkbenchMessages(state, {
+      type: 'assistant_done',
+      subtaskId: 9,
+      content: 'Final',
+      blocks: [
+        {
+          id: 'thinking-real',
+          subtaskId: 9,
+          type: 'thinking',
+          content: 'Drafting',
+          status: 'streaming',
+          createdAt: 1770000000000,
+        },
+        {
+          id: 'call_1',
+          subtaskId: 9,
+          type: 'tool',
+          toolName: 'bash',
+          status: 'pending',
+          createdAt: 1770000001000,
+        },
+      ],
+    })
+
+    expect(done[0].blocks).toMatchObject([
+      { id: 'thinking-real', type: 'thinking', status: 'done' },
+      { id: 'call_1', type: 'tool', status: 'done' },
+    ])
+  })
+
   test('preserves state for unknown runtime actions', () => {
     const state: WorkbenchMessage[] = [
       {
@@ -102,7 +139,11 @@ describe('normalizeWorkbenchBlockStatus', () => {
     expect(normalizeWorkbenchBlockStatus('streaming')).toBe('streaming')
     expect(normalizeWorkbenchBlockStatus('done')).toBe('done')
     expect(normalizeWorkbenchBlockStatus('error')).toBe('error')
+    expect(normalizeWorkbenchBlockStatus('completed')).toBe('done')
+    expect(normalizeWorkbenchBlockStatus('succeeded')).toBe('done')
+    expect(normalizeWorkbenchBlockStatus('failed')).toBe('error')
     expect(normalizeWorkbenchBlockStatus('running')).toBe('pending')
+    expect(normalizeWorkbenchBlockStatus('inProgress')).toBe('pending')
     expect(normalizeWorkbenchBlockStatus('unsupported')).toBe('pending')
     expect(normalizeWorkbenchBlockStatus()).toBe('pending')
   })

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -163,7 +163,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
               ...message,
               content: action.content ?? message.content,
               status: 'done' as const,
-              blocks: action.blocks ?? finalizeProcessingBlocks(message.blocks),
+              blocks: finalizeProcessingBlocks(action.blocks ?? message.blocks, 'done'),
               fileChanges: action.fileChanges ?? message.fileChanges,
             }
           : message
@@ -182,6 +182,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
               status: 'failed' as const,
               error: action.error,
               errorType: action.errorType,
+              blocks: finalizeProcessingBlocks(message.blocks, 'error'),
             }
           : message
       )
@@ -213,14 +214,26 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
 }
 
 export function normalizeWorkbenchBlockStatus(status?: string): WorkbenchToolBlockStatus {
-  switch (status) {
+  const normalizedStatus = status?.trim().toLowerCase().replace(/[\s-]+/g, '_')
+
+  switch (normalizedStatus) {
     case 'generating_arguments':
     case 'pending':
     case 'streaming':
     case 'done':
     case 'error':
-      return status
+      return normalizedStatus
+    case 'completed':
+    case 'complete':
+    case 'succeeded':
+    case 'success':
+      return 'done'
+    case 'failed':
+    case 'failure':
+      return 'error'
     case 'running':
+    case 'in_progress':
+    case 'inprogress':
     default:
       return 'pending'
   }
@@ -274,18 +287,32 @@ function appendThinkingChunk(
 function finalizeThinkingBlocks(
   blocks: WorkbenchProcessingBlock[] | undefined
 ): WorkbenchProcessingBlock[] {
-  return (blocks ?? []).map(block =>
-    block.type === 'thinking' && block.status === 'streaming'
-      ? { ...block, status: 'done' as const }
-      : block
-  )
+  return finalizeBlocks(blocks)
+}
+
+function finalizeBlocks(
+  blocks: WorkbenchProcessingBlock[] | undefined,
+  finalStatus?: Extract<WorkbenchToolBlockStatus, 'done' | 'error'>
+): WorkbenchProcessingBlock[] {
+  return (blocks ?? []).map(block => {
+    if (block.type === 'thinking' && block.status === 'streaming') {
+      return { ...block, status: 'done' as const }
+    }
+
+    if (!finalStatus || block.status === 'done' || block.status === 'error') {
+      return block
+    }
+
+    return { ...block, status: finalStatus } as WorkbenchProcessingBlock
+  })
 }
 
 function finalizeProcessingBlocks(
-  blocks: WorkbenchProcessingBlock[] | undefined
+  blocks: WorkbenchProcessingBlock[] | undefined,
+  finalStatus: Extract<WorkbenchToolBlockStatus, 'done' | 'error'> = 'done'
 ): WorkbenchProcessingBlock[] | undefined {
   if (!blocks) return undefined
-  return finalizeThinkingBlocks(blocks)
+  return finalizeBlocks(blocks, finalStatus)
 }
 
 function mergeProcessingBlock(

--- a/wework/.prettierrc.json
+++ b/wework/.prettierrc.json
@@ -1,0 +1,10 @@
+{
+  "semi": false,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -7,11 +7,7 @@ import type { Attachment, SkillRef, UnifiedModel } from '@/types/api'
 
 function Probe() {
   const { state } = useWorkbench()
-  return (
-    <div data-testid="probe">
-      {state.isBootstrapping ? 'loading' : state.user?.user_name}
-    </div>
-  )
+  return <div data-testid="probe">{state.isBootstrapping ? 'loading' : state.user?.user_name}</div>
 }
 
 function ProjectChatProbe() {
@@ -42,14 +38,10 @@ function ProjectChatProbe() {
     <div>
       <span data-testid="message-attachment-filenames">
         {workbench.messages
-          .flatMap(message =>
-            (message.attachments ?? []).map(attachment => attachment.filename)
-          )
+          .flatMap(message => (message.attachments ?? []).map(attachment => attachment.filename))
           .join(',')}
       </span>
-      <span data-testid="project-execution-mode">
-        {workbench.projectExecutionMode}
-      </span>
+      <span data-testid="project-execution-mode">{workbench.projectExecutionMode}</span>
       <span data-testid="workbench-input">{workbench.state.input}</span>
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
       <button type="button" onClick={() => workbench.selectProject(7)}>
@@ -67,10 +59,7 @@ function ProjectChatProbe() {
       <button type="button" onClick={() => projectChat.addExistingAttachment(attachment)}>
         add attachment
       </button>
-      <button
-        type="button"
-        onClick={() => workbench.setProjectExecutionMode('git_worktree')}
-      >
+      <button type="button" onClick={() => workbench.setProjectExecutionMode('git_worktree')}>
         select worktree
       </button>
       <button type="button" onClick={() => workbench.setInput('build it')}>
@@ -86,7 +75,7 @@ function ProjectChatProbe() {
 function RetryFailedMessageProbe() {
   const workbench = useWorkbench()
   const failedMessage = workbench.messages.find(
-    message => message.role === 'assistant' && message.status === 'failed',
+    message => message.role === 'assistant' && message.status === 'failed'
   )
 
   return (
@@ -126,10 +115,7 @@ function ModelCompatibilityProbe() {
       </button>
       <div data-testid="model-compatibility-status">
         {workbench.projectChat.models
-          .map(
-            model =>
-              `${model.name}:${model.compatibilityDisabledReason ?? 'enabled'}`
-          )
+          .map(model => `${model.name}:${model.compatibilityDisabledReason ?? 'enabled'}`)
           .join('|')}
       </div>
     </div>
@@ -143,9 +129,7 @@ function ProjectTaskSendProbe() {
     <div>
       <span data-testid="workbench-input">{workbench.state.input}</span>
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
-      <span data-testid="current-task-id">
-        {workbench.state.currentTask?.id ?? 'no-task'}
-      </span>
+      <span data-testid="current-task-id">{workbench.state.currentTask?.id ?? 'no-task'}</span>
       <span data-testid="project-count">{workbench.state.projects.length}</span>
       <button type="button" onClick={() => void workbench.openTask(71)}>
         open project task
@@ -185,7 +169,9 @@ function RunningTasksProbe() {
   return (
     <div>
       <span data-testid="running-task-ids">
-        {Array.from(workbench.runningTaskIds).sort((a, b) => a - b).join(',')}
+        {Array.from(workbench.runningTaskIds)
+          .sort((a, b) => a - b)
+          .join(',')}
       </span>
       <span data-testid="current-task-title">
         {workbench.state.currentTask?.title ?? 'no-task'}
@@ -428,9 +414,7 @@ describe('WorkbenchProvider', () => {
       </WorkbenchProvider>
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('probe')).toHaveTextContent('alice')
-    )
+    await waitFor(() => expect(screen.getByTestId('probe')).toHaveTextContent('alice'))
   })
 
   test('does not automatically upgrade old online devices during bootstrap', async () => {
@@ -505,9 +489,7 @@ describe('WorkbenchProvider', () => {
       </WorkbenchProvider>
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('device-list')).toHaveTextContent('Old Device')
-    )
+    await waitFor(() => expect(screen.getByTestId('device-list')).toHaveTextContent('Old Device'))
     expect(upgradeDevice).not.toHaveBeenCalled()
   })
 
@@ -594,9 +576,7 @@ describe('WorkbenchProvider', () => {
     )
 
     await waitFor(() => expect(getTaskDetail).toHaveBeenCalledWith(8))
-    expect(await screen.findByTestId('current-task-title')).toHaveTextContent(
-      'Restored task',
-    )
+    expect(await screen.findByTestId('current-task-title')).toHaveTextContent('Restored task')
     expect(joinTask).toHaveBeenCalledWith(8)
   })
 
@@ -817,12 +797,8 @@ describe('WorkbenchProvider', () => {
     await userEvent.click(await screen.findByText('open task'))
 
     await waitFor(() => expect(joinTask).toHaveBeenCalledWith(8))
-    expect(screen.getByTestId('message-contents')).toHaveTextContent(
-      'assistant:done:'
-    )
-    expect(screen.getByTestId('message-contents')).not.toHaveTextContent(
-      'assistant:streaming'
-    )
+    expect(screen.getByTestId('message-contents')).toHaveTextContent('assistant:done:')
+    expect(screen.getByTestId('message-contents')).not.toHaveTextContent('assistant:streaming')
   })
 
   test('uses the opened task model as the runtime compatibility anchor', async () => {
@@ -1028,9 +1004,7 @@ describe('WorkbenchProvider', () => {
     )
 
     await waitFor(() =>
-      expect(screen.getByTestId('device-list')).toHaveTextContent(
-        'Linux-Device-0b18648b2e82'
-      )
+      expect(screen.getByTestId('device-list')).toHaveTextContent('Linux-Device-0b18648b2e82')
     )
 
     handlers.onDeviceOnline?.({
@@ -1040,9 +1014,7 @@ describe('WorkbenchProvider', () => {
     })
 
     await waitFor(() =>
-      expect(screen.getByTestId('device-list')).toHaveTextContent(
-        'macOS-Device-cb8262d8f25a'
-      )
+      expect(screen.getByTestId('device-list')).toHaveTextContent('macOS-Device-cb8262d8f25a')
     )
     expect(listDevices).toHaveBeenCalledTimes(2)
   })
@@ -1772,9 +1744,7 @@ describe('WorkbenchProvider', () => {
         })
       )
     )
-    expect(screen.getByTestId('message-attachment-filenames')).toHaveTextContent(
-      'brief.pdf'
-    )
+    expect(screen.getByTestId('message-attachment-filenames')).toHaveTextContent('brief.pdf')
     expect(updateCurrentUser).toHaveBeenCalledWith({
       preferences: {
         wework_new_chat_model_selection: {
@@ -1882,7 +1852,7 @@ describe('WorkbenchProvider', () => {
     expect(sendMessage).not.toHaveBeenCalled()
     expect(screen.getByTestId('workbench-input')).toHaveTextContent('build it')
     expect(screen.getByTestId('workbench-error')).toHaveTextContent(
-      'Offline Device 离线，恢复在线后可继续对话',
+      'Offline Device 离线，恢复在线后可继续对话'
     )
   })
 
@@ -1984,14 +1954,10 @@ describe('WorkbenchProvider', () => {
       </WorkbenchProvider>
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('project-count')).toHaveTextContent('1')
-    )
+    await waitFor(() => expect(screen.getByTestId('project-count')).toHaveTextContent('1'))
 
     await userEvent.click(screen.getByText('open project task'))
-    await waitFor(() =>
-      expect(screen.getByTestId('current-task-id')).toHaveTextContent('71')
-    )
+    await waitFor(() => expect(screen.getByTestId('current-task-id')).toHaveTextContent('71'))
 
     await userEvent.click(screen.getByText('set input'))
     await userEvent.click(screen.getByText('send'))
@@ -1999,7 +1965,7 @@ describe('WorkbenchProvider', () => {
     expect(sendMessage).not.toHaveBeenCalled()
     expect(screen.getByTestId('workbench-input')).toHaveTextContent('continue')
     expect(screen.getByTestId('workbench-error')).toHaveTextContent(
-      'missing-device 不可用，恢复在线后可继续对话',
+      'missing-device 不可用，恢复在线后可继续对话'
     )
   })
 
@@ -2239,9 +2205,7 @@ describe('WorkbenchProvider', () => {
     await userEvent.click(screen.getByText('start project 8 chat'))
 
     await waitFor(() =>
-      expect(screen.getByTestId('project-execution-mode')).toHaveTextContent(
-        'git_worktree'
-      )
+      expect(screen.getByTestId('project-execution-mode')).toHaveTextContent('git_worktree')
     )
 
     await userEvent.click(screen.getByText('set input'))
@@ -2359,9 +2323,7 @@ describe('WorkbenchProvider', () => {
     )
 
     await waitFor(() =>
-      expect(screen.getByTestId('standalone-device-id')).toHaveTextContent(
-        'cloud-online'
-      )
+      expect(screen.getByTestId('standalone-device-id')).toHaveTextContent('cloud-online')
     )
 
     await userEvent.click(screen.getByText('set input'))
@@ -2393,9 +2355,7 @@ describe('WorkbenchProvider', () => {
       const workbench = useWorkbench()
       return (
         <div>
-          <span data-testid="current-task-id">
-            {workbench.state.currentTask?.id ?? 'no-task'}
-          </span>
+          <span data-testid="current-task-id">{workbench.state.currentTask?.id ?? 'no-task'}</span>
           <button type="button" onClick={() => workbench.selectProject(7)}>
             select project
           </button>
@@ -2471,9 +2431,7 @@ describe('WorkbenchProvider', () => {
     await userEvent.click(screen.getByText('set first input'))
     await userEvent.click(screen.getByText('send'))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('current-task-id')).toHaveTextContent('99')
-    )
+    await waitFor(() => expect(screen.getByTestId('current-task-id')).toHaveTextContent('99'))
 
     await userEvent.click(screen.getByText('set second input'))
     await userEvent.click(screen.getByText('send'))
@@ -2491,11 +2449,7 @@ describe('WorkbenchProvider', () => {
 
   test('keeps later guidance queued while one guidance send is in progress', async () => {
     let streamHandlers: {
-      onChatStart?: (payload: {
-        task_id: number
-        subtask_id: number
-        shell_type?: string
-      }) => void
+      onChatStart?: (payload: { task_id: number; subtask_id: number; shell_type?: string }) => void
     } = {}
     let resolveCancel: ((value: { success: boolean }) => void) | undefined
     const cancelStream = vi.fn().mockImplementation(
@@ -2605,11 +2559,7 @@ describe('WorkbenchProvider', () => {
 
   test('does not drain remaining queued messages before the guided response starts', async () => {
     let streamHandlers: {
-      onChatStart?: (payload: {
-        task_id: number
-        subtask_id: number
-        shell_type?: string
-      }) => void
+      onChatStart?: (payload: { task_id: number; subtask_id: number; shell_type?: string }) => void
     } = {}
     const cancelStream = vi.fn().mockResolvedValue({ success: true })
     const sendMessage = vi.fn().mockResolvedValue({ success: true, task_id: 8 })
@@ -2704,11 +2654,7 @@ describe('WorkbenchProvider', () => {
 
   test('retries a failed assistant message using the previous user message', async () => {
     type StreamHandlers = {
-      onChatStart?: (payload: {
-        task_id: number
-        subtask_id: number
-        shell_type?: string
-      }) => void
+      onChatStart?: (payload: { task_id: number; subtask_id: number; shell_type?: string }) => void
       onChatError?: (payload: {
         task_id?: number
         subtask_id: number
@@ -2794,9 +2740,7 @@ describe('WorkbenchProvider', () => {
     })
 
     await waitFor(() =>
-      expect(screen.getByTestId('retry-message-states')).toHaveTextContent(
-        'assistant::failed',
-      )
+      expect(screen.getByTestId('retry-message-states')).toHaveTextContent('assistant::failed')
     )
 
     await userEvent.click(screen.getByText('retry failed message'))
@@ -2806,7 +2750,7 @@ describe('WorkbenchProvider', () => {
       expect.objectContaining({
         task_id: 8,
         message: 'hi',
-      }),
+      })
     )
   })
 
@@ -2932,9 +2876,7 @@ describe('WorkbenchProvider', () => {
         'user:我叫胡云鹏assistant:你好，胡云鹏！'
       )
     )
-    expect(screen.getByTestId('history-attachment-filenames')).toHaveTextContent(
-      'diagram.png'
-    )
+    expect(screen.getByTestId('history-attachment-filenames')).toHaveTextContent('diagram.png')
   })
 
   test('restores persisted tool blocks when opening task history', async () => {
@@ -2952,7 +2894,7 @@ describe('WorkbenchProvider', () => {
                   ? [
                       <li key={block.id}>
                         {block.toolName}:{String(block.toolInput?.command)}:
-                        {String(block.toolOutput)}
+                        {String(block.toolOutput)}:{block.status}
                       </li>,
                     ]
                   : [
@@ -3015,20 +2957,21 @@ describe('WorkbenchProvider', () => {
                         tool_name: 'exec',
                         tool_input: { command: 'pwd' },
                         tool_output: '/Users/yunpeng7/AIGCWorkSpace',
-                        status: 'done',
-                        timestamp: 1770000000000,
+                        status: 'completed',
+                        timestamp: 1770000000,
                       },
                       {
                         id: 'thinking_1',
                         type: 'thinking',
                         content: 'I will inspect the workspace',
-                        status: 'done',
+                        status: 'streaming',
                         timestamp: 1770000000100,
                       },
                     ],
                   },
                   status: 'COMPLETED',
                   created_at: '2026-05-27T00:02:00.000Z',
+                  completed_at: '2026-05-27T00:03:00.000Z',
                 },
               ],
             }),
@@ -3063,7 +3006,7 @@ describe('WorkbenchProvider', () => {
 
     await waitFor(() =>
       expect(screen.getByTestId('tool-blocks')).toHaveTextContent(
-        'exec:pwd:/Users/yunpeng7/AIGCWorkSpace'
+        'exec:pwd:/Users/yunpeng7/AIGCWorkSpace:done'
       )
     )
     expect(screen.getByTestId('tool-blocks')).toHaveTextContent(
@@ -3237,7 +3180,10 @@ describe('WorkbenchProvider', () => {
           <span data-testid="attachment-current-task-title">
             {workbench.state.currentTask?.title ?? ''}
           </span>
-          <button type="button" onClick={() => workbench.projectChat.addExistingAttachment(attachment)}>
+          <button
+            type="button"
+            onClick={() => workbench.projectChat.addExistingAttachment(attachment)}
+          >
             add attachment
           </button>
           <button type="button" onClick={() => void workbench.sendCurrentInput()}>
@@ -3327,15 +3273,9 @@ describe('WorkbenchProvider', () => {
         })
       )
     )
-    expect(screen.getByTestId('attachment-message-contents')).not.toHaveTextContent(
-      '请参考附件'
-    )
-    expect(screen.getByTestId('attachment-message-contents')).toHaveTextContent(
-      'user:done:'
-    )
-    expect(screen.getByTestId('attachment-current-task-title')).toHaveTextContent(
-      '新对话'
-    )
+    expect(screen.getByTestId('attachment-message-contents')).not.toHaveTextContent('请参考附件')
+    expect(screen.getByTestId('attachment-message-contents')).toHaveTextContent('user:done:')
+    expect(screen.getByTestId('attachment-current-task-title')).toHaveTextContent('新对话')
   })
 
   test('clears the open task and messages after archiving all chats', async () => {
@@ -3547,26 +3487,18 @@ describe('WorkbenchProvider', () => {
     // 1. Open the task; the dropdown anchors on the task's saved model.
     await userEvent.click(await screen.findByText('open task'))
     await waitFor(() =>
-      expect(screen.getByTestId('current-task-model')).toHaveTextContent(
-        'wecode-claude-sonnet-4-5'
-      )
+      expect(screen.getByTestId('current-task-model')).toHaveTextContent('wecode-claude-sonnet-4-5')
     )
-    expect(screen.getByTestId('selected-model')).toHaveTextContent(
-      'wecode-claude-sonnet-4-5'
-    )
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('wecode-claude-sonnet-4-5')
 
     // 2. User picks a different model. The dropdown updates immediately
     //    AND the open task's model_id is mirrored so subsequent
     //    task_status updates (e.g. chat:start) can't revert it.
     await userEvent.click(screen.getByTestId('switch-to-opus'))
     await waitFor(() =>
-      expect(screen.getByTestId('current-task-model')).toHaveTextContent(
-        'wecode-claude-opus-4'
-      )
+      expect(screen.getByTestId('current-task-model')).toHaveTextContent('wecode-claude-opus-4')
     )
-    expect(screen.getByTestId('selected-model')).toHaveTextContent(
-      'wecode-claude-opus-4'
-    )
+    expect(screen.getByTestId('selected-model')).toHaveTextContent('wecode-claude-opus-4')
 
     // 3. The next turn's chat:start event flips task status from SUCCESS to
     //    RUNNING. Before the fix this rebuilt state.currentTask and the
@@ -3580,13 +3512,9 @@ describe('WorkbenchProvider', () => {
     })
 
     await waitFor(() =>
-      expect(screen.getByTestId('selected-model')).toHaveTextContent(
-        'wecode-claude-opus-4'
-      )
+      expect(screen.getByTestId('selected-model')).toHaveTextContent('wecode-claude-opus-4')
     )
-    expect(screen.getByTestId('current-task-model')).toHaveTextContent(
-      'wecode-claude-opus-4'
-    )
+    expect(screen.getByTestId('current-task-model')).toHaveTextContent('wecode-claude-opus-4')
   })
 
   test('keeps a live running task indicator after switching to another task', async () => {
@@ -3692,9 +3620,7 @@ describe('WorkbenchProvider', () => {
       streamHandlers?.onChatStart?.({ task_id: 8, subtask_id: 80 })
     })
 
-    await waitFor(() =>
-      expect(screen.getByTestId('running-task-ids')).toHaveTextContent('8')
-    )
+    await waitFor(() => expect(screen.getByTestId('running-task-ids')).toHaveTextContent('8'))
 
     await userEvent.click(screen.getByText('open task 9'))
     await waitFor(() =>

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -60,10 +60,7 @@ import type {
   UnifiedSkill,
   User,
 } from '@/types/api'
-import type {
-  DeviceUpgradeState,
-  DeviceUpgradeStatusPayload,
-} from '@/types/device-events'
+import type { DeviceUpgradeState, DeviceUpgradeStatusPayload } from '@/types/device-events'
 import type { EnvironmentInfo } from '@/types/environment'
 import type {
   GuidanceWorkbenchMessage,
@@ -72,18 +69,12 @@ import type {
   WorkbenchMessage,
   WorkbenchState,
 } from '@/types/workbench'
-import {
-  normalizeWorkbenchBlockStatus,
-  reduceWorkbenchMessages,
-} from '@wegent/chat-core'
+import { normalizeWorkbenchBlockStatus, reduceWorkbenchMessages } from '@wegent/chat-core'
 import { useWorkbenchAttachments } from './useWorkbenchAttachments'
 import { useWorkbenchModels } from './useWorkbenchModels'
 import { useWorkbenchSkills } from './useWorkbenchSkills'
 import { normalizeTurnFileChanges } from './turnFileChanges'
-import {
-  initialWorkbenchState,
-  workbenchReducer,
-} from './workbenchReducer'
+import { initialWorkbenchState, workbenchReducer } from './workbenchReducer'
 import { WorkbenchContext } from './useWorkbench'
 
 const WEWORK_CLIENT_ORIGIN = 'wework'
@@ -106,11 +97,7 @@ function readCachedDeviceList(): DeviceInfo[] {
     const value = window.sessionStorage.getItem(DEVICE_LIST_CACHE_KEY)
     if (!value) return []
     const parsed = JSON.parse(value)
-    if (
-      !parsed ||
-      !Array.isArray(parsed.devices) ||
-      typeof parsed.updatedAt !== 'number'
-    ) {
+    if (!parsed || !Array.isArray(parsed.devices) || typeof parsed.updatedAt !== 'number') {
       return []
     }
     if (Date.now() - parsed.updatedAt > DEVICE_LIST_CACHE_TTL_MS) return []
@@ -125,7 +112,7 @@ function writeCachedDeviceList(devices: DeviceInfo[]) {
   try {
     window.sessionStorage.setItem(
       DEVICE_LIST_CACHE_KEY,
-      JSON.stringify({ devices, updatedAt: Date.now() }),
+      JSON.stringify({ devices, updatedAt: Date.now() })
     )
   } catch {
     // The live state remains authoritative when browser storage is unavailable.
@@ -169,13 +156,8 @@ export interface WorkbenchServices {
   teamApi: ReturnType<typeof createTeamApi>
   modelApi: ReturnType<typeof createModelApi>
   skillApi: ReturnType<typeof createSkillApi>
-  projectApi: Omit<
-    ReturnType<typeof createProjectApi>,
-    'createGitWorkspaceProject'
-  > & {
-    createGitWorkspaceProject?: ReturnType<
-      typeof createProjectApi
-    >['createGitWorkspaceProject']
+  projectApi: Omit<ReturnType<typeof createProjectApi>, 'createGitWorkspaceProject'> & {
+    createGitWorkspaceProject?: ReturnType<typeof createProjectApi>['createGitWorkspaceProject']
   }
   gitApi?: ReturnType<typeof createGitApi>
   taskApi: Omit<
@@ -183,12 +165,8 @@ export interface WorkbenchServices {
     'searchTasks' | 'getTurnFileChangesDiff' | 'revertTurnFileChanges'
   > & {
     searchTasks?: ReturnType<typeof createTaskApi>['searchTasks']
-    getTurnFileChangesDiff?: ReturnType<
-      typeof createTaskApi
-    >['getTurnFileChangesDiff']
-    revertTurnFileChanges?: ReturnType<
-      typeof createTaskApi
-    >['revertTurnFileChanges']
+    getTurnFileChangesDiff?: ReturnType<typeof createTaskApi>['getTurnFileChangesDiff']
+    revertTurnFileChanges?: ReturnType<typeof createTaskApi>['revertTurnFileChanges']
   }
   deviceApi: ReturnType<typeof createDeviceApi>
   userApi?: ReturnType<typeof createUserApi>
@@ -239,9 +217,7 @@ export interface WorkbenchContextValue {
   refreshDevices: () => Promise<void>
   upgradeDevice: (deviceId: string) => Promise<void>
   createProject: (data: CreateProjectRequest) => Promise<ProjectWithTasks>
-  createGitWorkspaceProject: (
-    data: CreateGitWorkspaceProjectRequest,
-  ) => Promise<ProjectWithTasks>
+  createGitWorkspaceProject: (data: CreateGitWorkspaceProjectRequest) => Promise<ProjectWithTasks>
   listGitRepositories: () => Promise<GitRepoInfo[]>
   listGitBranches: (repo: GitRepoInfo) => Promise<GitBranch[]>
   updateProjectName: (projectId: number, name: string) => Promise<void>
@@ -260,19 +236,10 @@ export interface WorkbenchContextValue {
   listDeviceDirectories: (deviceId: string, path: string) => Promise<string[]>
   createDeviceDirectory: (deviceId: string, path: string) => Promise<void>
   loadEnvironmentInfo: (project: ProjectWithTasks | null) => Promise<EnvironmentInfo>
-  commitEnvironmentChanges: (
-    project: ProjectWithTasks | null,
-    message: string,
-  ) => Promise<void>
+  commitEnvironmentChanges: (project: ProjectWithTasks | null, message: string) => Promise<void>
   listEnvironmentBranches: (project: ProjectWithTasks | null) => Promise<string[]>
-  checkoutEnvironmentBranch: (
-    project: ProjectWithTasks | null,
-    branchName: string,
-  ) => Promise<void>
-  createEnvironmentBranch: (
-    project: ProjectWithTasks | null,
-    branchName: string,
-  ) => Promise<void>
+  checkoutEnvironmentBranch: (project: ProjectWithTasks | null, branchName: string) => Promise<void>
+  createEnvironmentBranch: (project: ProjectWithTasks | null, branchName: string) => Promise<void>
   setInput: (input: string) => void
   sendCurrentInput: () => Promise<void>
   retryFailedMessage: (messageId: string) => Promise<void>
@@ -283,9 +250,7 @@ export interface WorkbenchContextValue {
   editQueuedMessage: (id: string) => void
   cancelGuidanceMessage: (id: string) => void
   loadTurnFileChangesDiff: (subtaskId: number) => Promise<string>
-  revertTurnFileChanges: (
-    subtaskId: number,
-  ) => Promise<TurnFileChangesSummary>
+  revertTurnFileChanges: (subtaskId: number) => Promise<TurnFileChangesSummary>
 }
 
 interface WorkbenchProviderProps {
@@ -348,19 +313,30 @@ function getSubtaskResult(result: unknown): SubtaskResult | undefined {
   }
 }
 
-function getBlockTimestamp(value: unknown): number {
-  if (typeof value !== 'number') return Date.now()
-  return value > 1_000_000_000_000 ? value : Date.now()
+function parseTimestampMs(value?: string | null): number | undefined {
+  if (!value) return undefined
+  const timestamp = new Date(value).getTime()
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+function getBlockTimestamp(value: unknown, fallbackTimestamp = Date.now()): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallbackTimestamp
+  }
+  if (value > 1_000_000_000_000) return value
+  if (value > 1_000_000_000) return value * 1000
+  return fallbackTimestamp
 }
 
 function normalizeProcessingBlock(
   subtaskId: number,
   block: unknown,
-  index: number
+  index: number,
+  fallbackTimestamp?: number
 ): ProcessingBlock | null {
   if (!isRecord(block)) return null
 
-  const timestamp = getBlockTimestamp(block.timestamp)
+  const timestamp = getBlockTimestamp(block.timestamp, fallbackTimestamp)
   const status = normalizeWorkbenchBlockStatus(
     typeof block.status === 'string' ? block.status : undefined
   )
@@ -385,8 +361,7 @@ function normalizeProcessingBlock(
   }
 
   if (block.type === 'thinking') {
-    const id =
-      typeof block.id === 'string' ? block.id : `thinking-${subtaskId}-${index}`
+    const id = typeof block.id === 'string' ? block.id : `thinking-${subtaskId}-${index}`
     return {
       id,
       subtaskId,
@@ -402,20 +377,18 @@ function normalizeProcessingBlock(
 
 function normalizeProcessingBlocks(
   subtaskId: number,
-  blocks?: unknown[]
+  blocks?: unknown[],
+  fallbackTimestamp?: number
 ): ProcessingBlock[] {
   if (!blocks) return []
 
   return blocks.flatMap((block, index) => {
-    const normalized = normalizeProcessingBlock(subtaskId, block, index)
+    const normalized = normalizeProcessingBlock(subtaskId, block, index, fallbackTimestamp)
     return normalized ? [normalized] : []
   })
 }
 
-function getResultBlocks(
-  subtaskId: number,
-  result: unknown
-): ProcessingBlock[] | undefined {
+function getResultBlocks(subtaskId: number, result: unknown): ProcessingBlock[] | undefined {
   if (!isRecord(result) || !Array.isArray(result.blocks)) return undefined
   const blocks = normalizeProcessingBlocks(subtaskId, result.blocks)
   return blocks.length > 0 ? blocks : undefined
@@ -423,15 +396,10 @@ function getResultBlocks(
 
 function getReasoningChunk(result: unknown): string | undefined {
   if (!isRecord(result)) return undefined
-  return typeof result.reasoning_chunk === 'string'
-    ? result.reasoning_chunk
-    : undefined
+  return typeof result.reasoning_chunk === 'string' ? result.reasoning_chunk : undefined
 }
 
-function normalizeChatBlock(
-  subtaskId: number,
-  block: ChatBlock
-): ProcessingBlock | null {
+function normalizeChatBlock(subtaskId: number, block: ChatBlock): ProcessingBlock | null {
   return normalizeProcessingBlock(subtaskId, block, 0)
 }
 
@@ -473,7 +441,14 @@ function getSubtaskAttachments(subtask: Subtask): Attachment[] | undefined {
 function subtaskToMessage(subtask: Subtask): WorkbenchMessage {
   const result = getSubtaskResult(subtask.result)
   const role = subtask.role.toLowerCase() === 'user' ? 'user' : 'assistant'
-  const blocks = normalizeProcessingBlocks(subtask.id, result?.blocks)
+  const blockFallbackTimestamp =
+    parseTimestampMs(subtask.completed_at) ??
+    parseTimestampMs(subtask.updated_at) ??
+    parseTimestampMs(subtask.created_at)
+  const blocks = finalizeBlocksForTerminalSubtask(
+    normalizeProcessingBlocks(subtask.id, result?.blocks, blockFallbackTimestamp),
+    subtask.status
+  )
   return {
     id: `subtask-${subtask.id}`,
     taskId: subtask.task_id,
@@ -547,14 +522,12 @@ function writeLastProjectId(userId: number, projectId: number) {
   }
 }
 
-function normalizeStoredModelOptions(
-  options?: Record<string, unknown> | null,
-): ModelOptions {
+function normalizeStoredModelOptions(options?: Record<string, unknown> | null): ModelOptions {
   if (!options) return {}
   return Object.fromEntries(
     Object.entries(options).filter((entry): entry is [string, string] => {
       return typeof entry[1] === 'string'
-    }),
+    })
   )
 }
 
@@ -575,6 +548,30 @@ function isRunningTaskStatus(status?: string) {
   return ['PENDING', 'RUNNING', 'STARTED', 'PROCESSING', 'IN_PROGRESS'].includes(
     String(status ?? '').toUpperCase()
   )
+}
+
+function isTerminalSubtaskStatus(status?: string) {
+  return ['COMPLETED', 'FAILED', 'CANCELLED'].includes(String(status ?? '').toUpperCase())
+}
+
+function finalizeBlocksForTerminalSubtask(
+  blocks: ProcessingBlock[],
+  subtaskStatus: string
+): ProcessingBlock[] {
+  if (!isTerminalSubtaskStatus(subtaskStatus)) return blocks
+
+  const finalStatus = String(subtaskStatus).toUpperCase() === 'FAILED' ? 'error' : 'done'
+  let changed = false
+  const finalized = blocks.map(block => {
+    if (block.status === 'done' || block.status === 'error') return block
+    changed = true
+    return {
+      ...block,
+      status: finalStatus,
+    } as ProcessingBlock
+  })
+
+  return changed ? finalized : blocks
 }
 
 function shouldRestoreCachedStreaming(
@@ -624,39 +621,23 @@ function getRememberedStandaloneDeviceId(
   )
 }
 
-export function WorkbenchProvider({
-  children,
-  user,
-  services,
-}: WorkbenchProviderProps) {
-  const resolvedServices = useMemo(
-    () => services ?? createDefaultServices(),
-    [services]
-  )
-  const [state, dispatch] = useReducer(
-    workbenchReducer,
-    initialWorkbenchState
-  )
+export function WorkbenchProvider({ children, user, services }: WorkbenchProviderProps) {
+  const resolvedServices = useMemo(() => services ?? createDefaultServices(), [services])
+  const [state, dispatch] = useReducer(workbenchReducer, initialWorkbenchState)
   const [messages, dispatchMessages] = useReducer(
     reduceWorkbenchMessages<Attachment, TurnFileChangesSummary>,
     [] as WorkbenchMessage[]
   )
   const [queuedSends, setQueuedSends] = useState<QueuedWorkbenchSend[]>([])
   const [guidanceMessages, setGuidanceMessages] = useState<GuidanceWorkbenchMessage[]>([])
-  const [upgradingDevices, setUpgradingDevices] = useState<
-    Record<string, DeviceUpgradeState>
-  >({})
+  const [upgradingDevices, setUpgradingDevices] = useState<Record<string, DeviceUpgradeState>>({})
   const [isAwaitingAssistantStart, setIsAwaitingAssistantStart] = useState(false)
-  const [liveRunningTaskIds, setLiveRunningTaskIds] = useState<Set<number>>(
-    () => new Set()
-  )
+  const [liveRunningTaskIds, setLiveRunningTaskIds] = useState<Set<number>>(() => new Set())
   const [routePath, setRoutePath] = useState(getCurrentAppPath)
   const [projectExecutionMode, setProjectExecutionMode] =
     useState<ProjectExecutionMode>('current_workspace')
   const guidanceSendInFlightRef = useRef(false)
-  const upgradeClearTimersRef = useRef<
-    Record<string, ReturnType<typeof window.setTimeout>>
-  >({})
+  const upgradeClearTimersRef = useRef<Record<string, ReturnType<typeof window.setTimeout>>>({})
   const localSkillsCacheRef = useRef<
     Map<string, { expiresAt: number; skills: LocalDeviceSkill[] }>
   >(new Map())
@@ -707,18 +688,11 @@ export function WorkbenchProvider({
         wework_project_execution_mode: mode,
       }
       dispatch({ type: 'user_preferences_updated', preferences })
-      void resolvedServices.userApi
-        ?.updateCurrentUser({ preferences })
-        .catch(() => {
-          dispatch({ type: 'error_set', error: '启动模式保存失败' })
-        })
+      void resolvedServices.userApi?.updateCurrentUser({ preferences }).catch(() => {
+        dispatch({ type: 'error_set', error: '启动模式保存失败' })
+      })
     },
-    [
-      currentUser.preferences,
-      resolvedServices.userApi,
-      state.currentProject,
-      state.currentTask,
-    ],
+    [currentUser.preferences, resolvedServices.userApi, state.currentProject, state.currentTask]
   )
 
   useEffect(() => {
@@ -731,7 +705,7 @@ export function WorkbenchProvider({
       return
     }
     setProjectExecutionMode(
-      currentUser.preferences?.wework_project_execution_mode ?? 'current_workspace',
+      currentUser.preferences?.wework_project_execution_mode ?? 'current_workspace'
     )
   }, [
     currentUser.preferences?.wework_project_execution_mode,
@@ -739,10 +713,7 @@ export function WorkbenchProvider({
     state.currentTask,
   ])
   const modelSelectionConfig = useMemo(
-    () =>
-      getTaskModelSelection(state.currentTask) ??
-      getNewChatModelSelection(currentUser) ??
-      null,
+    () => getTaskModelSelection(state.currentTask) ?? getNewChatModelSelection(currentUser) ?? null,
     [currentUser, state.currentTask]
   )
   const modelCompatibilityConfig = useMemo(
@@ -769,11 +740,9 @@ export function WorkbenchProvider({
         wework_new_chat_model_selection: selection,
       }
       dispatch({ type: 'user_preferences_updated', preferences })
-      void resolvedServices.userApi
-        ?.updateCurrentUser({ preferences })
-        .catch(() => {
-          dispatch({ type: 'error_set', error: '模型配置保存失败' })
-        })
+      void resolvedServices.userApi?.updateCurrentUser({ preferences }).catch(() => {
+        dispatch({ type: 'error_set', error: '模型配置保存失败' })
+      })
     },
     [currentUser.preferences, resolvedServices.userApi, state.currentTask]
   )
@@ -802,24 +771,24 @@ export function WorkbenchProvider({
     let cancelled = false
 
     async function bootstrap() {
-      const [defaultTeamResult, projectsResult, recentTasksResult, devicesResult] = await Promise.allSettled([
-        resolvedServices.teamApi.getDefaultWorkbenchTeam(),
-        resolvedServices.projectApi.listProjects(),
-        resolvedServices.taskApi.listRecentTasks({ limit: 20 }),
-        resolvedServices.deviceApi.listDevices(),
-      ])
+      const [defaultTeamResult, projectsResult, recentTasksResult, devicesResult] =
+        await Promise.allSettled([
+          resolvedServices.teamApi.getDefaultWorkbenchTeam(),
+          resolvedServices.projectApi.listProjects(),
+          resolvedServices.taskApi.listRecentTasks({ limit: 20 }),
+          resolvedServices.deviceApi.listDevices(),
+        ])
 
       if (cancelled) return
 
-      const projects =
-        projectsResult.status === 'fulfilled' ? projectsResult.value.items : []
+      const projects = projectsResult.status === 'fulfilled' ? projectsResult.value.items : []
       const rawDevices = devicesResult.status === 'fulfilled' ? devicesResult.value : []
       const devices = resolveDeviceListWithCache(rawDevices)
       const lastProjectId = readLastProjectId(user.id)
       const currentProject =
         lastProjectId === null
           ? null
-          : projects.find(project => project.id === lastProjectId) ?? null
+          : (projects.find(project => project.id === lastProjectId) ?? null)
 
       dispatch({
         type: 'bootstrapped',
@@ -827,8 +796,7 @@ export function WorkbenchProvider({
         defaultTeam: defaultTeamResult.status === 'fulfilled' ? defaultTeamResult.value : null,
         projects,
         devices,
-        recentTasks:
-          recentTasksResult.status === 'fulfilled' ? recentTasksResult.value.items : [],
+        recentTasks: recentTasksResult.status === 'fulfilled' ? recentTasksResult.value.items : [],
         currentProject,
         standaloneDeviceId: getRememberedStandaloneDeviceId(user, devices),
       })
@@ -856,10 +824,7 @@ export function WorkbenchProvider({
       projects: projectsResult.items,
       recentTasks: recentTasksResult.items,
       devices,
-      standaloneDeviceId: getPreferredStandaloneDeviceId(
-        devices,
-        state.standaloneDeviceId
-      ),
+      standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
     })
   }, [resolvedServices, state.standaloneDeviceId])
 
@@ -879,10 +844,7 @@ export function WorkbenchProvider({
     dispatch({
       type: 'devices_refreshed',
       devices,
-      standaloneDeviceId: getPreferredStandaloneDeviceId(
-        devices,
-        state.standaloneDeviceId
-      ),
+      standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
     })
   }, [resolvedServices, state.standaloneDeviceId])
 
@@ -905,7 +867,7 @@ export function WorkbenchProvider({
         delete upgradeClearTimersRef.current[deviceId]
       }, UPGRADE_STATE_CLEAR_DELAY_MS)
     },
-    [clearUpgradeStateTimer],
+    [clearUpgradeStateTimer]
   )
 
   const setDeviceUpgradeState = useCallback(
@@ -919,7 +881,7 @@ export function WorkbenchProvider({
         scheduleUpgradeStateClear(deviceId)
       }
     },
-    [clearUpgradeStateTimer, scheduleUpgradeStateClear],
+    [clearUpgradeStateTimer, scheduleUpgradeStateClear]
   )
 
   const upgradeDevice = useCallback(
@@ -962,12 +924,7 @@ export function WorkbenchProvider({
         dispatch({ type: 'error_set', error: message })
       }
     },
-    [
-      refreshDevices,
-      resolvedServices.deviceApi,
-      setDeviceUpgradeState,
-      state.devices,
-    ],
+    [refreshDevices, resolvedServices.deviceApi, setDeviceUpgradeState, state.devices]
   )
 
   useEffect(() => {
@@ -1029,10 +986,7 @@ export function WorkbenchProvider({
         dispatchMessages({
           type: 'assistant_done',
           subtaskId: payload.subtask_id,
-          content:
-            typeof payload.result.value === 'string'
-              ? payload.result.value
-              : undefined,
+          content: typeof payload.result.value === 'string' ? payload.result.value : undefined,
           blocks: getResultBlocks(payload.subtask_id, payload.result),
           fileChanges: normalizeTurnFileChanges(payload.result.file_changes),
         })
@@ -1080,8 +1034,7 @@ export function WorkbenchProvider({
       onGuidanceQueued: payload => {
         setGuidanceMessages(items =>
           items.map(item =>
-            item.id === payload.guidance_id ||
-            item.id === payload.client_guidance_id
+            item.id === payload.guidance_id || item.id === payload.client_guidance_id
               ? {
                   ...item,
                   id: payload.guidance_id,
@@ -1094,18 +1047,15 @@ export function WorkbenchProvider({
       },
       onGuidanceApplied: payload => {
         setGuidanceMessages(items =>
-          items.filter(item =>
-            item.id !== payload.guidance_id &&
-            item.id !== payload.client_guidance_id
+          items.filter(
+            item => item.id !== payload.guidance_id && item.id !== payload.client_guidance_id
           )
         )
       },
       onGuidanceExpired: payload => {
         setGuidanceMessages(items =>
           items.map(item =>
-            payload.guidance_ids.includes(item.id)
-              ? { ...item, status: 'expired' }
-              : item
+            payload.guidance_ids.includes(item.id) ? { ...item, status: 'expired' } : item
           )
         )
       },
@@ -1130,7 +1080,7 @@ export function WorkbenchProvider({
 
   useEffect(() => {
     const hasActiveUpgrade = Object.values(upgradingDevices).some(
-      upgradeState => !isTerminalDeviceUpgradeStatus(upgradeState.status),
+      upgradeState => !isTerminalDeviceUpgradeStatus(upgradeState.status)
     )
     if (!hasActiveUpgrade) return undefined
 
@@ -1161,8 +1111,7 @@ export function WorkbenchProvider({
     (deviceId: string) => {
       dispatch({
         type: 'standalone_device_preference_changed',
-        standaloneDeviceId:
-          getPreferredStandaloneDeviceId(state.devices, deviceId) ?? deviceId,
+        standaloneDeviceId: getPreferredStandaloneDeviceId(state.devices, deviceId) ?? deviceId,
       })
       void resolvedServices.userApi
         ?.updateCurrentUser({
@@ -1286,16 +1235,12 @@ export function WorkbenchProvider({
       const detail = await resolvedServices.taskApi.getTaskDetail(taskId)
       const detailTask = detail as Task
       const listTask = state.recentTasks.find(item => item.id === taskId)
-      const resolvedProjectId = resolveOpenedTaskProjectId(
-        detailTask,
-        listTask,
-        projectId
-      )
+      const resolvedProjectId = resolveOpenedTaskProjectId(detailTask, listTask, projectId)
       const project =
         resolvedProjectId === undefined
-          ? findProjectForTask(state.projects, detailTask) ?? undefined
+          ? (findProjectForTask(state.projects, detailTask) ?? undefined)
           : resolvedProjectId > 0
-            ? state.projects.find(item => item.id === resolvedProjectId) ?? null
+            ? (state.projects.find(item => item.id === resolvedProjectId) ?? null)
             : null
       if (project) {
         writeLastProjectId(user.id, project.id)
@@ -1321,11 +1266,7 @@ export function WorkbenchProvider({
       const joinResponse = await resolvedServices.chatStream.joinTask(taskId)
       if (
         joinResponse?.streaming &&
-        shouldRestoreCachedStreaming(
-          detailTask,
-          detail.subtasks,
-          joinResponse.streaming.subtask_id
-        )
+        shouldRestoreCachedStreaming(detailTask, detail.subtasks, joinResponse.streaming.subtask_id)
       ) {
         dispatchMessages({
           type: 'assistant_cached',
@@ -1334,8 +1275,7 @@ export function WorkbenchProvider({
           content: joinResponse.streaming.cached_content,
         })
       }
-      const routeProjectId =
-        resolvedProjectId === undefined ? undefined : resolvedProjectId
+      const routeProjectId = resolvedProjectId === undefined ? undefined : resolvedProjectId
       handledTaskRouteRef.current = getTaskRouteKey(taskId, routeProjectId)
       navigateTo(buildTaskRoute({ taskId, projectId: routeProjectId }))
     },
@@ -1365,8 +1305,7 @@ export function WorkbenchProvider({
 
     if (
       state.currentTask?.id === taskRoute.taskId &&
-      (taskRoute.projectId === undefined ||
-        state.currentTask.project_id === taskRoute.projectId)
+      (taskRoute.projectId === undefined || state.currentTask.project_id === taskRoute.projectId)
     ) {
       handledTaskRouteRef.current = routeKey
       return
@@ -1577,14 +1516,12 @@ export function WorkbenchProvider({
   )
 
   const listDeviceDirectories = useCallback(
-    (deviceId: string, path: string) =>
-      resolvedServices.deviceApi.listDirectories(deviceId, path),
+    (deviceId: string, path: string) => resolvedServices.deviceApi.listDirectories(deviceId, path),
     [resolvedServices]
   )
 
   const createDeviceDirectory = useCallback(
-    (deviceId: string, path: string) =>
-      resolvedServices.deviceApi.createDirectory(deviceId, path),
+    (deviceId: string, path: string) => resolvedServices.deviceApi.createDirectory(deviceId, path),
     [resolvedServices]
   )
 
@@ -1601,8 +1538,7 @@ export function WorkbenchProvider({
   )
 
   const listEnvironmentBranches = useCallback(
-    (project: ProjectWithTasks | null) =>
-      listProjectBranches(resolvedServices.deviceApi, project),
+    (project: ProjectWithTasks | null) => listProjectBranches(resolvedServices.deviceApi, project),
     [resolvedServices]
   )
 
@@ -1651,9 +1587,7 @@ export function WorkbenchProvider({
       const payload: ChatSendPayload = {
         task_id: state.currentTask?.id,
         team_id: state.defaultTeam.id,
-        project_id: state.currentTask
-          ? undefined
-          : activeProject?.id ?? STANDALONE_PROJECT_ID,
+        project_id: state.currentTask ? undefined : (activeProject?.id ?? STANDALONE_PROJECT_ID),
         client_origin: WEWORK_CLIENT_ORIGIN,
         device_id: activeDeviceId,
         task_type: 'code',
@@ -1812,12 +1746,9 @@ export function WorkbenchProvider({
     if (prepared.activeDeviceId) {
       const activeDevice = findWorkbenchDevice(state.devices, prepared.activeDeviceId)
       if (!isWorkbenchDeviceOnline(activeDevice)) {
-        const deviceName = getWorkbenchDeviceDisplayName(
-          activeDevice,
-          prepared.activeDeviceId,
-        )
+        const deviceName = getWorkbenchDeviceDisplayName(activeDevice, prepared.activeDeviceId)
         const status = activeDevice
-          ? DEVICE_STATUS_LABELS[activeDevice.status] ?? activeDevice.status
+          ? (DEVICE_STATUS_LABELS[activeDevice.status] ?? activeDevice.status)
           : '不可用'
         dispatch({
           type: 'error_set',
@@ -1826,10 +1757,7 @@ export function WorkbenchProvider({
         return
       }
       if (activeDevice && isDeviceBelowWeWorkVersion(activeDevice)) {
-        const deviceName = getWorkbenchDeviceDisplayName(
-          activeDevice,
-          prepared.activeDeviceId,
-        )
+        const deviceName = getWorkbenchDeviceDisplayName(activeDevice, prepared.activeDeviceId)
         dispatch({
           type: 'error_set',
           error: `${deviceName} 版本低于 ${WEWORK_MIN_EXECUTOR_VERSION}，升级后可继续对话`,
@@ -1838,7 +1766,7 @@ export function WorkbenchProvider({
       }
     } else if (!state.currentProject && !state.currentTask) {
       const hasOnlineCompatibleDevice = state.devices.some(
-        device => device.status === 'online' && isWeWorkCompatibleDevice(device),
+        device => device.status === 'online' && isWeWorkCompatibleDevice(device)
       )
       if (!hasOnlineCompatibleDevice) {
         dispatch({
@@ -1848,9 +1776,7 @@ export function WorkbenchProvider({
         return
       }
     }
-    const attachmentsSnapshot = hasAttachments
-      ? [...attachmentSelection.attachments]
-      : undefined
+    const attachmentsSnapshot = hasAttachments ? [...attachmentSelection.attachments] : undefined
 
     dispatch({ type: 'input_changed', input: '' })
 
@@ -1895,9 +1821,7 @@ export function WorkbenchProvider({
     async (messageId: string) => {
       const failedMessageIndex = messages.findIndex(
         message =>
-          message.id === messageId &&
-          message.role === 'assistant' &&
-          message.status === 'failed',
+          message.id === messageId && message.role === 'assistant' && message.status === 'failed'
       )
       if (failedMessageIndex === -1) {
         dispatch({ type: 'error_set', error: '未找到可重试的失败消息' })
@@ -1915,7 +1839,7 @@ export function WorkbenchProvider({
 
       const prepared = buildSendPayload(
         previousUserMessage.content,
-        previousUserMessage.attachments ?? [],
+        previousUserMessage.attachments ?? []
       )
       if (!prepared) return
 
@@ -1939,24 +1863,16 @@ export function WorkbenchProvider({
         previousUserMessage.content,
         prepared.payload,
         prepared.activeDeviceId,
-        previousUserMessage.attachments,
+        previousUserMessage.attachments
       )
     },
-    [
-      buildSendPayload,
-      hasActiveTurn,
-      messages,
-      sendPreparedMessage,
-      state.currentTask?.id,
-    ],
+    [buildSendPayload, hasActiveTurn, messages, sendPreparedMessage, state.currentTask?.id]
   )
 
   const sendNextQueuedMessage = useCallback(
     async (item: QueuedWorkbenchSend) => {
       setQueuedSends(items =>
-        items.map(queued =>
-          queued.id === item.id ? { ...queued, status: 'sending' } : queued
-        )
+        items.map(queued => (queued.id === item.id ? { ...queued, status: 'sending' } : queued))
       )
 
       const sent = await sendPreparedMessage(
@@ -1970,9 +1886,7 @@ export function WorkbenchProvider({
         sent
           ? items.filter(queued => queued.id !== item.id)
           : items.map(queued =>
-              queued.id === item.id
-                ? { ...queued, status: 'failed', error: '发送失败' }
-                : queued
+              queued.id === item.id ? { ...queued, status: 'failed', error: '发送失败' } : queued
             )
       )
     },
@@ -1988,28 +1902,25 @@ export function WorkbenchProvider({
     }, 0)
 
     return () => window.clearTimeout(timer)
-  }, [
-    hasActiveTurn,
-    isAwaitingAssistantStart,
-    queuedSends,
-    sendNextQueuedMessage,
-    state.isSending,
-  ])
+  }, [hasActiveTurn, isAwaitingAssistantStart, queuedSends, sendNextQueuedMessage, state.isSending])
 
   const cancelQueuedMessage = useCallback((id: string) => {
     setQueuedSends(items => items.filter(item => item.id !== id))
   }, [])
 
-  const editQueuedMessage = useCallback((id: string) => {
-    const item = queuedSends.find(queued => queued.id === id)
-    if (!item || item.status === 'sending') return
+  const editQueuedMessage = useCallback(
+    (id: string) => {
+      const item = queuedSends.find(queued => queued.id === id)
+      if (!item || item.status === 'sending') return
 
-    dispatch({ type: 'input_changed', input: item.content })
-    for (const attachment of item.attachments ?? []) {
-      attachmentSelection.addExistingAttachment(attachment)
-    }
-    setQueuedSends(items => items.filter(queued => queued.id !== id))
-  }, [attachmentSelection, queuedSends])
+      dispatch({ type: 'input_changed', input: item.content })
+      for (const attachment of item.attachments ?? []) {
+        attachmentSelection.addExistingAttachment(attachment)
+      }
+      setQueuedSends(items => items.filter(queued => queued.id !== id))
+    },
+    [attachmentSelection, queuedSends]
+  )
 
   const cancelGuidanceMessage = useCallback((id: string) => {
     setGuidanceMessages(items => items.filter(item => item.id !== id))
@@ -2022,7 +1933,7 @@ export function WorkbenchProvider({
       const response = await loadDiff(subtaskId)
       return response.diff
     },
-    [resolvedServices.taskApi],
+    [resolvedServices.taskApi]
   )
 
   const revertTurnFileChanges = useCallback(
@@ -2043,9 +1954,7 @@ export function WorkbenchProvider({
         return fileChanges
       } catch (error) {
         if (error instanceof ApiError && isRecord(error.detail)) {
-          const fileChanges = normalizeTurnFileChanges(
-            error.detail.file_changes,
-          )
+          const fileChanges = normalizeTurnFileChanges(error.detail.file_changes)
           if (fileChanges) {
             dispatchMessages({
               type: 'file_changes_updated',
@@ -2057,7 +1966,7 @@ export function WorkbenchProvider({
         throw error
       }
     },
-    [resolvedServices.taskApi],
+    [resolvedServices.taskApi]
   )
 
   const pauseCurrentResponse = useCallback(async () => {
@@ -2090,12 +1999,7 @@ export function WorkbenchProvider({
         status: 'CANCELLED',
       })
     }
-  }, [
-    activeAssistantMessage,
-    markTaskNotRunning,
-    resolvedServices.chatStream,
-    state.currentTask,
-  ])
+  }, [activeAssistantMessage, markTaskNotRunning, resolvedServices.chatStream, state.currentTask])
 
   const sendQueuedAsGuidance = useCallback(
     async (id: string) => {
@@ -2124,9 +2028,7 @@ export function WorkbenchProvider({
       guidanceSendInFlightRef.current = true
       setQueuedSends(items =>
         items.map(queued =>
-          queued.id === id
-            ? { ...queued, status: 'sending', error: undefined }
-            : queued
+          queued.id === id ? { ...queued, status: 'sending', error: undefined } : queued
         )
       )
 
@@ -2186,7 +2088,7 @@ export function WorkbenchProvider({
                   ...queued,
                   status: 'failed',
                   error: normalizeGuidanceError(
-                    error instanceof Error ? error.message : '取消当前回复失败',
+                    error instanceof Error ? error.message : '取消当前回复失败'
                   ),
                 }
               : queued
@@ -2228,11 +2130,7 @@ export function WorkbenchProvider({
       ids.add(state.currentTask.id)
     }
     for (const message of messages) {
-      if (
-        message.role === 'assistant' &&
-        message.status === 'streaming' &&
-        message.taskId
-      ) {
+      if (message.role === 'assistant' && message.status === 'streaming' && message.taskId) {
         ids.add(message.taskId)
       }
     }
@@ -2319,9 +2217,5 @@ export function WorkbenchProvider({
     revertTurnFileChanges,
   }
 
-  return (
-    <WorkbenchContext.Provider value={value}>
-      {children}
-    </WorkbenchContext.Provider>
-  )
+  return <WorkbenchContext.Provider value={value}>{children}</WorkbenchContext.Provider>
 }

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -331,16 +331,13 @@ export interface Subtask {
   message_id?: number
   created_at: string
   updated_at?: string
+  completed_at?: string | null
   contexts?: TaskContextData[]
   attachments?: Attachment[]
   sender_user_name?: string
 }
 
-export type TurnFileChangesStatus =
-  | 'active'
-  | 'reverted'
-  | 'conflicted'
-  | 'artifact_missing'
+export type TurnFileChangesStatus = 'active' | 'reverted' | 'conflicted' | 'artifact_missing'
 
 export interface TurnFileChangeItem {
   old_path?: string | null


### PR DESCRIPTION
## Summary
- Normalize Codex/OpenAPI completed block statuses to the workbench done state
- Finalize residual processing blocks when assistant turns finish or error
- Finalize persisted processing blocks when opening terminal subtasks from history after refresh
- Keep `wework/.prettierrc.json` so the wework pre-commit hook uses the project style instead of Prettier defaults
- Add regression coverage for completed incoming blocks and restored terminal history blocks

## Tests
- pnpm --filter @wegent/chat-core test -- src/workbench-message-reducer.test.ts
- pnpm --dir wework test -- src/features/workbench/WorkbenchProvider.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx
- pnpm --dir wework lint
- pre-push AI quality check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assistant completion/error handling so processing blocks consistently finalize to terminal states.
  * Enhanced block status normalization by trimming/lowercasing and mapping common status aliases to consistent outcomes.
  * Improved timestamp handling with safer fallbacks and finalized terminal subtasks for completed/failed/cancelled states.
  * Extended subtask metadata with an optional completion timestamp.
* **Tests**
  * Added coverage for terminal finalization and expanded status-mapping scenarios.
* **Style**
  * Updated formatting in tests and standardized Prettier configuration for consistent rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->