### PR TITLE
fix(executor): sync mcps to global cli configs

### DIFF
--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -64,6 +64,7 @@ from app.services.adapters.task_kinds import task_kinds_service
 from app.services.adapters.wework_conversation_search import (
     search_wework_conversation_tasks,
 )
+from app.services.chat.access import get_active_streaming
 from app.services.chat.storage import session_manager
 from app.services.remote_workspace_service import remote_workspace_service
 from app.services.shared_task import shared_task_service
@@ -354,18 +355,19 @@ async def get_task_runtime_check(
     )
 
     active_stream = None
-    streaming_status = await session_manager.get_task_streaming_status(task_id)
+    streaming_status = await get_active_streaming(task_id)
     if streaming_status:
         raw_subtask_id = streaming_status.get("subtask_id")
         subtask_id = int(raw_subtask_id) if raw_subtask_id is not None else None
         if subtask_id is not None:
             cached_content = await session_manager.get_streaming_content(subtask_id)
+            raw_last_activity_at = streaming_status.get("last_activity_at")
             active_stream = TaskRuntimeActiveStream(
                 subtask_id=subtask_id,
                 cursor=len(cached_content or ""),
                 last_activity_at=(
-                    datetime.fromisoformat(streaming_status["last_activity_at"])
-                    if streaming_status.get("last_activity_at")
+                    datetime.fromisoformat(raw_last_activity_at)
+                    if raw_last_activity_at
                     else None
                 ),
             )

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -72,6 +72,21 @@ class StatusUpdatingEmitter(ResultEmitter):
         self._executor_namespace = executor_namespace
         self._status_updated = False
 
+    async def _mark_streaming_started(self) -> None:
+        """Initialize task-level streaming status for refresh recovery."""
+        from app.services.chat.storage import session_manager
+
+        await session_manager.set_task_streaming_status(
+            task_id=self._task_id,
+            subtask_id=self._subtask_id,
+            user_id=0,
+            username="",
+        )
+        logger.info(
+            f"[StatusUpdatingEmitter] Set task streaming status: "
+            f"task_id={self._task_id}, subtask_id={self._subtask_id}"
+        )
+
     def _resolve_owner_user_id(self) -> Optional[int]:
         from app.db.session import SessionLocal
         from app.models.task import TaskResource
@@ -102,16 +117,7 @@ class StatusUpdatingEmitter(ResultEmitter):
         # Handle START event - set task streaming status for page refresh recovery
         if event.type == EventType.START.value:
             # Set task-level streaming status so get_active_streaming can find it
-            await session_manager.set_task_streaming_status(
-                task_id=self._task_id,
-                subtask_id=self._subtask_id,
-                user_id=0,  # Will be updated if needed
-                username="",
-            )
-            logger.info(
-                f"[StatusUpdatingEmitter] Set task streaming status: "
-                f"task_id={self._task_id}, subtask_id={self._subtask_id}"
-            )
+            await self._mark_streaming_started()
         elif event.type in (
             EventType.CHUNK.value,
             EventType.TOOL_START.value,
@@ -217,7 +223,8 @@ class StatusUpdatingEmitter(ResultEmitter):
         message_id: Optional[int] = None,
         **kwargs,
     ) -> None:
