### PR TITLE
fix(image): enforce max dimension limit to prevent vision API errors

### DIFF
--- a/backend/app/services/attachment/parser.py
+++ b/backend/app/services/attachment/parser.py
@@ -43,6 +43,13 @@ from app.services.attachment.smart_truncation import (
 )
 from shared.utils.xmind_parser import XMindParseError, parse_xmind_to_markdown
 
+# Maximum long-edge dimension (px) applied at image upload time.
+# Mirrors the constraint in chat_shell.messages.converter.MAX_IMAGE_LONG_EDGE.
+# Anthropic hard limit: 8000px; native visual resolution: 1568px for most models.
+# 1568px is the conservative universal limit that avoids Anthropic errors and
+# matches the effective visual resolution cap of standard Claude models.
+MAX_IMAGE_LONG_EDGE = 1568
+
 logger = logging.getLogger(__name__)
 
 
@@ -984,8 +991,10 @@ class DocumentParser:
 
         Images with formats natively supported by all major vision APIs
         (JPEG, PNG, WebP — intersection of Anthropic, OpenAI, Gemini) are
-        stored as-is without re-encoding.  Other formats (GIF, BMP) are
-        converted to JPEG, taking only the first frame for animated images.
+        stored as-is when they fit within the dimension limit.  Oversized images
+        are resized to MAX_IMAGE_LONG_EDGE on the long side and re-encoded as
+        JPEG.  Other formats (GIF, BMP) are converted to JPEG, taking only the
+        first frame for animated images.
 
         Returns:
             Tuple of (metadata_text, base64_encoded_image, actual_mime_type)
@@ -996,45 +1005,73 @@ class DocumentParser:
             image_file = io.BytesIO(binary_data)
             img = Image.open(image_file)
 
-            # Extract image metadata
-            width, height = img.size
+            orig_width, orig_height = img.size
             mode = img.mode
             format_name = img.format or extension[1:].upper()
 
-            # Build description
-            text = f"[图片文件]\n"
-            text += f"格式: {format_name}\n"
-            text += f"尺寸: {width} x {height} 像素\n"
-            text += f"颜色模式: {mode}\n"
-            text += f"文件大小: {len(binary_data)} 字节"
-
             # Try to extract EXIF data if available (JPEG only; PNG raises OSError)
+            has_exif = False
             try:
                 if hasattr(img, "_getexif") and img._getexif():
-                    text += "\n\n[EXIF 信息]\n包含 EXIF 元数据"
+                    has_exif = True
             except Exception:
                 pass
 
             # Force full image load to validate pixel data (Image.open is lazy)
             img.load()
 
+            # Resize if any dimension exceeds the long-edge limit so that the stored
+            # base64 data is always within the vision API constraint.
+            needs_reencode = False
+            if max(orig_width, orig_height) > MAX_IMAGE_LONG_EDGE:
+                scale = MAX_IMAGE_LONG_EDGE / max(orig_width, orig_height)
+                new_w = max(1, int(orig_width * scale))
+                new_h = max(1, int(orig_height * scale))
+                img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+                logger.info(
+                    f"Image resized at upload: {orig_width}x{orig_height} -> {new_w}x{new_h} "
+                    f"(long edge {max(orig_width, orig_height)}px > limit {MAX_IMAGE_LONG_EDGE}px)"
+                )
+                width, height = new_w, new_h
+                needs_reencode = True
+            else:
+                width, height = orig_width, orig_height
+
+            # Build description using the actual stored dimensions.
+            text = f"[图片文件]\n"
+            text += f"格式: {format_name}\n"
+            text += f"尺寸: {width} x {height} 像素\n"
+            text += f"颜色模式: {mode}\n"
+            text += f"文件大小: {len(binary_data)} 字节"
+
+            if has_exif:
+                text += "\n\n[EXIF 信息]\n包含 EXIF 元数据"
+
             ext = extension.lower()
