### PR TITLE
Recover stale local executor websocket connections

### DIFF
--- a/executor/modes/local/heartbeat.py
+++ b/executor/modes/local/heartbeat.py
@@ -116,6 +116,12 @@ class LocalHeartbeatService:
                     logger.error(
                         f"Heartbeat failed {self._consecutive_failures} consecutive times"
                     )
+                    recovered = await self.client.reconnect()
+                    if recovered:
+                        self._consecutive_failures = 0
+                        logger.info("Heartbeat reconnect recovery succeeded")
+                    else:
+                        logger.warning("Heartbeat reconnect recovery failed")
 
             except Exception as e:
                 self._consecutive_failures += 1

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -413,7 +413,14 @@ class WebSocketClient:
     @property
     def connected(self) -> bool:
         """Check if WebSocket is connected."""
-        return self._connected
+        return self._connected and self._socketio_connected()
+
+    def _socketio_connected(self) -> bool:
+        """Check whether Socket.IO has an active transport or namespace."""
+        namespaces = getattr(self.sio, "namespaces", {})
+        return bool(getattr(self.sio, "connected", False)) or (
+            "/local-executor" in namespaces
+        )
 
     @property
     def registered(self) -> bool:
@@ -443,9 +450,14 @@ class WebSocketClient:
                 "Auth token not configured. Set WEGENT_AUTH_TOKEN environment variable."
             )
 
-        if self._connected:
+        if self.connected:
             logger.info("Already connected to WebSocket")
             return True
+
+        if self._connected:
+            logger.warning("WebSocket local state was stale; resetting before connect")
+            self._connected = False
+            self._registered = False
 
         if self._connecting:
             logger.info("Connection already in progress")
@@ -478,6 +490,29 @@ class WebSocketClient:
             logger.error(f"Failed to connect to WebSocket: {e}")
             return False
 
+    async def reconnect(self, wait_timeout: float = 30.0) -> bool:
+        """Force a fresh WebSocket connection and re-register the device."""
+        logger.info("Forcing WebSocket reconnect")
+
+        try:
+            if self._connected or self._socketio_connected():
+                await self.sio.disconnect()
+        except Exception as e:
+            logger.warning(f"Error while disconnecting stale WebSocket: {e}")
+
+        self._connected = False
+        self._registered = False
+        self._connecting = False
+
+        connected = await self.connect(wait_timeout=wait_timeout)
+        if not connected:
+            return False
+
+        if self._was_registered and not self._registered:
+            return await self.register_device()
+
+        return True
+
     async def register_device(self, timeout: float = 10.0) -> bool:
         """Register device with Backend using call (request-response).
 
@@ -487,7 +522,7 @@ class WebSocketClient:
         Returns:
             True if registered successfully, False otherwise.
         """
-        if not self._connected:
+        if not self.connected:
             raise ConnectionError("WebSocket not connected")
 
         try:
@@ -541,7 +576,7 @@ class WebSocketClient:
         Returns:
             True if heartbeat acknowledged, False otherwise.
         """
-        if not self._connected:
+        if not self.connected:
             raise ConnectionError("WebSocket not connected")
 
         try:
@@ -589,7 +624,7 @@ class WebSocketClient:
 
     async def disconnect(self) -> None:
         """Disconnect from the WebSocket server."""
-        if self._connected:
+        if self._connected or self._socketio_connected():
             try:
                 await self.sio.disconnect()
                 logger.info("WebSocket disconnected gracefully")
@@ -608,7 +643,7 @@ class WebSocketClient:
             data: Event data payload.
             callback: Optional callback for acknowledgment.
         """
-        if not self._connected:
+        if not self.connected:
             raise ConnectionError("WebSocket not connected")
 
         try:
