### PR TITLE
[codex] Lazy load restored chat skill tools

### DIFF
--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -22,6 +22,7 @@ from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
+    ChatMessage,
     HumanMessage,
     SystemMessage,
     ToolMessage,
@@ -368,6 +369,8 @@ def _message_to_context_metrics_dict(msg: BaseMessage) -> dict[str, Any]:
     """Convert a LangChain message into the dict view used by metrics counting."""
     if isinstance(msg, SystemMessage):
         role = "system"
+    elif isinstance(msg, ChatMessage):
+        role = msg.role
     elif isinstance(msg, HumanMessage):
         role = "user"
     elif isinstance(msg, AIMessage):
@@ -731,7 +734,7 @@ class LangGraphAgentBuilder:
         return modifier_tools
 
     def _create_prompt_modifier(self) -> Callable | None:
-        """Create a prompt modifier function for dynamic prompt injection.
+        """Create a prompt modifier function for dynamic instruction injection.
 
         This function is called before each model invocation to inject
         prompt modifications from all PromptModifierTool instances.
@@ -744,12 +747,42 @@ class LangGraphAgentBuilder:
 
         modifier_tools = self._prompt_modifier_tools
 
+        def supports_developer_message() -> bool:
+            """Return whether the current LangChain adapter accepts developer role."""
+            return self._provider == "openai"
+
+        def create_dynamic_instruction_message(content: str) -> BaseMessage:
+            """Create a provider-safe message for dynamic skill instructions."""
+            if supports_developer_message():
+                return ChatMessage(role="developer", content=content)
+
+            wrapped_content = (
+                "<application_skill_context>\n"
+                "The following skill context was injected by the application for "
+                "this model call. It is not authored by the user.\n"
+                f"{content.strip()}\n"
+                "</application_skill_context>"
+            )
+            return HumanMessage(content=wrapped_content)
+
+        def insert_after_leading_system_messages(
+            messages: list[BaseMessage], dynamic_message: BaseMessage
+        ) -> list[BaseMessage]:
+            """Insert dynamic context without mutating stable system prompts."""
+            insert_at = 0
+            while insert_at < len(messages) and isinstance(
+                messages[insert_at], SystemMessage
+            ):
+                insert_at += 1
+            return messages[:insert_at] + [dynamic_message] + messages[insert_at:]
+
         def prompt_modifier(state: dict[str, Any]) -> list[BaseMessage]:
-            """Modify messages to inject prompt modifications into system message.
+            """Inject dynamic prompt modifications as a separate message.
 
             This function is called by LangGraph's create_react_agent before each
             model invocation. It collects prompt modifications from all
-            PromptModifierTool instances and appends them to the system message.
+            PromptModifierTool instances and inserts them after the stable system
+            prompts so prompt caching can keep the base system prefix unchanged.
             """
             messages = state.get("messages", [])
             if not messages:
@@ -766,55 +799,13 @@ class LangGraphAgentBuilder:
                 # No modifications, return messages unchanged
                 return messages
 
-            # Find and update the system message
-            new_messages = []
-            system_updated = False
-
-            for msg in messages:
-                if isinstance(msg, SystemMessage) and not system_updated:
-                    # Append modifications to existing system message.
-                    # Content may be a string or a list of content blocks
-                    # (e.g., when Anthropic cache_control breakpoints are set).
-                    # Preserve the original format to keep cache markers intact.
-                    if isinstance(msg.content, list):
-                        # List of content blocks — append modification as a new
-                        # text block so existing cache_control markers stay valid.
-                        updated_content = msg.content + [
-                            {"type": "text", "text": combined_modification}
-                        ]
-                    else:
-                        updated_content = msg.content + combined_modification
-                    new_messages.append(SystemMessage(content=updated_content))
-                    system_updated = True
-
-                    # Log the final system prompt metadata at INFO level
-                    # Full content is only logged at DEBUG level to avoid leaking sensitive data
-                    content_len = (
-                        sum(
-                            len(b.get("text", ""))
-                            for b in updated_content
-                            if isinstance(b, dict)
-                        )
-                        if isinstance(updated_content, list)
-                        else len(updated_content)
-                    )
-                    logger.info(
-                        "[prompt_modifier] Final system prompt (len=%d)",
-                        content_len,
-                    )
-                    # logger.debug(
-                    #     "[prompt_modifier] Final system prompt content:\n%s",
-                    #     updated_content,
-                    # )
-
-                else:
-                    new_messages.append(msg)
-
-            # If no system message found, prepend one with modifications
-            if not system_updated:
-                new_messages.insert(0, SystemMessage(content=combined_modification))
-
-            return new_messages
+            dynamic_message = create_dynamic_instruction_message(combined_modification)
+            logger.info(
+                "[prompt_modifier] Dynamic skill context injected role=%s len=%d",
+                getattr(dynamic_message, "role", dynamic_message.type),
+                len(str(dynamic_message.content)),
+            )
+            return insert_after_leading_system_messages(messages, dynamic_message)
 
         return prompt_modifier
 
@@ -906,7 +897,8 @@ class LangGraphAgentBuilder:
 
         # Get all registered skill tools
         all_skill_tools = load_skill_tool.get_all_registered_tools()
-        if not all_skill_tools:
+        has_deferred_loaders = load_skill_tool.has_deferred_tool_loaders()
+        if not all_skill_tools and not has_deferred_loaders:
             return None, self.tools
 
         # Create a set of skill tool names for quick lookup
@@ -948,6 +940,44 @@ class LangGraphAgentBuilder:
             return llm.bind_tools(selected_tools)
 
         return configure_model, all_tools
+
+    def _create_dynamic_tool_node(
+        self,
+        *,
+        all_tools: list[BaseTool],
+        load_skill_tool: Any | None,
+    ) -> list[BaseTool] | Any:
+        """Create a ToolNode that can execute tools registered after graph build."""
+        if not load_skill_tool:
+            return all_tools
+
+        from langgraph.prebuilt.tool_node import ToolCallRequest, ToolNode
+
+        async def awrap_tool_call(tool_request: Any, execute: Callable) -> Any:
+            """Resolve a dynamically registered skill tool before execution."""
+            if tool_request.tool is not None:
+                return await execute(tool_request)
+
+            finder = getattr(load_skill_tool, "find_registered_tool", None)
+            if not finder:
+                return await execute(tool_request)
+
+            tool_name = tool_request.tool_call["name"]
+            dynamic_tool = finder(tool_name)
+            if dynamic_tool is None:
+                return await execute(tool_request)
+
+            logger.info("[dynamic_tool_node] Resolved dynamic tool '%s'", tool_name)
+            return await execute(
+                ToolCallRequest(
+                    tool_call=tool_request.tool_call,
+                    tool=dynamic_tool,
+                    state=tool_request.state,
+                    runtime=tool_request.runtime,
+                )
+            )
+
+        return ToolNode(all_tools, awrap_tool_call=awrap_tool_call)
 
     @trace_sync(
         span_name="agent_builder.build_agent",
@@ -991,6 +1021,11 @@ class LangGraphAgentBuilder:
 
         # Store all_tools for external access (e.g., for display_name lookup)
         self.all_tools = all_tools
+        load_skill_tool = self._find_load_skill_tool()
+        tool_node_or_tools = self._create_dynamic_tool_node(
+            all_tools=all_tools,
+            load_skill_tool=load_skill_tool if model_configurator else None,
+        )
 
         # Add llm built-in tools if supported (currently none)
         model_with_tools: BaseChatModel | Callable = self.llm
@@ -1000,7 +1035,7 @@ class LangGraphAgentBuilder:
         if model_configurator:
             self._agent = create_react_agent(
                 model=model_configurator,
-                tools=all_tools,
+                tools=tool_node_or_tools,
                 checkpointer=checkpointer,
                 prompt=prompt_modifier,
                 pre_model_hook=self.pre_model_hook,
@@ -1008,7 +1043,7 @@ class LangGraphAgentBuilder:
         else:
             self._agent = create_react_agent(
                 model=model_with_tools,
-                tools=all_tools,
+                tools=tool_node_or_tools,
                 checkpointer=checkpointer,
                 prompt=prompt_modifier,
                 pre_model_hook=self.pre_model_hook,

--- a/chat_shell/chat_shell/api/v1/response.py
+++ b/chat_shell/chat_shell/api/v1/response.py
@@ -243,6 +243,68 @@ def _summarize_execution_request(
     }
 
 
+def _as_list(value: object) -> list:
+    """Return a list only when the original value is a list."""
+    return value if isinstance(value, list) else []
+
+
+def _summarize_metadata_for_log(metadata: Optional[dict]) -> dict[str, object]:
+    """Build a safe metadata summary without logging secrets or bulky configs."""
+    metadata = metadata or {}
+    skill_names = _as_list(metadata.get("skill_names"))
+    skill_configs = _as_list(metadata.get("skill_configs"))
+
+    skill_mcp_server_count = 0
+    skill_declared_tool_count = 0
+    for skill_config in skill_configs:
+        if not isinstance(skill_config, dict):
+            continue
+        mcp_servers = skill_config.get("mcpServers")
+        if isinstance(mcp_servers, dict):
+            skill_mcp_server_count += len(mcp_servers)
+        tools = skill_config.get("tools")
+        if isinstance(tools, list):
+            skill_declared_tool_count += len(tools)
+
+    knowledge_base_ids = _as_list(metadata.get("knowledge_base_ids"))
+    document_ids = _as_list(metadata.get("document_ids"))
+    knowledge_base_scopes = _as_list(metadata.get("knowledge_base_scopes"))
+    table_contexts = _as_list(metadata.get("table_contexts"))
+
+    return {
+        "task_id": metadata.get("task_id"),
+        "subtask_id": metadata.get("subtask_id"),
+        "request_id": metadata.get("request_id"),
+        "user_id": metadata.get("user_id"),
+        "user_name": metadata.get("user_name"),
+        "team_id": metadata.get("team_id"),
+        "team_name": metadata.get("team_name"),
+        "bot_name": metadata.get("bot_name"),
+        "message_id": metadata.get("message_id"),
+        "user_message_id": metadata.get("user_message_id"),
+        "user_subtask_id": metadata.get("user_subtask_id"),
+        "is_group_chat": metadata.get("is_group_chat"),
+        "stateless": metadata.get("stateless"),
+        "enable_tools": metadata.get("enable_tools"),
+        "enable_web_search": metadata.get("enable_web_search"),
+        "enable_deep_thinking": metadata.get("enable_deep_thinking"),
+        "skill_count": len(skill_names),
+        "skill_names": skill_names,
+        "skill_config_count": len(skill_configs),
+        "skill_mcp_server_count": skill_mcp_server_count,
+        "skill_declared_tool_count": skill_declared_tool_count,
+        "preload_skills": _as_list(metadata.get("preload_skills")),
+        "user_selected_skills": _as_list(metadata.get("user_selected_skills")),
+        "knowledge_base_count": len(knowledge_base_ids),
+        "document_count": len(document_ids),
+        "knowledge_base_scope_count": len(knowledge_base_scopes),
+        "table_context_count": len(table_contexts),
+        "has_auth_token": bool(metadata.get("auth_token")),
+        "has_skill_identity_token": bool(metadata.get("skill_identity_token")),
+        "has_task_data": bool(metadata.get("task_data")),
+    }
+
+
 # ============================================================
 # Stream Response Generator
 # ============================================================
@@ -313,7 +375,7 @@ async def _stream_response(
         request_summary["message_count"],
         json.dumps(request_summary["roles"], ensure_ascii=False),
         request_summary["last_user"],
-        json.dumps(request.metadata or {}, ensure_ascii=False),
+        json.dumps(_summarize_metadata_for_log(request.metadata), ensure_ascii=False),
     )
     execution_summary = _summarize_execution_request(execution_request)
     logger.info(

--- a/chat_shell/chat_shell/compression/context_metrics.py
+++ b/chat_shell/chat_shell/compression/context_metrics.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
 from typing import Any, Optional
@@ -149,7 +150,10 @@ class ContextMetricsTracker:
         phase: str,
     ) -> ContextMetricsSnapshot:
         """Compute, log, and optionally emit a context metrics snapshot."""
+        total_start = time.perf_counter()
+        compute_start = time.perf_counter()
         snapshot = self._metrics_fn(messages)
+        compute_ms = (time.perf_counter() - compute_start) * 1000
         self.latest_snapshot = snapshot
 
         logger.info(
@@ -165,15 +169,33 @@ class ContextMetricsTracker:
             snapshot.is_over_trigger,
         )
 
+        emitted = False
+        emit_ms = 0.0
         if should_emit_status_update(
             self.last_emitted_snapshot,
             snapshot,
             phase=phase,
         ):
+            emit_start = time.perf_counter()
             await self.emitter.status_updated(
                 phase=phase,
                 context_metrics=snapshot.to_dict(),
             )
+            emit_ms = (time.perf_counter() - emit_start) * 1000
+            emitted = True
             self.last_emitted_snapshot = snapshot
+
+        logger.info(
+            "[CONTEXT_METRICS_PERF] task_id=%d subtask_id=%d phase=%s "
+            "message_count=%d compute_ms=%.2f emit_ms=%.2f total_ms=%.2f emitted=%s",
+            self.task_id,
+            self.subtask_id,
+            phase,
+            len(messages),
+            compute_ms,
+            emit_ms,
+            (time.perf_counter() - total_start) * 1000,
+            emitted,
+        )
 
         return snapshot

--- a/chat_shell/chat_shell/prompts/builder.py
+++ b/chat_shell/chat_shell/prompts/builder.py
@@ -229,7 +229,8 @@ def build_system_prompt(
         1. Base prompt (caller should wrap Ghost systemPrompt in <base_prompt> tags if needed)
         2. Clarification mode instructions (if enabled) - now guides AI to use interactive_form_question tool
         3. Deep thinking mode instructions (if enabled)
-        4. Skill prompts (injected dynamically by LoadSkillTool via prompt_modifier)
+        4. Skill prompts are not added here; LoadSkillTool injects them dynamically
+           via prompt_modifier as separate model-call context.
     """
     system_prompt = base_prompt
 
