### PR TITLE
fix(runtime): prevent large transcript rpc timeouts

### DIFF
--- a/backend/app/api/endpoints/runtime_work.py
+++ b/backend/app/api/endpoints/runtime_work.py
@@ -29,6 +29,7 @@ from app.schemas.runtime_work import (
     RuntimeTaskForkResponse,
     RuntimeTaskIMNotificationSubscriptionRequest,
     RuntimeTaskIMNotificationSubscriptionResponse,
+    RuntimeTranscriptRequest,
     RuntimeTranscriptResponse,
     RuntimeWorkListResponse,
 )
@@ -138,7 +139,7 @@ def delete_device_workspace_endpoint(
     response_model_by_alias=True,
 )
 async def get_runtime_transcript_endpoint(
-    address: RuntimeTaskAddress,
+    address: RuntimeTranscriptRequest,
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):

--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -24,6 +24,13 @@ class RuntimeTaskAddress(BaseModel):
     local_task_id: str = Field(..., alias="localTaskId", min_length=1)
 
 
+class RuntimeTranscriptRequest(RuntimeTaskAddress):
+    """Request a page of a device-local runtime transcript."""
+
+    limit: Optional[int] = Field(default=None, ge=1, le=200)
+    before_cursor: Optional[str] = Field(default=None, alias="beforeCursor")
+
+
 class RuntimeMessageSource(BaseModel):
     """Optional source overlay for runtime transcript messages."""
 
@@ -220,6 +227,8 @@ class RuntimeTranscriptResponse(BaseModel):
     runtime: RuntimeName
     title: Optional[str] = None
     messages: list[NormalizedRuntimeMessage] = Field(default_factory=list)
+    has_more_before: bool = Field(default=False, alias="hasMoreBefore")
+    before_cursor: Optional[str] = Field(default=None, alias="beforeCursor")
     parse_error: Optional[str] = Field(default=None, alias="parseError")
 
 

--- a/backend/app/services/device/runtime_rpc_service.py
+++ b/backend/app/services/device/runtime_rpc_service.py
@@ -4,7 +4,11 @@
 
 """Typed runtime task RPC over the existing local executor Socket.IO channel."""
 
+import base64
+import gzip
+import json
 import logging
+import time
 from typing import Any, Optional
 
 from socketio.exceptions import BadNamespaceError, DisconnectedError
@@ -18,6 +22,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_RUNTIME_RPC_TIMEOUT_SECONDS = 30
 MAX_RUNTIME_RPC_TIMEOUT_SECONDS = 600
 SOCKET_ACK_GRACE_SECONDS = 5
+RUNTIME_RPC_COMPRESSED_ENCODING = "gzip+base64+json"
+RUNTIME_RPC_ENCODING_KEY = "__runtimeRpcEncoding"
 
 
 class RuntimeRpcError(RuntimeError):
@@ -48,11 +54,14 @@ class RuntimeRpcService:
             raise RuntimeRpcError(f"Device '{device_id}' has no socket information")
 
         request = {"method": method, "payload": payload}
+        started_at = time.perf_counter()
         logger.info(
-            "[RuntimeRpcService] Sending runtime RPC: user_id=%s device_id=%s method=%s",
+            "[RuntimeRpcService] Sending runtime RPC: user_id=%s device_id=%s method=%s timeout_seconds=%s payload_keys=%s",
             user_id,
             device_id,
             method,
+            normalized_timeout + SOCKET_ACK_GRACE_SECONDS,
+            sorted(payload.keys()),
         )
         try:
             result = await get_sio().call(
@@ -63,6 +72,15 @@ class RuntimeRpcService:
                 timeout=normalized_timeout + SOCKET_ACK_GRACE_SECONDS,
             )
         except Exception as exc:
+            elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+            logger.warning(
+                "[RuntimeRpcService] Runtime RPC failed: user_id=%s device_id=%s method=%s elapsed_ms=%s error_type=%s",
+                user_id,
+                device_id,
+                method,
+                elapsed_ms,
+                exc.__class__.__name__,
+            )
             raise RuntimeRpcError(
                 self._format_rpc_error(
                     exc,
@@ -72,9 +90,47 @@ class RuntimeRpcService:
                 )
             ) from exc
 
+        result = self._decode_response(result, method=method)
         if not isinstance(result, dict):
             raise RuntimeRpcError("Runtime RPC returned an invalid response")
+        elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "[RuntimeRpcService] Runtime RPC completed: user_id=%s device_id=%s method=%s elapsed_ms=%s result_keys=%s",
+            user_id,
+            device_id,
+            method,
+            elapsed_ms,
+            sorted(result.keys()),
+        )
         return result
+
+    @staticmethod
+    def _decode_response(result: Any, *, method: str) -> Any:
+        if not (
+            isinstance(result, dict)
+            and result.get(RUNTIME_RPC_ENCODING_KEY) == RUNTIME_RPC_COMPRESSED_ENCODING
+        ):
+            return result
+
+        payload = result.get("payload")
+        if not isinstance(payload, str):
+            raise RuntimeRpcError("Runtime RPC returned an invalid compressed payload")
+
+        try:
+            compressed = base64.b64decode(payload.encode("ascii"), validate=True)
+            decoded = gzip.decompress(compressed)
+            response = json.loads(decoded.decode("utf-8"))
+        except Exception as exc:
+            raise RuntimeRpcError("Runtime RPC returned an unreadable payload") from exc
+
+        logger.info(
+            "[RuntimeRpcService] Runtime RPC response decompressed: method=%s raw_bytes=%s compressed_bytes=%s encoded_bytes=%s",
+            method,
+            len(decoded),
+            len(compressed),
+            len(payload),
+        )
+        return response
 
     @staticmethod
     def _normalize_timeout(timeout_seconds: Any) -> int:

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -8,6 +8,7 @@ import json
 import logging
 import posixpath
 import re
+import time
 from dataclasses import dataclass, replace
 from datetime import datetime
 from hashlib import sha256
@@ -52,6 +53,7 @@ from app.schemas.runtime_work import (
     RuntimeTaskIMNotificationSubscription,
     RuntimeTaskIMNotificationSubscriptionRequest,
     RuntimeTaskIMNotificationSubscriptionResponse,
+    RuntimeTranscriptRequest,
     RuntimeTranscriptResponse,
     RuntimeWorkListResponse,
 )
@@ -297,27 +299,62 @@ async def get_runtime_transcript(
     *,
     db: Session,
     user_id: int,
-    address: RuntimeTaskAddress,
+    address: RuntimeTranscriptRequest,
 ) -> RuntimeTranscriptResponse:
     """Read a LocalTask transcript from the owning local executor."""
 
     normalized_address = _normalized_address(address)
     _ensure_owned_device(db, user_id, normalized_address.device_id)
     _touch_workspace_mapping(db, user_id, normalized_address)
+    payload = _runtime_transcript_payload(address, normalized_address)
+    started_at = time.perf_counter()
+    logger.info(
+        "[RuntimeWork] Requesting runtime transcript: user_id=%s device_id=%s local_task_id=%s workspace_path=%s limit=%s before_cursor=%s",
+        user_id,
+        normalized_address.device_id,
+        normalized_address.local_task_id,
+        normalized_address.workspace_path,
+        payload.get("limit"),
+        payload.get("beforeCursor"),
+    )
     try:
         result = await runtime_rpc_service.call(
             user_id=user_id,
             device_id=normalized_address.device_id,
             method="runtime.tasks.transcript",
-            payload=_runtime_task_address_payload(normalized_address),
+            payload=payload,
             timeout_seconds=RUNTIME_TRANSCRIPT_TIMEOUT_SECONDS,
         )
     except RuntimeRpcError as exc:
+        elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.warning(
+            "[RuntimeWork] Runtime transcript RPC failed: user_id=%s device_id=%s local_task_id=%s elapsed_ms=%s detail=%s",
+            user_id,
+            normalized_address.device_id,
+            normalized_address.local_task_id,
+            elapsed_ms,
+            str(exc),
+        )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail=str(exc),
         ) from exc
     _raise_runtime_rpc_failure(result)
+    elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+    logger.info(
+        "[RuntimeWork] Runtime transcript RPC completed: user_id=%s device_id=%s local_task_id=%s elapsed_ms=%s message_count=%s has_more_before=%s before_cursor=%s",
+        user_id,
+        normalized_address.device_id,
+        normalized_address.local_task_id,
+        elapsed_ms,
+        (
+            len(result.get("messages", []))
+            if isinstance(result.get("messages"), list)
+            else None
+        ),
+        result.get("hasMoreBefore"),
+        result.get("beforeCursor"),
+    )
     return RuntimeTranscriptResponse.model_validate(result)
 
 
@@ -1909,6 +1946,20 @@ def _normalized_address(address: RuntimeTaskAddress) -> RuntimeTaskAddress:
 
 def _runtime_task_address_payload(address: RuntimeTaskAddress) -> dict[str, Any]:
     return address.model_dump(by_alias=True, exclude_none=True)