@@ -636,7 +671,7 @@ class WebSocketClient:
         Returns:
             Response data or None if failed.
         """
-        if not self._connected:
+        if not self.connected:
             raise ConnectionError("WebSocket not connected")
 
         try:

--- a/executor/tests/test_local_heartbeat.py
+++ b/executor/tests/test_local_heartbeat.py
@@ -26,6 +26,21 @@ class DisconnectedClient:
         return True
 
 
+class ConnectedHeartbeatFailingClient:
+    def __init__(self):
+        self._connected = True
+        self.reconnect_called = asyncio.Event()
+        self.send_heartbeat = AsyncMock(return_value=False)
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def reconnect(self) -> bool:
+        self.reconnect_called.set()
+        return True
+
+
 @pytest.mark.asyncio
 async def test_heartbeat_reconnects_when_client_is_disconnected():
     client = DisconnectedClient()
@@ -38,3 +53,17 @@ async def test_heartbeat_reconnects_when_client_is_disconnected():
         await service.stop()
 
     assert client.connected is True
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_forces_reconnect_after_repeated_ack_failures():
+    client = ConnectedHeartbeatFailingClient()
+    service = LocalHeartbeatService(client, interval=0.01)
+
+    await service.start()
+    try:
+        await asyncio.wait_for(client.reconnect_called.wait(), timeout=0.2)
+    finally:
+        await service.stop()
+
+    assert client.send_heartbeat.await_count == 3

--- a/executor/tests/test_local_websocket_client.py
+++ b/executor/tests/test_local_websocket_client.py
@@ -2,7 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from executor.modes.local.websocket_client import build_runtime_auth_file_report
+import pytest
+
+from executor.modes.local.websocket_client import (
+    WebSocketClient,
+    build_runtime_auth_file_report,
+)
 
 
 def test_build_runtime_auth_file_report_reports_codex_auth_presence(tmp_path):
@@ -20,3 +25,59 @@ def test_build_runtime_auth_file_report_reports_codex_auth_presence(tmp_path):
     (codex_dir / "auth.json").write_text('{"token":"secret"}', encoding="utf-8")
 
     assert build_runtime_auth_file_report(home=tmp_path)["codex"]["exists"] is True
+
+
+def test_connected_accepts_namespace_connected_during_connect_callback():
+    client = WebSocketClient.__new__(WebSocketClient)
+
+    class FakeSocket:
+        connected = False
+        namespaces = {"/local-executor": "sid-1"}
+
+    client.sio = FakeSocket()
+    client._connected = True
+
+    assert client.connected is True
+
+
+@pytest.mark.asyncio
+async def test_reconnect_resets_socket_state_and_registers_device():
+    client = WebSocketClient.__new__(WebSocketClient)
+    connect_called = False
+    register_called = False
+
+    class FakeSocket:
+        connected = True
+
+        async def disconnect(self):
+            self.connected = False
+
+    async def fake_connect(wait_timeout=30.0):
+        nonlocal connect_called
+        connect_called = True
+        assert wait_timeout == 12.0
+        assert client._connected is False
+        assert client._registered is False
+        assert client._connecting is False
+        return True
+
+    async def fake_register_device():
+        nonlocal register_called
+        register_called = True
+        client._registered = True
+        return True
+
+    client.sio = FakeSocket()
+    client._connected = True
+    client._registered = True
+    client._connecting = True
+    client._was_registered = True
+    client.connect = fake_connect
+    client.register_device = fake_register_device
+
+    assert await client.reconnect(wait_timeout=12.0) is True
+
+    assert client.sio.connected is False
+    assert connect_called is True
+    assert register_called is True
+    assert client._registered is True


### PR DESCRIPTION
## Summary
- Treat Socket.IO namespace state as part of websocket connectivity
- Add a reconnect path that clears stale local state, reconnects, and re-registers the device when needed
- Retry the heartbeat loop by forcing reconnect after repeated ack failures
- Cover the reconnect and heartbeat recovery paths with unit tests

## Testing
- Unit tests added for websocket connectivity, reconnect recovery, and heartbeat-triggered reconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved connection state detection to more accurately reflect active connection status.
  * Added automatic recovery attempt when heartbeat failures exceed the configured threshold.

* **New Features**
  * Added explicit reconnection capability to reset and restore service connections.

* **Tests**
  * New tests validate connection state detection and recovery behavior under failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->