### PR TITLE
[codex] Add Wegent help knowledge skill

### DIFF
--- a/backend/app/core/system_knowledge_init.py
+++ b/backend/app/core/system_knowledge_init.py
@@ -1,0 +1,406 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Initialize built-in system knowledge bases from init_data seeds."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.models.kind import Kind
+from app.models.knowledge import KnowledgeDocument
+from app.models.namespace import Namespace
+from app.models.user import User
+from app.schemas.knowledge import KnowledgeBaseCreate, KnowledgeDocumentCreate
+from app.schemas.namespace import GroupLevel
+from app.services.context import context_service
+from app.services.knowledge.knowledge_service import KnowledgeService
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_KNOWLEDGE_DIR = "system_knowledge"
+DEFAULT_SEED_ID = "wegent-help"
+SYSTEM_SOURCE = "system_knowledge_seed"
+
+
+@dataclass(frozen=True)
+class SeedDocument:
+    source_path: str
+    seed_path: str
+    language: str
+    title: str
+    category: str
+    content_sha256: str
+    content: str
+
+
+@dataclass(frozen=True)
+class SystemKnowledgeSeed:
+    seed_id: str
+    kb_name: str
+    kb_display_name: str
+    namespace: str
+    description: str
+    documents: list[SeedDocument]
+
+
+def _safe_seed_file(seed_root: Path, seed_path: str) -> Path:
+    candidate = (seed_root / seed_path).resolve()
+    seed_root_resolved = seed_root.resolve()
+    if candidate != seed_root_resolved and seed_root_resolved not in candidate.parents:
+        raise ValueError(f"Unsafe seed path: {seed_path}")
+    return candidate
+
+
+def load_system_knowledge_seed(seed_root: Path) -> SystemKnowledgeSeed | None:
+    manifest_path = seed_root / "manifest.json"
+    if not manifest_path.exists():
+        logger.info("System knowledge manifest not found: %s", manifest_path)
+        return None
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    kb = manifest.get("knowledge_base") or {}
+    documents: list[SeedDocument] = []
+
+    for item in manifest.get("documents") or []:
+        seed_path = item["seed_path"]
+        content = _safe_seed_file(seed_root, seed_path).read_text(encoding="utf-8")
+        documents.append(
+            SeedDocument(
+                source_path=item["source_path"],
+                seed_path=seed_path,
+                language=item.get("language", ""),
+                title=item.get("title") or Path(seed_path).stem,
+                category=item.get("category", ""),
+                content_sha256=item["content_sha256"],
+                content=content,
+            )
+        )
+
+    return SystemKnowledgeSeed(
+        seed_id=manifest.get("seed_id") or DEFAULT_SEED_ID,
+        kb_name=kb.get("name") or "Wegent Help",
+        kb_display_name=kb.get("display_name") or "Wegent 帮助文档",
+        namespace=kb.get("namespace") or "system",
+        description=kb.get("description") or "",
+        documents=documents,
+    )
+
+
+def ensure_system_namespace(
+    db: Session,
+    *,
+    name: str,
+    owner_user_id: int,
+) -> Namespace:
+    namespace = db.query(Namespace).filter(Namespace.name == name).first()
+    if namespace:
+        changed = False
+        if namespace.level != GroupLevel.organization.value:
+            namespace.level = GroupLevel.organization.value
+            changed = True
+        if namespace.visibility != "internal":
+            namespace.visibility = "internal"
+            changed = True
+        if not namespace.is_active:
+            namespace.is_active = True
+            changed = True
+        if changed:
+            db.commit()
+            db.refresh(namespace)
+        return namespace
+
+    namespace = Namespace(
+        name=name,
+        display_name="System",
+        owner_user_id=owner_user_id,
+        visibility="internal",
+        description="Built-in system resources",
+        level=GroupLevel.organization.value,
+        is_active=True,
+    )
+    db.add(namespace)
+    db.commit()
+    db.refresh(namespace)
+    return namespace
+
+
+def _system_labels(seed: SystemKnowledgeSeed) -> dict[str, str]:
+    return {"source": SYSTEM_SOURCE, "seed_id": seed.seed_id}
+
+
+def _kind_labels(kind: Kind) -> dict[str, Any]:
+    metadata = (kind.json or {}).get("metadata") or {}
+    return metadata.get("labels") or {}
+
+
+def ensure_system_help_knowledge_base(
+    db: Session,
+    *,
+    seed: SystemKnowledgeSeed,
+    admin_user: User,
+) -> Kind:
+    labels = _system_labels(seed)
+    candidates = (
+        db.query(Kind)
+        .filter(
+            Kind.kind == "KnowledgeBase",
+            Kind.namespace == seed.namespace,
+            Kind.is_active == True,
+        )
+        .all()
+    )
+
+    for kb in candidates:
+        spec = (kb.json or {}).get("spec") or {}
+        existing_labels = _kind_labels(kb)
+        if (
+            existing_labels.get("seed_id") == seed.seed_id
+            or spec.get("name") == seed.kb_name
+        ):
+            kb_json = kb.json or {}
+            metadata = kb_json.setdefault("metadata", {})
+            metadata["labels"] = {**existing_labels, **labels}
+            kb.json = kb_json
+            flag_modified(kb, "json")
+            db.commit()
+            db.refresh(kb)
+            return kb
+
+    data = KnowledgeBaseCreate(
+        name=seed.kb_name,
+        description=seed.description,
+        namespace=seed.namespace,
+        kb_type="classic",
+        rag_config_mode="auto",
+        summary_enabled=False,
+    )
+    kb_id = KnowledgeService.create_knowledge_base(db, admin_user.id, data)
+    kb = db.query(Kind).filter(Kind.id == kb_id).one()
+    kb_json = kb.json or {}
+    metadata = kb_json.setdefault("metadata", {})
+    metadata["labels"] = {**(metadata.get("labels") or {}), **labels}
+    kb.json = kb_json
+    flag_modified(kb, "json")
+    db.commit()
+    db.refresh(kb)
+    return kb
+
+
+def _find_existing_system_docs(
+    db: Session,
+    knowledge_base_id: int,
+) -> dict[str, KnowledgeDocument]:
+    docs = (
+        db.query(KnowledgeDocument)
+        .filter(KnowledgeDocument.kind_id == knowledge_base_id)
+        .all()
+    )
+    result: dict[str, KnowledgeDocument] = {}
+    for doc in docs:
+        source_config = doc.source_config or {}
+        if source_config.get("source") == SYSTEM_SOURCE and source_config.get(
+            "source_path"
+        ):
+            result[source_config["source_path"]] = doc
+    return result
+
+
+def _source_config(seed: SystemKnowledgeSeed, document: SeedDocument) -> dict[str, Any]:
+    return {
+        "source": SYSTEM_SOURCE,
+        "seed_id": seed.seed_id,
+        "source_path": document.source_path,
+        "language": document.language,
+        "category": document.category,
+        "content_sha256": document.content_sha256,
+    }
+
+
+def _write_source_config(
+    db: Session,
+    *,
+    doc: KnowledgeDocument,
+    seed: SystemKnowledgeSeed,
+    seed_document: SeedDocument,
+) -> None:
+    doc.source_config = _source_config(seed, seed_document)
+    flag_modified(doc, "source_config")
+    db.commit()
+    db.refresh(doc)
+
+
+def _has_retrieval_config(knowledge_base: Kind) -> bool:
+    return bool(((knowledge_base.json or {}).get("spec") or {}).get("retrievalConfig"))
+
+
+def schedule_document_indexing_if_possible(
+    *,
+    db: Session,
+    knowledge_base: Kind,
+    document: KnowledgeDocument,
+    admin_user: User,
+) -> dict[str, Any]:
+    if not _has_retrieval_config(knowledge_base):
+        return {"scheduled": False, "reason": "missing_retrieval_config"}
+
+    from app.services.knowledge.orchestrator import knowledge_orchestrator
+
+    return knowledge_orchestrator._schedule_indexing_celery(
+        db=db,
+        knowledge_base=knowledge_base,
+        document=document,
+        user=admin_user,
+        trigger_summary=False,
+        allow_if_success=True,
+        replace_active=True,
+    )
+
+
+def _create_seed_document(
+    db: Session,
+    *,
+    seed: SystemKnowledgeSeed,
+    knowledge_base: Kind,
+    seed_document: SeedDocument,
+    admin_user: User,
+) -> KnowledgeDocument:
+    binary_content = seed_document.content.encode("utf-8")
+    attachment, _ = context_service.upload_attachment(
+        db=db,
+        user_id=admin_user.id,
+        filename=f"{seed_document.title}.md",
+        binary_data=binary_content,
+        subtask_id=0,
+    )
+    doc = KnowledgeService.create_document(
+        db=db,
+        knowledge_base_id=knowledge_base.id,
+        user_id=admin_user.id,
+        data=KnowledgeDocumentCreate(
+            name=seed_document.title,
+            source_type="text",
+            attachment_id=attachment.id,
+            file_extension="md",
+            file_size=len(binary_content),
+            folder_id=0,
+        ),
+    )
+    _write_source_config(db, doc=doc, seed=seed, seed_document=seed_document)
+    return doc
+
+
+def _update_seed_document(
+    db: Session,
+    *,
+    seed: SystemKnowledgeSeed,
+    doc: KnowledgeDocument,
+    seed_document: SeedDocument,
+    admin_user: User,
+) -> KnowledgeDocument:
+    from app.services.knowledge.orchestrator import knowledge_orchestrator
+
+    knowledge_orchestrator.update_document_content(
+        db=db,
+        user=admin_user,
+        document_id=doc.id,
+        content=seed_document.content,
+        trigger_reindex=False,
+    )
+    doc = db.query(KnowledgeDocument).filter(KnowledgeDocument.id == doc.id).one()
+    doc.name = seed_document.title
+    _write_source_config(db, doc=doc, seed=seed, seed_document=seed_document)
+    return doc
+
+
+def sync_system_documents(
+    db: Session,
+    *,
+    seed: SystemKnowledgeSeed,
+    knowledge_base: Kind,
+    admin_user: User,
+) -> dict[str, int]:
+    existing = _find_existing_system_docs(db, knowledge_base.id)
+    stats = {"created": 0, "updated": 0, "skipped": 0}
+
+    for seed_document in seed.documents:
+        doc = existing.get(seed_document.source_path)
+        if (
+            doc
+            and (doc.source_config or {}).get("content_sha256")
+            == seed_document.content_sha256
+        ):
+            stats["skipped"] += 1
+            continue
+
+        if doc is None:
+            doc = _create_seed_document(
+                db,
+                seed=seed,
+                knowledge_base=knowledge_base,
+                seed_document=seed_document,
+                admin_user=admin_user,
+            )
+            stats["created"] += 1
+        else:
+            doc = _update_seed_document(
+                db,
+                seed=seed,
+                doc=doc,
+                seed_document=seed_document,
+                admin_user=admin_user,
+            )
+            stats["updated"] += 1
+
+        schedule_document_indexing_if_possible(
+            db=db,
+            knowledge_base=knowledge_base,
+            document=doc,
+            admin_user=admin_user,
+        )
+
+    return stats
+
+
+def run_system_knowledge_initialization(
+    db: Session,
+    admin_user_id: int,
+    init_data_dir: Path,
+) -> dict[str, Any]:
+    seed_root = init_data_dir / SYSTEM_KNOWLEDGE_DIR / DEFAULT_SEED_ID
+    seed = load_system_knowledge_seed(seed_root)
+    if seed is None:
+        return {"status": "skipped", "reason": "missing_manifest"}
+
+    admin_user = db.query(User).filter(User.id == admin_user_id).first()
+    if not admin_user:
+        return {"status": "error", "reason": "admin_user_not_found"}
+
+    ensure_system_namespace(db, name=seed.namespace, owner_user_id=admin_user.id)
+    knowledge_base = ensure_system_help_knowledge_base(
+        db,
+        seed=seed,
+        admin_user=admin_user,
+    )
+    stats = sync_system_documents(
+        db,
+        seed=seed,
+        knowledge_base=knowledge_base,
+        admin_user=admin_user,
+    )
+
+    return {
+        "status": "completed",
+        "knowledge_base_id": knowledge_base.id,
+        "documents_created": stats["created"],
+        "documents_updated": stats["updated"],
+        "documents_skipped": stats["skipped"],
+    }

