### PR TITLE
fix(agents): correct assistant output block handling

### DIFF
--- a/executor/agents/claude_code/response_processor.py
+++ b/executor/agents/claude_code/response_processor.py
@@ -250,6 +250,9 @@ async def process_response(
                         stream_event_sent,
                         tool_file_change_tracker,
                     )
+                    # This guard only applies to the finalized AssistantMessage
+                    # corresponding to the text that was just streamed.
+                    stream_event_sent = False
 
                 elif isinstance(msg, ResultMessage):
 
@@ -866,8 +869,9 @@ async def _handle_stream_event(
             logger.debug("StreamEvent: defer tool_start until ToolUseBlock")
 
         elif block_type == "text":
-            # Text block is starting - mark as sent to avoid duplicate in AssistantMessage
-            sent_content = True
+            # A start event carries no text; only text_delta proves content
+            # reached the UI and should suppress the finalized TextBlock.
+            logger.debug("StreamEvent: text block started")
 
     elif event_type == "content_block_stop":
         # A content block has finished

--- a/executor/agents/codex/event_mapper.py
+++ b/executor/agents/codex/event_mapper.py
@@ -294,7 +294,7 @@ class CodeXEventMapper:
         await self.emitter.block_created(
             {
                 "id": block_id,
-                "type": "thinking",
+                "type": "text",
                 "content": content,
                 "status": status,
                 "timestamp": int(time.time() * 1000),

--- a/executor/tests/agents/test_claude_response_processor.py
+++ b/executor/tests/agents/test_claude_response_processor.py
@@ -16,6 +16,7 @@ from executor.agents.claude_code.response_processor import (
     _handle_stream_event,
     _handle_user_message,
     _process_result_message,
+    process_response,
 )
 from executor.tasks.task_state_manager import TaskState, TaskStateManager
 from shared.models import EmitterBuilder, GeneratorTransport
@@ -35,6 +36,21 @@ class DummyStateManager:
 
     def report_progress(self, *_args, **_kwargs):
         pass
+
+
+class FakeClaudeClient:
+    def __init__(self, messages):
+        self.messages = messages
+
+    async def query(self, *_args, **_kwargs):
+        pass
+
+    def receive_response(self):
+        async def _receive():
+            for message in self.messages:
+                yield message
+
+        return _receive()
 
 
 @pytest.mark.asyncio
@@ -60,6 +76,26 @@ async def test_stream_tool_use_start_does_not_emit_incomplete_tool_block():
 
     assert sent is False
     emitter.tool_start.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_text_block_start_does_not_mark_text_as_sent():
+    emitter = MagicMock()
+    emitter.text_delta = AsyncMock()
+
+    msg = StreamEvent(
+        uuid="event-text-start-1",
+        session_id="session-1",
+        event={
+            "type": "content_block_start",
+            "content_block": {"type": "text"},
+        },
+    )
+
+    sent = await _handle_stream_event(msg, emitter, DummyStateManager())
+
+    assert sent is False
+    emitter.text_delta.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -115,6 +151,60 @@ async def test_assistant_message_emits_tool_start_when_text_was_streamed():
         name="Bash",
         arguments={"command": "git status"},
     )
+
+
+@pytest.mark.asyncio
+async def test_process_response_resets_stream_dedupe_after_assistant_message():
+    emitter = MagicMock()
+    emitter.text_delta = AsyncMock()
+    emitter.done = AsyncMock()
+    emitter.error = AsyncMock()
+
+    client = FakeClaudeClient(
+        [
+            StreamEvent(
+                uuid="event-text-delta-1",
+                session_id="session-1",
+                event={
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {
+                        "type": "text_delta",
+                        "text": "Already streamed",
+                    },
+                },
+            ),
+            AssistantMessage(
+                content=[TextBlock(text="Already streamed")],
+                model="claude-test",
+            ),
+            AssistantMessage(
+                content=[TextBlock(text="Visible follow-up")],
+                model="claude-test",
+            ),
+            ResultMessage(
+                subtype="success",
+                duration_ms=1,
+                duration_api_ms=1,
+                is_error=False,
+                num_turns=1,
+                session_id=None,
+                result="done",
+            ),
+        ]
+    )
+
+    result = await process_response(
+        client=client,
+        state_manager=DummyStateManager(),
+        emitter=emitter,
+    )
+
+    assert result == TaskStatus.COMPLETED
+    assert [call.args[0] for call in emitter.text_delta.await_args_list] == [
+        "Already streamed",
+        "Visible follow-up",
+    ]
 
 
 @pytest.mark.asyncio

--- a/executor/tests/agents/test_codex_event_mapper.py
+++ b/executor/tests/agents/test_codex_event_mapper.py
@@ -16,7 +16,7 @@ from shared.models.execution import ExecutionRequest
 from shared.status import TaskStatus
 
 
-def assert_commentary_block(
+def assert_commentary_text_block(
     emitter: SimpleNamespace,
     content: str,
     status: str = "done",
@@ -24,7 +24,7 @@ def assert_commentary_block(
     emitter.block_created.assert_awaited_once()
     block = emitter.block_created.await_args.args[0]
     assert block["id"].startswith("codex-commentary-")
-    assert block["type"] == "thinking"
+    assert block["type"] == "text"
     assert block["content"] == content
     assert block["status"] == status
     assert isinstance(block["timestamp"], int)
@@ -210,7 +210,7 @@ async def test_codex_event_mapper_routes_commentary_to_processing_block():
     )
 
     assert status == TaskStatus.COMPLETED
-    assert_commentary_block(emitter, "Working on it")
+    assert_commentary_text_block(emitter, "Working on it")
     emitter.block_updated.assert_not_awaited()
     emitter.reasoning.assert_not_awaited()
     emitter.text_delta.assert_not_awaited()
@@ -253,7 +253,7 @@ async def test_codex_event_mapper_routes_commentary_delta_without_duplicate_done
             payload=SimpleNamespace(delta="Working", item_id="msg_1"),
         )
     )
-    block = assert_commentary_block(emitter, "", status="streaming")
+    block = assert_commentary_text_block(emitter, "", status="streaming")
     emitter.block_updated.assert_awaited_once_with(
         block["id"],
         {
@@ -333,7 +333,7 @@ async def test_codex_event_mapper_buffers_unphased_delta_until_commentary_done()
     )
 
     assert status == TaskStatus.COMPLETED
-    assert_commentary_block(emitter, "Working")
+    assert_commentary_text_block(emitter, "Working")
     emitter.reasoning.assert_not_awaited()
     emitter.text_delta.assert_not_awaited()
     emitter.done.assert_awaited_once_with(content="", usage=None)

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -1,6 +1,7 @@
 import '@/i18n'
 
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, test } from 'vitest'
 import { ToolBlockItem } from './ToolBlockItem'
 import type { ProcessingBlock } from '@/types/workbench'
@@ -35,7 +36,9 @@ describe('ToolBlockItem', () => {
     expect(screen.queryByTestId('thinking-toggle-button')).not.toBeInTheDocument()
   })
 
-  test('renders completed thinking without per-block folding', () => {
+  test('renders completed thinking collapsed and expands on click', async () => {
+    const user = userEvent.setup()
+
     render(
       <ToolBlockItem
         block={{
@@ -46,7 +49,14 @@ describe('ToolBlockItem', () => {
       />
     )
 
-    expect(screen.queryByTestId('thinking-toggle-button')).not.toBeInTheDocument()
+    const toggle = screen.getByTestId('thinking-toggle-button')
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('thinking-detail')).not.toBeInTheDocument()
+
+    await user.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByTestId('thinking-detail')).toHaveTextContent(
       'I will inspect the repository before answering.'
     )

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { ChevronDown } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -56,6 +57,7 @@ function ThinkingBlockItem({
   isRunning: boolean
 }) {
   const { t } = useTranslation('chat')
+  const [expanded, setExpanded] = useState(false)
 
   if (!block.content) return null
 
@@ -82,21 +84,36 @@ function ThinkingBlockItem({
   }
 
   const charCount = block.content.length
+  const detailId = `${block.id}-thinking-detail`
 
   return (
     <div className="min-w-0 overflow-x-hidden text-[13px]">
-      <div className="flex max-w-full items-center gap-1.5 text-text-muted">
+      <button
+        type="button"
+        data-testid="thinking-toggle-button"
+        aria-expanded={expanded}
+        aria-controls={detailId}
+        onClick={() => setExpanded(value => !value)}
+        className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"
+      >
         <CommentaryIcon className="h-4 w-4 shrink-0" />
         <span className="min-w-0 truncate">
           {t('thinking.completed')} · {charCount} {t('thinking.chars')}
         </span>
-      </div>
-      <div
-        className="mt-2 min-w-0 overflow-x-hidden border-l border-border pl-4"
-        data-testid="thinking-detail"
-      >
-        <ProcessMarkdown content={block.content} />
-      </div>
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
+          strokeWidth={2}
+        />
+      </button>
+      {expanded && (
+        <div
+          id={detailId}
+          className="mt-2 min-w-0 overflow-x-hidden border-l border-border pl-4"
+          data-testid="thinking-detail"
+        >
+          <ProcessMarkdown content={block.content} />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- map Codex commentary output to normal text blocks instead of thinking blocks
- collapse completed Wework thinking blocks while keeping them expandable
- fix Claude Code text dedupe so content_block_start does not suppress finalized assistant text and dedupe resets after the matching assistant message

## Testing
- cd executor && uv run pytest tests/agents/test_codex_event_mapper.py tests/agents/test_claude_response_processor.py
- cd wework && pnpm test src/components/chat/blocks/ToolBlockItem.test.tsx
- cd wework && pnpm lint

## Notes
- No schema or migration changes.
- Existing unstaged change in frontend/src/app/google-sans-local.css was intentionally excluded from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated chat “thinking” blocks to be collapsed by default, with a toggle that expands to show the details.

* **Bug Fixes**
  * Improved streaming response handling to avoid suppressing or duplicating text emissions across consecutive messages.
  * Corrected commentary block labeling so emitted blocks use the expected text type.

* **Tests**
  * Added/expanded coverage for collapsible thinking block rendering and toggle behavior.
  * Added async tests covering streaming edge cases and de-duplication reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->