### PR TITLE
Open terminal by default in workspace panel

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -58,6 +58,7 @@ const createDeviceApiMock = vi.mocked(createDeviceApi)
 const createProjectApiMock = vi.mocked(createProjectApi)
 const createQuotaApiMock = vi.mocked(createQuotaApi)
 const fetchQuotaMock = vi.fn()
+const startTerminalSessionMock = vi.fn()
 const startCodeServerSessionMock = vi.fn()
 
 describe('DesktopWorkbenchLayout', () => {
@@ -150,7 +151,14 @@ describe('DesktopWorkbenchLayout', () => {
       url: 'http://localhost/ide',
       path: '/workspace/projects/github_wegent',
     })
+    startTerminalSessionMock.mockResolvedValue({
+      session_id: 'terminal-1',
+      url: 'http://localhost/terminal-1',
+      device_id: 'workspace-cloud-device',
+      path: '/workspace/project',
+    })
     createProjectApiMock.mockReturnValue({
+      startTerminalSession: startTerminalSessionMock,
       startCodeServerSession: startCodeServerSessionMock,
     } as unknown as ReturnType<typeof createProjectApi>)
   })
@@ -4083,16 +4091,26 @@ describe('DesktopWorkbenchLayout', () => {
     expect(panel).toHaveAttribute('aria-hidden', 'false')
     expect(screen.getByTestId('toggle-bottom-workspace-panel-button')).toBeInTheDocument()
     expect(screen.getByTestId('toggle-right-workspace-panel-button')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-tool-launcher')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
-    expect(screen.getByTestId('workspace-desktop-card')).toBeInTheDocument()
 
     fireEvent.pointerDown(screen.getByTestId('bottom-workspace-resize-handle'), { clientY: 700 })
     fireEvent.pointerMove(document, { clientY: 620 })
     fireEvent.pointerUp(document)
 
     expect(panel).toHaveStyle({ height: '400px' })
+  })
+
+  test('opens the terminal by default when the bottom workspace panel opens', async () => {
+    renderWorkspacePanelLayout()
+
+    await userEvent.click(screen.getByTestId('toggle-bottom-workspace-panel-button'))
+
+    await waitFor(() => expect(startTerminalSessionMock).toHaveBeenCalledWith(12))
+    expect(screen.getByTestId('workspace-terminal-frame')).toHaveAttribute(
+      'src',
+      'http://localhost/terminal-1'
+    )
+    expect(screen.getByTestId('workspace-terminal-window')).toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-tool-launcher')).not.toBeInTheDocument()
   })
 
   test('closes the bottom workspace panel from the panel edge', async () => {

--- a/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/BottomWorkspacePanel.tsx
@@ -54,6 +54,7 @@ export function BottomWorkspacePanel({
             <WorkspacePanelCards
               currentProject={currentProject}
               devices={devices}
+              defaultOpenTool="terminal"
               onRequestClose={onRequestClose}
             />
           </div>

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -1,5 +1,5 @@
 import { Code2, Loader2, Monitor, Plus, SquareTerminal, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { createDeviceApi } from '@/api/devices'
 import { createHttpClient } from '@/api/http'
 import { createProjectApi } from '@/api/projects'
@@ -21,6 +21,7 @@ import { EmbeddedLocalTerminal } from './EmbeddedLocalTerminal'
 interface WorkspacePanelCardsProps {
   currentProject: ProjectWithTasks | null
   devices?: DeviceInfo[]
+  defaultOpenTool?: WorkspaceTool
   onRequestClose?: () => void
 }
 
@@ -78,6 +79,7 @@ function createDeviceSessionApi() {
 export function WorkspacePanelCards({
   currentProject,
   devices = [],
+  defaultOpenTool,
   onRequestClose,
 }: WorkspacePanelCardsProps) {
   const { t } = useTranslation('common')
@@ -85,6 +87,7 @@ export function WorkspacePanelCards({
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null)
   const [showToolLauncher, setShowToolLauncher] = useState(false)
   const [loadingTool, setLoadingTool] = useState<WorkspaceTool | null>(null)
+  const defaultOpenedProjectKeyRef = useRef<string | null>(null)
   const [toolAvailability, setToolAvailability] = useState<WorkspaceToolAvailabilityState>(() => ({
     projectKey: '',
     tools: createAvailableTools(),
@@ -180,7 +183,7 @@ export function WorkspacePanelCards({
     projectLocalPath,
   ])
 
-  const markToolUnavailable = (tool: WorkspaceTool) => {
+  const markToolUnavailable = useCallback((tool: WorkspaceTool) => {
     setToolAvailability(state => {
       const tools = state.projectKey === projectKey ? state.tools : createAvailableTools()
       if (!tools[tool]) {
@@ -191,15 +194,18 @@ export function WorkspacePanelCards({
         tools: { ...tools, [tool]: false },
       }
     })
-  }
+  }, [projectKey])
 
-  const setProjectError = (message: string | null) => {
+  const setProjectError = useCallback((message: string | null) => {
     setToolError({ projectKey, message })
-  }
+  }, [projectKey])
 
-  const getSessionStartErrorMessage = () => t('workbench.project_tool_start_failed', '启动失败')
+  const getSessionStartErrorMessage = useCallback(
+    () => t('workbench.project_tool_start_failed', '启动失败'),
+    [t]
+  )
 
-  const startTerminalSession = async () => {
+  const startTerminalSession = useCallback(async () => {
     if (!currentProject || loadingTool || !availableTools.terminal) return
     setLoadingTool('terminal')
     setProjectError(null)
@@ -238,7 +244,43 @@ export function WorkspacePanelCards({
     } finally {
       setLoadingTool(null)
     }
-  }
+  }, [
+    availableTools.terminal,
+    currentProject,
+    getSessionStartErrorMessage,
+    loadingTool,
+    localTerminalAvailable,
+    markToolUnavailable,
+    projectDeviceId,
+    projectLocalPath,
+    setProjectError,
+  ])
+
+  useEffect(() => {
+    if (
+      defaultOpenTool !== 'terminal' ||
+      defaultOpenedProjectKeyRef.current === projectKey ||
+      terminalSessions.length > 0 ||
+      !currentProject ||
+      loadingTool ||
+      !projectTerminalAvailable ||
+      !availableTools.terminal
+    ) {
+      return
+    }
+
+    defaultOpenedProjectKeyRef.current = projectKey
+    void startTerminalSession()
+  }, [
+    availableTools.terminal,
+    currentProject,
+    defaultOpenTool,
+    loadingTool,
+    projectKey,
+    projectTerminalAvailable,
+    startTerminalSession,
+    terminalSessions.length,
+  ])
 
   const handleTerminalClick = () => {
     void startTerminalSession()


### PR DESCRIPTION
## Summary
- Make the bottom workspace panel auto-launch the terminal when it opens
- Add per-project guard so the terminal only opens once for a given project
- Update layout tests to cover the default terminal behavior

## Testing
- Added unit test coverage for the workspace panel opening flow
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now automatically opens when the bottom workspace panel is displayed.

* **Tests**
  * Added test case verifying terminal launches by default upon workspace panel activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->