-            if ext in self.VISION_SUPPORTED_EXTENSIONS:
-                # Format is natively supported by all major vision APIs — use original bytes
+            if not needs_reencode and ext in self.VISION_SUPPORTED_EXTENSIONS:
+                # Format is natively supported by all major vision APIs and dimensions
+                # are within limits — use original bytes without re-encoding.
                 image_base64 = base64.b64encode(binary_data).decode("utf-8")
                 actual_mime_type = self.get_mime_type(ext)
             else:
-                # Convert to JPEG (supported by all major vision APIs, compact for photos)
-                # JPEG requires RGB or L mode; convert everything else accordingly
+                # Re-encode: either image was resized, or format is not natively supported.
+                # Convert to JPEG (supported by all major vision APIs, compact for photos).
+                # JPEG requires RGB or L mode; convert everything else accordingly.
                 if img.mode not in {"RGB", "L"}:
                     img = img.convert("RGB")
                 output_buf = io.BytesIO()
                 img.save(output_buf, format="JPEG", quality=85)
                 image_base64 = base64.b64encode(output_buf.getvalue()).decode("utf-8")
                 actual_mime_type = "image/jpeg"
-                logger.info(
-                    f"Converted {extension} image to JPEG for vision API compatibility"
-                )
+                if needs_reencode:
+                    logger.info(
+                        f"Re-encoded resized {extension} image as JPEG "
+                        f"({orig_width}x{orig_height} -> {width}x{height})"
+                    )
+                else:
+                    logger.info(
+                        f"Converted {extension} image to JPEG for vision API compatibility"
+                    )
 
             return text, image_base64, actual_mime_type
 

--- a/backend/tests/services/attachment/test_parser.py
+++ b/backend/tests/services/attachment/test_parser.py
@@ -452,6 +452,24 @@ def _make_image_bytes(fmt: str, mode: str = "RGB") -> bytes:
     return buf.getvalue()
 
 
+def _make_image_bytes_sized(width: int, height: int, fmt: str = "JPEG") -> bytes:
+    """Create valid image bytes with the given pixel dimensions."""
+    from PIL import Image
+
+    img = Image.new("RGB", (width, height), color="blue")
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    return buf.getvalue()
+
+
+def _decoded_dimensions(image_base64: str) -> tuple[int, int]:
+    """Return (width, height) from a base64-encoded image."""
+    from PIL import Image
+
+    img = Image.open(io.BytesIO(base64.b64decode(image_base64)))
+    return img.size
+
+
 class TestImageParsing:
     """Test image format normalisation in DocumentParser."""
 
@@ -510,3 +528,85 @@ class TestImageParsing:
         assert "application/json" in TEXT_MIME_TYPES
         assert "application/xml" in TEXT_MIME_TYPES
         assert "text/x-python" in TEXT_MIME_TYPES
