### PR TITLE
[codex] normalize pipeline completed text value

### DIFF
--- a/backend/app/services/chat/trigger/lifecycle.py
+++ b/backend/app/services/chat/trigger/lifecycle.py
@@ -80,6 +80,32 @@ def _merge_blocks(
     return merged
 
 
+def _is_blank_text_value(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return not value.strip()
+    return False
+
+
+def _extract_text_value_from_blocks(blocks: Any) -> str:
+    if not isinstance(blocks, list):
+        return ""
+
+    text_parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        content = block.get("content")
+        if not isinstance(content, str) or not content.strip():
+            content = block.get("text")
+        if isinstance(content, str) and content.strip():
+            text_parts.append(content.strip())
+    return "\n".join(text_parts)
+
+
 def _load_team_crd(team: Kind) -> Optional[Team]:
     """Best-effort load of Team CRD from ORM or lightweight test doubles."""
     team_json = getattr(team, "json", None)
@@ -411,11 +437,6 @@ async def collect_completed_result(
         ):
             final_result[key] = value
 
-    if final_result.get("value") is None and (
-        normalized_status == "COMPLETED" or accumulated_content
-    ):
-        final_result["value"] = accumulated_content
-
     if blocks:
         merged_blocks = _merge_blocks(final_result.get("blocks"), blocks)
         if merged_blocks:
@@ -426,6 +447,16 @@ async def collect_completed_result(
             normalized_status.lower(),
             subtask_id,
         )
+
+    if _is_blank_text_value(final_result.get("value")) and (
+        normalized_status == "COMPLETED" or accumulated_content.strip()
+    ):
+        text_value = (
+            accumulated_content
+            if accumulated_content.strip()
+            else _extract_text_value_from_blocks(final_result.get("blocks"))
+        )
+        final_result["value"] = text_value
 
     if normalized_status == "FAILED" and error_code:
         final_result["error_type"] = error_code

--- a/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
+++ b/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
@@ -37,6 +37,21 @@ class _SessionManager:
         ]
 
 
+class _TextBlockSessionManager:
+    async def get_accumulated_content(self, _subtask_id: int) -> str:
+        return ""
+
+    async def finalize_and_get_blocks(self, _subtask_id: int) -> list[dict]:
+        return [
+            {
+                "id": "text-1",
+                "type": "text",
+                "content": "Stage 1 found three release risks.",
+                "status": "done",
+            }
+        ]
+
+
 @pytest.mark.asyncio
 async def test_collect_completed_result_merges_duplicate_block_fields(monkeypatch):
     async def _empty_existing_result(_subtask_id: int) -> dict:
@@ -134,3 +149,30 @@ async def test_collect_completed_result_preserves_file_changes_with_blocks(monke
     assert result["value"] == "done"
     assert result["blocks"]
     assert result["file_changes"]["file_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_collect_completed_result_normalizes_empty_value_from_text_blocks(
+    monkeypatch,
+):
+    async def _empty_existing_result(_subtask_id: int) -> dict:
+        return {}
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_existing_subtask_result",
+        _empty_existing_result,
+    )
+
+    import app.services.chat.storage as chat_storage
+
+    monkeypatch.setattr(chat_storage, "session_manager", _TextBlockSessionManager())
+
+    result = await lifecycle.collect_completed_result(
+        1234,
+        status="COMPLETED",
+        result={"value": ""},
+    )
+
+    assert result is not None
+    assert result["value"] == "Stage 1 found three release risks."


### PR DESCRIPTION
## Summary

- Normalize completed execution results so an empty `result.value` is populated from finalized text blocks when accumulated streaming text is unavailable.
- Keep pipeline context passing on the normal `result.value` path instead of teaching context consumers to inspect block internals.
- Add lifecycle regression coverage for online-style completed results where visible assistant output exists only in text blocks.

## Root Cause

Online callback handling can finalize visible assistant output into `result.blocks` while `result.value` remains empty, especially across callback/streaming state boundaries. Pipeline auto-advance then correctly creates the next user handoff message, but the handoff text is blank because the completed result was not normalized at the lifecycle boundary.

## Block Handling

- `text` blocks may be used to populate `result.value` only when the standard text value is blank.
- `thinking` blocks remain in `result.blocks` for UI display and are not sent as pipeline handoff text.
- `tool` blocks remain in `result.blocks` for UI/tool state and are not sent as pipeline handoff text.

## Validation

- `uv run pytest tests/services/chat/trigger/test_lifecycle_completed_result.py tests/services/chat/storage/test_pipeline_context_passing.py tests/services/adapters/test_collaboration_strategy.py tests/services/chat/storage/test_pipeline_auto_advance_intent.py tests/services/chat/storage/test_task_manager.py tests/services/execution/test_status_updating_emitter.py -q`
- `uv run black --check app/services/chat/trigger/lifecycle.py tests/services/chat/trigger/test_lifecycle_completed_result.py`
- `uv run isort --check-only --diff app/services/chat/trigger/lifecycle.py tests/services/chat/trigger/test_lifecycle_completed_result.py`
- `git diff --check`
- `uv run pytest -q` (`2900 passed, 1 skipped`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result value population in chat completions to more robustly handle empty values, now normalizing them to extracted text content from available blocks when accumulated content is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->