### PR TITLE
Allow concurrent turns in distinct Git worktrees

### DIFF
--- a/executor/services/turn_file_changes.py
+++ b/executor/services/turn_file_changes.py
@@ -346,15 +346,15 @@ class TurnFileChangeTracker:
         temp_path.replace(path)
 
     def _acquire_lock(self) -> None:
-        common_dir = _run_git(
+        git_dir = _run_git(
             self.workspace,
             "rev-parse",
-            "--git-common-dir",
+            "--git-dir",
         ).stdout.strip()
-        common_path = Path(common_dir)
-        if not common_path.is_absolute():
-            common_path = self.workspace / common_path
-        self._lock_path = common_path.resolve() / LOCK_FILE_NAME
+        git_path = Path(git_dir)
+        if not git_path.is_absolute():
+            git_path = self.workspace / git_path
+        self._lock_path = git_path.resolve() / LOCK_FILE_NAME
         lock_metadata = {
             "pid": os.getpid(),
             "hostname": socket.gethostname(),

--- a/executor/tests/services/test_turn_file_changes.py
+++ b/executor/tests/services/test_turn_file_changes.py
@@ -265,6 +265,36 @@ async def test_tracker_rejects_concurrent_turns_in_same_workspace(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_tracker_allows_concurrent_turns_in_distinct_git_worktrees(tmp_path):
+    repo = init_repo(tmp_path)
+    worktrees_root = tmp_path / "worktrees"
+    worktrees_root.mkdir()
+    first_workspace = worktrees_root / "101" / "repo"
+    second_workspace = worktrees_root / "102" / "repo"
+    run_git(repo, "worktree", "add", "-q", "-b", "turn-101", str(first_workspace))
+    run_git(repo, "worktree", "add", "-q", "-b", "turn-102", str(second_workspace))
+    first = TurnFileChangeTracker(
+        workspace=first_workspace,
+        task_id=1,
+        subtask_id=2,
+        executor_home=tmp_path / "home",
+    )
+    second = TurnFileChangeTracker(
+        workspace=second_workspace,
+        task_id=1,
+        subtask_id=3,
+        executor_home=tmp_path / "home",
+    )
+
+    await first.start()
+    try:
+        assert await second.start() is True
+    finally:
+        await second.abort()
+        await first.abort()
+
+
+@pytest.mark.asyncio
 async def test_tracker_removes_stale_same_host_lock(tmp_path):
     repo = init_repo(tmp_path)
     lock_path = repo / ".git" / "wegent-turn-file-changes.lock"


### PR DESCRIPTION
## Summary
- Switch turn file change locking to use `git rev-parse --git-dir` so each worktree gets its own lock location
- Add a regression test proving concurrent turns are allowed across distinct Git worktrees

## Testing
- Added unit test coverage for concurrent worktrees
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace lock file handling to properly isolate locks per repository instance when using Git worktrees, enabling concurrent operations on different worktrees of the same base repository.

* **Tests**
  * Added test coverage verifying concurrent operations work correctly across multiple Git worktrees with the same base repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->