### PR TITLE
[codex] suppress stack trace for missing command cwd

### DIFF
--- a/executor/modes/local/command_handler.py
+++ b/executor/modes/local/command_handler.py
@@ -50,6 +50,11 @@ class CommandHandler:
             )
         )
 
+        cwd_error = self._missing_cwd_error(cwd)
+        if cwd_error:
+            logger.warning("[CommandHandler] %s", cwd_error)
+            return self._error_result(cwd_error, duration=self._elapsed(started_at))
+
         logger.info(
             "[CommandHandler] Executing command: cwd=%s, timeout=%s, mode=%s, command=%s",
             cwd or os.getcwd(),
@@ -60,6 +65,16 @@ class CommandHandler:
 
         try:
             process = await self._create_process(command, argv=argv, cwd=cwd, env=env)
+        except FileNotFoundError as exc:
+            if self._is_missing_cwd_error(exc, cwd):
+                cwd_error = self._missing_cwd_error(cwd) or str(exc)
+                logger.warning("[CommandHandler] %s", cwd_error)
+                return self._error_result(
+                    cwd_error,
+                    duration=self._elapsed(started_at),
+                )
+            logger.exception("[CommandHandler] Failed to start command")
+            return self._error_result(str(exc), duration=self._elapsed(started_at))
         except Exception as exc:
             logger.exception("[CommandHandler] Failed to start command")
             return self._error_result(str(exc), duration=self._elapsed(started_at))
@@ -163,6 +178,20 @@ class CommandHandler:
         if not isinstance(cwd, str) or not cwd.strip():
             return None
         return cwd
+
+    def _missing_cwd_error(self, cwd: Optional[str]) -> Optional[str]:
+        if cwd is None or os.path.isdir(cwd):
+            return None
+        return f"Working directory does not exist: {cwd}"
+
+    def _is_missing_cwd_error(
+        self,
+        exc: FileNotFoundError,
+        cwd: Optional[str],
+    ) -> bool:
+        if cwd is None:
+            return False
+        return exc.filename == cwd or not os.path.isdir(cwd)
 
     def _normalize_argv(self, argv: Any) -> Optional[list[str]]:
         if not isinstance(argv, list):

--- a/executor/tests/test_local_command_handler.py
+++ b/executor/tests/test_local_command_handler.py
@@ -121,3 +121,42 @@ async def test_execute_command_times_out_and_returns_error():
     assert result["exit_code"] is None
     assert result["timed_out"] is True
     assert "timed out" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_execute_command_missing_cwd_returns_error_without_exception_log(
+    tmp_path, monkeypatch
+):
+    """Missing worktrees should return a normal error without traceback logging."""
+    from executor.modes.local import command_handler
+    from executor.modes.local.command_handler import CommandHandler
+
+    missing_cwd = tmp_path / "deleted-worktree"
+    logger_calls = []
+
+    class FakeLogger:
+        def info(self, *args, **kwargs):
+            logger_calls.append(("info", args, kwargs))
+
+        def warning(self, *args, **kwargs):
+            logger_calls.append(("warning", args, kwargs))
+
+        def exception(self, *args, **kwargs):
+            logger_calls.append(("exception", args, kwargs))
+
+    monkeypatch.setattr(command_handler, "logger", FakeLogger())
+
+    result = await CommandHandler().handle_execute_command(
+        {
+            "command": "pwd",
+            "cwd": str(missing_cwd),
+            "timeout_seconds": 5,
+            "max_output_bytes": 1024,
+        }
+    )
+
+    assert result["success"] is False
+    assert result["exit_code"] is None
+    assert "Working directory does not exist" in result["error"]
+    assert str(missing_cwd) in result["error"]
+    assert not any(level == "exception" for level, _, _ in logger_calls)


### PR DESCRIPTION
## Summary
- Treat missing command working directories as expected command-start failures.
- Return a concise `Working directory does not exist` error and log a warning instead of emitting a traceback.
- Cover the missing worktree case with a local command handler regression test.

## Root Cause
A local command can be requested with a worktree path that has already been cleaned up. `asyncio.create_subprocess_exec` raises `FileNotFoundError` before the process starts, and the handler logged every start failure with `logger.exception`, producing noisy tracebacks for this normal race.

## Validation
- `uv run pytest tests/test_local_command_handler.py`
- `uv run black --check modes/local/command_handler.py tests/test_local_command_handler.py`
- `uv run isort --check-only modes/local/command_handler.py tests/test_local_command_handler.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution error handling to gracefully handle missing or invalid working directories, returning informative error messages with appropriate logging and elapsed duration tracking instead of generic failures.

* **Tests**
  * Added comprehensive test coverage for working directory validation scenarios to ensure proper error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->