@@ -249,5 +250,6 @@ def build_system_prompt(
     # via the prompt_modifier mechanism in LangGraphAgentBuilder. This ensures that:
     # 1. Available Skills and Loaded Skill Instructions are in the same <skill> block
     # 2. The skill prompt is always up-to-date with the current loaded skills state
+    # 3. The base system prompt remains stable for prompt caching
 
     return system_prompt

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -162,14 +162,25 @@ class ChatContext:
                 self._load_skill_tool.restore_from_history(history)
                 restored_skills = self._load_skill_tool.get_loaded_skills()
                 if restored_skills:
+                    restored_skill_tools = (
+                        await self._load_skill_tool.ensure_loaded_skill_tools_loaded()
+                    )
+                    restored_tool_count = sum(
+                        len(tools) for tools in restored_skill_tools.values()
+                    )
                     add_span_event(
                         "skill_state_restored",
-                        {"restored_skills": list(restored_skills)},
+                        {
+                            "restored_skills": list(restored_skills),
+                            "restored_tool_count": restored_tool_count,
+                        },
                     )
                     logger.info(
-                        "[CHAT_CONTEXT] Restored %d skills from history: %s",
+                        "[CHAT_CONTEXT] Restored %d skills from history: %s "
+                        "(materialized_tool_count=%d)",
                         len(restored_skills),
                         list(restored_skills),
+                        restored_tool_count,
                     )
 
             # Build extra_tools from all sources (including builtin tools)
@@ -217,12 +228,17 @@ class ChatContext:
         This method should be called after chat completion to release resources.
         """
         add_span_event("cleanup_started", {"mcp_clients_count": len(self._mcp_clients)})
-        if self._mcp_clients:
-            logger.debug(
-                "[CHAT_CONTEXT] Cleaning up %d MCP clients", len(self._mcp_clients)
-            )
+        dynamic_mcp_clients = []
+        if self._load_skill_tool and hasattr(
+            self._load_skill_tool, "drain_deferred_mcp_clients"
+        ):
+            dynamic_mcp_clients = self._load_skill_tool.drain_deferred_mcp_clients()
+
+        clients = self._mcp_clients + dynamic_mcp_clients
+        if clients:
+            logger.debug("[CHAT_CONTEXT] Cleaning up %d MCP clients", len(clients))
             await asyncio.gather(
-                *[self._close_mcp_client(c) for c in self._mcp_clients if c],
+                *[self._close_mcp_client(c) for c in clients if c],
                 return_exceptions=True,
             )
             self._mcp_clients = []

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -7,6 +7,7 @@ Used when chat_shell runs as HTTP service and needs to access Backend's data.
 
 import json
 import logging
+import time
 from typing import Any, Optional
 
 import httpx
@@ -92,7 +93,10 @@ class RemoteHistoryStore(HistoryStoreInterface):
         is_group_chat: bool = False,
     ) -> list[Message]:
         """Get chat history for a session."""
+        total_start = time.perf_counter()
+        client_start = time.perf_counter()
         client = await self._get_client()
+        client_ms = (time.perf_counter() - client_start) * 1000
         params = {}
         if limit:
             params["limit"] = limit
@@ -110,7 +114,9 @@ class RemoteHistoryStore(HistoryStoreInterface):
         )
 
         try:
+            request_start = time.perf_counter()
             response = await client.get(url, params=params)
+            request_ms = (time.perf_counter() - request_start) * 1000
 
             logger.debug(
                 "[RemoteHistoryStore] <<< Response status=%d, content_length=%s",
@@ -119,9 +125,29 @@ class RemoteHistoryStore(HistoryStoreInterface):
             )
 
             response.raise_for_status()
-            data = response.json()
 
+            parse_start = time.perf_counter()
+            data = response.json()
             messages = [Message.from_dict(m) for m in data.get("messages", [])]
+            parse_ms = (time.perf_counter() - parse_start) * 1000
+            total_ms = (time.perf_counter() - total_start) * 1000
+            logger.info(
+                "[RemoteHistoryStore_PERF] get_history session_id=%s "
+                "before_message_id=%s limit=%s is_group_chat=%s status=%d "
+                "message_count=%d client_ms=%.2f request_ms=%.2f parse_ms=%.2f "
+                "total_ms=%.2f content_length=%s",
+                session_id,
+                before_message_id,
+                limit,
+                is_group_chat,
+                response.status_code,
+                len(messages),
+                client_ms,
+                request_ms,
+                parse_ms,
+                total_ms,
+                response.headers.get("content-length", "unknown"),
+            )
             logger.debug(
                 "[RemoteHistoryStore] Loaded %d messages for session_id=%s",
                 len(messages),
@@ -130,9 +156,10 @@ class RemoteHistoryStore(HistoryStoreInterface):
             return messages
         except Exception as e:
             logger.error(
-                "[RemoteHistoryStore] Request failed: url=%s, error=%s",
+                "[RemoteHistoryStore] Request failed: url=%s, error=%s, total_ms=%.2f",
                 full_url,
                 e,
+                (time.perf_counter() - total_start) * 1000,
                 exc_info=True,
             )
             raise

--- a/chat_shell/chat_shell/tools/base.py
+++ b/chat_shell/chat_shell/tools/base.py
@@ -8,7 +8,7 @@ Note: Tool invocation is handled automatically by LangGraph's create_react_agent
 This registry is only for tool registration and retrieval.
 
 This module also defines the PromptModifierTool protocol for tools that can
-dynamically modify the system prompt during agent execution.
+dynamically inject model-call context during agent execution.
 """
 
 from typing import Protocol, runtime_checkable
@@ -18,10 +18,10 @@ from langchain_core.tools.base import BaseTool
 
 @runtime_checkable
 class PromptModifierTool(Protocol):
-    """Protocol for tools that can dynamically modify the system prompt.
+    """Protocol for tools that can dynamically inject model-call context.
 
-    Tools implementing this protocol can inject additional content into the
-    system prompt during agent execution. This is useful for:
+    Tools implementing this protocol can inject additional content into the model
+    input during agent execution. This is useful for:
     - On-demand skill loading (LoadSkillTool)
     - Dynamic context injection
     - Any tool that needs to modify agent behavior via prompt
@@ -30,25 +30,25 @@ class PromptModifierTool(Protocol):
     protocol from the tool registry and creates a combined prompt modifier.
 
     Unlike static prompt modification (e.g., KB tools that modify prompt at
-    preparation time), this protocol enables dynamic modification - the prompt
-    is updated after the tool is called during agent execution.
+    preparation time), this protocol enables dynamic modification after a tool
+    is called during agent execution.
 
     Example implementation:
         class MyTool(BaseTool):
             def get_prompt_modification(self) -> str:
