### PR TITLE
[codex] Fix executor E2E dependency setup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -462,14 +462,6 @@ jobs:
           source .venv/bin/activate
           uv pip install -e ../shared
 
-      - name: Install executor dependencies
-        if: steps.executor-python-cache.outputs.cache-hit != 'true'
-        working-directory: ./executor
-        run: |
-          uv sync
-          source .venv/bin/activate
-          uv pip install -e ../shared
-
       - name: Install Claude Code CLI
         if: steps.claude-code-cli-cache.outputs.cache-hit != 'true'
         run: npm install -g @anthropic-ai/claude-code@2.1.142

--- a/executor/tests/build_entrypoint_contract.rs
+++ b/executor/tests/build_entrypoint_contract.rs
@@ -81,6 +81,8 @@ fn executor_build_entrypoints_use_rust_binary_build() {
 
     let e2e_workflow = fs::read_to_string("../.github/workflows/e2e-tests.yml").unwrap();
     assert!(!e2e_workflow.contains("python -m executor.main"));
+    assert!(!e2e_workflow.contains("Install executor dependencies"));
+    assert!(!e2e_workflow.contains("source executor/.venv/bin/activate"));
     assert!(e2e_workflow.contains(
         "docker cp \"$container_id:/app/executor\" executor/target/release/wegent-executor"
     ));


### PR DESCRIPTION
## Summary
- Remove the stale Python executor dependency install step from the Executor E2E workflow.
- Add a Rust executor contract assertion so the E2E workflow cannot reintroduce the old Python executor setup path.

## Root Cause
The Rust executor rewrite removed executor/pyproject.toml and executor/uv.lock, but the Executor E2E workflow still ran uv sync from ./executor and then tried to source .venv/bin/activate. With no Python executor project left, uv created the workspace virtualenv outside ./executor and the step failed before E2E tests started.

## Validation
- cargo fmt --check
- cargo test --test build_entrypoint_contract
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-tests.yml")'
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the end-to-end test workflow by removing an unnecessary dependency installation step, helping the pipeline proceed more directly.
  * Added coverage to ensure the workflow stays aligned with the expected setup and does not reintroduce outdated Python-based executor steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->