### PR TITLE
fix(frontend): add server-side pagination for classic knowledge base …

### DIFF
--- a/frontend/src/apis/knowledge.ts
+++ b/frontend/src/apis/knowledge.ts
@@ -91,14 +91,33 @@ export async function updateKnowledgeBaseType(
 
 // ============== Knowledge Document APIs ==============
 
+/** Parameters for listing documents in a knowledge base */
+export interface ListDocumentsParams {
+  limit?: number
+  offset?: number
+  folder_id?: number
+}
+
 /**
  * List documents in a knowledge base
  */
 export async function listDocuments(
-  knowledgeBaseId: number
+  knowledgeBaseId: number,
+  params?: ListDocumentsParams
 ): Promise<KnowledgeDocumentListResponse> {
+  const searchParams = new URLSearchParams()
+  if (params?.limit !== undefined) {
+    searchParams.set('limit', String(params.limit))
+  }
+  if (params?.offset !== undefined) {
+    searchParams.set('offset', String(params.offset))
+  }
+  if (params?.folder_id !== undefined) {
+    searchParams.set('folder_id', String(params.folder_id))
+  }
+  const query = searchParams.toString()
   return apiClient.get<KnowledgeDocumentListResponse>(
-    `/knowledge-bases/${knowledgeBaseId}/documents`
+    `/knowledge-bases/${knowledgeBaseId}/documents${query ? `?${query}` : ''}`
   )
 }
 

--- a/frontend/src/components/ui/pagination.tsx
+++ b/frontend/src/components/ui/pagination.tsx
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useTranslation } from '@/hooks/useTranslation'
+
+interface PaginationProps {
+  /** Current page number (1-based) */
+  page: number
+  /** Total number of pages */
+  totalPages: number
+  /** Total number of items */
+  totalCount: number
+  /** Items per page */
+  pageSize: number
+  /** Available page size options */
+  pageSizeOptions?: number[]
+  /** Whether page size selector is shown */
+  showPageSizeSelector?: boolean
+  /** Callback when page changes */
+  onGoToPage: (page: number) => void
+  /** Callback when page size changes */
+  onPageSizeChange?: (pageSize: number) => void
+  /** Loading state */
+  disabled?: boolean
+}
+
+/**
+ * Generate page numbers to display with ellipsis.
+ * Shows: first page, last page, current page ± 1, with ellipsis for gaps.
+ *
+ * Examples:
+ *   totalPages=5, page=3  → [1, 2, 3, 4, 5]
+ *   totalPages=10, page=1 → [1, 2, 3, '...', 10]
+ *   totalPages=10, page=5 → [1, '...', 4, 5, 6, '...', 10]
+ *   totalPages=10, page=10 → [1, '...', 8, 9, 10]
+ */
+function generatePageNumbers(
+  currentPage: number,
+  totalPages: number
+): (number | 'ellipsis-start' | 'ellipsis-end')[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1)
+  }
+
+  const pages: (number | 'ellipsis-start' | 'ellipsis-end')[] = [1]
+
+  if (currentPage > 3) {
+    pages.push('ellipsis-start')
+  }
+
+  const start = Math.max(2, currentPage - 1)
+  const end = Math.min(totalPages - 1, currentPage + 1)
+
+  for (let i = start; i <= end; i++) {
+    pages.push(i)
+  }
+
+  if (currentPage < totalPages - 2) {
+    pages.push('ellipsis-end')
+  }
+
+  pages.push(totalPages)
+
+  return pages
+}
+
+export function Pagination({
+  page,
+  totalPages,
+  totalCount,
+  pageSize,
+  pageSizeOptions = [50, 100, 200],
+  showPageSizeSelector = true,
+  onGoToPage,
+  onPageSizeChange,
+  disabled = false,
+}: PaginationProps) {
+  const { t } = useTranslation('knowledge')
+
+  // Hide pagination when there's only one page or no items
+  if (totalPages <= 1 && totalCount <= pageSize) return null
+
+  const pageNumbers = generatePageNumbers(page, totalPages)
+  const hasPrev = page > 1
+  const hasNext = page < totalPages
+
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-border">
+      {/* Left: total count */}
+      <div className="text-xs text-text-muted">
+        {t('document.pagination.totalCount', { count: totalCount })}
+      </div>
+
+      {/* Center: page navigation */}
+      <div className="flex items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={() => onGoToPage(page - 1)}
+          disabled={!hasPrev || disabled}
+          data-testid="pagination-prev"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+
+        {pageNumbers.map(pageNum => {
+          if (pageNum === 'ellipsis-start' || pageNum === 'ellipsis-end') {
+            return (
+              <span
+                key={pageNum}
+                className="flex h-8 w-8 items-center justify-center text-text-muted"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </span>
+            )
+          }
+
+          const isActive = pageNum === page
+          return (
+            <Button
+              key={pageNum}
+              variant={isActive ? 'primary' : 'ghost'}
+              size="sm"
+              className="h-8 w-8 p-0 text-xs"
+              onClick={() => onGoToPage(pageNum)}
+              disabled={disabled}
+              data-testid={`pagination-page-${pageNum}`}
+            >
+              {pageNum}
+            </Button>
+          )
+        })}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 w-8 p-0"
+          onClick={() => onGoToPage(page + 1)}
+          disabled={!hasNext || disabled}
+          data-testid="pagination-next"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Right: page size selector */}
+      {showPageSizeSelector && onPageSizeChange && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-text-muted">{t('document.pagination.pageSize')}</span>
+          <Select
+            value={String(pageSize)}
+            onValueChange={value => onPageSizeChange(Number(value))}
+            disabled={disabled}
+          >
+            <SelectTrigger className="h-8 w-[72px] text-xs" data-testid="pagination-page-size">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {pageSizeOptions.map(size => (
+                <SelectItem key={size} value={String(size)} className="text-xs">
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -69,6 +69,28 @@ import {
 } from '../utils/summarySelectors'
 
 /**
+ * Find a document by name across all pages of a knowledge base.
+ * Uses iterative pagination (while has_more) to scan beyond the first 200 items.
+ * Returns undefined if not found or if the signal is aborted.
+ */
+async function findDocumentByName(
+  knowledgeBaseId: number,
+  documentName: string,
+  signal?: AbortSignal
+): Promise<KnowledgeDocument | undefined> {
+  let offset = 0
+  const batchSize = 200
+  while (!signal?.aborted) {
+    const response = await listDocuments(knowledgeBaseId, { limit: batchSize, offset })
+    if (signal?.aborted) return undefined
+    const found = response.items.find(doc => doc.name === documentName)
+    if (found || !response.has_more) return found
+    offset += response.items.length
+  }
+  return undefined
+}
+
+/**
  * Inner component that uses useSearchParams (must be inside Suspense boundary).
  * Reads the ?doc= URL parameter and auto-opens the matching document.
  * In paginated mode, falls back to an unpaginated API call to find documents
@@ -115,24 +137,11 @@ function DocAutoOpener({
     // In paginated mode, the document might be on a different page.
     // Search across all documents via iterative pagination.
     if (paginationEnabled) {
-      let cancelled = false
+      const controller = new AbortController()
       ;(async () => {
         try {
-          let offset = 0
-          const batchSize = 200
-          let found: KnowledgeDocument | undefined
-          // Iterate through all pages until found or exhausted
-          while (!cancelled) {
-            const response = await listDocuments(knowledgeBaseId, {
-              limit: batchSize,
-              offset,
-            })
-            if (cancelled) return
-            found = response.items.find(doc => doc.name === docParam)
-            if (found || !response.has_more) break
-            offset += response.items.length
-          }
-          if (!cancelled && found) {
+          const found = await findDocumentByName(knowledgeBaseId, docParam, controller.signal)
+          if (!controller.signal.aborted && found) {
             onOpen(found)
             const params = new URLSearchParams(searchParams.toString())
             params.delete('doc')
@@ -142,11 +151,11 @@ function DocAutoOpener({
         } catch {
           // Silently ignore - auto-open is best-effort
         } finally {
-          if (!cancelled) setDone(true)
+          if (!controller.signal.aborted) setDone(true)
         }
       })()
       return () => {
-        cancelled = true
+        controller.abort()
       }
     }
 
@@ -398,33 +407,25 @@ export function DocumentList({
     // In paginated mode, the document might be on a different page.
     // Search across all documents via iterative pagination.
     if (paginationEnabled) {
-      let cancelled = false
+      const controller = new AbortController()
       ;(async () => {
         try {
-          let offset = 0
-          const batchSize = 200
-          let found: KnowledgeDocument | undefined
-          while (!cancelled) {
-            const response = await listDocuments(knowledgeBase.id, {
-              limit: batchSize,
-              offset,
-            })
-            if (cancelled) return
-            found = response.items.find(doc => doc.name === initialDocPath)
-            if (found || !response.has_more) break
-            offset += response.items.length
-          }
-          if (!cancelled && found) {
+          const found = await findDocumentByName(
+            knowledgeBase.id,
+            initialDocPath,
+            controller.signal
+          )
+          if (!controller.signal.aborted && found) {
             setViewingDoc(found)
           }
         } catch {
           // Silently ignore - auto-open is best-effort
         } finally {
-          if (!cancelled) setInitialDocPathHandled(true)
+          if (!controller.signal.aborted) setInitialDocPathHandled(true)
         }
       })()
       return () => {
-        cancelled = true
+        controller.abort()
       }
     }
 

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -45,6 +45,7 @@ import { DeleteFolderDialog } from './DeleteFolderDialog'
 import { MoveDocumentDialog } from './MoveDocumentDialog'
 import { TransferToKbDialog } from './transfer-to-kb-dialog'
 import { useColumnResize } from '../hooks/useColumnResize'
+import { Pagination } from '@/components/ui/pagination'
 import { toast } from '@/hooks/use-toast'
 import type {
   KnowledgeBase,
@@ -131,6 +132,8 @@ interface DocumentListProps {
   initialDocPath?: string
   /** Whether this KB belongs to an organization-level namespace (affects URL format in DocumentDetailDialog) */
   isOrganization?: boolean
+  /** Whether server-side pagination is enabled (classic mode: true, notebook mode: false) */
+  paginationEnabled?: boolean
 }
 
 /** Flatten folder tree into a flat list for select dropdowns */
@@ -194,13 +197,30 @@ export function DocumentList({
   onGroupClick,
   initialDocPath,
   isOrganization = false,
+  paginationEnabled = false,
 }: DocumentListProps) {
   const { t } = useTranslation('knowledge')
   const { user } = useUser()
-  const { documents, loading, error, create, remove, refresh, batchDelete, transfer } =
-    useDocuments({
-      knowledgeBaseId: knowledgeBase.id,
-    })
+  const {
+    documents,
+    loading,
+    error,
+    create,
+    remove,
+    refresh,
+    batchDelete,
+    transfer,
+    // Pagination fields
+    page,
+    pageSize,
+    totalCount,
+    totalPages,
+    goToPage,
+    changePageSize,
+  } = useDocuments({
+    knowledgeBaseId: knowledgeBase.id,
+    paginationEnabled,
+  })
 
   // Folder state
   const {
@@ -955,7 +975,7 @@ export function DocumentList({
         <TooltipProvider>
           <Tooltip delayDuration={200}>
             <TooltipTrigger asChild>
-              <Button variant="outline" size="sm" onClick={refresh} disabled={loading}>
+              <Button variant="outline" size="sm" onClick={() => refresh()} disabled={loading}>
                 <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
               </Button>
             </TooltipTrigger>
@@ -1008,7 +1028,7 @@ export function DocumentList({
       ) : showLoadError ? (
         <div className="flex flex-col items-center justify-center py-12 text-text-secondary">
           <p>{error}</p>
-          <Button variant="outline" className="mt-4" onClick={refresh}>
+          <Button variant="outline" className="mt-4" onClick={() => refresh()}>
             {t('common:actions.retry')}
           </Button>
         </div>
@@ -1230,6 +1250,20 @@ export function DocumentList({
                   selectedFolderIds={selectedFolderIds}
                   onSelectFolder={handleSelectFolder}
                 />
+                {/* Pagination bar for classic mode */}
+                {paginationEnabled && (
+                  <div className="min-w-[880px]">
+                    <Pagination
+                      page={page}
+                      totalPages={totalPages}
+                      totalCount={totalCount}
+                      pageSize={pageSize}
+                      onGoToPage={goToPage}
+                      onPageSizeChange={changePageSize}
+                      disabled={loading}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -1242,6 +1276,9 @@ export function DocumentList({
         <div className="flex flex-col items-center justify-center py-12 text-text-secondary">
           <FileText className="w-12 h-12 mb-4 opacity-50" />
           <p>{t('document.document.noResults')}</p>
+          {paginationEnabled && (
+            <p className="text-xs text-text-muted mt-2">{t('document.pagination.searchHint')}</p>
+          )}
         </div>
       ) : canUpload ? (
         <div className="flex flex-col items-center justify-center py-16 text-text-secondary">

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -46,6 +46,7 @@ import { MoveDocumentDialog } from './MoveDocumentDialog'
 import { TransferToKbDialog } from './transfer-to-kb-dialog'
 import { useColumnResize } from '../hooks/useColumnResize'
 import { Pagination } from '@/components/ui/pagination'
+import { listDocuments } from '@/apis/knowledge'
 import { toast } from '@/hooks/use-toast'
 import type {
   KnowledgeBase,
@@ -70,15 +71,21 @@ import {
 /**
  * Inner component that uses useSearchParams (must be inside Suspense boundary).
  * Reads the ?doc= URL parameter and auto-opens the matching document.
+ * In paginated mode, falls back to an unpaginated API call to find documents
+ * that may not be on the current page.
  */
 function DocAutoOpener({
   documents,
   loading,
   onOpen,
+  knowledgeBaseId,
+  paginationEnabled,
 }: {
   documents: KnowledgeDocument[]
   loading: boolean
   onOpen: (doc: KnowledgeDocument) => void
+  knowledgeBaseId: number
+  paginationEnabled: boolean
 }) {
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -86,13 +93,13 @@ function DocAutoOpener({
   const [done, setDone] = useState(false)
 
   useEffect(() => {
-    if (done || loading || documents.length === 0) return
+    if (done || loading) return
     const docParam = searchParams.get('doc')
     if (!docParam) {
       setDone(true)
       return
     }
-    // Find document by name (exact match)
+    // Try to find document in current page
     const targetDoc = documents.find(doc => doc.name === docParam)
     if (targetDoc) {
       onOpen(targetDoc)
@@ -101,9 +108,50 @@ function DocAutoOpener({
       params.delete('doc')
       const newSearch = params.toString()
       router.replace(pathname + (newSearch ? `?${newSearch}` : ''), { scroll: false })
+      setDone(true)
+      return
     }
+
+    // In paginated mode, the document might be on a different page.
+    // Search across all documents via an unpaginated API call.
+    if (paginationEnabled && documents.length > 0) {
+      let cancelled = false
+      ;(async () => {
+        try {
+          // Fetch all documents without pagination to find the target
+          const response = await listDocuments(knowledgeBaseId, { limit: 200, offset: 0 })
+          if (cancelled) return
+          const found = response.items.find(doc => doc.name === docParam)
+          if (found) {
+            onOpen(found)
+            const params = new URLSearchParams(searchParams.toString())
+            params.delete('doc')
+            const newSearch = params.toString()
+            router.replace(pathname + (newSearch ? `?${newSearch}` : ''), { scroll: false })
+          }
+        } catch {
+          // Silently ignore - auto-open is best-effort
+        } finally {
+          if (!cancelled) setDone(true)
+        }
+      })()
+      return () => {
+        cancelled = true
+      }
+    }
+
     setDone(true)
-  }, [done, loading, documents, searchParams, onOpen, router, pathname])
+  }, [
+    done,
+    loading,
+    documents,
+    searchParams,
+    onOpen,
+    router,
+    pathname,
+    paginationEnabled,
+    knowledgeBaseId,
+  ])
 
   return null
 }
@@ -333,9 +381,42 @@ export function DocumentList({
     const targetDoc = documents.find(doc => doc.name === initialDocPath)
     if (targetDoc) {
       setViewingDoc(targetDoc)
+      setInitialDocPathHandled(true)
+      return
     }
+
+    // In paginated mode, the document might be on a different page.
+    // Search across all documents via an unpaginated API call.
+    if (paginationEnabled) {
+      let cancelled = false
+      ;(async () => {
+        try {
+          const response = await listDocuments(knowledgeBase.id, { limit: 200, offset: 0 })
+          if (cancelled) return
+          const found = response.items.find(doc => doc.name === initialDocPath)
+          if (found) {
+            setViewingDoc(found)
+          }
+        } catch {
+          // Silently ignore - auto-open is best-effort
+        } finally {
+          if (!cancelled) setInitialDocPathHandled(true)
+        }
+      })()
+      return () => {
+        cancelled = true
+      }
+    }
+
     setInitialDocPathHandled(true)
-  }, [initialDocPath, initialDocPathHandled, loading, documents])
+  }, [
+    initialDocPath,
+    initialDocPathHandled,
+    loading,
+    documents,
+    paginationEnabled,
+    knowledgeBase.id,
+  ])
 
   // Default select all documents when documents load (for notebook mode)
   useEffect(() => {
@@ -1294,7 +1375,13 @@ export function DocumentList({
 
       {/* Auto-open document from ?doc= URL parameter (wrapped in Suspense for useSearchParams) */}
       <Suspense fallback={null}>
-        <DocAutoOpener documents={documents} loading={loading} onOpen={setViewingDoc} />
+        <DocAutoOpener
+          documents={documents}
+          loading={loading}
+          onOpen={setViewingDoc}
+          knowledgeBaseId={knowledgeBase.id}
+          paginationEnabled={paginationEnabled}
+        />
       </Suspense>
 
       {/* Dialogs */}

--- a/frontend/src/features/knowledge/document/components/DocumentList.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentList.tsx
@@ -113,16 +113,26 @@ function DocAutoOpener({
     }
 
     // In paginated mode, the document might be on a different page.
-    // Search across all documents via an unpaginated API call.
-    if (paginationEnabled && documents.length > 0) {
+    // Search across all documents via iterative pagination.
+    if (paginationEnabled) {
       let cancelled = false
       ;(async () => {
         try {
-          // Fetch all documents without pagination to find the target
-          const response = await listDocuments(knowledgeBaseId, { limit: 200, offset: 0 })
-          if (cancelled) return
-          const found = response.items.find(doc => doc.name === docParam)
-          if (found) {
+          let offset = 0
+          const batchSize = 200
+          let found: KnowledgeDocument | undefined
+          // Iterate through all pages until found or exhausted
+          while (!cancelled) {
+            const response = await listDocuments(knowledgeBaseId, {
+              limit: batchSize,
+              offset,
+            })
+            if (cancelled) return
+            found = response.items.find(doc => doc.name === docParam)
+            if (found || !response.has_more) break
+            offset += response.items.length
+          }
+          if (!cancelled && found) {
             onOpen(found)
             const params = new URLSearchParams(searchParams.toString())
             params.delete('doc')
@@ -386,15 +396,25 @@ export function DocumentList({
     }
 
     // In paginated mode, the document might be on a different page.
-    // Search across all documents via an unpaginated API call.
+    // Search across all documents via iterative pagination.
     if (paginationEnabled) {
       let cancelled = false
       ;(async () => {
         try {
-          const response = await listDocuments(knowledgeBase.id, { limit: 200, offset: 0 })
-          if (cancelled) return
-          const found = response.items.find(doc => doc.name === initialDocPath)
-          if (found) {
+          let offset = 0
+          const batchSize = 200
+          let found: KnowledgeDocument | undefined
+          while (!cancelled) {
+            const response = await listDocuments(knowledgeBase.id, {
+              limit: batchSize,
+              offset,
+            })
+            if (cancelled) return
+            found = response.items.find(doc => doc.name === initialDocPath)
+            if (found || !response.has_more) break
+            offset += response.items.length
+          }
+          if (!cancelled && found) {
             setViewingDoc(found)
           }
         } catch {

--- a/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/DocumentPanel.tsx
@@ -303,6 +303,7 @@ export function DocumentPanel({
               canUpload={canUpload}
               canManageAllDocuments={canManageAllDocuments}
               compact={true}
+              paginationEnabled={false}
               onRefreshKnowledgeBase={onRefreshKnowledgeBase}
               onSelectionChange={onDocumentSelectionChange}
               groupInfo={groupInfo}
@@ -360,6 +361,7 @@ export function DocumentPanel({
               canUpload={canUpload}
               canManageAllDocuments={canManageAllDocuments}
               compact={true}
+              paginationEnabled={false}
               onRefreshKnowledgeBase={onRefreshKnowledgeBase}
               onSelectionChange={onDocumentSelectionChange}
               groupInfo={groupInfo}

--- a/frontend/src/features/knowledge/document/components/FolderTree.tsx
+++ b/frontend/src/features/knowledge/document/components/FolderTree.tsx
@@ -163,18 +163,25 @@ function convertFolderToNode(
 ): FolderNode {
   const folderDocs = docsByFolderId.get(folder.id) || []
 
+  // Build child folder nodes first so we can use their documentCount
+  const childFolderNodes = folder.children.map(child => convertFolderToNode(child, docsByFolderId))
+
   const children: TreeNode[] = [
     ...folderDocs.map(doc => ({
       type: 'document' as const,
       displayName: doc.name,
       document: doc,
     })),
-    ...folder.children.map(child => convertFolderToNode(child, docsByFolderId)),
+    ...childFolderNodes,
   ]
 
-  // Count total documents recursively
+  // Count total documents recursively.
+  // Use folder.document_count (server-computed accurate count) for the current
+  // folder's direct documents instead of folderDocs.length, which only reflects
+  // current-page documents when server-side pagination is active.
+  // Use childFolderNodes' documentCount for recursive accuracy.
   const totalDocs =
-    folderDocs.length + folder.children.reduce((sum, c) => sum + c.document_count, 0)
+    folder.document_count + childFolderNodes.reduce((sum, c) => sum + c.documentCount, 0)
 
   return {
     type: 'api-folder',

--- a/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
+++ b/frontend/src/features/knowledge/document/components/KnowledgeDetailPanel.tsx
@@ -286,6 +286,7 @@ export function KnowledgeDetailPanel({
               knowledgeBase={selectedKb}
               canUpload={canUploadDocuments}
               canManageAllDocuments={canManageKb}
+              paginationEnabled={true}
               onRefreshKnowledgeBase={handleRefreshKnowledgeBase}
               headerActions={headerActions}
               groupInfo={groupInfo}

--- a/frontend/src/features/knowledge/document/hooks/useDocuments.ts
+++ b/frontend/src/features/knowledge/document/hooks/useDocuments.ts
@@ -116,7 +116,7 @@ export function useDocuments(options: UseDocumentsOptions) {
           setPageSize(targetPageSize)
         }
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch documents')
+        setError(err instanceof Error ? err.message : t('document.document.fetchFailed'))
       } finally {
         setLoading(false)
       }

--- a/frontend/src/features/knowledge/document/hooks/useDocuments.ts
+++ b/frontend/src/features/knowledge/document/hooks/useDocuments.ts
@@ -294,14 +294,14 @@ export function useDocuments(options: UseDocumentsOptions) {
   )
 
   // Reset page and reload when knowledge base changes.
-  // Combined into a single effect to avoid stale-page fetches:
-  // resetting page state and fetching in one pass prevents the
-  // auto-load effect from firing with the old page number.
+  // Combined into a single effect to avoid stale-page fetches.
+  // Explicitly pass page=1 to fetchDocuments because setPage(1) is async
+  // and pageRef.current still holds the old page value at this point.
   useEffect(() => {
     setPage(1)
     setTotalCount(0)
     if (autoLoad && knowledgeBaseId) {
-      fetchDocuments()
+      fetchDocuments(1, pageSizeRef.current)
     }
   }, [autoLoad, knowledgeBaseId, fetchDocuments])
 

--- a/frontend/src/features/knowledge/document/hooks/useDocuments.ts
+++ b/frontend/src/features/knowledge/document/hooks/useDocuments.ts
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Custom hook for managing knowledge documents
+ * Custom hook for managing knowledge documents with optional server-side pagination.
+ *
+ * When `paginationEnabled` is true (classic KB mode), documents are fetched page-by-page
+ * using server-side offset/limit pagination. When false (notebook mode), all documents
+ * are loaded at once without pagination.
  */
 
 import { useState, useCallback, useEffect } from 'react'
@@ -28,36 +32,91 @@ import { toast } from '@/hooks/use-toast'
 import { useTranslation } from '@/hooks/useTranslation'
 import { mapKnowledgeDocumentErrorMessage } from '../utils/error-messages'
 
+const DEFAULT_PAGE_SIZE = 50
+
 interface UseDocumentsOptions {
   knowledgeBaseId: number | null
   autoLoad?: boolean
+  /** Whether server-side pagination is enabled (classic mode: true, notebook mode: false) */
+  paginationEnabled?: boolean
 }
 
 export function useDocuments(options: UseDocumentsOptions) {
-  const { knowledgeBaseId, autoLoad = true } = options
+  const { knowledgeBaseId, autoLoad = true, paginationEnabled = false } = options
   const { t } = useTranslation('knowledge')
 
   const [documents, setDocuments] = useState<KnowledgeDocument[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchDocuments = useCallback(async () => {
-    if (!knowledgeBaseId) {
-      setDocuments([])
-      return
-    }
+  // Pagination state (only meaningful when paginationEnabled=true)
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE)
+  const [totalCount, setTotalCount] = useState(0)
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
 
-    setLoading(true)
-    setError(null)
-    try {
-      const response = await listDocuments(knowledgeBaseId)
-      setDocuments(response.items)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch documents')
-    } finally {
-      setLoading(false)
-    }
-  }, [knowledgeBaseId])
+  const fetchDocuments = useCallback(
+    async (targetPage?: number, targetPageSize?: number) => {
+      if (!knowledgeBaseId) {
+        setDocuments([])
+        setTotalCount(0)
+        setPage(1)
+        return
+      }
+
+      const effectivePage = targetPage ?? page
+      const effectivePageSize = targetPageSize ?? pageSize
+
+      setLoading(true)
+      setError(null)
+      try {
+        let response
+
+        if (paginationEnabled) {
+          // Classic mode: server-side pagination
+          const offset = (effectivePage - 1) * effectivePageSize
+          response = await listDocuments(knowledgeBaseId, {
+            limit: effectivePageSize,
+            offset,
+          })
+        } else {
+          // Notebook mode: load all documents at once
+          response = await listDocuments(knowledgeBaseId)
+        }
+
+        setDocuments(response.items)
+        setTotalCount(response.total)
+        if (targetPage !== undefined) {
+          setPage(targetPage)
+        }
+        if (targetPageSize !== undefined) {
+          setPageSize(targetPageSize)
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch documents')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [knowledgeBaseId, page, pageSize, paginationEnabled]
+  )
+
+  // Page navigation methods
+  const goToPage = useCallback(
+    (targetPage: number) => {
+      if (targetPage < 1 || targetPage > totalPages) return
+      fetchDocuments(targetPage)
+    },
+    [fetchDocuments, totalPages]
+  )
+
+  const changePageSize = useCallback(
+    (newPageSize: number) => {
+      // When page size changes, go back to page 1
+      fetchDocuments(1, newPageSize)
+    },
+    [fetchDocuments]
+  )
 
   const create = useCallback(
     async (data: KnowledgeDocumentCreate) => {
@@ -69,7 +128,15 @@ export function useDocuments(options: UseDocumentsOptions) {
       setError(null)
       try {
         const created = await createDocument(knowledgeBaseId, data)
-        setDocuments(prev => [created, ...prev])
+
+        if (paginationEnabled) {
+          // In paginated mode, refresh current page to get correct server state
+          await fetchDocuments()
+        } else {
+          // In non-paginated mode, prepend to local state
+          setDocuments(prev => [created, ...prev])
+          setTotalCount(prev => prev + 1)
+        }
         return created
       } catch (err) {
         const message = mapKnowledgeDocumentErrorMessage(err, t, 'document.document.createFailed')
@@ -79,7 +146,7 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [knowledgeBaseId, t]
+    [knowledgeBaseId, t, paginationEnabled, fetchDocuments]
   )
 
   const update = useCallback(
@@ -107,7 +174,22 @@ export function useDocuments(options: UseDocumentsOptions) {
       setError(null)
       try {
         await deleteDocument(id)
-        setDocuments(prev => prev.filter(doc => doc.id !== id))
+        if (paginationEnabled) {
+          // In paginated mode, refresh to handle empty page redirect
+          const currentPage = page
+          await fetchDocuments()
+          // If the current page is now empty and we're not on page 1, go to previous page
+          setDocuments(prev => {
+            if (prev.length === 0 && currentPage > 1) {
+              // Schedule navigation to previous page
+              setTimeout(() => goToPage(currentPage - 1), 0)
+            }
+            return prev
+          })
+        } else {
+          setDocuments(prev => prev.filter(doc => doc.id !== id))
+          setTotalCount(prev => Math.max(0, prev - 1))
+        }
       } catch (err) {
         const message = mapKnowledgeDocumentErrorMessage(err, t, 'document.document.deleteFailed')
         toast({ title: message, variant: 'destructive' })
@@ -116,7 +198,7 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [t]
+    [t, paginationEnabled, fetchDocuments, page, goToPage]
   )
 
   // Batch operations
@@ -126,10 +208,15 @@ export function useDocuments(options: UseDocumentsOptions) {
       setError(null)
       try {
         const result = await batchDeleteDocuments(ids)
-        // Remove successfully deleted documents from state
-        setDocuments(prev =>
-          prev.filter(doc => !ids.includes(doc.id) || result.failed_ids.includes(doc.id))
-        )
+        if (paginationEnabled) {
+          await fetchDocuments()
+        } else {
+          // Remove successfully deleted documents from state
+          setDocuments(prev =>
+            prev.filter(doc => !ids.includes(doc.id) || result.failed_ids.includes(doc.id))
+          )
+          setTotalCount(prev => Math.max(0, prev - (ids.length - result.failed_ids.length)))
+        }
         return result
       } catch (err) {
         const message = mapKnowledgeDocumentErrorMessage(
@@ -143,10 +230,9 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [t]
+    [t, paginationEnabled, fetchDocuments]
   )
 
-  // Transfer documents to another KB
   // Transfer documents to another KB
   const transfer = useCallback(
     async (data: TransferDocumentsRequest): Promise<TransferDocumentsResponse | null> => {
@@ -179,6 +265,13 @@ export function useDocuments(options: UseDocumentsOptions) {
     },
     [knowledgeBaseId, fetchDocuments, t]
   )
+
+  // Reset page when knowledge base changes
+  useEffect(() => {
+    setPage(1)
+    setTotalCount(0)
+  }, [knowledgeBaseId])
+
   useEffect(() => {
     if (autoLoad && knowledgeBaseId) {
       fetchDocuments()
@@ -195,5 +288,12 @@ export function useDocuments(options: UseDocumentsOptions) {
     remove,
     batchDelete,
     transfer,
+    // Pagination fields
+    page,
+    pageSize,
+    totalCount,
+    totalPages,
+    goToPage,
+    changePageSize,
   }
 }

--- a/frontend/src/features/knowledge/document/hooks/useDocuments.ts
+++ b/frontend/src/features/knowledge/document/hooks/useDocuments.ts
@@ -10,7 +10,7 @@
  * are loaded at once without pagination.
  */
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { ApiError } from '@/apis/client'
 import {
   listDocuments,
@@ -55,33 +55,56 @@ export function useDocuments(options: UseDocumentsOptions) {
   const [totalCount, setTotalCount] = useState(0)
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize))
 
+  // Use refs for pagination state to avoid stale closures and duplicate fetches.
+  // This prevents fetchDocuments from depending on page/pageSize, which would
+  // cause the auto-load effect to re-fire on every page change.
+  const pageRef = useRef(page)
+  const pageSizeRef = useRef(pageSize)
+  const paginationEnabledRef = useRef(paginationEnabled)
+  const knowledgeBaseIdRef = useRef(knowledgeBaseId)
+
+  // Keep refs in sync with state
+  useEffect(() => {
+    pageRef.current = page
+  }, [page])
+  useEffect(() => {
+    pageSizeRef.current = pageSize
+  }, [pageSize])
+  useEffect(() => {
+    paginationEnabledRef.current = paginationEnabled
+  }, [paginationEnabled])
+  useEffect(() => {
+    knowledgeBaseIdRef.current = knowledgeBaseId
+  }, [knowledgeBaseId])
+
   const fetchDocuments = useCallback(
     async (targetPage?: number, targetPageSize?: number) => {
-      if (!knowledgeBaseId) {
+      const currentKbId = knowledgeBaseIdRef.current
+      if (!currentKbId) {
         setDocuments([])
         setTotalCount(0)
         setPage(1)
         return
       }
 
-      const effectivePage = targetPage ?? page
-      const effectivePageSize = targetPageSize ?? pageSize
+      const effectivePage = targetPage ?? pageRef.current
+      const effectivePageSize = targetPageSize ?? pageSizeRef.current
 
       setLoading(true)
       setError(null)
       try {
         let response
 
-        if (paginationEnabled) {
+        if (paginationEnabledRef.current) {
           // Classic mode: server-side pagination
           const offset = (effectivePage - 1) * effectivePageSize
-          response = await listDocuments(knowledgeBaseId, {
+          response = await listDocuments(currentKbId, {
             limit: effectivePageSize,
             offset,
           })
         } else {
           // Notebook mode: load all documents at once
-          response = await listDocuments(knowledgeBaseId)
+          response = await listDocuments(currentKbId)
         }
 
         setDocuments(response.items)
@@ -98,7 +121,9 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [knowledgeBaseId, page, pageSize, paginationEnabled]
+    // No page/pageSize dependencies — reads from refs instead to avoid
+    // recreating on every state change which would trigger the auto-load effect.
+    []
   )
 
   // Page navigation methods
@@ -120,16 +145,17 @@ export function useDocuments(options: UseDocumentsOptions) {
 
   const create = useCallback(
     async (data: KnowledgeDocumentCreate) => {
-      if (!knowledgeBaseId) {
+      const currentKbId = knowledgeBaseIdRef.current
+      if (!currentKbId) {
         throw new Error('Knowledge base ID is required')
       }
 
       setLoading(true)
       setError(null)
       try {
-        const created = await createDocument(knowledgeBaseId, data)
+        const created = await createDocument(currentKbId, data)
 
-        if (paginationEnabled) {
+        if (paginationEnabledRef.current) {
           // In paginated mode, refresh current page to get correct server state
           await fetchDocuments()
         } else {
@@ -146,7 +172,7 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [knowledgeBaseId, t, paginationEnabled, fetchDocuments]
+    [t, fetchDocuments]
   )
 
   const update = useCallback(
@@ -174,9 +200,9 @@ export function useDocuments(options: UseDocumentsOptions) {
       setError(null)
       try {
         await deleteDocument(id)
-        if (paginationEnabled) {
+        if (paginationEnabledRef.current) {
           // In paginated mode, refresh to handle empty page redirect
-          const currentPage = page
+          const currentPage = pageRef.current
           await fetchDocuments()
           // If the current page is now empty and we're not on page 1, go to previous page
           setDocuments(prev => {
@@ -198,7 +224,7 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [t, paginationEnabled, fetchDocuments, page, goToPage]
+    [t, fetchDocuments, goToPage]
   )
 
   // Batch operations
@@ -208,7 +234,7 @@ export function useDocuments(options: UseDocumentsOptions) {
       setError(null)
       try {
         const result = await batchDeleteDocuments(ids)
-        if (paginationEnabled) {
+        if (paginationEnabledRef.current) {
           await fetchDocuments()
         } else {
           // Remove successfully deleted documents from state
@@ -230,17 +256,18 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [t, paginationEnabled, fetchDocuments]
+    [t, fetchDocuments]
   )
 
   // Transfer documents to another KB
   const transfer = useCallback(
     async (data: TransferDocumentsRequest): Promise<TransferDocumentsResponse | null> => {
-      if (!knowledgeBaseId) return null
+      const currentKbId = knowledgeBaseIdRef.current
+      if (!currentKbId) return null
       setLoading(true)
       setError(null)
       try {
-        const result = await transferDocuments(knowledgeBaseId, data)
+        const result = await transferDocuments(currentKbId, data)
         toast({
           description: t('document.document.batch.transferSuccess', {
             docCount: result.transferred_document_count,
@@ -263,16 +290,16 @@ export function useDocuments(options: UseDocumentsOptions) {
         setLoading(false)
       }
     },
-    [knowledgeBaseId, fetchDocuments, t]
+    [fetchDocuments, t]
   )
 
-  // Reset page when knowledge base changes
+  // Reset page and reload when knowledge base changes.
+  // Combined into a single effect to avoid stale-page fetches:
+  // resetting page state and fetching in one pass prevents the
+  // auto-load effect from firing with the old page number.
   useEffect(() => {
     setPage(1)
     setTotalCount(0)
-  }, [knowledgeBaseId])
-
-  useEffect(() => {
     if (autoLoad && knowledgeBaseId) {
       fetchDocuments()
     }

--- a/frontend/src/features/knowledge/document/pages/KnowledgeBaseClassicPageDesktop.tsx
+++ b/frontend/src/features/knowledge/document/pages/KnowledgeBaseClassicPageDesktop.tsx
@@ -253,6 +253,7 @@ export function KnowledgeBaseClassicPageDesktop({ knowledgeBaseId, initialDocPat
                   onBack={handleBack}
                   canUpload={canUploadDocuments}
                   canManageAllDocuments={canManageKb}
+                  paginationEnabled={true}
                   onRefreshKnowledgeBase={refreshKnowledgeBase}
                   initialDocPath={initialDocPath}
                 />
@@ -270,6 +271,7 @@ export function KnowledgeBaseClassicPageDesktop({ knowledgeBaseId, initialDocPat
               onBack={handleBack}
               canUpload={canUploadDocuments}
               canManageAllDocuments={canManageKb}
+              paginationEnabled={true}
               initialDocPath={initialDocPath}
             />
           )}

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -697,6 +697,11 @@
         "KB_DUPLICATE_NAME_IN_GROUP": "A knowledge base with the same name already exists in the target group",
         "KB_MIGRATE_CONFLICT": "A knowledge base with the same name already exists in the target group"
       }
+    },
+    "pagination": {
+      "totalCount": "{{count}} items",
+      "pageSize": "Per page",
+      "searchHint": "Search applies to current page only"
     }
   },
   "add_repository": "Add Repository",

--- a/frontend/src/i18n/locales/en/knowledge.json
+++ b/frontend/src/i18n/locales/en/knowledge.json
@@ -377,7 +377,8 @@
         "splitterType": "Splitter Type",
         "splitterSubtype": "Splitter Subtype"
       },
-      "downloadFailed": "Failed to download file"
+      "downloadFailed": "Failed to download file",
+      "fetchFailed": "Failed to fetch documents"
     },
     "upload": {
       "dropzoneHint": "Select up to {{max}} files at once",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -697,6 +697,11 @@
         "KB_DUPLICATE_NAME_IN_GROUP": "目标群组中已存在同名知识库",
         "KB_MIGRATE_CONFLICT": "目标群组中已存在同名知识库"
       }
+    },
+    "pagination": {
+      "totalCount": "共 {{count}} 条",
+      "pageSize": "每页",
+      "searchHint": "搜索范围仅限当前页文档"
     }
   },
   "add_repository": "添加仓库",

--- a/frontend/src/i18n/locales/zh-CN/knowledge.json
+++ b/frontend/src/i18n/locales/zh-CN/knowledge.json
@@ -377,7 +377,8 @@
         "splitterType": "分段类型",
         "splitterSubtype": "分段子类型"
       },
-      "downloadFailed": "下载文件失败"
+      "downloadFailed": "下载文件失败",
+      "fetchFailed": "获取文档失败"
     },
     "upload": {
       "dropzoneHint": "一次最多选择 {{max}} 个文件",

--- a/frontend/src/types/knowledge.ts
+++ b/frontend/src/types/knowledge.ts
@@ -427,6 +427,10 @@ export interface KnowledgeDocumentUpdate {
 
 export interface KnowledgeDocumentListResponse {
   total: number
+  returned_count: number
+  limit: number | null
+  offset: number
+  has_more: boolean
   items: KnowledgeDocument[]
 }
 


### PR DESCRIPTION
…documents

Classic KB mode now supports traditional page-based pagination when documents exceed the default 50-item limit. Notebook mode remains unchanged (loads all documents at once).

Changes:
- Add pagination fields to KnowledgeDocumentListResponse type
- Add limit/offset/folder_id params to listDocuments API function
- Create reusable Pagination UI component (page nav + page size selector)
- Add pagination state and methods to useDocuments hook
- Render Pagination bar in DocumentList for classic mode only
- Pass paginationEnabled prop: false for notebook, true for classic
- Add i18n translations for pagination in zh-CN and en

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional server-side pagination for knowledge document listings, including folder filtering, page navigation, compact page controls, and (when enabled) page-size selection.
  * Exposed pagination metadata from the server for accurate total/limits.
* **Improvements**
  * Improved auto-opening/deep-linking to a specific document when pagination is active, even if it’s not on the current page.
  * More accurate folder child counts for API-backed folders.
* **Bug Fixes**
  * Improved reliability after refresh/removal to keep the correct page populated in paginated mode.
* **Documentation**
  * Updated pagination UI text and added a localized “fetch failed” message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->