### PR TITLE
[codex] Fix model list connection test payload

### DIFF
--- a/frontend/src/__tests__/features/settings/components/ResourceListLayout.consistency.test.tsx
+++ b/frontend/src/__tests__/features/settings/components/ResourceListLayout.consistency.test.tsx
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import '@testing-library/jest-dom'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import type { ReactNode } from 'react'
 
 import { modelApis } from '@/apis/models'
@@ -54,6 +55,9 @@ const translations: Record<string, string> = {
   'common:models.title': 'Models',
   'common:models.description': 'Manage models.',
   'common:models.create': 'New Model',
+  'common:models.test_connection': 'Test Connection',
+  'common:models.test_success': 'Connection successful',
+  'common:models.test_failed': 'Connection failed',
   'common:models.all_category_types': 'All',
   'models.all_category_types': 'All',
   'models.model_category_type_llm': 'LLM',
@@ -249,6 +253,71 @@ describe('resource list layout consistency', () => {
     expect(screen.queryByText('My Models (1)')).not.toBeInTheDocument()
     expect(screen.queryByText('Group Models (1)')).not.toBeInTheDocument()
     expect(screen.queryByText('System Models (1)')).not.toBeInTheDocument()
+  })
+
+  it('tests a personal model from the full CRD instead of sanitized list config', async () => {
+    const user = userEvent.setup()
+    ;(modelApis.getUnifiedModels as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          name: 'personal-model',
+          displayName: 'Personal Model',
+          type: 'user',
+          namespace: 'default',
+          modelCategoryType: 'llm',
+          config: {},
+        },
+      ],
+    })
+    ;(modelApis.getModel as jest.Mock).mockResolvedValue({
+      apiVersion: 'agent.wecode.io/v1',
+      kind: 'Model',
+      metadata: {
+        name: 'personal-model',
+        namespace: 'default',
+        displayName: 'Personal Model',
+      },
+      spec: {
+        modelType: 'llm',
+        modelConfig: {
+          env: {
+            model: 'claude',
+            model_id: 'deepseek-v4-flash',
+            api_key: 'sk-secret',
+            base_url: 'https://api.sensenova.cn/compatible-mode/v1',
+            custom_headers: { 'x-test': 'enabled' },
+          },
+        },
+      },
+    })
+    ;(modelApis.testConnection as jest.Mock).mockResolvedValue({
+      success: true,
+      message: 'ok',
+    })
+
+    render(
+      <ModelList
+        scope="all"
+        sourceFilter="personal"
+        sourceControls={sourceControls()}
+        groups={writableGroups}
+      />
+    )
+
+    await screen.findByText('Personal Model')
+    await user.click(screen.getByTitle('Test Connection'))
+
+    await waitFor(() => {
+      expect(modelApis.getModel).toHaveBeenCalledWith('personal-model', 'default')
+      expect(modelApis.testConnection).toHaveBeenCalledWith({
+        provider_type: 'anthropic',
+        model_id: 'deepseek-v4-flash',
+        api_key: 'sk-secret',
+        base_url: 'https://api.sensenova.cn/compatible-mode/v1',
+        custom_headers: { 'x-test': 'enabled' },
+        model_category_type: 'llm',
+      })
+    })
   })
 
   it('uses the same header action placement for executor and retriever lists', async () => {

--- a/frontend/src/apis/models.ts
+++ b/frontend/src/apis/models.ts
@@ -188,7 +188,13 @@ export type ErrorRecommendationsResponse = {
 
 // Test Connection Types
 export interface TestConnectionRequest {
-  provider_type: 'openai' | 'anthropic' | 'gemini' | 'gemini-deep-research' | 'openai-responses'
+  provider_type:
+    | 'openai'
+    | 'anthropic'
+    | 'gemini'
+    | 'gemini-deep-research'
+    | 'openai-responses'
+    | 'custom'
   model_id: string
   api_key: string
   base_url?: string

--- a/frontend/src/features/settings/components/ModelList.tsx
+++ b/frontend/src/features/settings/components/ModelList.tsx
@@ -31,7 +31,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
-import { modelApis, ModelCRD, UnifiedModel, ModelCategoryType } from '@/apis/models'
+import {
+  modelApis,
+  ModelCRD,
+  UnifiedModel,
+  ModelCategoryType,
+  type TestConnectionRequest,
+} from '@/apis/models'
 import type { BaseRole } from '@/types/base-role'
 import type { Group } from '@/types/group'
 import type { ManagedResourceSourceFilter } from '@/features/resource-library/types'
@@ -97,6 +103,50 @@ interface ModelListProps {
   sourceFilter?: ManagedResourceSourceFilter
   groups?: Group[]
   sortMode?: ResourceLibrarySortMode
+}
+
+type ModelProviderType = TestConnectionRequest['provider_type']
+
+function getTestConnectionProviderType(
+  modelProvider: string | undefined,
+  protocol?: string
+): ModelProviderType {
+  if (protocol === 'openai-responses' || protocol === 'gemini-deep-research') {
+    return protocol
+  }
+
+  if (modelProvider === 'claude') {
+    return 'anthropic'
+  }
+
+  if (
+    modelProvider === 'openai' ||
+    modelProvider === 'anthropic' ||
+    modelProvider === 'gemini' ||
+    modelProvider === 'custom'
+  ) {
+    return modelProvider
+  }
+
+  return 'openai'
+}
+
+function buildTestConnectionRequest(
+  model: ModelCRD,
+  fallbackCategoryType: ModelCategoryType
+): TestConnectionRequest {
+  const env = model.spec.modelConfig.env
+  const customHeaders = env.custom_headers
+
+  return {
+    provider_type: getTestConnectionProviderType(env.model, model.spec.protocol),
+    model_id: env.model_id,
+    api_key: env.api_key,
+    base_url: env.base_url || undefined,
+    custom_headers:
+      customHeaders && Object.keys(customHeaders).length > 0 ? customHeaders : undefined,
+    model_category_type: model.spec.modelType || fallbackCategoryType,
+  }
 }
 
 /**
@@ -262,28 +312,10 @@ const ModelList: React.FC<ModelListProps> = ({
 
     setTestingModelName(displayModel.name)
     try {
-      const env = (displayModel.config?.env as Record<string, unknown>) || {}
-      const apiKey = (env.api_key as string) || ''
-      const customHeaders = (env.custom_headers as Record<string, string>) || undefined
-
-      // Determine provider type
-      let providerType: 'openai' | 'anthropic' | 'gemini' = 'anthropic'
-      if (displayModel.modelType === 'openai') {
-        providerType = 'openai'
-      } else if (displayModel.modelType === 'gemini') {
-        providerType = 'gemini'
-      }
-
-      // Test connection requires api_key
-      // Pass model_category_type to use appropriate test method (e.g., embeddings for embedding models)
-      const result = await modelApis.testConnection({
-        provider_type: providerType,
-        model_id: displayModel.modelId,
-        api_key: apiKey,
-        base_url: env.base_url as string | undefined,
-        custom_headers: customHeaders,
-        model_category_type: displayModel.modelCategoryType,
-      })
+      const modelCRD = await modelApis.getModel(displayModel.name, displayModel.namespace)
+      const result = await modelApis.testConnection(
+        buildTestConnectionRequest(modelCRD, displayModel.modelCategoryType)
+      )
 
       if (result.success) {
         toast({


### PR DESCRIPTION
## Summary
- Fetch the full model CRD before testing a personal model from the resource list.
- Build the test connection payload from complete `modelConfig.env` data instead of the sanitized unified list response.
- Add regression coverage for the resource list test button path.

## Root Cause
The unified model list intentionally strips sensitive `config.env` fields, including `api_key`. The list-level test button used that sanitized data directly, so `/models/test-connection` received empty required fields. The edit dialog worked because it first loaded the full model CRD.

## Validation
- `pnpm --dir frontend test -- src/__tests__/features/settings/components/ResourceListLayout.consistency.test.tsx --runInBand`
- `pnpm --dir frontend exec tsc --noEmit --pretty false`
- `pnpm --dir frontend exec prettier --check src/apis/models.ts src/features/settings/components/ModelList.tsx src/__tests__/features/settings/components/ResourceListLayout.consistency.test.tsx`
- Pre-push hook: ESLint, TypeScript, unit tests