### PR TITLE
[codex] Cache runtime stream snapshots in executor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ Wegent is an open-source AI-native operating system for defining, organizing, an
 - When adding new features, put detailed docs in `docs/en/` and `docs/zh/`, reference from AGENTS.md
 
 **Recent design docs:**
+- Executor runtime stream cache (store active stream snapshots in executor memory while keeping Redis coordination): [`docs/zh/developer-guide/executor-runtime-stream-cache.md`](docs/zh/developer-guide/executor-runtime-stream-cache.md)
+- English version: [`docs/en/developer-guide/executor-runtime-stream-cache.md`](docs/en/developer-guide/executor-runtime-stream-cache.md)
 - Task runtime state machine and frontend consistency recovery: [`docs/zh/developer-guide/task-runtime-state-machine.md`](docs/zh/developer-guide/task-runtime-state-machine.md)
 - English version: [`docs/en/developer-guide/task-runtime-state-machine.md`](docs/en/developer-guide/task-runtime-state-machine.md)
 - Prompt caching optimization via dynamic context injection: [`docs/zh/developer-guide/dynamic-context.md`](docs/zh/developer-guide/dynamic-context.md)

--- a/backend/app/api/endpoints/adapter/tasks.py
+++ b/backend/app/api/endpoints/adapter/tasks.py
@@ -63,6 +63,7 @@ from app.services.adapters.task_kinds import task_kinds_service
 from app.services.adapters.wework_conversation_search import (
     search_wework_conversation_tasks,
 )
+from app.services.chat.runtime_stream_snapshot import runtime_stream_snapshot_service
 from app.services.chat.storage import session_manager
 from app.services.remote_workspace_service import remote_workspace_service
 from app.services.shared_task import shared_task_service
