### PR TITLE
feat(wework): embed local terminal in macOS app

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -628,6 +628,21 @@ TURN_FILE_CHANGES_REVERT_COMMAND = (
     f"python3 -c {shlex.quote(TURN_FILE_CHANGES_SCRIPT)} revert"
 )
 
+OPEN_TERMINAL_COMMAND = (
+    "sh -c "
+    "'target=${1:-$PWD}; "
+    'case "$(uname -s)" in '
+    'Darwin) open -a Terminal "$target" ;; '
+    "Linux) "
+    "if command -v x-terminal-emulator >/dev/null 2>&1; then "
+    'x-terminal-emulator --working-directory="$target" >/dev/null 2>&1 & '
+    "elif command -v gnome-terminal >/dev/null 2>&1; then "
+    'gnome-terminal --working-directory="$target" >/dev/null 2>&1 & '
+    'else echo "No supported graphical terminal found" >&2; exit 69; fi ;; '
+    '*) echo "Opening a graphical terminal is unsupported on this device" >&2; exit 69 ;; '
+    "esac' --"
+)
+
 
 DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
     "pwd": LocalDeviceCommandDefinition(command="pwd"),
@@ -709,6 +724,7 @@ DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
         command=SETUP_SHARED_SKILLS_COMMAND,
         post_processor="json",
     ),
