### PR TITLE
fix(frontend): constrain mobile input action menu height

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -167,5 +167,9 @@ describe('MobileChatInputControls layout', () => {
     expect(modelSlot).toHaveClass('overflow-hidden')
     expect(sendSlot).toHaveClass('flex-shrink-0')
     expect(screen.getByText('Attach')).toBeInTheDocument()
+
+    const menu = screen.getByTestId('mobile-input-more-actions-menu')
+    expect(menu).toHaveClass('max-h-[min(52dvh,18rem)]')
+    expect(menu).toHaveClass('overflow-y-auto')
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -171,5 +171,6 @@ describe('MobileChatInputControls layout', () => {
     const menu = screen.getByTestId('mobile-input-more-actions-menu')
     expect(menu).toHaveClass('max-h-[min(52dvh,18rem)]')
     expect(menu).toHaveClass('overflow-y-auto')
+    expect(menu).toHaveClass('overscroll-contain')
   })
 })

--- a/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/MobileChatInputControls.layout.test.tsx
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { MobileChatInputControlsProps } from '@/features/tasks/components/input/MobileChatInputControls'
 import { MobileChatInputControls } from '@/features/tasks/components/input/MobileChatInputControls'
 import type { Team } from '@/types/api'
@@ -67,23 +68,19 @@ jest.mock('@/components/ui/action-button', () => ({
   ),
 }))
 
