### PR TITLE
[codex] Source Wework runtime work from executor threads

### DIFF
--- a/backend/app/api/endpoints/runtime_work.py
+++ b/backend/app/api/endpoints/runtime_work.py
@@ -4,13 +4,10 @@
 
 """Runtime-native local work endpoints for Wework."""
 
-from typing import Annotated
-
 from fastapi import APIRouter, Body, Depends, Query
 from sqlalchemy.orm import Session
 
 from app.api.dependencies import get_db
-from app.core.constants import CLIENT_ORIGIN_WEWORK, SUPPORTED_CLIENT_ORIGINS
 from app.core.security import get_current_user
 from app.models.user import User
 from app.schemas.runtime_work import (
@@ -44,27 +41,17 @@ from shared.telemetry.decorators import (
 
 router = APIRouter()
 
-ClientOriginQuery = Annotated[
-    str,
-    Query(
-        pattern=f"^({'|'.join(SUPPORTED_CLIENT_ORIGINS)})$",
-        description="Client surface to scope projects",
-    ),
-]
-
 
 @router.get("", response_model=RuntimeWorkListResponse, response_model_by_alias=True)
 async def list_runtime_work_endpoint(
-    client_origin: ClientOriginQuery = CLIENT_ORIGIN_WEWORK,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """List Projects -> Device Workspaces -> executor-local LocalTasks."""
+    """List executor-local work grouped as projects and conversations."""
 
     return await runtime_work_service.list_runtime_work(
         db=db,
         user_id=current_user.id,
-        client_origin=client_origin,
     )
 
 

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -9,6 +9,7 @@ import logging
 import posixpath
 import re
 from dataclasses import dataclass, replace
+from datetime import datetime
 from hashlib import sha256
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -238,12 +239,9 @@ async def list_runtime_work(
     *,
     db: Session,
     user_id: int,
-    client_origin: Optional[str] = CLIENT_ORIGIN_WEWORK,
 ) -> RuntimeWorkListResponse:
-    """Return runtime-native work grouped by central Project and Device Workspace."""
+    """Return runtime-native work grouped by executor workspace."""
 
-    projects = _list_projects(db, user_id, client_origin)
-    mappings = _list_workspace_rows(db, user_id, [project.id for project in projects])
     devices = await device_service.get_all_devices(db, user_id)
     devices_by_id = {str(device.get("device_id")): device for device in devices}
     runtime_workspaces = await _list_online_runtime_workspaces(
@@ -251,118 +249,46 @@ async def list_runtime_work(
         devices=devices,
     )
 
-    workspace_items_by_project_id: dict[int, list[RuntimeDeviceWorkspace]] = {}
+    projects: list[RuntimeProjectWork] = []
+    conversations: list[RuntimeDeviceWorkspace] = []
     total_local_tasks = 0
-    mapped_keys: set[tuple[str, str]] = set()
 
-    for project in projects:
-        project_mappings = [row for row in mappings if row.project_id == project.id]
-        workspace_items: list[RuntimeDeviceWorkspace] = []
-        for mapping in project_mappings:
-            key = (mapping.device_id, mapping.workspace_path)
-            mapped_keys.add(key)
-            local_tasks = runtime_workspaces.get(key, [])
-            total_local_tasks += len(local_tasks)
-            workspace_items.append(
-                _build_device_workspace_item(
-                    mapping=mapping,
-                    device=devices_by_id.get(mapping.device_id),
-                    local_tasks=local_tasks,
-                )
-            )
-        configured_target = _project_runtime_target(project)
-        if configured_target:
-            materialized_mapping = _materialize_project_runtime_target(
-                db=db,
-                user_id=user_id,
-                project=project,
-                target=configured_target,
-            )
-            key = (materialized_mapping.device_id, materialized_mapping.workspace_path)
-            if key not in mapped_keys:
-                mapped_keys.add(key)
-                local_tasks = runtime_workspaces.get(key, [])
-                total_local_tasks += len(local_tasks)
-                workspace_items.append(
-                    _build_device_workspace_item(
-                        mapping=materialized_mapping,
-                        device=devices_by_id.get(materialized_mapping.device_id),
-                        local_tasks=local_tasks,
-                    )
-                )
-        workspace_items_by_project_id[project.id] = workspace_items
-
-    for (device_id, workspace_path), local_tasks in runtime_workspaces.items():
-        if (device_id, workspace_path) in mapped_keys:
-            continue
-        target = _find_project_target_for_runtime_git_info(
-            projects=projects,
-            mappings=mappings,
-            device_id=device_id,
-            local_tasks=local_tasks,
-        )
-        if target is not None and target.project is not None:
-            mapped_keys.add((device_id, workspace_path))
-            total_local_tasks += len(local_tasks)
-            _append_worktree_tasks_to_source_workspace(
-                db=db,
-                workspace_items_by_project_id=workspace_items_by_project_id,
-                target=target,
-                device=devices_by_id.get(device_id),
-                local_tasks=local_tasks,
-            )
-            continue
-
-        target = _find_project_target_for_runtime_worktree(
-            projects=projects,
-            mappings=mappings,
-            device_id=device_id,
-            workspace_path=workspace_path,
-        )
-        if target is None or target.project is None:
-            continue
-        mapped_keys.add((device_id, workspace_path))
-        total_local_tasks += len(local_tasks)
-        _append_worktree_tasks_to_source_workspace(
-            db=db,
-            workspace_items_by_project_id=workspace_items_by_project_id,
-            target=target,
-            device=devices_by_id.get(device_id),
-            local_tasks=local_tasks,
-        )
-
-    projects_response = [
-        RuntimeProjectWork(
-            project=_project_ref(project),
-            deviceWorkspaces=workspace_items_by_project_id.get(project.id, []),
-        )
-        for project in projects
-    ]
-
-    unmapped: list[RuntimeDeviceWorkspace] = []
-    for (device_id, workspace_path), local_tasks in runtime_workspaces.items():
-        if (device_id, workspace_path) in mapped_keys:
-            continue
+    for (device_id, workspace_path), local_tasks in sorted(
+        runtime_workspaces.items(),
+        key=lambda item: _runtime_workspace_sort_key(item[1]),
+    ):
         total_local_tasks += len(local_tasks)
         device = devices_by_id.get(device_id)
-        unmapped.append(
-            RuntimeDeviceWorkspace(
-                id=None,
-                projectId=None,
-                deviceId=device_id,
-                deviceName=_device_name(device, device_id),
-                deviceStatus=_device_status(device),
-                workspacePath=workspace_path,
-                **_runtime_workspace_kind_fields(workspace_path),
-                mapped=False,
-                available=True,
-                localTasks=local_tasks,
+        workspace_kind_fields = _runtime_workspace_kind_fields_from_tasks(
+            workspace_path,
+            local_tasks,
+        )
+        workspace = RuntimeDeviceWorkspace(
+            id=None,
+            projectId=None,
+            deviceId=device_id,
+            deviceName=_device_name(device, device_id),
+            deviceStatus=_device_status(device),
+            workspacePath=workspace_path,
+            **workspace_kind_fields,
+            mapped=True,
+            available=True,
+            localTasks=local_tasks,
+        )
+        if workspace.workspace_kind == "chat":
+            conversations.append(workspace)
+            continue
+        project_ref = _runtime_project_ref_from_workspace(workspace_path)
+        projects.append(
+            RuntimeProjectWork(
+                project=project_ref,
+                deviceWorkspaces=[workspace],
             )
         )
 
     return RuntimeWorkListResponse(
-        projects=projects_response,
-        unmappedDeviceWorkspaces=unmapped,
+        projects=projects,
+        unmappedDeviceWorkspaces=conversations,
         totalLocalTasks=total_local_tasks,
     )
 
@@ -1772,34 +1698,6 @@ def _project_id_for_runtime_workspace(
     return None
 
 
-def _list_projects(
-    db: Session,
-    user_id: int,
-    client_origin: Optional[str],
-) -> list[Project]:
-    query = db.query(Project).filter(
-        Project.user_id == user_id,
-        Project.is_active == True,
-    )
-    if client_origin:
-        query = query.filter(Project.client_origin == client_origin)
-    return query.order_by(Project.sort_order.asc(), Project.id.asc()).all()
-
-
-def _list_workspace_rows(
-    db: Session,
-    user_id: int,
-    project_ids: list[int],
-) -> list[DeviceWorkspaceResponse]:
-    if not project_ids:
-        return []
-    return list_device_workspace_kinds(
-        db=db,
-        user_id=user_id,
-        project_ids=project_ids,
-    )
-
-
 async def _list_online_runtime_workspaces(
     *,
     user_id: int,
@@ -1826,10 +1724,11 @@ async def _list_online_runtime_workspaces(
                 LocalTaskSummary.model_validate(
                     {
                         **task,
-                        **_runtime_workspace_kind_fields(
+                        **_runtime_task_kind_fields(
+                            task,
                             normalize_workspace_path(
                                 str(task.get("workspacePath") or workspace_path)
-                            )
+                            ),
                         ),
                         "workspacePath": normalize_workspace_path(
                             str(task.get("workspacePath") or workspace_path)
@@ -1842,6 +1741,25 @@ async def _list_online_runtime_workspaces(
             if tasks:
                 grouped[(device_id, workspace_path)] = tasks
     return grouped
+
+
+def _runtime_workspace_sort_key(
+    local_tasks: list[LocalTaskSummary],
+) -> tuple[float, str]:
+    latest = max((_task_timestamp(task) for task in local_tasks), default=0.0)
+    title = local_tasks[0].title if local_tasks else ""
+    return (-latest, title.lower())
+
+
+def _task_timestamp(task: LocalTaskSummary) -> float:
+    for value in (task.updated_at, task.created_at):
+        if not value:
+            continue
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            continue
+    return 0.0
 
 
 def _iter_runtime_workspaces(result: dict[str, Any]) -> list[dict[str, Any]]:
@@ -1888,17 +1806,42 @@ def _runtime_workspace_kind_fields(workspace_path: str) -> dict[str, Optional[st
     return {"workspaceKind": "worktree", "worktreeId": worktree.worktree_id}
 
 
-def _device_workspace_kind_fields(
+def _runtime_task_kind_fields(
+    task: dict[str, Any],
     workspace_path: str,
-    label: Optional[str],
 ) -> dict[str, Optional[str]]:
-    fields = _runtime_workspace_kind_fields(workspace_path)
-    if label not in {"worktree", "workspace"}:
-        return fields
-    return {
-        "workspaceKind": label,
-        "worktreeId": fields["worktreeId"] if label == "worktree" else None,
-    }
+    workspace_kind = task.get("workspaceKind") or task.get("workspace_kind")
+    if workspace_kind in {"workspace", "worktree", "chat"}:
+        worktree_id = task.get("worktreeId") or task.get("worktree_id")
+        return {
+            "workspaceKind": workspace_kind,
+            "worktreeId": (
+                str(worktree_id).strip()
+                if workspace_kind == "worktree"
+                and isinstance(worktree_id, str)
+                and worktree_id.strip()
+                else None
+            ),
+        }
+    return _runtime_workspace_kind_fields(workspace_path)
+
+
+def _runtime_workspace_kind_fields_from_tasks(
+    workspace_path: str,
+    local_tasks: list[LocalTaskSummary],
+) -> dict[str, Optional[str]]:
+    if any(task.workspace_kind == "chat" for task in local_tasks):
+        return {"workspaceKind": "chat", "worktreeId": None}
+    worktree_task = next(
+        (task for task in local_tasks if task.workspace_kind == "worktree"),
+        None,
+    )
+    if worktree_task:
+        return {
+            "workspaceKind": "worktree",
+            "worktreeId": worktree_task.worktree_id,
+        }
+    return _runtime_workspace_kind_fields(workspace_path)
 
 
 def _is_runtime_chat_workspace_path(path: str) -> bool:
@@ -1920,242 +1863,20 @@ def _is_runtime_chat_workspace_path(path: str) -> bool:
     )
 
 
-def _find_project_target_for_runtime_git_info(
-    *,
-    projects: list[Project],
-    mappings: list[DeviceWorkspaceResponse],
-    device_id: str,
-    local_tasks: list[LocalTaskSummary],
-) -> Optional[RuntimeTaskTarget]:
-    task_origin_urls = {
-        _canonical_git_url(_task_git_origin_url(task))
-        for task in local_tasks
-        if task.runtime == "codex" and task.workspace_kind != "chat"
-    }
-    task_origin_urls.discard(None)
-    if not task_origin_urls:
-        return None
-
-    projects_by_id = {project.id: project for project in projects}
-    candidates: list[tuple[int, RuntimeTaskTarget]] = []
-    for mapping in mappings:
-        if mapping.device_id != device_id:
-            continue
-        mapping_url = _canonical_git_url(mapping.repo_url)
-        project = projects_by_id.get(mapping.project_id)
-        if mapping_url and mapping_url in task_origin_urls and project is not None:
-            candidates.append(
-                (
-                    0,
-                    RuntimeTaskTarget(
-                        device_id=mapping.device_id,
-                        workspace_path=mapping.workspace_path,
-                        project=project,
-                        workspace_source="local_path",
-                    ),
-                )
-            )
-
-    for project in projects:
-        target = _project_runtime_target(project)
-        if not target or target.device_id != device_id:
-            continue
-        project_url = _canonical_git_url(_project_git_url(project))
-        if project_url and project_url in task_origin_urls:
-            candidates.append((1, target))
-
-    if not candidates:
-        return None
-    return sorted(
-        candidates,
-        key=lambda item: (item[0], item[1].project.id if item[1].project else 0),
-    )[0][1]
-
-
-def _task_git_origin_url(task: LocalTaskSummary) -> Optional[str]:
-    git_info = task.git_info
-    if not isinstance(git_info, dict):
-        return None
-    value = git_info.get("originUrl") or git_info.get("origin_url")
-    return value if isinstance(value, str) and value.strip() else None
-
-
-def _project_git_url(project: Project) -> Optional[str]:
-    config = _parse_project_config(project, strict=False)
-    if not config or not config.git:
-        return None
-    return config.git.url
-
-
-def _canonical_git_url(value: Optional[str]) -> Optional[str]:
-    if not value:
-        return None
-    text = value.strip()
-    if not text:
-        return None
-
-    scp_like = re.match(r"^(?:ssh://)?git@([^:/]+)[:/](.+)$", text)
-    if scp_like:
-        host, path = scp_like.groups()
-        return _canonical_git_host_path(host, path)
-
-    parsed = urlparse(text)
-    if parsed.netloc and parsed.path:
-        return _canonical_git_host_path(parsed.netloc, parsed.path)
-
-    return text.removesuffix(".git").lower()
-
-
-def _canonical_git_host_path(host: str, path: str) -> str:
-    normalized_host = host.lower().removeprefix("www.")
-    normalized_path = path.strip("/").removesuffix(".git").lower()
-    return f"{normalized_host}/{normalized_path}"
-
-
-def _find_project_target_for_runtime_worktree(
-    *,
-    projects: list[Project],
-    mappings: list[DeviceWorkspaceResponse],
-    device_id: str,
-    workspace_path: str,
-) -> Optional[RuntimeTaskTarget]:
-    worktree = _parse_runtime_worktree_path(workspace_path)
-    if not worktree:
-        return None
-
-    projects_by_id = {project.id: project for project in projects}
-    candidates: list[tuple[int, RuntimeTaskTarget]] = []
-    for mapping in mappings:
-        if mapping.device_id != device_id:
-            continue
-        project = projects_by_id.get(mapping.project_id)
-        if project is None:
-            continue
-        if _path_basename(mapping.workspace_path).lower() == (
-            worktree.project_dir_name.lower()
-        ):
-            candidates.append(
-                (
-                    0,
-                    RuntimeTaskTarget(
-                        device_id=mapping.device_id,
-                        workspace_path=mapping.workspace_path,
-                        project=project,
-                        workspace_source="local_path",
-                    ),
-                )
-            )
-
-    for project in projects:
-        target = _project_runtime_target(project)
-        if not target or target.device_id != device_id:
-            continue
-        if _path_basename(target.workspace_path).lower() == (
-            worktree.project_dir_name.lower()
-        ):
-            candidates.append((1, target))
-    if not candidates:
-        return None
-    return sorted(
-        candidates,
-        key=lambda item: (item[0], item[1].project.id if item[1].project else 0),
-    )[0][1]
-
-
-def _append_worktree_tasks_to_source_workspace(
-    *,
-    db: Session,
-    workspace_items_by_project_id: dict[int, list[RuntimeDeviceWorkspace]],
-    target: RuntimeTaskTarget,
-    device: Optional[dict[str, Any]],
-    local_tasks: list[LocalTaskSummary],
-) -> None:
-    if target.project is None:
-        return
-
-    workspace_items = workspace_items_by_project_id.setdefault(target.project.id, [])
-    for item in workspace_items:
-        if (
-            item.device_id == target.device_id
-            and item.workspace_path == target.workspace_path
-        ):
-            item.local_tasks.extend(local_tasks)
-            return
-
-    mapping = _materialize_project_runtime_target(
-        db=db,
-        user_id=target.project.user_id,
-        project=target.project,
-        target=target,
-    )
-    workspace_items.append(
-        _build_device_workspace_item(
-            mapping=mapping,
-            device=device,
-            local_tasks=local_tasks,
-        )
-    )
-
-
-def _materialize_project_runtime_target(
-    *,
-    db: Session,
-    user_id: int,
-    project: Project,
-    target: RuntimeTaskTarget,
-) -> DeviceWorkspaceResponse:
-    config = _parse_project_config(project, strict=False)
-    repo_url = config.git.url if config and config.git else None
-    return upsert_device_workspace(
-        db=db,
-        user_id=user_id,
-        payload=DeviceWorkspaceUpsert(
-            projectId=project.id,
-            deviceId=target.device_id,
-            workspacePath=target.workspace_path,
-            repoUrl=repo_url,
-            label="workspace",
-        ),
-    )
-
-
 def _path_basename(path: str) -> str:
     parts = [part for part in normalize_workspace_path(path).split("/") if part]
     return parts[-1] if parts else ""
 
 
-def _build_device_workspace_item(
-    *,
-    mapping: DeviceWorkspaceResponse,
-    device: Optional[dict[str, Any]],
-    local_tasks: list[LocalTaskSummary],
-) -> RuntimeDeviceWorkspace:
-    status_value = _device_status(device)
-    available = status_value in {"online", "busy"}
-    return RuntimeDeviceWorkspace(
-        id=mapping.id,
-        projectId=mapping.project_id,
-        deviceId=mapping.device_id,
-        deviceName=_device_name(device, mapping.device_id),
-        deviceStatus=status_value,
-        workspacePath=mapping.workspace_path,
-        **_device_workspace_kind_fields(mapping.workspace_path, mapping.label),
-        repoUrl=mapping.repo_url,
-        repoRootFingerprint=mapping.repo_root_fingerprint,
-        label=mapping.label,
-        mapped=True,
-        available=available,
-        error=None if available else "Device is offline",
-        localTasks=local_tasks if available else [],
-    )
-
-
-def _project_ref(project: Project) -> RuntimeProjectRef:
+def _runtime_project_ref_from_workspace(workspace_path: str) -> RuntimeProjectRef:
+    normalized_path = normalize_workspace_path(workspace_path)
+    project_id = int(sha256(normalized_path.encode("utf-8")).hexdigest()[:12], 16)
+    project_id = project_id % 1_000_000_000 + 1
     return RuntimeProjectRef(
-        id=project.id,
-        name=project.name,
-        description=project.description or "",
-        color=project.color,
+        id=project_id,
+        name=_path_basename(normalized_path) or normalized_path,
+        description=normalized_path,
+        color=None,
     )
 
 

--- a/backend/tests/api/endpoints/test_runtime_work_api.py
+++ b/backend/tests/api/endpoints/test_runtime_work_api.py
@@ -25,14 +25,11 @@ def test_list_runtime_work_endpoint_uses_current_user(
         runtime_work.runtime_work_service, "list_runtime_work", service_mock
     )
 
-    response = test_client.get(
-        "/api/runtime-work?client_origin=wework",
-        headers=_auth_headers(test_token),
-    )
+    response = test_client.get("/api/runtime-work", headers=_auth_headers(test_token))
 
     assert response.status_code == 200
     assert response.json()["totalLocalTasks"] == 0
-    assert service_mock.await_args.kwargs["client_origin"] == "wework"
+    assert "client_origin" not in service_mock.await_args.kwargs
 
 
 def test_upsert_device_workspace_endpoint_returns_mapping(

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -477,7 +477,7 @@ async def test_prepare_git_device_workspace_rejects_nonmatching_nonempty_directo
 
 
 @pytest.mark.asyncio
-async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
+async def test_list_runtime_work_groups_executor_workspaces_without_project_mapping(
     test_db,
     test_user,
     monkeypatch,
@@ -492,8 +492,8 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
         payload=DeviceWorkspaceUpsert(
             projectId=project.id,
             deviceId="device-1",
-            workspacePath="/repo/Wegent",
-            label="MacBook",
+            workspacePath="/repo/Legacy",
+            label="legacy mapping",
         ),
     )
 
@@ -507,6 +507,7 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
                     "name": "MacBook",
                     "status": "online",
                     "device_type": "local",
+                    "client_ip": "192.0.2.10",
                 }
             ]
         ),
@@ -522,6 +523,7 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
                             "workspacePath": "/repo/Wegent",
                             "title": "Fix reconnect",
                             "runtime": "codex",
+                            "workspaceKind": "workspace",
                             "createdAt": "2026-06-20T01:00:00Z",
                             "updatedAt": "2026-06-20T02:00:00Z",
                             "running": False,
@@ -536,9 +538,25 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
                             "workspacePath": "/tmp/spike",
                             "title": "Spike",
                             "runtime": "claude_code",
+                            "workspaceKind": "workspace",
                             "createdAt": "2026-06-20T03:00:00Z",
                             "updatedAt": "2026-06-20T04:00:00Z",
                             "running": True,
+                        }
+                    ],
+                },
+                {
+                    "workspacePath": "/Users/alice/Documents/Codex/2026-06-23/chat-1",
+                    "localTasks": [
+                        {
+                            "localTaskId": "chat-1",
+                            "workspacePath": (
+                                "/Users/alice/Documents/Codex/2026-06-23/chat-1"
+                            ),
+                            "title": "Hello",
+                            "runtime": "codex",
+                            "workspaceKind": "chat",
+                            "updatedAt": "2026-06-20T05:00:00Z",
                         }
                     ],
                 },
@@ -550,245 +568,40 @@ async def test_list_runtime_work_groups_local_tasks_under_device_workspaces(
     response = await runtime_work_service.list_runtime_work(
         db=test_db,
         user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
     )
 
-    assert response.total_local_tasks == 2
-    assert response.projects[0].project.id == project.id
-    assert response.projects[0].device_workspaces[0].workspace_path == "/repo/Wegent"
+    assert response.total_local_tasks == 3
+    assert [project_work.project.name for project_work in response.projects] == [
+        "spike",
+        "Wegent",
+    ]
+    assert {project_work.project.id for project_work in response.projects}.isdisjoint(
+        {project.id}
+    )
+    assert response.projects[0].device_workspaces[0].workspace_path == "/tmp/spike"
+    assert response.projects[0].device_workspaces[0].id is None
+    assert response.projects[0].device_workspaces[0].project_id is None
+    assert response.projects[0].device_workspaces[0].mapped is True
     assert (
-        response.projects[0].device_workspaces[0].local_tasks[0].local_task_id
+        response.projects[1].device_workspaces[0].local_tasks[0].local_task_id
         == "codex-1"
     )
-    assert response.unmapped_device_workspaces[0].workspace_path == "/tmp/spike"
+    assert len(response.unmapped_device_workspaces) == 1
+    assert response.unmapped_device_workspaces[0].workspace_kind == "chat"
     assert (
-        response.unmapped_device_workspaces[0].local_tasks[0].runtime == "claude_code"
+        response.unmapped_device_workspaces[0].local_tasks[0].local_task_id == "chat-1"
     )
     rpc.assert_awaited_once()
     assert test_db.query(TaskResource).count() == 0
 
 
 @pytest.mark.asyncio
-async def test_list_runtime_work_materializes_legacy_project_config_workspace(
+async def test_list_runtime_work_preserves_executor_workspace_kind(
     test_db,
     test_user,
     monkeypatch,
 ):
     from app.services import runtime_work_service
-
-    project = _local_path_project(
-        test_db,
-        test_user.id,
-        device_id="device-1",
-        path="/repo/Wegent",
-    )
-    monkeypatch.setattr(
-        runtime_work_service.device_service,
-        "get_all_devices",
-        AsyncMock(
-            return_value=[
-                {
-                    "device_id": "device-1",
-                    "name": "Local Device",
-                    "status": "online",
-                    "executor_version": "1.8.5",
-                }
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        runtime_work_service.runtime_rpc_service,
-        "call",
-        AsyncMock(
-            return_value={
-                "workspaces": [
-                    {
-                        "workspacePath": "/repo/Wegent",
-                        "localTasks": [],
-                    }
-                ]
-            }
-        ),
-    )
-
-    response = await runtime_work_service.list_runtime_work(
-        db=test_db,
-        user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
-    )
-
-    workspace = response.projects[0].device_workspaces[0]
-    assert workspace.id is not None
-    assert workspace.project_id == project.id
-    assert workspace.device_id == "device-1"
-    assert workspace.workspace_path == "/repo/Wegent"
-
-    rows = runtime_work_service.list_device_workspaces(
-        db=test_db,
-        user_id=test_user.id,
-        project_id=project.id,
-    )
-    assert len(rows) == 1
-    assert rows[0].id == workspace.id
-    assert rows[0].workspace_path == "/repo/Wegent"
-
-
-@pytest.mark.asyncio
-async def test_list_runtime_work_uses_mapping_label_as_workspace_kind(
-    test_db,
-    test_user,
-    monkeypatch,
-):
-    from app.schemas.runtime_work import DeviceWorkspaceUpsert
-    from app.services import runtime_work_service
-
-    project = _project(test_db, test_user.id)
-    runtime_work_service.upsert_device_workspace(
-        db=test_db,
-        user_id=test_user.id,
-        payload=DeviceWorkspaceUpsert(
-            projectId=project.id,
-            deviceId="device-1",
-            workspacePath="/repo/Wegent",
-            label="worktree",
-        ),
-    )
-
-    monkeypatch.setattr(
-        runtime_work_service.device_service,
-        "get_all_devices",
-        AsyncMock(
-            return_value=[
-                {
-                    "device_id": "device-1",
-                    "name": "MacBook",
-                    "status": "online",
-                    "device_type": "local",
-                }
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        runtime_work_service.runtime_rpc_service,
-        "call",
-        AsyncMock(return_value={"workspaces": []}),
-    )
-
-    response = await runtime_work_service.list_runtime_work(
-        db=test_db,
-        user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
-    )
-
-    workspace = response.projects[0].device_workspaces[0]
-    assert workspace.workspace_path == "/repo/Wegent"
-    assert workspace.label == "worktree"
-    assert workspace.workspace_kind == "worktree"
-
-
-@pytest.mark.asyncio
-async def test_list_runtime_work_matches_project_configured_local_directory_without_mapping_row(
-    test_db,
-    test_user,
-    monkeypatch,
-):
-    from app.services import runtime_work_service
-
-    project = _local_path_project(test_db, test_user.id)
-
-    monkeypatch.setattr(
-        runtime_work_service.device_service,
-        "get_all_devices",
-        AsyncMock(
-            return_value=[
-                {
-                    "device_id": "device-1",
-                    "name": "MacBook",
-                    "status": "online",
-                    "device_type": "local",
-                }
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        runtime_work_service.runtime_rpc_service,
-        "call",
-        AsyncMock(
-            return_value={
-                "workspaces": [
-                    {
-                        "workspacePath": "/repo/Wegent",
-                        "localTasks": [
-                            {
-                                "localTaskId": "018f2d6b-8c7a-7abc-9def-0123456789ab",
-                                "workspacePath": "/repo/Wegent",
-                                "title": "Implement runtime sidebar",
-                                "runtime": "codex",
-                                "updatedAt": "2026-06-20T02:00:00Z",
-                            }
-                        ],
-                    },
-                    {
-                        "workspacePath": (
-                            "/Users/axb-mac/.wecode/wegent-executor/workspace/"
-                            "chats/2026-06-20/hi-1"
-                        ),
-                        "localTasks": [
-                            {
-                                "localTaskId": "019ee579-f6f4-73d3-9b3e-2d4652e0c9e9",
-                                "workspacePath": (
-                                    "/Users/axb-mac/.wecode/wegent-executor/"
-                                    "workspace/chats/2026-06-20/hi-1"
-                                ),
-                                "title": "hi",
-                                "runtime": "codex",
-                                "updatedAt": "2026-06-20T14:40:46+00:00",
-                            }
-                        ],
-                    },
-                ]
-            }
-        ),
-    )
-
-    response = await runtime_work_service.list_runtime_work(
-        db=test_db,
-        user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
-    )
-
-    workspace = response.projects[0].device_workspaces[0]
-    assert response.projects[0].project.id == project.id
-    assert workspace.device_id == "device-1"
-    assert workspace.workspace_path == "/repo/Wegent"
-    assert workspace.local_tasks[0].title == "Implement runtime sidebar"
-    assert len(response.unmapped_device_workspaces) == 1
-    assert (
-        response.unmapped_device_workspaces[0].workspace_path
-        == "/Users/axb-mac/.wecode/wegent-executor/workspace/chats/2026-06-20/hi-1"
-    )
-    assert response.unmapped_device_workspaces[0].workspace_kind == "chat"
-    assert response.unmapped_device_workspaces[0].local_tasks[0].title == "hi"
-    assert (
-        response.unmapped_device_workspaces[0].local_tasks[0].workspace_kind == "chat"
-    )
-    assert test_db.query(TaskResource).count() == 0
-
-
-@pytest.mark.asyncio
-async def test_list_runtime_work_groups_managed_worktree_under_source_project(
-    test_db,
-    test_user,
-    monkeypatch,
-):
-    from app.services import runtime_work_service
-
-    project = _local_path_project(
-        test_db,
-        test_user.id,
-        path="/workspace/Wegent",
-        name="Wegent",
-    )
 
     monkeypatch.setattr(
         runtime_work_service.device_service,
@@ -818,6 +631,8 @@ async def test_list_runtime_work_groups_managed_worktree_under_source_project(
                                 "workspacePath": "/workspace/worktrees/42/Wegent",
                                 "title": "Fix worktree sidebar",
                                 "runtime": "codex",
+                                "workspaceKind": "worktree",
+                                "worktreeId": "42",
                                 "updatedAt": "2026-06-20T02:00:00Z",
                             }
                         ],
@@ -830,128 +645,25 @@ async def test_list_runtime_work_groups_managed_worktree_under_source_project(
     response = await runtime_work_service.list_runtime_work(
         db=test_db,
         user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
-    )
-
-    worktree_workspace = response.projects[0].device_workspaces[0]
-    task = worktree_workspace.local_tasks[0]
-    assert response.projects[0].project.id == project.id
-    assert worktree_workspace.workspace_path == "/workspace/Wegent"
-    assert worktree_workspace.workspace_kind == "workspace"
-    assert worktree_workspace.worktree_id is None
-    assert task.local_task_id == "codex-worktree"
-    assert task.workspace_path == "/workspace/worktrees/42/Wegent"
-    assert task.workspace_kind == "worktree"
-    assert task.worktree_id == "42"
-    assert response.unmapped_device_workspaces == []
-    assert test_db.query(TaskResource).count() == 0
-
-
-@pytest.mark.asyncio
-async def test_list_runtime_work_groups_mapped_device_worktree_under_project(
-    test_db,
-    test_user,
-    monkeypatch,
-):
-    from app.schemas.runtime_work import DeviceWorkspaceUpsert
-    from app.services import runtime_work_service
-
-    project = _git_project(test_db, test_user.id, name="Wegent_github")
-    runtime_work_service.upsert_device_workspace(
-        db=test_db,
-        user_id=test_user.id,
-        payload=DeviceWorkspaceUpsert(
-            projectId=project.id,
-            deviceId="target-device",
-            workspacePath="/target/Wegent_github",
-            repoUrl="https://github.com/wecode-ai/Wegent.git",
-            label="workspace",
-        ),
-    )
-
-    monkeypatch.setattr(
-        runtime_work_service.device_service,
-        "get_all_devices",
-        AsyncMock(
-            return_value=[
-                {
-                    "device_id": "target-device",
-                    "name": "Linux",
-                    "status": "online",
-                    "device_type": "local",
-                }
-            ]
-        ),
-    )
-    monkeypatch.setattr(
-        runtime_work_service.runtime_rpc_service,
-        "call",
-        AsyncMock(
-            return_value={
-                "workspaces": [
-                    {
-                        "workspacePath": "/target/worktrees/019eeb2c/Wegent_github",
-                        "localTasks": [
-                            {
-                                "localTaskId": "forked-codex",
-                                "workspacePath": (
-                                    "/target/worktrees/019eeb2c/Wegent_github"
-                                ),
-                                "title": "Forked Codex task",
-                                "runtime": "codex",
-                                "updatedAt": "2026-06-22T02:00:00Z",
-                            }
-                        ],
-                    }
-                ]
-            }
-        ),
-    )
-
-    response = await runtime_work_service.list_runtime_work(
-        db=test_db,
-        user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
     )
 
     workspace = response.projects[0].device_workspaces[0]
     task = workspace.local_tasks[0]
-    assert response.projects[0].project.id == project.id
-    assert workspace.device_id == "target-device"
-    assert workspace.workspace_path == "/target/Wegent_github"
-    assert task.local_task_id == "forked-codex"
-    assert task.workspace_path == "/target/worktrees/019eeb2c/Wegent_github"
+    assert workspace.workspace_path == "/workspace/worktrees/42/Wegent"
+    assert workspace.workspace_kind == "worktree"
+    assert workspace.worktree_id == "42"
     assert task.workspace_kind == "worktree"
-    assert task.worktree_id == "019eeb2c"
+    assert task.worktree_id == "42"
     assert response.unmapped_device_workspaces == []
-    assert test_db.query(TaskResource).count() == 0
 
 
 @pytest.mark.asyncio
-async def test_list_runtime_work_groups_codex_git_origin_under_matching_project(
+async def test_list_runtime_work_skips_offline_devices(
     test_db,
     test_user,
     monkeypatch,
 ):
-    from app.schemas.runtime_work import DeviceWorkspaceUpsert
     from app.services import runtime_work_service
-
-    project = _local_path_project(
-        test_db,
-        test_user.id,
-        path="/workspace/Wegent",
-        name="Wegent",
-    )
-    runtime_work_service.upsert_device_workspace(
-        db=test_db,
-        user_id=test_user.id,
-        payload=DeviceWorkspaceUpsert(
-            projectId=project.id,
-            deviceId="device-1",
-            workspacePath="/workspace/Wegent",
-            repoUrl="https://github.com/wecode-ai/Wegent.git",
-        ),
-    )
 
     monkeypatch.setattr(
         runtime_work_service.device_service,
@@ -961,52 +673,24 @@ async def test_list_runtime_work_groups_codex_git_origin_under_matching_project(
                 {
                     "device_id": "device-1",
                     "name": "MacBook",
-                    "status": "online",
+                    "status": "offline",
                     "device_type": "local",
                 }
             ]
         ),
     )
-    monkeypatch.setattr(
-        runtime_work_service.runtime_rpc_service,
-        "call",
-        AsyncMock(
-            return_value={
-                "workspaces": [
-                    {
-                        "workspacePath": "/Users/alice/dev/other/Wegent",
-                        "localTasks": [
-                            {
-                                "localTaskId": "codex-git-origin",
-                                "workspacePath": "/Users/alice/dev/other/Wegent",
-                                "title": "Fix Git grouped task",
-                                "runtime": "codex",
-                                "gitInfo": {
-                                    "originUrl": "git@github.com:wecode-ai/Wegent.git"
-                                },
-                                "updatedAt": "2026-06-20T02:00:00Z",
-                            }
-                        ],
-                    }
-                ]
-            }
-        ),
-    )
+    rpc = AsyncMock(return_value={"workspaces": []})
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
 
     response = await runtime_work_service.list_runtime_work(
         db=test_db,
         user_id=test_user.id,
-        client_origin=CLIENT_ORIGIN_WEWORK,
     )
 
-    workspace = response.projects[0].device_workspaces[0]
-    task = workspace.local_tasks[0]
-    assert response.projects[0].project.id == project.id
-    assert workspace.workspace_path == "/workspace/Wegent"
-    assert task.local_task_id == "codex-git-origin"
-    assert task.workspace_path == "/Users/alice/dev/other/Wegent"
+    assert response.projects == []
     assert response.unmapped_device_workspaces == []
-    assert test_db.query(TaskResource).count() == 0
+    assert response.total_local_tasks == 0
+    rpc.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/docs/en/developer-guide/runtime-local-work.md
+++ b/docs/en/developer-guide/runtime-local-work.md
@@ -4,20 +4,23 @@ sidebar_position: 16
 
 # Runtime Local Work
 
-Wework runtime local work surfaces Codex and Claude Code work that already exists on a user's device. It does not import that work into central `TaskResource` or `Subtask` rows. The visible model has three levels:
+Wework runtime local work surfaces Codex and Claude Code work that already exists on a user's device. It does not import that work into central `TaskResource` or `Subtask` rows, and it no longer depends on the Backend `projects` table to build the sidebar list. The list comes from runtime threads returned by online device executors and is shown in two groups:
 
 ```text
 Project
-  Device Workspace
-    LocalTask
+  LocalTask
+
+Conversation
+  LocalTask
 ```
 
 ## Ownership
 
-- Project is central Backend state.
-- Device Workspace is a central mapping from user, device, and local directory to a Project.
+- Project is a display group inferred from the runtime workspace information returned by the executor.
+- Conversation is a Codex chat thread that does not belong to a Project workspace.
 - LocalTask is executor-local state and remains on the device.
 - A LocalTask's stable identity is `deviceId + localTaskId`. `workspacePath` is only device-workspace context for list grouping, task creation, and right-side workspace tools; task URLs, IM notification subscriptions, and native Codex update deduplication do not use the path as an identity field.
+- The executor returns `workspaceKind` to distinguish Project work from Conversations. Codex App-style directories such as `~/Documents/Codex/YYYY-MM-DD/<name>` are marked as `chat` and shown under "Conversations"; other workspaces are shown under "Projects".
 
 The executor still keeps a JSON LocalTask index for non-Codex or imported local tasks:
 
@@ -29,15 +32,18 @@ Native Codex tasks are not written to this index. List refresh discovers them fr
 
 ## List Refresh
 
-The frontend drives task list refreshes through polling.
+Wework requests the task list on startup, explicit refresh, or device-state changes. It no longer refreshes the list through a fixed polling interval.
 
-1. Wework periodically requests `GET /api/runtime-work?client_origin=wework`.
-2. Backend reads the user's Projects and Device Workspace mappings.
-3. Backend calls `runtime.tasks.list` over the online device WebSocket RPC channel.
-4. The executor refreshes local Codex discovery and merges the non-Codex/imported JSON LocalTask index.
-5. Backend groups results by `deviceId + workspacePath` and returns Project -> Device Workspace -> LocalTask, while each LocalTask is still opened and notified by `deviceId + localTaskId`.
+1. Wework requests `GET /api/runtime-work`.
+2. Backend reads the current user's online devices and calls `runtime.tasks.list` over each device WebSocket RPC channel.
+3. The executor refreshes local Codex discovery and merges the non-Codex/imported JSON LocalTask index.
+4. The executor returns `workspaceKind`, workspace path, task title, update time, and device status.
+5. Backend performs light aggregation and returns the result to Wework without reading or matching the Backend `projects` table.
+6. Wework renders Projects and Conversations from the runtime work response, while each LocalTask is still opened and notified by `deviceId + localTaskId`.
 
 The executor does not poll or push task lists to Backend by itself. Offline devices do not contribute LocalTasks. Wework may show an offline mapped workspace, but it does not keep a central cache of local tasks.
+
+When there is only one device, Wework does not show an IP next to Project names. When there are multiple devices, the local device still omits the IP, while online remote devices show a usable non-loopback runtime transfer host or client IP with a green online dot.
 
 ## Open And Continue
 
@@ -110,9 +116,13 @@ When Wework forks a runtime task, it only offers target workspaces that belong t
 
 The forked task identity still uses `deviceId + localTaskId`. `workspacePath` is only target-directory and workspace-tool context.
 
-## Non-Project Workspaces
+## Projects And Conversations
 
-Directories discovered by an executor but not mapped to a central Project appear in Wework under "Unmapped Device Workspaces". They also come from online device `runtime.tasks.list` responses, not from central database tasks.
+Wework no longer shows "Unmapped Device Workspaces". Every thread returned by the executor must be grouped into either "Projects" or "Conversations":
+
+- Tasks with `workspaceKind: chat` are shown under "Conversations".
+- Other tasks are grouped as "Projects" by workspace name.
+- The "Conversations" section is always visible, even when empty, and supports the same collapse and expand interaction as "Projects".
 
 ## IM Notifications
 
@@ -136,4 +146,4 @@ The URL does not contain `workspacePath`. On refresh or shared links, the fronte
 
 ## Compatibility
 
-Wegent-native Task/Subtask flows remain available for existing chat, shared task, and historical task URL paths. Wework sidebar, mobile drawer, project task display, and new task creation use the runtime work API instead of the DB task list.
+Wegent-native Task/Subtask flows remain available for existing chat, shared task, and historical task URL paths. Wework sidebar, mobile drawer, project task display, and new task creation use the runtime work API instead of the DB task list or Backend `projects` table.

--- a/docs/zh/developer-guide/runtime-local-work.md
+++ b/docs/zh/developer-guide/runtime-local-work.md
@@ -4,20 +4,23 @@ sidebar_position: 16
 
 # 本地运行时任务
 
-Wework 的本地运行时任务用于展示和继续用户已经在设备上创建的 Codex 或 Claude Code 工作。它不再把这些工作导入中心库的 `TaskResource` 或 `Subtask`，而是按三层结构展示：
+Wework 的本地运行时任务用于展示和继续用户已经在设备上创建的 Codex 或 Claude Code 工作。它不再把这些工作导入中心库的 `TaskResource` 或 `Subtask`，也不再依赖 Backend `projects` 表生成侧栏列表。列表来自在线设备 executor 返回的运行时线程，并在前端展示为两类：
 
 ```text
 Project
-  Device Workspace
-    LocalTask
+  LocalTask
+
+Conversation
+  LocalTask
 ```
 
 ## 数据归属
 
-- Project 是中心状态，仍由 Backend 管理。
-- Device Workspace 是中心映射，表示某个用户、设备和本地目录属于哪个 Project。
+- Project 是 executor 线程所属工作区的展示分组，由运行时列表里的工作区信息推导。
+- Conversation 是没有项目归属的 Codex 对话线程展示分组。
 - LocalTask 是 executor 本机状态，只保存在设备上。
 - LocalTask 的稳定身份是 `deviceId + localTaskId`。`workspacePath` 只作为设备工作区上下文使用，用于列表分组、创建任务和右侧工具定位目录；任务 URL、IM 通知订阅和原生 Codex 更新去重都不把路径作为身份字段。
+- executor 返回的 `workspaceKind` 用于区分 Project 与 Conversation。Codex App 风格的目录（例如 `~/Documents/Codex/YYYY-MM-DD/<name>`）会被标记为 `chat` 并展示到“对话”，其他工作区展示到“项目”。
 
 executor 仍为非 Codex 或导入类本地任务保留 JSON LocalTask 索引：
 
@@ -29,15 +32,18 @@ $WEGENT_EXECUTOR_HOME/runtime-work/index.json
 
 ## 列表刷新
 
-任务列表由前端轮询触发。
+任务列表由 Wework 在启动、显式刷新或设备状态变化时请求，不再由固定 interval 轮询触发。
 
-1. Wework 定时请求 `GET /api/runtime-work?client_origin=wework`。
-2. Backend 读取当前用户的 Project 和 Device Workspace 映射。
-3. Backend 通过在线设备的 WebSocket RPC 调用 `runtime.tasks.list`。
-4. executor 刷新本机 Codex 发现结果，并合并非 Codex/导入类 JSON LocalTask 索引。
-5. Backend 按 `deviceId + workspacePath` 分组返回 Project -> Device Workspace -> LocalTask，但每个 LocalTask 的打开和通知身份仍是 `deviceId + localTaskId`。
+1. Wework 请求 `GET /api/runtime-work`。
+2. Backend 读取当前用户在线设备列表，并通过设备 WebSocket RPC 调用 `runtime.tasks.list`。
+3. executor 刷新本机 Codex 发现结果，并合并非 Codex/导入类 JSON LocalTask 索引。
+4. executor 在返回值中携带 `workspaceKind`、工作区路径、任务标题、更新时间和设备状态。
+5. Backend 做轻量聚合后返回给 Wework，不再读取或匹配 Backend `projects` 表。
+6. Wework 根据 runtime work 响应展示 Project 和 Conversation；每个 LocalTask 的打开和通知身份仍是 `deviceId + localTaskId`。
 
 executor 不主动向 Backend 轮询或推送任务列表。离线设备不会贡献 LocalTask；Wework 可以显示映射目录离线，但不会从中心库缓存本地任务。
+
+如果只有一个设备，Wework 不在项目名后显示设备 IP；如果有多个设备，本地设备不显示 IP，远端在线设备显示可用的非 loopback runtime transfer host 或客户端 IP，并配绿色在线点。
 
 ## 打开和继续任务
 
@@ -110,9 +116,13 @@ Project 场景必须使用可信的 Device Workspace 映射：
 
 复制任务的身份仍然使用 `deviceId + localTaskId`。`workspacePath` 只用于定位目标设备目录和工作区工具上下文。
 
-## 非 Project 工作区
+## Project 与 Conversation
 
-executor 发现但没有映射到中心 Project 的目录会在 Wework 的“未映射工作区”中显示。它们同样来自在线设备的 `runtime.tasks.list` 返回值，而不是中心数据库任务。
+Wework 不再显示“未映射工作区”。executor 返回的线程必须能归入“项目”或“对话”：
+
+- `workspaceKind: chat` 的任务展示在“对话”区。
+- 其他任务按工作区名称展示为“项目”。
+- “对话”区即使为空也始终显示，并且支持像“项目”区一样折叠和展开。
 
 ## IM 通知
 
@@ -136,4 +146,4 @@ URL 不包含 `workspacePath`。刷新页面或复制链接时，前端先用 UR
 
 ## 兼容性
 
-Wegent 原生 Task/Subtask 流程仍保留给现有聊天、共享任务和历史 task URL。Wework sidebar、移动端 drawer、项目下任务展示和新任务创建路径使用 runtime work API，不再依赖 DB task list。
+Wegent 原生 Task/Subtask 流程仍保留给现有聊天、共享任务和历史 task URL。Wework sidebar、移动端 drawer、项目下任务展示和新任务创建路径使用 runtime work API，不再依赖 DB task list 或 Backend `projects` 表。

--- a/executor/modes/local/websocket_client.py
+++ b/executor/modes/local/websocket_client.py
@@ -31,6 +31,7 @@ Example:
 
 import asyncio
 import hashlib
+import ipaddress
 import os
 import platform
 import re
@@ -70,6 +71,19 @@ def build_runtime_auth_file_report(
             "exists": codex_auth_path.is_file(),
         }
     }
+
+
+def _is_usable_device_ip(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value.strip())
+    except ValueError:
+        return False
+    return not (
+        address.is_loopback
+        or address.is_unspecified
+        or address.is_multicast
+        or address.is_link_local
+    )
 
 
 class WebSocketClient:
@@ -345,7 +359,7 @@ class WebSocketClient:
                 # Google's public DNS server (8.8.8.8)
                 s.connect(("8.8.8.8", 80))
                 ip = s.getsockname()[0]
-                if ip and ip != "127.0.0.1":
+                if ip and _is_usable_device_ip(ip):
                     return ip
         except Exception:
             logger.debug("Failed to detect IP via UDP socket", exc_info=True)
@@ -353,20 +367,31 @@ class WebSocketClient:
         try:
             # Method 2: Get hostname resolution
             ip = socket.gethostbyname(socket.gethostname())
-            if ip and ip != "127.0.0.1":
+            if ip and _is_usable_device_ip(ip):
                 return ip
         except Exception:
             logger.debug("Failed to detect IP via hostname resolution", exc_info=True)
 
         try:
-            # Method 3: Try to get IP from network interfaces (Linux only)
+            # Method 3: Enumerate hostname addresses, useful on macOS where
+            # gethostbyname may resolve to loopback only.
+            addresses = socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET)
+            for address in addresses:
+                ip = address[4][0]
+                if ip and _is_usable_device_ip(ip):
+                    return ip
+        except Exception:
+            logger.debug("Failed to detect IP via hostname addresses", exc_info=True)
+
+        try:
+            # Method 4: Try to get IP from network interfaces (Linux only)
             result = subprocess.run(
                 ["hostname", "-I"], capture_output=True, text=True, timeout=5
             )
             if result.returncode == 0:
                 ips = result.stdout.strip().split()
                 for ip in ips:
-                    if ip and not ip.startswith("127."):
+                    if ip and _is_usable_device_ip(ip):
                         return ip
         except Exception:
             logger.debug("Failed to detect IP via hostname -I", exc_info=True)

--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -7,6 +7,7 @@
 import contextlib
 import json
 import os
+import re
 from collections import deque
 from datetime import datetime, timezone
 from pathlib import Path
@@ -24,6 +25,7 @@ from shared.logger import setup_logger
 DEFAULT_CODEX_SESSION_LIMIT = 100
 CODEX_SESSION_RUNNING_TAIL_LINES = 200
 CODEX_TERMINAL_EVENT_TYPES = {"task_complete", "turn_aborted"}
+CODEX_CONVERSATION_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 logger = setup_logger("codex_session_discovery")
 
@@ -279,12 +281,31 @@ def _thread_to_local_task(thread: Any) -> Optional[LocalTaskRecord]:
         workspace_path=normalize_workspace_path(cwd),
         title=_thread_title(thread, thread_id),
         runtime="codex",
+        workspace_kind=_codex_thread_workspace_kind(cwd),
         runtime_handle=runtime_handle,
         created_at=created_at,
         updated_at=updated_at,
         running=_is_thread_running(thread)
         or _is_session_transcript_running(session_path),
         status="active",
+    )
+
+
+def _codex_thread_workspace_kind(cwd: str) -> str:
+    return "chat" if _is_codex_app_conversation_path(cwd) else "workspace"
+
+
+def _is_codex_app_conversation_path(cwd: str) -> bool:
+    try:
+        path = Path(cwd).expanduser().resolve(strict=False)
+        root = (Path.home() / "Documents" / "Codex").resolve(strict=False)
+        relative = path.relative_to(root)
+    except ValueError:
+        return False
+
+    parts = relative.parts
+    return len(parts) >= 2 and bool(
+        CODEX_CONVERSATION_DATE_PATTERN.fullmatch(parts[0])
     )
 
 

--- a/executor/runtime_work/local_task_store.py
+++ b/executor/runtime_work/local_task_store.py
@@ -33,6 +33,8 @@ class LocalTaskRecord:
     workspace_path: str
     title: str
     runtime: str
+    workspace_kind: str = "workspace"
+    worktree_id: Optional[str] = None
     runtime_handle: dict[str, Any] = field(default_factory=dict)
     parent: Optional[dict[str, Any]] = None
     children: list[dict[str, Any]] = field(default_factory=list)
@@ -64,6 +66,8 @@ class LocalTaskStore:
             workspace_path=workspace_path,
             title=task.title,
             runtime=task.runtime,
+            workspace_kind=task.workspace_kind or "workspace",
+            worktree_id=task.worktree_id,
             runtime_handle=task.runtime_handle,
             parent=task.parent,
             children=task.children,
@@ -153,6 +157,8 @@ class LocalTaskStore:
                 workspace_path=normalize_workspace_path(updated.workspace_path),
                 title=updated.title,
                 runtime=updated.runtime,
+                workspace_kind=updated.workspace_kind or current.workspace_kind or "workspace",
+                worktree_id=updated.worktree_id,
                 runtime_handle=updated.runtime_handle,
                 parent=updated.parent,
                 children=updated.children,
@@ -200,6 +206,8 @@ class LocalTaskStore:
             workspace_path=normalize_workspace_path(str(payload["workspace_path"])),
             title=str(payload["title"]),
             runtime=str(payload["runtime"]),
+            workspace_kind=str(payload.get("workspace_kind") or "workspace"),
+            worktree_id=self._optional_text_value(payload.get("worktree_id")),
             runtime_handle=self._dict_value(payload.get("runtime_handle")),
             parent=self._optional_dict_value(payload.get("parent")),
             children=self._list_value(payload.get("children")),
@@ -214,6 +222,9 @@ class LocalTaskStore:
 
     def _optional_dict_value(self, value: Any) -> Optional[dict[str, Any]]:
         return value if isinstance(value, dict) else None
+
+    def _optional_text_value(self, value: Any) -> Optional[str]:
+        return value if isinstance(value, str) and value.strip() else None
 
     def _list_value(self, value: Any) -> list[dict[str, Any]]:
         return value if isinstance(value, list) else []

--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -1327,6 +1327,8 @@ class RuntimeWorkRpcHandler:
             "workspacePath": task.workspace_path,
             "title": task.title,
             "runtime": task.runtime,
+            "workspaceKind": task.workspace_kind,
+            "worktreeId": task.worktree_id,
             "createdAt": task.created_at,
             "updatedAt": task.updated_at,
             "running": task.running,

--- a/executor/tests/test_local_websocket_client.py
+++ b/executor/tests/test_local_websocket_client.py
@@ -7,6 +7,7 @@ import pytest
 from executor.modes.local.websocket_client import (
     WebSocketClient,
     build_runtime_auth_file_report,
+    _is_usable_device_ip,
 )
 
 
@@ -25,6 +26,13 @@ def test_build_runtime_auth_file_report_reports_codex_auth_presence(tmp_path):
     (codex_dir / "auth.json").write_text('{"token":"secret"}', encoding="utf-8")
 
     assert build_runtime_auth_file_report(home=tmp_path)["codex"]["exists"] is True
+
+
+def test_usable_device_ip_rejects_loopback_and_accepts_non_loopback_address():
+    assert _is_usable_device_ip("192.0.2.10") is True
+    assert _is_usable_device_ip("192.168.1.8") is True
+    assert _is_usable_device_ip("127.0.0.1") is False
+    assert _is_usable_device_ip("localhost") is False
 
 
 def test_connected_accepts_namespace_connected_during_connect_callback():

--- a/frontend/src/apis/devices.ts
+++ b/frontend/src/apis/devices.ts
@@ -54,6 +54,8 @@ export interface DeviceInfo {
   executor_version: string | null
   latest_version: string | null
   update_available: boolean
+  client_ip?: string | null
+  runtime_transfer_host?: string | null
   // Cloud device specific config
   cloud_config?: CloudDeviceConfig
   // Shell binding type

--- a/wework/src/api/devices.test.ts
+++ b/wework/src/api/devices.test.ts
@@ -15,6 +15,8 @@ describe('createDeviceApi', () => {
             is_default: true,
             device_type: 'cloud',
             bind_shell: 'claudecode',
+            client_ip: '192.0.2.10',
+            runtime_transfer_host: '192.0.2.10:9000',
           },
           {
             id: 2,
@@ -33,7 +35,11 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi(client)
 
     await expect(api.listDevices()).resolves.toEqual([
-      expect.objectContaining({ device_id: 'claude-device' }),
+      expect.objectContaining({
+        device_id: 'claude-device',
+        client_ip: '192.0.2.10',
+        runtime_transfer_host: '192.0.2.10:9000',
+      }),
     ])
     await expect(api.getAllDevices()).resolves.toEqual([
       expect.objectContaining({ device_id: 'claude-device' }),
@@ -146,7 +152,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(api.listWorkspaceEntries('device-a', '/workspace/project')).rejects.toThrow(
-      'Invalid workspace tree response',
+      'Invalid workspace tree response'
     )
   })
 
@@ -162,7 +168,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(api.listWorkspaceEntries('device-a', '/workspace/project')).rejects.toThrow(
-      'Invalid workspace tree response',
+      'Invalid workspace tree response'
     )
   })
 
@@ -186,7 +192,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(api.listWorkspaceEntries('device-a', '/workspace/project')).rejects.toThrow(
-      'Invalid workspace tree response',
+      'Invalid workspace tree response'
     )
   })
 
@@ -195,7 +201,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(api.listWorkspaceEntries('device-a', 'workspace/project')).rejects.toThrow(
-      'Workspace path must be absolute',
+      'Workspace path must be absolute'
     )
     expect(post).not.toHaveBeenCalled()
   })
@@ -216,7 +222,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(
-      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts'),
+      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts')
     ).resolves.toMatchObject({
       path: '/workspace/project/src/main.ts',
       name: 'main.ts',
@@ -238,7 +244,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(api.readWorkspaceTextFile('device-a', 'src/main.ts')).rejects.toThrow(
-      'Workspace file path must be absolute',
+      'Workspace file path must be absolute'
     )
     expect(post).not.toHaveBeenCalled()
   })
@@ -259,7 +265,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(
-      api.readWorkspaceTextFile('device-a', '/workspace/project/src/../main.ts'),
+      api.readWorkspaceTextFile('device-a', '/workspace/project/src/../main.ts')
     ).resolves.toMatchObject({
       path: '/workspace/project/main.ts',
       name: 'main.ts',
@@ -289,7 +295,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(
-      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts'),
+      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts')
     ).rejects.toThrow('Invalid workspace text file response')
   })
 
@@ -309,7 +315,7 @@ describe('createDeviceApi', () => {
     const api = createDeviceApi({ post } as never)
 
     await expect(
-      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts'),
+      api.readWorkspaceTextFile('device-a', '/workspace/project/src/main.ts')
     ).rejects.toThrow('Invalid workspace text file response')
   })
 })

--- a/wework/src/api/runtimeWork.test.ts
+++ b/wework/src/api/runtimeWork.test.ts
@@ -3,6 +3,23 @@ import { createRuntimeWorkApi } from './runtimeWork'
 import type { HttpClient } from './http'
 
 describe('createRuntimeWorkApi', () => {
+  test('lists runtime work without client origin query', async () => {
+    const get = vi.fn().mockResolvedValue({
+      projects: [],
+      unmappedDeviceWorkspaces: [],
+      totalLocalTasks: 0,
+    })
+    const api = createRuntimeWorkApi({ get } as unknown as HttpClient)
+
+    await expect(api.listRuntimeWork()).resolves.toEqual({
+      projects: [],
+      unmappedDeviceWorkspaces: [],
+      totalLocalTasks: 0,
+    })
+
+    expect(get).toHaveBeenCalledWith('/runtime-work')
+  })
+
   test('deletes a device workspace mapping', async () => {
     const del = vi.fn().mockResolvedValue({ deleted: true })
     const api = createRuntimeWorkApi({ delete: del } as unknown as HttpClient)

--- a/wework/src/api/runtimeWork.ts
+++ b/wework/src/api/runtimeWork.ts
@@ -24,17 +24,10 @@ import type {
 } from '@/types/api'
 import type { HttpClient } from './http'
 
-const WEWORK_CLIENT_ORIGIN = 'wework'
-
-function withClientOrigin(path: string): string {
-  const separator = path.includes('?') ? '&' : '?'
-  return `${path}${separator}client_origin=${WEWORK_CLIENT_ORIGIN}`
-}
-
 export function createRuntimeWorkApi(client: HttpClient) {
   return {
     listRuntimeWork(): Promise<RuntimeWorkListResponse> {
-      return client.get(withClientOrigin('/runtime-work'))
+      return client.get('/runtime-work')
     },
     upsertDeviceWorkspace(data: DeviceWorkspaceUpsert): Promise<DeviceWorkspaceResponse> {
       return client.post('/runtime-work/device-workspaces', data)

--- a/wework/src/components/chat/composer/ProjectWorkBar.tsx
+++ b/wework/src/components/chat/composer/ProjectWorkBar.tsx
@@ -367,8 +367,8 @@ export function ProjectWorkBar({
 
   const handleSelectDeviceWorkspace = useCallback(
     (projectId: number, workspace: RuntimeDeviceWorkspace) => {
-      if (!isSelectableProjectWorkspace(workspace, devices) || !workspace.id) return
-      onSelectProjectWorkspace?.(projectId, workspace.id)
+      if (!isSelectableProjectWorkspace(workspace, devices)) return
+      onSelectProjectWorkspace?.(projectId, workspace.id ?? null)
       closeMenu()
     },
     [closeMenu, devices, onSelectProjectWorkspace]
@@ -723,7 +723,7 @@ export function ProjectWorkBar({
                               <button
                                 key={`${workspace.deviceId}:${workspace.workspacePath}`}
                                 type="button"
-                                data-testid={`project-workspace-option-${workspace.id}`}
+                                data-testid={`project-workspace-option-${workspace.id ?? workspace.deviceId}`}
                                 disabled={!selectable}
                                 onClick={() => handleSelectDeviceWorkspace(project.id, workspace)}
                                 className={cn(

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -78,17 +78,7 @@ describe('DesktopSidebar', () => {
     localStorage.clear()
   })
 
-  test('opens add device settings from the sidebar device section', async () => {
-    const props = renderSidebar()
-
-    await userEvent.click(screen.getByTestId('sidebar-add-device-button'))
-
-    expect(props.onOpenSettings).toHaveBeenCalledWith({
-      autoOpenAddCloudDeviceDialog: true,
-    })
-  })
-
-  test('renders unmapped device runtime tasks without local Codex import UI', async () => {
+  test('does not render unmapped runtime workspace groups', async () => {
     const onOpenRuntimeLocalTask = vi.fn()
 
     renderSidebar({
@@ -117,22 +107,27 @@ describe('DesktopSidebar', () => {
       onOpenRuntimeLocalTask,
     })
 
-    expect(screen.getByTestId('runtime-workspace-row-/tmp/spike')).toHaveTextContent(
-      'Local Mac /tmp/spike'
+    expect(screen.queryByTestId('unmapped-runtime-section')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('runtime-workspace-row-/tmp/spike')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('runtime-local-task-row-claude-1')).not.toBeInTheDocument()
+    expect(screen.getByTestId('runtime-chat-section')).toHaveTextContent('对话')
+    expect(screen.getByTestId('runtime-chat-section-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true'
     )
-    expect(screen.getByTestId('runtime-local-task-row-claude-1')).toHaveTextContent(
-      'Spike runtime task'
+    expect(screen.getByTestId('runtime-chat-empty')).toHaveTextContent('暂无会话')
+
+    await userEvent.click(screen.getByTestId('runtime-chat-section-toggle'))
+
+    expect(screen.getByTestId('runtime-chat-section-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false'
     )
-
-    await userEvent.click(screen.getByTestId('runtime-local-task-row-claude-1'))
-
-    expect(onOpenRuntimeLocalTask).toHaveBeenCalledWith({
-      deviceId: 'local-device',
-      localTaskId: 'claude-1',
-    })
+    expect(screen.queryByTestId('runtime-chat-empty')).not.toBeInTheDocument()
+    expect(onOpenRuntimeLocalTask).not.toHaveBeenCalled()
   })
 
-  test('renders unmapped chat runtime tasks as conversations instead of workspace groups', async () => {
+  test('renders chat runtime tasks as conversations instead of workspace groups', async () => {
     const onOpenRuntimeLocalTask = vi.fn()
     const chatPath = '/Users/alice/.wecode/wegent-executor/workspace/chats/2026-06-20/hi-1'
 
@@ -180,14 +175,22 @@ describe('DesktopSidebar', () => {
     })
 
     expect(screen.getByTestId('runtime-chat-section')).toHaveTextContent('对话')
+    expect(screen.getByTestId('runtime-chat-section-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
     expect(screen.queryByTestId(`runtime-workspace-row-${chatPath}`)).not.toBeInTheDocument()
     expect(screen.getByTestId('runtime-local-task-row-chat-1')).toHaveTextContent('hi')
     expect(screen.queryByTestId('runtime-local-task-device-marker-chat-1')).not.toBeInTheDocument()
     expect(screen.queryByTestId('runtime-local-task-device-icon-chat-1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('runtime-workspace-row-/tmp/spike')).toHaveTextContent(
-      'Local Mac /tmp/spike'
-    )
+    expect(screen.queryByTestId('runtime-workspace-row-/tmp/spike')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('runtime-local-task-row-workspace-1')).not.toBeInTheDocument()
 
+    await userEvent.click(screen.getByTestId('runtime-chat-section-toggle'))
+
+    expect(screen.queryByTestId('runtime-local-task-row-chat-1')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('runtime-chat-section-toggle'))
     await userEvent.click(screen.getByTestId('runtime-local-task-row-chat-1'))
 
     expect(onOpenRuntimeLocalTask).toHaveBeenCalledWith({
@@ -301,7 +304,7 @@ describe('DesktopSidebar', () => {
     expect(screen.queryByTestId('runtime-local-task-running-codex-idle')).not.toBeInTheDocument()
   })
 
-  test('shows online device colors and marks runtime tasks by device', async () => {
+  test('does not render online devices section and keeps all runtime tasks visible', async () => {
     renderSidebar({
       devices: [
         localDevice(),
@@ -366,77 +369,18 @@ describe('DesktopSidebar', () => {
       },
     })
 
-    expect(screen.getByTestId('sidebar-online-devices')).toHaveTextContent('在线设备2')
-    expect(screen.getByTestId('sidebar-devices-section-toggle')).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    )
-    expect(screen.getByTestId('sidebar-offline-devices-toggle').parentElement).toBe(
-      screen.getByTestId('sidebar-devices-header')
-    )
-    expect(screen.getByTestId('sidebar-offline-devices-toggle')).toHaveTextContent('离线 1')
-    expect(screen.queryByTestId('sidebar-online-device-local-device')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('sidebar-online-device-offline-device')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sidebar-online-devices')).not.toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
+    expect(screen.getByTestId('runtime-local-task-row-local-task')).toBeInTheDocument()
+    expect(screen.getByTestId('runtime-local-task-row-cloud-task')).toBeInTheDocument()
     expect(
       screen.queryByTestId('runtime-local-task-device-marker-local-task')
     ).not.toBeInTheDocument()
     expect(
       screen.queryByTestId('runtime-local-task-device-marker-cloud-task')
     ).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('sidebar-devices-section-toggle'))
-
-    expect(screen.getByTestId('sidebar-devices-section-toggle')).toHaveAttribute(
-      'aria-expanded',
-      'true'
-    )
-    expect(screen.getByTestId('sidebar-online-device-local-device')).toHaveTextContent('Local Mac')
-    expect(screen.getByTestId('sidebar-online-device-cloud-device')).toHaveTextContent('Cloud Box')
-
-    const localLegendColor = screen.getByTestId('sidebar-online-device-color-local-device')
-    const cloudLegendColor = screen.getByTestId('sidebar-online-device-color-cloud-device')
-    const localTaskMarker = screen.getByTestId('runtime-local-task-device-marker-local-task')
-    const cloudTaskMarker = screen.getByTestId('runtime-local-task-device-marker-cloud-task')
-
-    expect(localTaskMarker).toHaveAttribute('title', 'Local Mac /repo/Wegent')
-    expect(cloudTaskMarker).toHaveAttribute('title', 'Cloud Box /repo/Wegent')
-    expect(localTaskMarker.style.backgroundColor).toBe(localLegendColor.style.backgroundColor)
-    expect(cloudTaskMarker.style.backgroundColor).toBe(cloudLegendColor.style.backgroundColor)
-
-    await userEvent.click(screen.getByTestId('sidebar-online-device-local-device'))
-
-    expect(screen.getByTestId('sidebar-online-device-local-device')).toHaveAttribute(
-      'aria-pressed',
-      'true'
-    )
-    expect(screen.getByTestId('runtime-local-task-row-local-task')).toBeInTheDocument()
-    expect(screen.queryByTestId('runtime-local-task-row-cloud-task')).not.toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('sidebar-online-device-local-device'))
-
-    expect(screen.getByTestId('runtime-local-task-row-cloud-task')).toBeInTheDocument()
-
-    await userEvent.click(screen.getByTestId('sidebar-offline-devices-toggle'))
-
-    expect(screen.getByTestId('sidebar-online-device-offline-device')).toHaveTextContent(
-      'Offline Box'
-    )
-    expect(screen.getByTestId('sidebar-offline-devices-toggle')).toHaveTextContent('收起离线')
-
-    await userEvent.click(screen.getByTestId('sidebar-devices-section-toggle'))
-
-    expect(screen.getByTestId('sidebar-devices-section-toggle')).toHaveAttribute(
-      'aria-expanded',
-      'false'
-    )
-    expect(screen.queryByTestId('sidebar-online-device-local-device')).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId('runtime-local-task-device-marker-local-task')
-    ).not.toBeInTheDocument()
-    expect(screen.getByTestId('sidebar-offline-devices-toggle')).toBeInTheDocument()
   })
 
   test('shows hover actions to mark and archive project runtime tasks', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -3,7 +3,6 @@ import {
   Bell,
   ChevronRight,
   Edit3,
-  Folder,
   FolderPlus,
   GitCompareArrows,
   Loader2,
@@ -48,17 +47,14 @@ import { DesktopTopBar } from './DesktopTopBar'
 import { DesktopWindowControls } from './DesktopWindowControls'
 import {
   getRuntimeChatSidebarTaskItems,
-  getRuntimeDirectoryWorkspaces,
   getRuntimeTaskAddress,
   getRuntimeTaskTime,
   getRuntimeTaskWorkspaceTitle,
   getRuntimeSidebarTaskItems,
-  getRuntimeWorkspaceLabel,
   getVisibleRuntimeSidebarTaskItems,
   hasHiddenRuntimeSidebarTaskItems,
   isRuntimeTaskSelected,
   isRuntimeWorktreeTask,
-  sortRuntimeTasks,
 } from './runtimeTaskSidebarHelpers'
 import { useResizableSidebar } from './useResizableSidebar'
 
@@ -307,6 +303,16 @@ interface SidebarDeviceState {
   status: SidebarDeviceStatus
 }
 
+function runtimeProjectToProject(projectWork: RuntimeProjectWork): ProjectWithTasks {
+  return {
+    id: projectWork.project.id,
+    name: projectWork.project.name,
+    description: projectWork.project.description,
+    color: projectWork.project.color,
+    tasks: [],
+  }
+}
+
 function getProjectDeviceId(project: ProjectWithTasks): string | undefined {
   return project.config?.execution?.deviceId ?? project.config?.device_id
 }
@@ -333,12 +339,58 @@ function getSidebarDeviceName(deviceState: SidebarDeviceState): string {
   return deviceState.device?.name || deviceState.deviceId
 }
 
-function getRuntimeWorkspaceDeviceColor(workspace: RuntimeDeviceWorkspace): string {
-  return getSidebarDeviceColor(getSidebarDeviceColorKey(workspace.deviceName, workspace.deviceId))
+function getDeviceNetworkLabel(device?: DeviceInfo): string | null {
+  const runtimeTransferHost = getDisplayableNetworkHost(device?.runtime_transfer_host)
+  if (runtimeTransferHost) return runtimeTransferHost
+  return getDisplayableNetworkHost(device?.client_ip)
 }
 
-function getRuntimeWorkspaceTaskCount(workspaces: RuntimeDeviceWorkspace[]): number {
-  return workspaces.reduce((count, workspace) => count + workspace.localTasks.length, 0)
+function getDisplayableNetworkHost(value?: string | null): string | null {
+  if (!value) return null
+  const host = extractNetworkHost(value.trim())
+  if (!host || isLoopbackNetworkHost(host)) return null
+  return host
+}
+
+function extractNetworkHost(value: string): string {
+  const bracketMatch = value.match(/^\[([^\]]+)\](?::\d+)?$/)
+  if (bracketMatch?.[1]) return bracketMatch[1]
+  const colonParts = value.split(':')
+  if (colonParts.length === 2 && /^\d+$/.test(colonParts[1])) {
+    return colonParts[0]
+  }
+  return value
+}
+
+function isLoopbackNetworkHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase()
+  return normalized === 'localhost' || normalized === '::1' || normalized.startsWith('127.')
+}
+
+function getRuntimeProjectDeviceState(
+  runtimeProjectWork: RuntimeProjectWork | undefined,
+  devices: DeviceInfo[]
+): SidebarDeviceState | null {
+  const workspace = runtimeProjectWork?.deviceWorkspaces[0]
+  if (!workspace) return null
+  const device = devices.find(item => item.device_id === workspace.deviceId)
+  return {
+    deviceId: workspace.deviceId,
+    device,
+    status: (device?.status ?? workspace.deviceStatus ?? 'unavailable') as SidebarDeviceStatus,
+  }
+}
+
+function shouldShowProjectDeviceStatus(
+  deviceState: SidebarDeviceState | null,
+  devices: DeviceInfo[]
+): deviceState is SidebarDeviceState {
+  if (!deviceState || devices.length <= 1) return false
+  return deviceState.device?.device_type !== 'local'
+}
+
+function getRuntimeWorkspaceDeviceColor(workspace: RuntimeDeviceWorkspace): string {
+  return getSidebarDeviceColor(getSidebarDeviceColorKey(workspace.deviceName, workspace.deviceId))
 }
 
 function getProjectDeviceWorkspaces(
@@ -361,180 +413,6 @@ function getProjectDeviceWorkspaces(
       createdAt: '',
       updatedAt: '',
     })) ?? []
-  )
-}
-
-function filterRuntimeWorkspacesByDevice(
-  workspaces: RuntimeDeviceWorkspace[],
-  deviceId: string | null
-): RuntimeDeviceWorkspace[] {
-  if (!deviceId) return workspaces
-  return workspaces.filter(workspace => workspace.deviceId === deviceId)
-}
-
-function filterRuntimeProjectWorkByDevice(
-  projectWork: RuntimeProjectWork,
-  deviceId: string | null
-): RuntimeProjectWork {
-  if (!deviceId) return projectWork
-
-  const deviceWorkspaces = filterRuntimeWorkspacesByDevice(projectWork.deviceWorkspaces, deviceId)
-  return {
-    ...projectWork,
-    deviceWorkspaces,
-    totalLocalTasks: getRuntimeWorkspaceTaskCount(deviceWorkspaces),
-  }
-}
-
-function SidebarOnlineDevices({
-  devices,
-  expanded,
-  offlineExpanded,
-  selectedDeviceId,
-  onToggleExpanded,
-  onToggleOfflineExpanded,
-  onSelectDevice,
-  onAddDevice,
-}: {
-  devices: DeviceInfo[]
-  expanded: boolean
-  offlineExpanded: boolean
-  selectedDeviceId: string | null
-  onToggleExpanded: () => void
-  onToggleOfflineExpanded: () => void
-  onSelectDevice: (deviceId: string) => void
-  onAddDevice: () => void
-}) {
-  const { t } = useTranslation('common')
-  const onlineDevices = useMemo(
-    () => devices.filter(device => device.status === 'online'),
-    [devices]
-  )
-  const offlineDevices = useMemo(
-    () => devices.filter(device => device.status !== 'online'),
-    [devices]
-  )
-  const selectedDevice = devices.find(device => device.device_id === selectedDeviceId) ?? null
-  const selectedOfflineDevice =
-    selectedDevice && selectedDevice.status !== 'online' ? selectedDevice : null
-  const visibleOfflineDevices = offlineExpanded
-    ? offlineDevices
-    : selectedOfflineDevice
-      ? [selectedOfflineDevice]
-      : []
-  const visibleDevices = [...onlineDevices, ...visibleOfflineDevices]
-
-  return (
-    <section data-testid="sidebar-online-devices" className="mb-6 px-2.5">
-      <div
-        data-testid="sidebar-devices-header"
-        className="mb-1.5 flex h-5 items-center justify-between gap-2"
-      >
-        <button
-          type="button"
-          data-testid="sidebar-devices-section-toggle"
-          aria-expanded={expanded}
-          onClick={onToggleExpanded}
-          className="flex min-w-0 flex-1 items-center gap-1 rounded-sm text-left text-[12px] font-semibold leading-4 text-[rgb(var(--color-sidebar-text-muted))] hover:text-[rgb(var(--color-sidebar-text-secondary))]"
-        >
-          <ChevronRight
-            className={cn(
-              'h-3.5 w-3.5 shrink-0 transition-transform',
-              expanded ? 'rotate-90' : 'rotate-0'
-            )}
-          />
-          <span className="shrink-0">{t('workbench.online_devices', '在线设备')}</span>
-          <span className="shrink-0 text-[11px] font-medium text-[rgb(var(--color-sidebar-text-secondary))]">
-            {onlineDevices.length}
-          </span>
-          {selectedDevice && (
-            <span className="min-w-0 truncate text-[11px] font-medium text-[rgb(var(--color-sidebar-text-secondary))]">
-              {selectedDevice.name || selectedDevice.device_id}
-            </span>
-          )}
-        </button>
-        {offlineDevices.length > 0 && (
-          <button
-            type="button"
-            data-testid="sidebar-offline-devices-toggle"
-            onClick={() => {
-              if (!offlineExpanded && !expanded) {
-                onToggleExpanded()
-              }
-              onToggleOfflineExpanded()
-            }}
-            className="h-5 shrink-0 rounded-sm px-1 text-[11px] font-medium leading-4 text-[rgb(var(--color-sidebar-text-muted))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-secondary))]"
-          >
-            {offlineExpanded
-              ? t('workbench.hide_offline_devices', '收起离线')
-              : t('workbench.show_offline_devices', {
-                  count: offlineDevices.length,
-                  defaultValue: '离线 {{count}}',
-                })}
-          </button>
-        )}
-        <button
-          type="button"
-          data-testid="sidebar-add-device-button"
-          aria-label={t('workbench.add_device')}
-          title={t('workbench.add_device')}
-          onClick={onAddDevice}
-          className="flex h-5 w-5 shrink-0 items-center justify-center rounded-sm text-[rgb(var(--color-sidebar-text-muted))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-secondary))]"
-        >
-          <Plus className="h-3.5 w-3.5" />
-        </button>
-      </div>
-      {expanded && (
-        <div data-testid="sidebar-device-list" className="space-y-0.5">
-          {visibleDevices.map(device => {
-            const deviceName = device.name || device.device_id
-            const color = getSidebarDeviceColor(
-              getSidebarDeviceColorKey(device.name, device.device_id)
-            )
-            const selected = selectedDeviceId === device.device_id
-            const deviceState: SidebarDeviceState = {
-              deviceId: device.device_id,
-              device,
-              status: device.status,
-            }
-
-            return (
-              <button
-                type="button"
-                key={device.device_id}
-                data-testid={`sidebar-online-device-${device.device_id}`}
-                aria-pressed={selected}
-                onClick={() => onSelectDevice(device.device_id)}
-                title={deviceName}
-                className={cn(
-                  'flex h-5 w-full min-w-0 items-center gap-2 rounded-sm text-left text-[12px] leading-4 hover:text-[rgb(var(--color-sidebar-text-primary))]',
-                  selected
-                    ? 'font-semibold text-[rgb(var(--color-sidebar-text-primary))]'
-                    : 'font-medium text-[rgb(var(--color-sidebar-text-secondary))]',
-                  device.status !== 'online' && 'opacity-70'
-                )}
-              >
-                <span
-                  data-testid={`sidebar-online-device-color-${device.device_id}`}
-                  aria-hidden="true"
-                  className={cn(
-                    'h-2 w-2 shrink-0 rounded-full opacity-90',
-                    selected && 'h-2.5 w-2.5'
-                  )}
-                  style={{ backgroundColor: color }}
-                />
-                <span className="min-w-0 truncate">{deviceName}</span>
-                <SidebarDeviceStatusIndicator
-                  deviceState={deviceState}
-                  testId={`sidebar-device-status-${device.device_id}`}
-                  className="ml-auto"
-                />
-              </button>
-            )
-          })}
-        </div>
-      )}
-    </section>
   )
 }
 
@@ -601,7 +479,7 @@ function formatSidebarTemplate(template: string, values: Record<string, string>)
   )
 }
 
-function SidebarDeviceStatusIndicator({
+function ProjectDeviceInlineStatus({
   deviceState,
   testId,
   className,
@@ -610,27 +488,29 @@ function SidebarDeviceStatusIndicator({
   testId: string
   className?: string
 }) {
-  const { t } = useTranslation('common')
-  if (deviceState.status === 'online') return null
-
-  const label = getSidebarDeviceStatusLabel(t, deviceState.status)
-  const deviceName = getSidebarDeviceName(deviceState)
-  const title = formatSidebarTemplate(
-    t('workbench.project_device_status_title', '{{device}} · {{status}}'),
-    { device: deviceName, status: label }
-  )
+  const label = getDeviceNetworkLabel(deviceState.device) || deviceState.deviceId
+  const online = deviceState.status === 'online'
 
   return (
     <span
       data-testid={testId}
-      title={title}
-      aria-label={title}
+      title={label}
+      aria-label={label}
       className={cn(
-        'inline-flex h-5 shrink-0 items-center rounded-full text-[11px] leading-4 text-[rgb(var(--color-sidebar-text-muted))]',
+        'ml-auto flex min-w-0 shrink-0 items-center gap-2 text-[13px] leading-[18px] text-[rgb(var(--color-sidebar-text-muted))]',
         className
       )}
     >
-      <span className="shrink-0">{label}</span>
+      <span className="max-w-[96px] truncate">{label}</span>
+      <span
+        data-testid={`${testId}-dot`}
+        aria-hidden="true"
+        className={cn(
+          'h-2 w-2 shrink-0 rounded-full',
+          !online && 'bg-[rgb(var(--color-sidebar-text-muted))] opacity-55'
+        )}
+        style={online ? { backgroundColor: '#1FD660' } : undefined}
+      />
     </span>
   )
 }
@@ -860,85 +740,6 @@ function RuntimeLocalTaskRow({
   )
 }
 
-function RuntimeWorkspaceGroup({
-  workspace,
-  currentRuntimeTask,
-  imNotificationSettings,
-  showDeviceMarker,
-  onOpenRuntimeLocalTask,
-  onArchiveRuntimeLocalTask,
-  onToggleRuntimeTaskNotification,
-}: {
-  workspace: RuntimeDeviceWorkspace
-  currentRuntimeTask?: RuntimeTaskAddress | null
-  imNotificationSettings?: RuntimeIMNotificationSettingsResponse | null
-  showDeviceMarker: boolean
-  onOpenRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void> | void
-  onArchiveRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void> | void
-  onToggleRuntimeTaskNotification?: (
-    address: RuntimeTaskAddress,
-    subscribed: boolean
-  ) => Promise<void> | void
-}) {
-  const { t } = useTranslation('common')
-  const sortedTasks = useMemo(() => sortRuntimeTasks(workspace.localTasks), [workspace.localTasks])
-  const deviceState: SidebarDeviceState = {
-    deviceId: workspace.deviceId,
-    status: workspace.available
-      ? (workspace.deviceStatus as SidebarDeviceStatus) || 'online'
-      : 'unavailable',
-  }
-  const title = `${workspace.deviceName || workspace.deviceId} · ${workspace.workspacePath}`
-
-  return (
-    <div
-      data-testid={`runtime-workspace-row-${workspace.id ?? workspace.workspacePath}`}
-      className="space-y-0.5"
-    >
-      <div
-        className={cn(
-          'flex h-8 min-w-0 items-center rounded-md pl-9 pr-2 text-[13px] leading-[18px]',
-          workspace.available
-            ? 'text-[rgb(var(--color-sidebar-text-secondary))]'
-            : 'text-[rgb(var(--color-sidebar-text-muted))] opacity-70'
-        )}
-        title={title}
-      >
-        <Folder className="mr-2 h-3.5 w-3.5 shrink-0 text-[rgb(var(--color-sidebar-text-secondary))]" />
-        <span className="min-w-0 flex-1 truncate">{getRuntimeWorkspaceLabel(workspace)}</span>
-        {!workspace.available && (
-          <SidebarDeviceStatusIndicator
-            deviceState={deviceState}
-            testId={`runtime-workspace-device-status-${workspace.id ?? workspace.deviceId}`}
-          />
-        )}
-      </div>
-      {sortedTasks.length === 0 ? (
-        <div
-          data-testid={`runtime-workspace-empty-${workspace.id ?? workspace.workspacePath}`}
-          className="ml-14 rounded-md px-2 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]"
-        >
-          {t('workbench.no_chats', '暂无会话')}
-        </div>
-      ) : (
-        sortedTasks.map(task => (
-          <RuntimeLocalTaskRow
-            key={task.localTaskId}
-            workspace={workspace}
-            task={task}
-            selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
-            imNotificationSettings={imNotificationSettings}
-            showDeviceMarker={showDeviceMarker}
-            onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
-            onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
-            onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
-          />
-        ))
-      )}
-    </div>
-  )
-}
-
 function ProjectItem({
   project,
   expanded,
@@ -946,6 +747,7 @@ function ProjectItem({
   onSelectProject,
   devices,
   runtimeProjectWork,
+  runtimeOnlyProject,
   currentRuntimeTask,
   imNotificationSettings,
   showDeviceMarker,
@@ -963,6 +765,7 @@ function ProjectItem({
   onSelectProject: (projectId: number) => void
   devices: DeviceInfo[]
   runtimeProjectWork?: RuntimeProjectWork
+  runtimeOnlyProject: boolean
   currentRuntimeTask?: RuntimeTaskAddress | null
   imNotificationSettings?: RuntimeIMNotificationSettingsResponse | null
   showDeviceMarker: boolean
@@ -989,7 +792,10 @@ function ProjectItem({
     [runtimeTaskItems, runtimeTasksExpanded]
   )
   const hasHiddenRuntimeTasks = hasHiddenRuntimeSidebarTaskItems(runtimeTaskItems)
-  const projectDeviceState = getSidebarDeviceState(getProjectDeviceId(project), devices)
+  const projectDeviceState =
+    getRuntimeProjectDeviceState(runtimeProjectWork, devices) ??
+    getSidebarDeviceState(getProjectDeviceId(project), devices)
+  const showProjectDeviceStatus = shouldShowProjectDeviceStatus(projectDeviceState, devices)
   const canStartProjectChat = isSidebarDeviceOnline(projectDeviceState)
   const newProjectChatTitle =
     projectDeviceState && !canStartProjectChat
@@ -1019,56 +825,58 @@ function ProjectItem({
           <span className="min-w-0 flex-1 truncate" title={project.name}>
             {project.name}
           </span>
-          {projectDeviceState && (
-            <SidebarDeviceStatusIndicator
+          {showProjectDeviceStatus && (
+            <ProjectDeviceInlineStatus
               deviceState={projectDeviceState}
               testId={`project-device-status-${project.id}`}
               className="ml-auto justify-end text-right group-hover/project:invisible group-focus-within/project:invisible"
             />
           )}
         </button>
-        <div className="absolute right-1 invisible flex shrink-0 items-center opacity-0 transition-opacity group-hover/project:visible group-hover/project:opacity-100 focus-within:visible focus-within:opacity-100">
-          <ActionMenu
-            ariaLabel={t('workbench.project_actions', '项目操作')}
-            testId={`project-menu-${project.id}`}
-            items={[
-              {
-                label: t('workbench.edit_project', '编辑项目'),
-                icon: Settings,
-                testId: `edit-project-${project.id}`,
-                onSelect: () => onEditProject(project),
-              },
-              {
-                label: t('workbench.rename_project', '重命名项目'),
-                icon: Edit3,
-                testId: `rename-project-${project.id}`,
-                onSelect: () => onRenameProject(project),
-              },
-              {
-                label: t('workbench.remove_project', '移除'),
-                icon: X,
-                testId: `remove-project-${project.id}`,
-                danger: true,
-                onSelect: () => onRemoveProject(project.id),
-              },
-            ]}
-          />
-          <button
-            type="button"
-            data-testid="project-new-conversation-button"
-            disabled={!canStartProjectChat}
-            onClick={event => {
-              event.stopPropagation()
-              if (!canStartProjectChat) return
-              onStartNewProjectChat(project.id)
-            }}
-            className="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-[rgb(var(--color-sidebar-text-secondary))]"
-            title={newProjectChatTitle}
-            aria-label={newProjectChatTitle}
-          >
-            <MessageSquarePlus className="h-4 w-4" />
-          </button>
-        </div>
+        {!runtimeOnlyProject && (
+          <div className="absolute right-1 invisible flex shrink-0 items-center opacity-0 transition-opacity group-hover/project:visible group-hover/project:opacity-100 focus-within:visible focus-within:opacity-100">
+            <ActionMenu
+              ariaLabel={t('workbench.project_actions', '项目操作')}
+              testId={`project-menu-${project.id}`}
+              items={[
+                {
+                  label: t('workbench.edit_project', '编辑项目'),
+                  icon: Settings,
+                  testId: `edit-project-${project.id}`,
+                  onSelect: () => onEditProject(project),
+                },
+                {
+                  label: t('workbench.rename_project', '重命名项目'),
+                  icon: Edit3,
+                  testId: `rename-project-${project.id}`,
+                  onSelect: () => onRenameProject(project),
+                },
+                {
+                  label: t('workbench.remove_project', '移除'),
+                  icon: X,
+                  testId: `remove-project-${project.id}`,
+                  danger: true,
+                  onSelect: () => onRemoveProject(project.id),
+                },
+              ]}
+            />
+            <button
+              type="button"
+              data-testid="project-new-conversation-button"
+              disabled={!canStartProjectChat}
+              onClick={event => {
+                event.stopPropagation()
+                if (!canStartProjectChat) return
+                onStartNewProjectChat(project.id)
+              }}
+              className="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))] disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:bg-transparent disabled:hover:text-[rgb(var(--color-sidebar-text-secondary))]"
+              title={newProjectChatTitle}
+              aria-label={newProjectChatTitle}
+            >
+              <MessageSquarePlus className="h-4 w-4" />
+            </button>
+          </div>
+        )}
       </div>
       {expanded && (
         <div className="space-y-0.5">
@@ -1163,10 +971,7 @@ export function DesktopSidebar({
 
   const storageScope = getDesktopSidebarStorageScope(user)
   const projectsExpandedStorageKey = getDesktopSidebarStorageKey(storageScope, 'projectsExpanded')
-  const unmappedExpandedStorageKey = getDesktopSidebarStorageKey(
-    storageScope,
-    'unmappedRuntimeExpanded'
-  )
+  const chatsExpandedStorageKey = getDesktopSidebarStorageKey(storageScope, 'chatsExpanded')
   const expandedProjectIdsStorageKey = getDesktopSidebarStorageKey(
     storageScope,
     'expandedProjectIds'
@@ -1181,41 +986,32 @@ export function DesktopSidebar({
   const [projectsExpanded, setProjectsExpanded] = useState(() =>
     readStoredBoolean(projectsExpandedStorageKey, true)
   )
-  const [unmappedExpanded, setUnmappedExpanded] = useState(() =>
-    readStoredBoolean(unmappedExpandedStorageKey, true)
+  const [chatsExpanded, setChatsExpanded] = useState(() =>
+    readStoredBoolean(chatsExpandedStorageKey, true)
   )
   const [expandedProjectIds, setExpandedProjectIds] = useState<Set<number>>(() =>
     readStoredNumberSet(expandedProjectIdsStorageKey)
   )
-  const [devicesExpanded, setDevicesExpanded] = useState(false)
-  const [offlineDevicesExpanded, setOfflineDevicesExpanded] = useState(false)
-  const [selectedDeviceFilterId, setSelectedDeviceFilterId] = useState<string | null>(null)
-  const activeDeviceFilterId =
-    selectedDeviceFilterId && devices.some(device => device.device_id === selectedDeviceFilterId)
-      ? selectedDeviceFilterId
-      : null
-  const visibleExpandedProjectIds = useMemo(
-    () => pruneProjectIdSet(expandedProjectIds, projects),
-    [expandedProjectIds, projects]
-  )
   const filteredRuntimeProjects = useMemo(() => {
     const items = runtimeWork?.projects ?? []
-    return items.map(item => filterRuntimeProjectWorkByDevice(item, activeDeviceFilterId))
-  }, [runtimeWork?.projects, activeDeviceFilterId])
+    return items
+  }, [runtimeWork?.projects])
+  const sidebarProjects = useMemo(() => {
+    if (runtimeWork) {
+      return filteredRuntimeProjects.map(runtimeProjectToProject)
+    }
+    return projects
+  }, [filteredRuntimeProjects, projects, runtimeWork])
+  const visibleExpandedProjectIds = useMemo(
+    () => pruneProjectIdSet(expandedProjectIds, sidebarProjects),
+    [expandedProjectIds, sidebarProjects]
+  )
   const runtimeWorkByProjectId = useMemo(() => {
     return new Map(filteredRuntimeProjects.map(item => [item.project.id, item]))
   }, [filteredRuntimeProjects])
   const unmappedWorkspaces = useMemo(
-    () =>
-      filterRuntimeWorkspacesByDevice(
-        runtimeWork?.unmappedDeviceWorkspaces ?? [],
-        activeDeviceFilterId
-      ),
-    [runtimeWork?.unmappedDeviceWorkspaces, activeDeviceFilterId]
-  )
-  const unmappedDirectoryWorkspaces = useMemo(
-    () => getRuntimeDirectoryWorkspaces(unmappedWorkspaces),
-    [unmappedWorkspaces]
+    () => runtimeWork?.unmappedDeviceWorkspaces ?? [],
+    [runtimeWork?.unmappedDeviceWorkspaces]
   )
   const unmappedChatTaskItems = useMemo(
     () => getRuntimeChatSidebarTaskItems(unmappedWorkspaces),
@@ -1232,14 +1028,14 @@ export function DesktopSidebar({
     )
     return projectWork?.project.id ?? null
   }, [currentRuntimeTask, runtimeWork?.projects])
-  const selectedRuntimeInUnmapped = useMemo(() => {
+  const selectedRuntimeChatVisible = useMemo(() => {
     if (!currentRuntimeTask) return false
-    return unmappedDirectoryWorkspaces.some(workspace =>
-      workspace.localTasks.some(task => isRuntimeTaskSelected(currentRuntimeTask, workspace, task))
+    return unmappedChatTaskItems.some(({ workspace, task }) =>
+      isRuntimeTaskSelected(currentRuntimeTask, workspace, task)
     )
-  }, [currentRuntimeTask, unmappedDirectoryWorkspaces])
+  }, [currentRuntimeTask, unmappedChatTaskItems])
   const displayedProjectsExpanded = projectsExpanded || selectedRuntimeProjectId !== null
-  const displayedUnmappedExpanded = unmappedExpanded || selectedRuntimeInUnmapped
+  const displayedChatsExpanded = chatsExpanded || selectedRuntimeChatVisible
   const displayedExpandedProjectIds = useMemo(() => {
     if (selectedRuntimeProjectId === null) return visibleExpandedProjectIds
     if (visibleExpandedProjectIds.has(selectedRuntimeProjectId)) return visibleExpandedProjectIds
@@ -1256,10 +1052,6 @@ export function DesktopSidebar({
       }
       return next
     })
-  }
-
-  const handleSelectDeviceFilter = (deviceId: string) => {
-    setSelectedDeviceFilterId(previous => (previous === deviceId ? null : deviceId))
   }
 
   const openProjectCreateDialog = () => {
@@ -1281,8 +1073,8 @@ export function DesktopSidebar({
 
   useEffect(() => {
     if (storageScopeRef.current !== storageScope) return
-    writeStoredBoolean(unmappedExpandedStorageKey, unmappedExpanded)
-  }, [unmappedExpanded, unmappedExpandedStorageKey, storageScope])
+    writeStoredBoolean(chatsExpandedStorageKey, chatsExpanded)
+  }, [chatsExpanded, chatsExpandedStorageKey, storageScope])
 
   useEffect(() => {
     if (storageScopeRef.current !== storageScope) return
@@ -1294,13 +1086,13 @@ export function DesktopSidebar({
 
     storageScopeRef.current = storageScope
     setProjectsExpanded(readStoredBoolean(projectsExpandedStorageKey, true))
-    setUnmappedExpanded(readStoredBoolean(unmappedExpandedStorageKey, true))
+    setChatsExpanded(readStoredBoolean(chatsExpandedStorageKey, true))
     setExpandedProjectIds(readStoredNumberSet(expandedProjectIdsStorageKey))
   }, [
+    chatsExpandedStorageKey,
     expandedProjectIdsStorageKey,
     projectsExpandedStorageKey,
     storageScope,
-    unmappedExpandedStorageKey,
   ])
 
   useEffect(() => {
@@ -1333,9 +1125,9 @@ export function DesktopSidebar({
     taskRow?.scrollIntoView({ block: 'nearest' })
   }, [
     currentRuntimeTask,
+    displayedChatsExpanded,
     displayedExpandedProjectIds,
     displayedProjectsExpanded,
-    displayedUnmappedExpanded,
   ])
 
   return (
@@ -1369,22 +1161,11 @@ export function DesktopSidebar({
         data-testid="sidebar-worklists-scroll"
         className="scrollbar-none mt-8 min-h-0 flex-1 overflow-y-auto"
       >
-        <SidebarOnlineDevices
-          devices={devices}
-          expanded={devicesExpanded}
-          offlineExpanded={offlineDevicesExpanded}
-          selectedDeviceId={activeDeviceFilterId}
-          onToggleExpanded={() => setDevicesExpanded(expanded => !expanded)}
-          onToggleOfflineExpanded={() => setOfflineDevicesExpanded(expanded => !expanded)}
-          onSelectDevice={handleSelectDeviceFilter}
-          onAddDevice={() => onOpenSettings({ autoOpenAddCloudDeviceDialog: true })}
-        />
-
         <section>
           <SidebarSectionHeader
             title={t('workbench.projects', '项目')}
             expanded={displayedProjectsExpanded}
-            hasContent={projects.length > 0}
+            hasContent={sidebarProjects.length > 0}
             toggleTestId="projects-section-toggle"
             iconTestId="projects-section-chevron-right"
             onToggle={() => setProjectsExpanded(expanded => !expanded)}
@@ -1404,16 +1185,17 @@ export function DesktopSidebar({
           </SidebarSectionHeader>
           {displayedProjectsExpanded && (
             <div className="space-y-1">
-              {projects.map(project => (
+              {sidebarProjects.map(project => (
                 <ProjectItem
                   key={project.id}
                   project={project}
                   expanded={displayedExpandedProjectIds.has(project.id)}
                   devices={devices}
                   runtimeProjectWork={runtimeWorkByProjectId.get(project.id)}
+                  runtimeOnlyProject={!projects.some(item => item.id === project.id)}
                   currentRuntimeTask={currentRuntimeTask}
                   imNotificationSettings={imNotificationSettings}
-                  showDeviceMarker={devicesExpanded}
+                  showDeviceMarker={false}
                   onToggleProject={handleToggleProject}
                   onSelectProject={onSelectProject}
                   onStartNewProjectChat={onStartNewProjectChat}
@@ -1429,57 +1211,36 @@ export function DesktopSidebar({
           )}
         </section>
 
-        {unmappedChatTaskItems.length > 0 && (
-          <section data-testid="runtime-chat-section" className="mt-8">
-            <div className="mb-2 flex h-7 items-center px-2.5">
-              <span className="truncate text-[13px] font-semibold leading-[18px] text-[rgb(var(--color-sidebar-text-muted))]">
-                {t('workbench.chats', '对话')}
-              </span>
-            </div>
-            <div className="space-y-0.5 pb-2">
-              {unmappedChatTaskItems.map(({ workspace, task }) => (
-                <RuntimeLocalTaskRow
-                  key={`${workspace.deviceId}:${task.workspacePath}:${task.localTaskId}`}
-                  workspace={workspace}
-                  task={task}
-                  selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
-                  indentClassName="pl-2.5"
-                  imNotificationSettings={imNotificationSettings}
-                  showDeviceMarker={devicesExpanded}
-                  onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
-                  onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
-                  onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
-                />
-              ))}
-            </div>
-          </section>
-        )}
-
-        <section data-testid="unmapped-runtime-section" className="mt-8">
+        <section data-testid="runtime-chat-section" className="mt-8">
           <SidebarSectionHeader
-            title={t('workbench.unmapped_device_workspaces', '未映射工作区')}
-            expanded={displayedUnmappedExpanded}
-            hasContent={unmappedDirectoryWorkspaces.length > 0}
-            toggleTestId="unmapped-runtime-section-toggle"
-            iconTestId="unmapped-runtime-section-chevron-right"
-            onToggle={() => setUnmappedExpanded(expanded => !expanded)}
+            title={t('workbench.chats', '对话')}
+            expanded={displayedChatsExpanded}
+            hasContent={unmappedChatTaskItems.length > 0}
+            toggleTestId="runtime-chat-section-toggle"
+            iconTestId="runtime-chat-section-chevron-right"
+            onToggle={() => setChatsExpanded(expanded => !expanded)}
           >
             <span />
           </SidebarSectionHeader>
-          {displayedUnmappedExpanded && (
-            <div className="space-y-1 pb-2">
-              {unmappedDirectoryWorkspaces.length === 0 ? (
-                <div className="ml-2 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]">
-                  {t('workbench.no_unmapped_device_workspaces', '暂无未映射工作区')}
+          {displayedChatsExpanded && (
+            <div className="space-y-0.5 pb-2">
+              {unmappedChatTaskItems.length === 0 ? (
+                <div
+                  data-testid="runtime-chat-empty"
+                  className="ml-2 rounded-md px-3 py-1.5 text-xs text-[rgb(var(--color-sidebar-text-muted))]"
+                >
+                  {t('workbench.no_chats', '暂无会话')}
                 </div>
               ) : (
-                unmappedDirectoryWorkspaces.map(workspace => (
-                  <RuntimeWorkspaceGroup
-                    key={`${workspace.deviceId}:${workspace.workspacePath}`}
+                unmappedChatTaskItems.map(({ workspace, task }) => (
+                  <RuntimeLocalTaskRow
+                    key={`${workspace.deviceId}:${task.workspacePath}:${task.localTaskId}`}
                     workspace={workspace}
-                    currentRuntimeTask={currentRuntimeTask}
+                    task={task}
+                    selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
+                    indentClassName="pl-2.5"
                     imNotificationSettings={imNotificationSettings}
-                    showDeviceMarker={devicesExpanded}
+                    showDeviceMarker={false}
                     onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
                     onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
                     onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -1528,7 +1528,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
-  test('hides project device status when the project device is online', () => {
+  test('shows project device network status for non-local devices when multiple devices exist', () => {
     const onlineDevice = {
       id: 1,
       device_id: 'online-device',
@@ -1537,6 +1537,8 @@ describe('DesktopWorkbenchLayout', () => {
       is_default: false,
       device_type: 'cloud' as const,
       bind_shell: 'claudecode',
+      client_ip: '127.0.0.1',
+      runtime_transfer_host: '192.0.2.10:9000',
     }
 
     render(
@@ -1544,7 +1546,60 @@ describe('DesktopWorkbenchLayout', () => {
         {...baseProps}
         state={{
           ...baseProps.state,
-          devices: [onlineDevice],
+          devices: [
+            onlineDevice,
+            {
+              id: 2,
+              device_id: 'local-device',
+              name: 'Local Device',
+              status: 'online' as const,
+              is_default: true,
+              device_type: 'local' as const,
+              bind_shell: 'claudecode',
+            },
+          ],
+          projects: [
+            {
+              id: 7,
+              name: 'hello',
+              config: {
+                execution: {
+                  targetType: 'cloud',
+                  deviceId: 'online-device',
+                },
+              },
+              tasks: [],
+            },
+          ],
+        }}
+      />
+    )
+
+    const projectRow = screen.getByTestId('project-row-7')
+    expect(within(projectRow).getByTestId('project-device-status-7')).toHaveTextContent(
+      '192.0.2.10'
+    )
+    expect(within(projectRow).getByTestId('project-new-conversation-button')).not.toBeDisabled()
+  })
+
+  test('hides project device network status when only one device exists', () => {
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          devices: [
+            {
+              id: 1,
+              device_id: 'online-device',
+              name: 'Online Device',
+              status: 'online' as const,
+              is_default: false,
+              device_type: 'cloud' as const,
+              bind_shell: 'claudecode',
+              runtime_transfer_host: '192.0.2.10:9000',
+            },
+          ],
           projects: [
             {
               id: 7,
@@ -1564,7 +1619,54 @@ describe('DesktopWorkbenchLayout', () => {
 
     const projectRow = screen.getByTestId('project-row-7')
     expect(within(projectRow).queryByTestId('project-device-status-7')).not.toBeInTheDocument()
-    expect(within(projectRow).getByTestId('project-new-conversation-button')).not.toBeDisabled()
+  })
+
+  test('hides project device network status for local devices when multiple devices exist', () => {
+    render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        state={{
+          ...baseProps.state,
+          devices: [
+            {
+              id: 1,
+              device_id: 'local-device',
+              name: 'Local Device',
+              status: 'online' as const,
+              is_default: true,
+              device_type: 'local' as const,
+              bind_shell: 'claudecode',
+              runtime_transfer_host: '192.0.2.10:9000',
+            },
+            {
+              id: 2,
+              device_id: 'cloud-device',
+              name: 'Cloud Device',
+              status: 'online' as const,
+              is_default: false,
+              device_type: 'cloud' as const,
+              bind_shell: 'claudecode',
+            },
+          ],
+          projects: [
+            {
+              id: 7,
+              name: 'hello',
+              config: {
+                execution: {
+                  targetType: 'local',
+                  deviceId: 'local-device',
+                },
+              },
+              tasks: [],
+            },
+          ],
+        }}
+      />
+    )
+
+    const projectRow = screen.getByTestId('project-row-7')
+    expect(within(projectRow).queryByTestId('project-device-status-7')).not.toBeInTheDocument()
   })
 
   test('keeps offline project conversations readable but locks the composer', async () => {
@@ -1714,18 +1816,19 @@ describe('DesktopWorkbenchLayout', () => {
   test('selects a project while toggling an empty project task list', async () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
-    expect(screen.queryByText('暂无会话')).not.toBeInTheDocument()
+    expect(screen.getByTestId('runtime-chat-empty')).toHaveTextContent('暂无会话')
+    expect(screen.queryByTestId('project-local-tasks-empty-1')).not.toBeInTheDocument()
     expect(screen.getByTestId('project-row-1')).not.toHaveClass('bg-white')
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
     expect(baseProps.onSelectProject).toHaveBeenNthCalledWith(1, 1)
-    expect(screen.getByText('暂无会话')).toBeInTheDocument()
+    expect(screen.getByTestId('project-local-tasks-empty-1')).toHaveTextContent('暂无会话')
     expect(screen.getByTestId('project-row-1')).not.toHaveClass('bg-white')
 
     await userEvent.click(screen.getByTestId('project-item-button'))
 
-    expect(screen.queryByText('暂无会话')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('project-local-tasks-empty-1')).not.toBeInTheDocument()
     expect(baseProps.onSelectProject).toHaveBeenNthCalledWith(2, 1)
     expect(baseProps.onSelectProject).toHaveBeenCalledTimes(2)
   })

--- a/wework/src/components/layout/MobileDrawer.tsx
+++ b/wework/src/components/layout/MobileDrawer.tsx
@@ -32,17 +32,14 @@ import type {
 } from '@/types/api'
 import {
   getRuntimeChatSidebarTaskItems,
-  getRuntimeDirectoryWorkspaces,
   getRuntimeTaskAddress,
   getRuntimeTaskTime,
   getRuntimeTaskWorkspaceTitle,
   getRuntimeSidebarTaskItems,
-  getRuntimeWorkspaceLabel,
   getVisibleRuntimeSidebarTaskItems,
   hasHiddenRuntimeSidebarTaskItems,
   isRuntimeTaskSelected,
   isRuntimeWorktreeTask,
-  sortRuntimeTasks,
 } from './runtimeTaskSidebarHelpers'
 
 const MOBILE_RUNNING_SPINNER_CLASS = 'h-3.5 w-3.5 shrink-0 animate-spin'
@@ -159,10 +156,6 @@ export function MobileDrawer({
   const unmappedWorkspaces = useMemo(
     () => runtimeWork?.unmappedDeviceWorkspaces ?? [],
     [runtimeWork]
-  )
-  const unmappedDirectoryWorkspaces = useMemo(
-    () => getRuntimeDirectoryWorkspaces(unmappedWorkspaces),
-    [unmappedWorkspaces]
   )
   const unmappedChatTaskItems = useMemo(
     () => getRuntimeChatSidebarTaskItems(unmappedWorkspaces),
@@ -350,13 +343,20 @@ export function MobileDrawer({
                   <span className="min-w-0 truncate">{t('workbench.new_project', '新建项目')}</span>
                 </button>
               </div>
-              {unmappedChatTaskItems.length > 0 && (
-                <section className="mt-5">
-                  <div className="mb-2 px-6 text-[18px] font-bold leading-6 text-[#111111]">
-                    {t('workbench.chats', '对话')}
-                  </div>
-                  <div className="space-y-1">
-                    {unmappedChatTaskItems.map(({ workspace, task }) => {
+              <section className="mt-5" data-testid="mobile-runtime-chat-section">
+                <div className="mb-2 px-6 text-[18px] font-bold leading-6 text-[#111111]">
+                  {t('workbench.chats', '对话')}
+                </div>
+                <div className="space-y-1">
+                  {unmappedChatTaskItems.length === 0 ? (
+                    <div
+                      data-testid="mobile-runtime-chat-empty"
+                      className="mx-3 flex h-10 items-center rounded-lg px-3 text-left text-[15px] text-[#6B7280]"
+                    >
+                      {t('workbench.no_chats', '暂无会话')}
+                    </div>
+                  ) : (
+                    unmappedChatTaskItems.map(({ workspace, task }) => {
                       const selectedTask = isRuntimeTaskSelected(
                         currentRuntimeTask,
                         workspace,
@@ -402,10 +402,10 @@ export function MobileDrawer({
                           )}
                         </button>
                       )
-                    })}
-                  </div>
-                </section>
-              )}
+                    })
+                  )}
+                </div>
+              </section>
               {projects.map(project => {
                 const runtimeProjectWork = runtimeWorkByProjectId.get(project.id)
                 const workspaces = runtimeProjectWork?.deviceWorkspaces ?? []
@@ -592,78 +592,6 @@ export function MobileDrawer({
                   </div>
                 )
               })}
-            </div>
-          </section>
-
-          <section className="mt-8">
-            <div className="mb-3 flex items-center justify-between px-6">
-              <h2 className="text-[18px] font-bold leading-6 text-[#111111]">
-                {t('workbench.unmapped_device_workspaces', '未映射工作区')}
-              </h2>
-            </div>
-            <div className="space-y-2">
-              {unmappedDirectoryWorkspaces.length === 0 ? (
-                <div className="mx-3 flex h-10 items-center rounded-lg px-3 text-left text-[15px] text-[#6B7280]">
-                  {t('workbench.no_unmapped_device_workspaces', '暂无未映射工作区')}
-                </div>
-              ) : (
-                unmappedDirectoryWorkspaces.map(workspace => (
-                  <div
-                    key={`${workspace.deviceId}:${workspace.workspacePath}`}
-                    className="mx-3 rounded-[14px]"
-                  >
-                    <div className="flex h-9 items-center rounded-lg px-3 text-left text-[13px] font-medium text-[#6B7280]">
-                      <span className="min-w-0 flex-1 truncate">
-                        {getRuntimeWorkspaceLabel(workspace)}
-                      </span>
-                    </div>
-                    {sortRuntimeTasks(workspace.localTasks).map(task => {
-                      const selectedTask = isRuntimeTaskSelected(
-                        currentRuntimeTask,
-                        workspace,
-                        task
-                      )
-                      const disabled = !workspace.available || !onOpenRuntimeLocalTask
-                      return (
-                        <button
-                          key={task.localTaskId}
-                          type="button"
-                          data-testid="mobile-unmapped-runtime-task-button"
-                          disabled={disabled}
-                          onClick={() => {
-                            if (disabled) return
-                            void onOpenRuntimeLocalTask?.(getRuntimeTaskAddress(workspace, task))
-                            onClose()
-                          }}
-                          className={[
-                            'flex h-12 min-w-[44px] w-full items-center rounded-[14px] px-3 text-left text-[18px] font-normal leading-6 disabled:cursor-not-allowed disabled:opacity-50',
-                            selectedTask
-                              ? 'bg-[#F1F1F1] text-[#111111]'
-                              : 'text-[#111111] hover:bg-[#F7F7F7]',
-                          ].join(' ')}
-                        >
-                          <span className="min-w-0 flex-1 truncate">{task.title}</span>
-                          {task.running ? (
-                            renderRuntimeTaskRunningStatus(
-                              `mobile-unmapped-runtime-task-running-${task.localTaskId}`
-                            )
-                          ) : (
-                            <span className="ml-2 flex shrink-0 items-center gap-1 text-sm text-[#6B7280]">
-                              {isRuntimeWorktreeTask(task) && (
-                                <GitCompareArrows
-                                  className="h-3.5 w-3.5 shrink-0"
-                                  aria-label="Worktree"
-                                />
-                              )}
-                              {formatRelativeTime(getRuntimeTaskTime(task))}
-                            </span>
-                          )}
-                        </button>
-                      )
-                    })}
-                  </div>
-                ))
-              )}
             </div>
           </section>
         </div>

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -835,6 +835,9 @@ describe('MobileWorkbenchLayout', () => {
     )
 
     await userEvent.click(screen.getByTestId('open-mobile-drawer-button'))
+    expect(screen.getByTestId('mobile-runtime-chat-section')).toHaveTextContent('对话')
+    expect(screen.getByTestId('mobile-runtime-chat-empty')).toHaveTextContent('暂无会话')
+    expect(screen.queryByText('未映射工作区')).not.toBeInTheDocument()
     await userEvent.click(screen.getByText('github_wegent'))
 
     expect(screen.queryByText('Local Mac · Wegent local')).not.toBeInTheDocument()
@@ -897,7 +900,7 @@ describe('MobileWorkbenchLayout', () => {
     expect(runningStatus.querySelector('svg')).not.toBeNull()
   })
 
-  test('renders unmapped chat runtime tasks as conversations in the mobile drawer', async () => {
+  test('renders chat runtime tasks as conversations in the mobile drawer', async () => {
     const onOpenRuntimeLocalTask = vi.fn()
     const chatPath = '/Users/alice/.wecode/wegent-executor/workspace/chats/2026-06-20/hi-1'
 
@@ -939,8 +942,9 @@ describe('MobileWorkbenchLayout', () => {
 
     await userEvent.click(screen.getByTestId('open-mobile-drawer-button'))
 
-    expect(screen.getByText('对话')).toBeInTheDocument()
+    expect(screen.getByTestId('mobile-runtime-chat-section')).toHaveTextContent('对话')
     expect(screen.queryByText(`Local Mac ${chatPath}`)).not.toBeInTheDocument()
+    expect(screen.queryByText('未映射工作区')).not.toBeInTheDocument()
     await userEvent.click(screen.getByTestId('mobile-chat-runtime-task-button'))
 
     expect(onOpenRuntimeLocalTask).toHaveBeenCalledWith({

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -41,10 +41,6 @@ export function getRuntimeChatSidebarTaskItems(
   return getRuntimeSidebarTaskItems(workspaces.filter(isRuntimeChatWorkspace))
 }
 
-export function getRuntimeDirectoryWorkspaces(workspaces: RuntimeDeviceWorkspace[] = []) {
-  return workspaces.filter(workspace => !isRuntimeChatWorkspace(workspace))
-}
-
 export function sortRuntimeTaskItems(items: RuntimeSidebarTaskItem[]) {
   return [...items].sort((left, right) => {
     const leftTime = new Date(getRuntimeTaskTime(left.task) || 0).getTime()
@@ -65,11 +61,6 @@ export function getVisibleRuntimeSidebarTaskItems(
 
 export function hasHiddenRuntimeSidebarTaskItems(items: RuntimeSidebarTaskItem[]) {
   return items.length > RUNTIME_PROJECT_TASK_PREVIEW_LIMIT
-}
-
-export function getRuntimeWorkspaceLabel(workspace: RuntimeDeviceWorkspace) {
-  const deviceLabel = workspace.deviceName || workspace.deviceId
-  return `${deviceLabel} ${workspace.workspacePath}`
 }
 
 export function getRuntimeTaskWorkspaceTitle(workspace: RuntimeDeviceWorkspace) {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -57,7 +57,9 @@ function createProject(overrides: Partial<ProjectWithTasks> = {}): ProjectWithTa
   }
 }
 
-function createRuntimeWork(overrides: Partial<RuntimeWorkListResponse> = {}): RuntimeWorkListResponse {
+function createRuntimeWork(
+  overrides: Partial<RuntimeWorkListResponse> = {}
+): RuntimeWorkListResponse {
   return {
     projects: [
       {
@@ -225,7 +227,7 @@ function ProjectSendProbe() {
         {workbench.messages.map(message => `${message.role}:${message.content}`).join('|')}
       </span>
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
-      <button type="button" onClick={() => workbench.selectProjectWorkspace(7, 22)}>
+      <button type="button" onClick={() => workbench.selectProjectWorkspace(7, null)}>
         select project
       </button>
       <button type="button" onClick={() => workbench.setInput('修复 CI')}>
@@ -319,8 +321,9 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<BootstrapProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('boot-state')).toHaveTextContent('alice'))
-    expect(screen.getByTestId('project-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('project-count')).toHaveTextContent('0')
     expect(screen.getByTestId('runtime-total')).toHaveTextContent('3')
+    expect(services.projectApi.listProjects).not.toHaveBeenCalled()
     expect(services.runtimeWorkApi?.listRuntimeWork).toHaveBeenCalledTimes(1)
   })
 
@@ -345,6 +348,27 @@ describe('WorkbenchProvider runtime tasks', () => {
 
   test('creates a runtime local task for a new project message', async () => {
     const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  localTasks: [],
+                },
+              ],
+            },
+          ],
+          totalLocalTasks: 0,
+        })
+      ),
       createRuntimeTask: vi.fn().mockResolvedValue({
         accepted: true,
         deviceId: 'resolved-device',
@@ -373,14 +397,17 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
     expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledWith(
       expect.objectContaining({
-        projectId: 7,
-        deviceWorkspaceId: 22,
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
         teamId: 2,
         message: '修复 CI',
       })
     )
+    expect(runtimeWorkApi.createRuntimeTask.mock.calls[0][0]).not.toHaveProperty('projectId')
+    expect(runtimeWorkApi.createRuntimeTask.mock.calls[0][0]).not.toHaveProperty(
+      'deviceWorkspaceId'
+    )
     expect(runtimeWorkApi.createRuntimeTask.mock.calls[0][0]).not.toHaveProperty('task_id')
-    expect(runtimeWorkApi.createRuntimeTask.mock.calls[0][0]).not.toHaveProperty('workspacePath')
     await waitFor(() =>
       expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
         'resolved-device:runtime-created'
@@ -520,7 +547,9 @@ describe('WorkbenchProvider runtime tasks', () => {
       )
     )
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('恢复的问题')
-    expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent('thinking:读取历史记录:done')
+    expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent(
+      'thinking:读取历史记录:done'
+    )
     expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent('tool:exec_command:done')
     expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent('text:处理完成:done')
     expect(getRuntimeTranscript).toHaveBeenCalledWith({

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -33,11 +33,7 @@ import {
   isWeWorkCompatibleDevice,
 } from '@/lib/device-capabilities'
 import { getModelCompatibilityFamily } from '@/lib/model-ui'
-import {
-  buildRuntimeTaskRoute,
-  navigateTo,
-  parseRuntimeTaskRoute,
-} from '@/lib/navigation'
+import { buildRuntimeTaskRoute, navigateTo, parseRuntimeTaskRoute } from '@/lib/navigation'
 import type { RuntimeTaskRoute } from '@/lib/navigation'
 import { supportsGitWorktreeExecution } from '@/lib/projectClassification'
 import {
@@ -71,6 +67,7 @@ import type {
   RuntimeTaskAddress,
   RuntimeTaskCreateRequest,
   RuntimeDeviceWorkspace,
+  RuntimeProjectWork,
   RuntimeTaskForkTarget,
   RuntimeGlobalIMNotificationUpdateRequest,
   RuntimeIMNotificationSettingsResponse,
@@ -113,12 +110,10 @@ const OPENAI_RESPONSES_RUNTIME_FAMILY = 'openai.openai-responses'
 const OPENAI_RESPONSES_PROTOCOL = 'openai-responses'
 const RESPONSES_API_FORMAT = 'responses'
 const LOCAL_SKILLS_CACHE_TTL_MS = 60_000
-const RUNTIME_WORK_POLL_INTERVAL_MS = 5000
 const STANDALONE_PROJECT_ID = 0
 const EMPTY_MESSAGE_TASK_TITLE = '新对话'
 const RUNTIME_BLOCK_SUBTASK_ID_OFFSET = 1_000_000_000
 
-type SelectableProjectDeviceWorkspace = RuntimeDeviceWorkspace & { id: number }
 type ProjectMutationOptions = {
   refreshWorkLists?: boolean
 }
@@ -231,7 +226,10 @@ export interface WorkbenchServices {
     createGitWorkspaceProject?: ReturnType<typeof createProjectApi>['createGitWorkspaceProject']
   }
   gitApi?: ReturnType<typeof createGitApi>
-  taskApi: Pick<ReturnType<typeof createTaskApi>, 'getTurnFileChangesDiff' | 'revertTurnFileChanges'>
+  taskApi: Pick<
+    ReturnType<typeof createTaskApi>,
+    'getTurnFileChangesDiff' | 'revertTurnFileChanges'
+  >
   deviceApi: Pick<
     ReturnType<typeof createDeviceApi>,
     | 'listDevices'
@@ -568,7 +566,10 @@ function normalizeChatBlock(subtaskId: number, block: ChatBlock): ProcessingBloc
   return normalizeProcessingBlock(subtaskId, block, 0)
 }
 
-function getRuntimeMessageBlockSubtaskId(message: NormalizedRuntimeMessage, subtaskId?: number): number {
+function getRuntimeMessageBlockSubtaskId(
+  message: NormalizedRuntimeMessage,
+  subtaskId?: number
+): number {
   if (typeof subtaskId === 'number') return subtaskId
 
   let hash = 0
@@ -641,17 +642,6 @@ function chatMessageToWorkbenchMessage(payload: ChatMessagePayload): WorkbenchMe
 
 function getLastProjectStorageKey(userId: number) {
   return `wework.lastProjectId.${userId}`
-}
-
-function readLastProjectId(userId: number): number | null {
-  try {
-    const value = window.localStorage.getItem(getLastProjectStorageKey(userId))
-    if (!value) return null
-    const id = Number(value)
-    return Number.isFinite(id) && id > 0 ? id : null
-  } catch {
-    return null
-  }
 }
 
 function writeLastProjectId(userId: number, projectId: number) {
@@ -732,15 +722,10 @@ function findRuntimeWorkspaceForDevice(
 function getSelectableProjectDeviceWorkspaces(
   runtimeWork: RuntimeWorkListResponse | null | undefined,
   projectId: number | null | undefined
-): SelectableProjectDeviceWorkspace[] {
+): RuntimeDeviceWorkspace[] {
   if (!projectId) return []
   const projectWork = runtimeWork?.projects.find(item => item.project.id === projectId)
-  return (
-    projectWork?.deviceWorkspaces.filter(
-      (workspace): workspace is SelectableProjectDeviceWorkspace =>
-        workspace.id != null && workspace.available
-    ) ?? []
-  )
+  return projectWork?.deviceWorkspaces.filter(workspace => workspace.available) ?? []
 }
 
 function getSingleProjectDeviceWorkspaceId(
@@ -748,20 +733,40 @@ function getSingleProjectDeviceWorkspaceId(
   projectId: number | null | undefined
 ): number | null {
   const workspaces = getSelectableProjectDeviceWorkspaces(runtimeWork, projectId)
-  return workspaces.length === 1 ? workspaces[0].id : null
+  return workspaces.length === 1 ? (workspaces[0].id ?? null) : null
+}
+
+function runtimeProjectToProject(projectWork: RuntimeProjectWork): ProjectWithTasks {
+  return {
+    id: projectWork.project.id,
+    name: projectWork.project.name,
+    description: projectWork.project.description,
+    color: projectWork.project.color,
+    tasks: [],
+  }
+}
+
+function findSelectableProject(
+  projects: ProjectWithTasks[],
+  runtimeWork: RuntimeWorkListResponse | null | undefined,
+  projectId: number
+): ProjectWithTasks | null {
+  const project = projects.find(item => item.id === projectId)
+  if (project) return project
+  const runtimeProject = runtimeWork?.projects.find(item => item.project.id === projectId)
+  return runtimeProject ? runtimeProjectToProject(runtimeProject) : null
 }
 
 function findProjectDeviceWorkspace(
   runtimeWork: RuntimeWorkListResponse | null | undefined,
   projectId: number | null | undefined,
   deviceWorkspaceId: number | null | undefined
-): SelectableProjectDeviceWorkspace | null {
-  if (!deviceWorkspaceId) return null
-  return (
-    getSelectableProjectDeviceWorkspaces(runtimeWork, projectId).find(
-      workspace => workspace.id === deviceWorkspaceId
-    ) ?? null
-  )
+): RuntimeDeviceWorkspace | null {
+  const workspaces = getSelectableProjectDeviceWorkspaces(runtimeWork, projectId)
+  if (deviceWorkspaceId) {
+    return workspaces.find(workspace => workspace.id === deviceWorkspaceId) ?? null
+  }
+  return workspaces.length === 1 ? workspaces[0] : null
 }
 
 function inferRuntimeName(model: UnifiedModel | null): 'codex' | 'claude_code' {
@@ -869,10 +874,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       setProjectExecutionMode(nextMode)
     }, 0)
     return () => window.clearTimeout(timer)
-  }, [
-    currentUser.preferences?.wework_project_execution_mode,
-    state.currentProject,
-  ])
+  }, [currentUser.preferences?.wework_project_execution_mode, state.currentProject])
   const setProjectWorktreeBaseBranch = useCallback((branchName: string | null) => {
     const normalizedBranch = branchName?.trim() || null
     setProjectWorktreeBaseBranchState(normalizedBranch)
@@ -966,34 +968,26 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     let cancelled = false
 
     async function bootstrap() {
-      const [defaultTeamResult, projectsResult, devicesResult, runtimeWorkResult] =
-        await Promise.allSettled([
-          resolvedServices.teamApi.getDefaultWorkbenchTeam(),
-          resolvedServices.projectApi.listProjects(),
-          resolvedServices.deviceApi.listDevices(),
-          resolvedServices.runtimeWorkApi?.listRuntimeWork() ?? Promise.resolve(EMPTY_RUNTIME_WORK),
-        ])
+      const [defaultTeamResult, devicesResult, runtimeWorkResult] = await Promise.allSettled([
+        resolvedServices.teamApi.getDefaultWorkbenchTeam(),
+        resolvedServices.deviceApi.listDevices(),
+        resolvedServices.runtimeWorkApi?.listRuntimeWork() ?? Promise.resolve(EMPTY_RUNTIME_WORK),
+      ])
 
       if (cancelled) return
 
-      const projects = projectsResult.status === 'fulfilled' ? projectsResult.value.items : []
       const rawDevices = devicesResult.status === 'fulfilled' ? devicesResult.value : []
       const devices = resolveDeviceListWithCache(rawDevices)
-      const lastProjectId = readLastProjectId(user.id)
-      const currentProject =
-        lastProjectId === null
-          ? null
-          : (projects.find(project => project.id === lastProjectId) ?? null)
 
       dispatch({
         type: 'bootstrapped',
         user,
         defaultTeam: defaultTeamResult.status === 'fulfilled' ? defaultTeamResult.value : null,
-        projects,
+        projects: [],
         devices,
         runtimeWork:
           runtimeWorkResult.status === 'fulfilled' ? runtimeWorkResult.value : EMPTY_RUNTIME_WORK,
-        currentProject,
+        currentProject: null,
         standaloneDeviceId: getRememberedStandaloneDeviceId(user, devices),
       })
       if (defaultTeamResult.status === 'rejected') {
@@ -1014,8 +1008,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   }, [resolvedServices, user])
 
   const refreshWorkLists = useCallback(async () => {
-    const [projectsResult, devicesResult, runtimeWorkResult] = await Promise.all([
-      resolvedServices.projectApi.listProjects(),
+    const [devicesResult, runtimeWorkResult] = await Promise.all([
       resolvedServices.deviceApi.listDevices().catch(error => {
         const cachedDevices = readCachedDeviceList()
         if (cachedDevices.length === 0) throw error
@@ -1027,33 +1020,12 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     const devices = resolveDeviceListWithCache(devicesResult)
     dispatch({
       type: 'lists_refreshed',
-      projects: projectsResult.items,
+      projects: state.projects,
       devices,
       runtimeWork: runtimeWorkResult,
       standaloneDeviceId: getPreferredStandaloneDeviceId(devices, state.standaloneDeviceId),
     })
-  }, [resolvedServices, state.standaloneDeviceId])
-
-  useEffect(() => {
-    if (state.isBootstrapping || !resolvedServices.runtimeWorkApi) return
-
-    const pollRuntimeWork = () => {
-      if (document.visibilityState === 'hidden') return
-      void refreshWorkLists().catch(() => {
-        // Keep the last runtime work snapshot when a poll fails.
-      })
-    }
-    const intervalId = window.setInterval(pollRuntimeWork, RUNTIME_WORK_POLL_INTERVAL_MS)
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'hidden') pollRuntimeWork()
-    }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-
-    return () => {
-      window.clearInterval(intervalId)
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [refreshWorkLists, resolvedServices.runtimeWorkApi, state.isBootstrapping])
+  }, [resolvedServices, state.projects, state.standaloneDeviceId])
 
   const refreshDevices = useCallback(async () => {
     let devices: DeviceInfo[]
@@ -1278,12 +1250,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         )
       },
     })
-  }, [
-    refreshWorkLists,
-    refreshDevices,
-    resolvedServices,
-    setDeviceUpgradeState,
-  ])
+  }, [refreshWorkLists, refreshDevices, resolvedServices, setDeviceUpgradeState])
 
   useEffect(() => {
     return () => {
@@ -1366,7 +1333,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         navigateTo('/')
         return
       }
-      const project = state.projects.find(item => item.id === projectId)
+      const project = findSelectableProject(state.projects, state.runtimeWork, projectId)
       if (project) {
         writeLastProjectId(user.id, project.id)
         dispatch({ type: 'project_selected', project })
@@ -1379,12 +1346,19 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         navigateTo('/')
       }
     },
-    [cancelRuntimeTranscriptLoad, state.devices, state.projects, state.standaloneDeviceId, user]
+    [
+      cancelRuntimeTranscriptLoad,
+      state.devices,
+      state.projects,
+      state.runtimeWork,
+      state.standaloneDeviceId,
+      user,
+    ]
   )
 
   const selectProjectWorkspace = useCallback(
     (projectId: number, deviceWorkspaceId: number | null) => {
-      const project = state.projects.find(item => item.id === projectId)
+      const project = findSelectableProject(state.projects, state.runtimeWork, projectId)
       if (!project) return
       writeLastProjectId(user.id, project.id)
       dispatch({
@@ -1400,7 +1374,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       handledRuntimeTaskRouteRef.current = null
       navigateTo('/')
     },
-    [cancelRuntimeTranscriptLoad, state.projects, user.id]
+    [cancelRuntimeTranscriptLoad, state.projects, state.runtimeWork, user.id]
   )
 
   const selectStandaloneDevice = useCallback(
@@ -1888,9 +1862,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         .reverse()
         .find(
           message =>
-            message.role === 'assistant' &&
-            message.status === 'streaming' &&
-            message.subtaskId
+            message.role === 'assistant' && message.status === 'streaming' && message.subtaskId
         ),
     [messages]
   )
@@ -2010,10 +1982,16 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           reportSendBlocked('请选择任务运行位置')
           return false
         }
-        runtimeTaskTarget = {
-          projectId,
-          deviceWorkspaceId: selectedProjectWorkspace.id,
-        }
+        runtimeTaskTarget =
+          selectedProjectWorkspace.id != null
+            ? {
+                projectId,
+                deviceWorkspaceId: selectedProjectWorkspace.id,
+              }
+            : {
+                deviceId: selectedProjectWorkspace.deviceId,
+                workspacePath: selectedProjectWorkspace.workspacePath,
+              }
       } else {
         const workspacePath = findRuntimeWorkspaceForDevice(state.runtimeWork, activeDeviceId)
         if (!activeDeviceId || !workspacePath) {
@@ -2203,7 +2181,11 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
     dispatch({ type: 'input_changed', input: '' })
 
-    const sent = await sendPreparedRuntimeMessage(message, prepared.payload, prepared.activeDeviceId)
+    const sent = await sendPreparedRuntimeMessage(
+      message,
+      prepared.payload,
+      prepared.activeDeviceId
+    )
     if (sent) {
       attachmentSelection.resetAttachments()
       clearCodeCommentContexts()
@@ -2368,18 +2350,15 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     })
   }, [activeAssistantMessage, resolvedServices.chatStream])
 
-  const sendQueuedAsGuidance = useCallback(
-    async (id: string) => {
-      setQueuedSends(items =>
-        items.map(queued =>
-          queued.id === id
-            ? { ...queued, status: 'failed', error: '当前 LocalTask 暂不支持引导' }
-            : queued
-        )
+  const sendQueuedAsGuidance = useCallback(async (id: string) => {
+    setQueuedSends(items =>
+      items.map(queued =>
+        queued.id === id
+          ? { ...queued, status: 'failed', error: '当前 LocalTask 暂不支持引导' }
+          : queued
       )
-    },
-    []
-  )
+    )
+  }, [])
 
   const listLocalSkills = useCallback(async () => {
     if (!activeDeviceId) return []

--- a/wework/src/lib/project-workspace-selection.test.ts
+++ b/wework/src/lib/project-workspace-selection.test.ts
@@ -119,4 +119,41 @@ describe('project workspace selection', () => {
       workspaces: [],
     })
   })
+
+  test('allows runtime-native workspaces without central mapping ids', () => {
+    const options = buildProjectWorkspaceOptions({
+      projects: [{ id: 10, name: 'runtime-only', tasks: [] }],
+      devices,
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 10, name: 'runtime-only' },
+            deviceWorkspaces: [
+              {
+                projectId: null,
+                deviceId: 'device-1',
+                deviceName: 'MacBook Pro',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/runtime-only',
+                mapped: true,
+                localTasks: [],
+              },
+            ],
+          },
+        ],
+        unmappedDeviceWorkspaces: [],
+        totalLocalTasks: 0,
+      },
+    })
+
+    expect(options[0]).toMatchObject({
+      kind: 'single',
+      selectable: true,
+      workspace: {
+        deviceId: 'device-1',
+        workspacePath: '/repo/runtime-only',
+      },
+    })
+  })
 })

--- a/wework/src/lib/project-workspace-selection.ts
+++ b/wework/src/lib/project-workspace-selection.ts
@@ -27,14 +27,16 @@ function deviceById(devices: DeviceInfo[]) {
 }
 
 function runtimeWorkspacesByProjectId(runtimeWork: RuntimeWorkListResponse | null | undefined) {
-  return new Map((runtimeWork?.projects ?? []).map(item => [item.project.id, item.deviceWorkspaces]))
+  return new Map(
+    (runtimeWork?.projects ?? []).map(item => [item.project.id, item.deviceWorkspaces])
+  )
 }
 
 export function isSelectableProjectWorkspace(
   workspace: RuntimeDeviceWorkspace | null | undefined,
   devices: DeviceInfo[] = []
 ): workspace is RuntimeDeviceWorkspace {
-  if (!workspace || !workspace.id) return false
+  if (!workspace) return false
   if (!workspace.available) return false
 
   const device = deviceById(devices).get(workspace.deviceId)

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -108,6 +108,8 @@ export interface DeviceInfo {
   latest_version?: string | null
   update_available?: boolean
   bind_shell?: 'claudecode' | 'openclaw' | string
+  client_ip?: string | null
+  runtime_transfer_host?: string | null
 }
 
 export interface DeviceRunningTask {

--- a/wework/src/types/devices.ts
+++ b/wework/src/types/devices.ts
@@ -16,6 +16,8 @@ export interface DeviceInfo {
   executor_version?: string | null
   latest_version?: string | null
   update_available?: boolean
+  client_ip?: string | null
+  runtime_transfer_host?: string | null
   cloud_config?: {
     sandboxId?: string
     imageId?: string


### PR DESCRIPTION
## Summary
- source Wework runtime work from executor/device thread lists instead of Backend projects/task DB state
- group runtime threads into Projects and Conversations, remove unmapped workspace/sidebar polling paths, and make Conversations collapsible
- include device network metadata for remote project status and document the updated runtime local work flow

## Validation
- pnpm --dir wework test -- DesktopSidebar.test.tsx DesktopWorkbenchLayout.test.tsx
- pnpm --dir wework lint
- pnpm --dir wework build
- uv run pytest tests/api/endpoints/test_runtime_work_api.py tests/services/test_runtime_work_service.py -q
- uv run pytest tests/test_local_websocket_client.py tests/runtime_work/test_local_task_store.py -q
- pre-push quality gate passed with AI_VERIFIED=1 after docs were updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Show richer device network info (client IP / runtime transfer host) in the runtime sidebar.
  * Refine runtime organization into **Projects** vs **Conversations** (chat threads), with Conversations always available.

* **Improvements**
  * Runtime work refresh is now request-driven (startup/manual/device state changes) for fresher results than polling.
  * Improved grouping/sorting and metadata handling for runtime tasks, and unmapped chat sections are no longer rendered in the sidebar.

* **Bug Fixes**
  * Fixed runtime sidebar behavior and selection tests for conversation/project visibility edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->