+    "open_terminal": LocalDeviceCommandDefinition(command=OPEN_TERMINAL_COMMAND),
     "sync_runtime_auth_file": LocalDeviceCommandDefinition(
         command=SYNC_RUNTIME_AUTH_FILE_COMMAND,
         post_processor="json",

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -234,6 +234,9 @@ def test_local_device_command_registry_default_includes_diagnostic_commands():
     setup_shared_skills_definition = resolve_local_device_command(
         "setup_shared_skills", settings.LOCAL_DEVICE_COMMANDS
     )
+    open_terminal_definition = resolve_local_device_command(
+        "open_terminal", settings.LOCAL_DEVICE_COMMANDS
+    )
     sync_runtime_auth_file_definition = resolve_local_device_command(
         "sync_runtime_auth_file", settings.LOCAL_DEVICE_COMMANDS
     )
@@ -324,6 +327,10 @@ def test_local_device_command_registry_default_includes_diagnostic_commands():
     assert ".codex" in setup_shared_skills_definition.command
     assert ".claude" in setup_shared_skills_definition.command
     assert setup_shared_skills_definition.post_processor == "json"
+    assert open_terminal_definition is not None
+    assert "open -a Terminal" in open_terminal_definition.command
+    assert "x-terminal-emulator" in open_terminal_definition.command
+    assert open_terminal_definition.post_processor is None
     assert sync_runtime_auth_file_definition is not None
     assert "WEGENT_RUNTIME_CONFIG_CONTENT" in sync_runtime_auth_file_definition.command
     assert sync_runtime_auth_file_definition.post_processor == "json"

--- a/docs/en/developer-guide/local-device-command-rpc.md
+++ b/docs/en/developer-guide/local-device-command-rpc.md
@@ -18,7 +18,7 @@ The communication path is:
 6. The executor returns the completed result as the Socket.IO ack.
 7. Backend optionally post-processes the result according to the command definition's `post_processor`.
 
-This RPC is decoupled from `task:execute`, so it is suitable for short commands and one-shot diagnostics. Long-running interactive terminals and streaming stdout/stderr are outside the first version.
+This RPC is decoupled from `task:execute`, so it is suitable for short commands and one-shot diagnostics. Long-running interactive terminals and streaming stdout/stderr are not carried by this RPC. The macOS WeWork App embeds local project terminals through a Tauri local PTY, as described in "macOS App Local Terminal" below.
 
 ## API
 
@@ -64,7 +64,7 @@ When command startup fails, the command exits non-zero, or the command times out
 
 ## Security And Limits
 
-This feature follows a trusted Backend and restricted API model. The HTTP API does not accept raw commands; it accepts only configured keys. The real command must be configured by the Backend through the command registry or `LOCAL_DEVICE_COMMANDS`. The `pwd`, `ls_a`, `ls_dirs`, `git_clone`, `git_branch`, `git_diff_shortstat`, `git_remote_url`, `git_add_all`, and `git_commit` command keys are built in by default. `ls_a` uses the `file_list` post processor to filter `.` and `..` and return a file name array in `stdout`; `ls_dirs` uses the `directory_list` post processor to return only subdirectory names in the current directory. To add a built-in command, add one entry to `DEFAULT_LOCAL_DEVICE_COMMANDS` in `backend/app/services/device/command_registry.py`.
+This feature follows a trusted Backend and restricted API model. The HTTP API does not accept raw commands; it accepts only configured keys. The real command must be configured by the Backend through the command registry or `LOCAL_DEVICE_COMMANDS`. The `pwd`, `ls_a`, `ls_dirs`, `git_clone`, `git_branch`, `git_diff_shortstat`, `git_remote_url`, `git_add_all`, `git_commit`, and `open_terminal` command keys are built in by default. `ls_a` uses the `file_list` post processor to filter `.` and `..` and return a file name array in `stdout`; `ls_dirs` uses the `directory_list` post processor to return only subdirectory names in the current directory. `open_terminal` starts the system terminal window on local devices with a graphical session; it is a one-shot launch command and does not provide streaming terminal interaction. To add a built-in command, add one entry to `DEFAULT_LOCAL_DEVICE_COMMANDS` in `backend/app/services/device/command_registry.py`.
 
 At runtime, add or override command definitions with a single environment variable. Simple commands can use string values; commands that need post processing can use object values:
 
@@ -96,3 +96,17 @@ Because commands run on the user's machine, callers must treat this API as high 
 ## Executor Behavior
 
 The local executor prefers Backend-provided `argv`; it falls back to the system shell only when `argv` is missing. If `path`/`cwd` is empty, the executor uses its current working directory. `env` is merged into the current process environment. On timeout, the executor terminates the command process group and returns a timeout result.
+
+## macOS App Local Terminal
+
+When the WeWork macOS App opens a project that is bound to a local executor on the same Mac, it can embed a local terminal in the workspace panel. This terminal does not depend on `ttyd` and does not use the `/devices/{device_id}/commands` RPC. The App creates a local PTY through Tauri commands and renders the input/output stream with the frontend `xterm` component.
+
+Enablement rules:
+
+- The runtime must be the macOS Tauri App. Regular browsers and the iOS App do not enable this path.
+- The project device must be a local Claude Code device.
+- The App and executor must correspond to the same backend. The frontend passes the current `apiBaseUrl` to the native layer; the native layer first scans running `wegent-executor` processes and matches their `WEGENT_BACKEND_URL`.
+- If no matching process is found, the native layer falls back to local configuration files such as `WEGENT_EXECUTOR_HOME`, `~/.wecode/wegent-executor/device-config.json`, and `~/.wegent-executor/device-config.json`.
+- For project terminals, an existing project `localPath` on the current Mac is also accepted as a same-machine signal. This handles cases where multiple executor config files are temporarily out of sync.
+
+This check intentionally does not use IP or MAC addresses. IPs can be duplicated or distorted by proxies, VPNs, container networks, and loopback routing. MAC addresses can also be unstable because of permissions, virtual interfaces, and privacy behavior. Matching a running executor process to the backend URL is closer to the executor connection that the App is actually using.

--- a/docs/zh/developer-guide/local-device-command-rpc.md
+++ b/docs/zh/developer-guide/local-device-command-rpc.md
@@ -18,7 +18,7 @@ sidebar_position: 18
 6. executor 通过 Socket.IO ack 一次性返回完成结果。
 7. Backend 按命令定义中的 `post_processor` 对结果做可选后处理。
 
-该 RPC 与 `task:execute` 解耦，适合短命令和一次性诊断命令。长时间交互式终端、实时 stdout/stderr 流式输出不在第一版范围内。
+该 RPC 与 `task:execute` 解耦，适合短命令和一次性诊断命令。长时间交互式终端、实时 stdout/stderr 流式输出不通过该 RPC 承载。macOS WeWork App 的本地项目终端使用 Tauri 本地 PTY 嵌入在页面内，见下文“macOS App 本地终端”。
 
 ## API
 
@@ -64,7 +64,7 @@ POST /api/devices/{device_id}/commands
 
 ## 安全与限制
 
-该能力按“Backend 可信、API 受限”模型设计。HTTP API 不接受原始命令，只接受配置 key；实际命令必须由 Backend 通过命令 registry 或 `LOCAL_DEVICE_COMMANDS` 预配置。默认内置 `pwd`、`ls_a`、`ls_dirs`、`git_clone`、`git_branch`、`git_diff_shortstat`、`git_remote_url`、`git_add_all` 和 `git_commit` 命令 key，其中 `ls_a` 会使用 `file_list` 后处理器过滤 `.`、`..` 并在 `stdout` 中返回文件名数组，`ls_dirs` 会使用 `directory_list` 后处理器只返回当前目录下的子目录名称数组。新增内置命令只需要在 `backend/app/services/device/command_registry.py` 的 `DEFAULT_LOCAL_DEVICE_COMMANDS` 中增加一项。
+该能力按“Backend 可信、API 受限”模型设计。HTTP API 不接受原始命令，只接受配置 key；实际命令必须由 Backend 通过命令 registry 或 `LOCAL_DEVICE_COMMANDS` 预配置。默认内置 `pwd`、`ls_a`、`ls_dirs`、`git_clone`、`git_branch`、`git_diff_shortstat`、`git_remote_url`、`git_add_all`、`git_commit` 和 `open_terminal` 命令 key，其中 `ls_a` 会使用 `file_list` 后处理器过滤 `.`、`..` 并在 `stdout` 中返回文件名数组，`ls_dirs` 会使用 `directory_list` 后处理器只返回当前目录下的子目录名称数组。`open_terminal` 用于在支持图形界面的本地设备上打开系统终端窗口；它是一次性启动命令，不提供终端流式交互。新增内置命令只需要在 `backend/app/services/device/command_registry.py` 的 `DEFAULT_LOCAL_DEVICE_COMMANDS` 中增加一项。
 
 运行时可通过一个环境变量增加或覆盖配置。简单命令可以直接写字符串；需要后处理时写对象：
 
@@ -96,3 +96,17 @@ LOCAL_DEVICE_COMMANDS='{"repo_status":"git status","repo_files":{"command":"ls -
 ## Executor 行为
 
 local executor 优先使用 Backend 下发的 `argv` 执行命令；缺少 `argv` 时才回退到系统 shell。`path`/`cwd` 为空时使用 executor 当前工作目录；`env` 会合并到当前进程环境中。命令超时时，executor 会终止命令进程组并返回超时结果。
+
+## macOS App 本地终端
+
+WeWork macOS App 访问本机 local executor 项目时，可以在工作区面板内嵌入本地终端。该终端不依赖 `ttyd`，也不经过 `/devices/{device_id}/commands` RPC；App 通过 Tauri command 在本机创建 PTY，并用前端 `xterm` 组件渲染输入输出流。
+
+启用条件：
+
+- 运行环境必须是 macOS Tauri App；普通浏览器和 iOS App 不启用。
+- 项目绑定的设备必须是 local Claude Code 设备。
+- App 与 executor 必须对应同一个后端。App 会把当前 `apiBaseUrl` 传给 native 层，native 层优先扫描正在运行的 `wegent-executor` 进程，并按进程环境中的 `WEGENT_BACKEND_URL` 匹配。
+- 如果进程匹配不到，native 层才回退读取 `WEGENT_EXECUTOR_HOME`、`~/.wecode/wegent-executor/device-config.json`、`~/.wegent-executor/device-config.json` 等本地配置。
+- 对项目终端，项目 `localPath` 在当前 Mac 上存在时也可作为同机信号，用于处理多个 executor 配置文件不同步的情况。
+
+这个判断不使用 IP 或 MAC 地址。IP 在代理、VPN、容器网络和本机回环场景下容易重复或失真；MAC 地址也可能因权限、虚拟网卡和隐私策略不稳定。运行中 executor 进程与后端 URL 匹配是更接近实际连接状态的信号。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -471,6 +471,12 @@ importers:
       '@wegent/chat-core':
         specifier: workspace:*
         version: link:../packages/chat-core
+      '@xterm/addon-fit':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@xterm/xterm':
+        specifier: ^6.0.0
+        version: 6.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -3171,6 +3177,7 @@ packages:
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
@@ -3294,6 +3301,12 @@ packages:
 
   '@vitest/utils@4.1.8':
     resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  '@xterm/addon-fit@0.11.0':
+    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/xterm@6.0.0':
+    resolution: {integrity: sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==}
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -10544,6 +10557,10 @@ snapshots:
       '@vitest/pretty-format': 4.1.8
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/xterm@6.0.0': {}
 
   abab@2.0.6: {}
 

--- a/wework/package.json
+++ b/wework/package.json
@@ -24,6 +24,8 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tauri-apps/api": "^2.11.0",
     "@wegent/chat-core": "workspace:*",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "i18next": "^26.2.0",

--- a/wework/src-tauri/Cargo.lock
+++ b/wework/src-tauri/Cargo.lock
@@ -80,6 +80,7 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "log",
+ "portable-pty",
  "serde",
  "serde_json",
  "tauri",
@@ -754,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,7 +822,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -881,8 +888,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1641,6 +1659,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,6 +1792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1871,6 +1904,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -1955,6 +1997,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
 
 [[package]]
 name = "num-conv"
@@ -2323,6 +2379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2365,6 +2427,27 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -2969,6 +3052,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,6 +3134,22 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3528,6 +3669,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4651,6 +4801,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -23,3 +23,4 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.11.2", features = [] }
 tauri-plugin-log = "2"
+portable-pty = "0.8"

--- a/wework/src-tauri/build.rs
+++ b/wework/src-tauri/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-  tauri_build::build()
+    tauri_build::build()
 }

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -1,16 +1,248 @@
+mod local_terminal;
+
+fn normalized_non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn read_device_id_file(path: std::path::PathBuf) -> Option<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(normalized_non_empty)
+}
+
+fn read_device_config(path: std::path::PathBuf) -> Option<String> {
+    let value = std::fs::read_to_string(path).ok()?;
+    let json = serde_json::from_str::<serde_json::Value>(&value).ok()?;
+    json.get("device_id")
+        .and_then(|value| value.as_str())
+        .map(String::from)
+        .and_then(normalized_non_empty)
+}
+
+fn normalize_backend_url(value: &str) -> Option<String> {
+    let mut value = value.trim().trim_end_matches('/').to_string();
+    if value.is_empty() {
+        return None;
+    }
+    if let Some(stripped) = value.strip_suffix("/api") {
+        value = stripped.trim_end_matches('/').to_string();
+    }
+    if let Some(stripped) = value.strip_prefix("ws://") {
+        value = format!("http://{stripped}");
+    } else if let Some(stripped) = value.strip_prefix("wss://") {
+        value = format!("https://{stripped}");
+    }
+
+    Some(value)
+}
+
+fn read_device_config_for_backend(
+    path: std::path::PathBuf,
+    expected_backend_url: Option<&str>,
+) -> Option<String> {
+    let value = std::fs::read_to_string(path).ok()?;
+    let json = serde_json::from_str::<serde_json::Value>(&value).ok()?;
+
+    if let Some(expected_backend_url) = expected_backend_url {
+        let actual_backend_url = json
+            .get("connection")
+            .and_then(|connection| connection.get("backend_url"))
+            .and_then(|value| value.as_str())
+            .and_then(normalize_backend_url)?;
+        if actual_backend_url != expected_backend_url {
+            return None;
+        }
+    }
+
+    json.get("device_id")
+        .and_then(|value| value.as_str())
+        .map(String::from)
+        .and_then(normalized_non_empty)
+}
+
+fn process_env_value(tokens: &[&str], key: &str) -> Option<String> {
+    let prefix = format!("{key}=");
+    tokens
+        .iter()
+        .find_map(|token| token.strip_prefix(&prefix))
+        .map(String::from)
+        .and_then(normalized_non_empty)
+}
+
+fn process_config_arg(tokens: &[&str]) -> Option<std::path::PathBuf> {
+    tokens
+        .windows(2)
+        .find_map(|pair| (pair[0] == "--config").then(|| std::path::PathBuf::from(pair[1])))
+}
+
+fn read_executor_process_device_id(expected_backend_url: Option<&str>) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .args(["eww", "-axo", "pid=,command="])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut candidate_device_id = None;
+    let mut candidate_count = 0;
+
+    for line in stdout.lines() {
+        if !line.contains("wegent-executor") {
+            continue;
+        }
+
+        let tokens = line.split_whitespace().collect::<Vec<_>>();
+        if tokens.len() < 2 || !tokens[1].contains("wegent-executor") {
+            continue;
+        }
+
+        let process_backend_url = process_env_value(&tokens, "WEGENT_BACKEND_URL")
+            .as_deref()
+            .and_then(normalize_backend_url);
+        if let Some(expected_backend_url) = expected_backend_url {
+            if process_backend_url.as_deref() != Some(expected_backend_url) {
+                continue;
+            }
+        }
+
+        let device_id = process_env_value(&tokens, "DEVICE_ID")
+            .or_else(|| {
+                process_config_arg(&tokens)
+                    .and_then(|path| read_device_config_for_backend(path, expected_backend_url))
+            })
+            .or_else(|| {
+                process_env_value(&tokens, "WEGENT_EXECUTOR_HOME").and_then(|home| {
+                    read_device_config_for_backend(
+                        std::path::PathBuf::from(home).join("device-config.json"),
+                        expected_backend_url,
+                    )
+                })
+            })
+            .or_else(|| {
+                process_env_value(&tokens, "WECODE_HOME").and_then(|home| {
+                    read_device_config_for_backend(
+                        std::path::PathBuf::from(home)
+                            .join("wegent-executor")
+                            .join("device-config.json"),
+                        expected_backend_url,
+                    )
+                })
+            })
+            .or_else(|| {
+                process_env_value(&tokens, "HOME").and_then(|home| {
+                    read_device_config_for_backend(
+                        std::path::PathBuf::from(home)
+                            .join(".wegent-executor")
+                            .join("device-config.json"),
+                        expected_backend_url,
+                    )
+                })
+            });
+
+        if let Some(device_id) = device_id {
+            if expected_backend_url.is_some() {
+                return Some(device_id);
+            }
+            candidate_count += 1;
+            candidate_device_id = Some(device_id);
+        }
+    }
+
+    (candidate_count == 1)
+        .then_some(candidate_device_id)
+        .flatten()
+}
+
+#[tauri::command]
+fn local_path_exists(path: String) -> bool {
+    let Some(path) = normalized_non_empty(path) else {
+        return false;
+    };
+
+    std::path::Path::new(&path).exists()
+}
+
+#[tauri::command]
+fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<String> {
+    let expected_backend_url = expected_backend_url
+        .as_deref()
+        .and_then(normalize_backend_url);
+
+    for key in ["WEGENT_EXECUTOR_DEVICE_ID", "DEVICE_ID"] {
+        if let Ok(value) = std::env::var(key) {
+            if let Some(device_id) = normalized_non_empty(value) {
+                return Some(device_id);
+            }
+        }
+    }
+
+    if let Some(device_id) = read_executor_process_device_id(expected_backend_url.as_deref()) {
+        return Some(device_id);
+    }
+
+    let mut candidates = Vec::new();
+    if let Ok(home) = std::env::var("WEGENT_EXECUTOR_HOME") {
+        let executor_home = std::path::PathBuf::from(home);
+        if let Some(device_id) = read_device_config(executor_home.join("device-config.json")) {
+            return Some(device_id);
+        }
+        candidates.push(executor_home.join("device_id"));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        let home = std::path::PathBuf::from(home);
+        if let Some(device_id) = read_device_config(
+            home.join(".wecode")
+                .join("wegent-executor")
+                .join("device-config.json"),
+        ) {
+            return Some(device_id);
+        }
+        if let Some(device_id) =
+            read_device_config(home.join(".wegent-executor").join("device-config.json"))
+        {
+            return Some(device_id);
+        }
+        candidates.push(home.join(".wegent-executor").join("device_id"));
+    }
+
+    for path in candidates {
+        if let Some(device_id) = read_device_id_file(path) {
+            return Some(device_id);
+        }
+    }
+
+    None
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-  tauri::Builder::default()
-    .setup(|app| {
-      if cfg!(debug_assertions) {
-        app.handle().plugin(
-          tauri_plugin_log::Builder::default()
-            .level(log::LevelFilter::Info)
-            .build(),
-        )?;
-      }
-      Ok(())
-    })
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
+    tauri::Builder::default()
+        .manage(local_terminal::LocalTerminalState::default())
+        .setup(|app| {
+            if cfg!(debug_assertions) {
+                app.handle().plugin(
+                    tauri_plugin_log::Builder::default()
+                        .level(log::LevelFilter::Info)
+                        .build(),
+                )?;
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            local_terminal::close_local_terminal,
+            get_local_executor_device_id,
+            local_path_exists,
+            local_terminal::resize_local_terminal,
+            local_terminal::start_local_terminal,
+            local_terminal::write_local_terminal
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
 }

--- a/wework/src-tauri/src/local_terminal.rs
+++ b/wework/src-tauri/src/local_terminal.rs
@@ -1,0 +1,224 @@
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use tauri::{Emitter, State};
+
+const TERMINAL_OUTPUT_EVENT: &str = "local-terminal-output";
+const TERMINAL_EXIT_EVENT: &str = "local-terminal-exit";
+
+pub struct LocalTerminalState {
+    sessions: Mutex<HashMap<String, LocalTerminalSession>>,
+    next_id: AtomicU64,
+}
+
+struct LocalTerminalSession {
+    master: Box<dyn MasterPty + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+#[derive(Serialize, Clone)]
+struct LocalTerminalOutput {
+    session_id: String,
+    data: String,
+}
+
+#[derive(Serialize, Clone)]
+struct LocalTerminalExit {
+    session_id: String,
+}
+
+impl Default for LocalTerminalState {
+    fn default() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+}
+
+fn next_session_id(state: &LocalTerminalState) -> String {
+    let id = state.next_id.fetch_add(1, Ordering::Relaxed);
+    format!("local-terminal-{id}")
+}
+
+fn normalized_cwd(cwd: Option<String>) -> Result<Option<String>, String> {
+    let Some(cwd) = cwd else {
+        return Ok(None);
+    };
+    let cwd = cwd.trim();
+    if cwd.is_empty() {
+        return Ok(None);
+    }
+    if !std::path::Path::new(cwd).exists() {
+        return Err(format!("Terminal cwd does not exist: {cwd}"));
+    }
+
+    Ok(Some(cwd.to_string()))
+}
+
+#[tauri::command]
+pub fn start_local_terminal(
+    app: tauri::AppHandle,
+    state: State<'_, LocalTerminalState>,
+    cwd: Option<String>,
+    rows: Option<u16>,
+    cols: Option<u16>,
+) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let cwd = normalized_cwd(cwd)?;
+        let size = PtySize {
+            rows: rows.unwrap_or(24).max(1),
+            cols: cols.unwrap_or(80).max(1),
+            pixel_width: 0,
+            pixel_height: 0,
+        };
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(size)
+            .map_err(|error| format!("Failed to create PTY: {error}"))?;
+        let mut reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|error| format!("Failed to create PTY reader: {error}"))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|error| format!("Failed to create PTY writer: {error}"))?;
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+        let mut command = CommandBuilder::new(shell);
+        command.env("TERM", "xterm-256color");
+        command.env("COLORTERM", "truecolor");
+        if let Some(cwd) = cwd {
+            command.cwd(cwd);
+        }
+        let child = pair
+            .slave
+            .spawn_command(command)
+            .map_err(|error| format!("Failed to spawn shell: {error}"))?;
+        drop(pair.slave);
+
+        let session_id = next_session_id(&state);
+        let session = LocalTerminalSession {
+            master: pair.master,
+            writer,
+            child,
+        };
+        state
+            .sessions
+            .lock()
+            .map_err(|_| "Failed to lock local terminal state".to_string())?
+            .insert(session_id.clone(), session);
+
+        let output_session_id = session_id.clone();
+        let exit_session_id = session_id.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(80));
+            let mut buffer = [0_u8; 8192];
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(size) => {
+                        let data = String::from_utf8_lossy(&buffer[..size]).to_string();
+                        let _ = app.emit(
+                            TERMINAL_OUTPUT_EVENT,
+                            LocalTerminalOutput {
+                                session_id: output_session_id.clone(),
+                                data,
+                            },
+                        );
+                    }
+                    Err(_) => break,
+                }
+            }
+            let _ = app.emit(
+                TERMINAL_EXIT_EVENT,
+                LocalTerminalExit {
+                    session_id: exit_session_id,
+                },
+            );
+        });
+
+        Ok(session_id)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        let _ = state;
+        let _ = cwd;
+        let _ = rows;
+        let _ = cols;
+        Err("Local terminal is supported only on macOS".to_string())
+    }
+}
+
+#[tauri::command]
+pub fn write_local_terminal(
+    state: State<'_, LocalTerminalState>,
+    session_id: String,
+    data: String,
+) -> Result<(), String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "Failed to lock local terminal state".to_string())?;
+    let session = sessions
+        .get_mut(&session_id)
+        .ok_or_else(|| format!("Local terminal session not found: {session_id}"))?;
+
+    session
+        .writer
+        .write_all(data.as_bytes())
+        .map_err(|error| format!("Failed to write to terminal: {error}"))?;
+    session
+        .writer
+        .flush()
+        .map_err(|error| format!("Failed to flush terminal input: {error}"))
+}
+
+#[tauri::command]
+pub fn resize_local_terminal(
+    state: State<'_, LocalTerminalState>,
+    session_id: String,
+    rows: u16,
+    cols: u16,
+) -> Result<(), String> {
+    let sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "Failed to lock local terminal state".to_string())?;
+    let session = sessions
+        .get(&session_id)
+        .ok_or_else(|| format!("Local terminal session not found: {session_id}"))?;
+
+    session
+        .master
+        .resize(PtySize {
+            rows: rows.max(1),
+            cols: cols.max(1),
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|error| format!("Failed to resize terminal: {error}"))
+}
+
+#[tauri::command]
+pub fn close_local_terminal(
+    state: State<'_, LocalTerminalState>,
+    session_id: String,
+) -> Result<(), String> {
+    let mut sessions = state
+        .sessions
+        .lock()
+        .map_err(|_| "Failed to lock local terminal state".to_string())?;
+    if let Some(mut session) = sessions.remove(&session_id) {
+        let _ = session.child.kill();
+    }
+
+    Ok(())
+}

