### PR TITLE
fix(chat-shell): forward arguments through lazy skill tool proxy

### DIFF
--- a/chat_shell/chat_shell/agents/graph_builder.py
+++ b/chat_shell/chat_shell/agents/graph_builder.py
@@ -111,6 +111,30 @@ class InvalidToolMessageSequenceError(ValueError):
     """
 
 
+def _log_tool_error_event(tool_name: str, run_id: str, event_data: Any) -> None:
+    """Log a tool execution failure surfaced by LangGraph's ``on_tool_error``.
+
+    LangGraph reports tool failures (e.g. argument ``ValidationError``) via an
+    ``on_tool_error`` event and then converts them into an error ``ToolMessage``
+    that is only visible to the model. Without this, chat_shell logs stay silent
+    on tool failures, making them hard to diagnose. The ``input`` is included
+    because mismatches between it and the error (e.g. a "Field required" error
+    with an empty input) are the fastest way to spot argument-routing bugs.
+    """
+    data = event_data if isinstance(event_data, dict) else {}
+    error = data.get("error")
+    tool_input = data.get("input")
+    # Truncate both fields: tool args can be large (e.g. file contents) or carry
+    # sensitive values, so we cap the logged length to avoid log bloat / leakage.
+    logger.error(
+        "[stream_tokens] Tool '%s' failed (run_id=%s): input=%s error=%s",
+        tool_name,
+        run_id,
+        repr(tool_input)[:1000],
+        str(error)[:1000],
+    )
+
+
 def _require_non_empty_tool_id(tool_id: Any, context: str) -> str:
     """Return a validated tool ID or raise if it is missing/blank."""
     if tool_id is None:
@@ -680,6 +704,13 @@ class LangGraphAgentBuilder:
                                 "data": event.get("data", {}),
                             },
                         )
+
+                elif kind == "on_tool_error":
+                    _log_tool_error_event(
+                        event.get("name", "unknown"),
+                        event.get("run_id", ""),
+                        event.get("data", {}),
+                    )
 
                 elif kind == "on_chain_end" and event.get("name") == "LangGraph":
                     data = event.get("data", {})
@@ -1667,6 +1698,13 @@ class LangGraphAgentBuilder:
                         # Yield empty string to trigger _emit_pending_events() in chat_service
                         # This ensures tool events are sent immediately instead of being buffered
                         yield ""
+
+                elif kind == "on_tool_error":
+                    _log_tool_error_event(
+                        event.get("name", "unknown"),
+                        event.get("run_id", ""),
+                        event.get("data", {}),
+                    )
 
             # If no content was streamed but we have final content, yield it
             # This handles non-streaming models

--- a/chat_shell/chat_shell/tools/builtin/load_skill.py
+++ b/chat_shell/chat_shell/tools/builtin/load_skill.py
@@ -66,6 +66,21 @@ class LazySkillProviderTool(BaseTool):
         )
         self._load_skill_tool = load_skill_tool
 
+    def _to_args_and_kwargs(
+        self, tool_input: Any, *args: Any, **kwargs: Any
+    ) -> tuple[tuple, dict]:
+        """Forward all model-provided arguments to the proxy implementation.
+
+        ``LazySkillProviderInput`` declares no fields and accepts arbitrary input
+        via ``extra="allow"``. LangChain's default ``_to_args_and_kwargs`` discards
+        every argument when the schema has no declared fields, which would strip the
+        real tool's arguments (e.g. ``command``/``file_path``) before delegation.
+        Returning the raw input preserves them so the concrete tool can validate.
+        """
+        if isinstance(tool_input, dict):
+            return (), dict(tool_input)
+        return super()._to_args_and_kwargs(tool_input, *args, **kwargs)
+
     def _run(
         self,
         run_manager: CallbackManagerForToolRun | None = None,

--- a/chat_shell/tests/test_dynamic_skill_tools.py
+++ b/chat_shell/tests/test_dynamic_skill_tools.py
@@ -913,3 +913,69 @@ class TestSkillRetentionAcrossTurns:
         assert tool.is_skill_loaded("skill_a")
         # Loaded 0 turns ago, 5 - 0 = 5 remaining
         assert tool.get_skill_remaining_turns("skill_a") == 5
+
+
+class TestLazySkillProviderToolArgumentForwarding:
+    """Regression tests for LazySkillProviderTool argument forwarding.
+
+    LazySkillProviderInput uses ``extra="allow"`` with no declared fields.
+    LangChain's BaseTool._to_args_and_kwargs discards every argument when the
+    schema declares no fields, which previously stripped the real tool's
+    arguments (command/file_path) before delegation, surfacing as a paradoxical
+    "Field required" ValidationError even though the model provided the field.
+    """
+
+    @pytest.mark.asyncio
+    async def test_proxy_forwards_arguments_to_concrete_tool(self):
+        """Args provided by the model must reach the concrete tool intact."""
+        from langchain_core.tools import BaseTool
+        from pydantic import BaseModel, Field
+
+        from chat_shell.tools.builtin.load_skill import LazySkillProviderTool
+
+        received: dict = {}
+
+        class ExecInput(BaseModel):
+            command: str = Field(description="cmd")
+
+        class ConcreteExec(BaseTool):
+            name: str = "exec"
+            description: str = "run"
+            args_schema: type[BaseModel] = ExecInput
+
+            def _run(self, command: str, **_):
+                received["command"] = command
+                return f"ran:{command}"
+
+            async def _arun(self, command: str, **_):
+                return self._run(command)
+
+        concrete = ConcreteExec()
+
+        load_skill_tool = LoadSkillTool(
+            user_id=1,
+            skill_names=["sandbox"],
+            skill_metadata={"sandbox": {"description": "Sandbox", "prompt": "p"}},
+        )
+        load_skill_tool.register_skill_tools("sandbox", [concrete])
+
+        proxy = LazySkillProviderTool(
+            skill_name="sandbox",
+            tool_name="exec",
+            description="exec proxy",
+            load_skill_tool=load_skill_tool,
+        )
+
+        # Invoke through the proxy exactly as LangGraph ToolNode would.
+        result = await proxy.ainvoke(
+            {
+                "name": "exec",
+                "args": {"command": "echo hello"},
+                "id": "call_1",
+                "type": "tool_call",
+            }
+        )
+
+        content = getattr(result, "content", result)
+        assert "ran:echo hello" in content
+        assert received["command"] == "echo hello"


### PR DESCRIPTION
LazySkillProviderTool used an args_schema (LazySkillProviderInput) with extra="allow" and no declared fields. LangChain's BaseTool only forwards declared schema fields to _run/_arun, so every model-provided argument was discarded before delegating to the concrete tool. The concrete tool then raised "Field required" even though the model had supplied the field, while the ToolNode error displayed the original (intact) args - a paradoxical signature that made the failures hard to diagnose.

- Override LazySkillProviderTool._to_args_and_kwargs to forward all args.
- Handle on_tool_error events in both astream loops and log tool failures (including the input), since LangGraph otherwise only surfaces them to the model and chat_shell logs stayed silent.
- Add regression test asserting a proxy-routed call reaches the concrete tool with arguments intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced chat logging to capture tool execution errors, including when failures occur during streaming
* **Bug Fixes**
  * Fixed skill/tool proxying so dictionary-based inputs and required fields are forwarded unchanged to the underlying tool
* **Tests**
  * Added a regression test confirming proxy argument forwarding preserves required parameters and returns expected results
<!-- end of auto-generated comment: release notes by coderabbit.ai -->