### PR TITLE
[codex] fix e2e admin bootstrap setup flow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -614,7 +614,7 @@ jobs:
           ADMIN_PASSWORD = os.environ["E2E_BOOTSTRAP_ADMIN_PASSWORD"]
 
 
-          def request_json(path, *, method="GET", payload=None):
+          def request_json(path, *, method="GET", payload=None, allowed_statuses=()):
               data = None
               headers = {"Content-Type": "application/json"}
               if payload is not None:
@@ -629,19 +629,20 @@ jobs:
                   with urllib.request.urlopen(request, timeout=30) as response:
                       return json.load(response)
               except urllib.error.HTTPError as error:
+                  if error.code in allowed_statuses:
+                      return None
                   body = error.read().decode("utf-8", errors="replace")
                   raise RuntimeError(
                       f"{method} {path} failed with HTTP {error.code}: {body}"
                   ) from error
 
 
-          setup_status = request_json("/auth/admin-password/status")
-          if setup_status.get("required"):
-              request_json(
-                  "/auth/admin-password/setup",
-                  method="POST",
-                  payload={"password": ADMIN_PASSWORD},
-              )
+          request_json(
+              "/auth/admin-password/setup",
+              method="POST",
+              payload={"password": ADMIN_PASSWORD},
+              allowed_statuses=(409,),
+          )
 
           token_response = request_json(
               "/auth/login",

--- a/frontend/e2e/tests/global-setup.ts
+++ b/frontend/e2e/tests/global-setup.ts
@@ -4,6 +4,7 @@ import { promises as fsPromises } from 'fs'
 import { ADMIN_USER, BOOTSTRAP_ADMIN_USER, REGULAR_USER } from '../config/test-users'
 import type { TestUser } from '../config/test-users'
 import { buildStorageState, getJwtExpiryMs } from '../utils/auth-state'
+import { ensureBootstrapAdminPasswordInitialized } from '../utils/bootstrap-admin'
 
 const authFile = path.join(__dirname, '../.auth/user.json')
 const apiBaseUrl = process.env.E2E_API_URL || 'http://localhost:8000'
@@ -58,34 +59,6 @@ async function loginViaApi(request: APIRequestContext, user: TestUser): Promise<
   }
 
   throw lastError || new Error(`Login failed for ${user.username}`)
