### PR TITLE
[codex] Accept setup-required standalone API proxy check

### DIFF
--- a/scripts/test-verify-standalone-image.sh
+++ b/scripts/test-verify-standalone-image.sh
@@ -61,7 +61,7 @@ case "$url" in
         exit 0
         ;;
     *:13000/api/users/me)
-        echo "404"
+        echo "${FAKE_API_STATUS:-404}"
         exit 0
         ;;
     *)
@@ -79,7 +79,21 @@ export CONTAINER_NAME="wegent-standalone-test"
 export STANDALONE_VERIFY_TIMEOUT_SECONDS=0
 export STANDALONE_VERIFY_INTERVAL_SECONDS=1
 
-if "$VERIFY_SCRIPT" "ghcr.io/wecode-ai/wegent-standalone:test" > "$TMP_DIR/output.log" 2>&1; then
+export FAKE_API_STATUS=400
+if ! bash "$VERIFY_SCRIPT" "ghcr.io/wecode-ai/wegent-standalone:test" > "$TMP_DIR/output-success.log" 2>&1; then
+    echo "Expected standalone verification to pass when the API proxy reaches backend setup-required response."
+    cat "$TMP_DIR/output-success.log"
+    exit 1
+fi
+
+if ! grep -q "API proxy is reachable (HTTP 400)" "$TMP_DIR/output-success.log"; then
+    echo "Expected API proxy success message for HTTP 400 setup-required response."
+    cat "$TMP_DIR/output-success.log"
+    exit 1
+fi
+
+export FAKE_API_STATUS=404
+if bash "$VERIFY_SCRIPT" "ghcr.io/wecode-ai/wegent-standalone:test" > "$TMP_DIR/output.log" 2>&1; then
     echo "Expected standalone verification to fail when the API proxy returns 404."
     cat "$TMP_DIR/output.log"
     exit 1

--- a/scripts/verify-standalone-image.sh
+++ b/scripts/verify-standalone-image.sh
@@ -91,7 +91,7 @@ wait_for_api_proxy() {
             "$url" 2>/dev/null || true)"
 
         case "$status" in
-            200|401|403)
+            200|400|401|403)
                 echo "API proxy is reachable (HTTP ${status})"
                 return 0
                 ;;


### PR DESCRIPTION
## Summary

- Treat the fresh-install `ADMIN_PASSWORD_SETUP_REQUIRED` response from `/api/users/me` as a valid standalone API proxy reachability signal.
- Extend the standalone image verifier regression test to cover both accepted `400` setup-required responses and rejected `404` proxy failures.
- Invoke the verifier through `bash` inside the shell regression test to avoid environment-specific direct script execution failures.

## Why

After the standalone Host header fix landed in `main`, a fresh standalone container correctly reaches the backend for `/api/users/me`, but the backend responds with `HTTP 400` until the admin password is initialized. The verifier should distinguish that valid backend setup state from the original proxy 404 failure.

## Validation

- `bash scripts/test-verify-standalone-image.sh`
- `bash -n scripts/verify-standalone-image.sh scripts/test-verify-standalone-image.sh`
- `bash scripts/verify-standalone-image.sh wegent-standalone:local`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API proxy readiness verification to correctly handle HTTP 400 responses as successful connectivity checks, alongside existing 200/401/403 responses.

* **Chores**
  * Enhanced test verification with parameterized HTTP status configuration for more flexible regression testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->