+
+    # ------------------------------------------------------------------
+    # Dimension enforcement (MAX_IMAGE_LONG_EDGE)
+    # ------------------------------------------------------------------
+
+    def test_jpeg_within_limit_stored_as_original_bytes(self):
+        """JPEG with all dimensions within limit is stored without re-encoding."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        jpeg_bytes = _make_image_bytes_sized(MAX_IMAGE_LONG_EDGE, 100)
+        result = self.parser.parse(jpeg_bytes, ".jpg")
+
+        assert result.image_mime_type == "image/jpeg"
+        # Original bytes round-trip: decoded base64 equals input.
+        assert base64.b64decode(result.image_base64) == jpeg_bytes
+
+    def test_tall_jpeg_is_resized(self):
+        """Tall JPEG (height > 1568px) is resized so the long edge fits within the limit."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        jpeg_bytes = _make_image_bytes_sized(100, 13768)
+        result = self.parser.parse(jpeg_bytes, ".jpg")
+
+        assert result.image_mime_type == "image/jpeg"
+        w, h = _decoded_dimensions(result.image_base64)
+        assert max(w, h) <= MAX_IMAGE_LONG_EDGE
+
+    def test_wide_jpeg_is_resized(self):
+        """Wide JPEG (width > 1568px) is resized so the long edge fits within the limit."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        jpeg_bytes = _make_image_bytes_sized(9000, 100)
+        result = self.parser.parse(jpeg_bytes, ".jpg")
+
+        assert result.image_mime_type == "image/jpeg"
+        w, h = _decoded_dimensions(result.image_base64)
+        assert max(w, h) <= MAX_IMAGE_LONG_EDGE
+
+    def test_oversized_jpeg_aspect_ratio_preserved(self):
+        """Resized JPEG maintains aspect ratio (within 1px rounding tolerance)."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        orig_w, orig_h = 100, 9000  # 1:90 ratio
+        jpeg_bytes = _make_image_bytes_sized(orig_w, orig_h)
+        result = self.parser.parse(jpeg_bytes, ".jpg")
+
+        out_w, out_h = _decoded_dimensions(result.image_base64)
+        expected_w = max(1, int(orig_w * MAX_IMAGE_LONG_EDGE / max(orig_w, orig_h)))
+        assert abs(out_w - expected_w) <= 1
+
+    def test_oversized_jpeg_metadata_reflects_stored_dimensions(self):
+        """Metadata text reports the post-resize dimensions, not the original ones."""
+        jpeg_bytes = _make_image_bytes_sized(100, 13768)
+        result = self.parser.parse(jpeg_bytes, ".jpg")
+
+        # The metadata text should NOT say "13768"
+        assert "13768" not in result.text
+        # The stored dimensions should appear instead
+        w, h = _decoded_dimensions(result.image_base64)
+        assert f"{w} x {h}" in result.text
+
+    def test_oversized_png_is_resized_and_reencoded_as_jpeg(self):
+        """PNG with dimension > 1568px is resized and re-encoded as JPEG."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        png_bytes = _make_image_bytes_sized(100, 9000, fmt="PNG")
+        result = self.parser.parse(png_bytes, ".png")
+
+        assert result.image_mime_type == "image/jpeg"
+        w, h = _decoded_dimensions(result.image_base64)
+        assert max(w, h) <= MAX_IMAGE_LONG_EDGE
+
+    def test_oversized_webp_is_resized(self):
+        """WebP image with dimension > 1568px is resized."""
+        from app.services.attachment.parser import MAX_IMAGE_LONG_EDGE
+
+        webp_bytes = _make_image_bytes_sized(9000, 100, fmt="WEBP")
+        result = self.parser.parse(webp_bytes, ".webp")
+
+        assert result.image_mime_type == "image/jpeg"
+        w, h = _decoded_dimensions(result.image_base64)
+        assert max(w, h) <= MAX_IMAGE_LONG_EDGE

--- a/backend/tests/services/chat_shell/messages/test_converter.py
+++ b/backend/tests/services/chat_shell/messages/test_converter.py
@@ -6,117 +6,219 @@ import base64
 import io
 from unittest.mock import patch
 
+import pytest
 from PIL import Image
 
 from chat_shell.messages.converter import (
+    MAX_IMAGE_LONG_EDGE,
     MAX_IMAGE_SIZE_BYTES,
     MessageConverter,
 )
 
 
-def create_test_image(width, height, color="red"):
-    """Create a test image and return bytes."""
+def create_test_image(
+    width: int, height: int, color: str = "red", fmt: str = "JPEG"
+) -> bytes:
+    """Create a test image and return its bytes."""
     img = Image.new("RGB", (width, height), color=color)
     output = io.BytesIO()
-    img.save(output, format="JPEG")
+    img.save(output, format=fmt)
     return output.getvalue()
 
 
-def test_compress_image_small():
-    """Test that small images are not compressed."""
-    # Create small image
+def get_image_dimensions(img_bytes: bytes) -> tuple[int, int]:
+    """Return (width, height) of image bytes."""
+    img = Image.open(io.BytesIO(img_bytes))
+    return img.size
+
+
+# ---------------------------------------------------------------------------
+# _compress_image: size-only path (unchanged behaviour for small dimensions)
+# ---------------------------------------------------------------------------
+
+
+def test_compress_image_small_within_limits():
+    """Small image within both dimension and size limits is returned unchanged."""
     img_data = create_test_image(100, 100)
     assert len(img_data) < MAX_IMAGE_SIZE_BYTES
 
-    compressed = MessageConverter._compress_image(img_data, "image/jpeg")
-    assert compressed == img_data
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    # Same object returned (identity) when nothing changed.
+    assert result is img_data
 
 
-def test_compress_image_large():
-    """Test that large images are compressed."""
-    # Create large image (approx 5000x5000 should be large enough)
-    # Note: Generating a huge image in memory might be slow or consume memory,
-    # so we'll mock the size check or use a slightly smaller but still "large" one.
-    # Instead of generating a real huge image, we can mock the size check
-    # inside _compress_image, but that requires more complex mocking.
-
-    # Let's try a reasonable size that might exceed 1MB uncompressed,
-    # but compressed JPEG is small.
-    # To really test compression logic, we need an image that STAYS large if not compressed.
-    # A noise image is hard to compress.
-
-    # Generate random bytes to simulate a large non-compressible image is tricky
-    # because PIL needs to open it.
-
-    # Let's create a large solid color image, it compresses well,
-    # so we might need huge dimensions to exceed 1MB even in JPEG.
-    # 1MB = 1048576 bytes.
-    # A 2000x2000 RGB image is 12MB raw, but JPEG is much smaller.
-
-    # We can mock MAX_IMAGE_SIZE_BYTES to be very small for testing.
+def test_compress_image_oversized_file_reduced():
+    """Image whose encoded size exceeds MAX_IMAGE_SIZE_BYTES is compressed."""
     with patch("chat_shell.messages.converter.MAX_IMAGE_SIZE_BYTES", 100):
-        img_data = create_test_image(50, 50)  # Small image but larger than 100 bytes
+        img_data = create_test_image(50, 50)
 
-        compressed = MessageConverter._compress_image(img_data, "image/jpeg")
+        result = MessageConverter._compress_image(img_data, "image/jpeg")
 
-        # It should be compressed (quality reduced or resized)
-        # Since 100 bytes is very small, it might fail to compress that small and return original
-        # if quality reduction doesn't help enough.
-
-        # Let's just verify that logic runs without error.
-        assert isinstance(compressed, bytes)
+        assert isinstance(result, bytes)
+        # Result must differ from input because compression was applied.
+        assert result is not img_data
 
 
-def test_create_image_block_compression():
-    """Test that create_image_block triggers compression."""
-    img_data = create_test_image(200, 200)
-
-    # Mock compression to return a specific byte string
-    with patch.object(
-        MessageConverter, "_compress_image", return_value=b"compressed"
-    ) as mock_compress:
-        # Mock limit to force compression
-        with patch("chat_shell.messages.converter.MAX_IMAGE_SIZE_BYTES", 1):
-            block = MessageConverter.create_image_block(img_data, "image/jpeg")
-
-            mock_compress.assert_called_once()
-            assert block["type"] == "image_url"
-            assert block["image_url"]["url"].endswith(
-                base64.b64encode(b"compressed").decode("utf-8")
-            )
+# ---------------------------------------------------------------------------
+# _compress_image: dimension enforcement (new behaviour)
+# ---------------------------------------------------------------------------
 
 
-def test_build_messages_with_vision_compression():
-    """Test that build_messages with vision content triggers compression."""
-    img_data = create_test_image(200, 200)
+def test_compress_image_oversized_dimension_is_resized():
+    """Image with long edge > MAX_IMAGE_LONG_EDGE is downscaled to the limit."""
+    # Tall image: 100 wide, 13768 tall (the real-world failing case).
+    img_data = create_test_image(100, 13768)
+
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    out_w, out_h = get_image_dimensions(result)
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+def test_compress_image_wide_dimension_is_resized():
+    """Wide image with long edge > MAX_IMAGE_LONG_EDGE is downscaled."""
+    img_data = create_test_image(9000, 100)
+
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    out_w, out_h = get_image_dimensions(result)
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+def test_compress_image_aspect_ratio_preserved():
+    """Resized image preserves the original aspect ratio (within 1px rounding)."""
+    orig_w, orig_h = 100, 10000  # 1:100 ratio
+    img_data = create_test_image(orig_w, orig_h)
+
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    out_w, out_h = get_image_dimensions(result)
+    # Expected width: 100 * (1568 / 10000) ≈ 15
+    expected_w = max(1, int(orig_w * MAX_IMAGE_LONG_EDGE / max(orig_w, orig_h)))
+    assert abs(out_w - expected_w) <= 1
+
+
+def test_compress_image_small_dimension_unchanged():
+    """Image whose long edge is exactly at the limit is returned unchanged (no re-encode)."""
+    img_data = create_test_image(MAX_IMAGE_LONG_EDGE, 100)
+    assert len(img_data) < MAX_IMAGE_SIZE_BYTES
+
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    assert result is img_data  # Identity: no processing performed.
+
+
+def test_compress_image_small_file_but_large_dimension():
+    """Image that is small in bytes but has a dimension > 1568px must still be resized."""
+    # A tiny solid-colour image can be large in pixels but small as JPEG.
+    img_data = create_test_image(100, 9000)
+    assert (
+        len(img_data) < MAX_IMAGE_SIZE_BYTES
+    )  # Confirm it wouldn't trigger the old size guard.
+
+    result = MessageConverter._compress_image(img_data, "image/jpeg")
+
+    out_w, out_h = get_image_dimensions(result)
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+def test_compress_image_png_oversized_dimension():
+    """PNG image with oversized dimension is also resized (format preserved if small enough)."""
+    img_data = create_test_image(100, 9000, fmt="PNG")
+
+    result = MessageConverter._compress_image(img_data, "image/png")
+
+    out_w, out_h = get_image_dimensions(result)
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+# ---------------------------------------------------------------------------
+# _convert_responses_api_to_langchain: integration path
+# ---------------------------------------------------------------------------
+
+
+def test_build_messages_normalizes_oversized_dimension():
+    """build_messages normalises an oversized image in an input_image block."""
+    # Create a tall image that exceeds the dimension limit.
+    img_data = create_test_image(100, 9000)
     b64_img = base64.b64encode(img_data).decode("utf-8")
 
-    # Create OpenAI Responses API format input with image
     content_blocks = [
         {"type": "input_text", "text": "describe this image"},
         {"type": "input_image", "image_url": f"data:image/jpeg;base64,{b64_img}"},
     ]
 
-    # Mock compression
+    messages = MessageConverter.build_messages(
+        history=[],
+        current_message=content_blocks,
+        system_prompt="",
+        inject_datetime=False,
+    )
+
+    user_msg = messages[-1]
+    image_block = next(b for b in user_msg["content"] if b.get("type") == "image_url")
+    url = image_block["image_url"]["url"]
+    _, encoded = url.split(",", 1)
+    result_bytes = base64.b64decode(encoded)
+    out_w, out_h = get_image_dimensions(result_bytes)
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+def test_build_messages_leaves_small_image_unchanged():
+    """build_messages does not modify an image that is already within all limits."""
+    img_data = create_test_image(400, 300)
+    b64_img = base64.b64encode(img_data).decode("utf-8")
+
+    content_blocks = [
+        {"type": "input_text", "text": "describe this image"},
+        {"type": "input_image", "image_url": f"data:image/jpeg;base64,{b64_img}"},
+    ]
+
+    messages = MessageConverter.build_messages(
+        history=[],
+        current_message=content_blocks,
+        system_prompt="",
+        inject_datetime=False,
+    )
+
+    user_msg = messages[-1]
+    image_block = next(b for b in user_msg["content"] if b.get("type") == "image_url")
+    url = image_block["image_url"]["url"]
+    _, encoded = url.split(",", 1)
+    # Decoded bytes should be byte-equal to the original (no unnecessary re-encode).
+    assert base64.b64decode(encoded) == img_data
+
+
+# ---------------------------------------------------------------------------
+# create_image_block: always-normalize path
+# ---------------------------------------------------------------------------
+
+
+def test_create_image_block_normalizes_oversized_dimension():
+    """create_image_block resizes an image with dimension > MAX_IMAGE_LONG_EDGE."""
+    img_data = create_test_image(100, 9000)
+
+    block = MessageConverter.create_image_block(img_data, "image/jpeg")
+
+    url = block["image_url"]["url"]
+    _, encoded = url.split(",", 1)
+    out_w, out_h = get_image_dimensions(base64.b64decode(encoded))
+    assert max(out_w, out_h) <= MAX_IMAGE_LONG_EDGE
+
+
+def test_create_image_block_compression():
+    """create_image_block calls _compress_image even when image is below size limit."""
+    img_data = create_test_image(200, 200)
+
     with patch.object(
         MessageConverter, "_compress_image", return_value=b"compressed"
     ) as mock_compress:
-        # Mock limit to force compression
-        with patch("chat_shell.messages.converter.MAX_IMAGE_SIZE_BYTES", 1):
-            messages = MessageConverter.build_messages(
-                history=[],
-                current_message=content_blocks,
-                system_prompt="",
-                inject_datetime=False,
-            )
+        block = MessageConverter.create_image_block(img_data, "image/jpeg")
 
-            mock_compress.assert_called_once()
-            # The last message should be the user message with vision content
-            user_msg = messages[-1]
-            content = user_msg["content"]
-            assert len(content) == 2
-            assert content[1]["type"] == "image_url"
-            # Check if url contains encoded "compressed" bytes
-            assert content[1]["image_url"]["url"].endswith(
-                base64.b64encode(b"compressed").decode("utf-8")
-            )
+        # Must always be called regardless of file size.
+        mock_compress.assert_called_once_with(img_data, "image/jpeg")
+        assert block["type"] == "image_url"
+        assert block["image_url"]["url"].endswith(
+            base64.b64encode(b"compressed").decode("utf-8")
+        )

--- a/chat_shell/chat_shell/messages/converter.py
+++ b/chat_shell/chat_shell/messages/converter.py
@@ -18,6 +18,13 @@ logger = logging.getLogger(__name__)
 MAX_IMAGE_SIZE_MB = 1
 MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024
 
+# Maximum long-edge dimension for LLM vision APIs.
+# Anthropic native visual resolution: 1568px for most models (hard API limit: 8000px).
+# OpenAI resizes internally to ~2048px; Gemini to ~3072px.
+# 1568px is the conservative universal limit that avoids Anthropic errors and
+# matches the effective visual resolution cap of standard Claude models.
+MAX_IMAGE_LONG_EDGE = 1568
+
 
 class MessageConverter:
     """Utilities for building and converting messages.
