### PR TITLE
Feat/chat shell attachment context

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -111,8 +111,6 @@ INIT_DATA_ENABLED=True
 # File upload configuration
 # Maximum file size in MB (default: 20)
 MAX_UPLOAD_FILE_SIZE_MB=50
-# Maximum extracted text length (default: 1000000)
-MAX_EXTRACTED_TEXT_LENGTH=1000000
 
 # Attachment encryption configuration
 # Enable/disable AES-256-CBC encryption for attachment binary data (default: False)

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -47,6 +47,13 @@ router = APIRouter(prefix="/chat", tags=["internal-chat"])
 # Knowledge base injection mode constant for kb_head (not in enum as it's tool-specific)
 INJECTION_MODE_KB_HEAD = "kb_head"
 
+# Hard upper bound for a single attachment-text slice (characters). read_attachment
+# is a paginated reader; a page is token-clamped by the caller anyway, so there is
+# no legitimate reason to request a huge slice. This is HTTP-layer defense-in-depth:
+# the caller's real page window is page_token_limit * chars-per-token (~60K today),
+# so this sits just above it. Raise it if that page window grows.
+MAX_ATTACHMENT_TEXT_SLICE = 64_000
+
 
 def _is_restricted_kb_context(kb_ctx: SubtaskContext) -> bool:
     """Whether a KB history context should be suppressed for restricted mode."""
@@ -915,6 +922,9 @@ class AttachmentTextResponse(BaseModel):
     offset: int
     text: str
     has_more: bool
+    # Whether extracted_text itself was parse-truncated. When True, paging to
+    # has_more=False means "end of the extract", NOT "end of the original file".
+    source_truncated: bool
 
 
 @router.get("/attachments/{attachment_id}/text", response_model=AttachmentTextResponse)
@@ -922,16 +932,25 @@ async def get_attachment_text(
     attachment_id: int,
     session_id: str = Query(..., description="Conversation session, e.g. task-123"),
     offset: int = Query(0, ge=0, description="Start character offset (codepoint)"),
-    limit: int = Query(..., gt=0, description="Max characters to return"),
+    limit: int = Query(
+        ...,
+        gt=0,
+        le=MAX_ATTACHMENT_TEXT_SLICE,
+        description="Max characters to return (codepoint)",
+    ),
     db: Session = Depends(get_db),
 ):
     """Return a character slice of an attachment's extracted text.
 
     Scoped to the conversation: the attachment must belong to a subtask of the
-    session's task (or be unlinked). This mirrors the visibility of attachments
-    already injected into the chat history, so group-chat members can read each
-    other's attachments while cross-task access is denied. Pagination/token
-    budgeting is done by the caller (chat_shell); this endpoint only slices.
+    session's task, or be unlinked *and owned by the task's user*. This mirrors
+    the visibility of attachments already injected into the chat history, so
+    group-chat members can read each other's attachments while cross-task access
+    is denied. Unlinked attachments (subtask_id == 0, e.g. a just-uploaded or
+    quick-launch preset attachment not yet bound to a subtask) are restricted to
+    the same user, so the model cannot probe arbitrary ids across users.
+    Pagination/token budgeting is done by the caller (chat_shell); this endpoint
+    only slices.
     """
     session_type, task_id = parse_session_id(session_id)
     if session_type != "task":
