### PR TITLE
Enable standalone Codex conversation workspaces

### DIFF
--- a/executor/runtime_work/codex_discovery.py
+++ b/executor/runtime_work/codex_discovery.py
@@ -25,6 +25,7 @@ from executor.agents.codex.config_builder import _resolve_codex_binary
 from executor.config import config
 from executor.runtime_work.local_task_store import (
     LocalTaskRecord,
+    infer_runtime_workspace_kind,
     normalize_workspace_path,
     utc_now_iso,
 )
@@ -42,7 +43,6 @@ CODEX_TRANSCRIPT_INITIAL_WINDOW_BYTES = 1024 * 1024
 CODEX_TRANSCRIPT_MAX_WINDOW_BYTES = 64 * 1024 * 1024
 CODEX_LOCAL_IMAGE_PREVIEW_MAX_BYTES = 5 * 1024 * 1024
 CODEX_TERMINAL_EVENT_TYPES = {"task_complete", "turn_aborted"}
-CODEX_CONVERSATION_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 CODEX_TRANSCRIPT_CURSOR_PATTERN = re.compile(r"^offset:(\d+)$")
 
 logger = setup_logger("codex_session_discovery")
@@ -407,8 +407,12 @@ class CodexSessionDiscovery:
             "workspacePath": _thread_state_text(thread_state, "cwd"),
             "title": _thread_state_text(thread_state, "title")
             or _thread_state_text(thread_state, "preview"),
