### PR TITLE
feat(wework): mirror codex session view

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -217,8 +217,13 @@ impl RuntimeWorkRpcHandler {
             .unwrap_or_default();
         let messages = local_link
             .as_ref()
-            .map(|link| merge_cached_messages(transcript_messages(thread), cached_messages(link)))
-            .unwrap_or_else(|| transcript_messages(thread));
+            .map(|link| {
+                merge_cached_messages(
+                    transcript_messages(thread, &self.device_id),
+                    cached_messages(link),
+                )
+            })
+            .unwrap_or_else(|| transcript_messages(thread, &self.device_id));
 
         Ok(json!({
             "success": true,
@@ -866,7 +871,7 @@ impl RuntimeWorkRpcHandler {
         {
             Ok(response) => {
                 let thread = response.get("thread").unwrap_or(&response);
-                transcript_messages(thread)
+                transcript_messages(thread, &self.device_id)
             }
             Err(error) => {
                 eprintln!("failed to read Codex app-server thread {thread_id}: {error}");

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -2,24 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 use super::util::{
-    extract_text, item_id, item_type, now_ms, raw_string_field, reasoning_content, string_field,
-    timestamp_ms_field,
+    bool_field, extract_text, integer_field, item_id, item_type, normalize_workspace_path, now_ms,
+    raw_string_field, reasoning_content, string_field, timestamp_ms_field,
 };
 
-pub(crate) fn transcript_messages(thread: &Value) -> Vec<Value> {
+pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value> {
     let mut messages = Vec::new();
+    let workspace_path = string_field(thread, "cwd").unwrap_or_default();
     for turn in thread
         .get("turns")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
     {
-        let created_at = timestamp_ms_field(turn, "createdAt").unwrap_or_else(now_ms);
+        let created_at = turn_started_at(turn);
+        let completed_at = turn_completed_at(turn, created_at);
         let turn_file_changes = file_changes(turn);
+        let turn_id = item_id(turn, "turn");
+        let subtask_id = turn_subtask_id(turn, &turn_id);
         let mut blocks = Vec::new();
+        let mut pending_file_changes = turn_file_changes.clone();
+        let mut context_events = Vec::new();
+        let mut assistant_parts = Vec::new();
+        let mut memory_citations = Vec::new();
         for item in turn
             .get("items")
             .and_then(Value::as_array)
@@ -30,18 +38,107 @@ pub(crate) fn transcript_messages(thread: &Value) -> Vec<Value> {
                 "usermessage" => push_user_message(&mut messages, item, created_at),
                 "reasoning" => push_reasoning_block(&mut blocks, item, created_at),
                 "commandexecution" => blocks.push(command_block(item, created_at)),
-                "agentmessage" | "message" => {
-                    push_assistant_message(
-                        &mut messages,
+                "functioncall" | "customtoolcall" | "dynamictoolcall" | "mcptoolcall"
+                | "toolsearchcall" | "websearch" | "imagegeneration" | "imageview" | "sleep"
+                | "localshellcall" | "shellcall" => blocks.push(tool_block(item, created_at)),
+                "functioncalloutput" | "customtoolcalloutput" | "toolsearchoutput" => {
+                    merge_tool_output(&mut blocks, item, created_at);
+                }
+                "filechange" => {
+                    if let Some(summary) = file_changes_from_file_change_item(
+                        item,
+                        &turn_id,
+                        device_id,
+                        &workspace_path,
+                    ) {
+                        pending_file_changes = merge_file_changes(pending_file_changes, summary);
+                    }
+                }
+                "patchapplyend" => {
+                    if let Some(summary) = file_changes_from_patch_apply_end(
+                        item,
+                        &turn_id,
+                        device_id,
+                        &workspace_path,
+                    ) {
+                        pending_file_changes = merge_file_changes(pending_file_changes, summary);
+                    }
+                }
+                "contextcompaction" => {
+                    context_events.push(context_event(
                         item,
                         created_at,
-                        &blocks,
-                        file_changes(item).or_else(|| turn_file_changes.clone()),
+                        "context_compaction",
+                        "done",
+                    ));
+                }
+                "agentmessage" => {
+                    collect_assistant_message(
+                        item,
+                        created_at,
+                        &mut blocks,
+                        &mut assistant_parts,
+                        &mut memory_citations,
                     );
-                    blocks.clear();
+                    if let Some(file_changes) = file_changes(item) {
+                        pending_file_changes =
+                            merge_file_changes(pending_file_changes, file_changes);
+                    }
+                }
+                "message" => match string_field(item, "role")
+                    .unwrap_or_default()
+                    .to_ascii_lowercase()
+                    .as_str()
+                {
+                    "user" => push_user_message(&mut messages, item, created_at),
+                    "assistant" => {
+                        collect_assistant_message(
+                            item,
+                            created_at,
+                            &mut blocks,
+                            &mut assistant_parts,
+                            &mut memory_citations,
+                        );
+                        if let Some(file_changes) = file_changes(item) {
+                            pending_file_changes =
+                                merge_file_changes(pending_file_changes, file_changes);
+                        }
+                    }
+                    _ => {}
+                },
+                "agentmessageevent" => {
+                    collect_assistant_message(
+                        item,
+                        created_at,
+                        &mut blocks,
+                        &mut assistant_parts,
+                        &mut memory_citations,
+                    );
+                    if let Some(file_changes) = file_changes(item) {
+                        pending_file_changes =
+                            merge_file_changes(pending_file_changes, file_changes);
+                    }
                 }
                 _ => {}
             }
+        }
+        if !blocks.is_empty()
+            || pending_file_changes.is_some()
+            || !context_events.is_empty()
+            || !assistant_parts.is_empty()
+            || !memory_citations.is_empty()
+        {
+            apply_turn_completed_at(&mut blocks, completed_at);
+            messages.push(synthetic_assistant_message(AssistantMessageDraft {
+                turn_id: &turn_id,
+                subtask_id,
+                created_at,
+                blocks: &blocks,
+                file_changes: pending_file_changes,
+                context_events: &context_events,
+                assistant_parts: &assistant_parts,
+                memory_citations: &memory_citations,
+            }));
         }
     }
     messages
@@ -50,33 +147,75 @@ pub(crate) fn transcript_messages(thread: &Value) -> Vec<Value> {
 pub(crate) fn tool_block_from_notification(params: &Value, status: &str) -> Option<Value> {
     let item = params.get("item").unwrap_or(params);
     let item_type = item_type(item);
-    if !matches!(item_type.as_str(), "commandexecution" | "shellcall") {
+    if !is_tool_item_type(&item_type) {
         return None;
     }
-    Some(json!({
-        "id": item_id(item, "tool"),
-        "type": "tool",
-        "tool_use_id": item_id(item, "tool"),
-        "tool_name": "bash",
-        "tool_input": command_input(item),
-        "status": status,
-        "timestamp": now_ms(),
-    }))
+    let mut block = tool_block(item, now_ms());
+    if let Some(object) = block.as_object_mut() {
+        object.insert("status".to_owned(), Value::String(status.to_owned()));
+    }
+    Some(block)
 }
 
 pub(crate) fn tool_update_from_notification(params: &Value) -> Option<(String, Value)> {
     let item = params.get("item").unwrap_or(params);
     let item_type = item_type(item);
-    if !matches!(item_type.as_str(), "commandexecution" | "shellcall") {
+    if !is_tool_item_type(&item_type) && !is_tool_output_item_type(&item_type) {
         return None;
     }
     Some((
-        item_id(item, "tool"),
+        tool_call_id(item),
         json!({
-            "status": "done",
-            "tool_output": command_output(item),
+            "status": tool_status(item),
+            "tool_output": tool_output(item),
         }),
     ))
+}
+
+fn turn_started_at(turn: &Value) -> i64 {
+    timestamp_ms_field(turn, "startedAt")
+        .or_else(|| timestamp_ms_field(turn, "started_at"))
+        .or_else(|| timestamp_ms_field(turn, "createdAt"))
+        .or_else(|| timestamp_ms_field(turn, "created_at"))
+        .unwrap_or_else(now_ms)
+}
+
+fn turn_completed_at(turn: &Value, started_at: i64) -> Option<i64> {
+    timestamp_ms_field(turn, "completedAt")
+        .or_else(|| timestamp_ms_field(turn, "completed_at"))
+        .or_else(|| {
+            integer_field(turn, "durationMs")
+                .or_else(|| integer_field(turn, "duration_ms"))
+                .map(|duration| started_at.saturating_add(duration))
+        })
+        .filter(|completed_at| *completed_at >= started_at)
+}
+
+fn turn_subtask_id(turn: &Value, turn_id: &str) -> i64 {
+    integer_field(turn, "subtaskId")
+        .or_else(|| integer_field(turn, "subtask_id"))
+        .filter(|value| *value != 0)
+        .unwrap_or_else(|| synthetic_turn_subtask_id(turn_id))
+}
+
+fn synthetic_turn_subtask_id(turn_id: &str) -> i64 {
+    let mut hash = 2_166_136_261_u32;
+    for byte in turn_id.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(16_777_619);
+    }
+    let value = i64::from(hash & 0x7fff_ffff);
+    -value.max(1)
+}
+
+fn apply_turn_completed_at(blocks: &mut [Value], completed_at: Option<i64>) {
+    let Some(completed_at) = completed_at else {
+        return;
+    };
+    let Some(block) = blocks.last_mut().and_then(Value::as_object_mut) else {
+        return;
+    };
+    block.insert("timestamp".to_owned(), json!(completed_at));
 }
 
 fn push_user_message(messages: &mut Vec<Value>, item: &Value, created_at: i64) {
@@ -103,33 +242,107 @@ fn push_reasoning_block(blocks: &mut Vec<Value>, item: &Value, created_at: i64) 
     }
 }
 
-fn push_assistant_message(
-    messages: &mut Vec<Value>,
+fn collect_assistant_message(
     item: &Value,
-    created_at: i64,
-    blocks: &[Value],
-    file_changes: Option<Value>,
+    fallback_timestamp: i64,
+    blocks: &mut Vec<Value>,
+    assistant_parts: &mut Vec<String>,
+    memory_citations: &mut Vec<Value>,
 ) {
     if let Some(content) = extract_text(item) {
-        let mut message = json!({
-            "id": item_id(item, "assistant"),
-            "role": "assistant",
-            "content": content,
-            "status": "done",
-            "createdAt": created_at,
-            "blocks": blocks,
-        });
-        if let Some(file_changes) = file_changes {
-            if let Some(object) = message.as_object_mut() {
-                object.insert("fileChanges".to_owned(), file_changes);
+        match assistant_message_phase(item) {
+            AssistantMessagePhase::Process => {
+                blocks.push(process_text_block(item, content, fallback_timestamp));
+            }
+            AssistantMessagePhase::Final => {
+                assistant_parts.push(content);
             }
         }
-        messages.push(message);
+    }
+    if let Some(memory_citation) = memory_citation(item) {
+        memory_citations.push(memory_citation);
     }
 }
 
+enum AssistantMessagePhase {
+    Final,
+    Process,
+}
+
+fn assistant_message_phase(item: &Value) -> AssistantMessagePhase {
+    let phase = string_field(item, "phase")
+        .unwrap_or_default()
+        .replace(['_', '-'], "")
+        .to_ascii_lowercase();
+    match phase.as_str() {
+        "commentary" | "analysis" => AssistantMessagePhase::Process,
+        _ => AssistantMessagePhase::Final,
+    }
+}
+
+fn process_text_block(item: &Value, content: String, fallback_timestamp: i64) -> Value {
+    json!({
+        "id": item_id(item, "text"),
+        "type": "text",
+        "content": content,
+        "status": "done",
+        "timestamp": item_timestamp(item).unwrap_or(fallback_timestamp),
+    })
+}
+
+fn item_timestamp(item: &Value) -> Option<i64> {
+    timestamp_ms_field(item, "timestamp")
+        .or_else(|| timestamp_ms_field(item, "createdAt"))
+        .or_else(|| timestamp_ms_field(item, "created_at"))
+}
+
+struct AssistantMessageDraft<'a> {
+    turn_id: &'a str,
+    subtask_id: i64,
+    created_at: i64,
+    blocks: &'a [Value],
+    file_changes: Option<Value>,
+    context_events: &'a [Value],
+    assistant_parts: &'a [String],
+    memory_citations: &'a [Value],
+}
+
+fn synthetic_assistant_message(draft: AssistantMessageDraft<'_>) -> Value {
+    let mut message = json!({
+        "id": format!("assistant-{}", draft.turn_id),
+        "role": "assistant",
+        "content": draft.assistant_parts.join("\n\n"),
+        "status": "done",
+        "subtaskId": draft.subtask_id,
+        "subtask_id": draft.subtask_id,
+        "createdAt": draft.created_at,
+        "blocks": draft.blocks,
+    });
+    if let Some(file_changes) = draft.file_changes {
+        if let Some(object) = message.as_object_mut() {
+            object.insert("fileChanges".to_owned(), file_changes);
+        }
+    }
+    if !draft.context_events.is_empty() {
+        if let Some(object) = message.as_object_mut() {
+            object.insert(
+                "contextEvents".to_owned(),
+                Value::Array(draft.context_events.to_vec()),
+            );
+        }
+    }
+    if !draft.memory_citations.is_empty() {
+        if let Some(object) = message.as_object_mut() {
+            object.insert(
+                "memoryCitations".to_owned(),
+                Value::Array(draft.memory_citations.to_vec()),
+            );
+        }
+    }
+    message
+}
+
 fn command_block(item: &Value, timestamp: i64) -> Value {
-    let status = string_field(item, "status").unwrap_or_else(|| "completed".to_owned());
     json!({
         "id": item_id(item, "tool"),
         "type": "tool",
@@ -137,32 +350,615 @@ fn command_block(item: &Value, timestamp: i64) -> Value {
         "tool_name": "bash",
         "tool_input": command_input(item),
         "tool_output": command_output(item),
-        "status": if status.eq_ignore_ascii_case("failed") || status.eq_ignore_ascii_case("error") {
-            "error"
-        } else {
-            "done"
-        },
+        "status": tool_status(item),
         "timestamp": timestamp,
     })
 }
 
+fn tool_block(item: &Value, timestamp: i64) -> Value {
+    if matches!(
+        item_type(item).as_str(),
+        "commandexecution" | "shellcall" | "localshellcall"
+    ) {
+        return command_block(item, timestamp);
+    }
+    json!({
+        "id": tool_call_id(item),
+        "type": "tool",
+        "tool_use_id": tool_call_id(item),
+        "tool_name": tool_name(item),
+        "tool_input": tool_input(item),
+        "tool_output": tool_output(item),
+        "status": tool_status(item),
+        "timestamp": timestamp,
+    })
+}
+
+fn merge_tool_output(blocks: &mut Vec<Value>, item: &Value, timestamp: i64) {
+    let call_id = tool_call_id(item);
+    if let Some(block) = blocks.iter_mut().rev().find(|block| {
+        block
+            .get("tool_use_id")
+            .and_then(Value::as_str)
+            .is_some_and(|value| value == call_id)
+    }) {
+        if let Some(object) = block.as_object_mut() {
+            object.insert("tool_output".to_owned(), tool_output(item));
+            object.insert("status".to_owned(), Value::String(tool_status(item)));
+        }
+        return;
+    }
+    blocks.push(json!({
+        "id": call_id,
+        "type": "tool",
+        "tool_use_id": tool_call_id(item),
+        "tool_name": tool_name(item),
+        "tool_output": tool_output(item),
+        "status": tool_status(item),
+        "timestamp": timestamp,
+    }));
+}
+
 fn command_input(item: &Value) -> Value {
     json!({
-        "command": string_field(item, "command").unwrap_or_default(),
+        "command": string_field(item, "command")
+            .or_else(|| command_from_local_shell_action(item))
+            .unwrap_or_default(),
         "cwd": string_field(item, "cwd").unwrap_or_default(),
     })
 }
 
 fn command_output(item: &Value) -> String {
     raw_string_field(item, "aggregatedOutput")
+        .or_else(|| raw_string_field(item, "aggregated_output"))
         .or_else(|| raw_string_field(item, "output"))
         .unwrap_or_default()
+}
+
+fn command_from_local_shell_action(item: &Value) -> Option<String> {
+    item.get("action").and_then(|action| {
+        string_field(action, "command")
+            .or_else(|| string_field(action, "cmd"))
+            .or_else(|| string_field(action, "commandLine"))
+    })
+}
+
+fn is_tool_item_type(item_type: &str) -> bool {
+    matches!(
+        item_type,
+        "commandexecution"
+            | "shellcall"
+            | "localshellcall"
+            | "functioncall"
+            | "customtoolcall"
+            | "dynamictoolcall"
+            | "mcptoolcall"
+            | "toolsearchcall"
+            | "websearch"
+            | "imagegeneration"
+            | "imageview"
+            | "sleep"
+    )
+}
+
+fn is_tool_output_item_type(item_type: &str) -> bool {
+    matches!(
+        item_type,
+        "functioncalloutput" | "customtoolcalloutput" | "toolsearchoutput"
+    )
+}
+
+fn tool_call_id(item: &Value) -> String {
+    string_field(item, "call_id")
+        .or_else(|| string_field(item, "callId"))
+        .or_else(|| string_field(item, "id"))
+        .unwrap_or_else(|| format!("tool-{}", now_ms()))
+}
+
+fn tool_name(item: &Value) -> String {
+    match item_type(item).as_str() {
+        "functioncall" | "functioncalloutput" => string_field(item, "name")
+            .or_else(|| string_field(item, "tool"))
+            .unwrap_or_else(|| "function_call".to_owned()),
+        "customtoolcall" | "customtoolcalloutput" => string_field(item, "name")
+            .or_else(|| string_field(item, "tool"))
+            .unwrap_or_else(|| "custom_tool".to_owned()),
+        "dynamictoolcall" => {
+            string_field(item, "tool").unwrap_or_else(|| "dynamic_tool".to_owned())
+        }
+        "mcptoolcall" => {
+            let server = string_field(item, "server");
+            let tool = string_field(item, "tool").unwrap_or_else(|| "mcp_tool".to_owned());
+            server
+                .map(|server| format!("{server}.{tool}"))
+                .unwrap_or(tool)
+        }
+        "toolsearchcall" | "toolsearchoutput" => "tool_search".to_owned(),
+        "websearch" => "web_search".to_owned(),
+        "imagegeneration" => "image_generation".to_owned(),
+        "imageview" => "view_image".to_owned(),
+        "sleep" => "sleep".to_owned(),
+        _ => "tool".to_owned(),
+    }
+}
+
+fn tool_input(item: &Value) -> Value {
+    match item_type(item).as_str() {
+        "functioncall" => parse_json_object_string(item, "arguments").unwrap_or_else(
+            || json!({"arguments": raw_string_field(item, "arguments").unwrap_or_default()}),
+        ),
+        "customtoolcall" => json!({"input": raw_string_field(item, "input").unwrap_or_default()}),
+        "dynamictoolcall" | "toolsearchcall" => {
+            item.get("arguments").cloned().unwrap_or(Value::Null)
+        }
+        "mcptoolcall" => item.get("arguments").cloned().unwrap_or(Value::Null),
+        "websearch" => json!({"query": string_field(item, "query").unwrap_or_default()}),
+        "imageview" => json!({"path": string_field(item, "path").unwrap_or_default()}),
+        "sleep" => {
+            json!({"duration_ms": item.get("durationMs").or_else(|| item.get("duration_ms")).cloned().unwrap_or(Value::Null)})
+        }
+        "imagegeneration" => {
+            json!({"revised_prompt": string_field(item, "revisedPrompt").or_else(|| string_field(item, "revised_prompt")).unwrap_or_default()})
+        }
+        _ => Value::Object(Map::new()),
+    }
+}
+
+fn parse_json_object_string(item: &Value, key: &str) -> Option<Value> {
+    let text = raw_string_field(item, key)?;
+    serde_json::from_str::<Value>(&text)
+        .ok()
+        .filter(Value::is_object)
+}
+
+fn tool_output(item: &Value) -> Value {
+    match item_type(item).as_str() {
+        "commandexecution" | "shellcall" | "localshellcall" => Value::String(command_output(item)),
+        "functioncalloutput" | "customtoolcalloutput" => output_payload_text(item)
+            .map(Value::String)
+            .unwrap_or_else(|| item.get("output").cloned().unwrap_or(Value::Null)),
+        "toolsearchoutput" => item.get("results").cloned().unwrap_or_else(|| {
+            output_payload_text(item)
+                .map(Value::String)
+                .unwrap_or(Value::Null)
+        }),
+        "dynamictoolcall" => item
+            .get("contentItems")
+            .or_else(|| item.get("content_items"))
+            .map(output_content_items_text)
+            .map(Value::String)
+            .unwrap_or_else(|| item.get("result").cloned().unwrap_or(Value::Null)),
+        "mcptoolcall" => item
+            .get("error")
+            .and_then(|error| string_field(error, "message"))
+            .map(Value::String)
+            .or_else(|| item.get("result").cloned())
+            .unwrap_or(Value::Null),
+        "imagegeneration" => string_field(item, "savedPath")
+            .or_else(|| string_field(item, "saved_path"))
+            .or_else(|| raw_string_field(item, "result"))
+            .map(Value::String)
+            .unwrap_or(Value::Null),
+        _ => Value::Null,
+    }
+}
+
+fn output_payload_text(item: &Value) -> Option<String> {
+    let output = item.get("output")?;
+    output
+        .as_str()
+        .map(str::to_owned)
+        .or_else(|| Some(output_content_items_text(output)).filter(|value| !value.is_empty()))
+}
+
+fn output_content_items_text(value: &Value) -> String {
+    value
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|part| {
+            part.as_str().map(str::to_owned).or_else(|| {
+                part.get("text")
+                    .or_else(|| part.get("content"))
+                    .or_else(|| part.get("inputText"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn tool_status(item: &Value) -> String {
+    let status = string_field(item, "status").unwrap_or_else(|| "completed".to_owned());
+    if status.eq_ignore_ascii_case("failed")
+        || status.eq_ignore_ascii_case("failure")
+        || status.eq_ignore_ascii_case("error")
+        || bool_field(item, "success").is_some_and(|success| !success)
+        || item.get("error").is_some()
+    {
+        "error".to_owned()
+    } else if status.eq_ignore_ascii_case("completed")
+        || status.eq_ignore_ascii_case("complete")
+        || status.eq_ignore_ascii_case("done")
+        || status.eq_ignore_ascii_case("succeeded")
+        || bool_field(item, "success").is_some_and(|success| success)
+    {
+        "done".to_owned()
+    } else {
+        "pending".to_owned()
+    }
 }
 
 fn file_changes(value: &Value) -> Option<Value> {
     value
         .get("fileChanges")
         .or_else(|| value.get("file_changes"))
+        .filter(|value| value.is_object())
+        .cloned()
+}
+
+fn merge_file_changes(existing: Option<Value>, next: Value) -> Option<Value> {
+    let Some(mut current) = existing else {
+        return Some(next);
+    };
+    let Some(current_object) = current.as_object_mut() else {
+        return Some(next);
+    };
+    let Some(next_object) = next.as_object() else {
+        return Some(current);
+    };
+
+    let mut files = current_object
+        .get("files")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for next_file in next_object
+        .get("files")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let Some(next_path) = string_field(next_file, "path") else {
+            continue;
+        };
+        if let Some(existing_index) = files
+            .iter()
+            .position(|file| string_field(file, "path").is_some_and(|path| path == next_path))
+        {
+            files[existing_index] = next_file.clone();
+        } else {
+            files.push(next_file.clone());
+        }
+    }
+    if files.is_empty() {
+        return Some(current);
+    }
+
+    for key in [
+        "status",
+        "device_id",
+        "workspace_path",
+        "reverted_at",
+        "revertible",
+    ] {
+        if let Some(value) = next_object.get(key) {
+            current_object.insert(key.to_owned(), value.clone());
+        }
+    }
+
+    let additions = files
+        .iter()
+        .filter_map(|file| file.get("additions").and_then(Value::as_i64))
+        .sum::<i64>();
+    let deletions = files
+        .iter()
+        .filter_map(|file| file.get("deletions").and_then(Value::as_i64))
+        .sum::<i64>();
+    current_object.insert("file_count".to_owned(), json!(files.len()));
+    current_object.insert("additions".to_owned(), json!(additions));
+    current_object.insert("deletions".to_owned(), json!(deletions));
+    current_object.insert("files".to_owned(), Value::Array(files));
+
+    let combined_diff = [
+        current_object.get("diff").and_then(Value::as_str),
+        next_object.get("diff").and_then(Value::as_str),
+    ]
+    .into_iter()
+    .flatten()
+    .filter(|diff| !diff.trim().is_empty())
+    .collect::<Vec<_>>()
+    .join("\n");
+    if combined_diff.is_empty() {
+        current_object.remove("diff");
+    } else {
+        current_object.insert("diff".to_owned(), Value::String(combined_diff));
+    }
+
+    Some(current)
+}
+
+fn file_changes_from_file_change_item(
+    item: &Value,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+) -> Option<Value> {
+    let status = string_field(item, "status").unwrap_or_else(|| "completed".to_owned());
+    if !status.eq_ignore_ascii_case("completed") {
+        return None;
+    }
+    let changes = item.get("changes")?.as_array()?;
+    let files = changes
+        .iter()
+        .filter_map(|change| file_change_from_codex_change(change, workspace_path))
+        .collect::<Vec<_>>();
+    file_changes_summary(
+        &item_id(item, "file-change"),
+        turn_id,
+        device_id,
+        workspace_path,
+        files,
+        combined_diff_from_file_change_item(item, workspace_path),
+    )
+}
+
+fn file_changes_from_patch_apply_end(
+    item: &Value,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+) -> Option<Value> {
+    if bool_field(item, "success").is_some_and(|success| !success) {
+        return None;
+    }
+    let changes = item.get("changes")?.as_object()?;
+    let files = changes
+        .iter()
+        .filter_map(|(path, change)| file_change_from_patch_change(path, change, workspace_path))
+        .collect::<Vec<_>>();
+    file_changes_summary(
+        &item_id(item, "patch"),
+        turn_id,
+        device_id,
+        workspace_path,
+        files,
+        combined_diff_from_patch_apply_end(item, workspace_path),
+    )
+}
+
+fn file_changes_summary(
+    item_id: &str,
+    turn_id: &str,
+    device_id: &str,
+    workspace_path: &str,
+    files: Vec<Value>,
+    diff: Option<String>,
+) -> Option<Value> {
+    if files.is_empty() {
+        return None;
+    }
+    let additions = files
+        .iter()
+        .filter_map(|file| file.get("additions").and_then(Value::as_i64))
+        .sum::<i64>();
+    let deletions = files
+        .iter()
+        .filter_map(|file| file.get("deletions").and_then(Value::as_i64))
+        .sum::<i64>();
+    let mut summary = json!({
+        "version": 1,
+        "status": "active",
+        "artifact_id": format!("codex-{turn_id}-{item_id}"),
+        "device_id": device_id,
+        "workspace_path": workspace_path,
+        "file_count": files.len(),
+        "additions": additions,
+        "deletions": deletions,
+        "files": files,
+        "reverted_at": Value::Null,
+        "revertible": false,
+    });
+    if let Some(diff) = diff.filter(|diff| !diff.trim().is_empty()) {
+        if let Some(object) = summary.as_object_mut() {
+            object.insert("diff".to_owned(), Value::String(diff));
+        }
+    }
+    Some(summary)
+}
+
+fn file_change_from_codex_change(change: &Value, workspace_path: &str) -> Option<Value> {
+    let path = workspace_relative_path(&string_field(change, "path")?, workspace_path);
+    let kind = change
+        .get("kind")
+        .and_then(Value::as_object)
+        .and_then(|kind| kind.get("type").and_then(Value::as_str))
+        .unwrap_or("update")
+        .to_ascii_lowercase();
+    let diff = raw_string_field(change, "diff").unwrap_or_default();
+    let move_path = change
+        .get("kind")
+        .and_then(|kind| string_field(kind, "movePath").or_else(|| string_field(kind, "move_path")))
+        .map(|path| workspace_relative_path(&path, workspace_path));
+    let change_type = match kind.as_str() {
+        "add" | "create" | "created" => "created",
+        "delete" | "deleted" => "deleted",
+        "update" if move_path.is_some() => "renamed",
+        _ => "modified",
+    };
+    let (additions, deletions) = diff_stats(&diff, change_type);
+    Some(json!({
+        "old_path": if change_type == "renamed" { move_path } else { None },
+        "path": path,
+        "change_type": change_type,
+        "additions": additions,
+        "deletions": deletions,
+        "binary": false,
+    }))
+}
+
+fn file_change_from_patch_change(
+    path: &str,
+    change: &Value,
+    workspace_path: &str,
+) -> Option<Value> {
+    let kind = string_field(change, "type").unwrap_or_else(|| "update".to_owned());
+    let diff = raw_string_field(change, "unified_diff")
+        .or_else(|| raw_string_field(change, "diff"))
+        .or_else(|| raw_string_field(change, "content"))
+        .unwrap_or_default();
+    let path = workspace_relative_path(path, workspace_path);
+    let move_path = string_field(change, "move_path")
+        .or_else(|| string_field(change, "movePath"))
+        .map(|path| workspace_relative_path(&path, workspace_path));
+    let change_type = match kind.to_ascii_lowercase().as_str() {
+        "add" | "create" | "created" => "created",
+        "delete" | "deleted" => "deleted",
+        "update" if move_path.is_some() => "renamed",
+        _ => "modified",
+    };
+    let (additions, deletions) = diff_stats(&diff, change_type);
+    Some(json!({
+        "old_path": if change_type == "renamed" { move_path } else { None },
+        "path": path,
+        "change_type": change_type,
+        "additions": additions,
+        "deletions": deletions,
+        "binary": false,
+    }))
+}
+
+fn workspace_relative_path(path: &str, workspace_path: &str) -> String {
+    let trimmed_path = path.trim();
+    let normalized_path = normalize_workspace_path(trimmed_path);
+    let normalized_workspace = normalize_workspace_path(workspace_path);
+    if normalized_path.is_empty() || normalized_workspace.is_empty() {
+        return trimmed_path.replace('\\', "/");
+    }
+
+    let workspace_prefix = normalized_workspace.trim_end_matches(['/', '\\']);
+    if normalized_path == workspace_prefix {
+        return String::new();
+    }
+    if let Some(relative_path) = normalized_path.strip_prefix(workspace_prefix) {
+        if relative_path.starts_with('/') || relative_path.starts_with('\\') {
+            return relative_path
+                .trim_start_matches(['/', '\\'])
+                .replace('\\', "/");
+        }
+    }
+
+    trimmed_path.replace('\\', "/")
+}
+
+fn diff_stats(diff: &str, change_type: &str) -> (i64, i64) {
+    let additions = diff
+        .lines()
+        .filter(|line| line.starts_with('+') && !line.starts_with("+++"))
+        .count() as i64;
+    let deletions = diff
+        .lines()
+        .filter(|line| line.starts_with('-') && !line.starts_with("---"))
+        .count() as i64;
+    if additions > 0 || deletions > 0 {
+        return (additions, deletions);
+    }
+    let line_count = diff.lines().filter(|line| !line.trim().is_empty()).count() as i64;
+    match change_type {
+        "created" => (line_count, 0),
+        "deleted" => (0, line_count),
+        _ => (0, 0),
+    }
+}
+
+fn combined_diff_from_file_change_item(item: &Value, workspace_path: &str) -> Option<String> {
+    let diff = item
+        .get("changes")?
+        .as_array()?
+        .iter()
+        .filter_map(|change| {
+            let path = string_field(change, "path")?;
+            let move_path = change.get("kind").and_then(|kind| {
+                string_field(kind, "movePath").or_else(|| string_field(kind, "move_path"))
+            });
+            raw_string_field(change, "diff").map(|diff| {
+                diff_with_file_header(&path, move_path.as_deref(), &diff, workspace_path)
+            })
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(diff).filter(|diff| !diff.is_empty())
+}
+
+fn combined_diff_from_patch_apply_end(item: &Value, workspace_path: &str) -> Option<String> {
+    let diff = item
+        .get("changes")?
+        .as_object()?
+        .iter()
+        .filter_map(|(path, change)| {
+            let move_path =
+                string_field(change, "move_path").or_else(|| string_field(change, "movePath"));
+            raw_string_field(change, "unified_diff")
+                .or_else(|| raw_string_field(change, "diff"))
+                .or_else(|| raw_string_field(change, "content"))
+                .map(|diff| {
+                    diff_with_file_header(path, move_path.as_deref(), &diff, workspace_path)
+                })
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(diff).filter(|diff| !diff.is_empty())
+}
+
+fn diff_with_file_header(
+    path: &str,
+    old_path: Option<&str>,
+    diff: &str,
+    workspace_path: &str,
+) -> String {
+    if diff.trim_start().starts_with("diff --git ") {
+        return diff.to_owned();
+    }
+
+    let relative_path = workspace_relative_path(path, workspace_path);
+    if relative_path.is_empty() {
+        return diff.to_owned();
+    }
+
+    let relative_old_path = old_path
+        .map(|path| workspace_relative_path(path, workspace_path))
+        .filter(|path| !path.is_empty())
+        .unwrap_or_else(|| relative_path.clone());
+    format!(
+        "diff --git {} {}\n{}",
+        diff_git_path("a", &relative_old_path),
+        diff_git_path("b", &relative_path),
+        diff.trim_end()
+    )
+}
+
+fn diff_git_path(prefix: &str, path: &str) -> String {
+    let path = format!("{prefix}/{}", path.replace('\\', "/"));
+    if path.chars().any(char::is_whitespace) {
+        format!("\"{path}\"")
+    } else {
+        path
+    }
+}
+
+fn context_event(item: &Value, timestamp: i64, event_type: &str, status: &str) -> Value {
+    json!({
+        "id": item_id(item, event_type),
+        "type": event_type,
+        "status": status,
+        "createdAt": timestamp,
+    })
+}
+
+fn memory_citation(item: &Value) -> Option<Value> {
+    item.get("memoryCitation")
+        .or_else(|| item.get("memory_citation"))
         .filter(|value| value.is_object())
         .cloned()
 }

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -187,15 +187,21 @@ pub(crate) fn extract_text(item: &Value) -> Option<String> {
     if let Some(content) = string_field(item, "content") {
         return Some(content);
     }
+    if let Some(message) = string_field(item, "message") {
+        return Some(message);
+    }
     let text = item
         .get("content")
         .and_then(Value::as_array)
         .into_iter()
         .flatten()
         .filter_map(|part| {
-            part.get("text")
-                .or_else(|| part.get("content"))
-                .and_then(Value::as_str)
+            part.as_str().map(str::to_owned).or_else(|| {
+                part.get("text")
+                    .or_else(|| part.get("content"))
+                    .and_then(Value::as_str)
+                    .map(str::to_owned)
+            })
         })
         .collect::<Vec<_>>()
         .join("");

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -79,6 +79,194 @@ async fn runtime_transcript_preserves_assistant_file_changes_from_codex_items() 
     );
 }
 
+#[tokio::test]
+async fn runtime_transcript_normalizes_codex_file_change_items_without_backend_subtask_id() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-codex-file-change-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex =
+        write_fake_file_change_codex(&temp_path("runtime-codex-file-change-log", "jsonl"));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let assistant = &transcript["messages"][1];
+    assert_eq!(assistant["role"], "assistant");
+    assert_eq!(assistant["content"], "Done");
+    let subtask_id = assistant["subtaskId"]
+        .as_i64()
+        .expect("synthetic subtask id should be present");
+    assert!(subtask_id < 0);
+    assert_eq!(assistant["subtask_id"], assistant["subtaskId"]);
+    assert_eq!(assistant["fileChanges"]["device_id"], "device-1");
+    assert_eq!(assistant["fileChanges"]["workspace_path"], "/tmp/project");
+    assert_eq!(
+        assistant["fileChanges"]["artifact_id"],
+        "codex-turn-file-change-call-1"
+    );
+    assert_eq!(assistant["fileChanges"]["file_count"], 1);
+    assert_eq!(assistant["fileChanges"]["additions"], 1);
+    assert_eq!(assistant["fileChanges"]["deletions"], 1);
+    assert_eq!(
+        assistant["fileChanges"]["files"][0]["path"],
+        "references/github-pr-flow.md"
+    );
+    assert!(assistant["fileChanges"]["diff"]
+        .as_str()
+        .unwrap()
+        .starts_with("diff --git a/references/github-pr-flow.md b/references/github-pr-flow.md"));
+}
+
+#[tokio::test]
+async fn runtime_transcript_normalizes_codex_rich_turn_items() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-rich-transcript-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex = write_fake_rich_codex(&temp_path("runtime-rich-transcript-log", "jsonl"));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let assistant = &transcript["messages"][1];
+    assert_eq!(assistant["role"], "assistant");
+    assert_eq!(assistant["content"], "Done");
+    assert!(assistant["subtaskId"].as_i64().unwrap() < 0);
+    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 3);
+    assert_eq!(assistant["blocks"][0]["type"], "thinking");
+    assert_eq!(assistant["blocks"][1]["type"], "text");
+    assert_eq!(assistant["blocks"][1]["content"], "I checked the files.");
+    assert_eq!(assistant["blocks"][2]["tool_name"], "exec_command");
+    assert_eq!(assistant["blocks"][2]["tool_output"], "ok");
+    assert_eq!(assistant["blocks"][2]["timestamp"], 1780000007000_i64);
+    assert_eq!(assistant["fileChanges"]["device_id"], "device-1");
+    assert_eq!(assistant["fileChanges"]["workspace_path"], "/tmp/project");
+    assert_eq!(assistant["fileChanges"]["file_count"], 1);
+    assert_eq!(assistant["fileChanges"]["additions"], 1);
+    assert_eq!(assistant["fileChanges"]["deletions"], 1);
+    assert_eq!(assistant["fileChanges"]["revertible"], false);
+    assert_eq!(assistant["fileChanges"]["files"][0]["path"], "src/lib.rs");
+    assert!(assistant["fileChanges"]["diff"]
+        .as_str()
+        .unwrap()
+        .starts_with("diff --git a/src/lib.rs b/src/lib.rs"));
+    assert_eq!(
+        assistant["memoryCitations"][0]["entries"][0]["path"],
+        "MEMORY.md"
+    );
+    assert_eq!(assistant["contextEvents"][0]["type"], "context_compaction");
+}
+
+#[tokio::test]
+async fn runtime_transcript_merges_multiple_codex_file_change_items_in_one_turn() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-merged-file-changes-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex =
+        write_fake_multi_patch_codex(&temp_path("runtime-merged-file-changes-log", "jsonl"));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let assistant = &transcript["messages"][1];
+    assert_eq!(assistant["role"], "assistant");
+    assert_eq!(assistant["content"], "Done");
+    assert_eq!(assistant["fileChanges"]["file_count"], 4);
+    assert_eq!(assistant["fileChanges"]["additions"], 69);
+    assert_eq!(assistant["fileChanges"]["deletions"], 18);
+    assert_eq!(assistant["fileChanges"]["files"][0]["path"], "SKILL.md");
+    assert_eq!(
+        assistant["fileChanges"]["files"][1]["path"],
+        "references/acceptance-validation-contract.md"
+    );
+    assert_eq!(
+        assistant["fileChanges"]["files"][2]["path"],
+        "references/pr-review-notification.md"
+    );
+    assert_eq!(
+        assistant["fileChanges"]["files"][3]["path"],
+        "scripts/notify_pr_ready.sh"
+    );
+    assert!(assistant["fileChanges"]["diff"]
+        .as_str()
+        .unwrap()
+        .contains("scripts/notify_pr_ready.sh"));
+}
+
+fn write_fake_file_change_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-file-change-item", "sh");
+    let _ = fs::remove_file(log_path);
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"File change transcript","preview":"edit","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-file-change","createdAt":1780000000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"edit"}}]}},{{"id":"agent-progress","type":"agentMessage","text":"Editing.","phase":"commentary"}},{{"id":"call-1","type":"fileChange","changes":[{{"path":"/tmp/project/references/github-pr-flow.md","kind":{{"type":"update","move_path":null}},"diff":"@@ -1 +1 @@\n-old\n+new\n"}}],"status":"completed"}},{{"id":"agent-1","type":"agentMessage","text":"Done","phase":"final_answer"}}]}}]}}}}}}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display()
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
 fn write_fake_codex(log_path: &Path) -> PathBuf {
     let path = temp_path("fake-codex-file-changes", "sh");
     let _ = fs::remove_file(log_path);
@@ -95,6 +283,158 @@ while IFS= read -r line; do
       ;;
     *'"method":"thread/read"'*)
       printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Edit files","preview":"edit","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-1","createdAt":1780000000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"edit files"}}]}},{{"id":"agent-1","type":"agentMessage","text":"Edited files","phase":"final_answer","fileChanges":{{"version":1,"status":"active","artifact_id":"artifact-1","device_id":"device-1","workspace_path":"/tmp/project","file_count":1,"additions":6,"deletions":4,"files":[{{"path":"src/runtime_work.rs","change_type":"modified","additions":6,"deletions":4,"binary":false}}],"reverted_at":null}}}}]}}]}}}}}}'
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display()
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_multi_patch_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-multi-patch-transcript", "sh");
+    let _ = fs::remove_file(log_path);
+    let response = json!({
+        "id": 2,
+        "result": {
+            "thread": {
+                "id": "thread-1",
+                "cwd": "/tmp/project",
+                "name": "Merged file changes",
+                "preview": "edit",
+                "path": "/tmp/codex/thread-1.jsonl",
+                "createdAt": 1780000000_i64,
+                "updatedAt": 1780000060_i64,
+                "status": "idle",
+                "turns": [{
+                    "id": "turn-merged",
+                    "createdAt": 1780000000_i64,
+                    "items": [
+                        {
+                            "id": "user-1",
+                            "type": "userMessage",
+                            "content": [{"type": "text", "text": "edit files"}],
+                        },
+                        patch_apply_item(
+                            "patch-1",
+                            "SKILL.md",
+                            counted_diff("SKILL.md", 5, 3),
+                        ),
+                        patch_apply_item(
+                            "patch-2",
+                            "references/acceptance-validation-contract.md",
+                            counted_diff("references/acceptance-validation-contract.md", 16, 2),
+                        ),
+                        patch_apply_item(
+                            "patch-3",
+                            "references/pr-review-notification.md",
+                            counted_diff("references/pr-review-notification.md", 12, 8),
+                        ),
+                        patch_apply_item(
+                            "patch-4",
+                            "scripts/notify_pr_ready.sh",
+                            counted_diff("scripts/notify_pr_ready.sh", 36, 5),
+                        ),
+                        {
+                            "id": "agent-1",
+                            "type": "agentMessage",
+                            "text": "Done",
+                            "phase": "final_answer",
+                        },
+                    ],
+                }],
+            },
+        },
+    });
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' {}
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display(),
+        shell_single_quote(&response.to_string()),
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn patch_apply_item(id: &str, path: &str, diff: String) -> serde_json::Value {
+    json!({
+        "id": id,
+        "type": "patch_apply_end",
+        "success": true,
+        "changes": {
+            path: {
+                "type": "update",
+                "unified_diff": diff,
+                "move_path": null,
+            },
+        },
+    })
+}
+
+fn counted_diff(path: &str, additions: usize, deletions: usize) -> String {
+    let mut lines = vec![
+        format!("diff --git a/{path} b/{path}"),
+        "@@ -1 +1 @@".to_owned(),
+    ];
+    for index in 1..=deletions {
+        lines.push(format!("-old {index}"));
+    }
+    for index in 1..=additions {
+        lines.push(format!("+new {index}"));
+    }
+    lines.join("\n")
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn write_fake_rich_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-rich-transcript", "sh");
+    let _ = fs::remove_file(log_path);
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Rich transcript","preview":"rich","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-rich","startedAt":1780000000,"durationMs":7000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"inspect"}}]}},{{"id":"reason-1","type":"reasoning","summary":["thinking"]}},{{"id":"agent-progress","type":"agentMessage","text":"I checked the files.","phase":"analysis"}},{{"type":"function_call","name":"exec_command","arguments":"{{\"cmd\":\"rg -n test\"}}","call_id":"call-1"}},{{"type":"function_call_output","call_id":"call-1","output":"ok"}},{{"id":"patch-1","type":"patch_apply_end","success":true,"changes":{{"/tmp/project/src/lib.rs":{{"type":"update","unified_diff":"@@ -1 +1 @@\n-old\n+new\n","move_path":null}}}}}},{{"id":"ctx-1","type":"contextCompaction"}},{{"id":"agent-1","type":"agentMessage","text":"Done","phase":"final_answer","memoryCitation":{{"entries":[{{"path":"MEMORY.md","lineStart":1,"lineEnd":2,"note":"note"}}],"threadIds":["thread-a"]}}}}]}}]}}}}}}'
       exit 0
       ;;
   esac

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      react-syntax-highlighter:
+        specifier: ^15.6.6
+        version: 15.6.6(react@19.2.7)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -563,6 +566,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/react-syntax-highlighter':
+        specifier: ^15.5.13
+        version: 15.5.13
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@1.21.7)(tsx@4.22.4)(yaml@2.9.0))

