### PR TITLE
Add chat-core workspace dependencies to the frontend image

### DIFF
--- a/backend/tests/docker/test_frontend_dockerfile_contract.py
+++ b/backend/tests/docker/test_frontend_dockerfile_contract.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static contract tests for the frontend Docker image."""
+
+from pathlib import Path
+
+REPO_ROOT: Path = Path(__file__).resolve().parents[3]
+FRONTEND_DOCKERFILE: Path = REPO_ROOT / "docker" / "frontend" / "Dockerfile"
+
+
+def test_frontend_builder_includes_chat_core_workspace_dependencies() -> None:
+    """Frontend builds import chat-core source and need its workspace dependencies."""
+    dockerfile = FRONTEND_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "pnpm install --frozen-lockfile --filter wecode-ai-assistant..." in dockerfile
+    assert (
+        "COPY --from=deps /app/packages/chat-core/node_modules "
+        "./packages/chat-core/node_modules"
+    ) in dockerfile

--- a/docker/frontend/Dockerfile
+++ b/docker/frontend/Dockerfile
@@ -39,6 +39,7 @@ ENV NEXT_PUBLIC_APP_VERSION=${APP_VERSION}
 # Copy node_modules from deps stage
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/frontend/node_modules ./frontend/node_modules
+COPY --from=deps /app/packages/chat-core/node_modules ./packages/chat-core/node_modules
 
 # Copy source code
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Summary
- Copy `packages/chat-core/node_modules` into the frontend Docker image so the build has the workspace dependencies it needs
- Add a static contract test to guard the Dockerfile against regressions

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Docker build validation test to ensure frontend dependencies are correctly resolved during container builds.

* **Chores**
  * Updated Docker build configuration to improve dependency management in frontend builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->