### PR TITLE
[codex] Prevent runtime work list hangs

### DIFF
--- a/backend/app/services/device/runtime_rpc_service.py
+++ b/backend/app/services/device/runtime_rpc_service.py
@@ -35,10 +35,13 @@ class RuntimeRpcService:
         method: str,
         payload: dict[str, Any],
         timeout_seconds: int = DEFAULT_RUNTIME_RPC_TIMEOUT_SECONDS,
+        ack_grace_seconds: int = SOCKET_ACK_GRACE_SECONDS,
     ) -> dict[str, Any]:
         """Call `runtime:rpc` on an online local executor and return its result."""
 
         normalized_timeout = self._normalize_timeout(timeout_seconds)
+        normalized_ack_grace = self._normalize_ack_grace(ack_grace_seconds)
+        socket_timeout = normalized_timeout + normalized_ack_grace
         online_info = await device_service.get_device_online_info(user_id, device_id)
         if not online_info:
             raise RuntimeRpcError(f"Device '{device_id}' is offline")
@@ -60,7 +63,7 @@ class RuntimeRpcService:
                 request,
                 to=socket_id,
                 namespace="/local-executor",
-                timeout=normalized_timeout + SOCKET_ACK_GRACE_SECONDS,
+                timeout=socket_timeout,
             )
         except Exception as exc:
             raise RuntimeRpcError(
@@ -68,7 +71,7 @@ class RuntimeRpcService:
                     exc,
                     device_id=device_id,
                     method=method,
-                    timeout_seconds=normalized_timeout + SOCKET_ACK_GRACE_SECONDS,
+                    timeout_seconds=socket_timeout,
                 )
             ) from exc
 
@@ -85,6 +88,14 @@ class RuntimeRpcService:
         if parsed <= 0:
             return DEFAULT_RUNTIME_RPC_TIMEOUT_SECONDS
         return min(parsed, MAX_RUNTIME_RPC_TIMEOUT_SECONDS)
