### PR TITLE
[codex] improve wework image attachment preview

### DIFF
--- a/wework/src/components/chat/AttachmentImagePreview.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { FileText, Loader2, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
+import type { Attachment } from '@/types/api'
+import { getAttachmentImageUrl } from '@/lib/attachments'
+
+interface AttachmentImagePreviewProps {
+  attachment: Attachment
+  buttonTestId: string
+  imageTestId: string
+  loadingTestId: string
+  errorTestId: string
+  imageClassName: string
+  placeholderClassName: string
+  buttonClassName?: string
+}
+
+const MIN_ZOOM = 0.5
+const MAX_ZOOM = 4
+const ZOOM_STEP = 0.25
+
+function clampZoom(value: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+}
+
+export function AttachmentImagePreview({
+  attachment,
+  buttonTestId,
+  imageTestId,
+  loadingTestId,
+  errorTestId,
+  imageClassName,
+  placeholderClassName,
+  buttonClassName = 'block max-w-full cursor-zoom-in p-0 text-left',
+}: AttachmentImagePreviewProps) {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+  const [hasError, setHasError] = useState(false)
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false)
+  const [zoom, setZoom] = useState(1)
+
+  useEffect(() => {
+    let isMounted = true
+    let objectUrl: string | null = null
+
+    async function loadPreview() {
+      setPreviewUrl(null)
+      setHasError(false)
+      setIsLightboxOpen(false)
+      setZoom(1)
+
+      try {
+        const token = localStorage.getItem('auth_token')
+        const response = await fetch(getAttachmentImageUrl(attachment.id), {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        })
+
+        if (!response.ok) {
+          throw new Error(`Failed to load attachment preview: ${response.status}`)
+        }
+
+        const blob = await response.blob()
+        if (!blob.type.startsWith('image/')) {
+          throw new Error(`Attachment preview is not an image: ${blob.type || 'unknown'}`)
+        }
+
+        objectUrl = URL.createObjectURL(blob)
+        if (isMounted) {
+          setPreviewUrl(objectUrl)
+        } else {
+          URL.revokeObjectURL(objectUrl)
+        }
+      } catch {
+        if (isMounted) {
+          setHasError(true)
+        }
+      }
+    }
+
+    void loadPreview()
+
+    return () => {
+      isMounted = false
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [attachment.id])
+
+  useEffect(() => {
+    if (!isLightboxOpen) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsLightboxOpen(false)
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isLightboxOpen])
+
+  if (previewUrl) {
+    const lightbox =
+      isLightboxOpen && typeof document !== 'undefined'
+        ? createPortal(
+            <div
+              data-testid="attachment-image-lightbox"
+              role="dialog"
+              aria-modal="true"
+              aria-label={attachment.filename}
+              className="fixed inset-0 z-modal flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black/90 p-0"
+              onClick={() => setIsLightboxOpen(false)}
+              onWheel={event => {
+                event.stopPropagation()
+                setZoom(current => clampZoom(current + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP)))
+              }}
+            >
+              <div
+                data-testid="attachment-image-zoom-controls"
+                className="absolute left-1/2 top-4 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full bg-black/45 p-1 text-white shadow-[0_12px_36px_rgba(0,0,0,0.35)]"
+                onClick={event => event.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  data-testid="attachment-image-zoom-out"
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+                  onClick={() => setZoom(current => clampZoom(current - ZOOM_STEP))}
+                  disabled={zoom <= MIN_ZOOM}
+                  aria-label="Zoom out"
+                >
+                  <ZoomOut className="h-5 w-5" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="attachment-image-zoom-reset"
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15"
+                  onClick={() => setZoom(1)}
+                  aria-label="Reset zoom"
+                >
+                  <RotateCcw className="h-5 w-5" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="attachment-image-zoom-in"
+                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+                  onClick={() => setZoom(current => clampZoom(current + ZOOM_STEP))}
+                  disabled={zoom >= MAX_ZOOM}
+                  aria-label="Zoom in"
+                >
+                  <ZoomIn className="h-5 w-5" />
+                </button>
+              </div>
+              <button
+                type="button"
+                data-testid="attachment-image-lightbox-close"
+                className="absolute right-4 top-4 z-20 flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                onClick={event => {
+                  event.stopPropagation()
+                  setIsLightboxOpen(false)
+                }}
+                aria-label="Close image preview"
+              >
+                <X className="h-5 w-5" />
+              </button>
+              <img
+                data-testid="attachment-image-lightbox-image"
+                src={previewUrl}
+                alt={attachment.filename}
+                className="max-h-[calc(100dvh-6rem)] max-w-[calc(100dvw-2rem)] object-contain transition-transform duration-150 ease-out"
+                style={{ transform: `scale(${zoom})` }}
+                onClick={event => event.stopPropagation()}
+              />
+            </div>,
+            document.body
+          )
+        : null
+
+    return (
+      <>
+        <button
+          type="button"
+          data-testid={buttonTestId}
+          className={buttonClassName}
+          onClick={() => setIsLightboxOpen(true)}
+          aria-label={attachment.filename}
+        >
+          <img
+            data-testid={imageTestId}
+            src={previewUrl}
+            alt={attachment.filename}
+            className={imageClassName}
+          />
+        </button>
+        {lightbox}
+      </>
+    )
+  }
+
+  return (
+    <div
+      data-testid={hasError ? errorTestId : loadingTestId}
+      className={placeholderClassName}
+      aria-label={attachment.filename}
+    >
+      {hasError ? <FileText className="h-5 w-5" /> : <Loader2 className="h-5 w-5 animate-spin" />}
+    </div>
+  )
+}

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -13,10 +13,7 @@ import type { GuidanceWorkbenchMessage, QueuedWorkbenchMessage } from '@/types/w
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
-    t: (
-      key: string,
-      options?: string | { count?: number },
-    ) => {
+    t: (key: string, options?: string | { count?: number }) => {
       if (typeof options === 'string') return options
       if (key === 'workbench.code_comment_count') {
         return `${options?.count ?? 0} 个评论`
@@ -1524,6 +1521,52 @@ describe('ChatInput', () => {
         'blob:attachment-preview'
       )
     })
+  })
+
+  test('opens an enlarged image from the composer attachment preview', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['image'], { type: 'image/png' })),
+      })
+    )
+    URL.createObjectURL = vi.fn(() => 'blob:attachment-preview')
+    const attachment: Attachment = {
+      id: 43,
+      filename: 'screenshot.png',
+      file_size: 1200,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-05-27T00:00:00.000Z',
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({ attachments: [attachment] })}
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('attachment-image-preview'))
+
+    const lightbox = screen.getByTestId('attachment-image-lightbox')
+
+    expect(lightbox).toBeInTheDocument()
+    expect(lightbox.parentElement).toBe(document.body)
+    expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+      'src',
+      'blob:attachment-preview'
+    )
+    expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+      'alt',
+      'screenshot.png'
+    )
   })
 
   test('loads image previews with the auth token from local storage', async () => {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -207,6 +207,71 @@ describe('MessageList', () => {
     )
   })
 
+  test('opens an enlarged image from a user message attachment preview', async () => {
+    URL.createObjectURL = vi.fn(() => 'blob:message-image-preview')
+    URL.revokeObjectURL = vi.fn()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        blob: vi.fn().mockResolvedValue(new Blob(['image'], { type: 'image/png' })),
+      })
+    )
+
+    const attachment: Attachment = {
+      id: 43,
+      filename: 'diagram.png',
+      file_size: 1024,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-05-25T15:08:00.000+08:00',
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '1',
+            role: 'user',
+            content: '分析下这个图片',
+            status: 'done',
+            attachments: [attachment],
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('message-image-preview'))
+
+    const lightbox = screen.getByTestId('attachment-image-lightbox')
+    const lightboxImage = screen.getByTestId('attachment-image-lightbox-image')
+
+    expect(lightbox).toBeInTheDocument()
+    expect(lightbox.parentElement).toBe(document.body)
+    expect(lightbox).toHaveClass('h-dvh', 'w-dvw', 'p-0')
+    expect(lightbox).toHaveClass('overflow-hidden')
+    expect(lightboxImage).toHaveClass(
+      'max-h-[calc(100dvh-6rem)]',
+      'max-w-[calc(100dvw-2rem)]',
+      'object-contain'
+    )
+    expect(lightboxImage).not.toHaveClass('h-full', 'w-full')
+    expect(screen.getByTestId('attachment-image-lightbox-close')).toHaveClass('z-20')
+    expect(lightboxImage).toHaveAttribute('src', 'blob:message-image-preview')
+    expect(lightboxImage).toHaveAttribute('alt', 'diagram.png')
+    expect(lightboxImage).toHaveStyle({ transform: 'scale(1)' })
+
+    await userEvent.click(screen.getByTestId('attachment-image-zoom-in'))
+
+    expect(lightboxImage).toHaveStyle({ transform: 'scale(1.25)' })
+
+    await userEvent.click(screen.getByTestId('attachment-image-zoom-reset'))
+
+    expect(lightboxImage).toHaveStyle({ transform: 'scale(1)' })
+  })
+
   test('keeps image attachments compact and allows extras to wrap', async () => {
     URL.createObjectURL = vi.fn(() => 'blob:message-image-preview')
     URL.revokeObjectURL = vi.fn()

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,22 +1,14 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronUp,
-  Copy,
-  CopyCheck,
-  FileText,
-  Loader2,
-  Package,
-} from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronUp, Copy, CopyCheck, Package } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { Attachment, DeviceInfo, TurnFileChangesSummary } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
-import { getAttachmentImageUrl, getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
+import { getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
 import { parseChatError } from '@/lib/chat-error'
+import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
 import { FileChangesCard } from './FileChangesCard'
 
@@ -198,74 +190,16 @@ function MessageDocumentAttachment({ attachment }: { attachment: Attachment }) {
 }
 
 function MessageImageAttachmentPreview({ attachment }: { attachment: Attachment }) {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const [hasError, setHasError] = useState(false)
-
-  useEffect(() => {
-    let isMounted = true
-    let objectUrl: string | null = null
-
-    async function loadPreview() {
-      setPreviewUrl(null)
-      setHasError(false)
-
-      try {
-        const token = localStorage.getItem('auth_token')
-        const response = await fetch(getAttachmentImageUrl(attachment.id), {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        })
-
-        if (!response.ok) {
-          throw new Error(`Failed to load message attachment: ${response.status}`)
-        }
-
-        const blob = await response.blob()
-        if (!blob.type.startsWith('image/')) {
-          throw new Error(`Message attachment is not an image: ${blob.type || 'unknown'}`)
-        }
-
-        objectUrl = URL.createObjectURL(blob)
-        if (isMounted) {
-          setPreviewUrl(objectUrl)
-        } else {
-          URL.revokeObjectURL(objectUrl)
-        }
-      } catch {
-        if (isMounted) {
-          setHasError(true)
-        }
-      }
-    }
-
-    void loadPreview()
-
-    return () => {
-      isMounted = false
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl)
-      }
-    }
-  }, [attachment.id])
-
-  if (previewUrl) {
-    return (
-      <img
-        data-testid="message-image-preview"
-        src={previewUrl}
-        alt={attachment.filename}
-        className="block max-h-36 max-w-[180px] shrink-0 rounded-xl border border-border bg-base object-contain"
-      />
-    )
-  }
-
   return (
-    <div
-      data-testid={hasError ? 'message-image-preview-error' : 'message-image-preview-loading'}
-      className="flex h-20 w-28 shrink-0 items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
-      aria-label={attachment.filename}
-    >
-      {hasError ? <FileText className="h-5 w-5" /> : <Loader2 className="h-5 w-5 animate-spin" />}
-    </div>
+    <AttachmentImagePreview
+      attachment={attachment}
+      buttonTestId="message-image-preview-button"
+      imageTestId="message-image-preview"
+      loadingTestId="message-image-preview-loading"
+      errorTestId="message-image-preview-error"
+      imageClassName="block max-h-36 max-w-[180px] shrink-0 rounded-xl border border-border bg-base object-contain"
+      placeholderClassName="flex h-20 w-28 shrink-0 items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
+    />
   )
 }
 