@@ -358,7 +359,12 @@ async def get_task_runtime_check(
         raw_subtask_id = streaming_status.get("subtask_id")
         subtask_id = int(raw_subtask_id) if raw_subtask_id is not None else None
         if subtask_id is not None:
-            cached_content = await session_manager.get_streaming_content(subtask_id)
+            snapshot = await runtime_stream_snapshot_service.get_snapshot(
+                task_id=task_id,
+                subtask_id=subtask_id,
+                streaming_info=streaming_status,
+            )
+            cached_content = snapshot.get("content", "")
             active_stream = TaskRuntimeActiveStream(
                 subtask_id=subtask_id,
                 cursor=len(cached_content or ""),

--- a/backend/app/api/endpoints/internal/callback.py
+++ b/backend/app/api/endpoints/internal/callback.py
@@ -95,6 +95,10 @@ class CallbackRequest(BaseModel):
     message_id: Optional[int] = Field(None, description="Message ID for ordering")
     executor_name: Optional[str] = Field(None, description="Executor name")
     executor_namespace: Optional[str] = Field(None, description="Executor namespace")
+    runtime_cache: Optional[dict] = Field(
+        None,
+        description="Executor runtime stream cache capability metadata",
+    )
     data: dict = Field(
         default_factory=dict,
         description="Event data in OpenAI Responses API format",
@@ -166,7 +170,12 @@ async def handle_callback(
         # 1. Database status updates (including executor_name for container reuse)
         # 2. Publishing TaskCompletedEvent for unified handling
         ws_emitter = WebSocketResultEmitter(
-            task_id=request.task_id, subtask_id=request.subtask_id, user_id=user_id
+            task_id=request.task_id,
+            subtask_id=request.subtask_id,
+            user_id=user_id,
+            runtime_cache_enabled=bool(
+                request.runtime_cache and request.runtime_cache.get("enabled")
+            ),
         )
         emitter = StatusUpdatingEmitter(
             wrapped=ws_emitter,
@@ -174,6 +183,7 @@ async def handle_callback(
             subtask_id=request.subtask_id,
             executor_name=request.executor_name,
             executor_namespace=request.executor_namespace,
+            runtime_cache=request.runtime_cache,
         )
         await emitter.emit(event)
         await emitter.close()
@@ -273,6 +283,9 @@ async def handle_batch_callback(
                 task_id=request.task_id,
                 subtask_id=request.subtask_id,
                 user_id=user_id,
+                runtime_cache_enabled=bool(
+                    request.runtime_cache and request.runtime_cache.get("enabled")
+                ),
             )
             emitter = StatusUpdatingEmitter(
                 wrapped=ws_emitter,
@@ -280,6 +293,7 @@ async def handle_batch_callback(
                 subtask_id=request.subtask_id,
                 executor_name=request.executor_name,
                 executor_namespace=request.executor_namespace,
+                runtime_cache=request.runtime_cache,
             )
             await emitter.emit(event)
             await emitter.close()

--- a/backend/app/api/endpoints/subtasks.py
+++ b/backend/app/api/endpoints/subtasks.py
@@ -26,6 +26,7 @@ from app.schemas.turn_file_changes import (
     TurnFileChangesDiffResponse,
     TurnFileChangesRevertResponse,
 )
+from app.services.chat.runtime_stream_snapshot import runtime_stream_snapshot_service
 from app.services.chat.storage import session_manager
 from app.services.subtask import subtask_service
 from app.services.turn_file_changes import turn_file_changes_service
@@ -261,7 +262,12 @@ async def get_streaming_status(
     subtask_id = streaming_status.get("subtask_id")
     current_content = None
     if subtask_id:
-        current_content = await session_manager.get_streaming_content(subtask_id)
+        snapshot = await runtime_stream_snapshot_service.get_snapshot(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            streaming_info=streaming_status,
+        )
+        current_content = snapshot.get("content")
 
     return StreamingStatus(
         is_streaming=True,
@@ -310,7 +316,13 @@ async def subscribe_group_stream(
     async def event_generator():
         """Generate SSE events for the subscribed stream."""
         # Get current cached content
-        current_content = await session_manager.get_streaming_content(subtask_id)
+        streaming_status = await session_manager.get_task_streaming_status(task_id)
+        snapshot = await runtime_stream_snapshot_service.get_snapshot(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            streaming_info=streaming_status,
+        )
+        current_content = snapshot.get("content", "")
 
         # If offset is provided and we have cached content, send the portion after offset
         if offset > 0 and current_content:

--- a/backend/app/api/ws/chat_namespace.py
+++ b/backend/app/api/ws/chat_namespace.py
@@ -68,6 +68,7 @@ from app.services.chat.operations import (
     update_subtask_on_cancel,
 )
 from app.services.chat.rag import process_context_and_rag
+from app.services.chat.runtime_stream_snapshot import runtime_stream_snapshot_service
 from app.services.chat.storage import session_manager
 from app.services.chat.storage.db import get_db_session, run_sync_in_executor
 from app.services.chat.trigger import trigger_ai_response_unified
@@ -466,12 +467,14 @@ class ChatNamespace(socketio.AsyncNamespace):
         if streaming_info:
             subtask_id = streaming_info["subtask_id"]
 
-            # Get cached content and blocks from Redis
-            cached_content = await session_manager.get_streaming_content(subtask_id)
-            blocks = await session_manager.get_blocks(subtask_id)
-            cached_context_metrics = await session_manager.get_context_metrics(
-                subtask_id
+            snapshot = await runtime_stream_snapshot_service.get_snapshot(
+                task_id=payload.task_id,
+                subtask_id=subtask_id,
+                streaming_info=streaming_info,
             )
+            cached_content = snapshot.get("content", "")
+            blocks = snapshot.get("blocks", [])
+            cached_context_metrics = snapshot.get("context_metrics")
             offset = len(cached_content) if cached_content else 0
 
             logger.info(
@@ -1447,8 +1450,16 @@ class ChatNamespace(socketio.AsyncNamespace):
         task_room = f"task:{payload.task_id}"
         await self.enter_room(sid, task_room)
 
-        # Get cached content
-        cached_content = await session_manager.get_streaming_content(payload.subtask_id)
+        streaming_info = await get_active_streaming(payload.task_id)
+        if streaming_info and streaming_info.get("subtask_id") != payload.subtask_id:
+            streaming_info = None
+
+        snapshot = await runtime_stream_snapshot_service.get_snapshot(
+            task_id=payload.task_id,
+            subtask_id=payload.subtask_id,
+            streaming_info=streaming_info,
+        )
+        cached_content = snapshot.get("content", "")
 
         if cached_content and payload.offset < len(cached_content):
             # Send remaining content
@@ -1465,9 +1476,7 @@ class ChatNamespace(socketio.AsyncNamespace):
                 to=sid,
             )
 
-        cached_context_metrics = await session_manager.get_context_metrics(
-            payload.subtask_id
-        )
+        cached_context_metrics = snapshot.get("context_metrics")
         if cached_context_metrics:
             from app.api.ws.events import ServerEvents
 

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -1348,6 +1348,12 @@ class DeviceNamespace(socketio.AsyncNamespace):
         subtask_id = data.get("subtask_id")
         event_data = data.get("data", {})
         message_id = data.get("message_id")
+        runtime_cache = data.get("runtime_cache")
+        runtime_cache_enabled = bool(
+            isinstance(runtime_cache, dict) and runtime_cache.get("enabled")
+        )
+        executor_name = data.get("executor_name") or f"device-{device_id}"
+        executor_namespace = data.get("executor_namespace") or f"user-{user_id}"
 
         if not task_id or not subtask_id:
             return {"error": "Missing task_id or subtask_id"}
@@ -1386,11 +1392,15 @@ class DeviceNamespace(socketio.AsyncNamespace):
                     task_id=task_id,
                     subtask_id=subtask_id,
                     user_id=user_id,
+                    runtime_cache_enabled=runtime_cache_enabled,
                 )
                 emitter = StatusUpdatingEmitter(
                     wrapped=ws_emitter,
                     task_id=task_id,
                     subtask_id=subtask_id,
+                    executor_name=executor_name,
+                    executor_namespace=executor_namespace,
+                    runtime_cache=runtime_cache if runtime_cache_enabled else None,
                 )
                 await emitter.emit(event)
                 await emitter.close()

--- a/backend/app/api/ws/device_namespace.py
+++ b/backend/app/api/ws/device_namespace.py
@@ -78,6 +78,14 @@ REGISTER_CAPABILITY_SYNC_TIMEOUT_SECONDS = 5
 DEVICE_DISCONNECT_FAILURE_GRACE_SECONDS = 2
 
 
+def _normalize_runtime_cache_capability(value: Any) -> Optional[dict[str, bool]]:
+    """Return the normalized runtime cache capability."""
+
+    if isinstance(value, dict) and value.get("enabled") is True:
+        return {"enabled": True}
+    return None
+
+
 @contextmanager
 def _db_session() -> Generator[Session, None, None]:
     """Context manager for database session with auto-commit and auto-close."""
@@ -976,6 +984,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
             socket_id=sid,
             name=effective_device_name,
             executor_version=payload.executor_version,
+            runtime_cache=_normalize_runtime_cache_capability(payload.runtime_cache),
         )
 
         # Update session with device_id and device_name
@@ -1163,6 +1172,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
             payload.device_id,
             payload.running_task_ids,
             payload.executor_version,
+            runtime_cache=_normalize_runtime_cache_capability(payload.runtime_cache),
         )
 
         if not success:
@@ -1178,6 +1188,9 @@ class DeviceNamespace(socketio.AsyncNamespace):
                 socket_id=sid,
                 name=device_name,
                 executor_version=payload.executor_version,
+                runtime_cache=_normalize_runtime_cache_capability(
+                    payload.runtime_cache
+                ),
             )
             # Re-broadcast device online event
             await self._broadcast_device_online(user_id, payload.device_id, device_name)
@@ -1348,10 +1361,13 @@ class DeviceNamespace(socketio.AsyncNamespace):
         subtask_id = data.get("subtask_id")
         event_data = data.get("data", {})
         message_id = data.get("message_id")
-        runtime_cache = data.get("runtime_cache")
-        runtime_cache_enabled = bool(
-            isinstance(runtime_cache, dict) and runtime_cache.get("enabled")
+        device_online_info = await device_service.get_device_online_info(
+            user_id, device_id
         )
+        runtime_cache = _normalize_runtime_cache_capability(
+            device_online_info.get("runtime_cache") if device_online_info else None
+        )
+        runtime_cache_enabled = bool(runtime_cache)
         executor_name = data.get("executor_name") or f"device-{device_id}"
         executor_namespace = data.get("executor_namespace") or f"user-{user_id}"
 
@@ -1400,7 +1416,7 @@ class DeviceNamespace(socketio.AsyncNamespace):
                     subtask_id=subtask_id,
                     executor_name=executor_name,
                     executor_namespace=executor_namespace,
-                    runtime_cache=runtime_cache if runtime_cache_enabled else None,
+                    runtime_cache=runtime_cache,
                 )
                 await emitter.emit(event)
                 await emitter.close()

--- a/backend/app/schemas/device.py
+++ b/backend/app/schemas/device.py
@@ -113,6 +113,10 @@ class DeviceInfo(BaseModel):
         BindShell.CLAUDECODE,
         description="Shell runtime binding (claudecode or openclaw)",
     )
+    runtime_cache: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Device-level runtime cache capability, e.g. {'enabled': true}",
+    )
 
     class Config:
         from_attributes = True
@@ -278,6 +282,10 @@ class DeviceRegisterPayload(BaseModel):
         BindShell.CLAUDECODE,
         description="Shell runtime binding (claudecode or openclaw)",
     )
+    runtime_cache: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Device-level runtime cache capability, e.g. {'enabled': true}",
+    )
 
 
 class DeviceHeartbeatPayload(BaseModel):
@@ -295,6 +303,10 @@ class DeviceHeartbeatPayload(BaseModel):
     capabilities: Optional[Dict[str, Any]] = Field(
         None,
         description="Sanitized local global capability state reported by executor",
+    )
+    runtime_cache: Optional[Dict[str, Any]] = Field(
+        None,
+        description="Device-level runtime cache capability, e.g. {'enabled': true}",
     )
     runtime_auth_files: Optional[Dict[str, Any]] = Field(
         None,

--- a/backend/app/services/chat/runtime_stream_snapshot.py
+++ b/backend/app/services/chat/runtime_stream_snapshot.py
@@ -1,0 +1,425 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve active stream snapshots from executor runtime cache or Redis."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import httpx
+
+from app.core.config import settings
+from app.core.socketio import get_sio
+from app.services.device_service import device_service
+
+logger = logging.getLogger(__name__)
+
+LOCAL_EXECUTOR_PREFIX = "device-"
+LOCAL_EXECUTOR_NAMESPACE_PREFIX = "user-"
+RUNTIME_CACHE_RPC_TIMEOUT_SECONDS = 3
+EXECUTOR_HTTP_TIMEOUT_SECONDS = 3
+
+
+class RuntimeStreamSnapshotService:
+    """Read and clean up runtime stream snapshots with Redis fallback."""
+
+    async def get_snapshot(
+        self,
+        *,
+        task_id: int,
+        subtask_id: int,
+        streaming_info: Optional[dict[str, Any]] = None,
+        executor_name: Optional[str] = None,
+        executor_namespace: Optional[str] = None,
+        runtime_cache: Optional[dict[str, Any]] = None,
+        finalize_redis_blocks: bool = False,
+    ) -> dict[str, Any]:
+        """Return the best available stream snapshot."""
+
+        resolved_runtime_cache = self._resolve_runtime_cache(
+            runtime_cache,
+            streaming_info,
+        )
+        resolved_executor_name = executor_name or self._read_str(
+            streaming_info,
+            "executor_name",
+        )
+        resolved_executor_namespace = executor_namespace or self._read_str(
+            streaming_info,
+            "executor_namespace",
+        )
+
+        if self._runtime_cache_enabled(resolved_runtime_cache):
+            snapshot = await self._get_executor_snapshot(
+                subtask_id=subtask_id,
+                executor_name=resolved_executor_name,
+                executor_namespace=resolved_executor_namespace,
+            )
+            if snapshot is not None:
+                return self._normalize_snapshot(snapshot, task_id, subtask_id)
+
+        return await self._get_redis_snapshot(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            finalize_blocks=finalize_redis_blocks,
+        )
+
+    async def cleanup_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        task_id: Optional[int] = None,
+        executor_name: Optional[str] = None,
+        executor_namespace: Optional[str] = None,
+        runtime_cache: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Clean up executor runtime cache and Redis streaming state."""
+
+        if self._runtime_cache_enabled(runtime_cache):
+            await self._cleanup_executor_snapshot(
+                subtask_id=subtask_id,
+                executor_name=executor_name,
+                executor_namespace=executor_namespace,
+            )
+
+        import app.services.chat.storage as chat_storage
+
+        await chat_storage.session_manager.cleanup_streaming_state(
+            subtask_id,
+            task_id=task_id,
+        )
+
+    async def _get_redis_snapshot(
+        self,
+        *,
+        task_id: int,
+        subtask_id: int,
+        finalize_blocks: bool,
+    ) -> dict[str, Any]:
+        import app.services.chat.storage as chat_storage
+
+        if finalize_blocks:
+            content = await chat_storage.session_manager.get_accumulated_content(
+                subtask_id
+            )
+            blocks = await chat_storage.session_manager.finalize_and_get_blocks(
+                subtask_id
+            )
+        else:
+            content = await chat_storage.session_manager.get_streaming_content(
+                subtask_id
+            )
+            blocks = await chat_storage.session_manager.get_blocks(subtask_id)
+        get_context_metrics = getattr(
+            chat_storage.session_manager, "get_context_metrics", None
+        )
+        context_metrics = (
+            await get_context_metrics(subtask_id)
+            if callable(get_context_metrics)
+            else None
+        )
+        if not isinstance(content, str):
+            content = ""
+        if not isinstance(context_metrics, dict):
+            context_metrics = None
+        return {
+            "task_id": task_id,
+            "subtask_id": subtask_id,
+            "content": content or "",
+            "blocks": blocks or [],
+            "context_metrics": context_metrics,
+            "offset": len(content or ""),
+            "source": "redis",
+        }
+
+    async def _get_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: Optional[str],
+        executor_namespace: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        if not executor_name:
+            return None
+
+        if executor_name.startswith(LOCAL_EXECUTOR_PREFIX):
+            return await self._get_local_executor_snapshot(
+                subtask_id=subtask_id,
+                executor_name=executor_name,
+                executor_namespace=executor_namespace,
+            )
+
+        return await self._get_docker_executor_snapshot(
+            subtask_id=subtask_id,
+            executor_name=executor_name,
+            executor_namespace=executor_namespace,
+        )
+
+    async def _cleanup_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: Optional[str],
+        executor_namespace: Optional[str],
+    ) -> None:
+        if not executor_name:
+            return
+
+        try:
+            if executor_name.startswith(LOCAL_EXECUTOR_PREFIX):
+                await self._cleanup_local_executor_snapshot(
+                    subtask_id=subtask_id,
+                    executor_name=executor_name,
+                    executor_namespace=executor_namespace,
+                )
+                return
+            await self._cleanup_docker_executor_snapshot(
+                subtask_id=subtask_id,
+                executor_name=executor_name,
+                executor_namespace=executor_namespace,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[RuntimeStreamSnapshot] Executor snapshot cleanup failed: "
+                "subtask_id=%s executor=%s namespace=%s error=%s",
+                subtask_id,
+                executor_name,
+                executor_namespace,
+                exc,
+            )
+
+    async def _get_local_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: str,
+        executor_namespace: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        user_id = self._parse_user_id(executor_namespace)
+        device_id = executor_name.removeprefix(LOCAL_EXECUTOR_PREFIX)
+        if user_id is None or not device_id:
+            return None
+
+        online_info = await device_service.get_device_online_info(user_id, device_id)
+        socket_id = online_info.get("socket_id") if online_info else None
+        if not socket_id:
+            return None
+
+        sio = get_sio()
+        try:
+            response = await sio.call(
+                "runtime_cache:get_snapshot",
+                {"subtask_id": subtask_id},
+                to=socket_id,
+                namespace="/local-executor",
+                timeout=RUNTIME_CACHE_RPC_TIMEOUT_SECONDS,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[RuntimeStreamSnapshot] Local runtime cache read failed: "
+                "subtask_id=%s user_id=%s device_id=%s error=%s",
+                subtask_id,
+                user_id,
+                device_id,
+                exc,
+            )
+            return None
+
+        if not isinstance(response, dict) or not response.get("success"):
+            return None
+        snapshot = response.get("snapshot")
+        return snapshot if isinstance(snapshot, dict) else None
+
+    async def _cleanup_local_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: str,
+        executor_namespace: Optional[str],
+    ) -> None:
+        user_id = self._parse_user_id(executor_namespace)
+        device_id = executor_name.removeprefix(LOCAL_EXECUTOR_PREFIX)
+        if user_id is None or not device_id:
+            return
+
+        online_info = await device_service.get_device_online_info(user_id, device_id)
+        socket_id = online_info.get("socket_id") if online_info else None
+        if not socket_id:
+            return
+
+        sio = get_sio()
+        await sio.call(
+            "runtime_cache:cleanup",
+            {"subtask_id": subtask_id},
+            to=socket_id,
+            namespace="/local-executor",
+            timeout=RUNTIME_CACHE_RPC_TIMEOUT_SECONDS,
+        )
+
+    async def _get_docker_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: str,
+        executor_namespace: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        base_url = await self._resolve_docker_executor_base_url(
+            executor_name,
+            executor_namespace,
+        )
+        if not base_url:
+            return None
+
+        url = f"{base_url.rstrip('/')}/api/runtime-cache/subtasks/{subtask_id}"
+        try:
+            async with httpx.AsyncClient(
+                timeout=EXECUTOR_HTTP_TIMEOUT_SECONDS
+            ) as client:
+                response = await client.get(url)
+        except Exception as exc:
+            logger.warning(
+                "[RuntimeStreamSnapshot] Docker runtime cache read failed: "
+                "subtask_id=%s executor=%s namespace=%s error=%s",
+                subtask_id,
+                executor_name,
+                executor_namespace,
+                exc,
+            )
+            return None
+
+        if response.status_code == 404:
+            return None
+        if response.status_code != 200:
+            logger.warning(
+                "[RuntimeStreamSnapshot] Docker runtime cache read non-200: "
+                "subtask_id=%s status=%s body=%s",
+                subtask_id,
+                response.status_code,
+                response.text[:300],
+            )
+            return None
+
+        payload = response.json()
+        snapshot = payload.get("snapshot") if isinstance(payload, dict) else None
+        return snapshot if isinstance(snapshot, dict) else None
+
+    async def _cleanup_docker_executor_snapshot(
+        self,
+        *,
+        subtask_id: int,
+        executor_name: str,
+        executor_namespace: Optional[str],
+    ) -> None:
+        base_url = await self._resolve_docker_executor_base_url(
+            executor_name,
+            executor_namespace,
+        )
+        if not base_url:
+            return
+
+        url = f"{base_url.rstrip('/')}/api/runtime-cache/subtasks/{subtask_id}"
+        async with httpx.AsyncClient(timeout=EXECUTOR_HTTP_TIMEOUT_SECONDS) as client:
+            await client.delete(url)
+
+    async def _resolve_docker_executor_base_url(
+        self,
+        executor_name: str,
+        executor_namespace: Optional[str],
+    ) -> Optional[str]:
+        url = f"{settings.EXECUTOR_MANAGER_URL.rstrip('/')}/executor-manager/executor/address"
+        params: dict[str, Any] = {"executor_name": executor_name}
+        if executor_namespace is not None:
+            params["executor_namespace"] = executor_namespace
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=EXECUTOR_HTTP_TIMEOUT_SECONDS
+            ) as client:
+                response = await client.get(url, params=params)
+        except Exception as exc:
+            logger.warning(
+                "[RuntimeStreamSnapshot] Executor address lookup failed: "
+                "executor=%s namespace=%s error=%s",
+                executor_name,
+                executor_namespace,
+                exc,
+            )
+            return None
+
+        if response.status_code != 200:
+            return None
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("status") != "success":
+            return None
+        base_url = payload.get("base_url")
+        return base_url if isinstance(base_url, str) and base_url else None
+
+    @staticmethod
+    def _normalize_snapshot(
+        snapshot: dict[str, Any],
+        task_id: int,
+        subtask_id: int,
+    ) -> dict[str, Any]:
+        content = snapshot.get("content")
+        if not isinstance(content, str):
+            content = ""
+        blocks = snapshot.get("blocks")
+        if not isinstance(blocks, list):
+            blocks = []
+        context_metrics = snapshot.get("context_metrics")
+        if not isinstance(context_metrics, dict):
+            context_metrics = None
+        return {
+            "task_id": snapshot.get("task_id") or task_id,
+            "subtask_id": snapshot.get("subtask_id") or subtask_id,
+            "content": content,
+            "blocks": [block for block in blocks if isinstance(block, dict)],
+            "context_metrics": context_metrics,
+            "offset": snapshot.get("offset") or len(content),
+            "started_at": snapshot.get("started_at"),
+            "last_activity_at": snapshot.get("last_activity_at"),
+            "terminal": bool(snapshot.get("terminal")),
+            "source": snapshot.get("source") or "executor",
+            "version": snapshot.get("version"),
+        }
+
+    @staticmethod
+    def _resolve_runtime_cache(
+        runtime_cache: Optional[dict[str, Any]],
+        streaming_info: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        if isinstance(runtime_cache, dict):
+            return runtime_cache
+        if not isinstance(streaming_info, dict):
+            return None
+        candidate = streaming_info.get("runtime_cache")
+        return candidate if isinstance(candidate, dict) else None
+
+    @staticmethod
+    def _runtime_cache_enabled(runtime_cache: Optional[dict[str, Any]]) -> bool:
+        return bool(isinstance(runtime_cache, dict) and runtime_cache.get("enabled"))
+
+    @staticmethod
+    def _read_str(payload: Optional[dict[str, Any]], key: str) -> Optional[str]:
+        if not isinstance(payload, dict):
+            return None
+        value = payload.get(key)
+        return value if isinstance(value, str) and value else None
+
+    @staticmethod
+    def _parse_user_id(executor_namespace: Optional[str]) -> Optional[int]:
+        if not executor_namespace:
+            return None
+        raw = executor_namespace
+        if raw.startswith(LOCAL_EXECUTOR_NAMESPACE_PREFIX):
+            raw = raw.removeprefix(LOCAL_EXECUTOR_NAMESPACE_PREFIX)
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return None
+
+
+runtime_stream_snapshot_service = RuntimeStreamSnapshotService()

--- a/backend/app/services/chat/runtime_stream_snapshot.py
+++ b/backend/app/services/chat/runtime_stream_snapshot.py
@@ -39,10 +39,6 @@ class RuntimeStreamSnapshotService:
     ) -> dict[str, Any]:
         """Return the best available stream snapshot."""
 
-        resolved_runtime_cache = self._resolve_runtime_cache(
-            runtime_cache,
-            streaming_info,
-        )
         resolved_executor_name = executor_name or self._read_str(
             streaming_info,
             "executor_name",
@@ -50,6 +46,11 @@ class RuntimeStreamSnapshotService:
         resolved_executor_namespace = executor_namespace or self._read_str(
             streaming_info,
             "executor_namespace",
+        )
+        resolved_runtime_cache = await self._resolve_runtime_cache(
+            runtime_cache=runtime_cache,
+            executor_name=resolved_executor_name,
+            executor_namespace=resolved_executor_namespace,
         )
 
         if self._runtime_cache_enabled(resolved_runtime_cache):
@@ -385,21 +386,41 @@ class RuntimeStreamSnapshotService:
             "source": snapshot.get("source") or "executor",
         }
 
-    @staticmethod
-    def _resolve_runtime_cache(
+    async def _resolve_runtime_cache(
+        self,
+        *,
         runtime_cache: Optional[dict[str, Any]],
-        streaming_info: Optional[dict[str, Any]],
-    ) -> Optional[dict[str, Any]]:
-        if isinstance(runtime_cache, dict):
-            return runtime_cache
-        if not isinstance(streaming_info, dict):
+        executor_name: Optional[str],
+        executor_namespace: Optional[str],
+    ) -> Optional[dict[str, bool]]:
+        normalized = self._normalize_runtime_cache(runtime_cache)
+        if normalized is not None:
+            return normalized
+
+        device_id = self._parse_device_id(executor_name)
+        user_id = self._parse_user_id(executor_namespace)
+        if device_id is None or user_id is None:
             return None
-        candidate = streaming_info.get("runtime_cache")
-        return candidate if isinstance(candidate, dict) else None
+
+        device_online_info = await device_service.get_device_online_info(
+            user_id,
+            device_id,
+        )
+        if not isinstance(device_online_info, dict):
+            return None
+        return self._normalize_runtime_cache(device_online_info.get("runtime_cache"))
 
     @staticmethod
     def _runtime_cache_enabled(runtime_cache: Optional[dict[str, Any]]) -> bool:
         return bool(isinstance(runtime_cache, dict) and runtime_cache.get("enabled"))
+
+    @staticmethod
+    def _normalize_runtime_cache(
+        runtime_cache: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, bool]]:
+        if isinstance(runtime_cache, dict) and runtime_cache.get("enabled") is True:
+            return {"enabled": True}
+        return None
 
     @staticmethod
     def _read_str(payload: Optional[dict[str, Any]], key: str) -> Optional[str]:
@@ -419,6 +440,13 @@ class RuntimeStreamSnapshotService:
             return int(raw)
         except (TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _parse_device_id(executor_name: Optional[str]) -> Optional[str]:
+        if not executor_name or not executor_name.startswith(LOCAL_EXECUTOR_PREFIX):
+            return None
+        device_id = executor_name.removeprefix(LOCAL_EXECUTOR_PREFIX)
+        return device_id or None
 
 
 runtime_stream_snapshot_service = RuntimeStreamSnapshotService()

--- a/backend/app/services/chat/runtime_stream_snapshot.py
+++ b/backend/app/services/chat/runtime_stream_snapshot.py
@@ -383,7 +383,6 @@ class RuntimeStreamSnapshotService:
             "last_activity_at": snapshot.get("last_activity_at"),
             "terminal": bool(snapshot.get("terminal")),
             "source": snapshot.get("source") or "executor",
-            "version": snapshot.get("version"),
         }
 
     @staticmethod

--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -664,6 +664,9 @@ class SessionManager:
         subtask_id: int,
         user_id: int,
         username: str,
+        executor_name: Optional[str] = None,
+        executor_namespace: Optional[str] = None,
+        runtime_cache: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """
         Set task-level streaming status (used for group chat).
@@ -687,6 +690,13 @@ class SessionManager:
                 "started_at": now_iso,
                 "last_activity_at": now_iso,
             }
+            if executor_name:
+                value["executor_name"] = executor_name
+            if executor_namespace:
+                value["executor_namespace"] = executor_namespace
+            if isinstance(runtime_cache, dict) and runtime_cache.get("enabled"):
+                value["runtime_cache"] = runtime_cache
+                value["cache_source"] = "executor"
             logger.info(
                 f"[SessionManager] set_task_streaming_status: key={key}, "
                 f"task_id={task_id}, subtask_id={subtask_id}, user_id={user_id}, "
@@ -698,6 +708,59 @@ class SessionManager:
         except Exception as e:
             logger.error(
                 f"Error setting task streaming status for task {task_id}: {e}",
+                exc_info=True,
+            )
+            return False
+
+    async def update_task_streaming_runtime_cache(
+        self,
+        task_id: int,
+        subtask_id: int,
+        executor_name: Optional[str] = None,
+        executor_namespace: Optional[str] = None,
+        runtime_cache: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Attach executor runtime cache metadata to an active stream status."""
+
+        if not isinstance(runtime_cache, dict) or not runtime_cache.get("enabled"):
+            return False
+
+        try:
+            key = self._get_task_streaming_key(task_id)
+            status = await self._cache.get(key)
+            if not isinstance(status, dict):
+                return await self.set_task_streaming_status(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                    user_id=0,
+                    username="",
+                    executor_name=executor_name,
+                    executor_namespace=executor_namespace,
+                    runtime_cache=runtime_cache,
+                )
+
+            if (
+                status.get("cache_source") == "executor"
+                and status.get("runtime_cache") == runtime_cache
+                and status.get("executor_name") == executor_name
+                and status.get("executor_namespace") == executor_namespace
+            ):
+                return True
+
+            status["subtask_id"] = subtask_id
+            status["last_activity_at"] = datetime.now().isoformat()
+            status["runtime_cache"] = runtime_cache
+            status["cache_source"] = "executor"
+            if executor_name:
+                status["executor_name"] = executor_name
+            if executor_namespace:
+                status["executor_namespace"] = executor_namespace
+            return await self._cache.set(key, status, expire=STREAMING_TTL)
+        except Exception as e:
+            logger.error(
+                "Error updating task runtime cache metadata for task %s: %s",
+                task_id,
+                e,
                 exc_info=True,
             )
             return False

--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -694,8 +694,6 @@ class SessionManager:
                 value["executor_name"] = executor_name
             if executor_namespace:
                 value["executor_namespace"] = executor_namespace
-            if isinstance(runtime_cache, dict) and runtime_cache.get("enabled"):
-                value["runtime_cache"] = {"enabled": True}
             logger.info(
                 f"[SessionManager] set_task_streaming_status: key={key}, "
                 f"task_id={task_id}, subtask_id={subtask_id}, user_id={user_id}, "
@@ -719,7 +717,7 @@ class SessionManager:
         executor_namespace: Optional[str] = None,
         runtime_cache: Optional[Dict[str, Any]] = None,
     ) -> bool:
-        """Attach executor runtime cache metadata to an active stream status."""
+        """Ensure active stream status contains the executor route for cache lookup."""
 
         if not isinstance(runtime_cache, dict) or not runtime_cache.get("enabled"):
             return False
@@ -739,15 +737,13 @@ class SessionManager:
                 )
 
             if (
-                status.get("runtime_cache") == {"enabled": True}
-                and status.get("executor_name") == executor_name
+                status.get("executor_name") == executor_name
                 and status.get("executor_namespace") == executor_namespace
             ):
                 return True
 
             status["subtask_id"] = subtask_id
             status["last_activity_at"] = datetime.now().isoformat()
-            status["runtime_cache"] = {"enabled": True}
             if executor_name:
                 status["executor_name"] = executor_name
             if executor_namespace:
@@ -755,7 +751,7 @@ class SessionManager:
             return await self._cache.set(key, status, expire=STREAMING_TTL)
         except Exception as e:
             logger.error(
-                "Error updating task runtime cache metadata for task %s: %s",
+                "Error updating task runtime cache route for task %s: %s",
                 task_id,
                 e,
                 exc_info=True,

--- a/backend/app/services/chat/storage/session.py
+++ b/backend/app/services/chat/storage/session.py
@@ -695,8 +695,7 @@ class SessionManager:
             if executor_namespace:
                 value["executor_namespace"] = executor_namespace
             if isinstance(runtime_cache, dict) and runtime_cache.get("enabled"):
-                value["runtime_cache"] = runtime_cache
-                value["cache_source"] = "executor"
+                value["runtime_cache"] = {"enabled": True}
             logger.info(
                 f"[SessionManager] set_task_streaming_status: key={key}, "
                 f"task_id={task_id}, subtask_id={subtask_id}, user_id={user_id}, "
@@ -740,8 +739,7 @@ class SessionManager:
                 )
 
             if (
-                status.get("cache_source") == "executor"
-                and status.get("runtime_cache") == runtime_cache
+                status.get("runtime_cache") == {"enabled": True}
                 and status.get("executor_name") == executor_name
                 and status.get("executor_namespace") == executor_namespace
             ):
@@ -749,8 +747,7 @@ class SessionManager:
 
             status["subtask_id"] = subtask_id
             status["last_activity_at"] = datetime.now().isoformat()
-            status["runtime_cache"] = runtime_cache
-            status["cache_source"] = "executor"
+            status["runtime_cache"] = {"enabled": True}
             if executor_name:
                 status["executor_name"] = executor_name
             if executor_namespace:

--- a/backend/app/services/chat/trigger/lifecycle.py
+++ b/backend/app/services/chat/trigger/lifecycle.py
@@ -80,6 +80,28 @@ def _merge_blocks(
     return merged
 
 
+def _has_non_thinking_block(blocks: Any) -> bool:
+    if not isinstance(blocks, list):
+        return False
+
+    return any(
+        isinstance(block, dict) and block.get("type") != "thinking" for block in blocks
+    )
+
+
+def _should_merge_snapshot_blocks(
+    final_result: Dict[str, Any],
+    snapshot_blocks: Any,
+) -> bool:
+    if not isinstance(snapshot_blocks, list) or not snapshot_blocks:
+        return False
+
+    if _has_non_thinking_block(snapshot_blocks):
+        return True
+
+    return _has_non_thinking_block(final_result.get("blocks"))
+
+
 def _is_blank_text_value(value: Any) -> bool:
     if value is None:
         return True
@@ -409,7 +431,7 @@ async def collect_completed_result(
         finalize_redis_blocks=True,
     )
     accumulated_content = snapshot.get("content", "")
-    blocks = snapshot.get("blocks", [])
+    snapshot_blocks = snapshot.get("blocks", [])
     existing_result = await _get_existing_subtask_result(subtask_id)
 
     if result is not None and not isinstance(result, dict):
@@ -425,7 +447,7 @@ async def collect_completed_result(
         runtime_result
         or existing_result
         or accumulated_content
-        or blocks
+        or snapshot_blocks
         or normalized_status == "COMPLETED"
         or (normalized_status == "FAILED" and error_code)
     )
@@ -448,13 +470,13 @@ async def collect_completed_result(
         ):
             final_result[key] = value
 
-    if blocks:
-        merged_blocks = _merge_blocks(final_result.get("blocks"), blocks)
+    if _should_merge_snapshot_blocks(final_result, snapshot_blocks):
+        merged_blocks = _merge_blocks(final_result.get("blocks"), snapshot_blocks)
         if merged_blocks:
             final_result["blocks"] = merged_blocks
         logger.info(
             "[CompletedResult] Added %d blocks to %s result for subtask %s",
-            len(blocks),
+            len(snapshot_blocks),
             normalized_status.lower(),
             subtask_id,
         )

--- a/backend/app/services/chat/trigger/lifecycle.py
+++ b/backend/app/services/chat/trigger/lifecycle.py
@@ -389,16 +389,27 @@ async def collect_completed_result(
     result: Optional[Dict[str, Any]] = None,
     error_message: Optional[str] = None,
     error_code: Optional[str] = None,
+    executor_name: Optional[str] = None,
+    executor_namespace: Optional[str] = None,
+    runtime_cache: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Collect the final terminal result payload for a subtask."""
-    import app.services.chat.storage as chat_storage
+    from app.services.chat.runtime_stream_snapshot import (
+        runtime_stream_snapshot_service,
+    )
 
     normalized_status = status.upper()
 
-    accumulated_content = await chat_storage.session_manager.get_accumulated_content(
-        subtask_id
+    snapshot = await runtime_stream_snapshot_service.get_snapshot(
+        task_id=0,
+        subtask_id=subtask_id,
+        executor_name=executor_name,
+        executor_namespace=executor_namespace,
+        runtime_cache=runtime_cache,
+        finalize_redis_blocks=True,
     )
-    blocks = await chat_storage.session_manager.finalize_and_get_blocks(subtask_id)
+    accumulated_content = snapshot.get("content", "")
+    blocks = snapshot.get("blocks", [])
     existing_result = await _get_existing_subtask_result(subtask_id)
 
     if result is not None and not isinstance(result, dict):
@@ -479,10 +490,13 @@ async def persist_completed_result(
     error: Optional[str] = None,
     executor_name: Optional[str] = None,
     executor_namespace: Optional[str] = None,
+    runtime_cache: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Persist a terminal result and clean up streaming state."""
-    import app.services.chat.storage as chat_storage
     import app.services.chat.storage.db as chat_db
+    from app.services.chat.runtime_stream_snapshot import (
+        runtime_stream_snapshot_service,
+    )
 
     normalized_status = status.upper()
 
@@ -501,9 +515,12 @@ async def persist_completed_result(
     if normalized_status == "COMPLETED":
         await _persist_standalone_workspace_path(task_id, result)
     try:
-        await chat_storage.session_manager.cleanup_streaming_state(
-            subtask_id,
+        await runtime_stream_snapshot_service.cleanup_snapshot(
+            subtask_id=subtask_id,
             task_id=task_id,
+            executor_name=executor_name,
+            executor_namespace=executor_namespace,
+            runtime_cache=runtime_cache,
         )
     except Exception as exc:
         logger.warning(

--- a/backend/app/services/device/local_provider.py
+++ b/backend/app/services/device/local_provider.py
@@ -218,6 +218,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
         name: str,
         status: str = "online",
         executor_version: Optional[str] = None,
+        runtime_cache: Optional[dict] = None,
     ) -> bool:
         """Set device online status in Redis."""
         key = self.generate_online_key(user_id, device_id)
@@ -228,6 +229,8 @@ class LocalDeviceProvider(BaseDeviceProvider):
             "last_heartbeat": datetime.now().isoformat(),
             "executor_version": executor_version,
         }
+        if isinstance(runtime_cache, dict) and runtime_cache.get("enabled"):
+            data["runtime_cache"] = {"enabled": True}
         result = await cache_manager.set(key, data, expire=DEVICE_ONLINE_TTL)
         logger.info(f"[LocalDeviceProvider] set_online: key={key}, result={result}")
         return result
@@ -448,6 +451,7 @@ class LocalDeviceProvider(BaseDeviceProvider):
         device_id: str,
         running_task_ids: Optional[List[int]] = None,
         executor_version: Optional[str] = None,
+        runtime_cache: Optional[dict] = None,
     ) -> bool:
         """Refresh device heartbeat in Redis."""
         key = self.generate_online_key(user_id, device_id)
@@ -458,6 +462,8 @@ class LocalDeviceProvider(BaseDeviceProvider):
                 data["running_task_ids"] = running_task_ids
             if executor_version is not None:
                 data["executor_version"] = executor_version
+            if isinstance(runtime_cache, dict) and runtime_cache.get("enabled"):
+                data["runtime_cache"] = {"enabled": True}
             result = await cache_manager.set(key, data, expire=DEVICE_ONLINE_TTL)
             logger.debug(
                 f"[LocalDeviceProvider] refresh_heartbeat: key={key}, "

--- a/backend/app/services/device_service.py
+++ b/backend/app/services/device_service.py
@@ -74,6 +74,7 @@ class DeviceService:
         name: str,
         status: str = "online",
         executor_version: Optional[str] = None,
+        runtime_cache: Optional[dict] = None,
     ) -> bool:
         """Set device online status in Redis.
 
@@ -84,6 +85,7 @@ class DeviceService:
             name: Device name
             status: Device status (online, busy)
             executor_version: Executor version (e.g., '1.0.0')
+            runtime_cache: Device-level runtime cache capability
 
         Returns:
             True if set successfully
@@ -96,6 +98,7 @@ class DeviceService:
             name=name,
             status=status,
             executor_version=executor_version,
+            runtime_cache=runtime_cache,
         )
 
     @staticmethod
@@ -104,6 +107,7 @@ class DeviceService:
         device_id: str,
         running_task_ids: list[int] = None,
         executor_version: Optional[str] = None,
+        runtime_cache: Optional[dict] = None,
     ) -> bool:
         """Refresh device heartbeat in Redis (extend TTL) and update running task IDs.
 
@@ -122,6 +126,7 @@ class DeviceService:
             device_id=device_id,
             running_task_ids=running_task_ids,
             executor_version=executor_version,
+            runtime_cache=runtime_cache,
         )
 
     @staticmethod

--- a/backend/app/services/execution/emitters/status_updating.py
+++ b/backend/app/services/execution/emitters/status_updating.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 STREAMING_STORAGE_FLUSH_INTERVAL_SECONDS = 1.0
 TASK_STREAMING_ACTIVITY_TOUCH_INTERVAL_SECONDS = 1.0
+RUNTIME_CACHE_STATUS_ENSURE_INTERVAL_SECONDS = 30.0
+_RUNTIME_CACHE_STATUS_ENSURE_TIMES: dict[str, float] = {}
 
 STREAM_CONTENT_EVENT_TYPES = {
     EventType.CHUNK.value: StreamContentType.TEXT,
@@ -86,6 +88,7 @@ class StatusUpdatingEmitter(ResultEmitter):
         subtask_id: int,
         executor_name: Optional[str] = None,
         executor_namespace: Optional[str] = None,
+        runtime_cache: Optional[Dict[str, Any]] = None,
     ):
         """Initialize the status updating emitter.
 
@@ -95,12 +98,17 @@ class StatusUpdatingEmitter(ResultEmitter):
             subtask_id: Subtask ID for status updates
             executor_name: Optional executor name for container reuse
             executor_namespace: Optional executor namespace
+            runtime_cache: Optional executor runtime cache capability metadata
         """
         self._wrapped = wrapped
         self._task_id = task_id
         self._subtask_id = subtask_id
         self._executor_name = executor_name
         self._executor_namespace = executor_namespace
+        self._runtime_cache = runtime_cache if isinstance(runtime_cache, dict) else None
+        self._uses_executor_runtime_cache = bool(
+            self._runtime_cache and self._runtime_cache.get("enabled")
+        )
         self._status_updated = False
         self._stream_storage_buffer: list[_BufferedStreamContent] = []
         self._stream_storage_lock = asyncio.Lock()
@@ -127,6 +135,8 @@ class StatusUpdatingEmitter(ResultEmitter):
         content: str,
     ) -> None:
         """Buffer high-frequency stream content for batched Redis persistence."""
+        if self._uses_executor_runtime_cache:
+            return
         if not content:
             return
 
@@ -173,6 +183,9 @@ class StatusUpdatingEmitter(ResultEmitter):
 
     async def _flush_stream_storage(self) -> None:
         """Persist buffered stream content to Redis in order."""
+        if self._uses_executor_runtime_cache:
+            return
+
         async with self._stream_storage_lock:
             pending = self._stream_storage_buffer
             self._stream_storage_buffer = []
@@ -207,6 +220,43 @@ class StatusUpdatingEmitter(ResultEmitter):
         await session_manager.touch_task_streaming_activity(self._task_id)
         self._last_task_activity_touch = now
 
+    async def _ensure_runtime_cache_streaming_status(
+        self, session_manager: Any
+    ) -> None:
+        """Ensure Redis active-stream metadata points at executor runtime cache."""
+
+        if not self._uses_executor_runtime_cache:
+            return
+        if not self._should_ensure_runtime_cache_streaming_status():
+            return
+
+        await session_manager.update_task_streaming_runtime_cache(
+            task_id=self._task_id,
+            subtask_id=self._subtask_id,
+            executor_name=self._executor_name,
+            executor_namespace=self._executor_namespace,
+            runtime_cache=self._runtime_cache,
+        )
+
+    def _should_ensure_runtime_cache_streaming_status(self) -> bool:
+        key = (
+            f"{self._task_id}:{self._subtask_id}:"
+            f"{self._executor_namespace or ''}:{self._executor_name or ''}"
+        )
+        now = time.monotonic()
+        last_touch = _RUNTIME_CACHE_STATUS_ENSURE_TIMES.get(key, 0.0)
+        if now - last_touch < RUNTIME_CACHE_STATUS_ENSURE_INTERVAL_SECONDS:
+            return False
+        _RUNTIME_CACHE_STATUS_ENSURE_TIMES[key] = now
+        if len(_RUNTIME_CACHE_STATUS_ENSURE_TIMES) > 10000:
+            stale_before = now - RUNTIME_CACHE_STATUS_ENSURE_INTERVAL_SECONDS * 4
+            for cache_key, touched_at in list(
+                _RUNTIME_CACHE_STATUS_ENSURE_TIMES.items()
+            ):
+                if touched_at < stale_before:
+                    _RUNTIME_CACHE_STATUS_ENSURE_TIMES.pop(cache_key, None)
+        return True
+
     async def _cancel_pending_storage_flush_task(self) -> None:
         """Cancel a scheduled delayed flush after a synchronous flush."""
         task = self._stream_storage_flush_task
@@ -240,6 +290,8 @@ class StatusUpdatingEmitter(ResultEmitter):
             f"content_len={len(event.content) if event.content else 0}"
         )
 
+        await self._ensure_runtime_cache_streaming_status(session_manager)
+
         # Handle START event - set task streaming status for page refresh recovery
         if event.type == EventType.START.value:
             # Set task-level streaming status so get_active_streaming can find it
@@ -248,6 +300,9 @@ class StatusUpdatingEmitter(ResultEmitter):
                 subtask_id=self._subtask_id,
                 user_id=0,  # Will be updated if needed
                 username="",
+                executor_name=self._executor_name,
+                executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             logger.info(
                 f"[StatusUpdatingEmitter] Set task streaming status: "
@@ -263,7 +318,9 @@ class StatusUpdatingEmitter(ResultEmitter):
             await self._touch_task_streaming_activity(session_manager)
 
         # Collect blocks for mixed content rendering using session_manager
-        if event.type == EventType.TOOL_START.value:
+        if self._uses_executor_runtime_cache:
+            pass
+        elif event.type == EventType.TOOL_START.value:
             # When a tool starts, finalize any current text block and add tool block
             display_name = event.data.get("display_name") if event.data else None
             tool_protocol = event.data.get("tool_protocol") if event.data else None
@@ -359,7 +416,7 @@ class StatusUpdatingEmitter(ResultEmitter):
         **kwargs,
     ) -> None:
         """Forward chunk event and accumulate content."""
-        if content:
+        if content and not self._uses_executor_runtime_cache:
             await self._buffer_stream_content(
                 StreamContentType.TEXT,
                 content,
@@ -467,6 +524,9 @@ class StatusUpdatingEmitter(ResultEmitter):
                 self._subtask_id,
                 status="COMPLETED",
                 result=result,
+                executor_name=self._executor_name,
+                executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             await persist_completed_result(
                 subtask_id=self._subtask_id,
@@ -475,6 +535,7 @@ class StatusUpdatingEmitter(ResultEmitter):
                 result=final_result,
                 executor_name=self._executor_name,
                 executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             self._status_updated = True
             logger.info(
@@ -510,6 +571,9 @@ class StatusUpdatingEmitter(ResultEmitter):
                 status="FAILED",
                 error_message=error_message,
                 error_code=error_code,
+                executor_name=self._executor_name,
+                executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             await persist_completed_result(
                 subtask_id=self._subtask_id,
@@ -519,6 +583,7 @@ class StatusUpdatingEmitter(ResultEmitter):
                 error=error_message,
                 executor_name=self._executor_name,
                 executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             self._status_updated = True
             logger.info(
@@ -545,6 +610,9 @@ class StatusUpdatingEmitter(ResultEmitter):
             result = await collect_completed_result(
                 self._subtask_id,
                 status="CANCELLED",
+                executor_name=self._executor_name,
+                executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             await persist_completed_result(
                 subtask_id=self._subtask_id,
@@ -553,6 +621,7 @@ class StatusUpdatingEmitter(ResultEmitter):
                 result=result,
                 executor_name=self._executor_name,
                 executor_namespace=self._executor_namespace,
+                runtime_cache=self._runtime_cache,
             )
             self._status_updated = True
             logger.info(

--- a/backend/app/services/execution/emitters/websocket.py
+++ b/backend/app/services/execution/emitters/websocket.py
@@ -44,6 +44,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
         team_name: Optional[str] = None,
         task_title: Optional[str] = None,
         is_group_chat: bool = False,
+        runtime_cache_enabled: bool = False,
     ):
         """Initialize the WebSocket emitter.
 
@@ -55,6 +56,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
             team_name: Optional team name for task:created event
             task_title: Optional task title for task:created event
             is_group_chat: Whether this is a group chat task
+            runtime_cache_enabled: Whether executor runtime cache owns snapshots
         """
         super().__init__(task_id, subtask_id)
         self.user_id = user_id
@@ -62,6 +64,7 @@ class WebSocketResultEmitter(BaseResultEmitter):
         self.team_name = team_name
         self.task_title = task_title
         self.is_group_chat = is_group_chat
+        self.runtime_cache_enabled = runtime_cache_enabled
 
     async def emit(self, event: ExecutionEvent) -> None:
         """Emit event via WebSocket.
@@ -259,23 +262,24 @@ class WebSocketResultEmitter(BaseResultEmitter):
             )
             return
 
-        try:
-            await session_manager.save_context_metrics(
-                event.subtask_id,
-                {
-                    "task_id": event.task_id,
-                    "subtask_id": event.subtask_id,
-                    "phase": phase,
-                    "context_metrics": context_metrics,
-                },
-            )
-        except Exception as exc:
-            logger.warning(
-                "[WebSocketResultEmitter] Failed to cache context metrics for task_id=%s subtask_id=%s: %s",
-                event.task_id,
-                event.subtask_id,
-                exc,
-            )
+        if not self.runtime_cache_enabled:
+            try:
+                await session_manager.save_context_metrics(
+                    event.subtask_id,
+                    {
+                        "task_id": event.task_id,
+                        "subtask_id": event.subtask_id,
+                        "phase": phase,
+                        "context_metrics": context_metrics,
+                    },
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[WebSocketResultEmitter] Failed to cache context metrics for task_id=%s subtask_id=%s: %s",
+                    event.task_id,
+                    event.subtask_id,
+                    exc,
+                )
         await ws_emitter.emit_chat_status_updated(
             task_id=event.task_id,
             subtask_id=event.subtask_id,
@@ -346,11 +350,12 @@ class WebSocketResultEmitter(BaseResultEmitter):
             subtask_id=event.subtask_id,
             block=block,
         )
-        # Persist block to Redis so it survives page refresh and is included
-        # in the final subtask result via finalize_and_get_blocks().
-        import app.services.chat.storage as chat_storage
+        # When Redis owns snapshots, persist direct blocks for refresh recovery
+        # and final subtask result assembly.
+        if not self.runtime_cache_enabled:
+            import app.services.chat.storage as chat_storage
 
-        await chat_storage.session_manager.add_block(event.subtask_id, block)
+            await chat_storage.session_manager.add_block(event.subtask_id, block)
 
     async def _emit_direct_block_updated(
         self, event: ExecutionEvent, ws_emitter
@@ -376,17 +381,21 @@ class WebSocketResultEmitter(BaseResultEmitter):
                 update_kwargs[target_key] = updates[source_key]
         await ws_emitter.emit_block_updated(**update_kwargs)
 
-        import app.services.chat.storage as chat_storage
+        if not self.runtime_cache_enabled:
+            import app.services.chat.storage as chat_storage
 
-        blocks = await chat_storage.session_manager.get_blocks(event.subtask_id)
-        existing_block = next(
-            (block for block in blocks if block.get("id") == str(block_id)),
-            None,
-        )
-        if existing_block is None:
-            return
-        existing_block.update(updates)
-        await chat_storage.session_manager.add_block(event.subtask_id, existing_block)
+            blocks = await chat_storage.session_manager.get_blocks(event.subtask_id)
+            existing_block = next(
+                (block for block in blocks if block.get("id") == str(block_id)),
+                None,
+            )
+            if existing_block is None:
+                return
+            existing_block.update(updates)
+            await chat_storage.session_manager.add_block(
+                event.subtask_id,
+                existing_block,
+            )
 
     async def _emit_result_guidance_blocks(
         self, event: ExecutionEvent, ws_emitter

--- a/backend/tests/api/ws/test_device_capabilities_state.py
+++ b/backend/tests/api/ws/test_device_capabilities_state.py
@@ -84,6 +84,20 @@ def test_runtime_auth_file_missing_requires_explicit_false():
     assert device_namespace._runtime_auth_file_missing(None, "codex") is False
 
 
+def test_normalize_runtime_cache_capability_only_keeps_enabled():
+    assert device_namespace._normalize_runtime_cache_capability(
+        {
+            "enabled": True,
+            "source": "executor",
+            "active_idle_ttl_seconds": 3600,
+        }
+    ) == {"enabled": True}
+    assert (
+        device_namespace._normalize_runtime_cache_capability({"enabled": False}) is None
+    )
+    assert device_namespace._normalize_runtime_cache_capability(None) is None
+
+
 @pytest.mark.asyncio
 async def test_heartbeat_runtime_auth_sync_uses_user_preferences(monkeypatch):
     namespace = device_namespace.DeviceNamespace()
@@ -148,6 +162,75 @@ async def test_heartbeat_runtime_auth_sync_uses_user_preferences(monkeypatch):
         device_ids=["device-1"],
     )
     assert key not in namespace._runtime_auth_sync_inflight
+
+
+@pytest.mark.asyncio
+async def test_responses_api_event_uses_device_runtime_cache_capability(monkeypatch):
+    namespace = device_namespace.DeviceNamespace()
+    event = SimpleNamespace(type=device_namespace.EventType.CHUNK.value)
+    payload = {
+        "task_id": 101,
+        "subtask_id": 202,
+        "message_id": 303,
+        "runtime_cache": {"enabled": False, "source": "event"},
+        "data": {"delta": "hello"},
+    }
+    websocket_kwargs = {}
+    status_kwargs = {}
+
+    async def fake_get_session(sid):
+        return {"user_id": 7, "device_id": "device-1"}
+
+    def fake_parse(**kwargs):
+        return event
+
+    class FakeWebSocketResultEmitter:
+        def __init__(self, **kwargs):
+            websocket_kwargs.update(kwargs)
+
+    class FakeStatusUpdatingEmitter:
+        def __init__(self, **kwargs):
+            status_kwargs.update(kwargs)
+
+        async def emit(self, emitted_event):
+            assert emitted_event is event
+
+        async def close(self):
+            pass
+
+    monkeypatch.setattr(namespace, "get_session", fake_get_session)
+    monkeypatch.setattr(namespace._event_parser, "parse", fake_parse)
+    monkeypatch.setattr(
+        device_namespace.device_service,
+        "get_device_online_info",
+        AsyncMock(
+            return_value={
+                "runtime_cache": {
+                    "enabled": True,
+                    "source": "device",
+                    "active_idle_ttl_seconds": 3600,
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        device_namespace,
+        "WebSocketResultEmitter",
+        FakeWebSocketResultEmitter,
+    )
+    monkeypatch.setattr(
+        device_namespace,
+        "StatusUpdatingEmitter",
+        FakeStatusUpdatingEmitter,
+    )
+
+    result = await namespace._handle_responses_api_event(
+        "sid-1", "response.output_text.delta", payload
+    )
+
+    assert result == {"success": True}
+    assert websocket_kwargs["runtime_cache_enabled"] is True
+    assert status_kwargs["runtime_cache"] == {"enabled": True}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/chat/test_runtime_stream_snapshot.py
+++ b/backend/tests/services/chat/test_runtime_stream_snapshot.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.chat.runtime_stream_snapshot import RuntimeStreamSnapshotService
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_prefers_executor_cache(monkeypatch):
+    service = RuntimeStreamSnapshotService()
+    executor_snapshot = {
+        "task_id": 101,
+        "subtask_id": 202,
+        "content": "from executor",
+        "blocks": [{"id": "text-1", "type": "text", "content": "from executor"}],
+        "offset": 13,
+        "source": "executor",
+    }
+    get_executor_snapshot = AsyncMock(return_value=executor_snapshot)
+    get_redis_snapshot = AsyncMock(return_value={"content": "from redis"})
+    monkeypatch.setattr(service, "_get_executor_snapshot", get_executor_snapshot)
+    monkeypatch.setattr(service, "_get_redis_snapshot", get_redis_snapshot)
+
+    snapshot = await service.get_snapshot(
+        task_id=101,
+        subtask_id=202,
+        streaming_info={
+            "runtime_cache": {"enabled": True, "version": 1},
+            "executor_name": "executor-1",
+            "executor_namespace": "default",
+        },
+    )
+
+    assert snapshot["content"] == "from executor"
+    get_executor_snapshot.assert_awaited_once_with(
+        subtask_id=202,
+        executor_name="executor-1",
+        executor_namespace="default",
+    )
+    get_redis_snapshot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runtime_snapshot_uses_redis_without_runtime_marker(monkeypatch):
+    service = RuntimeStreamSnapshotService()
+    get_executor_snapshot = AsyncMock()
+    get_redis_snapshot = AsyncMock(
+        return_value={
+            "task_id": 101,
+            "subtask_id": 202,
+            "content": "from redis",
+            "blocks": [],
+            "offset": 10,
+            "source": "redis",
+        }
+    )
+    monkeypatch.setattr(service, "_get_executor_snapshot", get_executor_snapshot)
+    monkeypatch.setattr(service, "_get_redis_snapshot", get_redis_snapshot)
+
+    snapshot = await service.get_snapshot(
+        task_id=101,
+        subtask_id=202,
+        streaming_info={"executor_name": "old-executor"},
+    )
+
+    assert snapshot["content"] == "from redis"
+    get_executor_snapshot.assert_not_awaited()
+    get_redis_snapshot.assert_awaited_once_with(
+        task_id=101,
+        subtask_id=202,
+        finalize_blocks=False,
+    )

--- a/backend/tests/services/chat/test_runtime_stream_snapshot.py
+++ b/backend/tests/services/chat/test_runtime_stream_snapshot.py
@@ -29,7 +29,7 @@ async def test_runtime_snapshot_prefers_executor_cache(monkeypatch):
         task_id=101,
         subtask_id=202,
         streaming_info={
-            "runtime_cache": {"enabled": True, "version": 1},
+            "runtime_cache": {"enabled": True},
             "executor_name": "executor-1",
             "executor_namespace": "default",
         },

--- a/backend/tests/services/chat/test_runtime_stream_snapshot.py
+++ b/backend/tests/services/chat/test_runtime_stream_snapshot.py
@@ -24,22 +24,32 @@ async def test_runtime_snapshot_prefers_executor_cache(monkeypatch):
     get_redis_snapshot = AsyncMock(return_value={"content": "from redis"})
     monkeypatch.setattr(service, "_get_executor_snapshot", get_executor_snapshot)
     monkeypatch.setattr(service, "_get_redis_snapshot", get_redis_snapshot)
+    monkeypatch.setattr(
+        "app.services.chat.runtime_stream_snapshot.device_service.get_device_online_info",
+        AsyncMock(
+            return_value={
+                "runtime_cache": {
+                    "enabled": True,
+                    "source": "ignored",
+                }
+            }
+        ),
+    )
 
     snapshot = await service.get_snapshot(
         task_id=101,
         subtask_id=202,
         streaming_info={
-            "runtime_cache": {"enabled": True},
-            "executor_name": "executor-1",
-            "executor_namespace": "default",
+            "executor_name": "device-device-1",
+            "executor_namespace": "user-7",
         },
     )
 
     assert snapshot["content"] == "from executor"
     get_executor_snapshot.assert_awaited_once_with(
         subtask_id=202,
-        executor_name="executor-1",
-        executor_namespace="default",
+        executor_name="device-device-1",
+        executor_namespace="user-7",
     )
     get_redis_snapshot.assert_not_awaited()
 

--- a/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
+++ b/backend/tests/services/chat/trigger/test_lifecycle_completed_result.py
@@ -77,6 +77,14 @@ class _OutputTextBlockSessionManager:
         ]
 
 
+class _SnapshotService:
+    def __init__(self, snapshot: dict):
+        self.snapshot = snapshot
+
+    async def get_snapshot(self, **_kwargs) -> dict:
+        return self.snapshot
+
+
 @pytest.mark.asyncio
 async def test_collect_completed_result_merges_duplicate_block_fields(monkeypatch):
     async def _empty_existing_result(_subtask_id: int) -> dict:
@@ -230,3 +238,88 @@ async def test_collect_completed_result_normalizes_empty_value_from_output_text_
 
     assert result is not None
     assert result["value"] == "Visible assistant answer."
+
+
+@pytest.mark.asyncio
+async def test_collect_completed_result_drops_reasoning_only_snapshot_blocks(
+    monkeypatch,
+):
+    async def _empty_existing_result(_subtask_id: int) -> dict:
+        return {}
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_existing_subtask_result",
+        _empty_existing_result,
+    )
+    monkeypatch.setattr(
+        "app.services.chat.runtime_stream_snapshot.runtime_stream_snapshot_service",
+        _SnapshotService(
+            {
+                "content": "Visible assistant answer.",
+                "blocks": [
+                    {
+                        "id": "thinking-1",
+                        "type": "thinking",
+                        "content": "Drafting the answer.",
+                        "status": "done",
+                    }
+                ],
+            }
+        ),
+    )
+
+    result = await lifecycle.collect_completed_result(
+        1234,
+        status="COMPLETED",
+        result={"value": "Visible assistant answer."},
+    )
+
+    assert result is not None
+    assert result["value"] == "Visible assistant answer."
+    assert "blocks" not in result
+
+
+@pytest.mark.asyncio
+async def test_collect_completed_result_preserves_snapshot_blocks_with_tools(
+    monkeypatch,
+):
+    async def _empty_existing_result(_subtask_id: int) -> dict:
+        return {}
+
+    monkeypatch.setattr(
+        lifecycle,
+        "_get_existing_subtask_result",
+        _empty_existing_result,
+    )
+    monkeypatch.setattr(
+        "app.services.chat.runtime_stream_snapshot.runtime_stream_snapshot_service",
+        _SnapshotService(
+            {
+                "content": "Final answer.",
+                "blocks": [
+                    {
+                        "id": "thinking-1",
+                        "type": "thinking",
+                        "content": "Checking files.",
+                        "status": "done",
+                    },
+                    {
+                        "id": "tool-1",
+                        "type": "tool",
+                        "tool_name": "Bash",
+                        "status": "done",
+                    },
+                ],
+            }
+        ),
+    )
+
+    result = await lifecycle.collect_completed_result(
+        1234,
+        status="COMPLETED",
+        result={"value": "Final answer."},
+    )
+
+    assert result is not None
+    assert [block["type"] for block in result["blocks"]] == ["thinking", "tool"]

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -115,7 +115,7 @@ async def test_runtime_cache_mode_skips_redis_stream_snapshot_writes():
         subtask_id=202,
         executor_name="executor-1",
         executor_namespace="default",
-        runtime_cache={"enabled": True, "version": 1},
+        runtime_cache={"enabled": True},
     )
     mock_session_manager = AsyncMock()
 
@@ -146,7 +146,7 @@ async def test_runtime_cache_mode_skips_redis_stream_snapshot_writes():
         subtask_id=202,
         executor_name="executor-1",
         executor_namespace="default",
-        runtime_cache={"enabled": True, "version": 1},
+        runtime_cache={"enabled": True},
     )
     wrapped.emit.assert_has_awaits([call(chunk), call(tool_start)])
 

--- a/backend/tests/services/execution/test_status_updating_emitter.py
+++ b/backend/tests/services/execution/test_status_updating_emitter.py
@@ -101,6 +101,57 @@ async def test_done_event_flushes_pending_chunks_before_status_update(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_runtime_cache_mode_skips_redis_stream_snapshot_writes():
+    """Executor runtime cache owns content and block snapshots when advertised."""
+    from app.services.execution.emitters import status_updating
+    from app.services.execution.emitters.status_updating import StatusUpdatingEmitter
+
+    status_updating._RUNTIME_CACHE_STATUS_ENSURE_TIMES.clear()
+
+    wrapped = AsyncMock()
+    emitter = StatusUpdatingEmitter(
+        wrapped=wrapped,
+        task_id=101,
+        subtask_id=202,
+        executor_name="executor-1",
+        executor_namespace="default",
+        runtime_cache={"enabled": True, "version": 1},
+    )
+    mock_session_manager = AsyncMock()
+
+    chunk = ExecutionEvent(
+        type=EventType.CHUNK.value,
+        task_id=101,
+        subtask_id=202,
+        content="content",
+    )
+    tool_start = ExecutionEvent(
+        type=EventType.TOOL_START.value,
+        task_id=101,
+        subtask_id=202,
+        tool_use_id="tool-1",
+        tool_name="Bash",
+        tool_input={"command": "pwd"},
+    )
+
+    with patch("app.services.chat.storage.session_manager", mock_session_manager):
+        await emitter.emit(chunk)
+        await emitter.emit(tool_start)
+        await emitter.close()
+
+    mock_session_manager.add_stream_content.assert_not_awaited()
+    mock_session_manager.add_tool_block.assert_not_awaited()
+    mock_session_manager.update_task_streaming_runtime_cache.assert_awaited_once_with(
+        task_id=101,
+        subtask_id=202,
+        executor_name="executor-1",
+        executor_namespace="default",
+        runtime_cache={"enabled": True, "version": 1},
+    )
+    wrapped.emit.assert_has_awaits([call(chunk), call(tool_start)])
+
+
+@pytest.mark.asyncio
 async def test_done_event_waits_for_in_progress_background_flush(monkeypatch):
     """Terminal handling must wait if the scheduled Redis flush already started."""
     from app.services.execution.emitters import status_updating

--- a/docs/en/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/en/developer-guide/executor-runtime-stream-cache.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 22
+---
+
+# Executor Runtime Stream Cache
+
+## Background
+
+While a task is running, the browser may refresh or rejoin the task room and needs to recover in-progress streamed content. The legacy path wrote incremental text, tool blocks, and context metrics to Redis for refresh recovery and terminal result assembly. That path is reliable, but high-frequency streaming events create heavy Redis write traffic.
+
+Executor runtime stream cache keeps active task snapshots in executor-local memory. Backend still uses Redis for task-level active state and routing metadata, then asks the owning executor for the snapshot during recovery.
+
+## Goals
+
+- Reduce high-frequency Redis writes for streamed incremental content.
+- Keep Redis for active task indexing, TTL, cross-process coordination, and compatibility with older executors.
+- Avoid dual-write rollout. Executors that send the runtime cache marker use executor-local snapshots; executors that do not send it continue using Redis snapshots.
+- Accept losing unfinished intermediate snapshots if the executor process crashes. Terminal results are still persisted by the completion handler.
+
+## Capability Detection
+
+The current implementation does not depend on a global executor capability reported during registration or heartbeat. Instead, the executor attaches a `runtime_cache` marker to each Responses API streaming event payload:
+
+```json
+{
+  "runtime_cache": {
+    "enabled": true,
+    "version": 1,
+    "source": "executor",
+    "active_idle_ttl_seconds": 3600,
+    "terminal_ttl_seconds": 600
+  }
+}
+```
+
+Backend decides cache ownership from this event-level marker:
+
+- `runtime_cache.enabled == true`: Redis only stores the `chat:task_streaming:{task_id}` active status. Incremental content and blocks are not written to Redis.
+- Missing marker or `enabled != true`: Backend keeps the legacy path and writes incremental content and blocks to Redis.
+
+Because this is decided per task stream event, older executors remain compatible without a protocol upgrade.
+
+## Data Flow
+
+### Running
+
+1. The executor emits Responses API streaming events.
+2. The executor transport records each event in the local `RuntimeStreamCache`.
+3. The executor includes the `runtime_cache` marker in the event payload.
+4. Backend's WebSocket callback handler reads the marker.
+5. `StatusUpdatingEmitter` updates the Redis task-level active status with executor name, namespace, and runtime cache metadata.
+6. Backend still broadcasts events to the frontend, but skips Redis content snapshot writes.
+
+### Refresh Recovery
+
+1. The frontend rejoins the task room or triggers a runtime check.
+2. Backend reads `chat:task_streaming:{task_id}` from Redis to find the active subtask and executor route.
+3. If the status has `cache_source=executor`, Backend sends `runtime_cache:get_snapshot` to the local executor.
+4. The executor returns the in-memory snapshot, and Backend converts it into content, blocks, offset, and context metrics for join/resume.
+5. If there is no runtime cache marker, Backend falls back to the Redis content snapshot.
+
+### Completion
+
+1. After Backend receives a terminal event, it first fetches the final runtime snapshot from the executor.
+2. Backend uses the final snapshot to complete the persisted result blocks and context metrics.
+3. Backend sends `runtime_cache:cleanup` to the executor to delete the subtask snapshot.
+4. Backend clears Redis streaming content and the `chat:task_streaming:{task_id}` active status.
+
+## Redis Responsibilities
+
+Redis still owns:
+
+- The `chat:task_streaming:{task_id}` active task index.
+- Routing metadata from task to subtask, executor name, and executor namespace.
+- Active status TTL and last activity.
+- Content snapshots, blocks, and context metrics for older executors.
+- The common cleanup entry point after terminal events.
+
+Redis is still part of stream recovery. It simply no longer stores high-frequency incremental content for executors that support runtime cache.
+
+## Cleanup
+
+Executor memory snapshots are reclaimed in two ways:
+
+- Active cleanup: after Backend reads the final snapshot and assembles the terminal result, it calls `runtime_cache:cleanup`.
+- Passive cleanup: the executor evicts expired entries when the cache is accessed. Active snapshots default to a 3600-second idle TTL; terminal snapshots default to a 600-second TTL.
+
+If the executor crashes or restarts, in-memory snapshots are lost. Backend can no longer recover those unfinished snapshots and can only return already persisted task state. This is an accepted tradeoff in the current design.
+
+## Troubleshooting
+
+Do not rely only on executor registration or heartbeat capability logs when checking whether runtime cache is active. Inspect backend callback logs instead:
+
+- Whether event payloads or Redis active status contain `runtime_cache.enabled=true`.
+- Whether `chat:task_streaming:{task_id}` contains `cache_source=executor`.
+- Whether refresh or join sends `runtime_cache:get_snapshot`.
+- Whether completion sends `runtime_cache:cleanup` and receives `removed=true`.
+- Whether Redis content snapshot reads return key not found; that means content did not go through Redis, not that Redis active status failed.

--- a/docs/en/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/en/developer-guide/executor-runtime-stream-cache.md
@@ -14,7 +14,7 @@ Executor runtime stream cache keeps active task snapshots in executor-local memo
 
 - Reduce high-frequency Redis writes for streamed incremental content.
 - Keep Redis for active task indexing, TTL, cross-process coordination, and compatibility with older executors.
-- Avoid dual-write rollout. Executors that send the runtime cache marker use executor-local snapshots; executors that do not send it continue using Redis snapshots.
+- Avoid dual-write rollout. Devices that report the runtime cache capability use executor-local snapshots; devices that do not report it continue using Redis snapshots.
 - Accept losing unfinished intermediate snapshots if the executor process crashes. Terminal results are still persisted by the completion handler.
 
 ## Capability Detection
@@ -50,16 +50,16 @@ This prevents refresh recovery from exposing the same plain output through both 
 2. The executor transport records each event in the local `RuntimeStreamCache`.
 3. Backend's WebSocket callback handler decides snapshot ownership from `runtime_cache.enabled` in the device online state.
 4. When runtime cache is supported, `StatusUpdatingEmitter` skips Redis content snapshot writes.
-5. `StatusUpdatingEmitter` updates the Redis task-level active status with executor name, namespace, and runtime cache metadata.
+5. `StatusUpdatingEmitter` updates the Redis task-level active status with only active subtask, executor name, namespace, and other routing fields.
 6. Backend still broadcasts events to the frontend.
 
 ### Refresh Recovery
 
 1. The frontend rejoins the task room or triggers a runtime check.
 2. Backend reads `chat:task_streaming:{task_id}` from Redis to find the active subtask and executor route.
-3. If the status has `runtime_cache.enabled=true`, Backend sends `runtime_cache:get_snapshot` to the local executor.
+3. If the route points to an online device with `runtime_cache.enabled=true`, Backend sends `runtime_cache:get_snapshot` to the local executor.
 4. The executor returns the in-memory snapshot, and Backend converts it into content, blocks, offset, and context metrics for join/resume.
-5. If there is no runtime cache marker, Backend falls back to the Redis content snapshot.
+5. If the route has no matching runtime-cache-capable device, Backend falls back to the Redis content snapshot.
 
 ### Completion
 
@@ -93,7 +93,7 @@ If the executor crashes or restarts, in-memory snapshots are lost. Backend can n
 
 Do not rely only on executor registration or heartbeat capability logs when checking whether runtime cache is active. Inspect backend callback logs instead:
 
-- Whether device registration, heartbeat, or Redis active status contains `runtime_cache.enabled=true`.
+- Whether device registration, heartbeat, or device online state contains `runtime_cache.enabled=true`.
 - Whether refresh or join sends `runtime_cache:get_snapshot`.
 - Whether completion sends `runtime_cache:cleanup` and receives `removed=true`.
 - Whether Redis content snapshot reads return key not found; that means content did not go through Redis, not that Redis active status failed.

--- a/docs/en/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/en/developer-guide/executor-runtime-stream-cache.md
@@ -19,26 +19,22 @@ Executor runtime stream cache keeps active task snapshots in executor-local memo
 
 ## Capability Detection
 
-The current implementation does not depend on a global executor capability reported during registration or heartbeat. Instead, the executor attaches a `runtime_cache` marker to each Responses API streaming event payload:
+The executor reports a device-level `runtime_cache` capability during device registration and heartbeat:
 
 ```json
 {
   "runtime_cache": {
-    "enabled": true,
-    "version": 1,
-    "source": "executor",
-    "active_idle_ttl_seconds": 3600,
-    "terminal_ttl_seconds": 600
+    "enabled": true
   }
 }
 ```
 
-Backend decides cache ownership from this event-level marker:
+Backend decides cache ownership from the capability stored in the device online state:
 
 - `runtime_cache.enabled == true`: Redis only stores the `chat:task_streaming:{task_id}` active status. Incremental content and blocks are not written to Redis.
-- Missing marker or `enabled != true`: Backend keeps the legacy path and writes incremental content and blocks to Redis.
+- Missing device capability or `enabled != true`: Backend keeps the legacy path and writes incremental content and blocks to Redis.
 
-Because this is decided per task stream event, older executors remain compatible without a protocol upgrade.
+Because this is decided per device, streams sent to a runtime-cache-capable device always use executor-local snapshots.
 
 ## Snapshot Semantics
 
@@ -52,16 +48,16 @@ This prevents refresh recovery from exposing the same plain output through both 
 
 1. The executor emits Responses API streaming events.
 2. The executor transport records each event in the local `RuntimeStreamCache`.
-3. The executor includes the `runtime_cache` marker in the event payload.
-4. Backend's WebSocket callback handler reads the marker.
+3. Backend's WebSocket callback handler decides snapshot ownership from `runtime_cache.enabled` in the device online state.
+4. When runtime cache is supported, `StatusUpdatingEmitter` skips Redis content snapshot writes.
 5. `StatusUpdatingEmitter` updates the Redis task-level active status with executor name, namespace, and runtime cache metadata.
-6. Backend still broadcasts events to the frontend, but skips Redis content snapshot writes.
+6. Backend still broadcasts events to the frontend.
 
 ### Refresh Recovery
 
 1. The frontend rejoins the task room or triggers a runtime check.
 2. Backend reads `chat:task_streaming:{task_id}` from Redis to find the active subtask and executor route.
-3. If the status has `cache_source=executor`, Backend sends `runtime_cache:get_snapshot` to the local executor.
+3. If the status has `runtime_cache.enabled=true`, Backend sends `runtime_cache:get_snapshot` to the local executor.
 4. The executor returns the in-memory snapshot, and Backend converts it into content, blocks, offset, and context metrics for join/resume.
 5. If there is no runtime cache marker, Backend falls back to the Redis content snapshot.
 
@@ -97,8 +93,7 @@ If the executor crashes or restarts, in-memory snapshots are lost. Backend can n
 
 Do not rely only on executor registration or heartbeat capability logs when checking whether runtime cache is active. Inspect backend callback logs instead:
 
-- Whether event payloads or Redis active status contain `runtime_cache.enabled=true`.
-- Whether `chat:task_streaming:{task_id}` contains `cache_source=executor`.
+- Whether device registration, heartbeat, or Redis active status contains `runtime_cache.enabled=true`.
 - Whether refresh or join sends `runtime_cache:get_snapshot`.
 - Whether completion sends `runtime_cache:cleanup` and receives `removed=true`.
 - Whether Redis content snapshot reads return key not found; that means content did not go through Redis, not that Redis active status failed.

--- a/docs/en/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/en/developer-guide/executor-runtime-stream-cache.md
@@ -40,6 +40,12 @@ Backend decides cache ownership from this event-level marker:
 
 Because this is decided per task stream event, older executors remain compatible without a protocol upgrade.
 
+## Snapshot Semantics
+
+Plain assistant output in executor runtime snapshots is stored only in `content` and `offset`. `blocks` only stores independently rendered process information, such as reasoning, tool calls, and explicit commentary/text blocks produced by `response.block.*` events.
+
+This prevents refresh recovery from exposing the same plain output through both `cached_content` and a process `text` block, which would otherwise leave the process block stuck at the refresh point while the main answer keeps streaming.
+
 ## Data Flow
 
 ### Running

--- a/docs/zh/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/zh/developer-guide/executor-runtime-stream-cache.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 22
+---
+
+# 执行器运行态流缓存
+
+## 背景
+
+任务执行过程中，浏览器刷新或重新加入 task room 时需要恢复仍在流式生成的内容。旧路径把增量文本、工具块和上下文指标写入 Redis，用于刷新恢复和终态结果组装。这个方式可靠，但高频流式事件会增加 Redis 写入压力。
+
+执行器运行态流缓存把活跃任务的增量快照保存在 executor 本地内存中。Backend 仍使用 Redis 保存 task 级活跃状态和路由信息，恢复时再向对应 executor 拉取快照。
+
+## 设计目标
+
+- 降低流式增量内容对 Redis 的高频写入。
+- 保留 Redis 作为活跃任务索引、TTL、跨进程协调和旧 executor 兼容路径。
+- 不做双写灰度。支持 runtime cache 的 executor 走 executor 内存快照；未带能力标记的 executor 继续走 Redis 快照。
+- 接受 executor 进程崩溃时丢失未定稿的中间快照。终态结果仍在完成事件处理中落库。
+
+## 能力识别
+
+当前实现不依赖 executor 启动或心跳上报全局 capability。executor 在每个 Responses API 流式事件 payload 中携带 `runtime_cache` marker：
+
+```json
+{
+  "runtime_cache": {
+    "enabled": true,
+    "version": 1,
+    "source": "executor",
+    "active_idle_ttl_seconds": 3600,
+    "terminal_ttl_seconds": 600
+  }
+}
+```
+
+Backend 收到事件后按事件级 marker 判断缓存归属：
+
+- `runtime_cache.enabled == true`：Redis 只保存 `chat:task_streaming:{task_id}` 活跃状态，增量内容和 blocks 不写 Redis。
+- 无 marker 或 `enabled != true`：保持旧路径，增量内容和 blocks 继续写 Redis。
+
+这个判断是按任务流事件生效的，因此旧 executor 不需要升级协议即可继续工作。
+
+## 数据流
+
+### 运行中
+
+1. executor 发送 Responses API 流式事件。
+2. executor transport 先把事件写入本地 `RuntimeStreamCache`。
+3. executor 在事件 payload 中带上 `runtime_cache` marker。
+4. Backend 的 WebSocket callback handler 读取 marker。
+5. `StatusUpdatingEmitter` 更新 Redis task 级活跃状态，记录 executor 名称、namespace 和 runtime cache 元数据。
+6. Backend 继续把事件广播给前端，但跳过 Redis 内容快照写入。
+
+### 刷新恢复
+
+1. 前端重新加入 task room 或触发 runtime check。
+2. Backend 从 Redis 读取 `chat:task_streaming:{task_id}`，确认活跃 subtask 和对应 executor。
+3. 如果状态里带 `cache_source=executor`，Backend 向 local executor 发送 `runtime_cache:get_snapshot`。
+4. executor 返回内存快照，Backend 将快照转换为 join/resume 所需的 content、blocks、offset 和 context metrics。
+5. 如果状态没有 runtime cache marker，Backend 使用 Redis 内容快照恢复。
+
+### 任务完成
+
+1. Backend 收到 terminal 事件后，先向 executor 拉取最终 runtime snapshot。
+2. Backend 用最终快照补齐 completed result 中的 blocks 和上下文指标。
+3. Backend 向 executor 发送 `runtime_cache:cleanup` 删除该 subtask 的内存快照。
+4. Backend 清理 Redis 中的流式内容和 `chat:task_streaming:{task_id}` 活跃状态。
+
+## Redis 保留职责
+
+Redis 仍负责以下职责：
+
+- `chat:task_streaming:{task_id}` 活跃任务索引。
+- task 到 subtask、executor name、executor namespace 的路由信息。
+- 活跃状态 TTL 和 last activity。
+- 旧 executor 的内容快照、blocks 和上下文指标。
+- terminal 后的通用清理入口。
+
+因此 Redis 并未从任务流恢复链路中移除，只是不再承载支持 runtime cache 的 executor 的高频增量内容。
+
+## 回收策略
+
+executor 内存快照有两类回收：
+
+- 主动回收：Backend 在 terminal 事件完成最终快照读取和结果组装后调用 `runtime_cache:cleanup`。
+- 被动回收：executor 在访问缓存时清理过期条目。活跃快照默认 idle TTL 为 3600 秒；terminal 快照默认 TTL 为 600 秒。
+
+如果 executor 崩溃或重启，内存快照会丢失。Backend 后续无法从 executor 拉到 snapshot 时，只能返回已有的持久化任务状态；这是当前设计接受的取舍。
+
+## 排查方式
+
+判断 runtime cache 是否生效时，不要只看 executor 注册或心跳 capability 日志。应检查 backend callback 日志：
+
+- 事件或 Redis active status 中是否出现 `runtime_cache.enabled=true`。
+- `chat:task_streaming:{task_id}` 中是否出现 `cache_source=executor`。
+- 刷新或 join 时是否发送 `runtime_cache:get_snapshot`。
+- 完成时是否发送 `runtime_cache:cleanup`，且返回 `removed=true`。
+- Redis 内容快照读取是否为 key not found；这表示内容未走 Redis，而不是 Redis active status 未生效。

--- a/docs/zh/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/zh/developer-guide/executor-runtime-stream-cache.md
@@ -40,6 +40,12 @@ Backend 收到事件后按事件级 marker 判断缓存归属：
 
 这个判断是按任务流事件生效的，因此旧 executor 不需要升级协议即可继续工作。
 
+## 快照语义
+
+executor runtime snapshot 中的普通助手正文只写入 `content` 和 `offset`。`blocks` 只保存可独立展示的过程信息，例如 reasoning、tool 调用和显式 `response.block.*` 事件产生的 commentary/text block。
+
+这避免刷新恢复时同一段普通正文同时出现在 `cached_content` 和 process `text` block 中，导致后续正文继续增长后 process block 停留在刷新点。
+
 ## 数据流
 
 ### 运行中

--- a/docs/zh/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/zh/developer-guide/executor-runtime-stream-cache.md
@@ -14,7 +14,7 @@ sidebar_position: 22
 
 - 降低流式增量内容对 Redis 的高频写入。
 - 保留 Redis 作为活跃任务索引、TTL、跨进程协调和旧 executor 兼容路径。
-- 不做双写灰度。支持 runtime cache 的 executor 走 executor 内存快照；未带能力标记的 executor 继续走 Redis 快照。
+- 不做双写灰度。上报 runtime cache 能力的设备走 executor 内存快照；未上报该能力的设备继续走 Redis 快照。
 - 接受 executor 进程崩溃时丢失未定稿的中间快照。终态结果仍在完成事件处理中落库。
 
 ## 能力识别
@@ -50,16 +50,16 @@ executor runtime snapshot 中的普通助手正文只写入 `content` 和 `offse
 2. executor transport 先把事件写入本地 `RuntimeStreamCache`。
 3. Backend 的 WebSocket callback handler 根据设备在线状态中的 `runtime_cache.enabled` 判断快照归属。
 4. 支持 runtime cache 时，`StatusUpdatingEmitter` 跳过 Redis 内容快照写入。
-5. `StatusUpdatingEmitter` 更新 Redis task 级活跃状态，记录 executor 名称、namespace 和 runtime cache 元数据。
+5. `StatusUpdatingEmitter` 更新 Redis task 级活跃状态，只记录 active subtask、executor 名称和 namespace 等路由信息。
 6. Backend 继续把事件广播给前端。
 
 ### 刷新恢复
 
 1. 前端重新加入 task room 或触发 runtime check。
 2. Backend 从 Redis 读取 `chat:task_streaming:{task_id}`，确认活跃 subtask 和对应 executor。
-3. 如果状态里带 `runtime_cache.enabled=true`，Backend 向 local executor 发送 `runtime_cache:get_snapshot`。
+3. 如果路由对应的在线设备带 `runtime_cache.enabled=true`，Backend 向 local executor 发送 `runtime_cache:get_snapshot`。
 4. executor 返回内存快照，Backend 将快照转换为 join/resume 所需的 content、blocks、offset 和 context metrics。
-5. 如果状态没有 runtime cache marker，Backend 使用 Redis 内容快照恢复。
+5. 如果路由没有对应的 runtime cache 设备能力，Backend 使用 Redis 内容快照恢复。
 
 ### 任务完成
 
@@ -93,7 +93,7 @@ executor 内存快照有两类回收：
 
 判断 runtime cache 是否生效时，不要只看 executor 注册或心跳 capability 日志。应检查 backend callback 日志：
 
-- 设备注册、心跳或 Redis active status 中是否出现 `runtime_cache.enabled=true`。
+- 设备注册、心跳或设备在线状态中是否出现 `runtime_cache.enabled=true`。
 - 刷新或 join 时是否发送 `runtime_cache:get_snapshot`。
 - 完成时是否发送 `runtime_cache:cleanup`，且返回 `removed=true`。
 - Redis 内容快照读取是否为 key not found；这表示内容未走 Redis，而不是 Redis active status 未生效。

--- a/docs/zh/developer-guide/executor-runtime-stream-cache.md
+++ b/docs/zh/developer-guide/executor-runtime-stream-cache.md
@@ -19,26 +19,22 @@ sidebar_position: 22
 
 ## 能力识别
 
-当前实现不依赖 executor 启动或心跳上报全局 capability。executor 在每个 Responses API 流式事件 payload 中携带 `runtime_cache` marker：
+executor 在设备注册和心跳中上报设备级 `runtime_cache` capability：
 
 ```json
 {
   "runtime_cache": {
-    "enabled": true,
-    "version": 1,
-    "source": "executor",
-    "active_idle_ttl_seconds": 3600,
-    "terminal_ttl_seconds": 600
+    "enabled": true
   }
 }
 ```
 
-Backend 收到事件后按事件级 marker 判断缓存归属：
+Backend 按设备在线状态中的 capability 判断缓存归属：
 
 - `runtime_cache.enabled == true`：Redis 只保存 `chat:task_streaming:{task_id}` 活跃状态，增量内容和 blocks 不写 Redis。
-- 无 marker 或 `enabled != true`：保持旧路径，增量内容和 blocks 继续写 Redis。
+- 无设备 capability 或 `enabled != true`：保持旧路径，增量内容和 blocks 继续写 Redis。
 
-这个判断是按任务流事件生效的，因此旧 executor 不需要升级协议即可继续工作。
+这个判断是按设备生效的，因此发往支持 runtime cache 的设备的任务流一定使用 executor 内存快照。
 
 ## 快照语义
 
@@ -52,16 +48,16 @@ executor runtime snapshot 中的普通助手正文只写入 `content` 和 `offse
 
 1. executor 发送 Responses API 流式事件。
 2. executor transport 先把事件写入本地 `RuntimeStreamCache`。
-3. executor 在事件 payload 中带上 `runtime_cache` marker。
-4. Backend 的 WebSocket callback handler 读取 marker。
+3. Backend 的 WebSocket callback handler 根据设备在线状态中的 `runtime_cache.enabled` 判断快照归属。
+4. 支持 runtime cache 时，`StatusUpdatingEmitter` 跳过 Redis 内容快照写入。
 5. `StatusUpdatingEmitter` 更新 Redis task 级活跃状态，记录 executor 名称、namespace 和 runtime cache 元数据。
-6. Backend 继续把事件广播给前端，但跳过 Redis 内容快照写入。
+6. Backend 继续把事件广播给前端。
 
 ### 刷新恢复
 
 1. 前端重新加入 task room 或触发 runtime check。
 2. Backend 从 Redis 读取 `chat:task_streaming:{task_id}`，确认活跃 subtask 和对应 executor。
-3. 如果状态里带 `cache_source=executor`，Backend 向 local executor 发送 `runtime_cache:get_snapshot`。
+3. 如果状态里带 `runtime_cache.enabled=true`，Backend 向 local executor 发送 `runtime_cache:get_snapshot`。
 4. executor 返回内存快照，Backend 将快照转换为 join/resume 所需的 content、blocks、offset 和 context metrics。
 5. 如果状态没有 runtime cache marker，Backend 使用 Redis 内容快照恢复。
 
@@ -97,8 +93,7 @@ executor 内存快照有两类回收：
 
 判断 runtime cache 是否生效时，不要只看 executor 注册或心跳 capability 日志。应检查 backend callback 日志：
 
-- 事件或 Redis active status 中是否出现 `runtime_cache.enabled=true`。
-- `chat:task_streaming:{task_id}` 中是否出现 `cache_source=executor`。
+- 设备注册、心跳或 Redis active status 中是否出现 `runtime_cache.enabled=true`。
 - 刷新或 join 时是否发送 `runtime_cache:get_snapshot`。
 - 完成时是否发送 `runtime_cache:cleanup`，且返回 `removed=true`。
 - Redis 内容快照读取是否为 key not found；这表示内容未走 Redis，而不是 Redis active status 未生效。

--- a/executor/agents/base.py
+++ b/executor/agents/base.py
@@ -14,6 +14,9 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from executor.config import config
+from executor.services.runtime_stream_cache import (
+    runtime_stream_cache_transport_kwargs,
+)
 from executor.services.turn_file_changes import TurnFileChangeTracker
 from shared.logger import setup_logger
 from shared.models import EmitterBuilder, ResponsesAPIEmitter, TransportFactory
@@ -115,7 +118,8 @@ class Agent:
             .with_task(self.task_id, new_subtask_id)
             .with_transport(
                 TransportFactory.create_callback_throttled(
-                    callback_url=config.CALLBACK_URL
+                    callback_url=config.CALLBACK_URL,
+                    **runtime_stream_cache_transport_kwargs(),
                 )
             )
             .with_executor_info(

--- a/executor/app.py
+++ b/executor/app.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 
 from executor.services.agent_service import AgentService
 from executor.services.heartbeat_service import start_heartbeat, stop_heartbeat
+from executor.services.runtime_stream_cache import runtime_stream_cache
 from executor.tasks import process, process_async, run_task, run_task_async
 
 # Import the shared logger
@@ -557,6 +558,31 @@ agent_service = AgentService()
 async def health_check():
     """Health check endpoint for container readiness probes."""
     return {"status": "healthy", "service": "task_executor"}
+
+
+@app.get("/api/runtime-cache/capabilities")
+async def runtime_cache_capabilities():
+    """Return executor runtime stream cache capability metadata."""
+
+    return runtime_stream_cache.capability()
+
+
+@app.get("/api/runtime-cache/subtasks/{subtask_id}")
+async def get_runtime_cache_snapshot(subtask_id: int):
+    """Return a cached stream snapshot for backend recovery."""
+
+    snapshot = await runtime_stream_cache.get_snapshot(subtask_id)
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="Runtime stream cache not found")
+    return {"snapshot": snapshot}
+
+
+@app.delete("/api/runtime-cache/subtasks/{subtask_id}")
+async def delete_runtime_cache_snapshot(subtask_id: int):
+    """Delete a cached stream snapshot after backend persistence."""
+
+    removed = await runtime_stream_cache.cleanup(subtask_id)
+    return {"removed": removed}
 
 
 class OpenAIBackgroundResponse(BaseModel):

--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -265,6 +265,14 @@ class LocalRunner:
             self.capability_sync_handler.handle_sync_capabilities,
         )
         self.websocket_client.on(
+            "runtime_cache:get_snapshot",
+            self._handle_runtime_cache_get_snapshot,
+        )
+        self.websocket_client.on(
+            "runtime_cache:cleanup",
+            self._handle_runtime_cache_cleanup,
+        )
+        self.websocket_client.on(
             DeviceEvents.START_TERMINAL_SESSION,
             self.session_handler.handle_start_session,
         )
@@ -283,6 +291,32 @@ class LocalRunner:
         self._register_extension_handlers()
 
         logger.info("WebSocket event handlers registered")
+
+    async def _handle_runtime_cache_get_snapshot(self, data: dict) -> dict:
+        """Return a cached stream snapshot for backend recovery."""
+
+        from executor.services.runtime_stream_cache import runtime_stream_cache
+
+        try:
+            subtask_id = int((data or {}).get("subtask_id"))
+        except (TypeError, ValueError):
+            return {"success": False, "error": "Invalid subtask_id"}
+
+        snapshot = await runtime_stream_cache.get_snapshot(subtask_id)
+        return {"success": True, "snapshot": snapshot}
+
+    async def _handle_runtime_cache_cleanup(self, data: dict) -> dict:
+        """Delete a cached stream snapshot after backend persistence."""
+
+        from executor.services.runtime_stream_cache import runtime_stream_cache
+
+        try:
+            subtask_id = int((data or {}).get("subtask_id"))
+        except (TypeError, ValueError):
+            return {"success": False, "error": "Invalid subtask_id"}
+
+        removed = await runtime_stream_cache.cleanup(subtask_id)
+        return {"success": True, "removed": removed}
 
     def _register_extension_handlers(self) -> None:
         """Allow downstream distributions to attach local runner handlers."""
@@ -544,12 +578,18 @@ class LocalRunner:
         Returns:
             ResponsesAPIEmitter configured with WebSocket transport
         """
-        from shared.models import EmitterBuilder, WebSocketTransport
+        from executor.services.runtime_stream_cache import (
+            runtime_stream_cache_transport_kwargs,
+        )
+        from shared.models import EmitterBuilder, TransportFactory
 
         # Create WebSocket transport for local mode
         # No event_mapping - use original OpenAI Responses API event types as Socket.IO event names
         # This allows backend's DeviceNamespace to route events correctly to _handle_responses_api_event
-        ws_transport = WebSocketTransport(self.websocket_client)
+        ws_transport = TransportFactory.create_websocket(
+            self.websocket_client,
+            **runtime_stream_cache_transport_kwargs(),
+        )
 
         # Create WebSocket emitter for local mode
         return (

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -47,6 +47,7 @@ from executor.modes.local.capabilities import GlobalCapabilityReporter
 from executor.platform_compat import get_permissions_manager
 from executor.version import get_version
 from shared.logger import setup_logger
+from shared.models import runtime_stream_cache_capability
 
 if TYPE_CHECKING:
     from executor.config.device_config import DeviceConfig
@@ -498,6 +499,7 @@ class WebSocketClient:
                 "bind_shell": self.bind_shell,
                 "executor_version": get_version(),
                 "client_ip": self._get_client_ip(),
+                "runtime_cache": runtime_stream_cache_capability(),
             }
             logger.info(f"Sending device:register to /local-executor: {register_data}")
 
@@ -555,6 +557,7 @@ class WebSocketClient:
                 "running_task_ids": running_task_ids,
                 "executor_version": get_version(),
                 "capabilities": self.capability_reporter.build_report(),
+                "runtime_cache": runtime_stream_cache_capability(),
                 "runtime_auth_files": build_runtime_auth_file_report(),
             }
             logger.info(

--- a/executor/services/agent_service.py
+++ b/executor/services/agent_service.py
@@ -16,6 +16,9 @@ from typing import Any, ClassVar, Dict, List, Optional, Tuple, Union
 from executor.agents import Agent, AgentFactory
 from executor.agents.agno.agno_agent import AgnoAgent
 from executor.config import config
+from executor.services.runtime_stream_cache import (
+    runtime_stream_cache_transport_kwargs,
+)
 from shared.logger import setup_logger
 from shared.models import EmitterBuilder, TransportFactory
 from shared.models.execution import ExecutionRequest
@@ -119,7 +122,8 @@ class AgentService:
                 .with_task(task_id, subtask_id)
                 .with_transport(
                     TransportFactory.create_callback_throttled(
-                        callback_url=config.CALLBACK_URL
+                        callback_url=config.CALLBACK_URL,
+                        **runtime_stream_cache_transport_kwargs(),
                     )
                 )
                 .with_executor_info(
@@ -465,7 +469,10 @@ class AgentService:
                 EmitterBuilder()
                 .with_task(task_id, subtask_id)
                 .with_transport(
-                    TransportFactory.create_callback(callback_url=config.CALLBACK_URL)
+                    TransportFactory.create_callback(
+                        callback_url=config.CALLBACK_URL,
+                        **runtime_stream_cache_transport_kwargs(),
+                    )
                 )
                 .with_executor_info(
                     name=os.getenv("EXECUTOR_NAME"),

--- a/executor/services/heartbeat_service.py
+++ b/executor/services/heartbeat_service.py
@@ -19,6 +19,9 @@ from typing import Optional
 import requests
 
 from executor.config.env_reader import get_env, get_heartbeat_base_url
+from executor.services.runtime_stream_cache import (
+    runtime_stream_cache_transport_kwargs,
+)
 from shared.logger import setup_logger
 
 logger = setup_logger("heartbeat_service")
@@ -369,7 +372,8 @@ class HeartbeatService:
                 .with_task(task_id, -1)
                 .with_transport(
                     TransportFactory.create_callback_throttled(
-                        callback_url=config.CALLBACK_URL
+                        callback_url=config.CALLBACK_URL,
+                        **runtime_stream_cache_transport_kwargs(),
                     )
                 )
                 .build()

--- a/executor/services/runtime_stream_cache.py
+++ b/executor/services/runtime_stream_cache.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Executor-local in-memory runtime stream cache."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Optional
+
+from shared.models import RuntimeStreamAccumulator, runtime_stream_cache_capability
+
+logger = logging.getLogger(__name__)
+
+ACTIVE_STREAM_CACHE_IDLE_TTL_SECONDS = 3600
+TERMINAL_STREAM_CACHE_TTL_SECONDS = 600
+
+
+class RuntimeStreamCache:
+    """In-memory cache for active executor stream snapshots."""
+
+    def __init__(
+        self,
+        *,
+        active_idle_ttl_seconds: int = ACTIVE_STREAM_CACHE_IDLE_TTL_SECONDS,
+        terminal_ttl_seconds: int = TERMINAL_STREAM_CACHE_TTL_SECONDS,
+    ) -> None:
+        self._active_idle_ttl_seconds = active_idle_ttl_seconds
+        self._terminal_ttl_seconds = terminal_ttl_seconds
+        self._entries: dict[int, RuntimeStreamAccumulator] = {}
+        self._lock = asyncio.Lock()
+
+    def capability(self) -> dict[str, Any]:
+        """Return the capability marker sent with callback events."""
+
+        capability = runtime_stream_cache_capability()
+        capability["active_idle_ttl_seconds"] = self._active_idle_ttl_seconds
+        capability["terminal_ttl_seconds"] = self._terminal_ttl_seconds
+        return capability
+
+    async def record_event(
+        self,
+        *,
+        event_type: str,
+        task_id: int,
+        subtask_id: int,
+        data: Optional[dict[str, Any]] = None,
+    ) -> None:
+        """Record one streaming event into the in-memory snapshot."""
+
+        async with self._lock:
+            now = time.time()
+            self._cleanup_expired_locked(now)
+            accumulator = self._entries.get(subtask_id)
+            if accumulator is None:
+                accumulator = RuntimeStreamAccumulator(
+                    task_id=task_id,
+                    subtask_id=subtask_id,
+                )
+                self._entries[subtask_id] = accumulator
+
+            accumulator.apply_event(event_type, data or {})
+
+    async def get_snapshot(self, subtask_id: int) -> Optional[dict[str, Any]]:
+        """Return a serialized snapshot for a subtask if still cached."""
+
+        async with self._lock:
+            self._cleanup_expired_locked(time.time())
+            accumulator = self._entries.get(subtask_id)
+            if accumulator is None:
+                return None
+            return accumulator.to_snapshot().to_dict()
+
+    async def cleanup(self, subtask_id: int) -> bool:
+        """Remove a cached subtask snapshot."""
+
+        async with self._lock:
+            return self._entries.pop(subtask_id, None) is not None
+
+    async def stats(self) -> dict[str, Any]:
+        """Return lightweight cache diagnostics."""
+
+        async with self._lock:
+            self._cleanup_expired_locked(time.time())
+            terminal_count = sum(
+                1
+                for accumulator in self._entries.values()
+                if accumulator.snapshot.terminal
+            )
+            return {
+                "entry_count": len(self._entries),
+                "terminal_entry_count": terminal_count,
+                "active_idle_ttl_seconds": self._active_idle_ttl_seconds,
+                "terminal_ttl_seconds": self._terminal_ttl_seconds,
+            }
+
+    def _cleanup_expired_locked(self, now: float) -> None:
+        expired_subtask_ids: list[int] = []
+        for subtask_id, accumulator in self._entries.items():
+            snapshot = accumulator.snapshot
+            ttl = (
+                self._terminal_ttl_seconds
+                if snapshot.terminal
+                else self._active_idle_ttl_seconds
+            )
+            if now - snapshot.last_activity_at > ttl:
+                expired_subtask_ids.append(subtask_id)
+
+        for subtask_id in expired_subtask_ids:
+            self._entries.pop(subtask_id, None)
+
+        if expired_subtask_ids:
+            logger.info(
+                "[RuntimeStreamCache] Evicted %d expired snapshots",
+                len(expired_subtask_ids),
+            )
+
+
+runtime_stream_cache = RuntimeStreamCache()
+
+
+def runtime_stream_cache_transport_kwargs() -> dict[str, Any]:
+    """Build common transport kwargs for executor runtime stream caching."""
+
+    return {
+        "runtime_cache": runtime_stream_cache,
+        "runtime_cache_capability": runtime_stream_cache.capability(),
+    }

--- a/executor/services/runtime_stream_cache.py
+++ b/executor/services/runtime_stream_cache.py
@@ -11,7 +11,7 @@ import logging
 import time
 from typing import Any, Optional
 
-from shared.models import RuntimeStreamAccumulator, runtime_stream_cache_capability
+from shared.models import RuntimeStreamAccumulator
 
 logger = logging.getLogger(__name__)
 
@@ -32,14 +32,6 @@ class RuntimeStreamCache:
         self._terminal_ttl_seconds = terminal_ttl_seconds
         self._entries: dict[int, RuntimeStreamAccumulator] = {}
         self._lock = asyncio.Lock()
-
-    def capability(self) -> dict[str, Any]:
-        """Return the capability marker sent with callback events."""
-
-        capability = runtime_stream_cache_capability()
-        capability["active_idle_ttl_seconds"] = self._active_idle_ttl_seconds
-        capability["terminal_ttl_seconds"] = self._terminal_ttl_seconds
-        return capability
 
     async def record_event(
         self,
@@ -127,5 +119,4 @@ def runtime_stream_cache_transport_kwargs() -> dict[str, Any]:
 
     return {
         "runtime_cache": runtime_stream_cache,
-        "runtime_cache_capability": runtime_stream_cache.capability(),
     }

--- a/executor/tasks/task_processor.py
+++ b/executor/tasks/task_processor.py
@@ -12,6 +12,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from executor.agents import Agent
 from executor.services.agent_service import AgentService
+from executor.services.runtime_stream_cache import (
+    runtime_stream_cache_transport_kwargs,
+)
 from shared.logger import setup_logger
 from shared.models import EmitterBuilder, ResponsesAPIEmitter, TransportFactory
 from shared.models.execution import ExecutionRequest
@@ -88,7 +91,10 @@ def _create_emitter(
         EmitterBuilder()
         .with_task(task_id, subtask_id)
         .with_transport(
-            TransportFactory.create_callback(callback_url=config.CALLBACK_URL)
+            TransportFactory.create_callback(
+                callback_url=config.CALLBACK_URL,
+                **runtime_stream_cache_transport_kwargs(),
+            )
         )
         .with_executor_info(
             name=os.getenv("EXECUTOR_NAME"),

--- a/executor/tests/test_runtime_stream_cache.py
+++ b/executor/tests/test_runtime_stream_cache.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from executor.services.runtime_stream_cache import RuntimeStreamCache
+from shared.models.responses_api import ResponsesAPIStreamEvents
+
+
+@pytest.mark.asyncio
+async def test_runtime_stream_cache_records_and_cleans_snapshot():
+    cache = RuntimeStreamCache()
+
+    await cache.record_event(
+        event_type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        task_id=101,
+        subtask_id=202,
+        data={"delta": "hello"},
+    )
+    await cache.record_event(
+        event_type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
+        task_id=101,
+        subtask_id=202,
+        data={},
+    )
+
+    snapshot = await cache.get_snapshot(202)
+    assert snapshot is not None
+    assert snapshot["content"] == "hello"
+    assert snapshot["terminal"] is True
+    assert snapshot["blocks"][0]["status"] == "done"
+
+    removed = await cache.cleanup(202)
+    assert removed is True
+    assert await cache.get_snapshot(202) is None

--- a/executor/tests/test_runtime_stream_cache.py
+++ b/executor/tests/test_runtime_stream_cache.py
@@ -29,7 +29,7 @@ async def test_runtime_stream_cache_records_and_cleans_snapshot():
     assert snapshot is not None
     assert snapshot["content"] == "hello"
     assert snapshot["terminal"] is True
-    assert snapshot["blocks"][0]["status"] == "done"
+    assert snapshot["blocks"] == []
 
     removed = await cache.cleanup(202)
     assert removed is True

--- a/packages/chat-core/src/workbench-message-reducer.test.ts
+++ b/packages/chat-core/src/workbench-message-reducer.test.ts
@@ -75,6 +75,65 @@ describe('reduceWorkbenchMessages', () => {
     ])
   })
 
+  test('finalizes thinking blocks when visible assistant content starts', () => {
+    const state = reduceWorkbenchMessages(
+      reduceWorkbenchMessages([], {
+        type: 'assistant_started',
+        taskId: 1,
+        subtaskId: 9,
+      }),
+      {
+        type: 'assistant_chunk',
+        subtaskId: 9,
+        content: '',
+        reasoningChunk: 'Drafting the answer',
+      }
+    )
+
+    const withContent = reduceWorkbenchMessages(state, {
+      type: 'assistant_chunk',
+      subtaskId: 9,
+      content: 'Final answer starts here.',
+    })
+
+    expect(withContent[0].content).toBe('Final answer starts here.')
+    expect(withContent[0].blocks).toMatchObject([
+      {
+        type: 'thinking',
+        content: 'Drafting the answer',
+        status: 'done',
+      },
+    ])
+  })
+
+  test('finalizes cached thinking blocks when cached content already exists', () => {
+    const state = reduceWorkbenchMessages([], {
+      type: 'assistant_cached',
+      taskId: 1,
+      subtaskId: 9,
+      content: 'Cached visible answer.',
+      blocks: [
+        {
+          id: 'thinking-9-1',
+          subtaskId: 9,
+          type: 'thinking',
+          content: 'Drafting the answer',
+          status: 'streaming',
+          createdAt: 1770000000000,
+        },
+      ],
+    })
+
+    expect(state[0].content).toBe('Cached visible answer.')
+    expect(state[0].blocks).toMatchObject([
+      {
+        type: 'thinking',
+        content: 'Drafting the answer',
+        status: 'done',
+      },
+    ])
+  })
+
   test('moves streamed content into a text block before a tool block', () => {
     const state = reduceWorkbenchMessages(
       reduceWorkbenchMessages([], {
@@ -158,6 +217,34 @@ describe('reduceWorkbenchMessages', () => {
       { id: 'call_1', type: 'tool', status: 'done' },
       { id: 'text-real', type: 'text', status: 'done' },
     ])
+  })
+
+  test('preserves current processing blocks when done does not include blocks', () => {
+    const state = reduceWorkbenchMessages(
+      reduceWorkbenchMessages([], {
+        type: 'assistant_started',
+        taskId: 1,
+        subtaskId: 9,
+      }),
+      {
+        type: 'assistant_chunk',
+        subtaskId: 9,
+        content: '',
+        reasoningChunk: 'Drafting',
+      }
+    )
+
+    const done = reduceWorkbenchMessages(state, {
+      type: 'assistant_done',
+      subtaskId: 9,
+      content: 'Final',
+    })
+
+    expect(done[0]).toMatchObject({
+      content: 'Final',
+      status: 'done',
+      blocks: [{ type: 'thinking', content: 'Drafting', status: 'done' }],
+    })
   })
 
   test('clears stale stream error when an active block update arrives after disconnect', () => {

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -139,7 +139,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
                 taskId: action.taskId ?? message.taskId,
                 content: action.content,
                 status: 'streaming' as const,
-                blocks: action.blocks ?? message.blocks,
+                blocks: getCachedBlocks(action.blocks ?? message.blocks, action.content),
               }
             : message
         )
@@ -153,7 +153,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
           role: 'assistant',
           content: action.content,
           status: 'streaming',
-          blocks: action.blocks ?? [],
+          blocks: getCachedBlocks(action.blocks, action.content) ?? [],
           createdAt: new Date().toISOString(),
         },
       ]
@@ -251,6 +251,13 @@ function isActiveBlockStatus(status?: WorkbenchToolBlockStatus): boolean {
   )
 }
 
+function getCachedBlocks(
+  blocks: WorkbenchProcessingBlock[] | undefined,
+  content: string
+): WorkbenchProcessingBlock[] | undefined {
+  return content ? finalizeStreamingThinkingBlocks(blocks) : blocks
+}
+
 function createBlockCreatedMessage<TAttachment, TFileChanges>(
   message: WorkbenchMessage<TAttachment, TFileChanges>,
   action: Extract<WorkbenchMessageAction<TAttachment, TFileChanges>, { type: 'block_created' }>
@@ -304,8 +311,11 @@ function getChunkBlocks<TAttachment, TFileChanges>(
     action.reasoningChunk
   )
 
-  if (!action.blocks) return withReasoning
-  return action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
+  const withIncomingBlocks = action.blocks
+    ? action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
+    : withReasoning
+
+  return action.content ? finalizeStreamingThinkingBlocks(withIncomingBlocks) : withIncomingBlocks
 }
 
 function appendThinkingChunk(
@@ -337,6 +347,18 @@ function appendThinkingChunk(
       createdAt: Date.now(),
     },
   ]
+}
+
+function finalizeStreamingThinkingBlocks(
+  blocks: WorkbenchProcessingBlock[] | undefined
+): WorkbenchProcessingBlock[] | undefined {
+  if (!blocks) return undefined
+
+  return blocks.map(block =>
+    block.type === 'thinking' && block.status === 'streaming'
+      ? { ...block, status: 'done' as const }
+      : block
+  )
 }
 
 function getBlocksBeforeIncomingBlock<TAttachment, TFileChanges>(

--- a/shared/models/__init__.py
+++ b/shared/models/__init__.py
@@ -104,6 +104,13 @@ from .runtime_config import (
     RuntimeRetrievalConfig,
     RuntimeRetrieverConfig,
 )
+from .runtime_stream_cache import (
+    RUNTIME_STREAM_CACHE_SOURCE,
+    RUNTIME_STREAM_CACHE_VERSION,
+    RuntimeStreamAccumulator,
+    RuntimeStreamSnapshot,
+    runtime_stream_cache_capability,
+)
 from .search_hints import (
     MAX_SEARCH_HINT_KEYWORDS,
     MAX_SEARCH_HINT_PHRASES,
@@ -183,6 +190,12 @@ __all__ = [
     "RedisTransport",
     "ThrottleConfig",
     "ThrottledTransport",
+    # Runtime stream cache
+    "RUNTIME_STREAM_CACHE_SOURCE",
+    "RUNTIME_STREAM_CACHE_VERSION",
+    "RuntimeStreamAccumulator",
+    "RuntimeStreamSnapshot",
+    "runtime_stream_cache_capability",
     # OpenAI Request Converter
     "OpenAIRequestConverter",
     "OpenAIEventConverter",

--- a/shared/models/__init__.py
+++ b/shared/models/__init__.py
@@ -106,7 +106,6 @@ from .runtime_config import (
 )
 from .runtime_stream_cache import (
     RUNTIME_STREAM_CACHE_SOURCE,
-    RUNTIME_STREAM_CACHE_VERSION,
     RuntimeStreamAccumulator,
     RuntimeStreamSnapshot,
     runtime_stream_cache_capability,
@@ -192,7 +191,6 @@ __all__ = [
     "ThrottledTransport",
     # Runtime stream cache
     "RUNTIME_STREAM_CACHE_SOURCE",
-    "RUNTIME_STREAM_CACHE_VERSION",
     "RuntimeStreamAccumulator",
     "RuntimeStreamSnapshot",
     "runtime_stream_cache_capability",

--- a/shared/models/responses_api_emitter.py
+++ b/shared/models/responses_api_emitter.py
@@ -674,18 +674,15 @@ class CallbackTransport(EventTransport):
         self,
         client: Any,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ):
         """Initialize callback transport.
 
         Args:
             client: Callback client with send_event_dict method
             runtime_cache: Optional executor runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
         """
         self.client = client
         self.runtime_cache = runtime_cache
-        self.runtime_cache_capability = runtime_cache_capability
 
     async def _record_runtime_cache(
         self,
@@ -747,8 +744,6 @@ class CallbackTransport(EventTransport):
             event["executor_name"] = executor_name
         if executor_namespace is not None:
             event["executor_namespace"] = executor_namespace
-        if self.runtime_cache_capability:
-            event["runtime_cache"] = self.runtime_cache_capability
 
         import asyncio
 
@@ -767,7 +762,6 @@ class WebSocketTransport(EventTransport):
         client: Any,
         event_mapping: Optional[dict] = None,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ):
         """Initialize WebSocket transport.
 
@@ -775,12 +769,10 @@ class WebSocketTransport(EventTransport):
             client: WebSocket client with emit method
             event_mapping: Optional mapping from event_type to socket event name
             runtime_cache: Optional executor runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
         """
         self.client = client
         self.event_mapping = event_mapping or {}
         self.runtime_cache = runtime_cache
-        self.runtime_cache_capability = runtime_cache_capability
 
     async def _record_runtime_cache(
         self,
@@ -842,8 +834,6 @@ class WebSocketTransport(EventTransport):
             payload["executor_name"] = executor_name
         if executor_namespace is not None:
             payload["executor_namespace"] = executor_namespace
-        if self.runtime_cache_capability:
-            payload["runtime_cache"] = self.runtime_cache_capability
 
         # Map event_type to socket event name
         # If no mapping provided, use the original event_type as socket event name

--- a/shared/models/responses_api_emitter.py
+++ b/shared/models/responses_api_emitter.py
@@ -670,13 +670,54 @@ class EventTransport(ABC):
 class CallbackTransport(EventTransport):
     """HTTP callback transport for executor -> executor_manager -> backend."""
 
-    def __init__(self, client: Any):
+    def __init__(
+        self,
+        client: Any,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
+    ):
         """Initialize callback transport.
 
         Args:
             client: Callback client with send_event_dict method
+            runtime_cache: Optional executor runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
         """
         self.client = client
+        self.runtime_cache = runtime_cache
+        self.runtime_cache_capability = runtime_cache_capability
+
+    async def _record_runtime_cache(
+        self,
+        event_type: str,
+        task_id: int,
+        subtask_id: int,
+        data: dict,
+    ) -> None:
+        """Best-effort write to the executor-local runtime cache."""
+
+        if self.runtime_cache is None:
+            return
+
+        record_event = getattr(self.runtime_cache, "record_event", None)
+        if not callable(record_event):
+            return
+
+        try:
+            result = record_event(
+                event_type=event_type,
+                task_id=task_id,
+                subtask_id=subtask_id,
+                data=data,
+            )
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            logger.warning(
+                "[CallbackTransport] Failed to record runtime stream cache: %s",
+                exc,
+                exc_info=True,
+            )
 
     async def send(
         self,
@@ -693,6 +734,7 @@ class CallbackTransport(EventTransport):
         Returns:
             Callback response dict
         """
+        await self._record_runtime_cache(event_type, task_id, subtask_id, data)
         event = {
             "event_type": event_type,
             "task_id": task_id,
@@ -705,6 +747,8 @@ class CallbackTransport(EventTransport):
             event["executor_name"] = executor_name
         if executor_namespace is not None:
             event["executor_namespace"] = executor_namespace
+        if self.runtime_cache_capability:
+            event["runtime_cache"] = self.runtime_cache_capability
 
         import asyncio
 
@@ -718,15 +762,57 @@ class CallbackTransport(EventTransport):
 class WebSocketTransport(EventTransport):
     """WebSocket transport for executor local mode."""
 
-    def __init__(self, client: Any, event_mapping: Optional[dict] = None):
+    def __init__(
+        self,
+        client: Any,
+        event_mapping: Optional[dict] = None,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
+    ):
         """Initialize WebSocket transport.
 
         Args:
             client: WebSocket client with emit method
             event_mapping: Optional mapping from event_type to socket event name
+            runtime_cache: Optional executor runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
         """
         self.client = client
         self.event_mapping = event_mapping or {}
+        self.runtime_cache = runtime_cache
+        self.runtime_cache_capability = runtime_cache_capability
+
+    async def _record_runtime_cache(
+        self,
+        event_type: str,
+        task_id: int,
+        subtask_id: int,
+        data: dict,
+    ) -> None:
+        """Best-effort write to the executor-local runtime cache."""
+
+        if self.runtime_cache is None:
+            return
+
+        record_event = getattr(self.runtime_cache, "record_event", None)
+        if not callable(record_event):
+            return
+
+        try:
+            result = record_event(
+                event_type=event_type,
+                task_id=task_id,
+                subtask_id=subtask_id,
+                data=data,
+            )
+            if inspect.isawaitable(result):
+                await result
+        except Exception as exc:
+            logger.warning(
+                "[WebSocketTransport] Failed to record runtime stream cache: %s",
+                exc,
+                exc_info=True,
+            )
 
     async def send(
         self,
@@ -743,6 +829,7 @@ class WebSocketTransport(EventTransport):
         Returns:
             None
         """
+        await self._record_runtime_cache(event_type, task_id, subtask_id, data)
         payload = {
             "event_type": event_type,
             "task_id": task_id,
@@ -751,6 +838,12 @@ class WebSocketTransport(EventTransport):
         }
         if message_id is not None:
             payload["message_id"] = message_id
+        if executor_name is not None:
+            payload["executor_name"] = executor_name
+        if executor_namespace is not None:
+            payload["executor_namespace"] = executor_namespace
+        if self.runtime_cache_capability:
+            payload["runtime_cache"] = self.runtime_cache_capability
 
         # Map event_type to socket event name
         # If no mapping provided, use the original event_type as socket event name

--- a/shared/models/responses_api_factory.py
+++ b/shared/models/responses_api_factory.py
@@ -161,13 +161,18 @@ class TransportFactory:
 
     @staticmethod
     def create_callback(
-        callback_url: Optional[str] = None, client: Optional["CallbackClient"] = None
+        callback_url: Optional[str] = None,
+        client: Optional["CallbackClient"] = None,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> CallbackTransport:
         """Create HTTP Callback Transport.
 
         Args:
             callback_url: URL for the callback endpoint (required if client is None)
             client: HTTP callback client. If None, creates CallbackClient with callback_url.
+            runtime_cache: Optional executor-local runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             CallbackTransport instance
@@ -181,22 +186,36 @@ class TransportFactory:
             from shared.utils.callback_client import CallbackClient
 
             client = CallbackClient(callback_url=callback_url)
-        return CallbackTransport(client)
+        return CallbackTransport(
+            client,
+            runtime_cache=runtime_cache,
+            runtime_cache_capability=runtime_cache_capability,
+        )
 
     @staticmethod
     def create_websocket(
-        client: Any, event_mapping: Optional[dict] = None
+        client: Any,
+        event_mapping: Optional[dict] = None,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> WebSocketTransport:
         """Create WebSocket Transport.
 
         Args:
             client: WebSocket client (required)
             event_mapping: Event type to socket event name mapping
+            runtime_cache: Optional executor-local runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             WebSocketTransport instance
         """
-        return WebSocketTransport(client, event_mapping)
+        return WebSocketTransport(
+            client,
+            event_mapping,
+            runtime_cache=runtime_cache,
+            runtime_cache_capability=runtime_cache_capability,
+        )
 
     @staticmethod
     def create_generator(
@@ -234,6 +253,8 @@ class TransportFactory:
         callback_url: Optional[str] = None,
         client: Optional["CallbackClient"] = None,
         config: Optional[ThrottleConfig] = None,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> ThrottledTransport:
         """Create HTTP Callback Transport with throttling.
 
@@ -241,6 +262,8 @@ class TransportFactory:
             callback_url: URL for the callback endpoint (required if client is None)
             client: HTTP callback client. If None, creates CallbackClient with callback_url.
             config: Throttle configuration
+            runtime_cache: Optional executor-local runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             ThrottledTransport wrapping CallbackTransport
@@ -249,7 +272,10 @@ class TransportFactory:
             ValueError: If neither callback_url nor client is provided
         """
         base = TransportFactory.create_callback(
-            callback_url=callback_url, client=client
+            callback_url=callback_url,
+            client=client,
+            runtime_cache=runtime_cache,
+            runtime_cache_capability=runtime_cache_capability,
         )
         return ThrottledTransport(base, config)
 
@@ -258,6 +284,8 @@ class TransportFactory:
         client: Any,
         event_mapping: Optional[dict] = None,
         config: Optional[ThrottleConfig] = None,
+        runtime_cache: Optional[Any] = None,
+        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> ThrottledTransport:
         """Create WebSocket Transport with throttling.
 
@@ -265,11 +293,18 @@ class TransportFactory:
             client: WebSocket client (required)
             event_mapping: Event type to socket event name mapping
             config: Throttle configuration
+            runtime_cache: Optional executor-local runtime cache service.
+            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             ThrottledTransport wrapping WebSocketTransport
         """
-        base = TransportFactory.create_websocket(client, event_mapping)
+        base = TransportFactory.create_websocket(
+            client,
+            event_mapping,
+            runtime_cache=runtime_cache,
+            runtime_cache_capability=runtime_cache_capability,
+        )
         return ThrottledTransport(base, config)
 
     @staticmethod

--- a/shared/models/responses_api_factory.py
+++ b/shared/models/responses_api_factory.py
@@ -164,7 +164,6 @@ class TransportFactory:
         callback_url: Optional[str] = None,
         client: Optional["CallbackClient"] = None,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> CallbackTransport:
         """Create HTTP Callback Transport.
 
@@ -172,7 +171,6 @@ class TransportFactory:
             callback_url: URL for the callback endpoint (required if client is None)
             client: HTTP callback client. If None, creates CallbackClient with callback_url.
             runtime_cache: Optional executor-local runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             CallbackTransport instance
@@ -189,7 +187,6 @@ class TransportFactory:
         return CallbackTransport(
             client,
             runtime_cache=runtime_cache,
-            runtime_cache_capability=runtime_cache_capability,
         )
 
     @staticmethod
@@ -197,7 +194,6 @@ class TransportFactory:
         client: Any,
         event_mapping: Optional[dict] = None,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> WebSocketTransport:
         """Create WebSocket Transport.
 
@@ -205,7 +201,6 @@ class TransportFactory:
             client: WebSocket client (required)
             event_mapping: Event type to socket event name mapping
             runtime_cache: Optional executor-local runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             WebSocketTransport instance
@@ -214,7 +209,6 @@ class TransportFactory:
             client,
             event_mapping,
             runtime_cache=runtime_cache,
-            runtime_cache_capability=runtime_cache_capability,
         )
 
     @staticmethod
@@ -254,7 +248,6 @@ class TransportFactory:
         client: Optional["CallbackClient"] = None,
         config: Optional[ThrottleConfig] = None,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> ThrottledTransport:
         """Create HTTP Callback Transport with throttling.
 
@@ -263,7 +256,6 @@ class TransportFactory:
             client: HTTP callback client. If None, creates CallbackClient with callback_url.
             config: Throttle configuration
             runtime_cache: Optional executor-local runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             ThrottledTransport wrapping CallbackTransport
@@ -275,7 +267,6 @@ class TransportFactory:
             callback_url=callback_url,
             client=client,
             runtime_cache=runtime_cache,
-            runtime_cache_capability=runtime_cache_capability,
         )
         return ThrottledTransport(base, config)
 
@@ -285,7 +276,6 @@ class TransportFactory:
         event_mapping: Optional[dict] = None,
         config: Optional[ThrottleConfig] = None,
         runtime_cache: Optional[Any] = None,
-        runtime_cache_capability: Optional[dict[str, Any]] = None,
     ) -> ThrottledTransport:
         """Create WebSocket Transport with throttling.
 
@@ -294,7 +284,6 @@ class TransportFactory:
             event_mapping: Event type to socket event name mapping
             config: Throttle configuration
             runtime_cache: Optional executor-local runtime cache service.
-            runtime_cache_capability: Optional capability marker sent to backend.
 
         Returns:
             ThrottledTransport wrapping WebSocketTransport
@@ -303,7 +292,6 @@ class TransportFactory:
             client,
             event_mapping,
             runtime_cache=runtime_cache,
-            runtime_cache_capability=runtime_cache_capability,
         )
         return ThrottledTransport(base, config)
 

--- a/shared/models/runtime_stream_cache.py
+++ b/shared/models/runtime_stream_cache.py
@@ -15,18 +15,13 @@ from typing import Any, Optional
 from .blocks import BlockStatus, create_tool_block
 from .responses_api import ResponsesAPIStreamEvents
 
-RUNTIME_STREAM_CACHE_VERSION = 1
 RUNTIME_STREAM_CACHE_SOURCE = "executor"
 
 
 def runtime_stream_cache_capability() -> dict[str, Any]:
-    """Return the runtime cache capability marker sent with executor events."""
+    """Return the runtime cache capability marker."""
 
-    return {
-        "enabled": True,
-        "version": RUNTIME_STREAM_CACHE_VERSION,
-        "source": RUNTIME_STREAM_CACHE_SOURCE,
-    }
+    return {"enabled": True}
 
 
 @dataclass
@@ -43,7 +38,6 @@ class RuntimeStreamSnapshot:
     last_activity_at: float = field(default_factory=time.time)
     terminal: bool = False
     source: str = RUNTIME_STREAM_CACHE_SOURCE
-    version: int = RUNTIME_STREAM_CACHE_VERSION
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the snapshot to a JSON-serializable dictionary."""
@@ -58,7 +52,6 @@ class RuntimeStreamSnapshot:
             "last_activity_at": self.last_activity_at,
             "terminal": self.terminal,
             "source": self.source,
-            "version": self.version,
         }
         if self.context_metrics is not None:
             payload["context_metrics"] = dict(self.context_metrics)
@@ -164,7 +157,6 @@ class RuntimeStreamAccumulator:
             last_activity_at=source.last_activity_at,
             terminal=source.terminal,
             source=source.source,
-            version=source.version,
         )
 
     def _append_text(self, content: str) -> None:

--- a/shared/models/runtime_stream_cache.py
+++ b/shared/models/runtime_stream_cache.py
@@ -12,7 +12,7 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-from .blocks import BlockStatus, create_text_block, create_tool_block
+from .blocks import BlockStatus, create_tool_block
 from .responses_api import ResponsesAPIStreamEvents
 
 RUNTIME_STREAM_CACHE_VERSION = 1
@@ -70,7 +70,6 @@ class RuntimeStreamAccumulator:
 
     def __init__(self, task_id: int, subtask_id: int) -> None:
         self.snapshot = RuntimeStreamSnapshot(task_id=task_id, subtask_id=subtask_id)
-        self._current_text_block_id: Optional[str] = None
         self._current_thinking_block_id: Optional[str] = None
         self._tool_contexts: dict[str, dict[str, Any]] = {}
 
@@ -142,7 +141,6 @@ class RuntimeStreamAccumulator:
     def mark_terminal(self) -> None:
         """Mark the snapshot terminal and finalize open text-like blocks."""
 
-        self._finalize_current_text_block()
         self._finalize_current_thinking_block()
         self.snapshot.terminal = True
         self.snapshot.last_activity_at = time.time()
@@ -173,10 +171,6 @@ class RuntimeStreamAccumulator:
         if not content:
             return
 
-        self._finalize_current_thinking_block()
-        block = self._ensure_current_text_block()
-        block["content"] = str(block.get("content", "")) + content
-        block["status"] = BlockStatus.STREAMING.value
         self.snapshot.content += content
         self.snapshot.offset = len(self.snapshot.content)
 
@@ -184,22 +178,9 @@ class RuntimeStreamAccumulator:
         if not content:
             return
 
-        self._finalize_current_text_block()
         block = self._ensure_current_thinking_block()
         block["content"] = str(block.get("content", "")) + content
         block["status"] = BlockStatus.STREAMING.value
-
-    def _ensure_current_text_block(self) -> dict[str, Any]:
-        if self._current_text_block_id:
-            block = self._find_block(self._current_text_block_id)
-            if block is not None:
-                return block
-
-        block_id = f"text-{uuid.uuid4().hex[:12]}"
-        block = create_text_block(content="", block_id=block_id)
-        self.snapshot.blocks.append(block)
-        self._current_text_block_id = block_id
-        return block
 
     def _ensure_current_thinking_block(self) -> dict[str, Any]:
         if self._current_thinking_block_id:
@@ -218,14 +199,6 @@ class RuntimeStreamAccumulator:
         self.snapshot.blocks.append(block)
         self._current_thinking_block_id = block_id
         return block
-
-    def _finalize_current_text_block(self) -> None:
-        if not self._current_text_block_id:
-            return
-        block = self._find_block(self._current_text_block_id)
-        if block is not None:
-            block["status"] = BlockStatus.DONE.value
-        self._current_text_block_id = None
 
     def _finalize_current_thinking_block(self) -> None:
         if not self._current_thinking_block_id:
@@ -412,7 +385,6 @@ class RuntimeStreamAccumulator:
         if not isinstance(block, dict):
             return
 
-        self._finalize_current_text_block()
         self._finalize_current_thinking_block()
         block_to_store = dict(block)
         block_to_store.setdefault("id", f"block-{uuid.uuid4().hex[:12]}")
@@ -456,7 +428,6 @@ class RuntimeStreamAccumulator:
         if not tool_use_id:
             return
 
-        self._finalize_current_text_block()
         self._finalize_current_thinking_block()
         block = create_tool_block(
             tool_use_id=tool_use_id,

--- a/shared/models/runtime_stream_cache.py
+++ b/shared/models/runtime_stream_cache.py
@@ -1,0 +1,565 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory streaming snapshot helpers for executor runtime caches."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .blocks import BlockStatus, create_text_block, create_tool_block
+from .responses_api import ResponsesAPIStreamEvents
+
+RUNTIME_STREAM_CACHE_VERSION = 1
+RUNTIME_STREAM_CACHE_SOURCE = "executor"
+
+
+def runtime_stream_cache_capability() -> dict[str, Any]:
+    """Return the runtime cache capability marker sent with executor events."""
+
+    return {
+        "enabled": True,
+        "version": RUNTIME_STREAM_CACHE_VERSION,
+        "source": RUNTIME_STREAM_CACHE_SOURCE,
+    }
+
+
+@dataclass
+class RuntimeStreamSnapshot:
+    """Serializable in-memory stream snapshot."""
+
+    task_id: int
+    subtask_id: int
+    content: str = ""
+    blocks: list[dict[str, Any]] = field(default_factory=list)
+    context_metrics: Optional[dict[str, Any]] = None
+    offset: int = 0
+    started_at: float = field(default_factory=time.time)
+    last_activity_at: float = field(default_factory=time.time)
+    terminal: bool = False
+    source: str = RUNTIME_STREAM_CACHE_SOURCE
+    version: int = RUNTIME_STREAM_CACHE_VERSION
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the snapshot to a JSON-serializable dictionary."""
+
+        payload = {
+            "task_id": self.task_id,
+            "subtask_id": self.subtask_id,
+            "content": self.content,
+            "blocks": [dict(block) for block in self.blocks],
+            "offset": self.offset,
+            "started_at": self.started_at,
+            "last_activity_at": self.last_activity_at,
+            "terminal": self.terminal,
+            "source": self.source,
+            "version": self.version,
+        }
+        if self.context_metrics is not None:
+            payload["context_metrics"] = dict(self.context_metrics)
+        return payload
+
+
+class RuntimeStreamAccumulator:
+    """Accumulate Responses API stream events into a refreshable snapshot."""
+
+    def __init__(self, task_id: int, subtask_id: int) -> None:
+        self.snapshot = RuntimeStreamSnapshot(task_id=task_id, subtask_id=subtask_id)
+        self._current_text_block_id: Optional[str] = None
+        self._current_thinking_block_id: Optional[str] = None
+        self._tool_contexts: dict[str, dict[str, Any]] = {}
+
+    def apply_event(self, event_type: str, data: Optional[dict[str, Any]]) -> None:
+        """Apply one Responses API event payload to the snapshot."""
+
+        payload = data or {}
+        self.snapshot.last_activity_at = time.time()
+
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value:
+            self._append_text(payload.get("delta", ""))
+            return
+
+        if event_type in (
+            ResponsesAPIStreamEvents.RESPONSE_PART_ADDED.value,
+            ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value,
+        ):
+            reasoning_content = self._extract_reasoning_content(event_type, payload)
+            if reasoning_content:
+                self._append_thinking(reasoning_content)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value:
+            self._handle_output_item_added(payload)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DELTA.value:
+            self._handle_function_arguments_delta(payload)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.FUNCTION_CALL_ARGUMENTS_DONE.value:
+            self._handle_function_arguments_done(payload)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.MCP_CALL_ARGUMENTS_DONE.value:
+            self._handle_mcp_arguments_done(payload)
+            return
+
+        if event_type in (
+            ResponsesAPIStreamEvents.MCP_CALL_COMPLETED.value,
+            ResponsesAPIStreamEvents.MCP_CALL_FAILED.value,
+        ):
+            self._handle_mcp_call_done(event_type, payload)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value:
+            self._handle_output_item_done(payload)
+            return
+
+        if event_type == ResponsesAPIStreamEvents.BLOCK_CREATED.value:
+            self._add_custom_block(payload.get("block"))
+            return
+
+        if event_type == ResponsesAPIStreamEvents.BLOCK_UPDATED.value:
+            self._update_custom_block(payload.get("block_id"), payload.get("updates"))
+            return
+
+        if event_type == ResponsesAPIStreamEvents.STATUS_UPDATED.value:
+            self._update_context_metrics(payload)
+            return
+
+        if event_type in (
+            ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value,
+            ResponsesAPIStreamEvents.RESPONSE_INCOMPLETE.value,
+            ResponsesAPIStreamEvents.ERROR.value,
+        ):
+            self.mark_terminal()
+
+    def mark_terminal(self) -> None:
+        """Mark the snapshot terminal and finalize open text-like blocks."""
+
+        self._finalize_current_text_block()
+        self._finalize_current_thinking_block()
+        self.snapshot.terminal = True
+        self.snapshot.last_activity_at = time.time()
+
+    def to_snapshot(self) -> RuntimeStreamSnapshot:
+        """Return a copy-like serializable snapshot object."""
+
+        source = self.snapshot
+        return RuntimeStreamSnapshot(
+            task_id=source.task_id,
+            subtask_id=source.subtask_id,
+            content=source.content,
+            blocks=[dict(block) for block in source.blocks],
+            context_metrics=(
+                dict(source.context_metrics)
+                if isinstance(source.context_metrics, dict)
+                else None
+            ),
+            offset=source.offset,
+            started_at=source.started_at,
+            last_activity_at=source.last_activity_at,
+            terminal=source.terminal,
+            source=source.source,
+            version=source.version,
+        )
+
+    def _append_text(self, content: str) -> None:
+        if not content:
+            return
+
+        self._finalize_current_thinking_block()
+        block = self._ensure_current_text_block()
+        block["content"] = str(block.get("content", "")) + content
+        block["status"] = BlockStatus.STREAMING.value
+        self.snapshot.content += content
+        self.snapshot.offset = len(self.snapshot.content)
+
+    def _append_thinking(self, content: str) -> None:
+        if not content:
+            return
+
+        self._finalize_current_text_block()
+        block = self._ensure_current_thinking_block()
+        block["content"] = str(block.get("content", "")) + content
+        block["status"] = BlockStatus.STREAMING.value
+
+    def _ensure_current_text_block(self) -> dict[str, Any]:
+        if self._current_text_block_id:
+            block = self._find_block(self._current_text_block_id)
+            if block is not None:
+                return block
+
+        block_id = f"text-{uuid.uuid4().hex[:12]}"
+        block = create_text_block(content="", block_id=block_id)
+        self.snapshot.blocks.append(block)
+        self._current_text_block_id = block_id
+        return block
+
+    def _ensure_current_thinking_block(self) -> dict[str, Any]:
+        if self._current_thinking_block_id:
+            block = self._find_block(self._current_thinking_block_id)
+            if block is not None:
+                return block
+
+        block_id = f"thinking-{uuid.uuid4().hex[:12]}"
+        block = {
+            "id": block_id,
+            "type": "thinking",
+            "content": "",
+            "status": BlockStatus.STREAMING.value,
+            "timestamp": int(time.time() * 1000),
+        }
+        self.snapshot.blocks.append(block)
+        self._current_thinking_block_id = block_id
+        return block
+
+    def _finalize_current_text_block(self) -> None:
+        if not self._current_text_block_id:
+            return
+        block = self._find_block(self._current_text_block_id)
+        if block is not None:
+            block["status"] = BlockStatus.DONE.value
+        self._current_text_block_id = None
+
+    def _finalize_current_thinking_block(self) -> None:
+        if not self._current_thinking_block_id:
+            return
+        block = self._find_block(self._current_thinking_block_id)
+        if block is not None:
+            block["status"] = BlockStatus.DONE.value
+        self._current_thinking_block_id = None
+
+    def _handle_output_item_added(self, data: dict[str, Any]) -> None:
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return
+
+        item_type = item.get("type")
+        if item_type == "function_call":
+            tool_use_id = str(item.get("call_id") or item.get("id") or "")
+            tool_name = str(item.get("name") or "")
+            tool_input = self._resolve_tool_input(
+                data.get("arguments_summary"), item.get("arguments")
+            )
+            self._tool_contexts[tool_use_id] = {
+                "protocol": "function_call",
+                "name": tool_name,
+                "arguments": tool_input,
+            }
+            status = (
+                "generating_arguments"
+                if data.get("argument_status") == "streaming"
+                else BlockStatus.PENDING.value
+            )
+            self._upsert_tool_block(
+                tool_use_id=tool_use_id,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                display_name=data.get("display_name"),
+                tool_protocol="function_call",
+                status=status,
+            )
+            return
+
+        if item_type == "mcp_call":
+            tool_use_id = str(item.get("id") or "")
+            tool_name = str(item.get("name") or "")
+            server_label = item.get("server_label")
+            self._tool_contexts[tool_use_id] = {
+                "protocol": "mcp_call",
+                "name": tool_name,
+                "server_label": server_label,
+            }
+            self._upsert_tool_block(
+                tool_use_id=tool_use_id,
+                tool_name=tool_name,
+                tool_protocol="mcp_call",
+                server_label=server_label,
+            )
+            return
+
+        if item_type == "shell_call":
+            tool_use_id = str(item.get("call_id") or item.get("id") or "")
+            tool_name = str(item.get("name") or item.get("command") or "shell")
+            tool_input = self._extract_shell_call_input(item)
+            self._tool_contexts[tool_use_id] = {
+                "protocol": "shell_call",
+                "name": tool_name,
+                "arguments": tool_input,
+            }
+            self._upsert_tool_block(
+                tool_use_id=tool_use_id,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                display_name=data.get("display_name"),
+                tool_protocol="shell_call",
+            )
+
+    def _handle_function_arguments_delta(self, data: dict[str, Any]) -> None:
+        tool_use_id = str(data.get("call_id") or data.get("item_id") or "")
+        if not tool_use_id:
+            return
+
+        tool_context = self._tool_contexts.setdefault(
+            tool_use_id,
+            {"protocol": "function_call", "name": ""},
+        )
+        tool_input = data.get("arguments_summary")
+        if isinstance(tool_input, dict):
+            tool_context["arguments"] = tool_input
+        else:
+            tool_input = tool_context.get("arguments")
+        self._update_tool_block(
+            tool_use_id,
+            status="generating_arguments",
+            tool_input=tool_input if isinstance(tool_input, dict) else None,
+        )
+
+    def _handle_function_arguments_done(self, data: dict[str, Any]) -> None:
+        tool_use_id = str(data.get("call_id") or data.get("item_id") or "")
+        if not tool_use_id:
+            return
+
+        tool_context = self._tool_contexts.setdefault(
+            tool_use_id,
+            {"protocol": "function_call", "name": ""},
+        )
+        tool_input = self._resolve_tool_input(
+            data.get("arguments_summary"), data.get("arguments")
+        )
+        if tool_input:
+            tool_context["arguments"] = tool_input
+        else:
+            tool_input = tool_context.get("arguments")
+        self._update_tool_block(
+            tool_use_id,
+            status=BlockStatus.PENDING.value,
+            tool_input=tool_input if isinstance(tool_input, dict) else None,
+        )
+
+    def _handle_mcp_arguments_done(self, data: dict[str, Any]) -> None:
+        tool_use_id = str(data.get("item_id") or "")
+        if not tool_use_id:
+            return
+        tool_input = self._parse_json_object(data.get("arguments"))
+        context = self._tool_contexts.setdefault(
+            tool_use_id,
+            {"protocol": "mcp_call", "name": ""},
+        )
+        context["arguments"] = tool_input
+        self._update_tool_block(tool_use_id, tool_input=tool_input)
+
+    def _handle_mcp_call_done(self, event_type: str, data: dict[str, Any]) -> None:
+        tool_use_id = str(data.get("item_id") or "")
+        if not tool_use_id:
+            return
+
+        context = self._tool_contexts.pop(tool_use_id, {})
+        failed = event_type == ResponsesAPIStreamEvents.MCP_CALL_FAILED.value
+        self._update_tool_block(
+            tool_use_id,
+            status=BlockStatus.ERROR.value if failed else BlockStatus.DONE.value,
+            tool_input=context.get("arguments"),
+            tool_output=data.get("failure_reason") if failed else data.get("output"),
+            tool_protocol="mcp_call",
+            server_label=context.get("server_label"),
+        )
+
+    def _handle_output_item_done(self, data: dict[str, Any]) -> None:
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return
+
+        item_type = item.get("type")
+        if item_type == "function_call":
+            tool_use_id = str(item.get("call_id") or item.get("id") or "")
+            context = self._tool_contexts.pop(tool_use_id, {})
+            tool_input = context.get("arguments")
+            if not isinstance(tool_input, dict):
+                tool_input = self._parse_json_object(item.get("arguments"))
+            failed = item.get("status") == "failed"
+            self._update_tool_block(
+                tool_use_id,
+                status=BlockStatus.ERROR.value if failed else BlockStatus.DONE.value,
+                tool_input=tool_input,
+                tool_output=item.get("output"),
+                tool_protocol="function_call",
+            )
+            return
+
+        if item_type == "shell_call":
+            tool_use_id = str(item.get("call_id") or item.get("id") or "")
+            context = self._tool_contexts.pop(tool_use_id, {})
+            tool_input = self._extract_shell_call_input(item) or context.get(
+                "arguments"
+            )
+            failed = item.get("status") == "failed"
+            self._update_tool_block(
+                tool_use_id,
+                status=BlockStatus.ERROR.value if failed else BlockStatus.DONE.value,
+                tool_input=tool_input,
+                tool_output=item.get("output"),
+                tool_protocol="shell_call",
+            )
+
+    def _add_custom_block(self, block: Any) -> None:
+        if not isinstance(block, dict):
+            return
+
+        self._finalize_current_text_block()
+        self._finalize_current_thinking_block()
+        block_to_store = dict(block)
+        block_to_store.setdefault("id", f"block-{uuid.uuid4().hex[:12]}")
+        block_to_store.setdefault("timestamp", int(time.time() * 1000))
+        self._upsert_block(block_to_store)
+
+    def _update_custom_block(self, block_id: Any, updates: Any) -> None:
+        if not block_id or not isinstance(updates, dict):
+            return
+
+        block = self._find_block(str(block_id))
+        if block is None:
+            return
+        block.update(updates)
+
+    def _update_context_metrics(self, data: dict[str, Any]) -> None:
+        phase = data.get("phase")
+        context_metrics = data.get("context_metrics")
+        if not phase or not isinstance(context_metrics, dict):
+            return
+
+        self.snapshot.context_metrics = {
+            "task_id": self.snapshot.task_id,
+            "subtask_id": self.snapshot.subtask_id,
+            "phase": phase,
+            "context_metrics": context_metrics,
+        }
+
+    def _upsert_tool_block(
+        self,
+        *,
+        tool_use_id: str,
+        tool_name: str,
+        tool_input: Optional[dict[str, Any]] = None,
+        display_name: Optional[str] = None,
+        tool_protocol: Optional[str] = None,
+        server_label: Optional[str] = None,
+        status: Optional[str] = None,
+        tool_output: Optional[str] = None,
+    ) -> None:
+        if not tool_use_id:
+            return
+
+        self._finalize_current_text_block()
+        self._finalize_current_thinking_block()
+        block = create_tool_block(
+            tool_use_id=tool_use_id,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            display_name=display_name,
+            tool_protocol=tool_protocol,
+            server_label=server_label,
+        )
+        if status is not None:
+            block["status"] = status
+        if tool_output is not None:
+            block["tool_output"] = tool_output
+        self._upsert_block(block)
+
+    def _update_tool_block(
+        self,
+        tool_use_id: str,
+        *,
+        status: Optional[str] = None,
+        tool_input: Optional[dict[str, Any]] = None,
+        tool_output: Optional[str] = None,
+        tool_protocol: Optional[str] = None,
+        server_label: Optional[str] = None,
+    ) -> None:
+        block = self._find_tool_block(tool_use_id)
+        if block is None:
+            return
+        if status is not None:
+            block["status"] = status
+        if tool_input is not None:
+            block["tool_input"] = tool_input
+        if tool_output is not None:
+            block["tool_output"] = tool_output
+        if tool_protocol is not None:
+            block["tool_protocol"] = tool_protocol
+        if server_label is not None:
+            block["server_label"] = server_label
+
+    def _upsert_block(self, block: dict[str, Any]) -> None:
+        block_id = block.get("id")
+        if not block_id:
+            block_id = f"block-{uuid.uuid4().hex[:12]}"
+            block["id"] = block_id
+
+        existing = self._find_block(str(block_id))
+        if existing is None:
+            self.snapshot.blocks.append(block)
+            return
+
+        existing.clear()
+        existing.update(block)
+
+    def _find_block(self, block_id: str) -> Optional[dict[str, Any]]:
+        for block in self.snapshot.blocks:
+            if block.get("id") == block_id:
+                return block
+        return None
+
+    def _find_tool_block(self, tool_use_id: str) -> Optional[dict[str, Any]]:
+        for block in self.snapshot.blocks:
+            if block.get("type") == "tool" and block.get("tool_use_id") == tool_use_id:
+                return block
+        return None
+
+    @staticmethod
+    def _extract_reasoning_content(event_type: str, data: dict[str, Any]) -> str:
+        if event_type == ResponsesAPIStreamEvents.REASONING_SUMMARY_TEXT_DELTA.value:
+            return str(data.get("delta") or "")
+
+        part = data.get("part")
+        if not isinstance(part, dict):
+            return ""
+        if part.get("type") != "summary_text":
+            return ""
+        return str(part.get("text") or "")
+
+    @staticmethod
+    def _resolve_tool_input(summary: Any, arguments: Any) -> dict[str, Any]:
+        if isinstance(summary, dict):
+            return summary
+        return RuntimeStreamAccumulator._parse_json_object(arguments)
+
+    @staticmethod
+    def _parse_json_object(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict):
+            return value
+        if not isinstance(value, str) or not value:
+            return {}
+        try:
+            parsed = json.loads(value)
+        except (TypeError, json.JSONDecodeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+
+    @staticmethod
+    def _extract_shell_call_input(item: dict[str, Any]) -> dict[str, Any]:
+        for key in ("input", "arguments"):
+            parsed = RuntimeStreamAccumulator._parse_json_object(item.get(key))
+            if parsed:
+                return parsed
+
+        command = item.get("command")
+        if isinstance(command, str) and command:
+            return {"command": command}
+        return {}

--- a/shared/tests/test_runtime_stream_cache.py
+++ b/shared/tests/test_runtime_stream_cache.py
@@ -62,13 +62,61 @@ def test_runtime_stream_accumulator_builds_snapshot():
     assert snapshot["offset"] == len("hello world")
     assert snapshot["terminal"] is True
     assert snapshot["context_metrics"]["phase"] == "compacting"
-    assert [block["type"] for block in snapshot["blocks"]] == [
-        "text",
-        "tool",
-        "text",
-    ]
-    assert snapshot["blocks"][1]["tool_output"] == "/tmp"
+    assert [block["type"] for block in snapshot["blocks"]] == ["tool"]
+    assert snapshot["blocks"][0]["tool_output"] == "/tmp"
     assert all(block["status"] == "done" for block in snapshot["blocks"])
+
+
+def test_runtime_stream_accumulator_does_not_block_plain_output_text():
+    """Plain assistant output belongs in content, not process blocks."""
+
+    accumulator = RuntimeStreamAccumulator(task_id=101, subtask_id=202)
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        {"delta": "题目：从宜居标准看北京的不宜居性"},
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        {"delta": "\n\n北京是否宜居，不能只看资源丰富。"},
+    )
+
+    snapshot = accumulator.to_snapshot().to_dict()
+
+    assert snapshot["content"] == (
+        "题目：从宜居标准看北京的不宜居性" "\n\n北京是否宜居，不能只看资源丰富。"
+    )
+    assert snapshot["offset"] == len(snapshot["content"])
+    assert snapshot["blocks"] == []
+
+
+def test_runtime_stream_accumulator_keeps_custom_text_blocks():
+    """Explicit text blocks should still be preserved as process blocks."""
+
+    accumulator = RuntimeStreamAccumulator(task_id=101, subtask_id=202)
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.BLOCK_CREATED.value,
+        {
+            "block": {
+                "id": "codex-commentary-1",
+                "type": "text",
+                "content": "正在整理上下文",
+                "status": "done",
+            }
+        },
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        {"delta": "最终答案"},
+    )
+
+    snapshot = accumulator.to_snapshot().to_dict()
+
+    assert snapshot["content"] == "最终答案"
+    assert len(snapshot["blocks"]) == 1
+    assert snapshot["blocks"][0]["id"] == "codex-commentary-1"
+    assert snapshot["blocks"][0]["type"] == "text"
+    assert snapshot["blocks"][0]["content"] == "正在整理上下文"
+    assert snapshot["blocks"][0]["status"] == "done"
 
 
 class _RuntimeCacheRecorder:

--- a/shared/tests/test_runtime_stream_cache.py
+++ b/shared/tests/test_runtime_stream_cache.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared.models import (
+    CallbackTransport,
+    RuntimeStreamAccumulator,
+    runtime_stream_cache_capability,
+)
+from shared.models.responses_api import ResponsesAPIStreamEvents
+
+
+def test_runtime_stream_accumulator_builds_snapshot():
+    """Accumulator should preserve text, tools, context metrics, and terminal state."""
+
+    accumulator = RuntimeStreamAccumulator(task_id=101, subtask_id=202)
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        {"delta": "hello "},
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED.value,
+        {
+            "item": {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "Bash",
+                "arguments": '{"command": "pwd"}',
+            }
+        },
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE.value,
+        {
+            "item": {
+                "type": "function_call",
+                "call_id": "call-1",
+                "name": "Bash",
+                "arguments": '{"command": "pwd"}',
+                "output": "/tmp",
+                "status": "completed",
+            }
+        },
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        {"delta": "world"},
+    )
+    accumulator.apply_event(
+        ResponsesAPIStreamEvents.STATUS_UPDATED.value,
+        {"phase": "compacting", "context_metrics": {"usage": 0.8}},
+    )
+    accumulator.apply_event(ResponsesAPIStreamEvents.RESPONSE_COMPLETED.value, {})
+
+    snapshot = accumulator.to_snapshot().to_dict()
+
+    assert snapshot["content"] == "hello world"
+    assert snapshot["offset"] == len("hello world")
+    assert snapshot["terminal"] is True
+    assert snapshot["context_metrics"]["phase"] == "compacting"
+    assert [block["type"] for block in snapshot["blocks"]] == [
+        "text",
+        "tool",
+        "text",
+    ]
+    assert snapshot["blocks"][1]["tool_output"] == "/tmp"
+    assert all(block["status"] == "done" for block in snapshot["blocks"])
+
+
+class _RuntimeCacheRecorder:
+    def __init__(self):
+        self.events = []
+
+    async def record_event(self, **kwargs):
+        self.events.append(kwargs)
+
+
+@pytest.mark.asyncio
+async def test_callback_transport_records_runtime_cache_and_sends_marker():
+    """Callback transport should cache locally before sending the callback."""
+
+    client = MagicMock()
+    client.send_event_dict.return_value = {"status": "ok"}
+    recorder = _RuntimeCacheRecorder()
+    capability = runtime_stream_cache_capability()
+    transport = CallbackTransport(
+        client,
+        runtime_cache=recorder,
+        runtime_cache_capability=capability,
+    )
+
+    result = await transport.send(
+        event_type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+        task_id=101,
+        subtask_id=202,
+        data={"delta": "hello"},
+        executor_name="executor-1",
+        executor_namespace="default",
+    )
+
+    assert result == {"status": "ok"}
+    assert recorder.events == [
+        {
+            "event_type": ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA.value,
+            "task_id": 101,
+            "subtask_id": 202,
+            "data": {"delta": "hello"},
+        }
+    ]
+    sent_event = client.send_event_dict.call_args.args[0]
+    assert sent_event["runtime_cache"] == capability
+    assert sent_event["executor_name"] == "executor-1"

--- a/shared/tests/test_runtime_stream_cache.py
+++ b/shared/tests/test_runtime_stream_cache.py
@@ -6,11 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from shared.models import (
-    CallbackTransport,
-    RuntimeStreamAccumulator,
-    runtime_stream_cache_capability,
-)
+from shared.models import CallbackTransport, RuntimeStreamAccumulator
 from shared.models.responses_api import ResponsesAPIStreamEvents
 
 
@@ -128,17 +124,15 @@ class _RuntimeCacheRecorder:
 
 
 @pytest.mark.asyncio
-async def test_callback_transport_records_runtime_cache_and_sends_marker():
+async def test_callback_transport_records_runtime_cache_without_event_marker():
     """Callback transport should cache locally before sending the callback."""
 
     client = MagicMock()
     client.send_event_dict.return_value = {"status": "ok"}
     recorder = _RuntimeCacheRecorder()
-    capability = runtime_stream_cache_capability()
     transport = CallbackTransport(
         client,
         runtime_cache=recorder,
-        runtime_cache_capability=capability,
     )
 
     result = await transport.send(
@@ -160,5 +154,5 @@ async def test_callback_transport_records_runtime_cache_and_sends_marker():
         }
     ]
     sent_event = client.send_event_dict.call_args.args[0]
-    assert sent_event["runtime_cache"] == capability
+    assert "runtime_cache" not in sent_event
     assert sent_event["executor_name"] == "executor-1"

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -549,10 +549,28 @@ describe('MessageList', () => {
 
     expect(screen.queryByTestId('message-hover-time')).not.toBeInTheDocument()
     expect(screen.queryByTestId('copy-message-button')).not.toBeInTheDocument()
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
+  })
+
+  test('shows the thinking indicator before assistant content starts', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
     expect(screen.getByText('正在思考')).toBeInTheDocument()
   })
 
-  test('shows a single thinking indicator for streaming assistant messages with blocks', () => {
+  test('does not show the generic thinking indicator after visible content starts', () => {
     const runningBlock: ProcessingBlock = {
       id: 'call-1',
       subtaskId: 1,
@@ -578,7 +596,7 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getAllByText('正在思考')).toHaveLength(1)
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
   })
 
   test('renders process text inside the processing timeline before the following tool', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -386,6 +386,7 @@ function AssistantMessage({
         <ToolBlocksDisplay
           blocks={displayBlocks}
           isStreaming={isStreaming}
+          hasVisibleContent={hasVisibleContent}
           startedAt={getTurnStartMs(message.createdAt)}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
         />
@@ -458,9 +459,6 @@ function AssistantMessage({
         </div>
       )}
       {isThinking && <span className="text-text-muted">正在思考</span>}
-      {isStreaming && hasVisibleContent && !hasBlocks && (
-        <span className="text-text-muted">正在思考</span>
-      )}
       {message.status === 'failed' && message.error && (
         <AssistantErrorCard
           error={message.error}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -165,4 +165,21 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByTestId('process-text-block')).toBeInTheDocument()
     expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
   })
+
+  test('does not show the generic thinking indicator after assistant content starts', () => {
+    const doneBlock: ProcessingBlock = {
+      ...completedCommandBlock,
+      status: 'done',
+    }
+
+    render(
+      <ToolBlocksDisplay
+        blocks={[doneBlock]}
+        isStreaming={true}
+        hasVisibleContent={true}
+      />
+    )
+
+    expect(screen.queryByTestId('thinking-indicator')).not.toBeInTheDocument()
+  })
 })

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -7,6 +7,7 @@ import { buildProcessingDisplayRows, type ProcessingDisplayRow } from './toolBlo
 interface ToolBlocksDisplayProps {
   blocks: ProcessingBlock[]
   isStreaming: boolean
+  hasVisibleContent?: boolean
   // Wall-clock epoch ms when the turn started (the assistant subtask's
   // created_at). Used as the duration anchor so the elapsed time survives a
   // page refresh: after a refresh the in-progress blocks are re-streamed with
@@ -19,6 +20,7 @@ interface ToolBlocksDisplayProps {
 export function ToolBlocksDisplay({
   blocks,
   isStreaming,
+  hasVisibleContent = false,
   startedAt,
   onOpenWorkspaceFile,
 }: ToolBlocksDisplayProps) {
@@ -105,7 +107,7 @@ export function ToolBlocksDisplay({
               />
             )
           )}
-          {isRunning && !hasLiveNarrativeBlock && <ThinkingIndicator />}
+          {isRunning && !hasVisibleContent && !hasLiveNarrativeBlock && <ThinkingIndicator />}
         </div>
       )}
     </div>

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -3806,4 +3806,130 @@ describe('WorkbenchProvider', () => {
 
     expect(screen.getByTestId('running-task-ids')).toHaveTextContent('8')
   })
+
+  test('keeps live thinking blocks when chat done has no persisted blocks', async () => {
+    type StreamHandlers = {
+      onChatStart?: (payload: {
+        task_id: number
+        subtask_id: number
+        shell_type?: string
+      }) => void
+      onChatChunk?: (payload: {
+        task_id: number
+        subtask_id: number
+        content: string
+        result: Record<string, unknown>
+      }) => void
+      onChatDone?: (payload: {
+        task_id: number
+        subtask_id: number
+        result: { value?: string; file_changes?: unknown }
+      }) => void
+    }
+    let streamHandlers: StreamHandlers | undefined
+
+    function LiveBlocksProbe() {
+      const workbench = useWorkbench()
+
+      return (
+        <div>
+          <span data-testid="live-message">
+            {workbench.messages.map(message => `${message.status}:${message.content}`).join('|')}
+          </span>
+          <span data-testid="live-blocks">
+            {workbench.messages
+              .flatMap(message =>
+                (message.blocks ?? []).map(block =>
+                  block.type === 'thinking'
+                    ? `${block.type}:${block.status}:${block.content}`
+                    : `${block.type}:${block.status}`
+                )
+              )
+              .join('|')}
+          </span>
+        </div>
+      )
+    }
+
+    render(
+      <WorkbenchProvider
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={{
+          teamApi: {
+            getDefaultWorkbenchTeam: vi.fn().mockResolvedValue({ id: 2, name: 'coder' }),
+          },
+          modelApi: { listModels: vi.fn().mockResolvedValue({ data: [] }) },
+          skillApi: {
+            listSkills: vi.fn().mockResolvedValue([]),
+            getTeamSkills: vi.fn().mockResolvedValue({ skills: [], preload_skills: [] }),
+          },
+          projectApi: {
+            listProjects: vi.fn().mockResolvedValue({ items: [] }),
+            getProject: vi.fn(),
+            createProject: vi.fn(),
+            updateProject: vi.fn(),
+            deleteProject: vi.fn(),
+            archiveProjectChats: vi.fn(),
+            archiveAllProjectChats: vi.fn(),
+            createConversation: vi.fn(),
+          },
+          taskApi: {
+            listRecentTasks: vi.fn().mockResolvedValue({ total: 0, items: [] }),
+            getTaskDetail: vi.fn(),
+            renameTask: vi.fn(),
+            archiveTask: vi.fn(),
+            archiveAllChats: vi.fn(),
+            listArchivedTasks: vi.fn(),
+            unarchiveTask: vi.fn(),
+            deleteTask: vi.fn(),
+            deleteArchivedTasks: vi.fn(),
+          },
+          deviceApi: {
+            listDevices: vi.fn().mockResolvedValue([]),
+            getHomeDirectory: vi.fn(),
+            getProjectWorkspaceRoot: vi.fn(),
+            listDirectories: vi.fn(),
+            listSkills: vi.fn().mockResolvedValue([]),
+          },
+          chatStream: {
+            joinTask: vi.fn(),
+            leaveTask: vi.fn(),
+            sendMessage: vi.fn(),
+            subscribe: vi.fn(handlers => {
+              streamHandlers = handlers as StreamHandlers
+              return vi.fn()
+            }),
+          },
+        }}
+      >
+        <LiveBlocksProbe />
+      </WorkbenchProvider>
+    )
+
+    await waitFor(() => expect(streamHandlers?.onChatStart).toBeDefined())
+
+    act(() => {
+      streamHandlers?.onChatStart?.({ task_id: 8, subtask_id: 80, shell_type: 'Chat' })
+      streamHandlers?.onChatChunk?.({
+        task_id: 8,
+        subtask_id: 80,
+        content: '',
+        result: { reasoning_chunk: 'Drafting' },
+      })
+      streamHandlers?.onChatChunk?.({
+        task_id: 8,
+        subtask_id: 80,
+        content: 'Final answer',
+        result: {},
+      })
+      streamHandlers?.onChatDone?.({
+        task_id: 8,
+        subtask_id: 80,
+        result: { value: 'Final answer' },
+      })
+    })
+
+    expect(screen.getByTestId('live-message')).toHaveTextContent('done:Final answer')
+    expect(screen.getByTestId('live-blocks')).toHaveTextContent('thinking:done:Drafting')
+  })
 })

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1073,7 +1073,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           type: 'assistant_done',
           subtaskId: payload.subtask_id,
           content: typeof payload.result.value === 'string' ? payload.result.value : undefined,
-          blocks: getResultBlocks(payload.subtask_id, payload.result) ?? [],
+          blocks: getResultBlocks(payload.subtask_id, payload.result),
           fileChanges: normalizeTurnFileChanges(payload.result.file_changes),
         })
       },

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1073,7 +1073,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           type: 'assistant_done',
           subtaskId: payload.subtask_id,
           content: typeof payload.result.value === 'string' ? payload.result.value : undefined,
