### PR TITLE
Fix/web scraper iframe fallback

### DIFF
--- a/backend/app/services/web_scraper/classifier.py
+++ b/backend/app/services/web_scraper/classifier.py
@@ -57,6 +57,14 @@ class ScrapeResultClassifier:
                     error_message=result.error_message,
                     is_pdf=is_pdf,
                 )
+            if self._has_successful_http_status(result.status_code):
+                return ScrapeDecision(
+                    status=ScrapeStatus.EMPTY,
+                    error_code=ERROR_EMPTY_CONTENT,
+                    error_message="No extractable content found on the page",
+                    should_try_fallback=True,
+                    is_pdf=is_pdf,
+                )
             return ScrapeDecision(
                 status=ScrapeStatus.NETWORK_FAILED,
                 error_code=ERROR_FETCH_FAILED,
@@ -141,3 +149,12 @@ class ScrapeResultClassifier:
 
     def _looks_like_timeout(self, error_message: str | None) -> bool:
         return bool(error_message and "timeout" in error_message.lower())
+
+    def _has_successful_http_status(self, status_code: int | None) -> bool:
+        """Whether the page was reachable with a successful HTTP response.
+
+        A 2xx response with a failed extraction means the content is present
+        but unreachable by the primary strategy (e.g. nested iframes), so the
+        Playwright fallback is worth attempting.
+        """
+        return status_code is not None and 200 <= status_code < 300

--- a/backend/app/services/web_scraper/strategies/crawl4ai_strategy.py
+++ b/backend/app/services/web_scraper/strategies/crawl4ai_strategy.py
@@ -14,6 +14,7 @@ from app.services.web_scraper.classifier import ScrapeResultClassifier
 from app.services.web_scraper.models import (
     ERROR_SSRF_BLOCKED,
     InternalScrapeResult,
+    ScrapeDecision,
     ScrapeStatus,
 )
 from app.services.web_scraper.policy import ScrapePolicy
@@ -37,6 +38,14 @@ PROXY_RETRY_STATUSES = {
     ScrapeStatus.NETWORK_FAILED,
     ScrapeStatus.TIMEOUT,
     ScrapeStatus.BLOCKED,
+    ScrapeStatus.EMPTY,
+    ScrapeStatus.LOW_QUALITY,
+}
+
+# Statuses that mean the page was fetched (2xx) but the primary strategy could
+# not extract usable content. These are recoverable by Playwright at the service
+# layer, so a hard proxy failure must not overwrite them.
+REACHABLE_EXTRACTION_FAILURES = {
     ScrapeStatus.EMPTY,
     ScrapeStatus.LOW_QUALITY,
 }
@@ -95,7 +104,7 @@ class Crawl4AIScrapeStrategy:
                 or not proxy_plan.has_proxy
             ):
                 return direct_result
