### PR TITLE
Ensure standalone executor token is available before host setup

### DIFF
--- a/backend/tests/docker/test_standalone_wework_contract.py
+++ b/backend/tests/docker/test_standalone_wework_contract.py
@@ -73,6 +73,21 @@ def test_standalone_start_can_skip_container_executor() -> None:
     assert 'if [ -n "${EXECUTOR_PID:-}" ]; then' in start_script
 
 
+def test_standalone_start_ensures_token_before_optional_executor() -> None:
+    """Host-only mode still needs the standalone executor token for host setup."""
+    start_script = STANDALONE_START.read_text(encoding="utf-8")
+
+    backend_ready_index = start_script.index(
+        'wait_for_http "Backend" "http://localhost:${BACKEND_PORT}/health"'
+    )
+    token_ensure_index = start_script.index("\nensure_standalone_executor_token\n")
+    executor_branch_index = start_script.index(
+        'if [ "$STANDALONE_EXECUTOR_ENABLED" != "false" ]; then'
+    )
+
+    assert backend_ready_index < token_ensure_index < executor_branch_index
+
+
 def test_standalone_nginx_routes_frontend_backend_and_wework() -> None:
     """Nginx should expose Frontend, Backend, and Wework through one public port."""
     nginx_config = STANDALONE_NGINX_CONFIG.read_text(encoding="utf-8")
@@ -218,6 +233,16 @@ def test_installer_uses_release_installer_for_host_executor() -> None:
     assert "HOST_EXECUTOR_INSTALL_URL" in install_script
     assert "local_executor_install.sh" in install_script
     assert 'curl -fsSL "$HOST_EXECUTOR_INSTALL_URL" | bash' in install_script
+
+
+def test_installer_ensures_standalone_executor_token_when_reading_it() -> None:
+    """Host executor setup should not depend on the container executor being enabled."""
+    install_script = INSTALL_SCRIPT.read_text(encoding="utf-8")
+
+    assert (
+        install_script.count("python -m app.scripts.ensure_standalone_executor_token")
+        >= 2
+    )
     assert "configure_host_executor()" in install_script
     assert '"backend_url": "http://127.0.0.1:3000"' in install_script
     assert "start_host_executor()" in install_script

--- a/docker/standalone/start.sh
+++ b/docker/standalone/start.sh
@@ -249,13 +249,14 @@ BACKEND_PID=$!
 
 wait_for_http "Backend" "http://localhost:${BACKEND_PORT}/health" 60 "$BACKEND_PID" true
 
+# Host executor setup reads this token even when the in-container executor is disabled.
+ensure_standalone_executor_token
+
 # ========================================
 # Step 4: Start Standalone Executor
 # ========================================
 start_executor() {
     echo "[4/8] Starting Standalone Executor..."
-
-    ensure_standalone_executor_token
 
     export EXECUTOR_MODE=local
     export DEVICE_TYPE=cloud

--- a/install.sh
+++ b/install.sh
@@ -1033,7 +1033,8 @@ install_host_executor_from_release() {
 }
 
 read_standalone_executor_token() {
-    docker exec "$STANDALONE_CONTAINER_NAME" sh -lc 'cat /app/data/standalone_executor_token'
+    docker exec "$STANDALONE_CONTAINER_NAME" sh -lc \
+        'cd /app/backend && python -m app.scripts.ensure_standalone_executor_token'
 }
 
 redact_token() {
@@ -1329,7 +1330,8 @@ start_container() {
 }
 
 read_standalone_executor_token() {
-    docker exec "\$STANDALONE_CONTAINER_NAME" sh -lc 'cat /app/data/standalone_executor_token'
+    docker exec "\$STANDALONE_CONTAINER_NAME" sh -lc \\
+        'cd /app/backend && python -m app.scripts.ensure_standalone_executor_token'
 }
 
 host_executor_device_name() {


### PR DESCRIPTION
## Summary
- Move standalone executor token creation ahead of optional executor startup in standalone boot flow
- Read the token through the backend helper during install scripts so host executor setup does not depend on container executor state
- Add contract tests to lock the new ordering and token-read behavior

## Testing
- Added backend contract test coverage for standalone start ordering and installer token reads
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added verification tests for standalone executor token initialization behavior in startup and installation workflows

* **Bug Fixes**
  * Improved standalone executor token initialization timing to ensure availability earlier in startup, regardless of optional component configuration
  * Enhanced token retrieval reliability in installation and management workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->