### PR TITLE
[codex] Fix standalone Codex runtime dependencies

### DIFF
--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -886,6 +886,8 @@ records = []
 discovery_error = None
 
 try:
+    codex_home.mkdir(parents=True, exist_ok=True)
+
     from openai_codex import Codex, CodexConfig
 
     with Codex(

--- a/backend/tests/docker/test_standalone_wework_contract.py
+++ b/backend/tests/docker/test_standalone_wework_contract.py
@@ -37,6 +37,27 @@ def test_standalone_image_includes_wework_executor_and_workspace_volume() -> Non
     assert "http://localhost:7681" not in dockerfile
 
 
+def test_standalone_image_installs_codex_runtime_dependencies() -> None:
+    """Container executor needs both the Codex CLI and Python SDK in Linux."""
+    dockerfile = STANDALONE_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "@openai/codex@0.137.0" in dockerfile
+    assert (
+        "uv pip install --system --no-cache --no-deps openai-codex==0.1.0b3"
+        in dockerfile
+    )
+
+
+def test_standalone_runtime_prepares_persistent_codex_home() -> None:
+    """Codex SDK startup requires CODEX_HOME to point at an existing directory."""
+    dockerfile = STANDALONE_DOCKERFILE.read_text(encoding="utf-8")
+    start_script = STANDALONE_START.read_text(encoding="utf-8")
+
+    assert "ENV CODEX_HOME=/app/data/codex" in dockerfile
+    assert 'export CODEX_HOME="${CODEX_HOME:-/app/data/codex}"' in start_script
+    assert 'mkdir -p "$CODEX_HOME"' in start_script
+
+
 def test_standalone_start_registers_executor_as_admin_cloud_device() -> None:
     """Startup should launch a real executor registered through the device WebSocket."""
     start_script = STANDALONE_START.read_text(encoding="utf-8")

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -523,6 +523,7 @@ def test_codex_threads_list_command_reads_sdk_thread_list(tmp_path):
     assert payload["threads"][1]["running"] is False
     assert "transcript" not in json.dumps(payload)
     assert "session_index" not in json.dumps(payload)
+    assert (tmp_path / "codex-home").is_dir()
 
 
 def test_codex_threads_list_command_surfaces_sdk_errors(tmp_path):

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -107,7 +107,7 @@ RUN dnf install -y \
     procps-ng iproute lsof less tree unzip ripgrep \
     # Redis server for standalone mode (embedded)
     redis \
-    && npm install -g @anthropic-ai/claude-code@2.1.142 \
+    && npm install -g @anthropic-ai/claude-code@2.1.142 @openai/codex@0.137.0 \
     && dnf clean all \
     && rm -rf /var/cache/dnf/*
 
@@ -158,6 +158,7 @@ RUN cd /app/chat_shell && uv pip install --system --no-cache -r pyproject.toml
 
 # Install executor (depends on shared via ../shared -> /app/shared)
 RUN cd /app/executor && uv pip install --system --no-cache -r pyproject.toml
+RUN uv pip install --system --no-cache --no-deps openai-codex==0.1.0b3
 
 # Copy and install backend
 # Backend's pyproject.toml references:
@@ -196,6 +197,7 @@ ENV ENVIRONMENT=development
 # Note: SQLite absolute path requires 4 slashes: sqlite:////path/to/db
 ENV DATABASE_URL=sqlite:////app/data/wegent.db
 ENV CHAT_SHELL_MODE=package
+ENV CODEX_HOME=/app/data/codex
 ENV PYTHONPATH=/app:/app/backend:/app/chat_shell:/app/executor
 ENV NODE_PATH=/usr/lib/node_modules
 

--- a/docker/standalone/start.sh
+++ b/docker/standalone/start.sh
@@ -14,6 +14,8 @@ echo ""
 
 # Create persistent data and workspace directories.
 mkdir -p /app/data
+export CODEX_HOME="${CODEX_HOME:-/app/data/codex}"
+mkdir -p "$CODEX_HOME"
 mkdir -p /app/data/redis
 mkdir -p /workspace/projects
 mkdir -p /workspace/chats

--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -98,6 +98,7 @@ class CodexSessionDiscovery:
         return CodexConfig
 
     def _codex_config(self, config_type: Any) -> Any:
+        _ensure_codex_home(self.codex_home)
         return config_type(
             codex_bin=_resolve_codex_binary(config.CODEX_BINARY_PATH),
             client_name="wegent_executor",
@@ -478,10 +479,15 @@ def _codex_enum_value(enum_name: str, value: str) -> Any:
 def _codex_env(
     codex_home: Path, runtime_env: Optional[dict[str, str]]
 ) -> dict[str, str]:
+    _ensure_codex_home(codex_home)
     env = {**os.environ, "CODEX_HOME": str(codex_home)}
     if runtime_env:
         env.update(runtime_env)
     return env
+
+
+def _ensure_codex_home(codex_home: Path) -> None:
+    codex_home.mkdir(parents=True, exist_ok=True)
 
 
 def _developer_instructions(request: Any) -> Optional[str]:

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -1140,6 +1140,7 @@ def test_codex_discovery_passes_resolved_codex_binary_to_sdk(tmp_path, monkeypat
         == "/Applications/Codex.app/Contents/Resources/codex"
     )
     assert client.config.kwargs["env"]["CODEX_HOME"] == str(tmp_path / "codex-home")
+    assert (tmp_path / "codex-home").is_dir()
 
 
 def test_codex_discovery_reads_user_visible_transcript(tmp_path):


### PR DESCRIPTION
## Summary

Fixes standalone container startup failures when Codex runtime work discovery initializes the Codex SDK.

## Root Cause

The standalone image installed the executor on Linux from `pyproject.toml`, where `openai-codex` is intentionally excluded because its CLI-bin dependency has no Linux wheel. The standalone image also did not install the npm Codex CLI. After the SDK was added, Codex CLI startup still failed because `CODEX_HOME` pointed at a directory that did not exist.

## Changes

- Install `@openai/codex@0.137.0` and `openai-codex==0.1.0b3 --no-deps` in the standalone image.
- Default standalone `CODEX_HOME` to `/app/data/codex` and create it at startup.
- Ensure executor Codex discovery and Backend device Codex commands create `CODEX_HOME` before initializing the SDK.
- Add regression coverage for standalone image contracts and Codex SDK directory preparation.

## Validation

- `cd backend && uv run pytest tests/docker/test_standalone_wework_contract.py tests/services/test_local_device_command_service.py::test_codex_threads_list_command_reads_sdk_thread_list`
- `cd executor && uv run pytest tests/runtime_work/test_local_task_store.py::test_codex_discovery_passes_resolved_codex_binary_to_sdk`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic directory initialization for Codex home during application startup.

* **Bug Fixes**
  * Ensured Codex home directory is created before runtime operations to prevent initialization failures.

* **Chores**
  * Updated Docker image with openai-codex runtime dependency.
  * Added environment variable configuration for persistent Codex home directory.

* **Tests**
  * Added contract tests to verify Docker image and startup script configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->