@@ -266,15 +273,16 @@ class MessageConverter:
                             mime_type = header.split(":")[1].split(";")[0]
 
                             image_bytes = base64.b64decode(base64_data)
-                            if len(image_bytes) > MAX_IMAGE_SIZE_BYTES:
-                                compressed_bytes = MessageConverter._compress_image(
-                                    image_bytes, mime_type
-                                )
-                                compressed_base64 = base64.b64encode(
-                                    compressed_bytes
-                                ).decode("utf-8")
+                            # Always normalize: _compress_image checks both dimension and
+                            # file size, returning the original object unchanged when both
+                            # are within limits (identity comparison detects no-op).
+                            normalized_bytes = MessageConverter._compress_image(
+                                image_bytes, mime_type
+                            )
+                            if normalized_bytes is not image_bytes:
                                 image_url = (
-                                    f"data:{mime_type};base64,{compressed_base64}"
+                                    f"data:{mime_type};base64,"
+                                    f"{base64.b64encode(normalized_bytes).decode('utf-8')}"
                                 )
                     except Exception as e:
                         logger.warning(f"Failed to process image: {e}")
@@ -309,33 +317,55 @@ class MessageConverter:
 
     @staticmethod
     def _compress_image(image_data: bytes, mime_type: str = "image/png") -> bytes:
