### PR TITLE
Pin MCP SDK to 1.27.2 across Python services

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "html2text>=2024.2.26",
     "emoji>=2.9.0",
-    "mcp>=1.0.0",
+    "mcp==1.27.2",
     # Task queue (Celery)
     "celery[redis]>=5.3.0",
     "flower>=2.0.0", # Celery monitoring

--- a/backend/tests/test_dependency_constraints.py
+++ b/backend/tests/test_dependency_constraints.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+EXPECTED_MCP_SPECIFIER = "==1.27.2"
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _dependency_specifier(pyproject_path: Path, dependency_name: str) -> str:
+    prefix = f'"{dependency_name}'
+
+    for line in pyproject_path.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped.strip('",')[len(dependency_name) :]
+
+    raise AssertionError(f"{dependency_name} dependency not found in {pyproject_path}")
+
+
+def test_python_mcp_dependency_pin_matches_executor_runtime():
+    """Keep Python runtimes on one MCP SDK version to avoid API drift."""
+    pyproject_paths = [
+        PROJECT_ROOT / "backend" / "pyproject.toml",
+        PROJECT_ROOT / "chat_shell" / "pyproject.toml",
+        PROJECT_ROOT / "executor" / "pyproject.toml",
+    ]
+
+    for pyproject_path in pyproject_paths:
+        specifier = _dependency_specifier(pyproject_path, "mcp")
+
+        assert specifier == EXPECTED_MCP_SPECIFIER, (
+            f"{pyproject_path} must pin mcp{EXPECTED_MCP_SPECIFIER} so "
+            "backend, chat_shell, and executor share the same MCP SDK API"
+        )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2723,7 +2723,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.22.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2741,9 +2741,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/a2/c5ec0ab38b35ade2ae49a90fada718fbc76811dc5aa1760414c6aaa6b08a/mcp-1.22.0.tar.gz", hash = "sha256:769b9ac90ed42134375b19e777a2858ca300f95f2e800982b3e2be62dfc0ba01", size = 471788, upload-time = "2025-11-20T20:11:28.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/bb/711099f9c6bb52770f56e56401cdfb10da5b67029f701e0df29362df4c8e/mcp-1.22.0-py3-none-any.whl", hash = "sha256:bed758e24df1ed6846989c909ba4e3df339a27b4f30f1b8b627862a4bade4e98", size = 175489, upload-time = "2025-11-20T20:11:26.542Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -5978,7 +5978,7 @@ requires-dist = [
     { name = "llama-index-vector-stores-qdrant", specifier = ">=0.9.0" },
     { name = "lxml", specifier = ">=4.9.0" },
     { name = "markdown", specifier = ">=3.5.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = "==1.27.2" },
     { name = "minio", specifier = ">=7.2.20" },
     { name = "mysql-connector-python", specifier = ">=8.3.0" },
     { name = "openpyxl", specifier = ">=3.1.2" },
@@ -6127,7 +6127,7 @@ requires-dist = [
     { name = "llama-index-vector-stores-elasticsearch", specifier = ">=0.4.0" },
     { name = "llama-index-vector-stores-qdrant", specifier = ">=0.9.0" },
     { name = "markdown", specifier = ">=3.5.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = "==1.27.2" },
     { name = "openpyxl", specifier = ">=3.1.2" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },

--- a/chat_shell/pyproject.toml
+++ b/chat_shell/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     # SSE support
     "sse-starlette>=1.6.5",
     # MCP support
-    "mcp>=1.0.0",
+    "mcp==1.27.2",
     # OpenTelemetry
     "opentelemetry-api>=1.27.0",
     "opentelemetry-sdk>=1.27.0",

--- a/chat_shell/uv.lock
+++ b/chat_shell/uv.lock
@@ -1911,7 +1911,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1929,9 +1929,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]
@@ -4171,7 +4171,7 @@ requires-dist = [
     { name = "llama-index-vector-stores-elasticsearch", specifier = ">=0.4.0" },
     { name = "llama-index-vector-stores-qdrant", specifier = ">=0.9.0" },
     { name = "markdown", specifier = ">=3.5.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mcp", specifier = "==1.27.2" },
     { name = "openpyxl", specifier = ">=3.1.2" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.27.0" },


### PR DESCRIPTION
## Summary
- Pin the `mcp` dependency to `1.27.2` in backend and chat shell Python projects
- Refresh the corresponding `uv.lock` entries so resolved packages match the new constraint
- Add a backend regression test to keep the MCP version aligned across runtime projects

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned `mcp` dependency to exact version 1.27.2 across multiple projects, replacing flexible version constraints for improved stability and consistency.

* **Tests**
  * Added automated validation to ensure consistent dependency versioning across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->