### PR TITLE
feat(backend): add JWT Bearer token fallback to get_auth_context

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -432,8 +432,13 @@ def get_api_key_from_header(
     # Priority: X-API-Key > Authorization Bearer > wegent-source
     if x_api_key and x_api_key.startswith("wg-"):
         return x_api_key
-    if authorization.startswith("Bearer wg-"):
-        return authorization[7:]  # Remove "Bearer " prefix
+    if authorization and authorization.strip():
+        # Case-insensitive, whitespace-tolerant Bearer parsing (RFC 7235)
+        parts = authorization.split(maxsplit=1)
+        if parts[0].lower() == "bearer" and len(parts) == 2:
+            token = parts[1].strip()
+            if token.startswith("wg-"):
+                return token
     if wegent_source and wegent_source.startswith("wg-"):
         return wegent_source
     return ""

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -483,28 +483,38 @@ def get_auth_context(
         if not api_key:
             # Fallback: try JWT Bearer token from Authorization header
             # (e.g. task tokens, session tokens)
-            if authorization.startswith("Bearer "):
-                token = authorization[7:]
-                # Skip wg- prefixed tokens: already handled by get_api_key_from_header
-                if not token.startswith("wg-"):
-                    from app.core.auth_utils import verify_jwt_token_with_db
+            if authorization and authorization.strip():
+                # Split on whitespace, compare scheme case-insensitively (RFC 7235)
+                parts = authorization.split(maxsplit=1)
+                if parts[0].lower() == "bearer" and len(parts) == 2:
+                    token = parts[1].strip()
+                    # Skip wg- prefixed tokens: already handled by get_api_key_from_header
+                    if not token.startswith("wg-"):
+                        from app.core.auth_utils import verify_jwt_token_with_db
 
-                    user = verify_jwt_token_with_db(db, token)
-                    if user and user.is_active:
-                        if is_telemetry_enabled():
-                            span.set_attribute(SpanAttributes.AUTH_METHOD, "jwt")
-                            span.set_attribute(
-                                SpanAttributes.AUTH_SOURCE,
-                                "authorization_header",
-                            )
-                            span.set_attribute(SpanAttributes.AUTH_RESULT, "success")
-                            span.set_attribute(SpanAttributes.USER_ID, str(user.id))
-                            span.set_attribute(SpanAttributes.USER_NAME, user.user_name)
-                            _set_user_context(
-                                user_id=str(user.id),
-                                user_name=user.user_name,
-                            )
-                        return AuthContext(user=user, api_key_name=None)
+                        user = verify_jwt_token_with_db(db, token)
+                        if user and user.is_active:
+                            if is_telemetry_enabled():
+                                span.set_attribute(SpanAttributes.AUTH_METHOD, "jwt")
+                                span.set_attribute(
+                                    SpanAttributes.AUTH_TOKEN_TYPE, "bearer"
+                                )
+                                span.set_attribute(
+                                    SpanAttributes.AUTH_SOURCE,
+                                    "authorization_header",
+                                )
+                                span.set_attribute(
+                                    SpanAttributes.AUTH_RESULT, "success"
+                                )
+                                span.set_attribute(SpanAttributes.USER_ID, str(user.id))
+                                span.set_attribute(
+                                    SpanAttributes.USER_NAME, user.user_name
+                                )
+                                _set_user_context(
+                                    user_id=str(user.id),
+                                    user_name=user.user_name,
+                                )
+                            return AuthContext(user=user, api_key_name=None)
 
             if is_telemetry_enabled():
                 span.set_attribute(SpanAttributes.AUTH_RESULT, "failure")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -451,19 +451,22 @@ def get_auth_context(
     db: Session = Depends(get_db),
     api_key: str = Depends(get_api_key_from_header),
     wegent_username: Optional[str] = Header(default=None, alias="wegent-username"),
+    authorization: str = Header(default=""),
 ) -> AuthContext:
     """
-    Flexible authentication: supports personal API key and service key.
+    Flexible authentication: supports personal API key, service key, and JWT Bearer token.
 
     Authentication logic:
-    - Personal key: returns the key owner directly, ignores wegent-username
-    - Service key: requires username via wegent-username header OR api_key#username format
+    - Personal API key: returns the key owner directly, ignores wegent-username
+    - Service API key: requires username via wegent-username header OR api_key#username format
+    - JWT Bearer token: fallback when no API key is present; extracts user from JWT claims
 
     Args:
         db: Database session
         api_key: API key string (from X-API-Key, Authorization, or wegent-source header)
                  For service keys, supports "api_key#username" format
         wegent_username: Username to impersonate (from wegent-username header, required for service keys)
+        authorization: Raw Authorization header for JWT Bearer token fallback
 
     Returns:
         AuthContext containing authenticated User and optional api_key_name
@@ -478,6 +481,31 @@ def get_auth_context(
             span.set_attribute(SpanAttributes.AUTH_TOKEN_TYPE, "api_key")
 
         if not api_key:
+            # Fallback: try JWT Bearer token from Authorization header
+            # (e.g. task tokens, session tokens)
+            if authorization.startswith("Bearer "):
+                token = authorization[7:]
+                # Skip wg- prefixed tokens: already handled by get_api_key_from_header
+                if not token.startswith("wg-"):
+                    from app.core.auth_utils import verify_jwt_token_with_db
+
+                    user = verify_jwt_token_with_db(db, token)
+                    if user and user.is_active:
+                        if is_telemetry_enabled():
+                            span.set_attribute(SpanAttributes.AUTH_METHOD, "jwt")
+                            span.set_attribute(
+                                SpanAttributes.AUTH_SOURCE,
+                                "authorization_header",
+                            )
+                            span.set_attribute(SpanAttributes.AUTH_RESULT, "success")
+                            span.set_attribute(SpanAttributes.USER_ID, str(user.id))
+                            span.set_attribute(SpanAttributes.USER_NAME, user.user_name)
+                            _set_user_context(
+                                user_id=str(user.id),
+                                user_name=user.user_name,
+                            )
+                        return AuthContext(user=user, api_key_name=None)
+
             if is_telemetry_enabled():
                 span.set_attribute(SpanAttributes.AUTH_RESULT, "failure")
                 span.set_attribute(

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -516,6 +516,43 @@ def get_auth_context(
                                 )
                             return AuthContext(user=user, api_key_name=None)
 
+                        # Try task token as fallback
+                        from app.services.auth.task_token import verify_task_token
+
+                        token_info = verify_task_token(token)
+                        if token_info:
+                            user = (
+                                db.query(User)
+                                .filter(User.id == token_info.user_id)
+                                .first()
+                            )
+                            if user and user.is_active:
+                                if is_telemetry_enabled():
+                                    span.set_attribute(
+                                        SpanAttributes.AUTH_METHOD, "task_token"
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.AUTH_TOKEN_TYPE, "bearer"
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.AUTH_SOURCE,
+                                        "authorization_header",
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.AUTH_RESULT, "success"
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.USER_ID, str(user.id)
+                                    )
+                                    span.set_attribute(
+                                        SpanAttributes.USER_NAME, user.user_name
+                                    )
+                                    _set_user_context(
+                                        user_id=str(user.id),
+                                        user_name=user.user_name,
+                                    )
+                                return AuthContext(user=user, api_key_name=None)
+
             if is_telemetry_enabled():
                 span.set_attribute(SpanAttributes.AUTH_RESULT, "failure")
                 span.set_attribute(

--- a/backend/tests/api/test_knowledge_auth.py
+++ b/backend/tests/api/test_knowledge_auth.py
@@ -12,7 +12,7 @@ class TestKnowledgeApiJwtAuth:
 
     def test_list_with_jwt_bearer_returns_200(
         self, test_client: TestClient, test_token: str
-    ):
+    ) -> None:
         """GET /api/knowledge/list with JWT Bearer token should authenticate successfully."""
         response = test_client.get(
             "/api/knowledge/list",
@@ -26,7 +26,7 @@ class TestKnowledgeApiJwtAuth:
 
     def test_list_with_scope_personal_returns_200(
         self, test_client: TestClient, test_token: str
-    ):
+    ) -> None:
         """GET /api/knowledge/list?scope=personal with JWT Bearer token should work."""
         response = test_client.get(
             "/api/knowledge/list",
@@ -38,7 +38,7 @@ class TestKnowledgeApiJwtAuth:
         body = response.json()
         assert "items" in body
 
-    def test_list_no_auth_returns_401(self, test_client: TestClient):
+    def test_list_no_auth_returns_401(self, test_client: TestClient) -> None:
         """GET /api/knowledge/list without any auth should return 401."""
         response = test_client.get("/api/knowledge/list")
 
@@ -48,19 +48,24 @@ class TestKnowledgeApiJwtAuth:
 
     def test_search_with_jwt_bearer_auth_passes(
         self, test_client: TestClient, test_token: str
-    ):
-        """POST /api/knowledge/search with JWT Bearer token should pass auth (422 on missing kb_id is OK)."""
+    ) -> None:
+        """POST /api/knowledge/search with JWT Bearer token should pass auth.
+
+        Sending a request without knowledge_base_id triggers a 422
+        validation error, which confirms the request passed authentication
+        and reached endpoint-level Pydantic validation.
+        """
         response = test_client.post(
             "/api/knowledge/search",
             json={"query": "test", "limit": 3},
             headers={"Authorization": f"Bearer {test_token}"},
         )
 
-        assert response.status_code != 401
+        assert response.status_code == 422
 
     def test_list_with_task_token_returns_200(
         self, test_client: TestClient, test_task_token: str
-    ):
+    ) -> None:
         """GET /api/knowledge/list with task token should pass auth and return data."""
         response = test_client.get(
             "/api/knowledge/list",

--- a/backend/tests/api/test_knowledge_auth.py
+++ b/backend/tests/api/test_knowledge_auth.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for knowledge API authentication via JWT Bearer and task tokens."""
+
+from fastapi.testclient import TestClient
+
+
+class TestKnowledgeApiJwtAuth:
+    """Tests for knowledge API endpoints using JWT Bearer token authentication."""
+
+    def test_list_with_jwt_bearer_returns_200(
+        self, test_client: TestClient, test_token: str
+    ):
+        """GET /api/knowledge/list with JWT Bearer token should authenticate successfully."""
+        response = test_client.get(
+            "/api/knowledge/list",
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "items" in body
+        assert "total" in body
+
+    def test_list_with_scope_personal_returns_200(
+        self, test_client: TestClient, test_token: str
+    ):
+        """GET /api/knowledge/list?scope=personal with JWT Bearer token should work."""
+        response = test_client.get(
+            "/api/knowledge/list",
+            params={"scope": "personal"},
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "items" in body
+
+    def test_list_no_auth_returns_401(self, test_client: TestClient):
+        """GET /api/knowledge/list without any auth should return 401."""
+        response = test_client.get("/api/knowledge/list")
+
+        assert response.status_code == 401
+        body = response.json()
+        assert "API key is required" in body.get("detail", "")
+
+    def test_search_with_jwt_bearer_auth_passes(
+        self, test_client: TestClient, test_token: str
+    ):
+        """POST /api/knowledge/search with JWT Bearer token should pass auth (422 on missing kb_id is OK)."""
+        response = test_client.post(
+            "/api/knowledge/search",
+            json={"query": "test", "limit": 3},
+            headers={"Authorization": f"Bearer {test_token}"},
+        )
+
+        assert response.status_code != 401
+
+    def test_list_with_task_token_returns_200(
+        self, test_client: TestClient, test_task_token: str
+    ):
+        """GET /api/knowledge/list with task token should pass auth and return data."""
+        response = test_client.get(
+            "/api/knowledge/list",
+            headers={"Authorization": f"Bearer {test_task_token}"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "items" in body
+        assert "total" in body

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -335,6 +335,21 @@ def test_admin_token(test_admin_user: User) -> str:
 
 
 @pytest.fixture(scope="function")
+def test_task_token(test_user: User) -> str:
+    """
+    Create a valid task token for the test user, usable with executor/MCP auth.
+    """
+    from app.services.auth.task_token import create_task_token
+
+    return create_task_token(
+        task_id=1,
+        subtask_id=1,
+        user_id=test_user.id,
+        user_name=test_user.user_name,
+    )
+
+
+@pytest.fixture(scope="function")
 def test_client(test_db: Session) -> TestClient:
     """
     Create a test client with database dependency override.


### PR DESCRIPTION
When no API key is present, the auth context now attempts to verify a JWT Bearer token from the Authorization header before raising an error. This supports task tokens, session tokens, and other JWT-based auth scenarios alongside existing API key authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication support for Bearer/JWT tokens from the `Authorization` header when an API key isn’t provided.
  * Added a task-token authentication fallback when Bearer/JWT validation doesn’t yield an active user.
* **Improvements**
  * Improved reliability of `Authorization: Bearer …` parsing (case-insensitive, whitespace-tolerant) and enhanced auth telemetry for successful and fallback flows.
* **Tests**
  * Added integration tests covering knowledge API access with JWT Bearer (including `scope=personal`), missing auth (401), and task-token auth.
  * Added a fixture to generate task tokens for authentication tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->