-        """Compress image if it exceeds the size limit."""
-        original_size = len(image_data)
-        if original_size <= MAX_IMAGE_SIZE_BYTES:
-            logger.debug(
-                f"Image size {original_size / 1024 / 1024:.2f}MB is within limit {MAX_IMAGE_SIZE_MB}MB, skipping compression"
-            )
-            return image_data
+        """Normalize image: enforce max long-edge dimension and max file size.
 
-        logger.info(
-            f"Image size {original_size / 1024 / 1024:.2f}MB exceeds limit {MAX_IMAGE_SIZE_MB}MB, compressing..."
-        )
+        Applies two constraints in order:
+        1. Resize to MAX_IMAGE_LONG_EDGE on the long side if dimensions exceed the limit.
+        2. Reduce JPEG/WEBP quality (then progressively downscale) until file size
+           fits within MAX_IMAGE_SIZE_BYTES.
 
+        Returns the original bytes object unchanged when both constraints are already met,
+        so callers can use identity comparison (``is``) to detect whether the image changed.
+        """
         try:
-            # Convert mime_type to PIL format
             fmt = mime_type.split("/")[-1].upper()
             if fmt == "JPG":
                 fmt = "JPEG"
 
             img = Image.open(io.BytesIO(image_data))
+            orig_width, orig_height = img.size
+            original_size = len(image_data)
 
