### PR TITLE
[codex] Fix attachment preview lightbox layering

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/input/AttachmentPreview.lightbox.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/input/AttachmentPreview.lightbox.test.tsx
@@ -1,0 +1,67 @@
+import '@testing-library/jest-dom'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+
+import AttachmentPreview from '@/features/tasks/components/input/AttachmentPreview'
+import type { Attachment } from '@/types/api'
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+jest.mock('@/hooks/useAttachmentImage', () => ({
+  useAttachmentImage: () => ({
+    blobUrl: 'blob:preview-image',
+    isLoading: false,
+    error: false,
+  }),
+}))
+
+jest.mock('@/apis/attachments', () => ({
+  formatFileSize: () => '12 KB',
+  getFileIcon: () => 'file',
+  downloadAttachment: jest.fn(),
+  isImageExtension: (extension: string) =>
+    ['.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp'].includes(extension),
+  isHtmlExtension: () => false,
+}))
+
+jest.mock('@/components/common/FilePreview', () => ({
+  FilePreviewDialog: () => null,
+}))
+
+const imageAttachment: Attachment = {
+  id: 1049,
+  filename: 'screenshot.png',
+  file_size: 12_345,
+  mime_type: 'image/png',
+  status: 'ready',
+  text_length: null,
+  error_message: null,
+  error_code: null,
+  subtask_id: 88,
+  file_extension: '.png',
+  created_at: '2026-06-18T00:00:00Z',
+}
+
+describe('AttachmentPreview lightbox', () => {
+  it('opens image previews above the floating chat input layer', () => {
+    render(
+      <div data-testid="floating-input-layer" className="fixed bottom-0 z-50">
+        <AttachmentPreview attachment={imageAttachment} />
+      </div>
+    )
+
+    fireEvent.click(screen.getByAltText('screenshot.png'))
+
+    const dialog = screen.getByRole('dialog', { name: 'screenshot.png' })
+
+    expect(dialog).toHaveClass('fixed', 'inset-0', 'z-[9999]')
+    expect(dialog.parentElement).toBe(document.body)
+    expect(within(dialog).getByAltText('screenshot.png')).toHaveAttribute(
+      'src',
+      'blob:preview-image'
+    )
+  })
+})

--- a/frontend/src/features/tasks/components/input/AttachmentPreview.tsx
+++ b/frontend/src/features/tasks/components/input/AttachmentPreview.tsx
@@ -5,6 +5,7 @@
 'use client'
 
 import React, { useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Download, X, ZoomIn, ZoomOut, RotateCw, Loader2, Eye } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
@@ -102,8 +103,11 @@ function ImageLightbox({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
     >
       {/* Toolbar */}
       <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
@@ -159,6 +163,7 @@ function ImageLightbox({
 
       {/* Image container */}
       <div className="max-w-[90vw] max-h-[90vh] overflow-auto">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src={src}
           alt={alt}
@@ -225,6 +230,19 @@ export default function AttachmentPreview({
     error: imageError,
   } = useAttachmentImage(attachment.id, isImage, shareToken)
 
+  const lightbox =
+    showLightbox && typeof document !== 'undefined'
+      ? createPortal(
+          <ImageLightbox
+            src={imageUrl ?? ''}
+            alt={attachment.filename}
+            onClose={handleCloseLightbox}
+            onDownload={handleDownload}
+          />,
+          document.body
+        )
+      : null
+
   // Render image preview for image types
   if (isImage && !imageError) {
     // Show loading state while fetching image
@@ -253,16 +271,10 @@ export default function AttachmentPreview({
               onClick={handleImageClick}
               title={attachment.filename}
             >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={imageUrl} alt={attachment.filename} className="h-12 w-12 object-cover" />
             </div>
-            {showLightbox && (
-              <ImageLightbox
-                src={imageUrl}
-                alt={attachment.filename}
-                onClose={handleCloseLightbox}
-                onDownload={handleDownload}
-              />
-            )}
+            {lightbox}
           </>
         )
       }
@@ -274,6 +286,7 @@ export default function AttachmentPreview({
               className="cursor-pointer rounded-lg overflow-hidden border border-border hover:border-primary transition-colors"
               onClick={handleImageClick}
             >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={imageUrl}
                 alt={attachment.filename}
@@ -307,14 +320,7 @@ export default function AttachmentPreview({
               </div>
             </div>
           </div>
-          {showLightbox && (
-            <ImageLightbox
-              src={imageUrl}
-              alt={attachment.filename}
-              onClose={handleCloseLightbox}
-              onDownload={handleDownload}
-            />
-          )}
+          {lightbox}
         </>
       )
     }


### PR DESCRIPTION
## Summary
- Render attachment image lightboxes through a document body portal so they are not trapped inside the chat floating input stacking context.
- Raise the lightbox layer above the chat composer and add dialog accessibility attributes.
- Add a regression test covering image preview opened from a `z-50` floating chat input layer.

## Root cause
Attachment image previews were rendered inline under the component that opened them and used `z-50`, the same layer as the chat floating input. In the chat page this allowed the composer to appear above or overlap the dark preview overlay.

## Validation
- `pnpm --dir frontend test -- AttachmentPreview.lightbox.test.tsx MessageBubble.test.tsx ChatInputCard.layout.test.tsx`
- `pnpm --dir frontend exec eslint src/features/tasks/components/input/AttachmentPreview.tsx src/__tests__/features/tasks/components/input/AttachmentPreview.lightbox.test.tsx`
- Pre-push hook: ESLint, TypeScript check, and unit tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image attachments now open in an immersive full-screen lightbox preview when clicked, providing a focused and dedicated viewing experience for attachment images
  * Enhanced accessibility support with proper dialog attributes to ensure compatibility with screen readers and assistive technologies
  * Optimized visual layering and stacking context for improved presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->