### PR TITLE
Use Zap icon for the WeWork sidebar item

### DIFF
--- a/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
+++ b/frontend/src/__tests__/features/tasks/components/sidebar/TaskSidebar.test.tsx
@@ -261,7 +261,16 @@ describe('TaskSidebar scroll structure', () => {
     expect(
       within(fixedSection).queryByTestId('task-sidebar-nav-code-button')
     ).not.toBeInTheDocument()
-    expect(within(fixedSection).getByTestId('task-sidebar-nav-wework-button')).toBeInTheDocument()
+    const weworkButton = within(fixedSection).getByTestId('task-sidebar-nav-wework-button')
+    const weworkIcon = weworkButton.querySelector('svg')
+
+    if (!weworkIcon) {
+      throw new Error('Expected WeWork sidebar button to render an icon')
+    }
+
+    expect(weworkButton).toBeInTheDocument()
+    expect(weworkIcon).toHaveClass('lucide-zap')
+    expect(weworkIcon).not.toHaveClass('lucide-layout-grid')
   })
 
   it('does not keep Code highlighted on plain chat after leaving code agent mode', () => {

--- a/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
+++ b/frontend/src/features/tasks/components/sidebar/TaskSidebar.tsx
@@ -24,6 +24,7 @@ import {
   Inbox,
   Library,
   LayoutGrid,
+  Zap,
 } from 'lucide-react'
 import { useTaskSession } from '@/features/tasks/session/TaskSession'
 import TaskListSection from './TaskListSection'
@@ -188,7 +189,7 @@ export default function TaskSidebar({
     },
     {
       label: t(codingNavItem.labelKey),
-      icon: codingNavItem.key === 'wework' ? LayoutGrid : Code,
+      icon: codingNavItem.key === 'wework' ? Zap : Code,
       path: codingNavItem.href,
       isActive: pageType === 'code' || isCodeAgentActive,
       tooltip: pageType === 'code' ? t('common:tasks.new_task') : undefined,


### PR DESCRIPTION
## Summary
- Replace the WeWork sidebar icon with `Zap` to better match the product branding.
- Update the sidebar test to assert the WeWork button renders the new icon and no longer uses `LayoutGrid`.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the icon displayed on the WeWork sidebar button in the task navigation for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->