--- a/wework/src-tauri/src/main.rs
+++ b/wework/src-tauri/src/main.rs
@@ -2,5 +2,5 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-  app_lib::run();
+    app_lib::run();
 }

--- a/wework/src/api/devices.test.ts
+++ b/wework/src/api/devices.test.ts
@@ -19,9 +19,23 @@ describe('createDeviceApi', () => {
     expect(client.post).toHaveBeenCalledWith('/cloud-devices/device%2F1/restart')
     expect(client.delete).toHaveBeenCalledWith('/cloud-devices/device%2F1')
     expect(client.delete).toHaveBeenCalledWith('/devices/device%2F1')
-    expect(client.post).toHaveBeenCalledWith(
-      '/devices/device%2F1/upgrade',
-      { auto_confirm: true },
-    )
+    expect(client.post).toHaveBeenCalledWith('/devices/device%2F1/upgrade', { auto_confirm: true })
+  })
+
+  test('opens a local terminal through the configured device command', async () => {
+    const client = {
+      post: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as HttpClient
+
+    const api = createDeviceApi(client)
+
+    await api.openLocalTerminal('device/1', ' /workspace/project ')
+
+    expect(client.post).toHaveBeenCalledWith('/devices/device%2F1/commands', {
+      command_key: 'open_terminal',
+      args: ['/workspace/project'],
+      timeout_seconds: 10,
+      max_output_bytes: 4096,
+    })
   })
 })

--- a/wework/src/api/devices.ts
+++ b/wework/src/api/devices.ts
@@ -212,6 +212,22 @@ export function createDeviceApi(client: HttpClient) {
       )
     },
 
+    async openLocalTerminal(deviceId: string, cwd?: string): Promise<void> {
+      const args = cwd?.trim() ? [cwd.trim()] : []
+      const response = await client.post<DeviceCommandResponse>(
+        `/devices/${encodeURIComponent(deviceId)}/commands`,
+        {
+          command_key: 'open_terminal',
+          args,
+          timeout_seconds: 10,
+          max_output_bytes: 4096,
+        }
+      )
+      if (!response.success) {
+        throw new Error(response.error || response.stderr || 'Failed to open terminal')
+      }
+    },
+
     async createCloudDevice(): Promise<CloudDeviceResponse> {
       return client.post<CloudDeviceResponse>('/cloud-devices')
     },

--- a/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
+++ b/wework/src/components/layout/workspace-panels/EmbeddedLocalTerminal.tsx
@@ -1,0 +1,131 @@
+import { FitAddon } from '@xterm/addon-fit'
+import { Terminal } from '@xterm/xterm'
+import '@xterm/xterm/css/xterm.css'
+import { useEffect, useRef } from 'react'
+import {
+  listenLocalTerminalExit,
+  listenLocalTerminalOutput,
+  resizeLocalTerminal,
+  writeLocalTerminal,
+} from '@/lib/local-terminal'
+
+interface EmbeddedLocalTerminalProps {
+  sessionId: string
+  active: boolean
+}
+
+export function EmbeddedLocalTerminal({ sessionId, active }: EmbeddedLocalTerminalProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const terminalRef = useRef<Terminal | null>(null)
+  const fitAddonRef = useRef<FitAddon | null>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const terminal = new Terminal({
+      cursorBlink: true,
+      convertEol: true,
+      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontSize: 13,
+      lineHeight: 1.2,
+      scrollback: 2000,
+      theme: {
+        background: '#ffffff',
+        foreground: '#1a1a1a',
+        cursor: '#14b8a6',
+        selectionBackground: '#d8f3ee',
+      },
+    })
+    const fitAddon = new FitAddon()
+    const dataDisposable = terminal.onData(data => {
+      void writeLocalTerminal(sessionId, data)
+    })
+    let disposed = false
+    const unlisteners: Array<() => void> = []
+
+    terminal.loadAddon(fitAddon)
+    terminal.open(container)
+    terminalRef.current = terminal
+    fitAddonRef.current = fitAddon
+
+    const fitAndResize = () => {
+      if (disposed || !container.isConnected) return
+      try {
+        fitAddon.fit()
+        void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
+      } catch (error) {
+        console.error('Failed to resize local terminal:', error)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(fitAndResize)
+    resizeObserver.observe(container)
+    requestAnimationFrame(fitAndResize)
+
+    void listenLocalTerminalOutput(payload => {
+      if (!disposed && payload.session_id === sessionId) {
+        terminal.write(payload.data)
+      }
+    }).then(unlisten => {
+      if (disposed) {
+        unlisten()
+      } else {
+        unlisteners.push(unlisten)
+      }
+    })
+
+    void listenLocalTerminalExit(payload => {
+      if (!disposed && payload.session_id === sessionId) {
+        terminal.writeln('\r\n[Process exited]')
+      }
+    }).then(unlisten => {
+      if (disposed) {
+        unlisten()
+      } else {
+        unlisteners.push(unlisten)
+      }
+    })
+
+    return () => {
+      disposed = true
+      resizeObserver.disconnect()
+      dataDisposable.dispose()
+      unlisteners.forEach(unlisten => unlisten())
+      terminal.dispose()
+      terminalRef.current = null
+      fitAddonRef.current = null
+    }
+  }, [sessionId])
+
+  useEffect(() => {
+    if (!active) return
+
+    const frame = requestAnimationFrame(() => {
+      const terminal = terminalRef.current
+      const fitAddon = fitAddonRef.current
+      if (!terminal || !fitAddon) return
+
+      try {
+        fitAddon.fit()
+        terminal.focus()
+        void resizeLocalTerminal(sessionId, terminal.rows, terminal.cols)
+      } catch (error) {
+        console.error('Failed to activate local terminal:', error)
+      }
+    })
+
+    return () => {
+      cancelAnimationFrame(frame)
+    }
+  }, [active, sessionId])
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="embedded-local-terminal"
+      className="h-full min-h-0 w-full overflow-hidden bg-white px-2 py-2"
+      hidden={!active}
+    />
+  )
+}

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -3,6 +3,13 @@ import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { createDeviceApi } from '@/api/devices'
 import { createProjectApi } from '@/api/projects'