-                # Return content to append to system prompt
+                # Return dynamic instruction content for the next model call
                 # Return empty string if no modification needed
                 return "Additional instructions..."
     """
 
     def get_prompt_modification(self) -> str:
-        """Get the prompt modification content to inject into system prompt.
+        """Get the prompt modification content to inject into model input.
 
         This method is called by the prompt_modifier before each model invocation.
-        The returned content will be appended to the system message.
+        The returned content will be inserted as dynamic instruction context.
 
         Returns:
-            String content to append to the system prompt.
+            String content to inject into model input.
             Return empty string if no modification is needed.
         """
         ...

--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -14,12 +14,13 @@ This tool implements session-level skill expansion caching with persistence:
 In HTTP mode, skill prompts are obtained from the skill_configs passed via ChatRequest.
 """
 
+import asyncio
 import logging
-from typing import Any, Optional, Set
+from typing import Any, Awaitable, Callable, Optional, Set
 
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +34,71 @@ class LoadSkillInput(BaseModel):
     skill_name: str = Field(description="The name of the skill to load")
 
 
+class LazySkillProviderInput(BaseModel):
+    """Flexible input schema for lazy provider tool proxies."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class LazySkillProviderTool(BaseTool):
+    """Execution proxy for provider tools loaded after load_skill."""
+
+    name: str
+    description: str
+    args_schema: type[BaseModel] = LazySkillProviderInput
+    skill_name: str
+
+    _load_skill_tool: Any = PrivateAttr()
+
+    def __init__(
+        self,
+        *,
+        skill_name: str,
+        tool_name: str,
+        description: str,
+        load_skill_tool: "LoadSkillTool",
+    ):
+        super().__init__(
+            name=tool_name,
+            description=description
+            or f"Tool '{tool_name}' from skill '{skill_name}'. Load the skill before use.",
+            skill_name=skill_name,
+        )
+        self._load_skill_tool = load_skill_tool
+
+    def _run(
+        self,
+        run_manager: CallbackManagerForToolRun | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Synchronous execution is not used in chat streaming."""
+        return (
+            f"Tool '{self.name}' belongs to skill '{self.skill_name}' and must be "
+            "loaded asynchronously before execution."
+        )
+
+    async def _arun(
+        self,
+        run_manager: CallbackManagerForToolRun | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        """Load the real provider tool on demand and delegate execution."""
+        actual_tool = await self._load_skill_tool.get_loaded_tool(
+            self.skill_name, self.name
+        )
+        if actual_tool is None or actual_tool is self:
+            return (
+                f"Tool '{self.name}' for skill '{self.skill_name}' is not available "
+                "after loading the skill."
+            )
+        return await actual_tool.ainvoke(kwargs)
+
+
 class LoadSkillTool(BaseTool):
     """Tool to load a skill and get its full prompt content.
 
     This tool enables on-demand skill expansion - instead of including
-    all skill prompts in the system prompt, skills are loaded only
+    all skill prompts in the base system prompt, skills are loaded only
     when needed, keeping the context window efficient.
 
     Session-level caching with persistence:
@@ -76,7 +137,7 @@ class LoadSkillTool(BaseTool):
     # This tracks which skills have been expanded in the current conversation turn
     _expanded_skills: Set[str] = PrivateAttr(default_factory=set)
 
-    # Store the actual skill prompts that have been loaded (for system prompt injection)
+    # Store the actual skill prompts that have been loaded for dynamic injection
     _loaded_skill_prompts: dict[str, str] = PrivateAttr(default_factory=dict)
 
     # Cache for skill display names (skill_name -> displayName)
@@ -85,6 +146,14 @@ class LoadSkillTool(BaseTool):
     # Store skill tools for dynamic tool selection
     # skill_name -> list of tools
     _skill_tools: dict[str, list] = PrivateAttr(default_factory=dict)
+
+    # Deferred provider-backed tool loaders
+    # skill_name -> async loader returning concrete tool instances
+    _skill_tool_loaders: dict[str, list[Callable[[], Awaitable[list]]]] = PrivateAttr(
+        default_factory=dict
+    )
+    _loaded_skill_tool_loaders: Set[str] = PrivateAttr(default_factory=set)
+    _deferred_mcp_clients: list[Any] = PrivateAttr(default_factory=list)
 
     # Track remaining turns for each loaded skill
     # skill_name -> remaining_turns (decremented each turn, skill unloaded when 0)
@@ -104,6 +173,9 @@ class LoadSkillTool(BaseTool):
         self._loaded_skill_prompts = {}
         self._skill_display_names = {}
         self._skill_tools = {}
+        self._skill_tool_loaders = {}
+        self._loaded_skill_tool_loaders = set()
+        self._deferred_mcp_clients = []
         self._skill_remaining_turns = {}
         self._state_restored = False
         self._user_selected_skills = set()
@@ -184,23 +256,47 @@ class LoadSkillTool(BaseTool):
             self._skill_remaining_turns[skill_name] = self.skill_retention_turns
             return (
                 f"Skill '{skill_name}' is already active in this conversation turn. "
-                f"The skill instructions have been added to the system prompt."
+                "The skill instructions have been added to the conversation context."
             )
 
         # Use shared internal method to load the skill
         if not self._load_skill_internal(skill_name, source="load_skill"):
             return f"Error: Skill '{skill_name}' has no prompt content."
 
-        # Return a confirmation message (the actual prompt will be injected into system prompt)
-        return f"Skill '{skill_name}' has been loaded. The instructions have been added to the system prompt. Please follow them strictly."
+        skill_info = self.skill_metadata.get(skill_name, {})
+        mcp_servers = skill_info.get("mcpServers")
+        mcp_server_count = len(mcp_servers) if isinstance(mcp_servers, dict) else 0
+        registered_tool_count = len(self._skill_tools.get(skill_name, []))
+        if mcp_server_count and registered_tool_count == 0:
+            logger.warning(
+                "[LoadSkillTool_MCP_DEFERRED] skill=%s mcp_server_count=%d "
+                "registered_tool_count=0",
+                skill_name,
+                mcp_server_count,
+            )
+        if (
+            skill_name in self._skill_tool_loaders
+            and skill_name not in self._loaded_skill_tool_loaders
+        ):
+            logger.info(
+                "[LoadSkillTool_PROVIDER_DEFERRED] skill=%s registered_proxy_count=%d",
+                skill_name,
+                registered_tool_count,
+            )
+
+        # Return a confirmation message. The actual prompt is injected dynamically.
+        return f"Skill '{skill_name}' has been loaded. The instructions have been added to the conversation context. Please follow them strictly."
 
     async def _arun(
         self,
         skill_name: str,
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> str:
-        """Load skill asynchronously (same as sync since no I/O needed)."""
-        return self._run(skill_name, run_manager)
+        """Load skill asynchronously and materialize deferred provider tools."""
+        result = self._run(skill_name, run_manager)
+        if not result.startswith("Error:"):
+            await self.ensure_skill_tools_loaded(skill_name)
+        return result
 
     def clear_expanded_skills(self) -> None:
         """Clear the expanded skills cache and loaded prompts.
@@ -220,7 +316,7 @@ class LoadSkillTool(BaseTool):
         return self._expanded_skills.copy()
 
     def get_loaded_skill_prompts(self) -> dict[str, str]:
-        """Get all loaded skill prompts for system prompt injection.
+        """Get all loaded skill prompts for dynamic injection.
 
         Returns:
             Dictionary mapping skill names to their prompts
@@ -265,18 +361,18 @@ class LoadSkillTool(BaseTool):
         skill_config: dict,
         is_user_selected: bool = False,
     ) -> None:
-        """Preload a skill's prompt for system prompt injection.
+        """Preload a skill's prompt for dynamic injection.
 
         This method is called by prepare_skill_tools to preload skill prompts
         when skill tools are directly available. This ensures the skill instructions
-        are injected into the system message via prompt_modifier.
+        are injected into model input via prompt_modifier.
 
         Args:
             skill_name: The name of the skill
             skill_config: The skill configuration containing prompt and displayName
             is_user_selected: Whether this skill was explicitly selected by the user
                 for this message. User-selected skills will be highlighted in the
-                system prompt to encourage the model to prioritize them.
+                dynamic skill context to encourage the model to prioritize them.
         """
         # Temporarily add to skill_metadata if not present (for _load_skill_internal)
         if skill_name not in self.skill_metadata:
@@ -294,7 +390,7 @@ class LoadSkillTool(BaseTool):
             )
 
     def get_prompt_modification(self) -> str:
-        """Get prompt modification content for system prompt injection.
+        """Get prompt modification content for dynamic injection.
 
         This method implements the PromptModifierTool protocol, allowing
         LangGraphAgentBuilder to automatically detect and use this tool
@@ -458,7 +554,7 @@ The following skills provide specialized guidance for specific tasks. When your 
     def _build_user_selected_notice(self) -> str:
         """Build a notice about user-selected skills.
 
-        This notice is added to the system prompt to inform the model that
+        This notice is added to the dynamic skill context to inform the model that
         certain skills were explicitly selected by the user and should be
         prioritized.
 
@@ -518,6 +614,93 @@ The following skills provide specialized guidance for specific tasks. When your 
             skill_name,
             [t.name for t in tools],
         )
+
+    def register_skill_tool_loader(
+        self,
+        skill_name: str,
+        loader: Callable[[], Awaitable[list]],
+    ) -> None:
+        """Register an async loader for deferred skill-backed tools."""
+        self._skill_tool_loaders.setdefault(skill_name, []).append(loader)
+        self._loaded_skill_tool_loaders.discard(skill_name)
+        logger.debug("[LoadSkillTool] Registered lazy tool loader for '%s'", skill_name)
+
+    async def ensure_skill_tools_loaded(self, skill_name: str) -> list:
+        """Materialize deferred tools for a skill."""
+        loaders = self._skill_tool_loaders.get(skill_name, [])
+        if not loaders:
+            return self._skill_tools.get(skill_name, [])
+
+        if skill_name in self._loaded_skill_tool_loaders:
+            return self._skill_tools.get(skill_name, [])
+
+        loaded_tools: list[Any] = []
+        try:
+            for loader in loaders:
+                tools = await loader()
+                if tools:
+                    loaded_tools.extend(tools)
+        except Exception:
+            logger.exception(
+                "[LoadSkillTool] Failed to load deferred tools for skill '%s'",
+                skill_name,
+            )
+            return self._skill_tools.get(skill_name, [])
+
+        if loaded_tools:
+            self.register_skill_tools(skill_name, loaded_tools)
+        self._loaded_skill_tool_loaders.add(skill_name)
+        return self._skill_tools.get(skill_name, [])
+
+    async def ensure_loaded_skill_tools_loaded(self) -> dict[str, list]:
+        """Materialize deferred tools for all currently loaded skills."""
+        skill_names = sorted(self._expanded_skills)
+        if not skill_names:
+            return {}
+
+        results = await asyncio.gather(
+            *[self.ensure_skill_tools_loaded(skill_name) for skill_name in skill_names]
+        )
+        return {
+            skill_name: tools
+            for skill_name, tools in zip(skill_names, results, strict=False)
+            if tools
+        }
+
+    def has_deferred_tool_loaders(self) -> bool:
+        """Return whether any skill can materialize tools after load_skill."""
+        return any(self._skill_tool_loaders.values())
+
+    def add_deferred_mcp_clients(self, clients: list[Any]) -> None:
+        """Track MCP clients opened by deferred skill loading for cleanup."""
+        self._deferred_mcp_clients.extend(client for client in clients if client)
+
+    def drain_deferred_mcp_clients(self) -> list[Any]:
+        """Return and clear deferred MCP clients for request cleanup."""
+        clients = list(self._deferred_mcp_clients)
+        self._deferred_mcp_clients.clear()
+        return clients
+
+    def find_registered_tool(self, tool_name: str) -> Any:
+        """Find a concrete registered skill tool by name."""
+        for tools in self._skill_tools.values():
+            for tool in tools:
+                if getattr(tool, "name", None) != tool_name:
+                    continue
+                if isinstance(tool, LazySkillProviderTool):
+                    continue
+                return tool
+        return None
+
+    async def get_loaded_tool(self, skill_name: str, tool_name: str) -> Any:
+        """Return a concrete tool after loading a skill's deferred tools."""
+        tools = await self.ensure_skill_tools_loaded(skill_name)
+        for tool in tools:
+            if getattr(tool, "name", None) == tool_name and tool is not self:
+                if isinstance(tool, LazySkillProviderTool):
+                    continue
+                return tool
+        return None
 
     def get_skill_tools(self, skill_name: str) -> list:
         """Get tools for a specific skill.

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -14,6 +14,7 @@ In HTTP mode, skill binaries are downloaded from backend API.
 
 import asyncio
 import logging
+import time
 from typing import Any, Optional
 
 import httpx
@@ -131,6 +132,108 @@ async def _download_skill_binary(download_url: str, skill_name: str) -> Optional
     return None
 
 
+async def _create_provider_tools_for_skill(
+    *,
+    task_id: int,
+    subtask_id: int,
+    user_id: int,
+    skill_config: dict[str, Any],
+    registry: Any,
+    remote_url: str,
+    ws_emitter: Any = None,
+    user_name: Optional[str] = None,
+    auth_token: Optional[str] = None,
+    skill_identity_token: Optional[str] = None,
+) -> list[Any]:
+    """Load a skill provider if needed and create concrete tool instances."""
+    from chat_shell.skills import SkillToolContext
+
+    skill_name = skill_config.get("name", "unknown")
+    provider_config = skill_config.get("provider")
+    skill_id = skill_config.get("skill_id")
+    skill_user_id = skill_config.get("skill_user_id")
+
+    # Load provider from skill package if provider config is present.
+    # SECURITY: Only public skills (user_id=0) can load code.
+    if provider_config and skill_id:
+        is_public = skill_user_id == 0
+
+        if not is_public:
+            logger.warning(
+                "[skill_factory] SECURITY: Skipping code loading for non-public "
+                "skill '%s' (user_id=%s). Only public skills can load code.",
+                skill_name,
+                skill_user_id,
+            )
+        else:
+            try:
+                binary_data = None
+
+                if remote_url and skill_id:
+                    download_start = time.perf_counter()
+                    download_url = f"{remote_url}/skills/{skill_id}/binary"
+                    binary_data = await _download_skill_binary(download_url, skill_name)
+                    logger.info(
+                        "[skill_factory_perf] skill=%s binary_download=%.2fms",
+                        skill_name,
+                        (time.perf_counter() - download_start) * 1000,
+                    )
+
+                if binary_data:
+                    provider_start = time.perf_counter()
+                    loaded = registry.ensure_provider_loaded(
+                        skill_name=skill_name,
+                        provider_config=provider_config,
+                        zip_content=binary_data,
+                        is_public=is_public,
+                    )
+                    logger.info(
+                        "[skill_factory_perf] skill=%s provider_load=%.2fms loaded=%s",
+                        skill_name,
+                        (time.perf_counter() - provider_start) * 1000,
+                        loaded,
+                    )
+                    if not loaded:
+                        logger.warning(
+                            "[skill_factory] Failed to load provider for skill '%s'",
+                            skill_name,
+                        )
+                else:
+                    logger.warning(
+                        "[skill_factory] No binary data found for skill '%s' (id=%s)",
+                        skill_name,
+                        skill_id,
+                    )
+            except Exception as e:
+                logger.error(
+                    "[skill_factory] Error loading provider for skill '%s': %s",
+                    skill_name,
+                    str(e),
+                )
+
+    context = SkillToolContext(
+        task_id=task_id,
+        subtask_id=subtask_id,
+        user_id=user_id,
+        db_session=None,
+        ws_emitter=ws_emitter,
+        skill_config=skill_config,
+        user_name=user_name,
+        auth_token=auth_token,
+        skill_identity_token=skill_identity_token,
+    )
+
+    create_tools_start = time.perf_counter()
+    skill_tools = registry.create_tools_for_skill(skill_config, context)
+    logger.info(
+        "[skill_factory_perf] skill=%s create_tools=%.2fms tool_count=%d",
+        skill_name,
+        (time.perf_counter() - create_tools_start) * 1000,
+        len(skill_tools or []),
+    )
+    return skill_tools or []
+
+
 async def prepare_skill_tools(
     task_id: int,
     subtask_id: int,
@@ -148,24 +251,23 @@ async def prepare_skill_tools(
     """
     Prepare skill tools dynamically using SkillToolRegistry.
 
-    This function creates tool instances for ALL skills that have tool declarations
-    in their SKILL.md configuration. Tools are grouped by skill name and stored
-    in the LoadSkillTool for dynamic tool selection at runtime.
+    This function creates concrete tool instances only for active skills. For
+    inactive provider-backed skills, lightweight proxy tools are registered and
+    the provider package is downloaded only after load_skill activates the skill.
 
-    For preloaded skills, their tools are immediately available.
-    For non-preloaded skills, tools are created but only become available
-    after the skill is loaded via load_skill tool.
+    For preloaded or user-selected skills, their tools are immediately available.
+    For non-preloaded skills, registered tools become available after the skill
+    is loaded via load_skill tool.
 
-    Additionally, if a skill has mcpServers configured, the MCP servers will be
-    connected upfront and their tools will be registered to LoadSkillTool under
-    that skill name. These MCP tools are only exposed to the model after the
-    corresponding skill is loaded (or preloaded).
+    Additionally, if an active skill has mcpServers configured, the MCP servers
+    will be merged and loaded as one batch. Inactive skill MCP servers are
+    deferred so ordinary chat turns do not pay connection and schema loading cost.
 
     Skill binaries are downloaded from backend API using REMOTE_STORAGE_URL.
 
     When a load_skill_tool is provided, this function will preload skills specified
     in preload_skills by calling preload_skill_prompt(). These skills will be automatically
-    injected into the system prompt via prompt_modifier.
+    injected into model input via prompt_modifier.
 
     Args:
         task_id: Task ID for WebSocket room
@@ -176,11 +278,11 @@ async def prepare_skill_tools(
                                    "provider": {...}, "skill_id": int, "mcpServers": {...}}
         ws_emitter: Optional WebSocket emitter for real-time communication
         load_skill_tool: Optional LoadSkillTool instance to preload skill prompts
-        preload_skills: Optional list of skill names to preload into system prompt.
+        preload_skills: Optional list of skill names to preload into dynamic context.
                        Skills in this list will have their prompts injected automatically.
         user_selected_skills: Optional list of skill names that were explicitly selected
                              by the user for this message. These skills will be highlighted
-                             in the system prompt to encourage the model to prioritize them.
+                             in dynamic context to encourage the model to prioritize them.
         user_name: Username for identifying the user
         auth_token: JWT token for API authentication (e.g., attachment upload/download)
         skill_identity_token: JWT token for skill identity verification
@@ -209,19 +311,19 @@ async def prepare_skill_tools(
     # Get base URL for skill binary downloads
     remote_url = getattr(settings, "REMOTE_STORAGE_URL", "").rstrip("/")
 
-    # Collect all skill MCP server configs for batch loading.
-    #
-    # NOTE:
-    # - LangGraph's ToolNode builds a static tool map at agent creation time.
-    # - To make skill MCP tools available after a user calls load_skill, we must
-    #   connect and materialize these tools BEFORE the agent graph is built.
-    # - We still keep skill gating: MCP tools are registered under their owning
-    #   skill name and are only exposed to the model after that skill is loaded.
+    # Collect active skill MCP server configs for batch loading. Candidate skills
+    # stay available through load_skill prompt metadata without connecting their
+    # MCP servers during request startup.
     skill_mcp_configs: dict[str, dict[str, Any]] = {}
     skill_mcp_server_owner: dict[str, str] = {}  # prefixed_server_name -> skill_name
+    preload_skill_set = set(preload_skills or [])
+    user_selected_skill_set = set(user_selected_skills or [])
+    active_skill_set = preload_skill_set | user_selected_skill_set
+    function_start = time.perf_counter()
 
     # Process each skill configuration
     for skill_config in skill_configs:
+        skill_start = time.perf_counter()
         skill_name = skill_config.get("name", "unknown")
         tool_declarations = skill_config.get("tools", [])
         provider_config = skill_config.get("provider")
@@ -230,17 +332,20 @@ async def prepare_skill_tools(
         mcp_servers = skill_config.get("mcpServers")
 
         # Check if this skill should be preloaded
-        should_preload = preload_skills is not None and skill_name in preload_skills
+        should_preload = skill_name in preload_skill_set
+        is_user_selected = skill_name in user_selected_skill_set
+        should_activate = skill_name in active_skill_set
 
         # Collect MCP servers from skill config.
-        # We only load MCP tools if we can register them under LoadSkillTool
-        # (for skill-gated exposure) or the skill is explicitly preloaded.
-        if mcp_servers and (load_skill_tool is not None or should_preload):
+        # Only active skill MCP servers are loaded here.
+        if mcp_servers and should_activate:
             logger.info(
-                "[skill_factory] Skill '%s' has %d MCP server(s) configured (preload=%s)",
+                "[skill_factory] Skill '%s' has %d active MCP server(s) configured "
+                "(preload=%s, user_selected=%s)",
                 skill_name,
                 len(mcp_servers),
                 should_preload,
+                is_user_selected,
             )
             # Prefix MCP server names with skill name to avoid conflicts across skills.
             for server_name, server_config in mcp_servers.items():
@@ -248,25 +353,60 @@ async def prepare_skill_tools(
                 skill_mcp_configs[prefixed_name] = server_config
                 skill_mcp_server_owner[prefixed_name] = skill_name
         elif mcp_servers:
-            logger.debug(
-                "[skill_factory] Skipping MCP servers for skill '%s': load_skill_tool=%s, preload=%s",
+            logger.info(
+                "[skill_factory] Deferring %d MCP server(s) for inactive skill '%s' "
+                "(preload=%s, user_selected=%s)",
+                len(mcp_servers),
                 skill_name,
-                load_skill_tool is not None,
                 should_preload,
+                is_user_selected,
             )
+            if load_skill_tool is not None:
+
+                async def load_deferred_mcp_tools(
+                    skill_name=skill_name,
+                    mcp_servers=mcp_servers,
+                ):
+                    load_start = time.perf_counter()
+                    deferred_mcp_configs: dict[str, dict[str, Any]] = {}
+                    for server_name, server_config in mcp_servers.items():
+                        deferred_mcp_configs[f"{skill_name}_{server_name}"] = (
+                            server_config
+                        )
+
+                    tools_with_server, clients = await _load_skill_mcp_tools(
+                        deferred_mcp_configs,
+                        task_id,
+                        task_data,
+                    )
+                    if hasattr(load_skill_tool, "add_deferred_mcp_clients"):
+                        load_skill_tool.add_deferred_mcp_clients(clients)
+
+                    loaded_tools: list[Any] = []
+                    for server_tools in tools_with_server.values():
+                        loaded_tools.extend(server_tools)
+
+                    logger.info(
+                        "[skill_factory_perf] skill=%s deferred_mcp_load=%.2fms "
+                        "server_count=%d tool_count=%d",
+                        skill_name,
+                        (time.perf_counter() - load_start) * 1000,
+                        len(deferred_mcp_configs),
+                        len(loaded_tools),
+                    )
+                    return loaded_tools
+
+                load_skill_tool.register_skill_tool_loader(
+                    skill_name, load_deferred_mcp_tools
+                )
 
         if not tool_declarations:
             # No tools declared for this skill, skip tool creation
-            # but MCP servers may still be loaded above for preloaded skills
-            # Still preload the skill prompt if it's in preload_skills list
-            if should_preload and load_skill_tool is not None:
+            # but MCP servers may still be loaded above for active skills.
+            # Still preload the skill prompt if this skill is active.
+            if should_activate and load_skill_tool is not None:
                 skill_prompt = skill_config.get("prompt", "")
                 if skill_prompt:
-                    # Check if this skill was explicitly selected by the user
-                    is_user_selected = (
-                        user_selected_skills is not None
-                        and skill_name in user_selected_skills
-                    )
                     load_skill_tool.preload_skill_prompt(
                         skill_name, skill_config, is_user_selected=is_user_selected
                     )
@@ -276,6 +416,14 @@ async def prepare_skill_tools(
                         skill_name,
                         is_user_selected,
                     )
+            logger.info(
+                "[skill_factory_perf] skill=%s total=%.2fms active=%s "
+                "tool_declarations=0 mcp_servers=%d",
+                skill_name,
+                (time.perf_counter() - skill_start) * 1000,
+                should_activate,
+                len(mcp_servers or {}),
+            )
             continue
 
         logger.debug(
@@ -284,71 +432,84 @@ async def prepare_skill_tools(
             len(tool_declarations),
         )
 
-        # Load provider from skill package if provider config is present
-        # SECURITY: Only public skills (user_id=0) can load code
-        if provider_config and skill_id:
-            # Check if this is a public skill (user_id=0)
-            is_public = skill_user_id == 0
+        if not should_activate and load_skill_tool is not None:
+            from chat_shell.tools.builtin.load_skill import LazySkillProviderTool
 
-            if not is_public:
-                logger.warning(
-                    "[skill_factory] SECURITY: Skipping code loading for non-public "
-                    "skill '%s' (user_id=%s). Only public skills can load code.",
-                    skill_name,
-                    skill_user_id,
-                )
-            else:
-                try:
-                    binary_data = None
-
-                    # Download from backend API
-                    if remote_url and skill_id:
-                        download_url = f"{remote_url}/skills/{skill_id}/binary"
-                        binary_data = await _download_skill_binary(
-                            download_url, skill_name
-                        )
-
-                    if binary_data:
-                        # Load and register the provider
-                        loaded = registry.ensure_provider_loaded(
-                            skill_name=skill_name,
-                            provider_config=provider_config,
-                            zip_content=binary_data,
-                            is_public=is_public,
-                        )
-                        if not loaded:
-                            logger.warning(
-                                "[skill_factory] Failed to load provider for skill '%s'",
-                                skill_name,
-                            )
-                    else:
-                        logger.warning(
-                            "[skill_factory] No binary data found for skill '%s' (id=%s)",
-                            skill_name,
-                            skill_id,
-                        )
-                except Exception as e:
-                    logger.error(
-                        "[skill_factory] Error loading provider for skill '%s': %s",
-                        skill_name,
-                        str(e),
+            lazy_tools = []
+            for tool_decl in tool_declarations:
+                tool_name = tool_decl.get("name")
+                if not tool_name:
+                    continue
+                lazy_tools.append(
+                    LazySkillProviderTool(
+                        skill_name=skill_name,
+                        tool_name=tool_name,
+                        description=tool_decl.get("description", ""),
+                        load_skill_tool=load_skill_tool,
                     )
+                )
 
-        # Create context for this skill
-        context = SkillToolContext(
+            if lazy_tools:
+
+                async def load_deferred_tools(
+                    skill_config=skill_config,
+                    skill_name=skill_name,
+                ):
+                    load_start = time.perf_counter()
+                    loaded_tools = await _create_provider_tools_for_skill(
+                        task_id=task_id,
+                        subtask_id=subtask_id,
+                        user_id=user_id,
+                        skill_config=skill_config,
+                        registry=registry,
+                        remote_url=remote_url,
+                        ws_emitter=ws_emitter,
+                        user_name=user_name,
+                        auth_token=auth_token,
+                        skill_identity_token=skill_identity_token,
+                    )
+                    logger.info(
+                        "[skill_factory_perf] skill=%s deferred_provider_load=%.2fms "
+                        "tool_count=%d",
+                        skill_name,
+                        (time.perf_counter() - load_start) * 1000,
+                        len(loaded_tools),
+                    )
+                    return loaded_tools
+
+                load_skill_tool.register_skill_tools(skill_name, lazy_tools)
+                load_skill_tool.register_skill_tool_loader(
+                    skill_name, load_deferred_tools
+                )
+                logger.info(
+                    "[skill_factory] Deferred %d provider tool(s) for inactive skill '%s'",
+                    len(lazy_tools),
+                    skill_name,
+                )
+
+            logger.info(
+                "[skill_factory_perf] skill=%s total=%.2fms active=%s "
+                "tool_declarations=%d mcp_servers=%d",
+                skill_name,
+                (time.perf_counter() - skill_start) * 1000,
+                should_activate,
+                len(tool_declarations or []),
+                len(mcp_servers or {}),
+            )
+            continue
+
+        skill_tools = await _create_provider_tools_for_skill(
             task_id=task_id,
             subtask_id=subtask_id,
             user_id=user_id,
-            db_session=None,
-            ws_emitter=ws_emitter,
             skill_config=skill_config,
+            registry=registry,
+            remote_url=remote_url,
+            ws_emitter=ws_emitter,
             user_name=user_name,
             auth_token=auth_token,
             skill_identity_token=skill_identity_token,
         )
-
-        # Create tools using the registry
-        skill_tools = registry.create_tools_for_skill(skill_config, context)
 
         if skill_tools:
             logger.info(
@@ -367,18 +528,13 @@ async def prepare_skill_tools(
                     skill_name,
                 )
 
-            # For preloaded skills, add tools to the immediate tools list
+            # For active skills, add tools to the immediate tools list
             # and preload the skill prompt
-            if should_preload:
+            if should_activate:
                 tools.extend(skill_tools)
                 if load_skill_tool is not None:
                     skill_prompt = skill_config.get("prompt", "")
                     if skill_prompt:
-                        # Check if this skill was explicitly selected by the user
-                        is_user_selected = (
-                            user_selected_skills is not None
-                            and skill_name in user_selected_skills
-                        )
                         load_skill_tool.preload_skill_prompt(
                             skill_name, skill_config, is_user_selected=is_user_selected
                         )
@@ -395,12 +551,28 @@ async def prepare_skill_tools(
                     skill_name,
                 )
 
+        logger.info(
+            "[skill_factory_perf] skill=%s total=%.2fms active=%s "
+            "tool_declarations=%d mcp_servers=%d",
+            skill_name,
+            (time.perf_counter() - skill_start) * 1000,
+            should_activate,
+            len(tool_declarations or []),
+            len(mcp_servers or {}),
+        )
+
     # Load MCP tools from all skills if any MCP servers are configured
     if skill_mcp_configs:
+        mcp_load_start = time.perf_counter()
         mcp_tools_with_server, skill_mcp_clients = await _load_skill_mcp_tools(
             skill_mcp_configs, task_id, task_data
         )
         mcp_clients.extend(skill_mcp_clients)
+        logger.info(
+            "[skill_factory_perf] active_skill_mcp_load=%.2fms server_count=%d",
+            (time.perf_counter() - mcp_load_start) * 1000,
+            len(skill_mcp_configs),
+        )
 
         # Calculate total tools count
         total_mcp_tools = sum(len(tools) for tools in mcp_tools_with_server.values())
@@ -486,6 +658,16 @@ async def prepare_skill_tools(
             tool_names,
         )
 
+    logger.info(
+        "[skill_factory_perf] prepare_skill_tools total=%.2fms skill_count=%d "
+        "active_skill_count=%d loaded_mcp_server_count=%d immediate_tool_count=%d",
+        (time.perf_counter() - function_start) * 1000,
+        len(skill_configs),
+        len(active_skill_set),
+        len(skill_mcp_configs),
+        len(tools),
+    )
+
     return tools, mcp_clients
 
 
@@ -520,6 +702,7 @@ async def _load_skill_mcp_tools(
         len(mcp_configs),
         list(mcp_configs.keys()),
     )
+    load_start = time.perf_counter()
 
     mcp_tools_with_server: dict[str, list[Any]] = {}
     mcp_clients: list[Any] = []
@@ -541,10 +724,12 @@ async def _load_skill_mcp_tools(
                     len(tools) for tools in mcp_tools_with_server.values()
                 )
                 logger.info(
-                    "[skill_factory] Loaded %d MCP tools from %d skill servers for task %d",
+                    "[skill_factory] Loaded %d MCP tools from %d skill servers for task %d "
+                    "in %.2fms",
                     total_tools,
                     len(mcp_tools_with_server),
                     task_id,
+                    (time.perf_counter() - load_start) * 1000,
                 )
 
                 # Log tool count per server

--- a/chat_shell/tests/api/v1/test_response_logging.py
+++ b/chat_shell/tests/api/v1/test_response_logging.py
@@ -1,0 +1,77 @@
+from chat_shell.api.v1.response import _summarize_metadata_for_log
+
+
+def test_metadata_log_summary_excludes_sensitive_values() -> None:
+    metadata = {
+        "task_id": 1,
+        "subtask_id": 2,
+        "request_id": "req-123",
+        "user_id": 3,
+        "user_name": "alice",
+        "auth_token": "raw-auth-token",
+        "skill_identity_token": "raw-skill-token",
+        "user": {
+            "git_token": "github_pat_SECRET",
+            "sina_mail": {"token": "mail-secret"},
+        },
+        "skill_names": ["sandbox", "web-tools"],
+        "skill_configs": [
+            {"name": "sandbox", "mcpServers": {"sandbox": {}}},
+            {"name": "web-tools", "mcpServers": {"web": {}}, "tools": [{}]},
+        ],
+        "preload_skills": ["sandbox"],
+        "user_selected_skills": ["sandbox"],
+        "knowledge_base_ids": [10, 11],
+        "table_contexts": [{"table": "a"}],
+        "task_data": {
+            "user_mcps": {
+                "dingtalk": {
+                    "services": {
+                        "docs": {
+                            "credentials": {
+                                "url": "https://example.invalid/mcp?key=secret"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    }
+
+    summary = _summarize_metadata_for_log(metadata)
+
+    assert summary == {
+        "task_id": 1,
+        "subtask_id": 2,
+        "request_id": "req-123",
+        "user_id": 3,
+        "user_name": "alice",
+        "team_id": None,
+        "team_name": None,
+        "bot_name": None,
+        "message_id": None,
+        "user_message_id": None,
+        "user_subtask_id": None,
+        "is_group_chat": None,
+        "stateless": None,
+        "enable_tools": None,
+        "enable_web_search": None,
+        "enable_deep_thinking": None,
+        "skill_count": 2,
+        "skill_names": ["sandbox", "web-tools"],
+        "skill_config_count": 2,
+        "skill_mcp_server_count": 2,
+        "skill_declared_tool_count": 1,
+        "preload_skills": ["sandbox"],
+        "user_selected_skills": ["sandbox"],
+        "knowledge_base_count": 2,
+        "document_count": 0,
+        "knowledge_base_scope_count": 0,
+        "table_context_count": 1,
+        "has_auth_token": True,
+        "has_skill_identity_token": True,
+        "has_task_data": True,
+    }
+    assert "raw-auth-token" not in str(summary)
+    assert "github_pat_SECRET" not in str(summary)
+    assert "secret" not in str(summary)

--- a/chat_shell/tests/test_dynamic_skill_tools.py
+++ b/chat_shell/tests/test_dynamic_skill_tools.py
@@ -8,9 +8,12 @@ This module tests the ability to dynamically load skill tools when
 a skill is loaded via the load_skill tool.
 """
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import tool
 
 from chat_shell.tools.builtin.load_skill import LoadSkillTool
 
@@ -90,6 +93,33 @@ class TestLoadSkillToolDynamicTools:
         available = tool.get_available_tools()
         assert mock_tool_a in available
         assert mock_tool_b not in available
+
+    def test_load_skill_logs_deferred_mcp_without_registered_tools(self, caplog):
+        """Test that deferred MCP tools are visible in load_skill observability."""
+        tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_mcp"],
+            skill_metadata={
+                "skill_mcp": {
+                    "description": "Skill with MCP",
+                    "prompt": "Skill MCP prompt",
+                    "mcpServers": {
+                        "server_a": {
+                            "type": "stdio",
+                            "command": "python",
+                            "args": ["-m", "server"],
+                        }
+                    },
+                },
+            },
+        )
+
+        with caplog.at_level(logging.WARNING):
+            result = tool._run("skill_mcp")
+
+        assert "Skill 'skill_mcp' has been loaded" in result
+        assert "[LoadSkillTool_MCP_DEFERRED]" in caplog.text
+        assert "mcp_server_count=1" in caplog.text
 
     def test_get_available_tools_updates_after_loading_more_skills(self):
         """Test that get_available_tools updates when more skills are loaded."""
@@ -320,6 +350,173 @@ class TestDynamicToolSelectionIntegration:
         assert "load_skill" in tool_names
         assert "tool_a" in tool_names
         assert "tool_b" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_dynamic_tool_node_executes_tool_registered_after_build(self):
+        """Test ToolNode wrapper resolves tools registered after graph build."""
+        from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+        from chat_shell.tools.base import ToolRegistry
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        @tool
+        def dynamic_tool(value: str) -> str:
+            """Return a value from a dynamically registered tool."""
+            return f"dynamic:{value}"
+
+        mock_llm = MagicMock()
+        tool_registry = ToolRegistry()
+        tool_registry.register(load_skill_tool)
+
+        builder = LangGraphAgentBuilder(
+            llm=mock_llm,
+            tool_registry=tool_registry,
+        )
+        tool_node = builder._create_dynamic_tool_node(
+            all_tools=[load_skill_tool],
+            load_skill_tool=load_skill_tool,
+        )
+
+        load_skill_tool.register_skill_tools("skill_a", [dynamic_tool])
+        load_skill_tool._run("skill_a")
+
+        from langgraph._internal._constants import CONF, CONFIG_KEY_RUNTIME
+        from langgraph.runtime import Runtime
+
+        result = await tool_node.ainvoke(
+            {
+                "messages": [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "dynamic_tool",
+                                "args": {"value": "ok"},
+                                "id": "call_1",
+                            }
+                        ],
+                    )
+                ]
+            },
+            config={CONF: {CONFIG_KEY_RUNTIME: Runtime()}},
+        )
+
+        assert isinstance(result["messages"][0], ToolMessage)
+        assert result["messages"][0].name == "dynamic_tool"
+        assert result["messages"][0].content == "dynamic:ok"
+
+    @pytest.mark.asyncio
+    async def test_model_configurator_binds_deferred_loaded_tools(self):
+        """Test model binding includes tools materialized by load_skill."""
+        from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+        from chat_shell.tools.base import ToolRegistry
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["skill_a"],
+            skill_metadata={
+                "skill_a": {"description": "Skill A", "prompt": "Skill A prompt"},
+            },
+        )
+
+        deferred_tool = MagicMock()
+        deferred_tool.name = "deferred_tool"
+
+        async def load_deferred_tools():
+            return [deferred_tool]
+
+        load_skill_tool.register_skill_tool_loader("skill_a", load_deferred_tools)
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(return_value=mock_llm)
+
+        tool_registry = ToolRegistry()
+        tool_registry.register(load_skill_tool)
+
+        builder = LangGraphAgentBuilder(
+            llm=mock_llm,
+            tool_registry=tool_registry,
+        )
+
+        configurator, all_tools = builder._create_model_configurator()
+
+        assert configurator is not None
+        assert [tool.name for tool in all_tools] == ["load_skill"]
+
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        assert [tool.name for tool in call_args] == ["load_skill"]
+
+        await load_skill_tool._arun("skill_a")
+
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        assert [tool.name for tool in call_args] == ["load_skill", "deferred_tool"]
+
+    @pytest.mark.asyncio
+    async def test_restored_skill_materializes_deferred_tools_before_model_binding(
+        self,
+    ):
+        """Test restored skills expose deferred tools without another load_skill call."""
+        from chat_shell.agents.graph_builder import LangGraphAgentBuilder
+        from chat_shell.tools.base import ToolRegistry
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["interactive"],
+            skill_metadata={
+                "interactive": {
+                    "description": "Interactive skill",
+                    "prompt": "Interactive skill prompt",
+                },
+            },
+        )
+
+        deferred_tool = MagicMock()
+        deferred_tool.name = "interactive_form_question"
+
+        async def load_deferred_tools():
+            return [deferred_tool]
+
+        load_skill_tool.register_skill_tool_loader("interactive", load_deferred_tools)
+        load_skill_tool.restore_from_history(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "loaded_skills": ["interactive"],
+                }
+            ]
+        )
+
+        restored_tools = await load_skill_tool.ensure_loaded_skill_tools_loaded()
+
+        assert restored_tools == {"interactive": [deferred_tool]}
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(return_value=mock_llm)
+
+        tool_registry = ToolRegistry()
+        tool_registry.register(load_skill_tool)
+
+        builder = LangGraphAgentBuilder(
+            llm=mock_llm,
+            tool_registry=tool_registry,
+        )
+        configurator, _ = builder._create_model_configurator()
+
+        configurator({}, None)
+        call_args = mock_llm.bind_tools.call_args[0][0]
+        assert [tool.name for tool in call_args] == [
+            "load_skill",
+            "interactive_form_question",
+        ]
 
     def test_no_model_configurator_when_no_load_skill_tool(self):
         """Test that no model configurator is created when there's no LoadSkillTool."""

--- a/chat_shell/tests/test_prompt_modifier_tool.py
+++ b/chat_shell/tests/test_prompt_modifier_tool.py
@@ -14,7 +14,7 @@ This module tests:
 from unittest.mock import MagicMock, patch
 
 import pytest
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import ChatMessage, HumanMessage, SystemMessage
 
 from chat_shell.agents.graph_builder import LangGraphAgentBuilder
 from chat_shell.tools.base import PromptModifierTool, ToolRegistry
@@ -225,10 +225,13 @@ class TestPromptModifierFunction:
         assert len(result) == 2
         assert result[0].content == "Original system prompt"
 
-    def test_prompt_modifier_appends_to_system_message(self):
-        """Test that prompt_modifier appends modifications to system message."""
+    def test_prompt_modifier_injects_skill_context_as_developer_message_for_openai(
+        self,
+    ):
+        """Test that OpenAI skill context uses a developer message."""
         # Arrange
         mock_llm = MagicMock()
+        mock_llm._wegent_provider = "openai"
         registry = ToolRegistry()
         load_skill = LoadSkillTool(user_id=1, skill_names=["test"], skill_metadata={})
         load_skill.preload_skill_prompt("test", {"prompt": "Test instructions"})
@@ -247,14 +250,18 @@ class TestPromptModifierFunction:
         result = prompt_modifier(state)
 
         # Assert
-        assert len(result) == 2
-        assert "Original system prompt" in result[0].content
-        assert "Test instructions" in result[0].content
+        assert len(result) == 3
+        assert result[0].content == "Original system prompt"
+        assert isinstance(result[1], ChatMessage)
+        assert result[1].role == "developer"
+        assert "Test instructions" in result[1].content
+        assert result[2].content == "Hello"
 
-    def test_prompt_modifier_creates_system_message_if_missing(self):
-        """Test that prompt_modifier creates system message if none exists."""
+    def test_prompt_modifier_creates_developer_context_message_if_system_missing(self):
+        """Test that OpenAI dynamic context does not create a system message."""
         # Arrange
         mock_llm = MagicMock()
+        mock_llm._wegent_provider = "openai"
         registry = ToolRegistry()
         load_skill = LoadSkillTool(user_id=1, skill_names=["test"], skill_metadata={})
         load_skill.preload_skill_prompt("test", {"prompt": "Test instructions"})
@@ -271,13 +278,45 @@ class TestPromptModifierFunction:
 
         # Assert
         assert len(result) == 2
-        assert isinstance(result[0], SystemMessage)
+        assert isinstance(result[0], ChatMessage)
+        assert result[0].role == "developer"
         assert "Test instructions" in result[0].content
+        assert result[1].content == "Hello"
+
+    def test_prompt_modifier_uses_human_context_message_for_anthropic(self):
+        """Test that non-OpenAI providers avoid unsupported developer messages."""
+        # Arrange
+        mock_llm = MagicMock()
+        mock_llm._wegent_provider = "anthropic"
+        registry = ToolRegistry()
+        load_skill = LoadSkillTool(user_id=1, skill_names=["test"], skill_metadata={})
+        load_skill.preload_skill_prompt("test", {"prompt": "Test instructions"})
+        registry.register(load_skill)
+
+        builder = LangGraphAgentBuilder(llm=mock_llm, tool_registry=registry)
+        prompt_modifier = builder._create_prompt_modifier()
+
+        messages = [
+            SystemMessage(content="Original system prompt"),
+            HumanMessage(content="Hello"),
+        ]
+        state = {"messages": messages}
+
+        # Act
+        result = prompt_modifier(state)
+
+        # Assert
+        assert len(result) == 3
+        assert result[0].content == "Original system prompt"
+        assert isinstance(result[1], HumanMessage)
+        assert "Test instructions" in result[1].content
+        assert result[2].content == "Hello"
 
     def test_prompt_modifier_handles_empty_messages(self):
         """Test that prompt_modifier handles empty messages list."""
         # Arrange
         mock_llm = MagicMock()
+        mock_llm._wegent_provider = "openai"
         registry = ToolRegistry()
         load_skill = LoadSkillTool(user_id=1, skill_names=["test"], skill_metadata={})
         load_skill.preload_skill_prompt("test", {"prompt": "Test instructions"})
@@ -298,6 +337,7 @@ class TestPromptModifierFunction:
         """Test that prompt_modifier combines modifications from multiple tools."""
         # Arrange
         mock_llm = MagicMock()
+        mock_llm._wegent_provider = "openai"
         registry = ToolRegistry()
 
         tool1 = LoadSkillTool(user_id=1, skill_names=["skill1"], skill_metadata={})
@@ -324,8 +364,12 @@ class TestPromptModifierFunction:
         result = prompt_modifier(state)
 
         # Assert
-        assert "Instructions 1" in result[0].content
-        assert "Instructions 2" in result[0].content
+        assert result[0].content == "Original"
+        assert isinstance(result[1], ChatMessage)
+        assert result[1].role == "developer"
+        assert "Instructions 1" in result[1].content
+        assert "Instructions 2" in result[1].content
+        assert result[2].content == "Hello"
 
     def test_prompt_modifier_preserves_list_content_with_cache_control(self):
         """Test that prompt_modifier preserves list content blocks (e.g., Anthropic cache breakpoints).
@@ -337,6 +381,7 @@ class TestPromptModifierFunction:
         """
         # Arrange
         mock_llm = MagicMock()
+        mock_llm._wegent_provider = "openai"
         registry = ToolRegistry()
         load_skill = LoadSkillTool(user_id=1, skill_names=["test"], skill_metadata={})
         load_skill.preload_skill_prompt("test", {"prompt": "Skill instructions"})
@@ -362,13 +407,15 @@ class TestPromptModifierFunction:
         # Act
         result = prompt_modifier(state)
 
-        # Assert - content must remain a list, NOT a stringified representation
+        # Assert - system content must remain unchanged and cacheable.
         assert isinstance(result[0].content, list)
         # Original block with cache_control is preserved
         assert result[0].content[0]["type"] == "text"
         assert result[0].content[0]["text"] == "Original system prompt"
         assert "cache_control" in result[0].content[0]
-        # Modification is appended as a new content block
-        assert len(result[0].content) == 2
-        assert result[0].content[1]["type"] == "text"
-        assert "Skill instructions" in result[0].content[1]["text"]
+        assert len(result[0].content) == 1
+        # Modification is injected as a separate dynamic developer message.
+        assert isinstance(result[1], ChatMessage)
+        assert result[1].role == "developer"
+        assert "Skill instructions" in result[1].content
+        assert result[2].content == "Hello"

--- a/chat_shell/tests/test_skill_mcp_loader.py
+++ b/chat_shell/tests/test_skill_mcp_loader.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from chat_shell.tools import skill_factory
 from chat_shell.tools.builtin.load_skill import LoadSkillTool
 from chat_shell.tools.skill_factory import (
     _load_skill_mcp_tools,
@@ -220,8 +221,166 @@ class TestPrepareSkillToolsWithMcp:
             assert clients == []
 
     @pytest.mark.asyncio
-    async def test_skill_mcp_tools_registered_and_gated_by_load_skill(self):
-        """Test that MCP tools are registered but only exposed after load_skill."""
+    async def test_inactive_skill_mcp_tools_load_after_load_skill(self):
+        """Test that inactive skill MCP tools load on demand after load_skill."""
+        skill_configs = [
+            {
+                "name": "test_skill",
+                "description": "A test skill",
+                "prompt": "Test skill prompt",
+                "mcpServers": {
+                    "server1": {
+                        "type": "stdio",
+                        "command": "python",
+                        "args": ["-m", "test_server"],
+                    }
+                },
+            }
+        ]
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["test_skill"],
+            skill_metadata={
+                "test_skill": {
+                    "description": "A test skill",
+                    "prompt": "Test skill prompt",
+                }
+            },
+        )
+
+        with patch("chat_shell.tools.mcp.MCPClient") as mock_mcp_class:
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+                load_skill_tool=load_skill_tool,
+                # Not preloaded: should register but not expose yet
+                preload_skills=[],
+            )
+
+            # MCP client should not be created during startup.
+            mock_mcp_class.assert_not_called()
+
+            assert tools == []
+            assert clients == []
+
+            assert load_skill_tool.get_available_tools() == []
+            assert load_skill_tool.get_skill_tools("test_skill") == []
+
+            mock_mcp_tool = MagicMock()
+            mock_mcp_tool.name = "test_skill_server1_interactive_form_question"
+            mock_mcp_tool.server_name = "test_skill_server1"
+
+            mock_client = MagicMock()
+            mock_client.is_connected = True
+            mock_client.connect = AsyncMock()
+            mock_client.get_tools_with_server.return_value = {
+                "test_skill_server1": [mock_mcp_tool]
+            }
+            mock_mcp_class.return_value = mock_client
+
+            await load_skill_tool._arun("test_skill")
+
+            mock_mcp_class.assert_called_once()
+            mock_client.connect.assert_awaited_once()
+            assert load_skill_tool.get_available_tools() == [mock_mcp_tool]
+            assert load_skill_tool.get_skill_tools("test_skill") == [mock_mcp_tool]
+
+    @pytest.mark.asyncio
+    async def test_inactive_provider_skill_tools_load_only_after_load_skill(
+        self, monkeypatch
+    ):
+        """Test that inactive provider-backed tools are loaded on demand."""
+        skill_configs = [
+            {
+                "name": "slow_skill",
+                "description": "A slow provider-backed skill",
+                "prompt": "Slow skill prompt",
+                "skill_id": 123,
+                "skill_user_id": 0,
+                "provider": {
+                    "module": "provider",
+                    "class": "SlowProvider",
+                },
+                "tools": [
+                    {
+                        "name": "slow_tool",
+                        "provider": "slow_provider",
+                        "description": "A slow tool",
+                    }
+                ],
+            }
+        ]
+
+        monkeypatch.setattr(
+            skill_factory.settings,
+            "REMOTE_STORAGE_URL",
+            "http://backend.example",
+            raising=False,
+        )
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["slow_skill"],
+            skill_metadata={
+                "slow_skill": {
+                    "description": "A slow provider-backed skill",
+                    "prompt": "Slow skill prompt",
+                }
+            },
+        )
+
+        actual_tool = MagicMock()
+        actual_tool.name = "slow_tool"
+
+        registry = MagicMock()
+        registry.ensure_provider_loaded.return_value = True
+        registry.create_tools_for_skill.return_value = [actual_tool]
+
+        with (
+            patch(
+                "chat_shell.skills.SkillToolRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "chat_shell.tools.skill_factory._download_skill_binary",
+                new=AsyncMock(return_value=b"zip-content"),
+            ) as download_binary,
+        ):
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+                load_skill_tool=load_skill_tool,
+                preload_skills=[],
+                user_selected_skills=[],
+            )
+
+            download_binary.assert_not_awaited()
+            registry.ensure_provider_loaded.assert_not_called()
+            registry.create_tools_for_skill.assert_not_called()
+            assert tools == []
+            assert clients == []
+            assert load_skill_tool.get_available_tools() == []
+
+            registered_tools = load_skill_tool.get_skill_tools("slow_skill")
+            assert len(registered_tools) == 1
+            assert registered_tools[0].name == "slow_tool"
+
+            await load_skill_tool._arun("slow_skill")
+
+            download_binary.assert_awaited_once()
+            registry.ensure_provider_loaded.assert_called_once()
+            registry.create_tools_for_skill.assert_called_once()
+            assert load_skill_tool.get_skill_tools("slow_skill") == [actual_tool]
+            assert load_skill_tool.get_available_tools() == [actual_tool]
+
+    @pytest.mark.asyncio
+    async def test_user_selected_skill_mcp_tools_are_loaded(self):
+        """Test that user-selected skill MCP servers are treated as active."""
         skill_configs = [
             {
                 "name": "test_skill",
@@ -269,23 +428,14 @@ class TestPrepareSkillToolsWithMcp:
                 user_id=1,
                 skill_configs=skill_configs,
                 load_skill_tool=load_skill_tool,
-                # Not preloaded: should register but not expose yet
                 preload_skills=[],
+                user_selected_skills=["test_skill"],
             )
 
-            # MCP client should be created so tools can be registered for later exposure
             mock_mcp_class.assert_called_once()
-
-            # No immediate tools (skill not loaded yet)
             assert tools == []
             assert len(clients) == 1
-
-            # Tools are registered under the owning skill but gated by load_skill
-            assert load_skill_tool.get_available_tools() == []
             assert load_skill_tool.get_skill_tools("test_skill") == [mock_mcp_tool]
-
-            # After loading the skill, tools become available
-            load_skill_tool._run("test_skill")
             assert mock_mcp_tool in load_skill_tool.get_available_tools()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Move skill prompt injection out of the stable system prompt into dynamic per-call context so prompt caching is not invalidated by loaded skills.
- Defer inactive skill provider and MCP tool loading until `load_skill` is actually called.
- Materialize restored skill tools after history restore so a previously loaded skill exposes its real tool schema without another `load_skill` call.
- Add tracing/logging around chat shell request setup, context metrics, history loading, and deferred skill/MCP loading.

## Root Cause

The chat shell restored loaded skill prompt state from history, but did not restore/materialize the skill's MCP tools. On the next turn, the model only saw `load_skill`, not the real MCP tool schema, so it called `load_skill` again before using the actual skill tool.

## Validation

- `cd chat_shell && uv run pytest tests/test_prompt_modifier_tool.py tests/test_dynamic_skill_tools.py tests/test_skill_mcp_loader.py tests/api/v1/test_response_logging.py tests/test_context_metrics.py tests/test_messages.py -q`
- `git diff --check`
- pre-push quality checks passed