-            # Convert to RGB if necessary (e.g. for JPEG)
+            # Early return when both dimension and size constraints are already satisfied.
+            if (
+                max(orig_width, orig_height) <= MAX_IMAGE_LONG_EDGE
+                and original_size <= MAX_IMAGE_SIZE_BYTES
+            ):
+                logger.debug(
+                    f"Image {orig_width}x{orig_height} "
+                    f"{original_size / 1024 / 1024:.2f}MB is within limits, skipping"
+                )
+                return image_data
+
+            # Step 1: resize if any dimension exceeds the long-edge limit.
+            if max(orig_width, orig_height) > MAX_IMAGE_LONG_EDGE:
+                scale = MAX_IMAGE_LONG_EDGE / max(orig_width, orig_height)
+                new_w = max(1, int(orig_width * scale))
+                new_h = max(1, int(orig_height * scale))
+                img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
+                logger.info(
+                    f"Image dimension resized: {orig_width}x{orig_height} -> {new_w}x{new_h} "
+                    f"(long edge {max(orig_width, orig_height)}px > limit {MAX_IMAGE_LONG_EDGE}px)"
+                )
+
+            # Convert to RGB if necessary for JPEG output.
             if fmt == "JPEG" and img.mode != "RGB":
                 img = img.convert("RGB")
 
