### PR TITLE
[codex] fix compact toolbar loading spinner

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/ChatToolbarStatus.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/ChatToolbarStatus.test.tsx
@@ -125,4 +125,21 @@ describe('ChatToolbarStatus', () => {
     expect(await screen.findByTestId('quota-usage-section')).toHaveTextContent('Quota brief')
     expect(screen.queryByTestId('chat-status-section')).not.toBeInTheDocument()
   })
+
+  test('does not render a standalone loading spinner in compact mode', () => {
+    getRuntimeConfigSync.mockReturnValue({
+      enableDisplayQuotas: true,
+    })
+    fetchQuota.mockReturnValue(new Promise(() => {}))
+    useChatStatusIndicator.mockReturnValue({
+      enabled: false,
+      currentTaskId: null,
+      display: null,
+    })
+
+    render(<ChatToolbarStatus compact />)
+
+    expect(screen.queryByRole('status', { name: 'Loading' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('chat-toolbar-status-trigger')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/features/tasks/components/input/ChatToolbarStatus.tsx
+++ b/frontend/src/features/tasks/components/input/ChatToolbarStatus.tsx
@@ -170,6 +170,10 @@ export default function ChatToolbarStatus({ className, compact = false }: ChatTo
 
   if (!hasVisibleContent && !showStatusSection) {
     if (loading) {
+      if (compact) {
+        return null
+      }
+
       return (
         <div className={`flex items-center justify-center mt-1 mb-2 ${className ?? ''}`}>
           <Spinner size="sm" />


### PR DESCRIPTION
## Summary
- Hide the compact chat toolbar quota/status loading spinner while it has no visible content.
- Add a regression test so compact mode does not render a standalone loading indicator beside the send button.

## Root Cause
`ChatToolbarStatus` rendered a generic loading spinner in compact mode before quota/status data was available. In the chat input toolbar this appeared as a separate spinner next to the send button, making the loading effect look detached from the send action.

## Validation
- `pnpm --dir frontend test ChatToolbarStatus.test.tsx ChatInputControls.toolbar.test.tsx --runInBand`
- `pnpm -r --if-present test`
- Pre-push gate: ESLint, TypeScript, and frontend unit tests passed.

Docs were checked for relevant send button/quota/loading indicator references. This narrow visual bug fix does not require documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved loading indicator behavior in compact mode to prevent display of unnecessary loading spinners when quota information is still being fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->