### PR TITLE
fix(runtime-work): stabilize local task flow

### DIFF
--- a/backend/app/schemas/runtime_work.py
+++ b/backend/app/schemas/runtime_work.py
@@ -466,6 +466,7 @@ class RuntimeTaskCreateRequest(BaseModel):
     )
     device_id: Optional[str] = Field(default=None, alias="deviceId")
     workspace_path: Optional[str] = Field(default=None, alias="workspacePath")
+    local_task_id: Optional[str] = Field(default=None, alias="localTaskId")
     team_id: int = Field(..., alias="teamId", ge=1)
     runtime: RuntimeName
     message: str = Field(..., min_length=1)

--- a/backend/app/services/runtime_work_service.py
+++ b/backend/app/services/runtime_work_service.py
@@ -763,6 +763,8 @@ async def create_runtime_task(
         "title": _runtime_task_title(request),
         "executionRequest": execution_request.to_dict(),
     }
+    if request.local_task_id:
+        payload["localTaskId"] = request.local_task_id
     try:
         result = await runtime_rpc_service.call(
             user_id=user_id,

--- a/backend/tests/services/test_runtime_work_service.py
+++ b/backend/tests/services/test_runtime_work_service.py
@@ -1325,6 +1325,7 @@ async def test_create_runtime_task_dispatches_to_project_device_without_task_row
         user_id=test_user.id,
         request=RuntimeTaskCreateRequest(
             projectId=project.id,
+            localTaskId="runtime-client-1",
             teamId=3,
             runtime="claude_code",
             message="create runtime task",
@@ -1341,6 +1342,7 @@ async def test_create_runtime_task_dispatches_to_project_device_without_task_row
         method="runtime.tasks.create",
         payload={
             "runtime": "claude_code",
+            "localTaskId": "runtime-client-1",
             "workspacePath": "/repo/Wegent",
             "message": "create runtime task",
             "title": "Create runtime task",

--- a/docs/en/developer-guide/runtime-local-work.md
+++ b/docs/en/developer-guide/runtime-local-work.md
@@ -92,6 +92,8 @@ After an image attachment uploads successfully, Wework keeps a frontend-local `l
 
 When rendering a message that already has persisted image attachments, Wework prefers those attachment previews and ignores local image file mentions embedded in the Codex prompt. This avoids showing both the uploaded attachment and a temporary local path. Codex local image mentions are used only as a same-device preview fallback when no attachment record exists. If the current environment cannot convert the local path through Tauri `convertFileSrc`, or the converted image fails to load, the frontend does not display that local path.
 
+When the executor discovers a user message from a native Codex session, it writes local image paths from `local_images`, `localImages`, or `images` into the user-visible text so refreshes still show which files the user mentioned. If those paths are readable on the current device, have an image MIME type, and are no larger than 5 MB, the executor also creates ready attachments used only for transcript rendering and stores `local_preview_url` as a data URL. This preview attachment is not a persisted Backend attachment, and it is not uploaded or synced to the central database.
+
 Native Codex tasks have one additional rule: transcript refreshes trust only Codex's own session transcript. `runtimeHandle.messages` from a fork package or the executor JSON index is only an import-time snapshot and must not be used as a fallback for native Codex transcripts; otherwise Wework can show stale messages or lose follow-up turns after refresh. Non-SDK native tasks may still use the executor JSON index as their local transcript source.
 
 Assistant messages in a runtime transcript may include a `fileChanges` summary. During native Codex creation and continuation, the executor attaches a `NativeTurnFileChangeTracker` to the Codex SDK `turn/diff/updated` events and records the latest cumulative diff for the current turn. When the response completes, the tracker returns `file_changes` through Responses completion fields, and `runtime.tasks.create`, `runtime.tasks.send`, and `runtime.tasks.transcript` must normalize it onto the message as `fileChanges`. This lets the frontend show the file changes card under the current assistant message without waiting for the next list refresh.
@@ -116,6 +118,8 @@ POST /api/runtime-work/create
 ```
 
 Backend resolves the target device and directory from either a Project mapping or a standalone device workspace, builds a transient execution request, and calls device RPC `runtime.tasks.create`. This flow does not `db.add()` any `TaskResource` or `Subtask`.
+
+Before calling create, Wework generates a client-side `localTaskId` and sends it to Backend as `localTaskId`. Backend only forwards that value to the target device; it does not write it to the central database. The frontend immediately opens the runtime URL from `deviceId + localTaskId`, renders the user message, and shows the waiting state. If the device returns a different `localTaskId`, the frontend switches to the device-confirmed address. This lets a newly created task appear before the Backend RPC completes or the next list refresh runs, and queued sends wait until the current waiting state becomes a real assistant turn before continuing.
 
 The runtime owns persistence for newly created tasks:
 

--- a/docs/zh/developer-guide/runtime-local-work.md
+++ b/docs/zh/developer-guide/runtime-local-work.md
@@ -92,6 +92,8 @@ Backend 将 `deviceId + localTaskId` 转发为 `runtime.tasks.cancel`。executor
 
 消息渲染时，如果消息已经带有持久化图片附件，Wework 优先展示附件预览，并忽略 Codex prompt 中的本地图片文件提及，避免同时展示上传附件和临时本机路径。只有没有附件记录时，才把 Codex 本地图片提及作为本机预览兜底；如果当前环境不能通过 Tauri `convertFileSrc` 转换本机路径，或转换后的图片加载失败，前端不展示该本机路径。
 
+executor 从原生 Codex session 发现用户消息时，会把 `local_images`、`localImages` 或 `images` 中的本机图片路径写入用户可见文本，保持刷新后仍能看到“用户提到了哪些文件”。如果这些路径在当前设备上可读、是图片 MIME 类型且不超过 5 MB，executor 会额外生成只用于 transcript 渲染的 ready 附件，并把 `local_preview_url` 写成 data URL。这个预览附件不代表 Backend 持久化附件，也不会上传或同步到中心库。
+
 原生 Codex 任务有一个额外约束：刷新 transcript 时只信任 Codex 本身的会话记录。fork 包或 executor JSON 索引中携带的 `runtimeHandle.messages` 只是导入瞬间的快照，不能作为原生 Codex transcript 的回退来源，否则 Wework 刷新后会显示旧消息或丢失用户追问。非 SDK 原生任务仍可以使用 executor JSON 索引中的本地 transcript。
 
 runtime transcript 中的 assistant 消息可以携带 `fileChanges` 摘要。原生 Codex 创建和继续任务时，executor 会把 `NativeTurnFileChangeTracker` 接到 Codex SDK 的 `turn/diff/updated` 事件上，记录最新的本轮累计 diff；回复完成时 tracker 通过 Responses completion fields 返回 `file_changes`，`runtime.tasks.create`、`runtime.tasks.send` 和 `runtime.tasks.transcript` 都必须把它规范化为消息上的 `fileChanges`。这样前端无需等待下一次列表刷新，就能在当前 assistant 消息下显示本轮文件变更卡片。
@@ -116,6 +118,8 @@ POST /api/runtime-work/create
 ```
 
 Backend 根据请求中的项目映射或独立设备工作区解析目标设备和目录，构造一次临时 execution request，然后调用设备 RPC `runtime.tasks.create`。这个流程不会 `db.add()` 任何 `TaskResource` 或 `Subtask`。
+
+Wework 在调用 create 前先生成客户端侧 `localTaskId`，并在请求体中作为 `localTaskId` 传给 Backend。Backend 只把这个值转发给目标设备，不把它写入中心数据库。前端会立即用 `deviceId + localTaskId` 打开运行时 URL、展示用户消息和等待态；如果设备返回了不同的 `localTaskId`，前端再切换到设备确认的地址。这样新建任务不需要等待 Backend RPC 完成或下一次列表刷新，队列发送也会等当前等待态进入真实 assistant turn 后再继续。
 
 运行时创建的持久化位置由具体 runtime 决定：
 

--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -4,10 +4,12 @@
 
 """Discover Codex sessions as device-local runtime work items."""
 
+import base64
 import contextlib
 import gzip
 import hashlib
 import json
+import mimetypes
 import os
 import re
 import time
@@ -16,6 +18,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
+from urllib.parse import unquote, urlparse
 
 from executor.agents.codex.config_builder import _resolve_codex_binary
 from executor.config import config
@@ -36,6 +39,7 @@ CODEX_TRANSCRIPT_DEFAULT_LIMIT = 50
 CODEX_TRANSCRIPT_MAX_LIMIT = 200
 CODEX_TRANSCRIPT_INITIAL_WINDOW_BYTES = 1024 * 1024
 CODEX_TRANSCRIPT_MAX_WINDOW_BYTES = 64 * 1024 * 1024
+CODEX_LOCAL_IMAGE_PREVIEW_MAX_BYTES = 5 * 1024 * 1024
 CODEX_TERMINAL_EVENT_TYPES = {"task_complete", "turn_aborted"}
 CODEX_CONVERSATION_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 CODEX_TRANSCRIPT_CURSOR_PATTERN = re.compile(r"^offset:(\d+)$")
@@ -832,6 +836,113 @@ def _first_text(record: dict[str, Any], *keys: str) -> Optional[str]:
     return None
 
 
+def _codex_user_message_content(payload: dict[str, Any]) -> Optional[str]:
+    message = _first_text(payload, "message") or ""
+    local_image_paths = _local_image_paths_from_payload(payload)
+    if not local_image_paths:
+        return message or None
+    return _build_files_mentioned_text(message, local_image_paths).lstrip()
+
+
+def _local_image_paths_from_payload(payload: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    seen: set[str] = set()
+    for key in ("local_images", "localImages", "images"):
+        value = payload.get(key)
+        if not isinstance(value, list):
+            continue
+        for item in value:
+            path = _local_image_path_from_item(item)
+            if path is None or path in seen:
+                continue
+            seen.add(path)
+            paths.append(path)
+    return paths
+
+
+def _local_image_path_from_item(item: Any) -> Optional[str]:
+    if isinstance(item, str):
+        return _normalize_local_image_path(item)
+    if not isinstance(item, dict):
+        return None
+
+    for key in ("path", "local_path", "localPath", "file_path", "filePath"):
+        path = _normalize_local_image_path(item.get(key))
+        if path is not None:
+            return path
+    return None
+
+
+def _normalize_local_image_path(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    path = value.strip()
+    if not path:
+        return None
+    parsed = urlparse(path)
+    if parsed.scheme and parsed.scheme != "file":
+        return None
+    return path
+
+
+def _set_local_image_attachments(
+    message: dict[str, Any],
+    payload: dict[str, Any],
+    created_at: str,
+) -> None:
+    attachments = [
+        attachment
+        for path in _local_image_paths_from_payload(payload)
+        if (attachment := _local_image_attachment(path, created_at)) is not None
+    ]
+    if attachments:
+        message["attachments"] = attachments
+
+
+def _local_image_attachment(path: str, created_at: str) -> Optional[dict[str, Any]]:
+    filesystem_path = _local_image_filesystem_path(path)
+    file_path = Path(filesystem_path)
+    try:
+        stat = file_path.stat()
+    except OSError:
+        return None
+    if not file_path.is_file() or stat.st_size > CODEX_LOCAL_IMAGE_PREVIEW_MAX_BYTES:
+        return None
+
+    mime_type = mimetypes.guess_type(file_path.name)[0] or "application/octet-stream"
+    if not mime_type.startswith("image/"):
+        return None
+
+    try:
+        encoded = base64.b64encode(file_path.read_bytes()).decode("ascii")
+    except OSError:
+        return None
+
+    return {
+        "id": _local_image_attachment_id(path),
+        "filename": file_path.name,
+        "file_size": stat.st_size,
+        "mime_type": mime_type,
+        "status": "ready",
+        "file_extension": file_path.suffix,
+        "created_at": created_at,
+        "local_preview_url": f"data:{mime_type};base64,{encoded}",
+    }
+
+
+def _local_image_filesystem_path(path: str) -> str:
+    if not path.startswith("file://"):
+        return path
+    parsed = urlparse(path)
+    pathname = unquote(parsed.path)
+    return pathname[1:] if re.match(r"^/[a-zA-Z]:/", pathname) else pathname
+
+
+def _local_image_attachment_id(path: str) -> int:
+    digest = hashlib.sha256(path.encode("utf-8")).hexdigest()
+    return int(digest[:12], 16)
+
+
 def _parse_datetime(value: Any) -> Optional[datetime]:
     if not isinstance(value, str) or not value:
         return None
@@ -918,18 +1029,18 @@ def _read_session_transcript(path: Path, thread_id: str) -> list[dict[str, Any]]
                     processing_blocks = []
                     tool_blocks_by_call_id = {}
                     turn_started_at = timestamp
-                    message = _first_text(payload, "message")
+                    message = _codex_user_message_content(payload)
                     if message:
-                        messages.append(
-                            _transcript_message(
-                                thread_id=thread_id,
-                                turn_counter=turn_counter,
-                                role="user",
-                                content=message,
-                                created_at=timestamp,
-                                status="done",
-                            )
+                        user_message = _transcript_message(
+                            thread_id=thread_id,
+                            turn_counter=turn_counter,
+                            role="user",
+                            content=message,
+                            created_at=timestamp,
+                            status="done",
                         )
+                        _set_local_image_attachments(user_message, payload, timestamp)
+                        messages.append(user_message)
                 elif event_type == "agent_message":
                     message = _first_text(payload, "message")
                     if message:
@@ -1139,18 +1250,18 @@ def _read_session_transcript_window(
                     cwd = payload.get("cwd")
                     if isinstance(cwd, str) and cwd.strip():
                         turn_workspace_path = cwd.strip()
-                    message = _first_text(payload, "message")
+                    message = _codex_user_message_content(payload)
                     if message:
-                        messages.append(
-                            _transcript_message_from_offset(
-                                thread_id=thread_id,
-                                offset=line_start,
-                                role="user",
-                                content=message,
-                                created_at=timestamp,
-                                status="done",
-                            )
+                        user_message = _transcript_message_from_offset(
+                            thread_id=thread_id,
+                            offset=line_start,
+                            role="user",
+                            content=message,
+                            created_at=timestamp,
+                            status="done",
                         )
+                        _set_local_image_attachments(user_message, payload, timestamp)
+                        messages.append(user_message)
                 elif event_type == "agent_message":
                     message = _first_text(payload, "message")
                     if message:

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -2086,6 +2086,94 @@ def test_codex_discovery_reads_user_visible_transcript(tmp_path):
     assert transcript[1]["status"] == "done"
 
 
+def test_codex_discovery_preserves_local_images_in_user_message(tmp_path):
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789b0"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    image_path = "/var/folders/tmp/codex-clipboard.png"
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "分析下这个图片",
+                "images": [],
+                "local_images": [image_path],
+            },
+        },
+        {
+            "timestamp": "2026-06-20T05:52:23Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "task_complete",
+                "last_agent_message": "看到了",
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    assert [message["role"] for message in page.messages] == ["user", "assistant"]
+    assert page.messages[0]["content"] == "\n".join(
+        [
+            "# Files mentioned by the user:",
+            "",
+            f"## codex-clipboard.png: {image_path}",
+            "",
+            "## My request for Codex:",
+            "分析下这个图片",
+            "",
+        ]
+    )
+    assert page.messages[1]["content"] == "看到了"
+
+
+def test_codex_discovery_embeds_readable_local_image_previews(tmp_path):
+    from executor.runtime_work.codex_discovery import CodexSessionDiscovery
+
+    codex_home = tmp_path / "codex-home"
+    session_dir = codex_home / "sessions" / "2026" / "06" / "20"
+    session_dir.mkdir(parents=True)
+    thread_id = "018f2d6b-8c7a-7abc-9def-0123456789b1"
+    session_path = session_dir / f"rollout-2026-06-20T13-52-19-{thread_id}.jsonl"
+    image_path = tmp_path / "codex-clipboard.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+    _write_codex_session(
+        session_path,
+        {
+            "timestamp": "2026-06-20T05:52:21Z",
+            "type": "event_msg",
+            "payload": {
+                "type": "user_message",
+                "message": "分析下这个图片",
+                "local_images": [str(image_path)],
+            },
+        },
+    )
+
+    page = CodexSessionDiscovery(codex_home=codex_home).read_transcript_page(
+        thread_id,
+        str(session_path),
+    )
+
+    attachment = page.messages[0]["attachments"][0]
+    assert attachment["filename"] == "codex-clipboard.png"
+    assert attachment["mime_type"] == "image/png"
+    assert attachment["file_extension"] == ".png"
+    assert attachment["file_size"] == 8
+    assert attachment["status"] == "ready"
+    assert attachment["local_preview_url"] == "data:image/png;base64,iVBORw0KGgo="
+
+
 def test_codex_discovery_keeps_commentary_when_task_complete_is_empty(tmp_path):
     from executor.runtime_work.codex_discovery import CodexSessionDiscovery
 

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -9,12 +9,18 @@ const THINKING_PREVIEW_MAX_LENGTH = 96
 
 interface ToolBlockItemProps {
   block: ProcessingBlock
+  forceExpanded?: boolean
   onOpenWorkspaceFile?: (path: string) => void
 }
 
-export function ToolBlockItem({ block, onOpenWorkspaceFile }: ToolBlockItemProps) {
-  const [expanded, setExpanded] = useState(false)
+export function ToolBlockItem({
+  block,
+  forceExpanded = false,
+  onOpenWorkspaceFile,
+}: ToolBlockItemProps) {
+  const [userExpanded, setUserExpanded] = useState(false)
   const isRunning = block.status !== 'done' && block.status !== 'error'
+  const expanded = forceExpanded || userExpanded
 
   if (block.type === 'thinking') {
     return <ThinkingBlockItem block={block} isRunning={isRunning} />
@@ -36,7 +42,7 @@ export function ToolBlockItem({ block, onOpenWorkspaceFile }: ToolBlockItemProps
               onOpenWorkspaceFile(workspaceFilePath)
               return
             }
-            setExpanded(value => !value)
+            setUserExpanded(value => !value)
           }}
           className="flex min-w-0 items-center gap-1.5 hover:text-text-primary"
         >
@@ -46,7 +52,7 @@ export function ToolBlockItem({ block, onOpenWorkspaceFile }: ToolBlockItemProps
         </button>
         <button
           type="button"
-          onClick={() => setExpanded(value => !value)}
+          onClick={() => setUserExpanded(value => !value)}
           className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-muted hover:text-text-primary"
           aria-label={expanded ? '收起工具详情' : '展开工具详情'}
           aria-expanded={expanded}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -11,6 +11,7 @@ const completedCommandBlock: ProcessingBlock = {
   type: 'tool',
   toolName: 'bash',
   toolInput: { command: 'pwd' },
+  toolOutput: '/workspace/project\n',
   status: 'done',
   createdAt: 1770000000000,
 }
@@ -111,6 +112,14 @@ describe('ToolBlocksDisplay', () => {
     })
 
     expect(screen.getByText('已处理 5 秒')).toBeInTheDocument()
+  })
+
+  test('keeps completed tools expanded until the assistant turn finishes', () => {
+    render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={true} />)
+
+    expect(screen.queryByText('已运行 1 条命令')).not.toBeInTheDocument()
+    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
+    expect(screen.getByText('/workspace/project')).toBeInTheDocument()
   })
 
   test('anchors the running duration to the turn start, surviving a refresh', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -59,7 +59,7 @@ export function ToolBlocksDisplay({
   if (blocks.length === 0 && !isStreaming) return null
 
   const duration = getDurationText(blocks, turnStartedAt, now, completedAt, isRunning)
-  const rows = buildProcessingDisplayRows(blocks)
+  const rows = buildProcessingDisplayRows(blocks, { groupCompletedTools: !isRunning })
   const expanded = forceExpanded || isRunning || userExpanded
   const hasLiveNarrativeBlock = rows.some(
     row =>
@@ -105,6 +105,7 @@ export function ToolBlocksDisplay({
               <ToolBlockItem
                 key={row.id}
                 block={row.block}
+                forceExpanded={isRunning && row.block.type === 'tool'}
                 onOpenWorkspaceFile={onOpenWorkspaceFile}
               />
             )

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -26,8 +26,10 @@ const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag',
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'du', 'file'])
 
 export function buildProcessingDisplayRows(
-  blocks: ProcessingBlock[]
+  blocks: ProcessingBlock[],
+  options: { groupCompletedTools?: boolean } = {}
 ): ProcessingDisplayRow[] {
+  const groupCompletedTools = options.groupCompletedTools ?? true
   const rows: ProcessingDisplayRow[] = []
   let completedTools: ToolBlock[] = []
 
@@ -43,7 +45,7 @@ export function buildProcessingDisplayRows(
   }
 
   for (const block of blocks) {
-    if (block.type === 'tool' && isCompletedToolBlock(block)) {
+    if (groupCompletedTools && block.type === 'tool' && isCompletedToolBlock(block)) {
       completedTools.push(block)
       continue
     }

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -66,6 +66,7 @@ interface DesktopWorkbenchLayoutProps {
   guidanceMessages?: GuidanceWorkbenchMessage[]
   codeCommentContexts?: CodeCommentContext[]
   currentRuntimeTaskRunning?: boolean
+  isAwaitingAssistantStart?: boolean
   isRuntimeTranscriptLoading?: boolean
   runtimeTranscriptHasMoreBefore?: boolean
   isRuntimeTranscriptLoadingMore?: boolean
@@ -170,6 +171,7 @@ export function DesktopWorkbenchLayout({
   guidanceMessages = [],
   codeCommentContexts = [],
   currentRuntimeTaskRunning = false,
+  isAwaitingAssistantStart = false,
   isRuntimeTranscriptLoading = false,
   runtimeTranscriptHasMoreBefore = false,
   isRuntimeTranscriptLoadingMore = false,
@@ -777,6 +779,7 @@ export function DesktopWorkbenchLayout({
           guidanceMessages={guidanceMessages}
           codeCommentContexts={codeCommentContexts}
           currentRuntimeTaskRunning={currentRuntimeTaskRunning}
+          isWaitingForAssistant={state.isSending || isAwaitingAssistantStart}
           projectChat={projectChat}
           projectWork={projectWorkWithCreation}
           input={state.input}

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -164,6 +164,7 @@ interface DesktopWorkbenchMainProps {
   projectWork: ProjectWorkControls
   input: string
   isSending: boolean
+  isWaitingForAssistant?: boolean
   error?: string | null
   environmentInfo: EnvironmentInfo
   onRefreshEnvironmentInfo: () => Promise<void>
@@ -225,6 +226,7 @@ export function DesktopWorkbenchMain({
   projectWork,
   input,
   isSending,
+  isWaitingForAssistant = isSending,
   error,
   environmentInfo,
   onRefreshEnvironmentInfo,
@@ -717,7 +719,7 @@ export function DesktopWorkbenchMain({
             <ScrollableMessageArea
               messages={messages}
               loading={isRuntimeTranscriptLoading}
-              isWaitingForAssistant={isSending}
+              isWaitingForAssistant={isWaitingForAssistant}
               hasMoreBefore={runtimeTranscriptHasMoreBefore}
               loadingMoreBefore={isRuntimeTranscriptLoadingMore}
               conversationKey={currentRuntimeTask?.localTaskId ?? null}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -63,6 +63,7 @@ interface MobileWorkbenchLayoutProps {
   guidanceMessages?: GuidanceWorkbenchMessage[]
   codeCommentContexts?: CodeCommentContext[]
   currentRuntimeTaskRunning?: boolean
+  isAwaitingAssistantStart?: boolean
   isRuntimeTranscriptLoading?: boolean
   runtimeTranscriptHasMoreBefore?: boolean
   isRuntimeTranscriptLoadingMore?: boolean
@@ -162,6 +163,7 @@ export function MobileWorkbenchLayout({
   queuedMessages = [],
   guidanceMessages = [],
   codeCommentContexts = [],
+  isAwaitingAssistantStart = false,
   isRuntimeTranscriptLoading = false,
   runtimeTranscriptHasMoreBefore = false,
   isRuntimeTranscriptLoadingMore = false,
@@ -524,7 +526,7 @@ export function MobileWorkbenchLayout({
             <ScrollableMessageArea
               messages={messages}
               loading={isRuntimeTranscriptLoading}
-              isWaitingForAssistant={state.isSending}
+              isWaitingForAssistant={state.isSending || isAwaitingAssistantStart}
               hasMoreBefore={runtimeTranscriptHasMoreBefore}
               loadingMoreBefore={isRuntimeTranscriptLoadingMore}
               conversationKey={state.currentRuntimeTask?.localTaskId ?? null}

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -293,10 +293,9 @@ function ProjectSendProbe() {
       <span data-testid="message-roles">
         {workbench.messages.map(message => `${message.role}:${message.content}`).join('|')}
       </span>
-      <span data-testid="project-attachment-count">
-        {workbench.projectChat.attachments.length}
-      </span>
+      <span data-testid="project-attachment-count">{workbench.projectChat.attachments.length}</span>
       <span data-testid="workbench-error">{workbench.state.error ?? ''}</span>
+      <span data-testid="sending-state">{workbench.state.isSending ? 'sending' : 'idle'}</span>
       <button type="button" onClick={() => workbench.selectProjectWorkspace(7, null)}>
         select project
       </button>
@@ -318,7 +317,10 @@ function ProjectSendProbe() {
       <button type="button" onClick={() => void workbench.sendCurrentInput()}>
         send
       </button>
-      <MessageList messages={workbench.messages} />
+      <MessageList
+        messages={workbench.messages}
+        isWaitingForAssistant={workbench.state.isSending || workbench.isAwaitingAssistantStart}
+      />
     </div>
   )
 }
@@ -419,6 +421,10 @@ function RuntimeOpenProbe() {
       >
         open runtime b
       </button>
+      <MessageList
+        messages={workbench.messages}
+        isWaitingForAssistant={workbench.state.isSending || workbench.isAwaitingAssistantStart}
+      />
       <button type="button" onClick={() => void workbench.loadOlderRuntimeTranscript()}>
         load older
       </button>
@@ -469,9 +475,7 @@ function FollowUpProbe() {
       <span data-testid="queued-notices">
         {workbench.queuedMessages.map(message => message.notice ?? '').join('|')}
       </span>
-      <span data-testid="runtime-attachment-count">
-        {workbench.projectChat.attachments.length}
-      </span>
+      <span data-testid="runtime-attachment-count">{workbench.projectChat.attachments.length}</span>
       <span data-testid="guidance-messages">
         {workbench.guidanceMessages
           .map(message => `${message.status}:${message.content}`)
@@ -806,6 +810,71 @@ describe('WorkbenchProvider runtime tasks', () => {
       deviceId: 'resolved-device',
       localTaskId: 'runtime-created',
     })
+  })
+
+  test('opens the runtime route and shows thinking while runtime task creation is pending', async () => {
+    const createRuntimeTask =
+      deferred<
+        Awaited<ReturnType<NonNullable<WorkbenchServices['runtimeWorkApi']>['createRuntimeTask']>>
+      >()
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(
+        createRuntimeWork({
+          projects: [
+            {
+              project: { id: 7, name: 'Wegent' },
+              deviceWorkspaces: [
+                {
+                  deviceId: 'device-1',
+                  deviceName: 'Project Device',
+                  deviceStatus: 'online',
+                  workspacePath: '/workspace/project-alpha',
+                  mapped: true,
+                  available: true,
+                  localTasks: [],
+                },
+              ],
+            },
+          ],
+          totalLocalTasks: 0,
+        })
+      ),
+      createRuntimeTask: vi.fn().mockReturnValue(createRuntimeTask.promise),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByText('select project')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('select project'))
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    const request = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
+    expect(request.localTaskId).toMatch(/^runtime-/)
+    expect(parseRuntimeTaskRoute(window.location.pathname, window.location.search)).toEqual({
+      deviceId: 'device-1',
+      localTaskId: request.localTaskId,
+    })
+    expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+      `device-1:${request.localTaskId}`
+    )
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
+
+    await act(async () => {
+      createRuntimeTask.resolve({
+        accepted: true,
+        deviceId: 'device-1',
+        localTaskId: request.localTaskId,
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      })
+    })
+    await waitFor(() => expect(screen.getByTestId('sending-state')).toHaveTextContent('idle'))
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
   })
 
   test('renders image attachments immediately when creating a runtime local task', async () => {
@@ -1661,6 +1730,123 @@ describe('WorkbenchProvider runtime tasks', () => {
     await waitFor(() => expect(screen.getByTestId('queued-messages')).toHaveTextContent(''))
   })
 
+  test('waits for the sent queued runtime message to start before sending the next queued item', async () => {
+    const sendRuntimeMessage = vi.fn().mockResolvedValue({
+      accepted: true,
+      localTaskId: 'runtime-a',
+    })
+    const runningRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              localTasks: [
+                {
+                  localTaskId: 'runtime-a',
+                  workspacePath: '/workspace/project-alpha',
+                  title: 'Runtime A',
+                  runtime: 'claude_code',
+                  running: true,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      totalLocalTasks: 1,
+    })
+    const idleRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              localTasks: [
+                {
+                  localTaskId: 'runtime-a',
+                  workspacePath: '/workspace/project-alpha',
+                  title: 'Runtime A',
+                  runtime: 'claude_code',
+                  running: false,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      totalLocalTasks: 1,
+    })
+    let runtimeRunning = true
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi
+        .fn()
+        .mockImplementation(() =>
+          Promise.resolve(runtimeRunning ? runningRuntimeWork : idleRuntimeWork)
+        ),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        localTaskId: 'runtime-a',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [{ id: 'runtime-a:user:1', role: 'user', content: 'first message' }],
+      }),
+      sendRuntimeMessage,
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(
+      <>
+        <RuntimeOpenProbe />
+        <FollowUpProbe />
+      </>,
+      services
+    )
+
+    await userEvent.click(await screen.findByText('open runtime a'))
+    await waitFor(() =>
+      expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('first message')
+    )
+    await userEvent.click(screen.getByText('set follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+    await userEvent.click(screen.getByText('set ls follow-up'))
+    await userEvent.click(screen.getByText('send follow-up'))
+
+    expect(sendRuntimeMessage).not.toHaveBeenCalled()
+    expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:继续修|queued:执行ls')
+
+    runtimeRunning = false
+    await userEvent.click(screen.getByText('refresh work lists'))
+
+    await waitFor(() => expect(sendRuntimeMessage).toHaveBeenCalledTimes(1))
+    expect(sendRuntimeMessage).toHaveBeenCalledWith({
+      address: {
+        deviceId: 'device-1',
+        workspacePath: '/workspace/project-alpha',
+        localTaskId: 'runtime-a',
+      },
+      message: '继续修',
+    })
+    expect(screen.getByTestId('queued-messages')).toHaveTextContent('queued:执行ls')
+  })
+
   test('edits queued runtime messages back into the composer', async () => {
     const sendRuntimeMessage = vi.fn().mockResolvedValue({
       accepted: true,
@@ -1943,6 +2129,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     expect(screen.getByTestId('queued-errors')).not.toHaveTextContent('当前回复缺少引导上下文')
     expect(screen.getByTestId('guidance-messages')).toHaveTextContent('')
     expect(screen.getByTestId('runtime-open-messages')).toHaveTextContent('执行ls')
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
   })
 
   test('sends image attachments with current runtime task follow-up messages', async () => {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -268,6 +268,7 @@ export interface WorkbenchContextValue {
   guidanceMessages: GuidanceWorkbenchMessage[]
   codeCommentContexts: CodeCommentContext[]
   currentRuntimeTaskRunning: boolean
+  isAwaitingAssistantStart: boolean
   isRuntimeTranscriptLoading: boolean
   runtimeTranscriptHasMoreBefore: boolean
   isRuntimeTranscriptLoadingMore: boolean
@@ -894,6 +895,15 @@ function buildRuntimeTaskTitle(message: string, fallback?: string): string {
   return title ? title.slice(0, 100) : EMPTY_MESSAGE_TASK_TITLE
 }
 
+function createRuntimeLocalTaskId(runtime: RuntimeTaskCreateRequest['runtime']): string {
+  const prefix = runtime === 'codex' ? 'codex' : 'runtime'
+  const randomId =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  return `${prefix}-${randomId}`
+}
+
 export function WorkbenchProvider({ children, user, services }: WorkbenchProviderProps) {
   const resolvedServices = useMemo(() => services ?? createDefaultServices(), [services])
   const [state, dispatch] = useReducer(workbenchReducer, initialWorkbenchState)
@@ -913,7 +923,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     beforeCursor: null,
     loadingMore: false,
   })
-  const [, setIsAwaitingAssistantStart] = useState(false)
+  const [isAwaitingAssistantStart, setIsAwaitingAssistantStart] = useState(false)
   const [routePath, setRoutePath] = useState(getCurrentAppPath)
   const [routeSearch, setRouteSearch] = useState(() => window.location.search)
   const [projectExecutionMode, setProjectExecutionMode] =
@@ -1642,6 +1652,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     setQueuedSends([])
     setGuidanceMessages([])
     setCodeCommentContexts([])
+    setIsAwaitingAssistantStart(false)
     cancelRuntimeTranscriptLoad()
     handledRuntimeTaskRouteRef.current = null
     navigateTo('/')
@@ -1661,6 +1672,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     setQueuedSends([])
     setGuidanceMessages([])
     setCodeCommentContexts([])
+    setIsAwaitingAssistantStart(false)
     cancelRuntimeTranscriptLoad()
     handledRuntimeTaskRouteRef.current = null
     navigateTo('/')
@@ -1707,6 +1719,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       if (project) {
         writeLastProjectId(user.id, project.id)
       }
+      setIsAwaitingAssistantStart(false)
       dispatch({
         type: 'runtime_task_opened',
         address,
@@ -2144,6 +2157,8 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     [messages]
   )
   const hasActiveTurn = Boolean(activeAssistantMessage)
+  const currentRuntimeTaskBusy =
+    currentRuntimeTaskRunning || hasActiveTurn || isAwaitingAssistantStart
 
   const buildSendPayload = useCallback(
     (
@@ -2255,11 +2270,13 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         RuntimeTaskCreateRequest,
         'projectId' | 'deviceWorkspaceId' | 'deviceId' | 'workspacePath'
       >
+      let optimisticDeviceId: string
       if (projectId) {
         if (!selectedProjectWorkspace) {
           reportSendBlocked('请选择任务运行位置')
           return false
         }
+        optimisticDeviceId = selectedProjectWorkspace.deviceId
         runtimeTaskTarget =
           selectedProjectWorkspace.id != null
             ? {
@@ -2278,6 +2295,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           reportSendBlocked('请选择项目或打开设备工作区后再发送')
           return false
         }
+        optimisticDeviceId = activeDeviceId
         runtimeTaskTarget = {
           deviceId: activeDeviceId,
           workspacePath,
@@ -2286,10 +2304,13 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
       const selectedModel =
         modelSelection.selectedModel ?? resolveAutomaticModel(modelSelection.models)
+      const runtime = inferRuntimeName(selectedModel)
+      const localTaskId = createRuntimeLocalTaskId(runtime)
       const createRequest: RuntimeTaskCreateRequest = {
         ...runtimeTaskTarget,
+        localTaskId,
         teamId: payload.team_id,
-        runtime: inferRuntimeName(selectedModel),
+        runtime,
         message: payload.message,
         title: buildRuntimeTaskTitle(displayMessage, payload.title),
         modelId: payload.force_override_bot_model,
@@ -2299,6 +2320,24 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         attachmentIds: payload.attachment_ids ?? [],
         execution: payload.execution,
       }
+      const optimisticAddress: RuntimeTaskAddress = {
+        deviceId: optimisticDeviceId,
+        localTaskId,
+      }
+      const runtimeProject = projectId
+        ? (state.projects.find(project => project.id === projectId) ?? state.currentProject)
+        : null
+
+      if (optimisticAddress.deviceId) rememberExecutionDevice(optimisticAddress.deviceId)
+      currentRuntimeTaskRef.current = optimisticAddress
+      dispatch({
+        type: 'runtime_task_opened',
+        address: optimisticAddress,
+        project: runtimeProject,
+      })
+      handledRuntimeTaskRouteRef.current = getRuntimeTaskRouteKey(optimisticAddress)
+      navigateTo(buildRuntimeTaskRoute(optimisticAddress))
+      setIsAwaitingAssistantStart(true)
 
       dispatch({ type: 'sending_started' })
       dispatchMessages({
@@ -2320,19 +2359,20 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           throw new Error(response.error || '发送失败')
         }
         const address: RuntimeTaskAddress = {
-          deviceId: response.deviceId,
-          localTaskId: response.localTaskId,
+          deviceId: response.deviceId || optimisticAddress.deviceId,
+          localTaskId: response.localTaskId || optimisticAddress.localTaskId,
         }
-        const runtimeProject = projectId
-          ? (state.projects.find(project => project.id === projectId) ?? state.currentProject)
-          : null
-        if (address.deviceId) rememberExecutionDevice(address.deviceId)
-        currentRuntimeTaskRef.current = address
-        dispatch({
-          type: 'runtime_task_opened',
-          address,
-          project: runtimeProject,
-        })
+        if (!isSameRuntimeTaskIdentity(optimisticAddress, address)) {
+          if (address.deviceId) rememberExecutionDevice(address.deviceId)
+          currentRuntimeTaskRef.current = address
+          dispatch({
+            type: 'runtime_task_opened',
+            address,
+            project: runtimeProject,
+          })
+          handledRuntimeTaskRouteRef.current = getRuntimeTaskRouteKey(address)
+          navigateTo(buildRuntimeTaskRoute(address))
+        }
         await refreshWorkLists()
         // A freshly created task has no prior history, so reset pagination
         // directly instead of re-fetching the transcript. Re-fetching here would
@@ -2348,6 +2388,13 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         navigateTo(buildRuntimeTaskRoute(address))
         return true
       } catch (error) {
+        if (isSameRuntimeTaskIdentity(currentRuntimeTaskRef.current, optimisticAddress)) {
+          currentRuntimeTaskRef.current = null
+          setIsAwaitingAssistantStart(false)
+          dispatch({ type: 'current_task_cleared' })
+          handledRuntimeTaskRouteRef.current = null
+          navigateTo('/')
+        }
         dispatch({
           type: 'error_set',
           error: error instanceof Error ? error.message : '发送失败',
@@ -2390,7 +2437,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         reportSendBlocked('当前 LocalTask 暂不支持代码评论')
         return
       }
-      if (currentRuntimeTaskRunning || hasActiveTurn) {
+      if (currentRuntimeTaskBusy) {
         const currentAttachments = attachmentSelection.attachments
         setQueuedSends(items => [
           ...items,
@@ -2427,6 +2474,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         },
       })
       attachmentSelection.resetAttachments()
+      setIsAwaitingAssistantStart(true)
 
       try {
         const runtimeSendRequest: RuntimeSendRequest = {
@@ -2443,6 +2491,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         }
         await refreshWorkLists()
       } catch (error) {
+        setIsAwaitingAssistantStart(false)
         dispatch({
           type: 'error_set',
           error: error instanceof Error ? error.message : '发送失败',
@@ -2513,8 +2562,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     buildSendPayload,
     clearCodeCommentContexts,
     codeCommentContexts,
-    currentRuntimeTaskRunning,
-    hasActiveTurn,
+    currentRuntimeTaskBusy,
     reportSendBlocked,
     sendPreparedRuntimeMessage,
     state.devices,
@@ -2529,7 +2577,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
   useEffect(() => {
     const queuedMessage = queuedSends.find(item => item.status === 'queued')
     if (!queuedMessage) return
-    if (!state.currentRuntimeTask || currentRuntimeTaskRunning || hasActiveTurn) return
+    if (!state.currentRuntimeTask || currentRuntimeTaskBusy) return
     if (queuedSends.some(item => item.status === 'sending')) return
     const runtimeWorkApi = resolvedServices.runtimeWorkApi
     if (!runtimeWorkApi) return
@@ -2543,6 +2591,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         item.id === queuedMessageToSend.id ? { ...item, status: 'sending' } : item
       )
     )
+    setIsAwaitingAssistantStart(true)
 
     async function sendQueuedRuntimeMessage() {
       try {
@@ -2575,6 +2624,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         setQueuedSends(items => items.filter(item => item.id !== queuedMessageToSend.id))
         await refreshWorkLists()
       } catch (error) {
+        setIsAwaitingAssistantStart(false)
         setQueuedSends(items =>
           items.map(item =>
             item.id === queuedMessageToSend.id
@@ -2591,8 +2641,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
     void sendQueuedRuntimeMessage()
   }, [
-    currentRuntimeTaskRunning,
-    hasActiveTurn,
+    currentRuntimeTaskBusy,
     queuedSends,
     refreshWorkLists,
     resolvedServices.runtimeWorkApi,
@@ -2888,6 +2937,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
                 attachment => attachment.id
               )
             }
+            setIsAwaitingAssistantStart(true)
             dispatchMessages({
               type: 'user_added',
               message: {
@@ -2906,6 +2956,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
             setQueuedSends(items => items.filter(item => item.id !== id))
             await refreshWorkLists()
           } catch (error) {
+            setIsAwaitingAssistantStart(false)
             setQueuedSends(items =>
               items.map(item =>
                 item.id === id
@@ -3016,6 +3067,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     guidanceMessages,
     codeCommentContexts,
     currentRuntimeTaskRunning,
+    isAwaitingAssistantStart,
     isRuntimeTranscriptLoading,
     runtimeTranscriptHasMoreBefore: runtimeTranscriptPage.hasMoreBefore,
     isRuntimeTranscriptLoadingMore: runtimeTranscriptPage.loadingMore,

--- a/wework/src/pages/WorkbenchPage.tsx
+++ b/wework/src/pages/WorkbenchPage.tsx
@@ -15,6 +15,7 @@ export function WorkbenchPage() {
     guidanceMessages,
     codeCommentContexts,
     currentRuntimeTaskRunning,
+    isAwaitingAssistantStart,
     isRuntimeTranscriptLoading,
     runtimeTranscriptHasMoreBefore,
     isRuntimeTranscriptLoadingMore,
@@ -109,6 +110,7 @@ export function WorkbenchPage() {
       guidanceMessages={guidanceMessages}
       codeCommentContexts={codeCommentContexts}
       currentRuntimeTaskRunning={currentRuntimeTaskRunning}
+      isAwaitingAssistantStart={isAwaitingAssistantStart}
       isRuntimeTranscriptLoading={isRuntimeTranscriptLoading}
       runtimeTranscriptHasMoreBefore={runtimeTranscriptHasMoreBefore}
       isRuntimeTranscriptLoadingMore={isRuntimeTranscriptLoadingMore}

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -506,6 +506,7 @@ export interface RuntimeTaskCreateRequest {
   deviceWorkspaceId?: number
   deviceId?: string
   workspacePath?: string
+  localTaskId?: string
   teamId: number
   runtime: RuntimeName
   message: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime tasks can now open immediately with a client-generated task ID, improving responsiveness while the task is being created.
  * Local image references in messages are now shown with inline preview attachments when available.
  * Tool details stay expanded during active streaming, making in-progress output easier to follow.

* **Bug Fixes**
  * Improved waiting states so the app shows a clearer “thinking” indicator while assistant responses are starting.
  * Better handling of queued follow-up messages to keep their order consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->