### PR TITLE
Publish knowledge service images and make RAG services optional

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -436,6 +436,140 @@ jobs:
           cache-to: type=gha,mode=max,scope=chat-shell-arm64
 
   # ============================================================================
+  # Knowledge Runtime Image Build (parallel AMD64 + ARM64)
+  # ============================================================================
+  build-knowledge-runtime-amd64:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push knowledge-runtime image (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/knowledge_runtime/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_PREFIX }}/wegent-knowledge-runtime:${{ needs.prepare-release.outputs.new_version }}-amd64
+          cache-from: type=gha,scope=knowledge-runtime-amd64
+          cache-to: type=gha,mode=max,scope=knowledge-runtime-amd64
+
+  build-knowledge-runtime-arm64:
+    needs: prepare-release
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push knowledge-runtime image (arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/knowledge_runtime/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_PREFIX }}/wegent-knowledge-runtime:${{ needs.prepare-release.outputs.new_version }}-arm64
+          cache-from: type=gha,scope=knowledge-runtime-arm64
+          cache-to: type=gha,mode=max,scope=knowledge-runtime-arm64
+
+  # ============================================================================
+  # Knowledge Document Converter Image Build (parallel AMD64 + ARM64)
+  # ============================================================================
+  build-knowledge-doc-converter-amd64:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push knowledge-doc-converter image (amd64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/knowledge_doc_converter/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: ${{ env.IMAGE_PREFIX }}/wegent-knowledge-doc-converter:${{ needs.prepare-release.outputs.new_version }}-amd64
+          cache-from: type=gha,scope=knowledge-doc-converter-amd64
+          cache-to: type=gha,mode=max,scope=knowledge-doc-converter-amd64
+
+  build-knowledge-doc-converter-arm64:
+    needs: prepare-release
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push knowledge-doc-converter image (arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/knowledge_doc_converter/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ env.IMAGE_PREFIX }}/wegent-knowledge-doc-converter:${{ needs.prepare-release.outputs.new_version }}-arm64
+          cache-from: type=gha,scope=knowledge-doc-converter-arm64
+          cache-to: type=gha,mode=max,scope=knowledge-doc-converter-arm64
+
+  # ============================================================================
   # Standalone Image Build (parallel AMD64 + ARM64)
   # Single image containing Backend, Frontend, Chat Shell, and Executor
   # ============================================================================
@@ -778,6 +912,10 @@ jobs:
       - build-frontend-arm64
       - build-chat-shell-amd64
       - build-chat-shell-arm64
+      - build-knowledge-runtime-amd64
+      - build-knowledge-runtime-arm64
+      - build-knowledge-doc-converter-amd64
+      - build-knowledge-doc-converter-arm64
       - build-standalone-amd64
       - build-standalone-arm64
     runs-on: ubuntu-latest
@@ -825,6 +963,8 @@ jobs:
           create_manifest "wegent-executor-manager"
           create_manifest "wegent-web"
           create_manifest "wegent-chat-shell"
+          create_manifest "wegent-knowledge-runtime"
+          create_manifest "wegent-knowledge-doc-converter"
           create_manifest "wegent-standalone"
 
           echo "🎉 All multi-arch manifests created successfully!"

--- a/build_image.sh
+++ b/build_image.sh
@@ -91,3 +91,9 @@ docker buildx build --network=host ${PUSH_FLAG} --platform linux/amd64,linux/arm
 
 # Build chat shell image
 docker buildx build --network=host ${PUSH_FLAG} --platform linux/amd64,linux/arm64 -t ghcr.io/wecode-ai/wegent-chat-shell:${VERSION} -f docker/chat_shell/Dockerfile .
+
+# Build knowledge runtime image
+docker buildx build --network=host ${PUSH_FLAG} --platform linux/amd64,linux/arm64 -t ghcr.io/wecode-ai/wegent-knowledge-runtime:${VERSION} -f docker/knowledge_runtime/Dockerfile .
+
+# Build knowledge document converter image
+docker buildx build --network=host ${PUSH_FLAG} --platform linux/amd64,linux/arm64 -t ghcr.io/wecode-ai/wegent-knowledge-doc-converter:${VERSION} -f docker/knowledge_doc_converter/Dockerfile .

--- a/build_image_mac.sh
+++ b/build_image_mac.sh
@@ -91,3 +91,9 @@ docker build --network=host ${PUSH_FLAG} -t ghcr.io/wecode-ai/wegent-executor-ma
 
 # Build chat shell image
 docker build --network=host ${PUSH_FLAG} -t ghcr.io/wecode-ai/wegent-chat-shell:${VERSION} -f docker/chat_shell/Dockerfile .
+
+# Build knowledge runtime image
+docker build --network=host ${PUSH_FLAG} -t ghcr.io/wecode-ai/wegent-knowledge-runtime:${VERSION} -f docker/knowledge_runtime/Dockerfile .
+
+# Build knowledge document converter image
+docker build --network=host ${PUSH_FLAG} -t ghcr.io/wecode-ai/wegent-knowledge-doc-converter:${VERSION} -f docker/knowledge_doc_converter/Dockerfile .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -305,11 +305,12 @@ services:
       start_period: 10s
 
   knowledge_doc_converter:
