### PR TITLE
fix(knowledge-runtime): shorten db session boundary

### DIFF
--- a/knowledge_runtime/knowledge_runtime/api/endpoints/admin.py
+++ b/knowledge_runtime/knowledge_runtime/api/endpoints/admin.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from knowledge_runtime.services.admin_executor import AdminExecutor
-from shared.db.sync_session import get_db
 from shared.models import (
     RemoteDeleteDocumentIndexRequest,
     RemoteDropKnowledgeIndexRequest,
@@ -27,38 +25,34 @@ router = APIRouter()
 @router.post("/delete-document-index")
 async def delete_document_index(
     request: RemoteDeleteDocumentIndexRequest,
-    db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """Delete a document's index from a knowledge base."""
-    executor = AdminExecutor(db=db)
+    executor = AdminExecutor()
     return await executor.delete_document_index(request)
 
 
 @router.post("/purge-knowledge-index")
 async def purge_knowledge_index(
     request: RemotePurgeKnowledgeIndexRequest,
-    db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """Delete all chunks for a knowledge base."""
-    executor = AdminExecutor(db=db)
+    executor = AdminExecutor()
     return await executor.purge_knowledge_index(request)
 
 
 @router.post("/drop-knowledge-index")
 async def drop_knowledge_index(
     request: RemoteDropKnowledgeIndexRequest,
-    db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """Physically drop the index/collection for a knowledge base."""
-    executor = AdminExecutor(db=db)
+    executor = AdminExecutor()
     return await executor.drop_knowledge_index(request)
 
 
 @router.post("/all-chunks")
 async def list_chunks(
     request: RemoteListChunksRequest,
-    db: Session = Depends(get_db),
 ) -> RemoteListChunksResponse:
     """List all chunks in a knowledge base."""
-    executor = AdminExecutor(db=db)
+    executor = AdminExecutor()
     return await executor.list_chunks(request)

--- a/knowledge_runtime/knowledge_runtime/api/endpoints/index.py
+++ b/knowledge_runtime/knowledge_runtime/api/endpoints/index.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from knowledge_runtime.services.index_executor import IndexExecutor
-from shared.db.sync_session import get_db
 from shared.models import RemoteIndexRequest
 
 router = APIRouter()
@@ -21,16 +19,14 @@ router = APIRouter()
 @router.post("/index")
 async def index_document(
     request: RemoteIndexRequest,
-    db: Session = Depends(get_db),
 ) -> dict[str, Any]:
     """Index a document for RAG retrieval.
 
     Args:
         request: The index request containing knowledge_base_id and content_ref.
-        db: Database session for config resolution.
 
     Returns:
         Indexing result with chunk_count, doc_ref, etc.
     """
-    executor = IndexExecutor(db=db)
+    executor = IndexExecutor()
     return await executor.execute(request)

--- a/knowledge_runtime/knowledge_runtime/api/endpoints/query.py
+++ b/knowledge_runtime/knowledge_runtime/api/endpoints/query.py
@@ -6,11 +6,9 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
+from fastapi import APIRouter
 
 from knowledge_runtime.services.query_executor import QueryExecutor
-from shared.db.sync_session import get_db
 from shared.models import RemoteQueryRequest, RemoteQueryResponse
 
 router = APIRouter()
@@ -19,16 +17,14 @@ router = APIRouter()
 @router.post("/query")
 async def query_documents(
     request: RemoteQueryRequest,
-    db: Session = Depends(get_db),
 ) -> RemoteQueryResponse:
     """Query documents for RAG retrieval.
 
     Args:
         request: The query request containing query text and knowledge_base_ids.
-        db: Database session for config resolution.
 
     Returns:
         Query response with ranked records.
     """
-    executor = QueryExecutor(db=db)
+    executor = QueryExecutor()
     return await executor.execute(request)

--- a/knowledge_runtime/knowledge_runtime/services/admin_executor.py
+++ b/knowledge_runtime/knowledge_runtime/services/admin_executor.py
@@ -10,14 +10,8 @@ import asyncio
 import logging
 from typing import Any
 
-from sqlalchemy.orm import Session
-
-from knowledge_engine.services.document_service import DocumentService
 from knowledge_engine.storage.factory import create_storage_backend_from_runtime_config
-from knowledge_runtime.services.config_resolver import (
-    AdminResolvedConfig,
-    ConfigResolver,
-)
+from knowledge_runtime.services.config_loader import RuntimeConfigLoader
 from shared.models import (
     RemoteDeleteDocumentIndexRequest,
     RemoteDropKnowledgeIndexRequest,
@@ -42,9 +36,8 @@ class AdminExecutor:
     - test_connection: Test storage backend connection
     """
 
-    def __init__(self, db: Session) -> None:
-        self._db = db
-        self._config_resolver = ConfigResolver()
+    def __init__(self, config_loader: RuntimeConfigLoader | None = None) -> None:
+        self._config_loader = config_loader or RuntimeConfigLoader()
 
     @trace_async(
         span_name="delete_document_index",
@@ -55,8 +48,7 @@ class AdminExecutor:
         request: RemoteDeleteDocumentIndexRequest,
     ) -> dict[str, Any]:
         """Delete a document's index from a knowledge base."""
-        config = self._config_resolver.resolve_admin_config(
-            self._db,
+        config = self._config_loader.resolve_admin_config(
             knowledge_base_id=request.knowledge_base_id,
         )
 
@@ -89,8 +81,7 @@ class AdminExecutor:
         request: RemotePurgeKnowledgeIndexRequest,
     ) -> dict[str, Any]:
         """Delete all chunks for a knowledge base."""
-        config = self._config_resolver.resolve_admin_config(
-            self._db,
+        config = self._config_loader.resolve_admin_config(
             knowledge_base_id=request.knowledge_base_id,
         )
 
@@ -121,8 +112,7 @@ class AdminExecutor:
         request: RemoteDropKnowledgeIndexRequest,
     ) -> dict[str, Any]:
         """Physically drop the index/collection for a knowledge base."""
-        config = self._config_resolver.resolve_admin_config(
-            self._db,
+        config = self._config_loader.resolve_admin_config(
             knowledge_base_id=request.knowledge_base_id,
         )
 
@@ -153,8 +143,7 @@ class AdminExecutor:
         request: RemoteListChunksRequest,
     ) -> RemoteListChunksResponse:
         """List all chunks in a knowledge base."""
-        config = self._config_resolver.resolve_admin_config(
-            self._db,
+        config = self._config_loader.resolve_admin_config(
             knowledge_base_id=request.knowledge_base_id,
         )
 

--- a/knowledge_runtime/knowledge_runtime/services/config_loader.py
+++ b/knowledge_runtime/knowledge_runtime/services/config_loader.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Short-lived database session boundary for runtime config resolution."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TypeVar
+
+from sqlalchemy.orm import Session, sessionmaker
+
+from knowledge_runtime.services.config_resolver import (
+    AdminResolvedConfig,
+    ConfigResolver,
+    IndexConfig,
+    QueryConfig,
+)
+from shared.db.sync_session import get_session_factory
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class RuntimeConfigLoader:
+    """Resolve knowledge runtime configs inside a short DB transaction."""
+
+    def __init__(
+        self,
+        session_factory: sessionmaker | None = None,
+        resolver: ConfigResolver | None = None,
+    ) -> None:
+        self._session_factory = session_factory or get_session_factory()
+        self._resolver = resolver or ConfigResolver()
+
+    def resolve_index_config(
+        self,
+        *,
+        knowledge_base_id: int,
+        user_id: int,
+        document_id: int | None = None,
+    ) -> IndexConfig:
+        """Resolve all configs needed for document indexing."""
+        return self._resolve_with_session(
+            lambda db: self._resolver.resolve_index_config(
+                db=db,
+                knowledge_base_id=knowledge_base_id,
+                user_id=user_id,
+                document_id=document_id,
+            )
+        )
+
+    def resolve_query_config(
+        self,
+        *,
+        knowledge_base_id: int,
+        user_id: int,
+    ) -> QueryConfig:
+        """Resolve configs needed for querying a single knowledge base."""
+        return self._resolve_with_session(
+            lambda db: self._resolver.resolve_query_config(
+                db=db,
+                knowledge_base_id=knowledge_base_id,
+                user_id=user_id,
+            )
+        )
+
+    def resolve_query_configs(
+        self,
+        *,
+        knowledge_base_ids: list[int],
+        user_id: int,
+    ) -> dict[int, QueryConfig]:
+        """Resolve query configs for multiple knowledge bases in one session."""
+        return self._resolve_with_session(
+            lambda db: {
+                knowledge_base_id: self._resolver.resolve_query_config(
+                    db=db,
+                    knowledge_base_id=knowledge_base_id,
+                    user_id=user_id,
+                )
+                for knowledge_base_id in knowledge_base_ids
+            }
+        )
+
+    def resolve_admin_config(
+        self,
+        *,
+        knowledge_base_id: int,
+    ) -> AdminResolvedConfig:
+        """Resolve config for admin operations."""
+        return self._resolve_with_session(
+            lambda db: self._resolver.resolve_admin_config(
+                db=db,
+                knowledge_base_id=knowledge_base_id,
+            )
+        )
+
+    def _resolve_with_session(self, resolve: Callable[[Session], T]) -> T:
+        db = self._session_factory()
+        succeeded = False
+        rollback_error: Exception | None = None
+        close_error: Exception | None = None
+
+        try:
+            result = resolve(db)
+            succeeded = True
+            return result
+        finally:
+            try:
+                db.rollback()
+            except Exception as exc:  # pragma: no cover - defensive logging branch
+                rollback_error = exc
+                logger.exception("Failed to rollback runtime config DB session")
+
+            try:
+                db.close()
+            except Exception as exc:  # pragma: no cover - defensive logging branch
+                close_error = exc
+                logger.exception("Failed to close runtime config DB session")
+
+            if succeeded:
+                if rollback_error is not None:
+                    raise rollback_error
+                if close_error is not None:
+                    raise close_error

--- a/knowledge_runtime/knowledge_runtime/services/index_executor.py
+++ b/knowledge_runtime/knowledge_runtime/services/index_executor.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from sqlalchemy.orm import Session
-
 from knowledge_engine.embedding.factory import (
     create_embedding_model_from_runtime_config,
 )
 from knowledge_engine.services.document_service import DocumentService
 from knowledge_engine.storage.factory import create_storage_backend_from_runtime_config
-from knowledge_runtime.services.config_resolver import ConfigResolver
+from knowledge_runtime.services.config_loader import RuntimeConfigLoader
 from knowledge_runtime.services.content_fetcher import ContentFetcher
 from shared.models import RemoteIndexRequest
 
@@ -33,9 +31,8 @@ class IndexExecutor:
     4. Indexes the document using DocumentService
     """
 
-    def __init__(self, db: Session) -> None:
-        self._db = db
-        self._config_resolver = ConfigResolver()
+    def __init__(self, config_loader: RuntimeConfigLoader | None = None) -> None:
+        self._config_loader = config_loader or RuntimeConfigLoader()
         self._content_fetcher = ContentFetcher()
 
     async def execute(self, request: RemoteIndexRequest) -> dict[str, Any]:
@@ -52,8 +49,7 @@ class IndexExecutor:
             ContentFetchError: If content fetching fails.
         """
         # Resolve configs from database
-        config = self._config_resolver.resolve_index_config(
-            db=self._db,
+        config = self._config_loader.resolve_index_config(
             knowledge_base_id=request.knowledge_base_id,
             user_id=request.user_id,
             document_id=request.document_id,

--- a/knowledge_runtime/knowledge_runtime/services/query_executor.py
+++ b/knowledge_runtime/knowledge_runtime/services/query_executor.py
@@ -9,15 +9,14 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from knowledge_runtime.services.config_resolver import ConfigResolver
-from knowledge_runtime.services.query_planner import QueryPlan, QueryPlanner
-from sqlalchemy.orm import Session
-
 from knowledge_engine.embedding.factory import (
     create_embedding_model_from_runtime_config,
 )
 from knowledge_engine.query.executor import QueryExecutor as KnowledgeQueryExecutor
 from knowledge_engine.storage.factory import create_storage_backend_from_runtime_config
+from knowledge_runtime.services.config_loader import RuntimeConfigLoader
+from knowledge_runtime.services.config_resolver import QueryConfig
+from knowledge_runtime.services.query_planner import QueryPlan, QueryPlanner
 from shared.models import (
     RemoteKnowledgeBaseRetrievalOverride,
     RemoteQueryRecord,
@@ -38,9 +37,12 @@ class QueryExecutor:
     4. Aggregates and sorts results by score
     """
 
-    def __init__(self, db: Session, planner: QueryPlanner | None = None) -> None:
-        self._db = db
-        self._config_resolver = ConfigResolver()
+    def __init__(
+        self,
+        config_loader: RuntimeConfigLoader | None = None,
+        planner: QueryPlanner | None = None,
+    ) -> None:
+        self._config_loader = config_loader or RuntimeConfigLoader()
         self._planner = planner or QueryPlanner()
 
     async def execute(self, request: RemoteQueryRequest) -> RemoteQueryResponse:
@@ -58,6 +60,10 @@ class QueryExecutor:
             request.knowledge_base_ids,
             request.knowledge_base_retrieval_overrides,
         )
+        configs_by_kb_id = self._config_loader.resolve_query_configs(
+            knowledge_base_ids=request.knowledge_base_ids,
+            user_id=request.user_id,
+        )
 
         if request.search_hints is None:
             search_hints: dict[str, Any] = {}
@@ -66,7 +72,9 @@ class QueryExecutor:
         else:
             search_hints = request.search_hints.model_dump(exclude_none=True)
         logger.info(
-            "Query request: hint_source=%s, normalized_query='%s...', dense_query='%s...', sparse_query='%s...', hints_present=%s, semantic_query=%s, keywords=%s, phrases=%s",
+            "Query request: hint_source=%s, normalized_query='%s...', "
+            "dense_query='%s...', sparse_query='%s...', hints_present=%s, "
+            "semantic_query=%s, keywords=%s, phrases=%s",
             plan.hint_source,
             plan.normalized_query[:50],
             plan.dense_query[:50],
@@ -77,11 +85,12 @@ class QueryExecutor:
             len(search_hints.get("phrases") or []),
         )
 
-        # Resolve configs for each knowledge base
+        # Query each knowledge base after config loading has closed its DB session.
         for knowledge_base_id in request.knowledge_base_ids:
             records = await self._query_knowledge_base(
                 request=request,
                 knowledge_base_id=knowledge_base_id,
+                config=configs_by_kb_id[knowledge_base_id],
                 plan=plan,
                 retrieval_override=retrieval_override_by_kb_id.get(knowledge_base_id),
             )
@@ -97,7 +106,8 @@ class QueryExecutor:
         )
 
         logger.info(
-            "Query complete: hint_source=%s, normalized_query='%s...', total_results=%d, returned=%d",
+            "Query complete: hint_source=%s, normalized_query='%s...', "
+            "total_results=%d, returned=%d",
             plan.hint_source,
             plan.normalized_query[:50],
             len(all_records),
@@ -114,6 +124,7 @@ class QueryExecutor:
         self,
         request: RemoteQueryRequest,
         knowledge_base_id: int,
+        config: QueryConfig,
         plan: QueryPlan,
         retrieval_override: RemoteKnowledgeBaseRetrievalOverride | None = None,
     ) -> list[RemoteQueryRecord]:
@@ -126,12 +137,6 @@ class QueryExecutor:
         Returns:
             List of records from this knowledge base.
         """
-        # Resolve config from database
-        config = self._config_resolver.resolve_query_config(
-            db=self._db,
-            knowledge_base_id=knowledge_base_id,
-            user_id=request.user_id,
-        )
         if retrieval_override is not None:
             config = config.__class__(
                 knowledge_base_id=config.knowledge_base_id,
@@ -152,7 +157,9 @@ class QueryExecutor:
         storage_type = config.retriever_config.storage_config.get("type", "unknown")
 
         logger.info(
-            "Query KB config: knowledge_base_id=%d, config_source=%s, storage_type=%s, retrieval_mode=%s, top_k=%s, score_threshold=%s, vector_weight=%s, keyword_weight=%s",
+            "Query KB config: knowledge_base_id=%d, config_source=%s, "
+            "storage_type=%s, retrieval_mode=%s, top_k=%s, "
+            "score_threshold=%s, vector_weight=%s, keyword_weight=%s",
             knowledge_base_id,
             "request_override" if retrieval_override is not None else "database",
             storage_type,
@@ -221,11 +228,13 @@ class QueryExecutor:
         for override in retrieval_overrides or []:
             if override.knowledge_base_id not in allowed_ids:
                 raise ValueError(
-                    "knowledge_base_retrieval_overrides contains an unknown knowledge_base_id"
+                    "knowledge_base_retrieval_overrides contains an unknown "
+                    "knowledge_base_id"
                 )
             if override.knowledge_base_id in overrides_by_kb_id:
                 raise ValueError(
-                    "knowledge_base_retrieval_overrides contains duplicate knowledge_base_id entries"
+                    "knowledge_base_retrieval_overrides contains duplicate "
+                    "knowledge_base_id entries"
                 )
             overrides_by_kb_id[override.knowledge_base_id] = override
         return overrides_by_kb_id

--- a/knowledge_runtime/tests/test_admin_executor.py
+++ b/knowledge_runtime/tests/test_admin_executor.py
@@ -34,9 +34,8 @@ def mock_retriever_config():
 
 @pytest.fixture
 def admin_executor():
-    """Create an AdminExecutor instance with a mock db session."""
-    mock_db = MagicMock()
-    return AdminExecutor(db=mock_db)
+    """Create an AdminExecutor instance with a mock config loader."""
+    return AdminExecutor(config_loader=MagicMock())
 
 
 class TestAdminExecutor:
@@ -63,10 +62,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 
@@ -100,10 +98,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 
@@ -133,10 +130,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 
@@ -182,10 +178,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 
@@ -215,10 +210,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 
@@ -246,10 +240,9 @@ class TestAdminExecutor:
             "knowledge_runtime.services.admin_executor.create_storage_backend_from_runtime_config",
             return_value=mock_storage_backend,
         ):
-            admin_executor._config_resolver.resolve_admin_config = MagicMock(
-                return_value=AdminResolvedConfig(
-                    index_owner_user_id=7,
-                    retriever_config=mock_retriever_config,
+            admin_executor._config_loader.resolve_admin_config.return_value = (
+                AdminResolvedConfig(
+                    index_owner_user_id=7, retriever_config=mock_retriever_config
                 )
             )
 

--- a/knowledge_runtime/tests/test_config_loader.py
+++ b/knowledge_runtime/tests/test_config_loader.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for short-lived runtime config loading."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from knowledge_runtime.services.config_loader import RuntimeConfigLoader
+from knowledge_runtime.services.config_resolver import (
+    AdminResolvedConfig,
+    ConfigResolutionError,
+    IndexConfig,
+    QueryConfig,
+)
+from shared.models import (
+    RuntimeEmbeddingModelConfig,
+    RuntimeRetrievalConfig,
+    RuntimeRetrieverConfig,
+)
+
+
+def _make_retriever_config() -> RuntimeRetrieverConfig:
+    return RuntimeRetrieverConfig(
+        name="test-retriever",
+        namespace="default",
+        storage_config={"type": "qdrant", "url": "http://localhost:6333"},
+    )
+
+
+def _make_embedding_model_config() -> RuntimeEmbeddingModelConfig:
+    return RuntimeEmbeddingModelConfig(
+        model_name="text-embedding-3-small",
+        model_namespace="default",
+        resolved_config={"protocol": "openai", "api_key": "test-key"},
+    )
+
+
+def _make_query_config(knowledge_base_id: int) -> QueryConfig:
+    return QueryConfig(
+        knowledge_base_id=knowledge_base_id,
+        index_owner_user_id=7,
+        retriever_config=_make_retriever_config(),
+        embedding_model_config=_make_embedding_model_config(),
+        retrieval_config=RuntimeRetrievalConfig(top_k=5, score_threshold=0.7),
+    )
+
+
+def test_resolve_index_config_closes_session_after_success() -> None:
+    session = MagicMock()
+    session_factory = MagicMock(return_value=session)
+    resolver = MagicMock()
+    expected_config = IndexConfig(
+        index_owner_user_id=7,
+        retriever_config=_make_retriever_config(),
+        embedding_model_config=_make_embedding_model_config(),
+    )
+    resolver.resolve_index_config.return_value = expected_config
+
+    loader = RuntimeConfigLoader(session_factory=session_factory, resolver=resolver)
+
+    result = loader.resolve_index_config(
+        knowledge_base_id=1,
+        user_id=42,
+        document_id=100,
+    )
+
+    assert result is expected_config
+    session_factory.assert_called_once_with()
+    resolver.resolve_index_config.assert_called_once_with(
+        db=session,
+        knowledge_base_id=1,
+        user_id=42,
+        document_id=100,
+    )
+    session.rollback.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_resolve_index_config_closes_session_after_error() -> None:
+    session = MagicMock()
+    session_factory = MagicMock(return_value=session)
+    resolver = MagicMock()
+    resolver.resolve_index_config.side_effect = ConfigResolutionError(
+        "config_not_found",
+        "Knowledge base 1 not found",
+    )
+    loader = RuntimeConfigLoader(session_factory=session_factory, resolver=resolver)
+
+    with pytest.raises(ConfigResolutionError):
+        loader.resolve_index_config(
+            knowledge_base_id=1,
+            user_id=42,
+            document_id=None,
+        )
+
+    session.rollback.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_resolve_query_configs_uses_one_short_session() -> None:
+    session = MagicMock()
+    session_factory = MagicMock(return_value=session)
+    resolver = MagicMock()
+    config_1 = _make_query_config(1)
+    config_2 = _make_query_config(2)
+    resolver.resolve_query_config.side_effect = [config_1, config_2]
+    loader = RuntimeConfigLoader(session_factory=session_factory, resolver=resolver)
+
+    result = loader.resolve_query_configs(
+        knowledge_base_ids=[1, 2],
+        user_id=42,
+    )
+
+    assert result == {1: config_1, 2: config_2}
+    session_factory.assert_called_once_with()
+    assert resolver.resolve_query_config.call_count == 2
+    resolver.resolve_query_config.assert_any_call(
+        db=session,
+        knowledge_base_id=1,
+        user_id=42,
+    )
+    resolver.resolve_query_config.assert_any_call(
+        db=session,
+        knowledge_base_id=2,
+        user_id=42,
+    )
+    session.rollback.assert_called_once_with()
+    session.close.assert_called_once_with()
+
+
+def test_resolve_admin_config_closes_session_after_success() -> None:
+    session = MagicMock()
+    session_factory = MagicMock(return_value=session)
+    resolver = MagicMock()
+    expected_config = AdminResolvedConfig(
+        index_owner_user_id=7,
+        retriever_config=_make_retriever_config(),
+    )
+    resolver.resolve_admin_config.return_value = expected_config
+    loader = RuntimeConfigLoader(session_factory=session_factory, resolver=resolver)
+
+    result = loader.resolve_admin_config(knowledge_base_id=1)
+
+    assert result is expected_config
+    resolver.resolve_admin_config.assert_called_once_with(
+        db=session,
+        knowledge_base_id=1,
+    )
+    session.rollback.assert_called_once_with()
+    session.close.assert_called_once_with()

--- a/knowledge_runtime/tests/test_index_executor.py
+++ b/knowledge_runtime/tests/test_index_executor.py
@@ -68,7 +68,8 @@ class TestIndexExecutor:
         mock_storage_backend = MagicMock()
         mock_embed_model = MagicMock()
         mock_document_service = MagicMock()
-        mock_db = MagicMock()
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.return_value = mock_index_config
 
         mock_document_service.index_document_from_binary = AsyncMock(
             return_value={
@@ -97,10 +98,7 @@ class TestIndexExecutor:
             patch("httpx.AsyncClient") as mock_client,
             patch("knowledge_runtime.config._settings", None),
         ):
-            executor = IndexExecutor(db=mock_db)
-            executor._config_resolver.resolve_index_config = MagicMock(
-                return_value=mock_index_config
-            )
+            executor = IndexExecutor(config_loader=mock_config_loader)
 
             mock_response = MagicMock()
             mock_response.content = b"test content"
@@ -115,9 +113,8 @@ class TestIndexExecutor:
         assert result["doc_ref"] == "100"
         mock_document_service.index_document_from_binary.assert_called_once()
 
-        # Verify ConfigResolver was called with correct args
-        executor._config_resolver.resolve_index_config.assert_called_once_with(
-            db=mock_db,
+        # Verify RuntimeConfigLoader was called with correct args
+        mock_config_loader.resolve_index_config.assert_called_once_with(
             knowledge_base_id=1,
             user_id=42,
             document_id=100,
@@ -131,7 +128,8 @@ class TestIndexExecutor:
         mock_storage_backend = MagicMock()
         mock_embed_model = MagicMock()
         mock_document_service = MagicMock()
-        mock_db = MagicMock()
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.return_value = mock_index_config
 
         mock_document_service.index_document_from_binary = AsyncMock(
             return_value={
@@ -156,10 +154,7 @@ class TestIndexExecutor:
             patch("httpx.AsyncClient") as mock_client,
             patch("knowledge_runtime.config._settings", None),
         ):
-            executor = IndexExecutor(db=mock_db)
-            executor._config_resolver.resolve_index_config = MagicMock(
-                return_value=mock_index_config
-            )
+            executor = IndexExecutor(config_loader=mock_config_loader)
 
             mock_response = MagicMock()
             # Content from fetch has different filename
@@ -184,7 +179,8 @@ class TestIndexExecutor:
         mock_storage_backend = MagicMock()
         mock_embed_model = MagicMock()
         mock_document_service = MagicMock()
-        mock_db = MagicMock()
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.return_value = mock_index_config
 
         mock_document_service.index_document_from_binary = AsyncMock(
             return_value={"chunk_count": 1, "doc_ref": "100"}
@@ -206,10 +202,7 @@ class TestIndexExecutor:
             patch("httpx.AsyncClient") as mock_client,
             patch("knowledge_runtime.config._settings", None),
         ):
-            executor = IndexExecutor(db=mock_db)
-            executor._config_resolver.resolve_index_config = MagicMock(
-                return_value=mock_index_config
-            )
+            executor = IndexExecutor(config_loader=mock_config_loader)
 
             mock_response = MagicMock()
             mock_response.content = b"content"
@@ -241,16 +234,14 @@ class TestIndexExecutor:
         """Test that content fetch errors propagate correctly."""
         from knowledge_runtime.services.content_fetcher import ContentFetchError
 
-        mock_db = MagicMock()
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.return_value = mock_index_config
 
         with (
             patch("httpx.AsyncClient") as mock_client,
             patch("knowledge_runtime.config._settings", None),
         ):
-            executor = IndexExecutor(db=mock_db)
-            executor._config_resolver.resolve_index_config = MagicMock(
-                return_value=mock_index_config
-            )
+            executor = IndexExecutor(config_loader=mock_config_loader)
 
             mock_client.return_value.__aenter__.return_value.get = AsyncMock(
                 side_effect=ContentFetchError("Fetch failed", retryable=True)
@@ -269,7 +260,8 @@ class TestIndexExecutor:
         mock_storage_backend = MagicMock()
         mock_embed_model = MagicMock()
         mock_document_service = MagicMock()
-        mock_db = MagicMock()
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.return_value = mock_index_config
 
         mock_document_service.index_document_from_binary = AsyncMock(
             side_effect=ValueError("Storage connection failed")
@@ -291,10 +283,7 @@ class TestIndexExecutor:
             patch("httpx.AsyncClient") as mock_client,
             patch("knowledge_runtime.config._settings", None),
         ):
-            executor = IndexExecutor(db=mock_db)
-            executor._config_resolver.resolve_index_config = MagicMock(
-                return_value=mock_index_config
-            )
+            executor = IndexExecutor(config_loader=mock_config_loader)
 
             mock_response = MagicMock()
             mock_response.content = b"content"
@@ -313,14 +302,12 @@ class TestIndexExecutor:
         """Test that config resolution errors propagate correctly."""
         from knowledge_runtime.services.config_resolver import ConfigResolutionError
 
-        mock_db = MagicMock()
-
-        executor = IndexExecutor(db=mock_db)
-        executor._config_resolver.resolve_index_config = MagicMock(
-            side_effect=ConfigResolutionError(
-                "config_not_found", "Knowledge base 1 not found"
-            )
+        mock_config_loader = MagicMock()
+        mock_config_loader.resolve_index_config.side_effect = ConfigResolutionError(
+            "config_not_found", "Knowledge base 1 not found"
         )
+
+        executor = IndexExecutor(config_loader=mock_config_loader)
 
         with pytest.raises(ConfigResolutionError) as exc_info:
             await executor.execute(index_request)

--- a/knowledge_runtime/tests/test_query_executor.py
+++ b/knowledge_runtime/tests/test_query_executor.py
@@ -7,9 +7,9 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
 from knowledge_runtime.services.config_resolver import QueryConfig
 from knowledge_runtime.services.query_executor import QueryExecutor
-
 from shared.models import (
     RemoteKnowledgeBaseRetrievalOverride,
     RemoteQueryRequest,
@@ -46,6 +46,15 @@ def _make_query_config(knowledge_base_id: int = 1) -> QueryConfig:
             score_threshold=0.7,
         ),
     )
+
+
+def _make_config_loader(*configs: QueryConfig) -> MagicMock:
+    """Create a fake RuntimeConfigLoader returning configs by knowledge base ID."""
+    config_loader = MagicMock()
+    config_loader.resolve_query_configs.return_value = {
+        config.knowledge_base_id: config for config in configs
+    }
+    return config_loader
 
 
 @pytest.fixture
@@ -85,11 +94,9 @@ class TestQueryExecutor:
         ):
             query_request.query = "  红包   520 发送   金额 规则 "
             query_request.knowledge_base_ids = [1]
-            executor = QueryExecutor(db=MagicMock())
             config = _make_query_config(1)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                return_value=config
-            )
+            config_loader = _make_config_loader(config)
+            executor = QueryExecutor(config_loader=config_loader)
 
             await executor.execute(query_request)
 
@@ -137,11 +144,9 @@ class TestQueryExecutor:
                 "phrases": ["release checklist"],
             }
             query_request.knowledge_base_ids = [1]
-            executor = QueryExecutor(db=MagicMock())
             config = _make_query_config(1)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                return_value=config
-            )
+            config_loader = _make_config_loader(config)
+            executor = QueryExecutor(config_loader=config_loader)
 
             await executor.execute(query_request)
 
@@ -189,11 +194,9 @@ class TestQueryExecutor:
                 "operator": "and",
                 "conditions": [{"key": "source", "operator": "==", "value": "kb"}],
             }
-            executor = QueryExecutor(db=MagicMock())
             config = _make_query_config(1)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                return_value=config
-            )
+            config_loader = _make_config_loader(config)
+            executor = QueryExecutor(config_loader=config_loader)
 
             await executor.execute(query_request)
 
@@ -253,9 +256,9 @@ class TestQueryExecutor:
             }
         )
 
-        mock_db = MagicMock()
         config_1 = _make_query_config(1)
         config_2 = _make_query_config(2)
+        config_loader = _make_config_loader(config_1, config_2)
 
         with (
             patch(
@@ -271,10 +274,7 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=mock_db)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                side_effect=[config_1, config_2]
-            )
+            executor = QueryExecutor(config_loader=config_loader)
 
             result = await executor.execute(query_request)
 
@@ -305,10 +305,9 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=MagicMock())
-            executor._config_resolver.resolve_query_config = MagicMock(
-                return_value=_make_query_config(1)
-            )
+            config = _make_query_config(1)
+            config_loader = _make_config_loader(config)
+            executor = QueryExecutor(config_loader=config_loader)
             query_request.knowledge_base_ids = [1]
             query_request.knowledge_base_retrieval_overrides = [
                 RemoteKnowledgeBaseRetrievalOverride(
@@ -350,7 +349,7 @@ class TestQueryExecutor:
     async def test_execute_rejects_duplicate_retrieval_overrides(
         self, query_request
     ) -> None:
-        executor = QueryExecutor(db=MagicMock())
+        executor = QueryExecutor(config_loader=MagicMock())
         query_request.knowledge_base_ids = [1]
         query_request.knowledge_base_retrieval_overrides = [
             RemoteKnowledgeBaseRetrievalOverride(
@@ -373,7 +372,7 @@ class TestQueryExecutor:
     async def test_execute_rejects_unknown_retrieval_override_kb_id(
         self, query_request
     ) -> None:
-        executor = QueryExecutor(db=MagicMock())
+        executor = QueryExecutor(config_loader=MagicMock())
         query_request.knowledge_base_ids = [1]
         query_request.knowledge_base_retrieval_overrides = [
             RemoteKnowledgeBaseRetrievalOverride(
@@ -413,9 +412,9 @@ class TestQueryExecutor:
         mock_kb_executor = MagicMock()
         mock_kb_executor.execute = mock_execute
 
-        mock_db = MagicMock()
         config_1 = _make_query_config(1)
         config_2 = _make_query_config(2)
+        config_loader = _make_config_loader(config_1, config_2)
 
         with (
             patch(
@@ -431,10 +430,7 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=mock_db)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                side_effect=[config_1, config_2]
-            )
+            executor = QueryExecutor(config_loader=config_loader)
 
             result = await executor.execute(query_request)
 
@@ -460,9 +456,9 @@ class TestQueryExecutor:
             }
         )
 
-        mock_db = MagicMock()
         config_1 = _make_query_config(1)
         config_2 = _make_query_config(2)
+        config_loader = _make_config_loader(config_1, config_2)
 
         with (
             patch(
@@ -478,10 +474,7 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=mock_db)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                side_effect=[config_1, config_2]
-            )
+            executor = QueryExecutor(config_loader=config_loader)
 
             result = await executor.execute(query_request)
 
@@ -497,9 +490,9 @@ class TestQueryExecutor:
         mock_kb_executor = MagicMock()
         mock_kb_executor.execute = AsyncMock(return_value={"records": []})
 
-        mock_db = MagicMock()
         config_1 = _make_query_config(1)
         config_2 = _make_query_config(2)
+        config_loader = _make_config_loader(config_1, config_2)
 
         with (
             patch(
@@ -515,10 +508,7 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=mock_db)
-            executor._config_resolver.resolve_query_config = MagicMock(
-                side_effect=[config_1, config_2]
-            )
+            executor = QueryExecutor(config_loader=config_loader)
 
             result = await executor.execute(query_request)
 
@@ -535,9 +525,9 @@ class TestQueryExecutor:
         mock_kb_executor = MagicMock()
         mock_kb_executor.execute = AsyncMock(return_value={"records": []})
 
-        mock_db = MagicMock()
         config_1 = _make_query_config(1)
         config_2 = _make_query_config(2)
+        config_loader = _make_config_loader(config_1, config_2)
 
         with (
             patch(
@@ -553,30 +543,19 @@ class TestQueryExecutor:
                 return_value=mock_kb_executor,
             ),
         ):
-            executor = QueryExecutor(db=mock_db)
-            mock_resolve = MagicMock(side_effect=[config_1, config_2])
-            executor._config_resolver.resolve_query_config = mock_resolve
+            executor = QueryExecutor(config_loader=config_loader)
 
             await executor.execute(query_request)
 
-        # ConfigResolver should be called twice, once for each KB
-        assert mock_resolve.call_count == 2
-        mock_resolve.assert_any_call(
-            db=mock_db,
-            knowledge_base_id=1,
-            user_id=42,
-        )
-        mock_resolve.assert_any_call(
-            db=mock_db,
-            knowledge_base_id=2,
+        config_loader.resolve_query_configs.assert_called_once_with(
+            knowledge_base_ids=[1, 2],
             user_id=42,
         )
 
     @pytest.mark.asyncio
     async def test_extract_document_id_from_doc_ref(self) -> None:
         """Test document ID extraction from various doc_ref formats."""
-        mock_db = MagicMock()
-        executor = QueryExecutor(db=mock_db)
+        executor = QueryExecutor(config_loader=MagicMock())
 
         # Test "doc_XXX" format
         assert (
@@ -595,8 +574,7 @@ class TestQueryExecutor:
 
     def test_estimate_tokens(self) -> None:
         """Test token estimation heuristic."""
-        mock_db = MagicMock()
-        executor = QueryExecutor(db=mock_db)
+        executor = QueryExecutor(config_loader=MagicMock())
 
         # ~4 characters per token
         assert executor._estimate_tokens("test") == 1  # 4 chars


### PR DESCRIPTION
## Summary
- add a short-lived `RuntimeConfigLoader` to end DB transactions immediately after runtime config resolution
- remove request-scoped DB sessions from knowledge runtime index/query/admin endpoints and executors
- resolve multi-KB query configs before vector retrieval so external RAG I/O no longer holds MySQL sessions

## Verification
- `uv run pytest` in `knowledge_runtime` (109 passed, third-party Pydantic deprecation warning only)
- `uv run black --check knowledge_runtime tests`
- `uv run isort --check-only knowledge_runtime tests`
- `uv run flake8 --max-line-length=88 ...` on changed knowledge_runtime source files
- pre-push hook passed with `CI=true AI_VERIFIED=1 git push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated indexing, querying, and admin operations to use a new runtime configuration flow.
  * Simplified request handling so these endpoints no longer require database session wiring.
* **Tests**
  * Added coverage for the new configuration loader behavior and updated existing executor tests to match the revised setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->