-}
-
-async function ensureBootstrapAdminPasswordInitialized(
-  request: APIRequestContext,
-  password: string
-): Promise<void> {
-  const statusResponse = await request.get(`${apiBaseUrl}/api/auth/admin-password/status`)
-  expect(
-    statusResponse.ok(),
-    `Failed to read admin password setup status: ${await statusResponse.text()}`
-  ).toBe(true)
-
-  const statusBody = (await statusResponse.json()) as { required?: boolean }
-  if (!statusBody.required) {
-    return
-  }
-
-  const setupResponse = await request.post(`${apiBaseUrl}/api/auth/admin-password/setup`, {
-    data: {
-      password,
-    },
-  })
-
-  if (setupResponse.ok() || setupResponse.status() === 409) {
-    return
-  }
-
-  expect(false, `Failed to set bootstrap admin password: ${await setupResponse.text()}`).toBe(true)
 }
 
 async function ensureUser(
@@ -195,7 +168,7 @@ setup('authenticate', async ({ request }) => {
     await fsPromises.mkdir(authDir, { recursive: true })
   }
 
-  await ensureBootstrapAdminPasswordInitialized(request, BOOTSTRAP_ADMIN_USER.password)
+  await ensureBootstrapAdminPasswordInitialized(request, apiBaseUrl, BOOTSTRAP_ADMIN_USER.password)
 
   const bootstrapToken = await loginViaApi(request, BOOTSTRAP_ADMIN_USER)
   await ensureUser(request, bootstrapToken, ADMIN_USER)

--- a/frontend/e2e/utils/bootstrap-admin.ts
+++ b/frontend/e2e/utils/bootstrap-admin.ts
@@ -1,0 +1,27 @@
+type ApiResponse = {
+  ok(): boolean
+  status(): number
+  text(): Promise<string>
+}
+
+type ApiRequestContext = {
+  post(url: string, options: { data: { password: string } }): Promise<ApiResponse>
+}
+
+export async function ensureBootstrapAdminPasswordInitialized(
+  request: ApiRequestContext,
+  apiBaseUrl: string,
+  password: string
+): Promise<void> {
+  const setupResponse = await request.post(`${apiBaseUrl}/api/auth/admin-password/setup`, {
+    data: {
+      password,
+    },
+  })
+
+  if (setupResponse.ok() || setupResponse.status() === 409) {
+    return
+  }
+
+  throw new Error(`Failed to set bootstrap admin password: ${await setupResponse.text()}`)
+}

--- a/frontend/src/__tests__/e2e/bootstrap-admin.test.ts
+++ b/frontend/src/__tests__/e2e/bootstrap-admin.test.ts
@@ -1,0 +1,66 @@
+import { ensureBootstrapAdminPasswordInitialized } from '../../../e2e/utils/bootstrap-admin'
+
+function createRequest(responses: Array<{ ok: boolean; status: number; text?: string }>) {
+  return {
+    get: jest.fn(),
+    post: jest.fn(async () => {
+      const response = responses.shift()
+      if (!response) {
+        throw new Error('Unexpected request')
+      }
+      return {
+        ok: () => response.ok,
+        status: () => response.status,
+        text: async () => response.text ?? '',
+      }
+    }),
+  }
+}
+
+describe('E2E bootstrap admin setup helper', () => {
+  it('sets the bootstrap admin password through the setup endpoint', async () => {
+    const request = createRequest([{ ok: true, status: 200 }])
+
+    await ensureBootstrapAdminPasswordInitialized(
+      request,
+      'http://localhost:8000',
+      'secure-bootstrap-password'
+    )
+
+    expect(request.get).not.toHaveBeenCalled()
+    expect(request.post).toHaveBeenCalledWith(
+      'http://localhost:8000/api/auth/admin-password/setup',
+      {
+        data: {
+          password: 'secure-bootstrap-password',
+        },
+      }
+    )
+  })
+
+  it('continues when the bootstrap admin password is already initialized', async () => {
+    const request = createRequest([
+      { ok: false, status: 409, text: 'Admin password already initialized' },
+    ])
+
+    await expect(
+      ensureBootstrapAdminPasswordInitialized(
+        request,
+        'http://localhost:8000',
+        'secure-bootstrap-password'
+      )
+    ).resolves.toBeUndefined()
+  })
+
+  it('fails for unexpected setup errors', async () => {
+    const request = createRequest([{ ok: false, status: 500, text: 'Internal Server Error' }])
+
+    await expect(
+      ensureBootstrapAdminPasswordInitialized(
+        request,
+        'http://localhost:8000',
+        'secure-bootstrap-password'
+      )
+    ).rejects.toThrow('Failed to set bootstrap admin password: Internal Server Error')
+  })
+})


### PR DESCRIPTION
## Summary
- Update E2E global setup to use the current admin password setup flow instead of the removed status endpoint.
- Share the bootstrap admin setup helper between Playwright setup and Jest coverage.
- Update executor E2E bootstrap scripting to tolerate an already-initialized admin password via HTTP 409.

## Root Cause
The admin password status endpoint was removed when first-run setup moved to the login/user handshake error-code flow, but E2E setup still called `/auth/admin-password/status`, causing CI setup to fail with 404 before tests ran.

## Test Plan
- pnpm --dir frontend test -- e2e
- pnpm --dir frontend exec tsc --noEmit --pretty false
- uv run pytest tests/api/test_admin_password_bootstrap.py
- git diff --check
- pre-push hook: ESLint, TypeScript, and unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for admin password bootstrap functionality to ensure reliable initialization.

* **Chores**
  * Refactored E2E testing infrastructure to consolidate admin password setup logic into a reusable utility.
  * Enhanced error handling for authentication setup in test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->