### PR TITLE
Document standalone executor mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,22 @@ Then open http://localhost:3000 in your browser.
 | **Standard** | Multi-container + MySQL + Redis, best for teams and production |
 | **Development** | Source startup + hot reload, best for development and extensions |
 
+Standalone can choose where coding/execution agents run:
+
+| Standalone Executor Mode | Behavior | Best For |
+|--------------------------|----------|----------|
+| `host` | Run the executor on the host machine while Backend, Frontend, and Wework stay in Docker | macOS or any setup that needs host commands such as `open`, `osascript`, Terminal, or local CLI tools |
+| `container` | Run the executor inside the standalone container | Linux quick start and single-container deployments |
+| `hybrid` | Run both host and container executors | Keeping the container device while also using host-native capabilities |
+
+Interactive macOS installs default to `host`; Linux and non-interactive installs default to `container`.
+
 ```bash
-# Standalone mode (default)
+# Standalone mode (default executor mode)
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
+
+# Standalone mode with an explicit executor mode: host, container, or hybrid
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone --executor-mode host
 
 # Standard mode
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard

--- a/README_zh.md
+++ b/README_zh.md
@@ -51,9 +51,22 @@ curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | 
 | **Standard** | 多容器 + MySQL + Redis，适合团队和生产环境 |
 | **Development** | 源码启动 + 热重载，适合开发和二次扩展 |
 
+Standalone 可以选择编码/执行 Agent 的运行位置：
+
+| Standalone Executor 模式 | 行为 | 适合场景 |
+|--------------------------|------|----------|
+| `host` | Backend、Frontend 和 Wework 仍在 Docker 中运行，executor 在宿主机运行 | macOS，或需要调用 `open`、`osascript`、系统 Terminal、本机 CLI 工具等宿主机能力 |
+| `container` | executor 在 standalone 容器内运行 | Linux 快速体验和单容器部署 |
+| `hybrid` | 宿主机 executor 和容器 executor 同时运行 | 保留容器设备，同时使用宿主机能力 |
+
+交互式 macOS 安装默认选择 `host`；Linux 和非交互安装默认选择 `container`。
+
 ```bash
-# Standalone 模式（默认）
+# Standalone 模式（默认 executor 模式）
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone
+
+# Standalone 模式显式指定 executor 模式：host、container 或 hybrid
+curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standalone --executor-mode host
 
 # Standard 模式
 curl -fsSL https://raw.githubusercontent.com/wecode-ai/Wegent/main/install.sh | bash -s -- --standard


### PR DESCRIPTION
## Summary
- Document the new standalone executor placement options in both README files
- Clarify the `host`, `container`, and `hybrid` modes and their recommended use cases
- Note the default executor mode selection for interactive macOS, Linux, and non-interactive installs

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Standalone deployment mode instructions to document configurable Executor Mode options: host, container, or hybrid execution. Added default selection guidance for macOS (host) vs. Linux/non-interactive (container) environments. Expanded installation command examples demonstrating how to specify executor modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->