### PR TITLE
Add Redis-backed session streaming

### DIFF
--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -19,6 +19,7 @@ import logging
 import time
 import uuid
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from app.core.cache import cache_manager
@@ -44,6 +45,16 @@ CONTEXT_METRICS_KEY_PREFIX = "chat:context_metrics:"
 CALLBACK_CHANNEL_PREFIX = "callback:channel:"
 # Unified TTL for all streaming-related data (1 hour)
 STREAMING_TTL = 3600
+# Internal field stored in Redis block metadata. It is stripped before returning
+# blocks to callers so API consumers still see the existing block shape.
+BLOCK_CONTENT_KEY_FIELD = "_content_key"
+
+
+class StreamContentType(str, Enum):
+    """Content-bearing streaming event types persisted in Redis."""
+
+    TEXT = "text"
+    THINKING = "thinking"
 
 
 class SessionManager:
@@ -793,6 +804,84 @@ class SessionManager:
         """Generate Redis key for current thinking block ID."""
         return f"{STREAMING_KEY_PREFIX}thinking_block:{subtask_id}"
 
+    def _get_block_content_key(self, subtask_id: int, block_id: str) -> str:
+        """Generate Redis key for high-frequency stream block content."""
+        return f"{STREAMING_KEY_PREFIX}block_content:{subtask_id}:{block_id}"
+
+    @staticmethod
+    def _decode_redis_text(value: Any) -> str:
+        """Decode a Redis value into text."""
+        if value is None:
+            return ""
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return str(value)
+
+    @staticmethod
+    def _decode_block_id(value: Any) -> str:
+        """Decode a Redis block id value."""
+        return value.decode("utf-8") if isinstance(value, bytes) else str(value)
+
+    @staticmethod
+    def _extract_block_content_keys(blocks_raw: List[Any]) -> List[str]:
+        """Extract internal block content keys from serialized block metadata."""
+        content_keys: List[str] = []
+        for block_json in blocks_raw:
+            try:
+                block = json.loads(block_json)
+            except Exception:
+                continue
+            content_key = block.get(BLOCK_CONTENT_KEY_FIELD)
+            if isinstance(content_key, str):
+                content_keys.append(content_key)
+        return content_keys
+
+    async def _load_blocks_from_client(
+        self, redis_client: Any, blocks_key: str
+    ) -> List[Dict[str, Any]]:
+        """Load block metadata and hydrate content from per-block content keys."""
+        blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
+        if not blocks_raw:
+            return []
+
+        blocks: List[Dict[str, Any]] = []
+        content_refs: List[tuple[int, str]] = []
+        for block_json in blocks_raw:
+            block = json.loads(block_json)
+            content_key = block.get(BLOCK_CONTENT_KEY_FIELD)
+            if isinstance(content_key, str):
+                content_refs.append((len(blocks), content_key))
+            blocks.append(block)
+
+        if content_refs:
+            content_values = await redis_client.mget([key for _, key in content_refs])
+            for (block_index, _), content_value in zip(content_refs, content_values):
+                blocks[block_index]["content"] = self._decode_redis_text(content_value)
+
+        for block in blocks:
+            block.pop(BLOCK_CONTENT_KEY_FIELD, None)
+        return blocks
+
+    async def add_stream_content(
+        self,
+        subtask_id: int,
+        content_type: StreamContentType,
+        content: str,
+    ) -> None:
+        """Add buffered stream content by explicit content type."""
+        if content_type == StreamContentType.TEXT:
+            await self.add_text_content(subtask_id, content)
+            return
+        if content_type == StreamContentType.THINKING:
+            await self.add_thinking_content(subtask_id, content)
+            return
+
+        logger.warning(
+            "[SessionManager] Unsupported stream content type for subtask %s: %s",
+            subtask_id,
+            content_type,
+        )
+
     async def add_tool_block(
         self,
         subtask_id: int,
@@ -953,30 +1042,43 @@ class SessionManager:
                 # Check if block with this id already exists (upsert logic)
                 blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
                 existing_index = None
+                existing_block = None
                 for i, block_json in enumerate(blocks_raw):
-                    existing_block = json.loads(block_json)
-                    if existing_block.get("id") == block_id:
+                    candidate = json.loads(block_json)
+                    if candidate.get("id") == block_id:
                         existing_index = i
+                        existing_block = candidate
                         break
 
                 if existing_index is not None:
                     # Update existing block
-                    await redis_client.lset(
-                        blocks_key, existing_index, json.dumps(block)
-                    )
+                    block_to_store = block.copy()
+                    content_key = (existing_block or {}).get(BLOCK_CONTENT_KEY_FIELD)
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        if isinstance(content_key, str):
+                            content_value = block_to_store.get("content", "")
+                            block_to_store[BLOCK_CONTENT_KEY_FIELD] = content_key
+                            block_to_store["content"] = ""
+                            pipe.set(content_key, content_value, ex=STREAMING_TTL)
+                        pipe.lset(
+                            blocks_key, existing_index, json.dumps(block_to_store)
+                        )
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        await pipe.execute()
                     logger.debug(
                         f"[SessionManager] Updated block for subtask {subtask_id}: "
                         f"id={block_id}, type={block.get('type')}"
                     )
                 else:
                     # Append new block
-                    await redis_client.rpush(blocks_key, json.dumps(block))
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        pipe.rpush(blocks_key, json.dumps(block))
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        await pipe.execute()
                     logger.info(
                         f"[SessionManager] Added block for subtask {subtask_id}: "
                         f"id={block_id}, type={block.get('type')}"
                     )
-
-                await redis_client.expire(blocks_key, STREAMING_TTL)
             finally:
                 await redis_client.aclose()
 
@@ -989,7 +1091,8 @@ class SessionManager:
         """Add text content to the current text block.
 
         Creates a new text block if there isn't one currently active.
-        Uses Redis APPEND for O(1) content addition.
+        Uses Redis APPEND for O(1) content addition and keeps block metadata
+        separate from high-frequency content updates.
 
         Args:
             subtask_id: Subtask ID
@@ -1013,42 +1116,37 @@ class SessionManager:
 
             redis_client = await self._cache._get_client()
             try:
-                # Append content to streaming cache
-                new_len = await redis_client.append(streaming_key, content)
-                await redis_client.expire(streaming_key, STREAMING_TTL)
-                logger.debug(
-                    f"[SessionManager] add_text_content: appended to Redis, "
-                    f"subtask_id={subtask_id}, new_total_len={new_len}"
-                )
-
-                # Check if we have a current text block
                 current_block_id = await redis_client.get(text_block_key)
 
                 if current_block_id:
-                    # Update existing text block's content
-                    # We need to find and update the last text block
-                    blocks_raw = await redis_client.lrange(blocks_key, -1, -1)
-                    if blocks_raw:
-                        last_block = json.loads(blocks_raw[0])
-                        if (
-                            last_block.get("id") == current_block_id.decode()
-                            if isinstance(current_block_id, bytes)
-                            else current_block_id
-                        ):
-                            last_block["content"] = (
-                                last_block.get("content", "") + content
-                            )
-                            await redis_client.lset(
-                                blocks_key, -1, json.dumps(last_block)
-                            )
+                    block_id = self._decode_block_id(current_block_id)
+                    content_key = self._get_block_content_key(subtask_id, block_id)
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        pipe.append(streaming_key, content)
+                        pipe.expire(streaming_key, STREAMING_TTL)
+                        pipe.append(content_key, content)
+                        pipe.expire(content_key, STREAMING_TTL)
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        pipe.expire(text_block_key, STREAMING_TTL)
+                        results = await pipe.execute()
+                    logger.debug(
+                        f"[SessionManager] add_text_content: appended to Redis, "
+                        f"subtask_id={subtask_id}, new_total_len={results[0]}"
+                    )
                 else:
                     # Create new text block
-                    block = create_text_block(content=content)
-                    await redis_client.rpush(blocks_key, json.dumps(block))
-                    await redis_client.set(
-                        text_block_key, block["id"], ex=STREAMING_TTL
-                    )
-                    await redis_client.expire(blocks_key, STREAMING_TTL)
+                    block = create_text_block(content="")
+                    content_key = self._get_block_content_key(subtask_id, block["id"])
+                    block[BLOCK_CONTENT_KEY_FIELD] = content_key
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        pipe.rpush(blocks_key, json.dumps(block))
+                        pipe.set(text_block_key, block["id"], ex=STREAMING_TTL)
+                        pipe.append(streaming_key, content)
+                        pipe.expire(streaming_key, STREAMING_TTL)
+                        pipe.append(content_key, content)
+                        pipe.expire(content_key, STREAMING_TTL)
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        await pipe.execute()
                     logger.info(
                         f"[SessionManager] Created text block for subtask {subtask_id}: "
                         f"id={block['id']}"
@@ -1076,40 +1174,37 @@ class SessionManager:
                 current_block_id = await redis_client.get(thinking_block_key)
 
                 if current_block_id:
-                    block_id = (
-                        current_block_id.decode()
-                        if isinstance(current_block_id, bytes)
-                        else current_block_id
-                    )
-                    blocks_raw = await redis_client.lrange(blocks_key, -1, -1)
-                    if blocks_raw:
-                        last_block = json.loads(blocks_raw[0])
-                        if last_block.get("id") == block_id:
-                            last_block["content"] = (
-                                last_block.get("content", "") + content
-                            )
-                            await redis_client.lset(
-                                blocks_key, -1, json.dumps(last_block)
-                            )
+                    block_id = self._decode_block_id(current_block_id)
+                    content_key = self._get_block_content_key(subtask_id, block_id)
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        pipe.append(content_key, content)
+                        pipe.expire(content_key, STREAMING_TTL)
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        pipe.expire(thinking_block_key, STREAMING_TTL)
+                        await pipe.execute()
                 else:
                     ts = int(time.time() * 1000)
+                    block_id = f"thinking-{uuid.uuid4().hex[:12]}"
+                    content_key = self._get_block_content_key(subtask_id, block_id)
                     block = {
-                        "id": f"thinking-{uuid.uuid4().hex[:12]}",
+                        "id": block_id,
                         "type": "thinking",
-                        "content": content,
+                        "content": "",
                         "status": BlockStatus.STREAMING.value,
                         "timestamp": ts,
+                        BLOCK_CONTENT_KEY_FIELD: content_key,
                     }
-                    await redis_client.rpush(blocks_key, json.dumps(block))
-                    await redis_client.set(
-                        thinking_block_key, block["id"], ex=STREAMING_TTL
-                    )
+                    async with redis_client.pipeline(transaction=False) as pipe:
+                        pipe.rpush(blocks_key, json.dumps(block))
+                        pipe.set(thinking_block_key, block["id"], ex=STREAMING_TTL)
+                        pipe.append(content_key, content)
+                        pipe.expire(content_key, STREAMING_TTL)
+                        pipe.expire(blocks_key, STREAMING_TTL)
+                        await pipe.execute()
                     logger.info(
                         f"[SessionManager] Created thinking block for subtask {subtask_id}: "
                         f"id={block['id']}"
                     )
-
-                await redis_client.expire(blocks_key, STREAMING_TTL)
             finally:
                 await redis_client.aclose()
         except Exception as e:
@@ -1129,23 +1224,25 @@ class SessionManager:
                 if not current_block_id:
                     return
 
-                block_id = (
-                    current_block_id.decode()
-                    if isinstance(current_block_id, bytes)
-                    else current_block_id
-                )
+                block_id = self._decode_block_id(current_block_id)
 
                 # Find and update the text block
                 blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
+                block_found = False
                 for i, block_json in enumerate(blocks_raw):
                     block = json.loads(block_json)
                     if block.get("id") == block_id:
                         block["status"] = BlockStatus.DONE.value
-                        await redis_client.lset(blocks_key, i, json.dumps(block))
+                        async with redis_client.pipeline(transaction=False) as pipe:
+                            pipe.lset(blocks_key, i, json.dumps(block))
+                            pipe.delete(text_block_key)
+                            pipe.expire(blocks_key, STREAMING_TTL)
+                            await pipe.execute()
+                        block_found = True
                         break
 
-                # Clear current text block ID
-                await redis_client.delete(text_block_key)
+                if not block_found:
+                    await redis_client.delete(text_block_key)
             finally:
                 await redis_client.aclose()
         except Exception as e:
@@ -1165,21 +1262,24 @@ class SessionManager:
                 if not current_block_id:
                     return
 
-                block_id = (
-                    current_block_id.decode()
-                    if isinstance(current_block_id, bytes)
-                    else current_block_id
-                )
+                block_id = self._decode_block_id(current_block_id)
 
                 blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
+                block_found = False
                 for i, block_json in enumerate(blocks_raw):
                     block = json.loads(block_json)
                     if block.get("id") == block_id:
                         block["status"] = BlockStatus.DONE.value
-                        await redis_client.lset(blocks_key, i, json.dumps(block))
+                        async with redis_client.pipeline(transaction=False) as pipe:
+                            pipe.lset(blocks_key, i, json.dumps(block))
+                            pipe.delete(thinking_block_key)
+                            pipe.expire(blocks_key, STREAMING_TTL)
+                            await pipe.execute()
+                        block_found = True
                         break
 
-                await redis_client.delete(thinking_block_key)
+                if not block_found:
+                    await redis_client.delete(thinking_block_key)
             finally:
                 await redis_client.aclose()
         except Exception as e:
@@ -1203,8 +1303,7 @@ class SessionManager:
             blocks_key = self._get_blocks_key(subtask_id)
             redis_client = await self._cache._get_client()
             try:
-                blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
-                blocks = [json.loads(b) for b in blocks_raw] if blocks_raw else []
+                blocks = await self._load_blocks_from_client(redis_client, blocks_key)
                 logger.debug(
                     f"[SessionManager] get_blocks for subtask {subtask_id}: "
                     f"count={len(blocks)}"
@@ -1238,8 +1337,7 @@ class SessionManager:
             blocks_key = self._get_blocks_key(subtask_id)
             redis_client = await self._cache._get_client()
             try:
-                blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
-                blocks = [json.loads(b) for b in blocks_raw] if blocks_raw else []
+                blocks = await self._load_blocks_from_client(redis_client, blocks_key)
                 logger.info(
                     f"[SessionManager] Finalized blocks for subtask {subtask_id}: "
                     f"count={len(blocks)}"
@@ -1284,12 +1382,15 @@ class SessionManager:
 
             redis_client = await self._cache._get_client()
             try:
+                blocks_raw = await redis_client.lrange(blocks_key, 0, -1)
+                block_content_keys = self._extract_block_content_keys(blocks_raw)
                 await redis_client.delete(
                     streaming_key,
                     blocks_key,
                     text_block_key,
                     thinking_block_key,
                     context_metrics_key,
+                    *block_content_keys,
                 )
                 logger.debug(
                     f"[SessionManager] Cleaned up streaming state for subtask {subtask_id}"

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -16,9 +16,13 @@ using session_manager to maintain state across HTTP requests and support
 page refresh recovery.
 """
 
+import asyncio
 import logging
+import time
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from app.services.chat.storage.session import StreamContentType
 from app.services.chat.trigger.lifecycle import (
     collect_completed_result,
     persist_completed_result,
@@ -31,6 +35,33 @@ from shared.models import EventType, ExecutionEvent
 from .protocol import ResultEmitter
 
 logger = logging.getLogger(__name__)
+
+STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS = 1.0
+TASK_STREAMING_ACTIVITY_TOUCH_INTERVAL_SECONDS = 1.0
+
+STREAM_CONTENT_EVENT_TYPES = {
+    EventType.CHUNK.value: StreamContentType.TEXT,
+    EventType.THINKING.value: StreamContentType.THINKING,
+}
+STREAM_BOUNDARY_EVENT_TYPES = {
+    EventType.TOOL_START.value,
+    EventType.TOOL_ARGUMENT_DELTA.value,
+    EventType.TOOL_ARGUMENT_DONE.value,
+    EventType.TOOL_RESULT.value,
+    EventType.BLOCK_CREATED.value,
+    EventType.BLOCK_UPDATED.value,
+}
+STREAM_TERMINAL_EVENT_TYPES = {
+    EventType.DONE.value,
+    EventType.ERROR.value,
+    EventType.CANCELLED.value,
+}
+
+
+@dataclass
+class _BufferedStreamContent:
+    content_type: StreamContentType
+    content: str
 
 
 class StatusUpdatingEmitter(ResultEmitter):
@@ -71,6 +102,11 @@ class StatusUpdatingEmitter(ResultEmitter):
         self._executor_name = executor_name
         self._executor_namespace = executor_namespace
         self._status_updated = False
+        self._stream_storage_buffer: list[_BufferedStreamContent] = []
+        self._stream_storage_lock = asyncio.Lock()
+        self._stream_storage_flush_task: Optional[asyncio.Task[None]] = None
+        self._stream_storage_flush_in_progress = False
+        self._last_task_activity_touch = 0.0
 
     def _resolve_owner_user_id(self) -> Optional[int]:
         from app.db.session import SessionLocal
@@ -84,6 +120,111 @@ class StatusUpdatingEmitter(ResultEmitter):
                 states=TaskResource.is_active_query(),
             )
             return task.user_id if task else None
+
+    async def _buffer_stream_content(
+        self,
+        content_type: StreamContentType,
+        content: str,
+    ) -> None:
+        """Buffer high-frequency stream content for batched Redis persistence."""
+        if not content:
+            return
+
+        async with self._stream_storage_lock:
+            if (
+                self._stream_storage_buffer
+                and self._stream_storage_buffer[-1].content_type == content_type
+            ):
+                self._stream_storage_buffer[-1].content += content
+            else:
+                self._stream_storage_buffer.append(
+                    _BufferedStreamContent(
+                        content_type=content_type,
+                        content=content,
+                    )
+                )
+
+            if (
+                self._stream_storage_flush_task is None
+                or self._stream_storage_flush_task.done()
+            ):
+                self._stream_storage_flush_task = asyncio.create_task(
+                    self._flush_stream_storage_after_delay()
+                )
+
+    async def _flush_stream_storage_after_delay(self) -> None:
+        """Flush buffered stream content after the configured interval."""
+        try:
+            await asyncio.sleep(STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS)
+            self._stream_storage_flush_in_progress = True
+            await self._flush_stream_storage()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "[StatusUpdatingEmitter] Failed to flush buffered stream storage: %s",
+                exc,
+                exc_info=True,
+            )
+        finally:
+            self._stream_storage_flush_in_progress = False
+            if self._stream_storage_flush_task is asyncio.current_task():
+                self._stream_storage_flush_task = None
+
+    async def _flush_stream_storage(self) -> None:
+        """Persist buffered stream content to Redis in order."""
+        async with self._stream_storage_lock:
+            pending = self._stream_storage_buffer
+            self._stream_storage_buffer = []
+
+        if not pending:
+            return
+
+        from app.services.chat.storage import session_manager
+
+        for item in pending:
+            await session_manager.add_stream_content(
+                subtask_id=self._subtask_id,
+                content_type=item.content_type,
+                content=item.content,
+            )
+        await self._touch_task_streaming_activity(session_manager, force=True)
+
+    async def _touch_task_streaming_activity(
+        self,
+        session_manager: Any,
+        force: bool = False,
+    ) -> None:
+        """Refresh task activity at a limited cadence."""
+        now = time.monotonic()
+        if (
+            not force
+            and now - self._last_task_activity_touch
+            < TASK_STREAMING_ACTIVITY_TOUCH_INTERVAL_SECONDS
+        ):
+            return
+
+        await session_manager.touch_task_streaming_activity(self._task_id)
+        self._last_task_activity_touch = now
+
+    async def _cancel_pending_storage_flush_task(self) -> None:
+        """Cancel a scheduled delayed flush after a synchronous flush."""
+        task = self._stream_storage_flush_task
+        if not task or task.done() or task is asyncio.current_task():
+            return
+
+        if self._stream_storage_flush_in_progress:
+            await task
+            return
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._stream_storage_flush_task is task:
+                self._stream_storage_flush_task = None
 
     async def emit(self, event: ExecutionEvent) -> None:
         """Emit event and update status if terminal.
@@ -112,17 +253,14 @@ class StatusUpdatingEmitter(ResultEmitter):
                 f"[StatusUpdatingEmitter] Set task streaming status: "
                 f"task_id={self._task_id}, subtask_id={self._subtask_id}"
             )
-        elif event.type in (
-            EventType.CHUNK.value,
-            EventType.TOOL_START.value,
-            EventType.TOOL_ARGUMENT_DELTA.value,
-            EventType.TOOL_ARGUMENT_DONE.value,
-            EventType.TOOL_RESULT.value,
-            EventType.THINKING.value,
-            EventType.BLOCK_CREATED.value,
-            EventType.BLOCK_UPDATED.value,
-        ):
-            await session_manager.touch_task_streaming_activity(self._task_id)
+        elif event.type in STREAM_CONTENT_EVENT_TYPES:
+            await self._buffer_stream_content(
+                STREAM_CONTENT_EVENT_TYPES[event.type],
+                event.content or "",
+            )
+        elif event.type in STREAM_BOUNDARY_EVENT_TYPES:
+            await self._flush_stream_storage()
+            await self._touch_task_streaming_activity(session_manager)
 
         # Collect blocks for mixed content rendering using session_manager
         if event.type == EventType.TOOL_START.value:
@@ -183,29 +321,21 @@ class StatusUpdatingEmitter(ResultEmitter):
                 if render_payload is not None:
                     update_kwargs["render_payload"] = render_payload
                 await session_manager.update_tool_block_status(**update_kwargs)
-        elif event.type == EventType.CHUNK.value:
-            # Accumulate content and track text blocks
-            content = event.content or ""
-            if content:
-                await session_manager.add_text_content(
-                    subtask_id=self._subtask_id,
-                    content=content,
-                )
-        elif event.type == EventType.THINKING.value:
-            content = event.content or ""
-            if content:
-                await session_manager.add_thinking_content(
-                    subtask_id=self._subtask_id,
-                    content=content,
-                )
+        elif event.type in STREAM_CONTENT_EVENT_TYPES:
+            # Content is persisted by the 1s stream storage buffer.
+            pass
 
         # Handle terminal events - update status before forwarding
-        if event.type == EventType.DONE.value:
-            await self._handle_done(event)
-        elif event.type == EventType.ERROR.value:
-            await self._handle_error(event)
-        elif event.type == EventType.CANCELLED.value:
-            await self._handle_cancelled(event)
+        if event.type in STREAM_TERMINAL_EVENT_TYPES:
+            await self._flush_stream_storage()
+            await self._cancel_pending_storage_flush_task()
+
+            if event.type == EventType.DONE.value:
+                await self._handle_done(event)
+            elif event.type == EventType.ERROR.value:
+                await self._handle_error(event)
+            elif event.type == EventType.CANCELLED.value:
+                await self._handle_cancelled(event)
 
         # Forward event to wrapped emitter
         await self._wrapped.emit(event)
@@ -229,12 +359,10 @@ class StatusUpdatingEmitter(ResultEmitter):
         **kwargs,
     ) -> None:
         """Forward chunk event and accumulate content."""
-        from app.services.chat.storage import session_manager
-
         if content:
-            await session_manager.add_text_content(
-                subtask_id=subtask_id,
-                content=content,
+            await self._buffer_stream_content(
+                StreamContentType.TEXT,
+                content,
             )
         await self._wrapped.emit_chunk(task_id, subtask_id, content, offset, **kwargs)
 
@@ -246,6 +374,8 @@ class StatusUpdatingEmitter(ResultEmitter):
         **kwargs,
     ) -> None:
         """Update status to COMPLETED and forward done event."""
+        await self._flush_stream_storage()
+        await self._cancel_pending_storage_flush_task()
         if not self._status_updated:
             await self._update_status_completed(result)
         await self._wrapped.emit_done(task_id, subtask_id, result, **kwargs)
@@ -258,6 +388,8 @@ class StatusUpdatingEmitter(ResultEmitter):
         **kwargs,
     ) -> None:
         """Update status to FAILED and forward error event."""
+        await self._flush_stream_storage()
+        await self._cancel_pending_storage_flush_task()
         if not self._status_updated:
             error_code = kwargs.get("error_code")
             await self._update_status_failed(error, error_code=error_code)
@@ -270,12 +402,16 @@ class StatusUpdatingEmitter(ResultEmitter):
         **kwargs,
     ) -> None:
         """Update status to CANCELLED and forward cancelled event."""
+        await self._flush_stream_storage()
+        await self._cancel_pending_storage_flush_task()
         if not self._status_updated:
             await self._update_status_cancelled()
         await self._wrapped.emit_cancelled(task_id, subtask_id, **kwargs)
 
     async def close(self) -> None:
         """Close the wrapped emitter."""
+        await self._flush_stream_storage()
+        await self._cancel_pending_storage_flush_task()
         await self._wrapped.close()
 
     async def _handle_done(self, event: ExecutionEvent) -> None:

--- a/backend/tests/services/chat/storage/test_session_blocks.py
+++ b/backend/tests/services/chat/storage/test_session_blocks.py
@@ -15,12 +15,20 @@ class FakeRedisClient:
     def __init__(self):
         self.lists = {}
         self.values = {}
+        self.expirations = {}
+        self.lset_calls = []
+        self.pipeline_execute_count = 0
 
     async def get(self, key):
         return self.values.get(key)
 
+    async def mget(self, keys):
+        return [self.values.get(key) for key in keys]
+
     async def set(self, key, value, ex=None):
         self.values[key] = value
+        if ex is not None:
+            self.expirations[key] = ex
         return True
 
     async def append(self, key, value):
@@ -44,14 +52,79 @@ class FakeRedisClient:
         return values[start : end + 1]
 
     async def lset(self, key, index, value):
+        self.lset_calls.append((key, index, value))
         self.lists[key][index] = value
         return True
 
     async def expire(self, key, ttl):
+        self.expirations[key] = ttl
         return True
+
+    def pipeline(self, transaction=True):
+        return FakePipeline(self)
 
     async def aclose(self):
         return None
+
+
+class FakePipeline:
+    def __init__(self, redis_client):
+        self.redis_client = redis_client
+        self.commands = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def append(self, key, value):
+        self.commands.append(("append", key, value))
+        return self
+
+    def expire(self, key, ttl):
+        self.commands.append(("expire", key, ttl))
+        return self
+
+    def rpush(self, key, value):
+        self.commands.append(("rpush", key, value))
+        return self
+
+    def set(self, key, value, ex=None):
+        self.commands.append(("set", key, value, ex))
+        return self
+
+    def lset(self, key, index, value):
+        self.commands.append(("lset", key, index, value))
+        return self
+
+    def delete(self, *keys):
+        self.commands.append(("delete", *keys))
+        return self
+
+    async def execute(self):
+        self.redis_client.pipeline_execute_count += 1
+        results = []
+        for command in self.commands:
+            name = command[0]
+            if name == "append":
+                results.append(await self.redis_client.append(command[1], command[2]))
+            elif name == "expire":
+                results.append(await self.redis_client.expire(command[1], command[2]))
+            elif name == "rpush":
+                results.append(await self.redis_client.rpush(command[1], command[2]))
+            elif name == "set":
+                results.append(
+                    await self.redis_client.set(command[1], command[2], ex=command[3])
+                )
+            elif name == "lset":
+                results.append(
+                    await self.redis_client.lset(command[1], command[2], command[3])
+                )
+            elif name == "delete":
+                results.append(await self.redis_client.delete(*command[1:]))
+        self.commands = []
+        return results
 
 
 class FakeCache:
@@ -140,3 +213,55 @@ async def test_add_block_fills_wall_clock_epoch_timestamp():
     # An auto-generated id must also be derived from wall-clock time.
     assert blocks[0]["id"].startswith("block-")
     assert int(blocks[0]["id"].removeprefix("block-")) > 1_000_000_000_000
+
+
+@pytest.mark.asyncio
+async def test_text_chunks_use_block_content_key_and_pipeline():
+    manager = SessionManager()
+    redis_client = FakeRedisClient()
+    manager._cache = FakeCache(redis_client)
+
+    await manager.add_text_content(subtask_id=505, content="Hel")
+    await manager.add_text_content(subtask_id=505, content="lo")
+
+    raw_block = json.loads(redis_client.lists["chat:streaming:blocks:505"][0])
+    content_key = raw_block["_content_key"]
+
+    assert raw_block["content"] == ""
+    assert redis_client.values[content_key] == "Hello"
+    assert redis_client.values["chat:streaming:505"] == "Hello"
+    assert redis_client.pipeline_execute_count >= 2
+    assert redis_client.lset_calls == []
+
+    blocks = await manager.get_blocks(505)
+
+    assert blocks[0]["content"] == "Hello"
+    assert "_content_key" not in blocks[0]
+
+    await manager.cleanup_streaming_state(505)
+
+    assert content_key not in redis_client.values
+
+
+@pytest.mark.asyncio
+async def test_add_block_preserves_existing_block_content_key():
+    manager = SessionManager()
+    redis_client = FakeRedisClient()
+    manager._cache = FakeCache(redis_client)
+
+    await manager.add_text_content(subtask_id=606, content="old")
+    blocks = await manager.get_blocks(606)
+    content_key = json.loads(redis_client.lists["chat:streaming:blocks:606"][0])[
+        "_content_key"
+    ]
+
+    blocks[0]["content"] = "updated"
+    await manager.add_block(subtask_id=606, block=blocks[0])
+
+    raw_block = json.loads(redis_client.lists["chat:streaming:blocks:606"][0])
+    updated_blocks = await manager.get_blocks(606)
+
+    assert raw_block["_content_key"] == content_key
+    assert raw_block["content"] == ""
+    assert redis_client.values[content_key] == "updated"
+    assert updated_blocks[0]["content"] == "updated"

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -2,11 +2,155 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from unittest.mock import AsyncMock, patch
+import asyncio
+from unittest.mock import AsyncMock, call, patch
 
 import pytest
 
 from shared.models import EventType, ExecutionEvent
+
+
+@pytest.mark.asyncio
+async def test_chunk_events_batch_storage_without_blocking_forward(monkeypatch):
+    """Streaming chunks should forward immediately and persist as a batch."""
+    from app.services.chat.storage.session import StreamContentType
+    from app.services.execution.emitters import status_updating
+    from app.services.execution.emitters.status_updating import StatusUpdatingEmitter
+
+    monkeypatch.setattr(
+        status_updating,
+        "STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS",
+        3600.0,
+        raising=False,
+    )
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    mock_session_manager = AsyncMock()
+
+    first = ExecutionEvent(
+        type=EventType.CHUNK.value,
+        task_id=101,
+        subtask_id=202,
+        content="Hel",
+    )
+    second = ExecutionEvent(
+        type=EventType.CHUNK.value,
+        task_id=101,
+        subtask_id=202,
+        content="lo",
+    )
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit(first)
+        await emitter.emit(second)
+
+        wrapped.emit.assert_has_awaits([call(first), call(second)])
+        mock_session_manager.add_stream_content.assert_not_awaited()
+
+        await emitter.close()
+
+    mock_session_manager.add_stream_content.assert_awaited_once_with(
+        subtask_id=202,
+        content_type=StreamContentType.TEXT,
+        content="Hello",
+    )
+
+
+@pytest.mark.asyncio
+async def test_done_event_flushes_pending_chunks_before_status_update(monkeypatch):
+    """DONE must persist pending chunks before collecting the final result."""
+    from app.services.chat.storage.session import StreamContentType
+    from app.services.execution.emitters import status_updating
+    from app.services.execution.emitters.status_updating import StatusUpdatingEmitter
+
+    monkeypatch.setattr(
+        status_updating,
+        "STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS",
+        3600.0,
+        raising=False,
+    )
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    emitter._handle_done = AsyncMock()
+    mock_session_manager = AsyncMock()
+
+    chunk = ExecutionEvent(
+        type=EventType.CHUNK.value,
+        task_id=101,
+        subtask_id=202,
+        content="content",
+    )
+    done = ExecutionEvent(
+        type=EventType.DONE.value,
+        task_id=101,
+        subtask_id=202,
+    )
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit(chunk)
+        await emitter.emit(done)
+
+    mock_session_manager.add_stream_content.assert_awaited_once_with(
+        subtask_id=202,
+        content_type=StreamContentType.TEXT,
+        content="content",
+    )
+    emitter._handle_done.assert_awaited_once_with(done)
+
+
+@pytest.mark.asyncio
+async def test_done_event_waits_for_in_progress_background_flush(monkeypatch):
+    """Terminal handling must wait if the scheduled Redis flush already started."""
+    from app.services.execution.emitters import status_updating
+    from app.services.execution.emitters.status_updating import StatusUpdatingEmitter
+
+    monkeypatch.setattr(
+        status_updating,
+        "STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS",
+        0.0,
+        raising=False,
+    )
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(wrapped=wrapped, task_id=101, subtask_id=202)
+    emitter._handle_done = AsyncMock()
+    mock_session_manager = AsyncMock()
+    flush_started = asyncio.Event()
+    release_flush = asyncio.Event()
+
+    async def add_stream_content(**_kwargs):
+        flush_started.set()
+        await release_flush.wait()
+
+    mock_session_manager.add_stream_content.side_effect = add_stream_content
+
+    chunk = ExecutionEvent(
+        type=EventType.CHUNK.value,
+        task_id=101,
+        subtask_id=202,
+        content="content",
+    )
+    done = ExecutionEvent(
+        type=EventType.DONE.value,
+        task_id=101,
+        subtask_id=202,
+    )
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit(chunk)
+        await asyncio.wait_for(flush_started.wait(), timeout=1.0)
+
+        done_task = asyncio.create_task(emitter.emit(done))
+        await asyncio.sleep(0)
+
+        emitter._handle_done.assert_not_awaited()
+
+        release_flush.set()
+        await done_task
+
+    emitter._handle_done.assert_awaited_once_with(done)
 
 
 @pytest.mark.asyncio
@@ -250,6 +394,7 @@ async def test_interactive_form_tool_result_persists_render_payload_on_real_tool
 
 @pytest.mark.asyncio
 async def test_thinking_events_persist_thinking_blocks():
+    from app.services.chat.storage.session import StreamContentType
     from app.services.execution.emitters import StatusUpdatingEmitter
 
     wrapped = AsyncMock()
@@ -265,8 +410,10 @@ async def test_thinking_events_persist_thinking_blocks():
 
     with patch("app.services.chat.storage.session_manager", mock_session_manager):
         await emitter.emit(thinking_event)
+        await emitter.close()
 
-    mock_session_manager.add_thinking_content.assert_awaited_once_with(
+    mock_session_manager.add_stream_content.assert_awaited_once_with(
         subtask_id=202,
+        content_type=StreamContentType.THINKING,
         content="Reasoning chunk.",
     )


### PR DESCRIPTION
## Summary
- Move chat session block storage and execution status updates onto Redis-backed streaming paths
- Add coverage for session block handling and status update emission
- Refresh the Google Sans local font stylesheet for the frontend build

## Testing
- Added and updated unit tests for chat session blocks and status-updating emitter behavior
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized streaming block storage to decouple high-frequency content updates from metadata, improving efficiency during chat streaming operations.
  * Enhanced event handling with asynchronous buffering to reduce database write frequency and improve resource utilization.
  * Strengthened streaming state persistence and recovery for better reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->