### PR TITLE
[codex] Add chat_shell TTFT diagnostics and cached skill provider reuse

### DIFF
--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -8,6 +8,7 @@ Used when chat_shell runs as HTTP service and needs to access Backend's data.
 import json
 import logging
 import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 
 import httpx
@@ -18,6 +19,7 @@ from chat_shell.storage.interfaces import (
     StorageProvider,
     ToolResultStoreInterface,
 )
+from shared.telemetry.context import get_request_id
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +96,8 @@ class RemoteHistoryStore(HistoryStoreInterface):
     ) -> list[Message]:
         """Get chat history for a session."""
         total_start = time.perf_counter()
+        wall_start = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+        client_was_initialized = self._client is not None
         client_start = time.perf_counter()
         client = await self._get_client()
         client_ms = (time.perf_counter() - client_start) * 1000
@@ -107,23 +111,56 @@ class RemoteHistoryStore(HistoryStoreInterface):
 
         url = f"/chat/history/{session_id}"
         full_url = f"{self.base_url}{url}"
-        logger.debug(
-            "[RemoteHistoryStore] >>> GET %s params=%s",
+        request_id = get_request_id()
+        request_headers = {"X-Request-ID": request_id} if request_id else None
+        logger.info(
+            "[RemoteHistoryStore_TRACE] get_history_start session_id=%s "
+            "before_message_id=%s limit=%s is_group_chat=%s request_id=%s "
+            "client_reused=%s wall_start_utc=%s url=%s params=%s",
+            session_id,
+            before_message_id,
+            limit,
+            is_group_chat,
+            request_id or "",
+            client_was_initialized,
+            wall_start,
             full_url,
             params,
         )
 
+        response: httpx.Response | None = None
         try:
-            request_start = time.perf_counter()
-            response = await client.get(url, params=params)
-            request_ms = (time.perf_counter() - request_start) * 1000
+            build_start = time.perf_counter()
+            request = client.build_request(
+                "GET",
+                url,
+                params=params,
+                headers=request_headers,
+            )
+            build_ms = (time.perf_counter() - build_start) * 1000
 
-            logger.debug(
-                "[RemoteHistoryStore] <<< Response status=%d, content_length=%s",
+            request_start = time.perf_counter()
+            response = await client.send(request, stream=True)
+            headers_ms = (time.perf_counter() - request_start) * 1000
+            headers_wall = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+            logger.info(
+                "[RemoteHistoryStore_TRACE] get_history_headers session_id=%s "
+                "request_id=%s status=%d headers_ms=%.2f wall_headers_utc=%s "
+                "content_length=%s http_version=%s",
+                session_id,
+                request_id or "",
                 response.status_code,
+                headers_ms,
+                headers_wall,
                 response.headers.get("content-length", "unknown"),
+                response.http_version,
             )
 
+            body_start = time.perf_counter()
+            body = await response.aread()
+            body_read_ms = (time.perf_counter() - body_start) * 1000
+            request_ms = (time.perf_counter() - request_start) * 1000
             response.raise_for_status()
 
             parse_start = time.perf_counter()
@@ -131,22 +168,38 @@ class RemoteHistoryStore(HistoryStoreInterface):
             messages = [Message.from_dict(m) for m in data.get("messages", [])]
             parse_ms = (time.perf_counter() - parse_start) * 1000
             total_ms = (time.perf_counter() - total_start) * 1000
+            http_elapsed_ms = (
+                response.elapsed.total_seconds() * 1000
+                if response.elapsed is not None
+                else None
+            )
             logger.info(
                 "[RemoteHistoryStore_PERF] get_history session_id=%s "
                 "before_message_id=%s limit=%s is_group_chat=%s status=%d "
-                "message_count=%d client_ms=%.2f request_ms=%.2f parse_ms=%.2f "
-                "total_ms=%.2f content_length=%s",
+                "message_count=%d request_id=%s client_reused=%s client_ms=%.2f "
+                "build_ms=%.2f headers_ms=%.2f body_read_ms=%.2f request_ms=%.2f "
+                "http_elapsed_ms=%s parse_ms=%.2f total_ms=%.2f content_length=%s "
+                "body_bytes=%d http_version=%s wall_start_utc=%s",
                 session_id,
                 before_message_id,
                 limit,
                 is_group_chat,
                 response.status_code,
                 len(messages),
+                request_id or "",
+                client_was_initialized,
                 client_ms,
+                build_ms,
+                headers_ms,
+                body_read_ms,
                 request_ms,
+                f"{http_elapsed_ms:.2f}" if http_elapsed_ms is not None else "",
                 parse_ms,
                 total_ms,
                 response.headers.get("content-length", "unknown"),
+                len(body),
+                response.http_version,
+                wall_start,
             )
             logger.debug(
                 "[RemoteHistoryStore] Loaded %d messages for session_id=%s",
@@ -163,6 +216,9 @@ class RemoteHistoryStore(HistoryStoreInterface):
                 exc_info=True,
             )
             raise
+        finally:
+            if response is not None:
+                await response.aclose()
 
     async def append_message(
         self,

--- a/chat_shell/chat_shell/tools/skill_factory.py
+++ b/chat_shell/chat_shell/tools/skill_factory.py
@@ -155,7 +155,23 @@ async def _create_provider_tools_for_skill(
 
     # Load provider from skill package if provider config is present.
     # SECURITY: Only public skills (user_id=0) can load code.
-    if provider_config and skill_id:
+    provider_names = {
+        tool_decl.get("provider")
+        for tool_decl in skill_config.get("tools", [])
+        if tool_decl.get("provider")
+    }
+    providers_already_loaded = bool(provider_names) and all(
+        registry.get_provider(provider_name) is not None
+        for provider_name in provider_names
+    )
+    if providers_already_loaded:
+        logger.info(
+            "[skill_factory] Skill '%s' provider(s) already registered, "
+            "skipping binary download: %s",
+            skill_name,
+            sorted(provider_names),
+        )
+    elif provider_config and skill_id:
         is_public = skill_user_id == 0
 
         if not is_public:

--- a/chat_shell/tests/test_skill_mcp_loader.py
+++ b/chat_shell/tests/test_skill_mcp_loader.py
@@ -336,6 +336,7 @@ class TestPrepareSkillToolsWithMcp:
         actual_tool.name = "slow_tool"
 
         registry = MagicMock()
+        registry.get_provider.return_value = None
         registry.ensure_provider_loaded.return_value = True
         registry.create_tools_for_skill.return_value = [actual_tool]
 
@@ -377,6 +378,71 @@ class TestPrepareSkillToolsWithMcp:
             registry.create_tools_for_skill.assert_called_once()
             assert load_skill_tool.get_skill_tools("slow_skill") == [actual_tool]
             assert load_skill_tool.get_available_tools() == [actual_tool]
+
+    @pytest.mark.asyncio
+    async def test_active_provider_skill_uses_registered_provider_without_download(
+        self, monkeypatch
+    ):
+        """Test that already-registered providers do not download skill binaries."""
+        skill_configs = [
+            {
+                "name": "cached_skill",
+                "description": "A cached provider-backed skill",
+                "prompt": "Cached skill prompt",
+                "skill_id": 123,
+                "skill_user_id": 0,
+                "provider": {
+                    "module": "provider",
+                    "class": "CachedProvider",
+                },
+                "tools": [
+                    {
+                        "name": "cached_tool",
+                        "provider": "cached_provider",
+                        "description": "A cached tool",
+                    }
+                ],
+            }
+        ]
+
+        monkeypatch.setattr(
+            skill_factory.settings,
+            "REMOTE_STORAGE_URL",
+            "http://backend.example",
+            raising=False,
+        )
+
+        actual_tool = MagicMock()
+        actual_tool.name = "cached_tool"
+
+        registry = MagicMock()
+        registry.get_provider.return_value = MagicMock()
+        registry.create_tools_for_skill.return_value = [actual_tool]
+
+        with (
+            patch(
+                "chat_shell.skills.SkillToolRegistry.get_instance",
+                return_value=registry,
+            ),
+            patch(
+                "chat_shell.tools.skill_factory._download_skill_binary",
+                new=AsyncMock(return_value=b"zip-content"),
+            ) as download_binary,
+        ):
+            tools, clients = await prepare_skill_tools(
+                task_id=1,
+                subtask_id=1,
+                user_id=1,
+                skill_configs=skill_configs,
+                preload_skills=["cached_skill"],
+                user_selected_skills=[],
+            )
+
+            download_binary.assert_not_awaited()
+            registry.ensure_provider_loaded.assert_not_called()
+            registry.create_tools_for_skill.assert_called_once()
+            assert tools == [actual_tool]
+            assert clients == []
 
     @pytest.mark.asyncio
     async def test_user_selected_skill_mcp_tools_are_loaded(self):


### PR DESCRIPTION
## Summary

- Add detailed chat_shell remote history timing logs so backend latency can be compared with client-side header/body/parse timings.
- Propagate `X-Request-ID` on remote history calls for cross-service log correlation.
- Skip skill binary downloads when all declared provider tools are already registered in `SkillToolRegistry`.
- Add regression coverage for cached provider-backed skill loading.

## Root Cause

Remote history timing was logged as a single `client.get()` duration, which made backend-side 20ms timings hard to reconcile with chat_shell-side 1s timings. Provider-backed active skills also downloaded the skill ZIP before checking whether the provider was already registered.

## Validation

- `cd chat_shell && uv run pytest tests/test_skill_mcp_loader.py -q` (`16 passed`)
- `cd chat_shell && uv run python -m compileall chat_shell/storage/remote.py chat_shell/tools/skill_factory.py tests/test_skill_mcp_loader.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized provider loading to skip unnecessary downloads when providers are already registered.
  * Improved HTTP response resource cleanup to prevent resource leaks.

* **Tests**
  * Added test coverage for active provider scenarios to ensure correct behavior when providers are already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->