### PR TITLE
[codex] Fix same-id retry streams

### DIFF
--- a/packages/chat-core/src/task-state/TaskStateMachine.chatEvents.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.chatEvents.ts
@@ -37,11 +37,20 @@ export function reduceChatStartEvent({
 }: ChatEventReducerParams<Extract<Event, { type: 'CHAT_START' }>>): TaskMachineInternalState {
   const aiMessageId = generateMessageId('ai', event.subtaskId)
   const existingMessage = state.messages.get(aiMessageId)
+  const isTerminalRuntime = isTerminalTaskStatus(state.runtime.taskStatus)
+  const isRetryingTerminalMessage =
+    isTerminalRuntime &&
+    existingMessage &&
+    (existingMessage.status === 'error' ||
+      existingMessage.subtaskStatus === 'FAILED' ||
+      existingMessage.subtaskStatus === 'CANCELLED')
   const isRestartingAfterTerminal =
-    isTerminalTaskStatus(state.runtime.taskStatus) && !existingMessage
+    isTerminalRuntime && (!existingMessage || isRetryingTerminalMessage)
 
-  if (isTerminalTaskStatus(state.runtime.taskStatus) && existingMessage) return state
-  if (existingMessage && existingMessage.status !== 'streaming') return state
+  if (isTerminalRuntime && existingMessage && !isRetryingTerminalMessage) return state
+  if (existingMessage && existingMessage.status !== 'streaming' && !isRetryingTerminalMessage) {
+    return state
+  }
 
   const initialResult = event.shellType ? { shell_type: event.shellType } : undefined
   const newMessages = new Map(state.messages)

--- a/packages/chat-core/src/task-state/TaskStateMachine.test.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.test.ts
@@ -740,6 +740,51 @@ describe('TaskStateMachine', () => {
     expect(state.messages.get('ai-42')?.status).toBe('completed')
   })
 
+  it('reopens a failed same-id subtask when retry emits chat start', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: vi.fn(),
+      isConnected: () => true,
+    })
+
+    machine.handleTaskStatus('RUNNING')
+    machine.handleChatStart(42, 'Chat', 7)
+    machine.handleChatChunk(42, 'stale partial')
+    machine.handleChatError(42, 'model unavailable', 7, 'model_unavailable')
+
+    const failedMessage = machine.getState().messages.get('ai-42')
+    expect(failedMessage?.status).toBe('error')
+    expect(failedMessage?.content).toBe('stale partial')
+    expect(failedMessage?.error).toBe('model unavailable')
+
+    machine.handleChatStart(42, 'Chat', 7)
+
+    const retryingState = machine.getState()
+    const retryingMessage = retryingState.messages.get('ai-42')
+    expect(retryingState.phase).toBe('streaming')
+    expect(retryingState.runtime.taskStatus).toBe('RUNNING')
+    expect(retryingState.runtime.activeStreamSubtaskId).toBe(42)
+    expect(retryingState.derived.isTerminal).toBe(false)
+    expect(retryingState.derived.isStreaming).toBe(true)
+    expect(retryingMessage).toMatchObject({
+      status: 'streaming',
+      content: '',
+      subtaskId: 42,
+      messageId: 7,
+      result: { shell_type: 'Chat' },
+    })
+    expect(retryingMessage?.error).toBeUndefined()
+    expect(retryingMessage?.errorType).toBeUndefined()
+    expect(retryingMessage?.subtaskStatus).toBeUndefined()
+
+    machine.handleChatChunk(42, 'Hi')
+    machine.handleChatDone(42, 'Hi there!')
+
+    const completedMessage = machine.getState().messages.get('ai-42')
+    expect(completedMessage?.status).toBe('completed')
+    expect(completedMessage?.content).toBe('Hi there!')
+    expect(completedMessage?.error).toBeUndefined()
+  })
+
   it('allows a new chat start after terminal lifecycle status for follow-up sends', () => {
     const machine = new TaskStateMachine(100, {
       joinTask: vi.fn(),


### PR DESCRIPTION
## Summary

- Allow chat-core to reopen failed or cancelled same-ID assistant subtasks when retry emits a new `chat:start` event.
- Preserve the existing guard that ignores duplicate `chat:start` events for completed terminal messages.
- Add a regression test covering failed same-ID retry streaming through completion.

## Root Cause

The backend `chat:retry` path resets and reuses the failed assistant subtask ID. The frontend state machine treated any terminal task with an existing AI message for that subtask as immutable, so the retry `chat:start` was ignored and later chunks/done events could not update the visible message until a page refresh rebuilt state from backend task detail.

## Validation

- `pnpm --filter @wegent/chat-core test`
- `pnpm --filter @wegent/chat-core build`
- `git diff --check`

Pre-push AI code quality checks also passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failed task retry behavior—users can now successfully restart failed chat operations from error states.

* **Tests**
  * Added test coverage for failed subtask retry functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->