-    build:
-      context: .
-      dockerfile: docker/knowledge_doc_converter/Dockerfile
+    image: ghcr.io/wecode-ai/wegent-knowledge-doc-converter:latest
+    pull_policy: ${DOCKER_PULL_POLICY:-always}
     container_name: wegent-knowledge-doc-converter
     restart: always
+    profiles:
+      - rag
     depends_on:
       redis:
         condition: service_healthy

--- a/knowledge_doc_converter/README.md
+++ b/knowledge_doc_converter/README.md
@@ -56,7 +56,13 @@ celery -A knowledge_doc_converter.celery_app:celery_app worker \
 
 ## Docker Deployment
 
-The service is configured in `docker-compose.yml` under the `knowledge_doc_converter` service. Set `KNOWLEDGE_CONVERSION_ENABLED=true` in Backend to enable conversion dispatch.
+The service is configured in `docker-compose.yml` under the `knowledge_doc_converter` service and starts with the RAG profile:
+
+```bash
+docker compose --profile rag up -d
+```
+
+Set `KNOWLEDGE_CONVERSION_ENABLED=true` in Backend to enable conversion dispatch.
 
 ## Prometheus Metrics
 

--- a/tests/install/test_install_env.sh
+++ b/tests/install/test_install_env.sh
@@ -78,6 +78,85 @@ EOF
     assert_internal_token_present .env
 }
 
+test_standard_compose_uses_prebuilt_images_only() {
+    local compose_json
+
+    compose_json="$(
+        cd "$REPO_ROOT"
+        INTERNAL_SERVICE_TOKEN=dummy docker compose --profile rag -f docker-compose.yml config --format json
+    )"
+
+    python3 - "$compose_json" <<'PY'
+import json
+import sys
+
+config = json.loads(sys.argv[1])
+services_with_build = sorted(
+    name
+    for name, service in config.get("services", {}).items()
+    if "build" in service
+)
+
+if services_with_build:
+    print(
+        "standard docker-compose.yml must not require local build contexts: "
+        + ", ".join(services_with_build)
+    )
+    sys.exit(1)
+PY
+}
+
+test_default_standard_compose_keeps_rag_services_optional() {
+    local compose_json
+
+    compose_json="$(
+        cd "$REPO_ROOT"
+        INTERNAL_SERVICE_TOKEN=dummy docker compose -f docker-compose.yml config --format json
+    )"
+
+    python3 - "$compose_json" <<'PY'
+import json
+import sys
+
+config = json.loads(sys.argv[1])
+services = config.get("services", {})
+default_rag_services = sorted(
+    name
+    for name in ("knowledge_runtime", "knowledge_doc_converter")
+    if name in services
+)
+
+if default_rag_services:
+    print(
+        "default standard compose should keep RAG services behind a profile: "
+        + ", ".join(default_rag_services)
+    )
+    sys.exit(1)
+PY
+}
+
+test_knowledge_service_images_are_published() {
+    local image_name
+    local image_names=(
+        "wegent-knowledge-runtime"
+        "wegent-knowledge-doc-converter"
+    )
+
+    for image_name in "${image_names[@]}"; do
+        grep -q "ghcr.io/wecode-ai/${image_name}:\${VERSION}" \
+            "$REPO_ROOT/build_image.sh"
+        grep -q "ghcr.io/wecode-ai/${image_name}:\${VERSION}" \
+            "$REPO_ROOT/build_image_mac.sh"
+        grep -q "create_manifest \"${image_name}\"" \
+            "$REPO_ROOT/.github/workflows/publish-image.yml"
+    done
+
+    grep -q "file: docker/knowledge_runtime/Dockerfile" \
+        "$REPO_ROOT/.github/workflows/publish-image.yml"
+    grep -q "file: docker/knowledge_doc_converter/Dockerfile" \
+        "$REPO_ROOT/.github/workflows/publish-image.yml"
+}
+
 run_test() {
     local name="$1"
     local test_fn="$2"
@@ -94,3 +173,9 @@ run_test "new standard .env includes internal service token" \
     test_new_standard_env_includes_internal_service_token
 run_test "existing standard .env backfills internal service token" \
     test_existing_standard_env_backfills_internal_service_token
+run_test "standard compose uses prebuilt images only" \
+    test_standard_compose_uses_prebuilt_images_only
+run_test "default standard compose keeps RAG services optional" \
+    test_default_standard_compose_keeps_rag_services_optional
+run_test "knowledge service images are published" \
+    test_knowledge_service_images_are_published


### PR DESCRIPTION
## Summary
- Split knowledge runtime and knowledge doc converter image builds into parallel amd64 and arm64 jobs
- Publish multi-arch manifests for both knowledge service images in the release workflow
- Switch docker-compose to use prebuilt knowledge doc converter images behind the `rag` profile
- Update local build scripts and the converter README to match the new deployment flow
- Add install tests to verify standard compose no longer requires local builds and that knowledge images are published

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prebuilt Docker images now published for `wegent-knowledge-runtime` and `wegent-knowledge-doc-converter` across multiple architectures
  * Docker Compose configuration updated to use prebuilt container images instead of local builds

* **Documentation**
  * Updated deployment instructions to specify the `rag` profile requirement for knowledge services

* **Tests**
  * Added verification tests for Docker Compose profiles and image publication setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->