### PR TITLE
Fix/read attachment document only

### DIFF
--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -67,9 +67,12 @@ def _attachments_have_document(attachments: Any) -> bool:
     if not isinstance(attachments, list):
         return False
     for att in attachments:
-        if not isinstance(att, dict):
-            continue
-        mime = str(att.get("mime_type") or "").lower()
+        # ExecutionRequest.attachments is untyped: entries may be plain dicts or
+        # attachment objects that expose mime_type as an attribute.
+        if isinstance(att, dict):
+            mime = str(att.get("mime_type") or "").lower()
+        else:
+            mime = str(getattr(att, "mime_type", "") or "").lower()
         if mime and not mime.startswith("image/") and not mime.startswith("video/"):
             return True
     return False
@@ -243,6 +246,7 @@ class ChatContext:
                 or any(
                     _content_has_readable_attachment(message.get("content"))
                     for message in history
+                    if isinstance(message, dict)
                 )
             )
 

--- a/chat_shell/chat_shell/services/context.py
+++ b/chat_shell/chat_shell/services/context.py
@@ -15,6 +15,7 @@ Note: Agent creation is NOT handled here - it belongs to the service layer.
 import asyncio
 import json
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -47,15 +48,48 @@ class ChatContextResult:
     mcp_clients: list = field(default_factory=list)
 
 
-def _content_has_attachment(content: Any) -> bool:
-    """Return True if a message content (str or block list) has an attachment."""
+# A document attachment header is ``[Attachment: …]``; images use
+# ``[Image Attachment: …]`` and videos ``[Video Attachment: …]``. The
+# ``\[Attachment:`` anchor (a bracket immediately before the colon-terminated
+# label) matches only documents — not image/video headers, and not the
+# ``[Attachment N]`` index label (no colon).
+_DOCUMENT_ATTACHMENT = re.compile(r"\[Attachment:")
+
+
+def _attachments_have_document(attachments: Any) -> bool:
+    """Return True if the structured request payload includes a document attachment.
+
+    Preferred, format-independent signal for the current turn: the backend sets
+    ``request.attachments`` with each attachment's ``mime_type``. A document is
+    anything that is not an image or a video — only those carry extracted text
+    for read_attachment to serve.
+    """
+    if not isinstance(attachments, list):
+        return False
+    for att in attachments:
+        if not isinstance(att, dict):
+            continue
+        mime = str(att.get("mime_type") or "").lower()
+        if mime and not mime.startswith("image/") and not mime.startswith("video/"):
+            return True
+    return False
+
+
+def _content_has_readable_attachment(content: Any) -> bool:
+    """Return True if rendered content carries a document attachment block.
+
+    Header-text fallback used for history (prior turns are not in
+    ``request.attachments``) and as a safety net for the current turn. Only
+    document attachments have extracted text; image/video blocks do not, so a
+    conversation with only those must NOT get the read_attachment tool.
+    """
     if isinstance(content, str):
-        return "<attachment>" in content
+        return bool(_DOCUMENT_ATTACHMENT.search(content))
     if isinstance(content, list):
         return any(
             isinstance(block, dict)
             and isinstance(block.get("text"), str)
-            and "<attachment>" in block["text"]
+            and _DOCUMENT_ATTACHMENT.search(block["text"])
             for block in content
         )
     return False
@@ -197,11 +231,19 @@ class ChatContext:
                         restored_tool_count,
                     )
 
