### PR TITLE
[codex] stop caching Codex runtime tasks

### DIFF
--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -100,6 +100,7 @@ class RuntimeWorkRpcHandler:
         self.codex_discovery = codex_discovery or CodexSessionDiscovery()
         self.responses_event_emitter = responses_event_emitter
         self._running_sdk_tasks: set[asyncio.Task] = set()
+        self._running_sdk_task_ids: set[str] = set()
         self._codex_seen_updated_at: dict[str, str] = {}
         self._codex_updates_from_wegent: set[str] = set()
         self._codex_watcher_task: Optional[asyncio.Task] = None
@@ -177,14 +178,10 @@ class RuntimeWorkRpcHandler:
         if self.codex_discovery is None:
             return []
         try:
-            records = self.codex_discovery.discover()
+            return self.codex_discovery.discover()
         except Exception:
             logger.exception("Failed to discover Codex runtime tasks")
             return []
-
-        for record in records:
-            self.store.upsert_task(record)
-        return records
 
     async def poll_codex_updates_once(self) -> None:
         """Detect native Codex thread updates and report them to Backend."""
@@ -193,7 +190,7 @@ class RuntimeWorkRpcHandler:
             return
 
         for record in self._refresh_discovered_tasks():
-            if record.runtime != "codex":
+            if not self._is_codex_runtime(record.runtime):
                 continue
 
             previous = self._codex_seen_updated_at.get(record.local_task_id)
@@ -323,13 +320,9 @@ class RuntimeWorkRpcHandler:
         workspace_path: Any,
         include_archived: bool,
     ) -> list[LocalTaskRecord]:
-        discovered_ids = {task.local_task_id for task in discovered_tasks}
         visible_tasks: list[LocalTaskRecord] = []
         for task in store_tasks:
-            if (
-                task.runtime.lower() != "codex"
-                or task.local_task_id not in discovered_ids
-            ):
+            if not self._is_codex_runtime(task.runtime):
                 visible_tasks.append(task)
         visible_tasks.extend(
             task
@@ -373,7 +366,6 @@ class RuntimeWorkRpcHandler:
 
     def _default_adapters(self) -> dict[str, RuntimeAgentAdapter]:
         return {
-            "codex": RuntimeAgentAdapter(runtime="codex", store=self.store),
             "claude_code": RuntimeAgentAdapter(
                 runtime="claude_code",
                 store=self.store,
@@ -381,8 +373,8 @@ class RuntimeWorkRpcHandler:
         }
 
     async def _transcript(self, payload: dict[str, Any]) -> dict[str, Any]:
-        self._refresh_discovered_tasks()
-        task = self._load_payload_task(payload)
+        discovered_tasks = self._refresh_discovered_tasks()
+        task = self._load_payload_task(payload, discovered_tasks=discovered_tasks)
         messages = await self._task_transcript_messages(task)
 
         return {
@@ -421,7 +413,7 @@ class RuntimeWorkRpcHandler:
     def _codex_session_messages(
         self, task: LocalTaskRecord
     ) -> Optional[list[dict[str, Any]]]:
-        if task.runtime != "codex" or self.codex_discovery is None:
+        if not self._is_codex_runtime(task.runtime) or self.codex_discovery is None:
             return None
         if not hasattr(self.codex_discovery, "read_transcript"):
             return None
@@ -484,13 +476,12 @@ class RuntimeWorkRpcHandler:
         thread_id = task.runtime_handle.get("threadId") or task.local_task_id
         if not isinstance(thread_id, str) or not thread_id.strip():
             raise ValueError("Codex threadId is required")
+        if task.local_task_id in self._running_sdk_task_ids:
+            raise ValueError("runtime task is already running")
 
         subtask_id = self._next_sdk_codex_subtask_id(task)
-        task = self.store.update_task(
-            task.local_task_id,
-            lambda current: self._mark_task_running(current, subtask_id),
-            workspace_path=task.workspace_path,
-        )
+        task = self._mark_task_running(task, subtask_id)
+        self._running_sdk_task_ids.add(task.local_task_id)
         sdk_task = asyncio.create_task(
             self._run_sdk_codex_task(
                 task=task,
@@ -554,17 +545,7 @@ class RuntimeWorkRpcHandler:
                 logger.exception("Failed to emit Codex SDK stream error")
         finally:
             self.mark_codex_task_updated_by_wegent(task.local_task_id, source)
-            self.store.update_task(
-                task.local_task_id,
-                lambda current: replace(
-                    current,
-                    running=False,
-                    updated_at=datetime.now(timezone.utc)
-                    .replace(microsecond=0)
-                    .isoformat(),
-                ),
-                workspace_path=task.workspace_path,
-            )
+            self._running_sdk_task_ids.discard(task.local_task_id)
 
     def _create_local_task_emitter(
         self,
@@ -590,12 +571,15 @@ class RuntimeWorkRpcHandler:
         return int(time.time() * 1000)
 
     def _is_sdk_codex_task(self, task: LocalTaskRecord) -> bool:
-        if task.runtime != "codex":
+        if not self._is_codex_runtime(task.runtime):
             return False
         if isinstance(task.runtime_handle.get("executionRequest"), dict):
             return False
-        thread_id = task.runtime_handle.get("threadId") or task.local_task_id
+        thread_id = task.runtime_handle.get("threadId")
         return isinstance(thread_id, str) and bool(thread_id.strip())
+
+    def _is_codex_runtime(self, runtime: str) -> bool:
+        return runtime.lower() == "codex"
 
     def _has_explicit_codex_thread(self, task: LocalTaskRecord) -> bool:
         thread_id = task.runtime_handle.get("threadId")
@@ -604,11 +588,19 @@ class RuntimeWorkRpcHandler:
     async def _archive(self, payload: dict[str, Any]) -> dict[str, Any]:
         task = self._load_payload_task(payload)
 
-        if task.runtime == "codex" and self.codex_discovery is not None:
+        if self._is_codex_runtime(task.runtime) and self.codex_discovery is not None:
             thread_id = task.runtime_handle.get("threadId") or task.local_task_id
             archive_thread = getattr(self.codex_discovery, "archive_thread", None)
             if isinstance(thread_id, str) and thread_id.strip() and archive_thread:
                 await self._maybe_await(archive_thread(thread_id))
+
+        if self._is_sdk_codex_task(task):
+            return {
+                "success": True,
+                "accepted": True,
+                "localTaskId": task.local_task_id,
+                "workspacePath": task.workspace_path,
+            }
 
         archived = self.store.update_task(
             task.local_task_id,
@@ -811,6 +803,10 @@ class RuntimeWorkRpcHandler:
             )
         local_task_id = str(payload.get("localTaskId") or f"runtime-{uuid.uuid4()}")
         runtime = str(fork_package.get("sourceRuntime") or "codex")
+        if self._is_codex_runtime(runtime):
+            raise ValueError(
+                "Codex fork imports must restore into native Codex, not runtime index"
+            )
         runtime_handle = self._imported_runtime_handle(fork_package)
         messages = fork_package.get("recentMessages")
         if isinstance(messages, list):
@@ -863,7 +859,7 @@ class RuntimeWorkRpcHandler:
         handle_session = task.runtime_handle.get("executorSession")
         if isinstance(handle_session, dict):
             return handle_session
-        if task.runtime == "codex":
+        if self._is_codex_runtime(task.runtime):
             thread_id = task.runtime_handle.get("threadId") or task.local_task_id
             if isinstance(thread_id, str) and thread_id.strip():
                 return {"agent": "CodeX", "threadId": thread_id}
@@ -876,7 +872,7 @@ class RuntimeWorkRpcHandler:
         return []
 
     def _codex_thread_id(self, task: LocalTaskRecord) -> Optional[str]:
-        if task.runtime != "codex":
+        if not self._is_codex_runtime(task.runtime):
             return None
         thread_id = task.runtime_handle.get("threadId") or task.local_task_id
         if isinstance(thread_id, str) and thread_id.strip():
@@ -898,6 +894,11 @@ class RuntimeWorkRpcHandler:
         payload: dict[str, Any],
     ) -> dict[str, Any]:
         runtime = payload.get("runtime")
+        if isinstance(runtime, str) and self._is_codex_runtime(runtime):
+            return self._error(
+                "Codex runtime tasks are discovered from native Codex only",
+                code="unsupported_runtime",
+            )
         adapter = self.adapters.get(runtime) if isinstance(runtime, str) else None
         adapter_method_name = method.rsplit(".", maxsplit=1)[-1]
 
@@ -912,7 +913,12 @@ class RuntimeWorkRpcHandler:
             return {"success": True, **result}
         return {"success": True, "result": result}
 
-    def _load_payload_task(self, payload: dict[str, Any]) -> LocalTaskRecord:
+    def _load_payload_task(
+        self,
+        payload: dict[str, Any],
+        *,
+        discovered_tasks: Optional[list[LocalTaskRecord]] = None,
+    ) -> LocalTaskRecord:
         local_task_id = payload.get("localTaskId")
         if not isinstance(local_task_id, str) or not local_task_id.strip():
             raise ValueError("localTaskId is required")
@@ -921,7 +927,45 @@ class RuntimeWorkRpcHandler:
         if workspace_path is not None and not isinstance(workspace_path, str):
             raise ValueError("workspacePath must be a string")
 
-        return self.store.get_task(local_task_id, workspace_path=workspace_path)
+        try:
+            task = self.store.get_task(local_task_id, workspace_path=workspace_path)
+            if not self._is_codex_runtime(task.runtime):
+                return task
+        except KeyError:
+            pass
+
+        discovered_task = self._find_discovered_task(
+            local_task_id,
+            workspace_path=workspace_path,
+            discovered_tasks=discovered_tasks,
+        )
+        if discovered_task is not None:
+            return discovered_task
+
+        raise KeyError(f"Local task not found: {local_task_id}")
+
+    def _find_discovered_task(
+        self,
+        local_task_id: str,
+        *,
+        workspace_path: Optional[str],
+        discovered_tasks: Optional[list[LocalTaskRecord]] = None,
+    ) -> Optional[LocalTaskRecord]:
+        records = (
+            discovered_tasks
+            if discovered_tasks is not None
+            else self._refresh_discovered_tasks()
+        )
+        normalized_workspace = (
+            normalize_workspace_path(workspace_path) if workspace_path else None
+        )
+        for task in records:
+            if task.local_task_id != local_task_id:
+                continue
+            if normalized_workspace and task.workspace_path != normalized_workspace:
+                continue
+            return task
+        return None
 
     def _task_summary(self, task: LocalTaskRecord) -> dict[str, Any]:
         summary = {

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -64,6 +64,33 @@ async def _drain_runtime_adapter(adapter):
         await asyncio.gather(*adapter._running_tasks)
 
 
+def _sdk_codex_record(
+    thread_id,
+    *,
+    workspace_path="/repo/Wegent",
+    title="hi",
+    running=False,
+    runtime_handle=None,
+):
+    from executor.runtime_work.local_task_store import LocalTaskRecord
+
+    handle = {"threadId": thread_id}
+    if isinstance(runtime_handle, dict):
+        handle.update(runtime_handle)
+
+    return LocalTaskRecord(
+        local_task_id=thread_id,
+        workspace_path=workspace_path,
+        title=title,
+        runtime="codex",
+        runtime_handle=handle,
+        created_at="2026-06-21T02:15:37Z",
+        updated_at="2026-06-21T02:15:58Z",
+        running=running,
+        status="active",
+    )
+
+
 def test_local_task_store_persists_tasks_and_validates_workspace(tmp_path):
     from executor.runtime_work.local_task_store import LocalTaskRecord, LocalTaskStore
 
@@ -244,7 +271,52 @@ async def test_runtime_work_handler_lists_codex_tasks_from_sdk_only(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_runtime_work_handler_keeps_adapter_codex_and_archived_store_tasks(
+async def test_runtime_work_handler_ignores_stale_cached_codex_tasks(
+    tmp_path,
+):
+    from executor.runtime_work.local_task_store import LocalTaskRecord, LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    store = LocalTaskStore(tmp_path / "index.json")
+    store.upsert_task(
+        LocalTaskRecord(
+            local_task_id="stale-thread",
+            workspace_path="/repo/Wegent",
+            title="Stale cached Codex task",
+            runtime="codex",
+            runtime_handle={"threadId": "stale-thread"},
+            created_at="2026-06-21T02:15:37Z",
+            updated_at="2026-06-21T02:15:58Z",
+            running=False,
+            status="active",
+        )
+    )
+    store.upsert_task(
+        LocalTaskRecord(
+            local_task_id="stale-runtime-codex",
+            workspace_path="/repo/Wegent",
+            title="Stale adapter Codex task",
+            runtime="codex",
+            runtime_handle={"executionRequest": {"message": "hi"}, "messages": []},
+            created_at="2026-06-21T02:15:37Z",
+            updated_at="2026-06-21T02:15:58Z",
+            running=False,
+            status="active",
+        )
+    )
+
+    result = await RuntimeWorkRpcHandler(
+        store=store,
+        codex_discovery=EmptyDiscovery(),
+    ).handle_runtime_rpc({"method": "runtime.tasks.list", "payload": {}})
+
+    assert result == {"success": True, "workspaces": []}
+    assert store.get_task("stale-thread").status == "active"
+    assert store.get_task("stale-runtime-codex").status == "active"
+
+
+@pytest.mark.asyncio
+async def test_runtime_work_handler_ignores_store_codex_and_keeps_live_discovery(
     tmp_path,
 ):
     from executor.runtime_work.local_task_store import LocalTaskRecord, LocalTaskStore
@@ -297,7 +369,7 @@ async def test_runtime_work_handler_keeps_adapter_codex_and_archived_store_tasks
     )
 
     tasks = {item["localTaskId"] for item in result["workspaces"][0]["localTasks"]}
-    assert tasks == {sdk_thread_id, "adapter-codex-1", "archived-codex-1"}
+    assert tasks == {sdk_thread_id}
 
 
 @pytest.mark.asyncio
@@ -346,10 +418,8 @@ async def test_runtime_work_handler_archives_codex_thread_through_sdk(tmp_path):
         "workspacePath": "/repo/Wegent",
     }
     assert fake_codex.archived_thread_ids == [thread_id]
-    assert (
-        handler.store.get_task(thread_id, workspace_path="/repo/Wegent").status
-        == "archived"
-    )
+    with pytest.raises(KeyError):
+        handler.store.get_task(thread_id, workspace_path="/repo/Wegent")
 
 
 @pytest.mark.asyncio
@@ -367,7 +437,7 @@ async def test_runtime_work_handler_continues_discovered_codex_thread_through_sd
             self.finished = finished
 
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, thread_id, message, *, cwd=None, emitter):
             self.streamed_messages.append((thread_id, message, cwd))
@@ -421,7 +491,7 @@ async def test_runtime_work_handler_continues_discovered_codex_thread_through_sd
     assert discovery.streamed_messages == [
         (thread_id, "continue from Telegram", "/repo/Wegent")
     ]
-    assert store.get_task(thread_id, workspace_path="/repo/Wegent").running is True
+    assert thread_id in handler._running_sdk_task_ids
     second_result = await handler.handle_runtime_rpc(
         {
             "method": "runtime.tasks.send",
@@ -440,7 +510,7 @@ async def test_runtime_work_handler_continues_discovered_codex_thread_through_sd
     release.set()
     await asyncio.wait_for(finished.wait(), timeout=1)
     await asyncio.gather(*handler._running_sdk_tasks)
-    assert store.get_task(thread_id, workspace_path="/repo/Wegent").running is False
+    assert thread_id not in handler._running_sdk_task_ids
 
 
 @pytest.mark.asyncio
@@ -456,7 +526,7 @@ async def test_runtime_work_handler_rejects_concurrent_sdk_codex_send_atomically
             self.release = asyncio.Event()
 
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, _thread_id, _message, *, cwd=None, emitter):
             self.calls += 1
@@ -510,7 +580,7 @@ async def test_runtime_work_handler_streams_discovered_codex_thread_over_respons
 
     class FakeCodexStreamDiscovery:
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, thread_id, message, *, cwd=None, emitter):
             await emitter.start(shell_type="Codex")
@@ -570,7 +640,7 @@ async def test_runtime_work_handler_emits_error_when_sdk_stream_fails(tmp_path):
 
     class FailingCodexStreamDiscovery:
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, thread_id, message, *, cwd=None, emitter):
             await emitter.start(shell_type="Codex")
@@ -614,7 +684,7 @@ async def test_runtime_work_handler_emits_error_when_sdk_stream_fails(tmp_path):
     assert [event for event, _payload in events] == ["response.created", "error"]
     assert events[-1][1]["data"]["message"] == "stream failed"
     assert events[-1][1]["data"]["code"] == "execution_error"
-    assert store.get_task(thread_id, workspace_path="/repo/Wegent").running is False
+    assert thread_id not in handler._running_sdk_task_ids
 
 
 @pytest.mark.asyncio
@@ -626,7 +696,7 @@ async def test_runtime_work_handler_includes_im_source_on_sdk_stream_events(
 
     class FakeCodexStreamDiscovery:
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, thread_id, message, *, cwd=None, emitter):
             await emitter.start(shell_type="Codex")
@@ -691,7 +761,7 @@ async def test_runtime_work_handler_rejects_sdk_codex_send_without_event_emitter
             self.streamed = False
 
         def discover(self):
-            return []
+            return [_sdk_codex_record(thread_id)]
 
         async def stream_message(self, thread_id, message, *, cwd=None, emitter):
             self.streamed = True
@@ -711,11 +781,12 @@ async def test_runtime_work_handler_rejects_sdk_codex_send_without_event_emitter
         )
     )
 
-    result = await RuntimeWorkRpcHandler(
+    handler = RuntimeWorkRpcHandler(
         store=store,
         adapters={"codex": SimpleNamespace()},
         codex_discovery=discovery,
-    ).handle_runtime_rpc(
+    )
+    result = await handler.handle_runtime_rpc(
         {
             "method": "runtime.tasks.send",
             "payload": {
@@ -732,7 +803,7 @@ async def test_runtime_work_handler_rejects_sdk_codex_send_without_event_emitter
         "code": "unsupported_runtime",
     }
     assert discovery.streamed is False
-    assert store.get_task(thread_id, workspace_path="/repo/Wegent").running is False
+    assert thread_id not in handler._running_sdk_task_ids
 
 
 @pytest.mark.asyncio
@@ -1027,6 +1098,8 @@ async def test_runtime_work_handler_refreshes_codex_sessions_before_listing(tmp_
     assert task["localTaskId"] == thread_id
     assert task["runtime"] == "codex"
     assert task["running"] is True
+    with pytest.raises(KeyError):
+        store.get_task(thread_id, workspace_path="/repo/Wegent")
 
 
 @pytest.mark.asyncio
@@ -1506,7 +1579,7 @@ async def test_runtime_work_handler_prefers_codex_transcript_over_imported_cache
 
     class CurrentCodexTranscript:
         def discover(self):
-            return []
+            return [_sdk_codex_record("codex-1")]
 
         def read_transcript(self, thread_id, session_path=None):
             return [
@@ -1579,7 +1652,7 @@ async def test_runtime_work_handler_does_not_fallback_to_imported_cache_for_sdk_
 
     class EmptyCodexTranscript:
         def discover(self):
-            return []
+            return [_sdk_codex_record("codex-1")]
 
         def read_transcript(self, thread_id, session_path=None):
             return []
@@ -1634,7 +1707,13 @@ async def test_runtime_work_handler_marks_active_codex_streaming_message_with_su
 
     class StreamingDiscovery:
         def discover(self):
-            return []
+            return [
+                _sdk_codex_record(
+                    "codex-1",
+                    running=True,
+                    runtime_handle={"activeSubtaskId": 7001},
+                )
+            ]
 
         def read_transcript(self, thread_id, session_path=None):
             return [
@@ -1764,6 +1843,44 @@ async def test_runtime_work_handler_creates_runtime_task_with_local_transcript(
 
 
 @pytest.mark.asyncio
+async def test_runtime_work_handler_rejects_codex_runtime_task_create(tmp_path):
+    from executor.runtime_work.local_task_store import LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    store = LocalTaskStore(tmp_path / "index.json")
+    result = await RuntimeWorkRpcHandler(
+        store=store,
+        codex_discovery=EmptyDiscovery(),
+    ).handle_runtime_rpc(
+        {
+            "method": "runtime.tasks.create",
+            "payload": {
+                "runtime": "codex",
+                "workspacePath": "/repo/Wegent",
+                "message": "create a Codex task",
+                "executionRequest": {
+                    "task_id": 1001,
+                    "subtask_id": 2001,
+                    "team_id": 1,
+                    "prompt": "create a Codex task",
+                    "workspace_source": "local_path",
+                    "project_workspace_path": "/repo/Wegent",
+                    "model_config": {},
+                    "bot": [],
+                },
+            },
+        }
+    )
+
+    assert result == {
+        "success": False,
+        "error": "Codex runtime tasks are discovered from native Codex only",
+        "code": "unsupported_runtime",
+    }
+    assert store.list_tasks() == []
+
+
+@pytest.mark.asyncio
 async def test_runtime_work_handler_prepares_git_workspace_fork_patch_archive(
     tmp_path,
     monkeypatch,
@@ -1792,10 +1909,10 @@ async def test_runtime_work_handler_prepares_git_workspace_fork_patch_archive(
     store = LocalTaskStore(tmp_path / "index.json")
     store.upsert_task(
         LocalTaskRecord(
-            local_task_id="codex-1",
+            local_task_id="claude-1",
             workspace_path=str(workspace),
             title="Fork dirty worktree",
-            runtime="codex",
+            runtime="claude_code",
             runtime_handle={},
         )
     )
@@ -1806,7 +1923,7 @@ async def test_runtime_work_handler_prepares_git_workspace_fork_patch_archive(
             "method": "runtime.tasks.prepare_fork_transfer",
             "payload": {
                 "workspacePath": str(workspace),
-                "localTaskId": "codex-1",
+                "localTaskId": "claude-1",
                 "transferId": "transfer-1",
                 "workspaceTransfer": "git_workspace",
             },
@@ -1823,7 +1940,6 @@ async def test_runtime_work_handler_prepares_git_workspace_fork_patch_archive(
         "directToken": "token",
         "sizeBytes": 128,
         "requiresWorkspaceRestore": True,
-        "requiresSessionRestore": True,
     }
 
 
@@ -1854,16 +1970,16 @@ async def test_runtime_work_handler_imports_git_workspace_fork_without_archive_r
                 "source": {
                     "deviceId": "source-device",
                     "workspacePath": "/source/Wegent",
-                    "localTaskId": "codex-1",
+                    "localTaskId": "claude-1",
                 },
                 "workspacePath": str(tmp_path / "target"),
                 "forkPackage": {
-                    "sourceRuntime": "codex",
+                    "sourceRuntime": "claude_code",
                     "title": "Forked runtime task",
                     "recentMessages": [
                         {"id": "m1", "role": "user", "content": "hello"}
                     ],
-                    "runtimeHandle": {"threadId": "codex-1"},
+                    "runtimeHandle": {"executorSession": {"agent": "ClaudeCode"}},
                     "archive": {"mode": "git_workspace"},
                 },
             },
@@ -1878,6 +1994,44 @@ async def test_runtime_work_handler_imports_git_workspace_fork_without_archive_r
     assert record.runtime_handle["messages"] == [
         {"id": "m1", "role": "user", "content": "hello"}
     ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_work_handler_rejects_codex_fork_import_to_runtime_index(
+    tmp_path,
+):
+    from executor.runtime_work.local_task_store import LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    store = LocalTaskStore(tmp_path / "index.json")
+    handler = RuntimeWorkRpcHandler(store=store, codex_discovery=EmptyDiscovery())
+
+    result = await handler.handle_runtime_rpc(
+        {
+            "method": "runtime.tasks.import_fork",
+            "payload": {
+                "source": {
+                    "deviceId": "source-device",
+                    "workspacePath": "/source/Wegent",
+                    "localTaskId": "codex-1",
+                },
+                "workspacePath": str(tmp_path / "target"),
+                "forkPackage": {
+                    "sourceRuntime": "codex",
+                    "title": "Forked Codex task",
+                    "runtimeHandle": {"threadId": "codex-1"},
+                    "archive": {"mode": "git_workspace"},
+                },
+            },
+        }
+    )
+
+    assert result == {
+        "success": False,
+        "error": "Codex fork imports must restore into native Codex, not runtime index",
+        "code": "bad_request",
+    }
+    assert store.list_tasks() == []
 
 
 @pytest.mark.asyncio
@@ -1911,15 +2065,14 @@ async def test_runtime_work_handler_restores_git_workspace_session_archive(
                 "source": {
                     "deviceId": "source-device",
                     "workspacePath": "/source/Wegent",
-                    "localTaskId": "codex-1",
+                    "localTaskId": "claude-1",
                 },
                 "workspacePath": target_workspace,
                 "forkPackage": {
-                    "sourceRuntime": "codex",
+                    "sourceRuntime": "claude_code",
                     "title": "Forked runtime task",
                     "runtimeHandle": {
-                        "threadId": "codex-1",
-                        "sessionPath": "/source/.codex/sessions/thread.jsonl",
+                        "executorSession": {"agent": "ClaudeCode"},
                     },
                     "archive": {
                         "mode": "git_workspace",
@@ -1974,17 +2127,17 @@ async def test_runtime_work_handler_imports_fork_package_with_parent_metadata(
                 "source": {
                     "deviceId": "source-device",
                     "workspacePath": "/source/Wegent",
-                    "localTaskId": "codex-1",
+                    "localTaskId": "claude-1",
                 },
                 "workspacePath": str(tmp_path / "target"),
                 "forkPackage": {
-                    "sourceRuntime": "codex",
+                    "sourceRuntime": "claude_code",
                     "title": "Forked runtime task",
                     "recentMessages": [
                         {"id": "m1", "role": "user", "content": "hello"}
                     ],
-                    "runtimeHandle": {"threadId": "codex-1"},
-                    "executorSession": {"agent": "CodeX", "threadId": "codex-1"},
+                    "runtimeHandle": {"executorSession": {"agent": "ClaudeCode"}},
+                    "executorSession": {"agent": "ClaudeCode"},
                     "archive": {
                         "directUrls": ["http://source/archive"],
                         "downloadUrl": "https://storage/download",
@@ -1996,7 +2149,7 @@ async def test_runtime_work_handler_imports_fork_package_with_parent_metadata(
 
     assert result["success"] is True
     assert result["accepted"] is True
-    assert result["runtime"] == "codex"
+    assert result["runtime"] == "claude_code"
     assert restored["archive"]["directUrls"] == ["http://source/archive"]
     record = store.get_task(
         result["localTaskId"], workspace_path=str(tmp_path / "target")
@@ -2004,12 +2157,9 @@ async def test_runtime_work_handler_imports_fork_package_with_parent_metadata(
     assert record.parent == {
         "deviceId": "source-device",
         "workspacePath": "/source/Wegent",
-        "localTaskId": "codex-1",
+        "localTaskId": "claude-1",
     }
-    assert record.runtime_handle["executorSession"] == {
-        "agent": "CodeX",
-        "threadId": "codex-1",
-    }
+    assert record.runtime_handle["executorSession"] == {"agent": "ClaudeCode"}
     assert record.runtime_handle["messages"][0]["content"] == "hello"
 
 
@@ -2031,20 +2181,20 @@ async def test_runtime_work_handler_sends_followup_with_same_runtime_session(tmp
 
     store = LocalTaskStore(tmp_path / "index.json")
     adapter = RuntimeAgentAdapter(
-        runtime="codex",
+        runtime="claude_code",
         store=store,
         execute_agent=execute_agent,
     )
     handler = RuntimeWorkRpcHandler(
         store=store,
-        adapters={"codex": adapter},
+        adapters={"claude_code": adapter},
         codex_discovery=EmptyDiscovery(),
     )
     create = await handler.handle_runtime_rpc(
         {
             "method": "runtime.tasks.create",
             "payload": {
-                "runtime": "codex",
+                "runtime": "claude_code",
                 "workspacePath": "/repo/Wegent",
                 "message": "first",
                 "executionRequest": {
@@ -2107,10 +2257,10 @@ async def test_runtime_work_handler_transcript_overlays_im_source(tmp_path):
     store = LocalTaskStore(tmp_path / "index.json")
     store.upsert_task(
         LocalTaskRecord(
-            local_task_id="codex-1",
+            local_task_id="claude-1",
             workspace_path="/repo/Wegent",
             title="Fix reconnect",
-            runtime="codex",
+            runtime="claude_code",
             runtime_handle={
                 "messages": [
                     {
@@ -2137,12 +2287,15 @@ async def test_runtime_work_handler_transcript_overlays_im_source(tmp_path):
         )
     )
 
-    result = await RuntimeWorkRpcHandler(store=store).handle_runtime_rpc(
+    result = await RuntimeWorkRpcHandler(
+        store=store,
+        codex_discovery=EmptyDiscovery(),
+    ).handle_runtime_rpc(
         {
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/repo/Wegent",
-                "localTaskId": "codex-1",
+                "localTaskId": "claude-1",
             },
         }
     )


### PR DESCRIPTION
## Summary

- Stop persisting discovered Codex threads into `runtime-work/index.json`.
- Treat native Codex as the source of truth for Codex runtime tasks: lists, transcripts, sends, and archives resolve live discovered threads instead of store-backed records.
- Reject store-backed Codex task creation/import paths so stale `runtime=codex` records no longer reappear in wework.
- Update runtime work tests for stale cached Codex records, live discovery, and rejected Codex index writes.

## Root Cause

Wework merged live Codex discovery with `~/.wegent-executor/runtime-work/index.json`. Archived or synthetic `runtime=codex` records in the local runtime index could still be shown even when Codex itself no longer listed them.

## Validation

- `uv run --project executor black executor/runtime_work/rpc_handler.py executor/tests/runtime_work/test_local_task_store.py`
- `uv run --project executor isort executor/runtime_work/rpc_handler.py executor/tests/runtime_work/test_local_task_store.py`
- `PYTHONPATH=/Users/axb-mac/.codex/worktrees/0d27/Wegent uv run --project executor pytest executor/tests/runtime_work -q`
- Local exact check for `/Users/axb-mac/dev/aigc/wegent_workspace/Wegent` title `hi`: handler now returns only the live Codex thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex runtime task handling and filtering logic
  * Enhanced concurrency controls for simultaneous SDK task operations
  * Stricter validation to reject invalid runtime task creation requests

* **Tests**
  * Updated test suite to reflect new Codex runtime task semantics and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->