### PR TITLE
feat: 修复会话列表的文件diff展示；右侧边栏支持展示为未暂存、已暂存、提交、分支、上轮对话；调整ui样式

### DIFF
--- a/backend/app/api/endpoints/runtime_work.py
+++ b/backend/app/api/endpoints/runtime_work.py
@@ -17,6 +17,8 @@ from app.schemas.runtime_work import (
     DeviceWorkspacePrepareResponse,
     DeviceWorkspaceResponse,
     DeviceWorkspaceUpsert,
+    RuntimeFileChangesRevertRequest,
+    RuntimeFileChangesRevertResponse,
     RuntimeGlobalIMNotificationUpdateRequest,
     RuntimeIMNotificationSettingsResponse,
     RuntimeSendRequest,
@@ -149,6 +151,25 @@ async def get_runtime_transcript_endpoint(
         db=db,
         user_id=current_user.id,
         address=address,
+    )
+
+
+@router.post(
+    "/file-changes/revert",
+    response_model=RuntimeFileChangesRevertResponse,
+    response_model_by_alias=True,
+)
+async def revert_runtime_file_changes_endpoint(
+    request: RuntimeFileChangesRevertRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Revert a native runtime file-change artifact on the owning device."""
+
+    return await runtime_work_service.revert_runtime_file_changes(
+        db=db,
+        user_id=current_user.id,
+        request=request,
     )
 
 

--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -57,6 +57,7 @@ class NormalizedRuntimeMessage(BaseModel):
     source: Optional[RuntimeMessageSource] = None
     attachments: list[dict[str, Any]] = Field(default_factory=list)
     blocks: list[dict[str, Any]] = Field(default_factory=list)
+    file_changes: Optional[dict[str, Any]] = Field(default=None, alias="fileChanges")
 
 
 class RuntimeTaskAddressRef(RuntimeTaskAddress):

--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -31,6 +31,23 @@ class RuntimeTranscriptRequest(RuntimeTaskAddress):
     before_cursor: Optional[str] = Field(default=None, alias="beforeCursor")
 
 
+class RuntimeFileChangesRevertRequest(BaseModel):
+    """Revert a device-local runtime file-change artifact."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    address: RuntimeTaskAddress
+    file_changes: dict[str, Any] = Field(..., alias="fileChanges")
+
+
+class RuntimeFileChangesRevertResponse(BaseModel):
+    """Updated runtime artifact summary after revert."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    file_changes: dict[str, Any] = Field(..., alias="fileChanges")
+
+
 class RuntimeMessageSource(BaseModel):
     """Optional source overlay for runtime transcript messages."""
 

--- a/backend/app/services/device/command_registry.py
+++ b/backend/app/services/device/command_registry.py
@@ -928,6 +928,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -949,6 +950,70 @@ def fail(message, code=64, status=None):
     if status:
         payload["status"] = status
     finish(payload, code)
+
+
+def sequence_patches(raw_patch):
+    try:
+        patches = json.loads(raw_patch.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        fail(f"invalid patch sequence: {exc}", code=65)
+    if not isinstance(patches, list) or not all(isinstance(item, str) for item in patches):
+        fail("invalid patch sequence", code=65)
+    return patches
+
+
+def patch_paths(patch_text):
+    paths = set()
+    for line in patch_text.splitlines():
+        match = re.match(r"diff --git a/(.+?) b/(.+)$", line)
+        if not match:
+            continue
+        for value in match.groups():
+            if value != "/dev/null":
+                paths.add(value)
+    return paths
+
+
+def copy_patch_paths(workspace, temp_workspace, patches):
+    for patch_text in patches:
+        for path in patch_paths(patch_text):
+            source = (workspace / path).resolve()
+            target = temp_workspace / path
+            if workspace not in source.parents and source != workspace:
+                fail("patch path escapes workspace", code=65)
+            if source.is_file():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(source, target)
+
+
+def run_reverse_patch_sequence(workspace, patches, check_only=False):
+    with tempfile.TemporaryDirectory(prefix="wegent-turn-sequence-") as temp_dir:
+        temp_workspace = Path(temp_dir)
+        if check_only:
+            copy_patch_paths(workspace, temp_workspace, patches)
+            target_workspace = temp_workspace
+        else:
+            target_workspace = workspace
+        for patch_text in reversed(patches):
+            with tempfile.NamedTemporaryFile(
+                prefix="wegent-sequence-",
+                suffix=".patch",
+                delete=False,
+            ) as temp_file:
+                temp_file.write(patch_text.encode("utf-8"))
+                temp_path = Path(temp_file.name)
+            try:
+                result = subprocess.run(
+                    ["git", "apply", "--reverse", "--binary", str(temp_path)],
+                    cwd=target_workspace,
+                    capture_output=True,
+                    text=True,
+                )
+            finally:
+                temp_path.unlink(missing_ok=True)
+            if result.returncode != 0:
+                return False
+    return True
 
 
 if len(sys.argv) != 3:
@@ -1012,13 +1077,39 @@ if len(patch) > MAX_PATCH_BYTES:
 if hashlib.sha256(patch).hexdigest() != metadata.get("checksum"):
     fail("artifact patch checksum mismatch", code=65)
 
+patch_sequence = metadata.get("patch_sequence") is True
+patches = sequence_patches(patch) if patch_sequence else None
+
 if mode == "review":
     finish(
         {
             "success": True,
-            "diff": patch.decode("utf-8", errors="replace"),
+            "diff": (
+                "\\n".join(patches)
+                if patches is not None
+                else patch.decode("utf-8", errors="replace")
+            ),
         }
     )
+
+if patches is not None:
+    if not run_reverse_patch_sequence(workspace, patches, check_only=True):
+        finish(
+            {
+                "success": False,
+                "status": "conflicted",
+                "error": "patch does not apply",
+            }
+        )
+    if not run_reverse_patch_sequence(workspace, patches, check_only=False):
+        finish(
+            {
+                "success": False,
+                "status": "conflicted",
+                "error": "patch does not apply",
+            }
+        )
+    finish({"success": True, "status": "reverted"})
 
 temp_path = None
 try:
@@ -1182,6 +1273,13 @@ DEFAULT_LOCAL_DEVICE_COMMANDS: dict[str, LocalDeviceCommandDefinition] = {
     "git_checkout_new": LocalDeviceCommandDefinition(command="git checkout -b"),
     "git_diff_shortstat": LocalDeviceCommandDefinition(command="git diff --shortstat"),
     "git_diff": LocalDeviceCommandDefinition(command=GIT_WORKSPACE_DIFF_COMMAND),
+    "git_diff_unstaged": LocalDeviceCommandDefinition(command="git diff --binary --"),
+    "git_diff_staged": LocalDeviceCommandDefinition(
+        command="git diff --binary --cached --"
+    ),
+    "git_diff_last_commit": LocalDeviceCommandDefinition(
+        command="git diff --binary HEAD~1..HEAD --"
+    ),
     "git_branch_diff_shortstat": LocalDeviceCommandDefinition(
         command=GIT_BRANCH_DIFF_SHORTSTAT_COMMAND
     ),

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -10,7 +10,7 @@ import posixpath
 import re
 import time
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha256
 from types import SimpleNamespace
 from typing import Any, Optional
@@ -37,6 +37,8 @@ from app.schemas.runtime_work import (
     DeviceWorkspaceUpsert,
     LocalTaskSummary,
     RuntimeDeviceWorkspace,
+    RuntimeFileChangesRevertRequest,
+    RuntimeFileChangesRevertResponse,
     RuntimeGlobalIMNotificationUpdateRequest,
     RuntimeIMNotificationSession,
     RuntimeIMNotificationSettingsResponse,
@@ -57,6 +59,7 @@ from app.schemas.runtime_work import (
     RuntimeTranscriptResponse,
     RuntimeWorkListResponse,
 )
+from app.schemas.turn_file_changes import TurnFileChangesSummary
 from app.services.device.command_service import execute_configured_device_command
 from app.services.device.runtime_rpc_service import RuntimeRpcError, runtime_rpc_service
 from app.services.device_service import device_service
@@ -342,7 +345,7 @@ async def get_runtime_transcript(
     _raise_runtime_rpc_failure(result)
     elapsed_ms = int((time.perf_counter() - started_at) * 1000)
     logger.info(
-        "[RuntimeWork] Runtime transcript RPC completed: user_id=%s device_id=%s local_task_id=%s elapsed_ms=%s message_count=%s has_more_before=%s before_cursor=%s",
+        "[RuntimeWork] Runtime transcript RPC completed: user_id=%s device_id=%s local_task_id=%s elapsed_ms=%s message_count=%s messages_with_subtask=%s messages_with_file_changes=%s has_more_before=%s before_cursor=%s",
         user_id,
         normalized_address.device_id,
         normalized_address.local_task_id,
@@ -352,10 +355,79 @@ async def get_runtime_transcript(
             if isinstance(result.get("messages"), list)
             else None
         ),
+        _runtime_message_count(result, "subtaskId"),
+        _runtime_message_count(result, "fileChanges"),
         result.get("hasMoreBefore"),
         result.get("beforeCursor"),
     )
     return RuntimeTranscriptResponse.model_validate(result)
+
+
+async def revert_runtime_file_changes(
+    *,
+    db: Session,
+    user_id: int,
+    request: RuntimeFileChangesRevertRequest,
+) -> RuntimeFileChangesRevertResponse:
+    """Revert a native runtime file-change artifact on the owning device."""
+
+    address = _normalized_address(request.address)
+    _ensure_owned_device(db, user_id, address.device_id)
+    summary = TurnFileChangesSummary.model_validate(
+        _runtime_file_changes_summary_payload(request.file_changes)
+    )
+    if summary.device_id != address.device_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Runtime file changes device does not match the task address",
+        )
+    if summary.status == "reverted":
+        return RuntimeFileChangesRevertResponse(
+            fileChanges=summary.model_dump(mode="json")
+        )
+
+    result = await execute_configured_device_command(
+        db=db,
+        user_id=user_id,
+        device_id=address.device_id,
+        command_key="turn_file_changes_revert",
+        path=summary.workspace_path,
+        args=[summary.artifact_id],
+        timeout_seconds=30,
+        max_output_bytes=5 * 1024 * 1024,
+    )
+    payload = result.get("stdout") if isinstance(result, dict) else None
+    if not isinstance(payload, dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Device returned malformed artifact output",
+        )
+    if payload.get("success") is not True:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(payload.get("error") or "Runtime file changes revert failed"),
+        )
+    if payload.get("status") == "conflicted":
+        updated = _runtime_file_changes_with_status(summary, "conflicted")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"file_changes": updated, "message": "Patch does not apply"},
+        )
+    if payload.get("status") == "artifact_missing":
+        updated = _runtime_file_changes_with_status(summary, "artifact_missing")
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE,
+            detail={"file_changes": updated, "message": "Artifact is missing"},
+        )
+    if payload.get("status") != "reverted":
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Device returned an invalid revert result",
+        )
+
+    return RuntimeFileChangesRevertResponse(
+        fileChanges=_runtime_file_changes_with_status(summary, "reverted")
+    )
 
 
 async def send_runtime_message(
@@ -1960,6 +2032,36 @@ def _runtime_transcript_payload(
     if before_cursor:
         payload["beforeCursor"] = before_cursor
     return payload
+
+
+def _runtime_message_count(result: dict[str, Any], key: str) -> int | None:
+    messages = result.get("messages")
+    if not isinstance(messages, list):
+        return None
+    snake_key = "file_changes" if key == "fileChanges" else "subtask_id"
+    return sum(
+        1
+        for message in messages
+        if isinstance(message, dict)
+        and (message.get(key) is not None or message.get(snake_key) is not None)
+    )
+
+
+def _runtime_file_changes_with_status(
+    summary: TurnFileChangesSummary,
+    status_value: str,
+) -> dict[str, Any]:
+    updated = summary.model_dump(mode="json")
+    updated["status"] = status_value
+    if status_value == "reverted":
+        updated["reverted_at"] = datetime.now(timezone.utc).isoformat()
+    return updated
+
+
+def _runtime_file_changes_summary_payload(value: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: item for key, item in value.items() if key not in {"diff", "revertible"}
+    }
 
 
 def _project_runtime_target(

--- a/backend/tests/services/test_local_device_command_service.py
+++ b/backend/tests/services/test_local_device_command_service.py
@@ -55,6 +55,101 @@ def _create_turn_file_changes_artifact(tmp_path):
     return repo, executor_home
 
 
+def _create_turn_file_changes_sequence_artifact(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run_git(repo, "init", "-q")
+    _run_git(repo, "config", "user.email", "tests@example.com")
+    _run_git(repo, "config", "user.name", "Tests")
+    changed_file = repo / "changed.txt"
+    changed_file.write_text("before\n", encoding="utf-8")
+    _run_git(repo, "add", "--all")
+    _run_git(repo, "commit", "-qm", "initial")
+    changed_file.write_text("final\n", encoding="utf-8")
+    patches = [
+        "\n".join(
+            [
+                "diff --git a/changed.txt b/changed.txt",
+                "--- a/changed.txt",
+                "+++ b/changed.txt",
+                "@@ -1 +1 @@",
+                "-before",
+                "+middle",
+            ]
+        )
+        + "\n",
+        "\n".join(
+            [
+                "diff --git a/changed.txt b/changed.txt",
+                "--- a/changed.txt",
+                "+++ b/changed.txt",
+                "@@ -1 +1 @@",
+                "-middle",
+                "+final",
+            ]
+        )
+        + "\n",
+    ]
+    patch = json.dumps(patches).encode("utf-8")
+    executor_home = tmp_path / "executor-home"
+    artifact_dir = executor_home / "artifacts" / "turn-file-changes" / "10" / "21"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "changes.patch.gz").write_bytes(gzip.compress(patch))
+    (artifact_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "task_id": 10,
+                "subtask_id": 21,
+                "workspace_path": str(repo.resolve()),
+                "checksum": hashlib.sha256(patch).hexdigest(),
+                "patch_sequence": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return repo, executor_home
+
+
+def _create_plain_workspace_add_sequence_artifact(tmp_path):
+    workspace = tmp_path / "plain-workspace"
+    workspace.mkdir()
+    changed_file = workspace / "note.txt"
+    changed_file.write_text("hello\n", encoding="utf-8")
+    patches = [
+        "\n".join(
+            [
+                "diff --git a/note.txt b/note.txt",
+                "new file mode 100644",
+                "--- /dev/null",
+                "+++ b/note.txt",
+                "@@ -0,0 +1,1 @@",
+                "+hello",
+            ]
+        )
+        + "\n"
+    ]
+    patch = json.dumps(patches).encode("utf-8")
+    executor_home = tmp_path / "executor-home"
+    artifact_dir = executor_home / "artifacts" / "turn-file-changes" / "10" / "22"
+    artifact_dir.mkdir(parents=True)
+    (artifact_dir / "changes.patch.gz").write_bytes(gzip.compress(patch))
+    (artifact_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "task_id": 10,
+                "subtask_id": 22,
+                "workspace_path": str(workspace.resolve()),
+                "checksum": hashlib.sha256(patch).hexdigest(),
+                "patch_sequence": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return workspace, executor_home
+
+
 def test_turn_file_changes_commands_are_registered():
     from app.services.device.command_registry import resolve_local_device_command
 
@@ -161,6 +256,52 @@ def test_turn_file_changes_revert_applies_reverse_patch(tmp_path):
 
     assert json.loads(result.stdout) == {"success": True, "status": "reverted"}
     assert (repo / "changed.txt").read_text(encoding="utf-8") == "before\n"
+
+
+def test_turn_file_changes_revert_applies_patch_sequence(tmp_path):
+    from app.services.device.command_registry import TURN_FILE_CHANGES_SCRIPT
+
+    repo, executor_home = _create_turn_file_changes_sequence_artifact(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            TURN_FILE_CHANGES_SCRIPT,
+            "revert",
+            "turn-file-changes/10/21",
+        ],
+        cwd=repo,
+        env={**os.environ, "WEGENT_EXECUTOR_HOME": str(executor_home)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == {"success": True, "status": "reverted"}
+    assert (repo / "changed.txt").read_text(encoding="utf-8") == "before\n"
+
+
+def test_turn_file_changes_revert_applies_plain_workspace_add_sequence(tmp_path):
+    from app.services.device.command_registry import TURN_FILE_CHANGES_SCRIPT
+
+    workspace, executor_home = _create_plain_workspace_add_sequence_artifact(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            TURN_FILE_CHANGES_SCRIPT,
+            "revert",
+            "turn-file-changes/10/22",
+        ],
+        cwd=workspace,
+        env={**os.environ, "WEGENT_EXECUTOR_HOME": str(executor_home)},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert json.loads(result.stdout) == {"success": True, "status": "reverted"}
+    assert not (workspace / "note.txt").exists()
 
 
 def test_local_device_command_registry_default_includes_diagnostic_commands():

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -789,7 +789,34 @@ async def test_runtime_transcript_dispatches_pagination_payload(
             "localTaskId": "codex-1",
             "workspacePath": "/repo/Wegent",
             "runtime": "codex",
-            "messages": [],
+            "messages": [
+                {
+                    "id": "assistant-1",
+                    "role": "assistant",
+                    "content": "done",
+                    "subtaskId": 2001,
+                    "fileChanges": {
+                        "version": 1,
+                        "status": "active",
+                        "artifact_id": "turn-2001",
+                        "device_id": "device-1",
+                        "workspace_path": "/repo/Wegent",
+                        "file_count": 1,
+                        "additions": 3,
+                        "deletions": 1,
+                        "files": [
+                            {
+                                "path": "src/app.ts",
+                                "change_type": "modified",
+                                "additions": 3,
+                                "deletions": 1,
+                                "binary": False,
+                            }
+                        ],
+                        "reverted_at": None,
+                    },
+                }
+            ],
             "hasMoreBefore": True,
             "beforeCursor": "offset:120",
         }
@@ -809,6 +836,8 @@ async def test_runtime_transcript_dispatches_pagination_payload(
 
     assert response.has_more_before is True
     assert response.before_cursor == "offset:120"
+    assert response.messages[0].file_changes is not None
+    assert response.messages[0].file_changes["artifact_id"] == "turn-2001"
     rpc.assert_awaited_once_with(
         user_id=test_user.id,
         device_id="device-1",

--- a/executor/runtime_work/agent_adapter.py
+++ b/executor/runtime_work/agent_adapter.py
@@ -92,6 +92,7 @@ class RuntimeTranscriptTransport(EventTransport):
                 subtask_id=subtask_id,
                 executor_session=data.get("executor_session"),
                 blocks=self._consume_processing_blocks(terminal_status="done"),
+                file_changes=_completed_file_changes(data),
             )
             self._assistant_draft = ""
             await self._forward_event(
@@ -360,6 +361,7 @@ class RuntimeTranscriptTransport(EventTransport):
         subtask_id: int,
         executor_session: Optional[Any] = None,
         blocks: Optional[list[dict[str, Any]]] = None,
+        file_changes: Optional[dict[str, Any]] = None,
     ) -> None:
         message = {
             "id": f"{self.local_task_id}:assistant:{subtask_id}",
@@ -371,6 +373,8 @@ class RuntimeTranscriptTransport(EventTransport):
         }
         if blocks:
             message["blocks"] = blocks
+        if file_changes:
+            message["fileChanges"] = copy.deepcopy(file_changes)
 
         def update(task: LocalTaskRecord) -> LocalTaskRecord:
             handle = dict(task.runtime_handle)
@@ -683,6 +687,16 @@ def _completed_content(data: dict[str, Any]) -> str:
             if isinstance(text, str):
                 parts.append(text)
     return "\n".join(parts).strip()
+
+
+def _completed_file_changes(data: dict[str, Any]) -> Optional[dict[str, Any]]:
+    response = data.get("response")
+    if not isinstance(response, dict):
+        return None
+    file_changes = response.get("file_changes") or response.get("fileChanges")
+    if isinstance(file_changes, dict):
+        return file_changes
+    return None
 
 
 def _incomplete_content(data: dict[str, Any]) -> str:

--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -5,6 +5,8 @@
 """Discover Codex sessions as device-local runtime work items."""
 
 import contextlib
+import gzip
+import hashlib
 import json
 import os
 import re
@@ -22,6 +24,7 @@ from executor.runtime_work.local_task_store import (
     normalize_workspace_path,
     utc_now_iso,
 )
+from executor.services.turn_file_changes import TurnFileChangeArtifactStore
 from shared.logger import setup_logger
 
 DEFAULT_CODEX_SESSION_LIMIT = 100
@@ -809,7 +812,7 @@ def _read_session_transcript(path: Path, thread_id: str) -> list[dict[str, Any]]
                 if not isinstance(payload, dict):
                     continue
 
-                event_type = payload.get("type")
+                event_type = payload.get("type") or record.get("type")
                 timestamp = _record_timestamp(record, payload)
                 if record.get("type") == "response_item":
                     if turn_counter > 0:
@@ -824,6 +827,10 @@ def _read_session_transcript(path: Path, thread_id: str) -> list[dict[str, Any]]
                     continue
 
                 if event_type == "user_message":
+                    if pending_agent_message:
+                        pending_agent_message["status"] = "done"
+                        _set_message_blocks(pending_agent_message, processing_blocks)
+                        messages.append(pending_agent_message)
                     turn_counter += 1
                     pending_agent_message = None
                     processing_blocks = []
@@ -868,6 +875,10 @@ def _read_session_transcript(path: Path, thread_id: str) -> list[dict[str, Any]]
                                 blocks=processing_blocks,
                             )
                         )
+                    elif pending_agent_message:
+                        pending_agent_message["status"] = "done"
+                        _set_message_blocks(pending_agent_message, processing_blocks)
+                        messages.append(pending_agent_message)
                     pending_agent_message = None
                     processing_blocks = []
                     tool_blocks_by_call_id = {}
@@ -937,7 +948,7 @@ def _read_session_transcript_page(
             complete=complete,
         )
         logger.info(
-            "[CodexTranscript] Window parsed: thread_id=%s path=%s file_size=%s window_start=%s segment_end=%s window_bytes=%s window_elapsed_ms=%s total_elapsed_ms=%s parsed_messages=%s page_messages=%s complete=%s has_more_before=%s",
+            "[CodexTranscript] Window parsed: thread_id=%s path=%s file_size=%s window_start=%s segment_end=%s window_bytes=%s window_elapsed_ms=%s total_elapsed_ms=%s parsed_messages=%s page_messages=%s file_change_messages=%s complete=%s has_more_before=%s",
             thread_id,
             path,
             file_size,
@@ -948,6 +959,7 @@ def _read_session_transcript_page(
             int((time.perf_counter() - started_at) * 1000),
             len(messages),
             len(page.messages),
+            sum(1 for message in page.messages if message.get("fileChanges")),
             complete,
             page.has_more_before,
         )
@@ -972,6 +984,8 @@ def _read_session_transcript_window(
     processing_blocks: list[dict[str, Any]] = []
     tool_blocks_by_call_id: dict[str, dict[str, Any]] = {}
     turn_started_at: Optional[str] = None
+    turn_workspace_path: Optional[str] = None
+    turn_patch_diffs: list[dict[str, Any]] = []
     turn_counter = 0
 
     try:
@@ -991,8 +1005,16 @@ def _read_session_transcript_window(
                 if not isinstance(payload, dict):
                     continue
 
-                event_type = payload.get("type")
+                event_type = payload.get("type") or record.get("type")
                 timestamp = _record_timestamp(record, payload)
+                if event_type == "turn_context":
+                    cwd = payload.get("cwd")
+                    if isinstance(cwd, str) and cwd.strip():
+                        turn_workspace_path = cwd.strip()
+                    continue
+                if event_type == "patch_apply_end":
+                    turn_patch_diffs.extend(_patch_diffs_from_payload(payload))
+                    continue
                 if record.get("type") == "response_item":
                     if turn_counter > 0:
                         _append_response_item_block(
@@ -1006,6 +1028,21 @@ def _read_session_transcript_window(
                     continue
 
                 if event_type == "user_message":
+                    if pending_agent_message:
+                        pending_agent_message["status"] = "done"
+                        _set_message_blocks(pending_agent_message, processing_blocks)
+                        file_changes = _codex_turn_file_changes(
+                            thread_id=thread_id,
+                            turn_index=turn_counter,
+                            workspace_path=turn_workspace_path,
+                            patch_diffs=turn_patch_diffs,
+                        )
+                        if file_changes:
+                            pending_agent_message["subtaskId"] = _codex_turn_subtask_id(
+                                thread_id, turn_counter
+                            )
+                            pending_agent_message["fileChanges"] = file_changes
+                        messages.append(pending_agent_message)
                     global_turn = _payload_turn_index(payload)
                     if global_turn is None:
                         turn_counter += 1
@@ -1016,6 +1053,10 @@ def _read_session_transcript_window(
                     processing_blocks = []
                     tool_blocks_by_call_id = {}
                     turn_started_at = timestamp
+                    turn_patch_diffs = []
+                    cwd = payload.get("cwd")
+                    if isinstance(cwd, str) and cwd.strip():
+                        turn_workspace_path = cwd.strip()
                     message = _first_text(payload, "message")
                     if message:
                         messages.append(
@@ -1044,6 +1085,12 @@ def _read_session_transcript_window(
                     message = _first_text(payload, "last_agent_message")
                     _finish_processing_blocks(processing_blocks, timestamp)
                     if message:
+                        file_changes = _codex_turn_file_changes(
+                            thread_id=thread_id,
+                            turn_index=turn_counter,
+                            workspace_path=turn_workspace_path,
+                            patch_diffs=turn_patch_diffs,
+                        )
                         messages.append(
                             _transcript_message_from_offset(
                                 thread_id=thread_id,
@@ -1053,15 +1100,43 @@ def _read_session_transcript_window(
                                 created_at=turn_started_at or timestamp,
                                 status="done",
                                 blocks=processing_blocks,
+                                subtask_id=(
+                                    _codex_turn_subtask_id(thread_id, turn_counter)
+                                    if file_changes
+                                    else None
+                                ),
+                                file_changes=file_changes,
                             )
                         )
+                    elif pending_agent_message:
+                        pending_agent_message["status"] = "done"
+                        _set_message_blocks(pending_agent_message, processing_blocks)
+                        file_changes = _codex_turn_file_changes(
+                            thread_id=thread_id,
+                            turn_index=turn_counter,
+                            workspace_path=turn_workspace_path,
+                            patch_diffs=turn_patch_diffs,
+                        )
+                        if file_changes:
+                            pending_agent_message["subtaskId"] = _codex_turn_subtask_id(
+                                thread_id, turn_counter
+                            )
+                            pending_agent_message["fileChanges"] = file_changes
+                        messages.append(pending_agent_message)
                     pending_agent_message = None
                     processing_blocks = []
                     tool_blocks_by_call_id = {}
                     turn_started_at = None
+                    turn_patch_diffs = []
                 elif event_type == "turn_aborted":
                     reason = _first_text(payload, "reason") or "Codex turn aborted"
                     _finish_processing_blocks(processing_blocks, timestamp)
+                    file_changes = _codex_turn_file_changes(
+                        thread_id=thread_id,
+                        turn_index=turn_counter,
+                        workspace_path=turn_workspace_path,
+                        patch_diffs=turn_patch_diffs,
+                    )
                     messages.append(
                         _transcript_message_from_offset(
                             thread_id=thread_id,
@@ -1071,17 +1146,35 @@ def _read_session_transcript_window(
                             created_at=turn_started_at or timestamp,
                             status="cancelled",
                             blocks=processing_blocks,
+                            subtask_id=(
+                                _codex_turn_subtask_id(thread_id, turn_counter)
+                                if file_changes
+                                else None
+                            ),
+                            file_changes=file_changes,
                         )
                     )
                     pending_agent_message = None
                     processing_blocks = []
                     tool_blocks_by_call_id = {}
                     turn_started_at = None
+                    turn_patch_diffs = []
     except OSError:
         return []
 
     if pending_agent_message:
         _set_message_blocks(pending_agent_message, processing_blocks)
+        file_changes = _codex_turn_file_changes(
+            thread_id=thread_id,
+            turn_index=turn_counter,
+            workspace_path=turn_workspace_path,
+            patch_diffs=turn_patch_diffs,
+        )
+        if file_changes:
+            pending_agent_message["subtaskId"] = _codex_turn_subtask_id(
+                thread_id, turn_counter
+            )
+            pending_agent_message["fileChanges"] = file_changes
         messages.append(pending_agent_message)
     return messages
 
@@ -1314,6 +1407,8 @@ def _transcript_message_from_offset(
     created_at: str,
     status: str,
     blocks: Optional[list[dict[str, Any]]] = None,
+    subtask_id: Optional[int] = None,
+    file_changes: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     message = {
         "id": f"{thread_id}:{role}:o{max(offset, 0)}",
@@ -1323,8 +1418,232 @@ def _transcript_message_from_offset(
         "status": status,
         "_cursorOffset": max(offset, 0),
     }
+    if subtask_id is not None:
+        message["subtaskId"] = subtask_id
+    if file_changes:
+        message["fileChanges"] = file_changes
     _set_message_blocks(message, blocks or [])
     return message
+
+
+def _patch_diffs_from_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if payload.get("success") is not True:
+        return []
+    changes = payload.get("changes")
+    if not isinstance(changes, dict):
+        return []
+    diffs: list[dict[str, Any]] = []
+    for path, change in changes.items():
+        if not isinstance(change, dict):
+            continue
+        change_type = _codex_patch_change_type(change.get("type"))
+        diff = change.get("unified_diff")
+        if not isinstance(diff, str) or not diff.strip():
+            diff = _codex_patch_diff_from_content(change)
+        if isinstance(diff, str) and diff.strip():
+            diffs.append(
+                {
+                    "path": str(path),
+                    "change_type": change_type,
+                    "diff": diff,
+                }
+            )
+    return diffs
+
+
+def _codex_turn_subtask_id(thread_id: str, turn_index: int) -> int:
+    digest = hashlib.sha256(f"{thread_id}:{turn_index}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % 8_000_000_000_000 + 1
+
+
+def _codex_turn_file_changes(
+    *,
+    thread_id: str,
+    turn_index: int,
+    workspace_path: Optional[str],
+    patch_diffs: list[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    if not workspace_path or not patch_diffs:
+        return None
+    files: list[dict[str, Any]] = []
+    files_by_path: dict[str, dict[str, Any]] = {}
+    rendered_diffs: list[str] = []
+    for item in patch_diffs:
+        path = item.get("path")
+        diff = item.get("diff")
+        change_type = item.get("change_type")
+        if not isinstance(path, str) or not path or not isinstance(diff, str):
+            continue
+        display_path = _codex_display_path(path, workspace_path)
+        additions, deletions = _codex_patch_line_stats(diff)
+        existing = files_by_path.get(display_path)
+        if existing is None:
+            existing = {
+                "old_path": None,
+                "path": display_path,
+                "change_type": (
+                    change_type if isinstance(change_type, str) else "modified"
+                ),
+                "additions": 0,
+                "deletions": 0,
+                "binary": False,
+            }
+            files_by_path[display_path] = existing
+        existing["additions"] += additions
+        existing["deletions"] += deletions
+        existing["change_type"] = _merge_codex_change_type(
+            str(existing["change_type"]),
+            change_type if isinstance(change_type, str) else "modified",
+        )
+        rendered_diffs.append(_render_codex_patch_diff(display_path, diff, change_type))
+    if not files_by_path:
+        return None
+    artifact_id = _persist_codex_patch_sequence(
+        workspace_path=workspace_path,
+        task_id=_codex_turn_subtask_id(thread_id, 0),
+        subtask_id=_codex_turn_subtask_id(thread_id, turn_index),
+        patch_sequence=rendered_diffs,
+    )
+    files = list(files_by_path.values())
+    files = sorted(files, key=lambda item: item["path"])
+    rendered_diff = "\n".join(rendered_diffs)
+    return {
+        "version": 1,
+        "status": "active",
+        "artifact_id": artifact_id,
+        "device_id": "runtime-device",
+        "workspace_path": str(Path(workspace_path).expanduser()),
+        "file_count": len(files),
+        "additions": sum(item["additions"] for item in files),
+        "deletions": sum(item["deletions"] for item in files),
+        "files": files,
+        "reverted_at": None,
+        "diff": rendered_diff,
+        "revertible": True,
+    }
+
+
+def _codex_patch_change_type(value: Any) -> str:
+    if value == "add":
+        return "created"
+    if value == "delete":
+        return "deleted"
+    return "modified"
+
+
+def _codex_patch_diff_from_content(change: dict[str, Any]) -> Optional[str]:
+    content = change.get("content")
+    if not isinstance(content, str):
+        return None
+
+    change_type = _codex_patch_change_type(change.get("type"))
+    if change_type == "created":
+        prefix = "+"
+        old_start = "0,0"
+        new_start = f"1,{_codex_patch_content_line_count(content)}"
+    elif change_type == "deleted":
+        prefix = "-"
+        old_start = f"1,{_codex_patch_content_line_count(content)}"
+        new_start = "0,0"
+    else:
+        return None
+
+    lines = [f"@@ -{old_start} +{new_start} @@"]
+    lines.extend(f"{prefix}{line}" for line in content.splitlines())
+    if content.endswith("\n"):
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _codex_patch_content_line_count(content: str) -> int:
+    if not content:
+        return 0
+    return len(content.splitlines())
+
+
+def _persist_codex_patch_sequence(
+    *,
+    workspace_path: str,
+    task_id: int,
+    subtask_id: int,
+    patch_sequence: list[str],
+) -> str:
+    artifact_id = f"turn-file-changes/{task_id}/{subtask_id}"
+    artifact_dir = (
+        Path(config.WEGENT_EXECUTOR_HOME).expanduser() / "artifacts" / artifact_id
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    patch_path = artifact_dir / "changes.patch.gz"
+    metadata_path = artifact_dir / "metadata.json"
+    payload = json.dumps(patch_sequence, ensure_ascii=True).encode("utf-8")
+    metadata = {
+        "version": 1,
+        "task_id": task_id,
+        "subtask_id": subtask_id,
+        "workspace_path": str(Path(workspace_path).expanduser()),
+        "checksum": hashlib.sha256(payload).hexdigest(),
+        "patch_sequence": True,
+    }
+    TurnFileChangeArtifactStore.atomic_write(patch_path, gzip.compress(payload))
+    TurnFileChangeArtifactStore.atomic_write(
+        metadata_path,
+        json.dumps(metadata, ensure_ascii=True, sort_keys=True).encode("utf-8"),
+    )
+    return artifact_id
+
+
+def _merge_codex_change_type(current: str, incoming: str) -> str:
+    if current == incoming:
+        return current
+    if "deleted" in {current, incoming}:
+        return "deleted" if incoming == "deleted" else "modified"
+    if "created" in {current, incoming}:
+        return "created" if current == "created" else "modified"
+    return "modified"
+
+
+def _codex_patch_line_stats(diff: str) -> tuple[int, int]:
+    additions = 0
+    deletions = 0
+    for line in diff.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            additions += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            deletions += 1
+    return additions, deletions
+
+
+def _render_codex_patch_diff(path: str, diff: str, change_type: Optional[str]) -> str:
+    normalized = path.replace("\\", "/")
+    if change_type == "created":
+        header = [
+            f"diff --git a/{normalized} b/{normalized}",
+            "new file mode 100644",
+            "--- /dev/null",
+            f"+++ b/{normalized}",
+        ]
+    elif change_type == "deleted":
+        header = [
+            f"diff --git a/{normalized} b/{normalized}",
+            "deleted file mode 100644",
+            f"--- a/{normalized}",
+            "+++ /dev/null",
+        ]
+    else:
+        header = [
+            f"diff --git a/{normalized} b/{normalized}",
+            f"--- a/{normalized}",
+            f"+++ b/{normalized}",
+        ]
+    return "\n".join([*header, diff.rstrip()]) + "\n"
+
+
+def _codex_display_path(path: str, workspace_path: str) -> str:
+    workspace = Path(workspace_path).expanduser()
+    candidate = Path(path).expanduser()
+    with contextlib.suppress(ValueError):
+        return candidate.relative_to(workspace).as_posix()
+    return path
 
 
 def _record_timestamp(record: dict[str, Any], payload: dict[str, Any]) -> str:

--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -1604,6 +1604,10 @@ class RuntimeWorkRpcHandler:
                 if normalized_blocks:
                     normalized_message["blocks"] = normalized_blocks
 
+            file_changes = message.get("fileChanges") or message.get("file_changes")
+            if isinstance(file_changes, dict):
+                normalized_message["fileChanges"] = file_changes
+
             source = message.get("source") or source_by_message_id.get(message_id)
             if isinstance(source, dict):
                 normalized_message["source"] = source

--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -506,16 +506,22 @@ class RuntimeWorkRpcHandler:
             "workspacePath": task.workspace_path,
             "runtime": task.runtime,
             "title": task.title,
-            "messages": self._normalize_messages(task, page["messages"]),
+            "messages": self._normalize_messages(
+                task,
+                page["messages"],
+                device_id=payload.get("deviceId"),
+            ),
             "hasMoreBefore": page["hasMoreBefore"],
             "beforeCursor": page["beforeCursor"],
         }
         completed_ms = int((time.perf_counter() - started_at) * 1000)
         logger.info(
-            "[RuntimeWorkRpc] Transcript response ready: local_task_id=%s elapsed_ms=%s normalized_message_count=%s",
+            "[RuntimeWorkRpc] Transcript response ready: local_task_id=%s elapsed_ms=%s normalized_message_count=%s messages_with_subtask=%s messages_with_file_changes=%s",
             task.local_task_id,
             completed_ms,
             len(response["messages"]),
+            sum(1 for message in response["messages"] if message.get("subtaskId")),
+            sum(1 for message in response["messages"] if message.get("fileChanges")),
         )
         return response
 
@@ -1558,6 +1564,8 @@ class RuntimeWorkRpcHandler:
         self,
         task: LocalTaskRecord,
         messages: Any,
+        *,
+        device_id: Any = None,
     ) -> list[dict[str, Any]]:
         if not isinstance(messages, list):
             return []
@@ -1606,6 +1614,8 @@ class RuntimeWorkRpcHandler:
 
             file_changes = message.get("fileChanges") or message.get("file_changes")
             if isinstance(file_changes, dict):
+                if isinstance(device_id, str) and device_id.strip():
+                    file_changes = {**file_changes, "device_id": device_id.strip()}
                 normalized_message["fileChanges"] = file_changes
 
             source = message.get("source") or source_by_message_id.get(message_id)

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -1235,6 +1235,341 @@ def test_codex_discovery_reads_user_visible_transcript(tmp_path):
     assert transcript[1]["status"] == "done"
 
 
+def test_codex_discovery_keeps_commentary_when_task_complete_is_empty(tmp_path):
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789ae"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Check the page",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:22Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "phase": "commentary",
+                "message": "I refreshed the page and checked the DOM.",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:23Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "last_agent_message": "",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assert [message["role"] for message in page.messages] == ["user", "assistant"]
+    assert page.messages[1]["content"] == "I refreshed the page and checked the DOM."
+    assert page.messages[1]["status"] == "done"
+
+
+def test_codex_discovery_keeps_commentary_before_next_user_message(tmp_path):
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789af"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "First request",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:22Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "agent_message",
+                "phase": "commentary",
+                "message": "I checked the current page.",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:23Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Second request",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:24Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "last_agent_message": "",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assert [message["role"] for message in page.messages] == [
+        "user",
+        "assistant",
+        "user",
+    ]
+    assert [message["content"] for message in page.messages] == [
+        "First request",
+        "I checked the current page.",
+        "Second request",
+    ]
+
+
+def test_codex_discovery_adds_file_changes_from_patch_apply_end(tmp_path, monkeypatch):
+    from executor.config import config
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    monkeypatch.setattr(config, "WEGENT_EXECUTOR_HOME", str(tmp_path / "executor-home"))
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    changed_file = workspace / "src" / "app.ts"
+    changed_file.parent.mkdir()
+    changed_file.write_text("const label = 'new'\n", encoding="utf-8")
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789df"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:19Z",
+            "type": "turn_context",
+            "payload": {"cwd": str(workspace)},
+        },
+        {
+            "timestamp": "2026-06-20T05:52:20Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Edit the app",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "success": True,
+                "changes": {
+                    str(changed_file): {
+                        "type": "update",
+                        "unified_diff": "@@ -1 +1 @@\n-const label = 'old'\n+const label = 'new'",
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "success": True,
+                "changes": {
+                    str(changed_file): {
+                        "type": "update",
+                        "unified_diff": "@@ -1 +1 @@\n-const label = 'new'\n+const label = 'final'",
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:22Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "last_agent_message": "Done",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assistant = page.messages[1]
+    assert assistant["subtaskId"] > 0
+    assert assistant["fileChanges"]["file_count"] == 1
+    assert assistant["fileChanges"]["files"][0]["path"] == "src/app.ts"
+    assert assistant["fileChanges"]["additions"] == 2
+    assert assistant["fileChanges"]["deletions"] == 2
+    assert assistant["fileChanges"]["revertible"] is True
+    assert assistant["fileChanges"]["artifact_id"].startswith("turn-file-changes/")
+    assert "diff --git a/src/app.ts b/src/app.ts" in assistant["fileChanges"]["diff"]
+
+
+def test_codex_discovery_adds_file_changes_to_aborted_turn(tmp_path, monkeypatch):
+    from executor.config import config
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    monkeypatch.setattr(config, "WEGENT_EXECUTOR_HOME", str(tmp_path / "executor-home"))
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    changed_file = workspace / "src" / "app.ts"
+    changed_file.parent.mkdir()
+    changed_file.write_text("const label = 'new'\n", encoding="utf-8")
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789ab"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:19Z",
+            "type": "turn_context",
+            "payload": {"cwd": str(workspace)},
+        },
+        {
+            "timestamp": "2026-06-20T05:52:20Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Edit the app",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "success": True,
+                "changes": {
+                    str(changed_file): {
+                        "type": "update",
+                        "unified_diff": "@@ -1 +1 @@\n-const label = 'old'\n+const label = 'new'",
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:22Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "turn_aborted",
+                "reason": "interrupted",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assistant = page.messages[1]
+    assert assistant["status"] == "cancelled"
+    assert assistant["content"] == "interrupted"
+    assert assistant["subtaskId"] > 0
+    assert assistant["fileChanges"]["file_count"] == 1
+    assert assistant["fileChanges"]["files"][0]["path"] == "src/app.ts"
+    assert assistant["fileChanges"]["additions"] == 1
+    assert assistant["fileChanges"]["deletions"] == 1
+
+
+def test_codex_discovery_adds_file_changes_from_patch_content(tmp_path, monkeypatch):
+    from executor.config import config
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    monkeypatch.setattr(config, "WEGENT_EXECUTOR_HOME", str(tmp_path / "executor-home"))
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    workspace = tmp_path / "plain-project"
+    workspace.mkdir()
+    changed_file = workspace / "note.txt"
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789e0"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:19Z",
+            "type": "turn_context",
+            "payload": {"cwd": str(workspace)},
+        },
+        {
+            "timestamp": "2026-06-20T05:52:20Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "Create a note",
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "patch_apply_end",
+                "success": True,
+                "changes": {
+                    str(changed_file): {
+                        "type": "add",
+                        "content": "hello\n",
+                    }
+                },
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:22Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "last_agent_message": "Done",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assistant = page.messages[1]
+    assert assistant["fileChanges"]["file_count"] == 1
+    assert assistant["fileChanges"]["files"][0] == {
+        "old_path": None,
+        "path": "note.txt",
+        "change_type": "created",
+        "additions": 1,
+        "deletions": 0,
+        "binary": False,
+    }
+    assert assistant["fileChanges"]["revertible"] is True
+    assert "--- /dev/null" in assistant["fileChanges"]["diff"]
+    assert "+++ b/note.txt" in assistant["fileChanges"]["diff"]
+    assert "+hello" in assistant["fileChanges"]["diff"]
+
+
 def test_codex_discovery_reads_transcript_pages(tmp_path):
     from executor.runtime_work.codex_discovery import CodexSessionDiscovery
 

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -2288,7 +2288,29 @@ async def test_runtime_work_handler_creates_runtime_task_with_local_transcript(
         executed_requests.append(request)
         await emitter.start(shell_type="ClaudeCode")
         await emitter.text_delta("Created")
-        await emitter.done(content="Created")
+        await emitter.done(
+            content="Created",
+            file_changes={
+                "version": 1,
+                "status": "active",
+                "artifact_id": "turn-2001",
+                "device_id": "device-1",
+                "workspace_path": "/repo/Wegent",
+                "file_count": 1,
+                "additions": 3,
+                "deletions": 1,
+                "files": [
+                    {
+                        "path": "src/app.ts",
+                        "change_type": "modified",
+                        "additions": 3,
+                        "deletions": 1,
+                        "binary": False,
+                    }
+                ],
+                "reverted_at": None,
+            },
+        )
 
     store = LocalTaskStore(tmp_path / "index.json")
     adapter = RuntimeAgentAdapter(
@@ -2344,6 +2366,8 @@ async def test_runtime_work_handler_creates_runtime_task_with_local_transcript(
         "assistant",
     ]
     assert transcript["messages"][0]["content"] == "create the task"
+    assert transcript["messages"][1]["fileChanges"]["artifact_id"] == "turn-2001"
+    assert transcript["messages"][1]["fileChanges"]["files"][0]["path"] == "src/app.ts"
 
 
 @pytest.mark.asyncio

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -6,6 +6,26 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEWORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_DIR="$(cd "$WEWORK_DIR/.." && pwd)"
 ENV_FILE="$PROJECT_DIR/.env"
+INITIAL_WEWORK_PORT="${WEWORK_PORT:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: bash wework/scripts/dev-mac-app.sh [options]
+
+Options:
+  -p, --port PORT       Vite/Tauri dev server port. Overrides WEWORK_PORT.
+  -h, --help            Show this help message.
+
+Environment:
+  WEWORK_PORT           Default dev server port when --port is not provided.
+  WEWORK_HOST           Host IP used to build backend proxy targets.
+  BACKEND_PORT          Backend port used when proxy targets are not set.
+
+Examples:
+  bash wework/scripts/dev-mac-app.sh --port 9130
+  WEWORK_PORT=9130 bash wework/scripts/dev-mac-app.sh
+EOF
+}
 
 if [ -f "$ENV_FILE" ]; then
   set -a
@@ -13,6 +33,39 @@ if [ -f "$ENV_FILE" ]; then
   source "$ENV_FILE"
   set +a
 fi
+
+if [ -n "$INITIAL_WEWORK_PORT" ]; then
+  WEWORK_PORT="$INITIAL_WEWORK_PORT"
+fi
+
+REQUESTED_WEWORK_PORT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -p|--port)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: $1 requires a port value." >&2
+        usage
+        exit 1
+      fi
+      REQUESTED_WEWORK_PORT="$2"
+      shift 2
+      ;;
+    --port=*)
+      REQUESTED_WEWORK_PORT="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
 
 get_local_ip() {
   local ip
@@ -40,7 +93,12 @@ get_local_ip() {
 
 LOCAL_IP="${WEWORK_HOST:-$(get_local_ip)}"
 BACKEND_PORT="${BACKEND_PORT:-9100}"
-WEWORK_PORT="${WEWORK_PORT:-1420}"
+WEWORK_PORT="${REQUESTED_WEWORK_PORT:-${WEWORK_PORT:-1420}}"
+
+if ! [[ "$WEWORK_PORT" =~ ^[0-9]+$ ]] || [ "$WEWORK_PORT" -lt 1 ] || [ "$WEWORK_PORT" -gt 65535 ]; then
+  echo "Error: WEWORK_PORT must be a number between 1 and 65535. Got: $WEWORK_PORT" >&2
+  exit 1
+fi
 
 export VITE_API_PROXY_TARGET="${VITE_API_PROXY_TARGET:-http://$LOCAL_IP:$BACKEND_PORT}"
 export VITE_SOCKET_PROXY_TARGET="${VITE_SOCKET_PROXY_TARGET:-${WEGENT_SOCKET_URL:-$VITE_API_PROXY_TARGET}}"

--- a/wework/src/api/environment.ts
+++ b/wework/src/api/environment.ts
@@ -27,6 +27,15 @@ const EMPTY_ENVIRONMENT_INFO: EnvironmentInfo = {
 const INVALID_BRANCH_CHARACTERS = new Set([' ', '~', '^', ':', '?', '*', '[', '\\', ']'])
 const ENVIRONMENT_INFO_CACHE_TTL_MS = 1500
 
+export type EnvironmentDiffMode = 'branch' | 'unstaged' | 'staged' | 'commit'
+
+const ENVIRONMENT_DIFF_COMMANDS: Record<EnvironmentDiffMode, string> = {
+  branch: 'git_diff',
+  unstaged: 'git_diff_unstaged',
+  staged: 'git_diff_staged',
+  commit: 'git_diff_last_commit',
+}
+
 type EnvironmentInfoCacheEntry = {
   expiresAt: number
   promise: Promise<EnvironmentInfo>
@@ -397,10 +406,11 @@ export async function loadProjectEnvironment(
 export async function loadProjectEnvironmentDiff(
   api: DeviceCommandApi,
   project: ProjectWithTasks | null,
-  target?: EnvironmentWorkspaceTarget | null
+  target?: EnvironmentWorkspaceTarget | null,
+  mode: EnvironmentDiffMode = 'branch'
 ): Promise<string> {
   const { deviceId, path } = await commandContext(api, project, target)
-  return runGitCommand(api, deviceId, 'git_diff', path, {
+  return runGitCommand(api, deviceId, ENVIRONMENT_DIFF_COMMANDS[mode], path, {
     timeoutSeconds: 30,
     maxOutputBytes: 5 * 1024 * 1024,
   })

--- a/wework/src/api/runtimeWork.ts
+++ b/wework/src/api/runtimeWork.ts
@@ -8,6 +8,8 @@ import type {
   DeviceWorkspacePrepareResponse,
   DeviceWorkspaceUpsert,
   RuntimeGlobalIMNotificationUpdateRequest,
+  RuntimeFileChangesRevertRequest,
+  RuntimeFileChangesRevertResponse,
   RuntimeIMNotificationSettingsResponse,
   RuntimeSendRequest,
   RuntimeSendResponse,
@@ -50,6 +52,11 @@ export function createRuntimeWorkApi(client: HttpClient) {
     },
     getRuntimeTranscript(request: RuntimeTranscriptRequest): Promise<RuntimeTranscriptResponse> {
       return client.post('/runtime-work/transcript', request)
+    },
+    revertRuntimeFileChanges(
+      request: RuntimeFileChangesRevertRequest
+    ): Promise<RuntimeFileChangesRevertResponse> {
+      return client.post('/runtime-work/file-changes/revert', request)
     },
     sendRuntimeMessage(data: RuntimeSendRequest): Promise<RuntimeSendResponse> {
       return client.post('/runtime-work/send', data)

--- a/wework/src/components/chat/FileChangesCard.test.tsx
+++ b/wework/src/components/chat/FileChangesCard.test.tsx
@@ -84,6 +84,8 @@ describe('FileChangesCard', () => {
     expect(onOpenReview).toHaveBeenCalledTimes(1)
     const request = vi.mocked(onOpenReview).mock.calls[0][0]
     expect(request.subtaskId).toBe(21)
+    expect(request.reviewTitle).toMatch(/Previous turn|上轮对话/)
+    expect(request.defaultFileTreeVisible).toBe(false)
     expect(request.loadDiff).toEqual(expect.any(Function))
     expect(onLoadDiff).not.toHaveBeenCalled()
 
@@ -118,6 +120,8 @@ describe('FileChangesCard', () => {
     expect(onOpenReview).toHaveBeenCalledTimes(1)
     const request = vi.mocked(onOpenReview).mock.calls[0][0]
     expect(request.subtaskId).toBe(21)
+    expect(request.reviewTitle).toMatch(/Previous turn|上轮对话/)
+    expect(request.defaultFileTreeVisible).toBe(false)
     expect(onLoadDiff).not.toHaveBeenCalled()
 
     await request.loadDiff()

--- a/wework/src/components/chat/FileChangesCard.tsx
+++ b/wework/src/components/chat/FileChangesCard.tsx
@@ -15,7 +15,12 @@ interface FileChangesCardProps {
   deviceOnline: boolean
   onLoadDiff: (subtaskId: number) => Promise<string>
   onRevert: (subtaskId: number) => Promise<TurnFileChangesSummary>
-  onOpenReview?: (request: { subtaskId: number; loadDiff: () => Promise<string> }) => void
+  onOpenReview?: (request: {
+    subtaskId: number
+    loadDiff: () => Promise<string>
+    reviewTitle?: string
+    defaultFileTreeVisible?: boolean
+  }) => void
 }
 
 function getErrorMessage(error: unknown, fallback: string) {
@@ -75,12 +80,14 @@ export function FileChangesCard({
   const visibleFiles = expanded ? summary.files : summary.files.slice(0, DEFAULT_VISIBLE_FILE_COUNT)
   const actionsDisabled = !deviceOnline || summary.status === 'artifact_missing'
   const reviewDisabled = actionsDisabled || !onOpenReview
-  const canRevert = summary.status === 'active'
+  const canRevert = summary.status === 'active' && summary.revertible !== false
 
   const openReview = () => {
     onOpenReview?.({
       subtaskId,
       loadDiff: () => onLoadDiff(subtaskId),
+      reviewTitle: t('file_changes.previous_turn_label'),
+      defaultFileTreeVisible: false,
     })
   }
 

--- a/wework/src/components/chat/FileChangesReviewPanel.test.tsx
+++ b/wework/src/components/chat/FileChangesReviewPanel.test.tsx
@@ -163,6 +163,33 @@ describe('FileChangesReviewPanel', () => {
     expect(diff).toHaveTextContent('new 13')
   })
 
+  test('merges multiple diff blocks for the same file into one section', async () => {
+    const duplicatePathDiff = [
+      'diff --git a/src/env.ts b/src/env.ts',
+      '--- a/src/env.ts',
+      '+++ b/src/env.ts',
+      '@@ -1 +1 @@',
+      '-old staged',
+      '+new staged',
+      'diff --git a/src/env.ts b/src/env.ts',
+      '--- a/src/env.ts',
+      '+++ b/src/env.ts',
+      '@@ -5 +5 @@',
+      '-old unstaged',
+      '+new unstaged',
+    ].join('\n')
+
+    render(<FileChangesReviewPanel loading={false} diff={duplicatePathDiff} />)
+
+    expect(screen.getAllByTestId('file-changes-review-file-option')).toHaveLength(1)
+    expect(screen.getAllByTestId('file-changes-review-file-diff-section')).toHaveLength(1)
+
+    const diff = screen.getByTestId('file-changes-review-diff')
+    expect(diff).toHaveTextContent('new staged')
+    expect(diff).toHaveTextContent('new unstaged')
+    expect(diff).not.toHaveTextContent('diff --git')
+  })
+
   test('keeps the review toolbar available when the selected view has no diff', async () => {
     const onSelectPreviousTurn = vi.fn()
 

--- a/wework/src/components/chat/FileChangesReviewPanel.test.tsx
+++ b/wework/src/components/chat/FileChangesReviewPanel.test.tsx
@@ -49,9 +49,35 @@ const treeDiff = [
   '+new chinese',
 ].join('\n')
 
+const largeDiff = Array.from({ length: 13 }, (_, index) => {
+  const fileIndex = index + 1
+  return [
+    `diff --git a/src/file-${fileIndex}.ts b/src/file-${fileIndex}.ts`,
+    `--- a/src/file-${fileIndex}.ts`,
+    `+++ b/src/file-${fileIndex}.ts`,
+    '@@ -1 +1 @@',
+    `-old ${fileIndex}`,
+    `+new ${fileIndex}`,
+  ].join('\n')
+}).join('\n')
+
 describe('FileChangesReviewPanel', () => {
   test('keeps every changed file diff visible when a file is selected', async () => {
-    render(<FileChangesReviewPanel loading={false} diff={twoFileDiff} />)
+    render(
+      <FileChangesReviewPanel
+        loading={false}
+        diff={twoFileDiff}
+        branchName="human/dingo-20260624-023038"
+        targetBranchName="origin/main"
+      />
+    )
+
+    const toolbar = screen.getByTestId('file-changes-review-toolbar')
+    expect(within(toolbar).getByText(/Branch|分支/)).toBeInTheDocument()
+    expect(within(toolbar).getByText('+2')).toBeInTheDocument()
+    expect(within(toolbar).getByText('-2')).toBeInTheDocument()
+    expect(within(toolbar).getByText('human/dingo-20260624-023038')).toBeInTheDocument()
+    expect(within(toolbar).getByText('origin/main')).toBeInTheDocument()
 
     const options = screen.getAllByTestId('file-changes-review-file-option')
     expect(options).toHaveLength(2)
@@ -59,6 +85,8 @@ describe('FileChangesReviewPanel', () => {
     expect(options[1]).toHaveAttribute('aria-selected', 'false')
     expect(screen.getByTestId('file-changes-review-diff')).toHaveTextContent('new alpha')
     expect(screen.getByTestId('file-changes-review-diff')).toHaveTextContent('new beta')
+    expect(screen.getByTestId('file-changes-review-diff')).not.toHaveTextContent('diff --git')
+    expect(screen.getByTestId('file-changes-review-diff')).not.toHaveTextContent('@@ -1 +1 @@')
 
     await userEvent.click(options[1])
 
@@ -103,6 +131,72 @@ describe('FileChangesReviewPanel', () => {
     expect(diffText.indexOf('new test')).toBeLessThan(diffText.indexOf('new component'))
     expect(diffText.indexOf('new component')).toBeLessThan(diffText.indexOf('new english'))
     expect(diffText.indexOf('new english')).toBeLessThan(diffText.indexOf('new chinese'))
+  })
+
+  test('shows only the selected file when the diff is large', async () => {
+    render(
+      <FileChangesReviewPanel
+        loading={false}
+        diff={largeDiff}
+        reviewTitle="上轮对话"
+        defaultFileTreeVisible={false}
+      />
+    )
+
+    expect(screen.getByText(/This diff is large|此差异较大/)).toBeInTheDocument()
+    expect(screen.getByTestId('file-changes-review-toolbar')).toHaveTextContent('上轮对话')
+    expect(screen.queryByTestId('file-changes-review-file-tree')).not.toBeInTheDocument()
+
+    const diff = screen.getByTestId('file-changes-review-diff')
+    expect(diff).toHaveTextContent('new 1')
+    expect(diff).not.toHaveTextContent('new 2')
+    expect(screen.getByText('new 1').closest('div')).toHaveClass('w-max', 'min-w-full')
+
+    await userEvent.click(screen.getByTestId('toggle-file-tree-button'))
+    await userEvent.click(
+      screen.getByRole('tab', {
+        name: /src\/file-13\.ts/,
+      })
+    )
+
+    expect(diff).not.toHaveTextContent('new 2')
+    expect(diff).toHaveTextContent('new 13')
+  })
+
+  test('keeps the review toolbar available when the selected view has no diff', async () => {
+    const onSelectPreviousTurn = vi.fn()
+
+    render(
+      <FileChangesReviewPanel
+        loading={false}
+        diff=""
+        reviewTitle="提交"
+        viewOptions={[
+          {
+            id: 'commit',
+            label: '提交',
+            active: true,
+            onSelect: vi.fn(),
+          },
+          {
+            id: 'previous-turn',
+            label: '上轮对话',
+            active: false,
+            onSelect: onSelectPreviousTurn,
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('file-changes-review-toolbar')).toHaveTextContent('提交')
+    expect(screen.getByTestId('file-changes-review-empty')).toHaveTextContent(
+      /No text changes|没有可展示/
+    )
+
+    await userEvent.click(screen.getByTestId('review-view-switcher-button'))
+    await userEvent.click(screen.getByRole('menuitemradio', { name: '上轮对话' }))
+
+    expect(onSelectPreviousTurn).toHaveBeenCalledTimes(1)
   })
 
   test('supports review toolbar actions', async () => {

--- a/wework/src/components/chat/FileChangesReviewPanel.tsx
+++ b/wework/src/components/chat/FileChangesReviewPanel.tsx
@@ -625,7 +625,7 @@ function AllDiffSections({
       <div
         data-testid="file-changes-review-diff-lines"
         data-wrap={wrapLines ? 'true' : 'false'}
-        className="min-h-0 flex-1 overflow-auto bg-background font-mono text-xs leading-5"
+        className="min-h-0 flex-1 overflow-y-auto bg-background font-mono text-xs leading-5"
       >
         {sections.map((section, index) => (
           <DiffFileSectionView
@@ -675,12 +675,11 @@ function DiffFileSectionView({
       id={getDiffSectionDomId(sectionIndex)}
       data-testid="file-changes-review-file-diff-section"
       className={cn(
-        'scroll-mt-0 border-b border-border last:border-b-0',
-        wrapLines ? 'w-full' : 'w-max min-w-full',
+        'scroll-mt-0 w-full border-b border-border last:border-b-0',
         selected && 'ring-1 ring-inset ring-primary/25'
       )}
     >
-      <header className="sticky top-0 z-10 flex min-h-9 items-center gap-2 border-b border-border bg-background px-2 py-1 font-mono text-sm font-semibold text-text-primary">
+      <header className="sticky top-0 z-10 flex min-h-9 items-center gap-2 border-b border-border bg-background px-2 py-1 text-sm font-medium">
         <button
           type="button"
           data-testid="toggle-file-diff-section-button"
@@ -691,16 +690,14 @@ function DiffFileSectionView({
         >
           <ChevronRight className={cn('h-4 w-4 transition-transform', !collapsed && 'rotate-90')} />
         </button>
-        <span className="min-w-0 flex-1 truncate" title={section.path}>
-          {compactPath(section.path)}
-        </span>
+        <DiffFilePathLabel path={section.path} />
         <span className="shrink-0 font-mono text-xs">
           <span className="text-green-600">+{additions}</span>{' '}
           <span className="text-red-600">-{deletions}</span>
         </span>
       </header>
       {!collapsed && !hunksCollapsed ? (
-        <div>
+        <div className={cn(!wrapLines && 'overflow-x-auto')}>
           <div className={cn(wrapLines ? 'min-w-full' : 'w-max min-w-full')}>
             {hunks
               .filter(hunk => hunk.header)
@@ -773,12 +770,23 @@ function formatDiffLineContent(line: string) {
   return line
 }
 
-function compactPath(path: string) {
-  const parts = path.split('/').filter(Boolean)
-  if (parts.length <= 2) {
-    return path
-  }
-  return `...${parts.slice(-2).join('/')}`
+function DiffFilePathLabel({ path }: { path: string }) {
+  const separatorIndex = path.lastIndexOf('/')
+  const directory = separatorIndex >= 0 ? path.slice(0, separatorIndex + 1) : ''
+  const fileName = separatorIndex >= 0 ? path.slice(separatorIndex + 1) : path
+
+  return (
+    <span className="flex min-w-0 flex-1 items-center" title={path}>
+      {directory ? (
+        // direction:rtl keeps the ellipsis on the leading edge so the file name
+        // stays visible when the header is narrow; <bdi> preserves left-to-right text.
+        <span dir="rtl" className="min-w-0 truncate text-text-muted">
+          <bdi>{directory}</bdi>
+        </span>
+      ) : null}
+      <span className="shrink-0 text-text-primary">{fileName}</span>
+    </span>
+  )
 }
 
 function buildReviewTree(sections: DiffFileSection[]): ReviewTreeNode[] {
@@ -851,17 +859,34 @@ function filterTreeNodes(nodes: ReviewTreeNode[], normalizedQuery: string): Revi
 
 function parseDiffHunks(section: DiffFileSection): DiffHunk[] {
   const hunks: DiffHunk[] = []
+  let metadataIndex = 0
   let current: DiffHunk = {
-    id: `${section.path}:metadata`,
+    id: `${section.path}:metadata:${metadataIndex}`,
     lines: [],
   }
   let hunkIndex = 0
 
+  const flush = () => {
+    if (current.header || current.lines.length > 0) {
+      hunks.push(current)
+    }
+  }
+
   section.lines.forEach(line => {
-    if (line.startsWith('@@')) {
-      if (current.header || current.lines.length > 0) {
-        hunks.push(current)
+    // A new "diff --git" inside a merged section starts a fresh metadata block
+    // so its header/index/--- /+++ lines are not rendered as diff content.
+    if (line.startsWith('diff --git')) {
+      flush()
+      metadataIndex += 1
+      current = {
+        id: `${section.path}:metadata:${metadataIndex}`,
+        lines: [],
       }
+      return
+    }
+
+    if (line.startsWith('@@')) {
+      flush()
       current = {
         id: `${section.path}:hunk:${hunkIndex}`,
         header: line,
@@ -874,9 +899,7 @@ function parseDiffHunks(section: DiffFileSection): DiffHunk[] {
     current.lines.push(line)
   })
 
-  if (current.header || current.lines.length > 0) {
-    hunks.push(current)
-  }
+  flush()
 
   return hunks
 }

--- a/wework/src/components/chat/FileChangesReviewPanel.tsx
+++ b/wework/src/components/chat/FileChangesReviewPanel.tsx
@@ -1,7 +1,12 @@
 import {
+  ArrowRight,
+  Check,
+  ChevronDown,
   ChevronRight,
   Copy,
   FileText,
+  GitBranch,
+  GitCompareArrows,
   ListCollapse,
   PanelRightClose,
   PanelRightOpen,
@@ -14,12 +19,28 @@ import { useTranslation } from '@/hooks/useTranslation'
 import { cn } from '@/lib/utils'
 import { parseUnifiedDiff, type DiffFileSection } from './parseUnifiedDiff'
 
+const LARGE_DIFF_FILE_COUNT_THRESHOLD = 12
+const LARGE_DIFF_LINE_COUNT_THRESHOLD = 700
+
 interface FileChangesReviewPanelProps {
   loading: boolean
   diff: string
   error?: string
   className?: string
+  reviewTitle?: string
+  defaultFileTreeVisible?: boolean
+  branchName?: string
+  targetBranchName?: string
+  viewOptions?: FileChangesReviewViewOption[]
   onRefresh?: () => void
+}
+
+export interface FileChangesReviewViewOption {
+  id: string
+  label: string
+  active: boolean
+  disabled?: boolean
+  onSelect: () => void
 }
 
 interface ReviewTreeNode {
@@ -50,19 +71,37 @@ export function FileChangesReviewPanel({
   diff,
   error,
   className,
+  reviewTitle,
+  defaultFileTreeVisible = true,
+  branchName,
+  targetBranchName,
+  viewOptions,
   onRefresh,
 }: FileChangesReviewPanelProps) {
   const { t } = useTranslation('chat')
   const [selection, setSelection] = useState({ diff: '', index: 0 })
-  const [fileTreeVisible, setFileTreeVisible] = useState(true)
+  const [fileTreeVisibility, setFileTreeVisibility] = useState({
+    diff,
+    defaultFileTreeVisible,
+    visible: defaultFileTreeVisible,
+  })
   const [wrapLines, setWrapLines] = useState(false)
   const [hunksCollapsed, setHunksCollapsed] = useState(false)
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set())
 
   const sections = useMemo(() => parseUnifiedDiff(diff), [diff])
   const selectedIndex =
     selection.diff === diff && selection.index < sections.length ? selection.index : 0
   const selectedSection = sections[selectedIndex] ?? sections[0]
   const treeNodes = useMemo(() => buildReviewTree(sections), [sections])
+  const diffStats = useMemo(() => getSectionsDiffStats(sections), [sections])
+  const isLargeDiff = useMemo(() => isLargeReviewDiff(sections), [sections])
+  const displayedSections = isLargeDiff && selectedSection ? [selectedSection] : sections
+  const fileTreeVisible =
+    fileTreeVisibility.diff === diff &&
+    fileTreeVisibility.defaultFileTreeVisible === defaultFileTreeVisible
+      ? fileTreeVisibility.visible
+      : defaultFileTreeVisible
 
   const selectSection = (index: number) => {
     setSelection({ diff, index })
@@ -79,42 +118,83 @@ export function FileChangesReviewPanel({
     void navigator.clipboard?.writeText(`git apply <<'PATCH'\n${patch}\nPATCH`)
   }
 
+  const toggleSectionCollapsed = (section: DiffFileSection, index: number) => {
+    const key = getDiffSectionKey(section, index)
+    setCollapsedSections(current => {
+      const next = new Set(current)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
   return (
     <div
       data-testid="file-changes-review-panel"
-      className={cn('min-h-0 flex-1 overflow-hidden p-3', className)}
+      className={cn('min-h-0 flex-1 overflow-hidden bg-background', className)}
     >
       {loading ? (
         <p className="py-8 text-center text-sm text-text-muted">{t('file_changes.loading_diff')}</p>
       ) : error ? (
         <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
-      ) : sections.length === 0 ? (
-        <p className="py-8 text-center text-sm text-text-muted">{t('file_changes.empty_diff')}</p>
       ) : (
         <div className="flex h-full min-h-0 flex-col overflow-hidden">
           <ReviewToolbar
+            title={reviewTitle}
+            branchName={branchName}
+            targetBranchName={targetBranchName}
+            viewOptions={viewOptions}
+            additions={diffStats.additions}
+            deletions={diffStats.deletions}
             fileTreeVisible={fileTreeVisible}
             wrapLines={wrapLines}
             hunksCollapsed={hunksCollapsed}
             canRefresh={Boolean(onRefresh)}
             onRefresh={onRefresh}
-            onToggleFileTree={() => setFileTreeVisible(visible => !visible)}
+            onToggleFileTree={() =>
+              setFileTreeVisibility({
+                diff,
+                defaultFileTreeVisible,
+                visible: !fileTreeVisible,
+              })
+            }
             onToggleWrap={() => setWrapLines(value => !value)}
             onToggleHunks={() => setHunksCollapsed(value => !value)}
             onCopyGitApplyCommand={copyGitApplyCommand}
           />
+          {isLargeDiff ? (
+            <p className="shrink-0 border-b border-border bg-background px-6 py-2 text-sm text-text-muted">
+              {t('file_changes.large_diff_single_file_notice')}
+            </p>
+          ) : null}
           <div
             data-testid="file-changes-review-content"
             className="flex min-h-0 flex-1 overflow-hidden"
           >
-            <AllDiffSections
-              sections={sections}
-              selectedIndex={selectedIndex}
-              ariaLabel={t('file_changes.all_files_diff_label')}
-              wrapLines={wrapLines}
-              hunksCollapsed={hunksCollapsed}
-            />
-            {fileTreeVisible && (
+            {sections.length === 0 ? (
+              <div
+                data-testid="file-changes-review-empty"
+                className="flex min-w-0 flex-1 items-center justify-center px-4 py-8 text-center text-sm text-text-muted"
+              >
+                {t('file_changes.empty_diff')}
+              </div>
+            ) : (
+              <AllDiffSections
+                sections={displayedSections}
+                selectedIndex={isLargeDiff ? 0 : selectedIndex}
+                ariaLabel={t('file_changes.all_files_diff_label')}
+                wrapLines={wrapLines}
+                hunksCollapsed={hunksCollapsed}
+                collapsedSections={collapsedSections}
+                expandFileLabel={t('file_changes.actions.expand_file_diff')}
+                collapseFileLabel={t('file_changes.actions.collapse_file_diff')}
+                onToggleSectionCollapsed={toggleSectionCollapsed}
+              />
+            )}
+            {sections.length > 0 && fileTreeVisible && (
               <ReviewFileTree
                 nodes={treeNodes}
                 selectedSection={selectedSection}
@@ -130,6 +210,12 @@ export function FileChangesReviewPanel({
 }
 
 function ReviewToolbar({
+  title,
+  branchName,
+  targetBranchName,
+  viewOptions,
+  additions,
+  deletions,
   fileTreeVisible,
   wrapLines,
   hunksCollapsed,
@@ -140,6 +226,12 @@ function ReviewToolbar({
   onToggleHunks,
   onCopyGitApplyCommand,
 }: {
+  title?: string
+  branchName?: string
+  targetBranchName?: string
+  viewOptions?: FileChangesReviewViewOption[]
+  additions: number
+  deletions: number
   fileTreeVisible: boolean
   wrapLines: boolean
   hunksCollapsed: boolean
@@ -151,54 +243,132 @@ function ReviewToolbar({
   onCopyGitApplyCommand: () => void
 }) {
   const { t } = useTranslation('chat')
+  const [menuOpen, setMenuOpen] = useState(false)
+  const sourceBranchLabel = branchName?.trim() || t('file_changes.branch_unknown')
+  const targetBranchLabel = targetBranchName?.trim()
+  const hasBranchContext = Boolean(branchName?.trim() || targetBranchName?.trim())
+  const toolbarTitle =
+    title?.trim() ||
+    (hasBranchContext ? t('file_changes.branch_label') : t('file_changes.changes_label'))
+  const canSwitchView = Boolean(viewOptions?.length)
 
   return (
     <div
       data-testid="file-changes-review-toolbar"
-      className="mb-3 flex min-h-9 shrink-0 items-center justify-end gap-1.5"
+      className="flex min-h-11 shrink-0 flex-col justify-center gap-0.5 border-b border-border bg-background px-3 py-1"
     >
-      <ToolbarButton
-        testId="refresh-review-diff-button"
-        label={t('file_changes.actions.refresh')}
-        onClick={onRefresh}
-        disabled={!canRefresh}
-        icon={RefreshCw}
-      />
-      <ToolbarButton
-        testId="toggle-line-wrap-button"
-        label={t('file_changes.actions.toggle_wrap')}
-        onClick={onToggleWrap}
-        pressed={wrapLines}
-        icon={WrapText}
-      />
-      <ToolbarButton
-        testId="collapse-all-diff-hunks-button"
-        label={
-          hunksCollapsed
-            ? t('file_changes.actions.expand_all_hunks')
-            : t('file_changes.actions.collapse_all_hunks')
-        }
-        onClick={onToggleHunks}
-        pressed={hunksCollapsed}
-        icon={ListCollapse}
-      />
-      <ToolbarButton
-        testId="copy-git-apply-command-button"
-        label={t('file_changes.actions.copy_git_apply')}
-        onClick={onCopyGitApplyCommand}
-        icon={Copy}
-      />
-      <ToolbarButton
-        testId="toggle-file-tree-button"
-        label={
-          fileTreeVisible
-            ? t('file_changes.actions.hide_files')
-            : t('file_changes.actions.show_files')
-        }
-        onClick={onToggleFileTree}
-        pressed={fileTreeVisible}
-        icon={fileTreeVisible ? PanelRightClose : PanelRightOpen}
-      />
+      <div className="flex min-h-7 items-center gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2 text-xs font-medium text-text-primary">
+          <div className="relative shrink-0">
+            {canSwitchView ? (
+              <>
+                <button
+                  type="button"
+                  data-testid="review-view-switcher-button"
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  onClick={() => setMenuOpen(open => !open)}
+                  className="flex h-7 items-center gap-1 rounded-md bg-muted px-2 text-xs font-medium text-text-primary transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
+                  <span>{toolbarTitle}</span>
+                  <ChevronDown className="h-3.5 w-3.5" />
+                </button>
+                {menuOpen ? (
+                  <div
+                    data-testid="review-view-switcher-menu"
+                    role="menu"
+                    className="absolute left-0 top-full z-popover mt-1 w-40 overflow-hidden rounded-lg border border-border bg-background py-1 text-xs shadow-lg"
+                  >
+                    {viewOptions?.map(option => (
+                      <button
+                        key={option.id}
+                        type="button"
+                        role="menuitemradio"
+                        aria-checked={option.active}
+                        disabled={option.disabled}
+                        data-testid="review-view-switcher-option"
+                        onClick={() => {
+                          setMenuOpen(false)
+                          option.onSelect()
+                        }}
+                        className="flex h-7 w-full items-center gap-2 px-2.5 text-left font-medium text-text-primary transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-45"
+                      >
+                        <span className="min-w-0 flex-1 truncate">{option.label}</span>
+                        {option.active ? <Check className="h-4 w-4 shrink-0" /> : null}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </>
+            ) : (
+              <span className="shrink-0">{toolbarTitle}</span>
+            )}
+          </div>
+          <span className="shrink-0 font-normal text-green-600">+{additions.toLocaleString()}</span>
+          <span className="shrink-0 font-normal text-red-600">-{deletions.toLocaleString()}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <ToolbarButton
+            testId="refresh-review-diff-button"
+            label={t('file_changes.actions.refresh')}
+            onClick={onRefresh}
+            disabled={!canRefresh}
+            icon={RefreshCw}
+          />
+          <ToolbarButton
+            testId="toggle-line-wrap-button"
+            label={t('file_changes.actions.toggle_wrap')}
+            onClick={onToggleWrap}
+            pressed={wrapLines}
+            icon={WrapText}
+          />
+          <ToolbarButton
+            testId="collapse-all-diff-hunks-button"
+            label={
+              hunksCollapsed
+                ? t('file_changes.actions.expand_all_hunks')
+                : t('file_changes.actions.collapse_all_hunks')
+            }
+            onClick={onToggleHunks}
+            pressed={hunksCollapsed}
+            icon={ListCollapse}
+          />
+          <ToolbarButton
+            testId="copy-git-apply-command-button"
+            label={t('file_changes.actions.copy_git_apply')}
+            onClick={onCopyGitApplyCommand}
+            icon={Copy}
+          />
+          <ToolbarButton
+            testId="toggle-file-tree-button"
+            label={
+              fileTreeVisible
+                ? t('file_changes.actions.hide_files')
+                : t('file_changes.actions.show_files')
+            }
+            onClick={onToggleFileTree}
+            pressed={fileTreeVisible}
+            icon={fileTreeVisible ? PanelRightClose : PanelRightOpen}
+          />
+        </div>
+      </div>
+      {hasBranchContext ? (
+        <div className="flex min-h-4 min-w-0 items-center gap-2.5 text-xs text-text-muted">
+          <GitBranch className="hidden h-4 w-4 shrink-0 text-text-muted sm:block" />
+          <span className="min-w-0 truncate">{sourceBranchLabel}</span>
+          {targetBranchLabel ? (
+            <>
+              <ArrowRight className="h-4 w-4 shrink-0 text-text-muted" />
+              <span className="min-w-0 truncate">{targetBranchLabel}</span>
+            </>
+          ) : null}
+        </div>
+      ) : (
+        <div className="flex min-h-4 min-w-0 items-center gap-2 text-xs text-text-muted">
+          <GitCompareArrows className="hidden h-4 w-4 shrink-0 text-text-muted sm:block" />
+          <span className="min-w-0 truncate">{t('file_changes.all_files_diff_label')}</span>
+        </div>
+      )}
     </div>
   )
 }
@@ -228,11 +398,11 @@ function ToolbarButton({
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        'flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-text-secondary transition-colors hover:bg-muted hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40',
+        'flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-text-secondary transition-colors hover:bg-muted hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-40',
         pressed && 'border-border bg-muted text-text-primary'
       )}
     >
-      <Icon className="h-4 w-4" />
+      <Icon className="h-3.5 w-3.5" />
     </button>
   )
 }
@@ -272,11 +442,11 @@ function ReviewFileTree({
   return (
     <aside
       data-testid="file-changes-review-file-tree"
-      className="flex h-full min-h-0 w-[260px] shrink-0 flex-col border-l border-border bg-background"
+      className="flex h-full min-h-0 w-[34%] min-w-[240px] max-w-[380px] shrink-0 flex-col border-l border-border bg-background"
       aria-label={t('file_changes.file_list_label')}
     >
-      <div className="border-b border-border p-3">
-        <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-2">
+      <div className="px-3 py-2.5">
+        <div className="flex h-9 items-center gap-2 rounded-xl border border-border bg-background px-3">
           <Search className="h-4 w-4 text-text-muted" />
           <input
             data-testid="file-changes-review-file-search-input"
@@ -284,11 +454,11 @@ function ReviewFileTree({
             onChange={event => setQuery(event.target.value)}
             placeholder={t('file_changes.file_search_placeholder')}
             aria-label={t('file_changes.file_search_placeholder')}
-            className="h-9 min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-text-muted"
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none placeholder:text-text-muted"
           />
         </div>
       </div>
-      <div role="tablist" className="min-h-0 flex-1 overflow-auto p-2">
+      <div role="tablist" className="min-h-0 flex-1 overflow-auto px-2 pb-3">
         {visibleNodes.length === 0 ? (
           <p className="px-2 py-3 text-sm text-text-muted">{t('file_changes.file_search_empty')}</p>
         ) : (
@@ -390,7 +560,7 @@ function ReviewTreeNodeRow({
         }
       }}
       className={cn(
-        'flex min-h-8 w-full items-center rounded-md pr-2 text-left font-mono text-xs text-text-secondary outline-none transition-colors hover:bg-muted hover:text-text-primary focus-visible:ring-2 focus-visible:ring-primary/40',
+        'flex min-h-8 w-full items-center rounded-md pr-2 text-left font-sans text-sm text-text-muted outline-none transition-colors hover:bg-muted hover:text-text-primary focus-visible:ring-2 focus-visible:ring-primary/40',
         selected && 'bg-muted text-text-primary'
       )}
     >
@@ -401,7 +571,7 @@ function ReviewTreeNodeRow({
       <span className="min-w-0 flex-1 truncate" title={node.path}>
         {node.name}
       </span>
-      <span className="ml-2 shrink-0 font-mono text-[11px]">
+      <span className="ml-2 shrink-0 font-mono text-xs">
         <span className="text-green-600">+{node.additions}</span>{' '}
         <span className="text-red-600">-{node.deletions}</span>
       </span>
@@ -430,18 +600,26 @@ function AllDiffSections({
   ariaLabel,
   wrapLines,
   hunksCollapsed,
+  collapsedSections,
+  expandFileLabel,
+  collapseFileLabel,
+  onToggleSectionCollapsed,
 }: {
   sections: DiffFileSection[]
   selectedIndex: number
   ariaLabel: string
   wrapLines: boolean
   hunksCollapsed: boolean
+  collapsedSections: Set<string>
+  expandFileLabel: string
+  collapseFileLabel: string
+  onToggleSectionCollapsed: (section: DiffFileSection, index: number) => void
 }) {
   return (
     <section
       id="file-changes-review-diff"
       data-testid="file-changes-review-diff"
-      className="flex min-w-0 flex-1 flex-col overflow-hidden rounded-lg border border-border"
+      className="flex min-w-0 flex-1 flex-col overflow-hidden bg-background"
       aria-label={ariaLabel}
     >
       <div
@@ -457,6 +635,10 @@ function AllDiffSections({
             selected={index === selectedIndex}
             wrapLines={wrapLines}
             hunksCollapsed={hunksCollapsed}
+            collapsed={collapsedSections.has(getDiffSectionKey(section, index))}
+            expandFileLabel={expandFileLabel}
+            collapseFileLabel={collapseFileLabel}
+            onToggleCollapsed={() => onToggleSectionCollapsed(section, index)}
           />
         ))}
       </div>
@@ -470,12 +652,20 @@ function DiffFileSectionView({
   selected,
   wrapLines,
   hunksCollapsed,
+  collapsed,
+  expandFileLabel,
+  collapseFileLabel,
+  onToggleCollapsed,
 }: {
   section: DiffFileSection
   sectionIndex: number
   selected: boolean
   wrapLines: boolean
   hunksCollapsed: boolean
+  collapsed: boolean
+  expandFileLabel: string
+  collapseFileLabel: string
+  onToggleCollapsed: () => void
 }) {
   const { additions, deletions } = getDiffStats(section.lines)
   const hunks = useMemo(() => parseDiffHunks(section), [section])
@@ -485,40 +675,60 @@ function DiffFileSectionView({
       id={getDiffSectionDomId(sectionIndex)}
       data-testid="file-changes-review-file-diff-section"
       className={cn(
-        'scroll-mt-2 border-b border-border last:border-b-0',
-        selected && 'ring-1 ring-inset ring-primary/40'
+        'scroll-mt-0 border-b border-border last:border-b-0',
+        wrapLines ? 'w-full' : 'w-max min-w-full',
+        selected && 'ring-1 ring-inset ring-primary/25'
       )}
     >
-      <header className="sticky top-0 z-10 flex min-h-10 items-center gap-2 border-b border-border bg-surface px-2.5 py-1.5 font-mono text-xs font-medium text-text-primary">
+      <header className="sticky top-0 z-10 flex min-h-9 items-center gap-2 border-b border-border bg-background px-2 py-1 font-mono text-sm font-semibold text-text-primary">
+        <button
+          type="button"
+          data-testid="toggle-file-diff-section-button"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-secondary hover:bg-surface hover:text-text-primary"
+          aria-label={collapsed ? expandFileLabel : collapseFileLabel}
+          aria-expanded={!collapsed}
+          onClick={onToggleCollapsed}
+        >
+          <ChevronRight className={cn('h-4 w-4 transition-transform', !collapsed && 'rotate-90')} />
+        </button>
         <span className="min-w-0 flex-1 truncate" title={section.path}>
-          {section.path}
+          {compactPath(section.path)}
         </span>
-        <span className="shrink-0 font-mono text-[11px]">
+        <span className="shrink-0 font-mono text-xs">
           <span className="text-green-600">+{additions}</span>{' '}
           <span className="text-red-600">-{deletions}</span>
         </span>
       </header>
-      {hunks.map(hunk => (
-        <section
-          key={hunk.id}
-          data-testid={hunk.header ? 'file-changes-review-hunk' : 'file-changes-review-metadata'}
-        >
-          {hunk.header ? (
-            <div className="grid grid-cols-[4rem_4rem_minmax(0,1fr)] bg-surface text-text-secondary">
-              <span />
-              <span />
-              <span className="min-w-0 px-2">{hunk.header}</span>
-            </div>
-          ) : null}
-          {!hunksCollapsed
-            ? buildDiffLineRows(hunk).map((row, index) => (
-                <DiffLine key={`${hunk.id}:${index}:${row.line}`} row={row} wrapLines={wrapLines} />
-              ))
-            : null}
-        </section>
-      ))}
+      {!collapsed && !hunksCollapsed ? (
+        <div>
+          <div className={cn(wrapLines ? 'min-w-full' : 'w-max min-w-full')}>
+            {hunks
+              .filter(hunk => hunk.header)
+              .map(hunk => (
+                <section
+                  key={hunk.id}
+                  data-testid={
+                    hunk.header ? 'file-changes-review-hunk' : 'file-changes-review-metadata'
+                  }
+                >
+                  {buildDiffLineRows(hunk).map((row, index) => (
+                    <DiffLine
+                      key={`${hunk.id}:${index}:${row.line}`}
+                      row={row}
+                      wrapLines={wrapLines}
+                    />
+                  ))}
+                </section>
+              ))}
+          </div>
+        </div>
+      ) : null}
     </article>
   )
+}
+
+function getDiffSectionKey(section: DiffFileSection, index: number) {
+  return `${section.path}:${index}`
 }
 
 function getDiffSectionDomId(index: number) {
@@ -529,21 +739,15 @@ function DiffLine({ row, wrapLines }: { row: DiffLineRow; wrapLines: boolean }) 
   return (
     <div
       className={cn(
-        'grid grid-cols-[4rem_4rem_minmax(0,1fr)]',
-        row.line.startsWith('+') && !row.line.startsWith('+++') && 'bg-green-50 text-green-800',
-        row.line.startsWith('-') && !row.line.startsWith('---') && 'bg-red-50 text-red-800',
-        (row.line.startsWith('diff --git') ||
-          row.line.startsWith('index ') ||
-          row.line.startsWith('---') ||
-          row.line.startsWith('+++')) &&
-          'bg-surface text-text-secondary'
+        wrapLines
+          ? 'grid w-full grid-cols-[3rem_minmax(0,1fr)]'
+          : 'grid w-max min-w-full grid-cols-[3rem_max-content]',
+        row.line.startsWith('+') && 'bg-green-50 text-green-800',
+        row.line.startsWith('-') && 'bg-red-50 text-red-800'
       )}
     >
       <span className="select-none border-r border-border/70 px-2 text-right text-text-muted">
-        {row.oldLine ?? ''}
-      </span>
-      <span className="select-none border-r border-border/70 px-2 text-right text-text-muted">
-        {row.newLine ?? ''}
+        {getDisplayLineNumber(row)}
       </span>
       <span
         className={cn(
@@ -551,10 +755,30 @@ function DiffLine({ row, wrapLines }: { row: DiffLineRow; wrapLines: boolean }) 
           wrapLines ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
         )}
       >
-        {row.line || ' '}
+        {formatDiffLineContent(row.line)}
       </span>
     </div>
   )
+}
+
+function getDisplayLineNumber(row: DiffLineRow) {
+  return row.newLine ?? row.oldLine ?? ''
+}
+
+function formatDiffLineContent(line: string) {
+  if (!line) return ' '
+  if (line.startsWith('+') || line.startsWith('-') || line.startsWith(' ')) {
+    return line.slice(1) || ' '
+  }
+  return line
+}
+
+function compactPath(path: string) {
+  const parts = path.split('/').filter(Boolean)
+  if (parts.length <= 2) {
+    return path
+  }
+  return `...${parts.slice(-2).join('/')}`
 }
 
 function buildReviewTree(sections: DiffFileSection[]): ReviewTreeNode[] {
@@ -708,4 +932,25 @@ function getDiffStats(lines: string[]) {
     },
     { additions: 0, deletions: 0 }
   )
+}
+
+function getSectionsDiffStats(sections: DiffFileSection[]) {
+  return sections.reduce(
+    (total, section) => {
+      const stats = getDiffStats(section.lines)
+      total.additions += stats.additions
+      total.deletions += stats.deletions
+      return total
+    },
+    { additions: 0, deletions: 0 }
+  )
+}
+
+function isLargeReviewDiff(sections: DiffFileSection[]) {
+  if (sections.length > LARGE_DIFF_FILE_COUNT_THRESHOLD) {
+    return true
+  }
+
+  const lineCount = sections.reduce((total, section) => total + section.lines.length, 0)
+  return lineCount > LARGE_DIFF_LINE_COUNT_THRESHOLD
 }

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -56,6 +56,74 @@ describe('MessageList', () => {
     expect(screen.getByTestId('file-changes-card')).toHaveTextContent('src/main.ts')
   })
 
+  test('renders cancelled assistant turns like stopped Codex turns', () => {
+    const commandBlock: ProcessingBlock = {
+      id: 'call-1',
+      subtaskId: 21,
+      type: 'tool',
+      toolName: 'Bash',
+      toolInput: { command: 'pnpm test' },
+      status: 'done',
+      createdAt: Date.parse('2026-06-11T10:09:18Z'),
+    }
+
+    render(
+      <MessageList
+        devices={[
+          {
+            id: 1,
+            device_id: 'device-1',
+            name: 'Device 1',
+            status: 'online',
+            is_default: false,
+          },
+        ]}
+        onLoadFileChangesDiff={vi.fn().mockResolvedValue('')}
+        onRevertFileChanges={vi.fn()}
+        messages={[
+          {
+            id: 'assistant-stopped',
+            subtaskId: 21,
+            role: 'assistant',
+            content: 'interrupted',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            createdAt: '2026-06-11T10:00:00Z',
+            blocks: [commandBlock],
+            fileChanges: {
+              version: 1,
+              status: 'active',
+              artifact_id: 'turn-21',
+              device_id: 'device-1',
+              workspace_path: '/workspace/project',
+              file_count: 1,
+              additions: 4,
+              deletions: 2,
+              files: [
+                {
+                  path: 'src/main.ts',
+                  change_type: 'modified',
+                  additions: 4,
+                  deletions: 2,
+                  binary: false,
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.queryByText('interrupted')).not.toBeInTheDocument()
+    expect(screen.getByTestId('processing-activity-group-toggle')).toHaveTextContent(
+      '已运行 1 条命令'
+    )
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('src/main.ts')
+    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent(
+      '你在 9m 18s 后停止了'
+    )
+  })
+
   test('uses compact spacing between messages and hover actions', () => {
     render(
       <MessageList

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -24,6 +24,8 @@ interface MessageListProps {
   onOpenFileChangesReview?: (request: {
     subtaskId: number
     loadDiff: () => Promise<string>
+    reviewTitle?: string
+    defaultFileTreeVisible?: boolean
   }) => void
   onOpenWorkspaceFile?: (path: string) => void
 }
@@ -79,6 +81,36 @@ export function MessageList({
 function getTurnStartMs(createdAt: string): number | undefined {
   const ms = new Date(createdAt).getTime()
   return Number.isFinite(ms) ? ms : undefined
+}
+
+function formatCompactDuration(durationMs: number): string {
+  const seconds = Math.max(0, Math.floor(durationMs / 1000))
+  if (seconds < 60) return `${seconds}s`
+
+  const minutes = Math.floor(seconds / 60)
+  const remainingSeconds = seconds % 60
+  if (minutes < 60) return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}
+
+function getStoppedElapsedDuration(message: WorkbenchMessage): string {
+  const startedAt = getTurnStartMs(message.createdAt)
+  if (startedAt === undefined) return '0s'
+
+  const blockEndTimes =
+    message.blocks
+      ?.map(block => block.createdAt)
+      .filter((createdAt): createdAt is number => Number.isFinite(createdAt)) ?? []
+  const endedAt = blockEndTimes.length > 0 ? Math.max(...blockEndTimes) : startedAt
+
+  return formatCompactDuration(endedAt - startedAt)
+}
+
+function isCancelledAssistantMessage(message: WorkbenchMessage): boolean {
+  return message.runtimeStatus === 'cancelled'
 }
 
 function formatMessageTime(createdAt: string) {
@@ -379,12 +411,16 @@ function AssistantMessage({
   onOpenFileChangesReview?: (request: {
     subtaskId: number
     loadDiff: () => Promise<string>
+    reviewTitle?: string
+    defaultFileTreeVisible?: boolean
   }) => void
   onOpenWorkspaceFile?: (path: string) => void
 }) {
-  const shouldHideContent = shouldHideFailedAssistantContent(message)
+  const { t } = useTranslation('chat')
+  const isCancelled = isCancelledAssistantMessage(message)
+  const shouldHideContent = isCancelled || shouldHideFailedAssistantContent(message)
   const visibleContent = shouldHideContent ? '' : message.content
-  const hiddenErrorContent = shouldHideContent ? message.content.trim() : undefined
+  const hiddenErrorContent = shouldHideContent && !isCancelled ? message.content.trim() : undefined
   const displayBlocks = getDisplayProcessingBlocks(message.blocks, visibleContent)
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
@@ -397,6 +433,8 @@ function AssistantMessage({
           blocks={displayBlocks}
           isStreaming={isStreaming}
           startedAt={getTurnStartMs(message.createdAt)}
+          forceExpanded={isCancelled}
+          showSummary={!isCancelled}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
         />
       )}
@@ -500,9 +538,21 @@ function AssistantMessage({
           onOpenReview={onOpenFileChangesReview}
         />
       ) : null}
-      {message.status !== 'streaming' && (hasVisibleContent || message.status === 'failed') && (
-        <MessageHoverActions message={message} align="left" />
-      )}
+      {isCancelled ? (
+        <div
+          data-testid="assistant-stopped-notice"
+          className="mt-4 flex justify-end border-b border-border pb-2 text-sm font-medium text-text-muted"
+        >
+          {t('assistant_status.stopped_after', {
+            duration: getStoppedElapsedDuration(message),
+          })}
+        </div>
+      ) : null}
+      {message.status !== 'streaming' &&
+        !isCancelled &&
+        (hasVisibleContent || message.status === 'failed') && (
+          <MessageHoverActions message={message} align="left" />
+        )}
     </div>
   )
 }

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -27,6 +27,8 @@ interface ScrollableMessageAreaProps {
   onOpenFileChangesReview?: (request: {
     subtaskId: number
     loadDiff: () => Promise<string>
+    reviewTitle?: string
+    defaultFileTreeVisible?: boolean
   }) => void
   onOpenWorkspaceFile?: (path: string) => void
   onLoadMoreBefore?: () => Promise<void> | void

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -13,6 +13,8 @@ interface ToolBlocksDisplayProps {
   // fresh client timestamps, so anchoring to the first block would restart the
   // timer from the refresh moment.
   startedAt?: number
+  forceExpanded?: boolean
+  showSummary?: boolean
   onOpenWorkspaceFile?: (path: string) => void
 }
 
@@ -20,6 +22,8 @@ export function ToolBlocksDisplay({
   blocks,
   isStreaming,
   startedAt,
+  forceExpanded = false,
+  showSummary = true,
   onOpenWorkspaceFile,
 }: ToolBlocksDisplayProps) {
   const isRunning = isStreaming || blocks.some(b => b.status !== 'done' && b.status !== 'error')
@@ -56,7 +60,7 @@ export function ToolBlocksDisplay({
 
   const duration = getDurationText(blocks, turnStartedAt, now, completedAt, isRunning)
   const rows = buildProcessingDisplayRows(blocks)
-  const expanded = isRunning || userExpanded
+  const expanded = forceExpanded || isRunning || userExpanded
   const hasLiveNarrativeBlock = rows.some(
     row =>
       row.type === 'block' &&
@@ -68,13 +72,13 @@ export function ToolBlocksDisplay({
 
   return (
     <div className="mb-3 min-w-0">
-      {isRunning ? (
+      {showSummary && isRunning ? (
         // While the turn is still running the summary is informational only:
         // render it as plain, non-interactive text so it does not look clickable.
         <div className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-xs text-text-muted">
           <span>{duration}</span>
         </div>
-      ) : (
+      ) : showSummary ? (
         <button
           type="button"
           className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-left text-xs text-text-muted hover:text-text-secondary"
@@ -91,7 +95,7 @@ export function ToolBlocksDisplay({
             <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
-      )}
+      ) : null}
       {expanded && (
         <div className="flex min-w-0 flex-col gap-3">
           {rows.map(row =>

--- a/wework/src/components/chat/parseUnifiedDiff.ts
+++ b/wework/src/components/chat/parseUnifiedDiff.ts
@@ -8,16 +8,27 @@ const DIFF_HEADER_PATTERN = /^diff --git "?a\/(.+?)"? "?b\/(.+?)"?$/
 
 export function parseUnifiedDiff(diff: string): DiffFileSection[] {
   const sections: DiffFileSection[] = []
+  const sectionsByPath = new Map<string, DiffFileSection>()
   let current: DiffFileSection | null = null
 
   for (const line of diff.split('\n')) {
     const match = line.match(DIFF_HEADER_PATTERN)
     if (match) {
+      const path = match[2]
+      const existing = sectionsByPath.get(path)
+      if (existing) {
+        // Merge multiple diff blocks for the same file into a single section
+        // so the file shows up once with all of its hunks.
+        existing.lines.push(line)
+        current = existing
+        continue
+      }
       current = {
         oldPath: match[1],
-        path: match[2],
+        path,
         lines: [line],
       }
+      sectionsByPath.set(path, current)
       sections.push(current)
       continue
     }

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -78,6 +78,15 @@ describe('DesktopSidebar', () => {
     localStorage.clear()
   })
 
+  test('keeps section header actions out of the flex layout while hidden', () => {
+    renderSidebar()
+
+    const actions = screen.getByTestId('projects-section-toggle-actions')
+
+    expect(actions).toHaveClass('absolute', 'right-2.5', 'pointer-events-none', 'invisible')
+    expect(screen.getByTestId('projects-create-button')).toBeInTheDocument()
+  })
+
   test('does not render unmapped runtime workspace groups', async () => {
     const onOpenRuntimeLocalTask = vi.fn()
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -251,13 +251,13 @@ function SidebarSectionHeader({
     hasContent && !expanded ? 'opacity-100' : 'opacity-0 group-hover/section:opacity-100'
 
   return (
-    <div className="group/section mb-2 flex h-7 items-center justify-between px-2.5">
+    <div className="group/section relative mb-2 flex h-7 items-center px-2.5">
       <button
         type="button"
         data-testid={toggleTestId}
         onClick={onToggle}
         aria-expanded={expanded}
-        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md text-left"
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-md pr-8 text-left"
       >
         <span className="truncate text-[13px] font-semibold leading-[18px] text-[rgb(var(--color-sidebar-text-muted))]">
           {title}
@@ -271,7 +271,10 @@ function SidebarSectionHeader({
           )}
         />
       </button>
-      <div className="flex items-center opacity-0 transition-opacity group-hover/section:opacity-100 focus-within:opacity-100">
+      <div
+        data-testid={`${toggleTestId}-actions`}
+        className="pointer-events-none invisible absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center opacity-0 transition-opacity group-hover/section:pointer-events-auto group-hover/section:visible group-hover/section:opacity-100 focus-within:pointer-events-auto focus-within:visible focus-within:opacity-100"
+      >
         {children}
       </div>
     </div>

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -2023,8 +2023,8 @@ describe('DesktopWorkbenchLayout', () => {
     expect(fileTab).toHaveClass('group')
     const closeButton = within(fileTab).getByTestId('close-right-workspace-panel-button')
     expect(closeButton).toHaveClass(
-      'h-5',
-      'w-5',
+      'h-[18px]',
+      'w-[18px]',
       'rounded-full',
       'border',
       'bg-muted',
@@ -2170,8 +2170,8 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.queryByTestId('right-workspace-file-tab')).not.toBeInTheDocument()
     const closeButton = within(reviewTab).getByTestId('close-right-workspace-panel-button')
     expect(closeButton).toHaveClass(
-      'h-5',
-      'w-5',
+      'h-[18px]',
+      'w-[18px]',
       'rounded-full',
       'border',
       'bg-muted',
@@ -2233,7 +2233,7 @@ describe('DesktopWorkbenchLayout', () => {
 
     await waitFor(() => expect(onLoadEnvironmentDiff).toHaveBeenCalledTimes(2))
     expect(await screen.findByTestId('file-changes-review-panel')).toHaveTextContent('src/env.ts')
-    expect(screen.getByTestId('file-changes-review-panel')).toHaveTextContent('+new')
+    expect(screen.getByTestId('file-changes-review-panel')).toHaveTextContent('new')
     expect(screen.getByTestId('file-changes-review-panel')).not.toHaveTextContent(
       '设备暂时不可用，请稍后重试'
     )
@@ -3052,7 +3052,8 @@ describe('DesktopWorkbenchLayout', () => {
           deviceId: 'device-1',
           path: '/workspace/github_wegent',
           source: 'project',
-        }
+        },
+        'branch'
       )
     )
     expect(screen.queryByRole('dialog', { name: '本轮文件变更' })).not.toBeInTheDocument()
@@ -3062,7 +3063,7 @@ describe('DesktopWorkbenchLayout', () => {
       'true'
     )
     expect(await screen.findByTestId('file-changes-review-panel')).toHaveTextContent('src/env.ts')
-    expect(screen.getByTestId('file-changes-review-panel')).toHaveTextContent('+new')
+    expect(screen.getByTestId('file-changes-review-panel')).toHaveTextContent('new')
   })
 
   test('submits environment commits from the popover', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -31,6 +31,7 @@ import type {
   TurnFileChangesSummary,
 } from '@/types/api'
 import type { EnvironmentInfo } from '@/types/environment'
+import type { EnvironmentDiffMode } from '@/api/environment'
 import type { DeviceUpgradeState } from '@/types/device-events'
 import type { CodeCommentContext, WorkspaceTarget } from '@/types/workspace-files'
 import { stripAppBasePath } from '@/config/runtime'
@@ -115,7 +116,8 @@ interface DesktopWorkbenchLayoutProps {
   ) => Promise<void>
   onLoadEnvironmentDiff?: (
     project: ProjectWithTasks | null,
-    workspaceTarget: WorkspaceTarget
+    workspaceTarget: WorkspaceTarget,
+    mode?: EnvironmentDiffMode
   ) => Promise<string>
   onListEnvironmentBranches: (
     project: ProjectWithTasks | null,
@@ -254,8 +256,7 @@ export function DesktopWorkbenchLayout({
       }),
     [state.currentRuntimeTask, state.projects, state.runtimeWork]
   )
-  const activeConversationProject =
-    state.currentProject ?? runtimeWorkspaceContext?.project ?? null
+  const activeConversationProject = state.currentProject ?? runtimeWorkspaceContext?.project ?? null
   const environmentProject = useMemo(() => {
     if (state.currentRuntimeTask) {
       return runtimeWorkspaceContext?.project ?? null
@@ -748,7 +749,8 @@ export function DesktopWorkbenchLayout({
           onCommitEnvironmentChanges={handleCommitEnvironmentChanges}
           onLoadEnvironmentDiff={
             onLoadEnvironmentDiff
-              ? workspaceTarget => onLoadEnvironmentDiff(environmentProject, workspaceTarget)
+              ? (workspaceTarget, mode) =>
+                  onLoadEnvironmentDiff(environmentProject, workspaceTarget, mode)
               : undefined
           }
           onListEnvironmentBranches={() => {

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { ArrowLeftRight, MessageCircle } from 'lucide-react'
 import { ChatInput } from '@/components/chat/ChatInput'
 import type { ProjectChatControls, ProjectWorkControls } from '@/components/chat/ChatInput'
@@ -27,6 +27,7 @@ import type {
 } from '@/types/api'
 import type { DeviceUpgradeState } from '@/types/device-events'
 import type { EnvironmentInfo } from '@/types/environment'
+import type { EnvironmentDiffMode } from '@/api/environment'
 import type {
   GuidanceWorkbenchMessage,
   QueuedWorkbenchMessage,
@@ -121,8 +122,23 @@ interface DesktopReviewState {
   loading: boolean
   diff: string
   error?: string
+  reviewTitle?: string
+  reviewMode?: DesktopReviewMode
+  defaultFileTreeVisible?: boolean
+  branchName?: string
+  targetBranchName?: string
   reloadDiff?: () => Promise<string>
 }
+
+interface DesktopReviewMetadata {
+  reviewTitle?: string
+  reviewMode?: DesktopReviewMode
+  defaultFileTreeVisible?: boolean
+  branchName?: string
+  targetBranchName?: string
+}
+
+type DesktopReviewMode = EnvironmentDiffMode | 'previous-turn'
 
 interface DesktopWorkbenchMainProps {
   sidebarCollapsed: boolean
@@ -149,7 +165,10 @@ interface DesktopWorkbenchMainProps {
   environmentInfo: EnvironmentInfo
   onRefreshEnvironmentInfo: () => Promise<void>
   onCommitEnvironmentChanges: (message: string) => Promise<void>
-  onLoadEnvironmentDiff?: (workspaceTarget: WorkspaceTarget) => Promise<string>
+  onLoadEnvironmentDiff?: (
+    workspaceTarget: WorkspaceTarget,
+    mode?: EnvironmentDiffMode
+  ) => Promise<string>
   onListEnvironmentBranches: () => Promise<string[]>
   onCheckoutEnvironmentBranch: (branchName: string) => Promise<void>
   onCreateEnvironmentBranch: (branchName: string) => Promise<void>
@@ -238,16 +257,23 @@ export function DesktopWorkbenchMain({
   onCreateDeviceDirectory,
 }: DesktopWorkbenchMainProps) {
   const { t } = useTranslation('common')
+  const { t: tChat } = useTranslation('chat')
   const [rightPanelOpen, setRightPanelOpen] = useState(false)
   const [rightPanelView, setRightPanelView] = useState<RightWorkspacePanelView>('launcher')
   const [rightPanelTabs, setRightPanelTabs] = useState<RightWorkspacePanelTab[]>([])
   const [bottomPanelOpen, setBottomPanelOpen] = useState(false)
   const [openFileRequest, setOpenFileRequest] = useState<WorkspaceFileOpenRequest | null>(null)
   const [forkDialogOpen, setForkDialogOpen] = useState(false)
+  const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const [reviewState, setReviewState] = useState<DesktopReviewState>({
     loading: false,
     diff: '',
     error: undefined,
+    reviewTitle: undefined,
+    reviewMode: undefined,
+    defaultFileTreeVisible: undefined,
+    branchName: undefined,
+    targetBranchName: undefined,
     reloadDiff: undefined,
   })
   const { width: rightSplitChatWidth, handleResizeStart: handleRightSplitResizeStart } =
@@ -255,6 +281,20 @@ export function DesktopWorkbenchMain({
   const chatColumnWidth = rightPanelOpen ? rightSplitChatWidth : '100%'
   const rightPanelShellWidth = rightPanelOpen ? `calc(100% - ${rightSplitChatWidth}px)` : '0px'
   const reviewRequestSequence = useRef(0)
+  const previousTurnReviewRef = useRef<{
+    loadDiff: () => Promise<string>
+    defaultFileTreeVisible?: boolean
+  } | null>(null)
+  const latestPreviousTurnSubtaskId = useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index]
+      if (message.fileChanges && typeof message.subtaskId === 'number') {
+        return message.subtaskId
+      }
+    }
+
+    return null
+  }, [messages])
   const rightPanelSessionKey = workbenchSessionKey({
     currentRuntimeTask,
     currentProject,
@@ -333,7 +373,7 @@ export function DesktopWorkbenchMain({
   )
 
   const openReviewFromDiffLoader = useCallback(
-    async (loadDiff: () => Promise<string>) => {
+    async (loadDiff: () => Promise<string>, metadata: DesktopReviewMetadata = {}) => {
       const requestId = reviewRequestSequence.current + 1
       reviewRequestSequence.current = requestId
       openRightPanelTab('review')
@@ -341,6 +381,11 @@ export function DesktopWorkbenchMain({
         loading: true,
         diff: '',
         error: undefined,
+        reviewTitle: metadata.reviewTitle,
+        reviewMode: metadata.reviewMode,
+        defaultFileTreeVisible: metadata.defaultFileTreeVisible,
+        branchName: metadata.branchName,
+        targetBranchName: metadata.targetBranchName,
         reloadDiff: loadDiff,
       })
       try {
@@ -350,6 +395,11 @@ export function DesktopWorkbenchMain({
             loading: false,
             diff,
             error: undefined,
+            reviewTitle: metadata.reviewTitle,
+            reviewMode: metadata.reviewMode,
+            defaultFileTreeVisible: metadata.defaultFileTreeVisible,
+            branchName: metadata.branchName,
+            targetBranchName: metadata.targetBranchName,
             reloadDiff: loadDiff,
           })
         }
@@ -363,6 +413,11 @@ export function DesktopWorkbenchMain({
               fallbackMessage: t('workbench.environment_review_failed'),
               deviceUnavailableMessage: t('workbench.environment_review_device_unavailable'),
             }),
+            reviewTitle: metadata.reviewTitle,
+            reviewMode: metadata.reviewMode,
+            defaultFileTreeVisible: metadata.defaultFileTreeVisible,
+            branchName: metadata.branchName,
+            targetBranchName: metadata.targetBranchName,
             reloadDiff: loadDiff,
           })
         }
@@ -371,14 +426,33 @@ export function DesktopWorkbenchMain({
     [openRightPanelTab, t]
   )
 
-  const openEnvironmentChangesReview = useCallback(async () => {
-    await openReviewFromDiffLoader(async () => {
-      if (!onLoadEnvironmentDiff || !workspaceTarget) {
-        throw new Error(t('workbench.environment_review_unavailable'))
-      }
-      return onLoadEnvironmentDiff(workspaceTarget)
-    })
-  }, [onLoadEnvironmentDiff, openReviewFromDiffLoader, t, workspaceTarget])
+  const openEnvironmentChangesReview = useCallback(
+    async (mode: EnvironmentDiffMode = 'branch') => {
+      await openReviewFromDiffLoader(
+        async () => {
+          if (!onLoadEnvironmentDiff || !workspaceTarget) {
+            throw new Error(t('workbench.environment_review_unavailable'))
+          }
+          return onLoadEnvironmentDiff(workspaceTarget, mode)
+        },
+        {
+          reviewTitle: tChat(`file_changes.${mode}_label`),
+          reviewMode: mode,
+          branchName: environmentInfo.branchName,
+          targetBranchName: projectWork.worktreeBaseBranch ?? undefined,
+        }
+      )
+    },
+    [
+      environmentInfo.branchName,
+      onLoadEnvironmentDiff,
+      openReviewFromDiffLoader,
+      projectWork.worktreeBaseBranch,
+      t,
+      tChat,
+      workspaceTarget,
+    ]
+  )
 
   const selectReviewView = useCallback(() => {
     if (reviewState.diff || reviewState.loading) {
@@ -411,8 +485,89 @@ export function DesktopWorkbenchMain({
       return
     }
 
-    void openReviewFromDiffLoader(reviewState.reloadDiff)
-  }, [openReviewFromDiffLoader, reviewState.reloadDiff])
+    void openReviewFromDiffLoader(reviewState.reloadDiff, {
+      reviewTitle: reviewState.reviewTitle,
+      reviewMode: reviewState.reviewMode,
+      defaultFileTreeVisible: reviewState.defaultFileTreeVisible,
+      branchName: reviewState.branchName,
+      targetBranchName: reviewState.targetBranchName,
+    })
+  }, [
+    openReviewFromDiffLoader,
+    reviewState.branchName,
+    reviewState.defaultFileTreeVisible,
+    reviewState.reloadDiff,
+    reviewState.reviewMode,
+    reviewState.reviewTitle,
+    reviewState.targetBranchName,
+  ])
+
+  const reviewViewOptions = useMemo(
+    () => [
+      {
+        id: 'unstaged',
+        label: tChat('file_changes.unstaged_label'),
+        active: reviewState.reviewMode === 'unstaged',
+        disabled: !onLoadEnvironmentDiff || !workspaceTarget,
+        onSelect: () => void openEnvironmentChangesReview('unstaged'),
+      },
+      {
+        id: 'staged',
+        label: tChat('file_changes.staged_label'),
+        active: reviewState.reviewMode === 'staged',
+        disabled: !onLoadEnvironmentDiff || !workspaceTarget,
+        onSelect: () => void openEnvironmentChangesReview('staged'),
+      },
+      {
+        id: 'commit',
+        label: tChat('file_changes.commit_label'),
+        active: reviewState.reviewMode === 'commit',
+        disabled: !onLoadEnvironmentDiff || !workspaceTarget,
+        onSelect: () => void openEnvironmentChangesReview('commit'),
+      },
+      {
+        id: 'branch',
+        label: tChat('file_changes.branch_label'),
+        active: reviewState.reviewMode === 'branch',
+        disabled: !onLoadEnvironmentDiff || !workspaceTarget,
+        onSelect: () => void openEnvironmentChangesReview('branch'),
+      },
+      {
+        id: 'previous-turn',
+        label: tChat('file_changes.previous_turn_label'),
+        active: reviewState.reviewMode === 'previous-turn',
+        disabled:
+          (!onLoadFileChangesDiff || latestPreviousTurnSubtaskId === null) &&
+          !hasPreviousTurnReview,
+        onSelect: () => {
+          const previousTurn =
+            onLoadFileChangesDiff && latestPreviousTurnSubtaskId !== null
+              ? {
+                  loadDiff: () => onLoadFileChangesDiff(latestPreviousTurnSubtaskId),
+                  defaultFileTreeVisible: false,
+                }
+              : previousTurnReviewRef.current
+          if (!previousTurn) return
+          void openReviewFromDiffLoader(previousTurn.loadDiff, {
+            reviewTitle: tChat('file_changes.previous_turn_label'),
+            reviewMode: 'previous-turn',
+            defaultFileTreeVisible: previousTurn.defaultFileTreeVisible,
+          })
+        },
+      },
+    ],
+    [
+      hasPreviousTurnReview,
+      latestPreviousTurnSubtaskId,
+      onLoadEnvironmentDiff,
+      onLoadFileChangesDiff,
+      openEnvironmentChangesReview,
+      openReviewFromDiffLoader,
+      reviewState.reviewMode,
+      tChat,
+      workspaceTarget,
+    ]
+  )
 
   const toggleRightPanel = useCallback(() => {
     setRightPanelOpen(open => {
@@ -491,12 +646,19 @@ export function DesktopWorkbenchMain({
 
     previousRightPanelSessionKey.current = rightPanelSessionKey
     reviewRequestSequence.current += 1
+    previousTurnReviewRef.current = null
+    setHasPreviousTurnReview(false)
     setRightPanelView('launcher')
     setRightPanelTabs([])
     setReviewState({
       loading: false,
       diff: '',
       error: undefined,
+      reviewTitle: undefined,
+      reviewMode: undefined,
+      defaultFileTreeVisible: undefined,
+      branchName: undefined,
+      targetBranchName: undefined,
       reloadDiff: undefined,
     })
   }, [rightPanelSessionKey])
@@ -514,7 +676,7 @@ export function DesktopWorkbenchMain({
       {!isTauri && (
         <div
           data-testid="workspace-panel-floating-actions"
-          className="pointer-events-auto absolute right-7 top-3 z-popover flex shrink-0 items-center gap-2"
+          className="pointer-events-auto absolute right-7 top-1.5 z-popover flex shrink-0 items-center gap-2"
         >
           {topRightActions}
         </div>
@@ -560,8 +722,17 @@ export function DesktopWorkbenchMain({
               onSwitchModelForFailedMessage={() => setModelSelectorOpenSignal(signal => signal + 1)}
               onLoadFileChangesDiff={onLoadFileChangesDiff}
               onRevertFileChanges={onRevertFileChanges}
-              onOpenFileChangesReview={({ loadDiff }) => {
-                void openReviewFromDiffLoader(loadDiff)
+              onOpenFileChangesReview={({ loadDiff, reviewTitle, defaultFileTreeVisible }) => {
+                previousTurnReviewRef.current = {
+                  loadDiff,
+                  defaultFileTreeVisible,
+                }
+                setHasPreviousTurnReview(true)
+                void openReviewFromDiffLoader(loadDiff, {
+                  reviewTitle,
+                  reviewMode: 'previous-turn',
+                  defaultFileTreeVisible,
+                })
               }}
               onOpenWorkspaceFile={openWorkspaceFileFromMessage}
             />
@@ -693,6 +864,7 @@ export function DesktopWorkbenchMain({
             openFileRequest={openFileRequest}
             workspaceTargetError={workspaceTargetError}
             review={reviewState}
+            reviewViewOptions={reviewViewOptions}
             canOpenReview={Boolean(onLoadEnvironmentDiff && workspaceTarget)}
             onAddCodeComment={onAddCodeComment}
             onResizeStart={handleRightSplitResizeStart}

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -1,6 +1,9 @@
 import { File, FileDiff, Plus, X } from 'lucide-react'
 import type { KeyboardEvent, PointerEvent } from 'react'
-import { FileChangesReviewPanel } from '@/components/chat/FileChangesReviewPanel'
+import {
+  FileChangesReviewPanel,
+  type FileChangesReviewViewOption,
+} from '@/components/chat/FileChangesReviewPanel'
 import { useTranslation } from '@/hooks/useTranslation'
 import type {
   CodeCommentContext,
@@ -17,6 +20,10 @@ interface RightWorkspaceReviewState {
   loading: boolean
   diff: string
   error?: string
+  reviewTitle?: string
+  defaultFileTreeVisible?: boolean
+  branchName?: string
+  targetBranchName?: string
 }
 
 interface RightWorkspacePanelProps {
@@ -27,6 +34,7 @@ interface RightWorkspacePanelProps {
   workspaceTargetError?: string | null
   review: RightWorkspaceReviewState
   canOpenReview: boolean
+  reviewViewOptions?: FileChangesReviewViewOption[]
   onAddCodeComment: (context: CodeCommentContext) => void
   onResizeStart: (event: PointerEvent<HTMLDivElement>) => void
   onSelectReview: () => void
@@ -44,6 +52,7 @@ export function RightWorkspacePanel({
   workspaceTargetError,
   review,
   canOpenReview,
+  reviewViewOptions,
   onAddCodeComment,
   onResizeStart,
   onSelectReview,
@@ -70,7 +79,7 @@ export function RightWorkspacePanel({
         <header
           data-testid="right-workspace-tabbar"
           role="tablist"
-          className="flex h-[52px] shrink-0 items-center gap-2 border-b border-border bg-background px-4"
+          className="flex h-10 shrink-0 items-center gap-1.5 border-b border-border bg-background px-3"
         >
           {openTabs.map(tab => (
             <RightWorkspaceTitleTab
@@ -91,14 +100,14 @@ export function RightWorkspacePanel({
             type="button"
             data-testid="right-workspace-new-tab-button"
             onClick={onSelectLauncher}
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-muted hover:text-text-primary"
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-muted hover:text-text-primary"
             aria-label={t('workbench.workspace_tab_new', '打开新标签页')}
           >
             <Plus className="h-4 w-4" />
           </button>
         </header>
       ) : (
-        <header className="flex h-[52px] shrink-0 items-center border-b border-border bg-background px-4" />
+        <header className="flex h-10 shrink-0 items-center border-b border-border bg-background px-3" />
       )}
       <div className="flex min-h-0 flex-1">
         {activeView === 'launcher' ? (
@@ -112,6 +121,11 @@ export function RightWorkspacePanel({
             loading={review.loading}
             diff={review.diff}
             error={review.error}
+            reviewTitle={review.reviewTitle}
+            defaultFileTreeVisible={review.defaultFileTreeVisible}
+            branchName={review.branchName}
+            targetBranchName={review.targetBranchName}
+            viewOptions={reviewViewOptions}
             onRefresh={onRefreshReview}
           />
         ) : workspaceTargetError ? (
@@ -123,11 +137,7 @@ export function RightWorkspacePanel({
           </section>
         ) : (
           <FileWorkspacePanel
-            key={
-              workspaceTarget
-                ? `${workspaceTarget.deviceId}:${workspaceTarget.path}`
-                : 'empty'
-            }
+            key={workspaceTarget ? `${workspaceTarget.deviceId}:${workspaceTarget.path}` : 'empty'}
             target={workspaceTarget}
             openFileRequest={openFileRequest}
             onAddCodeComment={onAddCodeComment}
@@ -171,16 +181,16 @@ function RightWorkspaceTitleTab({
       onClick={onSelect}
       onKeyDown={handleKeyDown}
       className={cn(
-        'group flex h-10 min-w-0 max-w-[240px] cursor-pointer items-center gap-2 rounded-xl py-1 pl-2 pr-4 text-left text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'group flex h-8 min-w-0 max-w-[200px] cursor-pointer items-center gap-1.5 rounded-md py-1 pl-2 pr-3 text-left text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         active
           ? 'bg-muted text-text-primary'
           : 'text-text-secondary hover:bg-muted hover:text-text-primary'
       )}
     >
-      <span className="relative h-5 w-5 shrink-0">
+      <span className="relative h-[18px] w-[18px] shrink-0">
         <Icon
           data-testid={`${tab === 'review' ? 'right-workspace-review' : 'right-workspace-file'}-tab-icon`}
-          className="absolute inset-0 m-auto h-4 w-4 text-text-secondary opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0"
+          className="absolute inset-0 m-auto h-3.5 w-3.5 text-text-secondary opacity-100 transition-opacity group-hover:opacity-0 group-focus-within:opacity-0"
         />
         <button
           type="button"
@@ -189,7 +199,7 @@ function RightWorkspaceTitleTab({
             event.stopPropagation()
             onClose()
           }}
-          className="pointer-events-none absolute inset-0 m-auto flex h-5 w-5 items-center justify-center rounded-full border border-border bg-muted text-text-secondary opacity-0 transition-colors hover:border-text-muted hover:bg-hover hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
+          className="pointer-events-none absolute inset-0 m-auto flex h-[18px] w-[18px] items-center justify-center rounded-full border border-border bg-muted text-text-secondary opacity-0 transition-colors hover:border-text-muted hover:bg-hover hover:text-text-primary focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 group-hover:pointer-events-auto group-hover:opacity-100"
           aria-label={t('workbench.close_right_workspace_panel')}
         >
           <X className="h-3 w-3" />

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -268,6 +268,11 @@ function RuntimeOpenProbe() {
           })
           .join('|')}
       </span>
+      <span data-testid="runtime-open-file-changes">
+        {workbench.messages
+          .map(message => message.fileChanges?.files.map(file => file.path).join(',') ?? '')
+          .join('|')}
+      </span>
       <button
         type="button"
         onClick={() =>
@@ -512,6 +517,26 @@ describe('WorkbenchProvider runtime tasks', () => {
           role: 'assistant',
           content: '恢复的回答',
           subtaskId: 901,
+          fileChanges: {
+            version: 1,
+            status: 'active',
+            artifact_id: 'turn-901',
+            device_id: 'device-1',
+            workspace_path: '/workspace/project-alpha',
+            file_count: 1,
+            additions: 4,
+            deletions: 2,
+            files: [
+              {
+                path: 'src/runtime.ts',
+                change_type: 'modified',
+                additions: 4,
+                deletions: 2,
+                binary: false,
+              },
+            ],
+            reverted_at: null,
+          },
           blocks: [
             {
               id: 'thinking-901',
@@ -558,6 +583,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
     expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent('tool:exec_command:done')
     expect(screen.getByTestId('runtime-open-blocks')).toHaveTextContent('text:处理完成:done')
+    expect(screen.getByTestId('runtime-open-file-changes')).toHaveTextContent('src/runtime.ts')
     expect(getRuntimeTranscript).toHaveBeenCalledWith({
       deviceId: 'device-1',
       localTaskId: 'runtime-restored',

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -591,6 +591,48 @@ describe('WorkbenchProvider runtime tasks', () => {
     })
   })
 
+  test('restores a runtime local task from the URL even when it is missing from the work list', async () => {
+    window.history.pushState({}, '', '/runtime-tasks?deviceId=device-1&localTaskId=codex-hidden')
+    const getRuntimeTranscript = vi.fn().mockResolvedValue({
+      localTaskId: 'codex-hidden',
+      workspacePath: '/workspace/project-alpha',
+      runtime: 'codex',
+      messages: [
+        { id: 'user-hidden', role: 'user', content: 'hidden user message' },
+        { id: 'assistant-hidden', role: 'assistant', content: 'hidden assistant message' },
+      ],
+    } satisfies RuntimeTranscriptResponse)
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [],
+          unmappedDeviceWorkspaces: [],
+          totalLocalTasks: 0,
+        })
+      ),
+      getRuntimeTranscript,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimeOpenProbe />, services)
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:codex-hidden'
+      )
+    )
+    expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent(
+      'hidden user message|hidden assistant message'
+    )
+    expect(getRuntimeTranscript).toHaveBeenCalledWith({
+      deviceId: 'device-1',
+      localTaskId: 'codex-hidden',
+      limit: 50,
+    })
+  })
+
   test('loads older runtime transcript messages before the current page', async () => {
     const getRuntimeTranscript = vi.fn(request => {
       if (request.beforeCursor === 'offset:120') {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -625,6 +625,7 @@ function runtimeMessageToWorkbenchMessage(
     source,
     attachments: message.attachments,
     blocks: blocks.length > 0 ? blocks : undefined,
+    fileChanges: normalizeTurnFileChanges(message.fileChanges ?? message.file_changes),
     createdAt: message.createdAt ?? new Date().toISOString(),
   }
 }

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -8,6 +8,7 @@ import {
   listProjectBranches,
   loadProjectEnvironment,
   loadProjectEnvironmentDiff,
+  type EnvironmentDiffMode,
 } from '@/api/environment'
 import { createGitApi } from '@/api/git'
 import { ApiError, createHttpClient } from '@/api/http'
@@ -345,7 +346,8 @@ export interface WorkbenchContextValue {
   ) => Promise<EnvironmentInfo>
   loadEnvironmentDiff: (
     project: ProjectWithTasks | null,
-    workspaceTarget?: WorkspaceTarget | null
+    workspaceTarget?: WorkspaceTarget | null,
+    mode?: EnvironmentDiffMode
   ) => Promise<string>
   commitEnvironmentChanges: (
     project: ProjectWithTasks | null,
@@ -608,6 +610,7 @@ function runtimeMessageToWorkbenchMessage(
       : normalizedStatus === 'streaming'
         ? 'streaming'
         : 'done'
+  const runtimeStatus = normalizedStatus === 'cancelled' ? 'cancelled' : status
   const source =
     role === 'user' && message.source?.source === 'im'
       ? ({ ...message.source, source: 'im' } as MessageSource)
@@ -622,6 +625,7 @@ function runtimeMessageToWorkbenchMessage(
     subtaskId,
     content: message.content,
     status,
+    runtimeStatus,
     source,
     attachments: message.attachments,
     blocks: blocks.length > 0 ? blocks : undefined,
@@ -825,6 +829,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     null
   )
   const upgradeClearTimersRef = useRef<Record<string, ReturnType<typeof window.setTimeout>>>({})
+  const messagesRef = useRef<WorkbenchMessage[]>(messages)
   const localSkillsCacheRef = useRef<
     Map<string, { expiresAt: number; skills: LocalDeviceSkill[] }>
   >(new Map())
@@ -835,6 +840,10 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   const currentRuntimeTaskKey = state.currentRuntimeTask
     ? getRuntimeTaskRouteKey(state.currentRuntimeTask)
     : null
+
+  useEffect(() => {
+    messagesRef.current = messages
+  }, [messages])
   const isRuntimeTranscriptLoading =
     Boolean(currentRuntimeTaskKey) && runtimeTranscriptLoadingKey === currentRuntimeTaskKey
   const currentUser = state.user ?? user
@@ -1695,8 +1704,8 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       return
     }
 
-    const runtimeTaskAddress = resolveRuntimeTaskRouteAddress(state.runtimeWork, runtimeTaskRoute)
-    if (!runtimeTaskAddress) return
+    const runtimeTaskAddress =
+      resolveRuntimeTaskRouteAddress(state.runtimeWork, runtimeTaskRoute) ?? runtimeTaskRoute
 
     handledRuntimeTaskRouteRef.current = routeKey
     const timer = window.setTimeout(() => {
@@ -1903,8 +1912,11 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   )
 
   const loadEnvironmentDiff = useCallback(
-    (project: ProjectWithTasks | null, workspaceTarget?: WorkspaceTarget | null) =>
-      loadProjectEnvironmentDiff(resolvedServices.deviceApi, project, workspaceTarget),
+    (
+      project: ProjectWithTasks | null,
+      workspaceTarget?: WorkspaceTarget | null,
+      mode?: EnvironmentDiffMode
+    ) => loadProjectEnvironmentDiff(resolvedServices.deviceApi, project, workspaceTarget, mode),
     [resolvedServices]
   )
 
@@ -2373,6 +2385,10 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
   const loadTurnFileChangesDiff = useCallback(
     async (subtaskId: number) => {
+      const runtimeSummary = messagesRef.current.find(
+        message => message.subtaskId === subtaskId && message.fileChanges?.diff
+      )?.fileChanges
+      if (runtimeSummary?.diff) return runtimeSummary.diff
       const loadDiff = resolvedServices.taskApi.getTurnFileChangesDiff
       if (!loadDiff) throw new Error('File changes review is unavailable')
       const response = await loadDiff(subtaskId)
@@ -2383,6 +2399,41 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
   const revertTurnFileChanges = useCallback(
     async (subtaskId: number) => {
+      const runtimeSummary = messagesRef.current.find(
+        message => message.subtaskId === subtaskId && message.fileChanges?.diff
+      )?.fileChanges
+      if (runtimeSummary && state.currentRuntimeTask && resolvedServices.runtimeWorkApi) {
+        try {
+          const response = await resolvedServices.runtimeWorkApi.revertRuntimeFileChanges({
+            address: state.currentRuntimeTask,
+            fileChanges: runtimeSummary,
+          })
+          const fileChanges = normalizeTurnFileChanges(
+            response.fileChanges ?? response.file_changes
+          )
+          if (!fileChanges) {
+            throw new Error('Invalid file changes response')
+          }
+          dispatchMessages({
+            type: 'file_changes_updated',
+            subtaskId,
+            fileChanges: { ...fileChanges, diff: runtimeSummary.diff, revertible: true },
+          })
+          return { ...fileChanges, diff: runtimeSummary.diff, revertible: true }
+        } catch (error) {
+          if (error instanceof ApiError && isRecord(error.detail)) {
+            const fileChanges = normalizeTurnFileChanges(error.detail.file_changes)
+            if (fileChanges) {
+              dispatchMessages({
+                type: 'file_changes_updated',
+                subtaskId,
+                fileChanges: { ...fileChanges, diff: runtimeSummary.diff, revertible: true },
+              })
+            }
+          }
+          throw error
+        }
+      }
       const revert = resolvedServices.taskApi.revertTurnFileChanges
       if (!revert) throw new Error('File changes revert is unavailable')
       try {
@@ -2411,7 +2462,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         throw error
       }
     },
-    [resolvedServices.taskApi]
+    [resolvedServices.runtimeWorkApi, resolvedServices.taskApi, state.currentRuntimeTask]
   )
 
   const pauseCurrentResponse = useCallback(async () => {

--- a/wework/src/features/workbench/turnFileChanges.test.ts
+++ b/wework/src/features/workbench/turnFileChanges.test.ts
@@ -26,6 +26,20 @@ describe('normalizeTurnFileChanges', () => {
     expect(normalizeTurnFileChanges(summary)).toEqual(summary)
   })
 
+  test('keeps runtime inline diff metadata', () => {
+    expect(
+      normalizeTurnFileChanges({
+        ...summary,
+        diff: 'diff --git a/src/main.ts b/src/main.ts',
+        revertible: false,
+      }),
+    ).toEqual({
+      ...summary,
+      diff: 'diff --git a/src/main.ts b/src/main.ts',
+      revertible: false,
+    })
+  })
+
   test('rejects malformed files and inconsistent file counts', () => {
     expect(
       normalizeTurnFileChanges({

--- a/wework/src/features/workbench/turnFileChanges.ts
+++ b/wework/src/features/workbench/turnFileChanges.ts
@@ -103,5 +103,7 @@ export function normalizeTurnFileChanges(
     deletions: value.deletions,
     files: files as TurnFileChangeItem[],
     reverted_at: value.reverted_at as string | null | undefined,
+    diff: typeof value.diff === 'string' ? value.diff : undefined,
+    revertible: typeof value.revertible === 'boolean' ? value.revertible : undefined,
   }
 }

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -8,6 +8,9 @@
   "process_text": {
     "running": "Working"
   },
+  "assistant_status": {
+    "stopped_after": "You stopped after {{duration}}"
+  },
   "file_changes": {
     "edited_files": "Edited {{count}} files",
     "show_more": "Show {{count}} more files",
@@ -24,6 +27,14 @@
     "reverting": "Reverting",
     "loading_diff": "Loading changes from the device...",
     "empty_diff": "No text changes to display",
+    "changes_label": "Changes",
+    "unstaged_label": "Unstaged",
+    "staged_label": "Staged",
+    "commit_label": "Commit",
+    "previous_turn_label": "Previous turn",
+    "branch_label": "Branch",
+    "branch_unknown": "Current workspace",
+    "large_diff_single_file_notice": "This diff is large, so only one file is shown at a time",
     "file_list_label": "Changed files",
     "file_search_placeholder": "Filter files...",
     "file_search_empty": "No matching files",
@@ -33,6 +44,8 @@
       "toggle_wrap": "Toggle word wrap",
       "collapse_all_hunks": "Collapse all hunks",
       "expand_all_hunks": "Expand all hunks",
+      "collapse_file_diff": "Collapse file diff",
+      "expand_file_diff": "Expand file diff",
       "copy_git_apply": "Copy git apply command",
       "hide_files": "Hide files",
       "show_files": "Show files"

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -8,6 +8,9 @@
   "process_text": {
     "running": "正在处理"
   },
+  "assistant_status": {
+    "stopped_after": "你在 {{duration}} 后停止了"
+  },
   "file_changes": {
     "edited_files": "已编辑 {{count}} 个文件",
     "show_more": "再显示 {{count}} 个文件",
@@ -24,6 +27,14 @@
     "reverting": "撤销中",
     "loading_diff": "正在从设备加载变更...",
     "empty_diff": "没有可展示的文本变更",
+    "changes_label": "变更",
+    "unstaged_label": "未暂存",
+    "staged_label": "已暂存",
+    "commit_label": "提交",
+    "previous_turn_label": "上轮对话",
+    "branch_label": "分支",
+    "branch_unknown": "当前工作区",
+    "large_diff_single_file_notice": "此差异较大，每次仅显示一个文件",
     "file_list_label": "变更文件",
     "file_search_placeholder": "筛选文件...",
     "file_search_empty": "没有匹配的文件",
@@ -33,6 +44,8 @@
       "toggle_wrap": "启用自动换行",
       "collapse_all_hunks": "折叠全部差异",
       "expand_all_hunks": "展开全部差异",
+      "collapse_file_diff": "折叠文件差异",
+      "expand_file_diff": "展开文件差异",
       "copy_git_apply": "复制 git apply 命令",
       "hide_files": "隐藏文件",
       "show_files": "显示文件"

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -253,6 +253,8 @@ export interface NormalizedRuntimeMessage {
   source?: RuntimeMessageSource | null
   attachments?: Attachment[]
   blocks?: ChatBlock[]
+  fileChanges?: TurnFileChangesSummary | null
+  file_changes?: TurnFileChangesSummary | null
 }
 
 export interface LocalTaskSummary {

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -682,6 +682,8 @@ export interface TurnFileChangesSummary {
   deletions: number
   files: TurnFileChangeItem[]
   reverted_at?: string | null
+  diff?: string
+  revertible?: boolean
 }
 
 export interface TurnFileChangesDiffResponse {
@@ -692,6 +694,16 @@ export interface TurnFileChangesDiffResponse {
 export interface TurnFileChangesRevertResponse {
   subtask_id: number
   file_changes: TurnFileChangesSummary
+}
+
+export interface RuntimeFileChangesRevertRequest {
+  address: RuntimeTaskAddress
+  fileChanges: TurnFileChangesSummary
+}
+
+export interface RuntimeFileChangesRevertResponse {
+  fileChanges: TurnFileChangesSummary
+  file_changes?: TurnFileChangesSummary
 }
 
 export interface TaskDetail extends Task {

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -37,7 +37,11 @@ export type ProcessingBlock = WorkbenchProcessingBlock
 
 export type MessageSource = NonNullable<CoreWorkbenchMessage['source']>
 
-export type WorkbenchMessage = CoreWorkbenchMessage<Attachment, TurnFileChangesSummary>
+export type RuntimeWorkbenchMessageStatus = WorkbenchMessageStatus | 'cancelled'
+
+export type WorkbenchMessage = CoreWorkbenchMessage<Attachment, TurnFileChangesSummary> & {
+  runtimeStatus?: RuntimeWorkbenchMessageStatus | null
+}
 
 export type QueuedMessageStatus = 'queued' | 'sending' | 'failed'
 export type GuidanceMessageStatus = 'sending' | 'queued' | 'applied' | 'expired' | 'failed'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment diff review modes (branch/unstaged/staged/commit) and “previous turn” support.
  * Added runtime file-change revert API, including patch-sequence–aware revert behavior.
  * Assistant turns can now show a “stopped after …” duration when cancelled.
* **Bug Fixes**
  * Improved file-change review rendering for large diffs (single-file focus) and collapsed sections, with review metadata preserved after reloads.
  * Runtime transcripts/workbench/chat now consistently retain and normalize file-change details (including revertability).
  * Consolidated repeated diff headers into a single per-file section for cleaner review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->