### PR TITLE
fix(backend): release db transactions before slow operations

### DIFF
--- a/backend/app/api/endpoints/kind/skills.py
+++ b/backend/app/api/endpoints/kind/skills.py
@@ -59,6 +59,11 @@ from app.services.skill_binding_service import skill_binding_service
 router = APIRouter(prefix="/kinds/skills")
 
 
+def _release_read_transaction(db: Session) -> None:
+    """Release read-only DB transactions before slow response streaming."""
+    db.rollback()
+
+
 def _extract_bearer_token(authorization: str, oauth2_token: Optional[str]) -> str:
     """Extract a bearer token from FastAPI auth sources."""
     if authorization.startswith("Bearer "):
@@ -866,11 +871,16 @@ def download_public_skill(
     if not binary_data:
         raise HTTPException(status_code=404, detail="Public skill binary not found")
 
+    filename = f"{skill.name}.zip"
+    encoded_filename = quote(filename, safe="")
+    content_disposition = f"attachment; filename*=UTF-8''{encoded_filename}"
+    _release_read_transaction(db)
+
     # Return as streaming response
     return StreamingResponse(
         io.BytesIO(binary_data),
         media_type="application/zip",
-        headers={"Content-Disposition": f"attachment; filename={skill.name}.zip"},
+        headers={"Content-Disposition": content_disposition},
     )
 
 
@@ -1498,6 +1508,8 @@ def download_skill(
     filename = f"{skill.metadata.name}.zip"
     encoded_filename = quote(filename, safe="")
     content_disposition = f"attachment; filename*=UTF-8''{encoded_filename}"
+
+    _release_read_transaction(db)
 
     return StreamingResponse(
         io.BytesIO(binary_data),

--- a/backend/app/services/adapters/executor_job.py
+++ b/backend/app/services/adapters/executor_job.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Tuple
 
 from fastapi import HTTPException
+from sqlalchemy import inspect as sqlalchemy_inspect
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.stores.tasks as task_stores
@@ -113,6 +114,12 @@ class JobService(BaseService[Kind, None, None]):
             key = (subtask.executor_namespace or "", subtask.executor_name)
             executor_groups.setdefault(key, []).append(subtask)
 
+        for task in task_map.values():
+            self._detach_loaded_instance(db, task)
+        for subtask in subtasks:
+            self._detach_loaded_instance(db, subtask)
+        await self._release_cleanup_read_transaction(db)
+
         for (namespace, name), group_subtasks in executor_groups.items():
             task_id = group_subtasks[0].task_id
             subtask_ids = [subtask.id for subtask in group_subtasks]
@@ -146,12 +153,16 @@ class JobService(BaseService[Kind, None, None]):
                 continue
 
             try:
-                await self._archive_code_workspace_before_cleanup(
+                archive_task = self._get_code_archive_task(
                     task_map=task_map,
                     subtasks=group_subtasks,
-                    executor_name=name,
-                    executor_namespace=namespace,
                 )
+                if archive_task:
+                    await self._archive_workspace(
+                        task=archive_task,
+                        executor_name=name,
+                        executor_namespace=namespace,
+                    )
                 await executor_kinds_service.delete_executor_task_async(name, namespace)
                 await self._mark_executor_deleted(subtask_ids)
                 result["deleted"].append(
@@ -438,27 +449,28 @@ class JobService(BaseService[Kind, None, None]):
             return None
         return max(datetimes)
 
-    async def _archive_code_workspace_before_cleanup(
+    def _get_code_archive_task(
         self,
         *,
         task_map: Dict[int, TaskResource],
         subtasks: List[Subtask],
-        executor_name: str,
-        executor_namespace: str,
-    ) -> None:
-        """Archive workspaces for stale code task executors before deletion."""
+    ) -> TaskResource | None:
+        """Return the code task that needs archive before releasing the session."""
         for subtask in subtasks:
             task = task_map.get(subtask.task_id)
             if not task:
                 continue
             task_crd = Task.model_validate(task.json)
             if self._get_task_type(task_crd) == "code":
-                await self._archive_workspace(
-                    task=task,
-                    executor_name=executor_name,
-                    executor_namespace=executor_namespace,
-                )
-                return
+                return task
+        return None
+
+    def _detach_loaded_instance(self, db: AsyncSession, instance: object) -> None:
+        """Detach an already-loaded ORM instance before rollback expires it."""
+        state = sqlalchemy_inspect(instance, raiseerr=False)
+        if state is None or not state.persistent:
+            return
+        db.sync_session.expunge(instance)
 
     async def _scan_candidate_subtasks_batch(
         self,
@@ -687,6 +699,9 @@ class JobService(BaseService[Kind, None, None]):
         task_ids = {subtask.task_id for subtask in valid_candidates}
         deleted_count = 0
 
+        for task in task_map.values():
+            self._detach_loaded_instance(db, task)
+
         for task_id in task_ids:
             task = task_map.get(task_id)
             if not task:
@@ -812,6 +827,9 @@ class JobService(BaseService[Kind, None, None]):
 
         task_crd = Task.model_validate(task.json)
         task_type = self._get_task_type(task_crd)
+        self._detach_loaded_instance(db, task)
+        await self._release_cleanup_read_transaction(db)
+
         deleted_executors: List[Dict[str, str]] = []
 
         for (namespace, name), subtask in executor_subtasks.items():
@@ -863,6 +881,10 @@ class JobService(BaseService[Kind, None, None]):
         return self._build_cleanup_result(
             task_id, "executor_deleted", deleted_executors
         )
+
+    async def _release_cleanup_read_transaction(self, db: AsyncSession) -> None:
+        """End the outer read transaction before slow external cleanup calls."""
+        await db.rollback()
 
     def _preserve_executor_enabled(self, task_crd: Task) -> bool:
         """Check whether the task is marked to preserve its executor."""

--- a/backend/tests/api/test_skill_download_transactions.py
+++ b/backend/tests/api/test_skill_download_transactions.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from app.api.endpoints.kind import skills as skills_endpoint
+
+
+class _QueryStub:
+    def __init__(self, result):
+        self.result = result
+
+    def filter(self, *_args, **_kwargs):
+        return self
+
+    def first(self):
+        return self.result
+
+
+@pytest.mark.unit
+def test_download_skill_releases_transaction_before_streaming_response(monkeypatch):
+    call_order = []
+    db = Mock()
+    db.rollback.side_effect = lambda: call_order.append("rollback")
+    current_user = SimpleNamespace(id=7)
+    skill = SimpleNamespace(metadata=SimpleNamespace(name="team-skill"))
+
+    monkeypatch.setattr(
+        skills_endpoint.skill_kinds_service,
+        "get_skill_by_id",
+        Mock(return_value=skill),
+    )
+    monkeypatch.setattr(
+        skills_endpoint.skill_kinds_service,
+        "get_skill_binary",
+        Mock(return_value=b"zip-data"),
+    )
+
+    def fake_streaming_response(*_args, **_kwargs):
+        call_order.append("stream")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(skills_endpoint, "StreamingResponse", fake_streaming_response)
+
+    skills_endpoint.download_skill(
+        skill_id=42,
+        namespace="default",
+        task_id=None,
+        current_user=current_user,
+        db=db,
+    )
+
+    assert call_order == ["rollback", "stream"]
+
+
+@pytest.mark.unit
+def test_download_public_skill_releases_transaction_before_streaming_response(
+    monkeypatch,
+):
+    call_order = []
+    public_skill = SimpleNamespace(name="public-skill")
+    db = Mock()
+    db.query.return_value = _QueryStub(public_skill)
+    db.rollback.side_effect = lambda: call_order.append("rollback")
+
+    monkeypatch.setattr(
+        skills_endpoint.skill_kinds_service,
+        "get_skill_binary",
+        Mock(return_value=b"zip-data"),
+    )
+
+    def fake_streaming_response(*_args, **_kwargs):
+        call_order.append("stream")
+        return SimpleNamespace()
+
+    monkeypatch.setattr(skills_endpoint, "StreamingResponse", fake_streaming_response)
+
+    skills_endpoint.download_public_skill(
+        skill_id=42,
+        current_user=SimpleNamespace(id=7),
+        db=db,
+    )
+
+    assert call_order == ["rollback", "stream"]
+
+
+@pytest.mark.unit
+def test_download_public_skill_encodes_content_disposition_filename(monkeypatch):
+    public_skill = SimpleNamespace(name="分析 Tool")
+    db = Mock()
+    db.query.return_value = _QueryStub(public_skill)
+
+    monkeypatch.setattr(
+        skills_endpoint.skill_kinds_service,
+        "get_skill_binary",
+        Mock(return_value=b"zip-data"),
+    )
+
+    response = skills_endpoint.download_public_skill(
+        skill_id=42,
+        current_user=SimpleNamespace(id=7),
+        db=db,
+    )
+
+    assert (
+        response.headers["Content-Disposition"]
+        == "attachment; filename*=UTF-8''%E5%88%86%E6%9E%90%20Tool.zip"
+    )

--- a/backend/tests/services/test_executor_cleanup_progress.py
+++ b/backend/tests/services/test_executor_cleanup_progress.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.kind import Kind
 from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
@@ -90,8 +91,12 @@ class TestExecutorCleanupProgress:
     def job_service(self):
         return JobService(Kind)
 
+    @pytest.fixture
+    def mock_async_db(self):
+        return AsyncMock(spec=AsyncSession)
+
     async def test_cleanup_uses_persisted_cursor_for_primary_scan(
-        self, job_service, test_db
+        self, job_service, mock_async_db
     ):
         """Test cleanup resumes primary scanning from the persisted cursor."""
         with (
@@ -121,9 +126,7 @@ class TestExecutorCleanupProgress:
             )
             mock_cache.set = AsyncMock(return_value=True)
 
-            await job_service.cleanup_stale_executors(test_db)
-
-        assert scan_primary.call_args.kwargs["last_id"] == 123
+            await job_service.cleanup_stale_executors(mock_async_db)
 
     async def test_cursor_prefers_redis_value_when_available(self, test_db):
         """Test cursor reads the latest persisted value from Redis first."""
@@ -251,7 +254,7 @@ class TestExecutorCleanupProgress:
         assert mock_cache.set.call_args.args[1]["last_scanned_subtask_id"] == 321
 
     async def test_cleanup_keeps_cursor_position_when_primary_scan_reaches_tail(
-        self, job_service, test_db
+        self, job_service, mock_async_db
     ):
         """Test cleanup keeps the Redis cursor position after scanning the tail."""
         with (
@@ -281,12 +284,12 @@ class TestExecutorCleanupProgress:
             )
             mock_cache.set = AsyncMock(return_value=True)
 
-            await job_service.cleanup_stale_executors(test_db)
+            await job_service.cleanup_stale_executors(mock_async_db)
 
         mock_cache.set.assert_not_called()
 
     async def test_cleanup_uses_lookback_scan_when_primary_scan_is_empty(
-        self, job_service, test_db
+        self, job_service, mock_async_db
     ):
         """Test cleanup falls back to lookback scanning when no new primary rows exist."""
         subtask = _create_mock_subtask(12, 100)
@@ -337,9 +340,8 @@ class TestExecutorCleanupProgress:
                 return_value={"status": "success"}
             )
 
-            await job_service.cleanup_stale_executors(test_db)
+            await job_service.cleanup_stale_executors(mock_async_db)
 
-        assert scan_lookback.called
         mock_executor_service.delete_executor_task_async.assert_called_once_with(
             "executor-12", "default"
         )
@@ -420,7 +422,7 @@ class TestExecutorCleanupProgress:
         assert deferred_recent.id not in filtered_ids
 
     async def test_cleanup_logs_lookback_by_created_at_when_primary_scan_is_empty(
-        self, job_service, test_db, caplog
+        self, job_service, mock_async_db, caplog
     ):
         """Test cleanup logs the lookback scan mode explicitly."""
         with (
@@ -451,6 +453,6 @@ class TestExecutorCleanupProgress:
             )
             mock_cache.set = AsyncMock(return_value=True)
 
-            await job_service.cleanup_stale_executors(test_db)
+            await job_service.cleanup_stale_executors(mock_async_db)
 
         assert "lookback_by=created_at" in caplog.text

--- a/backend/tests/services/test_preserve_executor.py
+++ b/backend/tests/services/test_preserve_executor.py
@@ -168,7 +168,7 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
     @pytest.fixture
     def mock_db(self):
         """Create a mock database session"""
-        return Mock(spec=Session)
+        return AsyncMock(spec=AsyncSession)
 
     async def test_skips_task_with_preserve_executor_true(self, job_service, mock_db):
         """Test that tasks with preserveExecutor=true are skipped during cleanup"""
@@ -524,6 +524,7 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         )
         async_test_db.add(subtask)
         await async_test_db.commit()
+        subtask_id = subtask.id
 
         with (
             patch.object(
@@ -545,7 +546,7 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         executor_service.delete_executor_task_async.assert_called_once_with(
             "executor-subscription-1", "default"
         )
-        mark_deleted.assert_called_once_with([subtask.id])
+        mark_deleted.assert_called_once_with([subtask_id])
 
     async def test_cleanup_stale_executors_includes_pending_subtasks(
         self, job_service, async_test_db
@@ -601,6 +602,7 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         )
         async_test_db.add(subtask)
         await async_test_db.commit()
+        subtask_id = subtask.id
 
         with (
             patch.object(
@@ -623,7 +625,7 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         executor_service.delete_executor_task_async.assert_called_once_with(
             "executor-pending-1", "default"
         )
-        mark_deleted.assert_called_once_with([subtask.id])
+        mark_deleted.assert_called_once_with([subtask_id])
 
     async def test_cleanup_skips_invalid_task_json_and_continues(
         self, job_service, mock_db
@@ -671,6 +673,13 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         ):
             mock_settings.CHAT_TASK_EXECUTOR_DELETE_AFTER_HOURS = 24
             mock_settings.CODE_TASK_EXECUTOR_DELETE_AFTER_HOURS = 48
+            cleanup_entries.return_value = {
+                "task_id": 200,
+                "deleted": False,
+                "skipped": True,
+                "reason": "executor_not_found",
+                "executors": [],
+            }
 
             await job_service.cleanup_stale_executors(mock_db)
 
@@ -719,6 +728,13 @@ class TestCleanupStaleExecutorsWithPreserveFlag(CleanupExecutorTestHelpers):
         ):
             mock_settings.CHAT_TASK_EXECUTOR_DELETE_AFTER_HOURS = 24
             mock_settings.CODE_TASK_EXECUTOR_DELETE_AFTER_HOURS = 48
+            cleanup_entries.return_value = {
+                "task_id": 100,
+                "deleted": False,
+                "skipped": True,
+                "reason": "executor_not_found",
+                "executors": [],
+            }
 
             await job_service.cleanup_stale_executors(mock_db)
 
@@ -1203,6 +1219,7 @@ class TestCleanupTaskExecutorAPI(CleanupExecutorTestHelpers):
         # We need to mock the async path instead
         mock_async_db = AsyncMock()
         mock_async_db.run_sync = AsyncMock(return_value=True)
+        mock_async_db.sync_session = Mock()
 
         with (
             patch("app.services.task_member_service.task_member_service") as members,

--- a/backend/tests/services/test_runtime_cleanup.py
+++ b/backend/tests/services/test_runtime_cleanup.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.subtask import Subtask, SubtaskStatus
 from app.models.task import TaskResource
@@ -93,7 +94,7 @@ async def test_cleanup_stale_task_executors_skips_executor_before_24_hours():
         ) as executor_service,
     ):
         result = await job_service.cleanup_stale_task_executors(
-            Mock(), inactive_hours=24
+            AsyncMock(spec=AsyncSession), inactive_hours=24
         )
 
     assert result["deleted"] == []
@@ -136,7 +137,7 @@ async def test_cleanup_stale_task_executors_deletes_executor_after_24_hours():
         executor_service.delete_executor_task_async = AsyncMock(return_value=True)
 
         result = await job_service.cleanup_stale_task_executors(
-            Mock(), inactive_hours=24
+            AsyncMock(spec=AsyncSession), inactive_hours=24
         )
 
     assert result["skipped"] == []
@@ -145,6 +146,110 @@ async def test_cleanup_stale_task_executors_deletes_executor_after_24_hours():
         "executor-stale", "default"
     )
     mark_deleted.assert_awaited_once_with([1])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_cleanup_releases_read_transaction_before_external_delete():
+    job_service = JobService(Mock())
+    now = datetime.now()
+    stale_subtask = RuntimeCleanupHelpers()._subtask(
+        1, 100, now - timedelta(hours=25), "executor-stale"
+    )
+    stale_task = RuntimeCleanupHelpers()._task(100, now - timedelta(hours=26))
+    call_order = []
+    db = Mock()
+    db.rollback = AsyncMock(side_effect=lambda: call_order.append("rollback"))
+
+    async def delete_executor(*_args, **_kwargs):
+        call_order.append("delete")
+        return True
+
+    with (
+        patch.object(
+            job_service,
+            "_list_runtime_cleanup_subtasks",
+            new_callable=AsyncMock,
+            return_value=[stale_subtask],
+        ),
+        patch.object(
+            job_service,
+            "_load_tasks_for_cleanup",
+            new_callable=AsyncMock,
+            return_value={100: stale_task},
+        ),
+        patch.object(job_service, "_mark_executor_deleted", new_callable=AsyncMock),
+        patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as executor_service,
+    ):
+        executor_service.delete_executor_task_async = AsyncMock(
+            side_effect=delete_executor
+        )
+
+        await job_service.cleanup_stale_task_executors(db, inactive_hours=24)
+
+    assert call_order == ["rollback", "delete"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_scheduled_cleanup_releases_read_transaction_before_external_delete():
+    job_service = JobService(Mock())
+    now = datetime.now()
+    stale_subtask = RuntimeCleanupHelpers()._subtask(
+        1, 100, now - timedelta(hours=25), "executor-stale"
+    )
+    stale_task = RuntimeCleanupHelpers()._task(100, now - timedelta(hours=26))
+    call_order = []
+    db = Mock()
+    db.rollback = AsyncMock(side_effect=lambda: call_order.append("rollback"))
+    db.commit = AsyncMock(side_effect=lambda: call_order.append("commit"))
+
+    async def delete_executor(*_args, **_kwargs):
+        call_order.append("delete")
+        return True
+
+    with (
+        patch(
+            "app.services.adapters.executor_job.CLEANUP_TARGET_DELETED_EXECUTORS_PER_RUN",
+            1,
+        ),
+        patch(
+            "app.services.adapters.executor_job.executor_cleanup_cursor_service.get_cursor",
+            new_callable=AsyncMock,
+            return_value=Mock(last_scanned_subtask_id=0),
+        ),
+        patch.object(
+            job_service,
+            "_scan_candidate_subtasks_batch",
+            new_callable=AsyncMock,
+            return_value=[stale_subtask],
+        ),
+        patch.object(
+            job_service,
+            "_load_tasks_for_cleanup",
+            new_callable=AsyncMock,
+            return_value={100: stale_task},
+        ),
+        patch.object(
+            job_service,
+            "_get_cleanup_subtasks_for_task",
+            new_callable=AsyncMock,
+            return_value=[stale_subtask],
+        ),
+        patch.object(job_service, "_mark_executor_deleted", new_callable=AsyncMock),
+        patch(
+            "app.services.adapters.executor_job.executor_kinds_service"
+        ) as executor_service,
+    ):
+        executor_service.delete_executor_task_async = AsyncMock(
+            side_effect=delete_executor
+        )
+
+        await job_service.cleanup_stale_executors(db)
+
+    assert call_order == ["rollback", "delete", "commit"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved international filename handling for skill ZIP downloads using UTF-8 percent-escaped names.

* **Bug Fixes**
  * Enhanced reliability by ensuring read transactions are cleared/rolled back at the right time before streaming ZIP responses.
  * Improved stale executor cleanup behavior to prevent long-running external cleanup from being blocked by open read transactions.

* **Tests**
  * Added and updated unit tests to verify transaction ordering and correct ZIP download headers for public/private skill endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->