### PR TITLE
[codex] Avoid regenerating Google Sans CSS during install

### DIFF
--- a/frontend/scripts/download-fonts.cjs
+++ b/frontend/scripts/download-fonts.cjs
@@ -13,6 +13,7 @@
  * - Skip via environment variables
  * - Progress and timeout
  * - Atomic write with temp file
+ * - Stable Google Sans CSS manifest unless explicitly refreshed
  * - Configurable Google Sans CSS source URL(s) for internal deployments
  */
 
@@ -33,6 +34,7 @@ const PDF_FONT_DIR = FONTS_DIR
 const GOOGLE_SANS_DIR = path.join(FONTS_DIR, 'google-sans')
 const GOOGLE_SANS_CSS_OUTPUT = path.join(__dirname, '..', 'src', 'app', 'google-sans-local.css')
 const DOWNLOAD_TIMEOUT = 30_000 // 30s
+const REFRESH_UI_FONT_CSS = process.env.REFRESH_UI_FONT_CSS === '1'
 const GOOGLE_FONTS_USER_AGENT =
   process.env.GOOGLE_FONT_USER_AGENT ||
   'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0 Safari/537.36'
@@ -295,6 +297,12 @@ async function downloadPdfFonts() {
 
 async function downloadGoogleSansAssets() {
   try {
+    if (fs.existsSync(GOOGLE_SANS_CSS_OUTPUT) && !REFRESH_UI_FONT_CSS) {
+      console.log(`✓ Reusing ${path.relative(process.cwd(), GOOGLE_SANS_CSS_OUTPUT)}`)
+      console.log('  Set REFRESH_UI_FONT_CSS=1 to refresh the tracked CSS manifest.\n')
+      return true
+    }
+
     console.log('⬇ Downloading local Google Sans assets')
     console.log(`  CSS source candidates: ${googleSansCssUrls.join(', ')}`)
 

--- a/frontend/scripts/download-fonts.test.cjs
+++ b/frontend/scripts/download-fonts.test.cjs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2025 Weibo, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+const assert = require('assert')
+const { spawn } = require('child_process')
+const fs = require('fs')
+const http = require('http')
+const os = require('os')
+const path = require('path')
+const test = require('node:test')
+
+const SCRIPT_PATH = path.join(__dirname, 'download-fonts.cjs')
+
+function createFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'download-fonts-'))
+  const scriptDir = path.join(root, 'scripts')
+  const appDir = path.join(root, 'src', 'app')
+  fs.mkdirSync(scriptDir, { recursive: true })
+  fs.mkdirSync(appDir, { recursive: true })
+  fs.copyFileSync(SCRIPT_PATH, path.join(scriptDir, 'download-fonts.cjs'))
+  return {
+    root,
+    scriptPath: path.join(scriptDir, 'download-fonts.cjs'),
+    cssPath: path.join(appDir, 'google-sans-local.css'),
+  }
+}
+
+function createFontServer() {
+  let baseUrl = ''
+  const server = http.createServer((req, res) => {
+    if (req.url === '/google.css') {
+      res.writeHead(200, { 'content-type': 'text/css' })
+      res.end(
+        [
+          '@font-face {',
+          "  font-family: 'Google Sans';",
+          `  src: url('${baseUrl}/fonts/test.woff2') format('woff2');`,
+          '}',
+          '',
+        ].join('\n')
+      )
+      return
+    }
+
+    if (req.url === '/fonts/test.woff2') {
+      res.writeHead(200, { 'content-type': 'font/woff2' })
+      res.end(Buffer.from('font-bytes'))
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      baseUrl = `http://${address.address}:${address.port}`
+      resolve({
+        cssUrl: `${baseUrl}/google.css`,
+        close: () => new Promise(closeResolve => server.close(closeResolve)),
+      })
+    })
+  })
+}
+
+function runDownloadScript(scriptPath, cssUrl, extraEnv = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath], {
+      cwd: path.dirname(path.dirname(scriptPath)),
+      env: {
+        ...process.env,
+        SKIP_FONT_DOWNLOAD: '0',
+        SKIP_PDF_FONT_DOWNLOAD: '1',
+        SKIP_UI_FONT_DOWNLOAD: '0',
+        GOOGLE_SANS_CSS_URLS: cssUrl,
+        ...extraEnv,
+      },
+      stdio: 'pipe',
+    })
+
+    let output = ''
+    child.stdout.on('data', chunk => {
+      output += chunk
+    })
+    child.stderr.on('data', chunk => {
+      output += chunk
+    })
+    child.on('error', reject)
+    child.on('close', code => {
+      if (code === 0) {
+        resolve(output)
+        return
+      }
+      reject(new Error(`download-fonts exited with ${code}\n${output}`))
+    })
+  })
+}
+
+test('regular install does not rewrite existing tracked Google Sans CSS', async () => {
+  const fixture = createFixture()
+  const server = await createFontServer()
+  const trackedCss = '/* tracked css */\n'
+
+  try {
+    fs.writeFileSync(fixture.cssPath, trackedCss, 'utf8')
+
+    await runDownloadScript(fixture.scriptPath, server.cssUrl)
+
+    assert.strictEqual(fs.readFileSync(fixture.cssPath, 'utf8'), trackedCss)
+
+    await runDownloadScript(fixture.scriptPath, server.cssUrl, {
+      REFRESH_UI_FONT_CSS: '1',
+    })
+
+    assert.match(
+      fs.readFileSync(fixture.cssPath, 'utf8'),
+      /url\('\/fonts\/google-sans\/01-test\.woff2'\)/
+    )
+  } finally {
+    await server.close()
+    fs.rmSync(fixture.root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Reuse the tracked `frontend/src/app/google-sans-local.css` manifest during regular font install runs.
- Add `REFRESH_UI_FONT_CSS=1` as the explicit path for refreshing the tracked Google Sans CSS manifest.
- Add a Node regression test that verifies regular install does not rewrite the tracked CSS and explicit refresh still regenerates it.

## Root Cause

`frontend/scripts/download-fonts.cjs` fetched Google Fonts CSS and wrote it to `frontend/src/app/google-sans-local.css` on every install. Because that file is tracked and the remote CSS/raw formatting can differ from the checked-in formatted file, installs produced noisy diffs.

## Validation

- `node --test frontend/scripts/download-fonts.test.cjs`
- `git diff --check`
- `SKIP_PDF_FONT_DOWNLOAD=1 node frontend/scripts/download-fonts.cjs && git diff -- frontend/src/app/google-sans-local.css`

## Notes

The repository pre-push hook completed successfully, but reported that frontend checks were skipped because `node_modules` is not installed in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized font asset caching with environment-driven refresh control to accelerate build times

* **Tests**
  * Added integration tests validating font asset download and CSS rewrite functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->