@@ -955,10 +974,13 @@ async def get_attachment_text(
     if context is None:
         raise HTTPException(status_code=404, detail="Attachment not found")
 
-    # Task scoping: the attachment's subtask must belong to this task (or be
-    # unlinked). Not user-scoped — attachments are shared conversation context.
+    # Task scoping: a linked attachment must belong to this task; an unlinked
+    # one (subtask_id == 0) must at least belong to this task's user, so the
+    # model cannot read arbitrary unlinked attachments across users.
     task_subtask_ids = set(subtask_store.list_ids_by_task(db, task_id=task_id))
-    if not (context.subtask_id == 0 or context.subtask_id in task_subtask_ids):
+    is_in_task = context.subtask_id in task_subtask_ids
+    is_unlinked_same_user = context.subtask_id == 0 and context.user_id == task.user_id
+    if not (is_in_task or is_unlinked_same_user):
         raise HTTPException(
             status_code=403, detail="Attachment does not belong to this conversation"
         )
@@ -974,6 +996,7 @@ async def get_attachment_text(
         offset=offset,
         text=chunk,
         has_more=offset + len(chunk) < total_chars,
+        source_truncated=context.is_truncated,
     )
 
 

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -905,6 +905,78 @@ async def get_chat_history(
     return HistoryResponse(session_id=session_id, messages=messages)
 
 
+class AttachmentTextResponse(BaseModel):
+    """A character slice of an attachment's extracted text."""
+
+    attachment_id: int
+    name: str
+    mime_type: str
+    total_chars: int
+    offset: int
+    text: str
+    has_more: bool
+
+
+@router.get("/attachments/{attachment_id}/text", response_model=AttachmentTextResponse)
+async def get_attachment_text(
+    attachment_id: int,
+    session_id: str = Query(..., description="Conversation session, e.g. task-123"),
+    offset: int = Query(0, ge=0, description="Start character offset (codepoint)"),
+    limit: int = Query(..., gt=0, description="Max characters to return"),
+    db: Session = Depends(get_db),
+):
+    """Return a character slice of an attachment's extracted text.
+
+    Scoped to the conversation: the attachment must belong to a subtask of the
+    session's task (or be unlinked). This mirrors the visibility of attachments
+    already injected into the chat history, so group-chat members can read each
+    other's attachments while cross-task access is denied. Pagination/token
+    budgeting is done by the caller (chat_shell); this endpoint only slices.
+    """
+    session_type, task_id = parse_session_id(session_id)
+    if session_type != "task":
+        raise HTTPException(
+            status_code=400, detail="Only task-based sessions are supported"
+        )
+
+    task = task_store.get_by_id(db, task_id=task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    context = (
+        db.query(SubtaskContext)
+        .filter(
+            SubtaskContext.id == attachment_id,
+            SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+            SubtaskContext.status == ContextStatus.READY.value,
+        )
+        .first()
+    )
+    if context is None:
+        raise HTTPException(status_code=404, detail="Attachment not found")
+
+    # Task scoping: the attachment's subtask must belong to this task (or be
+    # unlinked). Not user-scoped — attachments are shared conversation context.
+    task_subtask_ids = set(subtask_store.list_ids_by_task(db, task_id=task_id))
+    if not (context.subtask_id == 0 or context.subtask_id in task_subtask_ids):
+        raise HTTPException(
+            status_code=403, detail="Attachment does not belong to this conversation"
+        )
+
+    full_text = context.extracted_text or ""
+    total_chars = len(full_text)
+    chunk = full_text[offset : offset + limit]
+    return AttachmentTextResponse(
+        attachment_id=attachment_id,
+        name=context.name or "",
+        mime_type=context.mime_type or "",
+        total_chars=total_chars,
+        offset=offset,
+        text=chunk,
+        has_more=offset + len(chunk) < total_chars,
+    )
+
+
 def _build_subtask_content_fields(
     role: SubtaskRole,
     message: MessageCreate | MessageUpdate,

--- a/backend/app/api/endpoints/internal/chat_storage.py
+++ b/backend/app/api/endpoints/internal/chat_storage.py
@@ -981,9 +981,9 @@ async def get_attachment_text(
     is_in_task = context.subtask_id in task_subtask_ids
     is_unlinked_same_user = context.subtask_id == 0 and context.user_id == task.user_id
     if not (is_in_task or is_unlinked_same_user):
-        raise HTTPException(
-            status_code=403, detail="Attachment does not belong to this conversation"
-        )
+        # Return 404 (not 403) so callers cannot distinguish "exists but
+        # forbidden" from "missing" and probe valid ids across conversations.
+        raise HTTPException(status_code=404, detail="Attachment not found")
 
     full_text = context.extracted_text or ""
     total_chars = len(full_text)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -469,7 +469,7 @@ class Settings(BaseSettings):
     # page the full text via read_attachment, and executor/device modes read the
     # downloaded file directly. Keeps the prompt bounded for modes without the
     # chat_shell token-level preview (executor/device, which have no L3 guard).
-    ATTACHMENT_INJECT_MAX_CHARS: int = 64000
+    ATTACHMENT_INJECT_MAX_CHARS: int = 32000
 
     # Attachment storage backend configuration
     # Supported backends: "mysql" (default), "s3", "minio"

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -463,7 +463,13 @@ class Settings(BaseSettings):
 
     # File upload configuration
     MAX_UPLOAD_FILE_SIZE_MB: int = 100  # Maximum file size in MB
-    MAX_EXTRACTED_TEXT_LENGTH: int = 500000  # Maximum extracted text length
+    MAX_EXTRACTED_TEXT_LENGTH: int = 500000  # Maximum extracted (stored) text length
+    # Max chars of extracted text injected inline into the prompt. Far smaller
+    # than the stored length: the inline copy is only a preview — chat_shell can
+    # page the full text via read_attachment, and executor/device modes read the
+    # downloaded file directly. Keeps the prompt bounded for modes without the
+    # chat_shell token-level preview (executor/device, which have no L3 guard).
+    ATTACHMENT_INJECT_MAX_CHARS: int = 64000
 
     # Attachment storage backend configuration
     # Supported backends: "mysql" (default), "s3", "minio"

--- a/backend/app/services/attachment/parser.py
+++ b/backend/app/services/attachment/parser.py
@@ -29,7 +29,7 @@ import io
 import logging
 import zipfile
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import chardet
 import magic
@@ -45,110 +45,16 @@ from shared.utils.image_preprocessor import (
     MAX_MODEL_IMAGE_LONG_EDGE,
     prepare_image_bytes_for_model,
 )
+from shared.utils.mime_types import TEXT_READABLE_MIME_TYPES, is_text_readable_mime
 from shared.utils.xmind_parser import XMindParseError, parse_xmind_to_markdown
 
 MAX_IMAGE_LONG_EDGE = MAX_MODEL_IMAGE_LONG_EDGE
 
+# Backwards-compatible alias: text-based MIME types now live in shared so the
+# backend parser and the chat_shell attachment preview share one definition.
+TEXT_MIME_TYPES = TEXT_READABLE_MIME_TYPES
+
 logger = logging.getLogger(__name__)
-
-
-# MIME types that are considered text-based files
-# These files can be parsed as plain text
-TEXT_MIME_TYPES: Set[str] = {
-    # text/* family
-    "text/plain",
-    "text/html",
-    "text/css",
-    "text/javascript",
-    "text/xml",
-    "text/csv",
-    "text/markdown",
-    "text/x-python",
-    "text/x-java",
-    "text/x-c",
-    "text/x-c++",
-    "text/x-ruby",
-    "text/x-perl",
-    "text/x-php",
-    "text/x-shellscript",
-    "text/x-script.python",
-    "text/x-go",
-    "text/x-rust",
-    "text/x-swift",
-    "text/x-kotlin",
-    "text/x-scala",
-    "text/x-typescript",
-    "text/x-coffeescript",
-    "text/x-lua",
-    "text/x-r",
-    "text/x-matlab",
-    "text/x-sql",
-    "text/x-yaml",
-    "text/x-toml",
-    "text/x-ini",
-    "text/x-properties",
-    "text/x-diff",
-    "text/x-patch",
-    "text/x-log",
-    "text/x-makefile",
-    "text/x-cmake",
-    "text/x-dockerfile",
-    "text/x-nginx-conf",
-    "text/x-apache-conf",
-    "text/x-systemd-unit",
-    "text/x-tex",
-    "text/x-latex",
-    "text/x-bibtex",
-    "text/x-rst",
-    "text/x-asciidoc",
-    "text/x-org",
-    "text/troff",
-    "text/rtf",
-    "text/calendar",
-    "text/vcard",
-    # application/* text-based types
-    "application/json",
-    "application/xml",
-    "application/javascript",
-    "application/x-javascript",
-    "application/ecmascript",
-    "application/x-sh",
-    "application/x-bash",
-    "application/x-csh",
-    "application/x-zsh",
-    "application/x-python",
-    "application/x-ruby",
-    "application/x-perl",
-    "application/x-php",
-    "application/sql",
-    "application/graphql",
-    "application/toml",
-    "application/x-yaml",
-    "application/yaml",
-    "application/x-httpd-php",
-    "application/x-typescript",
-    "application/typescript",
-    "application/x-tex",
-    "application/x-latex",
-    "application/x-troff",
-    "application/x-troff-man",
-    "application/x-ndjson",
-    "application/ld+json",
-    "application/manifest+json",
-    "application/schema+json",
-    "application/vnd.api+json",
-    "application/hal+json",
-    "application/problem+json",
-    "application/x-www-form-urlencoded",
-    "application/xhtml+xml",
-    "application/atom+xml",
-    "application/rss+xml",
-    "application/soap+xml",
-    "application/mathml+xml",
-    "application/xslt+xml",
-    "application/x-subrip",
-    "application/x-wine-extension-ini",
-}
 
 
 @dataclass
@@ -344,29 +250,16 @@ class DocumentParser:
         """
         Check if a MIME type represents a text-based file.
 
+        Delegates to the shared classification so the parser and the chat_shell
+        attachment preview stay consistent as file types are added.
+
         Args:
             mime_type: MIME type string to check, or None
 
         Returns:
             True if the MIME type is text-based, False otherwise
         """
-        if not mime_type:
-            return False
-
-        # Check if it starts with text/
-        if mime_type.startswith("text/"):
-            return True
-
-        # Check if it's in our whitelist of text-based application/* types
-        if mime_type in TEXT_MIME_TYPES:
-            return True
-
-        # Check for common text-based patterns
-        # Many text formats use +json, +xml suffixes
-        if mime_type.endswith("+json") or mime_type.endswith("+xml"):
-            return True
-
-        return False
+        return is_text_readable_mime(mime_type)
 
     @classmethod
     def is_supported_extension(cls, extension: str) -> bool:

--- a/backend/app/services/attachment/truncation_strategies/base.py
+++ b/backend/app/services/attachment/truncation_strategies/base.py
@@ -76,10 +76,15 @@ class BaseTruncationStrategy(ABC):
     """Base class for truncation strategies."""
 
     # Distribution ratios for head/middle/tail (should sum to 1.0)
-    # These can be overridden by subclasses
-    HEAD_RATIO = 0.25  # 25% for head content
-    MIDDLE_RATIO = 0.50  # 50% for uniformly sampled middle content
-    TAIL_RATIO = 0.25  # 25% for tail content
+    # These can be overridden by subclasses.
+    #
+    # Middle is 0: we keep a CONTIGUOUS head + tail and drop the middle behind a
+    # single omission marker, instead of scattering uniformly-sampled fragments.
+    # Contiguous content reads coherently and lets read_attachment page real
+    # text; the inline preview / read_attachment cover on-demand access to more.
+    HEAD_RATIO = 0.5  # 50% head (contiguous)
+    MIDDLE_RATIO = 0.0  # middle dropped (single omission marker)
+    TAIL_RATIO = 0.5  # 50% tail (contiguous)
 
     def __init__(self, config: SmartTruncationConfig):
         self.config = config
@@ -188,6 +193,12 @@ class BaseTruncationStrategy(ABC):
         head_count = max(1, int(items_to_keep * self.HEAD_RATIO))
         tail_count = max(1, int(items_to_keep * self.TAIL_RATIO))
         middle_count = max(0, items_to_keep - head_count - tail_count)
+
+        # When middle sampling is disabled, keep a contiguous head + tail and
+        # fold any rounding remainder into the head (no scattered middle).
+        if self.MIDDLE_RATIO <= 0:
+            head_count += middle_count
+            middle_count = 0
 
         # Ensure we don't exceed total items
         if head_count + tail_count >= total_items:

--- a/backend/app/services/attachment/truncation_strategies/excel.py
+++ b/backend/app/services/attachment/truncation_strategies/excel.py
@@ -30,9 +30,9 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
     """
 
     # Distribution ratios for head/middle/tail (should sum to 1.0)
-    HEAD_RATIO = 0.25  # 25% for head data rows
-    MIDDLE_RATIO = 0.50  # 50% for uniformly sampled middle rows
-    TAIL_RATIO = 0.25  # 25% for tail data rows
+    HEAD_RATIO = 0.5  # 50% head data rows (contiguous)
+    MIDDLE_RATIO = 0.0  # middle dropped (single "[N rows skipped]" marker)
+    TAIL_RATIO = 0.5  # 50% tail data rows (contiguous)
 
     def truncate(
         self, sheets_data: List[Dict[str, Any]], max_length: int
@@ -172,10 +172,17 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
             # No truncation needed for this sheet
             return full_text[:max_length], total_rows, 0
 
-        # Distribute data rows: head (25%), middle (50%), tail (25%)
+        # Distribute data rows. With MIDDLE_RATIO == 0 keep a contiguous head +
+        # tail (fold the rounding remainder into head, no sampled middle);
+        # otherwise uniformly sample the middle.
         head_count = max(1, int(data_rows_to_keep * self.HEAD_RATIO))
         tail_count = max(1, int(data_rows_to_keep * self.TAIL_RATIO))
-        middle_count = max(1, data_rows_to_keep - head_count - tail_count)
+        remainder = max(0, data_rows_to_keep - head_count - tail_count)
+        if self.MIDDLE_RATIO <= 0:
+            head_count += remainder
+            middle_count = 0
+        else:
+            middle_count = max(1, remainder)
 
         # Adjust if we don't have enough middle rows to sample from
         middle_start = header_count + head_count

--- a/backend/app/services/attachment/truncation_strategies/excel.py
+++ b/backend/app/services/attachment/truncation_strategies/excel.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Excel and CSV truncation strategies using head + uniform sampling + tail approach.
+Excel and CSV truncation strategies using head + tail (contiguous, middle dropped) approach.
 """
 
 from typing import Any, Dict, List, Tuple
@@ -17,7 +17,7 @@ from .base import (
 
 class ExcelTruncationStrategy(BaseTruncationStrategy):
     """
-    Smart truncation for Excel files using head + uniform sampling + tail strategy.
+    Smart truncation for Excel files using head + tail (contiguous, middle dropped) strategy.
 
     This strategy preserves:
     1. Header row(s) - column names
@@ -38,7 +38,7 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
         self, sheets_data: List[Dict[str, Any]], max_length: int
     ) -> Tuple[str, SmartTruncationInfo]:
         """
-        Truncate Excel data with head + uniform sampling + tail strategy.
+        Truncate Excel data with head + tail (contiguous, middle dropped) strategy.
 
         Args:
             sheets_data: List of sheet data, each containing:
@@ -111,13 +111,13 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
         info.kept_structure = {
             "kept_rows": kept_rows_total,
             "omitted_rows": omitted_rows_total,
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
         }
 
         info.summary_message = (
-            f"[Smart Truncation Applied - Head + Uniform Sampling + Tail]\n"
+            f"[Smart Truncation Applied - Head + Tail (contiguous)]\n"
             f"Total: {total_rows} rows across {total_sheets} sheet(s)\n"
-            f"Kept: {kept_rows_total} rows (head + uniformly sampled middle + tail)\n"
+            f"Kept: {kept_rows_total} rows (contiguous head + tail; middle dropped by default)\n"
             f"Omitted: {omitted_rows_total} rows"
         )
 
@@ -127,7 +127,7 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
         self, sheet_name: str, rows: List[List[Any]], max_length: int
     ) -> Tuple[str, int, int]:
         """
-        Truncate a single sheet using head + uniform sampling + tail strategy.
+        Truncate a single sheet using head + tail (contiguous, middle dropped) strategy.
 
         Distribution:
         - Header rows (always kept)
@@ -201,7 +201,9 @@ class ExcelTruncationStrategy(BaseTruncationStrategy):
         head_section = rows[header_count : header_count + head_count]
         tail_section = rows[total_rows - tail_count :] if tail_count > 0 else []
 
-        # Sample middle section uniformly
+        # Sample middle section uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 # Keep all middle rows

--- a/backend/app/services/attachment/truncation_strategies/pdf.py
+++ b/backend/app/services/attachment/truncation_strategies/pdf.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-PDF truncation strategy using head + uniform sampling + tail approach.
+PDF truncation strategy using head + tail (contiguous, middle dropped) approach.
 """
 
 from typing import List, Tuple
@@ -17,7 +17,7 @@ from .base import (
 
 class PDFTruncationStrategy(BaseTruncationStrategy):
     """
-    Smart truncation for PDF files using head + uniform sampling + tail strategy.
+    Smart truncation for PDF files using head + tail (contiguous, middle dropped) strategy.
 
     This strategy preserves:
     1. Head pages - introduction, abstract, table of contents
@@ -29,7 +29,7 @@ class PDFTruncationStrategy(BaseTruncationStrategy):
         self, pages_text: List[str], max_length: int
     ) -> Tuple[str, SmartTruncationInfo]:
         """
-        Truncate PDF with head + uniform sampling + tail strategy.
+        Truncate PDF with head + tail (contiguous, middle dropped) strategy.
 
         Args:
             pages_text: List of text content per page
@@ -103,7 +103,9 @@ class PDFTruncationStrategy(BaseTruncationStrategy):
             )
         )
 
-        # Sample middle section uniformly
+        # Sample middle section uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 middle_indices = list(range(middle_available))
@@ -176,10 +178,10 @@ class PDFTruncationStrategy(BaseTruncationStrategy):
             "total_kept": head_count + len(middle_section) + len(tail_section),
             "omitted_pages": total_pages
             - (head_count + len(middle_section) + len(tail_section)),
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
         }
         info.summary_message = (
-            f"[Smart Truncation Applied - Head + Uniform Sampling + Tail]\n"
+            f"[Smart Truncation Applied - Head + Tail (contiguous)]\n"
             f"Total: {total_pages} pages\n"
             f"Kept: {head_count} head + {len(middle_section)} middle (sampled) + {len(tail_section)} tail pages\n"
             f"Omitted: {total_pages - (head_count + len(middle_section) + len(tail_section))} pages"

--- a/backend/app/services/attachment/truncation_strategies/powerpoint.py
+++ b/backend/app/services/attachment/truncation_strategies/powerpoint.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-PowerPoint truncation strategy using head + uniform sampling + tail approach.
+PowerPoint truncation strategy using head + tail (contiguous, middle dropped) approach.
 """
 
 from typing import List, Tuple
@@ -17,7 +17,7 @@ from .base import (
 
 class PowerPointTruncationStrategy(BaseTruncationStrategy):
     """
-    Smart truncation for PowerPoint files using head + uniform sampling + tail strategy.
+    Smart truncation for PowerPoint files using head + tail (contiguous, middle dropped) strategy.
 
     This strategy preserves:
     1. Head slides - title, agenda, introduction
@@ -29,7 +29,7 @@ class PowerPointTruncationStrategy(BaseTruncationStrategy):
         self, slides_text: List[str], max_length: int
     ) -> Tuple[str, SmartTruncationInfo]:
         """
-        Truncate PowerPoint with head + uniform sampling + tail strategy.
+        Truncate PowerPoint with head + tail (contiguous, middle dropped) strategy.
 
         Args:
             slides_text: List of text content per slide
@@ -98,7 +98,9 @@ class PowerPointTruncationStrategy(BaseTruncationStrategy):
             )
         )
 
-        # Sample middle section uniformly
+        # Sample middle section uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 middle_indices = list(range(middle_available))
@@ -171,10 +173,10 @@ class PowerPointTruncationStrategy(BaseTruncationStrategy):
             "total_kept": head_count + len(middle_section) + len(tail_section),
             "omitted_slides": total_slides
             - (head_count + len(middle_section) + len(tail_section)),
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
         }
         info.summary_message = (
-            f"[Smart Truncation Applied - Head + Uniform Sampling + Tail]\n"
+            f"[Smart Truncation Applied - Head + Tail (contiguous)]\n"
             f"Total: {total_slides} slides\n"
             f"Kept: {head_count} head + {len(middle_section)} middle (sampled) + {len(tail_section)} tail slides\n"
             f"Omitted: {total_slides - (head_count + len(middle_section) + len(tail_section))} slides"

--- a/backend/app/services/attachment/truncation_strategies/text.py
+++ b/backend/app/services/attachment/truncation_strategies/text.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Text and Markdown truncation strategy using head + uniform sampling + tail approach.
+Text and Markdown truncation strategy using head + tail (contiguous, middle dropped) approach.
 """
 
 import re
@@ -26,7 +26,7 @@ class TextTruncationStrategy(BaseTruncationStrategy):
     3. Uniformly samples middle sections
     4. Keeps tail content (conclusion, summary)
 
-    For plain text, uses line-based head + uniform sampling + tail strategy.
+    For plain text, uses line-based head + tail (contiguous, middle dropped) strategy.
     """
 
     # Markdown heading patterns (# to ######)
@@ -37,7 +37,7 @@ class TextTruncationStrategy(BaseTruncationStrategy):
         Truncate text/markdown with structure-aware strategy.
 
         For markdown: Preserves headings and uses section-based truncation.
-        For plain text: Uses line-based head + uniform sampling + tail.
+        For plain text: Uses line-based head + tail (contiguous).
 
         Args:
             text: The text content
@@ -159,7 +159,9 @@ class TextTruncationStrategy(BaseTruncationStrategy):
             middle_count = 0
             middle_available = 0
 
-        # Sample middle sections uniformly
+        # Sample middle sections uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 middle_indices = list(range(middle_available))
@@ -249,7 +251,7 @@ class TextTruncationStrategy(BaseTruncationStrategy):
             "total_kept": head_count + len(middle_section_indices) + tail_count,
             "omitted_sections": total_sections
             - (head_count + len(middle_section_indices) + tail_count),
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
             "structure_preserved": "markdown_headings",
         }
         info.summary_message = (
@@ -269,7 +271,7 @@ class TextTruncationStrategy(BaseTruncationStrategy):
         info: SmartTruncationInfo,
     ) -> Tuple[str, SmartTruncationInfo]:
         """
-        Truncate plain text with line-based head + uniform sampling + tail strategy.
+        Truncate plain text with line-based head + tail (contiguous, middle dropped) strategy.
         """
         total_lines = len(lines)
         original_length = len(text)
@@ -315,7 +317,9 @@ class TextTruncationStrategy(BaseTruncationStrategy):
             )
         )
 
-        # Sample middle section uniformly
+        # Sample middle section uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 middle_indices = list(range(middle_available))
@@ -387,10 +391,10 @@ class TextTruncationStrategy(BaseTruncationStrategy):
             "total_kept": head_count + len(middle_section) + len(tail_section),
             "omitted_lines": total_lines
             - (head_count + len(middle_section) + len(tail_section)),
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
         }
         info.summary_message = (
-            f"[Smart Truncation Applied - Head + Uniform Sampling + Tail]\n"
+            f"[Smart Truncation Applied - Head + Tail (contiguous)]\n"
             f"Total: {total_lines} lines\n"
             f"Kept: {head_count} head + {len(middle_section)} middle (sampled) + {len(tail_section)} tail lines\n"
             f"Omitted: {total_lines - (head_count + len(middle_section) + len(tail_section))} lines"

--- a/backend/app/services/attachment/truncation_strategies/word.py
+++ b/backend/app/services/attachment/truncation_strategies/word.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Word document truncation strategy using head + uniform sampling + tail approach.
+Word document truncation strategy using head + tail (contiguous, middle dropped) approach.
 """
 
 from typing import List, Tuple
@@ -17,7 +17,7 @@ from .base import (
 
 class WordTruncationStrategy(BaseTruncationStrategy):
     """
-    Smart truncation for Word documents using head + uniform sampling + tail strategy.
+    Smart truncation for Word documents using head + tail (contiguous, middle dropped) strategy.
 
     This strategy preserves:
     1. Head paragraphs - introduction, abstract, document purpose
@@ -29,7 +29,7 @@ class WordTruncationStrategy(BaseTruncationStrategy):
         self, paragraphs: List[str], max_length: int
     ) -> Tuple[str, SmartTruncationInfo]:
         """
-        Truncate Word document with head + uniform sampling + tail strategy.
+        Truncate Word document with head + tail (contiguous, middle dropped) strategy.
 
         Args:
             paragraphs: List of paragraph texts
@@ -98,7 +98,9 @@ class WordTruncationStrategy(BaseTruncationStrategy):
             )
         )
 
-        # Sample middle section uniformly
+        # Sample middle section uniformly. Only reached when MIDDLE_RATIO > 0;
+        # with the default MIDDLE_RATIO = 0 the middle folds into head
+        # (contiguous head + tail), so this branch is inactive by default.
         if middle_count > 0 and middle_available > 0:
             if middle_count >= middle_available:
                 middle_indices = list(range(middle_available))
@@ -171,10 +173,10 @@ class WordTruncationStrategy(BaseTruncationStrategy):
             "total_kept": head_count + len(middle_section) + len(tail_section),
             "omitted_paragraphs": total_paragraphs
             - (head_count + len(middle_section) + len(tail_section)),
-            "sampling_method": "head_uniform_tail",
+            "sampling_method": "head_tail_contiguous",
         }
         info.summary_message = (
-            f"[Smart Truncation Applied - Head + Uniform Sampling + Tail]\n"
+            f"[Smart Truncation Applied - Head + Tail (contiguous)]\n"
             f"Total: {total_paragraphs} paragraphs\n"
             f"Kept: {head_count} head + {len(middle_section)} middle (sampled) + {len(tail_section)} tail paragraphs\n"
             f"Omitted: {total_paragraphs - (head_count + len(middle_section) + len(tail_section))} paragraphs"

--- a/backend/app/services/chat/preprocessing/contexts.py
+++ b/backend/app/services/chat/preprocessing/contexts.py
@@ -39,6 +39,7 @@ from shared.prompts import (
     KB_PROMPT_RESTRICTED_ANALYST,
     KB_PROMPT_STRICT,
 )
+from shared.utils.attachment_block import build_attachment_header
 
 logger = logging.getLogger(__name__)
 
@@ -282,26 +283,20 @@ def _process_attachment_context(
         # Build image attachment metadata
         attachment_id = context.id
         filename = context.original_filename
-        mime_type = context.mime_type or "unknown"
-        file_size = context.file_size or 0
-        formatted_size = context_service.format_file_size(file_size)
         url = context_service.build_attachment_url(attachment_id)
 
         # Build sandbox path if task_id and subtask_id are provided
         sandbox_path = context_service.build_sandbox_path(task_id, subtask_id, filename)
 
-        # Build image metadata header with optional sandbox path
-        if sandbox_path:
-            image_header = (
-                f"[Image Attachment: {filename} | ID: {attachment_id} | "
-                f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-                f"File Path(already in sandbox): {sandbox_path}]"
-            )
-        else:
-            image_header = (
-                f"[Image Attachment: {filename} | ID: {attachment_id} | "
-                f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]"
-            )
+        # Build image metadata header (shared with chat_shell loader)
+        image_header = build_attachment_header(
+            attachment_id=attachment_id,
+            filename=filename,
+            mime_type=context.mime_type or "unknown",
+            file_size=context.file_size or 0,
+            sandbox_path=sandbox_path,
+            is_image=True,
+        )
 
         image_contents.append(
             {

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -732,34 +732,20 @@ class ContextService:
         if not context.extracted_text:
             return None
 
-        # Check if text was truncated by comparing text_length with max limit
-        max_text_length = DocumentParser.get_max_text_length()
-        is_truncated = context.text_length >= max_text_length
-
-        # Build attachment metadata header (shared with chat_shell loader)
+        # Build attachment metadata header (shared with chat_shell loader).
+        # Parse-time truncation is self-described by the omission marker baked
+        # into extracted_text; no separate "(Note: truncated ...)" line is added
+        # (it duplicated that marker and the chat_shell preview's Truncated flag).
         filename = context.original_filename
         sandbox_path = build_sandbox_path(task_id, subtask_id, filename)
-        prefix = (
-            build_attachment_header(
-                attachment_id=context.id,
-                filename=filename,
-                mime_type=context.mime_type or "unknown",
-                file_size=context.file_size or 0,
-                sandbox_path=sandbox_path,
-            )
-            + "\n"
+        header = build_attachment_header(
+            attachment_id=context.id,
+            filename=filename,
+            mime_type=context.mime_type or "unknown",
+            file_size=context.file_size or 0,
+            sandbox_path=sandbox_path,
         )
-
-        if is_truncated:
-            prefix += (
-                f"(Note: The file content is too long and has been truncated to "
-                f"{max_text_length} characters. The following is only partial content.)\n"
-            )
-
-        prefix += f"{context.extracted_text}\n\n"
-
-        # Wrap in <attachment> XML tags
-        return prefix
+        return f"{header}\n{context.extracted_text}\n\n"
 
     # ==================== Knowledge Base Operations ====================
 

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -35,6 +35,12 @@ from app.services.attachment.storage_backend import StorageError, generate_stora
 from app.services.attachment.storage_factory import get_storage_backend
 from app.stores.tasks import subtask_store
 from shared.telemetry.decorators import trace_sync
+from shared.utils.attachment_block import (
+    build_attachment_download_url,
+    build_attachment_header,
+    build_sandbox_path,
+    format_file_size,
+)
 from shared.utils.crypto import decrypt_attachment, encrypt_attachment
 
 logger = logging.getLogger(__name__)
@@ -70,36 +76,19 @@ class ContextService:
 
     # ==================== Helper Methods ====================
 
+    # File-size / URL / sandbox-path formatting is shared with chat_shell's
+    # history loader (single source of truth in shared.utils.attachment_block)
+    # so the attachment block format stays consistent across first-send and
+    # history replay. These thin wrappers preserve the existing public API.
     @staticmethod
     def format_file_size(size_bytes: int) -> str:
-        """
-        Format file size in bytes to human-readable format.
-
-        Args:
-            size_bytes: File size in bytes
-
-        Returns:
-            Formatted string like "2.5 MB", "156.3 KB", or "512 bytes"
-        """
-        if size_bytes >= 1024 * 1024:
-            return f"{size_bytes / (1024 * 1024):.1f} MB"
-        elif size_bytes >= 1024:
-            return f"{size_bytes / 1024:.1f} KB"
-        else:
-            return f"{size_bytes} bytes"
+        """Format file size in bytes to human-readable format."""
+        return format_file_size(size_bytes)
 
     @staticmethod
     def build_attachment_url(attachment_id: int) -> str:
-        """
-        Build the download URL for an attachment.
-
-        Args:
-            attachment_id: Attachment ID
-
-        Returns:
-            Relative URL path for downloading the attachment
-        """
-        return f"/api/attachments/{attachment_id}/download"
+        """Build the download URL for an attachment."""
+        return build_attachment_download_url(attachment_id)
 
     @staticmethod
     def build_sandbox_path(
@@ -107,26 +96,8 @@ class ContextService:
         subtask_id: Optional[int],
         filename: str,
     ) -> Optional[str]:
-        """
-        Build the sandbox file path for an attachment.
-
-        This path corresponds to where the Executor downloads attachments
-        in the sandbox environment.
-
-        Args:
-            task_id: Task ID
-            subtask_id: Subtask ID
-            filename: Original filename
-
-        Returns:
-            Sandbox path in format: /home/user/{task_id}:executor:attachments/{subtask_id}/{filename}
-            Returns None if task_id or subtask_id is not provided.
-        """
-        if task_id is None or subtask_id is None:
-            return None
-        # Guard against None filename and strip control characters
-        safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
-        return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+        """Build the sandbox file path where the Executor downloads an attachment."""
+        return build_sandbox_path(task_id, subtask_id, filename)
 
     # ==================== Attachment Operations ====================
 
@@ -765,29 +736,19 @@ class ContextService:
         max_text_length = DocumentParser.get_max_text_length()
         is_truncated = context.text_length >= max_text_length
 
-        # Build attachment metadata header
-        attachment_id = context.id
+        # Build attachment metadata header (shared with chat_shell loader)
         filename = context.original_filename
-        mime_type = context.mime_type or "unknown"
-        file_size = context.file_size or 0
-        formatted_size = self.format_file_size(file_size)
-        url = self.build_attachment_url(attachment_id)
-
-        # Build sandbox path if task_id and subtask_id are provided
-        sandbox_path = self.build_sandbox_path(task_id, subtask_id, filename)
-
-        # Build the prefix with metadata and optional truncation notice
-        if sandbox_path:
-            prefix = (
-                f"[Attachment: {filename} | ID: {attachment_id} | "
-                f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-                f"File Path(already in sandbox): {sandbox_path}]\n"
+        sandbox_path = build_sandbox_path(task_id, subtask_id, filename)
+        prefix = (
+            build_attachment_header(
+                attachment_id=context.id,
+                filename=filename,
+                mime_type=context.mime_type or "unknown",
+                file_size=context.file_size or 0,
+                sandbox_path=sandbox_path,
             )
-        else:
-            prefix = (
-                f"[Attachment: {filename} | ID: {attachment_id} | "
-                f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]\n"
-            )
+            + "\n"
+        )
 
         if is_truncated:
             prefix += (

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.models.subtask_context import (
     ContextStatus,
     ContextType,
@@ -41,6 +42,7 @@ from shared.utils.attachment_block import (
     build_sandbox_path,
     build_truncation_note,
     format_file_size,
+    truncate_for_injection,
 )
 from shared.utils.crypto import decrypt_attachment, encrypt_attachment
 
@@ -758,8 +760,20 @@ class ContextService:
             file_size=context.file_size or 0,
             sandbox_path=sandbox_path,
         )
-        note = build_truncation_note(context.is_truncated)
-        return f"{header}\n{note}{context.extracted_text}\n\n"
+        # Bound the inline copy: the injected text is only a preview (the full
+        # file stays reachable via the downloaded file / sandbox, or read_attachment
+        # in chat_shell), so cap it well below the stored length. This is the only
+        # length guard for modes without the chat_shell token preview (executor /
+        # device).
+        inject_text, inj_truncated = truncate_for_injection(
+            context.extracted_text, settings.ATTACHMENT_INJECT_MAX_CHARS
+        )
+        # Single partial-content signal: when the injection was capped, its inline
+        # marker already flags partiality and points to the file. Fall back to a
+        # prefix note only when parsing truncated the stored text but the inject
+        # cap did not re-truncate (rare; e.g. an unusually small cap).
+        note = build_truncation_note(context.is_truncated and not inj_truncated)
+        return f"{header}\n{note}{inject_text}\n\n"
 
     # ==================== Knowledge Base Operations ====================
 

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -276,19 +276,24 @@ class ContextService:
                 }
             context.status = ContextStatus.READY.value
 
+            # Persist the parse-time truncation flag so the injected attachment
+            # block can render a partial-content notice for modes without the
+            # chat_shell preview (executor / device). Always write it (even when
+            # False) so overwriting a previously-truncated attachment with a
+            # smaller, non-truncated file clears the stale True.
+            context.type_data = {
+                **context.type_data,
+                "is_truncated": bool(
+                    parse_result.truncation_info
+                    and parse_result.truncation_info.is_truncated
+                ),
+            }
             if parse_result.truncation_info:
                 truncation_info = TruncationInfo(
                     is_truncated=parse_result.truncation_info.is_truncated,
                     original_length=parse_result.truncation_info.original_length,
                     truncated_length=parse_result.truncation_info.truncated_length,
                 )
-                # Persist the parse-time truncation flag so the injected
-                # attachment block can render a partial-content notice for modes
-                # without the chat_shell preview (executor / device).
-                context.type_data = {
-                    **context.type_data,
-                    "is_truncated": parse_result.truncation_info.is_truncated,
-                }
         except DocumentParseError as e:
             logger.exception(f"Document parsing failed for context {context.id}: {e}")
             context.status = ContextStatus.FAILED.value

--- a/backend/app/services/context/context_service.py
+++ b/backend/app/services/context/context_service.py
@@ -39,6 +39,7 @@ from shared.utils.attachment_block import (
     build_attachment_download_url,
     build_attachment_header,
     build_sandbox_path,
+    build_truncation_note,
     format_file_size,
 )
 from shared.utils.crypto import decrypt_attachment, encrypt_attachment
@@ -281,6 +282,13 @@ class ContextService:
                     original_length=parse_result.truncation_info.original_length,
                     truncated_length=parse_result.truncation_info.truncated_length,
                 )
+                # Persist the parse-time truncation flag so the injected
+                # attachment block can render a partial-content notice for modes
+                # without the chat_shell preview (executor / device).
+                context.type_data = {
+                    **context.type_data,
+                    "is_truncated": parse_result.truncation_info.is_truncated,
+                }
         except DocumentParseError as e:
             logger.exception(f"Document parsing failed for context {context.id}: {e}")
             context.status = ContextStatus.FAILED.value
@@ -733,9 +741,9 @@ class ContextService:
             return None
 
         # Build attachment metadata header (shared with chat_shell loader).
-        # Parse-time truncation is self-described by the omission marker baked
-        # into extracted_text; no separate "(Note: truncated ...)" line is added
-        # (it duplicated that marker and the chat_shell preview's Truncated flag).
+        # When the parser truncated the file, prepend a length-free partial-content
+        # notice so modes without the chat_shell preview (executor / device) still
+        # know the text is incomplete and the full file should be read.
         filename = context.original_filename
         sandbox_path = build_sandbox_path(task_id, subtask_id, filename)
         header = build_attachment_header(
@@ -745,7 +753,8 @@ class ContextService:
             file_size=context.file_size or 0,
             sandbox_path=sandbox_path,
         )
-        return f"{header}\n{context.extracted_text}\n\n"
+        note = build_truncation_note(context.is_truncated)
+        return f"{header}\n{note}{context.extracted_text}\n\n"
 
     # ==================== Knowledge Base Operations ====================
 

--- a/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
+++ b/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.models.subtask import Subtask, SubtaskRole, SubtaskStatus
+from app.models.subtask_context import ContextStatus, ContextType, SubtaskContext
+from app.models.task import TaskResource
+from app.models.user import User
+
+
+def _create_task(db: Session, *, user_id: int, task_id: int) -> TaskResource:
+    task = TaskResource(
+        id=task_id,
+        user_id=user_id,
+        kind="Task",
+        name=f"task-{task_id}",
+        namespace="default",
+        json={
+            "apiVersion": "agent.wecode.io/v1",
+            "kind": "Task",
+            "metadata": {"name": f"task-{task_id}", "namespace": "default"},
+            "spec": {"title": f"task-{task_id}", "prompt": ""},
+            "status": {"state": "Available", "status": "COMPLETED"},
+        },
+        is_active=TaskResource.STATE_ACTIVE,
+        client_origin="wework",
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+def _create_user_subtask(db: Session, *, user_id: int, task_id: int) -> Subtask:
+    subtask = Subtask(
+        user_id=user_id,
+        task_id=task_id,
+        team_id=1,
+        title="user-message",
+        bot_ids=[1],
+        role=SubtaskRole.USER,
+        prompt="hello",
+        message_id=1,
+        parent_id=0,
+        status=SubtaskStatus.COMPLETED,
+        progress=100,
+        completed_at=datetime.now(),
+    )
+    db.add(subtask)
+    db.commit()
+    db.refresh(subtask)
+    return subtask
+
+
+def _create_attachment(
+    db: Session,
+    *,
+    user_id: int,
+    subtask_id: int,
+    extracted_text: str,
+    status: str = ContextStatus.READY.value,
+) -> SubtaskContext:
+    ctx = SubtaskContext(
+        subtask_id=subtask_id,
+        user_id=user_id,
+        context_type=ContextType.ATTACHMENT.value,
+        name="report.pdf",
+        status=status,
+        binary_data=b"",
+        extracted_text=extracted_text,
+        text_length=len(extracted_text),
+        type_data={"mime_type": "application/pdf", "original_filename": "report.pdf"},
+    )
+    db.add(ctx)
+    db.commit()
+    db.refresh(ctx)
+    return ctx
+
+
+def test_get_attachment_text_returns_slice(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7001
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    sub = _create_user_subtask(test_db, user_id=test_user.id, task_id=task_id)
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id, subtask_id=sub.id, extracted_text="0123456789"
+    )
+
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 4},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["text"] == "0123"
+    assert body["total_chars"] == 10
+    assert body["has_more"] is True
+    assert body["mime_type"] == "application/pdf"
+
+    # Tail slice
+    resp2 = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 8, "limit": 100},
+    )
+    body2 = resp2.json()
+    assert body2["text"] == "89"
+    assert body2["has_more"] is False
+
+
+def test_cross_task_attachment_is_denied(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_a, task_b = 7101, 7102
+    _create_task(test_db, user_id=test_user.id, task_id=task_a)
+    _create_task(test_db, user_id=test_user.id, task_id=task_b)
+    sub_b = _create_user_subtask(test_db, user_id=test_user.id, task_id=task_b)
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id, subtask_id=sub_b.id, extracted_text="secret"
+    )
+
+    # Request the task_b attachment through task_a's session.
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_a}", "offset": 0, "limit": 10},
+    )
+    assert resp.status_code == 403
+
+
+def test_missing_attachment_returns_404(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7201
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    resp = test_client.get(
+        "/api/internal/chat/attachments/999999/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10},
+    )
+    assert resp.status_code == 404
+
+
+def test_non_ready_attachment_returns_404(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7301
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    sub = _create_user_subtask(test_db, user_id=test_user.id, task_id=task_id)
+    ctx = _create_attachment(
+        test_db,
+        user_id=test_user.id,
+        subtask_id=sub.id,
+        extracted_text="pending",
+        status=ContextStatus.PENDING.value,
+    )
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10},
+    )
+    assert resp.status_code == 404