--- a/backend/app/core/system_knowledge_init.py
+++ b/backend/app/core/system_knowledge_init.py
@@ -23,6 +23,7 @@ from app.schemas.knowledge import KnowledgeBaseCreate, KnowledgeDocumentCreate
 from app.schemas.namespace import GroupLevel
 from app.services.context import context_service
 from app.services.knowledge.knowledge_service import KnowledgeService
+from shared.telemetry.decorators import add_span_event, set_span_attribute, trace_sync
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,13 @@ SYSTEM_SOURCE = "system_knowledge_seed"
 
 @dataclass(frozen=True)
 class SeedDocument:
+    """A Markdown document copied into a system knowledge seed package.
+
+    The source and seed paths identify the original docs location and the
+    packaged file path. The content hash is used to decide whether an existing
+    system knowledge document needs to be updated during startup.
+    """
+
     source_path: str
     seed_path: str
     language: str
@@ -44,6 +52,12 @@ class SeedDocument:
 
 @dataclass(frozen=True)
 class SystemKnowledgeSeed:
+    """A complete system knowledge seed manifest loaded from init data.
+
+    The seed describes the target knowledge base metadata and the Markdown
+    documents that should be synchronized into that built-in knowledge base.
+    """
+
     seed_id: str
     kb_name: str
     kb_display_name: str
@@ -61,26 +75,60 @@ def _safe_seed_file(seed_root: Path, seed_path: str) -> Path:
 
 
 def load_system_knowledge_seed(seed_root: Path) -> SystemKnowledgeSeed | None:
+    """Load a system knowledge seed manifest and its packaged documents.
+
+    Args:
+        seed_root: Directory containing `manifest.json` and copied seed files.
+
+    Returns:
+        Parsed seed data, or None when the manifest is missing or malformed.
+        Invalid document entries are skipped so one bad file does not abort
+        startup initialization.
+    """
+
     manifest_path = seed_root / "manifest.json"
     if not manifest_path.exists():
         logger.info("System knowledge manifest not found: %s", manifest_path)
         return None
 
-    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.error("Invalid system knowledge manifest at %s: %s", manifest_path, exc)
+        return None
+
+    if not isinstance(manifest, dict):
+        logger.error("Invalid system knowledge manifest shape at %s", manifest_path)
+        return None
+
     kb = manifest.get("knowledge_base") or {}
+    if not isinstance(kb, dict):
+        logger.warning("Invalid knowledge_base metadata in %s", manifest_path)
+        kb = {}
     documents: list[SeedDocument] = []
 
-    for item in manifest.get("documents") or []:
-        seed_path = item["seed_path"]
-        content = _safe_seed_file(seed_root, seed_path).read_text(encoding="utf-8")
+    document_items = manifest.get("documents") or []
+    if not isinstance(document_items, list):
+        logger.warning("Invalid documents metadata in %s", manifest_path)
+        document_items = []
+
+    for item in document_items:
+        try:
+            seed_path = item["seed_path"]
+            source_path = item["source_path"]
+            content_sha256 = item["content_sha256"]
+            content = _safe_seed_file(seed_root, seed_path).read_text(encoding="utf-8")
+        except (KeyError, OSError, TypeError, ValueError) as exc:
+            logger.warning("Skipping invalid seed document entry %r: %s", item, exc)
+            continue
         documents.append(
             SeedDocument(
-                source_path=item["source_path"],
+                source_path=source_path,
                 seed_path=seed_path,
                 language=item.get("language", ""),
                 title=item.get("title") or Path(seed_path).stem,
                 category=item.get("category", ""),
-                content_sha256=item["content_sha256"],
+                content_sha256=content_sha256,
                 content=content,
             )
         )
@@ -101,6 +149,17 @@ def ensure_system_namespace(
     name: str,
     owner_user_id: int,
 ) -> Namespace:
+    """Create or normalize the namespace used by built-in system knowledge.
+
+    Args:
+        db: SQLAlchemy session used for reads and writes.
+        name: Namespace name to create or update.
+        owner_user_id: User id that owns newly created namespace records.
+
+    Returns:
+        Active organization-level namespace with internal visibility.
+    """
+
     namespace = db.query(Namespace).filter(Namespace.name == name).first()
     if namespace:
         changed = False
@@ -148,6 +207,17 @@ def ensure_system_help_knowledge_base(
     seed: SystemKnowledgeSeed,
     admin_user: User,
 ) -> Kind:
