### PR TITLE
Verify standalone images before publishing to GHCR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -460,18 +460,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push standalone image (amd64)
+      - name: Build standalone image for verification (amd64)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/standalone/Dockerfile
-          push: true
+          load: true
           platforms: linux/amd64
           tags: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-amd64
           cache-from: type=gha,scope=standalone-amd64
           cache-to: type=gha,mode=max,scope=standalone-amd64
           build-args: |
             APP_VERSION=${{ needs.prepare-release.outputs.new_version }}
+
+      - name: Verify standalone image startup (amd64)
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-amd64
+          CONTAINER_NAME: wegent-standalone-verify-amd64
+        run: bash scripts/verify-standalone-image.sh "$IMAGE"
+
+      - name: Push verified standalone image (amd64)
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-amd64
+        run: docker push "$IMAGE"
 
   build-standalone-arm64:
     needs: prepare-release
@@ -494,18 +505,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push standalone image (arm64)
+      - name: Build standalone image for verification (arm64)
         uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/standalone/Dockerfile
-          push: true
+          load: true
           platforms: linux/arm64
           tags: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-arm64
           cache-from: type=gha,scope=standalone-arm64
           cache-to: type=gha,mode=max,scope=standalone-arm64
           build-args: |
             APP_VERSION=${{ needs.prepare-release.outputs.new_version }}
+
+      - name: Verify standalone image startup (arm64)
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-arm64
+          CONTAINER_NAME: wegent-standalone-verify-arm64
+        run: bash scripts/verify-standalone-image.sh "$IMAGE"
+
+      - name: Push verified standalone image (arm64)
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-release.outputs.new_version }}-arm64
+        run: docker push "$IMAGE"
 
   # ============================================================================
   # Executor Local Binary Build (macOS)

--- a/scripts/test-publish-image-standalone-gate.sh
+++ b/scripts/test-publish-image-standalone-gate.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression test for standalone image verification gates in publish-image workflow.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$PROJECT_ROOT/.github/workflows/publish-image.yml"
+
+extract_job() {
+    local arch="$1"
+    awk -v start="  build-standalone-${arch}:" '
+        $0 == start {
+            in_block = 1
+            print
+            next
+        }
+        in_block && $0 ~ /^  [A-Za-z0-9_-]+:$/ {
+            exit
+        }
+        in_block {
+            print
+        }
+    ' "$WORKFLOW"
+}
+
+require_line() {
+    local block="$1"
+    local pattern="$2"
+    local description="$3"
+
+    if ! grep -Fq "$pattern" <<< "$block"; then
+        echo "Expected ${description}: ${pattern}"
+        exit 1
+    fi
+}
+
+line_number() {
+    local block="$1"
+    local pattern="$2"
+
+    awk -v pattern="$pattern" 'index($0, pattern) { print NR; exit }' <<< "$block"
+}
+
+verify_arch_gate() {
+    local arch="$1"
+    local block
+    block="$(extract_job "$arch")"
+
+    require_line "$block" "Build standalone image for verification (${arch})" "${arch} verification build step"
+    require_line "$block" "load: true" "${arch} local Docker load"
+    require_line "$block" "Verify standalone image startup (${arch})" "${arch} startup verification step"
+    require_line "$block" 'run: bash scripts/verify-standalone-image.sh "$IMAGE"' "${arch} verification script call"
+    require_line "$block" "Push verified standalone image (${arch})" "${arch} verified push step"
+
+    local build_line verify_line push_line
+    build_line="$(line_number "$block" "Build standalone image for verification (${arch})")"
+    verify_line="$(line_number "$block" "Verify standalone image startup (${arch})")"
+    push_line="$(line_number "$block" "Push verified standalone image (${arch})")"
+
+    if [ "$build_line" -ge "$verify_line" ] || [ "$verify_line" -ge "$push_line" ]; then
+        echo "Expected ${arch} standalone job order to be build, verify, then push."
+        exit 1
+    fi
+}
+
+verify_arch_gate "amd64"
+verify_arch_gate "arm64"
+
+echo "publish-image standalone gate regression test passed"