--- a/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
+++ b/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
@@ -130,7 +130,8 @@ def test_cross_task_attachment_is_denied(
         f"/api/internal/chat/attachments/{ctx.id}/text",
         params={"session_id": f"task-{task_a}", "offset": 0, "limit": 10},
     )
-    assert resp.status_code == 403
+    # 404 (not 403): don't leak existence of attachments in other conversations.
+    assert resp.status_code == 404
 
 
 def test_unlinked_attachment_same_user_allowed(
@@ -164,7 +165,8 @@ def test_unlinked_attachment_other_user_denied(
         f"/api/internal/chat/attachments/{ctx.id}/text",
         params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10},
     )
-    assert resp.status_code == 403
+    # 404 (not 403): don't leak existence across users.
+    assert resp.status_code == 404
 
 
 def test_source_truncated_flag_propagates(

--- a/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
+++ b/backend/tests/api/endpoints/test_internal_chat_storage_attachment.py
@@ -102,6 +102,7 @@ def test_get_attachment_text_returns_slice(
     assert body["total_chars"] == 10
     assert body["has_more"] is True
     assert body["mime_type"] == "application/pdf"
+    assert body["source_truncated"] is False
 
     # Tail slice
     resp2 = test_client.get(
@@ -130,6 +131,78 @@ def test_cross_task_attachment_is_denied(
         params={"session_id": f"task-{task_a}", "offset": 0, "limit": 10},
     )
     assert resp.status_code == 403
+
+
+def test_unlinked_attachment_same_user_allowed(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7401
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    # Unlinked (subtask_id == 0) but owned by the task's user — readable.
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id, subtask_id=0, extracted_text="preset"
+    )
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "preset"
+
+
+def test_unlinked_attachment_other_user_denied(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7501
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    # Unlinked attachment owned by a DIFFERENT user — must not be readable, so
+    # the model cannot probe arbitrary unlinked ids across users.
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id + 9999, subtask_id=0, extracted_text="secret"
+    )
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10},
+    )
+    assert resp.status_code == 403
+
+
+def test_source_truncated_flag_propagates(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7601
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    sub = _create_user_subtask(test_db, user_id=test_user.id, task_id=task_id)
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id, subtask_id=sub.id, extracted_text="partial"
+    )
+    # Mark the stored extract as parse-truncated.
+    ctx.type_data = {**ctx.type_data, "is_truncated": True}
+    test_db.commit()
+
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 100},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["source_truncated"] is True
+
+
+def test_oversized_limit_is_rejected(
+    test_client: TestClient, test_db: Session, test_user: User
+):
+    task_id = 7701
+    _create_task(test_db, user_id=test_user.id, task_id=task_id)
+    sub = _create_user_subtask(test_db, user_id=test_user.id, task_id=task_id)
+    ctx = _create_attachment(
+        test_db, user_id=test_user.id, subtask_id=sub.id, extracted_text="0123456789"
+    )
+    # A page is token-clamped anyway; the endpoint caps a single slice.
+    resp = test_client.get(
+        f"/api/internal/chat/attachments/{ctx.id}/text",
+        params={"session_id": f"task-{task_id}", "offset": 0, "limit": 10_000_000},
+    )
+    assert resp.status_code == 422
 
 
 def test_missing_attachment_returns_404(

--- a/backend/tests/services/attachment/test_smart_truncation.py
+++ b/backend/tests/services/attachment/test_smart_truncation.py
@@ -117,7 +117,23 @@ class TestExcelTruncationStrategy:
         # First data rows should be present (head section)
         assert "Item0" in text
 
-    def test_multiple_sheets(self):
+    def test_truncation_keeps_header_and_contiguous_head_tail(self):
+        """Header is always kept; data rows are contiguous head + tail, no
+        scattered middle sampling (single '[N rows skipped]' marker)."""
+        rows = [["ID", "Name", "Value", "Description"]]  # Header
+        for i in range(300):
+            rows.append([i, f"Item{i}", i * 10, "desc " + "v" * 40])
+        sheets_data = [{"name": "Data", "rows": rows}]
+
+        text, info = self.strategy.truncate(sheets_data, 3000)
+
+        assert info.is_truncated is True
+        # Header preserved.
+        assert "ID" in text and "Name" in text
+        # Contiguous head data rows (consecutive, not sampled).
+        assert "Item0" in text and "Item1" in text and "Item2" in text
+        # Exactly one omission marker between head and tail (no scattered samples).
+        assert text.count("rows skipped") <= 1
         """Test truncation with multiple sheets."""
         sheets_data = [
             {
@@ -348,6 +364,23 @@ class TestTextTruncationStrategy:
         )
         # First lines should be present
         assert "Line 0" in result
+
+    def test_truncation_keeps_contiguous_head_tail_no_middle_sampling(self):
+        """Middle is dropped behind one omission marker (no scattered sampling)."""
+        lines = [f"Line {i}: content " + "v" * 50 for i in range(200)]
+        text = "\n".join(lines)
+
+        result, info = self.strategy.truncate(text, 2000)
+
+        assert info.is_truncated is True
+        # Contiguous head (consecutive early lines, not scattered samples).
+        assert "Line 0:" in result and "Line 1:" in result and "Line 2:" in result
+        # Contiguous tail (the very last line is kept).
+        assert "Line 199:" in result
+        # Single omission marker; no scattered "[N lines skipped]" middle samples.
+        assert "omitted" in result.lower()
+        assert "Middle" not in result
+        assert "lines skipped" not in result
 
     def test_length_limit_fallback(self):
         """Test that length limit is enforced as fallback."""

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -1389,6 +1389,48 @@ class TestContextServiceFormatting:
         assert "has been truncated to" not in prefix
         assert "characters" not in prefix
 
+    def test_build_document_text_prefix_bounds_injected_text(self):
+        """Long extracted text is bounded inline; full text stays in the DB."""
+        from app.core.config import settings
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.context import context_service
+
+        long_text = "x" * (settings.ATTACHMENT_INJECT_MAX_CHARS + 50_000)
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="huge.txt",
+            status=ContextStatus.READY.value,
+            extracted_text=long_text,
+            text_length=len(long_text),
+            type_data={
+                "original_filename": "huge.txt",
+                "mime_type": "text/plain",
+                "file_size": len(long_text),
+                # Parse also truncated this file: the merged logic must still emit
+                # only the inline marker, not an additional prefix note.
+                "is_truncated": True,
+            },
+        )
+        context.id = 102
+
+        prefix = context_service.build_document_text_prefix(context)
+
+        assert prefix is not None
+        # Inline copy is bounded well below the stored text length.
+        assert len(prefix) < len(long_text)
+        assert "inline preview truncated" in prefix
+        # Mode-neutral marker: no chat_shell-only read_attachment mention.
+        assert "read_attachment" not in prefix
+        # Merged signal: the inline marker is the only notice — no separate
+        # "(parsing truncated ...)" prefix note is duplicated.
+        assert "parsing truncated this file" not in prefix
+
     def test_build_document_text_prefix_without_truncation_has_no_notice(self):
         """Non-truncated attachments get no partial-content notice."""
         from app.models.subtask_context import (

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -1346,7 +1346,12 @@ class TestContextServiceFormatting:
         assert "File Path(already in sandbox)" in prefix
 
     def test_build_document_text_prefix_with_truncation(self):
-        """Test building document text prefix with truncation notice"""
+        """At-cap attachments no longer get a separate truncation notice.
+
+        Parse-time truncation is self-described by the omission marker baked into
+        extracted_text, so build_document_text_prefix does not add a duplicate
+        "(Note: truncated ...)" line anymore.
+        """
         from app.models.subtask_context import (
             ContextStatus,
             ContextType,
@@ -1383,7 +1388,8 @@ class TestContextServiceFormatting:
         assert "Type: application/pdf" in prefix
         assert "Size: 5.0 MB" in prefix
         assert "URL: /api/attachments/100/download" in prefix
-        assert "truncated" in prefix.lower()
+        # No separate "(Note: ... truncated to N characters ...)" line.
+        assert "has been truncated to" not in prefix
 
 
 class TestContextServiceOverwrite:

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -1346,22 +1346,20 @@ class TestContextServiceFormatting:
         assert "File Path(already in sandbox)" in prefix
 
     def test_build_document_text_prefix_with_truncation(self):
-        """At-cap attachments no longer get a separate truncation notice.
+        """Truncated attachments get a length-free partial-content notice.
 
-        Parse-time truncation is self-described by the omission marker baked into
-        extracted_text, so build_document_text_prefix does not add a duplicate
-        "(Note: truncated ...)" line anymore.
+        The notice is driven by the persisted ``is_truncated`` flag (not a
+        length-vs-cap comparison) and intentionally omits any character count,
+        so it never restates the old "(truncated to N characters)" wording.
         """
         from app.models.subtask_context import (
             ContextStatus,
             ContextType,
             SubtaskContext,
         )
-        from app.services.attachment.parser import DocumentParser
         from app.services.context import context_service
 
-        # Arrange - set text_length >= max to trigger truncation notice
-        max_text_length = DocumentParser.get_max_text_length()
+        # Arrange - parse-time truncation recorded in type_data
         context = SubtaskContext(
             subtask_id=0,
             user_id=1,
@@ -1369,11 +1367,12 @@ class TestContextServiceFormatting:
             name="large.pdf",
             status=ContextStatus.READY.value,
             extracted_text="Content...",
-            text_length=max_text_length,  # At max length
+            text_length=10,
             type_data={
                 "original_filename": "large.pdf",
                 "mime_type": "application/pdf",
                 "file_size": 5242880,  # 5 MB
+                "is_truncated": True,
             },
         )
         context.id = 100
@@ -1385,11 +1384,41 @@ class TestContextServiceFormatting:
         assert prefix is not None
         assert "[Attachment: large.pdf |" in prefix
         assert "ID: 100" in prefix
-        assert "Type: application/pdf" in prefix
-        assert "Size: 5.0 MB" in prefix
-        assert "URL: /api/attachments/100/download" in prefix
-        # No separate "(Note: ... truncated to N characters ...)" line.
+        # Partial-content notice present, but no character count.
+        assert "only partial content is shown" in prefix
         assert "has been truncated to" not in prefix
+        assert "characters" not in prefix
+
+    def test_build_document_text_prefix_without_truncation_has_no_notice(self):
+        """Non-truncated attachments get no partial-content notice."""
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.context import context_service
+
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="small.pdf",
+            status=ContextStatus.READY.value,
+            extracted_text="Full content.",
+            text_length=13,
+            type_data={
+                "original_filename": "small.pdf",
+                "mime_type": "application/pdf",
+                "file_size": 1024,
+            },
+        )
+        context.id = 101
+
+        prefix = context_service.build_document_text_prefix(context)
+
+        assert prefix is not None
+        assert "only partial content is shown" not in prefix
+        assert "Full content." in prefix
 
 
 class TestContextServiceOverwrite:

--- a/backend/tests/services/test_context_service.py
+++ b/backend/tests/services/test_context_service.py
@@ -1496,6 +1496,68 @@ class TestContextServiceOverwrite:
         assert saved_data == new_binary_data
         assert saved_metadata["file_size"] == len(new_binary_data)
 
+    def test_overwrite_clears_stale_is_truncated_flag(self):
+        """Overwriting a truncated attachment with a non-truncated file clears
+        the persisted is_truncated flag (so prefixes/readback stop warning)."""
+        import sys
+
+        from app.models.subtask_context import (
+            ContextStatus,
+            ContextType,
+            SubtaskContext,
+        )
+        from app.services.attachment.parser import ParseResult
+        from app.services.context.context_service import context_service as cs_instance
+
+        cs_module = sys.modules["app.services.context.context_service"]
+
+        mock_db = Mock()
+        storage_key = "attachments/test_trunc"
+        context = SubtaskContext(
+            subtask_id=0,
+            user_id=1,
+            context_type=ContextType.ATTACHMENT.value,
+            name="big.txt",
+            status=ContextStatus.READY.value,
+            binary_data=b"old big data",
+            type_data={
+                "storage_backend": "mysql",
+                "storage_key": storage_key,
+                "original_filename": "big.txt",
+                "file_extension": ".txt",
+                "file_size": 12,
+                "mime_type": "text/plain",
+                "is_encrypted": False,
+                "is_truncated": True,  # previously truncated
+            },
+        )
+        context.id = 101
+
+        mock_query = Mock()
+        mock_db.query.return_value = mock_query
+        mock_query.filter.return_value = mock_query
+        mock_query.first.return_value = context
+
+        # New parse does NOT truncate (no truncation_info).
+        parse_result = ParseResult(text="small", text_length=5)
+
+        with patch.object(cs_module, "_should_encrypt", return_value=False):
+            with patch.object(cs_module, "get_storage_backend") as mock_get_backend:
+                mock_get_backend.return_value = Mock()
+                with patch.object(
+                    cs_instance.parser, "parse", return_value=parse_result
+                ):
+                    updated_context, truncation_info = cs_instance.overwrite_attachment(
+                        db=mock_db,
+                        context_id=context.id,
+                        user_id=context.user_id,
+                        filename="small.txt",
+                        binary_data=b"small",
+                    )
+
+        assert truncation_info is None
+        assert updated_context.is_truncated is False
+
 
 class TestContextServiceCreateKnowledgeBaseContextWithResult:
     """Test create_knowledge_base_context_with_result functionality."""

--- a/chat_shell/chat_shell/agent.py
+++ b/chat_shell/chat_shell/agent.py
@@ -434,15 +434,24 @@ class ChatAgent:
         from chat_shell.core.config import settings
         from chat_shell.messages.attachment_preview import apply_attachment_preview
 
+        # Fall back to the AgentConfig's model_config (the canonical CRD source)
+        # so the CRD-provided context_window is honored even if the explicit
+        # model_config arg is omitted.
+        effective_model_config = model_config or (
+            config.model_config if config else None
+        )
+        effective_model_id = model_id or (
+            effective_model_config.get("model_id", "") if effective_model_config else ""
+        )
         context_window = get_model_context_config(
-            model_id or "", model_config=model_config
+            effective_model_id, model_config=effective_model_config
         ).context_window
         preview_limit = min(
             context_window // 2, settings.ATTACHMENT_PREVIEW_TOKEN_LIMIT
         )
         messages = apply_attachment_preview(
             messages,
-            token_counter=TokenCounter(model_name=model_id),
+            token_counter=TokenCounter(model_name=effective_model_id),
             limit=preview_limit,
         )
 

--- a/chat_shell/chat_shell/agent.py
+++ b/chat_shell/chat_shell/agent.py
@@ -365,6 +365,7 @@ class ChatAgent:
         model_id: str | None = None,
         inject_datetime: bool | None = None,
         dynamic_context: str | None = None,
+        model_config: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Build messages for agent execution.
 
@@ -420,6 +421,30 @@ class ChatAgent:
         # assembles. The hook fires before every model call (turn start +
         # every follow-up) so both pre-turn and mid-turn budgets share the
         # same accounting and policy.
+
+        # Bound the inline attachment preview to a token budget. This is content
+        # normalization (a fixed-size preview, like the legacy char cap), not
+        # budget enforcement: the full content stays reachable via the sandbox
+        # file / read_attachment. Runs on the assembled layout so the current
+        # turn and replayed history are treated identically. The budget is
+        # capped relative to the model window so a small-context model is not
+        # swamped by the preview: min(window * 50%, configured limit).
+        from chat_shell.compression.config import get_model_context_config
+        from chat_shell.compression.token_counter import TokenCounter
+        from chat_shell.core.config import settings
+        from chat_shell.messages.attachment_preview import apply_attachment_preview
+
+        context_window = get_model_context_config(
+            model_id or "", model_config=model_config
+        ).context_window
+        preview_limit = min(
+            context_window // 2, settings.ATTACHMENT_PREVIEW_TOKEN_LIMIT
+        )
+        messages = apply_attachment_preview(
+            messages,
+            token_counter=TokenCounter(model_name=model_id),
+            limit=preview_limit,
+        )
 
         # Apply Anthropic explicit cache breakpoints on the assembled layout
         # so breakpoints land on the final structure. The guard never edits

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -114,7 +114,7 @@ class Settings(BaseSettings):
     # a message share one <attachment> block). The full content stays available
     # via the sandbox file / read_attachment. The budget is split across
     # per-attachment segments (head/tail each), every header is preserved.
-    ATTACHMENT_PREVIEW_TOKEN_LIMIT: int = 30000
+    ATTACHMENT_PREVIEW_TOKEN_LIMIT: int = 15000
 
     # Backend RAG service configuration (for knowledge base HTTP fallback)
     BACKEND_RAG_URL: str = "http://localhost:8000/api/knowledge/v1/retrieve"

--- a/chat_shell/chat_shell/core/config.py
+++ b/chat_shell/chat_shell/core/config.py
@@ -110,6 +110,11 @@ class Settings(BaseSettings):
 
     # Attachment/Context configuration
     MAX_EXTRACTED_TEXT_LENGTH: int = 100000
+    # Shared token budget for the inline attachment preview (all attachments in
+    # a message share one <attachment> block). The full content stays available
+    # via the sandbox file / read_attachment. The budget is split across
+    # per-attachment segments (head/tail each), every header is preserved.
+    ATTACHMENT_PREVIEW_TOKEN_LIMIT: int = 30000
 
     # Backend RAG service configuration (for knowledge base HTTP fallback)
     BACKEND_RAG_URL: str = "http://localhost:8000/api/knowledge/v1/retrieve"

--- a/chat_shell/chat_shell/guard/context_guard.py
+++ b/chat_shell/chat_shell/guard/context_guard.py
@@ -36,6 +36,7 @@ material changed.
 from __future__ import annotations
 
 import logging
+import time
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -72,6 +73,7 @@ from chat_shell.compression.summary_compactor import (
 )
 from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.guard.tool_output import COMPACTED_FLAG
+from chat_shell.guard.traces import record_protection_trace
 from chat_shell.guard.types import GuardSource
 from chat_shell.guard_flags import BYPASS_COMPACTION_FLAG
 
@@ -559,6 +561,7 @@ class UnifiedContextGuard:
         if not self._sources:
             return _StagePass(updates=[], view=list(view))
 
+        started = time.perf_counter()
         updates: list[Any] = []
         new_view = list(view)
         idx_by_id: dict[str, int] = {
@@ -644,6 +647,16 @@ class UnifiedContextGuard:
                 "(emergency=%s, sources=%d)",
                 emergency,
                 len(self._sources),
+            )
+        else:
+            # Only trace when truncation actually happened — the pass runs before
+            # every model call and is usually a no-op.
+            record_protection_trace(
+                "tool_output",
+                "applied",
+                duration_ms=(time.perf_counter() - started) * 1000,
+                messages_truncated=len(updates),
+                emergency=emergency,
             )
 
         return _StagePass(updates=updates, view=new_view)
@@ -733,6 +746,7 @@ class UnifiedContextGuard:
                 created_at=created_at,
             ),
         )
+        compact_started = time.perf_counter()
         try:
             result = await self._summary_compactor.compact(
                 [_dict_to_state_message(message_dict) for message_dict in view],
@@ -743,6 +757,14 @@ class UnifiedContextGuard:
                 "summary_compact_not_applicable"
                 if isinstance(exc, SummaryCompactNotApplicable)
                 else "summary_compact_failed"
+            )
+            record_protection_trace(
+                "summary_compact",
+                "fallback",
+                duration_ms=(time.perf_counter() - compact_started) * 1000,
+                before_tokens=before_tokens,
+                failure_reason=failure_reason,
+                used_legacy_fallback=self._compressor is not None,
             )
             self._context_compactions.append(
                 {
@@ -817,6 +839,14 @@ class UnifiedContextGuard:
                 created_at=created_at,
                 summary_message_id=summary_message_id,
             ),
+        )
+        record_protection_trace(
+            "summary_compact",
+            "completed",
+            duration_ms=(time.perf_counter() - compact_started) * 1000,
+            before_tokens=before_tokens,
+            after_tokens=after_tokens,
+            removed_history_items=result.removed_history_items,
         )
         logger.info(
             "[UnifiedContextGuard] Summary compact applied: %d -> %d tokens, "

--- a/chat_shell/chat_shell/guard/traces.py
+++ b/chat_shell/chat_shell/guard/traces.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Span traces for the context-length protections.
+
+One helper emits a uniformly-shaped span event for each of the three
+protections (attachment preview, tool-output truncation, summary compact). A
+consistent schema lets the tracing backend derive, per operation:
+
+* **event count** — number of events,
+* **success rate** — breakdown by ``status``,
+* **duration** — ``duration_ms`` distribution,
+
+plus token savings where applicable. All attribute values are primitives so
+they are safe as OpenTelemetry event attributes; ``None`` values are dropped.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from shared.telemetry.decorators import add_span_event
+
+EVENT_PREFIX = "context_protection"
+
+
+def record_protection_trace(
+    operation: str,
+    status: str,
+    *,
+    duration_ms: float | None = None,
+    before_tokens: int | None = None,
+    after_tokens: int | None = None,
+    **extra: Any,
+) -> None:
+    """Emit a span event for a context-protection operation.
+
+    Args:
+        operation: ``attachment_preview`` | ``tool_output`` | ``summary_compact``.
+        status: outcome label, e.g. ``applied`` / ``noop`` / ``completed`` /
+            ``fallback`` / ``error`` — used to compute success rate.
+        duration_ms: wall time of the operation.
+        before_tokens / after_tokens: token size before/after (adds
+            ``tokens_saved`` when both are present).
+        **extra: additional primitive attributes (None values are dropped).
+    """
+    attributes: dict[str, Any] = {"operation": operation, "status": status}
+    if duration_ms is not None:
+        attributes["duration_ms"] = round(duration_ms, 2)
+    if before_tokens is not None:
+        attributes["before_tokens"] = before_tokens
+    if after_tokens is not None:
+        attributes["after_tokens"] = after_tokens
+    if before_tokens is not None and after_tokens is not None:
+        attributes["tokens_saved"] = max(0, before_tokens - after_tokens)
+    for key, value in extra.items():
+        if value is not None:
+            attributes[key] = value
+
+    add_span_event(f"{EVENT_PREFIX}.{operation}", attributes)

--- a/chat_shell/chat_shell/history/attachment_text.py
+++ b/chat_shell/chat_shell/history/attachment_text.py
@@ -6,11 +6,13 @@
 
 Mirrors the loader's mode switch: HTTP mode calls the backend internal endpoint
 (``/chat/attachments/{id}/text``) via ``RemoteHistoryStore``; package mode reads
-the database directly. Both enforce the same task scoping as the endpoint (the
-attachment's subtask must belong to the task, or be unlinked).
+the database directly. Both enforce the same task scoping as the endpoint: a
+linked attachment must belong to the task; an unlinked one must belong to the
+task's user.
 
 The returned payload matches the backend ``AttachmentTextResponse`` shape:
-``{attachment_id, name, mime_type, total_chars, offset, text, has_more}``.
+``{attachment_id, name, mime_type, total_chars, offset, text, has_more,
+source_truncated}``.
 """
 
 from __future__ import annotations
@@ -51,6 +53,7 @@ def _fetch_local(
         ContextType,
         SubtaskContext,
     )
+    from app.models.task import TaskResource
 
     db = SessionLocal()
     try:
@@ -66,11 +69,22 @@ def _fetch_local(
         if context is None:
             raise AttachmentNotAvailable("Attachment not found")
 
+        task = db.query(TaskResource).filter(TaskResource.id == task_id).first()
+        if task is None:
+            raise AttachmentNotAvailable("Task not found")
+
+        # Linked attachment must belong to this task; an unlinked one must belong
+        # to the task's user, so the model cannot read arbitrary unlinked
+        # attachments across users.
         task_subtask_ids = {
             row[0]
             for row in db.query(Subtask.id).filter(Subtask.task_id == task_id).all()
         }
-        if not (context.subtask_id == 0 or context.subtask_id in task_subtask_ids):
+        is_in_task = context.subtask_id in task_subtask_ids
+        is_unlinked_same_user = (
+            context.subtask_id == 0 and context.user_id == task.user_id
+        )
+        if not (is_in_task or is_unlinked_same_user):
             raise AttachmentNotAvailable(
                 "Attachment does not belong to this conversation"
             )
@@ -85,6 +99,7 @@ def _fetch_local(
             "offset": offset,
             "text": chunk,
             "has_more": offset + len(chunk) < len(full_text),
+            "source_truncated": context.is_truncated,
         }
     finally:
         db.close()

--- a/chat_shell/chat_shell/history/attachment_text.py
+++ b/chat_shell/chat_shell/history/attachment_text.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch a character slice of an attachment's extracted text.
+
+Mirrors the loader's mode switch: HTTP mode calls the backend internal endpoint
+(``/chat/attachments/{id}/text``) via ``RemoteHistoryStore``; package mode reads
+the database directly. Both enforce the same task scoping as the endpoint (the
+attachment's subtask must belong to the task, or be unlinked).
+
+The returned payload matches the backend ``AttachmentTextResponse`` shape:
+``{attachment_id, name, mime_type, total_chars, offset, text, has_more}``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from chat_shell.history.loader import _get_remote_history_store, _is_http_mode
+
+
+class AttachmentNotAvailable(Exception):
+    """Raised when an attachment cannot be read (missing or out of scope)."""
+
+
+async def fetch_attachment_text(
+    *,
+    task_id: int,
+    attachment_id: int,
+    offset: int,
+    limit: int,
+) -> dict[str, Any]:
+    """Return a character slice of *attachment_id*'s extracted text."""
+    session_id = f"task-{task_id}"
+    if _is_http_mode():
+        store = _get_remote_history_store()
+        return await store.get_attachment_text(session_id, attachment_id, offset, limit)
+    return await asyncio.to_thread(_fetch_local, task_id, attachment_id, offset, limit)
+
+
+def _fetch_local(
+    task_id: int, attachment_id: int, offset: int, limit: int
+) -> dict[str, Any]:
+    """Package-mode DB read with the same task scoping as the endpoint."""
+    from app.db.session import SessionLocal
+    from app.models.subtask import Subtask
+    from app.models.subtask_context import (
+        ContextStatus,
+        ContextType,
+        SubtaskContext,
+    )
+
+    db = SessionLocal()
+    try:
+        context = (
+            db.query(SubtaskContext)
+            .filter(
+                SubtaskContext.id == attachment_id,
+                SubtaskContext.context_type == ContextType.ATTACHMENT.value,
+                SubtaskContext.status == ContextStatus.READY.value,
+            )
+            .first()
+        )
+        if context is None:
+            raise AttachmentNotAvailable("Attachment not found")
+
+        task_subtask_ids = {
+            row[0]
+            for row in db.query(Subtask.id).filter(Subtask.task_id == task_id).all()
+        }
+        if not (context.subtask_id == 0 or context.subtask_id in task_subtask_ids):
+            raise AttachmentNotAvailable(
+                "Attachment does not belong to this conversation"
+            )
+
+        full_text = context.extracted_text or ""
+        chunk = full_text[offset : offset + limit]
+        return {
+            "attachment_id": attachment_id,
+            "name": context.name or "",
+            "mime_type": context.mime_type or "",
+            "total_chars": len(full_text),
+            "offset": offset,
+            "text": chunk,
+            "has_more": offset + len(chunk) < len(full_text),
+        }
+    finally:
+        db.close()

--- a/chat_shell/chat_shell/history/attachment_text.py
+++ b/chat_shell/chat_shell/history/attachment_text.py
@@ -35,6 +35,10 @@ async def fetch_attachment_text(
     limit: int,
 ) -> dict[str, Any]:
     """Return a character slice of *attachment_id*'s extracted text."""
+    # Match the endpoint contract in both modes (HTTP validates via Query; this
+    # guards package mode, where raw slicing would otherwise accept bad values).
+    if offset < 0 or limit <= 0:
+        raise AttachmentNotAvailable("Invalid attachment text pagination")
     session_id = f"task-{task_id}"
     if _is_http_mode():
         store = _get_remote_history_store()

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -24,6 +24,10 @@ from typing import Any, Optional
 from chat_shell.core.config import settings
 from chat_shell.messages.utils import group_tool_call_messages as _group_messages
 from shared.prompts.constants import parse_prompt_blocks
+from shared.utils.attachment_block import (
+    build_attachment_header,
+    build_sandbox_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -754,72 +758,21 @@ def _build_vision_content_block(context) -> dict[str, Any] | None:
     }
 
 
-def _format_file_size(size_bytes: int) -> str:
-    """Format file size in bytes to human-readable format."""
-    if size_bytes >= 1024 * 1024:
-        return f"{size_bytes / (1024 * 1024):.1f} MB"
-    elif size_bytes >= 1024:
-        return f"{size_bytes / 1024:.1f} KB"
-    else:
-        return f"{size_bytes} bytes"
-
-
-def _build_attachment_url(attachment_id: int) -> str:
-    """Build the download URL for an attachment."""
-    return f"/api/attachments/{attachment_id}/download"
-
-
-def _build_sandbox_path(
-    task_id: int | None,
-    subtask_id: int | None,
-    filename: str,
-) -> str | None:
-    """Build the sandbox file path for an attachment.
-
-    This path corresponds to where the Executor downloads attachments
-    in the sandbox environment.
-
-    Args:
-        task_id: Task ID
-        subtask_id: Subtask ID
-        filename: Original filename
-
-    Returns:
-        Sandbox path in format: /home/user/{task_id}:executor:attachments/{subtask_id}/{filename}
-        Returns None if task_id or subtask_id is not provided.
-    """
-    if task_id is None or subtask_id is None:
-        return None
-    # Guard against None filename and strip control characters
-    safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
-    return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
-
-
 def _build_image_metadata_header(
     context,
     task_id: int | None = None,
     subtask_id: int | None = None,
 ) -> str:
     """Build image attachment metadata header string."""
-    attachment_id = context.id
     filename = context.name or "image"
-    mime_type = context.mime_type or "unknown"
-    file_size = context.file_size if hasattr(context, "file_size") else 0
-    formatted_size = _format_file_size(file_size)
-    url = _build_attachment_url(attachment_id)
-
-    # Build sandbox path if task_id and subtask_id are provided
-    sandbox_path = _build_sandbox_path(task_id, subtask_id, filename)
-
-    if sandbox_path:
-        return (
-            f"[Image Attachment: {filename} | ID: {attachment_id} | "
-            f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-            f"File Path in Sandbox: {sandbox_path}]"
-        )
-    return (
-        f"[Image Attachment: {filename} | ID: {attachment_id} | "
-        f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]"
+    sandbox_path = build_sandbox_path(task_id, subtask_id, filename)
+    return build_attachment_header(
+        attachment_id=context.id,
+        filename=filename,
+        mime_type=context.mime_type or "unknown",
+        file_size=context.file_size if hasattr(context, "file_size") else 0,
+        sandbox_path=sandbox_path,
+        is_image=True,
     )
 
 
@@ -838,29 +791,16 @@ def _build_document_text_prefix(
     if not context.extracted_text:
         return ""
 
-    # Build attachment metadata
-    attachment_id = context.id
     filename = context.name or "document"
-    mime_type = context.mime_type if hasattr(context, "mime_type") else "unknown"
-    file_size = context.file_size if hasattr(context, "file_size") else 0
-    formatted_size = _format_file_size(file_size)
-    url = _build_attachment_url(attachment_id)
-
-    # Build sandbox path if task_id and subtask_id are provided
-    sandbox_path = _build_sandbox_path(task_id, subtask_id, filename)
-
-    if sandbox_path:
-        return (
-            f"[Attachment: {filename} | ID: {attachment_id} | "
-            f"Type: {mime_type} | Size: {formatted_size} | URL: {url} | "
-            f"File Path(already in sandbox): {sandbox_path}]\n"
-            f"{context.extracted_text}\n\n"
-        )
-    return (
-        f"[Attachment: {filename} | ID: {attachment_id} | "
-        f"Type: {mime_type} | Size: {formatted_size} | URL: {url}]\n"
-        f"{context.extracted_text}\n\n"
+    sandbox_path = build_sandbox_path(task_id, subtask_id, filename)
+    header = build_attachment_header(
+        attachment_id=context.id,
+        filename=filename,
+        mime_type=context.mime_type if hasattr(context, "mime_type") else "unknown",
+        file_size=context.file_size if hasattr(context, "file_size") else 0,
+        sandbox_path=sandbox_path,
     )
+    return f"{header}\n{context.extracted_text}\n\n"
 
 
 def _build_knowledge_base_text_prefix(context) -> str:

--- a/chat_shell/chat_shell/history/loader.py
+++ b/chat_shell/chat_shell/history/loader.py
@@ -27,6 +27,7 @@ from shared.prompts.constants import parse_prompt_blocks
 from shared.utils.attachment_block import (
     build_attachment_header,
     build_sandbox_path,
+    build_truncation_note,
 )
 
 logger = logging.getLogger(__name__)
@@ -800,7 +801,8 @@ def _build_document_text_prefix(
         file_size=context.file_size if hasattr(context, "file_size") else 0,
         sandbox_path=sandbox_path,
     )
-    return f"{header}\n{context.extracted_text}\n\n"
+    note = build_truncation_note(getattr(context, "is_truncated", False))
+    return f"{header}\n{note}{context.extracted_text}\n\n"
 
 
 def _build_knowledge_base_text_prefix(context) -> str:

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -45,6 +45,7 @@ from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.guard.tool_output import _truncate_body
 from chat_shell.guard.traces import record_protection_trace
 from chat_shell.guard.types import TruncationPolicy
+from shared.utils.mime_types import is_text_readable_mime
 
 _ATTACHMENT_BLOCK = re.compile(r"<attachment>(.*?)</attachment>", re.DOTALL)
 
@@ -54,30 +55,20 @@ _ATTACHMENT_BLOCK = re.compile(r"<attachment>(.*?)</attachment>", re.DOTALL)
 _SEGMENT_HEADER = re.compile(r"\[(?:Image )?Attachment: [^\n]*? \| ID: (\d+) \|")
 _HEADER_TYPE = re.compile(r"\| Type: ([^|\]]+)")
 _HEADER_PATH = re.compile(r"File Path[^:]*: ([^\]]+)")
-# MIME substrings of binary office/pdf documents whose sandbox file cannot be
-# read as text — these must be read via read_attachment (parsed extracted text).
-_BINARY_MIME_HINTS = (
-    "pdf",
-    "msword",
-    "officedocument",
-    "ms-excel",
-    "ms-powerpoint",
-    "spreadsheet",
-    "presentation",
-)
 
 
 def _full_content_hint(header: str, attachment_id: str) -> str:
     """Type-aware pointer to the full content when a segment is truncated.
 
     Text files: the complete original is readable in the sandbox (beyond the
-    preview, and beyond read_attachment's parse cap). Binary docs: the sandbox
-    file is not text, so the parsed text is fetched via read_attachment.
+    preview, and beyond read_attachment's parse cap). Binary docs (pdf/office/
+    xmind/...): the sandbox file is not text, so the parsed text is fetched via
+    read_attachment. The text/binary split uses the shared MIME classification
+    so it stays consistent with the backend parser as file types are added.
     """
     type_match = _HEADER_TYPE.search(header)
     mime = type_match.group(1).strip().lower() if type_match else ""
-    is_binary = any(hint in mime for hint in _BINARY_MIME_HINTS)
-    if not is_binary:
+    if is_text_readable_mime(mime):
         path_match = _HEADER_PATH.search(header)
         if path_match:
             return (

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -167,7 +167,7 @@ def _preview_attachment_body(
     before_tokens = 0
     after_tokens = 0
     for (header, seg_body), alloc, attachment_id, orig_tokens in zip(
-        headers_and_bodies, allocations, ids, body_sizes
+        headers_and_bodies, allocations, ids, body_sizes, strict=True
     ):
         if not seg_body:
             rebuilt.append(header)  # image header etc. — no body to bound

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Token-bounded preview for inline ``<attachment>`` blocks.
+
+Attachment extracted-text is injected inline in the user message as its own text
+block (alongside the question / images / knowledge-base block). Carrying the
+full text every turn is wasteful, and summary-compact would otherwise fold or
+crudely truncate the whole user message. This pass bounds the inline copy to a
+fixed token budget, leaving the full content reachable via the sandbox file
+(text) or the ``read_attachment`` tool (binary).
+
+Design (all attachments share one ``<attachment>`` block):
+
+* **Shared budget** across all attachments in the block (avoids N×budget blowups
+  with many attachments), configurable via ``ATTACHMENT_PREVIEW_TOKEN_LIMIT``.
+* **Per-segment head/tail**: the shared body budget is split across attachment
+  segments so every attachment keeps both a head and a tail, each truncated with
+  the same logic as tool outputs (:func:`guard.tool_output._truncate_body`).
+* **Every header preserved**: each ``[Attachment: … | ID: n | …]`` header is kept
+  verbatim, so every ``read_attachment`` id stays discoverable. When more than
+  one attachment is present, a consolidated id list is also prepended.
+* **Fast path**: blocks already within budget are returned untouched (keeps the
+  prefix cache stable for the common small-attachment case).
+
+The pass is origin-agnostic: it runs after message assembly and treats the
+current turn and replayed history identically.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.guard.tool_output import _truncate_body
+from chat_shell.guard.traces import record_protection_trace
+from chat_shell.guard.types import TruncationPolicy
+
+_ATTACHMENT_BLOCK = re.compile(r"<attachment>(.*?)</attachment>", re.DOTALL)
+
+# Matches the shared attachment/image header start and captures its id. The
+# header is a single line produced by shared.utils.attachment_block; the
+# ``| ID: <n> |`` segment is distinctive enough to anchor on.
+_SEGMENT_HEADER = re.compile(r"\[(?:Image )?Attachment: [^\n]*? \| ID: (\d+) \|")
+_HEADER_TYPE = re.compile(r"\| Type: ([^|\]]+)")
+_HEADER_PATH = re.compile(r"File Path[^:]*: ([^\]]+)")
+# MIME substrings of binary office/pdf documents whose sandbox file cannot be
+# read as text — these must be read via read_attachment (parsed extracted text).
+_BINARY_MIME_HINTS = (
+    "pdf",
+    "msword",
+    "officedocument",
+    "ms-excel",
+    "ms-powerpoint",
+    "spreadsheet",
+    "presentation",
+)
+
+
+def _full_content_hint(header: str, attachment_id: str) -> str:
+    """Type-aware pointer to the full content when a segment is truncated.
+
+    Text files: the complete original is readable in the sandbox (beyond the
+    preview, and beyond read_attachment's parse cap). Binary docs: the sandbox
+    file is not text, so the parsed text is fetched via read_attachment.
+    """
+    type_match = _HEADER_TYPE.search(header)
+    mime = type_match.group(1).strip().lower() if type_match else ""
+    is_binary = any(hint in mime for hint in _BINARY_MIME_HINTS)
+    if not is_binary:
+        path_match = _HEADER_PATH.search(header)
+        if path_match:
+            return (
+                f"\n[Preview truncated. Full file readable in sandbox: "
+                f"{path_match.group(1).strip()}]"
+            )
+    return (
+        f"\n[Preview truncated. Use read_attachment(attachment_id={attachment_id}) "
+        f"for the full text.]"
+    )
+
+
+def _split_header_body(segment: str) -> tuple[str, str]:
+    """Split an attachment segment into its first (header) line and the rest."""
+    newline = segment.find("\n")
+    if newline == -1:
+        return segment, ""
+    return segment[:newline], segment[newline + 1 :]
+
+
+def _preview_attachment_body(body: str, total_limit: int, counter: TokenCounter) -> str:
+    """Bound a single ``<attachment>`` block body to *total_limit* tokens.
+
+    Splits the body into per-attachment segments, preserves every header, and
+    distributes the remaining budget across segment bodies (each head/tail
+    truncated). Falls back to a whole-body head/tail when no headers are found.
+    """
+    if counter.count_text(body) <= total_limit:
+        return body  # fast path: already within budget, keep verbatim
+
+    matches = list(_SEGMENT_HEADER.finditer(body))
+    if not matches:
+        # No recognizable headers (legacy/malformed) — bound the whole body.
+        rendered, _t, _tr, _f = _truncate_body(
+            body, TruncationPolicy(kind="tokens", limit=total_limit), counter
+        )
+        return rendered
+
+    preamble = body[: matches[0].start()]
+    segments: list[str] = []
+    ids: list[str] = []
+    for i, match in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        segments.append(body[match.start() : end])
+        ids.append(match.group(1))
+
+    # Consolidate ids up front when multiple attachments share the block, so
+    # every read_attachment id is discoverable even after heavy truncation.
+    # Per-segment hints (below) carry the type-aware "how to get the rest".
+    id_line = ""
+    if len(ids) > 1:
+        id_line = "[Attachment IDs in this message: " + ", ".join(ids) + "]\n"
+
+    # Reserve budget for the id line and every header (always kept), then
+    # distribute the remainder across segment bodies.
+    reserved = counter.count_text(preamble) + counter.count_text(id_line)
+    headers_and_bodies: list[tuple[str, str]] = [
+        _split_header_body(seg) for seg in segments
+    ]
+    reserved += sum(counter.count_text(header) for header, _ in headers_and_bodies)
+    body_budget = max(0, total_limit - reserved)
+
+    body_sizes = [counter.count_text(seg_body) for _, seg_body in headers_and_bodies]
+    allocations = _allocate_budget(body_sizes, body_budget)
+
+    rebuilt: list[str] = []
+    for (header, seg_body), alloc, attachment_id in zip(
+        headers_and_bodies, allocations, ids
+    ):
+        if seg_body:
+            rendered, _t, truncated, _f = _truncate_body(
+                seg_body, TruncationPolicy(kind="tokens", limit=alloc), counter
+            )
+            hint = _full_content_hint(header, attachment_id) if truncated else ""
+            rebuilt.append(f"{header}\n{rendered}{hint}")
+        else:
+            rebuilt.append(header)
+
+    return preamble + id_line + "".join(rebuilt)
+
+
+def _allocate_budget(sizes: list[int], budget: int) -> list[int]:
+    """Water-fill *budget* across segment bodies of the given *sizes*.
+
+    Segments that fit their fair share keep their full size and return the
+    leftover to the pool; the fair share is recomputed for the remaining
+    (larger) segments so big attachments absorb the freed budget instead of
+    being over-truncated while small ones waste their allocation. Result sums to
+    at most *budget* (each allocation floored at 1 so truncation stays valid).
+    """
+    allocations = [0] * len(sizes)
+    remaining_budget = budget
+    # Smallest first: a segment that fits its share frees budget for the rest.
+    for rank, idx in enumerate(sorted(range(len(sizes)), key=lambda i: sizes[i])):
+        share = remaining_budget // (len(sizes) - rank)
+        take = max(1, min(sizes[idx], share))
+        allocations[idx] = take
+        remaining_budget = max(0, remaining_budget - take)
+    return allocations
+
+
+def _preview_text(text: str, total_limit: int, counter: TokenCounter) -> str:
+    """Truncate the body of every ``<attachment>`` block found in *text*."""
+    if "<attachment>" not in text:
+        return text
+
+    def _replace(match: re.Match[str]) -> str:
+        rendered = _preview_attachment_body(match.group(1), total_limit, counter)
+        return f"<attachment>{rendered}</attachment>"
+
+    return _ATTACHMENT_BLOCK.sub(_replace, text)
+
+
+def apply_attachment_preview(
+    messages: list[dict[str, Any]],
+    *,
+    token_counter: TokenCounter,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return *messages* with every inline ``<attachment>`` body token-bounded.
+
+    Input dicts are not mutated; only messages that actually carry an attachment
+    block are copied and rewritten.
+    """
+    if limit <= 0:
+        return messages
+
+    started = time.perf_counter()
+    saw_attachment = False
+    truncated_blocks = 0
+    before_tokens = 0
+    after_tokens = 0
+
+    def _preview_block_text(text: str) -> str:
+        nonlocal saw_attachment, truncated_blocks, before_tokens, after_tokens
+        if "<attachment>" not in text:
+            return text
+        saw_attachment = True
+        new_text = _preview_text(text, limit, token_counter)
+        if new_text is not text:
+            truncated_blocks += 1
+            before_tokens += token_counter.count_text(text)
+            after_tokens += token_counter.count_text(new_text)
+        return new_text
+
+    result: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+
+        if isinstance(content, str):
+            new_content = _preview_block_text(content)
+            if new_content is not content:
+                message = {**message, "content": new_content}
+
+        elif isinstance(content, list):
+            new_blocks: list[Any] = []
+            changed = False
+            for block in content:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") == "text"
+                    and isinstance(block.get("text"), str)
+                ):
+                    new_text = _preview_block_text(block["text"])
+                    if new_text is not block["text"]:
+                        block = {**block, "text": new_text}
+                        changed = True
+                new_blocks.append(block)
+            if changed:
+                message = {**message, "content": new_blocks}
+
+        result.append(message)
+
+    if saw_attachment:
+        record_protection_trace(
+            "attachment_preview",
+            "applied" if truncated_blocks else "noop",
+            duration_ms=(time.perf_counter() - started) * 1000,
+            before_tokens=before_tokens if truncated_blocks else None,
+            after_tokens=after_tokens if truncated_blocks else None,
+            attachment_blocks_truncated=truncated_blocks,
+        )
+
+    return result

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -60,24 +60,30 @@ _HEADER_PATH = re.compile(r"File Path[^:]*: ([^\]]+)")
 def _full_content_hint(header: str, attachment_id: str) -> str:
     """Type-aware pointer to the full content when a segment is truncated.
 
-    Text files: the complete original is readable in the sandbox (beyond the
-    preview, and beyond read_attachment's parse cap). Binary docs (pdf/office/
-    xmind/...): the sandbox file is not text, so the parsed text is fetched via
-    read_attachment. The text/binary split uses the shared MIME classification
-    so it stays consistent with the backend parser as file types are added.
+    Both branches point at the full content without locking the model into a
+    single action. Text files: the original sits in the sandbox and can be read
+    or grep/searched with file tools. Binary docs (pdf/office/xmind/...): the
+    bytes aren't plain text, so the model can page the parsed text via
+    read_attachment OR open the sandbox file with a suitable tool. The
+    text/binary split uses the shared MIME classification so it stays consistent
+    with the backend parser as file types are added.
     """
     type_match = _HEADER_TYPE.search(header)
     mime = type_match.group(1).strip().lower() if type_match else ""
     if is_text_readable_mime(mime):
         path_match = _HEADER_PATH.search(header)
         if path_match:
+            # Encourage targeted access (grep/search), not just reading the whole
+            # file — the full text may be large, and it's a normal sandbox file.
             return (
-                f"\n[Preview truncated. Full file readable in sandbox: "
-                f"{path_match.group(1).strip()}]"
+                f"\n[Preview truncated. Full file in the sandbox at "
+                f"{path_match.group(1).strip()} — read or grep/search it with "
+                f"your file tools to get the rest.]"
             )
     return (
-        f"\n[Preview truncated. Use read_attachment(attachment_id={attachment_id}) "
-        f"to read the full extracted text (parsed from the binary).]"
+        f"\n[Preview truncated. Get the rest via "
+        f"read_attachment(attachment_id={attachment_id}) for the parsed text, or "
+        f"open the sandbox file (path in the header above) with a suitable tool.]"
     )
 
 

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -18,11 +18,14 @@ Design (all attachments share one ``<attachment>`` block):
 * **Per-segment head/tail**: the shared body budget is split across attachment
   segments so every attachment keeps both a head and a tail, each truncated with
   the same logic as tool outputs (:func:`guard.tool_output._truncate_body`).
-* **Every header preserved**: each ``[Attachment: … | ID: n | …]`` header is kept
-  verbatim, so every ``read_attachment`` id stays discoverable. When more than
-  one attachment is present, a consolidated id list is also prepended.
-* **Fast path**: blocks already within budget are returned untouched (keeps the
-  prefix cache stable for the common small-attachment case).
+* **Every header preserved + annotated**: each ``[Attachment: … | ID: n | …]``
+  header is kept and gets ``| Chars | Tokens | Truncated: yes|no`` appended, so
+  the model always sees the size and whether the inline copy is partial. The
+  annotation is deterministic, so it stays prefix-cache stable across turns.
+  When more than one attachment is present, a consolidated id list is prepended.
+* **Type-aware hint**: a truncated segment also gets a pointer to the full
+  content (text → sandbox file, binary → ``read_attachment``); a non-truncated
+  segment needs none (its full text is already inline).
 
 The pass is origin-agnostic: it runs after message assembly and treats the
 current turn and replayed history identically.
@@ -91,23 +94,42 @@ def _split_header_body(segment: str) -> tuple[str, str]:
     return segment[:newline], segment[newline + 1 :]
 
 
-def _preview_attachment_body(body: str, total_limit: int, counter: TokenCounter) -> str:
+def _annotate_header(header: str, *, chars: int, tokens: int, truncated: bool) -> str:
+    """Append size / truncation fields to an attachment header line.
+
+    Adds ``| Chars: N | Tokens: M | Truncated: yes|no`` inside the trailing
+    ``]`` so the model always sees how large the attachment is and whether the
+    inline copy is partial.
+    """
+    suffix = f" | Chars: {chars} | Tokens: {tokens} | Truncated: {'yes' if truncated else 'no'}"
+    if header.endswith("]"):
+        return header[:-1] + suffix + "]"
+    return header + suffix
+
+
+def _preview_attachment_body(
+    body: str, total_limit: int, counter: TokenCounter
+) -> tuple[str, int, int, int]:
     """Bound a single ``<attachment>`` block body to *total_limit* tokens.
 
-    Splits the body into per-attachment segments, preserves every header, and
-    distributes the remaining budget across segment bodies (each head/tail
-    truncated). Falls back to a whole-body head/tail when no headers are found.
-    """
-    if counter.count_text(body) <= total_limit:
-        return body  # fast path: already within budget, keep verbatim
+    Splits the body into per-attachment segments, annotates each header with
+    size / truncation fields, preserves every header, and distributes the
+    remaining budget across segment bodies (each head/tail truncated). Falls
+    back to a whole-body head/tail when no headers are found.
 
+    Returns ``(rendered_body, truncated_segments, before_tokens, after_tokens)``
+    where the token figures cover only segments that were actually truncated.
+    """
     matches = list(_SEGMENT_HEADER.finditer(body))
     if not matches:
         # No recognizable headers (legacy/malformed) — bound the whole body.
+        before = counter.count_text(body)
+        if before <= total_limit:
+            return body, 0, 0, 0
         rendered, _t, _tr, _f = _truncate_body(
             body, TruncationPolicy(kind="tokens", limit=total_limit), counter
         )
-        return rendered
+        return rendered, 1, before, counter.count_text(rendered)
 
     preamble = body[: matches[0].start()]
     segments: list[str] = []
@@ -137,19 +159,34 @@ def _preview_attachment_body(body: str, total_limit: int, counter: TokenCounter)
     allocations = _allocate_budget(body_sizes, body_budget)
 
     rebuilt: list[str] = []
-    for (header, seg_body), alloc, attachment_id in zip(
-        headers_and_bodies, allocations, ids
+    truncated_segments = 0
+    before_tokens = 0
+    after_tokens = 0
+    for (header, seg_body), alloc, attachment_id, orig_tokens in zip(
+        headers_and_bodies, allocations, ids, body_sizes
     ):
-        if seg_body:
-            rendered, _t, truncated, _f = _truncate_body(
-                seg_body, TruncationPolicy(kind="tokens", limit=alloc), counter
-            )
-            hint = _full_content_hint(header, attachment_id) if truncated else ""
-            rebuilt.append(f"{header}\n{rendered}{hint}")
-        else:
-            rebuilt.append(header)
+        if not seg_body:
+            rebuilt.append(header)  # image header etc. — no body to bound
+            continue
+        rendered, _t, truncated, _f = _truncate_body(
+            seg_body, TruncationPolicy(kind="tokens", limit=alloc), counter
+        )
+        annotated = _annotate_header(
+            header, chars=len(seg_body), tokens=orig_tokens, truncated=truncated
+        )
+        hint = _full_content_hint(header, attachment_id) if truncated else ""
+        rebuilt.append(f"{annotated}\n{rendered}{hint}")
+        if truncated:
+            truncated_segments += 1
+            before_tokens += orig_tokens
+            after_tokens += counter.count_text(rendered)
 
-    return preamble + id_line + "".join(rebuilt)
+    return (
+        preamble + id_line + "".join(rebuilt),
+        truncated_segments,
+        before_tokens,
+        after_tokens,
+    )
 
 
 def _allocate_budget(sizes: list[int], budget: int) -> list[int]:
@@ -172,16 +209,33 @@ def _allocate_budget(sizes: list[int], budget: int) -> list[int]:
     return allocations
 
 
-def _preview_text(text: str, total_limit: int, counter: TokenCounter) -> str:
-    """Truncate the body of every ``<attachment>`` block found in *text*."""
+def _preview_text(
+    text: str, total_limit: int, counter: TokenCounter
+) -> tuple[str, int, int, int]:
+    """Annotate/bound every ``<attachment>`` block found in *text*.
+
+    Returns ``(new_text, truncated_segments, before_tokens, after_tokens)``.
+    """
     if "<attachment>" not in text:
-        return text
+        return text, 0, 0, 0
 
-    def _replace(match: re.Match[str]) -> str:
-        rendered = _preview_attachment_body(match.group(1), total_limit, counter)
-        return f"<attachment>{rendered}</attachment>"
-
-    return _ATTACHMENT_BLOCK.sub(_replace, text)
+    pieces: list[str] = []
+    last = 0
+    truncated_segments = 0
+    before_tokens = 0
+    after_tokens = 0
+    for match in _ATTACHMENT_BLOCK.finditer(text):
+        pieces.append(text[last : match.start()])
+        rendered, n_truncated, before, after = _preview_attachment_body(
+            match.group(1), total_limit, counter
+        )
+        pieces.append(f"<attachment>{rendered}</attachment>")
+        last = match.end()
+        truncated_segments += n_truncated
+        before_tokens += before
+        after_tokens += after
+    pieces.append(text[last:])
+    return "".join(pieces), truncated_segments, before_tokens, after_tokens
 
 
 def apply_attachment_preview(
@@ -200,20 +254,19 @@ def apply_attachment_preview(
 
     started = time.perf_counter()
     saw_attachment = False
-    truncated_blocks = 0
+    truncated_segments = 0
     before_tokens = 0
     after_tokens = 0
 
     def _preview_block_text(text: str) -> str:
-        nonlocal saw_attachment, truncated_blocks, before_tokens, after_tokens
+        nonlocal saw_attachment, truncated_segments, before_tokens, after_tokens
         if "<attachment>" not in text:
             return text
         saw_attachment = True
-        new_text = _preview_text(text, limit, token_counter)
-        if new_text is not text:
-            truncated_blocks += 1
-            before_tokens += token_counter.count_text(text)
-            after_tokens += token_counter.count_text(new_text)
+        new_text, n_truncated, before, after = _preview_text(text, limit, token_counter)
+        truncated_segments += n_truncated
+        before_tokens += before
+        after_tokens += after
         return new_text
 
     result: list[dict[str, Any]] = []
@@ -222,7 +275,7 @@ def apply_attachment_preview(
 
         if isinstance(content, str):
             new_content = _preview_block_text(content)
-            if new_content is not content:
+            if new_content != content:
                 message = {**message, "content": new_content}
 
         elif isinstance(content, list):
@@ -235,7 +288,7 @@ def apply_attachment_preview(
                     and isinstance(block.get("text"), str)
                 ):
                     new_text = _preview_block_text(block["text"])
-                    if new_text is not block["text"]:
+                    if new_text != block["text"]:
                         block = {**block, "text": new_text}
                         changed = True
                 new_blocks.append(block)
@@ -247,11 +300,11 @@ def apply_attachment_preview(
     if saw_attachment:
         record_protection_trace(
             "attachment_preview",
-            "applied" if truncated_blocks else "noop",
+            "applied" if truncated_segments else "noop",
             duration_ms=(time.perf_counter() - started) * 1000,
-            before_tokens=before_tokens if truncated_blocks else None,
-            after_tokens=after_tokens if truncated_blocks else None,
-            attachment_blocks_truncated=truncated_blocks,
+            before_tokens=before_tokens if truncated_segments else None,
+            after_tokens=after_tokens if truncated_segments else None,
+            attachment_segments_truncated=truncated_segments,
         )
 
     return result

--- a/chat_shell/chat_shell/messages/attachment_preview.py
+++ b/chat_shell/chat_shell/messages/attachment_preview.py
@@ -15,6 +15,10 @@ Design (all attachments share one ``<attachment>`` block):
 
 * **Shared budget** across all attachments in the block (avoids N×budget blowups
   with many attachments), configurable via ``ATTACHMENT_PREVIEW_TOKEN_LIMIT``.
+  The bound applies to the budget split across bodies; every header is always
+  kept (for read_attachment discoverability), so the inherent floor is the sum
+  of header lines. When bodies can't all fit, the smallest get 0 budget and
+  render header-only rather than each leaking a token past the bound.
 * **Per-segment head/tail**: the shared body budget is split across attachment
   segments so every attachment keeps both a head and a tail, each truncated with
   the same logic as tool outputs (:func:`guard.tool_output._truncate_body`).
@@ -82,7 +86,7 @@ def _full_content_hint(header: str, attachment_id: str) -> str:
             )
     return (
         f"\n[Preview truncated. Use read_attachment(attachment_id={attachment_id}) "
-        f"for the full text.]"
+        f"to read the full extracted text (parsed from the binary).]"
     )
 
 
@@ -168,14 +172,22 @@ def _preview_attachment_body(
         if not seg_body:
             rebuilt.append(header)  # image header etc. — no body to bound
             continue
-        rendered, _t, truncated, _f = _truncate_body(
-            seg_body, TruncationPolicy(kind="tokens", limit=alloc), counter
-        )
+        if alloc <= 0:
+            # Budget exhausted (many attachments): keep only the annotated header
+            # + hint so growth is bounded to the header cost, instead of letting
+            # _truncate_body emit its two truncation markers per segment.
+            rendered = ""
+            truncated = True
+        else:
+            rendered, _t, truncated, _f = _truncate_body(
+                seg_body, TruncationPolicy(kind="tokens", limit=alloc), counter
+            )
         annotated = _annotate_header(
             header, chars=len(seg_body), tokens=orig_tokens, truncated=truncated
         )
         hint = _full_content_hint(header, attachment_id) if truncated else ""
-        rebuilt.append(f"{annotated}\n{rendered}{hint}")
+        body_part = f"\n{rendered}" if rendered else ""
+        rebuilt.append(f"{annotated}{body_part}{hint}")
         if truncated:
             truncated_segments += 1
             before_tokens += orig_tokens
@@ -196,14 +208,16 @@ def _allocate_budget(sizes: list[int], budget: int) -> list[int]:
     leftover to the pool; the fair share is recomputed for the remaining
     (larger) segments so big attachments absorb the freed budget instead of
     being over-truncated while small ones waste their allocation. Result sums to
-    at most *budget* (each allocation floored at 1 so truncation stays valid).
+    **at most** *budget* — allocations are not floored, so when the budget is
+    exhausted (many attachments) a segment may get 0 and render header-only,
+    rather than each segment leaking a minimum token past the bound.
     """
     allocations = [0] * len(sizes)
     remaining_budget = budget
     # Smallest first: a segment that fits its share frees budget for the rest.
     for rank, idx in enumerate(sorted(range(len(sizes)), key=lambda i: sizes[i])):
         share = remaining_budget // (len(sizes) - rank)
-        take = max(1, min(sizes[idx], share))
+        take = min(sizes[idx], share)
         allocations[idx] = take
         remaining_budget = max(0, remaining_budget - take)
     return allocations

--- a/chat_shell/chat_shell/services/chat_service.py
+++ b/chat_shell/chat_shell/services/chat_service.py
@@ -393,6 +393,7 @@ class ChatService(ChatInterface):
                 config=agent_config,
                 model_id=model_id,
                 dynamic_context=dynamic_context,
+                model_config=request.model_config,
             )
             logger.info(
                 "[CHAT_SERVICE_PERF] build_messages: %.2fms",

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -47,6 +47,20 @@ class ChatContextResult:
     mcp_clients: list = field(default_factory=list)
 
 
+def _content_has_attachment(content: Any) -> bool:
+    """Return True if a message content (str or block list) has an attachment."""
+    if isinstance(content, str):
+        return "<attachment>" in content
+    if isinstance(content, list):
+        return any(
+            isinstance(block, dict)
+            and isinstance(block.get("text"), str)
+            and "<attachment>" in block["text"]
+            for block in content
+        )
+    return False
+
+
 class ChatContext:
     """Manages chat context preparation and cleanup.
 
@@ -183,9 +197,18 @@ class ChatContext:
                         restored_tool_count,
                     )
 
+            # Only offer read_attachment when this conversation actually carries
+            # an attachment (current turn or history), to avoid bloating the
+            # tool list for plain chats.
+            has_attachments = _content_has_attachment(self._request.prompt) or any(
+                _content_has_attachment(message.get("content")) for message in history
+            )
+
             # Build extra_tools from all sources (including builtin tools)
             add_span_event("building_extra_tools")
-            extra_tools = self._build_extra_tools(kb_result, skill_tools, mcp_result)
+            extra_tools = self._build_extra_tools(
+                kb_result, skill_tools, mcp_result, has_attachments=has_attachments
+            )
 
             # Process KB tools result for system prompt
             system_prompt = self._request.system_prompt or ""
@@ -721,6 +744,7 @@ class ChatContext:
         kb_result,
         skill_tools: list,
         mcp_result: tuple[list, list],
+        has_attachments: bool = False,
     ) -> list:
         """Build the complete list of extra tools from all sources.
 
@@ -814,6 +838,24 @@ class ChatContext:
             logger.info(
                 "[CHAT_CONTEXT] Added DataTableTool with %d table context(s)",
                 len(self._request.table_contexts),
+            )
+
+        # Add ReadAttachmentTool when the conversation carries an attachment, so
+        # the model can page the full extracted text beyond the inline preview.
+        if has_attachments:
+            from chat_shell.compression.token_counter import TokenCounter
+            from chat_shell.tools.builtin import ReadAttachmentTool
+
+            model_id = (self._request.model_config or {}).get("model_id")
+            extra_tools.append(
+                ReadAttachmentTool(
+                    task_id=self._request.task_id,
+                    token_counter=TokenCounter(model_name=model_id),
+                )
+            )
+            logger.info(
+                "[CHAT_CONTEXT] Added ReadAttachmentTool for task_id=%d",
+                self._request.task_id,
             )
 
         # Note: Subscription tools (preview_subscription, create_subscription) have been moved

--- a/chat_shell/chat_shell/storage/remote.py
+++ b/chat_shell/chat_shell/storage/remote.py
@@ -220,6 +220,26 @@ class RemoteHistoryStore(HistoryStoreInterface):
             if response is not None:
                 await response.aclose()
 
+    async def get_attachment_text(
+        self,
+        session_id: str,
+        attachment_id: int,
+        offset: int,
+        limit: int,
+    ) -> dict:
+        """Fetch a character slice of an attachment's extracted text.
+
+        Returns the backend ``AttachmentTextResponse`` payload
+        (``text`` / ``total_chars`` / ``has_more`` / ``name`` / ``mime_type``).
+        """
+        client = await self._get_client()
+        response = await client.get(
+            f"/chat/attachments/{attachment_id}/text",
+            params={"session_id": session_id, "offset": offset, "limit": limit},
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def append_message(
         self,
         session_id: str,

--- a/chat_shell/chat_shell/tools/builtin/__init__.py
+++ b/chat_shell/chat_shell/tools/builtin/__init__.py
@@ -10,11 +10,14 @@ from .file_reader import FileListSkill, FileReaderSkill
 from .knowledge_base import KnowledgeBaseTool, ScopedKnowledgeBaseTool
 from .knowledge_listing import KbHeadTool, KbLsTool, KBToolCallCounter
 from .load_skill import LoadSkillTool
+from .read_attachment import ReadAttachmentInput, ReadAttachmentTool
 from .silent_exit import SilentExitException
 from .web_search import WebSearchTool
 
 __all__ = [
     "WebSearchTool",
+    "ReadAttachmentTool",
+    "ReadAttachmentInput",
     "KnowledgeBaseTool",
     "ScopedKnowledgeBaseTool",
     "KbLsTool",

--- a/chat_shell/chat_shell/tools/builtin/read_attachment.py
+++ b/chat_shell/chat_shell/tools/builtin/read_attachment.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""``read_attachment`` tool — paginated read of an attachment's extracted text.
+
+Complements the inline attachment preview: the preview shows a bounded head/tail
+of each attachment; this tool lets the model page through the full extracted text
+(mainly for binary attachments — pdf/ppt/docx — whose sandbox file is not
+directly readable as text; text attachments can be read from the sandbox).
+
+Pagination uses a **character offset** cursor (tokenizer-independent, stable
+across turns/models) with a **token-clamped page**: a page never exceeds the
+per-page token budget, so the request-level tool-output guard never has to
+re-truncate it (which would break page contiguity). Content upper bound is the
+parse-time extracted-text cap; beyond that the original file must be read from
+the sandbox. Access is task-scoped by the backend endpoint / DB query.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field, PrivateAttr
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.history.attachment_text import (
+    AttachmentNotAvailable,
+    fetch_attachment_text,
+)
+
+logger = logging.getLogger(__name__)
+
+# Default per-page token budget. Aligned with the tool-output budget so a page
+# stays within what the request-level guard allows (no re-truncation).
+DEFAULT_PAGE_TOKEN_LIMIT = 15000
+# Chars requested per fetch ~ 4x the token budget (English ≈ 4 chars/token); the
+# slice is then token-clamped down. Bounds how much text crosses the wire.
+_CHARS_PER_TOKEN = 4
+
+
+class ReadAttachmentInput(BaseModel):
+    """Input schema for the read_attachment tool."""
+
+    attachment_id: int = Field(
+        description="Attachment id, shown as 'ID: <n>' in the <attachment> block"
+    )
+    offset: int = Field(
+        default=0, description="Start character offset (0-indexed codepoint)"
+    )
+    limit: int = Field(
+        default=0,
+        description="Max characters to read (0 = use default; page is also "
+        "token-bounded so the actual returned size may be smaller)",
+    )
+
+
+class ReadAttachmentTool(BaseTool):
+    """Read an attachment's extracted text with character-offset pagination."""
+
+    name: str = "read_attachment"
+    description: str = (
+        "Read the full extracted text of an attachment by id, with pagination. "
+        "Use this for binary attachments (pdf/ppt/docx) whose content was shown "
+        "only as a truncated preview. Returns a page of text plus next_offset / "
+        "has_more for paging."
+    )
+    args_schema: type[BaseModel] = ReadAttachmentInput
+
+    task_id: int
+    token_counter: TokenCounter
+    page_token_limit: int = DEFAULT_PAGE_TOKEN_LIMIT
+    max_calls: int = 30
+    _call_count: int = PrivateAttr(default=0)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _run(self, *args: Any, **kwargs: Any) -> str:
+        raise NotImplementedError("read_attachment is async-only; use _arun")
+
+    async def _arun(
+        self, attachment_id: int, offset: int = 0, limit: int = 0, **_: Any
+    ) -> str:
+        if self._call_count >= self.max_calls:
+            return json.dumps(
+                {
+                    "status": "rejected",
+                    "message": f"read_attachment call limit ({self.max_calls}) reached",
+                }
+            )
+        self._call_count += 1
+
+        offset = max(0, offset)
+        char_window = limit if limit > 0 else self.page_token_limit * _CHARS_PER_TOKEN
+
+        try:
+            payload = await fetch_attachment_text(
+                task_id=self.task_id,
+                attachment_id=attachment_id,
+                offset=offset,
+                limit=char_window,
+            )
+        except AttachmentNotAvailable as exc:
+            return json.dumps({"status": "error", "message": str(exc)})
+        except Exception as exc:  # network / HTTP errors
+            logger.warning("[read_attachment] fetch failed: %s", exc)
+            return json.dumps(
+                {"status": "error", "message": "Attachment could not be read"}
+            )
+
+        text = payload.get("text", "")
+        total_chars = int(payload.get("total_chars", 0))
+        if not text and total_chars == 0:
+            return json.dumps(
+                {
+                    "status": "empty",
+                    "attachment_id": attachment_id,
+                    "message": "Attachment has no extractable text",
+                }
+            )
+
+        # Token-clamp the page so it never exceeds the per-page budget. The char
+        # cursor advances only by the chars actually kept, so next_offset stays
+        # honest even when the clamp shortens the slice.
+        clamped = self._clamp_to_tokens(text, self.page_token_limit)
+        chars_read = len(clamped)
+        next_offset = offset + chars_read
+        has_more = next_offset < total_chars
+
+        return json.dumps(
+            {
+                "status": "success",
+                "attachment_id": attachment_id,
+                "name": payload.get("name", ""),
+                "mime_type": payload.get("mime_type", ""),
+                "offset": offset,
+                "chars_read": chars_read,
+                "total_chars": total_chars,
+                "next_offset": next_offset if has_more else None,
+                "has_more": has_more,
+                "content": clamped,
+            },
+            ensure_ascii=False,
+        )
+
+    def _clamp_to_tokens(self, text: str, token_limit: int) -> str:
+        """Return the longest prefix of *text* within *token_limit* tokens."""
+        encoding = self.token_counter.encoding
+        ids = encoding.encode(text, disallowed_special=())
+        if len(ids) <= token_limit:
+            return text
+        return encoding.decode(ids[:token_limit])

--- a/chat_shell/chat_shell/tools/builtin/read_attachment.py
+++ b/chat_shell/chat_shell/tools/builtin/read_attachment.py
@@ -95,7 +95,12 @@ class ReadAttachmentTool(BaseTool):
         self._call_count += 1
 
         offset = max(0, offset)
-        char_window = limit if limit > 0 else self.page_token_limit * _CHARS_PER_TOKEN
+        # Cap the fetch window. A page is token-clamped to page_token_limit, so
+        # fetching more than that many tokens' worth of chars is pure waste — the
+        # excess crosses the wire only to be discarded by the clamp. Capping here
+        # also makes an arbitrarily large caller-supplied limit harmless.
+        max_window = self.page_token_limit * _CHARS_PER_TOKEN
+        char_window = min(limit, max_window) if limit > 0 else max_window
 
         try:
             payload = await fetch_attachment_text(
@@ -131,21 +136,32 @@ class ReadAttachmentTool(BaseTool):
         next_offset = offset + chars_read
         has_more = next_offset < total_chars
 
-        return json.dumps(
-            {
-                "status": "success",
-                "attachment_id": attachment_id,
-                "name": payload.get("name", ""),
-                "mime_type": payload.get("mime_type", ""),
-                "offset": offset,
-                "chars_read": chars_read,
-                "total_chars": total_chars,
-                "next_offset": next_offset if has_more else None,
-                "has_more": has_more,
-                "content": clamped,
-            },
-            ensure_ascii=False,
-        )
+        # The extracted text may itself be a parse-time truncation of a larger
+        # original (big pdf/docx). When the model reaches the end of the extract
+        # (has_more=False) but the source was truncated, reaching the end does
+        # NOT mean the whole file was read — say so explicitly.
+        source_truncated = bool(payload.get("source_truncated", False))
+        result: dict[str, Any] = {
+            "status": "success",
+            "attachment_id": attachment_id,
+            "name": payload.get("name", ""),
+            "mime_type": payload.get("mime_type", ""),
+            "offset": offset,
+            "chars_read": chars_read,
+            "total_chars": total_chars,
+            "next_offset": next_offset if has_more else None,
+            "has_more": has_more,
+            "source_truncated": source_truncated,
+            "content": clamped,
+        }
+        if source_truncated and not has_more:
+            result["warning"] = (
+                "End of extracted text reached, but the original file was "
+                "truncated during parsing — this is NOT the complete file. "
+                "Some content beyond this point is unavailable."
+            )
+
+        return json.dumps(result, ensure_ascii=False)
 
     def _clamp_to_tokens(self, text: str, token_limit: int) -> str:
         """Return the longest prefix of *text* within *token_limit* tokens."""

--- a/chat_shell/tests/test_attachment_preview.py
+++ b/chat_shell/tests/test_attachment_preview.py
@@ -30,6 +30,13 @@ def test_allocate_budget_all_fit():
     assert alloc == [1000, 2000]
 
 
+def test_allocate_budget_exhausted_does_not_floor_past_bound():
+    # Budget smaller than the segment count: with the old max(1) floor this
+    # summed to 5 (one token each); now it stays within budget.
+    alloc = _allocate_budget([1000] * 5, 3)
+    assert sum(alloc) <= 3
+
+
 def _attachment_block(body: str) -> str:
     return f"<attachment>{body}</attachment>"
 
@@ -47,6 +54,28 @@ def test_small_attachment_body_preserved_and_marked_not_truncated():
     assert "Truncated: no" in new
     assert "Chars:" in new and "Tokens:" in new
     assert "Preview truncated" not in new
+
+
+def test_many_attachments_exhausted_budget_render_header_only():
+    # Many attachments + tiny limit: header cost alone exceeds the budget, so
+    # every body gets 0 allocation and renders header-only — no per-segment
+    # truncation markers leaking past the bound (the bug Fix 3 addresses).
+    blocks = "".join(
+        f"[Attachment: f{i}.pdf | ID: {i} | Type: application/pdf]\n" + ("word " * 1000)
+        for i in range(8)
+    )
+    text = _attachment_block(blocks)
+    messages = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=50)
+    new = out[0]["content"][0]["text"]
+    # All ids stay discoverable for read_attachment.
+    for i in range(8):
+        assert f"ID: {i}" in new
+    # No per-segment truncation markers emitted (header-only segments).
+    assert "tokens truncated" not in new
+    # Still marked truncated with a pointer to the full content.
+    assert "Truncated: yes" in new
+    assert "read_attachment" in new
 
 
 def test_truncated_attachment_header_marks_truncated_yes():
@@ -163,6 +192,8 @@ def test_truncated_binary_attachment_hints_read_attachment():
     new = out[0]["content"]
     assert "read_attachment(attachment_id=9)" in new
     assert "Full file readable in sandbox" not in new
+    # Binary hint makes clear this is parsed/extracted text, not the raw file.
+    assert "extracted text (parsed from the binary)" in new
 
 
 def test_truncated_text_attachment_hints_sandbox_path():

--- a/chat_shell/tests/test_attachment_preview.py
+++ b/chat_shell/tests/test_attachment_preview.py
@@ -196,6 +196,22 @@ def test_truncated_binary_attachment_hints_read_attachment():
     assert "extracted text (parsed from the binary)" in new
 
 
+def test_truncated_xmind_attachment_hints_read_attachment():
+    # XMind is a binary (zip) doc: the sandbox file isn't text, so the hint must
+    # point to read_attachment, not the sandbox path (shared MIME classification).
+    header = (
+        "[Attachment: mind.xmind | ID: 4 | Type: application/vnd.xmind.workbook | "
+        "Size: 1.0 KB | URL: /api/attachments/4/download | "
+        "File Path(already in sandbox): /home/user/1:executor:attachments/2/mind.xmind]"
+    )
+    text = _attachment_block(header + "\n" + ("word " * 5000))
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    new = out[0]["content"]
+    assert "read_attachment(attachment_id=4)" in new
+    assert "Full file readable in sandbox" not in new
+
+
 def test_truncated_text_attachment_hints_sandbox_path():
     path = "/home/user/1:executor:attachments/2/notes.txt"
     header = (

--- a/chat_shell/tests/test_attachment_preview.py
+++ b/chat_shell/tests/test_attachment_preview.py
@@ -191,9 +191,9 @@ def test_truncated_binary_attachment_hints_read_attachment():
     out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
     new = out[0]["content"]
     assert "read_attachment(attachment_id=9)" in new
-    assert "Full file readable in sandbox" not in new
-    # Binary hint makes clear this is parsed/extracted text, not the raw file.
-    assert "extracted text (parsed from the binary)" in new
+    assert "parsed text" in new
+    # Not locked to read_attachment: also offers the sandbox file as an option.
+    assert "sandbox file" in new
 
 
 def test_truncated_xmind_attachment_hints_read_attachment():
@@ -209,7 +209,7 @@ def test_truncated_xmind_attachment_hints_read_attachment():
     out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
     new = out[0]["content"]
     assert "read_attachment(attachment_id=4)" in new
-    assert "Full file readable in sandbox" not in new
+    assert "parsed text" in new
 
 
 def test_truncated_text_attachment_hints_sandbox_path():
@@ -222,7 +222,9 @@ def test_truncated_text_attachment_hints_sandbox_path():
     messages = [{"role": "user", "content": text}]
     out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
     new = out[0]["content"]
-    assert f"Full file readable in sandbox: {path}" in new
+    assert f"Full file in the sandbox at {path}" in new
+    # Encourages targeted access (grep/search), not just reading the whole file.
+    assert "grep/search" in new
     assert "read_attachment" not in new
 
 

--- a/chat_shell/tests/test_attachment_preview.py
+++ b/chat_shell/tests/test_attachment_preview.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.messages.attachment_preview import (
+    _allocate_budget,
+    apply_attachment_preview,
+)
+
+_COUNTER = TokenCounter(model_name="gpt-4o")
+
+
+def test_allocate_budget_waterfills_small_first():
+    # Two attachments: large 30000, small 5000; budget 30000.
+    # The small one passes through fully; the large one absorbs the rest.
+    alloc = _allocate_budget([30000, 5000], 30000)
+    assert alloc[1] == 5000  # small kept whole
+    assert alloc[0] == 25000  # large gets the leftover
+    assert sum(alloc) <= 30000
+
+
+def test_allocate_budget_even_when_all_large():
+    alloc = _allocate_budget([30000, 30000], 30000)
+    assert alloc == [15000, 15000]
+
+
+def test_allocate_budget_all_fit():
+    alloc = _allocate_budget([1000, 2000], 30000)
+    assert alloc == [1000, 2000]
+
+
+def _attachment_block(body: str) -> str:
+    return f"<attachment>{body}</attachment>"
+
+
+def test_small_attachment_passes_through_unchanged():
+    text = _attachment_block("[Attachment: a.txt | ID: 1 | ...]\nshort body\n\n")
+    messages = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=15000)
+    assert out[0]["content"][0]["text"] == text
+
+
+def test_large_attachment_body_is_truncated_with_marker():
+    big_body = "[Attachment: a.txt | ID: 1 | ...]\n" + ("word " * 5000)
+    text = _attachment_block(big_body)
+    messages = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+
+    new_text = out[0]["content"][0]["text"]
+    assert new_text.startswith("<attachment>")
+    assert new_text.endswith("</attachment>")
+    assert "tokens truncated" in new_text
+    # Header (with read_attachment id) survives at the head.
+    assert "ID: 1" in new_text
+    assert _COUNTER.count_text(new_text) < _COUNTER.count_text(text)
+
+
+def test_no_newline_blob_still_truncates():
+    # A single giant line (OCR/minified) must still be bounded.
+    blob = "x" * 200_000
+    text = _attachment_block(blob)
+    messages = [{"role": "user", "content": text}]  # string content path
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    assert "tokens truncated" in out[0]["content"]
+    assert _COUNTER.count_text(out[0]["content"]) < _COUNTER.count_text(text)
+
+
+def test_non_attachment_text_untouched():
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": [{"type": "text", "text": "just a question"}]},
+    ]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    assert out[0]["content"] == "system prompt"
+    assert out[1]["content"][0]["text"] == "just a question"
+
+
+def test_image_blocks_preserved_alongside_attachment():
+    big_body = "[Attachment: a.pdf | ID: 5 | ...]\n" + ("word " * 5000)
+    content = [
+        {"type": "text", "text": _attachment_block(big_body)},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAA"}},
+        {"type": "text", "text": "what is in the file?"},
+    ]
+    messages = [{"role": "user", "content": content}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+
+    blocks = out[0]["content"]
+    assert blocks[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAA"},
+    }
+    assert blocks[2]["text"] == "what is in the file?"
+    assert "tokens truncated" in blocks[0]["text"]
+
+
+def test_limit_zero_disables_preview():
+    big_body = "[Attachment: a.txt | ID: 1]\n" + ("word " * 5000)
+    text = _attachment_block(big_body)
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=0)
+    assert out[0]["content"] == text
+
+
+def test_single_attachment_has_no_consolidated_id_list():
+    big_body = "[Attachment: a.txt | ID: 1 | Type: t]\n" + ("word " * 5000)
+    text = _attachment_block(big_body)
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    assert "Attachment IDs in this message" not in out[0]["content"]
+
+
+def test_multiple_attachments_preserve_all_headers_and_consolidate_ids():
+    seg1 = "[Attachment: a.pdf | ID: 1 | Type: x]\n" + ("alpha " * 4000)
+    seg2 = "[Attachment: b.pdf | ID: 2 | Type: y]\n" + ("beta " * 4000)
+    seg3 = "[Attachment: c.pdf | ID: 3 | Type: z]\n" + ("gamma " * 4000)
+    text = _attachment_block(seg1 + seg2 + seg3)
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=600)
+
+    new = out[0]["content"]
+    # Every header survives — including the middle one (its read_attachment id).
+    for marker in ("ID: 1", "ID: 2", "ID: 3"):
+        assert marker in new
+    # Ids consolidated up front.
+    assert "Attachment IDs in this message: 1, 2, 3" in new
+    # Each segment kept a head and a tail (so the body got truncated).
+    assert "tokens truncated" in new
+    # Shared budget: total is bounded well below the original.
+    assert _COUNTER.count_text(new) < _COUNTER.count_text(text)
+
+
+def test_truncated_binary_attachment_hints_read_attachment():
+    header = (
+        "[Attachment: report.pdf | ID: 9 | Type: application/pdf | Size: 1.0 KB | "
+        "URL: /api/attachments/9/download | "
+        "File Path(already in sandbox): /home/user/1:executor:attachments/2/report.pdf]"
+    )
+    text = _attachment_block(header + "\n" + ("word " * 5000))
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    new = out[0]["content"]
+    assert "read_attachment(attachment_id=9)" in new
+    assert "Full file readable in sandbox" not in new
+
+
+def test_truncated_text_attachment_hints_sandbox_path():
+    path = "/home/user/1:executor:attachments/2/notes.txt"
+    header = (
+        "[Attachment: notes.txt | ID: 3 | Type: text/plain | Size: 1.0 KB | "
+        f"URL: /api/attachments/3/download | File Path(already in sandbox): {path}]"
+    )
+    text = _attachment_block(header + "\n" + ("word " * 5000))
+    messages = [{"role": "user", "content": text}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    new = out[0]["content"]
+    assert f"Full file readable in sandbox: {path}" in new
+    assert "read_attachment" not in new
+
+
+def test_input_dicts_not_mutated():
+    big_body = "[Attachment: a.txt | ID: 1]\n" + ("word " * 5000)
+    text = _attachment_block(big_body)
+    original = {"role": "user", "content": [{"type": "text", "text": text}]}
+    messages = [original]
+    apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    # original untouched
+    assert original["content"][0]["text"] == text

--- a/chat_shell/tests/test_attachment_preview.py
+++ b/chat_shell/tests/test_attachment_preview.py
@@ -34,11 +34,31 @@ def _attachment_block(body: str) -> str:
     return f"<attachment>{body}</attachment>"
 
 
-def test_small_attachment_passes_through_unchanged():
-    text = _attachment_block("[Attachment: a.txt | ID: 1 | ...]\nshort body\n\n")
+def test_small_attachment_body_preserved_and_marked_not_truncated():
+    text = _attachment_block(
+        "[Attachment: a.txt | ID: 1 | Type: text/plain]\nshort body\n\n"
+    )
     messages = [{"role": "user", "content": [{"type": "text", "text": text}]}]
     out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=15000)
-    assert out[0]["content"][0]["text"] == text
+    new = out[0]["content"][0]["text"]
+    # Body kept verbatim; header annotated with size + not-truncated; no hint.
+    assert "short body" in new
+    assert "tokens truncated" not in new
+    assert "Truncated: no" in new
+    assert "Chars:" in new and "Tokens:" in new
+    assert "Preview truncated" not in new
+
+
+def test_truncated_attachment_header_marks_truncated_yes():
+    big_body = "[Attachment: a.pdf | ID: 2 | Type: application/pdf]\n" + (
+        "word " * 5000
+    )
+    text = _attachment_block(big_body)
+    messages = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+    out = apply_attachment_preview(messages, token_counter=_COUNTER, limit=200)
+    new = out[0]["content"][0]["text"]
+    assert "Truncated: yes" in new
+    assert "Chars:" in new and "Tokens:" in new
 
 
 def test_large_attachment_body_is_truncated_with_marker():

--- a/chat_shell/tests/test_context_metrics.py
+++ b/chat_shell/tests/test_context_metrics.py
@@ -330,7 +330,9 @@ def test_auto_compact_token_limit_clamps_trigger_and_target(monkeypatch):
     # reserved = min(clamp(1000, 16k, 48k), 4000) = 4000 -> available 6000
     assert config.available_tokens == 6000
     assert config.trigger_limit == 3000
-    assert config.target_limit == 3000
+    # target is clamped strictly below the trigger so compaction lands under the
+    # trigger threshold rather than exactly on it (trigger_limit - 1).
+    assert config.target_limit == 2999
 
 
 def test_auto_compact_token_limit_never_exceeds_available_tokens(monkeypatch):

--- a/chat_shell/tests/test_guard_traces.py
+++ b/chat_shell/tests/test_guard_traces.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import chat_shell.guard.traces as traces
+from chat_shell.guard.traces import record_protection_trace
+
+
+def _capture(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        traces, "add_span_event", lambda name, attrs: calls.append((name, attrs))
+    )
+    return calls
+
+
+def test_event_name_and_status(monkeypatch):
+    calls = _capture(monkeypatch)
+    record_protection_trace("summary_compact", "completed", duration_ms=12.345)
+    name, attrs = calls[0]
+    assert name == "context_protection.summary_compact"
+    assert attrs["operation"] == "summary_compact"
+    assert attrs["status"] == "completed"
+    assert attrs["duration_ms"] == 12.35  # rounded to 2dp
+
+
+def test_tokens_saved_derived(monkeypatch):
+    calls = _capture(monkeypatch)
+    record_protection_trace(
+        "attachment_preview", "applied", before_tokens=1000, after_tokens=300
+    )
+    _, attrs = calls[0]
+    assert attrs["before_tokens"] == 1000
+    assert attrs["after_tokens"] == 300
+    assert attrs["tokens_saved"] == 700
+
+
+def test_none_values_dropped(monkeypatch):
+    calls = _capture(monkeypatch)
+    record_protection_trace(
+        "tool_output",
+        "applied",
+        duration_ms=None,
+        before_tokens=None,
+        after_tokens=None,
+        failure_reason=None,
+        messages_truncated=3,
+    )
+    _, attrs = calls[0]
+    assert "duration_ms" not in attrs
+    assert "before_tokens" not in attrs
+    assert "tokens_saved" not in attrs
+    assert "failure_reason" not in attrs
+    assert attrs["messages_truncated"] == 3

--- a/chat_shell/tests/test_history_loader.py
+++ b/chat_shell/tests/test_history_loader.py
@@ -7,11 +7,38 @@ from types import SimpleNamespace
 import pytest
 
 from chat_shell.history.loader import (
+    _build_document_text_prefix,
     _build_knowledge_base_text_prefix,
     _extract_user_text,
     _truncate_history,
     get_chat_history,
 )
+
+
+class TestBuildDocumentTextPrefix:
+    def _context(self, **extra):
+        return SimpleNamespace(
+            id=7,
+            name="report.pdf",
+            extracted_text="partial content",
+            mime_type="application/pdf",
+            file_size=2048,
+            **extra,
+        )
+
+    def test_truncated_context_gets_partial_content_notice(self):
+        prefix = _build_document_text_prefix(self._context(is_truncated=True))
+        assert "only partial content is shown" in prefix
+        assert "characters" not in prefix
+
+    def test_non_truncated_context_has_no_notice(self):
+        prefix = _build_document_text_prefix(self._context(is_truncated=False))
+        assert "only partial content is shown" not in prefix
+
+    def test_missing_flag_defaults_to_no_notice(self):
+        # Remote-mode contexts may not carry the attribute at all.
+        prefix = _build_document_text_prefix(self._context())
+        assert "only partial content is shown" not in prefix
 
 
 class TestHistoryLoaderRestrictedKnowledgeBase:

--- a/chat_shell/tests/test_read_attachment_tool.py
+++ b/chat_shell/tests/test_read_attachment_tool.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from chat_shell.compression.token_counter import TokenCounter
+from chat_shell.history.attachment_text import AttachmentNotAvailable
+from chat_shell.tools.builtin import ReadAttachmentTool
+
+_COUNTER = TokenCounter(model_name="gpt-4o")
+
+
+def _make_tool(monkeypatch, payload=None, exc=None, page_token_limit=15000):
+    async def fake_fetch(*, task_id, attachment_id, offset, limit):
+        if exc is not None:
+            raise exc
+        full = payload
+        chunk = full[offset : offset + limit]
+        return {
+            "attachment_id": attachment_id,
+            "name": "a.pdf",
+            "mime_type": "application/pdf",
+            "total_chars": len(full),
+            "offset": offset,
+            "text": chunk,
+            "has_more": offset + len(chunk) < len(full),
+        }
+
+    monkeypatch.setattr(
+        "chat_shell.tools.builtin.read_attachment.fetch_attachment_text", fake_fetch
+    )
+    return ReadAttachmentTool(
+        task_id=1, token_counter=_COUNTER, page_token_limit=page_token_limit
+    )
+
+
+@pytest.mark.asyncio
+async def test_reads_full_small_attachment(monkeypatch):
+    tool = _make_tool(monkeypatch, payload="hello world")
+    result = json.loads(await tool._arun(attachment_id=5))
+    assert result["status"] == "success"
+    assert result["content"] == "hello world"
+    assert result["has_more"] is False
+    assert result["next_offset"] is None
+    assert result["total_chars"] == 11
+
+
+@pytest.mark.asyncio
+async def test_token_clamp_bounds_page_and_advances_char_offset(monkeypatch):
+    # Large body, tiny page budget -> page clamped, next_offset honest.
+    body = "word " * 5000
+    tool = _make_tool(monkeypatch, payload=body, page_token_limit=50)
+    result = json.loads(await tool._arun(attachment_id=5, offset=0))
+
+    assert result["status"] == "success"
+    assert result["has_more"] is True
+    # Page token count within budget.
+    assert _COUNTER.count_text(result["content"]) <= 50
+    # Char cursor advanced by exactly the chars kept.
+    assert result["next_offset"] == result["offset"] + result["chars_read"]
+    assert result["chars_read"] == len(result["content"])
+
+
+@pytest.mark.asyncio
+async def test_pagination_reaches_end(monkeypatch):
+    body = "abcdefghij" * 3  # 30 chars
+    tool = _make_tool(monkeypatch, payload=body, page_token_limit=100000)
+    # request a small char window to force paging
+    page1 = json.loads(await tool._arun(attachment_id=5, offset=0, limit=10))
+    assert page1["has_more"] is True
+    assert page1["next_offset"] == 10
+    page2 = json.loads(
+        await tool._arun(attachment_id=5, offset=page1["next_offset"], limit=100)
+    )
+    assert page2["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_not_available_returns_error(monkeypatch):
+    tool = _make_tool(monkeypatch, exc=AttachmentNotAvailable("nope"))
+    result = json.loads(await tool._arun(attachment_id=5))
+    assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_call_limit_enforced(monkeypatch):
+    tool = _make_tool(monkeypatch, payload="x")
+    tool.max_calls = 2
+    assert json.loads(await tool._arun(attachment_id=5))["status"] == "success"
+    assert json.loads(await tool._arun(attachment_id=5))["status"] == "success"
+    assert json.loads(await tool._arun(attachment_id=5))["status"] == "rejected"

--- a/chat_shell/tests/test_read_attachment_tool.py
+++ b/chat_shell/tests/test_read_attachment_tool.py
@@ -9,11 +9,18 @@ import pytest
 from chat_shell.compression.token_counter import TokenCounter
 from chat_shell.history.attachment_text import AttachmentNotAvailable
 from chat_shell.tools.builtin import ReadAttachmentTool
+from chat_shell.tools.builtin.read_attachment import _CHARS_PER_TOKEN
 
 _COUNTER = TokenCounter(model_name="gpt-4o")
 
 
-def _make_tool(monkeypatch, payload=None, exc=None, page_token_limit=15000):
+def _make_tool(
+    monkeypatch,
+    payload=None,
+    exc=None,
+    page_token_limit=15000,
+    source_truncated=False,
+):
     async def fake_fetch(*, task_id, attachment_id, offset, limit):
         if exc is not None:
             raise exc
@@ -27,6 +34,7 @@ def _make_tool(monkeypatch, payload=None, exc=None, page_token_limit=15000):
             "offset": offset,
             "text": chunk,
             "has_more": offset + len(chunk) < len(full),
+            "source_truncated": source_truncated,
         }
 
     monkeypatch.setattr(
@@ -76,6 +84,58 @@ async def test_pagination_reaches_end(monkeypatch):
         await tool._arun(attachment_id=5, offset=page1["next_offset"], limit=100)
     )
     assert page2["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_source_truncated_warns_at_end_of_extract(monkeypatch):
+    # Small extract that is itself a parse-time truncation of a larger file.
+    tool = _make_tool(monkeypatch, payload="partial", source_truncated=True)
+    result = json.loads(await tool._arun(attachment_id=5))
+    assert result["has_more"] is False
+    assert result["source_truncated"] is True
+    # Reaching the end must NOT read as "whole file complete".
+    assert "warning" in result
+    assert "NOT the complete file" in result["warning"]
+
+
+@pytest.mark.asyncio
+async def test_no_warning_while_more_pages_remain(monkeypatch):
+    body = "abcdefghij" * 3  # 30 chars
+    tool = _make_tool(
+        monkeypatch, payload=body, page_token_limit=100000, source_truncated=True
+    )
+    page1 = json.loads(await tool._arun(attachment_id=5, offset=0, limit=10))
+    assert page1["has_more"] is True
+    assert page1["source_truncated"] is True
+    # Warning only at the end of the extract, not mid-paging.
+    assert "warning" not in page1
+
+
+@pytest.mark.asyncio
+async def test_large_caller_limit_is_capped_to_page_window(monkeypatch):
+    # A huge caller-supplied limit must not pull a huge slice over the wire:
+    # the fetch window is capped to page_token_limit * _CHARS_PER_TOKEN.
+    captured = {}
+
+    async def fake_fetch(*, task_id, attachment_id, offset, limit):
+        captured["limit"] = limit
+        return {
+            "attachment_id": attachment_id,
+            "name": "",
+            "mime_type": "",
+            "total_chars": 10,
+            "offset": offset,
+            "text": "x" * min(limit, 10),
+            "has_more": False,
+            "source_truncated": False,
+        }
+
+    monkeypatch.setattr(
+        "chat_shell.tools.builtin.read_attachment.fetch_attachment_text", fake_fetch
+    )
+    tool = ReadAttachmentTool(task_id=1, token_counter=_COUNTER, page_token_limit=100)
+    await tool._arun(attachment_id=5, limit=10_000_000)
+    assert captured["limit"] == 100 * _CHARS_PER_TOKEN
 
 
 @pytest.mark.asyncio

--- a/chat_shell/tests/test_read_attachment_tool.py
+++ b/chat_shell/tests/test_read_attachment_tool.py
@@ -7,7 +7,10 @@ import json
 import pytest
 
 from chat_shell.compression.token_counter import TokenCounter
-from chat_shell.history.attachment_text import AttachmentNotAvailable
+from chat_shell.history.attachment_text import (
+    AttachmentNotAvailable,
+    fetch_attachment_text,
+)
 from chat_shell.tools.builtin import ReadAttachmentTool
 from chat_shell.tools.builtin.read_attachment import _CHARS_PER_TOKEN
 
@@ -143,6 +146,16 @@ async def test_not_available_returns_error(monkeypatch):
     tool = _make_tool(monkeypatch, exc=AttachmentNotAvailable("nope"))
     result = json.loads(await tool._arun(attachment_id=5))
     assert result["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_fetch_rejects_invalid_pagination():
+    # Validation happens before HTTP/package branching, matching the endpoint
+    # contract in both modes.
+    with pytest.raises(AttachmentNotAvailable):
+        await fetch_attachment_text(task_id=1, attachment_id=1, offset=-1, limit=10)
+    with pytest.raises(AttachmentNotAvailable):
+        await fetch_attachment_text(task_id=1, attachment_id=1, offset=0, limit=0)
 
 
 @pytest.mark.asyncio

--- a/shared/models/db/subtask_context.py
+++ b/shared/models/db/subtask_context.py
@@ -166,6 +166,18 @@ class SubtaskContext(Base):
             return self.type_data.get("encryption_version", 0)
         return 0
 
+    @property
+    def is_truncated(self) -> bool:
+        """Whether extracted_text was truncated during parsing (attachment type).
+
+        Recorded from the parser's truncation result at parse time, so it is
+        accurate regardless of the final text length (smart truncation rarely
+        fills the cap exactly, so a length-vs-cap comparison under-reports).
+        """
+        if self.type_data and isinstance(self.type_data, dict):
+            return self.type_data.get("is_truncated", False)
+        return False
+
     # === Helper properties for knowledge_base type ===
 
     @property

--- a/shared/tests/utils/test_attachment_block.py
+++ b/shared/tests/utils/test_attachment_block.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from shared.utils.attachment_block import (
+    ATTACHMENT_TRUNCATION_NOTE,
     build_attachment_download_url,
     build_attachment_header,
     build_sandbox_path,
+    build_truncation_note,
     format_file_size,
 )
 
@@ -68,6 +70,17 @@ def test_document_header_without_sandbox_path():
         "[Attachment: report.pdf | ID: 7 | Type: unknown | "
         "Size: 0 bytes | URL: /api/attachments/7/download]"
     )
+
+
+def test_build_truncation_note_when_truncated():
+    note = build_truncation_note(True)
+    assert note == ATTACHMENT_TRUNCATION_NOTE + "\n"
+    # Length-free: must not restate a character count.
+    assert "characters" not in note
+
+
+def test_build_truncation_note_when_not_truncated():
+    assert build_truncation_note(False) == ""
 
 
 def test_image_header_uses_image_label_and_wording():

--- a/shared/tests/utils/test_attachment_block.py
+++ b/shared/tests/utils/test_attachment_block.py
@@ -9,7 +9,33 @@ from shared.utils.attachment_block import (
     build_sandbox_path,
     build_truncation_note,
     format_file_size,
+    truncate_for_injection,
 )
+
+
+def test_truncate_for_injection_short_text_unchanged():
+    text, truncated = truncate_for_injection("short", 64000)
+    assert text == "short"
+    assert truncated is False
+
+
+def test_truncate_for_injection_bounds_long_text():
+    text = "a" * 10000 + "b" * 10000
+    out, truncated = truncate_for_injection(text, 5000)
+    assert truncated is True
+    assert len(out) <= 5000
+    # Contiguous head + tail with a single marker pointing to the file in the
+    # header. The marker is mode-neutral and must NOT mention read_attachment
+    # (a chat_shell-only tool).
+    assert out.startswith("a")
+    assert out.endswith("b")
+    assert "inline preview truncated" in out
+    assert "header above" in out
+    assert "read_attachment" not in out
+
+
+def test_truncate_for_injection_zero_limit_noop():
+    assert truncate_for_injection("anything", 0) == ("anything", False)
 
 
 def test_format_file_size_units():

--- a/shared/tests/utils/test_attachment_block.py
+++ b/shared/tests/utils/test_attachment_block.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from shared.utils.attachment_block import (
+    build_attachment_download_url,
+    build_attachment_header,
+    build_sandbox_path,
+    format_file_size,
+)
+
+
+def test_format_file_size_units():
+    assert format_file_size(512) == "512 bytes"
+    assert format_file_size(2048) == "2.0 KB"
+    assert format_file_size(3 * 1024 * 1024) == "3.0 MB"
+
+
+def test_build_attachment_download_url():
+    assert build_attachment_download_url(42) == "/api/attachments/42/download"
+
+
+def test_build_sandbox_path_requires_ids():
+    assert build_sandbox_path(None, 2, "a.pdf") is None
+    assert build_sandbox_path(1, None, "a.pdf") is None
+    assert (
+        build_sandbox_path(1, 2, "a.pdf") == "/home/user/1:executor:attachments/2/a.pdf"
+    )
+
+
+def test_build_sandbox_path_strips_control_chars():
+    assert (
+        build_sandbox_path(1, 2, "a\nb\r.pdf")
+        == "/home/user/1:executor:attachments/2/ab.pdf"
+    )
+
+
+def test_build_sandbox_path_defaults_missing_filename():
+    assert (
+        build_sandbox_path(1, 2, "") == "/home/user/1:executor:attachments/2/document"
+    )
+
+
+def test_document_header_with_sandbox_path():
+    header = build_attachment_header(
+        attachment_id=7,
+        filename="report.pdf",
+        mime_type="application/pdf",
+        file_size=2048,
+        sandbox_path="/home/user/1:executor:attachments/2/report.pdf",
+    )
+    assert header == (
+        "[Attachment: report.pdf | ID: 7 | Type: application/pdf | "
+        "Size: 2.0 KB | URL: /api/attachments/7/download | "
+        "File Path(already in sandbox): /home/user/1:executor:attachments/2/report.pdf]"
+    )
+
+
+def test_document_header_without_sandbox_path():
+    header = build_attachment_header(
+        attachment_id=7,
+        filename="report.pdf",
+        mime_type=None,
+        file_size=0,
+        sandbox_path=None,
+    )
+    assert header == (
+        "[Attachment: report.pdf | ID: 7 | Type: unknown | "
+        "Size: 0 bytes | URL: /api/attachments/7/download]"
+    )
+
+
+def test_image_header_uses_image_label_and_wording():
+    header = build_attachment_header(
+        attachment_id=9,
+        filename="pic.png",
+        mime_type="image/png",
+        file_size=1024,
+        sandbox_path="/home/user/1:executor:attachments/2/pic.png",
+        is_image=True,
+    )
+    assert header == (
+        "[Image Attachment: pic.png | ID: 9 | Type: image/png | "
+        "Size: 1.0 KB | URL: /api/attachments/9/download | "
+        "File Path in Sandbox: /home/user/1:executor:attachments/2/pic.png]"
+    )

--- a/shared/tests/utils/test_attachment_block.py
+++ b/shared/tests/utils/test_attachment_block.py
@@ -72,6 +72,20 @@ def test_document_header_without_sandbox_path():
     )
 
 
+def test_header_strips_control_chars_in_filename():
+    # A crafted filename must not break the single-line header / inject content.
+    header = build_attachment_header(
+        attachment_id=1,
+        filename="evil\n[Attachment: fake | ID: 999]\r.txt",
+        mime_type="text/plain",
+        file_size=10,
+        sandbox_path=None,
+    )
+    assert "\n" not in header
+    assert "\r" not in header
+    assert header.count("\n") == 0
+
+
 def test_build_truncation_note_when_truncated():
     note = build_truncation_note(True)
     assert note == ATTACHMENT_TRUNCATION_NOTE + "\n"

--- a/shared/tests/utils/test_mime_types.py
+++ b/shared/tests/utils/test_mime_types.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from shared.utils.mime_types import (
+    TEXT_READABLE_MIME_TYPES,
+    is_text_readable_mime,
+)
+
+
+def test_text_family_is_readable():
+    assert is_text_readable_mime("text/plain")
+    assert is_text_readable_mime("text/markdown")
+    assert is_text_readable_mime("text/x-python")
+    # Any text/* subtype, even one not enumerated, is readable by prefix.
+    assert is_text_readable_mime("text/some-new-subtype")
+
+
+def test_application_text_types_are_readable():
+    assert is_text_readable_mime("application/json")
+    assert is_text_readable_mime("application/xml")
+    assert is_text_readable_mime("application/yaml")
+
+
+def test_structured_suffixes_are_readable():
+    assert is_text_readable_mime("application/ld+json")
+    assert is_text_readable_mime("application/atom+xml")
+
+
+def test_binary_documents_and_media_are_not_readable():
+    assert not is_text_readable_mime("application/pdf")
+    assert not is_text_readable_mime(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert not is_text_readable_mime("application/vnd.xmind.workbook")
+    assert not is_text_readable_mime("image/png")
+    assert not is_text_readable_mime("video/mp4")
+    assert not is_text_readable_mime("application/octet-stream")
+
+
+def test_empty_or_none_is_not_readable():
+    assert not is_text_readable_mime("")
+    assert not is_text_readable_mime(None)
+
+
+def test_parameters_and_case_are_normalized():
+    assert is_text_readable_mime("text/plain; charset=utf-8")
+    assert is_text_readable_mime("Application/JSON")
+    assert is_text_readable_mime("  text/csv  ")
+
+
+def test_set_membership_is_usable_directly():
+    # Callers that test the set directly still work (e.g. the parser alias).
+    assert "text/plain" in TEXT_READABLE_MIME_TYPES
+    assert "application/json" in TEXT_READABLE_MIME_TYPES

--- a/shared/utils/attachment_block.py
+++ b/shared/utils/attachment_block.py
@@ -90,8 +90,11 @@ def build_attachment_header(
     label = "Image Attachment" if is_image else "Attachment"
     formatted_size = format_file_size(file_size or 0)
     url = build_attachment_download_url(attachment_id)
+    # Strip control chars so a crafted filename can't break the single-line
+    # header or inject extra prompt content (mirrors build_sandbox_path).
+    safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
     parts = [
-        f"[{label}: {filename} | ID: {attachment_id} | "
+        f"[{label}: {safe_filename} | ID: {attachment_id} | "
         f"Type: {mime_type or 'unknown'} | Size: {formatted_size} | URL: {url}"
     ]
     if sandbox_path:

--- a/shared/utils/attachment_block.py
+++ b/shared/utils/attachment_block.py
@@ -50,6 +50,28 @@ def build_sandbox_path(
     return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
 
 
+# Inline notice prepended to a truncated attachment body. It is intentionally
+# length-free: the old "(truncated to N characters)" notice reported the fixed
+# parse cap (not the real injected length), which drifted from the actual text
+# and clashed with chat_shell's per-preview "Truncated" header field. This note
+# only signals that the parsed text is partial — its main value is for execution
+# modes WITHOUT the chat_shell preview (executor / device), which otherwise have
+# no leading indication that the file was cut and the full file should be read.
+ATTACHMENT_TRUNCATION_NOTE = (
+    "(Note: parsing truncated this file; only partial content is shown below. "
+    "Read the full file at the path above for the complete content.)"
+)
+
+
+def build_truncation_note(is_truncated: bool) -> str:
+    """Return the truncation notice line (trailing newline) or empty string.
+
+    Prepended to a truncated attachment body so every execution mode — including
+    those without chat_shell's token-budget preview — knows the text is partial.
+    """
+    return f"{ATTACHMENT_TRUNCATION_NOTE}\n" if is_truncated else ""
+
+
 def build_attachment_header(
     *,
     attachment_id: int,

--- a/shared/utils/attachment_block.py
+++ b/shared/utils/attachment_block.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared builders for attachment context block metadata.
+
+Both the backend chat preprocessing (first-send) and the chat_shell history
+loader (history replay) embed an ``<attachment>`` block describing each
+attachment. These two sites previously each formatted the metadata header on
+their own and had already drifted. This module owns the single source of truth
+for that header plus the small helpers it needs (file-size formatting, download
+URL, sandbox path), so the format stays consistent across both paths.
+
+Scope note: this module is pure string formatting and intentionally has **no**
+dependency on a tokenizer. Token-based preview truncation of the attachment body
+lives in chat_shell (where ``tiktoken`` is available); per-runtime usage hints
+(e.g. ``read_attachment``) also stay in their respective callers.
+"""
+
+from __future__ import annotations
+
+
+def format_file_size(size_bytes: int) -> str:
+    """Format a byte count into a human-readable string (B / KB / MB)."""
+    if size_bytes >= 1024 * 1024:
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+    if size_bytes >= 1024:
+        return f"{size_bytes / 1024:.1f} KB"
+    return f"{size_bytes} bytes"
+
+
+def build_attachment_download_url(attachment_id: int) -> str:
+    """Build the download URL for an attachment."""
+    return f"/api/attachments/{attachment_id}/download"
+
+
+def build_sandbox_path(
+    task_id: int | None,
+    subtask_id: int | None,
+    filename: str,
+) -> str | None:
+    """Build the sandbox file path where the Executor downloads an attachment.
+
+    Returns ``None`` when *task_id* or *subtask_id* is missing. Control
+    characters in *filename* are stripped to keep the path single-line.
+    """
+    if task_id is None or subtask_id is None:
+        return None
+    safe_filename = (filename or "document").replace("\n", "").replace("\r", "")
+    return f"/home/user/{task_id}:executor:attachments/{subtask_id}/{safe_filename}"
+
+
+def build_attachment_header(
+    *,
+    attachment_id: int,
+    filename: str,
+    mime_type: str | None,
+    file_size: int,
+    sandbox_path: str | None,
+    is_image: bool = False,
+) -> str:
+    """Build the single-line metadata header for an attachment block.
+
+    Documents render as ``[Attachment: ...]`` and images as
+    ``[Image Attachment: ...]``. The sandbox path, when available, is appended
+    so the model knows where the source file lives.
+    """
+    label = "Image Attachment" if is_image else "Attachment"
+    formatted_size = format_file_size(file_size or 0)
+    url = build_attachment_download_url(attachment_id)
+    parts = [
+        f"[{label}: {filename} | ID: {attachment_id} | "
+        f"Type: {mime_type or 'unknown'} | Size: {formatted_size} | URL: {url}"
+    ]
+    if sandbox_path:
+        # Images historically used "File Path in Sandbox", documents used
+        # "File Path(already in sandbox)"; preserve both verbatim.
+        if is_image:
+            parts.append(f" | File Path in Sandbox: {sandbox_path}")
+        else:
+            parts.append(f" | File Path(already in sandbox): {sandbox_path}")
+    parts.append("]")
+    return "".join(parts)

--- a/shared/utils/attachment_block.py
+++ b/shared/utils/attachment_block.py
@@ -72,6 +72,38 @@ def build_truncation_note(is_truncated: bool) -> str:
     return f"{ATTACHMENT_TRUNCATION_NOTE}\n" if is_truncated else ""
 
 
+# Marker inserted where the inline injected copy is truncated. Points to the
+# full file referenced in the header (valid for every mode: executor/device read
+# the downloaded file, chat_shell reads the sandbox file). It deliberately does
+# NOT mention read_attachment — that tool is chat_shell-only; chat_shell surfaces
+# it via the tool list and its own L3 hint, not via this shared marker.
+_INJECT_TRUNCATION_MARKER = (
+    "\n\n…[inline preview truncated; the full file is referenced in the "
+    "header above]…\n\n"
+)
+
+
+def truncate_for_injection(text: str, max_chars: int) -> tuple[str, bool]:
+    """Bound the inline attachment text to *max_chars* (contiguous head + tail).
+
+    The injected ``<attachment>`` copy is only a preview; the full text stays
+    reachable via read_attachment (chat_shell) or the downloaded file
+    (executor/device). Returns ``(text, truncated)``. When truncation happens a
+    coherent head and tail are kept with a single marker between them, and the
+    result length stays within *max_chars*.
+    """
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text, False
+    budget = max_chars - len(_INJECT_TRUNCATION_MARKER)
+    if budget <= 0:
+        # max_chars smaller than the marker itself: fall back to a hard head cut.
+        return text[:max_chars], True
+    head = int(budget * 0.6)
+    tail = budget - head
+    truncated = text[:head] + _INJECT_TRUNCATION_MARKER + (text[-tail:] if tail else "")
+    return truncated, True
+
+
 def build_attachment_header(
     *,
     attachment_id: int,

--- a/shared/utils/mime_types.py
+++ b/shared/utils/mime_types.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical text/binary classification for attachment MIME types.
+
+Single source of truth shared by the backend document parser (which decides how
+to parse/extract a file) and the chat_shell attachment preview (which decides
+whether the sandbox file is directly readable as text, or the parsed text must
+be fetched via ``read_attachment``). Keeping one definition here prevents the
+two sides from drifting as new file types are added.
+"""
+
+from __future__ import annotations
+
+# Text-based ``application/*`` MIME types. The ``text/*`` family is matched by
+# prefix in ``is_text_readable_mime`` (so it need not be enumerated), but the
+# text/* entries are kept here too so the set itself is a complete answer for
+# callers that test membership directly.
+TEXT_READABLE_MIME_TYPES: frozenset[str] = frozenset(
+    {
+        # text/* family
+        "text/plain",
+        "text/html",
+        "text/css",
+        "text/javascript",
+        "text/xml",
+        "text/csv",
+        "text/markdown",
+        "text/x-python",
+        "text/x-java",
+        "text/x-c",
+        "text/x-c++",
+        "text/x-ruby",
+        "text/x-perl",
+        "text/x-php",
+        "text/x-shellscript",
+        "text/x-script.python",
+        "text/x-go",
+        "text/x-rust",
+        "text/x-swift",
+        "text/x-kotlin",
+        "text/x-scala",
+        "text/x-typescript",
+        "text/x-coffeescript",
+        "text/x-lua",
+        "text/x-r",
+        "text/x-matlab",
+        "text/x-sql",
+        "text/x-yaml",
+        "text/x-toml",
+        "text/x-ini",
+        "text/x-properties",
+        "text/x-diff",
+        "text/x-patch",
+        "text/x-log",
+        "text/x-makefile",
+        "text/x-cmake",
+        "text/x-dockerfile",
+        "text/x-nginx-conf",
+        "text/x-apache-conf",
+        "text/x-systemd-unit",
+        "text/x-tex",
+        "text/x-latex",
+        "text/x-bibtex",
+        "text/x-rst",
+        "text/x-asciidoc",
+        "text/x-org",
+        "text/troff",
+        "text/rtf",
+        "text/calendar",
+        "text/vcard",
+        # application/* text-based types
+        "application/json",
+        "application/xml",
+        "application/javascript",
+        "application/x-javascript",
+        "application/ecmascript",
+        "application/x-sh",
+        "application/x-bash",
+        "application/x-csh",
+        "application/x-zsh",
+        "application/x-python",
+        "application/x-ruby",
+        "application/x-perl",
+        "application/x-php",
+        "application/sql",
+        "application/graphql",
+        "application/toml",
+        "application/x-yaml",
+        "application/yaml",
+        "application/x-httpd-php",
+        "application/x-typescript",
+        "application/typescript",
+        "application/x-tex",
+        "application/x-latex",
+        "application/x-troff",
+        "application/x-troff-man",
+        "application/x-ndjson",
+        "application/ld+json",
+        "application/manifest+json",
+        "application/schema+json",
+        "application/vnd.api+json",
+        "application/hal+json",
+        "application/problem+json",
+        "application/x-www-form-urlencoded",
+        "application/xhtml+xml",
+        "application/atom+xml",
+        "application/rss+xml",
+        "application/soap+xml",
+        "application/mathml+xml",
+        "application/xslt+xml",
+        "application/x-subrip",
+        "application/x-wine-extension-ini",
+    }
+)
+
+
+def is_text_readable_mime(mime: str | None) -> bool:
+    """Whether *mime* denotes a file whose bytes are directly readable as text.
+
+    Covers the ``text/*`` family, an allowlist of text-based ``application/*``
+    types, and ``+json`` / ``+xml`` structured suffixes. MIME parameters (e.g.
+    ``; charset=utf-8``) and case are normalized away. Images and binary
+    documents (pdf, office, xmind, ...) return ``False`` — their bytes are not
+    directly readable as text.
+    """
+    if not mime:
+        return False
+    normalized = mime.split(";", 1)[0].strip().lower()
+    if not normalized:
+        return False
+    if normalized.startswith("text/"):
+        return True
+    if normalized in TEXT_READABLE_MIME_TYPES:
+        return True
+    if normalized.endswith("+json") or normalized.endswith("+xml"):
+        return True
+    return False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated attachment extracted-text reading (with offset/limit slicing) and an inline token-budgeted attachment preview.
  * Introduced a `read_attachment` tool to page through attachment text, enabled only when attachment content is present.
* **Bug Fixes**
  * Improved attachment access scoping for cross-conversation safety (returns **404** when not accessible).
  * Updated truncation labeling/behavior to a contiguous **head+tail** approach (“middle dropped”) and aligned partial-content notices to stored truncation state.
* **Chores**
  * Centralized shared attachment formatting/injection truncation and added configurable injection/preview limits.
* **Tests**
  * Expanded coverage for attachment text paging, preview budgeting, truncation behavior, and trace-event instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->