### PR TITLE
Fix unicode-aware chunk merging for streamed chat content

### DIFF
--- a/packages/chat-core/src/task-state/TaskStateMachine.messageUtils.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.messageUtils.ts
@@ -28,31 +28,45 @@ export function mergeChunkContent(
     }
   }
 
+  const existingCodePoints = Array.from(existingContent)
+  const incomingCodePoints = Array.from(incomingContent)
+  const existingLength = existingCodePoints.length
+
+  const sliceExisting = (start: number, end?: number) =>
+    existingCodePoints.slice(start, end).join('')
+  const sliceIncoming = (start: number, end?: number) =>
+    incomingCodePoints.slice(start, end).join('')
+  const getAppendedContent = (content: string) => {
+    const contentCodePoints = Array.from(content)
+    return contentCodePoints.length > existingLength
+      ? contentCodePoints.slice(existingLength).join('')
+      : ''
+  }
+
   const replaceTail = () => {
-    const content = existingContent.slice(0, offset) + incomingContent
+    const content = sliceExisting(0, offset) + incomingContent
     return {
       content,
-      appendedContent:
-        content.length > existingContent.length ? content.slice(existingContent.length) : '',
+      appendedContent: getAppendedContent(content),
     }
   }
 
-  if (offset > existingContent.length) {
+  if (offset > existingLength) {
     return replaceTail()
   }
 
-  const existingAtOffset = existingContent.slice(offset, offset + incomingContent.length)
+  const existingAtOffset = sliceExisting(offset, offset + incomingCodePoints.length)
   if (existingAtOffset === incomingContent) {
     return { content: existingContent, appendedContent: '' }
   }
 
-  if (offset < existingContent.length) {
-    const overlapLength = existingContent.length - offset
-    const existingOverlap = existingContent.slice(offset)
-    const incomingOverlap = incomingContent.slice(0, overlapLength)
+  if (offset < existingLength) {
+    const overlapLength = existingLength - offset
+    const existingOverlap = sliceExisting(offset)
+    const incomingOverlap = sliceIncoming(0, overlapLength)
 
     if (existingOverlap === incomingOverlap) {
-      const appendedContent = incomingContent.slice(overlapLength)
+      const appendedContent = sliceIncoming(overlapLength)
       return {
         content: existingContent + appendedContent,
         appendedContent,

--- a/packages/chat-core/src/task-state/TaskStateMachine.test.ts
+++ b/packages/chat-core/src/task-state/TaskStateMachine.test.ts
@@ -160,6 +160,49 @@ describe('TaskStateMachine', () => {
     expect(blocks.every(block => block.status === 'done')).toBe(true)
   })
 
+  it('does not duplicate done text blocks after unicode offset streaming', () => {
+    const machine = new TaskStateMachine(100, {
+      joinTask: vi.fn(),
+      isConnected: () => true,
+    })
+    const finalContent = '看起来您在继续发数字 🤔\n\n不过目前'
+
+    machine.handleChatStart(42, 'Chat', 7)
+    machine.handleChatChunk(42, '', { reasoning_chunk: 'Thought.' })
+    machine.handleChatChunk(42, '看起来您在', undefined, undefined, undefined, 0)
+    machine.handleChatChunk(42, '继续发', undefined, undefined, undefined, 5)
+    machine.handleChatChunk(42, '数字', undefined, undefined, undefined, 8)
+    machine.handleChatChunk(42, ' 🤔\n\n', undefined, undefined, undefined, 10)
+    machine.handleChatChunk(42, '不过目前', undefined, undefined, undefined, 14)
+    machine.handleChatDone(42, finalContent, {
+      blocks: [
+        {
+          id: 'backend-thinking-1',
+          type: 'thinking',
+          content: 'Thought.',
+          status: 'done',
+        },
+        {
+          id: 'backend-text-1',
+          type: 'text',
+          content: finalContent,
+          status: 'done',
+        },
+      ],
+    })
+
+    const message = machine.getState().messages.get('ai-42')
+    const textBlocks = (message?.result?.blocks ?? []).filter(block => block.type === 'text')
+
+    expect(message?.content).toBe(finalContent)
+    expect(textBlocks).toHaveLength(1)
+    expect(textBlocks[0]).toMatchObject({
+      type: 'text',
+      content: finalContent,
+      status: 'done',
+    })
+  })
+
   it('finalizes streaming blocks on chat done without event result', () => {
     const machine = new TaskStateMachine(100, {
       joinTask: vi.fn(),


### PR DESCRIPTION
## Summary
- Make streamed chunk merging operate on Unicode code points instead of UTF-16 code units
- Prevent duplicated done text blocks when offsets land around multi-byte characters
- Add a regression test covering Unicode offset streaming with final block reconciliation

## Testing
- Added a unit test for unicode offset streaming and final text block deduplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed chat text with Unicode characters, preventing incorrect duplication or truncation when offsets include surrogate-pair characters.
  * Fixed cases where completed message content could be duplicated after streaming updates, ensuring the final text matches the intended result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->