-            "createdAt": _codex_time_to_iso(_thread_state_value(thread_state, "created_at")),
-            "updatedAt": _codex_time_to_iso(_thread_state_value(thread_state, "updated_at")),
+            "createdAt": _codex_time_to_iso(
+                _thread_state_value(thread_state, "created_at")
+            ),
+            "updatedAt": _codex_time_to_iso(
+                _thread_state_value(thread_state, "updated_at")
+            ),
         }
 
     async def stream_message(
@@ -629,13 +633,17 @@ def _filter_local_tasks(
     for record in records:
         if normalized_workspace and record.workspace_path != normalized_workspace:
             continue
-        if normalized_search and normalized_search not in " ".join(
-            [
-                record.title,
-                record.local_task_id,
-                record.workspace_path,
-            ]
-        ).lower():
+        if (
+            normalized_search
+            and normalized_search
+            not in " ".join(
+                [
+                    record.title,
+                    record.local_task_id,
+                    record.workspace_path,
+                ]
+            ).lower()
+        ):
             continue
         filtered.append(record)
     return filtered
@@ -684,11 +692,7 @@ def _find_codex_state_path(codex_home: Path) -> Optional[Path]:
         codex_home / "sqlite",
         codex_home / ".codex" / "sqlite",
     ]
-    candidates = [
-        root / "state_5.sqlite"
-        for root in roots
-        if root is not None
-    ]
+    candidates = [root / "state_5.sqlite" for root in roots if root is not None]
     for root in roots:
         with contextlib.suppress(OSError):
             candidates.extend(
@@ -733,8 +737,7 @@ def _rename_thread_state(
                 if not title_columns:
                     return {"updated": False, "matched": False}
                 if all(
-                    _sqlite_row_text(row, column) == title
-                    for column in title_columns
+                    _sqlite_row_text(row, column) == title for column in title_columns
                 ):
                     return {"updated": False, "matched": True}
 
@@ -929,19 +932,7 @@ def _thread_state_value(
 
 
 def _codex_thread_workspace_kind(cwd: str) -> str:
-    return "chat" if _is_codex_app_conversation_path(cwd) else "workspace"
-
-
-def _is_codex_app_conversation_path(cwd: str) -> bool:
-    try:
-        path = Path(cwd).expanduser().resolve(strict=False)
-        root = (Path.home() / "Documents" / "Codex").resolve(strict=False)
-        relative = path.relative_to(root)
-    except ValueError:
-        return False
-
-    parts = relative.parts
-    return len(parts) >= 2 and bool(CODEX_CONVERSATION_DATE_PATTERN.fullmatch(parts[0]))
+    return infer_runtime_workspace_kind(cwd)
 
 
 def _thread_title(thread: Any, thread_id: str) -> str:

--- a/executor/runtime_work/local_task_store.py
+++ b/executor/runtime_work/local_task_store.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import re
 import threading
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -15,6 +16,7 @@ from typing import Any, Callable, Optional
 from executor.config import config
 
 INDEX_VERSION = 1
+CODEX_CONVERSATION_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
 def utc_now_iso() -> str:
@@ -25,6 +27,32 @@ def normalize_workspace_path(workspace_path: str) -> str:
     if not isinstance(workspace_path, str) or not workspace_path.strip():
         raise ValueError("workspace_path is required")
     return os.path.abspath(os.path.expanduser(workspace_path.strip()))
+
+
+def infer_runtime_workspace_kind(
+    workspace_path: str,
+    workspace_kind: Optional[str] = None,
+) -> str:
+    normalized_kind = workspace_kind.strip() if isinstance(workspace_kind, str) else ""
+    if normalized_kind and normalized_kind != "workspace":
+        return normalized_kind
+    if is_codex_conversation_workspace_path(workspace_path):
+        return "chat"
+    return normalized_kind or "workspace"
+
+
+def is_codex_conversation_workspace_path(workspace_path: str) -> bool:
+    if not isinstance(workspace_path, str) or not workspace_path.strip():
+        return False
+    try:
+        path = Path(workspace_path).expanduser().resolve(strict=False)
+        root = (Path.home() / "Documents" / "Codex").resolve(strict=False)
+        relative = path.relative_to(root)
+    except (OSError, ValueError):
+        return False
+
+    parts = relative.parts
+    return len(parts) >= 2 and bool(CODEX_CONVERSATION_DATE_PATTERN.fullmatch(parts[0]))
 
 
 @dataclass
@@ -77,7 +105,10 @@ class LocalTaskStore:
             workspace_path=workspace_path,
             title=task.title,
             runtime=task.runtime,
-            workspace_kind=task.workspace_kind or "workspace",
+            workspace_kind=infer_runtime_workspace_kind(
+                workspace_path,
+                task.workspace_kind,
+            ),
             worktree_id=task.worktree_id,
             runtime_handle=task.runtime_handle,
             parent=task.parent,
@@ -212,14 +243,16 @@ class LocalTaskStore:
                 raise KeyError(f"Local task not found in workspace: {local_task_id}")
 
             updated = updater(current)
+            normalized_workspace_path = normalize_workspace_path(updated.workspace_path)
             normalized = LocalTaskRecord(
                 local_task_id=current.local_task_id,
-                workspace_path=normalize_workspace_path(updated.workspace_path),
+                workspace_path=normalized_workspace_path,
                 title=updated.title,
                 runtime=updated.runtime,
-                workspace_kind=updated.workspace_kind
-                or current.workspace_kind
-                or "workspace",
+                workspace_kind=infer_runtime_workspace_kind(
+                    normalized_workspace_path,
+                    updated.workspace_kind or current.workspace_kind,
+                ),
                 worktree_id=updated.worktree_id,
                 runtime_handle=updated.runtime_handle,
                 parent=updated.parent,
@@ -300,7 +333,10 @@ class LocalTaskStore:
             workspace_path=normalize_workspace_path(str(payload["workspace_path"])),
             title=str(payload["title"]),
             runtime=str(payload["runtime"]),
-            workspace_kind=str(payload.get("workspace_kind") or "workspace"),
+            workspace_kind=infer_runtime_workspace_kind(
+                str(payload["workspace_path"]),
+                str(payload.get("workspace_kind") or "workspace"),
+            ),
             worktree_id=self._optional_text_value(payload.get("worktree_id")),
             runtime_handle=self._dict_value(payload.get("runtime_handle")),
             parent=self._optional_dict_value(payload.get("parent")),

--- a/executor/runtime_work/rpc_handler.py
+++ b/executor/runtime_work/rpc_handler.py
@@ -32,6 +32,7 @@ from executor.runtime_work.codex_global_state import (
 from executor.runtime_work.local_task_store import (
     LocalTaskRecord,
     LocalTaskStore,
+    infer_runtime_workspace_kind,
     normalize_workspace_path,
     utc_now_iso,
 )
@@ -323,9 +324,9 @@ class RuntimeWorkRpcHandler:
                 "workspaceSource": project.source,
             }
             if project.host_id:
-                workspace_metadata[project.workspace_path]["remoteHostId"] = (
-                    project.host_id
-                )
+                workspace_metadata[project.workspace_path][
+                    "remoteHostId"
+                ] = project.host_id
         for task in tasks:
             group_workspace = self._task_group_workspace(task, codex_project_index)
             if group_workspace is None:
@@ -1493,7 +1494,9 @@ class RuntimeWorkRpcHandler:
             runtime_handle = current.runtime_handle
             if self._is_codex_runtime(current.runtime):
                 runtime_handle = {**current.runtime_handle, "titleOverride": True}
-            return replace(current, title=normalized_title, runtime_handle=runtime_handle)
+            return replace(
+                current, title=normalized_title, runtime_handle=runtime_handle
+            )
 
         codex_rename: Optional[dict[str, Any]] = None
         if self._is_codex_runtime(task.runtime) and self.codex_discovery is not None:
@@ -2079,6 +2082,7 @@ class RuntimeWorkRpcHandler:
             workspace_path=workspace_path,
             title=title,
             runtime="codex",
+            workspace_kind=infer_runtime_workspace_kind(workspace_path),
             runtime_handle={
                 "pendingNativeCodexThread": True,
                 "activeSubtaskId": subtask_id,

--- a/executor/tests/runtime_work/test_local_task_store.py
+++ b/executor/tests/runtime_work/test_local_task_store.py
@@ -749,6 +749,81 @@ async def test_runtime_work_handler_lists_codex_tasks_from_sdk_only(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runtime_work_handler_lists_standalone_chat_workspace_tasks(
+    tmp_path,
+    monkeypatch,
+):
+    from executor.runtime_work.local_task_store import LocalTaskRecord, LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    chat_workspace = home / "Documents" / "Codex" / "2026-06-25" / "ci"
+    store = LocalTaskStore(tmp_path / "index.json")
+    store.upsert_task(
+        LocalTaskRecord(
+            local_task_id="chat-1",
+            workspace_path=str(chat_workspace),
+            title="CI",
+            runtime="claude_code",
+            runtime_handle={"messages": []},
+            created_at="2026-06-25T01:00:00Z",
+            updated_at="2026-06-25T01:05:00Z",
+            running=True,
+        )
+    )
+
+    result = await RuntimeWorkRpcHandler(
+        store=store,
+        codex_discovery=EmptyDiscovery(),
+    ).handle_runtime_rpc({"method": "runtime.tasks.list", "payload": {}})
+
+    assert result["success"] is True
+    workspaces = {item["workspacePath"]: item for item in result["workspaces"]}
+    assert str(chat_workspace) in workspaces
+    task = workspaces[str(chat_workspace)]["localTasks"][0]
+    assert task["localTaskId"] == "chat-1"
+    assert task["workspaceKind"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_runtime_work_handler_lists_pending_codex_chat_workspace_tasks(
+    tmp_path,
+    monkeypatch,
+):
+    from executor.runtime_work.local_task_store import LocalTaskStore
+    from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    chat_workspace = home / "Documents" / "Codex" / "2026-06-25" / "ci"
+    handler = RuntimeWorkRpcHandler(
+        store=LocalTaskStore(tmp_path / "index.json"),
+        codex_discovery=EmptyDiscovery(),
+    )
+    handler._remember_sdk_codex_task(
+        handler._sdk_codex_create_record(
+            local_task_id="codex-chat-1",
+            workspace_path=str(chat_workspace),
+            title="CI",
+            message="run ci",
+            subtask_id=2001,
+        )
+    )
+
+    result = await handler.handle_runtime_rpc(
+        {"method": "runtime.tasks.list", "payload": {}}
+    )
+
+    assert result["success"] is True
+    workspaces = {item["workspacePath"]: item for item in result["workspaces"]}
+    task = workspaces[str(chat_workspace)]["localTasks"][0]
+    assert task["localTaskId"] == "codex-chat-1"
+    assert task["runtime"] == "codex"
+    assert task["workspaceKind"] == "chat"
+
+
+@pytest.mark.asyncio
 async def test_runtime_work_handler_uses_codex_global_projects(tmp_path):
     from executor.runtime_work.local_task_store import LocalTaskStore
     from executor.runtime_work.rpc_handler import RuntimeWorkRpcHandler

--- a/wework/src/components/layout/workspace-panels/WorkspaceFileTree.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspaceFileTree.tsx
@@ -1,4 +1,5 @@
 import { FileTree, useFileTree } from '@pierre/trees/react'
+import type { FileTreeDirectoryHandle, FileTreeItemHandle } from '@pierre/trees'
 import { RefreshCw, Search } from 'lucide-react'
 import type { CSSProperties } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -189,6 +190,21 @@ function getEntryByTreePath(entries: Map<string, WorkspaceFileEntry>, treePath: 
   return null
 }
 
+function isDirectoryHandle(
+  item: FileTreeItemHandle | null
+): item is FileTreeDirectoryHandle {
+  if (!item) return false
+
+  const candidate = item as FileTreeItemHandle & {
+    expand?: unknown
+    isDirectory?: unknown
+  }
+  if (typeof candidate.isDirectory === 'function') {
+    return candidate.isDirectory()
+  }
+  return typeof candidate.expand === 'function'
+}
+
 function WorkspacePierreFileTree({
   modelKey,
   treeModel,
@@ -217,7 +233,10 @@ function WorkspacePierreFileTree({
       if (!entry) return
 
       if (entry.isDirectory) {
-        model.getItem(nextPath)?.expand()
+        const item = model.getItem(nextPath)
+        if (isDirectoryHandle(item)) {
+          item.expand()
+        }
         onOpenDirectory(entry)
       } else {
         onOpenFile(entry)
@@ -239,7 +258,12 @@ function WorkspacePierreFileTree({
   }, [model, treeModel.selectedTreePath])
 
   useEffect(() => {
-    treeModel.expandedTreePaths.forEach(path => model.getItem(path)?.expand())
+    treeModel.expandedTreePaths.forEach(path => {
+      const item = model.getItem(path)
+      if (isDirectoryHandle(item)) {
+        item.expand()
+      }
+    })
   }, [model, treeModel.expandedTreePaths])
 
   return (

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1069,6 +1069,52 @@ describe('WorkbenchProvider runtime tasks', () => {
     )
   })
 
+  test('creates a conversation workspace when sending without a selected project', async () => {
+    vi.setSystemTime(new Date('2026-06-25T09:30:00.000Z'))
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(createRuntimeWork({ projects: [], chats: [] })),
+      createRuntimeTask: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-1',
+        localTaskId: 'conversation-created',
+        workspacePath: '/Users/alice/Documents/Codex/2026-06-25/ci',
+        runtime: 'codex',
+      }),
+    })
+    const services = createWorkbenchServices({
+      deviceApi: {
+        getHomeDirectory: vi.fn().mockResolvedValue('/Users/alice'),
+        createDirectory: vi.fn().mockResolvedValue(undefined),
+      } as Partial<WorkbenchServices['deviceApi']> as WorkbenchServices['deviceApi'],
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<ProjectSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByText('set input')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('set input'))
+    await userEvent.click(screen.getByText('send'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    expect(services.deviceApi.getHomeDirectory).toHaveBeenCalledWith('device-1')
+    expect(services.deviceApi.createDirectory).toHaveBeenCalledWith(
+      'device-1',
+      '/Users/alice/Documents/Codex/2026-06-25/ci'
+    )
+    expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: 'device-1',
+        workspacePath: '/Users/alice/Documents/Codex/2026-06-25/ci',
+        teamId: 2,
+        message: '修复 CI',
+      })
+    )
+    expect(runtimeWorkApi.createRuntimeTask.mock.calls[0][0]).not.toHaveProperty('projectId')
+    expect(screen.getByTestId('workbench-error')).not.toHaveTextContent(
+      '请选择项目或打开设备工作区后再发送'
+    )
+  })
+
   test('registers a standalone Codex workspace with an optional label', async () => {
     const runtimeWorkApi = createRuntimeWorkApiMock({
       listRuntimeWork: vi.fn().mockResolvedValue(createRuntimeWork({ projects: [] })),

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -121,6 +121,8 @@ const LOCAL_SKILLS_CACHE_TTL_MS = 60_000
 const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 const STANDALONE_PROJECT_ID = 0
 const EMPTY_MESSAGE_TASK_TITLE = '新对话'
+const DEFAULT_CONVERSATION_WORKSPACE_NAME = 'new-chat'
+const MAX_CONVERSATION_WORKSPACE_NAME_LENGTH = 20
 const RUNTIME_BLOCK_SUBTASK_ID_OFFSET = 1_000_000_000
 
 type ProjectMutationOptions = {
@@ -260,6 +262,57 @@ export interface WorkbenchServices {
   userApi?: ReturnType<typeof createUserApi>
   socketClient?: Pick<AuthenticatedSocketClient, 'ensureConnected' | 'dispose'>
   chatStream: ReturnType<typeof createChatStream>
+}
+
+async function createConversationWorkspace(
+  deviceApi: WorkbenchServices['deviceApi'],
+  deviceId: string,
+  message: string
+): Promise<string> {
+  const homeDirectory = await deviceApi.getHomeDirectory(deviceId)
+  const workspacePath = buildConversationWorkspacePath(homeDirectory, message)
+  await deviceApi.createDirectory(deviceId, workspacePath)
+  return workspacePath
+}
+
+function buildConversationWorkspacePath(homeDirectory: string, message: string): string {
+  return joinDevicePath(
+    homeDirectory,
+    'Documents',
+    'Codex',
+    formatConversationWorkspaceDate(new Date()),
+    slugifyConversationWorkspaceName(message)
+  )
+}
+
+function formatConversationWorkspaceDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function slugifyConversationWorkspaceName(message: string): string {
+  const words = message.match(/[A-Za-z0-9]+/g) ?? []
+  const name = words.length > 0 ? words.map(word => word.toLowerCase()).join('-') : ''
+  return trimConversationWorkspaceName(name || DEFAULT_CONVERSATION_WORKSPACE_NAME)
+}
+
+function trimConversationWorkspaceName(name: string): string {
+  const trimmed = name.slice(0, MAX_CONVERSATION_WORKSPACE_NAME_LENGTH).replace(/-+$/g, '')
+  return trimmed || DEFAULT_CONVERSATION_WORKSPACE_NAME
+}
+
+function joinDevicePath(root: string, ...segments: string[]): string {
+  const trimmedRoot = root.trim()
+  const normalizedRoot = trimmedRoot === '/' ? '' : trimmedRoot.replace(/\/+$/g, '')
+  const joined = [
+    normalizedRoot,
+    ...segments.map(segment => segment.replace(/^\/+|\/+$/g, '')),
+  ]
+    .filter(Boolean)
+    .join('/')
+  return trimmedRoot.startsWith('/') ? `/${joined.replace(/^\/+/g, '')}` : joined
 }
 
 export interface WorkbenchContextValue {
@@ -851,22 +904,6 @@ function getRememberedStandaloneDeviceId(
     devices,
     user.preferences?.default_execution_target ?? fallbackDeviceId
   )
-}
-
-function findRuntimeWorkspaceForDevice(
-  runtimeWork: RuntimeWorkListResponse | null | undefined,
-  deviceId: string | undefined
-): string | null {
-  if (!deviceId) return null
-  const workspaces = [
-    ...(runtimeWork?.chats ?? []),
-    ...(runtimeWork?.projects ?? []).flatMap(project => project.deviceWorkspaces),
-  ]
-  const matches = workspaces.filter(
-    item => item.deviceId === deviceId && item.available && item.workspacePath
-  )
-  const workspacePaths = [...new Set(matches.map(item => item.workspacePath))]
-  return workspacePaths.length === 1 ? workspacePaths[0] : null
 }
 
 function getSelectableProjectDeviceWorkspaces(
@@ -2356,7 +2393,10 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
           ? selectedProjectWorkspace.deviceId
           : getActiveWorkbenchDeviceId({
               currentProject: activeProject,
-              standaloneDeviceId: state.standaloneDeviceId,
+              standaloneDeviceId: getPreferredStandaloneDeviceId(
+                state.devices,
+                state.standaloneDeviceId
+              ),
             })
 
       const payload: ChatSendPayload = {
@@ -2420,6 +2460,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       projectWorktreeBaseBranch,
       projectExecutionMode,
       state.currentProject,
+      state.devices,
       state.defaultTeam,
       state.runtimeWork,
       state.selectedDeviceWorkspaceId,
@@ -2439,6 +2480,10 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         return false
       }
       const projectId = payload.project_id && payload.project_id > 0 ? payload.project_id : null
+      const selectedModel =
+        modelSelection.selectedModel ?? resolveAutomaticModel(modelSelection.models)
+      const runtime = inferRuntimeName(selectedModel)
+      const localTaskId = createRuntimeLocalTaskId(runtime)
       const selectedProjectWorkspace = findProjectDeviceWorkspace(
         state.runtimeWork,
         projectId,
@@ -2466,9 +2511,19 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
                 workspacePath: selectedProjectWorkspace.workspacePath,
               }
       } else {
-        const workspacePath =
-          state.standaloneWorkspacePath ??
-          findRuntimeWorkspaceForDevice(state.runtimeWork, activeDeviceId)
+        let workspacePath = state.standaloneWorkspacePath
+        if (!workspacePath && activeDeviceId) {
+          try {
+            workspacePath = await createConversationWorkspace(
+              resolvedServices.deviceApi,
+              activeDeviceId,
+              displayMessage
+            )
+          } catch (error) {
+            reportSendBlocked(error instanceof Error ? error.message : '创建对话工作区失败')
+            return false
+          }
+        }
         if (!activeDeviceId || !workspacePath) {
           reportSendBlocked('请选择项目或打开设备工作区后再发送')
           return false
@@ -2480,10 +2535,6 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
         }
       }
 
-      const selectedModel =
-        modelSelection.selectedModel ?? resolveAutomaticModel(modelSelection.models)
-      const runtime = inferRuntimeName(selectedModel)
-      const localTaskId = createRuntimeLocalTaskId(runtime)
       const createRequest: RuntimeTaskCreateRequest = {
         ...runtimeTaskTarget,
         localTaskId,
@@ -2589,6 +2640,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
       refreshWorkLists,
       rememberExecutionDevice,
       reportSendBlocked,
+      resolvedServices.deviceApi,
       resolvedServices.runtimeWorkApi,
       state.currentProject,
       state.projects,


### PR DESCRIPTION
## Summary
- Infer chat workspace kinds from Codex conversation paths and persist them consistently in the local task store
- Create a conversation workspace automatically when sending from the workbench without a selected project
- Harden workspace tree expansion for directory handles and add coverage for new chat workspace flows

## Testing
- Added unit tests for runtime task listing and conversation workspace creation behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages can now create a standalone conversation workspace automatically when no project is selected.
  * Workspace locations are organized under a dated conversation folder and use a safe, message-based name.

* **Bug Fixes**
  * Improved workspace detection so conversation-style paths are correctly recognized as chat workspaces.
  * Fixed task listing and workspace expansion behavior for chat workspaces and directory items.

* **Tests**
  * Added coverage for conversation workspace creation and chat workspace task listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->