### PR TITLE
[codex] add main snapshot image workflow

### DIFF
--- a/.github/workflows/snapshot-image.yml
+++ b/.github/workflows/snapshot-image.yml
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Snapshot Image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  GIT_REF: ${{ github.event_name == 'push' && github.sha || 'main' }}
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+concurrency:
+  group: snapshot-image-main
+  cancel-in-progress: true
+
+jobs:
+  prepare-snapshot:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    outputs:
+      app_version: ${{ steps.meta.outputs.app_version }}
+      git_sha: ${{ steps.meta.outputs.git_sha }}
+      short_sha: ${{ steps.meta.outputs.short_sha }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - name: Prepare snapshot metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          GIT_SHA="$(git rev-parse HEAD)"
+          SHORT_SHA="$(git rev-parse --short=12 HEAD)"
+          APP_VERSION="main-${SHORT_SHA}"
+
+          echo "git_sha=${GIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "app_version=${APP_VERSION}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Snapshot metadata"
+            echo ""
+            echo "- Git SHA: \`${GIT_SHA}\`"
+            echo "- Commit-scoped image tag: \`${APP_VERSION}\`"
+            echo "- Channel tags after verification: \`main\`, \`edge\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-images:
+    needs: prepare-snapshot
+    runs-on: ${{ matrix.platform.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            value: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            value: linux/arm64
+            suffix: arm64
+        image:
+          - name: wegent-backend
+            dockerfile: docker/backend/Dockerfile
+            cache_scope: backend
+          - name: wegent-executor
+            dockerfile: docker/executor/Dockerfile
+            cache_scope: executor
+          - name: wegent-executor-manager
+            dockerfile: docker/executor_manager/Dockerfile
+            cache_scope: executor-manager
+          - name: wegent-web
+            dockerfile: docker/frontend/Dockerfile
+            cache_scope: frontend
+          - name: wegent-chat-shell
+            dockerfile: docker/chat_shell/Dockerfile
+            cache_scope: chat-shell
+          - name: wegent-knowledge-runtime
+            dockerfile: docker/knowledge_runtime/Dockerfile
+            cache_scope: knowledge-runtime
+          - name: wegent-knowledge-doc-converter
+            dockerfile: docker/knowledge_doc_converter/Dockerfile
+            cache_scope: knowledge-doc-converter
+          - name: wegent-standalone
+            dockerfile: docker/standalone/Dockerfile
+            cache_scope: standalone
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-snapshot.outputs.git_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare build arguments
+        id: build-args
+        shell: bash
+        env:
+          IMAGE_NAME: ${{ matrix.image.name }}
+          APP_VERSION: ${{ needs.prepare-snapshot.outputs.app_version }}
+        run: |
+          set -euo pipefail
+
+          case "${IMAGE_NAME}" in
+            wegent-web)
+              {
+                echo "args<<EOF"
+                echo "NEXT_TELEMETRY_DISABLED=1"
+                echo "APP_VERSION=${APP_VERSION}"
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            wegent-standalone)
+              {
+                echo "args<<EOF"
+                echo "APP_VERSION=${APP_VERSION}"
+                echo "EOF"
+              } >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "args=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          push: true
+          platforms: ${{ matrix.platform.value }}
+          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:${{ needs.prepare-snapshot.outputs.app_version }}-${{ matrix.platform.suffix }}
+          cache-from: type=gha,scope=snapshot-${{ matrix.image.cache_scope }}-${{ matrix.platform.suffix }}
+          cache-to: type=gha,mode=max,scope=snapshot-${{ matrix.image.cache_scope }}-${{ matrix.platform.suffix }}
+          build-args: ${{ steps.build-args.outputs.args }}
+
+  create-commit-manifests:
+    needs:
+      - prepare-snapshot
+      - build-images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create commit-scoped multi-arch manifests
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare-snapshot.outputs.app_version }}
+        run: |
+          set -euo pipefail
+
+          create_manifest() {
+            local image_name="$1"
+            echo "Creating commit-scoped manifest for ${image_name}:${VERSION}"
+
+            docker buildx imagetools create -t "${IMAGE_PREFIX}/${image_name}:${VERSION}" \
+              "${IMAGE_PREFIX}/${image_name}:${VERSION}-amd64" \
+              "${IMAGE_PREFIX}/${image_name}:${VERSION}-arm64"
+          }
+
+          create_manifest "wegent-backend"
+          create_manifest "wegent-executor"
+          create_manifest "wegent-executor-manager"
+          create_manifest "wegent-web"
+          create_manifest "wegent-chat-shell"
+          create_manifest "wegent-knowledge-runtime"
+          create_manifest "wegent-knowledge-doc-converter"
+          create_manifest "wegent-standalone"
+
+  verify-standalone:
+    needs:
+      - prepare-snapshot
+      - create-commit-manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare-snapshot.outputs.git_sha }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify standalone snapshot image
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/wegent-standalone:${{ needs.prepare-snapshot.outputs.app_version }}
+          CONTAINER_NAME: wegent-standalone-snapshot-verify
+        run: bash scripts/verify-standalone-image.sh "$IMAGE"
+
+  promote-channel-tags:
+    needs:
+      - prepare-snapshot
+      - verify-standalone
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Promote verified snapshot to channel tags
+        shell: bash
+        env:
+          VERSION: ${{ needs.prepare-snapshot.outputs.app_version }}
+        run: |
+          set -euo pipefail
+
+          promote_manifest() {
+            local image_name="$1"
+            echo "Promoting ${image_name}:${VERSION} to ${image_name}:main and ${image_name}:edge"
+
+            docker buildx imagetools create \
+              -t "${IMAGE_PREFIX}/${image_name}:main" \
+              -t "${IMAGE_PREFIX}/${image_name}:edge" \
+              "${IMAGE_PREFIX}/${image_name}:${VERSION}"
+          }
+
+          promote_manifest "wegent-backend"
+          promote_manifest "wegent-executor"
+          promote_manifest "wegent-executor-manager"
+          promote_manifest "wegent-web"
+          promote_manifest "wegent-chat-shell"
+          promote_manifest "wegent-knowledge-runtime"
+          promote_manifest "wegent-knowledge-doc-converter"
+          promote_manifest "wegent-standalone"
+
+          {
+            echo "### Snapshot channel tags promoted"
+            echo ""
+            echo "- Commit-scoped tag: \`${VERSION}\`"
+            echo "- Mutable tags: \`main\`, \`edge\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/en/deployment/container-image-tags.md
+++ b/docs/en/deployment/container-image-tags.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+---
+
+# Container Image Tags
+
+Wegent separates stable release images from main branch snapshot images. Regular users and production deployments should use stable tags; maintainers, contributors, and test environments can use main branch snapshot tags to validate the latest merged changes.
+
+## Tag Semantics
+
+| Tag | Type | Updated By | Recommended Use |
+|-----|------|------------|-----------------|
+| `latest` | Mutable stable tag | Release workflow | Quick deployment for regular users and non-strict production environments |
+| `1.2.3` | Version tag | Release workflow | Production deployments, reproducible deployments, rollback |
+| `main` | Mutable snapshot tag | Snapshot workflow after main merges | Internal testing and contributor validation |
+| `edge` | Mutable snapshot tag | Snapshot workflow after main merges | Same as `main`, for users familiar with edge channels |
+| `main-<short-sha>` | Commit-scoped snapshot tag | Snapshot workflow after main merges | Reproducing a specific main build, debugging, rollback |
+| `main-<short-sha>-amd64` / `main-<short-sha>-arm64` | Architecture tag | Internal snapshot workflow tag | Used to assemble multi-arch manifests; direct deployment is not recommended |
+
+`latest` means the latest stable release, not the latest commit on main. `main` and `edge` may contain changes that have not been released yet, so only use them where unstable updates are acceptable.
+
+## Snapshot Images
+
+Every merge to `main` triggers the `Snapshot Image` workflow, which builds these images:
+
+```text
+ghcr.io/wecode-ai/wegent-backend
+ghcr.io/wecode-ai/wegent-web
+ghcr.io/wecode-ai/wegent-executor
+ghcr.io/wecode-ai/wegent-executor-manager
+ghcr.io/wecode-ai/wegent-chat-shell
+ghcr.io/wecode-ai/wegent-knowledge-runtime
+ghcr.io/wecode-ai/wegent-knowledge-doc-converter
+ghcr.io/wecode-ai/wegent-standalone
+```
+
+The workflow first pushes commit-scoped `main-<short-sha>` multi-arch tags and verifies that the standalone image can start. Only after verification passes does it promote the same image set to the mutable `main` and `edge` tags.
+
+## Examples
+
+Use the latest stable release:
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:latest
+```
+
+Use the latest main branch snapshot:
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:edge
+```
+
+Reproduce a specific main build:
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:main-631609e5a123
+```
+
+When testing a standard multi-container deployment with a main snapshot, keep every Wegent service on the same snapshot tag to avoid cross-service version drift.

--- a/docs/en/deployment/standalone-mode.md
+++ b/docs/en/deployment/standalone-mode.md
@@ -48,6 +48,8 @@ This will automatically:
 4. Publish a single Nginx entry port
 5. Start the container and wait for Backend and Wework readiness
 
+The default installer uses the latest stable image. To test main branch snapshots, see [Container Image Tags](./container-image-tags.md).
+
 After startup, open:
 
 | Entry | URL | Purpose |

--- a/docs/zh/deployment/container-image-tags.md
+++ b/docs/zh/deployment/container-image-tags.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 4
+---
+
+# 容器镜像标签
+
+Wegent 将稳定发布镜像和 main 分支快照镜像分开。普通用户和生产环境应使用稳定标签；维护者、贡献者和测试环境可以使用 main 分支快照标签验证最新合并结果。
+
+## 标签语义
+
+| 标签 | 类型 | 更新来源 | 推荐用途 |
+|------|------|----------|----------|
+| `latest` | 可移动稳定标签 | 正式发布流程 | 普通用户快速部署、非严格生产环境 |
+| `1.2.3` | 版本标签 | 正式发布流程 | 生产环境、可复现部署、回滚 |
+| `main` | 可移动快照标签 | main 分支合并后的快照流程 | 内部测试、贡献者验证 |
+| `edge` | 可移动快照标签 | main 分支合并后的快照流程 | 与 `main` 等价，面向习惯使用 edge 通道的用户 |
+| `main-<short-sha>` | 提交快照标签 | main 分支合并后的快照流程 | 精确复现某次 main 构建、排障和回滚 |
+| `main-<short-sha>-amd64` / `main-<short-sha>-arm64` | 架构标签 | 快照流程内部使用 | 组成多架构 manifest，不建议直接部署 |
+
+`latest` 只表示最新稳定发布版，不代表 main 分支的最新提交。`main` 和 `edge` 可能包含尚未正式发布的功能，部署前应确认测试环境可以接受不稳定变更。
+
+## 快照镜像
+
+每次代码合并到 `main` 后，`Snapshot Image` workflow 会构建以下镜像：
+
+```text
+ghcr.io/wecode-ai/wegent-backend
+ghcr.io/wecode-ai/wegent-web
+ghcr.io/wecode-ai/wegent-executor
+ghcr.io/wecode-ai/wegent-executor-manager
+ghcr.io/wecode-ai/wegent-chat-shell
+ghcr.io/wecode-ai/wegent-knowledge-runtime
+ghcr.io/wecode-ai/wegent-knowledge-doc-converter
+ghcr.io/wecode-ai/wegent-standalone
+```
+
+流程会先推送按提交命名的 `main-<short-sha>` 多架构标签，并验证 standalone 镜像可以启动。验证通过后，才会将同一批镜像提升到可移动的 `main` 和 `edge` 标签。
+
+## 使用示例
+
+使用最新稳定版：
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:latest
+```
+
+使用 main 分支最新快照：
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:edge
+```
+
+复现某次 main 构建：
+
+```bash
+docker pull ghcr.io/wecode-ai/wegent-standalone:main-631609e5a123
+```
+
+标准多容器部署测试 main 快照时，应让所有 Wegent 服务使用同一个快照标签，避免不同服务之间版本不一致。

--- a/docs/zh/deployment/standalone-mode.md
+++ b/docs/zh/deployment/standalone-mode.md
@@ -48,6 +48,8 @@ curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | 
 4. 映射单个 Nginx 入口端口
 5. 启动容器并等待 Backend 和 Wework 就绪
 
+默认安装命令使用最新稳定镜像。需要测试 main 分支快照时，请参考 [容器镜像标签](./container-image-tags.md)。
+
 启动完成后访问：
 
 | 入口 | 地址 | 用途 |


### PR DESCRIPTION
## Summary

- Add a `Snapshot Image` workflow that builds main branch snapshot container images on every push to `main`.
- Publish commit-scoped `main-<short-sha>` tags first, verify the standalone image, then promote the same image set to `main` and `edge`.
- Document stable vs snapshot image tag semantics in Chinese and English deployment docs.

## Why

Merging to `main` did not produce a deployable test image unless maintainers ran the existing public release image flow. This separates main branch testing artifacts from the formal release process, keeping `latest`, release tags, and GitHub Releases stable-only.

## Validation

- `git diff --cached --check`
- Parsed `.github/workflows/snapshot-image.yml` with Ruby YAML
- Checked snapshot image manifest list matches `publish-image.yml`
- Checked snapshot promotion list matches snapshot manifest list
- Checked new deployment docs include required `sidebar_position` frontmatter

Note: local `actionlint` could not be run because the available Go/toolchain environment failed before linting the workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated snapshot image tagging for main branch builds with `main`, `edge`, and commit-scoped tags.

* **Documentation**
  * Added comprehensive guide on container image tag semantics and usage (stable vs. snapshot tags).
  * Clarified that stable releases use the `latest` tag; main-branch snapshots require the `main` or `edge` tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->