### PR TITLE
[codex] Show standalone device in project work trigger

### DIFF
--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -13,10 +13,13 @@ import type { GuidanceWorkbenchMessage, QueuedWorkbenchMessage } from '@/types/w
 
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({
-    t: (key: string, options?: string | { count?: number }) => {
+    t: (key: string, options?: string | { action?: string; count?: number; device?: string }) => {
       if (typeof options === 'string') return options
       if (key === 'workbench.code_comment_count') {
         return `${options?.count ?? 0} 个评论`
+      }
+      if (key === 'workbench.project_work_trigger_device_aria') {
+        return `${options?.action ?? ''}，当前设备 ${options?.device ?? ''}`
       }
       if (key === 'workbench.remove_code_comments') {
         return '移除代码评论'
@@ -1932,6 +1935,41 @@ describe('ChatInput', () => {
     expect(
       screen.queryByTestId('standalone-device-selected-icon-cloud-online')
     ).not.toBeInTheDocument()
+  })
+
+  test('shows the current standalone device in the project work trigger', () => {
+    const devices: DeviceInfo[] = [
+      {
+        id: 1,
+        device_id: 'local-online',
+        name: 'Local Online',
+        status: 'online',
+        is_default: false,
+        device_type: 'local',
+      },
+    ]
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectWork={projectWorkControls({
+          projects: [{ id: 7, name: 'hello', tasks: [] }],
+          devices,
+          currentProjectId: undefined,
+          currentStandaloneDeviceId: 'local-online',
+        })}
+      />
+    )
+
+    const trigger = screen.getByTestId('project-work-button')
+
+    expect(trigger).toHaveTextContent('进入项目工作')
+    expect(trigger).toHaveTextContent('Local Online')
+    expect(trigger).toHaveAccessibleName('进入项目工作，当前设备 Local Online')
   })
 
   test('does not include enter-project work as a menu item', async () => {

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -402,6 +402,24 @@ export function ProjectWorkBar({
     [currentStandaloneDeviceId, devices]
   )
   const selectedStandaloneDeviceId = defaultStandaloneDeviceId
+  const selectedStandaloneDevice = useMemo(
+    () =>
+      selectedStandaloneDeviceId
+        ? standaloneDevices.find(device => device.device_id === selectedStandaloneDeviceId)
+        : undefined,
+    [selectedStandaloneDeviceId, standaloneDevices]
+  )
+  const selectedStandaloneDeviceLabel = selectedStandaloneDevice
+    ? selectedStandaloneDevice.name || selectedStandaloneDevice.device_id
+    : null
+  const projectWorkTriggerLabel = emptyLabel ?? t('workbench.enter_project_work', '进入项目工作')
+  const projectWorkTriggerAriaLabel =
+    !currentProject && isStandaloneMode && selectedStandaloneDeviceLabel
+      ? t('workbench.project_work_trigger_device_aria', {
+          action: projectWorkTriggerLabel,
+          device: selectedStandaloneDeviceLabel,
+        })
+      : (currentProject?.name ?? projectWorkTriggerLabel)
 
   const handleSelectProject = (projectId: number) => {
     onSelectProject(projectId)
@@ -764,7 +782,7 @@ export function ProjectWorkBar({
             buttonClassName
           )}
           aria-expanded={open}
-          aria-label={t('workbench.enter_project_work', '进入项目工作')}
+          aria-label={projectWorkTriggerAriaLabel}
         >
           {currentProject ? (
             <>
@@ -774,7 +792,21 @@ export function ProjectWorkBar({
           ) : (
             <>
               <FolderPlus className="h-5 w-5" />
-              <span>{emptyLabel ?? t('workbench.enter_project_work', '进入项目工作')}</span>
+              <span className="shrink-0">{projectWorkTriggerLabel}</span>
+              {isStandaloneMode && selectedStandaloneDevice && selectedStandaloneDeviceLabel && (
+                <>
+                  <span className="text-text-muted">·</span>
+                  <span
+                    className={`h-1.5 w-1.5 shrink-0 rounded-full ${getDeviceStatusDotClass(selectedStandaloneDevice)}`}
+                  />
+                  <span
+                    className="max-w-[8rem] truncate text-text-secondary"
+                    title={selectedStandaloneDeviceLabel}
+                  >
+                    {selectedStandaloneDeviceLabel}
+                  </span>
+                </>
+              )}
             </>
           )}
           <ChevronDown className="h-4 w-4" />

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -198,6 +198,7 @@
     "model_disabled_missing_target_runtime_family": "This model is missing runtime.family",
     "model_disabled_runtime_family_mismatch": "Incompatible with the current model protocol",
     "enter_project_work": "Enter project work",
+    "project_work_trigger_device_aria": "{{action}}, current device {{device}}",
     "select_project": "Select project",
     "no_project": "No project",
     "user_fallback": "Me",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -198,6 +198,7 @@
     "model_disabled_missing_target_runtime_family": "该模型缺少 runtime.family",
     "model_disabled_runtime_family_mismatch": "与当前模型协议不兼容",
     "enter_project_work": "进入项目工作",
+    "project_work_trigger_device_aria": "{{action}}，当前设备 {{device}}",
     "select_project": "选择项目",
     "no_project": "不使用项目",
     "user_fallback": "我",


### PR DESCRIPTION
## Summary

- Show the selected standalone device in the project work trigger when no project is selected.
- Keep concrete project selection focused on the project name only.
- Add localized accessible-label copy and regression coverage for the trigger text and accessible name.

## Impact

Users can see which device will run standalone work before opening the project/device menu, reducing ambiguity when multiple devices are online.

## Validation

- `pnpm --dir wework lint`
- `pnpm --dir wework test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project work trigger button now displays the current device name when in standalone mode.
  * Enhanced accessibility labels to include device information.

* **Tests**
  * Added test case for verifying button displays correctly with standalone device selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->