### PR TITLE
Update workbench file title styling and add layout coverage

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2485,8 +2485,16 @@ describe('DesktopWorkbenchLayout', () => {
     expect(fileTab).toHaveAttribute('role', 'tab')
     expect(fileTab).toHaveAttribute('aria-selected', 'true')
     expect(fileTab).toHaveTextContent('打开文件')
+    expect(fileTab).toHaveClass('group')
+    const fileIcon = within(fileTab).getByTestId('right-workspace-file-tab-icon')
+    expect(fileIcon).toHaveClass('opacity-100', 'group-hover:opacity-0')
     const closeButton = within(fileTab).getByTestId('close-right-workspace-panel-button')
-    expect(closeButton).toHaveClass('rounded-full')
+    expect(closeButton).toHaveClass(
+      'rounded-full',
+      'opacity-0',
+      'group-hover:opacity-100',
+      'focus-visible:opacity-100'
+    )
     expect(closeButton).not.toHaveClass('ml-auto')
     expect(screen.getByTestId('right-workspace-new-tab-button')).toBeInTheDocument()
     expect(await screen.findByTestId('workspace-file-tree')).toBeInTheDocument()

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -47,21 +47,24 @@ export function RightWorkspacePanel({
           data-testid="right-workspace-file-tab"
           role="tab"
           aria-selected="true"
-          className="flex h-10 min-w-0 max-w-[240px] items-center gap-2 rounded-xl bg-muted py-1 pl-2 pr-4 text-left text-sm font-medium text-text-primary"
+          className="group flex h-10 min-w-0 max-w-[240px] items-center gap-2 rounded-xl bg-muted py-1 pl-2 pr-4 text-left text-sm font-medium text-text-primary"
         >
-          <button
-            type="button"
-            data-testid="close-right-workspace-panel-button"
-            onClick={onRequestClose}
-            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-text-muted text-background transition-colors hover:bg-text-secondary"
-            aria-label={t('workbench.close_right_workspace_panel')}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-          <File className="h-4 w-4 shrink-0 text-text-secondary" />
-          <span className="truncate">
-            {t('workbench.workspace_tab_open_file', '打开文件')}
+          <span className="relative h-6 w-6 shrink-0">
+            <File
+              data-testid="right-workspace-file-tab-icon"
+              className="absolute inset-0 m-auto h-4 w-4 text-text-secondary opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0"
+            />
+            <button
+              type="button"
+              data-testid="close-right-workspace-panel-button"
+              onClick={onRequestClose}
+              className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-full bg-text-muted text-background opacity-0 transition-colors hover:bg-text-secondary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
+              aria-label={t('workbench.close_right_workspace_panel')}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
           </span>
+          <span className="truncate">{t('workbench.workspace_tab_open_file', '打开文件')}</span>
         </div>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Adjust the local Google Sans stylesheet used by the frontend
- Update the right workspace panel implementation in the desktop workbench layout
- Add test coverage for the desktop workbench layout behavior

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file tab interface with close button that appears on hover, enhancing workspace visual clarity and reducing visual clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->