### PR TITLE
[codex] Speed up executor pytest defaults

### DIFF
--- a/executor/pyproject.toml
+++ b/executor/pyproject.toml
@@ -105,10 +105,3 @@ ensure_newline_before_comments = true
 skip = [".venv", "venv"]
 skip_gitignore = true
 known_first_party = ["agents", "callback", "code_server", "config", "envd", "services", "tasks", "utils", "shared"]
-
-[tool.pytest.ini_options]
-testpaths = ["tests"]
-python_files = ["test_*.py"]
-python_classes = ["Test*"]
-python_functions = ["test_*"]
-addopts = "-v --tb=short"

--- a/executor/pytest.ini
+++ b/executor/pytest.ini
@@ -4,14 +4,13 @@
 
 [pytest]
 testpaths = tests
+norecursedirs = tests/manual
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 addopts =
     -v
     --strict-markers
-    --cov=agents
-    --cov-report=term-missing
 asyncio_mode = auto
 markers =
     unit: Unit tests

--- a/executor/tests/config/test_pytest_config.py
+++ b/executor/tests/config/test_pytest_config.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import tomllib
+from configparser import ConfigParser
+from pathlib import Path
+
+
+def test_default_pytest_addopts_do_not_enable_coverage():
+    config = ConfigParser()
+    config.read(Path(__file__).parents[2] / "pytest.ini")
+
+    addopts = config.get("pytest", "addopts", fallback="")
+
+    assert "--cov" not in addopts
+
+
+def test_default_pytest_collection_excludes_manual_tests():
+    config = ConfigParser()
+    config.read(Path(__file__).parents[2] / "pytest.ini")
+
+    ignored_dirs = config.get("pytest", "norecursedirs", fallback="")
+
+    assert "tests/manual" in ignored_dirs.split()
+
+
+def test_pytest_configuration_has_single_source():
+    pyproject_path = Path(__file__).parents[2] / "pyproject.toml"
+    pyproject = tomllib.loads(pyproject_path.read_text())
+
+    assert "pytest" not in pyproject.get("tool", {})

--- a/executor/tests/config/test_pytest_config.py
+++ b/executor/tests/config/test_pytest_config.py
@@ -2,9 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import tomllib
 from configparser import ConfigParser
 from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 
 def test_default_pytest_addopts_do_not_enable_coverage():


### PR DESCRIPTION
## Summary

- Remove default executor pytest coverage collection so local pytest runs stay fast by default.
- Exclude `tests/manual` from default executor pytest discovery to avoid manual/network checks in normal runs.
- Add configuration regression tests covering the intended pytest defaults.

## Root Cause

Executor `pytest.ini` enabled `--cov=agents --cov-report=term-missing` by default. Coverage tracing and report generation made collection alone take over a minute. The default test discovery also included manual tests, including a GitHub API connectivity check.

## Impact

Local executor test runs now use the fast unit-test path by default. CI coverage remains explicit through the existing workflow command that passes `--cov=agents`.

## Validation

- `uv run pytest -q --durations=10` from `executor/`: 584 passed, 3 warnings in 19.25s
- `uv run pytest --collect-only -q` from `executor/`: 584 tests collected in 1.50s
- `uv run pytest tests/ --collect-only -q` from `executor/`: 584 tests collected in 1.83s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Restructured test configuration to disable automatic coverage reporting in default test runs.
  * Configured test discovery to exclude manual test directory from automatic scanning.

* **Tests**
  * Added configuration validation tests to ensure consistent pytest settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->