### PR TITLE
[codex] Load environment info on popover open

### DIFF
--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -186,7 +186,7 @@ export function ProjectWorkBar({
     currentProject && hasGitBranch && supportsGitWorktreeExecution(currentProject)
   )
   const canShowExecutionModeControl = Boolean(currentProject)
-  const canShowBranchSelector = hasGitBranch
+  const canShowBranchSelector = Boolean(currentProject && (hasGitBranch || onListBranches))
   const canShowWorktreeBranchSelector = Boolean(
     currentProject &&
     executionMode === 'git_worktree' &&

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -3783,7 +3783,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(onGetProjectWorkspaceRoot).not.toHaveBeenCalled()
   })
 
-  test('refreshes environment info when an assistant message completes', async () => {
+  test('loads environment info only when the environment popover opens', async () => {
     const onLoadEnvironmentInfo = vi.fn().mockResolvedValue({
       additions: '+4',
       deletions: '-1',
@@ -3826,14 +3826,8 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await waitFor(() => {
-      expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(1)
-      expect(onLoadEnvironmentInfo).toHaveBeenCalledWith(workspaceProject, {
-        deviceId: 'device-1',
-        path: '/repo',
-        source: 'project',
-      })
-    })
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onLoadEnvironmentInfo).not.toHaveBeenCalled()
 
     rerender(
       <DesktopWorkbenchLayout
@@ -3852,7 +3846,19 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    await waitFor(() => expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(2))
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onLoadEnvironmentInfo).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByTestId('environment-info-button'))
+
+    await waitFor(() => {
+      expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(1)
+      expect(onLoadEnvironmentInfo).toHaveBeenCalledWith(workspaceProject, {
+        deviceId: 'device-1',
+        path: '/repo',
+        source: 'project',
+      })
+    })
   })
 
   test('closes the right workspace panel from the panel actions', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -262,8 +262,6 @@ export function DesktopWorkbenchLayout({
     state.currentRuntimeTask,
     state.projects,
   ])
-  const completedAssistantMessageIds = useRef<Set<string>>(new Set())
-  const completedAssistantMessagesInitialized = useRef(false)
   const currentTaskWorkspaceKey = state.currentTask
     ? [
         state.currentTask.id,
@@ -383,33 +381,12 @@ export function DesktopWorkbenchLayout({
     }
   }, [autoOpenAddCloudDeviceDialog, settingsOpen])
 
-  useEffect(() => {
-    const nextCompletedIds = new Set(
-      messages
-        .filter(message => message.role === 'assistant' && message.status === 'done')
-        .map(message => message.id)
-    )
-    const hasNewCompletedMessage = [...nextCompletedIds].some(
-      id => !completedAssistantMessageIds.current.has(id)
-    )
-    completedAssistantMessageIds.current = nextCompletedIds
-
-    if (!completedAssistantMessagesInitialized.current) {
-      completedAssistantMessagesInitialized.current = true
-      return
-    }
-
-    if (hasNewCompletedMessage) {
-      void refreshEnvironmentInfo()
-    }
-  }, [messages, refreshEnvironmentInfo])
-
   async function handleCommitEnvironmentChanges(message: string) {
     if (!workspaceTarget) {
       throw new Error(workspaceTargetError ?? 'Workspace is not ready')
     }
     await onCommitEnvironmentChanges(environmentProject, message, workspaceTarget)
-    await refreshEnvironmentInfo()
+    setEnvironmentInfo(info => ({ ...info, additions: '', deletions: '' }))
   }
 
   async function handleCheckoutEnvironmentBranch(branchName: string) {
@@ -417,7 +394,7 @@ export function DesktopWorkbenchLayout({
       throw new Error(workspaceTargetError ?? 'Workspace is not ready')
     }
     await onCheckoutEnvironmentBranch(environmentProject, branchName, workspaceTarget)
-    await refreshEnvironmentInfo()
+    setEnvironmentInfo(info => ({ ...info, branchName }))
   }
 
   async function handleCreateEnvironmentBranch(branchName: string) {
@@ -425,7 +402,7 @@ export function DesktopWorkbenchLayout({
       throw new Error(workspaceTargetError ?? 'Workspace is not ready')
     }
     await onCreateEnvironmentBranch(environmentProject, branchName, workspaceTarget)
-    await refreshEnvironmentInfo()
+    setEnvironmentInfo(info => ({ ...info, branchName }))
   }
 
   const openProjectFromWorkMenu = useCallback(
@@ -663,19 +640,13 @@ export function DesktopWorkbenchLayout({
     onCreateProjectMode: openProjectFromWorkMenu,
     branchName: environmentInfo.branchName,
     branchLoading: environmentInfo.loading,
-    onRefreshBranch: refreshEnvironmentInfo,
+    onRefreshBranch: undefined,
     onListBranches: workspaceTarget
       ? () => onListEnvironmentBranches(environmentProject, workspaceTarget)
       : undefined,
     onCheckoutBranch: handleCheckoutEnvironmentBranch,
     onCreateBranch: handleCreateEnvironmentBranch,
   }
-
-  useEffect(() => {
-    if (state.currentProject && !state.currentTask) {
-      void refreshEnvironmentInfo()
-    }
-  }, [refreshEnvironmentInfo, state.currentProject, state.currentTask])
 
   return (
     <div className="relative flex h-full overflow-hidden bg-transparent text-text-primary">

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -387,6 +387,7 @@ describe('MobileWorkbenchLayout', () => {
       executionTarget: 'local' as const,
       branchName: 'main',
     })
+    const onListEnvironmentBranches = vi.fn().mockResolvedValue(['feature/mobile', 'main'])
     const onCheckoutEnvironmentBranch = vi.fn().mockResolvedValue(undefined)
 
     renderAtMobileWidth(
@@ -409,7 +410,7 @@ describe('MobileWorkbenchLayout', () => {
         }}
         onSelectProject={vi.fn()}
         onLoadEnvironmentInfo={onLoadEnvironmentInfo}
-        onListEnvironmentBranches={vi.fn().mockResolvedValue(['feature/mobile', 'main'])}
+        onListEnvironmentBranches={onListEnvironmentBranches}
         onCheckoutEnvironmentBranch={onCheckoutEnvironmentBranch}
         onCreateEnvironmentBranch={vi.fn().mockResolvedValue(undefined)}
         onInputChange={vi.fn()}
@@ -417,9 +418,10 @@ describe('MobileWorkbenchLayout', () => {
       />
     )
 
-    await waitFor(() =>
-      expect(screen.getByTestId('project-branch-button')).toHaveTextContent('main')
-    )
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onLoadEnvironmentInfo).not.toHaveBeenCalled()
+    expect(onListEnvironmentBranches).not.toHaveBeenCalled()
+    expect(screen.getByTestId('project-branch-button')).toBeInTheDocument()
     const controls = screen.getByTestId('project-work-button').parentElement?.parentElement
     expect(controls).toHaveClass('flex-col')
     expect(screen.getByTestId('execution-mode-button')).toBeInTheDocument()
@@ -430,13 +432,9 @@ describe('MobileWorkbenchLayout', () => {
     expect(screen.getByTestId('project-search-input')).not.toHaveFocus()
     await userEvent.click(screen.getByTestId('project-work-mobile-close-button'))
 
-    await userEvent.click(screen.getByTestId('execution-mode-button'))
-    expect(screen.getByTestId('project-execution-mode-menu')).toHaveAttribute('data-mobile', 'true')
-    expect(screen.getByTestId('project-execution-mode-menu')).toHaveClass('fixed', 'max-h-[45dvh]')
-    await userEvent.click(screen.getByTestId('project-work-mobile-close-button'))
-
     await userEvent.click(screen.getByTestId('project-branch-button'))
     expect(await screen.findByTestId('project-branch-menu')).toHaveAttribute('data-mobile', 'true')
+    expect(onListEnvironmentBranches).toHaveBeenCalledTimes(1)
     expect(screen.getByTestId('project-branch-menu')).toHaveClass('fixed', 'max-h-[56dvh]')
     expect(screen.getByTestId('project-branch-search-input')).not.toHaveFocus()
     const options = await screen.findAllByTestId('project-branch-option')

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -176,7 +176,6 @@ export function MobileWorkbenchLayout({
   onGetProjectWorkspaceRoot,
   onListDeviceDirectories,
   onCreateDeviceDirectory,
-  onLoadEnvironmentInfo,
   onListEnvironmentBranches,
   onCheckoutEnvironmentBranch,
   onCreateEnvironmentBranch,
@@ -209,8 +208,6 @@ export function MobileWorkbenchLayout({
     executionTarget: 'local',
   })
   const [workspaceTarget, setWorkspaceTarget] = useState<WorkspaceTarget | null>(null)
-  const [workspaceTargetError, setWorkspaceTargetError] = useState<string | null>(null)
-  const [workspaceTargetResolving, setWorkspaceTargetResolving] = useState(true)
   const [continueInImOpen, setContinueInImOpen] = useState(false)
   const [forkDialogOpen, setForkDialogOpen] = useState(false)
   const [imSessions, setImSessions] = useState<IMPrivateSession[]>([])
@@ -264,42 +261,6 @@ export function MobileWorkbenchLayout({
         projectName: state.currentProject.name,
       })
     : t('workbench.empty_title', '我们该做什么？')
-  const refreshEnvironmentInfo = useCallback(async () => {
-    if (!onLoadEnvironmentInfo || !activeConversationProject) return
-
-    if (workspaceTargetResolving) {
-      setEnvironmentInfo(info => ({ ...info, loading: true }))
-      return
-    }
-
-    if (!workspaceTarget) {
-      setEnvironmentInfo(info => ({
-        ...info,
-        loading: false,
-        error: workspaceTargetError ?? 'Workspace is not ready',
-      }))
-      return
-    }
-
-    setEnvironmentInfo(info => ({ ...info, loading: true }))
-    try {
-      const info = await onLoadEnvironmentInfo(activeConversationProject, workspaceTarget)
-      setEnvironmentInfo({ ...info, loading: false })
-    } catch (error) {
-      setEnvironmentInfo(info => ({
-        ...info,
-        loading: false,
-        error: error instanceof Error ? error.message : 'Failed to load environment info',
-      }))
-    }
-  }, [
-    activeConversationProject,
-    onLoadEnvironmentInfo,
-    workspaceTarget,
-    workspaceTargetError,
-    workspaceTargetResolving,
-  ])
-
   const baseProjectWork = projectWork ?? {
     projects: state.projects,
     devices: state.devices,
@@ -315,7 +276,7 @@ export function MobileWorkbenchLayout({
     ...baseProjectWork,
     branchName: environmentInfo.branchName,
     branchLoading: environmentInfo.loading,
-    onRefreshBranch: refreshEnvironmentInfo,
+    onRefreshBranch: undefined,
     onListBranches:
       activeConversationProject && onListEnvironmentBranches && workspaceTarget
         ? () => onListEnvironmentBranches(activeConversationProject, workspaceTarget)
@@ -328,14 +289,14 @@ export function MobileWorkbenchLayout({
               branchName,
               workspaceTarget
             )
-            await refreshEnvironmentInfo()
+            setEnvironmentInfo(info => ({ ...info, branchName }))
           }
         : undefined,
     onCreateBranch:
       activeConversationProject && onCreateEnvironmentBranch && workspaceTarget
         ? async branchName => {
             await onCreateEnvironmentBranch(activeConversationProject, branchName, workspaceTarget)
-            await refreshEnvironmentInfo()
+            setEnvironmentInfo(info => ({ ...info, branchName }))
           }
         : undefined,
   }
@@ -384,37 +345,28 @@ export function MobileWorkbenchLayout({
   }, [])
 
   useEffect(() => {
-    if (activeConversationProject && !state.currentTask) {
-      void refreshEnvironmentInfo()
-    }
-  }, [activeConversationProject, refreshEnvironmentInfo, state.currentTask])
-
-  useEffect(() => {
     let cancelled = false
-    setWorkspaceTargetResolving(true)
-    setWorkspaceTarget(null)
-    setWorkspaceTargetError(null)
-    resolveWorkspaceTarget({
-      currentTask: state.currentTask,
-      currentProject: activeConversationProject,
-      api: workspaceTargetResolverApi,
-    })
+    Promise.resolve()
+      .then(() => {
+        if (!cancelled) {
+          setWorkspaceTarget(null)
+        }
+        return resolveWorkspaceTarget({
+          currentTask: state.currentTask,
+          currentProject: activeConversationProject,
+          api: workspaceTargetResolverApi,
+        })
+      })
       .then(target => {
         if (!cancelled) {
           setWorkspaceTarget(current =>
             workspaceTargetKey(current) === workspaceTargetKey(target) ? current : target
           )
-          setWorkspaceTargetError(null)
-          setWorkspaceTargetResolving(false)
         }
       })
-      .catch(error => {
+      .catch(() => {
         if (!cancelled) {
           setWorkspaceTarget(null)
-          setWorkspaceTargetError(
-            error instanceof Error ? error.message : 'Failed to resolve workspace'
-          )
-          setWorkspaceTargetResolving(false)
         }
       })
     return () => {


### PR DESCRIPTION
## Summary

- Stop automatically loading environment Git status from the desktop workbench when assistant messages complete or when a project empty state mounts.
- Remove the mobile workbench automatic environment-info load path while keeping explicit branch menu actions available.
- Keep post-commit and post-branch actions local to the UI state instead of issuing another environment aggregation request.

## Why

Opening worktree/environment surfaces was causing repeated local executor Git RPC commands. The environment details query should be user-initiated from the environment popover instead of running from layout lifecycle effects.

## Validation

- `pnpm --dir wework lint`
- `pnpm --dir wework exec vitest run src/components/layout/DesktopWorkbenchLayout.test.tsx src/components/layout/MobileWorkbenchLayout.test.tsx src/components/chat/composer/ProjectWorkBar.test.tsx`
- `pnpm --dir wework build`
- Pre-push AI code quality check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Branch selector is now available in additional scenarios where Git branch listing is supported.

* **Bug Fixes**
  * Environment information now updates on-demand when you perform branch operations, rather than automatically refreshing after messages complete, improving performance and accuracy.

* **Tests**
  * Updated environment and branch operation tests for both desktop and mobile platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->