+
+    @staticmethod
+    def _normalize_ack_grace(ack_grace_seconds: Any) -> int:
+        try:
+            parsed = int(ack_grace_seconds)
+        except (TypeError, ValueError):
+            parsed = SOCKET_ACK_GRACE_SECONDS
+        return max(parsed, 0)
 
     @staticmethod
     def _format_rpc_error(

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -4,6 +4,7 @@
 
 """Service for Project -> Device Workspace -> LocalTask runtime work trees."""
 
+import asyncio
 import json
 import logging
 import posixpath
@@ -70,12 +71,13 @@ from app.services.runtime_work_kind_store import (
 
 logger = logging.getLogger(__name__)
 
-RUNTIME_LIST_TIMEOUT_SECONDS = 30
+RUNTIME_LIST_TIMEOUT_SECONDS = 3
 RUNTIME_TRANSCRIPT_TIMEOUT_SECONDS = 30
 RUNTIME_SEND_TIMEOUT_SECONDS = 600
 RUNTIME_CREATE_TIMEOUT_SECONDS = 600
 RUNTIME_FORK_TIMEOUT_SECONDS = 600
 DEVICE_WORKSPACE_PREPARE_TIMEOUT_SECONDS = 600
+RUNTIME_WORK_BIND_SHELL = "claudecode"
 RUNTIME_MODEL_TYPE = "runtime"
 WORKTREE_ROOT_DIR = "worktrees"
 CHAT_WORKSPACE_DIR = "chats"
@@ -1413,6 +1415,7 @@ async def _runtime_task_workspace_path(
             method="runtime.tasks.list",
             payload={},
             timeout_seconds=RUNTIME_LIST_TIMEOUT_SECONDS,
+            ack_grace_seconds=0,
         )
     except RuntimeRpcError as exc:
         raise HTTPException(
@@ -1803,20 +1806,14 @@ async def _list_online_runtime_workspaces(
     devices: list[dict[str, Any]],
 ) -> dict[tuple[str, str], list[LocalTaskSummary]]:
     grouped: dict[tuple[str, str], list[LocalTaskSummary]] = {}
-    for device in devices:
-        device_id = str(device.get("device_id") or "")
-        if not device_id or _device_status(device) not in {"online", "busy"}:
-            continue
-        try:
-            result = await runtime_rpc_service.call(
-                user_id=user_id,
-                device_id=device_id,
-                method="runtime.tasks.list",
-                payload={},
-                timeout_seconds=RUNTIME_LIST_TIMEOUT_SECONDS,
-            )
-        except RuntimeRpcError:
-            continue
+    results = await asyncio.gather(
+        *[
+            _list_device_runtime_workspaces(user_id=user_id, device=device)
+            for device in devices
+            if _should_poll_runtime_work_device(device)
+        ]
+    )
+    for device_id, result in results:
         for workspace in _iter_runtime_workspaces(result):
             workspace_path = normalize_workspace_path(workspace["workspacePath"])
             tasks = [
@@ -1839,6 +1836,40 @@ async def _list_online_runtime_workspaces(
             if tasks:
                 grouped[(device_id, workspace_path)] = tasks
     return grouped
+
+
+async def _list_device_runtime_workspaces(
+    *,
+    user_id: int,
+    device: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    device_id = str(device.get("device_id") or "")
+    try:
+        result = await runtime_rpc_service.call(
+            user_id=user_id,
+            device_id=device_id,
+            method="runtime.tasks.list",
+            payload={},
+            timeout_seconds=RUNTIME_LIST_TIMEOUT_SECONDS,
+            ack_grace_seconds=0,
+        )
+    except RuntimeRpcError:
+        return device_id, {"workspaces": []}
+    return device_id, result
+
+
+def _should_poll_runtime_work_device(device: dict[str, Any]) -> bool:
+    device_id = str(device.get("device_id") or "")
+    if not device_id or _device_status(device) not in {"online", "busy"}:
+        return False
+    return _device_bind_shell(device) == RUNTIME_WORK_BIND_SHELL
+
+
+def _device_bind_shell(device: dict[str, Any]) -> str:
+    raw_bind_shell = device.get("bind_shell") or device.get("bindShell")
+    if not isinstance(raw_bind_shell, str) or not raw_bind_shell.strip():
+        return RUNTIME_WORK_BIND_SHELL
+    return raw_bind_shell.strip().lower()
 
 
 def _iter_runtime_workspaces(result: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -52,3 +52,50 @@ async def test_runtime_rpc_service_returns_runtime_failure_ack(monkeypatch):
         namespace="/local-executor",
         timeout=35,
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_can_use_strict_timeout_without_ack_grace(
+    monkeypatch,
+):
+    from app.services.device import runtime_rpc_service as module
+
+    monkeypatch.setattr(
+        module.device_service,
+        "get_device_online_info",
+        AsyncMock(return_value={"socket_id": "socket-1"}),
+    )
+    sio = type(
+        "Sio",
+        (),
+        {
+            "call": AsyncMock(
+                return_value={
+                    "success": True,
+                    "workspaces": [],
+                }
+            )
+        },
+    )()
+    monkeypatch.setattr(module, "get_sio", lambda: sio)
+
+    result = await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.list",
+        payload={},
+        timeout_seconds=3,
+        ack_grace_seconds=0,
+    )
+
+    assert result == {"success": True, "workspaces": []}
+    sio.call.assert_awaited_once_with(
+        "runtime:rpc",
+        {
+            "method": "runtime.tasks.list",
+            "payload": {},
+        },
+        to="socket-1",
+        namespace="/local-executor",
+        timeout=3,
+    )

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -519,6 +520,102 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
     )
     rpc.assert_awaited_once()
     assert test_db.query(TaskResource).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_list_runtime_work_polls_online_devices_concurrently(monkeypatch):
+    from app.services import runtime_work_service
+    from app.services.device.runtime_rpc_service import RuntimeRpcError
+
+    second_device_started = asyncio.Event()
+    calls: list[str] = []
+
+    async def rpc(**kwargs):
+        device_id = kwargs["device_id"]
+        calls.append(device_id)
+        if device_id == "stale-device":
+            await second_device_started.wait()
+            raise RuntimeRpcError("stale device did not acknowledge runtime list")
+
+        second_device_started.set()
+        return {
+            "workspaces": [
+                {
+                    "workspacePath": "/repo/Wegent",
+                    "localTasks": [
+                        {
+                            "localTaskId": "codex-1",
+                            "workspacePath": "/repo/Wegent",
+                            "title": "Healthy device task",
+                            "runtime": "codex",
+                            "createdAt": "2026-06-20T01:00:00Z",
+                            "updatedAt": "2026-06-20T02:00:00Z",
+                        }
+                    ],
+                }
+            ]
+        }
+
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+
+    result = await asyncio.wait_for(
+        runtime_work_service._list_online_runtime_workspaces(
+            user_id=7,
+            devices=[
+                {
+                    "device_id": "stale-device",
+                    "name": "Stale",
+                    "status": "online",
+                },
+                {
+                    "device_id": "healthy-device",
+                    "name": "Healthy",
+                    "status": "online",
+                },
+            ],
+        ),
+        timeout=0.2,
+    )
+
+    assert calls == ["stale-device", "healthy-device"]
+    assert result[("healthy-device", "/repo/Wegent")][0].title == "Healthy device task"
+
+
+@pytest.mark.asyncio
+async def test_list_runtime_work_only_polls_claudecode_devices_with_short_timeout(
+    monkeypatch,
+):
+    from app.services import runtime_work_service
+
+    calls: list[dict] = []
+
+    async def rpc(**kwargs):
+        calls.append(kwargs)
+        return {"workspaces": []}
+
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+
+    await runtime_work_service._list_online_runtime_workspaces(
+        user_id=7,
+        devices=[
+            {
+                "device_id": "claude-device",
+                "name": "Claude",
+                "status": "online",
+                "bind_shell": "claudecode",
+            },
+            {
+                "device_id": "openclaw-device",
+                "name": "OpenClaw",
+                "status": "online",
+                "bind_shell": "openclaw",
+            },
+        ],
+    )
+
+    assert [call["device_id"] for call in calls] == ["claude-device"]
+    assert calls[0]["timeout_seconds"] == 3
+    assert calls[0]["ack_grace_seconds"] == 0
 
 
 @pytest.mark.asyncio
@@ -1798,6 +1895,8 @@ async def test_fork_runtime_task_without_source_workspace_path_resolves_git_work
     )
 
     assert response.accepted is True
+    assert calls[0]["timeout_seconds"] == 3
+    assert calls[0]["ack_grace_seconds"] == 0
     assert [call["method"] for call in calls] == [
         "runtime.tasks.list",
         "runtime.tasks.prepare_fork_transfer",


### PR DESCRIPTION
## What changed

- Limit `runtime.tasks.list` RPC calls to a strict 3 second socket timeout.
- Poll eligible online local executor devices concurrently when building Wework runtime work data.
- Skip runtime work polling for devices whose `bind_shell` is not `claudecode`.
- Add regression coverage for concurrent polling, strict timeout behavior, bind shell filtering, and fork source workspace resolution.

## Why

Wework could hang while loading runtime work when the backend sent `runtime.tasks.list` to a stale or unsupported local executor. The previous list path waited up to 35 seconds per device because the 30 second business timeout also included the default 5 second Socket.IO ACK grace.

## Validation

- `uv run pytest tests/services/test_runtime_rpc_service.py tests/services/test_runtime_work_service.py -q`
- `uv run pytest tests/api/endpoints/test_runtime_work_api.py -q`
- `uv run black app/services/runtime_work_service.py app/services/device/runtime_rpc_service.py tests/services/test_runtime_work_service.py tests/services/test_runtime_rpc_service.py --check`
- `uv run isort app/services/runtime_work_service.py app/services/device/runtime_rpc_service.py tests/services/test_runtime_work_service.py tests/services/test_runtime_rpc_service.py --check-only`
