### PR TITLE
[codex] Skip reopening selected runtime task

### DIFF
--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -731,6 +731,33 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('runtime-open-messages')).not.toHaveTextContent('message a')
   })
 
+  test('does not reload the currently selected runtime task when clicked again', async () => {
+    const getRuntimeTranscript = vi.fn().mockResolvedValue({
+      localTaskId: 'runtime-a',
+      workspacePath: '/workspace/project-alpha',
+      runtime: 'claude_code',
+      messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'message a' }],
+    } satisfies RuntimeTranscriptResponse)
+    const runtimeWorkApi = createRuntimeWorkApiMock({ getRuntimeTranscript })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimeOpenProbe />, services)
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('message a')
+    )
+    expect(getRuntimeTranscript).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByText('open runtime a'))
+
+    expect(getRuntimeTranscript).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('message a')
+    expect(screen.getByTestId('runtime-transcript-loading')).toHaveTextContent('idle')
+  })
+
   test('reuses the current runtime task address for follow-up messages', async () => {
     const sendRuntimeMessage = vi.fn().mockResolvedValue({
       accepted: true,

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -1527,6 +1527,10 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
   const openRuntimeLocalTask = useCallback(
     async (address: RuntimeTaskAddress) => {
+      if (isSameRuntimeTaskIdentity(currentRuntimeTaskRef.current, address)) {
+        return
+      }
+
       if (!resolvedServices.runtimeWorkApi) {
         dispatch({ type: 'error_set', error: 'Local runtime work is unavailable' })
         return


### PR DESCRIPTION
## Summary
- Skip reopening a runtime task when the clicked session is already selected.
- Preserve the current messages, loading state, and workspace panel instead of re-fetching the transcript.
- Add a regression test for repeated clicks on the current runtime task.

## Validation
- pnpm --dir wework test -- WorkbenchProvider --runInBand
- pnpm --dir wework exec prettier --check src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-opening the currently selected runtime task no longer triggers an unnecessary transcript reload.
  * The app now keeps the existing transcript state when the same runtime task is clicked again, avoiding redundant loading and navigation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->