-jest.mock('@/components/ui/button', () => ({
-  Button: ({
-    children,
-    className,
-    disabled,
-    ...props
-  }: {
-    children: React.ReactNode
-    className?: string
-    disabled?: boolean
-    [key: string]: unknown
-  }) => (
-    <button type="button" className={className} disabled={disabled} {...props}>
+jest.mock('@/components/ui/button', () => {
+  const MockButton = React.forwardRef<
+    HTMLButtonElement,
+    React.ButtonHTMLAttributes<HTMLButtonElement>
+  >(({ children, className, disabled, ...props }, ref) => (
+    <button ref={ref} type="button" className={className} disabled={disabled} {...props}>
       {children}
     </button>
-  ),
-}))
+  ))
+  MockButton.displayName = 'MockButton'
+
+  return { Button: MockButton }
+})
 
 jest.mock('@/components/ui/dropdown', () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -146,10 +143,26 @@ const buildProps = (): MobileChatInputControlsProps => ({
 })
 
 describe('MobileChatInputControls layout', () => {
-  it('keeps long selector labels clipped without clipping the overflow menu', () => {
+  it('keeps long selector labels clipped without clipping the overflow menu', async () => {
     render(<MobileChatInputControls {...buildProps()} />)
 
-    fireEvent.click(screen.getByRole('button', { name: 'More actions' }))
+    const moreActionsButton = screen.getByRole('button', { name: 'More actions' })
+    moreActionsButton.getBoundingClientRect = jest.fn(
+      () =>
+        ({
+          left: 32,
+          top: 420,
+          right: 64,
+          bottom: 452,
+          width: 32,
+          height: 32,
+          x: 32,
+          y: 420,
+          toJSON: () => {},
+        }) as DOMRect
+    )
+
+    fireEvent.click(moreActionsButton)
 
     const sendSlot = screen.getByTestId('send-button').parentElement
     const rightControls = sendSlot?.parentElement
@@ -169,7 +182,14 @@ describe('MobileChatInputControls layout', () => {
     expect(screen.getByText('Attach')).toBeInTheDocument()
 
     const menu = screen.getByTestId('mobile-input-more-actions-menu')
-    expect(menu).toHaveClass('max-h-[min(52dvh,18rem)]')
+    await waitFor(() => {
+      expect(menu).toHaveStyle({
+        left: '32px',
+        top: '124px',
+        maxHeight: '288px',
+      })
+    })
+    expect(menu).toHaveClass('fixed')
     expect(menu).toHaveClass('overflow-y-auto')
     expect(menu).toHaveClass('overscroll-contain')
   })

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -4,7 +4,7 @@
 
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { CircleStop, Hand, Plus } from 'lucide-react'
 import MobileModelSelector from '../selector/MobileModelSelector'
 import type { Model } from '../selector/ModelSelector'
@@ -38,6 +38,12 @@ import { supportsAttachments } from '../../service/attachmentService'
 import SkillSelectorPopover from '../selector/SkillSelectorPopover'
 import { getChatSendState } from './chatSendState'
 import { useTranslation } from '@/hooks/useTranslation'
+
+const MOBILE_ACTION_MENU_WIDTH = 224
+const MOBILE_ACTION_MENU_MARGIN = 12
+const MOBILE_ACTION_MENU_GAP = 8
+const MOBILE_ACTION_MENU_MAX_HEIGHT = 288
+const MOBILE_ACTION_MENU_MIN_HEIGHT = 44
 
 export interface MobileChatInputControlsProps {
   taskType?: TaskType
@@ -174,6 +180,8 @@ export function MobileChatInputControls({
 }: MobileChatInputControlsProps) {
   const { t } = useTranslation('chat')
   const [moreMenuOpen, setMoreMenuOpen] = useState(false)
+  const moreMenuButtonRef = useRef<HTMLButtonElement>(null)
+  const [moreMenuStyle, setMoreMenuStyle] = useState<React.CSSProperties>({})
   const showChatContexts = canUseChatContexts(taskType, selectedTeam)
   const showAttachmentAction = supportsAttachments(selectedTeam)
   const showSkillAction = availableSkills.length > 0 && Boolean(onToggleSkill)
@@ -203,6 +211,51 @@ export function MobileChatInputControls({
     effectiveRequiresWorkspace !== false
   const showBranchAction = showRepositoryAction && Boolean(selectedRepo)
   const hasSecondaryActions = showAttachmentAction || showChatContexts || showSkillAction
+
+  const updateMoreMenuPosition = useCallback(() => {
+    const button = moreMenuButtonRef.current
+    if (!button) return
+
+    const rect = button.getBoundingClientRect()
+    const viewport = window.visualViewport
+    const viewportTop = viewport?.offsetTop ?? 0
+    const viewportWidth = viewport?.width ?? window.innerWidth
+    const topBoundary = viewportTop + MOBILE_ACTION_MENU_MARGIN
+    const menuBottom = Math.max(
+      topBoundary + MOBILE_ACTION_MENU_MIN_HEIGHT,
+      rect.top - MOBILE_ACTION_MENU_GAP
+    )
+    const availableHeight = Math.max(MOBILE_ACTION_MENU_MIN_HEIGHT, menuBottom - topBoundary)
+    const menuHeight = Math.min(MOBILE_ACTION_MENU_MAX_HEIGHT, availableHeight)
+    const maxLeft = Math.max(
+      MOBILE_ACTION_MENU_MARGIN,
+      viewportWidth - MOBILE_ACTION_MENU_WIDTH - MOBILE_ACTION_MENU_MARGIN
+    )
+
+    setMoreMenuStyle({
+      left: Math.min(Math.max(rect.left, MOBILE_ACTION_MENU_MARGIN), maxLeft),
+      top: menuBottom - menuHeight,
+      maxHeight: menuHeight,
+    })
+  }, [])
+
+  useEffect(() => {
+    if (!moreMenuOpen) return
+
+    updateMoreMenuPosition()
+    const viewport = window.visualViewport
+    window.addEventListener('resize', updateMoreMenuPosition)
+    window.addEventListener('scroll', updateMoreMenuPosition, true)
+    viewport?.addEventListener('resize', updateMoreMenuPosition)
+    viewport?.addEventListener('scroll', updateMoreMenuPosition)
+
+    return () => {
+      window.removeEventListener('resize', updateMoreMenuPosition)
+      window.removeEventListener('scroll', updateMoreMenuPosition, true)
+      viewport?.removeEventListener('resize', updateMoreMenuPosition)
+      viewport?.removeEventListener('scroll', updateMoreMenuPosition)
+    }
+  }, [moreMenuOpen, updateMoreMenuPosition])
 
   // Render send button based on state
   const renderSendButton = () => {
@@ -309,6 +362,7 @@ export function MobileChatInputControls({
       >
         {/* Secondary actions menu */}
         <Button
+          ref={moreMenuButtonRef}
           type="button"
           variant="ghost"
           size="sm"
@@ -325,7 +379,8 @@ export function MobileChatInputControls({
         {moreMenuOpen && (
           <div
             data-testid="mobile-input-more-actions-menu"
-            className="absolute bottom-full left-0 z-50 mb-2 max-h-[min(52dvh,18rem)] w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+            className="fixed z-50 w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+            style={moreMenuStyle}
           >
             {hasSecondaryActions && (
               <div className="flex flex-col">

--- a/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
+++ b/frontend/src/features/tasks/components/input/MobileChatInputControls.tsx
@@ -325,7 +325,7 @@ export function MobileChatInputControls({
         {moreMenuOpen && (
           <div
             data-testid="mobile-input-more-actions-menu"
-            className="absolute bottom-full left-0 z-50 mb-2 w-56 rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
+            className="absolute bottom-full left-0 z-50 mb-2 max-h-[min(52dvh,18rem)] w-56 overflow-y-auto overscroll-contain rounded-lg border border-border bg-popover p-1 text-popover-foreground shadow-md"
           >
             {hasSecondaryActions && (
               <div className="flex flex-col">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/updated coverage to verify the mobile “More actions” menu renders with deterministic positioning and enforces max height with vertical scrolling behavior.

* **Style**
  * Improved the mobile “More actions” dropdown to position reliably relative to its trigger and to use a fixed, bounded-height overlay with scroll support for smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->