+
+
+def _runtime_transcript_payload(
+    request: RuntimeTranscriptRequest,
+    normalized_address: RuntimeTaskAddress,
+) -> dict[str, Any]:
+    payload = _runtime_task_address_payload(normalized_address)
+    limit = getattr(request, "limit", None)
+    before_cursor = getattr(request, "before_cursor", None)
+    if limit is not None:
+        payload["limit"] = limit
+    if before_cursor:
+        payload["beforeCursor"] = before_cursor
+    return payload
 
 
 def _project_runtime_target(

--- a/backend/tests/api/endpoints/test_runtime_work_api.py
+++ b/backend/tests/api/endpoints/test_runtime_work_api.py
@@ -182,12 +182,16 @@ def test_runtime_transcript_endpoint_dispatches_address(
             "deviceId": "device-1",
             "workspacePath": "/repo/Wegent",
             "localTaskId": "codex-1",
+            "limit": 25,
+            "beforeCursor": "offset:120",
         },
     )
 
     assert response.status_code == 200
     assert response.json()["localTaskId"] == "codex-1"
     assert service_mock.await_args.kwargs["address"].local_task_id == "codex-1"
+    assert service_mock.await_args.kwargs["address"].limit == 25
+    assert service_mock.await_args.kwargs["address"].before_cursor == "offset:120"
 
 
 def test_runtime_archive_endpoint_dispatches_address(

--- a/backend/tests/services/test_runtime_rpc_service.py
+++ b/backend/tests/services/test_runtime_rpc_service.py
@@ -7,6 +7,23 @@ from unittest.mock import AsyncMock
 import pytest
 
 
+def _compressed_runtime_rpc_response(response: dict):
+    import base64
+    import gzip
+    import json
+
+    raw = json.dumps(response, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    compressed = gzip.compress(raw)
+    return {
+        "__runtimeRpcEncoding": "gzip+base64+json",
+        "payload": base64.b64encode(compressed).decode("ascii"),
+        "rawBytes": len(raw),
+        "compressedBytes": len(compressed),
+    }
+
+
 @pytest.mark.asyncio
 async def test_runtime_rpc_service_returns_runtime_failure_ack(monkeypatch):
     from app.services.device import runtime_rpc_service as module
@@ -52,3 +69,34 @@ async def test_runtime_rpc_service_returns_runtime_failure_ack(monkeypatch):
         namespace="/local-executor",
         timeout=35,
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_rpc_service_decodes_compressed_ack(monkeypatch):
+    from app.services.device import runtime_rpc_service as module
+
+    expected = {
+        "success": True,
+        "messages": [{"id": "m1", "content": "hello" * 200000}],
+    }
+    monkeypatch.setattr(
+        module.device_service,
+        "get_device_online_info",
+        AsyncMock(return_value={"socket_id": "socket-1"}),
+    )
+    sio = type(
+        "Sio",
+        (),
+        {"call": AsyncMock(return_value=_compressed_runtime_rpc_response(expected))},
+    )()
+    monkeypatch.setattr(module, "get_sio", lambda: sio)
+
+    result = await module.RuntimeRpcService().call(
+        user_id=7,
+        device_id="device-1",
+        method="runtime.tasks.transcript",
+        payload={"localTaskId": "codex-1"},
+        timeout_seconds=30,
+    )
+
+    assert result == expected

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -761,6 +761,69 @@ async def test_open_runtime_transcript_dispatches_to_owned_mapped_device_without
 
 
 @pytest.mark.asyncio
+async def test_runtime_transcript_dispatches_pagination_payload(
+    test_db,
+    test_user,
+    monkeypatch,
+):
+    from app.schemas.runtime_work import DeviceWorkspaceUpsert, RuntimeTranscriptRequest
+    from app.services import runtime_work_service
+
+    project = _project(test_db, test_user.id)
+    runtime_work_service.upsert_device_workspace(
+        db=test_db,
+        user_id=test_user.id,
+        payload=DeviceWorkspaceUpsert(
+            projectId=project.id,
+            deviceId="device-1",
+            workspacePath="/repo/Wegent",
+        ),
+    )
+    monkeypatch.setattr(
+        runtime_work_service.device_service,
+        "get_device_by_device_id",
+        lambda db, user_id, device_id: object(),
+    )
+    rpc = AsyncMock(
+        return_value={
+            "localTaskId": "codex-1",
+            "workspacePath": "/repo/Wegent",
+            "runtime": "codex",
+            "messages": [],
+            "hasMoreBefore": True,
+            "beforeCursor": "offset:120",
+        }
+    )
+    monkeypatch.setattr(runtime_work_service.runtime_rpc_service, "call", rpc)
+
+    response = await runtime_work_service.get_runtime_transcript(
+        db=test_db,
+        user_id=test_user.id,
+        address=RuntimeTranscriptRequest(
+            deviceId="device-1",
+            localTaskId="codex-1",
+            limit=25,
+            beforeCursor="offset:240",
+        ),
+    )
+
+    assert response.has_more_before is True
+    assert response.before_cursor == "offset:120"
+    rpc.assert_awaited_once_with(
+        user_id=test_user.id,
+        device_id="device-1",
+        method="runtime.tasks.transcript",
+        payload={
+            "deviceId": "device-1",
+            "localTaskId": "codex-1",
+            "limit": 25,
+            "beforeCursor": "offset:240",
+        },
+        timeout_seconds=30,
+    )
+
+
+@pytest.mark.asyncio
 async def test_archive_runtime_task_dispatches_to_owned_device_without_task_rows(
     test_db,
     test_user,

--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -8,7 +8,9 @@ import contextlib
 import json
 import os
 import re
+import time
 from collections import deque
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
@@ -24,10 +26,31 @@ from shared.logger import setup_logger
 
 DEFAULT_CODEX_SESSION_LIMIT = 100
 CODEX_SESSION_RUNNING_TAIL_LINES = 200
+CODEX_TRANSCRIPT_DEFAULT_LIMIT = 50
+CODEX_TRANSCRIPT_MAX_LIMIT = 200
+CODEX_TRANSCRIPT_INITIAL_WINDOW_BYTES = 1024 * 1024
+CODEX_TRANSCRIPT_MAX_WINDOW_BYTES = 64 * 1024 * 1024
 CODEX_TERMINAL_EVENT_TYPES = {"task_complete", "turn_aborted"}
 CODEX_CONVERSATION_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+CODEX_TRANSCRIPT_CURSOR_PATTERN = re.compile(r"^offset:(\d+)$")
 
 logger = setup_logger("codex_session_discovery")
+
+
+@dataclass(frozen=True)
+class CodexTranscriptPage:
+    """A page of user-visible Codex transcript messages."""
+
+    messages: list[dict[str, Any]]
+    has_more_before: bool = False
+    before_cursor: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class _TranscriptCacheEntry:
+    stat_key: tuple[int, int, int]
+    messages: list[dict[str, Any]]
+    complete: bool
 
 
 class CodexSessionDiscovery:
@@ -44,6 +67,7 @@ class CodexSessionDiscovery:
         ).expanduser()
         self.limit = max(1, limit)
         self.codex_client_factory = codex_client_factory
+        self._transcript_cache: dict[str, _TranscriptCacheEntry] = {}
 
     def discover(self) -> list[LocalTaskRecord]:
         try:
@@ -115,6 +139,92 @@ class CodexSessionDiscovery:
         if path is None:
             return []
         return _read_session_transcript(path, thread_id)
+
+    def read_transcript_page(
+        self,
+        thread_id: str,
+        session_path: Optional[str] = None,
+        *,
+        limit: int = CODEX_TRANSCRIPT_DEFAULT_LIMIT,
+        before_cursor: Optional[str] = None,
+    ) -> CodexTranscriptPage:
+        started_at = time.perf_counter()
+        path = self._resolve_session_path(thread_id, session_path)
+        if path is None:
+            logger.info(
+                "[CodexTranscript] Session path not found: thread_id=%s requested_session_path=%s elapsed_ms=%s",
+                thread_id,
+                session_path,
+                int((time.perf_counter() - started_at) * 1000),
+            )
+            return CodexTranscriptPage(messages=[])
+
+        safe_limit = _normalize_transcript_limit(limit)
+        before_offset = _parse_transcript_cursor(before_cursor)
+        cache_key = str(path)
+        stat_key = _transcript_stat_key(path)
+        if stat_key is None:
+            logger.info(
+                "[CodexTranscript] Session stat failed: thread_id=%s path=%s elapsed_ms=%s",
+                thread_id,
+                path,
+                int((time.perf_counter() - started_at) * 1000),
+            )
+            return CodexTranscriptPage(messages=[])
+
+        cached = self._transcript_cache.get(cache_key)
+        if (
+            cached
+            and cached.stat_key == stat_key
+            and (cached.complete or before_offset is None)
+        ):
+            page = _paginate_transcript_messages(
+                cached.messages,
+                limit=safe_limit,
+                before_offset=before_offset,
+                complete=cached.complete,
+            )
+            logger.info(
+                "[CodexTranscript] Page served from cache: thread_id=%s path=%s limit=%s before_cursor=%s elapsed_ms=%s message_count=%s has_more_before=%s next_cursor=%s complete=%s",
+                thread_id,
+                path,
+                safe_limit,
+                before_cursor,
+                int((time.perf_counter() - started_at) * 1000),
+                len(page.messages),
+                page.has_more_before,
+                page.before_cursor,
+                cached.complete,
+            )
+            return page
+
+        page = _read_session_transcript_page(
+            path,
+            thread_id,
+            limit=safe_limit,
+            before_offset=before_offset,
+        )
+        messages_for_cache = page.messages
+        complete = not page.has_more_before
+        if complete or before_offset is None:
+            self._transcript_cache[cache_key] = _TranscriptCacheEntry(
+                stat_key=stat_key,
+                messages=messages_for_cache,
+                complete=complete,
+            )
+        logger.info(
+            "[CodexTranscript] Page read from session file: thread_id=%s path=%s limit=%s before_cursor=%s elapsed_ms=%s message_count=%s has_more_before=%s next_cursor=%s cached=%s",
+            thread_id,
+            path,
+            safe_limit,
+            before_cursor,
+            int((time.perf_counter() - started_at) * 1000),
+            len(page.messages),
+            page.has_more_before,
+            page.before_cursor,
+            complete or before_offset is None,
+        )
+        return page
 
     def _resolve_session_path(
         self,
@@ -305,9 +415,7 @@ def _is_codex_app_conversation_path(cwd: str) -> bool:
         return False
 
     parts = relative.parts
-    return len(parts) >= 2 and bool(
-        CODEX_CONVERSATION_DATE_PATTERN.fullmatch(parts[0])
-    )
+    return len(parts) >= 2 and bool(CODEX_CONVERSATION_DATE_PATTERN.fullmatch(parts[0]))
 
 
 def _thread_title(thread: Any, thread_id: str) -> str:
@@ -791,6 +899,276 @@ def _read_session_transcript(path: Path, thread_id: str) -> list[dict[str, Any]]
     return messages
 
 
+def _read_session_transcript_page(
+    path: Path,
+    thread_id: str,
+    *,
+    limit: int,
+    before_offset: Optional[int],
+) -> CodexTranscriptPage:
+    started_at = time.perf_counter()
+    try:
+        file_size = path.stat().st_size
+    except OSError:
+        return CodexTranscriptPage(messages=[])
+
+    if file_size <= 0:
+        return CodexTranscriptPage(messages=[])
+
+    window_size = min(CODEX_TRANSCRIPT_INITIAL_WINDOW_BYTES, file_size)
+    max_window_size = min(CODEX_TRANSCRIPT_MAX_WINDOW_BYTES, file_size)
+
+    while True:
+        segment_end = min(before_offset or file_size, file_size)
+        window_start = max(0, segment_end - window_size)
+        window_started_at = time.perf_counter()
+        messages = _read_session_transcript_window(
+            path,
+            thread_id,
+            window_start,
+            segment_end,
+        )
+        window_elapsed_ms = int((time.perf_counter() - window_started_at) * 1000)
+        complete = window_start == 0
+        page = _paginate_transcript_messages(
+            messages,
+            limit=limit,
+            before_offset=before_offset,
+            complete=complete,
+        )
+        logger.info(
+            "[CodexTranscript] Window parsed: thread_id=%s path=%s file_size=%s window_start=%s segment_end=%s window_bytes=%s window_elapsed_ms=%s total_elapsed_ms=%s parsed_messages=%s page_messages=%s complete=%s has_more_before=%s",
+            thread_id,
+            path,
+            file_size,
+            window_start,
+            segment_end,
+            segment_end - window_start,
+            window_elapsed_ms,
+            int((time.perf_counter() - started_at) * 1000),
+            len(messages),
+            len(page.messages),
+            complete,
+            page.has_more_before,
+        )
+
+        if len(page.messages) >= limit or complete:
+            return page
+
+        if window_size >= max_window_size:
+            return page
+
+        window_size = min(window_size * 2, max_window_size)
+
+
+def _read_session_transcript_window(
+    path: Path,
+    thread_id: str,
+    window_start: int,
+    segment_end: int,
+) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    pending_agent_message: Optional[dict[str, Any]] = None
+    processing_blocks: list[dict[str, Any]] = []
+    tool_blocks_by_call_id: dict[str, dict[str, Any]] = {}
+    turn_started_at: Optional[str] = None
+    turn_counter = 0
+
+    try:
+        with path.open("rb") as handle:
+            if window_start > 0:
+                handle.seek(window_start)
+                handle.readline()
+            for raw_line in handle:
+                line_start = handle.tell() - len(raw_line)
+                if line_start >= segment_end:
+                    break
+                record = _parse_json_line(raw_line)
+                if record is None:
+                    continue
+
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+
+                event_type = payload.get("type")
+                timestamp = _record_timestamp(record, payload)
+                if record.get("type") == "response_item":
+                    if turn_counter > 0:
+                        _append_response_item_block(
+                            payload=payload,
+                            timestamp=timestamp,
+                            thread_id=thread_id,
+                            turn_counter=turn_counter,
+                            processing_blocks=processing_blocks,
+                            tool_blocks_by_call_id=tool_blocks_by_call_id,
+                        )
+                    continue
+
+                if event_type == "user_message":
+                    global_turn = _payload_turn_index(payload)
+                    if global_turn is None:
+                        turn_counter += 1
+                        global_turn = turn_counter
+                    else:
+                        turn_counter = global_turn
+                    pending_agent_message = None
+                    processing_blocks = []
+                    tool_blocks_by_call_id = {}
+                    turn_started_at = timestamp
+                    message = _first_text(payload, "message")
+                    if message:
+                        messages.append(
+                            _transcript_message_from_offset(
+                                thread_id=thread_id,
+                                offset=line_start,
+                                role="user",
+                                content=message,
+                                created_at=timestamp,
+                                status="done",
+                            )
+                        )
+                elif event_type == "agent_message":
+                    message = _first_text(payload, "message")
+                    if message:
+                        pending_agent_message = _transcript_message_from_offset(
+                            thread_id=thread_id,
+                            offset=line_start,
+                            role="assistant",
+                            content=message,
+                            created_at=turn_started_at or timestamp,
+                            status="streaming",
+                            blocks=processing_blocks,
+                        )
+                elif event_type == "task_complete":
+                    message = _first_text(payload, "last_agent_message")
+                    _finish_processing_blocks(processing_blocks, timestamp)
+                    if message:
+                        messages.append(
+                            _transcript_message_from_offset(
+                                thread_id=thread_id,
+                                offset=line_start,
+                                role="assistant",
+                                content=message,
+                                created_at=turn_started_at or timestamp,
+                                status="done",
+                                blocks=processing_blocks,
+                            )
+                        )
+                    pending_agent_message = None
+                    processing_blocks = []
+                    tool_blocks_by_call_id = {}
+                    turn_started_at = None
+                elif event_type == "turn_aborted":
+                    reason = _first_text(payload, "reason") or "Codex turn aborted"
+                    _finish_processing_blocks(processing_blocks, timestamp)
+                    messages.append(
+                        _transcript_message_from_offset(
+                            thread_id=thread_id,
+                            offset=line_start,
+                            role="assistant",
+                            content=reason,
+                            created_at=turn_started_at or timestamp,
+                            status="cancelled",
+                            blocks=processing_blocks,
+                        )
+                    )
+                    pending_agent_message = None
+                    processing_blocks = []
+                    tool_blocks_by_call_id = {}
+                    turn_started_at = None
+    except OSError:
+        return []
+
+    if pending_agent_message:
+        _set_message_blocks(pending_agent_message, processing_blocks)
+        messages.append(pending_agent_message)
+    return messages
+
+
+def _paginate_transcript_messages(
+    messages: list[dict[str, Any]],
+    *,
+    limit: int,
+    before_offset: Optional[int],
+    complete: bool,
+) -> CodexTranscriptPage:
+    eligible = [
+        message
+        for message in messages
+        if before_offset is None or _message_cursor_offset(message) < before_offset
+    ]
+    page_messages = eligible[-limit:]
+    first_offset = _first_message_offset(page_messages)
+    has_more_before = False
+    if first_offset is not None:
+        has_more_before = (
+            any(_message_cursor_offset(message) < first_offset for message in eligible)
+            or not complete
+        )
+
+    before_cursor = (
+        f"offset:{first_offset}" if has_more_before and first_offset else None
+    )
+    return CodexTranscriptPage(
+        messages=page_messages,
+        has_more_before=has_more_before,
+        before_cursor=before_cursor,
+    )
+
+
+def _normalize_transcript_limit(value: Any) -> int:
+    if isinstance(value, bool):
+        return CODEX_TRANSCRIPT_DEFAULT_LIMIT
+    if isinstance(value, int):
+        return min(max(1, value), CODEX_TRANSCRIPT_MAX_LIMIT)
+    return CODEX_TRANSCRIPT_DEFAULT_LIMIT
+
+
+def _parse_transcript_cursor(value: Optional[str]) -> Optional[int]:
+    if not isinstance(value, str):
+        return None
+    match = CODEX_TRANSCRIPT_CURSOR_PATTERN.match(value.strip())
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _transcript_stat_key(path: Path) -> Optional[tuple[int, int, int]]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (int(stat.st_ino), int(stat.st_mtime_ns), int(stat.st_size))
+
+
+def _payload_turn_index(payload: dict[str, Any]) -> Optional[int]:
+    for key in ("turn_counter", "turnCounter", "turn_index", "turnIndex"):
+        value = payload.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and value > 0:
+            return value
+    return None
+
+
+def _message_cursor_offset(message: dict[str, Any]) -> int:
+    value = message.get("_cursorOffset")
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int) and value >= 0:
+        return value
+    return 0
+
+
+def _first_message_offset(messages: list[dict[str, Any]]) -> Optional[int]:
+    for message in messages:
+        offset = _message_cursor_offset(message)
+        if offset > 0:
+            return offset
+    return None
+
+
 def _append_response_item_block(
     *,
     payload: dict[str, Any],
@@ -922,6 +1300,28 @@ def _transcript_message(
         "content": content,
         "createdAt": created_at,
         "status": status,
+    }
+    _set_message_blocks(message, blocks or [])
+    return message
+
+
+def _transcript_message_from_offset(
+    *,
+    thread_id: str,
+    offset: int,
+    role: str,
+    content: str,
+    created_at: str,
+    status: str,
+    blocks: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    message = {
+        "id": f"{thread_id}:{role}:o{max(offset, 0)}",
+        "role": role,
+        "content": content,
+        "createdAt": created_at,
+        "status": status,
+        "_cursorOffset": max(offset, 0),
     }
     _set_message_blocks(message, blocks or [])
     return message

--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -5,6 +5,8 @@
 """Runtime work RPC dispatcher for local executor mode."""
 
 import asyncio
+import base64
+import gzip
 import inspect
 import json
 import time
@@ -29,6 +31,11 @@ from shared.models.responses_api import ResponsesAPIStreamEvents
 from shared.models.responses_api_emitter import EventTransport, ResponsesAPIEmitter
 
 logger = setup_logger("runtime_work_rpc_handler")
+RUNTIME_TRANSCRIPT_DEFAULT_LIMIT = 50
+RUNTIME_TRANSCRIPT_MAX_LIMIT = 200
+RUNTIME_RPC_COMPRESSION_THRESHOLD_BYTES = 512 * 1024
+RUNTIME_RPC_COMPRESSED_ENCODING = "gzip+base64+json"
+RUNTIME_RPC_ENCODING_KEY = "__runtimeRpcEncoding"
 CODEX_NATIVE_UPDATE_TERMINAL_STATUSES = {
     "done",
     "complete",
@@ -40,6 +47,32 @@ CODEX_NATIVE_UPDATE_TERMINAL_STATUSES = {
     "cancelled",
     "canceled",
 }
+
+
+def _compress_runtime_rpc_response(
+    response: dict[str, Any], *, method: str | None
+) -> dict[str, Any]:
+    raw = json.dumps(response, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    if len(raw) <= RUNTIME_RPC_COMPRESSION_THRESHOLD_BYTES:
+        return response
+
+    compressed = gzip.compress(raw)
+    encoded = base64.b64encode(compressed).decode("ascii")
+    logger.info(
+        "[RuntimeWorkRpc] Compressed runtime RPC response: method=%s raw_bytes=%s compressed_bytes=%s encoded_bytes=%s",
+        method,
+        len(raw),
+        len(compressed),
+        len(encoded),
+    )
+    return {
+        RUNTIME_RPC_ENCODING_KEY: RUNTIME_RPC_COMPRESSED_ENCODING,
+        "payload": encoded,
+        "rawBytes": len(raw),
+        "compressedBytes": len(compressed),
+    }
 
 
 class LocalTaskResponsesTransport(EventTransport):
@@ -135,31 +168,43 @@ class RuntimeWorkRpcHandler:
 
         try:
             if method == "runtime.tasks.list":
-                return self._list_tasks(payload)
+                response = self._list_tasks(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.transcript":
-                return await self._transcript(payload)
+                response = await self._transcript(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.send":
-                return await self._send(payload)
+                response = await self._send(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.archive":
-                return await self._archive(payload)
+                response = await self._archive(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.status":
-                return self._status(payload)
+                response = self._status(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.prepare_fork_transfer":
-                return await self._prepare_fork_transfer(payload)
+                response = await self._prepare_fork_transfer(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.prepare_fork_receiver":
-                return await self._prepare_fork_receiver(payload)
+                response = await self._prepare_fork_receiver(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.push_fork_transfer":
-                return await self._push_fork_transfer(payload)
+                response = await self._push_fork_transfer(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.upload_fork_transfer":
-                return await self._upload_fork_transfer(payload)
+                response = await self._upload_fork_transfer(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method == "runtime.tasks.import_fork":
-                return await self._import_fork(payload)
+                response = await self._import_fork(payload)
+                return _compress_runtime_rpc_response(response, method=method)
             if method in {
                 "runtime.tasks.create",
                 "runtime.tasks.cancel",
             }:
-                return await self._adapter_method(method, payload)
-            return self._error(f"Unsupported runtime RPC method: {method}")
+                response = await self._adapter_method(method, payload)
+                return _compress_runtime_rpc_response(response, method=method)
+            response = self._error(f"Unsupported runtime RPC method: {method}")
+            return _compress_runtime_rpc_response(response, method=method)
         except KeyError as exc:
             return self._error(str(exc), code="not_found")
         except ValueError as exc:
@@ -416,17 +461,113 @@ class RuntimeWorkRpcHandler:
         }
 
     async def _transcript(self, payload: dict[str, Any]) -> dict[str, Any]:
-        discovered_tasks = self._refresh_discovered_tasks()
-        task = self._load_payload_task(payload, discovered_tasks=discovered_tasks)
-        messages = await self._task_transcript_messages(task)
+        started_at = time.perf_counter()
+        local_task_id = payload.get("localTaskId")
+        workspace_path = payload.get("workspacePath")
+        logger.info(
+            "[RuntimeWorkRpc] Transcript request received: local_task_id=%s workspace_path=%s limit=%s before_cursor=%s",
+            local_task_id,
+            workspace_path,
+            payload.get("limit"),
+            payload.get("beforeCursor"),
+        )
+        task = self._load_payload_transcript_task(payload)
+        task_loaded_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "[RuntimeWorkRpc] Transcript task loaded: local_task_id=%s runtime=%s workspace_path=%s elapsed_ms=%s",
+            task.local_task_id,
+            task.runtime,
+            task.workspace_path,
+            task_loaded_ms,
+        )
+        limit = self._transcript_limit(payload.get("limit"))
+        before_cursor = payload.get("beforeCursor")
+        if not isinstance(before_cursor, str):
+            before_cursor = None
+        page = await self._task_transcript_page(
+            task,
+            limit=limit,
+            before_cursor=before_cursor,
+        )
+        page_loaded_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "[RuntimeWorkRpc] Transcript page loaded: local_task_id=%s runtime=%s elapsed_ms=%s message_count=%s has_more_before=%s before_cursor=%s",
+            task.local_task_id,
+            task.runtime,
+            page_loaded_ms,
+            len(page["messages"]) if isinstance(page.get("messages"), list) else None,
+            page.get("hasMoreBefore"),
+            page.get("beforeCursor"),
+        )
 
-        return {
+        response = {
             "success": True,
             "localTaskId": task.local_task_id,
             "workspacePath": task.workspace_path,
             "runtime": task.runtime,
             "title": task.title,
-            "messages": self._normalize_messages(task, messages),
+            "messages": self._normalize_messages(task, page["messages"]),
+            "hasMoreBefore": page["hasMoreBefore"],
+            "beforeCursor": page["beforeCursor"],
+        }
+        completed_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "[RuntimeWorkRpc] Transcript response ready: local_task_id=%s elapsed_ms=%s normalized_message_count=%s",
+            task.local_task_id,
+            completed_ms,
+            len(response["messages"]),
+        )
+        return response
+
+    async def _task_transcript_page(
+        self,
+        task: LocalTaskRecord,
+        *,
+        limit: int,
+        before_cursor: Optional[str],
+    ) -> dict[str, Any]:
+        if self._is_codex_runtime(task.runtime):
+            started_at = time.perf_counter()
+            codex_page = self._codex_session_page(
+                task,
+                limit=limit,
+                before_cursor=before_cursor,
+            )
+            elapsed_ms = int((time.perf_counter() - started_at) * 1000)
+            logger.info(
+                "[RuntimeWorkRpc] Codex transcript page attempt finished: local_task_id=%s elapsed_ms=%s found=%s message_count=%s",
+                task.local_task_id,
+                elapsed_ms,
+                codex_page is not None,
+                (
+                    len(codex_page["messages"])
+                    if codex_page is not None
+                    and isinstance(codex_page.get("messages"), list)
+                    else None
+                ),
+            )
+            if codex_page is not None and (
+                codex_page["messages"] or before_cursor is not None
+            ):
+                return codex_page
+
+        fallback_started_at = time.perf_counter()
+        messages = await self._task_transcript_messages(task)
+        fallback_elapsed_ms = int((time.perf_counter() - fallback_started_at) * 1000)
+        logger.info(
+            "[RuntimeWorkRpc] Transcript fallback loaded: local_task_id=%s runtime=%s elapsed_ms=%s message_count=%s before_cursor=%s",
+            task.local_task_id,
+            task.runtime,
+            fallback_elapsed_ms,
+            len(messages) if isinstance(messages, list) else None,
+            before_cursor,
+        )
+        page_messages = messages[-limit:] if before_cursor is None else []
+        return {
+            "messages": page_messages,
+            "hasMoreBefore": before_cursor is None
+            and len(messages) > len(page_messages),
+            "beforeCursor": None,
         }
 
     async def _task_transcript_messages(
@@ -470,6 +611,38 @@ class RuntimeWorkRpcHandler:
         if not isinstance(session_path, str):
             session_path = None
         return self.codex_discovery.read_transcript(thread_id, session_path)
+
+    def _codex_session_page(
+        self,
+        task: LocalTaskRecord,
+        *,
+        limit: int,
+        before_cursor: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        if not self._is_codex_runtime(task.runtime) or self.codex_discovery is None:
+            return None
+        if not hasattr(self.codex_discovery, "read_transcript_page"):
+            return None
+
+        thread_id = task.runtime_handle.get("threadId") or task.local_task_id
+        if not isinstance(thread_id, str) or not thread_id.strip():
+            return None
+
+        session_path = task.runtime_handle.get("sessionPath")
+        if not isinstance(session_path, str):
+            session_path = None
+
+        page = self.codex_discovery.read_transcript_page(
+            thread_id,
+            session_path,
+            limit=limit,
+            before_cursor=before_cursor,
+        )
+        return {
+            "messages": page.messages,
+            "hasMoreBefore": page.has_more_before,
+            "beforeCursor": page.before_cursor,
+        }
 
     async def _send(self, payload: dict[str, Any]) -> dict[str, Any]:
         task = self._load_payload_task(payload)
@@ -1180,6 +1353,46 @@ class RuntimeWorkRpcHandler:
 
         raise KeyError(f"Local task not found: {local_task_id}")
 
+    def _load_payload_transcript_task(self, payload: dict[str, Any]) -> LocalTaskRecord:
+        local_task_id = payload.get("localTaskId")
+        if not isinstance(local_task_id, str) or not local_task_id.strip():
+            raise ValueError("localTaskId is required")
+
+        workspace_path = payload.get("workspacePath")
+        if workspace_path is not None and not isinstance(workspace_path, str):
+            raise ValueError("workspacePath must be a string")
+
+        try:
+            task = self.store.get_task(local_task_id, workspace_path=workspace_path)
+            if self._is_codex_runtime(task.runtime):
+                handle = dict(task.runtime_handle)
+                handle.pop("messages", None)
+                return replace(task, runtime_handle=handle)
+            return task
+        except KeyError:
+            pass
+
+        sdk_task = self._find_sdk_codex_task(
+            local_task_id,
+            workspace_path=workspace_path,
+        )
+        if sdk_task is not None:
+            return sdk_task
+
+        return LocalTaskRecord(
+            local_task_id=local_task_id.strip(),
+            workspace_path=(
+                normalize_workspace_path(workspace_path) if workspace_path else ""
+            ),
+            title=local_task_id.strip(),
+            runtime="codex",
+            runtime_handle={"threadId": local_task_id.strip()},
+            created_at=utc_now_iso(),
+            updated_at=utc_now_iso(),
+            running=False,
+            status="active",
+        )
+
     def _remember_sdk_codex_task(self, task: LocalTaskRecord) -> None:
         if self._is_sdk_codex_task(task):
             self._sdk_codex_task_records[task.local_task_id] = task
@@ -1431,6 +1644,12 @@ class RuntimeWorkRpcHandler:
             parsed = int(value)
             return parsed if parsed > 0 else None
         return None
+
+    def _transcript_limit(self, value: Any) -> int:
+        parsed = self._positive_int(value)
+        if parsed is None:
+            return RUNTIME_TRANSCRIPT_DEFAULT_LIMIT
+        return min(parsed, RUNTIME_TRANSCRIPT_MAX_LIMIT)
 
     def _string_content(self, content: Any) -> str:
         if content is None:

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -1235,6 +1235,63 @@ def test_codex_discovery_reads_user_visible_transcript(tmp_path):
     assert transcript[1]["status"] == "done"
 
 
+def test_codex_discovery_reads_transcript_pages(tmp_path):
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789pg"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+
+    records = []
+    for index in range(1, 4):
+        records.extend(
+            [
+                {
+                    "timestamp": f"2026-06-20T05:52:{index * 2:02d}Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "user_message",
+                        "message": f"Question {index}",
+                    },
+                },
+                {
+                    "timestamp": f"2026-06-20T05:52:{index * 2 + 1:02d}Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "task_complete",
+                        "last_agent_message": f"Answer {index}",
+                    },
+                },
+            ]
+        )
+    _write_codex_session(session_path, *records)
+
+    discovery = CodexSessionDiscovery(codex_home=codex_home)
+    recent_page = discovery.read_transcript_page(thread_id, str(session_path), limit=2)
+
+    assert [message["content"] for message in recent_page.messages] == [
+        "Question 3",
+        "Answer 3",
+    ]
+    assert recent_page.has_more_before is True
+    assert recent_page.before_cursor
+
+    older_page = discovery.read_transcript_page(
+        thread_id,
+        str(session_path),
+        limit=2,
+        before_cursor=recent_page.before_cursor,
+    )
+
+    assert [message["content"] for message in older_page.messages] == [
+        "Question 2",
+        "Answer 2",
+    ]
+    assert older_page.has_more_before is True
+
+
 def test_codex_discovery_restores_processing_blocks_from_response_items(tmp_path):
     from executor.runtime_work.codex_discovery import CodexSessionDiscovery
 
@@ -1937,6 +1994,8 @@ async def test_runtime_work_handler_reads_discovered_codex_transcript(tmp_path):
         "Show project task",
         "Project task is visible",
     ]
+    assert result["hasMoreBefore"] is False
+    assert result["beforeCursor"] is None
     assert result["messages"][1]["createdAt"] == "2026-06-20T06:00:01Z"
     assert result["messages"][1]["blocks"] == [
         {
@@ -1961,6 +2020,58 @@ async def test_runtime_work_handler_reads_discovered_codex_transcript(tmp_path):
             ),
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_work_handler_transcript_does_not_require_codex_discovery(
+    tmp_path,
+):
+    from executor.runtime_work.local_task_store import LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    class TranscriptOnlyCodexDiscovery:
+        def discover(self):
+            raise AssertionError("transcript should not list Codex threads")
+
+        def read_transcript_page(self, thread_id, session_path=None, **_kwargs):
+            from executor.runtime_work.codex_discovery import CodexTranscriptPage
+
+            assert thread_id == "codex-thread-slow-list"
+            assert session_path is None
+            return CodexTranscriptPage(
+                messages=[
+                    {
+                        "id": f"{thread_id}:user:o1",
+                        "role": "user",
+                        "content": "recent question",
+                        "createdAt": "2026-06-20T06:00:01Z",
+                        "status": "done",
+                    }
+                ],
+                has_more_before=True,
+                before_cursor="offset:1",
+            )
+
+    handler = RuntimeWorkRpcHandler(
+        store=LocalTaskStore(tmp_path / "index.json"),
+        codex_discovery=TranscriptOnlyCodexDiscovery(),
+    )
+
+    result = await handler.handle_runtime_rpc(
+        {
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "localTaskId": "codex-thread-slow-list",
+                "limit": 50,
+            },
+        }
+    )
+
+    assert result["success"] is True
+    assert result["runtime"] == "codex"
+    assert result["messages"][0]["content"] == "recent question"
+    assert result["hasMoreBefore"] is True
+    assert result["beforeCursor"] == "offset:1"
 
 
 @pytest.mark.asyncio
@@ -3096,3 +3207,55 @@ async def test_runtime_work_handler_transcript_overlays_im_source(tmp_path):
     assert result["success"] is True
     assert result["messages"][0]["source"]["source"] == "im"
     assert result["messages"][0]["source"]["conversation_id"] == "conv-1"
+
+
+@pytest.mark.asyncio
+async def test_runtime_work_handler_compresses_large_transcript_ack(tmp_path):
+    import base64
+    import gzip
+    import json
+
+    from executor.runtime_work.local_task_store import LocalTaskRecord, LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    store = LocalTaskStore(tmp_path / "index.json")
+    store.upsert_task(
+        LocalTaskRecord(
+            local_task_id="claude-large",
+            workspace_path="/repo/Wegent",
+            title="Large transcript",
+            runtime="claude_code",
+            runtime_handle={
+                "messages": [
+                    {
+                        "id": "m1",
+                        "role": "assistant",
+                        "content": "large transcript " * 50000,
+                        "createdAt": "2026-06-20T01:00:00Z",
+                    }
+                ]
+            },
+            created_at="2026-06-20T01:00:00Z",
+            updated_at="2026-06-20T02:00:00Z",
+            running=False,
+        )
+    )
+
+    result = await RuntimeWorkRpcHandler(
+        store=store,
+        codex_discovery=EmptyDiscovery(),
+    ).handle_runtime_rpc(
+        {
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/repo/Wegent",
+                "localTaskId": "claude-large",
+            },
+        }
+    )
+
+    assert result["__runtimeRpcEncoding"] == "gzip+base64+json"
+    compressed = base64.b64decode(result["payload"].encode("ascii"), validate=True)
+    decoded = json.loads(gzip.decompress(compressed).decode("utf-8"))
+    assert decoded["success"] is True
+    assert decoded["messages"][0]["content"].startswith("large transcript")

--- a/wework/src/api/runtimeWork.ts
+++ b/wework/src/api/runtimeWork.ts
@@ -19,6 +19,7 @@ import type {
   RuntimeTaskForkResponse,
   RuntimeTaskIMNotificationSubscriptionRequest,
   RuntimeTaskIMNotificationSubscriptionResponse,
+  RuntimeTranscriptRequest,
   RuntimeTranscriptResponse,
   RuntimeWorkListResponse,
 } from '@/types/api'
@@ -47,8 +48,8 @@ export function createRuntimeWorkApi(client: HttpClient) {
       })
       return client.delete(`/runtime-work/device-workspaces?${params.toString()}`)
     },
-    getRuntimeTranscript(address: RuntimeTaskAddress): Promise<RuntimeTranscriptResponse> {
-      return client.post('/runtime-work/transcript', address)
+    getRuntimeTranscript(request: RuntimeTranscriptRequest): Promise<RuntimeTranscriptResponse> {
+      return client.post('/runtime-work/transcript', request)
     },
     sendRuntimeMessage(data: RuntimeSendRequest): Promise<RuntimeSendResponse> {
       return client.post('/runtime-work/send', data)

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -12,6 +12,8 @@ const STABLE_SCROLL_DELAYS = [0, 50, 150, 300]
 interface ScrollableMessageAreaProps {
   messages: WorkbenchMessage[]
   loading?: boolean
+  hasMoreBefore?: boolean
+  loadingMoreBefore?: boolean
   className?: string
   scrollerClassName?: string
   scrollButtonClassName?: string
@@ -27,11 +29,14 @@ interface ScrollableMessageAreaProps {
     loadDiff: () => Promise<string>
   }) => void
   onOpenWorkspaceFile?: (path: string) => void
+  onLoadMoreBefore?: () => Promise<void> | void
 }
 
 export function ScrollableMessageArea({
   messages,
   loading = false,
+  hasMoreBefore = false,
+  loadingMoreBefore = false,
   className,
   scrollerClassName,
   scrollButtonClassName,
@@ -44,6 +49,7 @@ export function ScrollableMessageArea({
   onRevertFileChanges,
   onOpenFileChangesReview,
   onOpenWorkspaceFile,
+  onLoadMoreBefore,
 }: ScrollableMessageAreaProps) {
   const { t } = useTranslation('common')
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -233,16 +239,33 @@ export function ScrollableMessageArea({
               </div>
             )
           ) : (
-            <MessageList
-              messages={messages}
-              devices={devices}
-              onRetryFailedMessage={onRetryFailedMessage}
-              onSwitchModelForFailedMessage={onSwitchModelForFailedMessage}
-              onLoadFileChangesDiff={onLoadFileChangesDiff}
-              onRevertFileChanges={onRevertFileChanges}
-              onOpenFileChangesReview={onOpenFileChangesReview}
-              onOpenWorkspaceFile={onOpenWorkspaceFile}
-            />
+            <>
+              {hasMoreBefore && (
+                <div className="flex justify-center px-4 pb-2 pt-4">
+                  <button
+                    type="button"
+                    data-testid="load-older-runtime-transcript-button"
+                    onClick={() => void onLoadMoreBefore?.()}
+                    disabled={loadingMoreBefore}
+                    className="flex h-11 min-w-[44px] items-center justify-center rounded-md border border-border bg-surface px-4 text-xs font-medium text-text-secondary hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {loadingMoreBefore
+                      ? t('workbench.loading_older_messages')
+                      : t('workbench.load_older_messages')}
+                  </button>
+                </div>
+              )}
+              <MessageList
+                messages={messages}
+                devices={devices}
+                onRetryFailedMessage={onRetryFailedMessage}
+                onSwitchModelForFailedMessage={onSwitchModelForFailedMessage}
+                onLoadFileChangesDiff={onLoadFileChangesDiff}
+                onRevertFileChanges={onRevertFileChanges}
+                onOpenFileChangesReview={onOpenFileChangesReview}
+                onOpenWorkspaceFile={onOpenWorkspaceFile}
+              />
+            </>
           )}
         </div>
       </div>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -57,6 +57,8 @@ interface DesktopWorkbenchLayoutProps {
   guidanceMessages?: GuidanceWorkbenchMessage[]
   codeCommentContexts?: CodeCommentContext[]
   isRuntimeTranscriptLoading?: boolean
+  runtimeTranscriptHasMoreBefore?: boolean
+  isRuntimeTranscriptLoadingMore?: boolean
   upgradingDevices?: Record<string, DeviceUpgradeState>
   activeItem?: 'chat' | 'plugins' | 'automation'
   onNewChat: () => void
@@ -67,6 +69,7 @@ interface DesktopWorkbenchLayoutProps {
   onSelectProject: (projectId: number | null) => void
   onStartNewProjectChat: (projectId: number) => void
   onOpenRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void>
+  onLoadOlderRuntimeTranscript?: () => Promise<void>
   onArchiveRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void>
   onForkCurrentRuntimeTask?: (target: RuntimeTaskForkTarget) => Promise<void>
   onRememberExecutionDevice?: (deviceId: string) => void
@@ -154,6 +157,8 @@ export function DesktopWorkbenchLayout({
   guidanceMessages = [],
   codeCommentContexts = [],
   isRuntimeTranscriptLoading = false,
+  runtimeTranscriptHasMoreBefore = false,
+  isRuntimeTranscriptLoadingMore = false,
   upgradingDevices = {},
   activeItem = 'chat',
   onNewChat,
@@ -163,6 +168,7 @@ export function DesktopWorkbenchLayout({
   onSelectProject,
   onStartNewProjectChat,
   onOpenRuntimeLocalTask,
+  onLoadOlderRuntimeTranscript,
   onArchiveRuntimeLocalTask,
   onForkCurrentRuntimeTask,
   onRememberExecutionDevice,
@@ -727,6 +733,8 @@ export function DesktopWorkbenchLayout({
           upgradingDevices={upgradingDevices}
           messages={messages}
           isRuntimeTranscriptLoading={isRuntimeTranscriptLoading}
+          runtimeTranscriptHasMoreBefore={runtimeTranscriptHasMoreBefore}
+          isRuntimeTranscriptLoadingMore={isRuntimeTranscriptLoadingMore}
           queuedMessages={queuedMessages}
           guidanceMessages={guidanceMessages}
           codeCommentContexts={codeCommentContexts}
@@ -760,6 +768,7 @@ export function DesktopWorkbenchLayout({
           onInputChange={onInputChange}
           onSend={onSend}
           onRetryFailedMessage={onRetryFailedMessage}
+          onLoadOlderRuntimeTranscript={onLoadOlderRuntimeTranscript}
           isResponseStreaming={isResponseStreaming}
           onPauseResponse={onPauseResponse}
           onCancelQueuedMessage={onCancelQueuedMessage}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -136,6 +136,8 @@ interface DesktopWorkbenchMainProps {
   upgradingDevices: Record<string, DeviceUpgradeState>
   messages: WorkbenchMessage[]
   isRuntimeTranscriptLoading?: boolean
+  runtimeTranscriptHasMoreBefore?: boolean
+  isRuntimeTranscriptLoadingMore?: boolean
   queuedMessages: QueuedWorkbenchMessage[]
   guidanceMessages: GuidanceWorkbenchMessage[]
   codeCommentContexts?: CodeCommentContext[]
@@ -156,6 +158,7 @@ interface DesktopWorkbenchMainProps {
   onInputChange: (value: string) => void
   onSend: () => void
   onRetryFailedMessage?: (messageId: string) => void
+  onLoadOlderRuntimeTranscript?: () => Promise<void>
   isResponseStreaming: boolean
   onPauseResponse: () => void
   onCancelQueuedMessage: (id: string) => void
@@ -191,6 +194,8 @@ export function DesktopWorkbenchMain({
   upgradingDevices,
   messages,
   isRuntimeTranscriptLoading = false,
+  runtimeTranscriptHasMoreBefore = false,
+  isRuntimeTranscriptLoadingMore = false,
   queuedMessages,
   guidanceMessages,
   codeCommentContexts = [],
@@ -211,6 +216,7 @@ export function DesktopWorkbenchMain({
   onInputChange,
   onSend,
   onRetryFailedMessage,
+  onLoadOlderRuntimeTranscript,
   isResponseStreaming,
   onPauseResponse,
   onCancelQueuedMessage,
@@ -537,6 +543,8 @@ export function DesktopWorkbenchMain({
             <ScrollableMessageArea
               messages={messages}
               loading={isRuntimeTranscriptLoading}
+              hasMoreBefore={runtimeTranscriptHasMoreBefore}
+              loadingMoreBefore={isRuntimeTranscriptLoadingMore}
               conversationKey={currentRuntimeTask?.localTaskId ?? null}
               className="h-full"
               scrollTestId="desktop-chat-scroll"
@@ -548,6 +556,7 @@ export function DesktopWorkbenchMain({
               }
               devices={devices}
               onRetryFailedMessage={message => onRetryFailedMessage?.(message.id)}
+              onLoadMoreBefore={onLoadOlderRuntimeTranscript}
               onSwitchModelForFailedMessage={() => setModelSelectorOpenSignal(signal => signal + 1)}
               onLoadFileChangesDiff={onLoadFileChangesDiff}
               onRevertFileChanges={onRevertFileChanges}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -63,6 +63,8 @@ interface MobileWorkbenchLayoutProps {
   guidanceMessages?: GuidanceWorkbenchMessage[]
   codeCommentContexts?: CodeCommentContext[]
   isRuntimeTranscriptLoading?: boolean
+  runtimeTranscriptHasMoreBefore?: boolean
+  isRuntimeTranscriptLoadingMore?: boolean
   upgradingDevices?: Record<string, DeviceUpgradeState>
   activeItem?: 'chat' | 'plugins' | 'automation'
   onNewChat?: () => void
@@ -73,6 +75,7 @@ interface MobileWorkbenchLayoutProps {
   onSelectProject: (projectId: number | null) => void
   onStartNewProjectChat?: (projectId: number) => void
   onOpenRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void>
+  onLoadOlderRuntimeTranscript?: () => Promise<void>
   onArchiveRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void>
   onForkCurrentRuntimeTask?: (target: RuntimeTaskForkTarget) => Promise<void>
   onCreateProject?: (data: CreateProjectRequest) => Promise<ProjectWithTasks>
@@ -158,6 +161,8 @@ export function MobileWorkbenchLayout({
   guidanceMessages = [],
   codeCommentContexts = [],
   isRuntimeTranscriptLoading = false,
+  runtimeTranscriptHasMoreBefore = false,
+  isRuntimeTranscriptLoadingMore = false,
   upgradingDevices = {},
   activeItem,
   onNewChat,
@@ -167,6 +172,7 @@ export function MobileWorkbenchLayout({
   projectWork,
   onSelectProject,
   onOpenRuntimeLocalTask,
+  onLoadOlderRuntimeTranscript,
   onForkCurrentRuntimeTask,
   onCreateProject,
   onCreateGitWorkspaceProject,
@@ -513,11 +519,14 @@ export function MobileWorkbenchLayout({
             <ScrollableMessageArea
               messages={messages}
               loading={isRuntimeTranscriptLoading}
+              hasMoreBefore={runtimeTranscriptHasMoreBefore}
+              loadingMoreBefore={isRuntimeTranscriptLoadingMore}
               conversationKey={state.currentRuntimeTask?.localTaskId ?? null}
               className="h-full"
               scrollerClassName="pb-28 pt-16"
               devices={state.devices}
               onRetryFailedMessage={message => onRetryFailedMessage?.(message.id)}
+              onLoadMoreBefore={onLoadOlderRuntimeTranscript}
               onSwitchModelForFailedMessage={() => setModelSelectorOpenSignal(signal => signal + 1)}
               onLoadFileChangesDiff={onLoadFileChangesDiff}
               onRevertFileChanges={onRevertFileChanges}

--- a/wework/src/features/auth/AuthProvider.test.tsx
+++ b/wework/src/features/auth/AuthProvider.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import { setToken } from '@/api/auth'
+import { ApiError } from '@/api/http'
 import { AuthProvider } from './AuthProvider'
 import { useAuth } from './useAuth'
 
@@ -9,8 +10,14 @@ function createJwt(expSeconds: number) {
 }
 
 function Probe() {
-  const { user, isLoading } = useAuth()
-  return <div data-testid="auth-probe">{isLoading ? 'loading' : (user?.user_name ?? 'none')}</div>
+  const { user, isLoading, adminPasswordSetupRequired, adminUsername } = useAuth()
+  return (
+    <div data-testid="auth-probe">
+      {isLoading
+        ? 'loading'
+        : `${user?.user_name ?? 'none'}:${adminPasswordSetupRequired ? adminUsername : 'ready'}`}
+    </div>
+  )
 }
 
 describe('AuthProvider', () => {
@@ -38,6 +45,34 @@ describe('AuthProvider', () => {
     )
 
     await waitFor(() => expect(screen.getByTestId('auth-probe')).toHaveTextContent('alice'))
+  })
+
+  test('redirects protected routes to login when admin password setup is required', async () => {
+    setToken(createJwt(Math.floor(Date.now() / 1000) + 3600))
+    window.history.pushState({}, '', '/')
+    const authApi = {
+      getCurrentUser: vi.fn().mockRejectedValue(
+        new ApiError('ADMIN_PASSWORD_SETUP_REQUIRED', 400, 'ADMIN_PASSWORD_SETUP_REQUIRED', {
+          error_code: 'ADMIN_PASSWORD_SETUP_REQUIRED',
+          admin_username: 'admin',
+        })
+      ),
+      getCurrentUserWithoutAuthRedirect: vi.fn(),
+      login: vi.fn(),
+      logout: vi.fn(),
+      loginWithOidcToken: vi.fn(),
+      setupAdminPassword: vi.fn(),
+    }
+
+    render(
+      <AuthProvider authApi={authApi}>
+        <Probe />
+      </AuthProvider>
+    )
+
+    await waitFor(() => expect(screen.getByTestId('auth-probe')).toHaveTextContent('none:admin'))
+    expect(window.location.pathname).toBe('/login')
+    expect(sessionStorage.getItem('postLoginRedirectPath')).toBe('/')
   })
 
   test('redirects protected routes to login when token is missing', async () => {

--- a/wework/src/features/auth/AuthProvider.tsx
+++ b/wework/src/features/auth/AuthProvider.tsx
@@ -50,6 +50,9 @@ export function AuthProvider({ children, authApi }: AuthProviderProps) {
     setUser(null)
     setAdminPasswordSetupRequired(true)
     setAdminUsername(getAdminUsernameFromSetupError(error))
+    if (!isAuthRoute(window.location.pathname)) {
+      redirectToLogin()
+    }
   }, [])
 
   const fetchAnonymousLoginHandshake = useCallback(async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -255,6 +255,9 @@ function RuntimeOpenProbe() {
       <span data-testid="runtime-transcript-loading">
         {workbench.isRuntimeTranscriptLoading ? 'loading' : 'idle'}
       </span>
+      <span data-testid="runtime-transcript-has-more">
+        {workbench.runtimeTranscriptHasMoreBefore ? 'more' : 'done'}
+      </span>
       <span data-testid="runtime-open-blocks">
         {workbench.messages
           .flatMap(message => message.blocks ?? [])
@@ -288,6 +291,9 @@ function RuntimeOpenProbe() {
         }
       >
         open runtime b
+      </button>
+      <button type="button" onClick={() => void workbench.loadOlderRuntimeTranscript()}>
+        load older
       </button>
     </div>
   )
@@ -555,7 +561,59 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(getRuntimeTranscript).toHaveBeenCalledWith({
       deviceId: 'device-1',
       localTaskId: 'runtime-restored',
+      limit: 50,
     })
+  })
+
+  test('loads older runtime transcript messages before the current page', async () => {
+    const getRuntimeTranscript = vi.fn(request => {
+      if (request.beforeCursor === 'offset:120') {
+        return Promise.resolve({
+          localTaskId: 'runtime-a',
+          workspacePath: '/workspace/project-alpha',
+          runtime: 'codex',
+          messages: [{ id: 'runtime-a:user:o20', role: 'user', content: 'older message' }],
+          hasMoreBefore: false,
+          beforeCursor: null,
+        } satisfies RuntimeTranscriptResponse)
+      }
+      return Promise.resolve({
+        localTaskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'codex',
+        messages: [{ id: 'runtime-a:user:o120', role: 'user', content: 'recent message' }],
+        hasMoreBefore: true,
+        beforeCursor: 'offset:120',
+      } satisfies RuntimeTranscriptResponse)
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({ getRuntimeTranscript })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimeOpenProbe />, services)
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('recent message')
+    )
+    expect(screen.getByTestId('runtime-transcript-has-more')).toHaveTextContent('more')
+
+    await userEvent.click(screen.getByText('load older'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent(
+        'older message|recent message'
+      )
+    )
+    expect(getRuntimeTranscript).toHaveBeenLastCalledWith({
+      deviceId: 'device-1',
+      workspacePath: '/workspace/project-alpha',
+      localTaskId: 'runtime-a',
+      limit: 50,
+      beforeCursor: 'offset:120',
+    })
+    expect(screen.getByTestId('runtime-transcript-has-more')).toHaveTextContent('done')
   })
 
   test('switches the selected runtime task before transcript loading finishes', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -110,6 +110,7 @@ const OPENAI_RESPONSES_RUNTIME_FAMILY = 'openai.openai-responses'
 const OPENAI_RESPONSES_PROTOCOL = 'openai-responses'
 const RESPONSES_API_FORMAT = 'responses'
 const LOCAL_SKILLS_CACHE_TTL_MS = 60_000
+const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 const STANDALONE_PROJECT_ID = 0
 const EMPTY_MESSAGE_TASK_TITLE = '新对话'
 const RUNTIME_BLOCK_SUBTASK_ID_OFFSET = 1_000_000_000
@@ -205,6 +206,12 @@ interface QueuedWorkbenchSend extends QueuedWorkbenchMessage {
   codeComments?: CodeCommentContext[]
 }
 
+interface RuntimeTranscriptPageState {
+  hasMoreBefore: boolean
+  beforeCursor: string | null
+  loadingMore: boolean
+}
+
 function isTerminalDeviceUpgradeStatus(status: string): boolean {
   return TERMINAL_UPGRADE_STATUSES.has(status)
 }
@@ -255,6 +262,8 @@ export interface WorkbenchContextValue {
   guidanceMessages: GuidanceWorkbenchMessage[]
   codeCommentContexts: CodeCommentContext[]
   isRuntimeTranscriptLoading: boolean
+  runtimeTranscriptHasMoreBefore: boolean
+  isRuntimeTranscriptLoadingMore: boolean
   projectChat: {
     models: UnifiedModel[]
     skills: UnifiedSkill[]
@@ -290,6 +299,7 @@ export interface WorkbenchContextValue {
   startStandaloneChat: () => void
   startNewProjectChat: (projectId: number) => void
   openRuntimeLocalTask: (address: RuntimeTaskAddress) => Promise<void>
+  loadOlderRuntimeTranscript: () => Promise<void>
   archiveRuntimeLocalTask: (address: RuntimeTaskAddress) => Promise<void>
   forkCurrentRuntimeTask: (target: RuntimeTaskForkTarget) => Promise<void>
   listImPrivateSessions: () => Promise<IMPrivateSessionListResponse>
@@ -619,6 +629,13 @@ function runtimeMessageToWorkbenchMessage(
   }
 }
 
+function runtimeMessagesToWorkbenchMessages(
+  address: RuntimeTaskAddress,
+  messages: NormalizedRuntimeMessage[]
+): WorkbenchMessage[] {
+  return messages.map(message => runtimeMessageToWorkbenchMessage(address, message))
+}
+
 function chatMessageToWorkbenchMessage(payload: ChatMessagePayload): WorkbenchMessage {
   const role = payload.role.toLowerCase() === 'user' ? 'user' : 'assistant'
   const source =
@@ -793,6 +810,11 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   const [runtimeTranscriptLoadingKey, setRuntimeTranscriptLoadingKey] = useState<string | null>(
     null
   )
+  const [runtimeTranscriptPage, setRuntimeTranscriptPage] = useState<RuntimeTranscriptPageState>({
+    hasMoreBefore: false,
+    beforeCursor: null,
+    loadingMore: false,
+  })
   const [, setIsAwaitingAssistantStart] = useState(false)
   const [routePath, setRoutePath] = useState(getCurrentAppPath)
   const [routeSearch, setRouteSearch] = useState(() => window.location.search)
@@ -845,6 +867,11 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   const cancelRuntimeTranscriptLoad = useCallback(() => {
     runtimeOpenRequestIdRef.current += 1
     setRuntimeTranscriptLoadingKey(null)
+    setRuntimeTranscriptPage({
+      hasMoreBefore: false,
+      beforeCursor: null,
+      loadingMore: false,
+    })
   }, [])
 
   const selectProjectExecutionMode = useCallback(
@@ -1492,19 +1519,30 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       setQueuedSends([])
       setGuidanceMessages([])
       setCodeCommentContexts([])
+      setRuntimeTranscriptPage({
+        hasMoreBefore: false,
+        beforeCursor: null,
+        loadingMore: false,
+      })
       setRuntimeTranscriptLoadingKey(loadingKey)
       handledRuntimeTaskRouteRef.current = loadingKey
       navigateTo(buildRuntimeTaskRoute(address))
 
       try {
-        const transcript = await resolvedServices.runtimeWorkApi.getRuntimeTranscript(address)
+        const transcript = await resolvedServices.runtimeWorkApi.getRuntimeTranscript({
+          ...address,
+          limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+        })
         if (runtimeOpenRequestIdRef.current !== requestId) return
 
         dispatchMessages({
           type: 'reset',
-          messages: transcript.messages.map(message =>
-            runtimeMessageToWorkbenchMessage(address, message)
-          ),
+          messages: runtimeMessagesToWorkbenchMessages(address, transcript.messages),
+        })
+        setRuntimeTranscriptPage({
+          hasMoreBefore: Boolean(transcript.hasMoreBefore),
+          beforeCursor: transcript.beforeCursor ?? null,
+          loadingMore: false,
         })
       } finally {
         if (runtimeOpenRequestIdRef.current === requestId) {
@@ -1581,17 +1619,66 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   const refreshRuntimeTranscript = useCallback(
     async (address: RuntimeTaskAddress, shouldApply: () => boolean = () => true) => {
       if (!resolvedServices.runtimeWorkApi) return
-      const transcript = await resolvedServices.runtimeWorkApi.getRuntimeTranscript(address)
+      const transcript = await resolvedServices.runtimeWorkApi.getRuntimeTranscript({
+        ...address,
+        limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+      })
       if (!shouldApply()) return
       dispatchMessages({
         type: 'reset',
-        messages: transcript.messages.map(message =>
-          runtimeMessageToWorkbenchMessage(address, message)
-        ),
+        messages: runtimeMessagesToWorkbenchMessages(address, transcript.messages),
+      })
+      setRuntimeTranscriptPage({
+        hasMoreBefore: Boolean(transcript.hasMoreBefore),
+        beforeCursor: transcript.beforeCursor ?? null,
+        loadingMore: false,
       })
     },
     [resolvedServices.runtimeWorkApi]
   )
+
+  const loadOlderRuntimeTranscript = useCallback(async () => {
+    const address = currentRuntimeTaskRef.current
+    if (!address || !resolvedServices.runtimeWorkApi) return
+    if (!runtimeTranscriptPage.hasMoreBefore || !runtimeTranscriptPage.beforeCursor) return
+    if (runtimeTranscriptPage.loadingMore) return
+
+    const requestKey = getRuntimeTaskRouteKey(address)
+    const beforeCursor = runtimeTranscriptPage.beforeCursor
+    setRuntimeTranscriptPage(previous => ({ ...previous, loadingMore: true }))
+
+    try {
+      const transcript = await resolvedServices.runtimeWorkApi.getRuntimeTranscript({
+        ...address,
+        limit: RUNTIME_TRANSCRIPT_PAGE_SIZE,
+        beforeCursor,
+      })
+      const currentAddress = currentRuntimeTaskRef.current
+      if (!currentAddress || getRuntimeTaskRouteKey(currentAddress) !== requestKey) return
+
+      const olderMessages = runtimeMessagesToWorkbenchMessages(address, transcript.messages)
+      dispatchMessages({
+        type: 'reset',
+        messages: [...olderMessages, ...messages],
+      })
+      setRuntimeTranscriptPage({
+        hasMoreBefore: Boolean(transcript.hasMoreBefore),
+        beforeCursor: transcript.beforeCursor ?? null,
+        loadingMore: false,
+      })
+    } finally {
+      const currentAddress = currentRuntimeTaskRef.current
+      if (currentAddress && getRuntimeTaskRouteKey(currentAddress) === requestKey) {
+        setRuntimeTranscriptPage(previous => ({ ...previous, loadingMore: false }))
+      }
+    }
+  }, [
+    messages,
+    resolvedServices.runtimeWorkApi,
+    runtimeTranscriptPage.beforeCursor,
+    runtimeTranscriptPage.hasMoreBefore,
+    runtimeTranscriptPage.loadingMore,
+  ])
 
   useEffect(() => {
     if (state.isBootstrapping) return
@@ -2383,6 +2470,8 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     guidanceMessages,
     codeCommentContexts,
     isRuntimeTranscriptLoading,
+    runtimeTranscriptHasMoreBefore: runtimeTranscriptPage.hasMoreBefore,
+    isRuntimeTranscriptLoadingMore: runtimeTranscriptPage.loadingMore,
     upgradingDevices,
     projectExecutionMode,
     setProjectExecutionMode: selectProjectExecutionMode,
@@ -2418,6 +2507,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     startStandaloneChat,
     startNewProjectChat,
     openRuntimeLocalTask,
+    loadOlderRuntimeTranscript,
     archiveRuntimeLocalTask,
     forkCurrentRuntimeTask,
     listImPrivateSessions,

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -349,6 +349,8 @@
     "project_terminal_frame_title": "Project terminal",
     "scroll_to_bottom": "Scroll to bottom",
     "loading_conversation": "Loading conversation...",
+    "load_older_messages": "Load older messages",
+    "loading_older_messages": "Loading...",
     "empty_conversation_title": "Start a new conversation",
     "empty_conversation_description": "Ask a question, paste context, or add attachments below. Codex responses will appear here.",
     "account_fallback": "Current account",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -349,6 +349,8 @@
     "project_terminal_frame_title": "项目终端",
     "scroll_to_bottom": "下拉到底",
     "loading_conversation": "正在加载会话...",
+    "load_older_messages": "加载更早记录",
+    "loading_older_messages": "正在加载...",
     "empty_conversation_title": "开始新的对话",
     "empty_conversation_description": "在下方输入问题、粘贴上下文或添加附件，Codex 会在这里展示回复。",
     "account_fallback": "当前账号",

--- a/wework/src/pages/WorkbenchPage.tsx
+++ b/wework/src/pages/WorkbenchPage.tsx
@@ -15,6 +15,8 @@ export function WorkbenchPage() {
     guidanceMessages,
     codeCommentContexts,
     isRuntimeTranscriptLoading,
+    runtimeTranscriptHasMoreBefore,
+    isRuntimeTranscriptLoadingMore,
     upgradingDevices,
     projectExecutionMode,
     setProjectExecutionMode,
@@ -28,6 +30,7 @@ export function WorkbenchPage() {
     startStandaloneChat,
     startNewProjectChat,
     openRuntimeLocalTask,
+    loadOlderRuntimeTranscript,
     archiveRuntimeLocalTask,
     forkCurrentRuntimeTask,
     rememberExecutionDevice,
@@ -102,6 +105,8 @@ export function WorkbenchPage() {
       guidanceMessages={guidanceMessages}
       codeCommentContexts={codeCommentContexts}
       isRuntimeTranscriptLoading={isRuntimeTranscriptLoading}
+      runtimeTranscriptHasMoreBefore={runtimeTranscriptHasMoreBefore}
+      isRuntimeTranscriptLoadingMore={isRuntimeTranscriptLoadingMore}
       upgradingDevices={upgradingDevices}
       onNewChat={startNewChat}
       onStartStandaloneChat={startStandaloneChat}
@@ -111,6 +116,7 @@ export function WorkbenchPage() {
       onSelectProject={selectProject}
       onStartNewProjectChat={startNewProjectChat}
       onOpenRuntimeLocalTask={openRuntimeLocalTask}
+      onLoadOlderRuntimeTranscript={loadOlderRuntimeTranscript}
       onArchiveRuntimeLocalTask={archiveRuntimeLocalTask}
       onForkCurrentRuntimeTask={forkCurrentRuntimeTask}
       onRememberExecutionDevice={rememberExecutionDevice}

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -360,6 +360,14 @@ export interface RuntimeTranscriptResponse {
   runtime: RuntimeName
   title?: string | null
   messages: NormalizedRuntimeMessage[]
+  hasMoreBefore?: boolean
+  beforeCursor?: string | null
+  parseError?: string | null
+}
+
+export interface RuntimeTranscriptRequest extends RuntimeTaskAddress {
+  limit?: number
+  beforeCursor?: string | null
 }
 
 export interface RuntimeSendRequest {


### PR DESCRIPTION
Add paginated runtime transcript loading, compress oversized runtime RPC acknowledgements, and keep backend/executor timing logs for transcript diagnostics. Also redirect packaged wework to the admin password setup flow instead of rendering a blank screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pagination support for runtime transcripts; users can now load older conversation messages using the new "Load older messages" button
  * Large transcripts are automatically compressed to improve performance and reduce load times

* **Improvements**
  * Enhanced admin password setup authentication flow with better state management and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->