-          blocks: getResultBlocks(payload.subtask_id, payload.result),
+          blocks: getResultBlocks(payload.subtask_id, payload.result) ?? [],
           fileChanges: normalizeTurnFileChanges(payload.result.file_changes),
         })
       },
@@ -1637,11 +1637,8 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   )
 
   const commitEnvironmentChanges = useCallback(
-    (
-      project: ProjectWithTasks | null,
-      message: string,
-      workspaceTarget?: WorkspaceTarget | null
-    ) => commitProjectChanges(resolvedServices.deviceApi, project, message, workspaceTarget),
+    (project: ProjectWithTasks | null, message: string, workspaceTarget?: WorkspaceTarget | null) =>
+      commitProjectChanges(resolvedServices.deviceApi, project, message, workspaceTarget),
     [resolvedServices]
   )
 

--- a/wework/src/features/workbench/messageReducer.test.ts
+++ b/wework/src/features/workbench/messageReducer.test.ts
@@ -161,6 +161,65 @@ describe('messageReducer', () => {
     ])
   })
 
+  test('finalizes thinking blocks when visible assistant content starts', () => {
+    const state = messageReducer(
+      messageReducer([], {
+        type: 'assistant_started',
+        taskId: 1,
+        subtaskId: 9,
+      }),
+      {
+        type: 'assistant_chunk',
+        subtaskId: 9,
+        content: '',
+        reasoningChunk: 'Drafting the answer',
+      }
+    )
+
+    const withContent = messageReducer(state, {
+      type: 'assistant_chunk',
+      subtaskId: 9,
+      content: 'Final answer starts here.',
+    })
+
+    expect(withContent[0].content).toBe('Final answer starts here.')
+    expect(withContent[0].blocks).toMatchObject([
+      {
+        type: 'thinking',
+        content: 'Drafting the answer',
+        status: 'done',
+      },
+    ])
+  })
+
+  test('finalizes cached thinking blocks when cached content already exists', () => {
+    const state = messageReducer([], {
+      type: 'assistant_cached',
+      taskId: 1,
+      subtaskId: 9,
+      content: 'Cached visible answer.',
+      blocks: [
+        {
+          id: 'thinking-9-1',
+          subtaskId: 9,
+          type: 'thinking',
+          content: 'Drafting the answer',
+          status: 'streaming',
+          createdAt: 1770000000000,
+        },
+      ],
+    })
+
+    expect(state[0].content).toBe('Cached visible answer.')
+    expect(state[0].blocks).toMatchObject([
+      {
+        type: 'thinking',
+        content: 'Drafting the answer',
+        status: 'done',
+      },
+    ])
+  })
+
   test('places streamed process text before the following tool block', () => {
     const state = messageReducer(
       messageReducer([], {
@@ -235,6 +294,34 @@ describe('messageReducer', () => {
       content: 'Final',
       status: 'done',
       blocks: [{ id: 'thinking-real', type: 'thinking', status: 'done' }],
+    })
+  })
+
+  test('preserves current processing blocks when done does not include blocks', () => {
+    const state = messageReducer(
+      messageReducer([], {
+        type: 'assistant_started',
+        taskId: 1,
+        subtaskId: 9,
+      }),
+      {
+        type: 'assistant_chunk',
+        subtaskId: 9,
+        content: '',
+        reasoningChunk: 'Drafting',
+      }
+    )
+
+    const done = messageReducer(state, {
+      type: 'assistant_done',
+      subtaskId: 9,
+      content: 'Final',
+    })
+
+    expect(done[0]).toMatchObject({
+      content: 'Final',
+      status: 'done',
+      blocks: [{ type: 'thinking', content: 'Drafting', status: 'done' }],
     })
   })
 

--- a/wework/src/features/workbench/messageReducer.test.ts
+++ b/wework/src/features/workbench/messageReducer.test.ts
@@ -238,6 +238,38 @@ describe('messageReducer', () => {
     })
   })
 
+  test('clears restored processing blocks when completion has no blocks', () => {
+    const state = messageReducer([], {
+      type: 'assistant_cached',
+      taskId: 1,
+      subtaskId: 9,
+      content: 'Partial answer',
+      blocks: [
+        {
+          id: 'text-restored',
+          subtaskId: 9,
+          type: 'text',
+          content: 'Partial answer',
+          status: 'streaming',
+          createdAt: 1770000000000,
+        },
+      ],
+    })
+
+    const done = messageReducer(state, {
+      type: 'assistant_done',
+      subtaskId: 9,
+      content: 'Final answer',
+      blocks: [],
+    })
+
+    expect(done[0]).toMatchObject({
+      content: 'Final answer',
+      status: 'done',
+      blocks: [],
+    })
+  })
+
   test('stores file changes on completion and updates them after revert', () => {
     const activeFileChanges = {
       version: 1 as const,


### PR DESCRIPTION
## Summary

- Add executor-local runtime stream snapshots for active Responses API streams, including event accumulation, snapshot retrieval, cleanup, and diagnostics.
- Keep Redis as the active task coordination layer while skipping high-frequency Redis content/block snapshot writes when executor runtime cache is enabled.
- Add backend snapshot resolution for join/resume and terminal result assembly, with Redis fallback for older executors.
- Preserve recovered thinking blocks correctly in Wework while streaming: close thinking when visible answer content starts, keep live thinking through `chat:done` when no persisted blocks are returned, and avoid showing generic "正在思考" once answer text is visible.
- Document the runtime cache behavior in Chinese and English developer guides.

## Impact

This reduces Redis write pressure during active streaming sessions. Executor crashes may lose unfinished in-memory snapshots, which is an accepted tradeoff for this path. Existing executors that do not expose runtime cache support continue using Redis snapshots. Pure reasoning-only blocks are not persisted to completed task history by backend completion assembly, but the active Wework session keeps the completed thinking block visible until the user reloads completed history.

## Validation

- `cd shared && uv run pytest tests/test_runtime_stream_cache.py`
- `cd executor && uv run pytest tests/test_runtime_stream_cache.py`
- `cd backend && uv run pytest tests/services/chat/test_runtime_stream_snapshot.py tests/services/execution/test_status_updating_emitter.py`
- `cd backend && uv run pytest tests/services/chat/trigger/test_lifecycle_completed_result.py tests/services/chat/test_runtime_stream_snapshot.py`
- `pnpm --filter @wegent/chat-core test`
- `pnpm --dir wework test -- src/components/chat/MessageList.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/features/workbench/messageReducer.test.ts src/features/workbench/WorkbenchProvider.test.tsx`
- Manual validation with tasks 224 and 226: active refresh recovered executor snapshots, completion cleaned runtime cache, and visible answer text no longer kept the generic thinking indicator running.
- Pre-push hook: black, isort, syntax checks, settings check, Alembic multi-head check passed.