### PR TITLE
[codex] fix pipeline auto advance stage selection

### DIFF
--- a/backend/app/services/adapters/collaboration_strategy.py
+++ b/backend/app/services/adapters/collaboration_strategy.py
@@ -208,11 +208,21 @@ class PipelineCollaborationStrategy(CollaborationStrategy):
             from app.services.readers.kinds import KindType, kindReader
 
             subtask = task_stores.subtask_store.get_by_id(db, subtask_id=subtask_id)
-            if not subtask or not subtask.bot_ids:
+            if not subtask:
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: subtask not found "
+                    "task=%s subtask=%s",
+                    task_id,
+                    subtask_id,
+                )
                 return None
 
             task = task_stores.task_store.get_regular_active_task(db, task_id=task_id)
             if not task:
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: task not found task=%s",
+                    task_id,
+                )
                 return None
 
             task_crd = Task.model_validate(task.json)
@@ -228,54 +238,85 @@ class PipelineCollaborationStrategy(CollaborationStrategy):
                 .first()
             )
             if not team:
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: team not found "
+                    "task=%s team=%s/%s",
+                    task_id,
+                    team_ref.namespace,
+                    team_ref.name,
+                )
                 return None
 
             team_crd = Team.model_validate(team.json)
             members = team_crd.spec.members
             if not members:
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: no team members task=%s",
+                    task_id,
+                )
                 return None
 
-            # Find which stage this subtask belongs to by matching bot_id
-            bot_id = subtask.bot_ids[0]
-            bot = kindReader.get_by_id(db, KindType.BOT, bot_id)
-            if not bot:
+            current_stage_index = task_crd.spec.currentStage or 0
+            if (
+                not isinstance(current_stage_index, int)
+                or current_stage_index < 0
+                or current_stage_index >= len(members)
+            ):
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: invalid currentStage "
+                    "task=%s currentStage=%s total=%s",
+                    task_id,
+                    current_stage_index,
+                    len(members),
+                )
                 return None
 
-            current_stage_index = None
-            for i, member in enumerate(members):
-                if (
-                    member.botRef.name == bot.name
-                    and member.botRef.namespace == bot.namespace
-                ):
-                    current_stage_index = i
-                    break
+            subtask_stage_index = None
+            if subtask.bot_ids:
+                bot = kindReader.get_by_id(db, KindType.BOT, subtask.bot_ids[0])
+                if bot:
+                    for i, member in enumerate(members):
+                        if (
+                            member.botRef.name == bot.name
+                            and member.botRef.namespace == bot.namespace
+                        ):
+                            subtask_stage_index = i
+                            break
 
-            if current_stage_index is None:
-                return None
-
-            active_stage_index = (
-                task_crd.spec.currentStage
-                if task_crd.spec.currentStage is not None
-                else 0
-            )
-            if current_stage_index != active_stage_index:
+            if (
+                subtask_stage_index is not None
+                and subtask_stage_index != current_stage_index
+            ):
                 logger.info(
                     "[PipelineStrategy] Skip stale auto-advance for task %s: "
                     "subtask_stage=%s, currentStage=%s",
                     task_id,
+                    subtask_stage_index,
                     current_stage_index,
-                    active_stage_index,
                 )
                 return None
 
             # Check requireConfirmation on current stage
             current_member = members[current_stage_index]
             if current_member.requireConfirmation:
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: confirmation required "
+                    "task=%s stage=%s",
+                    task_id,
+                    current_stage_index,
+                )
                 return None
 
             # Check if a next stage exists
             next_stage_index = current_stage_index + 1
             if next_stage_index >= len(members):
+                logger.info(
+                    "[PipelineStrategy] Auto-advance skipped: pipeline complete "
+                    "task=%s stage=%s total=%s",
+                    task_id,
+                    current_stage_index,
+                    len(members),
+                )
                 return None
 
             # Fetch next stage bot

--- a/backend/tests/services/adapters/test_collaboration_strategy.py
+++ b/backend/tests/services/adapters/test_collaboration_strategy.py
@@ -280,6 +280,55 @@ class TestPipelineAutoAdvance:
 
         assert result["context_passing"] == "previous_bot"
 
+    def test_auto_advance_uses_task_current_stage_as_source_of_truth(self):
+        """Auto advance should not infer stage from completed subtask bot metadata."""
+        strategy = self._make_strategy()
+        db = _make_db()
+
+        bot_2 = _make_bot(30, "bot-2")
+        members = [
+            _make_member("bot-0"),
+            _make_member("bot-1", context_passing="previous_bot"),
+            _make_member("bot-2"),
+        ]
+
+        subtask = _make_subtask(bot_id=10)
+
+        task_resource = MagicMock()
+        task_resource.user_id = 1
+        task_resource.json = {}
+        task_crd = _make_task_crd(current_stage=1)
+        team_crd = _make_team_crd(members)
+        team_resource = MagicMock()
+        team_resource.user_id = 1
+        team_resource.json = {}
+
+        db.query.return_value.filter.return_value.first.return_value = team_resource
+
+        with (
+            patch.object(strategy, "_should_require_confirmation", return_value=False),
+            patch("app.schemas.kind.Task") as mock_task_schema,
+            patch("app.schemas.kind.Team") as mock_team_schema,
+            patch("app.stores.tasks.subtask_store.get_by_id", return_value=subtask),
+            patch(
+                "app.stores.tasks.task_store.get_regular_active_task",
+                return_value=task_resource,
+            ),
+            patch("app.services.readers.kinds.kindReader") as mock_reader,
+        ):
+            mock_task_schema.model_validate.return_value = task_crd
+            mock_team_schema.model_validate.return_value = team_crd
+            mock_reader.get_by_id.return_value = _make_bot(10, "stale-bot-ref")
+            mock_reader.get_by_name_and_namespace.return_value = bot_2
+            result = strategy.get_auto_advance_info(db, 1, 1, "COMPLETED")
+
+        assert result == {
+            "next_stage_index": 2,
+            "next_bot_id": 30,
+            "next_bot_name": "bot-2",
+            "context_passing": "previous_bot",
+        }
+
     def test_auto_advance_via_patched_imports(self):
         """Stage 0 completes, requireConfirmation=False, stage 1 exists -> advance."""
         strategy = self._make_strategy()


### PR DESCRIPTION
## Summary

- Fix pipeline auto-advance to use `task.spec.currentStage` as the stage source of truth.
- Keep stale callback protection when the completed subtask can still be matched to an older stage.
- Add regression coverage for online-style data where subtask bot metadata cannot reliably infer the active stage.

## Root Cause

The auto-advance strategy could silently return `None` by inferring the current stage from completed subtask bot metadata. That worked locally but could fail online when the task already had the correct `currentStage` while the subtask metadata was insufficient or stale for stage inference.

## Validation

- `uv run pytest tests/services/adapters/test_collaboration_strategy.py -q`
- `uv run pytest tests/services/chat/storage/test_pipeline_auto_advance_intent.py tests/services/chat/storage/test_pipeline_context_passing.py tests/services/chat/storage/test_task_manager.py tests/services/execution/test_status_updating_emitter.py -q`
- `uv run black --check app/services/adapters/collaboration_strategy.py tests/services/adapters/test_collaboration_strategy.py`
- `uv run isort --check-only --diff app/services/adapters/collaboration_strategy.py tests/services/adapters/test_collaboration_strategy.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced pipeline auto-advance robustness with improved validation and error handling for edge cases such as missing data or stale references.

* **Tests**
  * Added comprehensive test coverage for pipeline auto-advance functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->