### PR TITLE
[codex] Fix project creation for prepared empty folders

### DIFF
--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -934,6 +934,9 @@ async def _prepare_plain_workspace_path(
     )
     if action == "create":
         if status_payload.get("exists"):
+            _ensure_selectable_directory(status_payload)
+            if status_payload.get("isEmpty"):
+                return "created"
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="Project folder already exists",

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -330,6 +330,53 @@ async def test_prepare_plain_device_workspace_creates_directory_and_mapping(
 
 
 @pytest.mark.asyncio
+async def test_prepare_plain_device_workspace_accepts_already_created_empty_directory(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    from app.schemas.runtime_work import DeviceWorkspacePrepareRequest
+    from app.services import runtime_work_service
+
+    project = _project(test_db, test_user.id)
+    calls: list[tuple[str, list[str]]] = []
+
+    async def execute(**kwargs):
+        calls.append((kwargs["command_key"], kwargs.get("args") or []))
+        if kwargs["command_key"] == "project_folder_status":
+            return {
+                "success": True,
+                "exit_code": 0,
+                "stdout": (
+                    '{"exists": true, "isDirectory": true, "isEmpty": true, '
+                    '"isGitRepo": false, "remoteUrl": null}'
+                ),
+            }
+        raise AssertionError(kwargs["command_key"])
+
+    monkeypatch.setattr(
+        runtime_work_service, "execute_configured_device_command", execute
+    )
+
+    response = await runtime_work_service.prepare_device_workspace(
+        db=test_db,
+        user_id=test_user.id,
+        payload=DeviceWorkspacePrepareRequest(
+            projectId=project.id,
+            deviceId="device-1",
+            workspacePath="/repo/Wegent",
+            action="create",
+        ),
+    )
+
+    assert response.mapping.project_id == project.id
+    assert response.mapping.workspace_path == "/repo/Wegent"
+    assert response.mapping.repo_url is None
+    assert response.prepared_action == "created"
+    assert calls == [("project_folder_status", ["/repo/Wegent"])]
+
+
+@pytest.mark.asyncio
 async def test_prepare_git_device_workspace_clones_into_empty_directory(
     test_db,
     test_user,


### PR DESCRIPTION
## Summary

- Allow plain device workspace preparation to accept an existing empty directory when the request action is `create`.
- Keep rejecting existing non-empty folders and invalid folder paths.
- Add a regression test for the create-folder-then-create-project flow.

## Root Cause

The folder picker creates the folder on the device before the project is submitted. The backend then received `action=create`, inspected the same path, saw that it already existed, and returned `Project folder already exists` even though the directory was the empty folder just created by the picker.

## Validation

- `cd backend && uv run pytest tests/services/test_runtime_work_service.py`
- `cd backend && uv run black --check app/services/runtime_work_service.py tests/services/test_runtime_work_service.py`
- `git diff --check HEAD~1..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace creation to properly handle existing but empty project folders, treating them as successfully created instead of raising a conflict error.

* **Tests**
  * Added test coverage for workspace creation with pre-existing empty directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->