+    """Create or locate the built-in help knowledge base for a seed.
+
+    Args:
+        db: SQLAlchemy session used for reads and writes.
+        seed: Parsed system knowledge seed metadata.
+        admin_user: Admin user that owns the system knowledge base.
+
+    Returns:
+        KnowledgeBase Kind labeled with the seed source and seed id.
+    """
+
     labels = _system_labels(seed)
     candidates = (
         db.query(Kind)
@@ -328,6 +398,18 @@ def sync_system_documents(
     knowledge_base: Kind,
     admin_user: User,
 ) -> dict[str, int]:
+    """Synchronize seed documents into the target knowledge base.
+
+    Args:
+        db: SQLAlchemy session used for reads and writes.
+        seed: Parsed seed documents and metadata.
+        knowledge_base: KnowledgeBase Kind that receives the documents.
+        admin_user: Admin user used for document creation and indexing.
+
+    Returns:
+        Counts for created, updated, and skipped documents.
+    """
+
     existing = _find_existing_system_docs(db, knowledge_base.id)
     stats = {"created": 0, "updated": 0, "skipped": 0}
 
@@ -370,18 +452,43 @@ def sync_system_documents(
     return stats
 
 
+@trace_sync("system_knowledge.initialization", "backend.system_knowledge")
 def run_system_knowledge_initialization(
     db: Session,
     admin_user_id: int,
     init_data_dir: Path,
 ) -> dict[str, Any]:
+    """Initialize built-in system knowledge from packaged init data.
+
+    Args:
+        db: SQLAlchemy session used for startup initialization.
+        admin_user_id: Admin user id that owns created system resources.
+        init_data_dir: Base init data directory containing system knowledge seeds.
+
+    Returns:
+        Summary dictionary with status, reason when skipped or errored, and
+        document synchronization counts when initialization completes.
+    """
+
     seed_root = init_data_dir / SYSTEM_KNOWLEDGE_DIR / DEFAULT_SEED_ID
     seed = load_system_knowledge_seed(seed_root)
     if seed is None:
+        set_span_attribute("system_knowledge.status", "skipped")
+        set_span_attribute("system_knowledge.reason", "missing_manifest")
+        add_span_event(
+            "system_knowledge.initialization.skipped",
+            {"reason": "missing_manifest"},
+        )
         return {"status": "skipped", "reason": "missing_manifest"}
 
     admin_user = db.query(User).filter(User.id == admin_user_id).first()
     if not admin_user:
+        set_span_attribute("system_knowledge.status", "error")
+        set_span_attribute("system_knowledge.reason", "admin_user_not_found")
+        add_span_event(
+            "system_knowledge.initialization.error",
+            {"reason": "admin_user_not_found"},
+        )
         return {"status": "error", "reason": "admin_user_not_found"}
 
     ensure_system_namespace(db, name=seed.namespace, owner_user_id=admin_user.id)
@@ -397,10 +504,25 @@ def run_system_knowledge_initialization(
         admin_user=admin_user,
     )
 
-    return {
+    result = {
         "status": "completed",
         "knowledge_base_id": knowledge_base.id,
         "documents_created": stats["created"],
         "documents_updated": stats["updated"],
         "documents_skipped": stats["skipped"],
     }
+    set_span_attribute("system_knowledge.status", result["status"])
+    set_span_attribute("system_knowledge.knowledge_base_id", knowledge_base.id)
+    set_span_attribute("system_knowledge.documents_created", stats["created"])
+    set_span_attribute("system_knowledge.documents_updated", stats["updated"])
+    set_span_attribute("system_knowledge.documents_skipped", stats["skipped"])
+    add_span_event(
+        "system_knowledge.initialization.completed",
+        {
+            "knowledge_base_id": knowledge_base.id,
+            "documents_created": stats["created"],
+            "documents_updated": stats["updated"],
+            "documents_skipped": stats["skipped"],
+        },
+    )
+    return result

--- a/backend/app/core/yaml_init.py
+++ b/backend/app/core/yaml_init.py
@@ -18,6 +18,7 @@ import yaml
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.core.system_knowledge_init import run_system_knowledge_initialization
 from app.models.user import User
 from app.services.admin_password_bootstrap import (
     create_unusable_password_hash,
@@ -685,6 +686,13 @@ def run_yaml_initialization(db: Session, skip_lock: bool = False) -> Dict[str, A
         # Apply all public resources (Shell, Ghost, Bot, Team, Skill)
         # All resources are now public (user_id=0) and accessible by all users
         summary = scan_and_apply_yaml_directory(user_id, init_dir, db, force=force)
+        system_knowledge_summary = run_system_knowledge_initialization(
+            db=db,
+            admin_user_id=user_id,
+            init_data_dir=init_dir,
+        )
+        if isinstance(summary, dict):
+            summary["system_knowledge"] = system_knowledge_summary
 
         logger.info(f"YAML initialization completed: {summary}")
         return summary

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,6 +91,7 @@ def _format_forwarded_headers_for_log(headers) -> str:
 
 def _get_mcp_lifespan_servers():
     from app.mcp_server.server import (
+        help_knowledge_mcp_server,
         interactive_form_question_mcp_server,
         knowledge_mcp_server,
         prompt_optimization_mcp_server,
@@ -101,6 +102,7 @@ def _get_mcp_lifespan_servers():
     servers = [
         ("System", system_mcp_server),
         ("Knowledge", knowledge_mcp_server),
+        ("Help knowledge", help_knowledge_mcp_server),
         ("interactive_form_question", interactive_form_question_mcp_server),
         ("Prompt optimization", prompt_optimization_mcp_server),
         ("Subscription", subscription_mcp_server),

--- a/backend/app/mcp_server/server.py
+++ b/backend/app/mcp_server/server.py
@@ -8,6 +8,8 @@ This module provides MCP servers for Wegent Backend with these endpoints:
 - /mcp/system - System-level tools (silent_exit) automatically injected into all tasks
 - /mcp/knowledge - Knowledge MCP module root
   - /mcp/knowledge/sse - Knowledge MCP streamable HTTP transport endpoint
+- /mcp/help-knowledge - Wegent Help query-only knowledge MCP module root
+  - /mcp/help-knowledge/sse - Wegent Help query MCP streamable HTTP endpoint
 - /mcp/knowledge-external - Trusted external knowledge integration MCP root
   - /mcp/knowledge-external/sse - External knowledge MCP streamable HTTP transport endpoint
 New MCP servers should follow /mcp/<name>/sse for streamable HTTP transport.
@@ -56,6 +58,8 @@ SYSTEM_MCP_MOUNT_PATH = "/mcp/system"
 SYSTEM_MCP_TRANSPORT_PATH = "/"
 KNOWLEDGE_MCP_MOUNT_PATH = "/mcp/knowledge"
 KNOWLEDGE_MCP_TRANSPORT_PATH = "/sse"
+HELP_KNOWLEDGE_MCP_MOUNT_PATH = "/mcp/help-knowledge"
+HELP_KNOWLEDGE_MCP_TRANSPORT_PATH = "/sse"
 EXTERNAL_KNOWLEDGE_MCP_MOUNT_PATH = "/mcp/knowledge-external"
 EXTERNAL_KNOWLEDGE_MCP_TRANSPORT_PATH = "/sse"
 EXTERNAL_KNOWLEDGE_PUBLIC_PATHS = frozenset({"", "/", "/health"})
@@ -204,6 +208,14 @@ knowledge_mcp_server = FastMCP(
     transport_security=_build_transport_security_settings(),
 )
 
+help_knowledge_mcp_server = FastMCP(
+    "wegent-help-knowledge-mcp",
+    stateless_http=True,
+    json_response=True,
+    streamable_http_path="/",
+    transport_security=_build_transport_security_settings(),
+)
+
 external_knowledge_mcp_server = FastMCP(
     "wegent-knowledge-external-mcp",
     stateless_http=True,
@@ -216,9 +228,13 @@ external_knowledge_mcp_server = FastMCP(
 _knowledge_request_token_info: contextvars.ContextVar[Optional[TaskTokenInfo]] = (
     contextvars.ContextVar("_knowledge_request_token_info", default=None)
 )
+_help_knowledge_request_token_info: contextvars.ContextVar[Optional[TaskTokenInfo]] = (
+    contextvars.ContextVar("_help_knowledge_request_token_info", default=None)
+)
 
 # Flag to track if tools have been registered
 _knowledge_tools_registered = False
+_help_knowledge_tools_registered = False
 
 _external_knowledge_request_user: contextvars.ContextVar[
     Optional[ExternalKnowledgeUser]
@@ -315,6 +331,31 @@ def ensure_knowledge_tools_registered() -> None:
     all @mcp_tool decorated endpoints as MCP tools.
     """
     _register_knowledge_tools()
+
+
+def _register_help_knowledge_tools() -> None:
+    """Register Wegent Help query-only tools."""
+    global _help_knowledge_tools_registered
+    if _help_knowledge_tools_registered:
+        return
+
+    from app.mcp_server.tool_registry import register_tools_to_server
+    from app.mcp_server.tools import (  # noqa: F401 side-effect: triggers @mcp_tool registration
+        help_knowledge,
+    )
+
+    count = register_tools_to_server(help_knowledge_mcp_server, "help_knowledge")
+    logger.info(
+        "[MCP:HelpKnowledge] Registered %s tools from decorated endpoints",
+        count,
+    )
+
+    _help_knowledge_tools_registered = True
+
+
+def ensure_help_knowledge_tools_registered() -> None:
+    """Ensure Wegent Help query-only MCP tools are registered."""
+    _register_help_knowledge_tools()
 
 
 def _register_external_knowledge_tools() -> None:
@@ -545,6 +586,17 @@ _KNOWLEDGE_MCP_SPEC = McpAppSpec(
     include_root_metadata=True,
 )
 
+_HELP_KNOWLEDGE_MCP_SPEC = McpAppSpec(
+    name="help_knowledge",
+    service_name="wegent-help-knowledge-mcp",
+    mount_path=HELP_KNOWLEDGE_MCP_MOUNT_PATH,
+    transport_path=HELP_KNOWLEDGE_MCP_TRANSPORT_PATH,
+    server=help_knowledge_mcp_server,
+    token_context=_help_knowledge_request_token_info,
+    log_prefix="HelpKnowledge",
+    include_root_metadata=True,
+)
+
 _INTERACTIVE_FORM_MCP_SPEC = McpAppSpec(
     name="interactive_form_question",
     service_name="wegent-interactive-form-question-mcp",
@@ -581,6 +633,7 @@ _SUBSCRIPTION_MCP_SPEC = McpAppSpec(
 MCP_APP_SPECS = (
     _SYSTEM_MCP_SPEC,
     _KNOWLEDGE_MCP_SPEC,
+    _HELP_KNOWLEDGE_MCP_SPEC,
     _INTERACTIVE_FORM_MCP_SPEC,
     _PROMPT_OPTIMIZATION_MCP_SPEC,
     _SUBSCRIPTION_MCP_SPEC,
@@ -611,6 +664,8 @@ def _build_mcp_app(spec: McpAppSpec) -> Starlette:
     # Ensure tools are registered before creating the app
     if spec.name == "knowledge":
         ensure_knowledge_tools_registered()
+    elif spec.name == "help_knowledge":
+        ensure_help_knowledge_tools_registered()
     elif spec.name == "interactive_form_question":
         ensure_interactive_form_question_tools_registered()
     elif spec.name == "prompt_optimization":
@@ -660,6 +715,7 @@ def _build_mcp_app(spec: McpAppSpec) -> Starlette:
                 # Set MCPRequestContext for decorator-based tools
                 if spec.name in (
                     "knowledge",
+                    "help_knowledge",
                     "interactive_form_question",
                     "prompt_optimization",
                     "subscription",
@@ -730,6 +786,11 @@ def _create_system_mcp_app() -> Starlette:
 def _create_knowledge_mcp_app() -> Starlette:
     """Create Starlette app for knowledge MCP server."""
     return _build_mcp_app(_KNOWLEDGE_MCP_SPEC)
+
+
+def _create_help_knowledge_mcp_app() -> Starlette:
+    """Create Starlette app for Wegent Help query-only MCP server."""
+    return _build_mcp_app(_HELP_KNOWLEDGE_MCP_SPEC)
 
 
 def register_mcp_apps(app: FastAPI, mount_prefix: str = "") -> None:

--- a/backend/app/mcp_server/tools/__init__.py
+++ b/backend/app/mcp_server/tools/__init__.py
@@ -8,6 +8,7 @@ Contains tools for:
 - System MCP (silent_exit)
 - Knowledge MCP (list_knowledge_bases, list_documents, create_knowledge_base,
   create_document, update_document_content)
+- Help Knowledge MCP (query-only access to built-in Wegent Help)
 
 Knowledge MCP tools are implemented independently using the KnowledgeOrchestrator
 service layer, with Celery-based async task scheduling for indexing and summary.
@@ -26,12 +27,14 @@ from .decorator import (
     get_registered_mcp_tools,
     mcp_tool,
 )
+from .help_knowledge import HELP_KNOWLEDGE_MCP_TOOLS
 from .knowledge import KNOWLEDGE_MCP_TOOLS
 from .silent_exit import silent_exit
 from .subscription import create_subscription, preview_subscription
 
 __all__ = [
     "silent_exit",
+    "HELP_KNOWLEDGE_MCP_TOOLS",
     "KNOWLEDGE_MCP_TOOLS",
     "mcp_tool",
     "get_registered_mcp_tools",

--- a/backend/app/mcp_server/tools/help_knowledge.py
+++ b/backend/app/mcp_server/tools/help_knowledge.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Query-only MCP tools for the built-in Wegent Help knowledge base."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.core.system_knowledge_init import DEFAULT_SEED_ID, SYSTEM_SOURCE
+from app.db.session import SessionLocal
+from app.mcp_server.auth import TaskTokenInfo
+from app.mcp_server.tools.decorator import build_mcp_tools_dict, mcp_tool
+from app.mcp_server.tools.knowledge_utils import (
+    build_search_sources,
+    get_user_from_task_token,
+)
+from app.models.kind import Kind
+from app.services.knowledge.orchestrator import knowledge_orchestrator
+
+logger = logging.getLogger(__name__)
+
+HELP_KNOWLEDGE_NAMESPACE = "system"
+HELP_KNOWLEDGE_DISPLAY_NAME = "Wegent Help"
+HELP_QUERY_DEFAULT_MAX_RESULTS = 8
+HELP_QUERY_MAX_RESULTS = 20
+
+
+def _kind_labels(kind: Kind) -> dict[str, Any]:
+    metadata = (kind.json or {}).get("metadata") or {}
+    labels = metadata.get("labels") or {}
+    return labels if isinstance(labels, dict) else {}
+
+
+def _kind_spec(kind: Kind) -> dict[str, Any]:
+    spec = (kind.json or {}).get("spec") or {}
+    return spec if isinstance(spec, dict) else {}
+
+
+def _is_help_knowledge_base(kind: Kind) -> bool:
+    labels = _kind_labels(kind)
+    if (
+        labels.get("source") == SYSTEM_SOURCE
+        and labels.get("seed_id") == DEFAULT_SEED_ID
+    ):
+        return True
+    return _kind_spec(kind).get("name") == HELP_KNOWLEDGE_DISPLAY_NAME
+
+
+def _find_help_knowledge_base(db: Session) -> Kind | None:
+    candidates = (
+        db.query(Kind)
+        .filter(
+            Kind.kind == "KnowledgeBase",
+            Kind.namespace == HELP_KNOWLEDGE_NAMESPACE,
+            Kind.is_active == True,
+        )
+        .all()
+    )
+    for knowledge_base in candidates:
+        if _is_help_knowledge_base(knowledge_base):
+            return knowledge_base
+    return None
+
+
+def _normalize_max_results(max_results: int) -> int:
+    if max_results < 1:
+        return HELP_QUERY_DEFAULT_MAX_RESULTS
+    return min(max_results, HELP_QUERY_MAX_RESULTS)
+
+
+@mcp_tool(
+    name="wegent_help_query",
+    description=(
+        "Search the built-in Wegent Help knowledge base. This read-only tool "
+        "always queries the system help documentation and does not manage user "
+        "knowledge bases or documents."
+    ),
+    server="help_knowledge",
+    param_descriptions={
+        "query": "The user's Wegent help question.",
+        "max_results": "Maximum number of relevant chunks to return.",
+    },
+)
+async def query_wegent_help(
+    token_info: TaskTokenInfo,
+    query: str,
+    max_results: int = HELP_QUERY_DEFAULT_MAX_RESULTS,
+) -> dict[str, Any]:
+    """Search the seeded Wegent Help knowledge base with RAG retrieval."""
+    normalized_query = (query or "").strip()
+    if not normalized_query:
+        return {
+            "error": "query is required",
+            "query": query,
+            "chunks": [],
+            "sources": [],
+            "total": 0,
+        }
+
+    db = SessionLocal()
+    try:
+        user = get_user_from_task_token(db, token_info)
+        if not user:
+            return {
+                "error": "User not found",
+                "query": normalized_query,
+                "chunks": [],
+                "sources": [],
+                "total": 0,
+            }
+
+        knowledge_base = _find_help_knowledge_base(db)
+        if knowledge_base is None:
+            return {
+                "error": "Built-in Wegent Help knowledge base is not initialized",
+                "query": normalized_query,
+                "chunks": [],
+                "sources": [],
+                "total": 0,
+            }
+
+        result = await knowledge_orchestrator.retrieve_knowledge(
+            db=db,
+            user=user,
+            knowledge_base_id=knowledge_base.id,
+            query=normalized_query,
+            max_results=_normalize_max_results(max_results),
+            route_mode="rag_retrieval",
+        )
+        chunks = result.get("records", [])
+
+        return {
+            "query": result.get("query", normalized_query),
+            "knowledge_base_id": knowledge_base.id,
+            "knowledge_base_name": _kind_spec(knowledge_base).get(
+                "name", HELP_KNOWLEDGE_DISPLAY_NAME
+            ),
+            "chunks": chunks,
+            "sources": build_search_sources(chunks),
+            "total": result.get("total", 0),
+            "mode": result.get("mode", "rag_retrieval"),
+        }
+
+    except ValueError as exc:
+        logger.warning("[MCP:HelpKnowledge] query validation error: %s", exc)
+        return {
+            "error": str(exc),
+            "query": normalized_query,
+            "chunks": [],
+            "sources": [],
+            "total": 0,
+        }
+    except Exception as exc:
+        logger.error("[MCP:HelpKnowledge] query error: %s", exc, exc_info=True)
+        return {
+            "error": str(exc),
+            "query": normalized_query,
+            "chunks": [],
+            "sources": [],
+            "total": 0,
+        }
+    finally:
+        db.close()
+
+
+HELP_KNOWLEDGE_MCP_TOOLS = build_mcp_tools_dict(server="help_knowledge")

--- a/backend/app/mcp_server/tools/knowledge.py
+++ b/backend/app/mcp_server/tools/knowledge.py
@@ -27,6 +27,10 @@ from sqlalchemy.orm import Session
 from app.db.session import SessionLocal
 from app.mcp_server.auth import TaskTokenInfo
 from app.mcp_server.tools.decorator import build_mcp_tools_dict, mcp_tool
+from app.mcp_server.tools.knowledge_utils import (
+    build_search_sources,
+    get_user_from_task_token,
+)
 from app.models.user import User
 from app.services.knowledge.orchestrator import (
     DEFAULT_KNOWLEDGE_LIST_LIMIT,
@@ -40,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 def _get_user_from_token(db: Session, token_info: TaskTokenInfo) -> Optional[User]:
     """Get user from token info."""
-    return db.query(User).filter(User.id == token_info.user_id).first()
+    return get_user_from_task_token(db, token_info)
 
 
 @mcp_tool(
@@ -112,23 +116,7 @@ async def search_knowledge_base(
         # MCP expects: chunks, sources, total, mode, query
         chunks = result.get("records", [])
 
-        # Build sources from chunks
-        sources = []
-        seen_docs = set()
-        for chunk in chunks:
-            doc_key = (chunk.get("knowledge_base_id"), chunk.get("document_id"))
-            if doc_key not in seen_docs:
-                seen_docs.add(doc_key)
-                sources.append(
-                    {
-                        "document_id": chunk.get("document_id"),
-                        "document_name": chunk.get("document_name", "Unknown"),
-                        "knowledge_base_id": chunk.get("knowledge_base_id"),
-                        "knowledge_base_name": chunk.get(
-                            "knowledge_base_name", "Unknown"
-                        ),
-                    }
-                )
+        sources = build_search_sources(chunks)
 
         return {
             "query": result.get("query", query),

--- a/backend/app/mcp_server/tools/knowledge_utils.py
+++ b/backend/app/mcp_server/tools/knowledge_utils.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for knowledge-related MCP tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from app.mcp_server.auth import TaskTokenInfo
+from app.models.user import User
+
+
+def get_user_from_task_token(db: Session, token_info: TaskTokenInfo) -> User | None:
+    """Get the current user from task token information."""
+    return db.query(User).filter(User.id == token_info.user_id).first()
+
+
+def build_search_sources(chunks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Build unique source references from retrieval chunks."""
+    sources: list[dict[str, Any]] = []
+    seen_docs: set[tuple[Any, Any]] = set()
+    for chunk in chunks:
+        doc_key = (chunk.get("knowledge_base_id"), chunk.get("document_id"))
+        if doc_key in seen_docs:
+            continue
+        seen_docs.add(doc_key)
+        sources.append(
+            {
+                "document_id": chunk.get("document_id"),
+                "document_name": chunk.get("document_name", "Unknown"),
+                "knowledge_base_id": chunk.get("knowledge_base_id"),
+                "knowledge_base_name": chunk.get("knowledge_base_name", "Unknown"),
+            }
+        )
+    return sources

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -250,9 +250,6 @@ class TaskRequestBuilder:
         extra_available_skills = self._inject_subscription_manager_skill(
             is_subscription=is_subscription,
         )
-        extra_available_skills = self._inject_default_help_skills(
-            extra_available_skills
-        )
         binding_context = self._build_skill_binding_context(task=task, team=team)
         user_default_skill_refs = skill_binding_service.list_user_default_skill_refs(
             self.db,
@@ -264,6 +261,9 @@ class TaskRequestBuilder:
                 effective_preload_skills.append(skill_ref)
             else:
                 extra_available_skills.append(skill_ref)
+        extra_available_skills = self._inject_default_help_skills(
+            extra_available_skills
+        )
 
         user_preload_skills = None
         if effective_preload_skills:

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -250,6 +250,9 @@ class TaskRequestBuilder:
         extra_available_skills = self._inject_subscription_manager_skill(
             is_subscription=is_subscription,
         )
+        extra_available_skills = self._inject_default_help_skills(
+            extra_available_skills
+        )
         binding_context = self._build_skill_binding_context(task=task, team=team)
         user_default_skill_refs = skill_binding_service.list_user_default_skill_refs(
             self.db,
@@ -2078,6 +2081,33 @@ Response template:
                 "is_public": True,
             }
         ]
+
+    @staticmethod
+    def _inject_default_help_skills(extra_available_skills: list) -> list:
+        """Add default on-demand help skills without preloading them."""
+        default_skill_refs = [
+            {
+                "name": "wegent-help",
+                "namespace": "default",
+                "is_public": True,
+            },
+            {
+                "name": "wegent-knowledge",
+                "namespace": "default",
+                "is_public": True,
+            },
+        ]
+        merged = list(extra_available_skills or [])
+        existing_names = {
+            item.get("name")
+            for item in merged
+            if isinstance(item, dict) and item.get("name")
+        }
+        for skill_ref in default_skill_refs:
+            if skill_ref["name"] not in existing_names:
+                merged.append(skill_ref)
+                existing_names.add(skill_ref["name"])
+        return merged
 
     def _inject_conditional_provider_skills(
         self,

--- a/backend/app/services/execution/request_builder.py
+++ b/backend/app/services/execution/request_builder.py
@@ -2092,7 +2092,7 @@ Response template:
                 "is_public": True,
             },
             {
-                "name": "wegent-knowledge",
+                "name": "wegent-help-knowledge",
                 "namespace": "default",
                 "is_public": True,
             },

--- a/backend/init_data/skills/wegent-help-knowledge/SKILL.md
+++ b/backend/init_data/skills/wegent-help-knowledge/SKILL.md
@@ -1,0 +1,38 @@
+---
+description: "Query the built-in Wegent Help knowledge base through a single read-only MCP tool. Use this skill only when Wegent Help needs documentation retrieval."
+displayName: "Wegent 帮助知识库查询"
+version: "1.0.0"
+author: "Wegent Team"
+tags: ["wegent", "help", "docs", "rag"]
+bindShells:
+  - Chat
+  - ClaudeCode
+preload: false
+mcpServers:
+  wegent-help-knowledge:
+    type: streamable-http
+    # NOTE: MCP client only supports ${{...}} variable substitution.
+    # The platform will inject `backend_url` via task_data.
+    url: "${{backend_url}}/mcp/help-knowledge/sse"
+    headers:
+      Authorization: "Bearer ${{task_token}}"
+    timeout: 300
+---
+
+# Wegent Help Knowledge Query
+
+Use this skill to search the built-in Wegent Help knowledge base.
+
+## Tool
+
+- `wegent_help_query`: Search Wegent Help with RAG retrieval.
+  - `query`: The user's full Wegent question.
+  - `max_results`: Optional result limit. Use `8` unless the user needs more detail.
+
+## Rules
+
+1. Pass the user's full question to `wegent_help_query`.
+2. Base the answer on returned chunks before using general model memory.
+3. Include source document names or source references from the response.
+4. If the tool returns an error or no chunks, say the built-in help content is unavailable or not indexed yet.
+5. Keep the answer in the same language as the user's question whenever possible.

--- a/backend/init_data/skills/wegent-help/SKILL.md
+++ b/backend/init_data/skills/wegent-help/SKILL.md
@@ -1,0 +1,30 @@
+---
+description: "Use when users ask Wegent usage, setup, configuration, troubleshooting, Agent/Bot/Skill, knowledge base, device, deployment, or developer-documentation questions. Load this skill and search the built-in Wegent Help knowledge base before answering."
+displayName: "Wegent 帮助"
+version: "1.0.0"
+author: "Wegent Team"
+tags: ["wegent", "help", "docs", "knowledge-base", "troubleshooting"]
+bindShells:
+  - Chat
+  - ClaudeCode
+preload: false
+---
+
+# Wegent Help
+
+Use this skill when the user asks about Wegent product usage, setup, configuration, troubleshooting, concepts, Agent/Team/Bot/Skill behavior, knowledge bases, devices, deployment, or developer documentation.
+
+## Required Workflow
+
+1. Use the existing `wegent-knowledge` skill tools to find the built-in knowledge base named `Wegent Help`.
+2. Search the `Wegent Help` knowledge base with the user's full question.
+3. Answer from retrieved Wegent documentation first.
+4. Use the same language as the user's question whenever possible.
+5. Include source document names or source references from the knowledge tool response.
+
+## Failure Handling
+
+- If the `Wegent Help` knowledge base is missing, say that the built-in help knowledge base is not initialized.
+- If documents are not indexed or no results are returned, say that the help documents are unavailable or not indexed yet, then give a concise next-step diagnostic.
+- Do not invent documentation details from general model memory.
+- Do not use web search unless the user explicitly asks for external or current information.

--- a/backend/init_data/skills/wegent-help/SKILL.md
+++ b/backend/init_data/skills/wegent-help/SKILL.md
@@ -16,11 +16,11 @@ Use this skill when the user asks about Wegent product usage, setup, configurati
 
 ## Required Workflow
 
-1. Use the existing `wegent-knowledge` skill tools to find the built-in knowledge base named `Wegent Help`.
-2. Search the `Wegent Help` knowledge base with the user's full question.
+1. Load the `wegent-help-knowledge` skill when you need documentation lookup.
+2. Use `wegent_help_query` with the user's full question.
 3. Answer from retrieved Wegent documentation first.
 4. Use the same language as the user's question whenever possible.
-5. Include source document names or source references from the knowledge tool response.
+5. Include source document names or source references from the query response.
 
 ## Failure Handling
 

--- a/backend/scripts/generate_wegent_help_knowledge_seed.py
+++ b/backend/scripts/generate_wegent_help_knowledge_seed.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate the built-in Wegent Help system knowledge seed."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_SEED_ID = "wegent-help"
+DEFAULT_KB_NAME = "Wegent Help"
+DEFAULT_KB_DISPLAY_NAME = "Wegent 帮助文档"
+DEFAULT_NAMESPACE = "system"
+
+
+def _strip_frontmatter(content: str) -> str:
+    if not content.startswith("---\n"):
+        return content
+
+    end = content.find("\n---\n", 4)
+    if end == -1:
+        return content
+
+    return content[end + len("\n---\n") :]
+
+
+def _extract_title(content: str, fallback: str) -> str:
+    body = _strip_frontmatter(content)
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("# "):
+            title = stripped[2:].strip()
+            if title:
+                return title
+    return fallback
+
+
+def _iter_markdown_docs(docs_root: Path) -> list[Path]:
+    zh_root = docs_root / "zh"
+    en_root = docs_root / "en"
+    if not zh_root.is_dir() or not en_root.is_dir():
+        raise ValueError("docs_root must contain docs/zh and docs/en directories")
+
+    docs = [
+        path
+        for root in (en_root, zh_root)
+        for path in root.rglob("*.md")
+        if path.is_file()
+    ]
+    return sorted(docs, key=lambda path: path.relative_to(docs_root).as_posix())
+
+
+def _build_document_entry(docs_root: Path, path: Path, content: str) -> dict[str, Any]:
+    relative = path.relative_to(docs_root)
+    relative_posix = relative.as_posix()
+    language = relative.parts[0]
+    category = "/".join(relative.parts[1:-1])
+
+    return {
+        "source_path": f"docs/{relative_posix}",
+        "seed_path": f"docs/{relative_posix}",
+        "language": language,
+        "title": _extract_title(content, path.stem),
+        "category": category,
+        "content_sha256": hashlib.sha256(content.encode("utf-8")).hexdigest(),
+    }
+
+
+def generate_seed(*, docs_root: Path, output_dir: Path) -> Path:
+    """Generate a deterministic system knowledge seed from Markdown docs."""
+    docs_root = docs_root.resolve()
+    output_dir = output_dir.absolute()
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+
+    (output_dir / "docs").mkdir(parents=True, exist_ok=True)
+
+    documents: list[dict[str, Any]] = []
+    for source_path in _iter_markdown_docs(docs_root):
+        content = source_path.read_text(encoding="utf-8")
+        entry = _build_document_entry(docs_root, source_path, content)
+        target_path = output_dir / entry["seed_path"]
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(content, encoding="utf-8")
+        documents.append(entry)
+
+    manifest = {
+        "seed_id": DEFAULT_SEED_ID,
+        "knowledge_base": {
+            "name": DEFAULT_KB_NAME,
+            "display_name": DEFAULT_KB_DISPLAY_NAME,
+            "namespace": DEFAULT_NAMESPACE,
+            "description": "Built-in Wegent user and developer documentation.",
+        },
+        "documents": documents,
+    }
+    manifest_path = output_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--docs-root", type=Path, default=_default_repo_root() / "docs")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1]
+        / "init_data"
+        / "system_knowledge"
+        / DEFAULT_SEED_ID,
+    )
+    args = parser.parse_args()
+
+    manifest_path = generate_seed(docs_root=args.docs_root, output_dir=args.output_dir)
+    print(f"Generated Wegent Help system knowledge seed: {manifest_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/generate_wegent_help_knowledge_seed.py
+++ b/backend/scripts/generate_wegent_help_knowledge_seed.py
@@ -14,7 +14,6 @@ import shutil
 from pathlib import Path
 from typing import Any
 
-
 DEFAULT_SEED_ID = "wegent-help"
 DEFAULT_KB_NAME = "Wegent Help"
 DEFAULT_KB_DISPLAY_NAME = "Wegent 帮助文档"
@@ -74,10 +73,22 @@ def _build_document_entry(docs_root: Path, path: Path, content: str) -> dict[str
     }
 
 
+def _validate_output_dir(*, docs_root: Path, output_dir: Path) -> None:
+    if output_dir == Path(output_dir.anchor):
+        raise ValueError("Refusing to use filesystem root as output_dir")
+    if (
+        output_dir == docs_root
+        or docs_root in output_dir.parents
+        or output_dir in docs_root.parents
+    ):
+        raise ValueError("output_dir must not overlap docs_root")
+
+
 def generate_seed(*, docs_root: Path, output_dir: Path) -> Path:
     """Generate a deterministic system knowledge seed from Markdown docs."""
     docs_root = docs_root.resolve()
-    output_dir = output_dir.absolute()
+    output_dir = output_dir.resolve()
+    _validate_output_dir(docs_root=docs_root, output_dir=output_dir)
 
     if output_dir.exists():
         shutil.rmtree(output_dir)

--- a/backend/tests/core/test_system_knowledge_init.py
+++ b/backend/tests/core/test_system_knowledge_init.py
@@ -9,7 +9,15 @@ from pathlib import Path
 
 import pytest
 
-from app.core.system_knowledge_init import run_system_knowledge_initialization
+from app.core.system_knowledge_init import (
+    SeedDocument,
+    SystemKnowledgeSeed,
+    ensure_system_help_knowledge_base,
+    ensure_system_namespace,
+    load_system_knowledge_seed,
+    run_system_knowledge_initialization,
+    sync_system_documents,
+)
 from app.models.kind import Kind
 from app.models.knowledge import KnowledgeDocument
 from app.models.namespace import Namespace
@@ -130,6 +138,110 @@ def test_system_knowledge_init_updates_changed_document(
     doc = test_db.query(KnowledgeDocument).one()
     assert result["documents_updated"] == 1
     assert doc.source_config["content_sha256"] == "hash-2"
+
+
+def test_load_system_knowledge_seed_returns_none_for_invalid_manifest(
+    tmp_path: Path,
+) -> None:
+    seed_dir = tmp_path / "system_knowledge" / "wegent-help"
+    seed_dir.mkdir(parents=True)
+    (seed_dir / "manifest.json").write_text("{not-json", encoding="utf-8")
+
+    assert load_system_knowledge_seed(seed_dir) is None
+
+
+def test_load_system_knowledge_seed_skips_invalid_document_entries(
+    tmp_path: Path,
+) -> None:
+    seed_dir = tmp_path / "system_knowledge" / "wegent-help"
+    valid_doc = seed_dir / "docs" / "en" / "quick-start.md"
+    valid_doc.parent.mkdir(parents=True)
+    valid_doc.write_text("# Quick Start\n\nUse Wegent.", encoding="utf-8")
+    manifest = {
+        "seed_id": "wegent-help",
+        "documents": [
+            {"seed_path": "docs/en/missing-source-path.md"},
+            {
+                "source_path": "docs/en/outside.md",
+                "seed_path": "../outside.md",
+                "content_sha256": "hash-outside",
+            },
+            {
+                "source_path": "docs/en/quick-start.md",
+                "seed_path": "docs/en/quick-start.md",
+                "language": "en",
+                "title": "Quick Start",
+                "category": "",
+                "content_sha256": "hash-1",
+            },
+        ],
+    }
+    (seed_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    seed = load_system_knowledge_seed(seed_dir)
+
+    assert seed is not None
+    assert [document.source_path for document in seed.documents] == [
+        "docs/en/quick-start.md"
+    ]
+
+
+def test_load_system_knowledge_seed_uses_defaults_for_invalid_kb_metadata(
+    tmp_path: Path,
+) -> None:
+    seed_dir = tmp_path / "system_knowledge" / "wegent-help"
+    seed_dir.mkdir(parents=True)
+    manifest = {
+        "seed_id": "wegent-help",
+        "knowledge_base": "invalid",
+        "documents": [],
+    }
+    (seed_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    seed = load_system_knowledge_seed(seed_dir)
+
+    assert seed is not None
+    assert seed.kb_name == "Wegent Help"
+    assert seed.namespace == "system"
+
+
+def test_run_system_knowledge_initialization_records_missing_manifest_trace(
+    test_db, tmp_path: Path, mocker
+) -> None:
+    add_event = mocker.patch(
+        "app.core.system_knowledge_init.add_span_event", create=True
+    )
+    set_attribute = mocker.patch(
+        "app.core.system_knowledge_init.set_span_attribute", create=True
+    )
+
+    result = run_system_knowledge_initialization(
+        db=test_db,
+        admin_user_id=123,
+        init_data_dir=tmp_path,
+    )
+
+    assert result == {"status": "skipped", "reason": "missing_manifest"}
+    set_attribute.assert_any_call("system_knowledge.status", "skipped")
+    set_attribute.assert_any_call("system_knowledge.reason", "missing_manifest")
+    add_event.assert_any_call(
+        "system_knowledge.initialization.skipped",
+        {"reason": "missing_manifest"},
+    )
+
+
+def test_public_system_knowledge_apis_have_docstrings() -> None:
+    public_objects = [
+        SeedDocument,
+        SystemKnowledgeSeed,
+        load_system_knowledge_seed,
+        ensure_system_namespace,
+        ensure_system_help_knowledge_base,
+        sync_system_documents,
+        run_system_knowledge_initialization,
+    ]
+
+    assert all(item.__doc__ for item in public_objects)
 
 
 def test_yaml_initialization_calls_system_knowledge_init(test_db, mocker) -> None:

--- a/backend/tests/core/test_system_knowledge_init.py
+++ b/backend/tests/core/test_system_knowledge_init.py
@@ -130,3 +130,25 @@ def test_system_knowledge_init_updates_changed_document(
     doc = test_db.query(KnowledgeDocument).one()
     assert result["documents_updated"] == 1
     assert doc.source_config["content_sha256"] == "hash-2"
+
+
+def test_yaml_initialization_calls_system_knowledge_init(test_db, mocker) -> None:
+    mocker.patch("app.core.yaml_init.settings.INIT_DATA_ENABLED", True)
+    mocker.patch("app.core.yaml_init.settings.ENVIRONMENT", "development")
+    mocker.patch("app.core.yaml_init.ensure_default_user", return_value=(123, False))
+    mocker.patch(
+        "app.core.yaml_init.scan_and_apply_yaml_directory",
+        return_value={"status": "completed", "resources_total": 0},
+    )
+    system_init = mocker.patch(
+        "app.core.yaml_init.run_system_knowledge_initialization",
+        return_value={"status": "completed"},
+    )
+
+    from app.core.yaml_init import run_yaml_initialization
+
+    result = run_yaml_initialization(test_db)
+
+    assert result["status"] == "completed"
+    assert result["system_knowledge"] == {"status": "completed"}
+    system_init.assert_called_once()

--- a/backend/tests/core/test_system_knowledge_init.py
+++ b/backend/tests/core/test_system_knowledge_init.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.core.system_knowledge_init import run_system_knowledge_initialization
+from app.models.kind import Kind
+from app.models.knowledge import KnowledgeDocument
+from app.models.namespace import Namespace
+from app.models.user import User
+from app.schemas.namespace import GroupLevel
+
+pytestmark = pytest.mark.unit
+
+
+def _admin_user(test_db) -> User:
+    user = User(
+        user_name="admin",
+        password_hash="hash",
+        email="admin@example.com",
+        role="admin",
+        is_active=True,
+        auth_source="password",
+    )
+    test_db.add(user)
+    test_db.commit()
+    test_db.refresh(user)
+    return user
+
+
+def _write_seed(root: Path, content: str = "# Quick Start\n\nUse Wegent.") -> Path:
+    seed_dir = root / "system_knowledge" / "wegent-help"
+    doc_path = seed_dir / "docs" / "en" / "quick-start.md"
+    doc_path.parent.mkdir(parents=True)
+    doc_path.write_text(content, encoding="utf-8")
+    manifest = {
+        "seed_id": "wegent-help",
+        "knowledge_base": {
+            "name": "Wegent Help",
+            "display_name": "Wegent 帮助文档",
+            "namespace": "system",
+            "description": "Built-in Wegent documentation.",
+        },
+        "documents": [
+            {
+                "source_path": "docs/en/quick-start.md",
+                "seed_path": "docs/en/quick-start.md",
+                "language": "en",
+                "title": "Quick Start",
+                "category": "",
+                "content_sha256": "hash-1",
+            }
+        ],
+    }
+    (seed_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return root
+
+
+def test_system_knowledge_init_creates_org_namespace_kb_and_document(
+    test_db, tmp_path: Path, mocker
+) -> None:
+    admin = _admin_user(test_db)
+    init_dir = _write_seed(tmp_path)
+    schedule = mocker.patch(
+        "app.core.system_knowledge_init.schedule_document_indexing_if_possible"
+    )
+
+    result = run_system_knowledge_initialization(
+        db=test_db,
+        admin_user_id=admin.id,
+        init_data_dir=init_dir,
+    )
+
+    assert result["status"] == "completed"
+    namespace = test_db.query(Namespace).filter(Namespace.name == "system").one()
+    assert namespace.level == GroupLevel.organization.value
+    kb = test_db.query(Kind).filter(Kind.kind == "KnowledgeBase").one()
+    assert kb.user_id == admin.id
+    assert kb.namespace == "system"
+    assert kb.json["metadata"]["labels"]["seed_id"] == "wegent-help"
+    doc = test_db.query(KnowledgeDocument).one()
+    assert doc.kind_id == kb.id
+    assert doc.name == "Quick Start"
+    assert doc.source_config["source_path"] == "docs/en/quick-start.md"
+    schedule.assert_called_once()
+
+
+def test_system_knowledge_init_is_idempotent(test_db, tmp_path: Path, mocker) -> None:
+    admin = _admin_user(test_db)
+    init_dir = _write_seed(tmp_path)
+    mocker.patch(
+        "app.core.system_knowledge_init.schedule_document_indexing_if_possible"
+    )
+
+    first = run_system_knowledge_initialization(test_db, admin.id, init_dir)
+    second = run_system_knowledge_initialization(test_db, admin.id, init_dir)
+
+    assert first["documents_created"] == 1
+    assert second["documents_skipped"] == 1
+    assert test_db.query(Kind).filter(Kind.kind == "KnowledgeBase").count() == 1
+    assert test_db.query(KnowledgeDocument).count() == 1
+
+
+def test_system_knowledge_init_updates_changed_document(
+    test_db, tmp_path: Path, mocker
+) -> None:
+    admin = _admin_user(test_db)
+    init_dir = _write_seed(tmp_path)
+    mocker.patch(
+        "app.core.system_knowledge_init.schedule_document_indexing_if_possible"
+    )
+    run_system_knowledge_initialization(test_db, admin.id, init_dir)
+    manifest_path = init_dir / "system_knowledge" / "wegent-help" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["documents"][0]["content_sha256"] = "hash-2"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    doc_file = (
+        init_dir / "system_knowledge" / "wegent-help" / "docs" / "en" / "quick-start.md"
+    )
+    doc_file.write_text("# Quick Start\n\nUpdated.", encoding="utf-8")
+
+    result = run_system_knowledge_initialization(test_db, admin.id, init_dir)
+
+    doc = test_db.query(KnowledgeDocument).one()
+    assert result["documents_updated"] == 1
+    assert doc.source_config["content_sha256"] == "hash-2"

--- a/backend/tests/init_data/skills/test_wegent_help_skill.py
+++ b/backend/tests/init_data/skills/test_wegent_help_skill.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.unit
 
 BACKEND_ROOT = Path(__file__).resolve().parents[3]
 SKILL_DIR = BACKEND_ROOT / "init_data" / "skills" / "wegent-help"
+HELP_QUERY_SKILL_DIR = BACKEND_ROOT / "init_data" / "skills" / "wegent-help-knowledge"
 
 
 def _create_skill_zip(skill_dir: Path) -> bytes:
@@ -37,5 +38,28 @@ def test_wegent_help_skill_package_validates() -> None:
     assert metadata["displayName"] == "Wegent 帮助"
     assert metadata["preload"] is False
     assert "Wegent Help" in metadata["prompt"]
-    assert "wegent-knowledge" in metadata["prompt"]
+    assert "wegent-help-knowledge" in metadata["prompt"]
+    assert "wegent-knowledge" not in metadata["prompt"]
     assert set(metadata["bindShells"]) == {"Chat", "ClaudeCode"}
+
+
+def test_wegent_help_knowledge_skill_package_validates() -> None:
+    zip_content = _create_skill_zip(HELP_QUERY_SKILL_DIR)
+
+    metadata = SkillValidator.validate_zip(zip_content, "wegent-help-knowledge.zip")
+
+    assert metadata["displayName"] == "Wegent 帮助知识库查询"
+    assert metadata["preload"] is False
+    assert set(metadata["bindShells"]) == {"Chat", "ClaudeCode"}
+    assert metadata["mcpServers"] == {
+        "wegent-help-knowledge": {
+            "type": "streamable-http",
+            "url": "${{backend_url}}/mcp/help-knowledge/sse",
+            "headers": {"Authorization": "Bearer ${{task_token}}"},
+            "timeout": 300,
+        }
+    }
+    assert "wegent_help_query" in metadata["prompt"]
+    assert "create" not in metadata["prompt"].lower()
+    assert "update" not in metadata["prompt"].lower()
+    assert "delete" not in metadata["prompt"].lower()

--- a/backend/tests/init_data/skills/test_wegent_help_skill.py
+++ b/backend/tests/init_data/skills/test_wegent_help_skill.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from app.services.skill_service import SkillValidator
+
+pytestmark = pytest.mark.unit
+
+BACKEND_ROOT = Path(__file__).resolve().parents[3]
+SKILL_DIR = BACKEND_ROOT / "init_data" / "skills" / "wegent-help"
+
+
+def _create_skill_zip(skill_dir: Path) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for file_path in skill_dir.rglob("*"):
+            if not file_path.is_file():
+                continue
+            arcname = f"{skill_dir.name}/{file_path.relative_to(skill_dir)}"
+            zip_file.write(file_path, arcname)
+    return buffer.getvalue()
+
+
+def test_wegent_help_skill_package_validates() -> None:
+    zip_content = _create_skill_zip(SKILL_DIR)
+
+    metadata = SkillValidator.validate_zip(zip_content, "wegent-help.zip")
+
+    assert metadata["displayName"] == "Wegent 帮助"
+    assert metadata["preload"] is False
+    assert "Wegent Help" in metadata["prompt"]
+    assert "wegent-knowledge" in metadata["prompt"]
+    assert set(metadata["bindShells"]) == {"Chat", "ClaudeCode"}

--- a/backend/tests/mcp_server/test_server_routes.py
+++ b/backend/tests/mcp_server/test_server_routes.py
@@ -21,10 +21,12 @@ from app.mcp_server import server as mcp_server_module
 from app.mcp_server.server import (
     ExternalKnowledgeUser,
     _build_external_knowledge_mcp_app,
+    _create_help_knowledge_mcp_app,
     _create_knowledge_mcp_app,
     _default_external_auth_handler,
     external_knowledge_mcp_server,
     get_mcp_knowledge_config,
+    help_knowledge_mcp_server,
     knowledge_mcp_server,
     set_external_knowledge_auth_handler,
 )
@@ -128,6 +130,23 @@ def test_knowledge_mcp_root_returns_metadata_json():
     }
 
 
+def test_help_knowledge_mcp_root_returns_metadata_json():
+    app = _create_help_knowledge_mcp_app()
+    client = TestClient(app)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "service": "wegent-help-knowledge-mcp",
+        "transport": "streamable-http",
+        "endpoints": {
+            "mcp": "/mcp/help-knowledge/sse",
+            "health": "/mcp/help-knowledge/health",
+        },
+    }
+
+
 def test_external_knowledge_mcp_root_returns_metadata_json():
     app = _build_external_knowledge_mcp_app()
     client = TestClient(app)
@@ -192,6 +211,25 @@ def test_knowledge_mcp_sse_without_trailing_slash_does_not_redirect():
         return_value=fake_streamable_app,
     ):
         app = _create_knowledge_mcp_app()
+
+    client = TestClient(app)
+    response = client.get("/sse", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert response.text == "ok"
+
+
+def test_help_knowledge_mcp_sse_without_trailing_slash_does_not_redirect():
+    fake_streamable_app = Starlette(
+        routes=[Route("/", lambda request: PlainTextResponse("ok"), methods=["GET"])]
+    )
+
+    with patch.object(
+        help_knowledge_mcp_server,
+        "streamable_http_app",
+        return_value=fake_streamable_app,
+    ):
+        app = _create_help_knowledge_mcp_app()
 
     client = TestClient(app)
     response = client.get("/sse", follow_redirects=False)

--- a/backend/tests/mcp_server/test_tools.py
+++ b/backend/tests/mcp_server/test_tools.py
@@ -8,7 +8,7 @@ import importlib
 import inspect
 import json
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -27,6 +27,14 @@ def get_silent_exit_module():
 def get_knowledge_module():
     """Get the knowledge module, handling import caching issues."""
     module_name = "app.mcp_server.tools.knowledge"
+    if module_name not in sys.modules:
+        importlib.import_module(module_name)
+    return sys.modules[module_name]
+
+
+def get_help_knowledge_module():
+    """Get the help knowledge module, handling import caching issues."""
+    module_name = "app.mcp_server.tools.help_knowledge"
     if module_name not in sys.modules:
         importlib.import_module(module_name)
     return sys.modules[module_name]
@@ -269,3 +277,90 @@ class TestKnowledgeTool:
             "plain-text" in tool_info["description"].lower()
             or "text" in tool_info["description"].lower()
         )
+
+
+class TestHelpKnowledgeTool:
+    """Tests for the Wegent Help query-only MCP tools."""
+
+    def test_help_knowledge_mcp_tools_registry_contains_only_query_tool(self):
+        """Test that the help knowledge MCP exposes only the query tool."""
+        module = get_help_knowledge_module()
+
+        assert list(module.HELP_KNOWLEDGE_MCP_TOOLS) == ["wegent_help_query"]
+
+    @pytest.mark.asyncio
+    async def test_query_wegent_help_uses_seeded_system_kb(self):
+        """Test that the help query tool finds the seeded system knowledge base."""
+        module = get_help_knowledge_module()
+        token_info = TaskTokenInfo(
+            task_id=1,
+            subtask_id=2,
+            user_id=3,
+            user_name="alice",
+        )
+        mock_user = object()
+        mock_kb = MagicMock()
+        mock_kb.id = 77
+        mock_kb.json = {
+            "metadata": {
+                "labels": {
+                    "source": "system_knowledge_seed",
+                    "seed_id": "wegent-help",
+                }
+            },
+            "spec": {"name": "Wegent Help"},
+        }
+        mock_session = MagicMock()
+        mock_user_query = MagicMock()
+        mock_user_query.filter.return_value.first.return_value = mock_user
+        mock_kb_query = MagicMock()
+        mock_kb_query.filter.return_value.all.return_value = [mock_kb]
+        mock_session.query.side_effect = [mock_user_query, mock_kb_query]
+        mock_retrieve = AsyncMock(
+            return_value={
+                "query": "how to use Wegent?",
+                "records": [
+                    {
+                        "knowledge_base_id": 77,
+                        "knowledge_base_name": "Wegent Help",
+                        "document_id": 9,
+                        "document_name": "Quick Start",
+                    }
+                ],
+                "total": 1,
+                "mode": "rag_retrieval",
+            }
+        )
+
+        with (
+            patch.object(module, "SessionLocal", return_value=mock_session),
+            patch.object(
+                module.knowledge_orchestrator,
+                "retrieve_knowledge",
+                mock_retrieve,
+            ),
+        ):
+            result = await module.query_wegent_help(
+                token_info=token_info,
+                query="how to use Wegent?",
+                max_results=5,
+            )
+
+        mock_retrieve.assert_awaited_once_with(
+            db=mock_session,
+            user=mock_user,
+            knowledge_base_id=77,
+            query="how to use Wegent?",
+            max_results=5,
+            route_mode="rag_retrieval",
+        )
+        assert result["knowledge_base_id"] == 77
+        assert result["sources"] == [
+            {
+                "document_id": 9,
+                "document_name": "Quick Start",
+                "knowledge_base_id": 77,
+                "knowledge_base_name": "Wegent Help",
+            }
+        ]
+        mock_session.close.assert_called_once()

--- a/backend/tests/scripts/test_generate_wegent_help_knowledge_seed.py
+++ b/backend/tests/scripts/test_generate_wegent_help_knowledge_seed.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.generate_wegent_help_knowledge_seed import generate_seed
+
+pytestmark = pytest.mark.unit
+
+
+def test_generate_seed_writes_stable_manifest_and_docs(tmp_path: Path) -> None:
+    docs_root = tmp_path / "docs"
+    zh_doc = docs_root / "zh" / "user-guide" / "quick-start.md"
+    en_doc = docs_root / "en" / "developer-guide" / "setup.md"
+    zh_doc.parent.mkdir(parents=True)
+    en_doc.parent.mkdir(parents=True)
+    zh_content = "---\nsidebar_position: 1\n---\n\n# 快速开始\n\n内容\n"
+    en_content = "# Setup\n\nInstall Wegent.\n"
+    zh_doc.write_text(zh_content, encoding="utf-8")
+    en_doc.write_text(en_content, encoding="utf-8")
+
+    output_dir = tmp_path / "seed"
+
+    result = generate_seed(docs_root=docs_root, output_dir=output_dir)
+
+    manifest_path = output_dir / "manifest.json"
+    assert result == manifest_path
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["knowledge_base"]["name"] == "Wegent Help"
+    assert [doc["source_path"] for doc in manifest["documents"]] == [
+        "docs/en/developer-guide/setup.md",
+        "docs/zh/user-guide/quick-start.md",
+    ]
+    assert manifest["documents"][0]["language"] == "en"
+    assert manifest["documents"][0]["title"] == "Setup"
+    assert manifest["documents"][1]["language"] == "zh"
+    assert manifest["documents"][1]["title"] == "快速开始"
+    assert manifest["documents"][1]["content_sha256"] == hashlib.sha256(
+        zh_content.encode("utf-8")
+    ).hexdigest()
+    assert (
+        output_dir / "docs" / "zh" / "user-guide" / "quick-start.md"
+    ).read_text(encoding="utf-8") == zh_content
+    assert (
+        output_dir / "docs" / "en" / "developer-guide" / "setup.md"
+    ).read_text(encoding="utf-8") == en_content
+
+
+def test_generate_seed_rejects_missing_language_roots(tmp_path: Path) -> None:
+    docs_root = tmp_path / "docs"
+    docs_root.mkdir()
+
+    with pytest.raises(ValueError, match="docs/zh and docs/en"):
+        generate_seed(docs_root=docs_root, output_dir=tmp_path / "seed")

--- a/backend/tests/scripts/test_generate_wegent_help_knowledge_seed.py
+++ b/backend/tests/scripts/test_generate_wegent_help_knowledge_seed.py
@@ -42,15 +42,16 @@ def test_generate_seed_writes_stable_manifest_and_docs(tmp_path: Path) -> None:
     assert manifest["documents"][0]["title"] == "Setup"
     assert manifest["documents"][1]["language"] == "zh"
     assert manifest["documents"][1]["title"] == "快速开始"
-    assert manifest["documents"][1]["content_sha256"] == hashlib.sha256(
-        zh_content.encode("utf-8")
-    ).hexdigest()
     assert (
-        output_dir / "docs" / "zh" / "user-guide" / "quick-start.md"
-    ).read_text(encoding="utf-8") == zh_content
-    assert (
-        output_dir / "docs" / "en" / "developer-guide" / "setup.md"
-    ).read_text(encoding="utf-8") == en_content
+        manifest["documents"][1]["content_sha256"]
+        == hashlib.sha256(zh_content.encode("utf-8")).hexdigest()
+    )
+    assert (output_dir / "docs" / "zh" / "user-guide" / "quick-start.md").read_text(
+        encoding="utf-8"
+    ) == zh_content
+    assert (output_dir / "docs" / "en" / "developer-guide" / "setup.md").read_text(
+        encoding="utf-8"
+    ) == en_content
 
 
 def test_generate_seed_rejects_missing_language_roots(tmp_path: Path) -> None:
@@ -59,3 +60,25 @@ def test_generate_seed_rejects_missing_language_roots(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="docs/zh and docs/en"):
         generate_seed(docs_root=docs_root, output_dir=tmp_path / "seed")
+
+
+def test_generate_seed_rejects_output_dir_that_contains_docs_root(
+    tmp_path: Path,
+) -> None:
+    docs_root = tmp_path / "docs"
+    (docs_root / "en").mkdir(parents=True)
+    (docs_root / "zh").mkdir()
+
+    with pytest.raises(ValueError, match="overlap docs_root"):
+        generate_seed(docs_root=docs_root, output_dir=tmp_path)
+
+    assert docs_root.exists()
+
+
+def test_generate_seed_rejects_output_dir_inside_docs_root(tmp_path: Path) -> None:
+    docs_root = tmp_path / "docs"
+    (docs_root / "en").mkdir(parents=True)
+    (docs_root / "zh").mkdir()
+
+    with pytest.raises(ValueError, match="overlap docs_root"):
+        generate_seed(docs_root=docs_root, output_dir=docs_root / "seed")

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -80,6 +80,35 @@ class TestClarificationSkillInjection:
         assert result == preload_skills
 
 
+class TestDefaultAvailableHelpSkills:
+    def test_inject_default_help_skills_adds_public_available_refs(self):
+        refs = TaskRequestBuilder._inject_default_help_skills(
+            [
+                {
+                    "name": "subscription-manager",
+                    "namespace": "default",
+                    "is_public": True,
+                }
+            ]
+        )
+
+        assert refs == [
+            {"name": "subscription-manager", "namespace": "default", "is_public": True},
+            {"name": "wegent-help", "namespace": "default", "is_public": True},
+            {"name": "wegent-knowledge", "namespace": "default", "is_public": True},
+        ]
+
+    def test_inject_default_help_skills_deduplicates_existing_refs(self):
+        refs = TaskRequestBuilder._inject_default_help_skills(
+            [{"name": "wegent-help", "namespace": "default", "is_public": True}]
+        )
+
+        assert [item["name"] for item in refs] == [
+            "wegent-help",
+            "wegent-knowledge",
+        ]
+
+
 class TestExtractSkillMcpToList:
     """Tests for _extract_skill_mcp_to_list static method."""
 

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -96,7 +96,11 @@ class TestDefaultAvailableHelpSkills:
         assert refs == [
             {"name": "subscription-manager", "namespace": "default", "is_public": True},
             {"name": "wegent-help", "namespace": "default", "is_public": True},
-            {"name": "wegent-knowledge", "namespace": "default", "is_public": True},
+            {
+                "name": "wegent-help-knowledge",
+                "namespace": "default",
+                "is_public": True,
+            },
         ]
 
     def test_inject_default_help_skills_deduplicates_existing_refs(self):
@@ -106,7 +110,7 @@ class TestDefaultAvailableHelpSkills:
 
         assert [item["name"] for item in refs] == [
             "wegent-help",
-            "wegent-knowledge",
+            "wegent-help-knowledge",
         ]
 
     def test_inject_default_help_skills_preserves_user_ref_on_name_collision(self):

--- a/backend/tests/services/execution/test_request_builder_mcp.py
+++ b/backend/tests/services/execution/test_request_builder_mcp.py
@@ -9,6 +9,7 @@ Verifies that skill MCP extraction, type normalization, and reachability
 filtering work correctly when preparing MCP servers for Claude Code executor.
 """
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -107,6 +108,26 @@ class TestDefaultAvailableHelpSkills:
             "wegent-help",
             "wegent-knowledge",
         ]
+
+    def test_inject_default_help_skills_preserves_user_ref_on_name_collision(self):
+        user_ref = {
+            "name": "wegent-help",
+            "namespace": "team-space",
+            "is_public": False,
+            "force_preload": False,
+        }
+
+        refs = TaskRequestBuilder._inject_default_help_skills([user_ref])
+
+        assert refs[0] == user_ref
+        assert refs[0] is user_ref
+
+    def test_build_appends_user_default_refs_before_injected_help_defaults(self):
+        source = inspect.getsource(TaskRequestBuilder.build)
+
+        assert source.index("for skill_ref in user_default_skill_refs:") < source.index(
+            "extra_available_skills = self._inject_default_help_skills("
+        )
 
 
 class TestExtractSkillMcpToList:

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -30,6 +30,13 @@ COPY backend /app
 # - skills/: Skill packages (mermaid-diagram, wiki_submit, sandbox)
 COPY backend/init_data /app/init_data
 
+# Generate built-in Wegent Help knowledge seed from repository docs.
+COPY docs /app/docs
+RUN python /app/scripts/generate_wegent_help_knowledge_seed.py \
+    --docs-root /app/docs \
+    --output-dir /app/init_data/system_knowledge/wegent-help \
+    && rm -rf /app/docs
+
 # Create .env file (if it doesn't exist)
 RUN if [ ! -f .env ]; then cp .env.example .env; fi
 

--- a/docker/standalone/Dockerfile
+++ b/docker/standalone/Dockerfile
@@ -186,6 +186,14 @@ COPY docker/standalone/nginx.conf /etc/nginx/conf.d/default.conf
 # Copy init_data directory with default resources and skills
 COPY backend/init_data /app/init_data
 
+# Generate built-in Wegent Help knowledge seed from repository docs.
+COPY backend/scripts/generate_wegent_help_knowledge_seed.py /app/backend/scripts/generate_wegent_help_knowledge_seed.py
+COPY docs /app/docs
+RUN python /app/backend/scripts/generate_wegent_help_knowledge_seed.py \
+    --docs-root /app/docs \
+    --output-dir /app/init_data/system_knowledge/wegent-help \
+    && rm -rf /app/docs
+
 # Copy startup script
 COPY docker/standalone/start.sh /app/start.sh
 RUN sed -i 's/\r$//' /app/start.sh && chmod +x /app/start.sh

--- a/docs/superpowers/specs/2026-06-24-wegent-help-knowledge-skill-design.md
+++ b/docs/superpowers/specs/2026-06-24-wegent-help-knowledge-skill-design.md
@@ -1,0 +1,255 @@
+---
+sidebar_position: 1
+---
+
+# Wegent 帮助知识库 Skill 设计
+
+## 背景
+
+Wegent 已经有两套相关能力：
+
+- `backend/init_data/skills/` 可以在后端启动时创建公共 Skill，所有用户都可使用。
+- 知识库系统可以存储、索引、检索文档，并通过 `wegent-knowledge` Skill 暴露给 AI Agent。
+
+用户希望系统内置一个 Wegent 帮助能力：当用户遇到使用、配置、排错或概念理解问题时，可以直接问 AI。经过方案讨论，本设计选择“系统知识库承载文档，薄帮助 Skill 负责路由和回答约束”，而不是把文档全文复制进 Skill prompt。
+
+## 目标
+
+1. 打包镜像时自动收集 `docs/zh` 和 `docs/en` 的文档内容，形成可初始化的系统文档 seed。
+2. 后端启动时创建一个系统级 Wegent 帮助知识库，并把系统文档导入为知识库文档。
+3. 文档 seed 导入必须幂等：重复启动不产生重复知识库或重复文档。
+4. 文档内容有变更时，系统能够按文档 hash 更新系统管理的文档并重新触发索引。
+5. 新增 `wegent-help` 公共 Skill，默认可用但不预加载。
+6. 当用户询问 Wegent 使用、配置、Agent/Bot/Skill、知识库、设备、部署或排错问题时，AI 可以按需加载 `wegent-help`。
+7. `wegent-help` 指示 AI 使用知识库检索系统文档，并优先用用户提问语言回答。
+8. 回答应尽量包含来源引用；当索引未就绪或无结果时，明确说明状态，不编造文档内容。
+
+## 非目标
+
+1. 不把全部文档正文塞入 `SKILL.md` prompt。
+2. 不在 Docker build 阶段生成向量索引；索引依赖运行时数据库、检索器和 embedding 模型。
+3. 不新增一套独立于知识库的文档检索 provider。
+4. 不改变用户自建知识库和用户上传文档的权限模型。
+5. 不默认强制预加载帮助 Skill。
+6. 不在首版实现跨版本历史文档浏览或文档差异查看。
+
+## 总体架构
+
+```text
+docs/zh + docs/en
+  -> build/generate step
+  -> backend/init_data/system_knowledge/wegent-help/manifest.json
+  -> backend/init_data/system_knowledge/wegent-help/docs/**
+  -> backend startup initialization
+  -> organization/system KnowledgeBase
+  -> KnowledgeDocument rows + attachments
+  -> RAG indexing task
+  -> wegent-help Skill
+  -> wegent-knowledge MCP search/read tools
+  -> AI answer with source references
+```
+
+核心原则：
+
+- 文档是知识库数据，不是 Skill prompt。
+- Skill 是入口和使用规范，不负责承载全文。
+- 初始化逻辑只管理带系统来源标记的知识库和文档，不触碰用户内容。
+
+## 系统文档 Seed
+
+新增生成脚本，例如 `backend/scripts/generate_wegent_help_knowledge_seed.py`。脚本在打包前运行，读取：
+
+- `docs/zh/**/*.md`
+- `docs/en/**/*.md`
+
+生成到：
+
+```text
+backend/init_data/system_knowledge/wegent-help/
+├── manifest.json
+└── docs/
+    ├── zh/...
+    └── en/...
+```
+
+`manifest.json` 包含每篇文档的稳定元数据：
+
+```json
+{
+  "knowledge_base": {
+    "name": "Wegent Help",
+    "display_name": "Wegent 帮助文档",
+    "namespace": "system",
+    "description": "Built-in Wegent user and developer documentation."
+  },
+  "documents": [
+    {
+      "source_path": "docs/zh/user-guide/knowledge/knowledge-base-guide.md",
+      "seed_path": "docs/zh/user-guide/knowledge/knowledge-base-guide.md",
+      "language": "zh",
+      "title": "使用指南",
+      "category": "user-guide/knowledge",
+      "content_sha256": "..."
+    }
+  ]
+}
+```
+
+生成规则：
+
+- 只纳入 Markdown 文档。
+- 保留 frontmatter，但初始化器可读取标题时忽略 frontmatter。
+- 文档名使用原路径生成稳定 display name，例如 `zh/user-guide/knowledge/knowledge-base-guide.md`。
+- `content_sha256` 基于最终写入知识库的正文计算。
+- 输出文件稳定排序，减少无意义 diff。
+
+## 系统知识库初始化
+
+新增初始化器，例如 `backend/app/core/system_knowledge_init.py`，由现有 `run_yaml_initialization()` 在 Skill 初始化后调用。
+
+初始化器职责：
+
+1. 读取 `INIT_DATA_DIR/system_knowledge/wegent-help/manifest.json`。
+2. 确保 `system` namespace 存在，且 `level = organization`，可作为组织级知识库 namespace 被所有用户读取。
+3. 确保存在一个系统管理的 `KnowledgeBase`。
+4. 为 manifest 中每篇文档创建或更新 `KnowledgeDocument`。
+5. 文档新增或 hash 变化时上传/更新附件并触发索引。
+6. 文档缺失于新 manifest 时，首版不自动删除，只在日志中记录 orphaned system docs。
+
+系统管理标记写入 `Kind.json.metadata.labels` 和文档 `source_config`：
+
+```json
+{
+  "source": "system_knowledge_seed",
+  "seed_id": "wegent-help",
+  "source_path": "docs/zh/user-guide/knowledge/knowledge-base-guide.md",
+  "content_sha256": "..."
+}
+```
+
+知识库创建建议：
+
+- `Kind.kind = "KnowledgeBase"`
+- `Kind.user_id = <bootstrap admin user id>`
+- `Kind.namespace = "system"`
+- `spec.name = "Wegent Help"`
+- `spec.description = "Built-in Wegent user and developer documentation."`
+- `spec.kbType = "classic"`
+- `spec.summaryEnabled = false`
+- `spec.retrievalConfig` 尽量通过现有 auto 逻辑补齐；无法补齐时创建无 RAG 配置知识库，并记录索引不可用原因。
+
+系统知识库不直接使用 `user_id=0` 作为 owner。公共可见性通过组织级 namespace 实现，owner 使用启动初始化阶段已经存在的 bootstrap admin 用户，这样可以复用现有知识库权限、默认模型选择和索引 owner 逻辑。
+
+## 索引策略
+
+RAG 索引只能在运行时执行。初始化器处理三种状态：
+
+1. **retrievalConfig 可用**：新增或变更文档后调用现有 indexing enqueue 流程。
+2. **retrievalConfig 不可用**：文档仍导入知识库，但 `wegent-help` 需要提示“系统帮助文档已导入，但检索索引未配置或未就绪”。
+3. **索引中或失败**：保留知识库和文档状态，AI 回答时使用工具返回的状态说明，不假装已检索到完整结果。
+
+首版不要求后台同步等待索引完成。启动初始化应快速返回，索引由现有 Celery/RAG pipeline 异步执行。
+
+## Wegent Help Skill
+
+新增内置公共 Skill：
+
+```text
+backend/init_data/skills/wegent-help/SKILL.md
+```
+
+Skill 元数据：
+
+```yaml
+---
+description: "Use when users ask Wegent usage, setup, configuration, troubleshooting, Agent/Bot/Skill, knowledge base, device, deployment, or developer-documentation questions. Load this skill and search the built-in Wegent Help knowledge base before answering."
+displayName: "Wegent 帮助"
+version: "1.0.0"
+author: "Wegent Team"
+tags: ["wegent", "help", "docs", "knowledge-base", "troubleshooting"]
+bindShells:
+  - Chat
+  - ClaudeCode
+---
+```
+
+Prompt 只包含行为规则：
+
+- 当问题属于 Wegent 产品、使用、配置、排错或开发文档范围时使用此 Skill。
+- 优先调用 `wegent-knowledge` 的知识库列表和检索工具，定位系统知识库 `Wegent Help`。
+- 优先使用用户提问语言回答；中文问题用中文，英文问题用英文。
+- 回答时标注来源文档名称或引用工具返回的 source。
+- 如果系统知识库不存在、无权限、索引未就绪或检索无结果，明确说明并给出下一步检查建议。
+- 不把通用模型记忆当作文档事实来源；除非用户明确要求外部最新信息，否则不使用 web search 代替系统文档。
+
+`wegent-help` 本身不声明新的 provider tool。它复用现有 `wegent-knowledge` Skill 的 MCP 工具。为了让默认可用体验稳定，需要在执行请求构建阶段让 `wegent-help` 与 `wegent-knowledge` 都作为公共可用 Skill 出现在普通 Chat/Code Agent 的 available skills 中，但二者都不预加载。
+
+## 数据流
+
+### 打包
+
+1. 开发者或 CI 运行生成脚本。
+2. 脚本读取 docs，生成 `system_knowledge/wegent-help` seed。
+3. Dockerfile 现有 `COPY backend/init_data /app/init_data` 将 seed 和 Skill 一起带入镜像。
+
+### 首次启动
+
+1. 后端执行 YAML 和 Skill 初始化。
+2. 后端执行系统知识库初始化。
+3. 初始化器创建系统知识库和文档。
+4. 如果 RAG 配置完整，文档进入 indexing queue。
+
+### 用户提问
+
+1. 用户问“Wegent 怎么配置知识库？”。
+2. Agent 在 available skills 中看到 `wegent-help`，按需调用 `load_skill("wegent-help")`。
+3. 根据 `wegent-help` 指令，Agent 加载或使用 `wegent-knowledge`。
+4. Agent 列出或搜索知识库，锁定 `Wegent Help`。
+5. Agent 使用搜索结果和来源回答用户。
+
+## 错误处理
+
+- **seed 文件缺失**：跳过系统知识库初始化，记录 warning，不影响后端启动。
+- **manifest 格式错误**：跳过该 seed，记录 error，不影响其他 init data。
+- **系统知识库已存在**：只更新系统管理字段和系统文档，不覆盖用户手动创建的其他知识库。
+- **文档 hash 未变化**：跳过该文档，避免重复上传和重复索引。
+- **文档 hash 变化**：更新附件内容和文档 metadata，重新触发索引。
+- **缺少 retriever 或 embedding model**：创建知识库和文档，但不触发索引；Skill 回答时提示管理员配置检索能力。
+- **索引失败**：不删除文档，保留失败状态，允许后续重试。
+- **用户无权访问系统知识库**：这是初始化或权限配置 bug，应通过测试覆盖组织级可见性。
+
+## 安全与权限
+
+- 系统知识库只包含仓库内公开文档，不包含密钥或运行时配置。
+- 初始化器不得扫描 `docs/` 之外的任意路径。
+- manifest 中的 `seed_path` 必须校验在 seed 根目录内，避免路径穿越。
+- 所有知识库访问仍走现有权限检查和 MCP task token 机制。
+- 系统知识库写入只在后端启动初始化阶段发生，不暴露给普通用户作为写入口。
+
+## 测试
+
+后端测试：
+
+- 生成脚本从测试 docs 目录生成稳定 `manifest.json` 和文档副本。
+- manifest 中包含 title、language、category、content hash。
+- 系统知识库初始化在空库中创建知识库和文档。
+- 重复初始化不创建重复知识库或重复文档。
+- 文档 hash 变化会更新对应文档并触发重新索引。
+- 缺少 retrievalConfig 时仍导入文档，但不会 enqueue 索引。
+- 系统知识库对普通用户通过 organization/all scope 可见。
+- `wegent-help` Skill 可以通过 init_data skills 初始化为公共 Skill。
+- 执行请求中 `wegent-help` 默认可用但不在 `preload_skills` 中。
+
+集成测试：
+
+- 用户提问 Wegent 帮助类问题时，available skills 包含 `wegent-help` 和 `wegent-knowledge`。
+- 选中或加载 `wegent-help` 后，Agent 能检索 `Wegent Help` 知识库。
+- 索引未就绪时返回明确状态提示，不生成伪引用。
+
+## First-Version Limits
+
+- 首版仅管理 `docs/zh` 和 `docs/en` Markdown 文件。
+- 首版不自动删除 manifest 中已经移除的旧文档。
+- 首版不保证启动后索引立即可用。
+- 首版不新增 UI；用户通过普通对话触发帮助能力。
+- 首版不实现独立文档版本管理。

--- a/scripts/test-wegent-help-seed-dockerfiles.sh
+++ b/scripts/test-wegent-help-seed-dockerfiles.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+grep -q "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/backend/Dockerfile"
+grep -q "COPY docs /app/docs" "$ROOT_DIR/docker/backend/Dockerfile"
+grep -q "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/standalone/Dockerfile"
+grep -q "COPY docs /app/docs" "$ROOT_DIR/docker/standalone/Dockerfile"
+
+echo "Wegent help seed Dockerfile checks passed"

--- a/scripts/test-wegent-help-seed-dockerfiles.sh
+++ b/scripts/test-wegent-help-seed-dockerfiles.sh
@@ -7,9 +7,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
-grep -q "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/backend/Dockerfile"
-grep -q "COPY docs /app/docs" "$ROOT_DIR/docker/backend/Dockerfile"
-grep -q "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/standalone/Dockerfile"
-grep -q "COPY docs /app/docs" "$ROOT_DIR/docker/standalone/Dockerfile"
+grep -Fq "COPY docs /app/docs" "$ROOT_DIR/docker/backend/Dockerfile"
+grep -Fq "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/backend/Dockerfile"
+grep -Fq -- "--docs-root /app/docs" "$ROOT_DIR/docker/backend/Dockerfile"
+grep -Fq -- "--output-dir /app/init_data/system_knowledge/wegent-help" "$ROOT_DIR/docker/backend/Dockerfile"
+
+grep -Fq "COPY docs /app/docs" "$ROOT_DIR/docker/standalone/Dockerfile"
+grep -Fq "generate_wegent_help_knowledge_seed.py" "$ROOT_DIR/docker/standalone/Dockerfile"
+grep -Fq -- "--docs-root /app/docs" "$ROOT_DIR/docker/standalone/Dockerfile"
+grep -Fq -- "--output-dir /app/init_data/system_knowledge/wegent-help" "$ROOT_DIR/docker/standalone/Dockerfile"
 
 echo "Wegent help seed Dockerfile checks passed"


### PR DESCRIPTION
## Summary

- Add a deterministic docs seed generator for the built-in Wegent Help knowledge base.
- Initialize a system organization knowledge base from generated seed data during startup.
- Add the prompt-only `wegent-help` skill and expose both help and knowledge skills as default on-demand skills.
- Generate the help seed during backend and standalone Docker image builds.

## Validation

- `cd backend && uv run pytest tests/scripts/test_generate_wegent_help_knowledge_seed.py tests/core/test_system_knowledge_init.py tests/init_data/skills/test_wegent_help_skill.py tests/services/execution/test_request_builder_mcp.py tests/services/execution/test_request_builder_user_mcp.py -v`
- `bash scripts/test-wegent-help-seed-dockerfiles.sh`
- `cd backend && uv run python scripts/generate_wegent_help_knowledge_seed.py`
- Manifest smoke check: `wegent-help 162`

## Notes

The generated real-doc seed was used for local verification and then removed from the working tree. Docker image builds generate it from `docs/` so the runtime initializer can import it from `/app/init_data/system_knowledge/wegent-help`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in “Wegent Help” skill backed by seeded system help knowledge for instant documentation-based answers.
  * Automatically initializes and keeps the help knowledge base in sync (create/update and hash-based change detection).
  * Injects default on-demand help skills so help querying is available without extra setup, and exposes a new help knowledge MCP query tool.
* **Infrastructure & Deployment**
  * Docker images now generate and bundle the built-in help knowledge seed at build time.
* **Tests**
  * Expanded unit and MCP test coverage for initialization, idempotency, and help tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->