### PR TITLE
[codex] clarify standalone quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Wegent is a self-hostable AI workspace for managing chat, coding tasks, knowledg
 Prerequisite: Docker and Docker Compose.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
 ```
+
+This starts the default Standalone mode: one container with SQLite for local trials and lightweight deployments.
 
 Then open http://localhost:3000 in your browser.
 
@@ -50,6 +52,9 @@ Then open http://localhost:3000 in your browser.
 | **Development** | Source startup + hot reload, best for development and extensions |
 
 ```bash
+# Standalone mode (default)
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
+
 # Standard mode
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -36,8 +36,10 @@ Wegent 是一个可自部署的 AI 工作台，用来统一管理对话、代码
 前置要求：已安装 Docker 和 Docker Compose。
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
 ```
+
+这会启动默认的 Standalone 模式：单容器 + SQLite，适合本地试用和轻量部署。
 
 启动后访问 http://localhost:3000。
 
@@ -50,6 +52,9 @@ curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | 
 | **Development** | 源码启动 + 热重载，适合开发和二次扩展 |
 
 ```bash
+# Standalone 模式（默认）
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
+
 # Standard 模式
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard
 


### PR DESCRIPTION
## Summary
- Make the README quick start command explicitly use `--standalone`.
- Put the Standalone example before Standard in both English and Chinese README deployment snippets.
- Add a short note explaining that Standalone is the default lightweight mode.

## Why
The deployment-mode snippet previously put Standard first, which made it easy to copy the production-oriented command by visual position rather than intent.

## Validation
- `git diff --check origin/main...HEAD -- README.md README_zh.md`
- Confirmed PR diff against `origin/main` only includes `README.md` and `README_zh.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify Standalone mode operation using SQLite as the default database.
  * Added explicit Standalone mode command example in the Deployment Modes section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->