-            # Only offer read_attachment when this conversation actually carries
-            # an attachment (current turn or history), to avoid bloating the
-            # tool list for plain chats.
-            has_attachments = _content_has_attachment(self._request.prompt) or any(
-                _content_has_attachment(message.get("content")) for message in history
+            # Only offer read_attachment when the conversation carries a document
+            # attachment whose text the tool can serve. Prefer the structured
+            # request payload (mime_type) for the current turn — robust to header
+            # format changes — then fall back to a header scan of the prompt and
+            # history (prior turns aren't in request.attachments). Image/video-only
+            # conversations and plain chats don't get it (it would return "empty").
+            has_attachments = (
+                _attachments_have_document(self._request.attachments)
+                or _content_has_readable_attachment(self._request.prompt)
+                or any(
+                    _content_has_readable_attachment(message.get("content"))
+                    for message in history
+                )
             )
 
             # Build extra_tools from all sources (including builtin tools)

--- a/chat_shell/tests/test_context_stateless.py
+++ b/chat_shell/tests/test_context_stateless.py
@@ -123,6 +123,19 @@ def test_attachments_have_document_empty_or_malformed():
     assert _attachments_have_document(["not-a-dict"]) is False
 
 
+def test_attachments_have_document_object_style():
+    # Entries may be attachment objects exposing mime_type as an attribute,
+    # not only plain dicts.
+    class _Att:
+        def __init__(self, mime_type):
+            self.mime_type = mime_type
+
+    assert _attachments_have_document([_Att("application/pdf")]) is True
+    assert _attachments_have_document([_Att("image/png")]) is False
+    assert _attachments_have_document([_Att(None)]) is False
+    assert _attachments_have_document([object()]) is False
+
+
 @pytest.mark.asyncio
 async def test_load_chat_history_uses_request_history_for_stateless_request():
     request = ExecutionRequest(

--- a/chat_shell/tests/test_context_stateless.py
+++ b/chat_shell/tests/test_context_stateless.py
@@ -8,8 +8,119 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from chat_shell.services.context import ChatContext
+from chat_shell.services.context import (
+    ChatContext,
+    _attachments_have_document,
+    _content_has_readable_attachment,
+)
 from shared.models.execution import ExecutionRequest
+from shared.utils.attachment_block import build_attachment_header
+
+
+def _block(text: str):
+    return [{"type": "input_text", "text": text}]
+
+
+def _doc_block() -> str:
+    # Anchor on the real header builder so a format change breaks this test
+    # loudly instead of silently disabling read_attachment registration.
+    header = build_attachment_header(
+        attachment_id=5,
+        filename="report.pdf",
+        mime_type="application/pdf",
+        file_size=2048,
+        sandbox_path=None,
+    )
+    return f"<attachment>[Attachment 1]\n{header}\nbody</attachment>"
+
+
+def _image_block() -> str:
+    header = build_attachment_header(
+        attachment_id=7,
+        filename="pic.png",
+        mime_type="image/png",
+        file_size=1024,
+        sandbox_path=None,
+        is_image=True,
+    )
+    return f"<attachment>{header}</attachment>"
+
+
+# --- header-text fallback (history / current-turn safety net) ---
+
+
+def test_readable_attachment_detects_document():
+    doc = _doc_block()
+    assert _content_has_readable_attachment(doc) is True
+    assert _content_has_readable_attachment(_block(doc)) is True
+
+
+def test_readable_attachment_ignores_image_only():
+    assert _content_has_readable_attachment(_image_block()) is False
+
+
+def test_readable_attachment_ignores_video_only():
+    # build_video_attachment_header is internal-only (not on this branch); assert
+    # the regex ignores the video header format directly (forward-compatible).
+    video = (
+        "<attachment>[Attachment 1]\n"
+        "[Video Attachment: clip.mp4 | ID: 9 | Type: video/mp4 | Size: 4.8 MB]\n"
+        '{"fid": 123}</attachment>'
+    )
+    assert _content_has_readable_attachment(video) is False
+
+
+def test_readable_attachment_true_for_mixed_doc_and_video():
+    header = build_attachment_header(
+        attachment_id=1,
+        filename="a.pdf",
+        mime_type="application/pdf",
+        file_size=10,
+        sandbox_path=None,
+    )
+    mixed = (
+        f"<attachment>{header}\nx\n"
+        "[Video Attachment: v.mp4 | ID: 2 | Type: video/mp4]\n{}</attachment>"
+    )
+    assert _content_has_readable_attachment(mixed) is True
+
+
+def test_readable_attachment_false_for_plain_text():
+    assert _content_has_readable_attachment("just a question") is False
+
+
+# --- structured request.attachments (preferred current-turn signal) ---
+
+
+def test_attachments_have_document_true_for_pdf():
+    assert _attachments_have_document([{"mime_type": "application/pdf"}]) is True
+
+
+def test_attachments_have_document_ignores_image_and_video():
+    assert _attachments_have_document([{"mime_type": "image/png"}]) is False
+    assert _attachments_have_document([{"mime_type": "video/mp4"}]) is False
+    assert (
+        _attachments_have_document(
+            [{"mime_type": "image/png"}, {"mime_type": "video/mp4"}]
+        )
+        is False
+    )
+
+
+def test_attachments_have_document_true_when_mixed():
+    assert (
+        _attachments_have_document(
+            [{"mime_type": "video/mp4"}, {"mime_type": "application/pdf"}]
+        )
+        is True
+    )
+
+
+def test_attachments_have_document_empty_or_malformed():
+    assert _attachments_have_document([]) is False
+    assert _attachments_have_document(None) is False
+    assert _attachments_have_document([{"mime_type": ""}]) is False
+    assert _attachments_have_document(["not-a-dict"]) is False
 
 
 @pytest.mark.asyncio

--- a/docs/en/developer-guide/README.md
+++ b/docs/en/developer-guide/README.md
@@ -29,6 +29,11 @@ Welcome to the Wegent Developer Guide! This guide will help you understand how t
 - [MCP Refactoring Guide](./mcp-refactoring-guide.md) - Knowledge MCP tool refactoring architecture
 - [External Knowledge MCP](./external-knowledge-mcp.md) - Knowledge MCP integration for trusted external systems
 
+### 💬 Chat Shell
+
+- [Chat Shell Context Governance](./chat-shell-context-governance.md) - Overview of the three-stage Chat Shell context-governance rollout
+- [Chat Shell Graceful Shutdown](./chat-shell-graceful-shutdown.md) - Service shutdown and streaming cleanup behavior
+
 ### 📊 Observability
 
 - [OpenTelemetry](./opentelemetry.md) - Tracing and observability setup

--- a/docs/en/developer-guide/chat-shell-attachment-context.md
+++ b/docs/en/developer-guide/chat-shell-attachment-context.md
@@ -1,0 +1,170 @@
+---
+sidebar_position: 32
+---
+
+# Chat Shell Attachment Context (Preview & On-Demand Read)
+
+If you want the broader three-stage rollout, design trade-offs, and maintenance
+boundaries first, start with
+[Chat Shell Context Governance](./chat-shell-context-governance.md).
+
+## Background
+
+When a user uploads an attachment (PDF / Word / Excel / image / text, etc.), its
+extracted text is injected inline as its own `<attachment>` text block in the
+user message. Injecting the whole thing causes two problems:
+
+- **Carried every turn**: the attachment text occupies many tokens on every turn
+  even when context compaction is not triggered;
+- **Lossy compaction**: once the threshold is hit, summary compact folds /
+  truncates the *whole* user message (cutting the question too), irreversibly.
+
+This feature bounds the inline copy to a token-limited **preview**; the full
+content is fetched on demand from the **sandbox file** or via the
+**`read_attachment` tool**.
+
+> Note: attachment parsing is synchronous (done within the upload request;
+> defaults to the `parser.py` Python libraries — MinerU is knowledge-base only and
+> off by default), so an attachment is READY as soon as it enters the
+> conversation — there is no "parsing not finished" race.
+
+## Message structure
+
+The assembled user message is a list of content blocks; the attachment is its
+**own block** (not merged with the question, which helps prefix caching):
+
+```text
+user.content = [
+  {type: text,      text: "<user question>"},
+  {type: image_url, ...},                          # images, if any
+  {type: text,      text: "<attachment>…</attachment>"},   # all attachments in one block
+  {type: text,      text: "<knowledge_base>…</knowledge_base>"},
+  {type: text,      text: "<system-reminder>…</system-reminder>"},
+]
+```
+
+Multiple attachments of one message are **merged into a single `<attachment>`
+block**, each with a `[Attachment: name | ID: n | Type: … | File Path(already in sandbox): …]`
+header.
+
+## Inline preview (token-bounded)
+
+After `agent.build_messages` assembles the messages (and before cache
+breakpoints), every `<attachment>` block is token-bounded (current turn and
+replayed history handled identically). See
+`chat_shell/messages/attachment_preview.py`, which reuses the tool-output
+truncation logic (`guard/tool_output._truncate_body`, head/tail +
+`…N tokens truncated…` marker).
+
+- **Budget**: `ATTACHMENT_PREVIEW_TOKEN_LIMIT` (default 30000, configurable;
+  `<=0` disables), capped relative to the window: `min(context_window // 2, configured)`,
+  so a small-context model is not swamped. The window comes from
+  `get_model_context_config(model_id, model_config)`.
+- **Fast path**: a block already within budget is returned untouched, keeping the
+  prefix cache stable.
+
+### Multi-attachment allocation (water-filling)
+
+All attachments share one budget (avoids N×budget blowups). The budget first
+reserves the consolidated id list and every header, then distributes the
+remainder across segments by **water-filling**:
+
+- a segment that fits its fair share keeps its full size and returns the leftover
+  to the pool; the fair share is recomputed for the remaining segments;
+- big segments absorb the freed budget — small ones don't waste their share while
+  large ones get over-truncated.
+
+Example: A=30k, B=5k tokens, budget 30k → B kept whole (5k), A truncated to ~25k.
+Each segment keeps a head and a tail, and **every header (with its ID) is
+preserved**; with multiple attachments a consolidated id index line is prepended.
+
+### Type-aware hint
+
+A truncated segment gets a trailing pointer to the full content, decided by the
+`Type:` in its header:
+
+- **Text**: `[Preview truncated. Full file readable in sandbox: <path>]` — the
+  sandbox original is complete and exceeds the parse-time cap;
+- **Binary (pdf/office)**: `[Preview truncated. Use read_attachment(attachment_id=N) for the full text.]`
+  — the sandbox file is binary, so the parsed text is fetched via the tool.
+
+## The `read_attachment` tool
+
+Complements the preview: lets the model page through an attachment's full
+extracted text (mainly for binary attachments; text attachments can be read
+directly from the sandbox).
+
+- **Conditional registration**: added to the function-calling schema only when
+  the conversation (history or current turn) contains an `<attachment>` block
+  (`services/context.py`). Plain chats don't register it; it does not use the
+  lazy provider (that is skill-system specific).
+- **Pagination protocol**: **character offset + token clamp** — the cursor is a
+  character position (tokenizer-independent, reproducible across turns/models);
+  the returned page is clamped to the per-page token budget (default aligned with
+  the 15k tool-output budget), so a page never exceeds budget nor gets
+  re-truncated by the request-level guard; `next_offset = offset + chars returned`.
+- **Content upper bound**: the parse-time cap (default 500k chars); beyond that
+  the original file must be read from the sandbox.
+- **Call limit**: a per-conversation cap prevents unbounded paging.
+
+### Permissions: task-scoped (incl. group chat)
+
+Readable set = `{ context | context.subtask_id ∈ the task's subtasks, or unlinked }`,
+matching history visibility.
+
+- In group chat, attachments uploaded by different users have different `user_id`
+  but belong to the same task — all are **readable**;
+- cross-task access is denied (403); not-found / non-READY returns 404.
+- **Not user-scoped** (attachments are conversation-shared, unlike user-owned
+  knowledge bases).
+
+### Dual path (remote / package)
+
+- **HTTP/remote mode** (production default; backend and chat shell deployed
+  separately): via the backend internal endpoint
+  `GET /api/internal/chat/attachments/{id}/text?session_id=task-X&offset=&limit=`,
+  returning a character slice + `total_chars` / `has_more`; pagination/token clamp
+  is done on the chat shell side.
+- **Package mode**: reads the database directly, with the same task scoping.
+
+See `chat_shell/history/attachment_text.py::fetch_attachment_text`,
+`chat_shell/storage/remote.py::get_attachment_text`, and
+`backend/app/api/endpoints/internal/chat_storage.py`.
+
+## Shared attachment header (consistency)
+
+The `<attachment>` header is built by
+`shared/utils/attachment_block.py::build_attachment_header`, shared between the
+backend first-send preprocessing (`context_service` / `contexts`) and the chat
+shell history rebuild (`history/loader`), so the format does not drift between the
+first turn and history replay.
+
+## Observability (traces)
+
+The three context protections emit a uniformly-shaped span event via
+`chat_shell/guard/traces.py::record_protection_trace`, named
+`context_protection.{operation}`, so the tracing backend can derive **event
+count / success rate (by status) / duration (duration_ms) / tokens saved**:
+
+| operation | Trigger | status | Key attributes |
+|---|---|---|---|
+| `attachment_preview` | message with an attachment block | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
+| `tool_output` | tool-output truncation (only when it happens) | `applied` | duration_ms, messages_truncated, emergency |
+| `summary_compact` | request-level summary compaction | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
+
+To avoid noise, no event is emitted on a no-op (`tool_output` only when it
+truncates, `attachment_preview` only when an attachment block is present);
+`add_span_event` is a no-op when telemetry is disabled.
+
+## Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 30000 | Shared attachment preview budget (min'd with `context_window // 2`); `<=0` disables the preview |
+
+## Non-goals (future tiers)
+
+- DuckDB query over tables (query xlsx/csv in place, return only result rows);
+- RAG over prose (task-level ephemeral index, not exposed as a user knowledge base);
+- outline / heading-addressed reads;
+- video/audio and other non-text-extractable types (no capability today).

--- a/docs/en/developer-guide/chat-shell-attachment-context.md
+++ b/docs/en/developer-guide/chat-shell-attachment-context.md
@@ -47,16 +47,33 @@ Multiple attachments of one message are **merged into a single `<attachment>`
 block**, each with a `[Attachment: name | ID: n | Type: … | File Path(already in sandbox): …]`
 header.
 
-## Inline preview (token-bounded)
+## Injection cap (backend, character-level, all modes)
+
+The extracted text is first capped on the backend injection layer
+(`context_service.build_document_text_prefix`) to `ATTACHMENT_INJECT_MAX_CHARS`
+**characters** (default 32000) before it enters any mode's prompt. This separates
+**storage** from **injection**:
+
+- **Storage**: the full extracted text (≤ `MAX_EXTRACTED_TEXT_LENGTH`, default
+  500k chars) stays in the DB for `read_attachment` paging and for the
+  executor/device to download the real file;
+- **Injection**: what enters the prompt is a bounded preview (contiguous head +
+  tail + a single marker pointing to the full file in the header).
+
+This layer applies to **all modes** and is the only injection-length guard for
+executor / device (which have no chat-shell token preview). chat shell adds a
+token-level preview on top (below).
+
+## Inline preview (token-bounded, chat shell)
 
 After `agent.build_messages` assembles the messages (and before cache
 breakpoints), every `<attachment>` block is token-bounded (current turn and
-replayed history handled identically). See
-`chat_shell/messages/attachment_preview.py`, which reuses the tool-output
-truncation logic (`guard/tool_output._truncate_body`, head/tail +
+replayed history handled identically; refining on top of the backend character
+cap above). See `chat_shell/messages/attachment_preview.py`, which reuses the
+tool-output truncation logic (`guard/tool_output._truncate_body`, head/tail +
 `…N tokens truncated…` marker).
 
-- **Budget**: `ATTACHMENT_PREVIEW_TOKEN_LIMIT` (default 30000, configurable;
+- **Budget**: `ATTACHMENT_PREVIEW_TOKEN_LIMIT` (default 15000, configurable;
   `<=0` disables), capped relative to the window: `min(context_window // 2, configured)`,
   so a small-context model is not swamped. The window comes from
   `get_model_context_config(model_id, model_config)`.
@@ -83,10 +100,15 @@ preserved**; with multiple attachments a consolidated id index line is prepended
 A truncated segment gets a trailing pointer to the full content, decided by the
 `Type:` in its header:
 
-- **Text**: `[Preview truncated. Full file readable in sandbox: <path>]` — the
-  sandbox original is complete and exceeds the parse-time cap;
-- **Binary (pdf/office)**: `[Preview truncated. Use read_attachment(attachment_id=N) for the full text.]`
-  — the sandbox file is binary, so the parsed text is fetched via the tool.
+- **Text**: `[Preview truncated. Full file in the sandbox at <path> — read or grep/search it with your file tools to get the rest.]`
+  — the sandbox original is complete; encourages targeted grep/search instead of
+  reading the whole file;
+- **Binary (pdf/office/xmind)**: `[Preview truncated. Get the rest via read_attachment(attachment_id=N) for the parsed text, or open the sandbox file (path in the header above) with a suitable tool.]`
+  — not locking the model into a single action.
+
+The text/binary split uses the shared MIME classification
+`shared/utils/mime_types.py::is_text_readable_mime`, consistent with the backend
+parser (new types are added in one place).
 
 ## The `read_attachment` tool
 
@@ -95,9 +117,14 @@ extracted text (mainly for binary attachments; text attachments can be read
 directly from the sandbox).
 
 - **Conditional registration**: added to the function-calling schema only when
-  the conversation (history or current turn) contains an `<attachment>` block
-  (`services/context.py`). Plain chats don't register it; it does not use the
-  lazy provider (that is skill-system specific).
+  the conversation has a **document** attachment (`services/context.py`).
+  `read_attachment` serves extracted text, which only documents have; images and
+  videos have none (a call would just return "empty"), so image/video-only
+  conversations don't register it. Detection: the structured
+  `request.attachments[].mime_type` for the current turn (a document is anything
+  not `image/*` or `video/*` — format-independent and stable), falling back to a
+  `[Attachment:` header scan for history. Plain chats don't register it; it does
+  not use the lazy provider (that is skill-system specific).
 - **Pagination protocol**: **character offset + token clamp** — the cursor is a
   character position (tokenizer-independent, reproducible across turns/models);
   the returned page is clamped to the per-page token budget (default aligned with
@@ -139,28 +166,20 @@ backend first-send preprocessing (`context_service` / `contexts`) and the chat
 shell history rebuild (`history/loader`), so the format does not drift between the
 first turn and history replay.
 
-## Observability (traces)
+## Observability
 
-The three context protections emit a uniformly-shaped span event via
-`chat_shell/guard/traces.py::record_protection_trace`, named
-`context_protection.{operation}`, so the tracing backend can derive **event
-count / success rate (by status) / duration (duration_ms) / tokens saved**:
-
-| operation | Trigger | status | Key attributes |
-|---|---|---|---|
-| `attachment_preview` | message with an attachment block | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
-| `tool_output` | tool-output truncation (only when it happens) | `applied` | duration_ms, messages_truncated, emergency |
-| `summary_compact` | request-level summary compaction | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
-
-To avoid noise, no event is emitted on a no-op (`tool_output` only when it
-truncates, `attachment_preview` only when an attachment block is present);
-`add_span_event` is a no-op when telemetry is disabled.
+Attachment-preview traces share the unified `context_protection.{operation}`
+structure with tool output and summary compact; see the consolidated reference
+(per-operation status / attribute schema) in
+[Chat Shell Context Governance · Observability](./chat-shell-context-governance.md#observability).
 
 ## Configuration
 
 | Setting | Default | Description |
 |---|---|---|
-| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 30000 | Shared attachment preview budget (min'd with `context_window // 2`); `<=0` disables the preview |
+| `ATTACHMENT_INJECT_MAX_CHARS` | 32000 | Backend injection char cap (all modes); head/tail truncation beyond it |
+| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 15000 | chat shell attachment preview budget (min'd with `context_window // 2`); `<=0` disables |
+| `MAX_EXTRACTED_TEXT_LENGTH` | 500000 | Parse-time storage cap (for read_attachment / real-file download, not the injected amount) |
 
 ## Non-goals (future tiers)
 

--- a/docs/en/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/developer-guide/chat-shell-context-governance.md
@@ -205,6 +205,21 @@ The most stable observability surfaces today are:
   for uniform timing and savings metrics across `tool_output`,
   `summary_compact`, and `attachment_preview`
 
+All three protections emit via `chat_shell/guard/traces.py::record_protection_trace`
+under the event name `context_protection.{operation}` with a consistent schema, so
+the backend can derive **event count / success rate (by status) / duration
+(duration_ms) / tokens saved**:
+
+| operation | Trigger | status | Key attributes |
+|---|---|---|---|
+| `attachment_preview` | message with an attachment block | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
+| `tool_output` | tool-output truncation (only when it happens) | `applied` | duration_ms, messages_truncated, emergency |
+| `summary_compact` | request-level summary compaction | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
+
+No event is emitted on a no-op (`tool_output` only when it truncates,
+`attachment_preview` only when an attachment block is present); `add_span_event`
+is a no-op when telemetry is disabled.
+
 This is why Stage 1 added status and metrics before Stage 2 and Stage 3:
 without observability, governance is hard to tune safely.
 
@@ -247,6 +262,3 @@ those two views.
 
 - [Chat Shell Attachment Context](./chat-shell-attachment-context.md)
 - [Dynamic Context](./dynamic-context.md)
-- `docs/superpowers/specs/2026-06-03-chat-shell-context-governance-design.md`
-- `docs/superpowers/specs/2026-06-09-chat-shell-summary-compact-design.md`
-- `docs/superpowers/specs/2026-06-23-chat-shell-attachment-reading-design.md`

--- a/docs/en/developer-guide/chat-shell-context-governance.md
+++ b/docs/en/developer-guide/chat-shell-context-governance.md
@@ -1,0 +1,252 @@
+---
+sidebar_position: 31
+---
+
+# Chat Shell Context Governance
+
+## Overview
+
+`chat_shell` context governance landed in three stages:
+
+1. **Stage 1: tool-output governance**
+   Bound oversized tool output into a stable model-visible compact form, and add
+   context metrics plus frontend status visibility.
+2. **Stage 2: summary compact**
+   When the full live state approaches the window limit, run request-level
+   summary compaction inside the same guard framework, with a conservative
+   fallback path.
+3. **Stage 3: attachment context governance**
+   Replace "full attachment text injected every turn" with bounded previews plus
+   on-demand reads.
+
+The shared objective is not "build a compressor". It is to establish one
+**unified, extensible, observable** control path before every model call.
+
+## What Was Missing Before
+
+Before the three-stage rollout, `chat_shell` already had a few local control
+points, but it still had three clear gaps:
+
+- **no single pre-request control point**
+  Some controls lived in `build_messages`, some depended on tool events or later
+  processing, and pre-turn / mid-turn budgeting did not naturally share one
+  path.
+- **no layered treatment for different context sources**
+  Tool output, restored history, and attachment injection could all inflate the
+  live state, but there was no unified framework to shrink risky sources first
+  and then judge the whole request.
+- **no stable runtime observability surface**
+  When a conversation felt "stuck" or suddenly became too large, it was hard to
+  answer which source was growing, whether compaction had fired, and whether the
+  post-compaction state had actually returned to a safe range.
+
+In practice, the old path had a few recurring problems:
+
+- large tool output could re-enter follow-up model calls, with only partial
+  guarding and easy drift between code paths
+- history compaction was biased toward turn-start handling, while repeated
+  mid-turn tool calls could still push the live state upward
+- extracted attachment text was injected inline as a persistent `<attachment>`
+  block, so it kept consuming context even when summary compact did not trigger
+- once attachment-heavy or history-heavy turns did trigger summary compact, the
+  current user question could get folded together with the rest of the message
+- the frontend had no stable remaining-context status surface, especially after
+  reload or reconnect
+
+That is why the goal of this work was not "improve one truncation path". The
+goal was to turn pre-model-call context governance into a single mechanism.
+
+## Design approach
+
+### One control point instead of scattered patches
+
+The key control point is the `LangGraph pre_model_hook`, because it naturally
+covers both:
+
+- **pre-turn** model calls at the start of a turn
+- **mid-turn** model calls after tools finish
+
+This is more reliable than spreading budget logic across `build_messages`, tool
+events, history serialization, and other side paths. In the final shape,
+budgeting converges on `UnifiedContextGuard`.
+
+### Separate UI-visible raw data from model-visible compact data
+
+This is one of the most important boundaries in the design.
+
+- **Raw / UI-visible representation** is for rendering, replay, and protocol
+  compatibility.
+- **Model-visible representation** is for the next provider call.
+
+Examples:
+
+- raw tool output still lives in block / result data
+- `messages_chain` stores the compact model-facing form
+- full attachment content still exists in sandbox files or extracted-text
+  storage, while the prompt only carries a preview
+
+The point is not to hide data. The point is to avoid forcing one field to serve
+both "good for display" and "good for the model".
+
+### Layered governance instead of one generic compression step
+
+Context governance now has three layers:
+
+1. **source-level guards**
+   Shrink risky payloads such as tool output and attachment previews first.
+2. **request-level compaction**
+   Recompute the full live-state budget and compact when needed.
+3. **emergency fallback**
+   If still over budget, apply stricter deterministic re-truncation or failover.
+
+This clearly borrows from systems like Codex, but it does not copy their
+history-rewrite model.
+
+## Borrowed ideas and deliberate trade-offs
+
+The implementation borrows a few ideas that work well in practice:
+
+- run the main budget decision **right before** provider invocation
+- bound **high-risk context sources** before evaluating the whole request
+- provide **on-demand retrieval paths** instead of forcing the model to keep
+  consuming long payloads inline
+
+But Wegent keeps its own trade-offs:
+
+- **No persisted Codex-style `replacement_history`**
+  Compaction rewrites only the current live state.
+- **Summary compact is not a long-term memory layer**
+  It is a request-time governance tool.
+- **Fallback is not the main feature path**
+  Tool-output guard, summary compact, and attachment preview are all first-class
+  main-path behaviors.
+
+## What each stage solved
+
+## Stage 1: tool-output governance and status visibility
+
+Stage 1 focused on the easiest source to let explode first: tool output.
+
+Main outcomes:
+
+- introduce the `UnifiedContextGuard` framework and wire it into
+  `pre_model_hook`
+- add `ToolOutputGuardAdapter` with a stable compact representation
+- remove old serialization-time tool truncation
+- emit `context_metrics` snapshots and surface them in the toolbar
+- support reload / reconnect recovery for the latest context status
+
+This stage established the **governance skeleton and observability surface**.
+
+## Stage 2: summary compact and budget closure
+
+Stage 2 completed request-level governance. When source-level shrinking is not
+enough, the full live state goes through summary compaction.
+
+Main outcomes:
+
+- summary compact becomes the Stage 2 main path inside `UnifiedContextGuard`
+- pre-turn and mid-turn share the same budget decision path
+- available input budget is derived from a flat reserved-output buffer rather
+  than directly using the model's maximum output ceiling
+- compaction results are persisted in `subtask.result.context_compactions`
+- add stable `[SummaryCompact]` logs and completion-state recovery
+
+The key win is not "summarization". It is **closing the full-request budget
+loop**.
+
+## Stage 3: attachment preview and on-demand read
+
+Stage 3 addressed another long-standing source of pressure: large attachments
+were injected inline and stayed in the context every turn.
+
+Main outcomes:
+
+- switch from full inline attachment text to bounded previews
+- size previews with token budgets on the chat-shell side, not plain character
+  caps alone
+- expose full content through sandbox files or the `read_attachment` tool
+- use different full-content hints for text vs binary attachments
+- align attachment preview, tool-output guard, and summary compact with the same
+  protection-trace shape
+
+This turns attachments from an implicit history burden into an explicit,
+governed context source.
+
+## Implementation map
+
+These modules are the best entry points for future maintenance:
+
+| Module | Role |
+|---|---|
+| `chat_shell/guard/context_guard.py` | Unified governance entry point: source pass, summary compact, emergency pass |
+| `chat_shell/guard/tool_output.py` | Compact tool-output rendering and emergency re-truncation |
+| `chat_shell/compression/summary_compactor.py` | Summary compact core logic |
+| `chat_shell/compression/config.py` | Context window, reserved output, trigger / target limit calculation |
+| `chat_shell/compression/context_metrics.py` | Context metrics snapshots |
+| `chat_shell/messages/attachment_preview.py` | Attachment preview budgeting and truncation |
+| `chat_shell/tools/builtin/read_attachment.py` | On-demand attachment reads |
+| `chat_shell/services/chat_service.py` | Guard, tracker, and summary-LLM assembly |
+
+For Stage 3 specifics, continue with
+[Chat Shell Attachment Context](./chat-shell-attachment-context.md).
+
+## Observability
+
+The most stable observability surfaces today are:
+
+- `context_metrics`
+  for current window, used tokens, remaining percentage, and trigger state
+- `[SummaryCompact]` logs
+  for trigger / fallback behavior and before-after token deltas
+- `subtask.result.context_compactions`
+  for offline reporting of compaction counts, success rates, and token savings
+- `context_protection.{operation}` traces
+  for uniform timing and savings metrics across `tool_output`,
+  `summary_compact`, and `attachment_preview`
+
+This is why Stage 1 added status and metrics before Stage 2 and Stage 3:
+without observability, governance is hard to tune safely.
+
+## Notes
+
+### Summary compact only rewrites live state
+
+The compacted replacement history is not persisted as the new canonical session
+history. Later turns rebuild from the full stored history and re-evaluate
+compaction when needed. This is an intentional simplification.
+
+### `max_output_tokens` is budget input, not a history-rewrite result
+
+Context governance uses `context_window` and `max_output_tokens` during
+reserved-output budgeting, but live-history rewriting does not mutate provider
+request parameters. If provider parameters look wrong, inspect the incoming
+`model_config` chain first.
+
+### Attachment preview is tokenized only inside chat shell
+
+backend / shared modules do not carry `tiktoken`. As a result:
+
+- shared is a good place for pure string helpers and MIME classification
+- token preview must stay in chat shell
+- executor / device paths see injected strings but do not have the
+  chat-shell-only `read_attachment` tool
+
+### Do not mix raw transcript and model-visible transcript
+
+When changing export, replay, or protocol paths, first confirm whether the code
+is reading:
+
+- the user-visible raw output
+- or the compact form seen by the model in the next turn
+
+Many "why is this shorter here but still full there?" issues reduce to mixing
+those two views.
+
+## Related documents
+
+- [Chat Shell Attachment Context](./chat-shell-attachment-context.md)
+- [Dynamic Context](./dynamic-context.md)
+- `docs/superpowers/specs/2026-06-03-chat-shell-context-governance-design.md`
+- `docs/superpowers/specs/2026-06-09-chat-shell-summary-compact-design.md`
+- `docs/superpowers/specs/2026-06-23-chat-shell-attachment-reading-design.md`

--- a/docs/zh/developer-guide/README.md
+++ b/docs/zh/developer-guide/README.md
@@ -25,6 +25,11 @@
 - [MCP 工具重构指南](./mcp-refactoring-guide.md) - Knowledge MCP 工具重构架构
 - [外部知识库 MCP](./external-knowledge-mcp.md) - 受信任外部系统的知识库 MCP 集成
 
+### 💬 Chat Shell
+
+- [Chat Shell 上下文治理](./chat-shell-context-governance.md) - Chat Shell 三阶段上下文治理总览
+- [Chat Shell 优雅关闭](./chat-shell-graceful-shutdown.md) - Chat Shell 服务关闭与流式清理
+
 ### 📱 前端开发
 
 - [响应式开发](./responsive-development.md) - 响应式设计指南

--- a/docs/zh/developer-guide/chat-shell-attachment-context.md
+++ b/docs/zh/developer-guide/chat-shell-attachment-context.md
@@ -34,11 +34,20 @@ user.content = [
 
 同一条消息的多个附件**合并在同一个 `<attachment>` 块**内，各自带 `[Attachment: name | ID: n | Type: … | File Path(already in sandbox): …]` 头。
 
-## 注入预览（token 化）
+## 注入截断（backend，字符级，所有模式）
 
-在 `agent.build_messages` 装配消息后、缓存断点前，对每条消息里的 `<attachment>` 块做 token 预览截断（当前轮与历史轮同一处理）。实现见 `chat_shell/messages/attachment_preview.py`，复用工具输出截断逻辑（`guard/tool_output._truncate_body`，head/tail + `…N tokens truncated…` 标记）。
+提取文本先在 backend 注入层（`context_service.build_document_text_prefix`）按**字符**截断到 `ATTACHMENT_INJECT_MAX_CHARS`（默认 32000），再进入各模式的 prompt。这是**存储**与**注入**的分离：
 
-- **预算**：`ATTACHMENT_PREVIEW_TOKEN_LIMIT`（默认 30000，可配；`<=0` 关闭），并与窗口取小：`min(context_window // 2, 配置值)`，避免小窗口模型被预览淹没。窗口由 `get_model_context_config(model_id, model_config)` 解析。
+- **存储**：完整提取文本（≤ `MAX_EXTRACTED_TEXT_LENGTH`，默认 50 万字符）留在 DB，供 `read_attachment` 分页、executor/device 下载真文件；
+- **注入**：进 prompt 的是有界预览（连续 head + tail + 单个标记，指向 header 里的完整文件）。
+
+这层对**所有模式**生效，是 executor / device（无 chat shell token 预览）唯一的注入长度护栏。chat shell 会在其上再做一道 token 级预览（见下）。
+
+## 注入预览（token 化，chat shell）
+
+在 `agent.build_messages` 装配消息后、缓存断点前，对每条消息里的 `<attachment>` 块做 token 预览截断（当前轮与历史轮同一处理；在上面 backend 字符截断之上再精修）。实现见 `chat_shell/messages/attachment_preview.py`，复用工具输出截断逻辑（`guard/tool_output._truncate_body`，head/tail + `…N tokens truncated…` 标记）。
+
+- **预算**：`ATTACHMENT_PREVIEW_TOKEN_LIMIT`（默认 15000，可配；`<=0` 关闭），并与窗口取小：`min(context_window // 2, 配置值)`，避免小窗口模型被预览淹没。窗口由 `get_model_context_config(model_id, model_config)` 解析。
 - **快路径**：整块在预算内则原样返回，保持 prefix 缓存稳定。
 
 ### 多附件分配（water-filling）
@@ -54,14 +63,16 @@ user.content = [
 
 被截断的段后追加一行“如何取完整内容”的提示，按 header 里的 `Type:` 判定：
 
-- **文本类**：`[Preview truncated. Full file readable in sandbox: <path>]` —— 沙箱原文完整，且可超过解析期截断上限；
-- **二进制类（pdf/office）**：`[Preview truncated. Use read_attachment(attachment_id=N) for the full text.]` —— 沙箱里是二进制不可直读，用工具取解析后的文本。
+- **文本类**：`[Preview truncated. Full file in the sandbox at <path> — read or grep/search it with your file tools to get the rest.]` —— 沙箱原文完整，鼓励 grep/search 定向取而非整篇读；
+- **二进制类（pdf/office/xmind）**：`[Preview truncated. Get the rest via read_attachment(attachment_id=N) for the parsed text, or open the sandbox file (path in the header above) with a suitable tool.]` —— 不把模型限定在单一手段。
+
+文本/二进制的判定用统一的 MIME 归类 `shared/utils/mime_types.py::is_text_readable_mime`，与 backend parser 保持一致（新增类型只改一处）。
 
 ## `read_attachment` 工具
 
 补充预览：让模型分页读取附件的完整提取文本（主要面向二进制附件；文本附件可直接读沙箱原文）。
 
-- **条件注册**：仅当对话（历史或当前轮）含 `<attachment>` 块时，才注册进 function-calling schema（`services/context.py`）。普通对话不注册，不走 lazy provider（那是技能系统专用）。
+- **条件注册**：仅当对话含**文档**附件时才注册进 function-calling schema（`services/context.py`）。`read_attachment` 只服务有提取文本的文档；图片/视频没有文本（调用只会返回 empty），故纯图片/视频对话**不注册**。判定：当前轮用结构化的 `request.attachments[].mime_type`（非 `image/`、非 `video/` 即文档，格式无关、稳定），历史轮 fallback 扫 `[Attachment:` 头。普通对话不注册，不走 lazy provider（那是技能系统专用）。
 - **分页协议**：**char 偏移 + token 夹紧** —— 游标用字符位（与分词器无关、跨轮/跨模型可复现），返回页按 token 夹到每页预算（默认对齐工具输出 15k），保证一页不超预算、不被请求级 guard 二次截断；`next_offset = offset + 实际返回字符数`。
 - **内容上界**：解析期截断（默认 50 万字符）；超出部分需读沙箱原文。
 - **调用上限**：每会话上限防止无限翻页。
@@ -86,23 +97,17 @@ user.content = [
 
 `<attachment>` 头部由 `shared/utils/attachment_block.py::build_attachment_header` 统一构建，backend 首发预处理（`context_service` / `contexts`）与 chat shell 历史重建（`history/loader`）共用，避免首轮与翻历史后格式漂移。
 
-## 可观测性（traces）
+## 可观测性
 
-三个上下文防护统一通过 `chat_shell/guard/traces.py::record_protection_trace` 发 span event，事件名 `context_protection.{operation}`，schema 一致，便于在追踪后端聚合**事件数 / 成功率（按 status）/ 耗时（duration_ms）/ token 节省**：
-
-| operation | 触发点 | status | 关键属性 |
-|---|---|---|---|
-| `attachment_preview` | 含附件块的消息 | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
-| `tool_output` | 工具输出截断（仅发生时） | `applied` | duration_ms, messages_truncated, emergency |
-| `summary_compact` | 请求级摘要压缩 | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
-
-为避免噪声，空跑不发事件（`tool_output` 仅截断时发，`attachment_preview` 仅有附件块时发）；telemetry 关闭时 `add_span_event` 为 no-op。
+附件预览的 traces 与 tool output、summary compact 共用统一的 `context_protection.{operation}` 结构,集中说明(各 operation 的 status / 属性 schema)见 [Chat Shell 上下文治理 · 可观测性](./chat-shell-context-governance.md#可观测性)。
 
 ## 配置
 
 | 配置项 | 默认 | 说明 |
 |---|---|---|
-| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 30000 | 附件预览共享预算（与 `context_window // 2` 取小）；`<=0` 关闭预览 |
+| `ATTACHMENT_INJECT_MAX_CHARS` | 32000 | backend 注入层字符上限（所有模式）；超出做 head/tail 截断 |
+| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 15000 | chat shell 附件预览共享预算（与 `context_window // 2` 取小）；`<=0` 关闭预览 |
+| `MAX_EXTRACTED_TEXT_LENGTH` | 500000 | 解析期存储上限（供 read_attachment / 真文件下载，非注入量） |
 
 ## 非目标（后续档位）
 

--- a/docs/zh/developer-guide/chat-shell-attachment-context.md
+++ b/docs/zh/developer-guide/chat-shell-attachment-context.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 32
+---
+
+# Chat Shell 附件上下文管理（预览与按需读取）
+
+如果需要先了解三阶段整体脉络、设计取舍和实现边界，先看
+[Chat Shell 上下文治理](./chat-shell-context-governance.md)。
+
+## 背景
+
+用户上传的附件（PDF / Word / Excel / 图片 / 文本等）在解析后，其提取文本会作为一个独立的 `<attachment>` 文本块内联进用户消息。如果整段注入，会带来两个问题：
+
+- **每轮常驻**：附件文本即使没触发上下文压缩，也会每轮占用大量 token；
+- **压缩有损**：到达压缩阈值时，summary compact 会把整条用户消息一起折叠/截断（连提问一起砍），且不可逆。
+
+本特性把附件的内联拷贝收敛成有界的**预览**，完整内容通过**沙箱原文**或 **`read_attachment` 工具**按需获取。
+
+> 说明：附件解析为同步流程（上传请求内完成，默认走 `parser.py` 的 Python 库，MinerU 为知识库专用、默认关闭），所以附件进入对话即 READY，不存在“解析未完成”的竞态。
+
+## 消息结构
+
+装配后的用户消息是一个内容块列表，附件**独立成块**（不与提问混合，利于 prefix 缓存）：
+
+```text
+user.content = [
+  {type: text,      text: "<用户提问>"},
+  {type: image_url, ...},                         # 图片（若有）
+  {type: text,      text: "<attachment>…</attachment>"},   # 所有附件合并在一个块
+  {type: text,      text: "<knowledge_base>…</knowledge_base>"},
+  {type: text,      text: "<system-reminder>…</system-reminder>"},
+]
+```
+
+同一条消息的多个附件**合并在同一个 `<attachment>` 块**内，各自带 `[Attachment: name | ID: n | Type: … | File Path(already in sandbox): …]` 头。
+
+## 注入预览（token 化）
+
+在 `agent.build_messages` 装配消息后、缓存断点前，对每条消息里的 `<attachment>` 块做 token 预览截断（当前轮与历史轮同一处理）。实现见 `chat_shell/messages/attachment_preview.py`，复用工具输出截断逻辑（`guard/tool_output._truncate_body`，head/tail + `…N tokens truncated…` 标记）。
+
+- **预算**：`ATTACHMENT_PREVIEW_TOKEN_LIMIT`（默认 30000，可配；`<=0` 关闭），并与窗口取小：`min(context_window // 2, 配置值)`，避免小窗口模型被预览淹没。窗口由 `get_model_context_config(model_id, model_config)` 解析。
+- **快路径**：整块在预算内则原样返回，保持 prefix 缓存稳定。
+
+### 多附件分配（water-filling）
+
+所有附件共享一份预算（避免附件多时 N×预算爆）。预算先扣掉“块首集中 ID 列表 + 所有头部”，剩余在各段之间按 **water-filling** 分配：
+
+- 小于公平份额的段整段保留，把余量退还池子，公平份额对剩余段重算；
+- 大段吸收富余 —— 避免“小附件浪费配额、大附件被多砍”。
+
+例：A=30k、B=5k tokens，预算 30k → B 整段保留(5k)，A 截到约 25k。每段各自 head/tail，**每个头（含 ID）都保留**；多附件时块首再加一行集中 ID 索引。
+
+### 类型化提示
+
+被截断的段后追加一行“如何取完整内容”的提示，按 header 里的 `Type:` 判定：
+
+- **文本类**：`[Preview truncated. Full file readable in sandbox: <path>]` —— 沙箱原文完整，且可超过解析期截断上限；
+- **二进制类（pdf/office）**：`[Preview truncated. Use read_attachment(attachment_id=N) for the full text.]` —— 沙箱里是二进制不可直读，用工具取解析后的文本。
+
+## `read_attachment` 工具
+
+补充预览：让模型分页读取附件的完整提取文本（主要面向二进制附件；文本附件可直接读沙箱原文）。
+
+- **条件注册**：仅当对话（历史或当前轮）含 `<attachment>` 块时，才注册进 function-calling schema（`services/context.py`）。普通对话不注册，不走 lazy provider（那是技能系统专用）。
+- **分页协议**：**char 偏移 + token 夹紧** —— 游标用字符位（与分词器无关、跨轮/跨模型可复现），返回页按 token 夹到每页预算（默认对齐工具输出 15k），保证一页不超预算、不被请求级 guard 二次截断；`next_offset = offset + 实际返回字符数`。
+- **内容上界**：解析期截断（默认 50 万字符）；超出部分需读沙箱原文。
+- **调用上限**：每会话上限防止无限翻页。
+
+### 权限：按 task 收口（含群聊）
+
+可读集合 = `{ context | context.subtask_id ∈ 本 task 的 subtasks 或未链接 }`，与历史可见性一致。
+
+- 群聊中不同用户上传的附件 `user_id` 不同但同属一个 task，**都可读**；
+- 跨 task 拒绝（403）；非 READY / 不存在返回 404。
+- **不按 user 收口**（附件是对话级共享资源，区别于用户级的知识库）。
+
+### 双路径（远程 / package）
+
+- **HTTP/远程模式**（生产默认，backend 与 chat shell 独立部署）：经 backend 内部端点
+  `GET /api/internal/chat/attachments/{id}/text?session_id=task-X&offset=&limit=`，返回字符切片 + `total_chars` / `has_more`；分页/token 夹紧在 chat shell 侧完成。
+- **package 模式**：直连数据库读取，同样的 task 收口。
+
+落点见 `chat_shell/history/attachment_text.py::fetch_attachment_text`、`chat_shell/storage/remote.py::get_attachment_text`、`backend/app/api/endpoints/internal/chat_storage.py`。
+
+## 共享附件头（一致性）
+
+`<attachment>` 头部由 `shared/utils/attachment_block.py::build_attachment_header` 统一构建，backend 首发预处理（`context_service` / `contexts`）与 chat shell 历史重建（`history/loader`）共用，避免首轮与翻历史后格式漂移。
+
+## 可观测性（traces）
+
+三个上下文防护统一通过 `chat_shell/guard/traces.py::record_protection_trace` 发 span event，事件名 `context_protection.{operation}`，schema 一致，便于在追踪后端聚合**事件数 / 成功率（按 status）/ 耗时（duration_ms）/ token 节省**：
+
+| operation | 触发点 | status | 关键属性 |
+|---|---|---|---|
+| `attachment_preview` | 含附件块的消息 | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
+| `tool_output` | 工具输出截断（仅发生时） | `applied` | duration_ms, messages_truncated, emergency |
+| `summary_compact` | 请求级摘要压缩 | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
+
+为避免噪声，空跑不发事件（`tool_output` 仅截断时发，`attachment_preview` 仅有附件块时发）；telemetry 关闭时 `add_span_event` 为 no-op。
+
+## 配置
+
+| 配置项 | 默认 | 说明 |
+|---|---|---|
+| `ATTACHMENT_PREVIEW_TOKEN_LIMIT` | 30000 | 附件预览共享预算（与 `context_window // 2` 取小）；`<=0` 关闭预览 |
+
+## 非目标（后续档位）
+
+- 表格 DuckDB 查询（就地查 xlsx/csv，只回结果行）；
+- 散文 RAG（task 级临时索引，不暴露为用户知识库）；
+- 大纲/标题寻址读；
+- 视频/音频等无文本提取的类型（当前无能力）。

--- a/docs/zh/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/developer-guide/chat-shell-context-governance.md
@@ -1,0 +1,206 @@
+---
+sidebar_position: 31
+---
+
+# Chat Shell 上下文治理
+
+## 概述
+
+`chat_shell` 的上下文治理分三步落地：
+
+1. **Stage 1：工具输出治理**
+   把超长 tool output 收敛成稳定的 model-visible 紧凑表示，并补齐上下文指标与前端状态展示。
+2. **Stage 2：总结压缩**
+   当完整 live state 接近窗口上限时，在同一个 guard 框架里做 request-level summary compact，并在失败时回退到更保守的 fallback。
+3. **Stage 3：附件上下文治理**
+   把大附件从“整段常驻注入”改成“有界预览 + 按需读取”，避免附件长期挤占上下文。
+
+这三步共同目标不是“做一个压缩器”，而是建立一套**统一、可扩展、可观测**的模型调用前治理框架。
+
+## 改造前的缺口
+
+在这三阶段改造之前，`chat_shell` 已经有一些局部控制手段，但整体上仍有三个明显缺口：
+
+- **没有统一的模型调用前入口**
+  一部分控制在 `build_messages`，一部分依赖 tool event 或后处理，pre-turn 和 mid-turn 的预算口径并不天然一致。
+- **缺少对不同上下文源的分层治理**
+  tool output、历史消息、附件注入都可能把 live state 推高，但系统没有一个统一框架先做 source-level 收缩，再看整体预算。
+- **缺少稳定的运行时观测面**
+  当会话“变卡”或“突然超长”时，很难快速回答到底是哪类上下文在膨胀、是否已经触发压缩、压缩后是否真的回到了安全区。
+
+更具体地说，旧链路里最典型的问题有：
+
+- 大 tool output 会进入后续模型调用，只有局部截断，且不同路径容易出现双重截断或口径漂移；
+- 历史压缩更偏 turn-start 行为，mid-turn 在多次 tool 调用后仍可能把 live state 推高；
+- 附件提取文本会作为 `<attachment>` 块整段常驻注入，即使当前轮没有触发 summary compact，也会持续占用上下文；
+- 一旦附件或旧历史进入 summary compact，往往会连同用户当前问题一起被折叠，恢复路径也不明确；
+- 前端缺少稳定的剩余上下文状态展示，reload / reconnect 后也不容易知道当前会话是否已经处于压缩或高压状态。
+
+因此，这次改造的重点不是单独优化某一条截断逻辑，而是把“模型调用前的上下文治理”从零散补丁收敛成统一机制。
+
+## 设计思路
+
+### 统一入口，而不是分散打补丁
+
+核心控制点是 `LangGraph pre_model_hook`。原因很简单：它天然覆盖两类模型调用：
+
+- **pre-turn**：本轮开始时的首次模型调用
+- **mid-turn**：工具执行结束后的后续模型调用
+
+这比把长度控制分散在 `build_messages`、tool event、history serialization 等多处更稳。治理逻辑最终收敛到 `UnifiedContextGuard`，避免不同路径口径漂移。
+
+### 区分“用户可见原始数据”和“模型可见紧凑数据”
+
+这是整个设计里最重要的边界之一。
+
+- **原始/UI 可见表示**：用于前端展示、结果回放、协议兼容
+- **模型可见表示**：用于下一次 provider 调用前的预算治理
+
+典型例子：
+
+- tool output 的原始内容仍保存在 block / result 侧；
+- `messages_chain` 里保存的是 compact 后的 model-visible 版本；
+- 附件完整内容仍在沙箱原文或数据库提取文本中，模型上下文里只放 preview。
+
+这样做的目的不是隐藏数据，而是避免把“方便展示”和“适合喂模型”混成一个字段。
+
+### 分层治理，而不是只靠一种压缩
+
+上下文治理最终形成了三层：
+
+1. **source-level guard**
+   先治理单一来源的大块内容，例如 tool output、附件预览。
+2. **request-level compaction**
+   在完整 live state 上重新计算预算，必要时做 summary compact。
+3. **emergency fallback**
+   若仍超预算，再做更保守的紧急再截断或失败恢复。
+
+这套分层明显借鉴了 Codex 一类系统的治理方式，但没有照搬其历史重写模型。
+
+## 借鉴与取舍
+
+本方案借鉴了几条被证明有效的思路：
+
+- 在**真正发起模型调用前**做统一预算判断，而不是只在 turn 开头估算一次。
+- 优先对**高风险上下文源**做 source-level 收缩，再看整体是否仍超窗口。
+- 对大内容提供**按需读取路径**，而不是逼模型反复消费长文本。
+
+同时明确保留了 Wegent 自己的取舍：
+
+- **不做 Codex 式持久 `replacement_history`**
+  当前压缩只改本轮 live state，不把摘要后的历史永久写回为新的规范历史。
+- **不把 summary compact 变成长期记忆层**
+  它是 request-time 治理手段，不是新的会话存储模型。
+- **不让单个 fallback 路径承载全部功能**
+  tool output、summary compact、attachment preview 都是主路径能力，不是互相替代的兜底。
+
+## 三个阶段各自解决了什么
+
+## Stage 1：工具输出治理与状态可观测
+
+Stage 1 的重点不是历史压缩，而是先把最容易失控的 source 收口，并让系统看得见当前上下文压力。
+
+主要结果：
+
+- 引入 `UnifiedContextGuard` 框架，并挂到 `pre_model_hook`
+- 用 `ToolOutputGuardAdapter` 把超长工具输出改写成稳定紧凑格式
+- 去掉旧的序列化期 tool truncation，避免双重截断和元数据漂移
+- 输出 `context_metrics` 快照，并把状态传到前端 toolbar
+- 支持 reload / reconnect 后恢复最近一次上下文状态
+
+这一阶段建立的是**治理骨架和观测面**，不是最终压缩策略。
+
+## Stage 2：总结压缩与预算闭环
+
+Stage 2 把 request-level 治理补齐：当 source-level 收缩后仍接近窗口上限，就对完整 live state 做 summary compact。
+
+主要结果：
+
+- summary compact 进入 `UnifiedContextGuard` 的 Stage 2 主路径
+- pre-turn 和 mid-turn 复用同一条预算判断与压缩链路
+- 以平坦 reserved-output buffer 计算可用输入预算，而不是直接拿模型最大输出上限当保留值
+- compaction 结果持久化到 `subtask.result.context_compactions`
+- 增加 `[SummaryCompact]` 日志和完成态恢复逻辑
+
+这一阶段的关键不是“总结能力”本身，而是**把整体上下文预算变成闭环**。
+
+## Stage 3：附件预览与按需读取
+
+Stage 3 解决的是另一个长期问题：附件提取文本会作为 `<attachment>` 块常驻注入，每轮都吃上下文，而且一旦进入 summary compact，往往会连同用户提问一起被折叠。
+
+主要结果：
+
+- 附件从“全文常驻注入”改成“有界 preview”
+- preview 预算由 chat shell 用 token 口径控制，而不是单纯字符数
+- 完整内容通过沙箱原文或 `read_attachment` 工具按需取
+- 文本类与二进制类附件给出不同的 full-content hint
+- 预览、tool output、summary compact 共用统一的保护 traces 结构
+
+这一步的实质是把附件从“隐式历史负担”改成“显式可控上下文源”。
+
+## 实现落点
+
+下列模块是后续维护最值得先看的入口：
+
+| 模块 | 作用 |
+|---|---|
+| `chat_shell/guard/context_guard.py` | 统一治理主入口，串 source pass、summary compact、emergency pass |
+| `chat_shell/guard/tool_output.py` | tool output 的 compact 表示和紧急重截断 |
+| `chat_shell/compression/summary_compactor.py` | summary compact 主逻辑 |
+| `chat_shell/compression/config.py` | 上下文窗口、reserved output、trigger/target limit 计算 |
+| `chat_shell/compression/context_metrics.py` | 上下文指标快照 |
+| `chat_shell/messages/attachment_preview.py` | 附件 preview 预算分配与截断 |
+| `chat_shell/tools/builtin/read_attachment.py` | 附件按需读取 |
+| `chat_shell/services/chat_service.py` | guard、tracker、summary llm 的组装位置 |
+
+如果只想理解 Stage 3 细节，继续看 [Chat Shell 附件上下文管理（预览与按需读取）](./chat-shell-attachment-context.md)。
+
+## 可观测性
+
+当前最稳定的观测面有四类：
+
+- `context_metrics`
+  用于展示当前窗口、已用 token、剩余比例和 trigger 状态。
+- `[SummaryCompact]` 日志
+  用于排查压缩是否触发、是否 fallback、压缩前后 token 变化。
+- `subtask.result.context_compactions`
+  用于离线统计 summary compact 次数、成功率、token 节省等。
+- `context_protection.{operation}` traces
+  用于统一统计 `tool_output`、`summary_compact`、`attachment_preview` 的耗时与节省量。
+
+这也是为什么 Stage 1 先补“状态与指标”，再做 Stage 2/3：没有观测面，很难知道治理是否真的生效。
+
+## 注意事项
+
+### summary compact 只治理 live state
+
+当前实现不会把 compact 后的 replacement history 永久写回成新的会话标准历史。下一轮仍会从重建后的完整历史重新评估，必要时再压一次。这是有意接受的简化。
+
+### `max_output_tokens` 主要是预算输入，不是历史改写结果
+
+上下文治理会用 `context_window` 和 `max_output_tokens` 参与 reserved-output 预算计算，但 live history 的改写本身不会反向修改模型实例参数。排查 provider 请求参数时，应优先看 `model_config` 传入链路，而不是先怀疑 guard 改写了参数。
+
+### 附件 preview 只在 chat shell 侧做 token 化
+
+backend / shared 不依赖 `tiktoken`。因此：
+
+- shared 适合放纯字符串头部和 MIME 归类逻辑；
+- token 预览必须放在 chat shell；
+- executor / device 路径看到的是注入后的字符串，不具备 `read_attachment` 这个 chat-shell-only 工具。
+
+### 不要混淆 raw transcript 和 model-visible transcript
+
+后续如果有导出、恢复、协议兼容改动，必须先确认读取的是：
+
+- 用户可见的原始输出
+- 还是模型下一轮会看到的 compact 版本
+
+很多“为什么内容变短了/为什么前端还显示全文”的问题，本质上都是这两个视图被混用了。
+
+## 相关文档
+
+- [Chat Shell 附件上下文管理（预览与按需读取）](./chat-shell-attachment-context.md)
+- [Dynamic Context（动态上下文注入）](./dynamic-context.md)
+- `docs/superpowers/specs/2026-06-03-chat-shell-context-governance-design.md`
+- `docs/superpowers/specs/2026-06-09-chat-shell-summary-compact-design.md`
+- `docs/superpowers/specs/2026-06-23-chat-shell-attachment-reading-design.md`

--- a/docs/zh/developer-guide/chat-shell-context-governance.md
+++ b/docs/zh/developer-guide/chat-shell-context-governance.md
@@ -168,6 +168,16 @@ Stage 3 解决的是另一个长期问题：附件提取文本会作为 `<attach
 - `context_protection.{operation}` traces
   用于统一统计 `tool_output`、`summary_compact`、`attachment_preview` 的耗时与节省量。
 
+三个防护统一通过 `chat_shell/guard/traces.py::record_protection_trace` 发出，事件名 `context_protection.{operation}`，schema 一致，便于聚合**事件数 / 成功率（按 status）/ 耗时（duration_ms）/ token 节省**：
+
+| operation | 触发点 | status | 关键属性 |
+|---|---|---|---|
+| `attachment_preview` | 含附件块的消息 | `applied` / `noop` | duration_ms, before/after_tokens, tokens_saved, attachment_blocks_truncated |
+| `tool_output` | 工具输出截断（仅发生时） | `applied` | duration_ms, messages_truncated, emergency |
+| `summary_compact` | 请求级摘要压缩 | `completed` / `fallback` | duration_ms, before/after_tokens, tokens_saved, removed_history_items / failure_reason |
+
+为避免噪声空跑不发事件（`tool_output` 仅截断时、`attachment_preview` 仅有附件块时）；telemetry 关闭时 `add_span_event` 为 no-op。
+
 这也是为什么 Stage 1 先补“状态与指标”，再做 Stage 2/3：没有观测面，很难知道治理是否真的生效。
 
 ## 注意事项
@@ -201,6 +211,3 @@ backend / shared 不依赖 `tiktoken`。因此：
 
 - [Chat Shell 附件上下文管理（预览与按需读取）](./chat-shell-attachment-context.md)
 - [Dynamic Context（动态上下文注入）](./dynamic-context.md)
-- `docs/superpowers/specs/2026-06-03-chat-shell-context-governance-design.md`
-- `docs/superpowers/specs/2026-06-09-chat-shell-summary-compact-design.md`
-- `docs/superpowers/specs/2026-06-23-chat-shell-attachment-reading-design.md`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved chat attachment handling so document/PDF attachments are detected more reliably, enabling attachment reading when appropriate.
  * Added developer guide documentation for Chat Shell context governance and attachment context behavior (English + Chinese).
* **Bug Fixes**
  * Reduced false positives by properly ignoring image/video-only content when deciding whether document attachment text is available.
  * More accurate detection of readable attachments embedded in chat prompts/history, including mixed scenarios.
* **Tests**
  * Expanded stateless context detection coverage for document/image/video, mixed, malformed, and object-style payloads.
* **Documentation**
  * Updated developer guide navigation and added detailed governance/attachment context pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->