### PR TITLE
Preserve specific task failure errors in workbench messages

### DIFF
--- a/executor/modes/local/runner.py
+++ b/executor/modes/local/runner.py
@@ -686,10 +686,16 @@ class LocalRunner:
         if result == TaskStatus.CANCELLED and not ws_emitter.terminal_event_emitted:
             await ws_emitter.incomplete(reason="cancelled")
         elif result != TaskStatus.COMPLETED and not ws_emitter.terminal_event_emitted:
-            error_msg = execution_result.get(
-                "error", f"Task failed with status: {result.value}"
-            )
-            await ws_emitter.error(error_msg, "execution_error")
+            error_msg = execution_result.get("error")
+            if error_msg:
+                await ws_emitter.error(error_msg, "execution_error")
+            else:
+                logger.warning(
+                    "Task ended without a terminal event or explicit error: "
+                    "task_id=%s, status=%s",
+                    task_id,
+                    result.value,
+                )
 
         # Send heartbeat immediately to reflect freed slot after task completion
         try:

--- a/executor/tests/test_local_task_dispatch_handler.py
+++ b/executor/tests/test_local_task_dispatch_handler.py
@@ -131,3 +131,57 @@ async def test_execute_task_does_not_emit_generic_error_after_agent_error(monkey
             "execution_error",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_task_does_not_emit_generic_error_without_agent_error(
+    monkeypatch,
+):
+    """Local runner should not invent a generic task status error."""
+
+    class FakeEmitter:
+        def __init__(self):
+            self.errors = []
+
+        async def in_progress(self):
+            return None
+
+        async def error(self, message, code=None):
+            self.errors.append((message, code))
+
+        async def incomplete(self, reason=None):
+            return None
+
+    class FakeStateManager:
+        def get_current_state(self):
+            return {}
+
+    class FakeAgent:
+        state_manager = FakeStateManager()
+
+        def initialize(self):
+            return TaskStatus.SUCCESS
+
+        async def pre_execute(self):
+            return TaskStatus.SUCCESS, None
+
+        async def execute_async(self):
+            return TaskStatus.FAILED
+
+    emitter = FakeEmitter()
+    runner = object.__new__(LocalRunner)
+    runner._running_tasks = {1: SimpleNamespace(agent=None, cancel_requested=False)}
+    runner.websocket_client = SimpleNamespace(send_heartbeat=AsyncMock())
+    monkeypatch.setattr(runner, "_create_emitter", lambda task_id, subtask_id: emitter)
+
+    from executor.agents.factory import AgentFactory
+
+    monkeypatch.setattr(
+        AgentFactory,
+        "get_code_agent",
+        lambda task_data, emitter: FakeAgent(),
+    )
+
+    await runner._execute_task(ExecutionRequest(task_id=1, subtask_id=2))
+
+    assert emitter.errors == []

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -10,6 +10,7 @@ export type {
 } from './api-types'
 export type { MessageBlock, MessageBlockStatus } from './message-blocks'
 export {
+  isGenericTaskStatusError,
   normalizeWorkbenchBlockStatus,
   reduceWorkbenchMessages,
 } from './workbench-message-reducer'

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -94,7 +94,7 @@ export type WorkbenchMessageAction<TAttachment = unknown, TFileChanges = unknown
   | { type: 'block_created'; subtaskId: number; block: WorkbenchProcessingBlock }
   | { type: 'block_updated'; subtaskId: number; blockId: string; updates: ProcessingBlockUpdate }
 
-function isGenericTaskStatusError(error?: string): boolean {
+export function isGenericTaskStatusError(error?: string): boolean {
   return /^Task failed with status:\s*\w+$/i.test(String(error ?? '').trim())
 }
 

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -693,6 +693,36 @@ describe('MessageList', () => {
     expect(screen.queryByText(rawError, { selector: 'p.text-red-500' })).not.toBeInTheDocument()
   })
 
+  test('renders retry card for failed assistant messages without error details', async () => {
+    const user = userEvent.setup()
+    const onRetryFailedMessage = vi.fn()
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '',
+            status: 'failed',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+          },
+        ]}
+        onRetryFailedMessage={onRetryFailedMessage}
+      />
+    )
+
+    expect(screen.getByTestId('assistant-error-card')).toBeInTheDocument()
+    expect(screen.getByText('消息生成失败')).toBeInTheDocument()
+    expect(screen.getByText('请求未能完成。你可以稍后重试。')).toBeInTheDocument()
+    expect(screen.queryByTestId('assistant-error-details-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('assistant-error-details')).not.toBeInTheDocument()
+
+    await user.click(screen.getByTestId('assistant-error-retry'))
+
+    expect(onRetryFailedMessage).toHaveBeenCalledWith(expect.objectContaining({ id: '2' }))
+  })
+
   test('classifies hidden raw failed content before generic task status errors', () => {
     const rawError =
       'API Error: 400 {"error":{"message":"模型 deepseek-v3.1 不支持 Anthropic 协议, model_id: ali-deepseek-v3.1"}}'

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -461,7 +461,7 @@ function AssistantMessage({
       {isStreaming && hasVisibleContent && !hasBlocks && (
         <span className="text-text-muted">正在思考</span>
       )}
-      {message.status === 'failed' && message.error && (
+      {message.status === 'failed' && (
         <AssistantErrorCard
           error={message.error}
           errorType={message.errorType}
@@ -499,7 +499,7 @@ function AssistantErrorCard({
   onRetry,
   onSwitchModel,
 }: {
-  error: string
+  error?: string
   errorType?: string
   rawError?: string
   message: WorkbenchMessage
@@ -509,10 +509,11 @@ function AssistantErrorCard({
   const { t } = useTranslation('chat')
   const [isDetailExpanded, setIsDetailExpanded] = useState(false)
   const displayError = rawError || error
-  const parsedError = parseChatError(displayError, errorType)
+  const hasErrorDetails = Boolean(displayError)
+  const parsedError = parseChatError(displayError ?? '', errorType)
   const modelName =
-    displayError.match(/model_id:\s*([^"'}\s]+)/)?.[1] ??
-    displayError.match(/model(?:\s+|_id["':\s]+)([a-z0-9._:-]+)/i)?.[1]
+    displayError?.match(/model_id:\s*([^"'}\s]+)/)?.[1] ??
+    displayError?.match(/model(?:\s+|_id["':\s]+)([a-z0-9._:-]+)/i)?.[1]
   const title = t(parsedError.titleKey, {
     defaultValue: t('assistant_error.types.generic_error.title', '消息生成失败'),
   })
@@ -522,6 +523,8 @@ function AssistantErrorCard({
           model: modelName,
           defaultValue: `${modelName} 不支持当前运行协议。请切换兼容模型后重试。`,
         })
+      : !hasErrorDetails && parsedError.type === 'generic_error'
+        ? t('assistant_error.types.generic_error.description_without_details')
       : t(parsedError.descriptionKey, {
           defaultValue: t(
             'assistant_error.types.generic_error.description',
@@ -557,33 +560,37 @@ function AssistantErrorCard({
           >
             {t('assistant_error.actions.retry', '重试')}
           </button>
-          <button
-            type="button"
-            data-testid="assistant-error-details-toggle"
-            aria-expanded={isDetailExpanded}
-            onClick={() => setIsDetailExpanded(value => !value)}
-            className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-base px-3 text-xs font-semibold text-text-secondary hover:bg-muted hover:text-text-primary"
-          >
-            <ChevronDown
-              className={[
-                'h-3.5 w-3.5 transition-transform',
-                isDetailExpanded ? 'rotate-180' : '',
-              ].join(' ')}
-            />
-            {t('assistant_error.details', '错误详情')}
-          </button>
+          {hasErrorDetails && (
+            <button
+              type="button"
+              data-testid="assistant-error-details-toggle"
+              aria-expanded={isDetailExpanded}
+              onClick={() => setIsDetailExpanded(value => !value)}
+              className="inline-flex h-8 items-center gap-1 rounded-lg border border-border bg-base px-3 text-xs font-semibold text-text-secondary hover:bg-muted hover:text-text-primary"
+            >
+              <ChevronDown
+                className={[
+                  'h-3.5 w-3.5 transition-transform',
+                  isDetailExpanded ? 'rotate-180' : '',
+                ].join(' ')}
+              />
+              {t('assistant_error.details', '错误详情')}
+            </button>
+          )}
         </div>
-        <pre
-          data-testid="assistant-error-details"
-          className={[
-            'mt-2 max-w-full rounded-md bg-base px-2.5 py-1.5 font-mono text-[11px] leading-4 text-text-muted',
-            isDetailExpanded
-              ? 'max-h-32 overflow-auto whitespace-pre-wrap break-words'
-              : 'overflow-hidden truncate whitespace-nowrap',
-          ].join(' ')}
-        >
-          {displayError}
-        </pre>
+        {hasErrorDetails && (
+          <pre
+            data-testid="assistant-error-details"
+            className={[
+              'mt-2 max-w-full rounded-md bg-base px-2.5 py-1.5 font-mono text-[11px] leading-4 text-text-muted',
+              isDetailExpanded
+                ? 'max-h-32 overflow-auto whitespace-pre-wrap break-words'
+                : 'overflow-hidden truncate whitespace-nowrap',
+            ].join(' ')}
+          >
+            {displayError}
+          </pre>
+        )}
       </div>
     </div>
   )

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -257,6 +257,14 @@ function TaskMessagesProbe() {
           .map(message => `${message.role}:${message.status}:${message.content}`)
           .join('|')}
       </span>
+      <span data-testid="message-errors">
+        {workbench.messages
+          .map(
+            message =>
+              `${message.role}:${message.status}:${message.error ?? ''}:${message.errorType ?? ''}`
+          )
+          .join('|')}
+      </span>
       <button type="button" onClick={() => void workbench.openTask(8)}>
         open task
       </button>
@@ -786,6 +794,112 @@ describe('WorkbenchProvider', () => {
     await waitFor(() => expect(joinTask).toHaveBeenCalledWith(8))
     expect(screen.getByTestId('message-contents')).toHaveTextContent(
       'assistant:streaming:已经输出的内容'
+    )
+  })
+
+  test('restores persisted failure with specific result error before generic task status error', async () => {
+    const specificError = 'Codex CLI failed to resume thread: session not found'
+    const getTaskDetail = vi.fn().mockResolvedValue({
+      id: 8,
+      title: 'Failed task',
+      status: 'FAILED',
+      task_type: 'code',
+      project_id: 0,
+      device_id: 'local-online',
+      created_at: '2026-06-04T00:00:00.000Z',
+      updated_at: '2026-06-04T00:01:00.000Z',
+      subtasks: [
+        {
+          id: 21,
+          task_id: 8,
+          role: 'assistant',
+          result: {
+            value: '',
+            error: specificError,
+            error_type: 'execution_error',
+          },
+          error_message: 'Task failed with status: FAILED',
+          status: 'FAILED',
+          created_at: '2026-06-04T00:00:01.000Z',
+        },
+      ],
+    })
+
+    render(
+      <WorkbenchProvider
+        user={{ id: 1, user_name: 'alice', email: 'a@b.c' }}
+        services={{
+          teamApi: {
+            getDefaultWorkbenchTeam: vi
+              .fn()
+              .mockResolvedValue({ id: 2, name: 'coder', is_active: true }),
+          },
+          modelApi: { listModels: vi.fn().mockResolvedValue({ data: [] }) },
+          skillApi: {
+            listSkills: vi.fn().mockResolvedValue([]),
+            getTeamSkills: vi.fn().mockResolvedValue({ skills: [], preload_skills: [] }),
+          },
+          projectApi: {
+            listProjects: vi.fn().mockResolvedValue({ items: [] }),
+            getProject: vi.fn(),
+            createProject: vi.fn(),
+            updateProject: vi.fn(),
+            deleteProject: vi.fn(),
+            archiveProjectChats: vi.fn(),
+            archiveAllProjectChats: vi.fn(),
+            createConversation: vi.fn(),
+          },
+          taskApi: {
+            listRecentTasks: vi.fn().mockResolvedValue({ total: 0, items: [] }),
+            getTaskDetail,
+            renameTask: vi.fn(),
+            archiveTask: vi.fn(),
+            archiveAllChats: vi.fn(),
+            listArchivedTasks: vi.fn(),
+            unarchiveTask: vi.fn(),
+            deleteTask: vi.fn(),
+            deleteArchivedTasks: vi.fn(),
+          },
+          deviceApi: {
+            listDevices: vi.fn().mockResolvedValue([
+              {
+                id: 1,
+                device_id: 'local-online',
+                name: 'Local Device',
+                status: 'online',
+                is_default: false,
+                device_type: 'local',
+                bind_shell: 'claudecode',
+              },
+            ]),
+            getHomeDirectory: vi.fn(),
+            getProjectWorkspaceRoot: vi.fn(),
+            listDirectories: vi.fn(),
+            listSkills: vi.fn().mockResolvedValue([]),
+          },
+          chatStream: {
+            joinTask: vi.fn(),
+            leaveTask: vi.fn(),
+            sendMessage: vi.fn(),
+            sendGuidance: vi.fn(),
+            cancelStream: vi.fn(),
+            subscribe: vi.fn(() => vi.fn()),
+          },
+        }}
+      >
+        <TaskMessagesProbe />
+      </WorkbenchProvider>
+    )
+
+    await userEvent.click(await screen.findByText('open task'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('message-errors')).toHaveTextContent(
+        `assistant:failed:${specificError}:execution_error`
+      )
+    )
+    expect(screen.getByTestId('message-errors')).not.toHaveTextContent(
+      'Task failed with status: FAILED'
     )
   })
 

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -81,6 +81,7 @@ import type {
 } from '@/types/workbench'
 import {
   createSocketClient,
+  isGenericTaskStatusError,
   normalizeWorkbenchBlockStatus,
   reduceWorkbenchMessages,
 } from '@wegent/chat-core'
@@ -547,6 +548,20 @@ function getSubtaskAttachments(subtask: Subtask): Attachment[] | undefined {
   return attachments.length > 0 ? attachments : undefined
 }
 
+function getSubtaskDisplayError(subtaskError?: string | null, resultError?: string): string | undefined {
+  const normalizedSubtaskError = subtaskError?.trim() ? subtaskError : undefined
+  const normalizedResultError = resultError?.trim() ? resultError : undefined
+
+  if (
+    normalizedResultError &&
+    (!normalizedSubtaskError || isGenericTaskStatusError(normalizedSubtaskError))
+  ) {
+    return normalizedResultError
+  }
+
+  return normalizedSubtaskError ?? normalizedResultError
+}
+
 function subtaskToMessage(subtask: Subtask): WorkbenchMessage {
   const result = getSubtaskResult(subtask.result)
   const role = subtask.role.toLowerCase() === 'user' ? 'user' : 'assistant'
@@ -565,7 +580,7 @@ function subtaskToMessage(subtask: Subtask): WorkbenchMessage {
     role,
     content: subtask.prompt || result?.value || '',
     status: subtask.status === 'FAILED' ? 'failed' : 'done',
-    error: subtask.error_message || result?.error,
+    error: getSubtaskDisplayError(subtask.error_message, result?.error),
     errorType: result?.errorType,
     attachments: getSubtaskAttachments(subtask),
     blocks: blocks.length > 0 ? blocks : undefined,

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -127,7 +127,8 @@
       },
       "generic_error": {
         "title": "Message generation failed",
-        "description": "The request could not be completed. Try again later, or view the error details."
+        "description": "The request could not be completed. Try again later, or view the error details.",
+        "description_without_details": "The request could not be completed. Try again later."
       }
     }
   }

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -127,7 +127,8 @@
       },
       "generic_error": {
         "title": "消息生成失败",
-        "description": "请求未能完成。你可以稍后重试，或查看错误详情。"
+        "description": "请求未能完成。你可以稍后重试，或查看错误详情。",
+        "description_without_details": "请求未能完成。你可以稍后重试。"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Stop emitting synthetic `Task failed with status: ...` errors when a task ends without an explicit error payload
- Prefer persisted specific result errors over generic task status errors when restoring failed workbench messages
- Add coverage for the executor runner and workbench message restoration path

## Testing
- Added unit tests for local task execution error emission
- Added UI-level component tests for failed task message restoration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task failure handling by avoiding generic error emissions when no explicit agent error is provided.
  * Enhanced Workbench and chat error rendering to prefer specific error details over generic “task status” messages.
  * Updated the failed-assistant error card to show error UI for failed states, with error-details toggle/details only when details exist.
* **Localization**
  * Added “no error details” variants for the generic error description in English and Chinese.
* **Tests**
  * Added coverage for preventing generic error emissions and verifying the retry card / error-details behavior in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->