### PR TITLE
Propagate bot names through chat start events

### DIFF
--- a/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
+++ b/frontend/src/__tests__/features/tasks/contexts/taskSessionContext.test.tsx
@@ -12,6 +12,15 @@ import type { Task, TaskDetail } from '@/types/api'
 
 let mockVisibleHandler: ((wasHiddenFor: number) => void) | null = null
 let mockIsConnected = true
+let mockChatHandlers: {
+  onChatStart?: (payload: {
+    task_id: number
+    subtask_id: number
+    bot_name?: string
+    shell_type?: string
+    message_id?: number
+  }) => void
+} | null = null
 
 const mockJoinTask = jest.fn()
 const mockLeaveTask = jest.fn()
@@ -24,7 +33,10 @@ const mockSocketContext = {
   leaveTask: mockLeaveTask,
   sendChatMessage: jest.fn(),
   cancelChatStream: jest.fn(),
-  registerChatHandlers: jest.fn(() => jest.fn()),
+  registerChatHandlers: jest.fn(handlers => {
+    mockChatHandlers = handlers
+    return jest.fn()
+  }),
   registerSkillHandlers: jest.fn(() => jest.fn()),
   registerTaskHandlers: jest.fn(() => jest.fn()),
   sendSkillResponse: jest.fn(),
@@ -144,6 +156,7 @@ describe('TaskSessionProvider', () => {
     jest.clearAllMocks()
     sessionProbe.current = null
     mockVisibleHandler = null
+    mockChatHandlers = null
     mockIsConnected = true
 
     mockJoinTask.mockResolvedValue({ subtasks: [] })
@@ -188,6 +201,38 @@ describe('TaskSessionProvider', () => {
 
     expect(mockedTaskApis.getTaskDetail).toHaveBeenCalledWith(713)
     expect(mockedTaskApis.getTaskRuntimeCheck).not.toHaveBeenCalled()
+  })
+
+  it('stores bot_name from chat start events in the current streaming message', async () => {
+    mockJoinTask.mockImplementation(() => new Promise(() => {}))
+    mockedTaskApis.getTaskDetail.mockImplementation(() => new Promise(() => {}))
+
+    render(
+      <TaskSessionProvider>
+        <SessionProbe />
+      </TaskSessionProvider>
+    )
+
+    await waitFor(() => {
+      expect(sessionProbe.current).not.toBeNull()
+      expect(mockChatHandlers?.onChatStart).toBeDefined()
+    })
+
+    act(() => {
+      sessionProbe.current?.selectTask(createTask())
+    })
+
+    act(() => {
+      mockChatHandlers?.onChatStart?.({
+        task_id: 713,
+        subtask_id: 714,
+        bot_name: 'Planner Bot',
+        shell_type: 'Chat',
+        message_id: 2,
+      })
+    })
+
+    expect(sessionProbe.current?.messages.get('ai-714')?.botName).toBe('Planner Bot')
   })
 
   it('loads task detail after a new chat message resolves to a real task id', async () => {

--- a/frontend/src/features/tasks/session/messageSyncer.tsx
+++ b/frontend/src/features/tasks/session/messageSyncer.tsx
@@ -207,10 +207,10 @@ export function useMessageSyncer({
    */
   const handleChatStart = useCallback(
     (data: ChatStartPayload) => {
-      const { task_id, subtask_id, shell_type, message_id } = data
+      const { task_id, subtask_id, bot_name, shell_type, message_id } = data
 
       const machine = getMachineForTask(task_id)
-      machine?.handleChatStart(subtask_id, shell_type, message_id)
+      machine?.handleChatStart(subtask_id, shell_type, message_id, bot_name)
     },
     [getMachineForTask]
   )

--- a/packages/chat-core/src/task-state/TaskStateMachine.chatEvents.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.chatEvents.ts
@@ -53,6 +53,7 @@ export function reduceChatStartEvent({
     timestamp: Date.now(),
     subtaskId: event.subtaskId,
     messageId: event.messageId,
+    botName: event.botName,
     result: initialResult,
   })
 

--- a/packages/chat-core/src/task-state/TaskStateMachine.test.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.test.ts
@@ -77,6 +77,17 @@ describe('TaskStateMachine', () => {
     })
   })
 
+  it('stores the bot name from chat start events on streaming AI messages', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: vi.fn(),
+      isConnected: () => true,
+    })
+
+    machine.handleChatStart(42, 'Chat', 7, 'Planner Bot')
+
+    expect(machine.getState().messages.get('ai-42')?.botName).toBe('Planner Bot')
+  })
+
   it('preserves new done text blocks when inline thinking blocks exist', () => {
     const machine = new TaskStateMachine(100, {
       joinTask: vi.fn(),

--- a/packages/chat-core/src/task-state/TaskStateMachine.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.ts
@@ -316,8 +316,13 @@ export class TaskStateMachine {
   /**
    * Handle chat:start event
    */
-  handleChatStart(subtaskId: number, shellType?: string, messageId?: number): void {
-    this.dispatch({ type: 'CHAT_START', subtaskId, shellType, messageId })
+  handleChatStart(
+    subtaskId: number,
+    shellType?: string,
+    messageId?: number,
+    botName?: string
+  ): void {
+    this.dispatch({ type: 'CHAT_START', subtaskId, shellType, messageId, botName })
   }
 
   /**

--- a/packages/chat-core/src/task-state/TaskStateMachine.types.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.types.ts
@@ -202,7 +202,13 @@ export type Event =
       syncAfterMessageId?: number
       syncUpdatedAt?: string
     }
-  | { type: 'CHAT_START'; subtaskId: number; shellType?: string; messageId?: number }
+  | {
+      type: 'CHAT_START'
+      subtaskId: number
+      shellType?: string
+      messageId?: number
+      botName?: string
+    }
   | {
       type: 'CHAT_CHUNK'
       subtaskId: number


### PR DESCRIPTION
## Summary
- Carry `bot_name` from chat start events through the task session sync layer
- Store the bot name on streaming AI messages in the task state machine
- Add coverage for the new message metadata path in frontend and chat-core tests

## Testing
- Added unit tests for chat-start bot name propagation in `TaskStateMachine`
- Added a frontend context test for persisting `bot_name` on the current streaming message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat sessions now capture and store the bot name during initialization, associating it with the corresponding streaming message for each task. This enables better tracking and identification of which bot is handling each conversation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->