+import {
+  closeLocalTerminal,
+  getLocalExecutorDeviceId,
+  isLocalTerminalAvailable,
+  localPathExists,
+  startLocalTerminal,
+} from '@/lib/local-terminal'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
 import type { DeviceInfo } from '@/types/api'
 
@@ -30,8 +37,27 @@ vi.mock('@/api/devices', () => ({
   createDeviceApi: vi.fn(),
 }))
 
+vi.mock('@/lib/local-terminal', () => ({
+  closeLocalTerminal: vi.fn(),
+  getLocalExecutorDeviceId: vi.fn(),
+  isLocalTerminalAvailable: vi.fn(),
+  localPathExists: vi.fn(),
+  startLocalTerminal: vi.fn(),
+}))
+
+vi.mock('./EmbeddedLocalTerminal', () => ({
+  EmbeddedLocalTerminal: ({ active, sessionId }: { active: boolean; sessionId: string }) => (
+    <div data-testid="embedded-local-terminal" data-session-id={sessionId} hidden={!active} />
+  ),
+}))
+
 const createDeviceApiMock = vi.mocked(createDeviceApi)
 const createProjectApiMock = vi.mocked(createProjectApi)
+const closeLocalTerminalMock = vi.mocked(closeLocalTerminal)
+const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
+const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
+const localPathExistsMock = vi.mocked(localPathExists)
+const startLocalTerminalMock = vi.mocked(startLocalTerminal)
 const getVncConfigMock = vi.fn()
 const fetchMock = vi.fn()
 
@@ -94,6 +120,11 @@ describe('WorkspacePanelCards', () => {
     fetchMock.mockResolvedValue(new Response(null, { status: 204 }))
     vi.spyOn(window, 'open').mockImplementation(() => null)
     window.localStorage.setItem('auth_token', 'token-1')
+    isLocalTerminalAvailableMock.mockReturnValue(true)
+    getLocalExecutorDeviceIdMock.mockResolvedValue('device-1')
+    localPathExistsMock.mockResolvedValue(true)
+    startLocalTerminalMock.mockResolvedValue('local-terminal-1')
+    closeLocalTerminalMock.mockResolvedValue(undefined)
     let terminalSessionCount = 0
     createProjectApiMock.mockReturnValue({
       startTerminalSession: vi.fn().mockImplementation(async () => {
@@ -133,21 +164,15 @@ describe('WorkspacePanelCards', () => {
     const api = createProjectApiMock()
     render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
-    await waitFor(() =>
-      expect(api.startTerminalSession).toHaveBeenCalledWith(7),
-    )
+    await waitFor(() => expect(api.startTerminalSession).toHaveBeenCalledWith(7))
     expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
       'src',
-      'http://localhost/terminal-1',
+      'http://localhost/terminal-1'
     )
-    expect(screen.getByTestId('workspace-terminal-window')).toHaveClass(
-      'bg-white',
-    )
-    expect(screen.getByTestId('workspace-terminal-tab')).toHaveTextContent(
-      'project38',
-    )
+    expect(screen.getByTestId('workspace-terminal-window')).toHaveClass('bg-white')
+    expect(screen.getByTestId('workspace-terminal-tab')).toHaveTextContent('project38')
     expect(screen.getByTestId('workspace-terminal-new-tab-button')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-terminal-close-button')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/projects/project38')).not.toBeInTheDocument()
@@ -157,12 +182,12 @@ describe('WorkspacePanelCards', () => {
     const api = createProjectApiMock()
     render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
     await waitFor(() =>
       expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
         'src',
-        'http://localhost/terminal-1',
-      ),
+        'http://localhost/terminal-1'
+      )
     )
 
     await userEvent.click(screen.getByTestId('workspace-terminal-new-tab-button'))
@@ -170,7 +195,7 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getByTestId('workspace-terminal-window')).not.toHaveAttribute('hidden')
     expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
       'src',
-      'http://localhost/terminal-1',
+      'http://localhost/terminal-1'
     )
     expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
     expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
@@ -178,24 +203,16 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getByTestId('workspace-desktop-card')).toBeInTheDocument()
     expect(api.startTerminalSession).toHaveBeenCalledTimes(1)
 
-    await userEvent.click(screen.getByTestId('workspace-terminal-card'))
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
 
-    await waitFor(() =>
-      expect(api.startTerminalSession).toHaveBeenCalledTimes(2),
-    )
+    await waitFor(() => expect(api.startTerminalSession).toHaveBeenCalledTimes(2))
     expect(screen.getAllByTestId('workspace-terminal-tab')).toHaveLength(2)
     expect(screen.getAllByTestId('workspace-terminal-close-button')).toHaveLength(2)
     const frames = screen.getAllByTestId('workspace-terminal-frame')
     expect(frames).toHaveLength(2)
-    expect(frames[0]).toHaveAttribute(
-      'src',
-      'http://localhost/terminal-1',
-    )
+    expect(frames[0]).toHaveAttribute('src', 'http://localhost/terminal-1')
     expect(frames[0]).toHaveAttribute('hidden')
-    expect(frames[1]).toHaveAttribute(
-      'src',
-      'http://localhost/terminal-2',
-    )
+    expect(frames[1]).toHaveAttribute('src', 'http://localhost/terminal-2')
     expect(frames[1]).not.toHaveAttribute('hidden')
 
     await userEvent.click(screen.getAllByTestId('workspace-terminal-close-button')[1])
@@ -203,7 +220,7 @@ describe('WorkspacePanelCards', () => {
     expect(screen.getAllByTestId('workspace-terminal-tab')).toHaveLength(1)
     expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
       'src',
-      'http://localhost/terminal-1',
+      'http://localhost/terminal-1'
     )
     expect(screen.getByTestId('workspace-terminal-frame')).not.toHaveAttribute('hidden')
   })
@@ -216,20 +233,14 @@ describe('WorkspacePanelCards', () => {
         currentProject={project}
         devices={cloudDevices}
         onRequestClose={onRequestClose}
-      />,
+      />
     )
 
     await userEvent.click(screen.getByTestId('workspace-ide-card'))
 
-    await waitFor(() =>
-      expect(api.startCodeServerSession).toHaveBeenCalledWith(7),
-    )
+    await waitFor(() => expect(api.startCodeServerSession).toHaveBeenCalledWith(7))
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(window.open).toHaveBeenCalledWith(
-      'http://localhost/ide',
-      '_blank',
-      'noopener',
-    )
+    expect(window.open).toHaveBeenCalledWith('http://localhost/ide', '_blank', 'noopener')
     expect(onRequestClose).toHaveBeenCalledTimes(1)
   })
 
@@ -240,36 +251,87 @@ describe('WorkspacePanelCards', () => {
         currentProject={project}
         devices={cloudDevices}
         onRequestClose={onRequestClose}
-      />,
+      />
     )
 
     await userEvent.click(screen.getByTestId('workspace-desktop-card'))
 
-    await waitFor(() =>
-      expect(getVncConfigMock).toHaveBeenCalledWith('device-1'),
-    )
+    await waitFor(() => expect(getVncConfigMock).toHaveBeenCalledWith('device-1'))
     expect(window.open).toHaveBeenCalledWith(
       expect.stringContaining('/vnc.html?wsUrl='),
       '_blank',
-      'noopener',
+      'noopener'
     )
     expect(window.open).toHaveBeenCalledWith(
       expect.stringContaining('sandboxId=sandbox-1'),
       '_blank',
-      'noopener',
+      'noopener'
     )
     expect(onRequestClose).toHaveBeenCalledTimes(1)
   })
 