-            # Initial quality
+            # Step 2: quality reduction loop until file size fits within the limit.
             quality = 85
             output = io.BytesIO()
+            compressed_data: bytes = b""
 
             while quality > 10:
                 output.seek(0)
@@ -344,32 +374,32 @@ class MessageConverter:
                 if fmt in ("JPEG", "WEBP"):
                     img.save(output, format=fmt, quality=quality)
                 else:
-                    # For PNG and others, quality param is ignored, try optimize
+                    # PNG: quality parameter is ignored; optimize=True is the only lever.
+                    # Break after the first attempt and fall through to resize if still too big.
                     img.save(output, format=fmt, optimize=True)
 
                 compressed_data = output.getvalue()
 
                 if len(compressed_data) <= MAX_IMAGE_SIZE_BYTES:
                     logger.info(
-                        f"Image compressed (quality reduction): {original_size / 1024 / 1024:.2f}MB -> {len(compressed_data) / 1024 / 1024:.2f}MB "
+                        f"Image normalized: {original_size / 1024 / 1024:.2f}MB -> "
+                        f"{len(compressed_data) / 1024 / 1024:.2f}MB "
                         f"(ratio: {len(compressed_data) / original_size:.2%})"
                     )
                     return compressed_data
 
                 quality -= 10
 
-                # For non-quality formats (like PNG), quality loop is ineffective
-                # so we break after first attempt (with optimize=True) and move to resizing
                 if fmt not in ("JPEG", "WEBP"):
                     break
 
-            # If still too big, resize
-            width, height = img.size
+            # Step 3: progressive downscale as last resort when quality reduction is insufficient.
+            cur_w, cur_h = img.size
             ratio = 0.8
