### PR TITLE
fix: include symlinked local skills in Wework autocomplete

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -197,6 +197,7 @@ print(
 
 LS_SKILLS_SCRIPT = """
 import json
+import os
 import re
 from pathlib import Path
 
@@ -325,6 +326,64 @@ def truncate(text, max_len=300):
     return text[: max_len - 1].rstrip() + "…"
 
 
+def real_directory_key(path):
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def matches_skill_pattern(skill_file, root, pattern):
+    if pattern == "**/SKILL.md":
+        return True
+    try:
+        relative_parts = skill_file.relative_to(root).parts
+    except ValueError:
+        relative_parts = skill_file.parts
+    if pattern == "**/skills/**/SKILL.md":
+        return "skills" in relative_parts[:-1]
+    return skill_file.match(pattern)
+
+
+def same_directory(left, right):
+    try:
+        return left.resolve() == right.resolve()
+    except OSError:
+        return False
+
+
+def is_shared_legacy_skill_root(root, source):
+    if source not in {"claude", "codex"} or not root.is_symlink():
+        return False
+    return same_directory(root, Path.home() / ".agents" / "skills")
+
+
+def iter_skill_files(root, pattern):
+    visited = set()
+    for current, dirnames, filenames in os.walk(root, followlinks=True):
+        current_path = Path(current)
+        current_key = real_directory_key(current_path)
+        if current_key in visited:
+            dirnames[:] = []
+            continue
+        visited.add(current_key)
+
+        next_dirs = []
+        for dirname in sorted(dirnames):
+            child = current_path / dirname
+            child_key = real_directory_key(child)
+            if child_key not in visited:
+                next_dirs.append(dirname)
+        dirnames[:] = next_dirs
+
+        for filename in sorted(filenames):
+            if filename != "SKILL.md":
+                continue
+            skill_file = current_path / filename
+            if matches_skill_pattern(skill_file, root, pattern):
+                yield skill_file
+
+
 def skill_metadata(skill_file, source, source_kind, manifest):
     stat = skill_file.stat()
     frontmatter = read_frontmatter(skill_file)
@@ -354,7 +413,14 @@ seen_names = set()
 for root, source, pattern, source_kind in SKILL_SOURCES:
     if not root.is_dir():
         continue
-    for skill_file in sorted(root.glob(pattern)):
+    if is_shared_legacy_skill_root(root, source):
+        continue
+    skill_files = (
+        iter_skill_files(root, pattern)
+        if source_kind == "skill"
+        else sorted(root.glob(pattern))
+    )
+    for skill_file in skill_files:
         key = str(skill_file)
         if key in seen_paths:
             continue

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -1006,6 +1006,94 @@ description: Shared local context.
     assert skills[0]["path"] == str(skill_dir / "SKILL.md")
 
 
+def test_ls_skills_command_follows_agents_skill_directory_symlinks(tmp_path):
+    """ls_skills should include skill directories symlinked under ~/.agents/skills."""
+    from app.services.device.command_registry import LS_SKILLS_SCRIPT
+
+    agents_skills_dir = tmp_path / ".agents" / "skills"
+    agents_skills_dir.mkdir(parents=True)
+    external_skill_dir = tmp_path / "external-skills" / "linked-helper"
+    external_skill_dir.mkdir(parents=True)
+    (agents_skills_dir / "linked-helper").symlink_to(
+        external_skill_dir,
+        target_is_directory=True,
+    )
+    (agents_skills_dir / "missing-helper").symlink_to(
+        tmp_path / "missing-helper",
+        target_is_directory=True,
+    )
+    (external_skill_dir / "SKILL.md").write_text(
+        """---
+name: linked-helper
+description: Linked helper skill.
+---
+
+# Linked Helper
+""",
+        encoding="utf-8",
+    )
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+    result = subprocess.run(
+        ["python3", "-c", LS_SKILLS_SCRIPT],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    skills = json.loads(result.stdout)
+
+    assert len(skills) == 1
+    assert skills[0]["name"] == "linked-helper"
+    assert skills[0]["source"] == "agents"
+    assert skills[0]["origin"] == "local"
+    assert skills[0]["path"] == str(agents_skills_dir / "linked-helper" / "SKILL.md")
+
+
+def test_ls_skills_command_scans_legacy_symlink_when_not_shared_root(tmp_path):
+    """ls_skills should scan legacy skill roots linked outside ~/.agents/skills."""
+    from app.services.device.command_registry import LS_SKILLS_SCRIPT
+
+    codex_target_dir = tmp_path / "custom-codex-skills"
+    codex_skill_dir = codex_target_dir / "codex-only"
+    codex_skill_dir.mkdir(parents=True)
+    (tmp_path / ".agents" / "skills").mkdir(parents=True)
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "skills").symlink_to(
+        codex_target_dir,
+        target_is_directory=True,
+    )
+    (codex_skill_dir / "SKILL.md").write_text(
+        """---
+name: codex-only
+description: Codex-only linked skill.
+---
+
+# Codex Only
+""",
+        encoding="utf-8",
+    )
+
+    env = {**os.environ, "HOME": str(tmp_path)}
+    result = subprocess.run(
+        ["python3", "-c", LS_SKILLS_SCRIPT],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    skills = json.loads(result.stdout)
+
+    assert len(skills) == 1
+    assert skills[0]["name"] == "codex-only"
+    assert skills[0]["source"] == "codex"
+    assert skills[0]["path"] == str(
+        tmp_path / ".codex" / "skills" / "codex-only" / "SKILL.md"
+    )
+
+
 def test_setup_shared_skills_command_migrates_legacy_skill_dirs(tmp_path):
     """setup_shared_skills should move existing skills and link legacy dirs."""
     from app.services.device.command_registry import SETUP_SHARED_SKILLS_SCRIPT


### PR DESCRIPTION
## Task

- Task ID: cn4zBEcxVv / 1017344_7#64263
- Title: 统一claude/codex/wegent的skill管理

## Summary

- Update local device `ls_skills` discovery to include skill directories symlinked under `~/.agents/skills`.
- Skip `~/.codex/skills` and `~/.claude/skills` when they are symlinks to `~/.agents/skills` to avoid duplicate scans.
- Keep plugin cache discovery on the existing `glob` path and preserve scanning for legacy skill roots that point somewhere other than the shared directory.
- Add regression tests for symlinked shared skills and non-shared legacy symlink roots.

## Verification

- `cd backend && uv run pytest tests/services/test_local_device_command_service.py -k "ls_skills"` : 5 passed
- `cd backend && uv run pytest tests/services/test_local_device_command_service.py` : 54 passed
- `cd backend && uv run isort app/services/device/command_registry.py tests/services/test_local_device_command_service.py`
- `cd backend && uv run black app/services/device/command_registry.py tests/services/test_local_device_command_service.py`
- `git diff --check -- backend/app/services/device/command_registry.py backend/tests/services/test_local_device_command_service.py`

## Notes

- Full browser validation was not run in this workspace; the change is in the Wework `$` autocomplete data source command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill directory discovery to properly handle symlinks and eliminate duplicate skill detection
* **Tests**
  * Added test coverage for symlink handling in local skill discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->