-            return await self._crawl_once(
+            proxy_result = await self._crawl_once(
                 url,
                 policy,
                 profile,
@@ -104,10 +113,38 @@ class Crawl4AIScrapeStrategy:
                 True,
                 guard,
             )
+            return self._select_fallback_result(
+                direct_result, direct_decision, proxy_result, policy
+            )
 
         return await self._crawl_once(
             url, policy, profile, None, proxy_plan, False, guard
         )
+
+    def _select_fallback_result(
+        self,
+        direct_result: InternalScrapeResult,
+        direct_decision: ScrapeDecision,
+        proxy_result: InternalScrapeResult,
+        policy: ScrapePolicy,
+    ) -> InternalScrapeResult:
+        """Pick the result that gives the best downstream recovery chance.
+
+        Proxy retry is meant to recover transport-level failures. When the
+        direct attempt reached the page (2xx) but extraction failed, a hard
+        proxy failure (network error, timeout, auth, rate limit) is strictly
+        worse: it hides the reachable-but-empty signal the service layer needs
+        to trigger the Playwright fallback. In that case keep the direct result.
+        """
+        proxy_quality = self._quality_evaluator.evaluate(
+            proxy_result.markdown, policy, proxy_result.quality_level
+        )
+        proxy_decision = self._classifier.classify(proxy_result, proxy_quality)
+        if proxy_decision.status == ScrapeStatus.OK:
+            return proxy_result
+        if direct_decision.status in REACHABLE_EXTRACTION_FAILURES:
+            return direct_result
+        return proxy_result
 
     @trace_async(
         span_name="web_scraper.crawl4ai.crawl_once",

--- a/backend/app/services/web_scraper/strategies/crawl4ai_strategy.py
+++ b/backend/app/services/web_scraper/strategies/crawl4ai_strategy.py
@@ -130,11 +130,23 @@ class Crawl4AIScrapeStrategy:
     ) -> InternalScrapeResult:
         """Pick the result that gives the best downstream recovery chance.
 
-        Proxy retry is meant to recover transport-level failures. When the
-        direct attempt reached the page (2xx) but extraction failed, a hard
-        proxy failure (network error, timeout, auth, rate limit) is strictly
-        worse: it hides the reachable-but-empty signal the service layer needs
-        to trigger the Playwright fallback. In that case keep the direct result.
+        Proxy retry exists to recover the page when the direct attempt could not
+        reach or extract it. If the proxy attempt produced a clean success, use
+        it. Otherwise, when the direct attempt reached the page (2xx) but the
+        primary strategy extracted nothing, keep that reachable-but-empty result
+        for ANY non-success proxy status (network failure, timeout, auth, rate
+        limit, block, or even a proxy-path SSRF block). This preserves the signal
+        the service layer needs to trigger the Playwright fallback instead of
+        surfacing a proxy-attempt error that would fail an otherwise reachable
+        page.
+
+        This does not weaken SSRF protection: a direct result can only be in
+        REACHABLE_EXTRACTION_FAILURES when it had no security error (the
+        classifier maps any security_error_code to SSRF_BLOCKED first), so the
+        direct result we keep was already validated. The Playwright fallback then
+        re-validates redirects, the final URL, and frame URLs through the same
+        guard (and the same proxy), so a proxy-path SSRF is re-enforced there
+        rather than silently bypassed.
         """
         proxy_quality = self._quality_evaluator.evaluate(
             proxy_result.markdown, policy, proxy_result.quality_level

--- a/backend/tests/services/web_scraper/test_classifier.py
+++ b/backend/tests/services/web_scraper/test_classifier.py
@@ -99,6 +99,43 @@ def test_deep_iframe_fallback_can_override_empty_fallback_flag() -> None:
     assert classifier.should_use_playwright_fallback(decision, None, policy)
 
 
+def test_reachable_failure_classified_as_empty_and_triggers_fallback() -> None:
+    policy = ScrapePolicy()
+    classifier = ScrapeResultClassifier()
+    decision = classifier.classify(
+        InternalScrapeResult(
+            url="https://example.com",
+            success=False,
+            status_code=200,
+            error_message=(
+                "Blocked by anti-bot protection: Structural: minimal_text, "
+                "no_content_elements, script_heavy_shell (11330 bytes, 24 chars visible)"
+            ),
+        )
+    )
+
+    assert decision.status == ScrapeStatus.EMPTY
+    assert decision.error_code == ERROR_EMPTY_CONTENT
+    assert decision.should_try_fallback is True
+    assert classifier.should_use_playwright_fallback(decision, None, policy)
+
+
+def test_genuine_network_failure_stays_network_failed_without_fallback() -> None:
+    policy = ScrapePolicy()
+    classifier = ScrapeResultClassifier()
+    decision = classifier.classify(
+        InternalScrapeResult(
+            url="https://example.com",
+            success=False,
+            status_code=None,
+            error_message="Connection refused",
+        )
+    )
+
+    assert decision.status == ScrapeStatus.NETWORK_FAILED
+    assert not classifier.should_use_playwright_fallback(decision, None, policy)
+
+
 def test_fallback_enabled_disables_deep_iframe_fallback() -> None:
     policy = ScrapePolicy(
         deep_iframe_extraction=True,

--- a/backend/tests/services/web_scraper/test_crawl4ai_strategy.py
+++ b/backend/tests/services/web_scraper/test_crawl4ai_strategy.py
@@ -1,0 +1,116 @@
+from typing import Any
+
+from app.services.web_scraper.classifier import ScrapeResultClassifier
+from app.services.web_scraper.models import InternalScrapeResult
+from app.services.web_scraper.policy import ScrapePolicy
+from app.services.web_scraper.proxy import ProxyMode, ProxyPlan
+from app.services.web_scraper.quality import MarkdownQualityEvaluator
+from app.services.web_scraper.security import WebScraperUrlGuard
+from app.services.web_scraper.strategies.crawl4ai_strategy import (
+    Crawl4AIScrapeStrategy,
+)
+
+
+def _build_strategy(
+    direct: InternalScrapeResult, proxy: InternalScrapeResult
+) -> Crawl4AIScrapeStrategy:
+    strategy = Crawl4AIScrapeStrategy(
+        crawler_provider=lambda: None,
+        classifier=ScrapeResultClassifier(),
+        quality_evaluator=MarkdownQualityEvaluator(),
+    )
+
+    async def fake_crawl_once(
+        url: str,
+        policy: ScrapePolicy,
+        profile: Any,
+        proxy_config: Any,
+        proxy_plan: ProxyPlan,
+        use_proxy: bool,
+        guard: WebScraperUrlGuard,
+    ) -> InternalScrapeResult:
+        return proxy if use_proxy else direct
+
+    strategy._crawl_once = fake_crawl_once  # type: ignore[assignment]
+    return strategy
+
+
+async def test_proxy_fallback_keeps_reachable_empty_over_hard_proxy_failure() -> None:
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=200,
+        error_message="Blocked by anti-bot protection: minimal_text",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=None,
+        error_message="Connection refused",
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is direct
+    assert result.status_code == 200
+
+
+async def test_proxy_fallback_prefers_successful_proxy_result() -> None:
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=200,
+        error_message="Blocked by anti-bot protection: minimal_text",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        final_url="https://example.com",
+        markdown="This proxied content is long enough to be accepted as content.",
+        status_code=200,
+        success=True,
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is proxy
+
+
+async def test_proxy_fallback_keeps_proxy_result_for_transport_failure() -> None:
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=None,
+        error_message="Connection refused",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        final_url="https://example.com",
+        markdown="This proxied content is long enough to be accepted as content.",
+        status_code=200,
+        success=True,
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is proxy

--- a/backend/tests/services/web_scraper/test_crawl4ai_strategy.py
+++ b/backend/tests/services/web_scraper/test_crawl4ai_strategy.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from app.services.web_scraper.classifier import ScrapeResultClassifier
-from app.services.web_scraper.models import InternalScrapeResult
+from app.services.web_scraper.models import ERROR_SSRF_BLOCKED, InternalScrapeResult
 from app.services.web_scraper.policy import ScrapePolicy
 from app.services.web_scraper.proxy import ProxyMode, ProxyPlan
 from app.services.web_scraper.quality import MarkdownQualityEvaluator
@@ -114,3 +114,84 @@ async def test_proxy_fallback_keeps_proxy_result_for_transport_failure() -> None
     )
 
     assert result is proxy
+
+
+async def test_proxy_fallback_keeps_reachable_empty_over_proxy_ssrf_block() -> None:
+    """A proxy-path SSRF block must not surface over a reachable-but-empty direct
+    result: direct already passed SSRF validation and the Playwright fallback
+    re-validates, so this is deliberate and safe."""
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=200,
+        error_message="Blocked by anti-bot protection: minimal_text",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        error_message="Redirect target resolves to a private network",
+        security_error_code=ERROR_SSRF_BLOCKED,
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is direct
+
+
+async def test_proxy_fallback_keeps_reachable_empty_over_proxy_blocked() -> None:
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=200,
+        error_message="Blocked by anti-bot protection: minimal_text",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=403,
+        error_message="Forbidden",
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is direct
+
+
+async def test_proxy_fallback_keeps_reachable_empty_over_proxy_rate_limited() -> None:
+    direct = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=200,
+        error_message="Blocked by anti-bot protection: minimal_text",
+    )
+    proxy = InternalScrapeResult(
+        url="https://example.com",
+        success=False,
+        status_code=429,
+        error_message="Too Many Requests",
+    )
+    strategy = _build_strategy(direct, proxy)
+
+    result = await strategy.scrape(
+        url="https://example.com",
+        policy=ScrapePolicy(),
+        profile=None,
+        proxy_plan=ProxyPlan(mode=ProxyMode.FALLBACK, raw_url="http://proxy:8080"),
+        guard=WebScraperUrlGuard(),
+    )
+
+    assert result is direct

--- a/backend/tests/services/web_scraper/test_scraper_service.py
+++ b/backend/tests/services/web_scraper/test_scraper_service.py
@@ -319,3 +319,31 @@ async def test_low_quality_primary_uses_playwright_fallback(
     assert playwright.called is True
     assert result.success is True
     assert result.content == "This fallback content is long enough to be accepted."
+
+
+async def test_reachable_empty_2xx_primary_uses_playwright_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = prepare_service(monkeypatch)
+    service._crawl4ai_strategy = FakeCrawlStrategy(
+        InternalScrapeResult(
+            url="https://example.com",
+            success=False,
+            status_code=200,
+            error_message="Blocked by anti-bot protection: minimal_text",
+        )
+    )
+    playwright = FakePlaywrightStrategy(
+        InternalScrapeResult(
+            url="https://example.com",
+            final_url="https://example.com",
+            markdown="This fallback content is long enough to be accepted.",
+        )
+    )
+    service._playwright_strategy = playwright
+
+    result = await service.scrape_url("https://example.com")
+
+    assert playwright.called is True
+    assert result.success is True
+    assert result.content == "This fallback content is long enough to be accepted."

--- a/docs/en/developer-guide/web-scraper-service.md
+++ b/docs/en/developer-guide/web-scraper-service.md
@@ -21,7 +21,7 @@ The service selects an extraction path based on content type and quality:
 1. Validate the initial URL and reject non-HTTP(S), local, private-network, and unsafe redirect targets.
 2. Use the PDF extractor for PDF URLs, including final response URL validation.
 3. Use the Crawl4AI strategy first for regular web pages and convert the result to Markdown.
-4. Enable Playwright frame extraction only when the primary result is empty or low quality and policy allows fallback.
+4. Enable Playwright frame extraction only when the primary result is empty or low quality and policy allows fallback. A failed primary extraction that still returns a 2xx HTTP status (the page is reachable but the primary strategy extracted nothing, e.g. content lives in nested iframes) is treated as empty content and is also fallback-eligible.
 5. Run fallback output through the Markdown cleaner, classifier, and quality evaluator.
 
 ```mermaid
@@ -136,7 +136,9 @@ When `fallback_enabled=true`:
 
 - `fallback_on_empty=true` allows empty content to trigger fallback.
 - `deep_iframe_extraction=true` allows empty or low-quality content to trigger fallback.
-- Auth-required, rate-limited, SSRF-blocked, network-failed, and other states that rendering cannot fix do not automatically trigger fallback through deep iframe extraction.
+- A failed primary extraction with a 2xx HTTP status is treated as reachable-but-empty (classified as empty content) and triggers fallback per `fallback_on_empty`. This covers content in nested iframes and SPA shells that the primary strategy misclassifies as anti-bot.
+- Genuine transport failures (no HTTP response, e.g. connection refused or DNS failure) are classified as network failures and do not trigger fallback, since re-rendering cannot help.
+- Auth-required, rate-limited, SSRF-blocked, and other states that rendering cannot fix do not automatically trigger fallback through deep iframe extraction.
 - Whether blocked pages trigger fallback is controlled by `fallback_on_blocked`.
 
 ## Security Boundary

--- a/docs/en/developer-guide/web-scraper-service.md
+++ b/docs/en/developer-guide/web-scraper-service.md
@@ -136,7 +136,7 @@ When `fallback_enabled=true`:
 
 - `fallback_on_empty=true` allows empty content to trigger fallback.
 - `deep_iframe_extraction=true` allows empty or low-quality content to trigger fallback.
-- A failed primary extraction with a 2xx HTTP status is treated as reachable-but-empty (classified as empty content) and triggers fallback per `fallback_on_empty`. This covers content in nested iframes and SPA shells that the primary strategy misclassifies as anti-bot.
+- A failed primary extraction with a 2xx HTTP status is treated as reachable-but-empty (classified as empty content) and triggers fallback per the empty-content rule, i.e. when `fallback_on_empty=true` or `deep_iframe_extraction=true`. This covers content in nested iframes and SPA shells that the primary strategy misclassifies as anti-bot.
 - Genuine transport failures (no HTTP response, e.g. connection refused or DNS failure) are classified as network failures and do not trigger fallback, since re-rendering cannot help.
 - Auth-required, rate-limited, SSRF-blocked, and other states that rendering cannot fix do not automatically trigger fallback through deep iframe extraction.
 - Whether blocked pages trigger fallback is controlled by `fallback_on_blocked`.

--- a/docs/zh/developer-guide/web-scraper-service.md
+++ b/docs/zh/developer-guide/web-scraper-service.md
@@ -21,7 +21,7 @@ sidebar_position: 13
 1. 先校验初始 URL，拒绝非 HTTP(S)、本地地址、私有网段和不安全重定向。
 2. PDF URL 使用 PDF extractor 下载并提取文本，同时校验最终响应 URL。
 3. 普通网页优先使用 Crawl4AI strategy 抓取并转换为 Markdown。
-4. 当主抓取结果为空或质量过低，且策略允许 fallback 时，才启用 Playwright frame extraction。
+4. 当主抓取结果为空或质量过低，且策略允许 fallback 时，才启用 Playwright frame extraction。主抓取虽失败但服务器仍返回 2xx（页面可达，仅主策略无法提取内容，例如内容位于嵌套 iframe）时，同样按空内容处理并允许 fallback。
 5. fallback 结果仍会经过 Markdown cleaner、classifier 和 quality evaluator。
 
 ```mermaid
@@ -136,7 +136,9 @@ WEB_SCRAPER_SITE_CONFIG={"example.com":{"wait_until":"networkidle","page_timeout
 
 - `fallback_on_empty=true` 时，空内容可以触发 fallback。
 - `deep_iframe_extraction=true` 时，空内容或低质量内容可以触发 fallback。
-- 被认证、限流、SSRF、网络错误等明确不可通过渲染改善的状态不会因为 deep iframe extraction 自动 fallback。
+- 主抓取失败但 HTTP 状态码为 2xx 时，按页面可达、仅主策略未提取到内容处理（归类为空内容），按 `fallback_on_empty` 触发 fallback。这样可以覆盖内容位于嵌套 iframe、或主策略误判为反爬的 SPA shell 等情况。
+- 真正的传输失败（没有 HTTP 响应，如连接被拒绝、DNS 失败）归类为网络失败，不会触发 fallback，因为重新渲染也无法改善。
+- 被认证、限流、SSRF 等明确不可通过渲染改善的状态不会因为 deep iframe extraction 自动 fallback。
 - blocked 页面是否 fallback 由 `fallback_on_blocked` 控制。
 
 ## 安全边界

--- a/docs/zh/developer-guide/web-scraper-service.md
+++ b/docs/zh/developer-guide/web-scraper-service.md
@@ -136,7 +136,7 @@ WEB_SCRAPER_SITE_CONFIG={"example.com":{"wait_until":"networkidle","page_timeout
 
 - `fallback_on_empty=true` 时，空内容可以触发 fallback。
 - `deep_iframe_extraction=true` 时，空内容或低质量内容可以触发 fallback。
-- 主抓取失败但 HTTP 状态码为 2xx 时，按页面可达、仅主策略未提取到内容处理（归类为空内容），按 `fallback_on_empty` 触发 fallback。这样可以覆盖内容位于嵌套 iframe、或主策略误判为反爬的 SPA shell 等情况。
+- 主抓取失败但 HTTP 状态码为 2xx 时，按页面可达、仅主策略未提取到内容处理（归类为空内容），按空内容 fallback 规则触发，即 `fallback_on_empty=true` 或 `deep_iframe_extraction=true` 时触发。这样可以覆盖内容位于嵌套 iframe、或主策略误判为反爬的 SPA shell 等情况。
 - 真正的传输失败（没有 HTTP 响应，如连接被拒绝、DNS 失败）归类为网络失败，不会触发 fallback，因为重新渲染也无法改善。
 - 被认证、限流、SSRF 等明确不可通过渲染改善的状态不会因为 deep iframe extraction 自动 fallback。
 - blocked 页面是否 fallback 由 `fallback_on_blocked` 控制。


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification of reachable HTTP 2xx responses that produce empty/low-quality extraction, so they’re treated as recoverable and eligible for fallback (including Playwright), while true transport failures remain non-fallback.
  * Refined proxy fallback selection to preserve reachable-empty/low-quality direct results instead of overwriting them with hard proxy failures (e.g., SSRF/security blocks, blocks, rate limits).
* **Tests**
  * Added/extended unit and service tests covering reachable-empty 2xx behavior and proxy fallback decisioning.
* **Documentation**
  * Updated English and Chinese web-scraper guides to clarify fallback eligibility for “2xx reachable but unextractable” cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->