--- a/wework/package.json
+++ b/wework/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.8",
     "react-markdown": "^10.1.0",
+    "react-syntax-highlighter": "^15.6.6",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0"
   },
@@ -56,6 +57,7 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-istanbul": "^4.1.8",
     "autoprefixer": "^10.5.0",

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -1,18 +1,45 @@
 import type { WorkbenchServices } from '@/features/workbench/WorkbenchProvider'
 import { createExecutorClientFromApis } from '@/api/executorAccess'
 import type {
+  ArchivedConversationsListRequest,
+  ArchivedConversationsListResponse,
+  DeleteDeviceWorkspaceRequest,
+  DeleteDeviceWorkspaceResponse,
   DeviceCommandResponse,
-  DeviceInfo,
+  DeviceWorkspacePrepareRequest,
+  DeviceWorkspacePrepareResponse,
   LocalTaskSummary,
   LocalDeviceSkill,
+  RuntimeArchiveProjectConversationsRequest,
+  RuntimeArchivedConversationBulkRequest,
+  RuntimeArchivedConversationBulkResponse,
   RuntimeDeviceWorkspace,
+  RuntimeFileChangesRevertRequest,
+  RuntimeFileChangesRevertResponse,
   RuntimeTaskAddress,
+  RuntimeTaskArchiveResponse,
+  RuntimeTaskCancelResponse,
   RuntimeTaskCreateRequest,
+  RuntimeTaskCreateResponse,
+  RuntimeTaskForkRequest,
+  RuntimeTaskForkResponse,
+  RuntimeTaskRenameRequest,
+  RuntimeSendRequest,
+  RuntimeSendResponse,
+  RuntimeTranscriptRequest,
+  RuntimeTranscriptResponse,
+  RuntimeWorkspaceOpenRequest,
+  RuntimeWorkspaceOpenResponse,
+  RuntimeWorkspaceRemoveRequest,
+  RuntimeWorkspaceRenameRequest,
   RuntimeWorkListResponse,
+  RuntimeWorkSearchRequest,
+  RuntimeWorkSearchResponse,
   Team,
   UnifiedModel,
   User,
 } from '@/types/api'
