### PR TITLE
[codex] Pre-cache chat_shell tiktoken encoding in image

### DIFF
--- a/chat_shell/tests/test_dockerfile.py
+++ b/chat_shell/tests/test_dockerfile.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHAT_SHELL_DOCKERFILE = REPO_ROOT / "docker" / "chat_shell" / "Dockerfile"
+
+
+def test_chat_shell_image_precaches_tiktoken_encoding() -> None:
+    dockerfile = CHAT_SHELL_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert 'ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"' in dockerfile
+    assert 'tiktoken.get_encoding("cl100k_base")' in dockerfile

--- a/docker/chat_shell/Dockerfile
+++ b/docker/chat_shell/Dockerfile
@@ -17,6 +17,12 @@ COPY chat_shell/pyproject.toml .
 RUN sed -i '/\[tool\.uv\.sources\]/,/^$/d' pyproject.toml && \
     uv pip install --system --no-cache -r pyproject.toml
 
+# Pre-cache tiktoken encoding data in the image so the first chat request does
+# not block while downloading the tokenizer vocabulary.
+ENV TIKTOKEN_CACHE_DIR="/app/.cache/tiktoken"
+RUN mkdir -p "${TIKTOKEN_CACHE_DIR}" && \
+    python -c 'import tiktoken; tiktoken.get_encoding("cl100k_base").encode("warmup")'
+
 # Copy application code
 COPY chat_shell/chat_shell /app/chat_shell
 


### PR DESCRIPTION
## Summary

- Set `TIKTOKEN_CACHE_DIR` inside the chat_shell image.
- Pre-load `cl100k_base` during Docker image build so the first chat request does not download tokenizer data.
- Add a focused test that guards the Dockerfile pre-cache behavior.

## Root Cause

`chat_shell` uses `tiktoken` for context metrics. Unknown model IDs fall back to `cl100k_base`, and `tiktoken` downloads the encoding vocabulary on first use when the cache is empty. In container deployments that cost was paid by the first `/v1/responses` request.

## Validation

- `uv run pytest tests/test_dockerfile.py`
- `docker build --progress=plain -f docker/chat_shell/Dockerfile -t wegent-chat-shell:tiktoken-cache-test .`
- `docker run --rm --entrypoint sh wegent-chat-shell:tiktoken-cache-test -c 'test "$TIKTOKEN_CACHE_DIR" = /app/.cache/tiktoken && test -d "$TIKTOKEN_CACHE_DIR" && test "$(ls -1 "$TIKTOKEN_CACHE_DIR" | wc -l | tr -d " ")" -ge 1 && python -c '\''import time, tiktoken; t=time.perf_counter(); tiktoken.get_encoding("cl100k_base").encode("warmup"); print(f"load_ms={(time.perf_counter()-t)*1000:.2f}")'\'''`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test to verify Docker image pre-caches tokenizer vocabulary during build process

* **Chores**
  * Docker build now pre-warms tokenizer to eliminate initial runtime startup delays
<!-- end of auto-generated comment: release notes by coderabbit.ai -->