-  test('does not show cloud-only project tools for local devices', () => {
+  test('launches the native terminal for local project devices without cloud-only tools', async () => {
+    const api = createProjectApiMock()
+    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
+
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
+
+    await waitFor(() =>
+      expect(startLocalTerminalMock).toHaveBeenCalledWith({
+        cwd: '/workspace/projects/project38',
+      })
+    )
+    expect(getLocalExecutorDeviceIdMock).toHaveBeenCalledWith('/api')
+    expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
+      'data-session-id',
+      'local-terminal-1'
+    )
+    expect(api.startTerminalSession).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
+  })
+
+  test('keeps local project tools hidden outside the WeWork macOS app', () => {
+    isLocalTerminalAvailableMock.mockReturnValue(false)
+
     render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
 
     expect(screen.queryByTestId('workspace-terminal-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
-    expect(screen.getByTestId('workspace-local-device-limited-tools')).toHaveTextContent(
-      'workbench.local_device_limited_tools_title',
+    expect(screen.getByTestId('workspace-local-device-limited-tools')).toBeInTheDocument()
+  })
+
+  test('launches the native terminal when the executor id differs but the local path exists', async () => {
+    getLocalExecutorDeviceIdMock.mockResolvedValue('another-device')
+
+    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
+
+    await userEvent.click(await screen.findByTestId('workspace-terminal-card'))
+
+    await waitFor(() =>
+      expect(startLocalTerminalMock).toHaveBeenCalledWith({
+        cwd: '/workspace/projects/project38',
+      })
     )
+    expect(screen.getByTestId('embedded-local-terminal')).toHaveAttribute(
+      'data-session-id',
+      'local-terminal-1'
+    )
+    expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
+  })
+
+  test('keeps local project tools hidden when neither executor id nor local path matches', async () => {
+    getLocalExecutorDeviceIdMock.mockResolvedValue('another-device')
+    localPathExistsMock.mockResolvedValue(false)
+
+    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
+
+    expect(await screen.findByTestId('workspace-local-device-limited-tools')).toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-terminal-card')).not.toBeInTheDocument()
+    expect(startLocalTerminalMock).not.toHaveBeenCalled()
   })
 
   test('does not show ClaudeCode-only project tools for OpenClaw devices', () => {
@@ -292,16 +354,12 @@ describe('WorkspacePanelCards', () => {
 
   test('marks terminal as unavailable when session probing fails', async () => {
     const api = createProjectApiMock()
-    vi.mocked(api.startTerminalSession).mockRejectedValueOnce(
-      new Error('terminal unavailable'),
-    )
+    vi.mocked(api.startTerminalSession).mockRejectedValueOnce(new Error('terminal unavailable'))
     render(<WorkspacePanelCards currentProject={project} devices={cloudDevices} />)
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-terminal-card')).toBeDisabled(),
-    )
+    await waitFor(() => expect(screen.getByTestId('workspace-terminal-card')).toBeDisabled())
     expect(screen.getByTestId('workspace-terminal-card')).toHaveTextContent('暂不可用')
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
@@ -318,16 +376,10 @@ describe('WorkspacePanelCards', () => {
 
     await userEvent.click(screen.getByTestId('workspace-ide-card'))
 
-    await waitFor(() =>
-      expect(api.startCodeServerSession).toHaveBeenCalledWith(7),
-    )
+    await waitFor(() => expect(api.startCodeServerSession).toHaveBeenCalledWith(7))
     expect(fetchMock).not.toHaveBeenCalled()
     expect(api.startCodeServerSession).toHaveBeenCalledTimes(1)
-    expect(window.open).toHaveBeenCalledWith(
-      'http://localhost/ide',
-      '_blank',
-      'noopener',
-    )
+    expect(window.open).toHaveBeenCalledWith('http://localhost/ide', '_blank', 'noopener')
   })
 
   test('marks IDE as unavailable when the returned session URL is missing', async () => {
@@ -344,9 +396,7 @@ describe('WorkspacePanelCards', () => {
 
     await userEvent.click(screen.getByTestId('workspace-ide-card'))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-ide-card')).toBeDisabled(),
-    )
+    await waitFor(() => expect(screen.getByTestId('workspace-ide-card')).toBeDisabled())
     expect(window.open).not.toHaveBeenCalled()
     expect(api.startCodeServerSession).toHaveBeenCalledTimes(1)
     expect(screen.getByRole('alert')).toHaveTextContent('启动失败')
@@ -358,9 +408,7 @@ describe('WorkspacePanelCards', () => {
 
     await userEvent.click(screen.getByTestId('workspace-desktop-card'))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-desktop-card')).toBeDisabled(),
-    )
+    await waitFor(() => expect(screen.getByTestId('workspace-desktop-card')).toBeDisabled())
     expect(screen.getByTestId('workspace-desktop-card')).toHaveTextContent('暂不可用')
     expect(window.open).not.toHaveBeenCalled()
 
@@ -373,29 +421,23 @@ describe('WorkspacePanelCards', () => {
 
   test('resets unavailable tools when the project changes', async () => {
     const api = createProjectApiMock()
-    vi.mocked(api.startTerminalSession).mockRejectedValueOnce(
-      new Error('terminal unavailable'),
-    )
+    vi.mocked(api.startTerminalSession).mockRejectedValueOnce(new Error('terminal unavailable'))
     const nextProject = {
       ...project,
       id: 8,
       name: 'project39',
     }
     const { rerender } = render(
-      <WorkspacePanelCards currentProject={project} devices={cloudDevices} />,
+      <WorkspacePanelCards currentProject={project} devices={cloudDevices} />
     )
 
     await userEvent.click(screen.getByTestId('workspace-terminal-card'))
 
-    await waitFor(() =>
-      expect(screen.getByTestId('workspace-terminal-card')).toBeDisabled(),
-    )
+    await waitFor(() => expect(screen.getByTestId('workspace-terminal-card')).toBeDisabled())
 
     rerender(<WorkspacePanelCards currentProject={nextProject} devices={cloudDevices} />)
 
     expect(screen.getByTestId('workspace-terminal-card')).not.toBeDisabled()
-    expect(screen.getByTestId('workspace-terminal-card')).not.toHaveTextContent(
-      '暂不可用',
-    )
+    expect(screen.getByTestId('workspace-terminal-card')).not.toHaveTextContent('暂不可用')
   })
 })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -1,13 +1,21 @@
 import { Code2, Loader2, Monitor, Plus, SquareTerminal, X } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createDeviceApi } from '@/api/devices'
 import { createHttpClient } from '@/api/http'
 import { createProjectApi } from '@/api/projects'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useTranslation } from '@/hooks/useTranslation'
-import { supportsCloudSessions } from '@/lib/device-capabilities'
+import { supportsCloudSessions, supportsLocalTerminalLaunch } from '@/lib/device-capabilities'
+import {
+  closeLocalTerminal,
+  getLocalExecutorDeviceId,
+  isLocalTerminalAvailable,
+  localPathExists,
+  startLocalTerminal,
+} from '@/lib/local-terminal'
 import { buildVncPageUrl } from '@/lib/vnc'
 import type { DeviceInfo, ProjectDeviceSessionResponse, ProjectWithTasks } from '@/types/api'
+import { EmbeddedLocalTerminal } from './EmbeddedLocalTerminal'
 
 interface WorkspacePanelCardsProps {
   currentProject: ProjectWithTasks | null
@@ -29,6 +37,17 @@ interface WorkspaceToolErrorState {
   message: string | null
 }
 
+interface LocalTerminalCheckState {
+  key: string
+  executorDeviceId: string | null
+  pathExists: boolean
+}
+
+type WorkspaceTerminalSession = ProjectDeviceSessionResponse & {
+  terminal_kind?: 'cloud' | 'local'
+  cwd?: string
+}
+
 function createAvailableTools(): WorkspaceToolAvailability {
   return {
     terminal: true,
@@ -39,6 +58,10 @@ function createAvailableTools(): WorkspaceToolAvailability {
 
 function getProjectDeviceId(project: ProjectWithTasks | null): string | undefined {
   return project?.config?.execution?.deviceId ?? project?.config?.device_id
+}
+
+function getProjectLocalPath(project: ProjectWithTasks): string | undefined {
+  return project.config?.workspace?.localPath ?? project.config?.path
 }
 
 function createProjectSessionApi() {
@@ -57,31 +80,60 @@ export function WorkspacePanelCards({
   onRequestClose,
 }: WorkspacePanelCardsProps) {
   const { t } = useTranslation('common')
-  const [terminalSessions, setTerminalSessions] = useState<ProjectDeviceSessionResponse[]>([])
+  const [terminalSessions, setTerminalSessions] = useState<WorkspaceTerminalSession[]>([])
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null)
   const [showToolLauncher, setShowToolLauncher] = useState(false)
   const [loadingTool, setLoadingTool] = useState<WorkspaceTool | null>(null)
-  const [toolAvailability, setToolAvailability] = useState<WorkspaceToolAvailabilityState>(
-    () => ({
-      projectKey: '',
-      tools: createAvailableTools(),
-    }),
-  )
+  const [toolAvailability, setToolAvailability] = useState<WorkspaceToolAvailabilityState>(() => ({
+    projectKey: '',
+    tools: createAvailableTools(),
+  }))
   const [toolError, setToolError] = useState<WorkspaceToolErrorState>({
     projectKey: '',
     message: null,
   })
   const projectDeviceId = getProjectDeviceId(currentProject)
+  const projectLocalPath = currentProject ? getProjectLocalPath(currentProject) : undefined
   const projectDevice = projectDeviceId
     ? devices.find(device => device.device_id === projectDeviceId)
     : undefined
+  const localTerminalSupported = Boolean(
+    projectDevice && supportsLocalTerminalLaunch(projectDevice)
+  )
+  const localTerminalRuntimeAvailable = isLocalTerminalAvailable()
+  const localTerminalCheckKey = [
+    localTerminalRuntimeAvailable ? 'tauri-macos' : 'unavailable',
+    projectDevice?.device_id ?? '',
+    projectDevice?.device_type ?? '',
+    projectDevice?.bind_shell ?? '',
+    projectLocalPath ?? '',
+  ].join(':')
+  const [localTerminalCheck, setLocalTerminalCheck] = useState<LocalTerminalCheckState>({
+    key: '',
+    executorDeviceId: null,
+    pathExists: false,
+  })
+  const localExecutorDeviceId =
+    localTerminalCheck.key === localTerminalCheckKey ? localTerminalCheck.executorDeviceId : null
+  const projectLocalPathExists =
+    localTerminalCheck.key === localTerminalCheckKey ? localTerminalCheck.pathExists : false
   const cloudToolsAvailable = Boolean(projectDevice && supportsCloudSessions(projectDevice))
-  const hasExplicitLocalDevice = Boolean(currentProject && projectDeviceId && !cloudToolsAvailable)
+  const sameExecutorDevice = Boolean(
+    projectDevice && localExecutorDeviceId === projectDevice.device_id
+  )
+  const localTerminalAvailable = Boolean(
+    projectDevice &&
+    localTerminalSupported &&
+    localTerminalRuntimeAvailable &&
+    (sameExecutorDevice || projectLocalPathExists)
+  )
+  const projectTerminalAvailable = cloudToolsAvailable || localTerminalAvailable
+  const hasLimitedProjectTools = Boolean(
+    currentProject && projectDeviceId && !cloudToolsAvailable && !localTerminalAvailable
+  )
   const projectKey = currentProject ? `${currentProject.id}:${projectDeviceId ?? ''}` : ''
   const availableTools =
-    toolAvailability.projectKey === projectKey
-      ? toolAvailability.tools
-      : createAvailableTools()
+    toolAvailability.projectKey === projectKey ? toolAvailability.tools : createAvailableTools()
   const error = toolError.projectKey === projectKey ? toolError.message : null
   const toolsDisabled = !currentProject || Boolean(loadingTool)
   const activeTerminalSession =
@@ -89,6 +141,43 @@ export function WorkspacePanelCards({
     terminalSessions[0] ??
     null
   const terminalTabLabel = currentProject?.name ?? activeTerminalSession?.device_id ?? ''
+
+  useEffect(() => {
+    if (!localTerminalSupported || !localTerminalRuntimeAvailable) {
+      return
+    }
+
+    let cancelled = false
+    const { apiBaseUrl } = getRuntimeConfig()
+    Promise.all([getLocalExecutorDeviceId(apiBaseUrl), localPathExists(projectLocalPath)])
+      .then(([deviceId, pathExists]) => {
+        if (!cancelled) {
+          setLocalTerminalCheck({
+            key: localTerminalCheckKey,
+            executorDeviceId: deviceId,
+            pathExists,
+          })
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLocalTerminalCheck({
+            key: localTerminalCheckKey,
+            executorDeviceId: null,
+            pathExists: false,
+          })
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    localTerminalCheckKey,
+    localTerminalRuntimeAvailable,
+    localTerminalSupported,
+    projectLocalPath,
+  ])
 
   const markToolUnavailable = (tool: WorkspaceTool) => {
     setToolAvailability(state => {
@@ -114,6 +203,26 @@ export function WorkspacePanelCards({
     setLoadingTool('terminal')
     setProjectError(null)
     try {
+      if (localTerminalAvailable && projectDeviceId) {
+        const sessionId = await startLocalTerminal({ cwd: projectLocalPath })
+        setTerminalSessions(sessions => [
+          ...sessions,
+          {
+            terminal_kind: 'local',
+            session_id: sessionId,
+            project_id: currentProject.id,
+            device_id: projectDeviceId,
+            type: 'terminal',
+            path: projectLocalPath ?? '',
+            url: '',
+            cwd: projectLocalPath,
+          },
+        ])
+        setActiveTerminalSessionId(sessionId)
+        setShowToolLauncher(false)
+        return
+      }
+
       const session = await createProjectSessionApi().startTerminalSession(currentProject.id)
       if (!session.url) {
         throw new Error('Terminal session URL is missing')
@@ -135,6 +244,11 @@ export function WorkspacePanelCards({
   }
 
   const handleCloseTerminalSession = (sessionId: string) => {
+    const session = terminalSessions.find(session => session.session_id === sessionId)
+    if (session?.terminal_kind === 'local') {
+      void closeLocalTerminal(sessionId)
+    }
+
     setTerminalSessions(sessions => {
       const closeIndex = sessions.findIndex(session => session.session_id === sessionId)
       const remaining = sessions.filter(session => session.session_id !== sessionId)
@@ -200,75 +314,81 @@ export function WorkspacePanelCards({
   }
 
   const terminalWindow = activeTerminalSession ? (
-      <div
-        data-testid="workspace-terminal-window"
-        className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-white"
-      >
-        <div className="flex h-10 shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-[#fafafa] px-2">
-          <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
-            {terminalSessions.map(session => {
-              const isActive = session.session_id === activeTerminalSession.session_id
+    <div
+      data-testid="workspace-terminal-window"
+      className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-white"
+    >
+      <div className="flex h-10 shrink-0 items-center gap-2 overflow-hidden border-b border-border bg-[#fafafa] px-2">
+        <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
+          {terminalSessions.map(session => {
+            const isActive = session.session_id === activeTerminalSession.session_id
 
-              return (
-                <div
-                  key={session.session_id}
-                  className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-md border border-transparent transition-colors ${
-                    isActive
-                      ? 'border-border bg-white text-text-primary shadow-sm after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
-                      : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
-                  }`}
-                  title={terminalTabLabel || session.device_id}
+            return (
+              <div
+                key={session.session_id}
+                className={`group relative flex h-8 max-w-[200px] shrink-0 items-center overflow-hidden rounded-md border border-transparent transition-colors ${
+                  isActive
+                    ? 'border-border bg-white text-text-primary shadow-sm after:absolute after:inset-x-2 after:bottom-0 after:h-0.5 after:rounded-full after:bg-primary'
+                    : 'text-text-secondary hover:border-border hover:bg-surface hover:text-text-primary'
+                }`}
+                title={terminalTabLabel || session.device_id}
+              >
+                <button
+                  type="button"
+                  data-testid="workspace-terminal-tab"
+                  onClick={() => {
+                    setActiveTerminalSessionId(session.session_id)
+                    setShowToolLauncher(false)
+                  }}
+                  className="flex min-w-0 flex-1 items-center gap-2 px-2.5 text-left text-[13px] leading-[18px]"
                 >
-                  <button
-                    type="button"
-                    data-testid="workspace-terminal-tab"
-                    onClick={() => {
-                      setActiveTerminalSessionId(session.session_id)
-                      setShowToolLauncher(false)
-                    }}
-                    className="flex min-w-0 flex-1 items-center gap-2 px-2.5 text-left text-[13px] leading-[18px]"
-                  >
-                    <SquareTerminal className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
-                    <span className="truncate">{terminalTabLabel || session.device_id}</span>
-                  </button>
-                  <button
-                    type="button"
-                    data-testid="workspace-terminal-close-button"
-                    onClick={() => handleCloseTerminalSession(session.session_id)}
-                    className="flex h-8 w-7 shrink-0 items-center justify-center text-text-secondary transition-colors group-hover:text-text-primary"
-                    aria-label={t('workbench.close_terminal', '关闭终端')}
-                  >
-                    <X className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              )
-            })}
-          </div>
-          <button
-            type="button"
-            data-testid="workspace-terminal-new-tab-button"
-            onClick={() => setShowToolLauncher(true)}
-            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-secondary hover:bg-muted disabled:cursor-wait disabled:opacity-50"
-            aria-label={t('workbench.show_project_tools', '显示项目工具')}
-          >
-            <Plus className="h-4 w-4" />
-          </button>
+                  <SquareTerminal className="h-3.5 w-3.5 shrink-0 text-text-secondary" />
+                  <span className="truncate">{terminalTabLabel || session.device_id}</span>
+                </button>
+                <button
+                  type="button"
+                  data-testid="workspace-terminal-close-button"
+                  onClick={() => handleCloseTerminalSession(session.session_id)}
+                  className="flex h-8 w-7 shrink-0 items-center justify-center text-text-secondary transition-colors group-hover:text-text-primary"
+                  aria-label={t('workbench.close_terminal', '关闭终端')}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )
+          })}
         </div>
-        {terminalSessions.map(session => {
-          const isActive = session.session_id === activeTerminalSession.session_id
-
-          return (
-            <iframe
-              key={session.session_id}
-              data-testid="workspace-terminal-frame"
-              title={t('workbench.project_terminal_frame_title', '项目终端')}
-              src={session.url}
-              hidden={!isActive}
-              className="min-h-0 flex-1 border-0"
-            />
-          )
-        })}
+        <button
+          type="button"
+          data-testid="workspace-terminal-new-tab-button"
+          onClick={() => setShowToolLauncher(true)}
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-secondary hover:bg-muted disabled:cursor-wait disabled:opacity-50"
+          aria-label={t('workbench.show_project_tools', '显示项目工具')}
+        >
+          <Plus className="h-4 w-4" />
+        </button>
       </div>
+      {terminalSessions.map(session => {
+        const isActive = session.session_id === activeTerminalSession.session_id
+
+        return session.terminal_kind === 'local' ? (
+          <EmbeddedLocalTerminal
+            key={session.session_id}
+            sessionId={session.session_id}
+            active={isActive}
+          />
+        ) : (
+          <iframe
+            key={session.session_id}
+            data-testid="workspace-terminal-frame"
+            title={t('workbench.project_terminal_frame_title', '项目终端')}
+            src={session.url}
+            hidden={!isActive}
+            className="min-h-0 flex-1 border-0"
+          />
+        )
+      })}
+    </div>
   ) : null
   const launcherClassName = activeTerminalSession
     ? 'absolute inset-0 z-10 flex w-full flex-col bg-white'
@@ -279,98 +399,102 @@ export function WorkspacePanelCards({
       {terminalWindow}
       {(!activeTerminalSession || showToolLauncher) && (
         <div data-testid="workspace-tool-launcher" className={launcherClassName}>
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-8 py-6">
-          {!currentProject && (
-            <p className="text-center text-[13px] leading-[18px] text-text-secondary">
-              {t('workbench.project_tool_requires_project', '请选择项目后使用')}
-            </p>
-          )}
-          {error && (
-            <p className="text-center text-[13px] leading-[18px] text-red-500" role="alert">
-              {error}
-            </p>
-          )}
-          {hasExplicitLocalDevice && (
-            <div
-              data-testid="workspace-local-device-limited-tools"
-              className="rounded-lg border border-border bg-surface px-4 py-5 text-center"
-            >
-              <p className="text-sm font-semibold text-text-primary">
-                {t('workbench.local_device_limited_tools_title')}
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-8 py-6">
+            {!currentProject && (
+              <p className="text-center text-[13px] leading-[18px] text-text-secondary">
+                {t('workbench.project_tool_requires_project', '请选择项目后使用')}
               </p>
-              <p className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                {t('workbench.local_device_limited_tools_desc')}
+            )}
+            {error && (
+              <p className="text-center text-[13px] leading-[18px] text-red-500" role="alert">
+                {error}
               </p>
-            </div>
-          )}
-          {cloudToolsAvailable && (
-            <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-4">
-              <button
-                type="button"
-                data-testid="workspace-terminal-card"
-                onClick={handleTerminalClick}
-                disabled={toolsDisabled || !availableTools.terminal}
-                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            )}
+            {hasLimitedProjectTools && (
+              <div
+                data-testid="workspace-local-device-limited-tools"
+                className="rounded-lg border border-border bg-surface px-4 py-5 text-center"
               >
-                {loadingTool === 'terminal' ? (
-                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                ) : (
-                  <SquareTerminal className="mb-5 h-7 w-7 text-text-secondary" />
+                <p className="text-sm font-semibold text-text-primary">
+                  {t('workbench.local_device_limited_tools_title')}
+                </p>
+                <p className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                  {t('workbench.local_device_limited_tools_desc')}
+                </p>
+              </div>
+            )}
+            {projectTerminalAvailable && (
+              <div className="grid w-full grid-cols-[repeat(auto-fit,minmax(120px,1fr))] gap-4">
+                <button
+                  type="button"
+                  data-testid="workspace-terminal-card"
+                  onClick={handleTerminalClick}
+                  disabled={toolsDisabled || !availableTools.terminal}
+                  className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {loadingTool === 'terminal' ? (
+                    <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                  ) : (
+                    <SquareTerminal className="mb-5 h-7 w-7 text-text-secondary" />
+                  )}
+                  <span className="text-sm font-semibold text-text-primary">
+                    {t('workbench.terminal', '终端')}
+                  </span>
+                  <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                    {availableTools.terminal
+                      ? t('workbench.start_shell', '启动交互式 shell')
+                      : t('workbench.project_tool_unavailable', '暂不可用')}
+                  </span>
+                </button>
+                {cloudToolsAvailable && (
+                  <>
+                    <button
+                      type="button"
+                      data-testid="workspace-ide-card"
+                      onClick={handleIdeClick}
+                      disabled={toolsDisabled || !availableTools.ide}
+                      className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {loadingTool === 'ide' ? (
+                        <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                      ) : (
+                        <Code2 className="mb-5 h-7 w-7 text-text-secondary" />
+                      )}
+                      <span className="text-sm font-semibold text-text-primary">
+                        {t('workbench.ide', 'IDE')}
+                      </span>
+                      <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                        {availableTools.ide
+                          ? t('workbench.open_project_ide', '打开项目 IDE')
+                          : t('workbench.project_tool_unavailable', '暂不可用')}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      data-testid="workspace-desktop-card"
+                      onClick={handleDesktopClick}
+                      disabled={toolsDisabled || !projectDeviceId || !availableTools.desktop}
+                      className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {loadingTool === 'desktop' ? (
+                        <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                      ) : (
+                        <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
+                      )}
+                      <span className="text-sm font-semibold text-text-primary">
+                        {t('workbench.desktop', '桌面')}
+                      </span>
+                      <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                        {availableTools.desktop
+                          ? t('workbench.open_project_desktop', '打开项目桌面')
+                          : t('workbench.project_tool_unavailable', '暂不可用')}
+                      </span>
+                    </button>
+                  </>
                 )}
-                <span className="text-sm font-semibold text-text-primary">
-                  {t('workbench.terminal', '终端')}
-                </span>
-                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                  {availableTools.terminal
-                    ? t('workbench.start_shell', '启动交互式 shell')
-                    : t('workbench.project_tool_unavailable', '暂不可用')}
-                </span>
-              </button>
-              <button
-                type="button"
-                data-testid="workspace-ide-card"
-                onClick={handleIdeClick}
-                disabled={toolsDisabled || !availableTools.ide}
-                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loadingTool === 'ide' ? (
-                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                ) : (
-                  <Code2 className="mb-5 h-7 w-7 text-text-secondary" />
-                )}
-                <span className="text-sm font-semibold text-text-primary">
-                  {t('workbench.ide', 'IDE')}
-                </span>
-                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                  {availableTools.ide
-                    ? t('workbench.open_project_ide', '打开项目 IDE')
-                    : t('workbench.project_tool_unavailable', '暂不可用')}
-                </span>
-              </button>
-              <button
-                type="button"
-                data-testid="workspace-desktop-card"
-                onClick={handleDesktopClick}
-                disabled={toolsDisabled || !projectDeviceId || !availableTools.desktop}
-                className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {loadingTool === 'desktop' ? (
-                  <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                ) : (
-                  <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
-                )}
-                <span className="text-sm font-semibold text-text-primary">
-                  {t('workbench.desktop', '桌面')}
-                </span>
-                <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                  {availableTools.desktop
-                    ? t('workbench.open_project_desktop', '打开项目桌面')
-                    : t('workbench.project_tool_unavailable', '暂不可用')}
-                </span>
-              </button>
-            </div>
-          )}
-        </div>
+              </div>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.test.tsx
@@ -6,6 +6,7 @@ import { createDeviceApi } from '@/api/devices'
 import { createProjectApi } from '@/api/projects'
 import { createUserApi } from '@/api/users'
 import { AppearanceProvider } from '@/features/appearance'
+import { getLocalExecutorDeviceId, isLocalTerminalAvailable } from '@/lib/local-terminal'
 import '@/i18n'
 import type { DeviceInfo } from '@/types/devices'
 
@@ -38,9 +39,16 @@ vi.mock('@/api/users', () => ({
   createUserApi: vi.fn(),
 }))
 
+vi.mock('@/lib/local-terminal', () => ({
+  getLocalExecutorDeviceId: vi.fn(),
+  isLocalTerminalAvailable: vi.fn(),
+}))
+
 const createDeviceApiMock = vi.mocked(createDeviceApi)
 const createProjectApiMock = vi.mocked(createProjectApi)
 const createUserApiMock = vi.mocked(createUserApi)
+const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
+const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 
 function cloudDevice(overrides: Partial<DeviceInfo> = {}): DeviceInfo {
   return {
@@ -78,6 +86,7 @@ describe('ConnectionsSettingsPage', () => {
     getAllDevices: vi.fn(),
     startTerminal: vi.fn(),
     startCodeServer: vi.fn(),
+    openLocalTerminal: vi.fn(),
     createCloudDevice: vi.fn(),
     renameDevice: vi.fn(),
     restartCloudDevice: vi.fn(),
@@ -116,6 +125,9 @@ describe('ConnectionsSettingsPage', () => {
       cloudDeviceScalingWikiUrl: '',
     }
     window.history.pushState({}, '', '/')
+    isLocalTerminalAvailableMock.mockReturnValue(true)
+    getLocalExecutorDeviceIdMock.mockResolvedValue('local-claude')
+    api.openLocalTerminal.mockResolvedValue(undefined)
     api.getMetrics.mockResolvedValue({
       cpu_usage: 42,
       memory_usage: 68,
@@ -731,7 +743,8 @@ describe('ConnectionsSettingsPage', () => {
     expect(moreButton).toHaveClass('bg-background', 'text-text-secondary')
   })
 
-  test('hides cloud-only actions and metrics for local devices', async () => {
+  test('launches a native terminal for online local devices without exposing cloud-only actions', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
     api.getAllDevices.mockResolvedValue([
       localDevice({
         device_id: 'local-claude',
@@ -742,8 +755,13 @@ describe('ConnectionsSettingsPage', () => {
     render(<ConnectionsSettingsPage onBack={vi.fn()} />)
 
     expect(await screen.findByTestId('connection-device-local-claude')).toBeInTheDocument()
+    await waitFor(() => expect(getLocalExecutorDeviceIdMock).toHaveBeenCalledWith('/api'))
     expect(screen.getByText('Local Claude Device')).toBeInTheDocument()
-    expect(screen.queryByTestId('connection-terminal-button-local-claude')).not.toBeInTheDocument()
+    await userEvent.click(await screen.findByTestId('connection-terminal-button-local-claude'))
+
+    await waitFor(() => expect(api.openLocalTerminal).toHaveBeenCalledWith('local-claude'))
+    expect(api.startTerminal).not.toHaveBeenCalled()
+    expect(openSpy).not.toHaveBeenCalled()
     expect(
       screen.queryByTestId('connection-code-server-button-local-claude')
     ).not.toBeInTheDocument()
@@ -753,6 +771,44 @@ describe('ConnectionsSettingsPage', () => {
     expect(screen.queryByTestId('device-metrics')).not.toBeInTheDocument()
     expect(screen.queryByTestId('connection-scale-wiki')).not.toBeInTheDocument()
     expect(api.getMetrics).not.toHaveBeenCalled()
+  })
+
+  test('keeps local device terminal hidden outside the WeWork macOS app', async () => {
+    isLocalTerminalAvailableMock.mockReturnValue(false)
+    api.getAllDevices.mockResolvedValue([
+      localDevice({
+        device_id: 'local-claude',
+        name: 'Local Claude Device',
+      }),
+    ])
+
+    render(<ConnectionsSettingsPage onBack={vi.fn()} />)
+
+    expect(await screen.findByTestId('connection-device-local-claude')).toBeInTheDocument()
+    expect(screen.queryByTestId('connection-terminal-button-local-claude')).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId('connection-code-server-button-local-claude')
+    ).not.toBeInTheDocument()
+  })
+
+  test('keeps local device terminal hidden when the executor is on another device', async () => {
+    getLocalExecutorDeviceIdMock.mockResolvedValue('another-local-device')
+    api.getAllDevices.mockResolvedValue([
+      localDevice({
+        device_id: 'local-claude',
+        name: 'Local Claude Device',
+      }),
+    ])
+
+    render(<ConnectionsSettingsPage onBack={vi.fn()} />)
+
+    expect(await screen.findByTestId('connection-device-local-claude')).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('connection-terminal-button-local-claude')
+      ).not.toBeInTheDocument()
+    )
+    expect(api.openLocalTerminal).not.toHaveBeenCalled()
   })
 
   test('shows configured cloud device scaling wiki link in the cloud section guidance', async () => {

--- a/wework/src/components/settings/ConnectionsSettingsPage.tsx
+++ b/wework/src/components/settings/ConnectionsSettingsPage.tsx
@@ -41,7 +41,9 @@ import {
   supportsCloudLifecycleActions,
   supportsCloudSessions,
   supportsDeviceMetrics,
+  supportsLocalTerminalLaunch,
 } from '@/lib/device-capabilities'
+import { getLocalExecutorDeviceId, isLocalTerminalAvailable } from '@/lib/local-terminal'
 import type { ArchivedTask } from '@/types/api'
 import type { CloudDeviceMetricsResponse, DeviceInfo } from '@/types/devices'
 import { AppearanceSettingsPage } from '@/features/appearance/AppearanceSettingsPage'
@@ -512,13 +514,58 @@ function DeviceCard({ device, onChanged }: { device: DeviceInfo; onChanged: () =
   const [saving, setSaving] = useState(false)
   const [restarting, setRestarting] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [localExecutorDeviceId, setLocalExecutorDeviceId] = useState<string | null>(null)
   const [actionMenuOpen, setActionMenuOpen] = useState(false)
   const [confirmAction, setConfirmAction] = useState<ConfirmDeviceAction | null>(null)
   const [connectionInfoOpen, setConnectionInfoOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const actionMenuRef = useRef<HTMLDivElement>(null)
 
-  const handleStartSession = useCallback(
+  const handleStartTerminal = useCallback(async () => {
+    if (device.status !== 'online') return
+    setSessionLoading('terminal')
+    try {
+      if (supportsLocalTerminalLaunch(device)) {
+        await createSettingsDeviceApi().openLocalTerminal(device.device_id)
+        return
+      }
+
+      const result = await createSettingsDeviceApi().startTerminal(device.device_id)
+      if (result.url) {
+        window.open(result.url, '_blank', 'noopener')
+      }
+    } catch (e) {
+      console.error('Failed to start terminal:', e)
+    } finally {
+      setSessionLoading(null)
+    }
+  }, [device])
+
+  useEffect(() => {
+    if (!supportsLocalTerminalLaunch(device) || !isLocalTerminalAvailable()) {
+      return
+    }
+
+    let cancelled = false
+    const { apiBaseUrl } = getRuntimeConfig()
+    getLocalExecutorDeviceId(apiBaseUrl)
+      .then(deviceId => {
+        if (!cancelled) {
+          setLocalExecutorDeviceId(deviceId)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLocalExecutorDeviceId(null)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [device])
+
+  const handleStartCloudSession = useCallback(
     async (type: 'terminal' | 'code-server') => {
       if (device.status !== 'online') return
       setSessionLoading(type)
@@ -635,7 +682,12 @@ function DeviceCard({ device, onChanged }: { device: DeviceInfo; onChanged: () =
 
   const isOnline = device.status === 'online'
   const isCloud = isCloudDevice(device)
+  const canLaunchLocalTerminal =
+    supportsLocalTerminalLaunch(device) &&
+    isLocalTerminalAvailable() &&
+    localExecutorDeviceId === device.device_id
   const canUseCloudSessions = supportsCloudSessions(device)
+  const canUseTerminal = canUseCloudSessions || canLaunchLocalTerminal
   const canUseCloudLifecycleActions = supportsCloudLifecycleActions(device)
   const canDeleteOfflineLocalDevice = !isCloud && device.status === 'offline'
 
@@ -702,20 +754,22 @@ function DeviceCard({ device, onChanged }: { device: DeviceInfo; onChanged: () =
           </div>
 
           <div className="flex shrink-0 gap-2">
+            {canUseTerminal && (
+              <DeviceActionButton
+                testId={`connection-terminal-button-${device.device_id}`}
+                icon={Terminal}
+                label="终端"
+                onClick={handleStartTerminal}
+                disabled={!isOnline || sessionLoading === 'terminal'}
+              />
+            )}
             {canUseCloudSessions && (
               <>
-                <DeviceActionButton
-                  testId={`connection-terminal-button-${device.device_id}`}
-                  icon={Terminal}
-                  label="终端"
-                  onClick={() => handleStartSession('terminal')}
-                  disabled={!isOnline || sessionLoading === 'terminal'}
-                />
                 <DeviceActionButton
                   testId={`connection-code-server-button-${device.device_id}`}
                   icon={Code2}
                   label="IDE"
-                  onClick={() => handleStartSession('code-server')}
+                  onClick={() => handleStartCloudSession('code-server')}
                   disabled={!isOnline || sessionLoading === 'code-server'}
                 />
                 <VncDesktopButton deviceId={device.device_id} />

--- a/wework/src/lib/device-capabilities.test.ts
+++ b/wework/src/lib/device-capabilities.test.ts
@@ -6,6 +6,7 @@ import {
   isDeviceBelowWeWorkVersion,
   isDeviceRunningTask,
   isVersionAtLeast,
+  supportsLocalTerminalLaunch,
 } from './device-capabilities'
 
 describe('device-capabilities', () => {
@@ -46,21 +47,38 @@ describe('device-capabilities', () => {
         status: 'online',
         bind_shell: 'claudecode',
         slot_used: 0,
-      }),
+      })
     ).toBe(true)
     expect(
       canRequestDeviceUpgrade({
         status: 'online',
         bind_shell: 'claudecode',
         slot_used: 1,
-      }),
+      })
     ).toBe(false)
     expect(
       canRequestDeviceUpgrade({
         status: 'offline',
         bind_shell: 'claudecode',
         slot_used: 0,
-      }),
+      })
+    ).toBe(false)
+  })
+
+  test('supports native terminal launch only on local Claude Code devices', () => {
+    const claudeDevice = {
+      bind_shell: 'claudecode',
+      status: 'online',
+    }
+
+    expect(supportsLocalTerminalLaunch({ ...claudeDevice, device_type: 'local' })).toBe(true)
+    expect(supportsLocalTerminalLaunch({ ...claudeDevice, device_type: 'cloud' })).toBe(false)
+    expect(
+      supportsLocalTerminalLaunch({
+        ...claudeDevice,
+        device_type: 'local',
+        bind_shell: 'openclaw',
+      })
     ).toBe(false)
   })
 })

--- a/wework/src/lib/device-capabilities.ts
+++ b/wework/src/lib/device-capabilities.ts
@@ -6,11 +6,7 @@ type DeviceLike = Pick<DeviceInfo, 'device_type' | 'bind_shell' | 'status'> &
   Partial<
     Pick<
       DeviceInfo,
-      | 'executor_version'
-      | 'update_available'
-      | 'slot_used'
-      | 'running_tasks'
-      | 'running_task_ids'
+      'executor_version' | 'update_available' | 'slot_used' | 'running_tasks' | 'running_task_ids'
     >
   >
 
@@ -60,9 +56,7 @@ export function isDeviceRunningTask(device: DeviceLike): boolean {
   )
 }
 
-export function isWeWorkExecutorVersionCompatible(
-  version?: string | null,
-): boolean {
+export function isWeWorkExecutorVersionCompatible(version?: string | null): boolean {
   if (!version) return false
   return isVersionAtLeast(version, WEWORK_MIN_EXECUTOR_VERSION)
 }
@@ -72,8 +66,7 @@ export function isDeviceBelowWeWorkVersion(device: DeviceLike): boolean {
 }
 
 export function isWeWorkCompatibleDevice(device: DeviceLike): boolean {
-  return isClaudeCodeDevice(device) &&
-    isWeWorkExecutorVersionCompatible(device.executor_version)
+  return isClaudeCodeDevice(device) && isWeWorkExecutorVersionCompatible(device.executor_version)
 }
 
 export function hasWeWorkUpdateAvailable(device: DeviceLike): boolean {
@@ -85,13 +78,19 @@ export function canRequestDeviceUpgrade(device: DeviceLike): boolean {
 }
 
 export function canUseForProjectCreation(device: DeviceLike): boolean {
-  return isClaudeCodeDevice(device) &&
+  return (
+    isClaudeCodeDevice(device) &&
     isUsableDevice(device) &&
     isWeWorkExecutorVersionCompatible(device.executor_version)
+  )
 }
 
 export function supportsCloudSessions(device: DeviceLike): boolean {
   return isCloudDevice(device) && isClaudeCodeDevice(device)
+}
+
+export function supportsLocalTerminalLaunch(device: DeviceLike): boolean {
+  return !isCloudDevice(device) && isClaudeCodeDevice(device)
 }
 
 export function supportsDeviceMetrics(device: Pick<DeviceInfo, 'device_type'>): boolean {

--- a/wework/src/lib/local-terminal.test.ts
+++ b/wework/src/lib/local-terminal.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { invoke } from '@tauri-apps/api/core'
+import { listen } from '@tauri-apps/api/event'
+import {
+  closeLocalTerminal,
+  getLocalExecutorDeviceId,
+  isLocalTerminalAvailable,
+  listenLocalTerminalExit,
+  listenLocalTerminalOutput,
+  localPathExists,
+  resizeLocalTerminal,
+  startLocalTerminal,
+  writeLocalTerminal,
+} from './local-terminal'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}))
+
+const invokeMock = vi.mocked(invoke)
+const listenMock = vi.mocked(listen)
+
+function setNavigatorValue<K extends keyof Navigator>(key: K, value: Navigator[K]) {
+  Object.defineProperty(navigator, key, {
+    configurable: true,
+    value,
+  })
+}
+
+describe('local-terminal', () => {
+  beforeEach(() => {
+    invokeMock.mockReset()
+    listenMock.mockReset()
+  })
+
+  afterEach(() => {
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+  })
+
+  test('is available only inside the WeWork macOS Tauri app', () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+
+    expect(isLocalTerminalAvailable()).toBe(true)
+  })
+
+  test('is unavailable for regular browsers even on macOS', () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+
+    expect(isLocalTerminalAvailable()).toBe(false)
+  })
+
+  test('is unavailable inside the iOS Tauri app', () => {
+    setNavigatorValue('userAgent', 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)')
+    setNavigatorValue('platform', 'iPhone')
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+
+    expect(isLocalTerminalAvailable()).toBe(false)
+  })
+
+  test('reads the local executor device id from the native app', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    invokeMock.mockResolvedValue(' local-device-1 ')
+
+    await expect(getLocalExecutorDeviceId(' http://localhost:8000/api ')).resolves.toBe(
+      'local-device-1'
+    )
+    expect(invokeMock).toHaveBeenCalledWith('get_local_executor_device_id', {
+      expectedBackendUrl: 'http://localhost:8000/api',
+    })
+  })
+
+  test('does not read the local executor device id in regular browsers', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+
+    await expect(getLocalExecutorDeviceId()).resolves.toBeNull()
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  test('checks local project path existence through the native app', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    invokeMock.mockResolvedValue(true)
+
+    await expect(localPathExists(' /Users/me/project ')).resolves.toBe(true)
+    expect(invokeMock).toHaveBeenCalledWith('local_path_exists', {
+      path: '/Users/me/project',
+    })
+  })
+
+  test('does not check local project paths in regular browsers', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+
+    await expect(localPathExists('/Users/me/project')).resolves.toBe(false)
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  test('starts an embedded local terminal session through the native app', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    invokeMock.mockResolvedValue('local-terminal-1')
+
+    await expect(
+      startLocalTerminal({ cwd: ' /Users/me/project ', rows: 30, cols: 100 })
+    ).resolves.toBe('local-terminal-1')
+    expect(invokeMock).toHaveBeenCalledWith('start_local_terminal', {
+      cwd: '/Users/me/project',
+      rows: 30,
+      cols: 100,
+    })
+  })
+
+  test('writes, resizes, and closes embedded local terminal sessions', async () => {
+    invokeMock.mockResolvedValue(undefined)
+
+    await writeLocalTerminal('local-terminal-1', 'pwd\r')
+    await resizeLocalTerminal('local-terminal-1', 40, 120)
+    await closeLocalTerminal('local-terminal-1')
+
+    expect(invokeMock).toHaveBeenCalledWith('write_local_terminal', {
+      sessionId: 'local-terminal-1',
+      data: 'pwd\r',
+    })
+    expect(invokeMock).toHaveBeenCalledWith('resize_local_terminal', {
+      sessionId: 'local-terminal-1',
+      rows: 40,
+      cols: 120,
+    })
+    expect(invokeMock).toHaveBeenCalledWith('close_local_terminal', {
+      sessionId: 'local-terminal-1',
+    })
+  })
+
+  test('listens to embedded local terminal native events', async () => {
+    const unlisten = vi.fn()
+    listenMock.mockResolvedValue(unlisten)
+    const outputHandler = vi.fn()
+    const exitHandler = vi.fn()
+
+    await listenLocalTerminalOutput(outputHandler)
+    await listenLocalTerminalExit(exitHandler)
+
+    expect(listenMock).toHaveBeenCalledWith('local-terminal-output', expect.any(Function))
+    expect(listenMock).toHaveBeenCalledWith('local-terminal-exit', expect.any(Function))
+  })
+})

--- a/wework/src/lib/local-terminal.ts
+++ b/wework/src/lib/local-terminal.ts
@@ -1,0 +1,108 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import { isTauriRuntime } from './runtime-environment'
+
+export function isLocalTerminalAvailable(): boolean {
+  if (typeof navigator === 'undefined') return false
+
+  const userAgent = navigator.userAgent || ''
+  const platform = navigator.platform || ''
+  const isIosLike =
+    /iPad|iPhone|iPod/.test(userAgent) || (platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  const isMacOs = platform.startsWith('Mac') || userAgent.includes('Mac OS X')
+
+  return isTauriRuntime() && isMacOs && !isIosLike
+}
+
+export async function getLocalExecutorDeviceId(
+  expectedBackendUrl?: string
+): Promise<string | null> {
+  if (!isLocalTerminalAvailable()) return null
+
+  const deviceId = await invoke<string | null>('get_local_executor_device_id', {
+    expectedBackendUrl: expectedBackendUrl?.trim() || null,
+  })
+  return deviceId?.trim() || null
+}
+
+export async function localPathExists(path?: string): Promise<boolean> {
+  if (!isLocalTerminalAvailable()) return false
+
+  const trimmedPath = path?.trim()
+  if (!trimmedPath) return false
+
+  return invoke<boolean>('local_path_exists', { path: trimmedPath })
+}
+
+export interface StartLocalTerminalOptions {
+  cwd?: string
+  rows?: number
+  cols?: number
+}
+
+export interface LocalTerminalOutputPayload {
+  session_id: string
+  data: string
+}
+
+export interface LocalTerminalExitPayload {
+  session_id: string
+}
+
+export async function startLocalTerminal({
+  cwd,
+  rows,
+  cols,
+}: StartLocalTerminalOptions = {}): Promise<string> {
+  if (!isLocalTerminalAvailable()) {
+    throw new Error('Local terminal is unavailable outside the macOS Tauri app')
+  }
+
+  const trimmedCwd = cwd?.trim()
+  return invoke<string>('start_local_terminal', {
+    cwd: trimmedCwd || null,
+    rows,
+    cols,
+  })
+}
+
+export async function writeLocalTerminal(sessionId: string, data: string): Promise<void> {
+  await invoke('write_local_terminal', {
+    sessionId,
+    data,
+  })
+}
+
+export async function resizeLocalTerminal(
+  sessionId: string,
+  rows: number,
+  cols: number
+): Promise<void> {
+  await invoke('resize_local_terminal', {
+    sessionId,
+    rows,
+    cols,
+  })
+}
+
+export async function closeLocalTerminal(sessionId: string): Promise<void> {
+  await invoke('close_local_terminal', {
+    sessionId,
+  })
+}
+
+export function listenLocalTerminalOutput(
+  handler: (payload: LocalTerminalOutputPayload) => void
+): Promise<UnlistenFn> {
+  return listen<LocalTerminalOutputPayload>('local-terminal-output', event => {
+    handler(event.payload)
+  })
+}
+
+export function listenLocalTerminalExit(
+  handler: (payload: LocalTerminalExitPayload) => void
+): Promise<UnlistenFn> {
+  return listen<LocalTerminalExitPayload>('local-terminal-exit', event => {
+    handler(event.payload)
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for launching terminals on local devices via a new `open_terminal` command.
  * Introduced embedded terminal sessions in the macOS WeWork app workspace, enabling direct interaction with local execution environments.
  * Updated settings page to support terminal launch on local executor devices.

* **Documentation**
  * Updated developer guides to clarify local device command RPC scope and local terminal behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->