--- a/wework/src/components/chat/composer/AttachmentBadges.tsx
+++ b/wework/src/components/chat/composer/AttachmentBadges.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useState } from 'react'
 import { FileText, Loader2, MessageSquare, X } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { Attachment } from '@/types/api'
 import type { CodeCommentContext } from '@/types/workspace-files'
-import {
-  getAttachmentImageUrl,
-  getAttachmentTypeLabel,
-  isImageAttachment,
-} from '@/lib/attachments'
+import { getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
+import { AttachmentImagePreview } from '../AttachmentImagePreview'
 
 interface AttachmentBadgesProps {
   attachments: Attachment[]
@@ -16,78 +12,6 @@ interface AttachmentBadgesProps {
   codeComments?: CodeCommentContext[]
   onRemoveAttachment: (attachmentId: number) => void
   onClearCodeComments?: () => void
-}
-
-function ImageAttachmentPreview({ attachment }: { attachment: Attachment }) {
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null)
-  const [hasError, setHasError] = useState(false)
-
-  useEffect(() => {
-    let isMounted = true
-    let objectUrl: string | null = null
-
-    async function loadPreview() {
-      setPreviewUrl(null)
-      setHasError(false)
-
-      try {
-        const token = localStorage.getItem('auth_token')
-        const response = await fetch(getAttachmentImageUrl(attachment.id), {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        })
-
-        if (!response.ok) {
-          throw new Error(`Failed to load attachment preview: ${response.status}`)
-        }
-
-        const blob = await response.blob()
-        if (!blob.type.startsWith('image/')) {
-          throw new Error(`Attachment preview is not an image: ${blob.type || 'unknown'}`)
-        }
-
-        objectUrl = URL.createObjectURL(blob)
-        if (isMounted) {
-          setPreviewUrl(objectUrl)
-        } else {
-          URL.revokeObjectURL(objectUrl)
-        }
-      } catch {
-        if (isMounted) {
-          setHasError(true)
-        }
-      }
-    }
-
-    void loadPreview()
-
-    return () => {
-      isMounted = false
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl)
-      }
-    }
-  }, [attachment.id])
-
-  if (previewUrl) {
-    return (
-      <img
-        data-testid="attachment-image-preview"
-        src={previewUrl}
-        alt={attachment.filename}
-        className="h-full w-full rounded-xl object-cover"
-      />
-    )
-  }
-
-  return (
-    <div
-      data-testid={hasError ? 'attachment-image-preview-error' : 'attachment-image-preview-loading'}
-      className="flex h-full w-full items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
-      aria-label={attachment.filename}
-    >
-      {hasError ? <FileText className="h-5 w-5" /> : <Loader2 className="h-5 w-5 animate-spin" />}
-    </div>
-  )
 }
 
 function RemoveAttachmentButton({
@@ -142,13 +66,7 @@ function DocumentAttachmentCard({
   )
 }
 
-function CodeCommentBadge({
-  count,
-  onRemove,
-}: {
-  count: number
-  onRemove?: () => void
-}) {
+function CodeCommentBadge({ count, onRemove }: { count: number; onRemove?: () => void }) {
   const { t } = useTranslation('common')
 
   return (
@@ -194,10 +112,7 @@ export function AttachmentBadges({
   return (
     <div className="mb-3 flex flex-wrap gap-2" data-testid="attachment-badge-list">
       {codeCommentCount > 0 && (
-        <CodeCommentBadge
-          count={codeCommentCount}
-          onRemove={onClearCodeComments}
-        />
+        <CodeCommentBadge count={codeCommentCount} onRemove={onClearCodeComments} />
       )}
       {attachments.map(attachment =>
         isImageAttachment(attachment) ? (
@@ -206,7 +121,16 @@ export function AttachmentBadges({
             data-testid="attachment-badge"
             className="relative h-20 w-20 shrink-0"
           >
-            <ImageAttachmentPreview attachment={attachment} />
+            <AttachmentImagePreview
+              attachment={attachment}
+              buttonTestId="attachment-image-preview-button"
+              imageTestId="attachment-image-preview"
+              loadingTestId="attachment-image-preview-loading"
+              errorTestId="attachment-image-preview-error"
+              imageClassName="h-full w-full rounded-xl object-cover"
+              placeholderClassName="flex h-full w-full items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
+              buttonClassName="block h-full w-full cursor-zoom-in p-0 text-left"
+            />
             <RemoveAttachmentButton
               attachmentId={attachment.id}
               onRemoveAttachment={onRemoveAttachment}


### PR DESCRIPTION
## Summary

- Add a shared `AttachmentImagePreview` component for Wework chat image attachments.
- Allow image attachments in both message history and the composer to open a full-window preview.
- Render the preview through a body portal so it is positioned relative to the viewport, not the chat layout.
- Add zoom controls while keeping the default image constrained inside the viewport so the close button remains visible.

## Root Cause

The enlarged image preview was rendered inside the message/composer subtree. That let surrounding layout and stacking contexts affect the fixed-position overlay. The preview image also used full viewport dimensions by default, which could cover the close control.

## Validation

- `pnpm --dir wework exec vitest run src/components/chat/MessageList.test.tsx src/components/chat/ChatInput.test.tsx`
- `pnpm --dir wework run lint`
- `pnpm --dir wework run build`

Build completed successfully with the existing Vite large chunk warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image attachment previews now include zoomable lightbox functionality with zoom in/out controls, keyboard shortcuts (Escape to close), and scroll-wheel zoom support.

* **Refactor**
  * Consolidated image preview handling into a shared component for consistent behavior across chat messages and the message composer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->