### PR TITLE
[codex] include output text blocks in pipeline handoff

### DIFF
--- a/backend/app/services/chat/trigger/lifecycle.py
+++ b/backend/app/services/chat/trigger/lifecycle.py
@@ -96,7 +96,7 @@ def _extract_text_value_from_blocks(blocks: Any) -> str:
     for block in blocks:
         if not isinstance(block, dict):
             continue
-        if block.get("type") != "text":
+        if block.get("type") not in {"text", "output_text"}:
             continue
         content = block.get("content")
         if not isinstance(content, str) or not content.strip():

--- a/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
+++ b/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
@@ -52,6 +52,31 @@ class _TextBlockSessionManager:
         ]
 
 
+class _OutputTextBlockSessionManager:
+    async def get_accumulated_content(self, _subtask_id: int) -> str:
+        return ""
+
+    async def finalize_and_get_blocks(self, _subtask_id: int) -> list[dict]:
+        return [
+            {
+                "id": "reasoning-1",
+                "type": "reasoning",
+                "text": "Private reasoning should not be handed off.",
+            },
+            {
+                "id": "output-1",
+                "type": "output_text",
+                "text": "Visible assistant answer.",
+            },
+            {
+                "id": "tool-1",
+                "type": "tool",
+                "tool_name": "Example",
+                "tool_output": "Tool output should not be handed off.",
+            },
+        ]
+
+
 @pytest.mark.asyncio
 async def test_collect_completed_result_merges_duplicate_block_fields(monkeypatch):
     async def _empty_existing_result(_subtask_id: int) -> dict:
@@ -176,3 +201,32 @@ async def test_collect_completed_result_normalizes_empty_value_from_text_blocks(
 
     assert result is not None
     assert result["value"] == "Stage 1 found three release risks."
+
+
+@pytest.mark.asyncio
+async def test_collect_completed_result_normalizes_empty_value_from_output_text_blocks(
+    monkeypatch,
+):
+    async def _empty_existing_result(_subtask_id: int) -> dict:
+        return {}
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_existing_subtask_result",
+        _empty_existing_result,
+    )
+
+    import app.services.chat.storage as chat_storage
+
+    monkeypatch.setattr(
+        chat_storage, "session_manager", _OutputTextBlockSessionManager()
+    )
+
+    result = await lifecycle.collect_completed_result(
+        1234,
+        status="COMPLETED",
+        result={"value": ""},
+    )
+
+    assert result is not None
+    assert result["value"] == "Visible assistant answer."


### PR DESCRIPTION
## Summary

- Normalize completed pipeline stage output from both internal `text` blocks and Responses API `output_text` blocks.
- Keep reasoning/thinking and tool blocks out of the handoff text.
- Add coverage for a completed result where visible assistant output is only present as `output_text` blocks.

## Root Cause

Production callbacks show the first pipeline stage streaming visible content through `response.output_text.delta`, then finalizing with completed blocks. The previous normalization only extracted visible text from internal `type: "text"` blocks, so a completed result could keep `value` blank even though the UI streamed visible assistant text. Pipeline handoff then built `previous_bot` context from `result.value`, so the generated user message for the next bot could be empty.

## Validation

- Added a failing regression case for `output_text` blocks, then fixed it.
- Ran focused lifecycle tests and related pipeline/storage/execution tests before the latest request:
  - `tests/services/chat/trigger/test_lifecycle_completed_result.py`
  - `tests/services/chat/storage/test_pipeline_context_passing.py`
  - `tests/services/adapters/test_collaboration_strategy.py`
  - `tests/services/chat/storage/test_pipeline_auto_advance_intent.py`
  - `tests/services/chat/storage/test_task_manager.py`
  - `tests/services/execution/test_status_updating_emitter.py`
  - `tests/services/execution/test_extract_completed_result.py`
- Formatting checks passed for the touched files.

Per request, I did not run additional tests before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text extraction logic to properly recognize and process additional content block types in chat messages.
  * Improved value normalization to correctly fallback to visible content from alternative block types when values are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->