### PR TITLE
[codex] Keep wework environment info visible

### DIFF
--- a/wework/src/api/environment.test.ts
+++ b/wework/src/api/environment.test.ts
@@ -224,6 +224,7 @@ describe('loadProjectEnvironment', () => {
       deletions: '-0',
       executionTarget: 'local',
       deviceId: 'device-123',
+      workspacePath: '/workspace/Wegent',
       error: 'Expected text stdout from device command',
     })
   })

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -275,15 +275,26 @@ async function loadProjectEnvironmentUncached(
     return baseInfo
   }
 
+  let path: string | undefined
   try {
-    const path = await workspacePath(api, deviceId, project)
-    if (!path) {
-      return baseInfo
-    }
-    const environmentWorkspaceInfo = {
+    path = await workspacePath(api, deviceId, project)
+  } catch (error) {
+    return {
       ...baseInfo,
-      workspacePath: path,
+      error: error instanceof Error ? error.message : 'Failed to load environment info',
     }
+  }
+
+  if (!path) {
+    return baseInfo
+  }
+
+  const environmentWorkspaceInfo = {
+    ...baseInfo,
+    workspacePath: path,
+  }
+
+  try {
     const [branchName, shortStat, porcelain] = await Promise.all([
       runGitCommand(api, deviceId, 'git_branch', path),
       loadBranchDiffShortStat(api, deviceId, path),
@@ -318,7 +329,7 @@ async function loadProjectEnvironmentUncached(
     }
   } catch (error) {
     return {
-      ...baseInfo,
+      ...environmentWorkspaceInfo,
       error: error instanceof Error ? error.message : 'Failed to load environment info',
     }
   }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3136,10 +3136,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(await screen.findByTestId('workspace-file-preview')).toHaveTextContent(
       'opened from tool block'
     )
-    expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute(
-      'aria-selected',
-      'true'
-    )
+    expect(screen.getByTestId('right-workspace-file-tab')).toHaveAttribute('aria-selected', 'true')
     expect(readWorkspaceTextFile).toHaveBeenCalledWith(
       'workspace-cloud-device',
       '/workspace/project/README.md'
@@ -3954,7 +3951,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('environment-branch-menu')).not.toBeInTheDocument()
   })
 
-  test('hides branch switching in the environment popover without a git branch', async () => {
+  test('keeps environment info visible without a git branch and hides git actions', async () => {
     render(
       <DesktopWorkbenchLayout
         {...baseProps}
@@ -3963,6 +3960,7 @@ describe('DesktopWorkbenchLayout', () => {
           deletions: '-0',
           executionTarget: 'local',
           deviceId: 'device-1',
+          workspacePath: '/workspace/plain-folder',
           branchName: '',
         })}
         onListEnvironmentBranches={vi.fn().mockResolvedValue([])}
@@ -3972,9 +3970,12 @@ describe('DesktopWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('environment-info-button'))
 
-    await waitFor(() =>
-      expect(screen.queryByTestId('environment-branch-row')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('environment-info-popover')).toBeInTheDocument())
+    expect(screen.getByTestId('environment-workspace-path')).toHaveTextContent(
+      '/workspace/plain-folder'
     )
+    expect(screen.queryByTestId('environment-git-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('environment-branch-row')).not.toBeInTheDocument()
   })
 
   test('closes the branch menu when Escape is pressed', async () => {

--- a/wework/src/components/layout/EnvironmentInfoPopover.tsx
+++ b/wework/src/components/layout/EnvironmentInfoPopover.tsx
@@ -61,7 +61,8 @@ export function EnvironmentInfoPopover({
   const deviceLabel = t('workbench.environment_device')
   const deviceDisplayName = deviceName || t('workbench.environment_device_unknown')
   const deviceTitle = [deviceLabel, deviceDisplayName].filter(Boolean).join(' · ')
-  const canShowBranchSelector = Boolean(info.branchName?.trim())
+  const hasGitInfo = Boolean(info.branchName?.trim())
+  const canShowBranchSelector = hasGitInfo
   const environmentInfoLabel = t('workbench.environment_info')
   function handleCreatePullRequest() {
     if (!info.createPullRequestUrl) {
@@ -231,122 +232,124 @@ export function EnvironmentInfoPopover({
               )}
             </section>
 
-            <section
-              data-testid="environment-git-section"
-              className="space-y-0.5 border-t border-border pt-3"
-            >
-              <button
-                type="button"
-                data-testid="environment-changes-button"
-                disabled={!onOpenChangesReview}
-                onClick={handleOpenChangesReview}
-                className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-default disabled:hover:bg-transparent"
+            {hasGitInfo && (
+              <section
+                data-testid="environment-git-section"
+                className="space-y-0.5 border-t border-border pt-3"
               >
-                <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                  <CircleDot className="h-[18px] w-[18px]" />
-                </span>
-                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                  {t('workbench.environment_changes', '变更')}
-                </span>
-                <span className="flex gap-1.5 text-[13px]">
-                  <span className="text-green-500">{additions}</span>
-                  <span className="text-red-500">{deletions}</span>
-                </span>
-              </button>
-              {canShowBranchSelector && onListBranches && onCheckoutBranch && (
-                <BranchSelector
-                  variant="environment"
-                  currentBranch={info.branchName}
-                  loading={info.loading}
-                  onRefresh={onRefresh}
-                  onListBranches={onListBranches}
-                  onCheckoutBranch={onCheckoutBranch}
-                  onCreateBranch={onCreateBranch}
-                />
-              )}
-              <button
-                type="button"
-                data-testid="environment-commit-button"
-                disabled={!onCommitChanges || commitStatus === 'committing'}
-                onClick={() => {
-                  setCommitFormOpen(open => !open)
-                  setCommitError(null)
-                }}
-                className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-not-allowed disabled:text-text-muted"
-              >
-                <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                  <GitCommit className="h-[18px] w-[18px]" />
-                </span>
-                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                  {t('workbench.environment_commit', '提交')}
-                </span>
-                {commitStatus === 'success' && (
-                  <span className="shrink-0 text-xs text-green-500">
-                    {t('workbench.environment_committed', '已提交')}
+                <button
+                  type="button"
+                  data-testid="environment-changes-button"
+                  disabled={!onOpenChangesReview}
+                  onClick={handleOpenChangesReview}
+                  className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-default disabled:hover:bg-transparent"
+                >
+                  <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
+                    <CircleDot className="h-[18px] w-[18px]" />
                   </span>
-                )}
-              </button>
-              {commitFormOpen && (
-                <form className="mb-2 ml-[30px] mt-1 space-y-2" onSubmit={handleSubmitCommit}>
-                  <input
-                    data-testid="environment-commit-message-input"
-                    value={commitMessage}
-                    onChange={event => setCommitMessage(event.target.value)}
-                    className="h-8 w-full rounded-md border border-border bg-background px-2 text-[13px] text-text-primary outline-none placeholder:text-text-muted focus:border-text-primary"
-                    placeholder={t('workbench.environment_commit_message', '提交说明')}
-                    autoFocus
+                  <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                    {t('workbench.environment_changes', '变更')}
+                  </span>
+                  <span className="flex gap-1.5 text-[13px]">
+                    <span className="text-green-500">{additions}</span>
+                    <span className="text-red-500">{deletions}</span>
+                  </span>
+                </button>
+                {canShowBranchSelector && onListBranches && onCheckoutBranch && (
+                  <BranchSelector
+                    variant="environment"
+                    currentBranch={info.branchName}
+                    loading={info.loading}
+                    onRefresh={onRefresh}
+                    onListBranches={onListBranches}
+                    onCheckoutBranch={onCheckoutBranch}
+                    onCreateBranch={onCreateBranch}
                   />
-                  <div className="flex items-center justify-end gap-2">
-                    <button
-                      type="button"
-                      data-testid="environment-cancel-commit-button"
-                      onClick={() => {
-                        setCommitFormOpen(false)
-                        setCommitError(null)
-                      }}
-                      className="h-7 rounded-md px-2 text-xs text-text-secondary hover:bg-hover hover:text-text-primary"
-                    >
-                      {t('workbench.environment_commit_cancel', '取消')}
-                    </button>
-                    <button
-                      type="submit"
-                      data-testid="environment-confirm-commit-button"
-                      disabled={!commitMessage.trim() || commitStatus === 'committing'}
-                      className="h-7 rounded-md bg-text-primary px-2 text-xs font-medium text-background hover:bg-text-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {commitStatus === 'committing'
-                        ? t('workbench.environment_committing', '提交中')
-                        : t('workbench.environment_commit_confirm', '确认')}
-                    </button>
-                  </div>
-                </form>
-              )}
-              <button
-                type="button"
-                data-testid="create-pull-request-button"
-                disabled={!info.createPullRequestUrl}
-                onClick={handleCreatePullRequest}
-                className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-not-allowed disabled:text-text-muted"
-              >
-                <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
-                  <GitPullRequest className="h-[18px] w-[18px]" />
-                </span>
-                <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                  {t('workbench.environment_create_pr', '创建拉取请求')}
-                </span>
-              </button>
+                )}
+                <button
+                  type="button"
+                  data-testid="environment-commit-button"
+                  disabled={!onCommitChanges || commitStatus === 'committing'}
+                  onClick={() => {
+                    setCommitFormOpen(open => !open)
+                    setCommitError(null)
+                  }}
+                  className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-not-allowed disabled:text-text-muted"
+                >
+                  <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
+                    <GitCommit className="h-[18px] w-[18px]" />
+                  </span>
+                  <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                    {t('workbench.environment_commit', '提交')}
+                  </span>
+                  {commitStatus === 'success' && (
+                    <span className="shrink-0 text-xs text-green-500">
+                      {t('workbench.environment_committed', '已提交')}
+                    </span>
+                  )}
+                </button>
+                {commitFormOpen && (
+                  <form className="mb-2 ml-[30px] mt-1 space-y-2" onSubmit={handleSubmitCommit}>
+                    <input
+                      data-testid="environment-commit-message-input"
+                      value={commitMessage}
+                      onChange={event => setCommitMessage(event.target.value)}
+                      className="h-8 w-full rounded-md border border-border bg-background px-2 text-[13px] text-text-primary outline-none placeholder:text-text-muted focus:border-text-primary"
+                      placeholder={t('workbench.environment_commit_message', '提交说明')}
+                      autoFocus
+                    />
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        data-testid="environment-cancel-commit-button"
+                        onClick={() => {
+                          setCommitFormOpen(false)
+                          setCommitError(null)
+                        }}
+                        className="h-7 rounded-md px-2 text-xs text-text-secondary hover:bg-hover hover:text-text-primary"
+                      >
+                        {t('workbench.environment_commit_cancel', '取消')}
+                      </button>
+                      <button
+                        type="submit"
+                        data-testid="environment-confirm-commit-button"
+                        disabled={!commitMessage.trim() || commitStatus === 'committing'}
+                        className="h-7 rounded-md bg-text-primary px-2 text-xs font-medium text-background hover:bg-text-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {commitStatus === 'committing'
+                          ? t('workbench.environment_committing', '提交中')
+                          : t('workbench.environment_commit_confirm', '确认')}
+                      </button>
+                    </div>
+                  </form>
+                )}
+                <button
+                  type="button"
+                  data-testid="create-pull-request-button"
+                  disabled={!info.createPullRequestUrl}
+                  onClick={handleCreatePullRequest}
+                  className="flex h-9 w-full items-center gap-3 rounded-md text-left text-[13px] text-text-primary hover:bg-hover disabled:cursor-not-allowed disabled:text-text-muted"
+                >
+                  <span className="flex h-[18px] w-[18px] shrink-0 items-center justify-center text-text-secondary">
+                    <GitPullRequest className="h-[18px] w-[18px]" />
+                  </span>
+                  <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                    {t('workbench.environment_create_pr', '创建拉取请求')}
+                  </span>
+                </button>
 
-              <div className="my-4 h-px bg-border" />
+                <div className="my-4 h-px bg-border" />
 
-              <section>
-                <h3 className="mb-3 text-[13px] text-text-secondary">
-                  {t('workbench.environment_sources', '来源')}
-                </h3>
-                <p className="text-[13px] text-text-muted">
-                  {t('workbench.environment_no_sources', '暂无来源')}
-                </p>
+                <section>
+                  <h3 className="mb-3 text-[13px] text-text-secondary">
+                    {t('workbench.environment_sources', '来源')}
+                  </h3>
+                  <p className="text-[13px] text-text-muted">
+                    {t('workbench.environment_no_sources', '暂无来源')}
+                  </p>
+                </section>
               </section>
-            </section>
+            )}
           </div>
 
           {info.error && (

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -21,7 +21,7 @@ const baseProps = {
 }
 
 describe('WorkspacePanelActions', () => {
-  test('shows environment info while git state is unknown and hides it after non-git detection', () => {
+  test('shows environment info while loading and keeps it when environment context is available', () => {
     const { rerender } = render(<WorkspacePanelActions {...baseProps} />)
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
@@ -35,7 +35,7 @@ describe('WorkspacePanelActions', () => {
           ...baseProps.environmentInfo,
           loading: false,
         }}
-      />,
+      />
     )
 
     expect(screen.queryByTestId('environment-info-button')).not.toBeInTheDocument()
@@ -46,9 +46,23 @@ describe('WorkspacePanelActions', () => {
         environmentInfo={{
           ...baseProps.environmentInfo,
           loading: false,
+          deviceId: 'device-1',
+          workspacePath: '/workspace/project',
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
+
+    rerender(
+      <WorkspacePanelActions
+        {...baseProps}
+        environmentInfo={{
+          ...baseProps.environmentInfo,
+          loading: false,
           branchName: 'main',
         }}
-      />,
+      />
     )
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -50,8 +50,13 @@ export function WorkspacePanelActions({
   const [codeServerError, setCodeServerError] = useState<string | null>(null)
   const showEnvironmentInfo = mode !== 'panel-toggles'
   const showPanelToggles = mode !== 'environment'
-  const canShowEnvironmentInfo =
-    environmentInfo.loading !== false || Boolean(environmentInfo.branchName?.trim())
+  const hasEnvironmentContext = Boolean(
+    environmentInfo.branchName?.trim() ||
+    environmentInfo.deviceId?.trim() ||
+    environmentInfo.workspacePath?.trim() ||
+    environmentInfo.error?.trim()
+  )
+  const canShowEnvironmentInfo = environmentInfo.loading !== false || hasEnvironmentContext
   const codeServerProjectDeviceId = getProjectDeviceId(currentProject)
   const canOpenCodeServer = Boolean(currentProject && codeServerProjectDeviceId)
   const codeServerDevice = codeServerProjectDeviceId


### PR DESCRIPTION
## Summary

- Keep the Wework environment info entry visible when environment context exists even if no git branch is detected.
- Hide git-only actions in the environment popover when the workspace has no branch information.
- Preserve resolved workspace paths when git environment loading fails so the popover still has useful context.

## Root Cause

The titlebar environment entry was gated on `branchName`, so non-git workspaces or git detection failures made the button disappear after loading finished.

## Validation

- `pnpm --dir wework exec vitest run src/api/environment.test.ts src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --dir wework lint`
- `pnpm --dir wework build`
- `git push` pre-push quality gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Environment information now displays workspace path consistently across all workspace types, including non-git projects
- Git-related UI elements (branch selector, changes button, PR features) conditionally render only when git information is available
- Enhanced error handling to preserve workspace path information even when git operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->