### PR TITLE
Preserve host header and verify standalone API proxy

### DIFF
--- a/docker/standalone/nginx.conf
+++ b/docker/standalone/nginx.conf
@@ -90,7 +90,7 @@ server {
 
     location / {
         proxy_pass http://wegent_frontend;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/scripts/test-standalone-nginx-conf.sh
+++ b/scripts/test-standalone-nginx-conf.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Regression checks for the standalone nginx reverse proxy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NGINX_CONF="$PROJECT_ROOT/docker/standalone/nginx.conf"
+
+if ! awk '
+    $1 == "location" && $2 == "/" {
+        in_frontend_location = 1
+    }
+    in_frontend_location && /proxy_set_header Host \$http_host;/ {
+        found = 1
+    }
+    in_frontend_location && /^    }/ {
+        in_frontend_location = 0
+    }
+    END {
+        exit found ? 0 : 1
+    }
+' "$NGINX_CONF"; then
+    echo "Expected standalone frontend proxy to preserve the original Host header with port."
+    exit 1
+fi
+
+echo "standalone nginx config regression test passed"

--- a/scripts/test-verify-standalone-image.sh
+++ b/scripts/test-verify-standalone-image.sh
@@ -48,7 +48,7 @@ cat > "$TMP_DIR/curl" <<'EOF'
 set -euo pipefail
 
 url="${@: -1}"
-echo "$url" >> "$FAKE_CURL_LOG"
+echo "$*" >> "$FAKE_CURL_LOG"
 
 case "$url" in
     *:13000/health)
@@ -58,7 +58,11 @@ case "$url" in
         exit 0
         ;;
     *:13000/wework/)
-        exit 22
+        exit 0
+        ;;
+    *:13000/api/users/me)
+        echo "404"
+        exit 0
         ;;
     *)
         echo "unexpected curl URL: $url" >&2
@@ -76,19 +80,31 @@ export STANDALONE_VERIFY_TIMEOUT_SECONDS=0
 export STANDALONE_VERIFY_INTERVAL_SECONDS=1
 
 if "$VERIFY_SCRIPT" "ghcr.io/wecode-ai/wegent-standalone:test" > "$TMP_DIR/output.log" 2>&1; then
-    echo "Expected standalone verification to fail when Wework is unreachable."
+    echo "Expected standalone verification to fail when the API proxy returns 404."
     cat "$TMP_DIR/output.log"
     exit 1
 fi
 
-if ! grep -q "Wework failed readiness check" "$TMP_DIR/output.log"; then
-    echo "Expected Wework readiness failure message."
+if ! grep -q "API proxy failed readiness check" "$TMP_DIR/output.log"; then
+    echo "Expected API proxy readiness failure message."
     cat "$TMP_DIR/output.log"
     exit 1
 fi
 
 if ! grep -q "http://localhost:13000/wework/" "$FAKE_CURL_LOG"; then
     echo "Expected Wework to be checked through the frontend standalone port."
+    cat "$FAKE_CURL_LOG"
+    exit 1
+fi
+
+if ! grep -q "http://localhost:13000/api/users/me" "$FAKE_CURL_LOG"; then
+    echo "Expected API proxy to be checked through the standalone port."
+    cat "$FAKE_CURL_LOG"
+    exit 1
+fi
+
+if ! grep -q "Referer: http://localhost:13000/" "$FAKE_CURL_LOG"; then
+    echo "Expected API proxy check to include a same-origin Referer header."
     cat "$FAKE_CURL_LOG"
     exit 1
 fi

--- a/scripts/verify-standalone-image.sh
+++ b/scripts/verify-standalone-image.sh
@@ -78,6 +78,39 @@ wait_for_url() {
     done
 }
 
+wait_for_api_proxy() {
+    local url="http://localhost:${STANDALONE_PORT}/api/users/me"
+    local referer="http://localhost:${STANDALONE_PORT}/"
+    local deadline=$((SECONDS + TIMEOUT_SECONDS))
+
+    echo "Waiting for API proxy: ${url}"
+    while true; do
+        local status
+        status="$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Referer: ${referer}" \
+            "$url" 2>/dev/null || true)"
+
+        case "$status" in
+            200|401|403)
+                echo "API proxy is reachable (HTTP ${status})"
+                return 0
+                ;;
+        esac
+
+        if ! is_container_running; then
+            echo "API proxy failed readiness check: container exited before ${url} became reachable." >&2
+            return 1
+        fi
+
+        if [ "$SECONDS" -ge "$deadline" ]; then
+            echo "API proxy failed readiness check: ${url} returned HTTP ${status:-000}." >&2
+            return 1
+        fi
+
+        sleep "$INTERVAL_SECONDS"
+    done
+}
+
 echo "Starting standalone verification container ${CONTAINER_NAME} from ${IMAGE}"
 docker run -d \
     --name "$CONTAINER_NAME" \
@@ -87,5 +120,6 @@ docker run -d \
 wait_for_url "Backend" "http://localhost:${STANDALONE_PORT}/health"
 wait_for_url "Frontend" "http://localhost:${STANDALONE_PORT}/"
 wait_for_url "Wework" "http://localhost:${STANDALONE_PORT}/wework/"
+wait_for_api_proxy
 
 echo "Standalone image verification succeeded for ${IMAGE}"


### PR DESCRIPTION
## Summary
- Preserve the original `Host` header in the standalone nginx frontend proxy by forwarding `$http_host`
- Add a standalone config regression test to ensure the host header keeps the port
- Extend standalone image verification to check the API proxy endpoint with a same-origin referer

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reverse proxy header handling in standalone deployments to properly preserve the original Host header including port numbers during request forwarding.

* **Tests**
  * Added comprehensive regression test to validate proxy configuration correctness.
  * Enhanced API proxy verification tests to ensure service readiness and validate proper request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->