-        """Forward start event to wrapped emitter."""
+        """Forward start event and initialize refresh recovery state."""
+        await self._mark_streaming_started()
         await self._wrapped.emit_start(task_id, subtask_id, message_id, **kwargs)
 
     async def emit_chunk(

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -10,6 +10,37 @@ from shared.models import EventType, ExecutionEvent
 
 
 @pytest.mark.asyncio
+async def test_emit_start_initializes_task_streaming_status():
+    """emit_start should match START events for refresh recovery."""
+    from app.services.execution.emitters import StatusUpdatingEmitter
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    mock_session_manager = AsyncMock()
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit_start(
+            task_id=101,
+            subtask_id=202,
+            message_id=303,
+            data={"shell_type": "ClaudeCode"},
+        )
+
+    mock_session_manager.set_task_streaming_status.assert_awaited_once_with(
+        task_id=101,
+        subtask_id=202,
+        user_id=0,
+        username="",
+    )
+    wrapped.emit_start.assert_awaited_once_with(
+        101,
+        202,
+        303,
+        data={"shell_type": "ClaudeCode"},
+    )
+
+
+@pytest.mark.asyncio
 async def test_emit_error_persists_partial_result_and_blocks():
     """FAILED subtasks should keep partial output generated before the error."""
     from app.services.execution.emitters import StatusUpdatingEmitter

--- a/backend/tests/services/test_task_runtime_check.py
+++ b/backend/tests/services/test_task_runtime_check.py
@@ -1,5 +1,10 @@
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+import pytest
+
+from app.api.endpoints.adapter import tasks as task_endpoints
 from app.schemas.task import (
     TaskRuntimeActiveStream,
     TaskRuntimeCheck,
@@ -38,3 +43,46 @@ def test_runtime_check_schema_allows_no_active_stream():
 
     assert response["task_status"] == "COMPLETED"
     assert response["active_stream"] is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_check_uses_active_streaming_fallback(monkeypatch):
+    """runtime-check should recover active streams through the shared helper."""
+    monkeypatch.setattr(
+        task_endpoints.task_kinds_service,
+        "get_task_by_id",
+        lambda db, task_id, user_id: {
+            "id": task_id,
+            "status": "RUNNING",
+            "updated_at": datetime(2026, 6, 1, 10, 0, 0),
+        },
+    )
+    get_active_streaming = AsyncMock(
+        return_value={
+            "subtask_id": 77,
+            "user_id": 7,
+            "started_at": "2026-06-01T10:00:00",
+        }
+    )
+    monkeypatch.setattr(
+        task_endpoints,
+        "get_active_streaming",
+        get_active_streaming,
+    )
+    monkeypatch.setattr(
+        task_endpoints.session_manager,
+        "get_streaming_content",
+        AsyncMock(return_value="running output"),
+    )
+
+    response = await task_endpoints.get_task_runtime_check(
+        task_id=42,
+        current_user=SimpleNamespace(id=7),
+        db=object(),
+    )
+
+    get_active_streaming.assert_awaited_once_with(42)
+    assert response.active_stream is not None
+    assert response.active_stream.subtask_id == 77
+    assert response.active_stream.cursor == len("running output")
+    assert response.active_stream.last_activity_at is None

--- a/docs/en/developer-guide/local-device-architecture.md
+++ b/docs/en/developer-guide/local-device-architecture.md
@@ -196,11 +196,13 @@ Backend can send desired global capability state to an online local device throu
 
 - `skills`: backend-resolved `InstalledSkill` / `Skill` entries, downloaded by the executor into `~/.claude/skills`
 - `plugins`: backend-resolved `InstalledPlugin` entries, written by the executor into `~/.claude/plugins/installed_plugins.json`
-- `mcps`: backend-resolved `InstalledMCP` entries, written into the Wegent-managed manifest
+- `mcps`: backend-resolved `InstalledMCP` entries, written into the Wegent-managed manifest and synced into Claude Code `~/.claude.json` and Codex `~/.codex/config.toml`
 
 In `replace` mode, the executor only removes capabilities marked as `managed` in the Wegent manifest and missing from the desired state. Plugins installed directly by the user on the local machine are not removed by a Wegent sync.
 
-When a project task runs through the local executor, its task-level `CLAUDE_CONFIG_DIR` exposes both global `skills` and `plugins` directories and inherits non-sensitive plugin settings such as `enabledPlugins` and `extraKnownMarketplaces` from the local `~/.claude/settings.json`. This lets Claude Code load global Skills and Skills provided by Plugins. Sensitive model and token configuration is still injected through runtime environment variables and is not copied from global settings into the task directory.
+When a project task runs through the local executor, including a new conversation workspace task with `standalone_chat_workspace=true`, its task-level `CLAUDE_CONFIG_DIR` exposes both global `skills` and `plugins` directories and inherits non-sensitive plugin settings such as `enabledPlugins` and `extraKnownMarketplaces` from the local `~/.claude/settings.json`. This lets Claude Code load global Skills and Skills provided by Plugins. Claude Code and Codex read MCP servers from their respective global config files instead of receiving bot/skill MCP definitions through per-task parameters. Sensitive model and token configuration is still injected through runtime environment variables and is not copied from global settings into the task directory.
+
+Project tasks persist the current `capabilities.revision` alongside Claude session IDs and Codex thread IDs. If global capability sync changes the revision, the next execution discards the old session/thread and starts a new one so Claude Code and Codex reload the latest global MCP configuration at startup.
 
 ---
 

--- a/docs/zh/developer-guide/local-device-architecture.md
+++ b/docs/zh/developer-guide/local-device-architecture.md
@@ -196,11 +196,13 @@ Plugin 上报必须包含其内部 Skill 列表。Executor 会扫描每个 Plugi
 
 - `skills`：通过 backend 解析后的 `InstalledSkill` / `Skill`，由 executor 下载到 `~/.claude/skills`
 - `plugins`：通过 backend 解析后的 `InstalledPlugin`，由 executor 写入 `~/.claude/plugins/installed_plugins.json`
-- `mcps`：通过 backend 解析后的 `InstalledMCP`，由 executor 写入 Wegent 管理清单
+- `mcps`：通过 backend 解析后的 `InstalledMCP`，由 executor 写入 Wegent 管理清单，并同步到 Claude Code 的 `~/.claude.json` 与 Codex 的 `~/.codex/config.toml`
 
 `replace` 模式只会清理由 Wegent manifest 标记为 `managed` 且不在期望状态中的能力。用户直接在本机安装的 plugin 不会因为一次 Wegent 同步被删除。
 
-项目任务使用本地 executor 执行时，任务级 `CLAUDE_CONFIG_DIR` 会同时暴露全局 `skills` 和 `plugins` 目录，并从本机 `~/.claude/settings.json` 继承 `enabledPlugins`、`extraKnownMarketplaces` 等非敏感插件配置，使 Claude Code 能加载全局 Skill 以及 Plugin 内部提供的 Skill。模型、Token 等敏感配置仍通过运行时环境变量注入，不会从全局 settings 写入任务目录。
+项目任务使用本地 executor 执行时，包括带 `standalone_chat_workspace=true` 的新对话工作区任务。任务级 `CLAUDE_CONFIG_DIR` 会同时暴露全局 `skills` 和 `plugins` 目录，并从本机 `~/.claude/settings.json` 继承 `enabledPlugins`、`extraKnownMarketplaces` 等非敏感插件配置，使 Claude Code 能加载全局 Skill 以及 Plugin 内部提供的 Skill。Claude Code 和 Codex 的 MCP 均从各自全局配置读取，不再把 bot/skill MCP 注入到单次任务参数。模型、Token 等敏感配置仍通过运行时环境变量注入，不会从全局 settings 写入任务目录。
+
+项目任务保存 Claude session ID 和 Codex thread ID 时会记录当前 `capabilities.revision`。如果全局能力同步导致 revision 变化，下一次执行会丢弃旧 session/thread 并新建会话，确保 Claude Code 和 Codex 在启动时重新读取最新全局 MCP 配置。
 
 ---
 

--- a/executor/agents/claude_code/claude_code_agent.py
+++ b/executor/agents/claude_code/claude_code_agent.py
@@ -1053,9 +1053,21 @@ class ClaudeCodeAgent(Agent):
             )
         elif "resume" not in self.options:
             # Load session ID for this specific bot (pipeline mode: each bot has its own session file)
-            saved_session_id = SessionManager.load_saved_session_id(
-                self.task_id, self._bot_id
+            from executor.modes.local.capabilities import (
+                get_project_capability_revision,
             )
+
+            capability_revision = get_project_capability_revision(self.task_data)
+            if capability_revision is None:
+                saved_session_id = SessionManager.load_saved_session_id(
+                    self.task_id, self._bot_id
+                )
+            else:
+                saved_session_id = SessionManager.load_saved_session_id(
+                    self.task_id,
+                    self._bot_id,
+                    capability_revision=capability_revision,
+                )
             if saved_session_id:
                 logger.info(
                     f"Resuming Claude session for task {self.task_id} "

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -359,6 +359,9 @@ def _remove_task_level_mcp_config(bot_config: dict[str, Any]) -> None:
 
 
 def _is_wework_project_task(task_data: ExecutionRequest) -> bool:
+    if getattr(task_data, "standalone_chat_workspace", False):
+        return True
+
     project_id = getattr(task_data, "project_id", None)
     if project_id and int(project_id) > 0:
         return True

--- a/executor/agents/claude_code/config_manager.py
+++ b/executor/agents/claude_code/config_manager.py
@@ -344,37 +344,36 @@ def _collect_mcp_servers_for_claude(
                 continue
             mcp_servers = bot.get("mcp_servers") or bot.get("mcpServers")
             _append_mcp_servers(collected, mcp_servers, f"bot[{index}]")
-        _append_global_mcp_servers(collected)
         return collected
 
     mcp_servers = primary_bot_config.get("mcp_servers") or primary_bot_config.get(
         "mcpServers"
     )
     _append_mcp_servers(collected, mcp_servers, "bot[0]")
-    _append_global_mcp_servers(collected)
     return collected
 
 
-def _append_global_mcp_servers(target: list[dict[str, Any]]) -> None:
-    """Append MCP servers synced to this local device."""
-    try:
-        from executor.modes.local.capabilities import GlobalCapabilityStore
+def _remove_task_level_mcp_config(bot_config: dict[str, Any]) -> None:
+    for key in ("mcp_servers", "mcpServers", "mcp_tools"):
+        bot_config.pop(key, None)
 
-        manifest = GlobalCapabilityStore().load()
-    except Exception as exc:
-        logger.warning("[MCP] Failed to load global MCP manifest: %s", exc)
-        return
 
-    appended: list[str] = []
-    for name, record in manifest.get("mcps", {}).items():
-        if not isinstance(record, dict):
-            continue
-        server = record.get("server") or {}
-        if not isinstance(server, dict):
-            continue
-        target.append({"name": name, **server})
-        appended.append(name)
-    logger.info("[MCP] Appended global MCP servers: names=%s", appended)
+def _is_wework_project_task(task_data: ExecutionRequest) -> bool:
+    project_id = getattr(task_data, "project_id", None)
+    if project_id and int(project_id) > 0:
+        return True
+
+    workspace = getattr(task_data, "workspace", None)
+    if isinstance(workspace, dict):
+        metadata = workspace.get("metadata") or {}
+        project = metadata.get("project") if isinstance(metadata, dict) else None
+        if isinstance(project, dict) and project.get("project_id"):
+            return True
+
+    task_data_payload = getattr(task_data, "task_data", None)
+    return bool(
+        isinstance(task_data_payload, dict) and task_data_payload.get("project_id")
+    )
 
 
 def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
@@ -427,51 +426,60 @@ def extract_claude_options(task_data: ExecutionRequest) -> Dict[str, Any]:
     if bot_config:
         # Create a shallow copy of bot_config to avoid modifying the original
         bot_config = bot_config.copy()
+        project_task = _is_wework_project_task(task_data)
 
         # Extract MCP servers. Claude Code subagents share the parent SDK
         # session, so coordinate mode must register member bot MCP servers on
         # that same session.
-        logger.info("[MCP] Extracting MCP servers for Claude Code session...")
-        mcp_servers = _collect_mcp_servers_for_claude(task_data, bot_config)
-        if mcp_servers:
-            logger.info(
-                "[MCP] Raw MCP servers for Claude Code: %s",
-                (
-                    list(mcp_servers.keys())
-                    if isinstance(mcp_servers, dict)
-                    else type(mcp_servers).__name__
-                ),
-            )
-            # Replace placeholders in MCP servers config with actual values
-            # NOTE: backend_url override for local mode is handled centrally
-            # in LocalRunner.enqueue_task() before any agent processes the task.
-            logger.info(
-                "[MCP] Variable substitution context: backend_url=%s, task_token=%s",
-                task_data.backend_url,
-                f"{task_data.task_token[:20]}..." if task_data.task_token else "EMPTY",
-            )
-            mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
-            # Convert list format to dict format for Claude Code SDK
-            mcp_servers = _convert_mcp_servers_list_to_dict(mcp_servers)
-            bot_config["mcp_servers"] = mcp_servers
-            # Log detailed MCP server configs for debugging
-            for name, cfg in mcp_servers.items():
-                logger.info(
-                    "[MCP] Server '%s': type=%s, url=%s, headers=%s",
-                    name,
-                    cfg.get("type", "?"),
-                    _redact_mcp_url_for_log(cfg),
-                    list(cfg.get("headers", {}).keys()),
-                )
-            logger.info(
-                "[MCP] MCP servers after processing: %s",
-                list(mcp_servers.keys()),
-            )
+        if project_task:
+            _remove_task_level_mcp_config(bot_config)
+            logger.info("[MCP] Skipping task-level MCP servers for project task")
         else:
-            logger.info("[MCP] No MCP servers configured")
+            logger.info("[MCP] Extracting MCP servers for Claude Code session...")
+            mcp_servers = _collect_mcp_servers_for_claude(task_data, bot_config)
+            if mcp_servers:
+                logger.info(
+                    "[MCP] Raw MCP servers for Claude Code: %s",
+                    (
+                        list(mcp_servers.keys())
+                        if isinstance(mcp_servers, dict)
+                        else type(mcp_servers).__name__
+                    ),
+                )
+                # Replace placeholders in MCP servers config with actual values
+                # NOTE: backend_url override for local mode is handled centrally
+                # in LocalRunner.enqueue_task() before any agent processes the task.
+                logger.info(
+                    "[MCP] Variable substitution context: backend_url=%s, task_token=%s",
+                    task_data.backend_url,
+                    (
+                        f"{task_data.task_token[:20]}..."
+                        if task_data.task_token
+                        else "EMPTY"
+                    ),
+                )
+                mcp_servers = replace_mcp_server_variables(mcp_servers, task_data)
+                # Convert list format to dict format for Claude Code SDK
+                mcp_servers = _convert_mcp_servers_list_to_dict(mcp_servers)
+                bot_config["mcp_servers"] = mcp_servers
+                # Log detailed MCP server configs for debugging
+                for name, cfg in mcp_servers.items():
+                    logger.info(
+                        "[MCP] Server '%s': type=%s, url=%s, headers=%s",
+                        name,
+                        cfg.get("type", "?"),
+                        _redact_mcp_url_for_log(cfg),
+                        list(cfg.get("headers", {}).keys()),
+                    )
+                logger.info(
+                    "[MCP] MCP servers after processing: %s",
+                    list(mcp_servers.keys()),
+                )
+            else:
+                logger.info("[MCP] No MCP servers configured")
 
         # Add wegent MCP server for subscription tasks
-        if task_data.is_subscription:
+        if task_data.is_subscription and not project_task:
             wegent_mcp_url = get_wegent_mcp_url()
             wegent_mcp = {
                 "wegent": {

--- a/executor/agents/claude_code/response_processor.py
+++ b/executor/agents/claude_code/response_processor.py
@@ -258,9 +258,17 @@ async def process_response(
                                 from executor.agents.claude_code.session_manager import (
                                     SessionManager,
                                 )
+                                from executor.modes.local.capabilities import (
+                                    get_project_capability_revision,
+                                )
 
                                 SessionManager.save_session_id(
-                                    task_id, msg.session_id, bot_id
+                                    task_id,
+                                    msg.session_id,
+                                    bot_id,
+                                    capability_revision=get_project_capability_revision(
+                                        state_manager.task_data
+                                    ),
                                 )
                             except Exception as save_error:
                                 logger.warning(
@@ -390,9 +398,19 @@ def _handle_system_message(msg: SystemMessage, state_manager, thinking_manager=N
         if task_id:
             try:
                 from executor.agents.claude_code.session_manager import SessionManager
+                from executor.modes.local.capabilities import (
+                    get_project_capability_revision,
+                )
 
                 claude_session_id = msg.data["session_id"]
-                SessionManager.save_session_id(task_id, claude_session_id, bot_id)
+                SessionManager.save_session_id(
+                    task_id,
+                    claude_session_id,
+                    bot_id,
+                    capability_revision=get_project_capability_revision(
+                        state_manager.task_data
+                    ),
+                )
                 logger.info(
                     f"Saved Claude session_id {claude_session_id} from init message for task {task_id} (bot_id={bot_id})"
                 )

--- a/executor/agents/claude_code/session_manager.py
+++ b/executor/agents/claude_code/session_manager.py
@@ -90,13 +90,17 @@ class SessionManager:
 
     @classmethod
     def load_saved_session_id(
-        cls, task_id: int, bot_id: Optional[int] = None
+        cls,
+        task_id: int,
+        bot_id: Optional[int] = None,
+        capability_revision: Optional[int] = None,
     ) -> str | None:
         """Load saved Claude session ID for a task and bot.
 
         Args:
             task_id: Task ID
             bot_id: Bot ID (optional, for pipeline mode)
+            capability_revision: Expected global capability revision for project tasks
 
         Returns:
             Saved session ID or None if not found
@@ -105,7 +109,18 @@ class SessionManager:
         try:
             if os.path.exists(session_file):
                 with open(session_file, "r", encoding="utf-8") as f:
-                    session_id = f.read().strip()
+                    raw_value = f.read().strip()
+                    session_id, saved_revision = cls._parse_session_file(raw_value)
+                    if not cls._capability_revision_matches(
+                        saved_revision, capability_revision
+                    ):
+                        logger.info(
+                            f"Ignoring Claude session for task {task_id} "
+                            f"(bot_id={bot_id}) because capability revision changed: "
+                            f"saved={saved_revision}, current={capability_revision}"
+                        )
+                        cls.delete_saved_session_id(task_id, bot_id)
+                        return None
                     if session_id:
                         logger.info(
                             f"Loaded saved Claude session ID for task {task_id} "
@@ -121,7 +136,11 @@ class SessionManager:
 
     @classmethod
     def save_session_id(
-        cls, task_id: int, claude_session_id: str, bot_id: Optional[int] = None
+        cls,
+        task_id: int,
+        claude_session_id: str,
+        bot_id: Optional[int] = None,
+        capability_revision: Optional[int] = None,
     ) -> None:
         """Save Claude session ID for a task and bot.
 
@@ -129,12 +148,22 @@ class SessionManager:
             task_id: Task ID
             claude_session_id: Claude's actual session ID
             bot_id: Bot ID (optional, for pipeline mode)
+            capability_revision: Global capability revision for project tasks
         """
         session_file = cls.get_session_id_file_path(task_id, bot_id)
         try:
             os.makedirs(os.path.dirname(session_file), exist_ok=True)
             with open(session_file, "w", encoding="utf-8") as f:
-                f.write(claude_session_id)
+                if capability_revision is None:
+                    f.write(claude_session_id)
+                else:
+                    json.dump(
+                        {
+                            "session_id": claude_session_id,
+                            "capability_revision": capability_revision,
+                        },
+                        f,
+                    )
             logger.info(
                 f"Saved Claude session ID for task {task_id} "
                 f"(bot_id={bot_id}): {claude_session_id}"
@@ -143,6 +172,33 @@ class SessionManager:
             logger.warning(
                 f"Failed to save session ID for task {task_id} (bot_id={bot_id}): {e}"
             )
+
+    @staticmethod
+    def _parse_session_file(raw_value: str) -> tuple[str, Optional[int]]:
+        """Parse legacy plain session IDs and revision-aware JSON session files."""
+        if not raw_value:
+            return "", None
+        try:
+            data = json.loads(raw_value)
+        except ValueError:
+            return raw_value, None
+        if not isinstance(data, dict):
+            return raw_value, None
+
+        session_id = str(data.get("session_id") or "")
+        revision = data.get("capability_revision")
+        try:
+            return session_id, int(revision) if revision is not None else None
+        except (TypeError, ValueError):
+            return session_id, None
+
+    @staticmethod
+    def _capability_revision_matches(
+        saved_revision: Optional[int], expected_revision: Optional[int]
+    ) -> bool:
+        if expected_revision is None:
+            return True
+        return saved_revision == expected_revision
 
     @classmethod
     def delete_saved_session_id(

--- a/executor/agents/codex/codex_agent.py
+++ b/executor/agents/codex/codex_agent.py
@@ -246,10 +246,14 @@ class CodeXAgent(Agent):
 
     async def _open_thread(self) -> None:
         assert self.codex_config is not None
+        from executor.modes.local.capabilities import get_project_capability_revision
+
+        capability_revision = get_project_capability_revision(self.task_data)
         thread_id = self._session_store.load(
             self.task_id,
             self._bot_id,
             self.new_session,
+            capability_revision=capability_revision,
         )
         developer_instructions = self._build_developer_instructions()
         thread_kwargs = self._build_thread_kwargs(developer_instructions)
@@ -274,7 +278,12 @@ class CodeXAgent(Agent):
                 **thread_kwargs,
                 service_name="wegent",
             )
-        self._session_store.save(self.task_id, self._bot_id, self._thread.id)
+        self._session_store.save(
+            self.task_id,
+            self._bot_id,
+            self._thread.id,
+            capability_revision=capability_revision,
+        )
 
     def _build_thread_kwargs(self, developer_instructions: str) -> dict[str, Any]:
         from openai_codex import ApprovalMode

--- a/executor/agents/codex/config_builder.py
+++ b/executor/agents/codex/config_builder.py
@@ -94,9 +94,8 @@ def build_codex_config(model_config: dict[str, Any]) -> CodeXConfig:
     proxy_env = _build_runtime_proxy_env(model_config, "codex")
     reasoning = _normalize_reasoning(model_config.get("reasoning"))
     service_tier = _normalize_service_tier(model_config.get("service_tier"))
-    mcp_overrides = _build_global_mcp_config_overrides()
     if local_config:
-        overrides = [f"model={model}", *mcp_overrides]
+        overrides = [f"model={model}"]
         return CodeXConfig(
             codex_bin=_resolve_codex_binary(config.CODEX_BINARY_PATH),
             model=model,
@@ -129,7 +128,6 @@ def build_codex_config(model_config: dict[str, Any]) -> CodeXConfig:
         f"model_providers.{model_provider}.base_url={base_url.rstrip('/')}",
         f"model_providers.{model_provider}.wire_api={wire_api}",
         f"model_providers.{model_provider}.experimental_bearer_token={api_key}",
-        *mcp_overrides,
     ]
 
     return CodeXConfig(
@@ -259,91 +257,6 @@ def _resolve_codex_binary(value: str) -> str:
     if "/" in value or "\\" in value:
         return value
     return shutil.which(value) or value
-
-
-def _build_global_mcp_config_overrides() -> tuple[str, ...]:
-    """Build Codex CLI config overrides from synced global MCP records."""
-    try:
-        from executor.modes.local.capabilities import GlobalCapabilityStore
-
-        manifest = GlobalCapabilityStore().load()
-    except Exception as exc:
-        logger.warning("Failed to load global MCP manifest for Codex: %s", exc)
-        return ()
-
-    overrides: list[str] = []
-    for name, record in sorted((manifest.get("mcps") or {}).items()):
-        if not isinstance(record, dict):
-            continue
-        server = record.get("server") or {}
-        if not isinstance(server, dict):
-            continue
-        overrides.extend(_codex_mcp_server_overrides(str(name), server))
-    if overrides:
-        logger.info("Injected Codex global MCP servers: count=%s", len(overrides))
-    return tuple(overrides)
-
-
-def _codex_mcp_server_overrides(name: str, server: dict[str, Any]) -> list[str]:
-    key = _toml_key_path("mcp_servers", name)
-    server_type = str(server.get("type") or "").strip()
-
-    if server_type == "stdio" or server.get("command"):
-        command = str(server.get("command") or "").strip()
-        if not command:
-            logger.warning("Skipping Codex stdio MCP without command: %s", name)
-            return []
-        overrides = [f"{key}.command={_toml_value(command)}"]
-        args = server.get("args")
-        if isinstance(args, list):
-            overrides.append(f"{key}.args={_toml_value([str(arg) for arg in args])}")
-        env = server.get("env")
-        if isinstance(env, dict):
-            for env_key, env_value in sorted(env.items()):
-                if env_value is None:
-                    continue
-                overrides.append(
-                    f"{key}.env.{_toml_key_segment(str(env_key))}="
-                    f"{_toml_value(str(env_value))}"
-                )
-        return overrides
-
-    url = str(server.get("url") or server.get("base_url") or "").strip()
-    if not url:
-        logger.warning("Skipping Codex URL MCP without URL: %s", name)
-        return []
-
-    overrides = [f"{key}.url={_toml_value(url)}"]
-    bearer_env = server.get("bearer_token_env_var") or server.get("bearerTokenEnvVar")
-    if bearer_env:
-        overrides.append(f"{key}.bearer_token_env_var={_toml_value(str(bearer_env))}")
-    oauth_client_id = server.get("oauth_client_id") or server.get("oauthClientId")
-    if oauth_client_id:
-        overrides.append(f"{key}.oauth_client_id={_toml_value(str(oauth_client_id))}")
-    oauth_resource = server.get("oauth_resource") or server.get("oauthResource")
-    if oauth_resource:
-        overrides.append(f"{key}.oauth_resource={_toml_value(str(oauth_resource))}")
-    return overrides
-
-
-def _toml_key_path(*segments: str) -> str:
-    return ".".join(_toml_key_segment(segment) for segment in segments)
-
-
-def _toml_key_segment(segment: str) -> str:
-    if re.fullmatch(r"[A-Za-z0-9_-]+", segment):
-        return segment
-    return json.dumps(segment)
-
-
-def _toml_value(value: Any) -> str:
-    if isinstance(value, list):
-        return "[" + ",".join(_toml_value(item) for item in value) + "]"
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (int, float)):
-        return str(value)
-    return json.dumps(str(value))
 
 
 def _normalize_reasoning(value: Any) -> dict[str, str]:

--- a/executor/agents/codex/session_store.py
+++ b/executor/agents/codex/session_store.py
@@ -24,7 +24,11 @@ class CodeXSessionStore:
         self.root.mkdir(parents=True, exist_ok=True)
 
     def load(
-        self, task_id: int, bot_id: Optional[int], new_session: bool
+        self,
+        task_id: int,
+        bot_id: Optional[int],
+        new_session: bool,
+        capability_revision: Optional[int] = None,
     ) -> Optional[str]:
         path = self._path(task_id, bot_id)
         if new_session:
@@ -37,12 +41,33 @@ class CodeXSessionStore:
         except (OSError, ValueError) as exc:
             logger.warning("Failed to read Codex session file %s: %s", path, exc)
             return None
+        if not self._capability_revision_matches(
+            data.get("capability_revision"), capability_revision
+        ):
+            logger.info(
+                "Ignoring Codex thread for task_id=%s bot_id=%s because capability "
+                "revision changed: saved=%s current=%s",
+                task_id,
+                bot_id,
+                data.get("capability_revision"),
+                capability_revision,
+            )
+            self.delete(task_id, bot_id)
+            return None
         thread_id = data.get("thread_id")
         return str(thread_id) if thread_id else None
 
-    def save(self, task_id: int, bot_id: Optional[int], thread_id: str) -> None:
+    def save(
+        self,
+        task_id: int,
+        bot_id: Optional[int],
+        thread_id: str,
+        capability_revision: Optional[int] = None,
+    ) -> None:
         path = self._path(task_id, bot_id)
         payload = {"task_id": task_id, "bot_id": bot_id, "thread_id": thread_id}
+        if capability_revision is not None:
+            payload["capability_revision"] = capability_revision
         try:
             path.write_text(json.dumps(payload), encoding="utf-8")
         except OSError as exc:
@@ -58,3 +83,14 @@ class CodeXSessionStore:
     def _path(self, task_id: int, bot_id: Optional[int]) -> Path:
         bot_segment = str(bot_id) if bot_id is not None else "default"
         return self.root / f"task-{task_id}-bot-{bot_segment}.json"
+
+    @staticmethod
+    def _capability_revision_matches(
+        saved_revision: object, expected_revision: Optional[int]
+    ) -> bool:
+        if expected_revision is None:
+            return True
+        try:
+            return int(saved_revision) == expected_revision
+        except (TypeError, ValueError):
+            return False

--- a/executor/modes/local/capabilities.py
+++ b/executor/modes/local/capabilities.py
@@ -68,6 +68,16 @@ def default_codex_plugins_dir() -> Path:
     return Path.home() / ".codex" / "plugins"
 
 
+def default_claude_mcp_config_path() -> Path:
+    """Return the Claude Code user-scoped MCP config file."""
+    return Path.home() / ".claude.json"
+
+
+def default_codex_config_path() -> Path:
+    """Return the Codex global config file."""
+    return Path.home() / ".codex" / "config.toml"
+
+
 def _peer_codex_capability_dir(source_dir: Path, directory_name: str) -> Path:
     root = (
         source_dir.parent.parent
@@ -150,6 +160,97 @@ def _atomic_write_json(
         temp_path.unlink(missing_ok=True)
 
 
+def _atomic_write_text(path: Path, content: str, *, backup: bool = True) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _set_owner_only(path.parent, is_directory=True)
+    if backup and path.exists():
+        backup_path = path.with_suffix(
+            path.suffix + f".bak.{int(datetime.now().timestamp())}"
+        )
+        shutil.copy2(path, backup_path)
+        _set_owner_only(backup_path, is_directory=False)
+
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(content)
+        _set_owner_only(temp_path, is_directory=False)
+        os.replace(temp_path, path)
+        _set_owner_only(path, is_directory=False)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def _read_toml_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        try:
+            import tomllib
+        except ModuleNotFoundError:
+            import tomli as tomllib  # type: ignore[no-redef]
+
+        with path.open("rb") as file:
+            value = tomllib.load(file)
+        return value if isinstance(value, dict) else {}
+    except Exception as exc:
+        logger.warning("Failed to read TOML file %s: %s", path, exc)
+        return {}
+
+
+def _toml_key_segment(segment: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9_-]+", segment):
+        return segment
+    return json.dumps(segment)
+
+
+def _toml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_scalar(item) for item in value) + "]"
+    return json.dumps(str(value))
+
+
+def _toml_sort_key(item: tuple[str, Any]) -> tuple[int, str]:
+    return (1 if isinstance(item[1], dict) else 0, item[0])
+
+
+def _dump_toml(data: dict[str, Any]) -> str:
+    lines: list[str] = []
+
+    def write_table(table: dict[str, Any], path: list[str]) -> None:
+        scalar_items = [
+            (key, value)
+            for key, value in sorted(table.items(), key=_toml_sort_key)
+            if not isinstance(value, dict)
+        ]
+        nested_items = [
+            (key, value)
+            for key, value in sorted(table.items(), key=_toml_sort_key)
+            if isinstance(value, dict)
+        ]
+        if path:
+            if lines and lines[-1] != "":
+                lines.append("")
+            lines.append("[" + ".".join(_toml_key_segment(part) for part in path) + "]")
+        for key, value in scalar_items:
+            if value is None:
+                continue
+            lines.append(f"{_toml_key_segment(key)} = {_toml_scalar(value)}")
+        for key, value in nested_items:
+            if value:
+                write_table(value, [*path, key])
+
+    write_table(data, [])
+    return "\n".join(lines).rstrip() + "\n"
+
+
 @contextmanager
 def _file_lock(path: Path) -> Iterator[None]:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -221,6 +322,8 @@ class GlobalCapabilityStore:
         plugins_dir: Path | None = None,
         codex_skills_dir: Path | None = None,
         codex_plugins_dir: Path | None = None,
+        claude_mcp_config_path: Path | None = None,
+        codex_config_path: Path | None = None,
         store_dir: Path | None = None,
     ):
         self.manifest = manifest or ManagedCapabilityManifest(
@@ -238,6 +341,10 @@ class GlobalCapabilityStore:
             if plugins_dir is None
             else _peer_codex_capability_dir(self.plugins_dir, "plugins")
         )
+        self.claude_mcp_config_path = (
+            claude_mcp_config_path or default_claude_mcp_config_path()
+        )
+        self.codex_config_path = codex_config_path or default_codex_config_path()
         self.store_dir = store_dir or default_store_dir()
         self.skill_store_dir = self.store_dir / "skills"
         self.plugin_store_dir = self.store_dir / "plugins"
@@ -282,6 +389,137 @@ class GlobalCapabilityStore:
                 manifest.setdefault("plugins", {}).update(plugins)
             manifest.setdefault("mcps", {}).update(mcps)
             self.manifest.save(self.manifest.bump_revision(manifest))
+
+    def sync_global_mcp_configs(
+        self,
+        *,
+        mcps: dict[str, dict[str, Any]],
+        remove_managed_names: set[str] | None = None,
+    ) -> None:
+        """Write synced MCP servers into Claude Code and Codex global configs."""
+        remove_names = remove_managed_names or set()
+        if not mcps and not remove_names:
+            return
+        self._sync_claude_mcp_config(mcps=mcps, remove_names=remove_names)
+        self._sync_codex_mcp_config(mcps=mcps, remove_names=remove_names)
+
+    def _sync_claude_mcp_config(
+        self,
+        *,
+        mcps: dict[str, dict[str, Any]],
+        remove_names: set[str],
+    ) -> None:
+        config = _read_json_file(self.claude_mcp_config_path, {})
+        servers = config.get("mcpServers")
+        if not isinstance(servers, dict):
+            servers = {}
+
+        for name in remove_names:
+            servers.pop(name, None)
+        for name, record in sorted(mcps.items()):
+            server = record.get("server") if isinstance(record, dict) else None
+            if not isinstance(server, dict):
+                continue
+            normalized = self._normalize_claude_mcp_server(server)
+            if normalized:
+                servers[name] = normalized
+
+        if servers:
+            config["mcpServers"] = servers
+        else:
+            config.pop("mcpServers", None)
+        _atomic_write_json(self.claude_mcp_config_path, config)
+
+    def _sync_codex_mcp_config(
+        self,
+        *,
+        mcps: dict[str, dict[str, Any]],
+        remove_names: set[str],
+    ) -> None:
+        config = _read_toml_file(self.codex_config_path)
+        servers = config.get("mcp_servers")
+        if not isinstance(servers, dict):
+            servers = {}
+
+        for name in remove_names:
+            servers.pop(name, None)
+        for name, record in sorted(mcps.items()):
+            server = record.get("server") if isinstance(record, dict) else None
+            if not isinstance(server, dict):
+                continue
+            normalized = self._normalize_codex_mcp_server(server)
+            if normalized:
+                servers[name] = normalized
+
+        if servers:
+            config["mcp_servers"] = servers
+        else:
+            config.pop("mcp_servers", None)
+        _atomic_write_text(self.codex_config_path, _dump_toml(config))
+
+    def _normalize_claude_mcp_server(self, server: dict[str, Any]) -> dict[str, Any]:
+        config = dict(server)
+        server_type = str(config.get("type") or "").strip()
+        if server_type == "streamable-http":
+            server_type = "http"
+            config["type"] = "http"
+
+        if server_type in {"http", "sse"}:
+            url = config.get("url") or config.get("base_url")
+            normalized: dict[str, Any] = {"type": server_type}
+            if url:
+                normalized["url"] = url
+            headers = config.get("headers")
+            if isinstance(headers, dict) and headers:
+                normalized["headers"] = headers
+            return normalized
+
+        if server_type == "stdio" or config.get("command"):
+            normalized = {"type": "stdio"}
+            for key in ("command", "args", "env"):
+                if config.get(key) is not None:
+                    normalized[key] = config[key]
+            return normalized
+
+        return config
+
+    def _normalize_codex_mcp_server(self, server: dict[str, Any]) -> dict[str, Any]:
+        server_type = str(server.get("type") or "").strip()
+        if server_type == "stdio" or server.get("command"):
+            command = str(server.get("command") or "").strip()
+            if not command:
+                logger.warning("Skipping Codex stdio MCP without command")
+                return {}
+            normalized: dict[str, Any] = {"command": command}
+            args = server.get("args")
+            if isinstance(args, list):
+                normalized["args"] = [str(arg) for arg in args]
+            env = server.get("env")
+            if isinstance(env, dict):
+                normalized["env"] = {
+                    str(key): str(value)
+                    for key, value in sorted(env.items())
+                    if value is not None
+                }
+            return normalized
+
+        url = str(server.get("url") or server.get("base_url") or "").strip()
+        if not url:
+            logger.warning("Skipping Codex URL MCP without URL")
+            return {}
+        normalized = {"url": url}
+        optional_fields = {
+            "bearer_token_env_var": server.get("bearer_token_env_var")
+            or server.get("bearerTokenEnvVar"),
+            "oauth_client_id": server.get("oauth_client_id")
+            or server.get("oauthClientId"),
+            "oauth_resource": server.get("oauth_resource")
+            or server.get("oauthResource"),
+        }
+        for key, value in optional_fields.items():
+            if value:
+                normalized[key] = str(value)
+        return normalized
 
     def remove_stale_managed_skills(self, desired_names: set[str]) -> list[str]:
         with _file_lock(self._lock_path):
@@ -925,6 +1163,11 @@ class CapabilitySyncHandler:
         mcp_results, mcp_records = self._sync_mcps(mcps)
 
         before_manifest = self.store.manifest.load()
+        old_managed_mcp_names = {
+            name
+            for name, record in (before_manifest.get("mcps") or {}).items()
+            if isinstance(record, dict) and record.get("managed", True)
+        }
         logger.info(
             "Persisting capability manifest: mode=%s old_skills=%s new_skills=%s old_plugins=%s new_plugins=%s old_mcps=%s new_mcps=%s",
             mode,
@@ -948,6 +1191,27 @@ class CapabilitySyncHandler:
                 mcps=mcp_records,
             )
 
+        mcp_config_errors: list[dict[str, Any]] = []
+        try:
+            stale_mcp_names = (
+                old_managed_mcp_names - set(mcp_records.keys())
+                if mode == "replace"
+                else set()
+            )
+            self.store.sync_global_mcp_configs(
+                mcps=mcp_records,
+                remove_managed_names=stale_mcp_names,
+            )
+        except Exception as exc:
+            logger.exception("Failed to sync MCP global config files")
+            mcp_config_errors.append(
+                {
+                    "name": "global-mcp-config",
+                    "status": "failed",
+                    "error": str(exc),
+                }
+            )
+
         manifest = self.store.manifest.load()
         manifest["last_sync_at"] = utc_now_iso()
         self.store.manifest.save(self.store.manifest.bump_revision(manifest))
@@ -956,7 +1220,7 @@ class CapabilitySyncHandler:
         if self.reporter:
             self.reporter.force_next_full_report()
 
-        results = skill_results + plugin_results + mcp_results
+        results = skill_results + plugin_results + mcp_results + mcp_config_errors
         errors = [item for item in results if item.get("status") == "failed"]
         logger.info(
             "Capability sync applied: success=%s mode=%s installed_skills=%s installed_plugins=%s configured_mcps=%s removed_skills=%s removed_plugins=%s errors=%s",

--- a/executor/modes/local/capabilities.py
+++ b/executor/modes/local/capabilities.py
@@ -109,6 +109,19 @@ def is_project_task(task_data: ExecutionRequest) -> bool:
     )
 
 
+def get_project_capability_revision(task_data: ExecutionRequest) -> int | None:
+    """Return current global capability revision for project tasks only."""
+    if not is_project_task(task_data):
+        return None
+
+    try:
+        revision = ManagedCapabilityManifest().load().get("revision")
+        return int(revision) if revision is not None else 0
+    except Exception as exc:
+        logger.warning("Failed to read global capability revision: %s", exc)
+        return None
+
+
 def _read_json_file(path: Path, default: dict[str, Any]) -> dict[str, Any]:
     if not path.exists():
         return default.copy()

--- a/executor/tests/agents/test_capability_session_revision.py
+++ b/executor/tests/agents/test_capability_session_revision.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from executor.agents.claude_code.session_manager import SessionManager
+from executor.agents.codex.session_store import CodeXSessionStore
+
+
+def test_claude_session_is_invalidated_when_capability_revision_changes(tmp_path):
+    SessionManager.set_task_session_root(1001, str(tmp_path / "sessions"))
+    try:
+        SessionManager.save_session_id(
+            1001,
+            "claude-session-old",
+            bot_id=2002,
+            capability_revision=1,
+        )
+
+        assert (
+            SessionManager.load_saved_session_id(
+                1001,
+                bot_id=2002,
+                capability_revision=1,
+            )
+            == "claude-session-old"
+        )
+        assert (
+            SessionManager.load_saved_session_id(
+                1001,
+                bot_id=2002,
+                capability_revision=2,
+            )
+            is None
+        )
+    finally:
+        SessionManager.set_task_session_root(1001, None)
+
+
+def test_codex_thread_is_invalidated_when_capability_revision_changes(tmp_path):
+    store = CodeXSessionStore(root=tmp_path / "codex")
+    store.save(
+        task_id=1001,
+        bot_id=2002,
+        thread_id="codex-thread-old",
+        capability_revision=1,
+    )
+
+    assert (
+        store.load(
+            task_id=1001,
+            bot_id=2002,
+            new_session=False,
+            capability_revision=1,
+        )
+        == "codex-thread-old"
+    )
+    assert (
+        store.load(
+            task_id=1001,
+            bot_id=2002,
+            new_session=False,
+            capability_revision=2,
+        )
+        is None
+    )

--- a/executor/tests/agents/test_codex_config_builder.py
+++ b/executor/tests/agents/test_codex_config_builder.py
@@ -130,7 +130,7 @@ def test_build_codex_config_uses_existing_no_proxy(monkeypatch):
     assert config.env["no_proxy"] == "localhost,.internal"
 
 
-def test_build_codex_config_injects_global_mcp_overrides(tmp_path, monkeypatch):
+def test_build_codex_config_does_not_inject_global_mcp_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("WEGENT_EXECUTOR_HOME", str(tmp_path / ".wegent-executor"))
     manifest_path = tmp_path / ".wegent-executor" / "capabilities" / "manifest.json"
     manifest_path.parent.mkdir(parents=True)
@@ -173,15 +173,9 @@ def test_build_codex_config_injects_global_mcp_overrides(tmp_path, monkeypatch):
         }
     )
 
-    assert 'mcp_servers.docs.url="https://mcp.example.com/docs"' in (
-        config.config_overrides
+    assert not any(
+        override.startswith("mcp_servers.") for override in config.config_overrides
     )
-    assert 'mcp_servers.docs.bearer_token_env_var="DOCS_TOKEN"' in (
-        config.config_overrides
-    )
-    assert 'mcp_servers.shell.command="uvx"' in config.config_overrides
-    assert 'mcp_servers.shell.args=["tool","--flag"]' in config.config_overrides
-    assert 'mcp_servers.shell.env.FOO="bar"' in config.config_overrides
 
 
 def test_build_codex_config_ignores_legacy_local_cli_env(monkeypatch):

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -165,10 +165,92 @@ class TestExtractClaudeOptionsWithMcp:
             "http://10.185.16.187:8121/mcp"
         )
 
-    def test_global_streamable_http_mcp_is_normalized_for_claude_sdk(
+    def test_project_task_omits_bot_and_subscription_mcp_servers(self):
+        """Wework project tasks rely on global config, not task-level MCP."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            project_id=123,
+            is_subscription=True,
+            bot=[
+                {
+                    "mcp_servers": [
+                        {
+                            "name": "skill-server",
+                            "type": "http",
+                            "url": "http://skill.example.com/mcp",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert "mcp_servers" not in options
+
+    def test_project_coordinate_task_omits_member_bot_mcp_servers(self):
+        """Project tasks should not preserve member bot MCP servers either."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            project_id=123,
+            mode="coordinate",
+            bot=[
+                {
+                    "name": "leader",
+                    "mcp_servers": [
+                        {
+                            "name": "leader-server",
+                            "type": "http",
+                            "url": "http://leader.example.com/mcp",
+                        }
+                    ],
+                },
+                {
+                    "name": "member",
+                    "mcp_servers": [
+                        {
+                            "name": "member-server",
+                            "type": "http",
+                            "url": "http://member.example.com/mcp",
+                        }
+                    ],
+                },
+            ],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert "mcp_servers" not in options
+
+    def test_standalone_chat_workspace_without_project_keeps_bot_mcp_servers(self):
+        """Only wework project tasks strip task-level MCP servers."""
+        task_data = ExecutionRequest(
+            task_id=1,
+            project_id=0,
+            standalone_chat_workspace=True,
+            bot=[
+                {
+                    "mcp_servers": [
+                        {
+                            "name": "bot-server",
+                            "type": "http",
+                            "url": "http://bot.example.com/mcp",
+                        }
+                    ],
+                }
+            ],
+        )
+
+        options = extract_claude_options(task_data)
+
+        assert options["mcp_servers"]["bot-server"]["url"] == (
+            "http://bot.example.com/mcp"
+        )
+
+    def test_global_manifest_mcp_is_not_injected_for_claude_sdk(
         self, tmp_path, monkeypatch
     ):
-        """Installed MCPs use provider type names but Claude SDK expects http."""
+        """Synced MCPs are read from Claude Code global config, not task options."""
         monkeypatch.setenv("HOME", str(tmp_path))
         manifest_path = tmp_path / ".wegent-executor" / "capabilities" / "manifest.json"
         manifest_path.parent.mkdir(parents=True)
@@ -199,8 +281,4 @@ class TestExtractClaudeOptionsWithMcp:
 
         options = extract_claude_options(task_data)
 
-        assert options["mcp_servers"]["docs"] == {
-            "type": "http",
-            "url": "https://mcp.example.com/docs",
-            "headers": {"Authorization": "Bearer test"},
-        }
+        assert "mcp_servers" not in options

--- a/executor/tests/agents/test_skill_mcp_extraction.py
+++ b/executor/tests/agents/test_skill_mcp_extraction.py
@@ -222,8 +222,8 @@ class TestExtractClaudeOptionsWithMcp:
 
         assert "mcp_servers" not in options
 
-    def test_standalone_chat_workspace_without_project_keeps_bot_mcp_servers(self):
-        """Only wework project tasks strip task-level MCP servers."""
+    def test_standalone_chat_workspace_omits_bot_mcp_servers(self):
+        """Standalone workspace tasks use global config, not task-level MCP."""
         task_data = ExecutionRequest(
             task_id=1,
             project_id=0,
@@ -243,9 +243,7 @@ class TestExtractClaudeOptionsWithMcp:
 
         options = extract_claude_options(task_data)
 
-        assert options["mcp_servers"]["bot-server"]["url"] == (
-            "http://bot.example.com/mcp"
-        )
+        assert "mcp_servers" not in options
 
     def test_global_manifest_mcp_is_not_injected_for_claude_sdk(
         self, tmp_path, monkeypatch

--- a/executor/tests/modes/local/test_global_capabilities.py
+++ b/executor/tests/modes/local/test_global_capabilities.py
@@ -14,10 +14,20 @@ from executor.modes.local.capabilities import (
 from shared.models.execution import ExecutionRequest
 
 
-def test_wework_standalone_chat_uses_global_capabilities():
+def test_standalone_chat_workspace_uses_global_capabilities():
     request = ExecutionRequest(
         task_id=1901,
         project_id=0,
+        standalone_chat_workspace=True,
+    )
+
+    assert is_project_task(request) is True
+
+
+def test_wework_project_chat_uses_global_capabilities():
+    request = ExecutionRequest(
+        task_id=1901,
+        project_id=123,
         standalone_chat_workspace=True,
     )
 

--- a/executor/tests/test_local_capability_sync_handler.py
+++ b/executor/tests/test_local_capability_sync_handler.py
@@ -5,6 +5,7 @@
 import hashlib
 import io
 import json
+import tomllib
 import zipfile
 from pathlib import Path
 
@@ -171,6 +172,157 @@ def test_apply_sync_records_downloaded_skill_and_mcp(tmp_path, monkeypatch):
     )
     assert manifest["skills"]["image-gen"]["runtime"]["codex_link"] == str(codex_link)
     assert manifest["mcps"]["docs"]["installed_mcp_id"] == 7
+
+
+def test_apply_sync_writes_mcps_to_claude_and_codex_global_configs(tmp_path):
+    skills_dir = tmp_path / ".claude" / "skills"
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    store_dir = tmp_path / ".wegent-executor" / "capabilities" / "store"
+    manifest_path = tmp_path / ".wegent-executor" / "capabilities" / "manifest.json"
+    claude_config_path = tmp_path / ".claude.json"
+    codex_config_path = tmp_path / ".codex" / "config.toml"
+    claude_config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local": {"type": "stdio", "command": "local-tool"},
+                }
+            }
+        )
+    )
+    codex_config_path.parent.mkdir(parents=True)
+    codex_config_path.write_text(
+        'model = "gpt-5"\n\n' "[mcp_servers.local]\n" 'command = "local-tool"\n'
+    )
+    store = GlobalCapabilityStore(
+        manifest_path=manifest_path,
+        skills_dir=skills_dir,
+        plugins_dir=plugins_dir,
+        store_dir=store_dir,
+        claude_mcp_config_path=claude_config_path,
+        codex_config_path=codex_config_path,
+    )
+    handler = CapabilitySyncHandler(
+        auth_token="token",
+        store=store,
+        skills_dir=skills_dir,
+        plugins_dir=plugins_dir,
+    )
+
+    result = handler.apply_sync(
+        {
+            "mode": "replace",
+            "skills": [],
+            "plugins": [],
+            "mcps": [
+                {
+                    "name": "docs",
+                    "installed_mcp_id": 7,
+                    "server": {
+                        "type": "streamable-http",
+                        "url": "https://mcp.example.com/docs",
+                        "headers": {"Authorization": "Bearer test"},
+                    },
+                },
+                {
+                    "name": "shell",
+                    "installed_mcp_id": 8,
+                    "server": {
+                        "type": "stdio",
+                        "command": "uvx",
+                        "args": ["tool", "--flag"],
+                        "env": {"FOO": "bar"},
+                    },
+                },
+            ],
+        }
+    )
+
+    assert result["success"] is True
+    claude_config = json.loads(claude_config_path.read_text())
+    assert claude_config["mcpServers"]["local"]["command"] == "local-tool"
+    assert claude_config["mcpServers"]["docs"] == {
+        "type": "http",
+        "url": "https://mcp.example.com/docs",
+        "headers": {"Authorization": "Bearer test"},
+    }
+    assert claude_config["mcpServers"]["shell"] == {
+        "type": "stdio",
+        "command": "uvx",
+        "args": ["tool", "--flag"],
+        "env": {"FOO": "bar"},
+    }
+    codex_config = tomllib.loads(codex_config_path.read_text())
+    assert codex_config["model"] == "gpt-5"
+    assert codex_config["mcp_servers"]["local"]["command"] == "local-tool"
+    assert codex_config["mcp_servers"]["docs"]["url"] == "https://mcp.example.com/docs"
+    assert codex_config["mcp_servers"]["shell"]["command"] == "uvx"
+    assert codex_config["mcp_servers"]["shell"]["args"] == ["tool", "--flag"]
+    assert codex_config["mcp_servers"]["shell"]["env"] == {"FOO": "bar"}
+
+
+def test_replace_sync_removes_stale_managed_mcps_from_global_configs(tmp_path):
+    skills_dir = tmp_path / ".claude" / "skills"
+    plugins_dir = tmp_path / ".claude" / "plugins"
+    store_dir = tmp_path / ".wegent-executor" / "capabilities" / "store"
+    manifest_path = tmp_path / ".wegent-executor" / "capabilities" / "manifest.json"
+    claude_config_path = tmp_path / ".claude.json"
+    codex_config_path = tmp_path / ".codex" / "config.toml"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "revision": 1,
+                "skills": {},
+                "plugins": {},
+                "mcps": {"old": {"managed": True, "server": {"command": "old-tool"}}},
+            }
+        )
+    )
+    claude_config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "old": {"type": "stdio", "command": "old-tool"},
+                    "local": {"type": "stdio", "command": "local-tool"},
+                }
+            }
+        )
+    )
+    codex_config_path.parent.mkdir(parents=True)
+    codex_config_path.write_text(
+        "[mcp_servers.old]\n"
+        'command = "old-tool"\n\n'
+        "[mcp_servers.local]\n"
+        'command = "local-tool"\n'
+    )
+    store = GlobalCapabilityStore(
+        manifest_path=manifest_path,
+        skills_dir=skills_dir,
+        plugins_dir=plugins_dir,
+        store_dir=store_dir,
+        claude_mcp_config_path=claude_config_path,
+        codex_config_path=codex_config_path,
+    )
+    handler = CapabilitySyncHandler(
+        auth_token="token",
+        store=store,
+        skills_dir=skills_dir,
+        plugins_dir=plugins_dir,
+    )
+
+    result = handler.apply_sync(
+        {"mode": "replace", "skills": [], "plugins": [], "mcps": []}
+    )
+
+    assert result["success"] is True
+    claude_config = json.loads(claude_config_path.read_text())
+    assert "old" not in claude_config["mcpServers"]
+    assert claude_config["mcpServers"]["local"]["command"] == "local-tool"
+    codex_config = tomllib.loads(codex_config_path.read_text())
+    assert "old" not in codex_config["mcp_servers"]
+    assert codex_config["mcp_servers"]["local"]["command"] == "local-tool"
 
 
 def test_apply_sync_redownloads_managed_skill_when_runtime_link_is_broken(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added local synchronization of globally managed MCP servers into both Claude JSON and Codex TOML configs.
  * Persist and reuse session/thread state with capability revision awareness.
* **Refactor**
  * Updated Claude Code MCP extraction so project tasks omit bot/subscription MCP entries; non-project tasks retain existing behavior.
  * Prevented global MCP data from generating Codex CLI `config_overrides`.
  * Updated streaming refresh initialization and session resume logic to use capability revisions.
* **Bug Fixes**
  * Runtime checks now fall back to active streaming state.
* **Tests**
  * Expanded coverage for MCP gating, config syncing/removal, and revision invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->