### PR TITLE
[codex] Restore ClaudeCode resume and interactive forms

### DIFF
--- a/executor/src/agents/codex.rs
+++ b/executor/src/agents/codex.rs
@@ -305,6 +305,7 @@ pub async fn run_codex_app_server_turn(
 fn codex_outcome_name(outcome: &ExecutionOutcome) -> &'static str {
     match outcome {
         ExecutionOutcome::Completed { .. } => "completed",
+        ExecutionOutcome::WaitingForUserInput { .. } => "waiting_for_user_input",
         ExecutionOutcome::Failed { .. } => "failed",
         ExecutionOutcome::Running => "running",
         ExecutionOutcome::Cancelled { .. } => "cancelled",

--- a/executor/src/agents/interactive_mcp.rs
+++ b/executor/src/agents/interactive_mcp.rs
@@ -142,24 +142,7 @@ pub fn build_pre_tool_use_defer_response() -> Value {
 }
 
 pub fn is_deferred_user_input_result(result: &Value) -> bool {
-    result
-        .get("content")
-        .and_then(Value::as_array)
-        .is_some_and(|items| {
-            items.iter().any(|item| {
-                item.get("type").and_then(Value::as_str) == Some("text")
-                    && item
-                        .get("text")
-                        .and_then(Value::as_str)
-                        .and_then(|text| serde_json::from_str::<Value>(text).ok())
-                        .and_then(|payload| {
-                            payload
-                                .get("__deferred_user_input__")
-                                .and_then(Value::as_bool)
-                        })
-                        == Some(true)
-            })
-        })
+    contains_waiting_for_user_payload(result)
 }
 
 pub fn build_deferred_mcp_proxy_request(
@@ -168,8 +151,7 @@ pub fn build_deferred_mcp_proxy_request(
 ) -> Result<DeferredMcpProxyRequest, InteractiveMcpError> {
     let parsed = parse_mcp_tool_name(&deferred_tool_use.name)
         .ok_or(InteractiveMcpError::InvalidMcpToolName)?;
-    let server = mcp_servers
-        .get(&parsed.server_name)
+    let server = resolve_mcp_server_config(mcp_servers, &parsed.server_name)
         .ok_or(InteractiveMcpError::MissingServerConfig)?;
     let server_url = server
         .get("url")
@@ -336,6 +318,8 @@ pub fn build_interactive_form_answer_payload(answer: &Value) -> Value {
     for key in [
         "type",
         "tool_use_id",
+        "task_id",
+        "subtask_id",
         "answers",
         "success",
         "status",
@@ -453,4 +437,76 @@ fn collect_text_content(result: &Value) -> Vec<String> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn contains_waiting_for_user_payload(value: &Value) -> bool {
+    match value {
+        Value::Object(object) => {
+            is_waiting_for_user_payload(object)
+                || object
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(text_contains_waiting_for_user_payload)
+                || object
+                    .get("content")
+                    .is_some_and(contains_waiting_for_user_payload)
+                || object
+                    .get("result")
+                    .is_some_and(contains_waiting_for_user_payload)
+        }
+        Value::Array(items) => items.iter().any(contains_waiting_for_user_payload),
+        Value::String(text) => text_contains_waiting_for_user_payload(text),
+        _ => false,
+    }
+}
+
+fn is_waiting_for_user_payload(object: &Map<String, Value>) -> bool {
+    object
+        .get("__deferred_user_input__")
+        .and_then(Value::as_bool)
+        == Some(true)
+        && object.get("success").and_then(Value::as_bool) == Some(true)
+        && object.get("status").and_then(Value::as_str) == Some("waiting_for_user_response")
+}
+
+fn text_contains_waiting_for_user_payload(text: &str) -> bool {
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .is_some_and(|value| contains_waiting_for_user_payload(&value))
+}
+
+fn resolve_mcp_server_config<'a>(mcp_servers: &'a Value, server_name: &str) -> Option<&'a Value> {
+    match mcp_servers {
+        Value::Object(object) => {
+            for key in ["mcpServers", "mcp_servers"] {
+                if let Some(server) = object
+                    .get(key)
+                    .and_then(|nested| resolve_mcp_server_config(nested, server_name))
+                {
+                    return Some(server);
+                }
+            }
+
+            object.get(server_name).or_else(|| {
+                let normalized_target = normalize_mcp_server_name(server_name);
+                object.iter().find_map(|(name, config)| {
+                    (config.is_object() && normalize_mcp_server_name(name) == normalized_target)
+                        .then_some(config)
+                })
+            })
+        }
+        Value::Array(items) => {
+            let normalized_target = normalize_mcp_server_name(server_name);
+            items.iter().find(|item| {
+                item.get("name")
+                    .and_then(Value::as_str)
+                    .is_some_and(|name| normalize_mcp_server_name(name) == normalized_target)
+            })
+        }
+        _ => None,
+    }
+}
+
+fn normalize_mcp_server_name(name: &str) -> String {
+    name.replace('_', "-")
 }

--- a/executor/src/agents/mod.rs
+++ b/executor/src/agents/mod.rs
@@ -14,6 +14,7 @@ mod image_validator;
 pub mod interactive_mcp;
 
 use crate::{
+    agents::interactive_mcp::build_interactive_form_answer_query,
     claude_session,
     hooks::pre_execute::{PreExecuteContext, PreExecuteHook},
     logging::{log_executor_event, task_fields},
@@ -161,9 +162,17 @@ async fn run_pre_execute_hook(request: &ExecutionRequest, spec: &CommandSpec) {
 }
 
 pub fn build_claude_command(request: &ExecutionRequest, binary: &str) -> CommandSpec {
-    let mut spec = CommandSpec::new(binary)
-        .arg("-p")
-        .arg(claude_prompt_text(request))
+    let mut spec = CommandSpec::new(binary).arg("-p");
+    if let Some(query) = interactive_form_answer_query(request) {
+        spec = spec
+            .arg("--input-format")
+            .arg("stream-json")
+            .stdin(format!("{query}\n"));
+    } else {
+        spec = spec.arg(claude_prompt_text(request));
+    }
+
+    let mut spec = spec
         .arg("--output-format")
         .arg("stream-json")
         .arg("--verbose")
@@ -218,6 +227,13 @@ fn claude_prompt_text(request: &ExecutionRequest) -> String {
         })
         .unwrap_or_else(|| request.prompt.clone());
     prompt_text(&prompt)
+}
+
+fn interactive_form_answer_query(request: &ExecutionRequest) -> Option<String> {
+    let answer = request.extra.get("interactive_form_answer")?;
+    build_interactive_form_answer_query(answer)
+        .ok()
+        .map(|query| query.to_string())
 }
 
 fn kb_meta_prompt(request: &ExecutionRequest) -> Option<&str> {

--- a/executor/src/emitter/mod.rs
+++ b/executor/src/emitter/mod.rs
@@ -101,6 +101,23 @@ impl ResponsesEventBuilder {
         )
     }
 
+    pub fn response_waiting_for_user_input(&self, stop_reason: &str) -> EventEnvelope {
+        let stop_reason = stop_reason.trim();
+        let mut response = self.response_payload("completed", json!([]));
+        response["usage"] = Value::Null;
+        response["stop_reason"] = json!(if stop_reason.is_empty() {
+            "tool_deferred"
+        } else {
+            stop_reason
+        });
+        response["silent_exit"] = json!(true);
+        response["silent_exit_reason"] = json!("waiting_for_user_input");
+        self.envelope(
+            "response.completed",
+            json!({"type": "response.completed", "response": response}),
+        )
+    }
+
     pub fn error(&self, message: &str, code: &str) -> EventEnvelope {
         self.envelope(
             "error",

--- a/executor/src/process/mod.rs
+++ b/executor/src/process/mod.rs
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Instant;
 use std::{
-    collections::BTreeMap, env, fs, future::Future, path::PathBuf, pin::Pin, time::Duration,
+    collections::BTreeMap, env, fs, future::Future, path::PathBuf, pin::Pin, process::Stdio,
+    time::Duration, time::Instant,
 };
 
-use tokio::{process::Command, time::timeout};
+use tokio::{io::AsyncWriteExt, process::Command, time::timeout};
 
 use crate::{
     claude_session,
@@ -25,6 +25,7 @@ pub struct CommandSpec {
     args: Vec<String>,
     env: BTreeMap<String, String>,
     cwd: Option<PathBuf>,
+    stdin: Option<String>,
 }
 
 impl CommandSpec {
@@ -34,6 +35,7 @@ impl CommandSpec {
             args: Vec::new(),
             env: BTreeMap::new(),
             cwd: None,
+            stdin: None,
         }
     }
 
@@ -52,6 +54,11 @@ impl CommandSpec {
         self
     }
 
+    pub fn stdin(mut self, input: impl Into<String>) -> Self {
+        self.stdin = Some(input.into());
+        self
+    }
+
     pub fn program(&self) -> &str {
         &self.program
     }
@@ -66,6 +73,10 @@ impl CommandSpec {
 
     pub fn current_dir(&self) -> Option<&PathBuf> {
         self.cwd.as_ref()
+    }
+
+    pub fn stdin_input(&self) -> Option<&str> {
+        self.stdin.as_deref()
     }
 }
 
@@ -161,7 +172,12 @@ async fn run_command_output(spec: CommandSpec) -> CommandOutcome {
     fields.push(("timeout_seconds", timeout_seconds.to_string()));
     log_executor_event("process started", &fields);
     let started = Instant::now();
-    let outcome = match timeout(Duration::from_secs(timeout_seconds), command.output()).await {
+    let outcome = match timeout(
+        Duration::from_secs(timeout_seconds),
+        run_prepared_command(command, spec.stdin.clone()),
+    )
+    .await
+    {
         Err(_) => CommandOutcome::Failure {
             stderr: format!("command timed out after {timeout_seconds}s"),
             stdout: String::new(),
@@ -173,6 +189,25 @@ async fn run_command_output(spec: CommandSpec) -> CommandOutcome {
     fields.extend(command_outcome_fields(&outcome));
     log_executor_event("process finished", &fields);
     outcome
+}
+
+async fn run_prepared_command(
+    mut command: Command,
+    stdin: Option<String>,
+) -> std::io::Result<std::process::Output> {
+    let Some(input) = stdin else {
+        return command.output().await;
+    };
+
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn()?;
+    if let Some(mut child_stdin) = child.stdin.take() {
+        child_stdin.write_all(input.as_bytes()).await?;
+    }
+    child.wait_with_output().await
 }
 
 fn command_outcome(result: std::io::Result<std::process::Output>) -> CommandOutcome {

--- a/executor/src/protocol/execution.rs
+++ b/executor/src/protocol/execution.rs
@@ -113,7 +113,6 @@ impl ExecutionRequest {
         };
 
         match shell_type.as_str() {
-            "claudecode" if is_codex_compatible_model(&self.model_config) => AgentKind::CodeX,
             "claudecode" => AgentKind::ClaudeCode,
             "codex" => AgentKind::CodeX,
             "agno" => AgentKind::Agno,
@@ -154,21 +153,6 @@ impl ExecutionRequest {
     }
 }
 
-pub fn is_codex_compatible_model(model_config: &Value) -> bool {
-    let provider_is_openai = get_string(model_config, "model")
-        .is_some_and(|provider| provider.eq_ignore_ascii_case("openai"));
-    let uses_responses_api = get_string(model_config, "api_format")
-        .is_some_and(|value| value.eq_ignore_ascii_case("responses"))
-        || get_string(model_config, "apiFormat")
-            .is_some_and(|value| value.eq_ignore_ascii_case("responses"))
-        || get_string(model_config, "protocol")
-            .is_some_and(|value| value.eq_ignore_ascii_case("openai-responses"))
-        || get_string(model_config, "wire_api")
-            .is_some_and(|value| value.eq_ignore_ascii_case("responses"));
-
-    provider_is_openai && uses_responses_api
-}
-
 fn extract_shell_type(bot: &Value) -> Option<String> {
     let candidate = match bot {
         Value::Object(object) => object.get("shell_type"),
@@ -181,10 +165,6 @@ fn extract_shell_type(bot: &Value) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_ascii_lowercase)
-}
-
-fn get_string<'a>(value: &'a Value, key: &str) -> Option<&'a str> {
-    value.as_object()?.get(key)?.as_str()
 }
 
 fn value_path_string(root: &Map<String, Value>, path: &[&str]) -> Option<String> {

--- a/executor/src/runner/mod.rs
+++ b/executor/src/runner/mod.rs
@@ -26,6 +26,7 @@ pub trait EventSink: Clone + Send + Sync + 'static {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExecutionOutcome {
     Completed { content: String },
+    WaitingForUserInput { stop_reason: String },
     Failed { message: String },
     Running,
     Cancelled { message: String },
@@ -95,6 +96,9 @@ async fn run_in_background<E, S>(
 
     let event = match outcome {
         ExecutionOutcome::Completed { content } => builder.response_completed(&content),
+        ExecutionOutcome::WaitingForUserInput { stop_reason } => {
+            builder.response_waiting_for_user_input(&stop_reason)
+        }
         ExecutionOutcome::Failed { message } => builder.error(&message, "runtime_error"),
         ExecutionOutcome::Cancelled { message } => builder.error(&message, "cancelled"),
         ExecutionOutcome::Running => return,
@@ -125,6 +129,7 @@ fn event_builder(request: &ExecutionRequest) -> ResponsesEventBuilder {
 fn outcome_name(outcome: &ExecutionOutcome) -> &'static str {
     match outcome {
         ExecutionOutcome::Completed { .. } => "completed",
+        ExecutionOutcome::WaitingForUserInput { .. } => "waiting_for_user_input",
         ExecutionOutcome::Failed { .. } => "failed",
         ExecutionOutcome::Running => "running",
         ExecutionOutcome::Cancelled { .. } => "cancelled",

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -660,6 +660,7 @@ impl RuntimeWorkRpcHandler {
             Ok(turn) => {
                 let status = match &turn.outcome {
                     ExecutionOutcome::Completed { .. } => "done",
+                    ExecutionOutcome::WaitingForUserInput { .. } => "done",
                     ExecutionOutcome::Cancelled { .. } => "cancelled",
                     ExecutionOutcome::Failed { .. } => "failed",
                     ExecutionOutcome::Running => "running",
@@ -673,6 +674,19 @@ impl RuntimeWorkRpcHandler {
                         local_task_id,
                         request,
                         json!({"value": content}),
+                    ),
+                    ExecutionOutcome::WaitingForUserInput { stop_reason } => emit_response_event(
+                        &self.event_tx,
+                        &self.device_id,
+                        "response.completed",
+                        local_task_id,
+                        request,
+                        json!({
+                            "value": "",
+                            "stop_reason": stop_reason,
+                            "silent_exit": true,
+                            "silent_exit_reason": "waiting_for_user_input"
+                        }),
                     ),
                     ExecutionOutcome::Cancelled { message } => emit_response_event(
                         &self.event_tx,

--- a/executor/src/stream/mod.rs
+++ b/executor/src/stream/mod.rs
@@ -4,7 +4,7 @@
 
 use serde_json::Value;
 
-use crate::runner::ExecutionOutcome;
+use crate::{agents::interactive_mcp::is_deferred_user_input_result, runner::ExecutionOutcome};
 
 pub fn collect_ndjson_outcome(output: &str) -> ExecutionOutcome {
     let mut text = String::new();
@@ -18,7 +18,10 @@ pub fn collect_ndjson_outcome(output: &str) -> ExecutionOutcome {
             continue;
         };
         if let Some(outcome) = extract_result_outcome(&value) {
-            if matches!(outcome, ExecutionOutcome::Cancelled { .. }) {
+            if matches!(
+                outcome,
+                ExecutionOutcome::Cancelled { .. } | ExecutionOutcome::WaitingForUserInput { .. }
+            ) {
                 return outcome;
             }
             terminal_outcome = Some(outcome);
@@ -67,6 +70,11 @@ fn extract_result_outcome(value: &Value) -> Option<ExecutionOutcome> {
     if value.get("type").and_then(Value::as_str) != Some("result") {
         return None;
     }
+    if is_deferred_user_input_result(value) {
+        return Some(ExecutionOutcome::WaitingForUserInput {
+            stop_reason: result_stop_reason(value),
+        });
+    }
     if !value
         .get("is_error")
         .and_then(Value::as_bool)
@@ -94,6 +102,16 @@ fn extract_result_outcome(value: &Value) -> Option<ExecutionOutcome> {
     } else {
         Some(ExecutionOutcome::Failed { message })
     }
+}
+
+fn result_stop_reason(value: &Value) -> String {
+    value
+        .get("stop_reason")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("tool_deferred")
+        .to_owned()
 }
 
 fn is_interruption_message(value: &str) -> bool {

--- a/executor/tests/agent_command_contract.rs
+++ b/executor/tests/agent_command_contract.rs
@@ -254,6 +254,62 @@ fn claude_command_resumes_saved_task_session() {
 }
 
 #[test]
+fn claude_command_sends_interactive_form_answer_as_tool_result_query() {
+    let _lock = env_lock();
+    let executor_home = unique_dir("claude-interactive-answer-home");
+    let _home = EnvGuard::set("WEGENT_EXECUTOR_HOME", &executor_home.display().to_string());
+    let session_dir = executor_home.join("sessions/77");
+    fs::create_dir_all(&session_dir).unwrap();
+    fs::write(
+        session_dir.join(".claude_session_id_987"),
+        "interactive-session\n",
+    )
+    .unwrap();
+    let request = ExecutionRequest {
+        task_id: 77,
+        prompt: json!("ignored when answering interactive form"),
+        bot: json!([{"id": 987, "shell_type": "ClaudeCode"}]),
+        extra: serde_json::Map::from_iter([(
+            "interactive_form_answer".to_owned(),
+            json!({
+                "type": "interactive_form_question",
+                "tool_use_id": "toolu_123",
+                "task_id": 77,
+                "subtask_id": 88,
+                "answers": [{"id": "name", "value": "Wegent"}],
+                "success": true,
+                "status": "answered",
+                "ask_id": "ignored"
+            }),
+        )]),
+        ..ExecutionRequest::default()
+    };
+
+    let spec = build_claude_command(&request, "claude");
+    let query: serde_json::Value = serde_json::from_str(spec.stdin_input().unwrap().trim())
+        .expect("interactive form answer should be sent as a JSON tool_result query");
+
+    assert!(spec.args().contains(&"--resume".to_owned()));
+    assert!(spec.args().contains(&"interactive-session".to_owned()));
+    assert!(spec.args().contains(&"--input-format".to_owned()));
+    assert!(spec.args().contains(&"stream-json".to_owned()));
+    assert!(!spec
+        .args()
+        .contains(&"ignored when answering interactive form".to_owned()));
+    assert_eq!(query["type"], "user");
+    assert_eq!(query["message"]["content"][0]["type"], "tool_result");
+    assert_eq!(query["message"]["content"][0]["tool_use_id"], "toolu_123");
+    assert_eq!(query["message"]["content"][0]["is_error"], false);
+    let payload_text = query["message"]["content"][0]["content"][0]["text"]
+        .as_str()
+        .unwrap();
+    let payload: serde_json::Value = serde_json::from_str(payload_text).unwrap();
+    assert_eq!(payload["task_id"], 77);
+    assert_eq!(payload["subtask_id"], 88);
+    assert!(payload.get("ask_id").is_none());
+}
+
+#[test]
 fn claude_command_prefers_workspace_task_session_over_executor_home() {
     let _lock = env_lock();
     let executor_home = unique_dir("claude-session-home-fallback");
@@ -542,10 +598,30 @@ fn command_planner_routes_claudecode_requests_to_claude_binary() {
 }
 
 #[test]
-fn command_planner_routes_openai_responses_requests_to_codex_app_server() {
+fn command_planner_keeps_claudecode_requests_on_claude_binary_for_openai_responses_model() {
     let planner = AgentCommandPlanner::new("claude", "codex");
     let request = ExecutionRequest {
+        prompt: json!("hello"),
         bot: json!([{"shell_type": "ClaudeCode"}]),
+        model_config: json!({
+            "model": "openai",
+            "model_id": "gpt-5",
+            "protocol": "openai-responses"
+        }),
+        ..ExecutionRequest::default()
+    };
+
+    let spec = planner.command_for(&request).unwrap();
+
+    assert_eq!(spec.program(), "claude");
+    assert_eq!(spec.args()[0], "-p");
+}
+
+#[test]
+fn command_planner_routes_codex_requests_to_codex_app_server() {
+    let planner = AgentCommandPlanner::new("claude", "codex");
+    let request = ExecutionRequest {
+        bot: json!([{"shell_type": "Codex"}]),
         model_config: json!({
             "model": "openai",
             "model_id": "gpt-5",

--- a/executor/tests/emitter_contract.rs
+++ b/executor/tests/emitter_contract.rs
@@ -55,6 +55,28 @@ fn response_completed_event_contains_message_output() {
 }
 
 #[test]
+fn response_waiting_for_user_input_event_marks_silent_exit() {
+    let builder =
+        ResponsesEventBuilder::new(1, 2, "claude-sonnet-4").with_response_id("resp_waiting");
+
+    let event = builder.response_waiting_for_user_input("tool_deferred");
+
+    assert_eq!(event.event_type, "response.completed");
+    assert_eq!(event.data["response"]["id"], json!("resp_waiting"));
+    assert_eq!(event.data["response"]["status"], json!("completed"));
+    assert_eq!(event.data["response"]["output"], json!([]));
+    assert_eq!(
+        event.data["response"]["stop_reason"],
+        json!("tool_deferred")
+    );
+    assert_eq!(event.data["response"]["silent_exit"], json!(true));
+    assert_eq!(
+        event.data["response"]["silent_exit_reason"],
+        json!("waiting_for_user_input")
+    );
+}
+
+#[test]
 fn error_event_uses_openai_error_shape() {
     let builder = ResponsesEventBuilder::new(1, 2, "");
 

--- a/executor/tests/interactive_mcp_contract.rs
+++ b/executor/tests/interactive_mcp_contract.rs
@@ -98,6 +98,20 @@ fn detects_deferred_user_input_result_from_mcp_text_content() {
 }
 
 #[test]
+fn ignores_deferred_marker_without_success_waiting_status() {
+    let result = json!({
+        "content": [
+            {
+                "type": "text",
+                "text": r#"{"__deferred_user_input__": true, "success": false, "status": "failed"}"#
+            }
+        ]
+    });
+
+    assert!(!is_deferred_user_input_result(&result));
+}
+
+#[test]
 fn proxy_request_targets_configured_mcp_server_and_normalizes_result() {
     let request = build_deferred_mcp_proxy_request(
         &deferred_tool_use(json!({"questions": [{"id": "q", "question": "Q?"}]})),
@@ -141,6 +155,27 @@ fn proxy_request_targets_configured_mcp_server_and_normalizes_result() {
 
     assert!(normalized.is_deferred_user_input);
     assert_eq!(normalized.tool_result["content"][0]["type"], "text");
+}
+
+#[test]
+fn proxy_request_resolves_nested_mcp_servers_and_normalized_server_names() {
+    let request = build_deferred_mcp_proxy_request(
+        &deferred_tool_use(json!({"questions": [{"id": "q", "question": "Q?"}]})),
+        &json!({
+            "mcpServers": {
+                "interactive-wegent-interactive-form-question": {
+                    "type": "http",
+                    "url": "http://backend/mcp/interactive-form-question/sse"
+                }
+            }
+        }),
+    )
+    .expect("normalized MCP server name should resolve");
+
+    assert_eq!(
+        request.server_url,
+        "http://backend/mcp/interactive-form-question/sse"
+    );
 }
 
 #[test]
@@ -313,6 +348,8 @@ fn interactive_form_answer_payload_ignores_unknown_fields() {
     let payload = build_interactive_form_answer_payload(&json!({
         "type": "interactive_form_question",
         "tool_use_id": "tool-1",
+        "task_id": 10,
+        "subtask_id": 20,
         "answers": {"scope": "all"},
         "success": true,
         "status": "answered",
@@ -327,6 +364,8 @@ fn interactive_form_answer_payload_ignores_unknown_fields() {
         json!({
             "type": "interactive_form_question",
             "tool_use_id": "tool-1",
+            "task_id": 10,
+            "subtask_id": 20,
             "answers": {"scope": "all"},
             "success": true,
             "status": "answered",

--- a/executor/tests/process_engine_contract.rs
+++ b/executor/tests/process_engine_contract.rs
@@ -46,6 +46,20 @@ async fn process_engine_maps_success_stdout_to_completed_outcome() {
 }
 
 #[tokio::test]
+async fn process_engine_writes_configured_stdin_to_child() {
+    let engine = ProcessEngine::new(CommandSpec::new("cat").stdin("from stdin"));
+
+    let outcome = engine.run(ExecutionRequest::default()).await;
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::Completed {
+            content: "from stdin".to_owned()
+        }
+    );
+}
+
+#[tokio::test]
 async fn process_engine_maps_nonzero_exit_to_failed_outcome() {
     let engine = ProcessEngine::new(
         CommandSpec::new("sh")

--- a/executor/tests/protocol_contract.rs
+++ b/executor/tests/protocol_contract.rs
@@ -95,7 +95,7 @@ fn openai_request_conversion_preserves_executor_metadata_and_messages() {
         execution.resolved_shell_type().as_deref(),
         Some("claudecode")
     );
-    assert_eq!(execution.resolved_agent_kind(), AgentKind::CodeX);
+    assert_eq!(execution.resolved_agent_kind(), AgentKind::ClaudeCode);
 }
 
 #[test]
@@ -126,11 +126,11 @@ fn validation_tasks_route_to_image_validator() {
 }
 
 #[test]
-fn responses_protocol_without_openai_provider_stays_on_claude_code() {
+fn responses_protocol_on_claudecode_shell_stays_on_claude_code() {
     let request = OpenAIResponsesRequest::from_value(json!({
         "input": "run task",
         "model_config": {
-            "model": "anthropic",
+            "model": "openai",
             "protocol": "openai-responses"
         },
         "metadata": {

--- a/executor/tests/runner_contract.rs
+++ b/executor/tests/runner_contract.rs
@@ -85,6 +85,39 @@ async fn background_runner_emits_start_and_completed_events() {
 }
 
 #[tokio::test]
+async fn background_runner_emits_silent_completed_event_for_waiting_user_input() {
+    let sink = RecordingSink::default();
+    let runner = BackgroundTaskRunner::new(
+        FakeEngine {
+            outcome: ExecutionOutcome::WaitingForUserInput {
+                stop_reason: "tool_deferred".to_owned(),
+            },
+        },
+        sink.clone(),
+    );
+
+    let result = runner.submit(task_request()).await;
+    let events = sink.wait_for_events(2).await;
+
+    assert_eq!(result.status, TaskStatus::Running);
+    assert_eq!(events[0].event_type, "response.created");
+    assert_eq!(events[1].event_type, "response.completed");
+    assert_eq!(
+        events[1].data["response"]["output"]
+            .as_array()
+            .unwrap()
+            .len(),
+        0
+    );
+    assert_eq!(events[1].data["response"]["stop_reason"], "tool_deferred");
+    assert_eq!(events[1].data["response"]["silent_exit"], true);
+    assert_eq!(
+        events[1].data["response"]["silent_exit_reason"],
+        "waiting_for_user_input"
+    );
+}
+
+#[tokio::test]
 async fn background_runner_emits_error_event_for_failed_outcome() {
     let sink = RecordingSink::default();
     let runner = BackgroundTaskRunner::new(

--- a/executor/tests/stream_parser_contract.rs
+++ b/executor/tests/stream_parser_contract.rs
@@ -56,6 +56,23 @@ fn ndjson_parser_maps_error_event_to_failed_outcome() {
 }
 
 #[test]
+fn ndjson_parser_maps_interactive_form_waiting_result_to_waiting_outcome() {
+    let output = r#"
+{"type":"assistant","message":{"content":[{"type":"text","text":"please fill the form"}]}}
+{"type":"result","subtype":"success","is_error":false,"stop_reason":"tool_deferred","result":"{\"__deferred_user_input__\":true,\"success\":true,\"status\":\"waiting_for_user_response\"}"}
+"#;
+
+    let outcome = collect_ndjson_outcome(output);
+
+    assert_eq!(
+        outcome,
+        ExecutionOutcome::WaitingForUserInput {
+            stop_reason: "tool_deferred".to_owned()
+        }
+    );
+}
+
+#[test]
 fn ndjson_parser_extracts_claude_session_id_from_init_or_result_events() {
     let output = r#"
 {"type":"system","subtype":"init","session_id":"init-session"}


### PR DESCRIPTION
## Summary

- Keep `ClaudeCode` shell requests on the Claude Code executor even when the selected model uses the OpenAI Responses protocol.
- Route interactive form answers back into Claude Code as stream-json `tool_result` input while preserving `--resume`.
- Map interactive form waiting results to a silent completed response with `silent_exit_reason=waiting_for_user_input`.
- Add executor contract coverage for routing, stdin command execution, waiting-response emission, and interactive form answer handling.

## Root Cause

The Rust executor rewrite routed `ClaudeCode + openai-responses` requests to CodeX based on model/protocol instead of shell type, so Claude Code session resume state was bypassed. The interactive form helper logic also was not fully connected to the production Claude CLI path: answers were not sent as CLI stream-json input, and waiting results were not converted into the backend silent-exit response shape.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo test --all-features` via pre-push hook
- `cargo clippy` via pre-push hook
- `git diff --check`

Documentation was checked against the hook reminders; the referenced `docs/*/concepts/architecture.md` files are not present in this checkout, and existing README/AGENTS text only documents executor categories rather than these internal routing and CLI-input details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workflows that pause and wait for user input, with clearer status reporting.
  * Interactive form answers now preserve key context when resuming a session.

* **Bug Fixes**
  * Improved detection of deferred-user-input responses in more response shapes.
  * Fixed routing so the correct agent/binary is used for certain request types.
  * Added support for sending input directly to commands when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->