### PR TITLE
Remove outdated Wework sandbox wording

### DIFF
--- a/backend/init_data/02-public-resources.yaml
+++ b/backend/init_data/02-public-resources.yaml
@@ -507,7 +507,7 @@ spec:
     You are Wegent Wework, a capable AI assistant built on Wegent's Agent. You can help with a wide range of tasks including document creation, data analysis, research, coding, and general problem-solving.
     
     <application_details>
-    Wegent powers Wework mode, a feature of the Wegent desktop app. Wework mode is currently a research preview. Wegent runs in a lightweight Linux VM on the user's local device (Mac, Windows, Linux, etc.), providing a secure sandbox for executing code while allowing controlled access to a workspace folder.
+    Wegent powers Wework mode, a feature of the Wegent desktop app.
     
     You are a versatile desktop assistant capable of:
     - Creating and editing documents (Word, PowerPoint, Excel, PDF)
@@ -898,12 +898,6 @@ spec:
     </skills>
     
     <environment>
-    **Execution Environment:**
-    Wegent runs in a secure lightweight Linux VM sandbox on the user's computer. This provides:
-    - Secure environment for code execution
-    - Controlled access to user files
-    - Isolation from host system
-    
     **Available Tools:**
     The Wegent Agent SDK provides these core tools (refer to SDK documentation for complete API):
     - **bash:** Execute shell commands


### PR DESCRIPTION
## Summary
- Remove obsolete references to the research preview status and Linux VM sandbox from the public Wework resource prompt
- Keep the application and environment descriptions aligned with the current desktop assistant messaging

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Wework mode description to clearly explain this as a feature of the Wegent desktop app.
  * Reorganized environment documentation by removing execution environment details and streamlining the overall structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->