--- a/scripts/test-verify-standalone-image.sh
+++ b/scripts/test-verify-standalone-image.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Regression tests for standalone image startup verification.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VERIFY_SCRIPT="$PROJECT_ROOT/scripts/verify-standalone-image.sh"
+
+TMP_DIR="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat > "$TMP_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "docker $*" >> "$FAKE_DOCKER_LOG"
+
+case "$1" in
+    run)
+        echo "container-id"
+        ;;
+    inspect)
+        echo "true"
+        ;;
+    ps)
+        echo "$CONTAINER_NAME"
+        ;;
+    logs)
+        echo "standalone container logs"
+        ;;
+    rm)
+        echo "removed"
+        ;;
+    *)
+        echo "unexpected docker command: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$TMP_DIR/docker"
+
+cat > "$TMP_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${@: -1}"
+echo "$url" >> "$FAKE_CURL_LOG"
+
+case "$url" in
+    *:18000/health)
+        exit 0
+        ;;
+    *:13000/)
+        exit 22
+        ;;
+    *)
+        echo "unexpected curl URL: $url" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$TMP_DIR/curl"
+
+export PATH="$TMP_DIR:$PATH"
+export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
+export FAKE_CURL_LOG="$TMP_DIR/curl.log"
+export CONTAINER_NAME="wegent-standalone-test"
+export STANDALONE_VERIFY_TIMEOUT_SECONDS=0
+export STANDALONE_VERIFY_INTERVAL_SECONDS=1
+
+if "$VERIFY_SCRIPT" "ghcr.io/wecode-ai/wegent-standalone:test" > "$TMP_DIR/output.log" 2>&1; then
+    echo "Expected standalone verification to fail when frontend is unreachable."
+    cat "$TMP_DIR/output.log"
+    exit 1
+fi
+
+if ! grep -q "Frontend failed readiness check" "$TMP_DIR/output.log"; then
+    echo "Expected frontend readiness failure message."
+    cat "$TMP_DIR/output.log"
+    exit 1
+fi
+
+if ! grep -q "standalone container logs" "$TMP_DIR/output.log"; then
+    echo "Expected container logs on verification failure."
+    cat "$TMP_DIR/output.log"
+    exit 1
+fi
+
+if ! grep -q "docker rm -f $CONTAINER_NAME" "$FAKE_DOCKER_LOG"; then
+    echo "Expected verification script to clean up the container."
+    cat "$FAKE_DOCKER_LOG"
+    exit 1
+fi
+
+echo "standalone image verification regression test passed"

--- a/scripts/verify-standalone-image.sh
+++ b/scripts/verify-standalone-image.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Start a Wegent standalone image and verify Backend and Frontend are reachable.
+
+set -euo pipefail
+
+IMAGE="${1:-}"
+
+if [ -z "$IMAGE" ]; then
+    echo "Usage: $0 IMAGE" >&2
+    exit 2
+fi
+
+BACKEND_PORT="${BACKEND_PORT:-18000}"
+FRONTEND_PORT="${FRONTEND_PORT:-13000}"
+CONTAINER_NAME="${CONTAINER_NAME:-wegent-standalone-verify-$$}"
+TIMEOUT_SECONDS="${STANDALONE_VERIFY_TIMEOUT_SECONDS:-180}"
+INTERVAL_SECONDS="${STANDALONE_VERIFY_INTERVAL_SECONDS:-2}"
+
+container_exists() {
+    docker ps -a --format '{{.Names}}' | grep -Fxq "$CONTAINER_NAME"
+}
+
+print_container_logs() {
+    if container_exists; then
+        echo ""
+        echo "===== Standalone container logs ====="
+        docker logs "$CONTAINER_NAME" || true
+        echo "===== End standalone container logs ====="
+    fi
+}
+
+cleanup() {
+    local status=$?
+
+    if [ "$status" -ne 0 ]; then
+        print_container_logs
+    fi
+
+    if container_exists; then
+        docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+    fi
+    return "$status"
+}
+trap cleanup EXIT
+
+is_container_running() {
+    [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)" = "true" ]
+}
+
+wait_for_url() {
+    local label="$1"
+    local url="$2"
+    local deadline=$((SECONDS + TIMEOUT_SECONDS))
+
+    echo "Waiting for ${label}: ${url}"
+    while true; do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            echo "${label} is reachable"
+            return 0
+        fi
+
+        if ! is_container_running; then
+            echo "${label} failed readiness check: container exited before ${url} became reachable." >&2
+            return 1
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "${label} failed readiness check: ${url} was not reachable within ${TIMEOUT_SECONDS}s." >&2
+            return 1
+        fi
+
+        sleep "$INTERVAL_SECONDS"
+    done
+}
+
+echo "Starting standalone verification container ${CONTAINER_NAME} from ${IMAGE}"
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "127.0.0.1:${BACKEND_PORT}:8000" \
+    -p "127.0.0.1:${FRONTEND_PORT}:3000" \
+    "$IMAGE"
+
+wait_for_url "Backend" "http://localhost:${BACKEND_PORT}/health"
+wait_for_url "Frontend" "http://localhost:${FRONTEND_PORT}/"
+
+echo "Standalone image verification succeeded for ${IMAGE}"


### PR DESCRIPTION
## Summary
- Build standalone amd64 and arm64 images locally first, verify backend and frontend startup, then push only after the check passes.
- Add a reusable `scripts/verify-standalone-image.sh` helper to run the container, probe health endpoints, and print logs on failure.
- Add regression scripts to cover the publish workflow gate and the standalone verification flow.

## Testing
- Not run (not requested)
- Added shell regression coverage for the workflow order and image verification behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Docker image publishing workflow with automatic startup verification gates before releasing images for both amd64 and arm64 architectures.

* **Tests**
  * Added regression tests for image verification and workflow gate validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->