### PR TITLE
feat(backend): add API to get group with its subgroups

### DIFF
--- a/backend/app/api/endpoints/groups.py
+++ b/backend/app/api/endpoints/groups.py
@@ -11,7 +11,10 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 from app.api.dependencies import get_db
-from app.core.security import get_current_user
+from app.core.security import (
+    get_current_user,
+    get_current_user_jwt_apikey_tasktoken,
+)
 from app.models.namespace import Namespace
 from app.models.resource_member import MemberStatus, ResourceMember
 from app.models.user import User
@@ -29,6 +32,7 @@ from app.schemas.namespace import (
     GroupResponse,
     GroupRole,
     GroupUpdate,
+    GroupWithChildrenResponse,
 )
 from app.schemas.namespace_member import (
     AddMemberResult,
@@ -161,7 +165,7 @@ def list_members(
     group_name: str = Path(
         ..., description="Group name (may contain slashes for subgroups)"
     ),
-    current_user: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user_jwt_apikey_tasktoken),
     db: Session = Depends(get_db),
 ):
     """
@@ -936,6 +940,57 @@ def transfer_ownership_endpoint(
 # ============================================================================
 # Generic group routes - MUST come after specific sub-routes
 # ============================================================================
+
+
+@router.get(
+    "/{group_name:path}/with-children", response_model=GroupWithChildrenResponse
+)
+@trace_sync("get_group_with_children", "groups.api")
+def get_group_with_children_endpoint(
+    group_name: str = Path(
+        ..., description="Group name (may contain slashes for subgroups)"
+    ),
+    current_user: User = Depends(get_current_user_jwt_apikey_tasktoken),
+    db: Session = Depends(get_db),
+) -> GroupWithChildrenResponse:
+    """
+    Get group details including its subgroups.
+    User must be a member of the group to view it.
+    Only returns subgroups where the user is also a member.
+    """
+    group = group_service.get_group(db=db, group_name=group_name)
+
+    if not group:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Group not found",
+        )
+
+    user_role = get_view_role_in_group(
+        db,
+        current_user.id,
+        group_name,
+        user_role=current_user.role,
+        group_level=group.level,
+    )
+    if user_role is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this group",
+        )
+
+    # Set the current user's role in the group
+    group.my_role = user_role
+
+    # Get subgroups
+    children = group_service.get_child_groups(
+        db=db,
+        parent_name=group_name,
+        user_id=current_user.id,
+        user_role=current_user.role,
+    )
+
+    return GroupWithChildrenResponse(group=group, children=children)
 
 
 @router.get("/{group_name:path}", response_model=GroupResponse)

--- a/backend/app/schemas/namespace.py
+++ b/backend/app/schemas/namespace.py
@@ -117,3 +117,10 @@ class GroupListResponse(BaseModel):
 
     total: int
     items: list[GroupResponse]
+
+
+class GroupWithChildrenResponse(BaseModel):
+    """Group response including its subgroups"""
+
+    group: GroupResponse
+    children: list[GroupResponse]

--- a/backend/app/services/group_service.py
+++ b/backend/app/services/group_service.py
@@ -1101,6 +1101,74 @@ def invite_all_users(
     return result
 
 
+def get_child_groups(
+    db: Session,
+    parent_name: str,
+    user_id: int,
+    user_role: str | None = None,
+) -> list[GroupResponse]:
+    """
+    Get all subgroups under the given parent group.
+
+    Args:
+        db: Database session
+        parent_name: Parent group name
+        user_id: Current user ID for permission filtering
+        user_role: User's system role ('admin' or 'user')
+
+    Returns:
+        List of GroupResponse for child groups the user can access
+    """
+    # Query all active subgroups with explicit LIKE escape for safety
+    escaped_name = (
+        parent_name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    )
+    subgroups = (
+        db.query(Namespace)
+        .filter(
+            Namespace.name.like(f"{escaped_name}/%", escape="\\"),
+            Namespace.is_active.is_(True),
+        )
+        .order_by(Namespace.name.asc())
+        .all()
+    )
+
+    if not subgroups:
+        return []
+
+    # Get user's role in each subgroup for permission filtering
+    from app.services.group_member_helper import get_user_groups_with_roles
+
+    member_data = get_user_groups_with_roles(db, user_id)
+    user_group_roles = {name: role for name, role in member_data}
+
+    if user_role == "admin":
+        organization_groups = (
+            db.query(Namespace.name)
+            .filter(
+                Namespace.level == GroupLevel.organization.value,
+                Namespace.is_active.is_(True),
+            )
+            .all()
+        )
+        for (group_name,) in organization_groups:
+            user_group_roles[group_name] = GroupRole.Owner.value
+
+    result = []
+    for group in subgroups:
+        # Only include groups where user has access
+        group_access_role = user_group_roles.get(group.name)
+        if group_access_role is None:
+            continue
+
+        group_response = GroupResponse.model_validate(group)
+        group_response.my_role = group_access_role
+        group_response.member_count = get_group_member_count(db, group.name)
+        result.append(group_response)
+
+    return result
+
+
 def _transfer_resources_to_owner(
     db: Session, group_name: str, from_user_id: int, to_user_id: int
 ) -> None:

--- a/backend/tests/api/endpoints/test_groups_api.py
+++ b/backend/tests/api/endpoints/test_groups_api.py
@@ -829,3 +829,335 @@ def test_add_entity_member_exceed_limit(
 
     assert response.status_code == 400
     assert "limit reached" in response.json()["detail"].lower()
+
+
+def test_get_group_with_children_success(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test GET /groups/{name}/with-children returns group and its subgroups."""
+    parent_group = _create_group(test_db, test_user, name="parent-group")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    child_group = Namespace(
+        name="parent-group/child",
+        display_name="Child Group",
+        owner_user_id=test_user.id,
+        visibility="internal",
+        description="child",
+        level="group",
+        is_active=True,
+    )
+    test_db.add(child_group)
+    test_db.commit()
+    _add_member(test_db, child_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "parent-group"
+    assert payload["group"]["my_role"] == "Owner"
+    assert len(payload["children"]) == 1
+    assert payload["children"][0]["name"] == "parent-group/child"
+    assert payload["children"][0]["my_role"] == "Owner"
+
+
+def test_get_group_with_children_with_api_key_x_header(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test with-children endpoint supports X-API-Key header."""
+    raw_key, _ = test_api_key
+    parent_group = _create_group(test_db, test_user, name="apikey-parent")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "apikey-parent"
+
+
+def test_get_group_with_children_with_api_key_bearer(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test with-children endpoint supports Authorization: Bearer API Key."""
+    raw_key, _ = test_api_key
+    parent_group = _create_group(test_db, test_user, name="apikey-bearer-parent")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers={"Authorization": f"Bearer {raw_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "apikey-bearer-parent"
+
+
+def test_list_members_with_api_key(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test members endpoint supports API Key authentication."""
+    raw_key, _ = test_api_key
+    group = _create_group(test_db, test_user, name="apikey-members-group")
+    _add_member(test_db, group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{group.name}/members",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["user_id"] == test_user.id
+    assert payload[0]["role"] == "Owner"
+
+
+def test_get_group_with_children_non_member_forbidden(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test non-member gets 403 on with-children endpoint."""
+    other_user = _create_user(test_db, "other", "other@example.com")
+    parent_group = _create_group(test_db, other_user, name="forbidden-parent")
+    _add_member(test_db, parent_group, other_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You are not a member of this group"
+
+
+def test_get_group_with_children_not_found(
+    test_client: TestClient, test_user: User, test_token: str
+):
+    """Test 404 on with-children endpoint for non-existent group."""
+    response = test_client.get(
+        "/api/groups/non-existent-group/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Group not found"
+
+
+def test_get_child_groups_sql_like_escape(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test SQL LIKE wildcard characters in parent_name are escaped."""
+    parent_group = _create_group(test_db, test_user, name="test_underscore")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    decoy_group = _create_group(test_db, test_user, name="testAunderscore")
+    _add_member(test_db, decoy_group, test_user, "Owner")
+
+    real_child = Namespace(
+        name="test_underscore/child",
+        display_name="Real Child",
+        owner_user_id=test_user.id,
+        visibility="internal",
+        description="child",
+        level="group",
+        is_active=True,
+    )
+    test_db.add(real_child)
+    test_db.commit()
+    _add_member(test_db, real_child, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "test_underscore"
+    children_names = [c["name"] for c in payload["children"]]
+    assert "test_underscore/child" in children_names
+    assert "testAunderscore" not in children_names
+
+
+def test_get_group_with_children_success(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test GET /groups/{name}/with-children returns group and its subgroups."""
+    parent_group = _create_group(test_db, test_user, name="parent-group")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    child_group = Namespace(
+        name="parent-group/child",
+        display_name="Child Group",
+        owner_user_id=test_user.id,
+        visibility="internal",
+        description="child",
+        level="group",
+        is_active=True,
+    )
+    test_db.add(child_group)
+    test_db.commit()
+    _add_member(test_db, child_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "parent-group"
+    assert payload["group"]["my_role"] == "Owner"
+    assert len(payload["children"]) == 1
+    assert payload["children"][0]["name"] == "parent-group/child"
+    assert payload["children"][0]["my_role"] == "Owner"
+
+
+def test_get_group_with_children_with_api_key_x_header(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test with-children endpoint supports X-API-Key header."""
+    raw_key, _ = test_api_key
+    parent_group = _create_group(test_db, test_user, name="apikey-parent")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "apikey-parent"
+
+
+def test_get_group_with_children_with_api_key_bearer(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test with-children endpoint supports Authorization: Bearer API Key."""
+    raw_key, _ = test_api_key
+    parent_group = _create_group(test_db, test_user, name="apikey-bearer-parent")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers={"Authorization": f"Bearer {raw_key}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "apikey-bearer-parent"
+
+
+def test_list_members_with_api_key(
+    test_client: TestClient,
+    test_db: Session,
+    test_user: User,
+    test_api_key: tuple[str, object],
+):
+    """Test members endpoint supports API Key authentication."""
+    raw_key, _ = test_api_key
+    group = _create_group(test_db, test_user, name="apikey-members-group")
+    _add_member(test_db, group, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{group.name}/members",
+        headers={"X-API-Key": raw_key},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+    assert payload[0]["user_id"] == test_user.id
+    assert payload[0]["role"] == "Owner"
+
+
+def test_get_group_with_children_non_member_forbidden(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test non-member gets 403 on with-children endpoint."""
+    other_user = _create_user(test_db, "other", "other@example.com")
+    parent_group = _create_group(test_db, other_user, name="forbidden-parent")
+    _add_member(test_db, parent_group, other_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You are not a member of this group"
+
+
+def test_get_group_with_children_not_found(
+    test_client: TestClient, test_user: User, test_token: str
+):
+    """Test 404 on with-children endpoint for non-existent group."""
+    response = test_client.get(
+        "/api/groups/non-existent-group/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Group not found"
+
+
+def test_get_child_groups_sql_like_escape(
+    test_client: TestClient, test_db: Session, test_user: User, test_token: str
+):
+    """Test SQL LIKE wildcard characters in parent_name are escaped."""
+    parent_group = _create_group(test_db, test_user, name="test_underscore")
+    _add_member(test_db, parent_group, test_user, "Owner")
+
+    decoy_group = _create_group(test_db, test_user, name="testAunderscore")
+    _add_member(test_db, decoy_group, test_user, "Owner")
+
+    real_child = Namespace(
+        name="test_underscore/child",
+        display_name="Real Child",
+        owner_user_id=test_user.id,
+        visibility="internal",
+        description="child",
+        level="group",
+        is_active=True,
+    )
+    test_db.add(real_child)
+    test_db.commit()
+    _add_member(test_db, real_child, test_user, "Owner")
+
+    response = test_client.get(
+        f"/api/groups/{parent_group.name}/with-children",
+        headers=_auth_header(test_token),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["group"]["name"] == "test_underscore"
+    children_names = [c["name"] for c in payload["children"]]
+    assert "test_underscore/child" in children_names
+    assert "testAunderscore" not in children_names


### PR DESCRIPTION
- Add GET /groups/{group_name}/with-children endpoint
- Add GroupWithChildrenResponse schema
- Add get_child_groups service to query subgroups by name prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new endpoint to retrieve a group together with its immediate child subgroups, including caller-specific role details and member counts in a single response.

* **Access Control**
  * Enforced authorization: missing groups return not found; non-members receive forbidden.
  * Updated group member listing authentication to support JWT/API key/task token flows.

* **Tests**
  * Added coverage for success and failure cases, API key header vs bearer auth, and correct handling of special characters in child-group lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->