-            while len(compressed_data) > MAX_IMAGE_SIZE_BYTES and width > 100:
-                width = int(width * ratio)
-                height = int(height * ratio)
-                img = img.resize((width, height), Image.Resampling.LANCZOS)
+            while len(compressed_data) > MAX_IMAGE_SIZE_BYTES and cur_w > 100:
+                cur_w = int(cur_w * ratio)
+                cur_h = int(cur_h * ratio)
+                img = img.resize((cur_w, cur_h), Image.Resampling.LANCZOS)
 
                 output.seek(0)
                 output.truncate()
@@ -381,16 +411,15 @@ class MessageConverter:
 
                 compressed_data = output.getvalue()
 
-            final_size = len(compressed_data)
             logger.info(
-                f"Image compressed: {original_size / 1024 / 1024:.2f}MB -> {final_size / 1024 / 1024:.2f}MB "
-                f"(ratio: {final_size / original_size:.2%})"
+                f"Image compressed: {original_size / 1024 / 1024:.2f}MB -> "
+                f"{len(compressed_data) / 1024 / 1024:.2f}MB "
+                f"(ratio: {len(compressed_data) / original_size:.2%})"
             )
             return compressed_data
 
         except Exception as e:
             logger.warning(f"Image compression failed: {e}")
-            # If compression fails, return original data
             return image_data
 
     @staticmethod
@@ -434,8 +463,7 @@ class MessageConverter:
         image_data: bytes, mime_type: str = "image/png"
     ) -> dict[str, Any]:
         """Create an image content block from raw bytes."""
-        if len(image_data) > MAX_IMAGE_SIZE_BYTES:
-            image_data = MessageConverter._compress_image(image_data, mime_type)
+        image_data = MessageConverter._compress_image(image_data, mime_type)
 
         encoded = base64.b64encode(image_data).decode("utf-8")
         return {


### PR DESCRIPTION
## Summary

- **Root cause**: Users uploading images with a dimension > 8000 px (e.g. a 990×13768 JPEG long-screenshot) caused the Anthropic API to return HTTP 400: `"At least one of the image dimensions exceed max allowed size: 8000 pixels"`. The existing `_compress_image` only reduced *file size* to < 1 MB but never checked *pixel dimensions*, so a 13768 px-tall image could be compressed to 900 KB and still fail the Anthropic hard limit.
- **P0 — `chat_shell/messages/converter.py`**: Add `MAX_IMAGE_LONG_EDGE = 1568`; rewrite `_compress_image` to resize on the long edge first, then reduce file size. Remove the `if len > 1 MB` call-site guards so `_compress_image` always runs (a small-byte image can still have huge dimensions). Uses identity (`is`) comparison to skip the data-URL rebuild when nothing changed.
- **P1 — `backend/app/services/attachment/parser.py`**: Add `MAX_IMAGE_LONG_EDGE = 1568`; resize oversized images in `_parse_image` at upload time so the stored `image_base64` is already within the limit.

**Why 1568 px?**
| Provider | Hard limit | Effective visual resolution |
|---|---|---|
| Anthropic | 8000 px (HTTP 400 above this) | 1568 px for most models; 2576 px for Opus 4.7+/Fable 5 |
| OpenAI | none (resizes internally to ~2048 px) | — |
| Gemini | none (tiles at 768 px) | — |

1568 px is the conservative universal limit: prevents Anthropic errors, matches the effective visual resolution of standard Claude models (anything larger is discarded by Claude anyway), and reduces token cost on all providers.

## Test plan

- [ ] `uv run pytest backend/tests/services/chat_shell/messages/test_converter.py -v` — 12 tests pass (new: dimension resize, aspect ratio, identity no-op, always-normalize call path)
- [ ] `uv run pytest backend/tests/services/attachment/test_parser.py::TestImageParsing -v` — 13 tests pass (new: tall/wide resize, PNG/WebP resize, aspect ratio, metadata text accuracy)
- [ ] `uv run pytest backend/tests/services/attachment/ -q` — 100 tests pass (no regressions)
- [ ] `uv run pytest chat_shell/tests/test_compression.py -q` — 57 tests pass (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Images are now automatically resized when their long edge exceeds 1568px, maintaining aspect ratio for consistent display.
  * Enhanced compatibility across different image formats with improved EXIF metadata support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->