+import type { DeviceInfo } from '@/types/devices'
 import type {
   WorkspaceFileEntry,
   WorkspaceTextFileResponse,
@@ -80,13 +107,13 @@ function cloudConnectionRequired(name: string): never {
 
 function localDeviceFromStatus(status: LocalExecutorStatus): DeviceInfo {
   const online = status.running && status.ready !== false && !status.error
-  return {
+  const device = {
     id: 0,
     device_id: status.deviceId || LOCAL_DEVICE_ID,
     name: 'Local Executor',
-    status: online ? 'online' : 'offline',
+    status: online ? ('online' as const) : ('offline' as const),
     is_default: true,
-    device_type: 'local',
+    device_type: 'local' as const,
     capabilities: ['runtime-work', 'device-commands'],
     slot_used: 0,
     slot_max: 5,
@@ -95,9 +122,10 @@ function localDeviceFromStatus(status: LocalExecutorStatus): DeviceInfo {
     latest_version: null,
     update_available: false,
     error: status.error ?? null,
-    bind_shell: 'claudecode',
+    bind_shell: 'claudecode' as const,
     runtime_transfer_host: null,
   }
+  return device
 }
 
 function localDeviceIdFromStatus(status: LocalExecutorStatus | null | undefined): string {
@@ -609,13 +637,16 @@ function createRuntimeWorkApi(
   request: <T>(method: string, params?: Record<string, unknown>) => Promise<T>,
   getLocalDeviceId: () => Promise<string>
 ) {
-  const normalizeRequest = async <T extends Record<string, unknown>>(data: T): Promise<T> =>
-    normalizeLocalDeviceRecord(data, await getLocalDeviceId())
+  const normalizeRequest = async <T extends object>(
+    data: T
+  ): Promise<T & Record<string, unknown>> =>
+    normalizeLocalDeviceRecord(data as Record<string, unknown>, await getLocalDeviceId()) as T &
+      Record<string, unknown>
 
-  const requestWithLocalDevice = async <T>(
+  const requestWithLocalDevice = async <TResponse, TRequest extends object>(
     method: string,
-    data: Record<string, unknown>
-  ): Promise<T> => request(method, await normalizeRequest(data))
+    data: TRequest
+  ): Promise<TResponse> => request(method, await normalizeRequest(data))
 
   return {
     async listRuntimeWork(): Promise<RuntimeWorkListResponse> {
@@ -625,31 +656,41 @@ function createRuntimeWorkApi(
     upsertDeviceWorkspace() {
       return cloudConnectionRequired('upsertDeviceWorkspace')
     },
-    prepareDeviceWorkspace(data: Record<string, unknown>) {
+    prepareDeviceWorkspace(
+      data: DeviceWorkspacePrepareRequest
+    ): Promise<DeviceWorkspacePrepareResponse> {
       return requestWithLocalDevice('runtime.workspaces.prepare', data)
     },
-    deleteDeviceWorkspace(data: Record<string, unknown>) {
+    deleteDeviceWorkspace(
+      data: DeleteDeviceWorkspaceRequest
+    ): Promise<DeleteDeviceWorkspaceResponse> {
       return requestWithLocalDevice('runtime.workspaces.delete', data)
     },
-    getRuntimeTranscript(data: Record<string, unknown>) {
+    getRuntimeTranscript(data: RuntimeTranscriptRequest): Promise<RuntimeTranscriptResponse> {
       return requestWithLocalDevice('runtime.tasks.transcript', data)
     },
-    searchRuntimeWork(data: Record<string, unknown>) {
+    searchRuntimeWork(data: RuntimeWorkSearchRequest): Promise<RuntimeWorkSearchResponse> {
       return requestWithLocalDevice('runtime.tasks.search', data)
     },
-    revertRuntimeFileChanges(data: Record<string, unknown>) {
+    revertRuntimeFileChanges(
+      data: RuntimeFileChangesRevertRequest
+    ): Promise<RuntimeFileChangesRevertResponse> {
       return requestWithLocalDevice('runtime.tasks.revert_file_changes', data)
     },
-    sendRuntimeMessage(data: Record<string, unknown>) {
+    sendRuntimeMessage(data: RuntimeSendRequest): Promise<RuntimeSendResponse> {
       return requestWithLocalDevice('runtime.tasks.send', data)
     },
-    openRuntimeWorkspace(data: Record<string, unknown>) {
+    openRuntimeWorkspace(data: RuntimeWorkspaceOpenRequest): Promise<RuntimeWorkspaceOpenResponse> {
       return requestWithLocalDevice('runtime.workspaces.open', data)
     },
-    renameRuntimeWorkspace(data: Record<string, unknown>) {
+    renameRuntimeWorkspace(
+      data: RuntimeWorkspaceRenameRequest
+    ): Promise<RuntimeWorkspaceOpenResponse> {
       return requestWithLocalDevice('runtime.workspaces.rename', data)
     },
-    removeRuntimeWorkspace(data: Record<string, unknown>) {
+    removeRuntimeWorkspace(
+      data: RuntimeWorkspaceRemoveRequest
+    ): Promise<RuntimeWorkspaceOpenResponse> {
       return requestWithLocalDevice('runtime.workspaces.remove', data)
     },
     bindRuntimeTaskImSessions() {
@@ -670,61 +711,59 @@ function createRuntimeWorkApi(
     unsubscribeRuntimeTaskNotifications(address: RuntimeTaskAddress) {
       return Promise.resolve({ address, subscribed: false, sessionKeys: [] })
     },
-    archiveRuntimeTask(data: RuntimeTaskAddress) {
-      return requestWithLocalDevice(
-        'runtime.tasks.archive',
-        data as unknown as Record<string, unknown>
-      )
+    archiveRuntimeTask(data: RuntimeTaskAddress): Promise<RuntimeTaskArchiveResponse> {
+      return requestWithLocalDevice('runtime.tasks.archive', data)
     },
-    renameRuntimeTask(data: Record<string, unknown>) {
+    renameRuntimeTask(data: RuntimeTaskRenameRequest): Promise<RuntimeTaskArchiveResponse> {
       return requestWithLocalDevice('runtime.tasks.rename', data)
     },
-    listArchivedConversations(data: Record<string, unknown> = {}) {
+    listArchivedConversations(
+      data: ArchivedConversationsListRequest = {}
+    ): Promise<ArchivedConversationsListResponse> {
       return requestWithLocalDevice('runtime.archived_conversations.list', data)
     },
-    archiveConversation(data: RuntimeTaskAddress) {
-      return requestWithLocalDevice(
-        'runtime.tasks.archive',
-        data as unknown as Record<string, unknown>
-      )
+    archiveConversation(data: RuntimeTaskAddress): Promise<RuntimeTaskArchiveResponse> {
+      return requestWithLocalDevice('runtime.tasks.archive', data)
     },
-    archiveProjectConversations(data: Record<string, unknown>) {
+    archiveProjectConversations(
+      data: RuntimeArchiveProjectConversationsRequest
+    ): Promise<RuntimeArchivedConversationBulkResponse> {
       return requestWithLocalDevice('runtime.archived_conversations.archive_project', data)
     },
-    archiveAllConversations() {
+    archiveAllConversations(): Promise<RuntimeArchivedConversationBulkResponse> {
       return request('runtime.archived_conversations.archive_all', {})
     },
-    unarchiveConversation(data: RuntimeTaskAddress) {
-      return requestWithLocalDevice(
-        'runtime.archived_conversations.unarchive',
-        data as unknown as Record<string, unknown>
-      )
+    unarchiveConversation(data: RuntimeTaskAddress): Promise<RuntimeTaskArchiveResponse> {
+      return requestWithLocalDevice('runtime.archived_conversations.unarchive', data)
     },
-    deleteArchivedConversation(data: RuntimeTaskAddress) {
-      return requestWithLocalDevice(
-        'runtime.archived_conversations.delete',
-        data as unknown as Record<string, unknown>
-      )
+    deleteArchivedConversation(data: RuntimeTaskAddress): Promise<RuntimeTaskArchiveResponse> {
+      return requestWithLocalDevice('runtime.archived_conversations.delete', data)
     },
-    deleteArchivedConversationsBulk(data: Record<string, unknown>) {
+    deleteArchivedConversationsBulk(
+      data: RuntimeArchivedConversationBulkRequest
+    ): Promise<RuntimeArchivedConversationBulkResponse> {
       return requestWithLocalDevice('runtime.archived_conversations.delete_bulk', data)
     },
-    cancelRuntimeTask(data: RuntimeTaskAddress) {
-      return requestWithLocalDevice(
-        'runtime.tasks.cancel',
-        data as unknown as Record<string, unknown>
-      )
+    cancelRuntimeTask(data: RuntimeTaskAddress): Promise<RuntimeTaskCancelResponse> {
+      return requestWithLocalDevice('runtime.tasks.cancel', data)
     },
-    async createRuntimeTask(data: RuntimeTaskCreateRequest) {
+    async createRuntimeTask(data: RuntimeTaskCreateRequest): Promise<RuntimeTaskCreateResponse> {
       const localDeviceId = await getLocalDeviceId()
       const payload = createLocalRuntimeTaskPayload(data, localDeviceId)
-      const response = await request<Record<string, unknown>>('runtime.tasks.create', payload)
+      const response = await request<Partial<RuntimeTaskCreateResponse>>(
+        'runtime.tasks.create',
+        payload
+      )
       return {
         ...response,
+        accepted: response.accepted ?? true,
         deviceId: localDeviceId,
+        localTaskId: response.localTaskId ?? data.localTaskId ?? '',
+        workspacePath: response.workspacePath ?? requiredRuntimeWorkspacePath(data),
+        runtime: response.runtime ?? data.runtime,
       }
     },
-    forkRuntimeTask(data: Record<string, unknown>) {
+    forkRuntimeTask(data: RuntimeTaskForkRequest): Promise<RuntimeTaskForkResponse> {
       return requestWithLocalDevice('runtime.tasks.import_fork', data)
     },
   }

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import { FileText, Link2 } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import {
+  classifyMarkdownLink,
+  getAuthenticatedImageFetchUrl,
+  isAuthenticatedAttachmentImageSrc,
+  resolveDirectMarkdownImageSrc,
+  type MarkdownLinkTarget,
+} from './assistantMarkdownLinks'
+import { MarkdownCodeBlock } from './MarkdownCodeBlock'
+
+const ASSISTANT_MARKDOWN_LINK_CLASS = [
+  'inline-flex max-w-full items-center gap-1 rounded-md px-0.5 align-baseline',
+  'text-[13px] font-medium leading-5 text-blue-600 no-underline',
+  'transition-colors hover:text-blue-700',
+  'dark:text-blue-300 dark:hover:text-blue-200',
+].join(' ')
+
+interface AssistantMarkdownProps {
+  content: string
+  onOpenFile?: (path: string) => void
+}
+
+export function AssistantMarkdown({ content, onOpenFile }: AssistantMarkdownProps) {
+  return (
+    <div className="assistant-markdown min-w-0 overflow-x-hidden break-words">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          h1: ({ children }) => <h1 className="mb-4 mt-6 text-lg font-semibold">{children}</h1>,
+          h2: ({ children }) => <h2 className="mb-3 mt-5 text-base font-semibold">{children}</h2>,
+          h3: ({ children }) => <h3 className="mb-2 mt-4 text-sm font-semibold">{children}</h3>,
+          p: ({ children }) => <p className="mb-3 min-w-0 break-words leading-6">{children}</p>,
+          ul: ({ children }) => <ul className="mb-3 list-disc space-y-1.5 pl-5">{children}</ul>,
+          ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1.5 pl-8">{children}</ol>,
+          li: ({ children }) => <li className="min-w-0 break-words pl-1 leading-6">{children}</li>,
+          strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+          code: ({ className, children }) => {
+            const match = /language-(\w*)/.exec(className || '')
+            const isBlock = Boolean(match) || String(children).includes('\n')
+            if (isBlock) {
+              const lang = match ? match[1] || '' : ''
+              return <MarkdownCodeBlock lang={lang}>{children}</MarkdownCodeBlock>
+            }
+            return (
+              <code className="break-words rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-text-primary">
+                {children}
+              </code>
+            )
+          },
+          pre: ({ children }) => <>{children}</>,
+          blockquote: ({ children }) => (
+            <blockquote className="mb-3 border-l-3 border-border pl-4 text-text-secondary">
+              {children}
+            </blockquote>
+          ),
+          table: ({ children }) => (
+            <div className="mb-3 max-w-full overflow-x-auto">
+              <table className="w-full min-w-max border-collapse text-[13px]">{children}</table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th className="border-b border-border px-3 py-2 text-left font-semibold">{children}</th>
+          ),
+          td: ({ children }) => <td className="border-b border-border px-3 py-2">{children}</td>,
+          a: ({ href, children }) => (
+            <AssistantMarkdownLink href={href} onOpenFile={onOpenFile}>
+              {children}
+            </AssistantMarkdownLink>
+          ),
+          img: ({ src, alt }) => <AssistantMarkdownImage src={src} alt={alt} />,
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}
+
+function formatMarkdownLineLabel(target: Extract<MarkdownLinkTarget, { kind: 'file' }>): string {
+  if (typeof target.lineStart !== 'number') return ''
+  if (typeof target.lineEnd === 'number' && target.lineEnd !== target.lineStart) {
+    return `lines ${target.lineStart}-${target.lineEnd}`
+  }
+  return `line ${target.lineStart}`
+}
+
+function formatMarkdownFileTooltip(target: Extract<MarkdownLinkTarget, { kind: 'file' }>): string {
+  const lineLabel = formatMarkdownLineLabel(target)
+  return lineLabel ? `${target.path} (${lineLabel})` : target.path
+}
+
+function AssistantMarkdownLink({
+  href,
+  onOpenFile,
+  children,
+}: {
+  href?: string
+  onOpenFile?: (path: string) => void
+  children?: ReactNode
+}) {
+  const target = classifyMarkdownLink(href)
+  const LinkIcon = target.kind === 'file' ? FileText : Link2
+  const icon = (
+    <LinkIcon
+      aria-hidden="true"
+      className="h-3.5 w-3.5 shrink-0"
+      data-testid="assistant-markdown-link-icon"
+    />
+  )
+
+  if (target.kind === 'file') {
+    const filePath = target.path
+    const lineLabel = formatMarkdownLineLabel(target)
+    const tooltip = formatMarkdownFileTooltip(target)
+    return (
+      <button
+        type="button"
+        className={`${ASSISTANT_MARKDOWN_LINK_CLASS} group/file-link relative`}
+        data-testid="assistant-markdown-link"
+        onClick={() => onOpenFile?.(filePath)}
+        aria-label={tooltip}
+      >
+        {icon}
+        {children}
+        {lineLabel ? (
+          <span className="shrink-0" data-testid="assistant-markdown-link-line">
+            ({lineLabel})
+          </span>
+        ) : null}
+        <span
+          data-testid="assistant-markdown-link-tooltip"
+          className="pointer-events-none absolute bottom-full left-0 z-30 mb-1 hidden w-max max-w-[min(36rem,calc(100vw-3rem))] whitespace-normal break-all rounded-xl border border-white/10 bg-[#2f2f2f] px-3 py-2 text-left text-[13px] font-normal leading-5 text-white shadow-lg group-hover/file-link:block group-focus-visible/file-link:block"
+        >
+          {tooltip}
+        </span>
+      </button>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      className={ASSISTANT_MARKDOWN_LINK_CLASS}
+      target="_blank"
+      rel="noopener noreferrer"
+      data-testid="assistant-markdown-link"
+    >
+      {icon}
+      {children}
+    </a>
+  )
+}
+
+function AssistantMarkdownImage({ src, alt }: { src?: string; alt?: string }) {
+  const rawSrc = typeof src === 'string' ? src.trim() : ''
+  const [authenticatedPreview, setAuthenticatedPreview] = useState<{
+    rawSrc: string
+    url: string
+  } | null>(null)
+  const [failedSrc, setFailedSrc] = useState<string | null>(null)
+  const isAuthenticatedSrc = rawSrc ? isAuthenticatedAttachmentImageSrc(rawSrc) : false
+  const resolvedSrc = isAuthenticatedSrc
+    ? authenticatedPreview?.rawSrc === rawSrc
+      ? authenticatedPreview.url
+      : null
+    : rawSrc
+      ? resolveDirectMarkdownImageSrc(rawSrc)
+      : null
+  const hasError = failedSrc === rawSrc
+
+  useEffect(() => {
+    let objectUrl: string | null = null
+    let isMounted = true
+
+    if (!rawSrc || !isAuthenticatedSrc) {
+      return () => {
+        isMounted = false
+      }
+    }
+
+    async function loadAuthenticatedImage() {
+      try {
+        const token = localStorage.getItem('auth_token')
+        const response = await fetch(getAuthenticatedImageFetchUrl(rawSrc), {
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        })
+
+        if (!response.ok) {
+          throw new Error(`Failed to load markdown image: ${response.status}`)
+        }
+
+        const blob = await response.blob()
+        if (!blob.type.startsWith('image/')) {
+          throw new Error(`Markdown image response is not an image: ${blob.type || 'unknown'}`)
+        }
+
+        objectUrl = URL.createObjectURL(blob)
+        if (isMounted) {
+          setAuthenticatedPreview({ rawSrc, url: objectUrl })
+        } else {
+          URL.revokeObjectURL(objectUrl)
+        }
+      } catch {
+        if (isMounted) {
+          setFailedSrc(rawSrc)
+        }
+      }
+    }
+
+    void loadAuthenticatedImage()
+
+    return () => {
+      isMounted = false
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [isAuthenticatedSrc, rawSrc])
+
+  if (hasError) {
+    return (
+      <span
+        data-testid="assistant-markdown-image-error"
+        className="my-2 inline-flex max-w-full rounded-xl border border-border bg-surface px-3 py-2 text-xs text-text-muted"
+      >
+        {alt || rawSrc}
+      </span>
+    )
+  }
+
+  if (!resolvedSrc) {
+    return (
+      <span
+        data-testid="assistant-markdown-image-loading"
+        className="my-2 inline-flex h-20 w-32 max-w-full items-center justify-center rounded-xl border border-border bg-surface text-xs text-text-muted"
+      >
+        {alt || 'Image'}
+      </span>
+    )
+  }
+
+  return (
+    <img
+      data-testid="assistant-markdown-image"
+      src={resolvedSrc}
+      alt={alt || ''}
+      className="my-2 block max-h-[360px] max-w-full rounded-xl border border-border bg-base object-contain"
+      loading="lazy"
+    />
+  )
+}

--- a/wework/src/components/chat/CodexTurnArtifacts.tsx
+++ b/wework/src/components/chat/CodexTurnArtifacts.tsx
@@ -1,0 +1,209 @@
+import { useState } from 'react'
+import { Archive, Box, ChevronDown, FileText } from 'lucide-react'
+import { useTranslation } from '@/hooks/useTranslation'
+import type {
+  CodexContextEvent,
+  CodexMemoryCitation,
+  CodexMemoryCitationEntry,
+  CodexReference,
+} from '@/types/api'
+import { basename, fileExtension, getDisplayCodexReferences } from './codexReferences'
+
+export function CodexContextEvents({ events }: { events: CodexContextEvent[] }) {
+  const { t } = useTranslation('chat')
+  const visibleEvents = events.filter(event => isContextCompactionEvent(event))
+  if (visibleEvents.length === 0) return null
+
+  return (
+    <div className="my-4 flex min-w-0 flex-col gap-2" data-testid="codex-context-events">
+      {visibleEvents.map(event => {
+        const isRunning = event.status === 'pending' || event.status === 'streaming'
+        return (
+          <div key={event.id} className="flex min-w-0 items-center gap-3 text-xs text-text-muted">
+            <span className="h-px min-w-6 flex-1 bg-border" />
+            <span className="inline-flex min-w-0 items-center gap-1.5">
+              <Archive className="h-3.5 w-3.5 shrink-0" strokeWidth={1.8} />
+              <span className="truncate">
+                {isRunning ? t('codex_context.compacting') : t('codex_context.compacted')}
+              </span>
+            </span>
+            <span className="h-px min-w-6 flex-1 bg-border" />
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export function CodexMemoryCitations({
+  citations,
+  onOpenFile,
+}: {
+  citations: CodexMemoryCitation[]
+  onOpenFile?: (path: string) => void
+}) {
+  const { t } = useTranslation('chat')
+  const [expanded, setExpanded] = useState(false)
+  const entries = citations.flatMap(citation => citation.entries ?? [])
+  if (entries.length === 0) return null
+
+  return (
+    <section className="mt-3 min-w-0 text-[13px]" data-testid="codex-memory-citations">
+      <button
+        type="button"
+        data-testid="codex-memory-citations-toggle"
+        aria-expanded={expanded}
+        onClick={() => setExpanded(value => !value)}
+        className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"
+      >
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
+          strokeWidth={2}
+        />
+        <span className="min-w-0 truncate">
+          {t('memory_citations.summary', { count: entries.length })}
+        </span>
+      </button>
+      {expanded && (
+        <div className="mt-4 flex min-w-0 flex-col gap-2 pl-5">
+          {entries.map((entry, index) => (
+            <MemoryCitationEntryRow
+              key={`${entry.path}:${index}`}
+              entry={entry}
+              onOpenFile={onOpenFile}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function CodexReferenceList({
+  references,
+  onOpenFile,
+}: {
+  references: CodexReference[]
+  onOpenFile: (path: string) => void
+}) {
+  const { t } = useTranslation('chat')
+  const uniqueReferences = getDisplayCodexReferences(references).slice(0, 6)
+  if (uniqueReferences.length === 0) return null
+
+  return (
+    <section
+      className="mt-3 min-w-0"
+      data-testid="codex-reference-list"
+      aria-label={t('codex_references.title')}
+    >
+      <div className="min-w-0 overflow-hidden rounded-xl border border-border bg-surface">
+        {uniqueReferences.map(reference => (
+          <button
+            type="button"
+            key={reference.path}
+            data-testid="codex-reference-card"
+            onClick={() => onOpenFile(reference.path)}
+            className="group/reference-card flex w-full min-w-0 items-center gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-muted"
+            aria-label={t('codex_references.open_label', { path: reference.path })}
+          >
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-base text-text-secondary">
+              <ReferenceFileIcon path={reference.path} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[13px] font-semibold text-text-primary">
+                {basename(reference.path)}
+              </span>
+              <span className="relative block h-5 truncate text-xs leading-5 text-text-secondary">
+                <span
+                  data-testid="codex-reference-kind-label"
+                  className="block truncate transition-opacity group-hover/reference-card:opacity-0 group-focus-visible/reference-card:opacity-0"
+                >
+                  {formatReferenceKind(reference.path, t)}
+                </span>
+                <span
+                  data-testid="codex-reference-preview-label"
+                  className="absolute inset-0 block truncate opacity-0 transition-opacity group-hover/reference-card:opacity-100 group-focus-visible/reference-card:opacity-100"
+                >
+                  {t('codex_references.preview_label')}
+                </span>
+              </span>
+            </span>
+            <span className="hidden shrink-0 items-center gap-1 rounded-lg border border-border bg-base px-3 py-1.5 text-xs text-text-secondary sm:inline-flex">
+              {t('codex_references.open_with')}
+              <ChevronDown className="h-3.5 w-3.5" strokeWidth={2} />
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ReferenceFileIcon({ path }: { path: string }) {
+  const extension = fileExtension(path)
+  if (extension === 'md' || extension === 'markdown') {
+    return <FileText className="h-5 w-5" strokeWidth={1.8} />
+  }
+
+  return <Box className="h-5 w-5" strokeWidth={1.8} />
+}
+
+function formatReferenceKind(
+  path: string,
+  t: (key: string, options?: Record<string, string>) => string
+) {
+  const extension = fileExtension(path)
+  if (!extension) return t('codex_references.kind')
+  return t('codex_references.kind_with_extension', { extension: extension.toUpperCase() })
+}
+
+function isContextCompactionEvent(event: CodexContextEvent): boolean {
+  const type = event.type.toLowerCase().replace(/[_-]/g, '')
+  return type === 'contextcompaction'
+}
+
+function MemoryCitationEntryRow({
+  entry,
+  onOpenFile,
+}: {
+  entry: CodexMemoryCitationEntry
+  onOpenFile?: (path: string) => void
+}) {
+  const { t } = useTranslation('chat')
+  const lineStart = entry.lineStart ?? entry.line_start
+  const lineEnd = entry.lineEnd ?? entry.line_end
+  const lineRange =
+    typeof lineStart === 'number'
+      ? lineEnd && lineEnd !== lineStart
+        ? `${lineStart}-${lineEnd}`
+        : String(lineStart)
+      : ''
+  const filename = basename(entry.path)
+
+  return (
+    <button
+      type="button"
+      className="group/memory-entry relative block w-full min-w-0 rounded-lg px-2 py-1 text-left text-[13px] leading-6 transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 disabled:cursor-default disabled:hover:bg-transparent"
+      data-testid="codex-memory-citation-entry"
+      onClick={() => onOpenFile?.(entry.path)}
+      disabled={!onOpenFile}
+      aria-label={t('memory_citations.open_label', { path: entry.path })}
+    >
+      <span className="block truncate text-text-primary">
+        <span className="font-mono">{entry.path}</span>
+        {lineRange ? (
+          <span className="ml-2 text-text-muted">
+            {t('memory_citations.line_label', { range: lineRange })}
+          </span>
+        ) : null}
+      </span>
+      {entry.note ? <span className="block break-words text-text-muted">{entry.note}</span> : null}
+      <span
+        data-testid="codex-memory-citation-tooltip"
+        className="pointer-events-none absolute bottom-full left-1/2 z-30 mb-1 hidden max-w-[min(28rem,calc(100vw-3rem))] -translate-x-1/2 whitespace-normal break-all rounded-xl border border-white/10 bg-[#2f2f2f] px-3 py-2 text-[13px] font-normal leading-5 text-white shadow-lg group-hover/memory-entry:block group-focus-visible/memory-entry:block"
+      >
+        {filename}
+      </span>
+    </button>
+  )
+}

--- a/wework/src/components/chat/FileChangesCard.test.tsx
+++ b/wework/src/components/chat/FileChangesCard.test.tsx
@@ -1,5 +1,5 @@
 import '@/i18n'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, test, vi } from 'vitest'
 import type { TurnFileChangesSummary } from '@/types/api'
@@ -65,14 +65,159 @@ describe('FileChangesCard', () => {
   test('shows summary and expands files after the first three', async () => {
     renderCard()
 
-    expect(screen.getByText('已编辑 6 个文件')).toBeInTheDocument()
-    expect(screen.getByText('+107')).toBeInTheDocument()
-    expect(screen.getByText('-121')).toBeInTheDocument()
+    expect(screen.getByTestId('file-changes-summary-title')).toHaveTextContent('已编辑 6 个文件')
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('+107')
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('-121')
     expect(screen.getAllByTestId('file-change-row')).toHaveLength(3)
+    expect(screen.getByText('src/file-1.ts')).toBeInTheDocument()
+    expect(screen.getAllByTestId('file-change-view-label')[0]).toHaveTextContent('查看更改')
+    expect(screen.getAllByTestId('file-change-stats-label')[0]).toHaveClass(
+      'group-hover/file-change-trigger:hidden'
+    )
+    expect(screen.getAllByTestId('file-change-view-label')[0]).toHaveClass(
+      'hidden',
+      'group-hover/file-change-trigger:flex'
+    )
+    expect(screen.getByText('+1')).toBeInTheDocument()
+    expect(screen.getByText('-0')).toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('toggle-file-changes-button'))
 
     expect(screen.getAllByTestId('file-change-row')).toHaveLength(6)
+    expect(screen.getByTestId('toggle-file-changes-button')).toHaveTextContent('收起文件')
+  })
+
+  test('opens a delayed diff preview from the changed file hover target', () => {
+    vi.useFakeTimers()
+    try {
+      renderCard({
+        summary: {
+          ...summary,
+          file_count: 1,
+          additions: 3,
+          deletions: 0,
+          files: [
+            {
+              path: 'references/github-pr-flow.md',
+              change_type: 'modified',
+              additions: 3,
+              deletions: 0,
+              binary: false,
+            },
+          ],
+          diff: [
+            '@@ -24,2 +24,4 @@',
+            ' 2. Capture the PR URL and PR number for later notification.',
+            '+3. After the PR is created, check whether it has merge conflicts before waiting for checks.',
+            '+4. If the PR has merge conflicts, update the task branch from the latest base branch.',
+            ' ',
+            '@@ -42,2 +44,3 @@',
+            ' gh pr create',
+            '+gh pr view <pr-url-or-number> --json mergeable,mergeStateStatus,state,url',
+            ' gh pr checks <pr-url> --watch',
+          ].join('\n'),
+        },
+      })
+
+      fireEvent.pointerEnter(screen.getByTestId('file-change-trigger'))
+      act(() => vi.advanceTimersByTime(499))
+      expect(screen.queryByTestId('file-change-diff-preview')).not.toBeInTheDocument()
+
+      act(() => vi.advanceTimersByTime(1))
+      const preview = screen.getByTestId('file-change-diff-preview')
+      expect(preview).toHaveAttribute('data-placement', 'below')
+      expect(preview).toHaveClass('fixed', 'z-[9999]', 'pointer-events-auto', 'select-text')
+      expect(preview).not.toHaveClass('pointer-events-none')
+      expect(preview).toHaveTextContent('github-pr-flow.md')
+      expect(preview.firstElementChild).not.toHaveTextContent('references/')
+      expect(preview).toHaveTextContent('+3')
+      expect(preview).toHaveTextContent('-0')
+      expect(preview).toHaveTextContent('After the PR is created')
+      expect(preview).toHaveTextContent('gh pr view <pr-url-or-number>')
+
+      fireEvent.pointerLeave(screen.getByTestId('file-change-trigger'))
+      expect(screen.getByTestId('file-change-diff-preview')).toBeInTheDocument()
+
+      fireEvent.pointerEnter(preview)
+      act(() => vi.advanceTimersByTime(140))
+      expect(screen.getByTestId('file-change-diff-preview')).toBeInTheDocument()
+
+      fireEvent.pointerLeave(preview)
+      act(() => vi.advanceTimersByTime(139))
+      expect(screen.getByTestId('file-change-diff-preview')).toBeInTheDocument()
+
+      act(() => vi.advanceTimersByTime(1))
+      expect(screen.queryByTestId('file-change-diff-preview')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('shows only the file name in the diff preview header for absolute paths', () => {
+    vi.useFakeTimers()
+    try {
+      renderCard({
+        summary: {
+          ...summary,
+          file_count: 1,
+          additions: 3,
+          deletions: 0,
+          files: [
+            {
+              path: '/Users/crystal/dev/git/if/skills/wegent-dev/SKILL.md',
+              change_type: 'modified',
+              additions: 3,
+              deletions: 0,
+              binary: false,
+            },
+          ],
+          diff: [
+            '@@ -43,2 +43,3 @@',
+            ' Previous line',
+            '+After creating the PR, check for merge conflicts and resolve them before waiting.',
+            ' Next line',
+          ].join('\n'),
+        },
+      })
+
+      fireEvent.pointerEnter(screen.getByTestId('file-change-trigger'))
+      act(() => vi.advanceTimersByTime(500))
+
+      const previewHeader = screen.getByTestId('file-change-diff-preview').firstElementChild
+      expect(previewHeader).toHaveTextContent('SKILL.md')
+      expect(previewHeader).not.toHaveTextContent('/Users/crystal/dev/git')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('makes the single-file change summary area open the review panel', () => {
+    const { onOpenReview } = renderCard({
+      summary: {
+        ...summary,
+        file_count: 1,
+        additions: 2,
+        deletions: 0,
+        files: [
+          {
+            path: 'SKILL.md',
+            change_type: 'modified',
+            additions: 2,
+            deletions: 0,
+            binary: false,
+          },
+        ],
+      },
+    })
+
+    const summaryButton = screen.getByRole('button', {
+      name: /SKILL\.md/,
+    })
+    expect(summaryButton).toHaveClass('h-full', 'w-full')
+
+    fireEvent.click(summaryButton)
+    expect(onOpenReview).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(onOpenReview).mock.calls[0][0].focusFilePath).toBe('SKILL.md')
   })
 
   test('renders file rows instead of inline diff preview when summary contains a diff', () => {
@@ -123,15 +268,75 @@ describe('FileChangesCard', () => {
     expect(
       screen.getByText('wework/src/components/layout/MobileWorkbenchLayout.tsx')
     ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', {
+        name: /wework\/src\/components\/layout\/DesktopWorkbenchMain\.tsx/,
+      })
+    ).toBeInTheDocument()
     expect(screen.queryByText('-const name = "old"')).not.toBeInTheDocument()
     expect(screen.queryByText('+const mobile = "new"')).not.toBeInTheDocument()
+  })
+
+  test('opens a delayed diff preview from a file row in a multi-file summary', () => {
+    vi.useFakeTimers()
+    try {
+      renderCard({
+        summary: {
+          ...summary,
+          file_count: 2,
+          additions: 6,
+          deletions: 4,
+          files: [
+            {
+              path: 'wework/src/components/layout/DesktopWorkbenchMain.tsx',
+              change_type: 'modified',
+              additions: 3,
+              deletions: 2,
+              binary: false,
+            },
+            {
+              path: 'scripts/notify_pr_ready.sh',
+              change_type: 'modified',
+              additions: 3,
+              deletions: 2,
+              binary: false,
+            },
+          ],
+          diff: [
+            'diff --git a/wework/src/components/layout/DesktopWorkbenchMain.tsx b/wework/src/components/layout/DesktopWorkbenchMain.tsx',
+            '--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx',
+            '+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx',
+            '@@ -1 +1 @@',
+            '-const name = "old"',
+            '+const name = "new"',
+            'diff --git a/scripts/notify_pr_ready.sh b/scripts/notify_pr_ready.sh',
+            '--- a/scripts/notify_pr_ready.sh',
+            '+++ b/scripts/notify_pr_ready.sh',
+            '@@ -8 +8 @@',
+            '-old notify command',
+            '+new notify command',
+          ].join('\n'),
+        },
+      })
+
+      fireEvent.pointerEnter(screen.getAllByTestId('file-change-trigger')[1])
+      act(() => vi.advanceTimersByTime(500))
+
+      const preview = screen.getByTestId('file-change-diff-preview')
+      expect(preview).toHaveTextContent('notify_pr_ready.sh')
+      expect(preview).toHaveTextContent('old notify command')
+      expect(preview).toHaveTextContent('new notify command')
+      expect(preview).not.toHaveTextContent('DesktopWorkbenchMain.tsx')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('requests the right review panel without loading diff immediately', async () => {
     const { onLoadDiff, onOpenReview } = renderCard()
 
     expect(onLoadDiff).not.toHaveBeenCalled()
-    await userEvent.click(screen.getByTestId('review-file-changes-button'))
+    await userEvent.click(screen.getAllByTestId('review-file-changes-button')[0])
 
     expect(onOpenReview).toHaveBeenCalledTimes(1)
     const request = vi.mocked(onOpenReview).mock.calls[0][0]
@@ -168,7 +373,7 @@ describe('FileChangesCard', () => {
         ),
     })
 
-    await userEvent.click(screen.getAllByTestId('file-change-row')[1])
+    await userEvent.click(screen.getByRole('button', { name: /src\/file-2\.ts/ }))
 
     expect(onOpenReview).toHaveBeenCalledTimes(1)
     const request = vi.mocked(onOpenReview).mock.calls[0][0]
@@ -185,19 +390,25 @@ describe('FileChangesCard', () => {
   test('disables review and revert while the owning device is offline', () => {
     renderCard({ deviceOnline: false })
 
-    expect(screen.getByTestId('review-file-changes-button')).toBeDisabled()
-    expect(screen.getByTestId('revert-file-changes-button')).toBeDisabled()
+    expect(screen.getAllByTestId('review-file-changes-button')[0]).toBeDisabled()
+    expect(screen.getAllByTestId('revert-file-changes-button')[0]).toBeDisabled()
     expect(screen.getByText('设备离线，无法审核或撤销')).toBeInTheDocument()
   })
 
-  test('confirms before reverting', async () => {
+  test('keeps the revert action visible but disabled while revert is unsupported', async () => {
     const { onRevert } = renderCard()
+    const revertButton = screen.getAllByTestId('revert-file-changes-button')[0]
 
-    await userEvent.click(screen.getByTestId('revert-file-changes-button'))
+    expect(revertButton).toBeDisabled()
+    await userEvent.click(revertButton)
     expect(onRevert).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('confirm-revert-file-changes-button')).not.toBeInTheDocument()
+  })
 
-    await userEvent.click(screen.getByTestId('confirm-revert-file-changes-button'))
-    await waitFor(() => expect(onRevert).toHaveBeenCalledWith(21))
+  test('keeps the revert action visible but disabled when active changes are not revertible', () => {
+    renderCard({ summary: { ...summary, revertible: false } })
+
+    expect(screen.getAllByTestId('revert-file-changes-button')[0]).toBeDisabled()
   })
 
   test('shows status without a revert action after a successful revert', () => {
@@ -212,7 +423,7 @@ describe('FileChangesCard', () => {
     renderCard({ summary: { ...summary, status: 'conflicted' } })
 
     expect(screen.getByText('存在后续冲突，未修改工作区')).toBeInTheDocument()
-    expect(screen.getByTestId('review-file-changes-button')).toBeEnabled()
+    expect(screen.getAllByTestId('review-file-changes-button')[0]).toBeEnabled()
     expect(screen.queryByTestId('revert-file-changes-button')).not.toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/FileChangesCard.tsx
+++ b/wework/src/components/chat/FileChangesCard.tsx
@@ -1,13 +1,21 @@
-import { Check, ChevronDown, ChevronUp, FileDiff, RotateCcw, X } from 'lucide-react'
-import { useState } from 'react'
+import { ArrowUpRight, Check, ChevronDown, ChevronUp, FileDiff, Undo2, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { ApiError } from '@/api/http'
 import { Button } from '@/components/ui/button'
 import { useEscapeKey } from '@/hooks/useEscapeKey'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
+import { parseUnifiedDiff } from './parseUnifiedDiff'
 
 const DEFAULT_VISIBLE_FILE_COUNT = 3
+const DIFF_PREVIEW_CLOSE_DELAY_MS = 140
+const DIFF_PREVIEW_DELAY_MS = 500
+const DIFF_PREVIEW_ESTIMATED_HEIGHT = 340
+const DIFF_PREVIEW_MAX_LINES = 14
+const DIFF_PREVIEW_MAX_WIDTH = 704
+const DIFF_PREVIEW_VIEWPORT_GUTTER = 32
+const DIFF_PREVIEW_VERTICAL_GAP = 8
 
 interface FileChangesCardProps {
   subtaskId: number
@@ -31,37 +39,514 @@ function getErrorMessage(error: unknown, fallback: string) {
 
 function FileChangeRow({
   file,
+  summary,
   disabled,
   onPreview,
 }: {
   file: TurnFileChangeItem
+  summary: TurnFileChangesSummary
   disabled: boolean
   onPreview: () => void
 }) {
   const { t } = useTranslation('chat')
   const displayPath =
     file.change_type === 'renamed' && file.old_path ? `${file.old_path} → ${file.path}` : file.path
+  const diffPreview = buildFileDiffPreview(file, summary)
+  const {
+    close: closeDiffPreview,
+    keepOpen: keepDiffPreviewOpen,
+    openAfterDelay: openDiffPreviewAfterDelay,
+    placement: diffPreviewPlacement,
+    position: diffPreviewPosition,
+    previewOpen: diffPreviewOpen,
+    triggerRef: diffPreviewTriggerRef,
+  } = useDelayedDiffPreview(diffPreview)
 
   return (
-    <button
-      type="button"
+    <div
       data-testid="file-change-row"
-      disabled={disabled}
-      onClick={onPreview}
-      className="flex w-full min-w-0 items-center gap-2 px-3 py-1.5 text-left text-xs hover:bg-muted disabled:cursor-not-allowed disabled:hover:bg-transparent"
-      aria-label={t('file_changes.preview_file_label', { path: displayPath })}
+      className="group/file-change-row flex min-w-0 items-center px-4 py-2.5 transition-colors hover:bg-muted"
     >
-      <span className="min-w-0 flex-1 truncate font-mono text-text-primary">{displayPath}</span>
-      {file.binary ? (
-        <span className="shrink-0 text-text-muted">{t('file_changes.binary_file')}</span>
-      ) : (
-        <span className="flex shrink-0 items-center gap-2 font-medium">
-          <span className="text-green-600">+{file.additions}</span>
-          <span className="text-red-500">-{file.deletions}</span>
-        </span>
-      )}
-    </button>
+      <div
+        ref={diffPreviewTriggerRef}
+        data-testid="file-change-trigger"
+        className="group/file-change-trigger relative min-w-0 flex-1"
+        onPointerEnter={openDiffPreviewAfterDelay}
+        onPointerLeave={closeDiffPreview}
+        onFocus={openDiffPreviewAfterDelay}
+        onBlur={closeDiffPreview}
+      >
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={onPreview}
+          className="grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 text-left disabled:cursor-not-allowed disabled:opacity-60"
+          aria-label={t('file_changes.preview_file_label', { path: displayPath })}
+        >
+          <span
+            data-testid="file-change-title-label"
+            className="min-w-0 truncate text-[13px] font-medium leading-5 text-text-primary"
+          >
+            {displayPath}
+          </span>
+          {file.binary ? (
+            <span className="shrink-0 text-xs leading-5 text-text-secondary">
+              {t('file_changes.binary_file')}
+            </span>
+          ) : (
+            <span className="relative h-5 min-w-[5.5rem] text-xs font-medium leading-5">
+              <span
+                data-testid="file-change-stats-label"
+                className="flex justify-end gap-2 group-hover/file-change-trigger:hidden group-focus-within/file-change-trigger:hidden"
+              >
+                <span className="text-green-600">+{file.additions}</span>
+                <span className="text-red-500">-{file.deletions}</span>
+              </span>
+              <span
+                data-testid="file-change-view-label"
+                className="hidden justify-end gap-1 truncate text-text-secondary group-hover/file-change-trigger:flex group-focus-within/file-change-trigger:flex"
+              >
+                {t('file_changes.view_changes')}
+                <ArrowUpRight className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </span>
+            </span>
+          )}
+        </button>
+        {diffPreviewOpen && diffPreview ? (
+          <FileChangeDiffPreview
+            preview={diffPreview}
+            placement={diffPreviewPlacement}
+            position={diffPreviewPosition}
+            onPointerEnter={keepDiffPreviewOpen}
+            onPointerLeave={closeDiffPreview}
+          />
+        ) : null}
+      </div>
+    </div>
   )
+}
+
+function FileChangeSummaryTrigger({
+  file,
+  summary,
+  disabled,
+  onPreview,
+}: {
+  file: TurnFileChangeItem
+  summary: TurnFileChangesSummary
+  disabled: boolean
+  onPreview: () => void
+}) {
+  const { t } = useTranslation('chat')
+  const displayPath =
+    file.change_type === 'renamed' && file.old_path ? `${file.old_path} → ${file.path}` : file.path
+  const filename = basename(file.path)
+  const diffPreview = buildFileDiffPreview(file, summary)
+  const {
+    close: closeDiffPreview,
+    keepOpen: keepDiffPreviewOpen,
+    openAfterDelay: openDiffPreviewAfterDelay,
+    placement: diffPreviewPlacement,
+    position: diffPreviewPosition,
+    previewOpen: diffPreviewOpen,
+    triggerRef: diffPreviewTriggerRef,
+  } = useDelayedDiffPreview(diffPreview)
+
+  return (
+    <div
+      ref={diffPreviewTriggerRef}
+      data-testid="file-change-trigger"
+      className="group/file-change-trigger relative min-w-0 flex-1 self-stretch"
+      onPointerEnter={openDiffPreviewAfterDelay}
+      onPointerLeave={closeDiffPreview}
+      onFocus={openDiffPreviewAfterDelay}
+      onBlur={closeDiffPreview}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onPreview}
+        className="flex h-full w-full min-w-0 items-center gap-3 rounded-lg text-left disabled:cursor-not-allowed disabled:opacity-60"
+        aria-label={t('file_changes.preview_file_label', { path: displayPath })}
+      >
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-base text-text-secondary">
+          <FileDiff className="h-5 w-5" strokeWidth={1.8} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span
+            data-testid="file-changes-summary-title"
+            className="block truncate text-[13px] font-semibold leading-5 text-text-primary"
+          >
+            {t(fileChangeLabelKey(file.change_type), { filename })}
+          </span>
+          {file.binary ? (
+            <span className="block truncate text-xs leading-5 text-text-secondary">
+              {t('file_changes.binary_file')}
+            </span>
+          ) : (
+            <span className="relative block h-5 text-xs font-medium leading-5">
+              <span
+                data-testid="file-change-stats-label"
+                className="flex items-center gap-2 group-hover/file-change-trigger:hidden group-focus-within/file-change-trigger:hidden"
+              >
+                <span className="text-green-600">+{summary.additions}</span>
+                <span className="text-red-500">-{summary.deletions}</span>
+              </span>
+              <span
+                data-testid="file-change-view-label"
+                className="hidden items-center gap-1 truncate text-text-secondary group-hover/file-change-trigger:flex group-focus-within/file-change-trigger:flex"
+              >
+                {t('file_changes.view_changes')}
+                <ArrowUpRight className="h-3.5 w-3.5" strokeWidth={1.8} />
+              </span>
+            </span>
+          )}
+        </span>
+      </button>
+      {diffPreviewOpen && diffPreview ? (
+        <FileChangeDiffPreview
+          preview={diffPreview}
+          placement={diffPreviewPlacement}
+          position={diffPreviewPosition}
+          onPointerEnter={keepDiffPreviewOpen}
+          onPointerLeave={closeDiffPreview}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+function fileChangeLabelKey(changeType: TurnFileChangeItem['change_type']) {
+  switch (changeType) {
+    case 'created':
+      return 'file_changes.created_file'
+    case 'deleted':
+      return 'file_changes.deleted_file'
+    case 'renamed':
+      return 'file_changes.renamed_file'
+    case 'modified':
+    default:
+      return 'file_changes.edited_file'
+  }
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}
+
+interface DiffPreview {
+  path: string
+  additions: number
+  deletions: number
+  lines: DiffPreviewLine[]
+  truncated: boolean
+}
+
+type DiffPreviewPlacement = 'above' | 'below'
+
+interface DiffPreviewPosition {
+  left: number
+  top: number
+  width: number
+}
+
+interface DiffPreviewLine {
+  key: string
+  type: 'addition' | 'deletion' | 'context' | 'separator'
+  lineNumber?: number
+  content: string
+}
+
+function FileChangesStats({ additions, deletions }: { additions: number; deletions: number }) {
+  return (
+    <span className="flex items-center gap-2 text-xs font-medium leading-5">
+      <span className="text-green-600">+{additions}</span>
+      <span className="text-red-500">-{deletions}</span>
+    </span>
+  )
+}
+
+function useDelayedDiffPreview(preview: DiffPreview | null) {
+  const triggerRef = useRef<HTMLDivElement | null>(null)
+  const closeTimerRef = useRef<number | null>(null)
+  const openTimerRef = useRef<number | null>(null)
+  const [previewOpen, setPreviewOpen] = useState(false)
+  const [placement, setPlacement] = useState<DiffPreviewPlacement>('above')
+  const [position, setPosition] = useState<DiffPreviewPosition>()
+
+  useEffect(
+    () => () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current)
+      }
+      if (openTimerRef.current !== null) {
+        window.clearTimeout(openTimerRef.current)
+      }
+    },
+    []
+  )
+
+  const clearCloseTimer = () => {
+    if (closeTimerRef.current !== null) {
+      window.clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+  }
+
+  const clearOpenTimer = () => {
+    if (openTimerRef.current !== null) {
+      window.clearTimeout(openTimerRef.current)
+      openTimerRef.current = null
+    }
+  }
+
+  const openAfterDelay = () => {
+    if (!preview) return
+    clearCloseTimer()
+    clearOpenTimer()
+    openTimerRef.current = window.setTimeout(() => {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (rect) {
+        const spaceAbove = rect.top
+        const spaceBelow = window.innerHeight - rect.bottom
+        const nextPlacement =
+          spaceAbove < DIFF_PREVIEW_ESTIMATED_HEIGHT && spaceBelow > spaceAbove ? 'below' : 'above'
+        const width = Math.min(
+          DIFF_PREVIEW_MAX_WIDTH,
+          Math.max(280, window.innerWidth - DIFF_PREVIEW_VIEWPORT_GUTTER * 2)
+        )
+        const maxLeft = window.innerWidth - width - DIFF_PREVIEW_VIEWPORT_GUTTER
+        const left = Math.min(Math.max(rect.left, DIFF_PREVIEW_VIEWPORT_GUTTER), maxLeft)
+        const top =
+          nextPlacement === 'above'
+            ? Math.max(DIFF_PREVIEW_VIEWPORT_GUTTER, rect.top - DIFF_PREVIEW_VERTICAL_GAP)
+            : rect.bottom + DIFF_PREVIEW_VERTICAL_GAP
+
+        setPlacement(nextPlacement)
+        setPosition({ left, top, width })
+      }
+      setPreviewOpen(true)
+      openTimerRef.current = null
+    }, DIFF_PREVIEW_DELAY_MS)
+  }
+
+  const keepOpen = () => {
+    clearCloseTimer()
+  }
+
+  const close = () => {
+    clearOpenTimer()
+    clearCloseTimer()
+    closeTimerRef.current = window.setTimeout(() => {
+      setPreviewOpen(false)
+      closeTimerRef.current = null
+    }, DIFF_PREVIEW_CLOSE_DELAY_MS)
+  }
+
+  return {
+    close,
+    keepOpen,
+    openAfterDelay,
+    placement,
+    position,
+    previewOpen,
+    triggerRef,
+  }
+}
+
+function FileChangeDiffPreview({
+  onPointerEnter,
+  onPointerLeave,
+  preview,
+  placement,
+  position,
+}: {
+  onPointerEnter: () => void
+  onPointerLeave: () => void
+  preview: DiffPreview
+  placement: DiffPreviewPlacement
+  position?: DiffPreviewPosition
+}) {
+  const content = (
+    <div
+      data-testid="file-change-diff-preview"
+      data-placement={placement}
+      style={{
+        left: position?.left,
+        top: position?.top,
+        width: position?.width,
+        transform: placement === 'above' ? 'translateY(-100%)' : undefined,
+      }}
+      className="pointer-events-auto fixed z-[9999] max-w-[calc(100vw-4rem)] select-text overflow-hidden rounded-xl border border-border bg-popover text-left text-text-primary shadow-2xl"
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+    >
+      <div className="flex h-10 items-center gap-3 border-b border-border px-4 text-[13px] font-semibold">
+        <span className="min-w-0 flex-1 truncate">{basename(preview.path)}</span>
+        <span className="shrink-0 font-medium text-green-400">+{preview.additions}</span>
+        <span className="shrink-0 font-medium text-red-400">-{preview.deletions}</span>
+      </div>
+      <div className="max-h-[18rem] overflow-auto py-1 font-mono text-[12px] leading-5">
+        {preview.lines.map(line =>
+          line.type === 'separator' ? (
+            <div key={line.key} className="my-1 h-px bg-border" />
+          ) : (
+            <div
+              key={line.key}
+              className={[
+                'grid min-w-full grid-cols-[3.5rem_max-content] overflow-visible',
+                line.type === 'addition'
+                  ? 'border-l-4 border-green-400 bg-green-500/10'
+                  : line.type === 'deletion'
+                    ? 'border-l-4 border-red-400 bg-red-500/10'
+                    : 'border-l-4 border-transparent',
+              ].join(' ')}
+            >
+              <span
+                className={[
+                  'select-none px-3 text-right',
+                  line.type === 'addition'
+                    ? 'text-green-400'
+                    : line.type === 'deletion'
+                      ? 'text-red-400'
+                      : 'text-text-muted',
+                ].join(' ')}
+              >
+                {line.lineNumber ?? ''}
+              </span>
+              <span className="pr-4 whitespace-pre">{line.content || ' '}</span>
+            </div>
+          )
+        )}
+        {preview.truncated ? <div className="px-4 py-1 text-xs text-text-muted">...</div> : null}
+      </div>
+    </div>
+  )
+
+  return createPortal(content, document.body)
+}
+
+function buildFileDiffPreview(
+  file: TurnFileChangeItem,
+  summary: TurnFileChangesSummary
+): DiffPreview | null {
+  if (file.binary || !summary.diff?.trim()) return null
+
+  const sectionLines = fileDiffLines(file, summary)
+  if (!sectionLines.length) return null
+
+  const lines = parseDiffPreviewLines(sectionLines)
+  if (!lines.length) return null
+
+  return {
+    path: file.path,
+    additions: file.additions,
+    deletions: file.deletions,
+    lines: lines.slice(0, DIFF_PREVIEW_MAX_LINES),
+    truncated: lines.length > DIFF_PREVIEW_MAX_LINES,
+  }
+}
+
+function fileDiffLines(file: TurnFileChangeItem, summary: TurnFileChangesSummary): string[] {
+  const diff = summary.diff?.trimEnd()
+  if (!diff) return []
+
+  const sections = parseUnifiedDiff(diff)
+  if (sections.length === 0) {
+    return summary.files.length === 1 ? diff.split('\n') : []
+  }
+
+  const section = sections.find(
+    item =>
+      pathsMatch(item.path, file.path) ||
+      (file.old_path ? pathsMatch(item.oldPath, file.old_path) : false)
+  )
+  return section?.lines ?? []
+}
+
+function pathsMatch(left: string | undefined, right: string | undefined): boolean {
+  if (!left || !right) return false
+  return left === right || left.endsWith(`/${right}`) || right.endsWith(`/${left}`)
+}
+
+function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
+  const previewLines: DiffPreviewLine[] = []
+  let oldLine: number | undefined
+  let newLine: number | undefined
+  let seenHunk = false
+
+  lines.forEach((rawLine, index) => {
+    if (
+      rawLine.startsWith('diff --git') ||
+      rawLine.startsWith('---') ||
+      rawLine.startsWith('+++')
+    ) {
+      return
+    }
+    if (
+      rawLine.startsWith('index ') ||
+      rawLine.startsWith('new file mode ') ||
+      rawLine.startsWith('deleted file mode ') ||
+      rawLine.startsWith('similarity index ') ||
+      rawLine.startsWith('rename from ') ||
+      rawLine.startsWith('rename to ') ||
+      rawLine.startsWith('\\ No newline')
+    ) {
+      return
+    }
+
+    const hunk = rawLine.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+    if (hunk) {
+      if (seenHunk && previewLines.length > 0) {
+        previewLines.push({
+          key: `separator-${index}`,
+          type: 'separator',
+          content: '',
+        })
+      }
+      oldLine = Number(hunk[1])
+      newLine = Number(hunk[2])
+      seenHunk = true
+      return
+    }
+
+    if (!seenHunk && !rawLine.startsWith('+') && !rawLine.startsWith('-')) {
+      return
+    }
+
+    const prefix = rawLine[0]
+    if (prefix === '+') {
+      previewLines.push({
+        key: `addition-${index}`,
+        type: 'addition',
+        lineNumber: newLine,
+        content: rawLine.slice(1),
+      })
+      if (newLine !== undefined) newLine += 1
+      return
+    }
+    if (prefix === '-') {
+      previewLines.push({
+        key: `deletion-${index}`,
+        type: 'deletion',
+        lineNumber: oldLine,
+        content: rawLine.slice(1),
+      })
+      if (oldLine !== undefined) oldLine += 1
+      return
+    }
+
+    previewLines.push({
+      key: `context-${index}`,
+      type: 'context',
+      lineNumber: newLine ?? oldLine,
+      content: prefix === ' ' ? rawLine.slice(1) : rawLine,
+    })
+    if (oldLine !== undefined) oldLine += 1
+    if (newLine !== undefined) newLine += 1
+  })
+
+  return previewLines
 }
 
 export function FileChangesCard({
@@ -79,9 +564,12 @@ export function FileChangesCard({
   const [actionError, setActionError] = useState<string>()
   const hiddenCount = Math.max(0, summary.files.length - DEFAULT_VISIBLE_FILE_COUNT)
   const visibleFiles = expanded ? summary.files : summary.files.slice(0, DEFAULT_VISIBLE_FILE_COUNT)
+  const singleFile = summary.files.length === 1 ? summary.files[0] : undefined
+  const shownFileCount = summary.file_count || summary.files.length
   const actionsDisabled = !deviceOnline || summary.status === 'artifact_missing'
   const reviewDisabled = actionsDisabled || !onOpenReview
-  const canRevert = summary.status === 'active' && summary.revertible !== false
+  const showRevert = summary.status === 'active'
+  const revertDisabled = true
 
   const openReview = (focusFilePath?: string) => {
     onOpenReview?.({
@@ -111,53 +599,8 @@ export function FileChangesCard({
     <>
       <section
         data-testid="file-changes-card"
-        className="mt-3 overflow-hidden rounded-xl border border-border bg-base"
+        className="mt-3 overflow-visible rounded-xl border border-border bg-surface"
       >
-        <div className="flex flex-wrap items-center gap-2 border-b border-border px-3 py-2">
-          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-surface text-text-secondary">
-            <FileDiff className="h-3.5 w-3.5" />
-          </span>
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium text-text-primary">
-              {t('file_changes.edited_files', {
-                count: summary.file_count,
-              })}
-            </p>
-            <p className="flex gap-2 text-xs font-medium">
-              <span className="text-green-600">+{summary.additions}</span>
-              <span className="text-red-500">-{summary.deletions}</span>
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            {summary.status === 'reverted' ? (
-              <span className="inline-flex items-center gap-1 text-xs font-medium text-text-secondary">
-                <Check className="h-3.5 w-3.5" />
-                {t('file_changes.reverted')}
-              </span>
-            ) : null}
-            <button
-              type="button"
-              data-testid="review-file-changes-button"
-              disabled={reviewDisabled}
-              onClick={() => void openReview()}
-              className="h-7 rounded border border-border px-2 text-xs font-medium text-text-primary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {t('file_changes.review')}
-            </button>
-            {canRevert ? (
-              <button
-                type="button"
-                data-testid="revert-file-changes-button"
-                disabled={actionsDisabled}
-                onClick={() => setConfirmOpen(true)}
-                className="flex h-7 items-center justify-center gap-1 rounded px-2 text-xs font-medium text-text-secondary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <RotateCcw className="h-3.5 w-3.5" />
-                {t('file_changes.revert')}
-              </button>
-            ) : null}
-          </div>
-        </div>
         {summary.status === 'conflicted' ? (
           <p className="border-b border-border bg-amber-50 px-3 py-1.5 text-xs text-amber-800">
             {t('file_changes.conflicted')}
@@ -178,32 +621,96 @@ export function FileChangesCard({
             {actionError}
           </p>
         ) : null}
-        <div className="divide-y divide-border/70">
-          {visibleFiles.map(file => (
-            <FileChangeRow
-              key={`${file.old_path ?? ''}:${file.path}`}
-              file={file}
+        <div
+          className={[
+            'flex min-h-[4.5rem] items-center gap-3 px-4 py-3',
+            singleFile ? '' : 'border-b border-border/70',
+          ].join(' ')}
+        >
+          {singleFile ? (
+            <FileChangeSummaryTrigger
+              file={singleFile}
+              summary={summary}
               disabled={reviewDisabled}
-              onPreview={() => openReview(file.path)}
+              onPreview={() => openReview(singleFile.path)}
             />
-          ))}
+          ) : (
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-base text-text-secondary">
+                <FileDiff className="h-5 w-5" strokeWidth={1.8} />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span
+                  data-testid="file-changes-summary-title"
+                  className="block truncate text-[13px] font-semibold leading-5 text-text-primary"
+                >
+                  {t('file_changes.edited_files', { count: shownFileCount })}
+                </span>
+                <FileChangesStats additions={summary.additions} deletions={summary.deletions} />
+              </span>
+            </div>
+          )}
+          <div className="flex shrink-0 items-center gap-2">
+            {summary.status === 'reverted' ? (
+              <span className="inline-flex items-center gap-1 text-xs font-medium text-text-secondary">
+                <Check className="h-3.5 w-3.5" />
+                {t('file_changes.reverted')}
+              </span>
+            ) : null}
+            {showRevert ? (
+              <button
+                type="button"
+                data-testid="revert-file-changes-button"
+                disabled={revertDisabled}
+                onClick={() => setConfirmOpen(true)}
+                className="flex h-8 items-center justify-center gap-1 rounded-lg px-2 text-xs font-medium text-text-primary hover:bg-base disabled:cursor-not-allowed disabled:text-text-muted disabled:opacity-50"
+              >
+                {t('file_changes.revert')}
+                <Undo2 className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              data-testid="review-file-changes-button"
+              disabled={reviewDisabled}
+              onClick={() => void openReview()}
+              className="h-8 rounded-lg border border-border bg-base px-3 text-xs font-medium text-text-primary hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {t('file_changes.review')}
+            </button>
+          </div>
         </div>
-        {hiddenCount > 0 ? (
+        {singleFile ? null : (
+          <div className="divide-y divide-border/70">
+            {visibleFiles.map(file => (
+              <FileChangeRow
+                key={`${file.old_path ?? ''}:${file.path}`}
+                file={file}
+                summary={summary}
+                disabled={reviewDisabled}
+                onPreview={() => openReview(file.path)}
+              />
+            ))}
+          </div>
+        )}
+        {!singleFile && hiddenCount > 0 ? (
           <button
             type="button"
             data-testid="toggle-file-changes-button"
             aria-expanded={expanded}
             onClick={() => setExpanded(value => !value)}
-            className="flex h-8 w-full items-center gap-1 border-t border-border px-3 text-xs font-medium text-text-secondary hover:bg-muted"
+            className="flex h-8 w-full items-center gap-1 px-4 text-xs font-medium text-text-secondary hover:bg-muted"
           >
+            <span>
+              {expanded
+                ? t('file_changes.show_less')
+                : t('file_changes.show_more', { count: hiddenCount })}
+            </span>
             {expanded ? (
               <ChevronUp className="h-3.5 w-3.5" />
             ) : (
               <ChevronDown className="h-3.5 w-3.5" />
             )}
-            {expanded
-              ? t('file_changes.show_less')
-              : t('file_changes.show_more', { count: hiddenCount })}
           </button>
         ) : null}
       </section>

--- a/wework/src/components/chat/MarkdownCodeBlock.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.tsx
@@ -1,0 +1,270 @@
+import { useState } from 'react'
+import type { CSSProperties, HTMLProps, ReactNode } from 'react'
+import { ArrowRightToLine, Copy, CopyCheck, TextWrap } from 'lucide-react'
+import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter'
+import bash from 'react-syntax-highlighter/dist/esm/languages/prism/bash'
+import css from 'react-syntax-highlighter/dist/esm/languages/prism/css'
+import diff from 'react-syntax-highlighter/dist/esm/languages/prism/diff'
+import docker from 'react-syntax-highlighter/dist/esm/languages/prism/docker'
+import go from 'react-syntax-highlighter/dist/esm/languages/prism/go'
+import ini from 'react-syntax-highlighter/dist/esm/languages/prism/ini'
+import javascript from 'react-syntax-highlighter/dist/esm/languages/prism/javascript'
+import json from 'react-syntax-highlighter/dist/esm/languages/prism/json'
+import jsx from 'react-syntax-highlighter/dist/esm/languages/prism/jsx'
+import less from 'react-syntax-highlighter/dist/esm/languages/prism/less'
+import markdown from 'react-syntax-highlighter/dist/esm/languages/prism/markdown'
+import python from 'react-syntax-highlighter/dist/esm/languages/prism/python'
+import rust from 'react-syntax-highlighter/dist/esm/languages/prism/rust'
+import scss from 'react-syntax-highlighter/dist/esm/languages/prism/scss'
+import shellSession from 'react-syntax-highlighter/dist/esm/languages/prism/shell-session'
+import sql from 'react-syntax-highlighter/dist/esm/languages/prism/sql'
+import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx'
+import typescript from 'react-syntax-highlighter/dist/esm/languages/prism/typescript'
+import yaml from 'react-syntax-highlighter/dist/esm/languages/prism/yaml'
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism'
+
+SyntaxHighlighter.registerLanguage('bash', bash)
+SyntaxHighlighter.registerLanguage('css', css)
+SyntaxHighlighter.registerLanguage('diff', diff)
+SyntaxHighlighter.registerLanguage('docker', docker)
+SyntaxHighlighter.registerLanguage('go', go)
+SyntaxHighlighter.registerLanguage('ini', ini)
+SyntaxHighlighter.registerLanguage('javascript', javascript)
+SyntaxHighlighter.registerLanguage('json', json)
+SyntaxHighlighter.registerLanguage('jsx', jsx)
+SyntaxHighlighter.registerLanguage('less', less)
+SyntaxHighlighter.registerLanguage('markdown', markdown)
+SyntaxHighlighter.registerLanguage('python', python)
+SyntaxHighlighter.registerLanguage('rust', rust)
+SyntaxHighlighter.registerLanguage('scss', scss)
+SyntaxHighlighter.registerLanguage('shell-session', shellSession)
+SyntaxHighlighter.registerLanguage('sql', sql)
+SyntaxHighlighter.registerLanguage('tsx', tsx)
+SyntaxHighlighter.registerLanguage('typescript', typescript)
+SyntaxHighlighter.registerLanguage('yaml', yaml)
+
+const LANGUAGE_ALIASES: Record<string, string> = {
+  cjs: 'javascript',
+  cmd: 'bash',
+  dockerfile: 'docker',
+  js: 'javascript',
+  md: 'markdown',
+  mjs: 'javascript',
+  py: 'python',
+  rs: 'rust',
+  sh: 'bash',
+  shell: 'bash',
+  ts: 'typescript',
+  yml: 'yaml',
+  zsh: 'bash',
+}
+
+const DISPLAY_LANGUAGE_ALIASES: Record<string, string> = {
+  markdown: 'md',
+}
+
+const CODE_ACTION_BUTTON_CLASS =
+  'flex h-7 w-7 items-center justify-center rounded-md text-[#b8c0cc] transition-colors hover:bg-white/10 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25'
+
+const CODE_FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+
+const codeCustomStyle: CSSProperties = {
+  margin: 0,
+  padding: '0.75rem 1rem',
+  background: 'transparent',
+  fontSize: '0.8125rem',
+  lineHeight: '1.6',
+}
+
+const markdownWrapStateByKey = new Map<string, boolean>()
+
+interface MarkdownCodeBlockProps {
+  lang?: string
+  children: ReactNode
+  compact?: boolean
+}
+
+export function MarkdownCodeBlock({
+  lang = '',
+  children,
+  compact = false,
+}: MarkdownCodeBlockProps) {
+  const [copied, setCopied] = useState(false)
+  const text = String(children).replace(/\n$/, '')
+  const language = normalizeLanguage(lang)
+  const canToggleWrap = language === 'markdown'
+  const wrapStateKey = canToggleWrap ? getMarkdownWrapStateKey(text, compact) : ''
+  const [wrapState, setWrapState] = useState(() => ({
+    key: wrapStateKey,
+    value: wrapStateKey ? (markdownWrapStateByKey.get(wrapStateKey) ?? false) : false,
+  }))
+  const storedWrapLines = wrapStateKey ? (markdownWrapStateByKey.get(wrapStateKey) ?? false) : false
+  const effectiveWrapLines =
+    canToggleWrap && (wrapState.key === wrapStateKey ? wrapState.value : storedWrapLines)
+  const displayLanguage = formatDisplayLanguage(language)
+  const wrapButtonLabel = effectiveWrapLines ? '禁用自动换行' : '开启自动换行'
+  const codeStyle = getCodeCustomStyle(effectiveWrapLines)
+  const codeProps = getCodeTagProps(effectiveWrapLines)
+  const lineProps = getLineProps(effectiveWrapLines)
+
+  const handleCopy = async () => {
+    await copyCodeText(text)
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1500)
+  }
+
+  const toggleWrapLines = () => {
+    if (!wrapStateKey) return
+    const nextValue = !effectiveWrapLines
+    markdownWrapStateByKey.set(wrapStateKey, nextValue)
+    setWrapState({ key: wrapStateKey, value: nextValue })
+  }
+
+  return (
+    <div
+      data-testid="markdown-code-block"
+      className={[
+        'max-w-full overflow-hidden rounded-lg border border-[#3c424a] bg-[#2f2f2f] text-left shadow-sm',
+        compact ? 'mb-1.5' : 'mb-3 mt-2',
+      ].join(' ')}
+    >
+      <div className="flex h-10 items-center justify-between border-b border-[#3c424a] px-3">
+        <span
+          data-testid="markdown-code-block-language"
+          className="text-xs font-medium text-[#b8c0cc]"
+        >
+          {displayLanguage}
+        </span>
+        <div className="flex items-center gap-1">
+          {canToggleWrap ? (
+            <button
+              type="button"
+              onClick={toggleWrapLines}
+              className={CODE_ACTION_BUTTON_CLASS}
+              aria-label={wrapButtonLabel}
+              aria-pressed={effectiveWrapLines}
+              title={wrapButtonLabel}
+              data-testid="markdown-code-wrap-button"
+            >
+              {effectiveWrapLines ? (
+                <TextWrap className="h-3.5 w-3.5" data-testid="markdown-code-wrap-enabled-icon" />
+              ) : (
+                <ArrowRightToLine
+                  className="h-3.5 w-3.5"
+                  data-testid="markdown-code-wrap-disabled-icon"
+                />
+              )}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className={CODE_ACTION_BUTTON_CLASS}
+            aria-label="复制代码"
+            title="复制代码"
+          >
+            {copied ? (
+              <CopyCheck className="h-3.5 w-3.5" data-testid="markdown-code-copy-success-icon" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" data-testid="markdown-code-copy-icon" />
+            )}
+          </button>
+        </div>
+      </div>
+      <div
+        data-testid="markdown-code-scroll-container"
+        data-wrap={effectiveWrapLines ? 'true' : 'false'}
+        className={
+          effectiveWrapLines ? 'max-w-full overflow-x-hidden' : 'max-w-full overflow-x-auto'
+        }
+      >
+        <SyntaxHighlighter
+          language={language || 'text'}
+          style={oneDark}
+          customStyle={codeStyle}
+          codeTagProps={codeProps}
+          lineProps={lineProps}
+          PreTag="div"
+          showLineNumbers={false}
+          wrapLines={effectiveWrapLines}
+          wrapLongLines={effectiveWrapLines}
+        >
+          {text}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  )
+}
+
+function normalizeLanguage(lang: string): string {
+  const value = lang.trim().toLowerCase()
+  return LANGUAGE_ALIASES[value] ?? value
+}
+
+function formatDisplayLanguage(language: string): string {
+  if (!language) return 'text'
+  return DISPLAY_LANGUAGE_ALIASES[language] ?? language
+}
+
+function getMarkdownWrapStateKey(text: string, compact: boolean): string {
+  return `${compact ? 'compact' : 'regular'}:${text.length}:${hashString(text)}`
+}
+
+function hashString(value: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+function getCodeCustomStyle(wrapLines: boolean): CSSProperties {
+  return {
+    ...codeCustomStyle,
+    overflowX: wrapLines ? 'hidden' : 'auto',
+    whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
+    wordBreak: wrapLines ? 'break-word' : 'normal',
+    overflowWrap: wrapLines ? 'anywhere' : 'normal',
+  }
+}
+
+function getCodeTagProps(wrapLines: boolean): HTMLProps<HTMLElement> {
+  return {
+    style: {
+      fontFamily: CODE_FONT_FAMILY,
+      whiteSpace: wrapLines ? 'pre-wrap' : 'pre',
+      wordBreak: wrapLines ? 'break-word' : 'normal',
+      overflowWrap: wrapLines ? 'anywhere' : 'normal',
+    },
+  }
+}
+
+function getLineProps(wrapLines: boolean): HTMLProps<HTMLElement> | undefined {
+  if (!wrapLines) return undefined
+
+  return {
+    style: {
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+      overflowWrap: 'anywhere',
+    },
+  }
+}
+
+async function copyCodeText(text: string) {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text)
+    return
+  }
+
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
+}

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -60,7 +60,8 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('src/main.ts')
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('已编辑 main.ts')
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('查看更改')
   })
 
   test('renders cancelled assistant turns like stopped Codex turns', () => {
@@ -125,7 +126,7 @@ describe('MessageList', () => {
     expect(screen.getByTestId('processing-activity-group-toggle')).toHaveTextContent(
       '已运行 1 条命令'
     )
-    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('src/main.ts')
+    expect(screen.getByTestId('file-changes-card')).toHaveTextContent('已编辑 main.ts')
     expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 9m 18s 后停止了')
   })
 
@@ -152,7 +153,7 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByTestId('message-user').parentElement).toHaveClass('gap-4')
-    expect(screen.getAllByTestId('message-hover-time')[0].parentElement).toHaveClass('min-h-5')
+    expect(screen.getAllByTestId('message-hover-actions')[0]).toHaveClass('min-h-5')
   })
 
   const originalCreateObjectUrl = URL.createObjectURL
@@ -272,6 +273,53 @@ describe('MessageList', () => {
     expect(screen.getByText('正在执行 pwd')).toBeInTheDocument()
   })
 
+  test('keeps completed process text collapsed when the assistant has final content', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'process-1',
+        subtaskId: 11,
+        type: 'text',
+        content: '我会先看这个 skill 当前的流程结构和相关记忆。',
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+      {
+        id: 'tool-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'rg -n workflow' },
+        toolOutput: 'ok',
+        status: 'done',
+        createdAt: 1770000001000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-with-process',
+            role: 'assistant',
+            content: '最终建议放在 PR flow 里。',
+            status: 'done',
+            blocks,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('最终建议放在 PR flow 里。')).toBeInTheDocument()
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+    expect(collapseContent).toHaveClass('grid-rows-[0fr]', 'opacity-0')
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByText('我会先看这个 skill 当前的流程结构和相关记忆。')).toBeInTheDocument()
+  })
+
   test('reserves enough marker gutter for multi-digit ordered lists', () => {
     const { container } = render(
       <MessageList
@@ -345,8 +393,38 @@ describe('MessageList', () => {
 
     // A filesystem path must not render as a navigating anchor.
     expect(screen.queryByRole('link', { name: /managing-tasks\.md/ })).not.toBeInTheDocument()
-    await userEvent.click(screen.getByTestId('assistant-markdown-link'))
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/dev/repo/docs/zh/managing-tasks.md')
+  })
+
+  test('renders assistant file link line numbers without passing them to open-file actions', async () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-file-line-link',
+            role: 'assistant',
+            content:
+              '放在 [references/github-pr-flow.md](references/github-pr-flow.md:18) 的 PR 段落。',
+            status: 'done',
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('assistant-markdown-link-line')).toHaveTextContent('(line 18)')
+    expect(screen.getByTestId('assistant-markdown-link-tooltip')).toHaveTextContent(
+      'references/github-pr-flow.md (line 18)'
+    )
+    expect(screen.getByTestId('assistant-markdown-link-tooltip')).toHaveClass(
+      'max-w-[min(36rem,calc(100vw-3rem))]',
+      'break-all'
+    )
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('references/github-pr-flow.md')
   })
 
   test('routes assistant file links to the turn diff review focused on that file', async () => {
@@ -391,7 +469,7 @@ describe('MessageList', () => {
       />
     )
 
-    await userEvent.click(screen.getByTestId('assistant-markdown-link'))
+    fireEvent.click(screen.getByTestId('assistant-markdown-link'))
     expect(onOpenWorkspaceFile).not.toHaveBeenCalled()
     expect(onOpenFileChangesReview).toHaveBeenCalledTimes(1)
     const request = onOpenFileChangesReview.mock.calls[0][0]
@@ -401,6 +479,100 @@ describe('MessageList', () => {
     expect(onLoadFileChangesDiff).not.toHaveBeenCalled()
     await request.loadDiff()
     expect(onLoadFileChangesDiff).toHaveBeenCalledWith(42)
+  })
+
+  test('renders Codex context events, memory citations, and one-column deduped file references', async () => {
+    const onOpenWorkspaceFile = vi.fn()
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'assistant-codex-rich',
+            role: 'assistant',
+            content:
+              'Updated [SKILL.md](/workspace/project/SKILL.md), [github-pr-flow.md](/workspace/project/references/github-pr-flow.md:18), and [notify_pr_ready.sh](/workspace/project/scripts/notify_pr_ready.sh).',
+            status: 'done',
+            createdAt: '2026-06-24T08:00:01.000Z',
+            references: [
+              { path: '/workspace/project/SKILL.md' },
+              { path: '/workspace/project/references/github-pr-flow.md', lineStart: 18 },
+              { path: '/workspace/project/SKILL.md:22' },
+              { path: '/workspace/project/scripts/notify_pr_ready.sh' },
+            ],
+            contextEvents: [
+              {
+                id: 'context-1',
+                type: 'context_compaction',
+                status: 'done',
+                createdAt: Date.parse('2026-06-24T08:00:00.000Z'),
+              },
+            ],
+            memoryCitations: [
+              {
+                entries: [
+                  {
+                    path: 'MEMORY.md',
+                    lineStart: 10,
+                    lineEnd: 12,
+                    note: 'repo guidance',
+                  },
+                ],
+                threadIds: ['thread-1'],
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('codex-context-events')).toBeInTheDocument()
+    expect(screen.queryByText('引用文件')).not.toBeInTheDocument()
+    expect(screen.getByTestId('codex-memory-citations')).toBeInTheDocument()
+    expect(screen.getByTestId('codex-reference-list')).toBeInTheDocument()
+    expect(
+      screen
+        .getByTestId('codex-memory-citations')
+        .compareDocumentPosition(screen.getByTestId('codex-reference-list')) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+
+    const referenceCards = screen.getAllByTestId('codex-reference-card')
+    expect(referenceCards).toHaveLength(2)
+    expect(screen.getByTestId('codex-reference-list')).not.toHaveTextContent('notify_pr_ready.sh')
+    expect(referenceCards[0]).toHaveTextContent('SKILL.md')
+    expect(referenceCards[0]).toHaveTextContent('文档 · MD')
+    expect(referenceCards[0]).toHaveTextContent('打开预览')
+    expect(screen.getAllByTestId('codex-reference-kind-label')[0]).toHaveClass(
+      'group-hover/reference-card:opacity-0'
+    )
+    expect(screen.getAllByTestId('codex-reference-preview-label')[0]).toHaveClass(
+      'opacity-0',
+      'group-hover/reference-card:opacity-100'
+    )
+    expect(referenceCards[1]).toHaveTextContent('github-pr-flow.md')
+
+    await userEvent.click(referenceCards[1])
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith(
+      '/workspace/project/references/github-pr-flow.md'
+    )
+
+    expect(screen.getByTestId('codex-memory-citations-toggle')).toHaveTextContent('1 条记忆引用')
+    await userEvent.click(screen.getByTestId('codex-memory-citations-toggle'))
+    const memoryEntry = screen.getByTestId('codex-memory-citation-entry')
+    expect(memoryEntry).toHaveTextContent('MEMORY.md')
+    expect(memoryEntry).toHaveTextContent('10-12 行')
+    expect(memoryEntry).toHaveTextContent('repo guidance')
+    expect(memoryEntry).toHaveAttribute('aria-label', '打开 MEMORY.md')
+    expect(screen.getByTestId('codex-memory-citation-tooltip')).toHaveTextContent('MEMORY.md')
+    expect(screen.getByTestId('codex-memory-citation-tooltip')).toHaveClass(
+      'max-w-[min(28rem,calc(100vw-3rem))]',
+      'break-all'
+    )
+
+    onOpenWorkspaceFile.mockClear()
+    await userEvent.click(memoryEntry)
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('MEMORY.md')
   })
 
   test('renders IM source badge for user messages with channel label', () => {
@@ -978,7 +1150,7 @@ describe('MessageList', () => {
     expect(screen.getByTestId('message-document-attachment')).toHaveTextContent('PDF')
   })
 
-  test('shows user message hover actions with time and copy', async () => {
+  test('shows user message hover actions with time, copy label, and resettable success icon', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-25T16:00:00.000+08:00'))
 
@@ -996,7 +1168,31 @@ describe('MessageList', () => {
       />
     )
 
+    const hoverRegion = screen.getByTestId('message-hover-region')
+    const hoverActions = screen.getByTestId('message-hover-actions')
+    expect(hoverActions).toHaveClass('opacity-0', 'pointer-events-none')
+    expect(hoverActions).not.toHaveClass(
+      'group-hover/message:opacity-100',
+      'group-focus-within/message:opacity-100'
+    )
+    expect(hoverRegion).toHaveClass('max-w-[80%]')
+
+    fireEvent.pointerEnter(hoverRegion)
+    expect(hoverActions).toHaveClass('opacity-100', 'pointer-events-auto')
+
     expect(screen.getByTestId('message-hover-time')).toHaveTextContent('15:08')
+    expect(screen.getByTestId('message-hover-time')).not.toHaveClass('opacity-0')
+    expect(screen.getByTestId('message-hover-time')).toHaveClass('select-text')
+    expect(screen.getByTestId('message-hover-time')).not.toHaveClass('pointer-events-none')
+    expect(screen.getByTestId('copy-message-label')).toHaveTextContent('复制')
+    expect(screen.getByTestId('copy-message-label')).toHaveClass(
+      'opacity-0',
+      'group-hover/copy:opacity-100'
+    )
+    expect(screen.getByTestId('copy-message-label')).not.toHaveClass(
+      'group-focus-within/copy:opacity-100'
+    )
+    expect(screen.getByTestId('copy-message-icon')).toBeInTheDocument()
 
     vi.useRealTimers()
 
@@ -1006,11 +1202,23 @@ describe('MessageList', () => {
     })
 
     const copyButton = screen.getByTestId('copy-message-button')
-    expect(copyButton).toHaveClass('opacity-0', 'group-hover:opacity-100')
+    expect(copyButton).toHaveAttribute('title', '复制')
+    expect(copyButton).not.toHaveClass('opacity-0')
 
     await userEvent.click(copyButton)
 
     expect(writeText).toHaveBeenCalledWith('对 bind_shell=openclaw 直接跳过')
+    expect(await screen.findByTestId('copy-message-success-icon')).toBeInTheDocument()
+    expect(copyButton).toHaveClass('bg-text-primary', 'text-background/70')
+
+    fireEvent.mouseLeave(hoverActions)
+    fireEvent.pointerLeave(hoverRegion)
+    expect(hoverActions).toHaveClass('opacity-0', 'pointer-events-none')
+    expect(screen.getByTestId('copy-message-success-icon')).toBeInTheDocument()
+    fireEvent.transitionEnd(screen.getByTestId('copy-message-label'), { propertyName: 'opacity' })
+    expect(screen.getByTestId('copy-message-success-icon')).toBeInTheDocument()
+    fireEvent.transitionEnd(hoverActions, { propertyName: 'opacity' })
+    expect(screen.getByTestId('copy-message-icon')).toBeInTheDocument()
   })
 
   test('collapses long user messages without changing copied content', async () => {
@@ -1046,6 +1254,10 @@ describe('MessageList', () => {
     expect(messageContent).not.toHaveClass('max-h-44')
     expect(toggleButton).toHaveAttribute('aria-expanded', 'true')
     expect(toggleButton).toHaveTextContent('收起')
+
+    const hoverRegion = screen.getByTestId('message-hover-region')
+    expect(hoverRegion).toHaveClass('max-w-[80%]')
+    fireEvent.pointerEnter(hoverRegion)
 
     await userEvent.click(screen.getByTestId('copy-message-button'))
     expect(writeText).toHaveBeenCalledWith(content)
@@ -1096,7 +1308,57 @@ describe('MessageList', () => {
     }
   })
 
-  test('shows assistant message hover actions with time and copy', async () => {
+  test('shows date and clock time for messages not created today in the current year', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-05-25T18:50:00.000+08:00'))
+
+      render(
+        <MessageList
+          messages={[
+            {
+              id: '1',
+              role: 'user',
+              content: '昨天的消息',
+              status: 'done',
+              createdAt: '2026-06-18T12:04:00.000+08:00',
+            },
+          ]}
+        />
+      )
+
+      expect(screen.getByTestId('message-hover-time')).toHaveTextContent('6月18日 12:04')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('shows year for messages not created this year', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-05-25T18:50:00.000+08:00'))
+
+      render(
+        <MessageList
+          messages={[
+            {
+              id: '1',
+              role: 'user',
+              content: '去年的消息',
+              status: 'done',
+              createdAt: '2025-06-18T12:04:00.000+08:00',
+            },
+          ]}
+        />
+      )
+
+      expect(screen.getByTestId('message-hover-time')).toHaveTextContent('2025年6月18日 12:04')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  test('shows assistant message hover actions with time and icon-hover copy label', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-25T19:00:00.000+08:00'))
 
@@ -1114,7 +1376,30 @@ describe('MessageList', () => {
       />
     )
 
+    const hoverRegion = screen.getByTestId('message-hover-region')
+    const hoverActions = screen.getByTestId('message-hover-actions')
+    expect(hoverActions).toHaveClass('opacity-0', 'pointer-events-none')
+    expect(hoverActions).not.toHaveClass(
+      'group-hover/message:opacity-100',
+      'group-focus-within/message:opacity-100'
+    )
+    expect(hoverRegion).toHaveClass('w-fit', 'max-w-full')
+
+    fireEvent.pointerEnter(hoverRegion)
+    expect(hoverActions).toHaveClass('opacity-100', 'pointer-events-auto')
+
     expect(screen.getByTestId('message-hover-time')).toHaveTextContent('18:38')
+    expect(screen.getByTestId('message-hover-time')).not.toHaveClass('opacity-0')
+    expect(screen.getByTestId('message-hover-time')).toHaveClass('select-text')
+    expect(screen.getByTestId('message-hover-time')).not.toHaveClass('pointer-events-none')
+    expect(screen.getByTestId('copy-message-label')).toHaveTextContent('复制')
+    expect(screen.getByTestId('copy-message-label')).toHaveClass(
+      'opacity-0',
+      'group-hover/copy:opacity-100'
+    )
+    expect(screen.getByTestId('copy-message-label')).not.toHaveClass(
+      'group-focus-within/copy:opacity-100'
+    )
 
     vi.useRealTimers()
 
@@ -1124,7 +1409,8 @@ describe('MessageList', () => {
     })
 
     const copyButton = screen.getByTestId('copy-message-button')
-    expect(copyButton).toHaveClass('opacity-0', 'group-hover:opacity-100')
+    expect(copyButton).toHaveAttribute('title', '复制')
+    expect(copyButton).not.toHaveClass('opacity-0')
 
     await userEvent.click(copyButton)
 
@@ -1472,7 +1758,7 @@ describe('MessageList', () => {
     expect(screen.queryByText('网络连接失败：请检查网络连接后重试')).not.toBeInTheDocument()
   })
 
-  test('keeps regular long content inside the page while tables and code scroll locally', () => {
+  test('keeps regular long content inside the page while tables and highlighted code scroll locally', () => {
     const longToken = 'a'.repeat(120)
     const { container } = render(
       <MessageList
@@ -1494,8 +1780,8 @@ describe('MessageList', () => {
               '| --- |',
               `| ${longToken} |`,
               '',
-              '```text',
-              longToken,
+              '```css',
+              `.collapsible { color: ${longToken}; }`,
               '```',
             ].join('\n'),
             status: 'done',
@@ -1515,7 +1801,9 @@ describe('MessageList', () => {
       'overflow-x-auto',
       'max-w-full'
     )
-    expect(container.querySelector('pre')).toHaveClass('max-w-full', 'overflow-hidden')
+    expect(screen.getByTestId('markdown-code-block')).toHaveTextContent('.collapsible')
+    expect(screen.getByTestId('markdown-code-block-language')).toHaveTextContent('css')
+    expect(screen.getByTestId('markdown-code-block')).toHaveClass('overflow-hidden')
   })
 
   test('renders local skill markdown links in user messages', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,26 +1,23 @@
-import { useEffect, useState } from 'react'
-import type { ReactNode } from 'react'
-import { convertFileSrc } from '@tauri-apps/api/core'
-import {
-  AlertTriangle,
-  ChevronDown,
-  ChevronUp,
-  Copy,
-  CopyCheck,
-  Link2,
-  Package,
-} from 'lucide-react'
-import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import { useEffect, useRef, useState } from 'react'
+import type {
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  TransitionEvent as ReactTransitionEvent,
+} from 'react'
+import { AlertTriangle, Check, ChevronDown, ChevronUp, Copy, Package } from 'lucide-react'
 import type { Attachment, DeviceInfo, TurnFileChangesSummary } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
-import { getAttachmentImageUrl, getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
+import { getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
 import { parseChatError } from '@/lib/chat-error'
 import { isIMSource } from '@/lib/im-source'
 import { ImSourceBadge } from '@/components/common/ImSourceBadge'
+import { AssistantMarkdown } from './AssistantMarkdown'
+import { resolveDirectMarkdownImageSrc } from './assistantMarkdownLinks'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
+import { CodexContextEvents, CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
+import { getAssistantReferences } from './codexReferences'
 import { FileChangesCard } from './FileChangesCard'
 
 interface MessageListProps {
@@ -43,17 +40,10 @@ interface MessageListProps {
 
 const USER_MESSAGE_COLLAPSE_LINES = 10
 const USER_MESSAGE_COLLAPSE_CHARACTERS = 600
-const ATTACHMENT_DOWNLOAD_PATH_PATTERN = /\/(?:api\/)?attachments\/(\d+)\/download(?:[?#].*)?$/
 const CODEX_FILE_MENTIONS_HEADER_PATTERN = /^\s*# Files mentioned by the user:\s*/i
 const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
 const CODEX_FILE_MENTION_LINE_PATTERN = /^##\s+(.+?):\s+(.+)$/gm
 const LOCAL_IMAGE_EXTENSION_PATTERN = /\.(?:apng|avif|gif|jpe?g|png|webp|bmp|svg)$/i
-const ASSISTANT_MARKDOWN_LINK_CLASS = [
-  'inline-flex max-w-full items-center gap-1 rounded-md px-0.5 align-baseline',
-  'text-[13px] font-medium leading-5 text-blue-600 no-underline',
-  'transition-colors hover:text-blue-700',
-  'dark:text-blue-300 dark:hover:text-blue-200',
-].join(' ')
 
 export function MessageList({
   messages,
@@ -115,6 +105,13 @@ function shouldRenderMessage(message: WorkbenchMessage): boolean {
   if (message.role !== 'assistant') return true
   if (message.status === 'streaming' || message.status === 'failed') return true
   if (message.fileChanges) return true
+  if (
+    message.references?.length ||
+    message.memoryCitations?.length ||
+    message.contextEvents?.length
+  ) {
+    return true
+  }
 
   const visibleContent = shouldHideFailedAssistantContent(message) ? '' : message.content
   if (visibleContent.trim()) return true
@@ -176,12 +173,15 @@ function formatMessageTime(createdAt: string) {
     date.getMonth() === now.getMonth() &&
     date.getDate() === now.getDate()
 
-  return new Intl.DateTimeFormat(undefined, {
-    ...(isToday ? {} : { weekday: 'short' as const }),
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(date)
+  const time = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
+  if (isToday) return time
+
+  const dateLabel = `${date.getMonth() + 1}月${date.getDate()}日`
+  if (date.getFullYear() === now.getFullYear()) {
+    return `${dateLabel} ${time}`
+  }
+
+  return `${date.getFullYear()}年${dateLabel} ${time}`
 }
 
 async function copyText(text: string) {
@@ -202,6 +202,7 @@ async function copyText(text: string) {
 
 function UserMessage({ message }: { message: WorkbenchMessage }) {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
   const codexLocalFileMentions = parseCodexLocalFileMentions(message.content)
   const displayContent = codexLocalFileMentions?.requestText ?? message.content
   const imageAttachments = (message.attachments ?? []).filter(isImageAttachment)
@@ -216,70 +217,77 @@ function UserMessage({ message }: { message: WorkbenchMessage }) {
   const showSourceBadge = isIMSource(message.source)
 
   return (
-    <div className="group flex max-w-[80%] flex-col items-end gap-1.5">
-      {(imageAttachments.length > 0 ||
-        localImageMentions.length > 0 ||
-        documentAttachments.length > 0) && (
-        <div className="flex max-w-full flex-col items-end gap-2">
-          {(imageAttachments.length > 0 || localImageMentions.length > 0) && (
+    <div
+      className="flex max-w-[80%] flex-col items-end gap-1.5"
+      data-testid="message-hover-region"
+      onPointerEnter={() => setAreHoverActionsVisible(true)}
+      onPointerLeave={() => setAreHoverActionsVisible(false)}
+    >
+      <div className="flex w-fit max-w-full flex-col items-end gap-1.5">
+        {(imageAttachments.length > 0 ||
+          localImageMentions.length > 0 ||
+          documentAttachments.length > 0) && (
+          <div className="flex max-w-full flex-col items-end gap-2">
+            {(imageAttachments.length > 0 || localImageMentions.length > 0) && (
+              <div
+                data-testid="message-image-attachments"
+                className="flex max-w-full flex-row flex-wrap justify-end gap-2"
+              >
+                {imageAttachments.map(attachment => (
+                  <MessageImageAttachmentPreview key={attachment.id} attachment={attachment} />
+                ))}
+                {localImageMentions.map(image => (
+                  <MessageLocalImagePreview key={image.path} image={image} />
+                ))}
+              </div>
+            )}
+            {documentAttachments.map(attachment => (
+              <MessageDocumentAttachment key={attachment.id} attachment={attachment} />
+            ))}
+          </div>
+        )}
+        {displayContent && (
+          <div className="max-w-full overflow-hidden rounded-2xl bg-muted text-[13px] leading-5 text-text-primary">
             <div
-              data-testid="message-image-attachments"
-              className="flex max-w-full flex-row flex-wrap justify-end gap-2"
+              data-testid="user-message-content"
+              className={[
+                'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-3',
+                shouldCollapse && !isExpanded ? 'max-h-44' : '',
+              ].join(' ')}
             >
-              {imageAttachments.map(attachment => (
-                <MessageImageAttachmentPreview key={attachment.id} attachment={attachment} />
-              ))}
-              {localImageMentions.map(image => (
-                <MessageLocalImagePreview key={image.path} image={image} />
-              ))}
+              {renderUserContent(displayContent)}
+              {shouldCollapse && !isExpanded && (
+                <span className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-muted to-transparent" />
+              )}
             </div>
-          )}
-          {documentAttachments.map(attachment => (
-            <MessageDocumentAttachment key={attachment.id} attachment={attachment} />
-          ))}
-        </div>
-      )}
-      {displayContent && (
-        <div className="max-w-full overflow-hidden rounded-2xl bg-muted text-[13px] leading-5 text-text-primary">
-          <div
-            data-testid="user-message-content"
-            className={[
-              'relative overflow-hidden break-words whitespace-pre-wrap bg-muted px-4 py-3',
-              shouldCollapse && !isExpanded ? 'max-h-44' : '',
-            ].join(' ')}
-          >
-            {renderUserContent(displayContent)}
-            {shouldCollapse && !isExpanded && (
-              <span className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-muted to-transparent" />
+            {shouldCollapse && (
+              <button
+                type="button"
+                data-testid="toggle-user-message-button"
+                aria-expanded={isExpanded}
+                onClick={() => setIsExpanded(value => !value)}
+                className="flex h-9 w-full items-center justify-center gap-1 border-t border-border/60 text-xs font-medium text-text-secondary transition-colors hover:bg-surface"
+              >
+                {isExpanded ? (
+                  <ChevronUp className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                )}
+                {isExpanded ? '收起' : '展开'}
+              </button>
             )}
           </div>
-          {shouldCollapse && (
-            <button
-              type="button"
-              data-testid="toggle-user-message-button"
-              aria-expanded={isExpanded}
-              onClick={() => setIsExpanded(value => !value)}
-              className="flex h-9 w-full items-center justify-center gap-1 border-t border-border/60 text-xs font-medium text-text-secondary transition-colors hover:bg-surface"
-            >
-              {isExpanded ? (
-                <ChevronUp className="h-3.5 w-3.5" />
-              ) : (
-                <ChevronDown className="h-3.5 w-3.5" />
-              )}
-              {isExpanded ? '收起' : '展开'}
-            </button>
-          )}
-        </div>
-      )}
-      {showSourceBadge && (
-        <div
-          data-testid="message-source-row"
-          className="flex min-h-5 items-center justify-end gap-1"
-        >
-          <ImSourceBadge source={message.source} testId="message-source-badge" />
-        </div>
-      )}
-      <MessageHoverActions message={message} align="right" />
+        )}
+        {showSourceBadge && (
+          <div
+            data-testid="message-source-row"
+            className="flex min-h-5 items-center justify-end gap-1"
+          >
+            <ImSourceBadge source={message.source} testId="message-source-badge" />
+          </div>
+        )}
+      </div>
+      <MessageHoverActions message={message} align="right" visible={areHoverActionsVisible} />
     </div>
   )
 }
@@ -367,41 +375,115 @@ function MessageImageAttachmentPreview({ attachment }: { attachment: Attachment 
 function MessageHoverActions({
   message,
   align,
+  visible,
 }: {
   message: WorkbenchMessage
   align: 'left' | 'right'
+  visible: boolean
 }) {
   const [copied, setCopied] = useState(false)
+  const resetCopiedAfterHideRef = useRef(false)
   const time = formatMessageTime(message.createdAt)
 
-  const handleCopy = () => {
+  useEffect(() => {
+    if (!visible && copied) {
+      resetCopiedAfterHideRef.current = true
+    }
+  }, [copied, visible])
+
+  const handleCopy = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    if (event.detail > 0) {
+      event.currentTarget.blur()
+    }
     void copyText(message.content).then(() => {
       setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
+      resetCopiedAfterHideRef.current = false
     })
   }
 
-  return (
-    <div
-      className={[
-        'flex min-h-5 items-center gap-1 text-xs text-text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100',
-        align === 'right' ? 'justify-end' : 'justify-start',
-      ].join(' ')}
+  const handleLeaveActions = () => {
+    if (copied) {
+      resetCopiedAfterHideRef.current = true
+    }
+  }
+
+  const handleActionsTransitionEnd = (event: ReactTransitionEvent<HTMLDivElement>) => {
+    if (
+      event.target !== event.currentTarget ||
+      event.propertyName !== 'opacity' ||
+      !resetCopiedAfterHideRef.current
+    ) {
+      return
+    }
+
+    resetCopiedAfterHideRef.current = false
+    setCopied(false)
+  }
+
+  const copyAction = (
+    <span
+      data-testid="copy-message-action"
+      className="group/copy relative flex h-6 w-6 items-center justify-center"
     >
-      {time && (
-        <span data-testid="message-hover-time" className="px-1">
-          {time}
-        </span>
-      )}
       <button
         type="button"
         data-testid="copy-message-button"
         onClick={handleCopy}
-        className="flex h-6 w-6 items-center justify-center rounded-md text-text-muted opacity-0 transition-colors hover:bg-muted hover:text-text-secondary group-hover:opacity-100 group-focus:opacity-100 group-focus-within:opacity-100"
+        title="复制"
+        className={[
+          'flex h-6 w-6 items-center justify-center rounded-md transition-colors',
+          copied
+            ? 'bg-text-primary text-background/70 shadow-sm hover:bg-text-primary/90 hover:text-background/80'
+            : 'text-text-muted hover:bg-muted hover:text-text-secondary',
+        ].join(' ')}
         aria-label={copied ? '已复制' : '复制消息'}
       >
-        {copied ? <CopyCheck className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        {copied ? (
+          <Check data-testid="copy-message-success-icon" className="h-4 w-4" strokeWidth={2.2} />
+        ) : (
+          <Copy data-testid="copy-message-icon" className="h-3.5 w-3.5" />
+        )}
       </button>
+      <span
+        data-testid="copy-message-label"
+        className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-1 -translate-x-1/2 whitespace-nowrap rounded-md border border-border bg-base px-1.5 py-0.5 text-xs text-text-secondary opacity-0 shadow-sm transition-opacity group-hover/copy:opacity-100"
+      >
+        复制
+      </span>
+    </span>
+  )
+
+  const timeLabel = time ? (
+    <span
+      data-testid="message-hover-time"
+      className="select-text whitespace-nowrap px-1 text-xs text-text-muted"
+    >
+      {time}
+    </span>
+  ) : null
+
+  return (
+    <div
+      data-testid="message-hover-actions"
+      onMouseLeave={handleLeaveActions}
+      onTransitionEnd={handleActionsTransitionEnd}
+      className={[
+        'flex min-h-5 select-text items-center gap-1 text-xs text-text-muted transition-opacity duration-150',
+        visible ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0',
+        align === 'right' ? 'justify-end' : 'justify-start',
+      ].join(' ')}
+    >
+      {align === 'right' ? (
+        <>
+          {timeLabel}
+          {copyAction}
+        </>
+      ) : (
+        <>
+          {copyAction}
+          {timeLabel}
+        </>
+      )}
     </div>
   )
 }
@@ -501,224 +583,6 @@ function getDisplayProcessingBlocks(
   })
 }
 
-function getAttachmentDownloadId(src: string): number | null {
-  try {
-    const url = new URL(src)
-    const match = url.pathname.match(ATTACHMENT_DOWNLOAD_PATH_PATTERN)
-    return match ? Number(match[1]) : null
-  } catch {
-    const match = src.match(ATTACHMENT_DOWNLOAD_PATH_PATTERN)
-    return match ? Number(match[1]) : null
-  }
-}
-
-function isAuthenticatedAttachmentImageSrc(src: string): boolean {
-  return getAttachmentDownloadId(src) !== null
-}
-
-function getAuthenticatedImageFetchUrl(src: string): string {
-  if (src.startsWith('/api/')) return src
-  if (/^https?:\/\//i.test(src)) return src
-
-  const attachmentId = getAttachmentDownloadId(src)
-  return attachmentId === null ? src : getAttachmentImageUrl(attachmentId)
-}
-
-function isLocalImagePath(src: string): boolean {
-  if (src.startsWith('file://')) return true
-  if (/^[a-zA-Z]:[\\/]/.test(src)) return true
-
-  return src.startsWith('/') && !isAuthenticatedAttachmentImageSrc(src)
-}
-
-type MarkdownLinkTarget = { kind: 'external' } | { kind: 'none' } | { kind: 'file'; path: string }
-
-// Assistant responses frequently reference repository files with relative or
-// absolute filesystem paths. Rendering those as plain anchors makes the browser
-// navigate the SPA to a broken `http://localhost/...` URL, so file links are
-// routed to the caller (the previous-turn diff review when available, otherwise
-// the workspace file panel) instead.
-function classifyMarkdownLink(href?: string): MarkdownLinkTarget {
-  const value = href?.trim()
-  if (!value) return { kind: 'none' }
-  if (/^(https?|mailto|tel):/i.test(value)) return { kind: 'external' }
-  if (value.startsWith('#')) return { kind: 'none' }
-  if (value.startsWith('file://')) {
-    return { kind: 'file', path: localPathFromMarkdownImageSrc(value) }
-  }
-  return { kind: 'file', path: value }
-}
-
-function AssistantMarkdownLink({
-  href,
-  onOpenFile,
-  children,
-}: {
-  href?: string
-  onOpenFile?: (path: string) => void
-  children?: ReactNode
-}) {
-  const target = classifyMarkdownLink(href)
-  const icon = (
-    <Link2
-      aria-hidden="true"
-      className="h-3.5 w-3.5 shrink-0"
-      data-testid="assistant-markdown-link-icon"
-    />
-  )
-
-  if (target.kind === 'file') {
-    const filePath = target.path
-    return (
-      <button
-        type="button"
-        className={ASSISTANT_MARKDOWN_LINK_CLASS}
-        data-testid="assistant-markdown-link"
-        onClick={() => onOpenFile?.(filePath)}
-      >
-        {icon}
-        {children}
-      </button>
-    )
-  }
-
-  return (
-    <a
-      href={href}
-      className={ASSISTANT_MARKDOWN_LINK_CLASS}
-      target="_blank"
-      rel="noopener noreferrer"
-      data-testid="assistant-markdown-link"
-    >
-      {icon}
-      {children}
-    </a>
-  )
-}
-
-function localPathFromMarkdownImageSrc(src: string): string {
-  if (!src.startsWith('file://')) return src
-
-  try {
-    const pathname = decodeURIComponent(new URL(src).pathname)
-    return pathname.match(/^\/[a-zA-Z]:\//) ? pathname.slice(1) : pathname
-  } catch {
-    return src
-  }
-}
-
-function resolveDirectMarkdownImageSrc(src: string): string | null {
-  if (!isLocalImagePath(src)) return src
-
-  const localPath = localPathFromMarkdownImageSrc(src)
-  if (typeof convertFileSrc !== 'function') return null
-
-  try {
-    return convertFileSrc(localPath)
-  } catch {
-    return null
-  }
-}
-
-function AssistantMarkdownImage({ src, alt }: { src?: string; alt?: string }) {
-  const rawSrc = typeof src === 'string' ? src.trim() : ''
-  const [authenticatedPreview, setAuthenticatedPreview] = useState<{
-    rawSrc: string
-    url: string
-  } | null>(null)
-  const [failedSrc, setFailedSrc] = useState<string | null>(null)
-  const isAuthenticatedSrc = rawSrc ? isAuthenticatedAttachmentImageSrc(rawSrc) : false
-  const resolvedSrc = isAuthenticatedSrc
-    ? authenticatedPreview?.rawSrc === rawSrc
-      ? authenticatedPreview.url
-      : null
-    : rawSrc
-      ? resolveDirectMarkdownImageSrc(rawSrc)
-      : null
-  const hasError = failedSrc === rawSrc
-
-  useEffect(() => {
-    let objectUrl: string | null = null
-    let isMounted = true
-
-    if (!rawSrc || !isAuthenticatedSrc) {
-      return () => {
-        isMounted = false
-      }
-    }
-
-    async function loadAuthenticatedImage() {
-      try {
-        const token = localStorage.getItem('auth_token')
-        const response = await fetch(getAuthenticatedImageFetchUrl(rawSrc), {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        })
-
-        if (!response.ok) {
-          throw new Error(`Failed to load markdown image: ${response.status}`)
-        }
-
-        const blob = await response.blob()
-        if (!blob.type.startsWith('image/')) {
-          throw new Error(`Markdown image response is not an image: ${blob.type || 'unknown'}`)
-        }
-
-        objectUrl = URL.createObjectURL(blob)
-        if (isMounted) {
-          setAuthenticatedPreview({ rawSrc, url: objectUrl })
-        } else {
-          URL.revokeObjectURL(objectUrl)
-        }
-      } catch {
-        if (isMounted) {
-          setFailedSrc(rawSrc)
-        }
-      }
-    }
-
-    void loadAuthenticatedImage()
-
-    return () => {
-      isMounted = false
-      if (objectUrl) {
-        URL.revokeObjectURL(objectUrl)
-      }
-    }
-  }, [isAuthenticatedSrc, rawSrc])
-
-  if (hasError) {
-    return (
-      <span
-        data-testid="assistant-markdown-image-error"
-        className="my-2 inline-flex max-w-full rounded-xl border border-border bg-surface px-3 py-2 text-xs text-text-muted"
-      >
-        {alt || rawSrc}
-      </span>
-    )
-  }
-
-  if (!resolvedSrc) {
-    return (
-      <span
-        data-testid="assistant-markdown-image-loading"
-        className="my-2 inline-flex h-20 w-32 max-w-full items-center justify-center rounded-xl border border-border bg-surface text-xs text-text-muted"
-      >
-        {alt || 'Image'}
-      </span>
-    )
-  }
-
-  return (
-    <img
-      data-testid="assistant-markdown-image"
-      src={resolvedSrc}
-      alt={alt || ''}
-      className="my-2 block max-h-[360px] max-w-full rounded-xl border border-border bg-base object-contain"
-      loading="lazy"
-    />
-  )
-}
-
 function AssistantMessage({
   message,
   devices,
@@ -754,6 +618,9 @@ function AssistantMessage({
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = message.status === 'streaming'
   const shouldShowCompactThinking = isStreaming && !hasBlocks && !hasVisibleContent
+  const contextEvents = message.contextEvents ?? []
+  const memoryCitations = message.memoryCitations ?? []
+  const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
 
   // A file referenced in the response usually belongs to this turn's changes, so
   // route the link into the previous-turn diff review focused on that file. When
@@ -772,123 +639,81 @@ function AssistantMessage({
     }
     onOpenWorkspaceFile?.(path)
   }
+  const references = getAssistantReferences(message.references, visibleContent)
 
   return (
-    <div className="group min-w-0 overflow-x-hidden text-[13px] leading-6 text-text-primary">
-      {hasBlocks && (
-        <ToolBlocksDisplay
-          blocks={displayBlocks}
-          isStreaming={isStreaming}
-          startedAt={getTurnStartMs(message.createdAt)}
-          forceExpanded={isCancelled}
-          showSummary={!isCancelled}
-          onOpenWorkspaceFile={onOpenWorkspaceFile}
-        />
-      )}
-      {hasVisibleContent && (
-        <div className="assistant-markdown min-w-0 overflow-x-hidden break-words">
-          <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
-            components={{
-              h1: ({ children }) => <h1 className="mb-4 mt-6 text-lg font-semibold">{children}</h1>,
-              h2: ({ children }) => (
-                <h2 className="mb-3 mt-5 text-base font-semibold">{children}</h2>
-              ),
-              h3: ({ children }) => <h3 className="mb-2 mt-4 text-sm font-semibold">{children}</h3>,
-              p: ({ children }) => <p className="mb-3 min-w-0 break-words leading-6">{children}</p>,
-              ul: ({ children }) => <ul className="mb-3 list-disc space-y-1.5 pl-5">{children}</ul>,
-              ol: ({ children }) => (
-                <ol className="mb-3 list-decimal space-y-1.5 pl-8">{children}</ol>
-              ),
-              li: ({ children }) => (
-                <li className="min-w-0 break-words pl-1 leading-6">{children}</li>
-              ),
-              strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-              code: ({ className, children }) => {
-                const match = /language-(\w*)/.exec(className || '')
-                const isBlock = Boolean(match) || String(children).includes('\n')
-                if (isBlock) {
-                  const lang = match ? match[1] || '' : ''
-                  return <CodeBlock lang={lang}>{children}</CodeBlock>
-                }
-                return (
-                  <code className="break-words rounded bg-muted px-1.5 py-0.5 text-xs font-medium text-text-primary">
-                    {children}
-                  </code>
-                )
-              },
-              pre: ({ children }) => (
-                <pre className="mb-3 mt-2 max-w-full overflow-hidden">{children}</pre>
-              ),
-              blockquote: ({ children }) => (
-                <blockquote className="mb-3 border-l-3 border-border pl-4 text-text-secondary">
-                  {children}
-                </blockquote>
-              ),
-              table: ({ children }) => (
-                <div className="mb-3 max-w-full overflow-x-auto">
-                  <table className="w-full min-w-max border-collapse text-[13px]">{children}</table>
-                </div>
-              ),
-              th: ({ children }) => (
-                <th className="border-b border-border px-3 py-2 text-left font-semibold">
-                  {children}
-                </th>
-              ),
-              td: ({ children }) => (
-                <td className="border-b border-border px-3 py-2">{children}</td>
-              ),
-              a: ({ href, children }) => (
-                <AssistantMarkdownLink href={href} onOpenFile={openFileFromLink}>
-                  {children}
-                </AssistantMarkdownLink>
-              ),
-              img: ({ src, alt }) => <AssistantMarkdownImage src={src} alt={alt} />,
-            }}
-          >
-            {visibleContent}
-          </ReactMarkdown>
-        </div>
-      )}
-      {shouldShowCompactThinking && <WaitingAssistantIndicator />}
-      {message.status === 'failed' && (
-        <AssistantErrorCard
-          error={message.error}
-          errorType={message.errorType}
-          rawError={hiddenErrorContent}
-          message={message}
-          onRetry={onRetryFailedMessage}
-          onSwitchModel={onSwitchModelForFailedMessage}
-        />
-      )}
-      {message.fileChanges && message.subtaskId && onLoadFileChangesDiff && onRevertFileChanges ? (
-        <FileChangesCard
-          subtaskId={message.subtaskId}
-          summary={message.fileChanges}
-          deviceOnline={devices.some(
-            device =>
-              device.device_id === message.fileChanges?.device_id && device.status === 'online'
+    <div className="min-w-0 overflow-x-hidden text-[13px] leading-6 text-text-primary">
+      <div
+        className="w-fit max-w-full"
+        data-testid="message-hover-region"
+        onPointerEnter={() => setAreHoverActionsVisible(true)}
+        onPointerLeave={() => setAreHoverActionsVisible(false)}
+      >
+        <div className="w-fit max-w-full">
+          {hasBlocks && (
+            <ToolBlocksDisplay
+              blocks={displayBlocks}
+              isStreaming={isStreaming}
+              startedAt={getTurnStartMs(message.createdAt)}
+              forceExpanded={isCancelled}
+              showSummary={!isCancelled}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
+            />
           )}
-          onLoadDiff={onLoadFileChangesDiff}
-          onRevert={onRevertFileChanges}
-          onOpenReview={onOpenFileChangesReview}
-        />
-      ) : null}
-      {isCancelled ? (
-        <div
-          data-testid="assistant-stopped-notice"
-          className="mt-4 flex justify-end border-b border-border pb-2 text-sm font-medium text-text-muted"
-        >
-          {t('assistant_status.stopped_after', {
-            duration: getStoppedElapsedDuration(message),
-          })}
+          {contextEvents.length > 0 && <CodexContextEvents events={contextEvents} />}
+          {hasVisibleContent && (
+            <AssistantMarkdown content={visibleContent} onOpenFile={openFileFromLink} />
+          )}
+          {memoryCitations.length > 0 && (
+            <CodexMemoryCitations citations={memoryCitations} onOpenFile={onOpenWorkspaceFile} />
+          )}
+          {references.length > 0 && (
+            <CodexReferenceList references={references} onOpenFile={openFileFromLink} />
+          )}
+          {shouldShowCompactThinking && <WaitingAssistantIndicator />}
+          {message.status === 'failed' && (
+            <AssistantErrorCard
+              error={message.error}
+              errorType={message.errorType}
+              rawError={hiddenErrorContent}
+              message={message}
+              onRetry={onRetryFailedMessage}
+              onSwitchModel={onSwitchModelForFailedMessage}
+            />
+          )}
+          {message.fileChanges &&
+          message.subtaskId &&
+          onLoadFileChangesDiff &&
+          onRevertFileChanges ? (
+            <FileChangesCard
+              subtaskId={message.subtaskId}
+              summary={message.fileChanges}
+              deviceOnline={devices.some(
+                device =>
+                  device.device_id === message.fileChanges?.device_id && device.status === 'online'
+              )}
+              onLoadDiff={onLoadFileChangesDiff}
+              onRevert={onRevertFileChanges}
+              onOpenReview={onOpenFileChangesReview}
+            />
+          ) : null}
+          {isCancelled ? (
+            <div
+              data-testid="assistant-stopped-notice"
+              className="mt-4 flex justify-end border-b border-border pb-2 text-sm font-medium text-text-muted"
+            >
+              {t('assistant_status.stopped_after', {
+                duration: getStoppedElapsedDuration(message),
+              })}
+            </div>
+          ) : null}
         </div>
-      ) : null}
-      {message.status !== 'streaming' &&
-        !isCancelled &&
-        (hasVisibleContent || message.status === 'failed') && (
-          <MessageHoverActions message={message} align="left" />
-        )}
+        {message.status !== 'streaming' &&
+          !isCancelled &&
+          (hasVisibleContent || message.status === 'failed') && (
+            <MessageHoverActions message={message} align="left" visible={areHoverActionsVisible} />
+          )}
+      </div>
     </div>
   )
 }
@@ -995,60 +820,5 @@ function AssistantErrorCard({
         )}
       </div>
     </div>
-  )
-}
-
-function CodeBlock({ lang, children }: { lang: string; children: React.ReactNode }) {
-  const [copied, setCopied] = useState(false)
-  const text = String(children).replace(/\n$/, '')
-
-  const handleCopy = () => {
-    void navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
-  }
-
-  return (
-    <code className="block max-w-full overflow-hidden rounded-lg border border-border">
-      <span className="flex items-center justify-between border-b border-border bg-surface px-3 py-1.5">
-        <span className="text-xs text-text-muted">{lang || 'text'}</span>
-        <span className="flex items-center gap-1">
-          <button
-            type="button"
-            onClick={handleCopy}
-            className="p-0.5 text-text-muted hover:text-text-secondary"
-          >
-            {copied ? (
-              <svg
-                className="h-3.5 w-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
-            ) : (
-              <svg
-                className="h-3.5 w-3.5"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                />
-              </svg>
-            )}
-          </button>
-        </span>
-      </span>
-      <span className="block max-w-full overflow-x-auto bg-base px-4 py-3 font-mono text-xs leading-5 text-text-primary">
-        {children}
-      </span>
-    </code>
   )
 }

--- a/wework/src/components/chat/assistantMarkdownLinks.ts
+++ b/wework/src/components/chat/assistantMarkdownLinks.ts
@@ -1,0 +1,99 @@
+import { convertFileSrc } from '@tauri-apps/api/core'
+import { getAttachmentImageUrl } from '@/lib/attachments'
+
+const ATTACHMENT_DOWNLOAD_PATH_PATTERN = /\/(?:api\/)?attachments\/(\d+)\/download(?:[?#].*)?$/
+
+export type MarkdownLinkTarget =
+  | { kind: 'external' }
+  | { kind: 'none' }
+  | { kind: 'file'; path: string; lineStart?: number; lineEnd?: number }
+
+// Assistant responses frequently reference repository files with relative or
+// absolute filesystem paths. Rendering those as plain anchors makes the browser
+// navigate the SPA to a broken `http://localhost/...` URL, so file links are
+// routed to the caller instead.
+export function classifyMarkdownLink(href?: string): MarkdownLinkTarget {
+  const value = href?.trim()
+  if (!value) return { kind: 'none' }
+  if (/^(https?|mailto|tel):/i.test(value)) return { kind: 'external' }
+  if (value.startsWith('#')) return { kind: 'none' }
+  if (value.startsWith('file://')) {
+    return { kind: 'file', ...splitMarkdownFileLineSuffix(localPathFromMarkdownImageSrc(value)) }
+  }
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return { kind: 'external' }
+  return { kind: 'file', ...splitMarkdownFileLineSuffix(value) }
+}
+
+export function splitMarkdownFileLineSuffix(path: string): {
+  path: string
+  lineStart?: number
+  lineEnd?: number
+} {
+  const match = path.match(/^(.*?):(\d+)(?:-(\d+))?$/)
+  if (!match) return { path }
+
+  const basePath = match[1]
+  if (!basePath || /^[a-zA-Z]$/.test(basePath)) return { path }
+
+  const lineStart = Number(match[2])
+  const lineEnd = match[3] ? Number(match[3]) : undefined
+  return {
+    path: basePath,
+    lineStart: Number.isFinite(lineStart) ? lineStart : undefined,
+    lineEnd: lineEnd && Number.isFinite(lineEnd) ? lineEnd : undefined,
+  }
+}
+
+export function resolveDirectMarkdownImageSrc(src: string): string | null {
+  if (!isLocalImagePath(src)) return src
+
+  const localPath = localPathFromMarkdownImageSrc(src)
+  if (typeof convertFileSrc !== 'function') return null
+
+  try {
+    return convertFileSrc(localPath)
+  } catch {
+    return null
+  }
+}
+
+export function localPathFromMarkdownImageSrc(src: string): string {
+  if (!src.startsWith('file://')) return src
+
+  try {
+    const pathname = decodeURIComponent(new URL(src).pathname)
+    return pathname.match(/^\/[a-zA-Z]:\//) ? pathname.slice(1) : pathname
+  } catch {
+    return src
+  }
+}
+
+function getAttachmentDownloadId(src: string): number | null {
+  try {
+    const url = new URL(src)
+    const match = url.pathname.match(ATTACHMENT_DOWNLOAD_PATH_PATTERN)
+    return match ? Number(match[1]) : null
+  } catch {
+    const match = src.match(ATTACHMENT_DOWNLOAD_PATH_PATTERN)
+    return match ? Number(match[1]) : null
+  }
+}
+
+export function isAuthenticatedAttachmentImageSrc(src: string): boolean {
+  return getAttachmentDownloadId(src) !== null
+}
+
+export function getAuthenticatedImageFetchUrl(src: string): string {
+  if (src.startsWith('/api/')) return src
+  if (/^https?:\/\//i.test(src)) return src
+
+  const attachmentId = getAttachmentDownloadId(src)
+  return attachmentId === null ? src : getAttachmentImageUrl(attachmentId)
+}
+
+function isLocalImagePath(src: string): boolean {
+  if (src.startsWith('file://')) return true
+  if (/^[a-zA-Z]:[\\/]/.test(src)) return true
+
+  return src.startsWith('/') && !isAuthenticatedAttachmentImageSrc(src)
+}

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -85,4 +85,142 @@ describe('ToolBlockItem', () => {
       'Let me explore the repository structure.'
     )
   })
+
+  test('renders process text code blocks with shared syntax highlighting', () => {
+    render(
+      <ToolBlockItem
+        block={{
+          ...streamingTextBlock,
+          status: 'done',
+          content: [
+            'Use CSS:',
+            '',
+            '```css',
+            '.collapsible {',
+            '  display: grid;',
+            '}',
+            '```',
+          ].join('\n'),
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('markdown-code-block')).toHaveTextContent('.collapsible')
+    expect(screen.getByTestId('markdown-code-block-language')).toHaveTextContent('css')
+    expect(screen.queryByTestId('markdown-code-wrap-button')).not.toBeInTheDocument()
+  })
+
+  test('renders markdown code labels as md and toggles line wrapping', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToolBlockItem
+        block={{
+          ...streamingTextBlock,
+          status: 'done',
+          content: ['```markdown', 'After creating the PR, check for merge conflicts.', '```'].join(
+            '\n'
+          ),
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('markdown-code-block-language')).toHaveTextContent('md')
+
+    const wrapButton = screen.getByTestId('markdown-code-wrap-button')
+    const scrollContainer = screen.getByTestId('markdown-code-scroll-container')
+    const code = screen.getByTestId('markdown-code-block').querySelector('code')
+
+    expect(wrapButton).toHaveAttribute('aria-pressed', 'false')
+    expect(wrapButton).toHaveAttribute('aria-label', '开启自动换行')
+    expect(wrapButton).toHaveAttribute('title', '开启自动换行')
+    expect(screen.getByTestId('markdown-code-wrap-disabled-icon')).toBeInTheDocument()
+    expect(scrollContainer).toHaveAttribute('data-wrap', 'false')
+    expect(scrollContainer).toHaveClass('overflow-x-auto')
+    expect(code).toHaveStyle({
+      whiteSpace: 'pre',
+      overflowWrap: 'normal',
+      wordBreak: 'normal',
+    })
+
+    await user.click(wrapButton)
+
+    expect(wrapButton).toHaveAttribute('aria-pressed', 'true')
+    expect(wrapButton).toHaveAttribute('aria-label', '禁用自动换行')
+    expect(wrapButton).toHaveAttribute('title', '禁用自动换行')
+    expect(screen.getByTestId('markdown-code-wrap-enabled-icon')).toBeInTheDocument()
+    expect(scrollContainer).toHaveAttribute('data-wrap', 'true')
+    expect(scrollContainer).toHaveClass('overflow-x-hidden')
+    expect(code).toHaveStyle({
+      whiteSpace: 'pre-wrap',
+      overflowWrap: 'anywhere',
+      wordBreak: 'break-word',
+    })
+
+    await user.unhover(wrapButton)
+
+    expect(wrapButton).toHaveAttribute('aria-pressed', 'true')
+    expect(wrapButton).toHaveAttribute('aria-label', '禁用自动换行')
+    expect(scrollContainer).toHaveAttribute('data-wrap', 'true')
+    expect(code).toHaveStyle({
+      whiteSpace: 'pre-wrap',
+      overflowWrap: 'anywhere',
+      wordBreak: 'break-word',
+    })
+
+    await user.click(wrapButton)
+
+    expect(wrapButton).toHaveAttribute('aria-pressed', 'false')
+    expect(wrapButton).toHaveAttribute('aria-label', '开启自动换行')
+    expect(scrollContainer).toHaveAttribute('data-wrap', 'false')
+    expect(code).toHaveStyle({
+      whiteSpace: 'pre',
+      overflowWrap: 'normal',
+      wordBreak: 'normal',
+    })
+  })
+
+  test('keeps markdown line wrapping when the code block remounts', async () => {
+    const user = userEvent.setup()
+    const markdownContent = [
+      '```markdown',
+      'Persistent markdown wrap state after pointer leaves and the block remounts.',
+      '```',
+    ].join('\n')
+
+    const { unmount } = render(
+      <ToolBlockItem
+        block={{
+          ...streamingTextBlock,
+          status: 'done',
+          content: markdownContent,
+        }}
+      />
+    )
+
+    await user.click(screen.getByTestId('markdown-code-wrap-button'))
+
+    expect(screen.getByTestId('markdown-code-scroll-container')).toHaveAttribute(
+      'data-wrap',
+      'true'
+    )
+
+    unmount()
+
+    render(
+      <ToolBlockItem
+        block={{
+          ...streamingTextBlock,
+          status: 'done',
+          content: markdownContent,
+        }}
+      />
+    )
+
+    expect(screen.getByTestId('markdown-code-wrap-button')).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByTestId('markdown-code-scroll-container')).toHaveAttribute(
+      'data-wrap',
+      'true'
+    )
+  })
 })

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -4,6 +4,8 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
+import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
+import { isCommandToolName } from './toolBlockActivity'
 
 const THINKING_PREVIEW_MAX_LENGTH = 96
 
@@ -185,14 +187,9 @@ function ProcessMarkdown({ content }: { content: string }) {
             if (isBlock) {
               const lang = match ? match[1] || '' : ''
               return (
-                <code className="mb-1.5 block max-w-full overflow-hidden rounded border border-border">
-                  <span className="block border-b border-border bg-surface px-3 py-1 text-xs text-text-muted">
-                    {lang || 'text'}
-                  </span>
-                  <span className="block max-w-full overflow-x-auto px-4 py-2 font-mono text-xs leading-5 text-text-primary">
-                    {String(children).replace(/\n$/, '')}
-                  </span>
-                </code>
+                <MarkdownCodeBlock lang={lang} compact>
+                  {children}
+                </MarkdownCodeBlock>
               )
             }
             return (
@@ -201,9 +198,7 @@ function ProcessMarkdown({ content }: { content: string }) {
               </code>
             )
           },
-          pre: ({ children }) => (
-            <pre className="mb-1.5 max-w-full overflow-hidden">{children}</pre>
-          ),
+          pre: ({ children }) => <>{children}</>,
           blockquote: ({ children }) => (
             <blockquote className="mb-1.5 border-l-3 border-border pl-3 opacity-80">
               {children}
@@ -231,7 +226,7 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
   const name = block.toolName.toLowerCase()
   const prefix = getToolStatusPrefix(block)
 
-  if (name === 'bash' || name === 'execute_command' || name === 'run_terminal_command') {
+  if (isCommandToolName(name)) {
     const command = getInputField(block, 'command', 'cmd')
     const shortCmd = command ? truncate(command.split('\n')[0], 40) : block.toolName
     return { icon: <TerminalIcon />, label: `${prefix.running} ${shortCmd}` }
@@ -359,7 +354,7 @@ function ToolIcon() {
 function renderBlockDetail(block: ToolBlock) {
   const name = block.toolName.toLowerCase()
 
-  if (name === 'bash' || name === 'execute_command' || name === 'run_terminal_command') {
+  if (isCommandToolName(name)) {
     return <BashBlockDetail block={block} />
   }
   if (name === 'write' || name === 'create_file' || name === 'write_file') {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -30,6 +30,32 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
   })
 
+  test('opens completed processing details with a short content transition', () => {
+    render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={false} />)
+
+    const toggle = screen.getByRole('button', { name: /已处理/ })
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+    expect(toggle).toHaveClass('inline-flex')
+    expect(toggle).not.toHaveClass('w-full')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+    expect(collapseContent).toHaveClass(
+      'transition-[grid-template-rows,opacity]',
+      'duration-[220ms]',
+      'grid-rows-[0fr]',
+      'opacity-0',
+      'pointer-events-none'
+    )
+
+    fireEvent.click(toggle.parentElement as HTMLElement)
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+
+    fireEvent.click(toggle)
+
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(collapseContent).toHaveClass('grid-rows-[1fr]', 'opacity-100')
+    expect(toggle.querySelector('svg')).toHaveClass('-rotate-90')
+  })
+
   test('keeps live duration when the run finishes', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-05T00:00:00.000Z'))

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
 import { ChevronDown, Search, SquareTerminal } from 'lucide-react'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { ToolBlockItem } from './ToolBlockItem'
-import { buildProcessingDisplayRows, type ProcessingDisplayRow } from './toolBlockActivity'
+import {
+  buildProcessingDisplayRows,
+  isCommandToolName,
+  type ProcessingDisplayRow,
+} from './toolBlockActivity'
 
 interface ToolBlocksDisplayProps {
   blocks: ProcessingBlock[]
@@ -56,63 +61,100 @@ export function ToolBlocksDisplay({
     }
   }, [completedAt, hasRenderedRunning, isRunning])
 
-  if (blocks.length === 0 && !isStreaming) return null
-
   const duration = getDurationText(blocks, turnStartedAt, now, completedAt, isRunning)
-  const rows = buildProcessingDisplayRows(blocks, { groupCompletedTools: !isRunning })
-  const expanded = forceExpanded || isRunning || userExpanded
-  const hasLiveNarrativeBlock = rows.some(
-    row =>
-      row.type === 'block' &&
-      (row.block.type === 'thinking' || row.block.type === 'text') &&
-      row.block.status !== 'done' &&
-      row.block.status !== 'error' &&
-      Boolean(row.block.content)
+  const rows = useMemo(
+    () => buildProcessingDisplayRows(blocks, { groupCompletedTools: !isRunning }),
+    [blocks, isRunning]
   )
+  const expanded = forceExpanded || isRunning || userExpanded
+  const hasLiveNarrativeBlock = useMemo(
+    () =>
+      rows.some(
+        row =>
+          row.type === 'block' &&
+          (row.block.type === 'thinking' || row.block.type === 'text') &&
+          row.block.status !== 'done' &&
+          row.block.status !== 'error' &&
+          Boolean(row.block.content)
+      ),
+    [rows]
+  )
+  const processingContent = useMemo(
+    () => (
+      <div className="flex min-w-0 flex-col gap-3 pt-0.5">
+        {rows.map(row =>
+          row.type === 'activity_group' ? (
+            <ToolActivityGroup key={row.id} row={row} onOpenWorkspaceFile={onOpenWorkspaceFile} />
+          ) : (
+            <ToolBlockItem
+              key={row.id}
+              block={row.block}
+              forceExpanded={isRunning && row.block.type === 'tool'}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
+            />
+          )
+        )}
+        {isRunning && !hasLiveNarrativeBlock && <ThinkingIndicator />}
+      </div>
+    ),
+    [hasLiveNarrativeBlock, isRunning, onOpenWorkspaceFile, rows]
+  )
+
+  if (blocks.length === 0 && !isStreaming) return null
 
   return (
     <div className="mb-3 min-w-0">
       {showSummary && isRunning ? (
         // While the turn is still running the summary is informational only:
         // render it as plain, non-interactive text so it does not look clickable.
-        <div className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-xs text-text-muted">
-          <span>{duration}</span>
+        <div className="mb-3 border-b border-border pb-2 text-xs text-text-muted">
+          <span className="inline-flex items-center gap-1">{duration}</span>
         </div>
       ) : showSummary ? (
-        <button
-          type="button"
-          className="mb-3 flex w-full items-center gap-1 border-b border-border pb-2 text-left text-xs text-text-muted hover:text-text-secondary"
-          onClick={() => setUserExpanded(value => !value)}
-        >
-          <span>{duration}</span>
-          <svg
-            className={`h-3 w-3 transition-transform ${expanded ? '' : '-rotate-90'}`}
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={2}
+        <div className="mb-3 border-b border-border pb-2">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-left text-xs text-text-muted hover:text-text-secondary"
+            onClick={() => setUserExpanded(value => !value)}
           >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-      ) : null}
-      {expanded && (
-        <div className="flex min-w-0 flex-col gap-3">
-          {rows.map(row =>
-            row.type === 'activity_group' ? (
-              <ToolActivityGroup key={row.id} row={row} onOpenWorkspaceFile={onOpenWorkspaceFile} />
-            ) : (
-              <ToolBlockItem
-                key={row.id}
-                block={row.block}
-                forceExpanded={isRunning && row.block.type === 'tool'}
-                onOpenWorkspaceFile={onOpenWorkspaceFile}
-              />
-            )
-          )}
-          {isRunning && !hasLiveNarrativeBlock && <ThinkingIndicator />}
+            <span>{duration}</span>
+            <svg
+              className="h-3 w-3 -rotate-90"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+            </svg>
+          </button>
         </div>
-      )}
+      ) : null}
+      <CollapsibleProcessingContent expanded={expanded}>
+        {processingContent}
+      </CollapsibleProcessingContent>
+    </div>
+  )
+}
+
+function CollapsibleProcessingContent({
+  expanded,
+  children,
+}: {
+  expanded: boolean
+  children: ReactNode
+}) {
+  return (
+    <div
+      data-testid="processing-collapse-content"
+      aria-hidden={!expanded}
+      inert={!expanded ? true : undefined}
+      className={[
+        'grid overflow-hidden transition-[grid-template-rows,opacity] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+        expanded ? 'grid-rows-[1fr] opacity-100' : 'pointer-events-none grid-rows-[0fr] opacity-0',
+      ].join(' ')}
+    >
+      <div className="min-h-0 overflow-hidden">{children}</div>
     </div>
   )
 }
@@ -155,9 +197,7 @@ function ToolActivityGroup({
 }
 
 function hasCommandBlocks(blocks: ToolBlock[]): boolean {
-  return blocks.some(block =>
-    ['bash', 'execute_command', 'run_terminal_command'].includes(block.toolName.toLowerCase())
-  )
+  return blocks.some(block => isCommandToolName(block.toolName))
 }
 
 function ThinkingIndicator() {

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -2,13 +2,18 @@ import { describe, expect, test } from 'vitest'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { buildProcessingDisplayRows, summarizeToolBlocks } from './toolBlockActivity'
 
-function tool(id: string, command: string, status: ToolBlock['status'] = 'done'): ToolBlock {
+function tool(
+  id: string,
+  command: string,
+  status: ToolBlock['status'] = 'done',
+  toolName = 'bash'
+): ToolBlock {
   return {
     id,
     subtaskId: 1,
     type: 'tool',
-    toolName: 'bash',
-    toolInput: { command },
+    toolName,
+    toolInput: toolName === 'exec_command' ? { cmd: command } : { command },
     status,
     createdAt: 1770000000000,
   }
@@ -24,6 +29,16 @@ describe('toolBlockActivity', () => {
         tool('failed-1', "/bin/zsh -lc 'wc -l missing.jsonl'", 'error'),
       ])
     ).toBe('已探索 1 个文件 1 次搜索 已运行 1 条命令 运行失败 1 条命令')
+  })
+
+  test('classifies Codex exec_command function calls as shell command activity', () => {
+    expect(
+      summarizeToolBlocks([
+        tool('read-1', "sed -n '1,5p' file.jsonl", 'done', 'exec_command'),
+        tool('search-1', 'rg session_meta .', 'done', 'exec_command'),
+        tool('cmd-1', 'node inspect.js', 'done', 'exec_command'),
+      ])
+    ).toBe('已探索 1 个文件 1 次搜索 已运行 1 条命令')
   })
 
   test('groups completed tools while preserving running tools as standalone rows', () => {

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -17,7 +17,13 @@ interface ActivityStats {
   failedTools: number
 }
 
-const COMMAND_TOOLS = new Set(['bash', 'execute_command', 'run_terminal_command'])
+const COMMAND_TOOLS = new Set([
+  'bash',
+  'exec_command',
+  'execute_command',
+  'functions.exec_command',
+  'run_terminal_command',
+])
 const FILE_TOOLS = new Set(['read', 'read_file'])
 const CREATE_TOOLS = new Set(['write', 'create_file', 'write_file'])
 const EDIT_TOOLS = new Set(['edit', 'str_replace_editor', 'edit_file'])
@@ -83,7 +89,7 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
     (stats, block) => {
       const kind = getToolActivityKind(block)
       if (block.status === 'error') {
-        if (kind === 'command' || isCommandTool(block.toolName)) {
+        if (kind === 'command' || isCommandToolName(block.toolName)) {
           stats.failedCommands += 1
         } else {
           stats.failedTools += 1
@@ -118,7 +124,7 @@ function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   if (CREATE_TOOLS.has(name)) return 'create'
   if (EDIT_TOOLS.has(name)) return 'edit'
   if (SEARCH_TOOL_HINTS.some(hint => name.includes(hint))) return 'search'
-  if (isCommandTool(name)) return getCommandActivityKind(getInputField(block, 'command', 'cmd'))
+  if (isCommandToolName(name)) return getCommandActivityKind(getInputField(block, 'command', 'cmd'))
   return 'tool'
 }
 
@@ -150,7 +156,7 @@ function isCompletedToolBlock(block: ToolBlock): boolean {
   return block.status === 'done' || block.status === 'error'
 }
 
-function isCommandTool(name: string): boolean {
+export function isCommandToolName(name: string): boolean {
   return COMMAND_TOOLS.has(name.toLowerCase())
 }
 

--- a/wework/src/components/chat/codexReferences.ts
+++ b/wework/src/components/chat/codexReferences.ts
@@ -1,0 +1,107 @@
+import type { CodexReference } from '@/types/api'
+import { classifyMarkdownLink, splitMarkdownFileLineSuffix } from './assistantMarkdownLinks'
+
+const MARKDOWN_LINK_PATTERN = /\[([^\]]+)]\((<[^>]+>|[^)\s]+)(?:\s+["'][^"']*["'])?\)/g
+const CODEX_REFERENCE_DOCUMENT_EXTENSIONS = new Set([
+  'doc',
+  'docx',
+  'log',
+  'markdown',
+  'md',
+  'mdx',
+  'odt',
+  'pages',
+  'pdf',
+  'rst',
+  'rtf',
+  'tex',
+  'txt',
+])
+
+export function getAssistantReferences(
+  references: CodexReference[] | null | undefined,
+  content: string
+): CodexReference[] {
+  const explicitReferences =
+    references?.filter(reference => reference.path && reference.path.trim()) ?? []
+  return filterCodexDocumentReferences(
+    uniqueCodexReferences([...explicitReferences, ...extractAssistantFileReferences(content)])
+  )
+}
+
+export function getDisplayCodexReferences(references: CodexReference[]): CodexReference[] {
+  return filterCodexDocumentReferences(uniqueCodexReferences(references))
+}
+
+function extractAssistantFileReferences(content: string): CodexReference[] {
+  const references: CodexReference[] = []
+  for (const match of content.matchAll(MARKDOWN_LINK_PATTERN)) {
+    const title = match[1]?.trim()
+    const href = unwrapMarkdownHref(match[2])
+    const target = classifyMarkdownLink(href)
+    if (target.kind !== 'file') continue
+    if (!isCodexDocumentReferencePath(target.path)) continue
+
+    references.push({
+      title: title || basename(target.path),
+      path: target.path,
+      lineStart: target.lineStart,
+      lineEnd: target.lineEnd,
+    })
+  }
+  return uniqueCodexReferences(references)
+}
+
+function unwrapMarkdownHref(rawHref: string | undefined): string | undefined {
+  const value = rawHref?.trim()
+  if (!value) return undefined
+  if (value.startsWith('<') && value.endsWith('>')) return value.slice(1, -1)
+  return value
+}
+
+function normalizeCodexReference(reference: CodexReference): CodexReference | null {
+  const path = reference.path.trim()
+  if (!path) return null
+
+  const parsed = splitMarkdownFileLineSuffix(path)
+  return {
+    ...reference,
+    path: parsed.path,
+    lineStart: reference.lineStart ?? parsed.lineStart,
+    lineEnd: reference.lineEnd ?? parsed.lineEnd,
+  }
+}
+
+function uniqueCodexReferences(references: CodexReference[]): CodexReference[] {
+  const seen = new Set<string>()
+  const uniqueReferences: CodexReference[] = []
+  for (const reference of references) {
+    const normalizedReference = normalizeCodexReference(reference)
+    if (!normalizedReference) continue
+
+    const key = normalizedReference.path
+    if (seen.has(key)) continue
+    seen.add(key)
+    uniqueReferences.push(normalizedReference)
+  }
+  return uniqueReferences
+}
+
+function filterCodexDocumentReferences(references: CodexReference[]): CodexReference[] {
+  return references.filter(reference => isCodexDocumentReferencePath(reference.path))
+}
+
+function isCodexDocumentReferencePath(path: string): boolean {
+  const extension = fileExtension(path)
+  return CODEX_REFERENCE_DOCUMENT_EXTENSIONS.has(extension)
+}
+
+export function fileExtension(path: string): string {
+  const filename = basename(path)
+  const index = filename.lastIndexOf('.')
+  return index > -1 && index < filename.length - 1 ? filename.slice(index + 1).toLowerCase() : ''
+}
+
+export function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -273,7 +273,7 @@ export interface WorkbenchServices {
 }
 
 async function createConversationWorkspace(
-  deviceApi: WorkbenchServices['deviceApi'],
+  deviceApi: Pick<WorkbenchServices['deviceApi'], 'createDirectory' | 'getHomeDirectory'>,
   deviceId: string,
   message: string
 ): Promise<string> {
@@ -775,6 +775,47 @@ function getRuntimeMessageBlockSubtaskId(
   return RUNTIME_BLOCK_SUBTASK_ID_OFFSET + hash
 }
 
+function normalizeRuntimeReferences(
+  references: NormalizedRuntimeMessage['references']
+): WorkbenchMessage['references'] {
+  if (!Array.isArray(references)) return undefined
+  const normalized = references.filter(
+    reference => reference && typeof reference.path === 'string' && reference.path.trim()
+  )
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function normalizeRuntimeMemoryCitations(
+  message: NormalizedRuntimeMessage
+): WorkbenchMessage['memoryCitations'] {
+  const citations: NonNullable<WorkbenchMessage['memoryCitations']> = []
+  const addCitation = (value: unknown) => {
+    if (isRecord(value) && Array.isArray(value.entries)) {
+      citations.push(value as NonNullable<WorkbenchMessage['memoryCitations']>[number])
+    }
+  }
+
+  if (Array.isArray(message.memoryCitations)) {
+    message.memoryCitations.forEach(addCitation)
+  }
+  if (Array.isArray(message.memory_citations)) {
+    message.memory_citations.forEach(addCitation)
+  }
+  addCitation(message.memoryCitation)
+  addCitation(message.memory_citation)
+
+  return citations.length > 0 ? citations : undefined
+}
+
+function normalizeRuntimeContextEvents(
+  message: NormalizedRuntimeMessage
+): WorkbenchMessage['contextEvents'] {
+  const events = [...(message.contextEvents ?? []), ...(message.context_events ?? [])].filter(
+    event => event && typeof event.id === 'string' && typeof event.type === 'string'
+  )
+  return events.length > 0 ? events : undefined
+}
+
 function runtimeMessageToWorkbenchMessage(
   address: RuntimeTaskAddress,
   message: NormalizedRuntimeMessage
@@ -816,6 +857,9 @@ function runtimeMessageToWorkbenchMessage(
     attachments: message.attachments,
     blocks: blocks.length > 0 ? blocks : undefined,
     fileChanges: normalizeTurnFileChanges(message.fileChanges ?? message.file_changes),
+    references: normalizeRuntimeReferences(message.references),
+    memoryCitations: normalizeRuntimeMemoryCitations(message),
+    contextEvents: normalizeRuntimeContextEvents(message),
     createdAt,
   }
 }

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -11,10 +11,32 @@
   "assistant_status": {
     "stopped_after": "You stopped after {{duration}}"
   },
+  "codex_context": {
+    "compacting": "Compacting context",
+    "compacted": "Context compacted"
+  },
+  "codex_references": {
+    "title": "Referenced files",
+    "open_label": "Open {{path}}",
+    "open_with": "Open with",
+    "preview_label": "Open preview",
+    "kind": "Document",
+    "kind_with_extension": "Document · {{extension}}"
+  },
+  "memory_citations": {
+    "summary": "{{count}} memory citations",
+    "line_label": "lines {{range}}",
+    "open_label": "Open {{path}}"
+  },
   "file_changes": {
     "edited_files": "Edited {{count}} files",
+    "edited_file": "Edited {{filename}}",
+    "created_file": "Created {{filename}}",
+    "deleted_file": "Deleted {{filename}}",
+    "renamed_file": "Renamed {{filename}}",
+    "view_changes": "View changes",
     "show_more": "Show {{count}} more files",
-    "show_less": "Show less",
+    "show_less": "Collapse files",
     "review": "Review",
     "review_title": "Changes from this turn",
     "preview_file_label": "Preview file changes for {{path}}",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -11,10 +11,32 @@
   "assistant_status": {
     "stopped_after": "你在 {{duration}} 后停止了"
   },
+  "codex_context": {
+    "compacting": "正在自动压缩上下文",
+    "compacted": "上下文已自动压缩"
+  },
+  "codex_references": {
+    "title": "引用文件",
+    "open_label": "打开 {{path}}",
+    "open_with": "打开方式",
+    "preview_label": "打开预览",
+    "kind": "文档",
+    "kind_with_extension": "文档 · {{extension}}"
+  },
+  "memory_citations": {
+    "summary": "{{count}} 条记忆引用",
+    "line_label": "{{range}} 行",
+    "open_label": "打开 {{path}}"
+  },
   "file_changes": {
     "edited_files": "已编辑 {{count}} 个文件",
+    "edited_file": "已编辑 {{filename}}",
+    "created_file": "已创建 {{filename}}",
+    "deleted_file": "已删除 {{filename}}",
+    "renamed_file": "已重命名 {{filename}}",
+    "view_changes": "查看更改",
     "show_more": "再显示 {{count}} 个文件",
-    "show_less": "收起",
+    "show_less": "收起文件",
     "review": "审核",
     "review_title": "本轮文件变更",
     "preview_file_label": "预览 {{path}} 的文件变更",

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -256,6 +256,45 @@ export interface NormalizedRuntimeMessage {
   blocks?: ChatBlock[]
   fileChanges?: TurnFileChangesSummary | null
   file_changes?: TurnFileChangesSummary | null
+  references?: CodexReference[] | null
+  memoryCitations?: CodexMemoryCitation[] | null
+  memory_citations?: CodexMemoryCitation[] | null
+  memoryCitation?: CodexMemoryCitation | null
+  memory_citation?: CodexMemoryCitation | null
+  contextEvents?: CodexContextEvent[] | null
+  context_events?: CodexContextEvent[] | null
+}
+
+export interface CodexReference {
+  path: string
+  title?: string | null
+  lineStart?: number | null
+  lineEnd?: number | null
+}
+
+export interface CodexMemoryCitationEntry {
+  path: string
+  lineStart?: number | null
+  line_start?: number | null
+  lineEnd?: number | null
+  line_end?: number | null
+  note?: string | null
+}
+
+export interface CodexMemoryCitation {
+  entries?: CodexMemoryCitationEntry[]
+  rolloutIds?: string[]
+  rollout_ids?: string[]
+  threadIds?: string[]
+  thread_ids?: string[]
+}
+
+export interface CodexContextEvent {
+  id: string
+  type: 'context_compaction' | 'contextCompaction' | string
+  status?: 'pending' | 'streaming' | 'done' | 'error' | string | null
+  createdAt?: number | string | null
+  created_at?: number | string | null
 }
 
 export interface LocalTaskSummary {

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -1,5 +1,8 @@
 import type {
   Attachment,
+  CodexContextEvent,
+  CodexMemoryCitation,
+  CodexReference,
   DeviceInfo,
   ProjectWithTasks,
   RuntimeTaskAddress,
@@ -41,6 +44,9 @@ export type RuntimeWorkbenchMessageStatus = WorkbenchMessageStatus | 'cancelled'
 
 export type WorkbenchMessage = CoreWorkbenchMessage<Attachment, TurnFileChangesSummary> & {
   runtimeStatus?: RuntimeWorkbenchMessageStatus | null
+  references?: CodexReference[] | null
+  memoryCitations?: CodexMemoryCitation[] | null
+  contextEvents?: CodexContextEvent[] | null
 }
 
 export type QueuedMessageStatus = 'queued' | 'sending' | 'failed'


### PR DESCRIPTION
## Summary
- Render Codex-style assistant turns in wework, including rich markdown/code blocks, tool activity, references, memory citations, and context events.
- Normalize Codex runtime transcripts in executor so archived/live sessions expose file changes, relative paths, merged edits, and hoverable diffs.
- Keep the file-change undo control visible as a grey disabled button while preserving review/diff interactions.

## Verification
- cargo test --test app_runtime_work_file_changes_contract
- cargo clippy --all-features --all-targets -- -D warnings
- pnpm --dir wework test src/components/chat/FileChangesCard.test.tsx src/components/chat/MessageList.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/blocks/toolBlockActivity.test.ts src/api/local/localServices.test.ts src/api/executorAccess.test.ts
- pnpm --dir wework exec tsc -b --pretty false
- pnpm --dir wework build
- git diff --check
- pre-push quality gate passed with AI_VERIFIED=1 after documentation scope review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant messages can now show referenced files, memory citations, and context-compaction events, rendered directly in the chat UI.
  * Added richer assistant Markdown rendering (file-aware links, authenticated images) and shared syntax-highlighted code blocks with a copy button and optional line-wrapping.
  * File change cards now offer interactive per-file hover previews for reviewing diffs across multiple files.

* **Bug Fixes**
  * Improved transcript/message normalization so file changes, tool activity, citations, and context events display consistently across different Codex response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->