### PR TITLE
[codex] Fix Claude Code image-only prompts

### DIFF
--- a/executor/agents/claude_code/multimodal_prompt.py
+++ b/executor/agents/claude_code/multimodal_prompt.py
@@ -108,11 +108,17 @@ def convert_openai_to_anthropic_content(
     for block in content_blocks:
         block_type = block.get("type", "")
 
-        if block_type == "input_text":
+        if block_type in ("input_text", "text"):
+            text = block.get("text", "")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            if block_type == "text":
+                anthropic_blocks.append(block)
+                continue
             anthropic_blocks.append(
                 {
                     "type": "text",
-                    "text": block.get("text", ""),
+                    "text": text,
                 }
             )
 

--- a/executor/tests/agents/test_multimodal_prompt.py
+++ b/executor/tests/agents/test_multimodal_prompt.py
@@ -131,6 +131,26 @@ class TestConvertOpenaiToAnthropicContent:
         assert result[1]["type"] == "image"
         assert result[1]["source"]["media_type"] == "image/png"
 
+    def test_omits_blank_input_text_for_image_only_prompt(self):
+        blocks = [
+            {"type": "input_text", "text": ""},
+            {"type": "input_image", "image_url": "data:image/png;base64,iVBOR"},
+        ]
+        result = convert_openai_to_anthropic_content(blocks)
+        assert len(result) == 1
+        assert result[0]["type"] == "image"
+        assert result[0]["source"]["media_type"] == "image/png"
+
+    def test_omits_blank_anthropic_text_for_image_only_prompt(self):
+        blocks = [
+            {"type": "text", "text": "   "},
+            {"type": "image", "source": {"type": "base64", "data": "iVBOR"}},
+        ]
+        result = convert_openai_to_anthropic_content(blocks)
+        assert result == [
+            {"type": "image", "source": {"type": "base64", "data": "iVBOR"}}
+        ]
+
     def test_passes_through_unknown_block_types(self):
         blocks = [{"type": "custom", "data": "foo"}]
         result = convert_openai_to_anthropic_content(blocks)


### PR DESCRIPTION
## Summary

- Filter blank `input_text` and `text` blocks when converting Claude Code multimodal prompts to Anthropic content.
- Add regression coverage for image-only prompts that previously produced empty text content blocks.

## Root Cause

Pure image sends can include an empty text block alongside the image block. The Claude Code multimodal converter passed that through as Anthropic `{ "type": "text", "text": "" }`, which the API rejects with `text content is empty`.

## Validation

- `cd executor && uv run pytest tests/agents/test_multimodal_prompt.py`
- `cd executor && uv run black --check agents/claude_code/multimodal_prompt.py tests/agents/test_multimodal_prompt.py`
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text block handling to skip empty or whitespace-only content in multimodal prompt conversion.

* **Tests**
  * Added tests verifying blank text blocks are properly omitted in image-only prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->