### PR TITLE
[codex] improve startup waiting screen

### DIFF
--- a/wework/src/App.apps.test.tsx
+++ b/wework/src/App.apps.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import './i18n'
 import App from './App'
 
@@ -23,7 +23,16 @@ vi.mock('@/features/auth/useAuth', () => ({
 }))
 
 vi.mock('@/features/workbench/WorkbenchProvider', () => ({
-  WorkbenchProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  WorkbenchProvider: ({
+    children,
+    onStartupReadyChange,
+  }: {
+    children: React.ReactNode
+    onStartupReadyChange?: (ready: boolean) => void
+  }) => {
+    queueMicrotask(() => onStartupReadyChange?.(true))
+    return <>{children}</>
+  },
 }))
 
 vi.mock('@/tauri/localExecutor', () => ({
@@ -47,6 +56,7 @@ describe('App center route', () => {
   beforeEach(() => {
     localStorage.clear()
     enableTauri()
+    vi.stubEnv('DEV', false)
     vi.stubGlobal(
       'fetch',
       vi.fn((url: string) => {
@@ -101,11 +111,22 @@ describe('App center route', () => {
     )
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  async function waitForStartupScreenToClose() {
+    await waitFor(() => {
+      expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
+    })
+  }
+
   test('opens the app center from the fixed titlebar tab', async () => {
     window.history.pushState({}, '', '/')
 
     render(<App />)
 
+    await waitForStartupScreenToClose()
     await userEvent.click(await screen.findByTestId('chrome-tab-apps'))
 
     await waitFor(() => expect(window.location.pathname).toBe('/apps'))
@@ -124,6 +145,7 @@ describe('App center route', () => {
 
     render(<App />)
 
+    await waitForStartupScreenToClose()
     expect(await screen.findByText('Executor 状态')).toBeInTheDocument()
 
     const appsPage = screen.getByTestId('apps-page')
@@ -143,6 +165,7 @@ describe('App center route', () => {
 
     render(<App />)
 
+    await waitForStartupScreenToClose()
     expect(await screen.findByText('Executor 状态')).toBeInTheDocument()
 
     const scrollContainer = screen.getByTestId('apps-scroll-container')

--- a/wework/src/App.plugins.test.tsx
+++ b/wework/src/App.plugins.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import type { WorkbenchContextValue } from '@/features/workbench/WorkbenchProvider'
 import './i18n'
 import App from './App'
@@ -30,6 +30,7 @@ const workbenchValue: WorkbenchContextValue = {
     isSending: false,
     error: null,
   },
+  isStartupReady: true,
   messages: [],
   queuedMessages: [],
   guidanceMessages: [],
@@ -200,7 +201,16 @@ vi.mock('@/features/auth/useAuth', () => ({
 }))
 
 vi.mock('@/features/workbench/WorkbenchProvider', () => ({
-  WorkbenchProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  WorkbenchProvider: ({
+    children,
+    onStartupReadyChange,
+  }: {
+    children: React.ReactNode
+    onStartupReadyChange?: (ready: boolean) => void
+  }) => {
+    queueMicrotask(() => onStartupReadyChange?.(true))
+    return <>{children}</>
+  },
 }))
 
 vi.mock('@/features/workbench/useWorkbench', () => ({
@@ -534,8 +544,13 @@ describe('App plugins route', () => {
   beforeEach(() => {
     delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
     localStorage.clear()
+    vi.stubEnv('DEV', false)
     mockViewport.isMobile = false
     mockSystemSkillsFetch()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 
   test('does not expose the plugins page from the desktop sidebar', async () => {

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -30,10 +30,19 @@ function useCurrentPath() {
   return path
 }
 
-function AppRoutes() {
+interface AppRoutesProps {
+  onWorkbenchStartupReadyChange?: (ready: boolean) => void
+}
+
+function AppRoutes({ onWorkbenchStartupReadyChange }: AppRoutesProps = {}) {
   const path = useCurrentPath()
   const { user, isLoading } = useAuth()
   const { activeTab, isNativeApp } = useChromeTabs(path)
+
+  useEffect(() => {
+    if (isLoading || !user || isNativeApp || !activeTab?.url) return
+    onWorkbenchStartupReadyChange?.(true)
+  }, [activeTab?.url, isLoading, isNativeApp, onWorkbenchStartupReadyChange, user])
 
   if (path === '/login') {
     return <LoginPage />
@@ -54,7 +63,7 @@ function AppRoutes() {
 
   // native WeWork routes
   return (
-    <WorkbenchProvider user={user}>
+    <WorkbenchProvider user={user} onStartupReadyChange={onWorkbenchStartupReadyChange}>
       {path === '/plugins/manage' ? (
         <PluginManagementPage />
       ) : path === '/plugins' ? (
@@ -82,17 +91,30 @@ export default function App() {
 
 function AppShell() {
   const path = useCurrentPath()
-  const { user } = useAuth()
+  const { user, isLoading } = useAuth()
   const { activeAppKey, tabs, navigateToApp } = useChromeTabs(path)
   const isTauri = isTauriRuntime()
+  const [workbenchStartupReady, setWorkbenchStartupReady] = useState(false)
 
   // No chrome on login/setup pages
-  if (path === '/login' || path === '/login/oidc' || !user) {
+  if (path === '/login' || path === '/login/oidc') {
+    return <AppRoutes />
+  }
+
+  if (isLoading) {
+    return (
+      <LocalRuntimeInitializer startupReady={false}>
+        <div />
+      </LocalRuntimeInitializer>
+    )
+  }
+
+  if (!user) {
     return <AppRoutes />
   }
 
   return (
-    <LocalRuntimeInitializer>
+    <LocalRuntimeInitializer startupReady={workbenchStartupReady}>
       <div className="flex h-screen flex-col overflow-hidden bg-surface">
         {isTauri && (
           <ChromeTitlebar
@@ -103,7 +125,7 @@ function AppShell() {
           />
         )}
         <div className="min-h-0 flex-1 overflow-hidden">
-          <AppRoutes />
+          <AppRoutes onWorkbenchStartupReadyChange={setWorkbenchStartupReady} />
         </div>
       </div>
     </LocalRuntimeInitializer>

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import '@/i18n'
 import { ensureLocalExecutorStarted } from '@/tauri/localExecutor'
 import { LocalRuntimeInitializer } from './LocalRuntimeInitializer'
@@ -10,6 +10,7 @@ vi.mock('@/tauri/localExecutor', () => ({
 }))
 
 const ensureMock = vi.mocked(ensureLocalExecutorStarted)
+const DEV_STARTUP_HOLD_MS = 4800
 
 function enableTauri() {
   Object.defineProperty(window, '__TAURI_INTERNALS__', {
@@ -21,7 +22,13 @@ function enableTauri() {
 describe('LocalRuntimeInitializer', () => {
   beforeEach(() => {
     enableTauri()
+    vi.stubEnv('DEV', false)
     ensureMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
   })
 
   test('holds the app on the initialization screen until executor is ready', async () => {
@@ -34,10 +41,39 @@ describe('LocalRuntimeInitializer', () => {
     )
 
     expect(screen.getByTestId('local-runtime-initializer')).toBeInTheDocument()
+    expect(screen.getByText('正在整理你的工作台')).toBeInTheDocument()
+    expect(screen.getByText('铺好工作台中')).toBeInTheDocument()
+    expect(screen.queryByText(/执行器|daemon/i)).not.toBeInTheDocument()
     expect(screen.queryByTestId('main-app')).not.toBeInTheDocument()
 
     expect(await screen.findByTestId('main-app')).toBeInTheDocument()
     expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
+  })
+
+  test('keeps the startup animation visible for one cycle in dev mode', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-26T00:00:00Z'))
+    vi.stubEnv('DEV', true)
+    ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
+
+    render(
+      <LocalRuntimeInitializer>
+        <div data-testid="main-app">Main app</div>
+      </LocalRuntimeInitializer>
+    )
+
+    expect(screen.getByTestId('local-runtime-initializer')).toBeInTheDocument()
+    expect(screen.queryByTestId('main-app')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEV_STARTUP_HOLD_MS - 1)
+    })
+    expect(screen.queryByTestId('main-app')).not.toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(screen.getByTestId('main-app')).toBeInTheDocument()
   })
 
   test('shows startup error and retries initialization', async () => {
@@ -51,14 +87,26 @@ describe('LocalRuntimeInitializer', () => {
       </LocalRuntimeInitializer>
     )
 
-    expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent(
-      'socket unavailable'
-    )
+    expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent('socket unavailable')
     expect(screen.getByText('~/.wegent-executor/logs/executor.log')).toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('local-runtime-retry-button'))
 
     await waitFor(() => expect(screen.getByTestId('main-app')).toBeInTheDocument())
+  })
+
+  test('uses friendly local runtime status errors', async () => {
+    ensureMock.mockResolvedValue({ running: false, ready: false, deviceId: 'local-device' })
+
+    render(
+      <LocalRuntimeInitializer>
+        <div data-testid="main-app">Main app</div>
+      </LocalRuntimeInitializer>
+    )
+
+    expect(await screen.findByTestId('local-runtime-error')).toHaveTextContent(
+      '本机工作台服务还没有启动'
+    )
   })
 
   test('does not block non-tauri runtimes', () => {

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import '@/i18n'
 import { ensureLocalExecutorStarted } from '@/tauri/localExecutor'
@@ -17,6 +18,14 @@ function enableTauri() {
     configurable: true,
     value: {},
   })
+}
+
+function MountProbe({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount()
+  }, [onMount])
+
+  return <div data-testid="main-app">Main app</div>
 }
 
 describe('LocalRuntimeInitializer', () => {
@@ -50,6 +59,45 @@ describe('LocalRuntimeInitializer', () => {
     expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
   })
 
+  test('mounts children behind the startup screen until app startup is ready', async () => {
+    ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
+
+    render(
+      <LocalRuntimeInitializer startupReady={false}>
+        <div data-testid="main-app">Main app</div>
+      </LocalRuntimeInitializer>
+    )
+
+    expect(await screen.findByTestId('main-app')).not.toBeVisible()
+    expect(screen.getByTestId('local-runtime-initializer')).toBeInTheDocument()
+  })
+
+  test('does not remount children when the startup screen is dismissed', async () => {
+    ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
+    const onMount = vi.fn()
+
+    const { rerender } = render(
+      <LocalRuntimeInitializer startupReady={false}>
+        <MountProbe onMount={onMount} />
+      </LocalRuntimeInitializer>
+    )
+
+    expect(await screen.findByTestId('main-app')).not.toBeVisible()
+    expect(onMount).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <LocalRuntimeInitializer startupReady>
+        <MountProbe onMount={onMount} />
+      </LocalRuntimeInitializer>
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByTestId('local-runtime-initializer')).not.toBeInTheDocument()
+    )
+    expect(screen.getByTestId('main-app')).toBeVisible()
+    expect(onMount).toHaveBeenCalledTimes(1)
+  })
+
   test('keeps the startup animation visible for one cycle in dev mode', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-06-26T00:00:00Z'))
@@ -68,7 +116,7 @@ describe('LocalRuntimeInitializer', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(DEV_STARTUP_HOLD_MS - 1)
     })
-    expect(screen.queryByTestId('main-app')).not.toBeInTheDocument()
+    expect(screen.getByTestId('main-app')).not.toBeVisible()
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1)

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -22,6 +22,7 @@ type LocalRuntimePhase = 'starting' | 'ready' | 'failed'
 
 interface LocalRuntimeInitializerProps {
   children: ReactNode
+  startupReady?: boolean
 }
 
 interface LocalRuntimeState {
@@ -56,24 +57,16 @@ function localRuntimeMinimumReadyDelayMs(): number {
   return import.meta.env.DEV ? LOCAL_RUNTIME_ANIMATION_CYCLE_MS : 0
 }
 
-function delay(ms: number): Promise<void> {
-  if (ms <= 0) return Promise.resolve()
-  return new Promise(resolve => window.setTimeout(resolve, ms))
-}
-
 async function resolveLocalRuntimeState(
   fallbackError: string,
-  errorText: LocalRuntimeErrorText,
-  minimumReadyDelayMs = localRuntimeMinimumReadyDelayMs()
+  errorText: LocalRuntimeErrorText
 ): Promise<LocalRuntimeState> {
-  const startedAt = Date.now()
   try {
     const status = await ensureLocalExecutorStarted()
     const statusError = localRuntimeError(status, errorText)
     if (statusError) {
       throw new Error(statusError)
     }
-    await delay(minimumReadyDelayMs - (Date.now() - startedAt))
     return { phase: 'ready', error: null }
   } catch (error) {
     return {
@@ -154,10 +147,15 @@ function StartupStatusList() {
   )
 }
 
-export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerProps) {
+export function LocalRuntimeInitializer({
+  children,
+  startupReady = true,
+}: LocalRuntimeInitializerProps) {
   const { t } = useTranslation('localRuntime')
   const enabled = useMemo(() => shouldInitializeLocalRuntime(), [])
   const fallbackError = t('fallback_error')
+  const minimumReadyDelayMs = localRuntimeMinimumReadyDelayMs()
+  const [minimumDelayElapsed, setMinimumDelayElapsed] = useState(() => minimumReadyDelayMs === 0)
   const runtimeErrorText = useMemo(
     () => ({
       notRunning: t('error_not_running'),
@@ -169,6 +167,17 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
     phase: enabled ? 'starting' : 'ready',
     error: null,
   }))
+
+  useEffect(() => {
+    if (minimumReadyDelayMs === 0) {
+      return undefined
+    }
+
+    const timer = window.setTimeout(() => {
+      setMinimumDelayElapsed(true)
+    }, minimumReadyDelayMs)
+    return () => window.clearTimeout(timer)
+  }, [minimumReadyDelayMs])
 
   const retryInitialize = useCallback(async () => {
     if (!enabled) return
@@ -189,72 +198,80 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
     }
   }, [enabled, fallbackError, runtimeErrorText])
 
-  if (state.phase === 'ready') {
-    return <>{children}</>
-  }
-
+  const canMountChildren = state.phase === 'ready'
+  const canRevealChildren = canMountChildren && (!enabled || (startupReady && minimumDelayElapsed))
+  const shouldShowStartupScreen = !canRevealChildren
   const failed = state.phase === 'failed'
 
   return (
-    <main
-      data-testid="local-runtime-initializer"
-      className="flex h-screen min-h-[520px] items-center justify-center overflow-hidden bg-base px-6 py-10 text-text-primary"
-    >
-      <section className="flex w-full max-w-[520px] flex-col items-center text-center">
-        {failed ? (
-          <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-lg border border-border bg-surface text-text-secondary">
-            <AlertCircle className="h-6 w-6 text-amber-600" />
-          </div>
-        ) : (
-          <WorkspaceSetupAnimation />
-        )}
-        {!failed && (
-          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-text-secondary">
-            <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-            {t('starting_status')}
-          </div>
-        )}
-        <h1 className="text-xl font-semibold">
-          {failed ? t('failed_title') : t('starting_title')}
-        </h1>
-        <p className="mt-3 max-w-[360px] text-sm leading-6 text-text-secondary">
-          {failed ? t('failed_description') : t('starting_description')}
-        </p>
-
-        {failed ? (
-          <div className="mt-6 w-full rounded-lg border border-border bg-surface px-4 py-3 text-left">
-            {state.error && (
-              <p
-                data-testid="local-runtime-error"
-                className="break-words text-sm leading-6 text-text-primary"
-              >
-                {state.error}
-              </p>
+    <>
+      {canMountChildren && (
+        <div hidden={!canRevealChildren} aria-hidden={!canRevealChildren}>
+          {children}
+        </div>
+      )}
+      {shouldShowStartupScreen && (
+        <main
+          data-testid="local-runtime-initializer"
+          className="flex h-screen min-h-[520px] items-center justify-center overflow-hidden bg-base px-6 py-10 text-text-primary"
+        >
+          <section className="flex w-full max-w-[520px] flex-col items-center text-center">
+            {failed ? (
+              <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-lg border border-border bg-surface text-text-secondary">
+                <AlertCircle className="h-6 w-6 text-amber-600" />
+              </div>
+            ) : (
+              <WorkspaceSetupAnimation />
             )}
-            <div className="mt-3 text-xs leading-5 text-text-secondary">
-              <span className="font-medium">{t('log_label')}: </span>
-              <code className="break-all rounded bg-base px-1.5 py-0.5 text-text-primary">
-                {LOCAL_EXECUTOR_LOG_PATH}
-              </code>
-            </div>
-          </div>
-        ) : (
-          <StartupStatusList />
-        )}
+            {!failed && (
+              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-text-secondary">
+                <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                {t('starting_status')}
+              </div>
+            )}
+            <h1 className="text-xl font-semibold">
+              {failed ? t('failed_title') : t('starting_title')}
+            </h1>
+            <p className="mt-3 max-w-[360px] text-sm leading-6 text-text-secondary">
+              {failed ? t('failed_description') : t('starting_description')}
+            </p>
 
-        {failed && (
-          <Button
-            type="button"
-            variant="primary"
-            className="mt-6 h-10 min-w-[112px]"
-            onClick={() => void retryInitialize()}
-            data-testid="local-runtime-retry-button"
-          >
-            <RefreshCw className="h-4 w-4" />
-            {t('retry')}
-          </Button>
-        )}
-      </section>
-    </main>
+            {failed ? (
+              <div className="mt-6 w-full rounded-lg border border-border bg-surface px-4 py-3 text-left">
+                {state.error && (
+                  <p
+                    data-testid="local-runtime-error"
+                    className="break-words text-sm leading-6 text-text-primary"
+                  >
+                    {state.error}
+                  </p>
+                )}
+                <div className="mt-3 text-xs leading-5 text-text-secondary">
+                  <span className="font-medium">{t('log_label')}: </span>
+                  <code className="break-all rounded bg-base px-1.5 py-0.5 text-text-primary">
+                    {LOCAL_EXECUTOR_LOG_PATH}
+                  </code>
+                </div>
+              </div>
+            ) : (
+              <StartupStatusList />
+            )}
+
+            {failed && (
+              <Button
+                type="button"
+                variant="primary"
+                className="mt-6 h-10 min-w-[112px]"
+                onClick={() => void retryInitialize()}
+                data-testid="local-runtime-retry-button"
+              >
+                <RefreshCw className="h-4 w-4" />
+                {t('retry')}
+              </Button>
+            )}
+          </section>
+        </main>
+      )}
+    </>
   )
 }

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
-import { AlertCircle, Loader2, RefreshCw, TerminalSquare } from 'lucide-react'
+import {
+  AlertCircle,
+  FileText,
+  FolderOpen,
+  MessageSquareText,
+  MousePointer2,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useTranslation } from '@/hooks/useTranslation'
@@ -8,6 +16,7 @@ import { isTauriRuntime } from '@/lib/runtime-environment'
 import { ensureLocalExecutorStarted, type LocalExecutorStatus } from '@/tauri/localExecutor'
 
 const LOCAL_EXECUTOR_LOG_PATH = '~/.wegent-executor/logs/executor.log'
+const LOCAL_RUNTIME_ANIMATION_CYCLE_MS = 4800
 
 type LocalRuntimePhase = 'starting' | 'ready' | 'failed'
 
@@ -20,14 +29,22 @@ interface LocalRuntimeState {
   error: string | null
 }
 
+interface LocalRuntimeErrorText {
+  notRunning: string
+  notReady: string
+}
+
 function shouldInitializeLocalRuntime(): boolean {
   return getRuntimeConfig().runtimeMode === 'local-first' && isTauriRuntime()
 }
 
-function localRuntimeError(status: LocalExecutorStatus): string | null {
+function localRuntimeError(
+  status: LocalExecutorStatus,
+  errorText: LocalRuntimeErrorText
+): string | null {
   if (status.error) return status.error
-  if (!status.running) return 'Local executor is not running'
-  if (status.ready === false) return 'Local executor is not ready'
+  if (!status.running) return errorText.notRunning
+  if (status.ready === false) return errorText.notReady
   return null
 }
 
@@ -35,13 +52,28 @@ function errorMessage(error: unknown, fallback: string): string {
   return error instanceof Error ? error.message : String(error || fallback)
 }
 
-async function resolveLocalRuntimeState(fallbackError: string): Promise<LocalRuntimeState> {
+function localRuntimeMinimumReadyDelayMs(): number {
+  return import.meta.env.DEV ? LOCAL_RUNTIME_ANIMATION_CYCLE_MS : 0
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve()
+  return new Promise(resolve => window.setTimeout(resolve, ms))
+}
+
+async function resolveLocalRuntimeState(
+  fallbackError: string,
+  errorText: LocalRuntimeErrorText,
+  minimumReadyDelayMs = localRuntimeMinimumReadyDelayMs()
+): Promise<LocalRuntimeState> {
+  const startedAt = Date.now()
   try {
     const status = await ensureLocalExecutorStarted()
-    const statusError = localRuntimeError(status)
+    const statusError = localRuntimeError(status, errorText)
     if (statusError) {
       throw new Error(statusError)
     }
+    await delay(minimumReadyDelayMs - (Date.now() - startedAt))
     return { phase: 'ready', error: null }
   } catch (error) {
     return {
@@ -51,10 +83,88 @@ async function resolveLocalRuntimeState(fallbackError: string): Promise<LocalRun
   }
 }
 
+function WorkspaceSetupAnimation() {
+  const { t } = useTranslation('localRuntime')
+  const cards = [
+    {
+      key: 'project',
+      label: t('animation_project'),
+      Icon: FolderOpen,
+      className: 'local-runtime-card-project',
+    },
+    {
+      key: 'files',
+      label: t('animation_files'),
+      Icon: FileText,
+      className: 'local-runtime-card-files',
+    },
+    {
+      key: 'chat',
+      label: t('animation_chat'),
+      Icon: MessageSquareText,
+      className: 'local-runtime-card-chat',
+    },
+  ]
+
+  return (
+    <div
+      aria-hidden="true"
+      className="relative mb-8 h-[180px] w-full max-w-[360px] overflow-hidden"
+    >
+      <div className="absolute left-1/2 top-[112px] h-12 w-[260px] -translate-x-1/2 rounded-lg border border-border bg-surface/80" />
+      <div className="absolute left-1/2 top-[128px] h-1.5 w-[210px] -translate-x-1/2 overflow-hidden rounded-full bg-muted">
+        <div className="local-runtime-progress-track h-full w-1/2 rounded-full bg-primary/70" />
+      </div>
+      <Sparkles className="local-runtime-sparkle absolute left-[58%] top-4 h-5 w-5 text-primary" />
+      {cards.map(({ key, label, Icon, className }) => (
+        <div
+          key={key}
+          className={`local-runtime-setup-card ${className} absolute left-1/2 top-10 flex h-14 w-[132px] items-center gap-2 rounded-lg border border-border bg-base px-3 text-left shadow-[0_14px_34px_rgb(0_0_0_/_0.08)]`}
+        >
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <Icon className="h-4 w-4" />
+          </span>
+          <span className="truncate text-sm font-medium text-text-primary">{label}</span>
+        </div>
+      ))}
+      <MousePointer2 className="local-runtime-cursor absolute h-5 w-5 text-text-primary" />
+    </div>
+  )
+}
+
+function StartupStatusList() {
+  const { t } = useTranslation('localRuntime')
+  const steps = [t('step_workspace'), t('step_files'), t('step_assistant')]
+
+  return (
+    <div className="mt-7 grid w-full max-w-[400px] grid-cols-3 gap-2" aria-hidden="true">
+      {steps.map((step, index) => (
+        <div
+          key={step}
+          className="flex min-h-10 items-center justify-center gap-2 rounded-lg border border-border bg-surface px-2 text-xs text-text-secondary"
+        >
+          <span
+            className="local-runtime-step-dot h-1.5 w-1.5 rounded-full bg-primary"
+            style={{ animationDelay: `${index * 0.22}s` }}
+          />
+          <span className="truncate">{step}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerProps) {
   const { t } = useTranslation('localRuntime')
   const enabled = useMemo(() => shouldInitializeLocalRuntime(), [])
   const fallbackError = t('fallback_error')
+  const runtimeErrorText = useMemo(
+    () => ({
+      notRunning: t('error_not_running'),
+      notReady: t('error_not_ready'),
+    }),
+    [t]
+  )
   const [state, setState] = useState<LocalRuntimeState>(() => ({
     phase: enabled ? 'starting' : 'ready',
     error: null,
@@ -63,13 +173,13 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
   const retryInitialize = useCallback(async () => {
     if (!enabled) return
     setState({ phase: 'starting', error: null })
-    setState(await resolveLocalRuntimeState(fallbackError))
-  }, [enabled, fallbackError])
+    setState(await resolveLocalRuntimeState(fallbackError, runtimeErrorText))
+  }, [enabled, fallbackError, runtimeErrorText])
 
   useEffect(() => {
     if (!enabled) return undefined
     let cancelled = false
-    void resolveLocalRuntimeState(fallbackError).then(nextState => {
+    void resolveLocalRuntimeState(fallbackError, runtimeErrorText).then(nextState => {
       if (!cancelled) {
         setState(nextState)
       }
@@ -77,7 +187,7 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
     return () => {
       cancelled = true
     }
-  }, [enabled, fallbackError])
+  }, [enabled, fallbackError, runtimeErrorText])
 
   if (state.phase === 'ready') {
     return <>{children}</>
@@ -88,16 +198,22 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
   return (
     <main
       data-testid="local-runtime-initializer"
-      className="flex h-screen min-h-[480px] items-center justify-center bg-base px-6 text-text-primary"
+      className="flex h-screen min-h-[520px] items-center justify-center overflow-hidden bg-base px-6 py-10 text-text-primary"
     >
-      <section className="flex w-full max-w-[420px] flex-col items-center text-center">
-        <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-lg border border-border bg-surface text-text-secondary">
-          {failed ? (
+      <section className="flex w-full max-w-[520px] flex-col items-center text-center">
+        {failed ? (
+          <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-lg border border-border bg-surface text-text-secondary">
             <AlertCircle className="h-6 w-6 text-amber-600" />
-          ) : (
-            <TerminalSquare className="h-6 w-6" />
-          )}
-        </div>
+          </div>
+        ) : (
+          <WorkspaceSetupAnimation />
+        )}
+        {!failed && (
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-text-secondary">
+            <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+            {t('starting_status')}
+          </div>
+        )}
         <h1 className="text-xl font-semibold">
           {failed ? t('failed_title') : t('starting_title')}
         </h1>
@@ -123,10 +239,7 @@ export function LocalRuntimeInitializer({ children }: LocalRuntimeInitializerPro
             </div>
           </div>
         ) : (
-          <div className="mt-6 flex items-center gap-2 text-sm text-text-secondary">
-            <Loader2 className="h-4 w-4 animate-spin text-primary" />
-            <span>{t('starting_title')}</span>
-          </div>
+          <StartupStatusList />
         )}
 
         {failed && (

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -302,6 +302,7 @@ function BootstrapProbe() {
       <span data-testid="boot-state">
         {workbench.state.isBootstrapping ? 'loading' : workbench.state.user?.user_name}
       </span>
+      <span data-testid="startup-ready">{workbench.isStartupReady ? 'ready' : 'loading'}</span>
       <span data-testid="project-count">{workbench.state.projects.length}</span>
       <span data-testid="runtime-total">{workbench.state.runtimeWork?.totalLocalTasks ?? 0}</span>
     </div>
@@ -638,6 +639,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbenchWithDefaultServices(<BootstrapProbe />)
 
     await waitFor(() => expect(screen.getByTestId('boot-state')).toHaveTextContent('local'))
+    await waitFor(() => expect(screen.getByTestId('startup-ready')).toHaveTextContent('ready'))
     expect(screen.getByTestId('project-count')).toHaveTextContent('0')
     expect(screen.getByTestId('runtime-total')).toHaveTextContent('0')
     expect(localExecutorMocks.ensureLocalExecutorStarted).toHaveBeenCalled()
@@ -650,6 +652,7 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbench(<BootstrapProbe />, services)
 
     await waitFor(() => expect(screen.getByTestId('boot-state')).toHaveTextContent('alice'))
+    await waitFor(() => expect(screen.getByTestId('startup-ready')).toHaveTextContent('ready'))
     expect(screen.getByTestId('project-count')).toHaveTextContent('0')
     expect(screen.getByTestId('runtime-total')).toHaveTextContent('3')
     expect(services.projectApi.listProjects).not.toHaveBeenCalled()

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -322,6 +322,7 @@ function joinDevicePath(root: string, ...segments: string[]): string {
 
 export interface WorkbenchContextValue {
   state: WorkbenchState
+  isStartupReady: boolean
   messages: WorkbenchMessage[]
   queuedMessages: QueuedWorkbenchMessage[]
   guidanceMessages: GuidanceWorkbenchMessage[]
@@ -465,6 +466,7 @@ interface WorkbenchProviderProps {
   children: ReactNode
   user: User
   services?: WorkbenchServices
+  onStartupReadyChange?: (ready: boolean) => void
 }
 
 function createBackendServices(): WorkbenchServices {
@@ -1057,7 +1059,12 @@ function createRuntimeLocalTaskId(runtime: RuntimeTaskCreateRequest['runtime']):
   return `${prefix}-${randomId}`
 }
 
-export function WorkbenchProvider({ children, user, services }: WorkbenchProviderProps) {
+export function WorkbenchProvider({
+  children,
+  user,
+  services,
+  onStartupReadyChange,
+}: WorkbenchProviderProps) {
   const resolvedServices = useMemo(() => services ?? createDefaultServices(), [services])
   const executorClient = useMemo(() => {
     if (resolvedServices.executorClient) return resolvedServices.executorClient
@@ -1264,6 +1271,13 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
     teamId: state.defaultTeam?.id,
     locked: isOptionsLocked,
   })
+  const isStartupReady =
+    !state.isBootstrapping && modelSelection.isSelectionReady && !skillSelection.isLoading
+
+  useEffect(() => {
+    onStartupReadyChange?.(isStartupReady)
+  }, [isStartupReady, onStartupReadyChange])
+
   const attachmentSelection = useWorkbenchAttachments()
   const addCodeCommentContext = useCallback((context: CodeCommentContext) => {
     setCodeCommentContexts(items => [...items.filter(item => item.id !== context.id), context])
@@ -3218,6 +3232,7 @@ export function WorkbenchProvider({ children, user, services }: WorkbenchProvide
 
   const value: WorkbenchContextValue = {
     state,
+    isStartupReady,
     messages,
     queuedMessages: queuedSends,
     guidanceMessages,

--- a/wework/src/features/workbench/useWorkbenchSkills.ts
+++ b/wework/src/features/workbench/useWorkbenchSkills.ts
@@ -27,6 +27,7 @@ export function useWorkbenchSkills({ api, teamId, locked }: UseWorkbenchSkillsOp
   const [preloadedSkillNames, setPreloadedSkillNames] = useState<string[]>([])
   const [selectedSkills, setSelectedSkillsState] = useState<SkillRef[]>([])
   const [isLoading, setIsLoading] = useState(false)
+  const [isTeamSkillsLoading, setIsTeamSkillsLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
 
   useEffect(() => {
@@ -64,9 +65,11 @@ export function useWorkbenchSkills({ api, teamId, locked }: UseWorkbenchSkillsOp
       if (!teamId) {
         setTeamSkillNames([])
         setPreloadedSkillNames([])
+        setIsTeamSkillsLoading(false)
         return
       }
 
+      setIsTeamSkillsLoading(true)
       try {
         const response = await api.getTeamSkills(teamId)
         if (!cancelled) {
@@ -77,6 +80,10 @@ export function useWorkbenchSkills({ api, teamId, locked }: UseWorkbenchSkillsOp
         if (!cancelled) {
           setTeamSkillNames([])
           setPreloadedSkillNames([])
+        }
+      } finally {
+        if (!cancelled) {
+          setIsTeamSkillsLoading(false)
         }
       }
     }
@@ -121,7 +128,7 @@ export function useWorkbenchSkills({ api, teamId, locked }: UseWorkbenchSkillsOp
     selectedSkillNames,
     setSelectedSkills,
     toggleSkill,
-    isLoading,
+    isLoading: isLoading || isTeamSkillsLoading,
     error,
   }
 }

--- a/wework/src/i18n/locales/en/localRuntime.json
+++ b/wework/src/i18n/locales/en/localRuntime.json
@@ -1,9 +1,18 @@
 {
-  "starting_title": "Starting local executor",
-  "starting_description": "Connecting to the local daemon. First startup may take a few seconds.",
-  "failed_title": "Local executor failed to start",
-  "failed_description": "Check whether the executor can start correctly, or inspect the log and retry.",
-  "log_label": "Log file",
+  "starting_title": "Setting up your workspace",
+  "starting_description": "Preparing files, conversations, and your local workspace. This should only take a moment.",
+  "starting_status": "Laying out the workspace",
+  "animation_project": "Project",
+  "animation_files": "Files",
+  "animation_chat": "Chat",
+  "step_workspace": "Arranging workspace",
+  "step_files": "Preparing files",
+  "step_assistant": "Waking assistant",
+  "failed_title": "Workspace is not ready",
+  "failed_description": "Retry once. If it still fails, share the diagnostic log with the team.",
+  "log_label": "Diagnostic log",
   "retry": "Retry",
-  "fallback_error": "Local executor is unavailable"
+  "fallback_error": "Workspace is unavailable",
+  "error_not_running": "The local workspace service is not running",
+  "error_not_ready": "The local workspace service is not ready"
 }

--- a/wework/src/i18n/locales/zh-CN/localRuntime.json
+++ b/wework/src/i18n/locales/zh-CN/localRuntime.json
@@ -1,9 +1,18 @@
 {
-  "starting_title": "正在启动本地执行器",
-  "starting_description": "正在连接本机 daemon。首次启动可能需要几秒。",
-  "failed_title": "本地执行器启动失败",
-  "failed_description": "请检查 executor 是否能正常启动，或查看日志后重试。",
-  "log_label": "日志位置",
-  "retry": "重试",
-  "fallback_error": "本地执行器不可用"
+  "starting_title": "正在整理你的工作台",
+  "starting_description": "我们在准备文件、会话和本机工作环境。马上就可以开始。",
+  "starting_status": "铺好工作台中",
+  "animation_project": "项目",
+  "animation_files": "文件",
+  "animation_chat": "对话",
+  "step_workspace": "整理工作台",
+  "step_files": "准备文件",
+  "step_assistant": "唤醒助手",
+  "failed_title": "工作台没准备好",
+  "failed_description": "可以重试一次；如果还不行，再把下面的诊断日志发给开发同学。",
+  "log_label": "诊断日志",
+  "retry": "再试一次",
+  "fallback_error": "工作台暂时不可用",
+  "error_not_running": "本机工作台服务还没有启动",
+  "error_not_ready": "本机工作台服务还没有准备好"
 }

--- a/wework/src/styles/globals.css
+++ b/wework/src/styles/globals.css
@@ -143,6 +143,165 @@ button:disabled {
     animation: waiting-thinking-text 1.4s ease-in-out infinite;
   }
 
+  @keyframes local-runtime-card-settle {
+    0%,
+    100% {
+      opacity: 0.72;
+      transform: translate3d(var(--local-runtime-card-from-x), var(--local-runtime-card-from-y), 0)
+        rotate(var(--local-runtime-card-from-rotate));
+    }
+
+    36%,
+    64% {
+      opacity: 1;
+      transform: translate3d(var(--local-runtime-card-to-x), var(--local-runtime-card-to-y), 0)
+        rotate(var(--local-runtime-card-to-rotate));
+    }
+  }
+
+  @keyframes local-runtime-cursor-sweep {
+    0%,
+    14% {
+      opacity: 0;
+      transform: translate3d(-132px, 58px, 0) rotate(-16deg);
+    }
+
+    22%,
+    54% {
+      opacity: 1;
+    }
+
+    42% {
+      transform: translate3d(92px, -24px, 0) rotate(-16deg);
+    }
+
+    72% {
+      opacity: 1;
+      transform: translate3d(36px, 46px, 0) rotate(-16deg);
+    }
+
+    100% {
+      opacity: 0;
+      transform: translate3d(-132px, 58px, 0) rotate(-16deg);
+    }
+  }
+
+  @keyframes local-runtime-progress-track {
+    0%,
+    100% {
+      transform: translateX(-78%) scaleX(0.45);
+    }
+
+    50% {
+      transform: translateX(155%) scaleX(0.82);
+    }
+  }
+
+  @keyframes local-runtime-sparkle {
+    0%,
+    100% {
+      opacity: 0.48;
+      transform: translateY(4px) scale(0.82) rotate(-8deg);
+    }
+
+    50% {
+      opacity: 1;
+      transform: translateY(-3px) scale(1) rotate(8deg);
+    }
+  }
+
+  @keyframes local-runtime-step-dot {
+    0%,
+    100% {
+      opacity: 0.42;
+      transform: scale(0.72);
+    }
+
+    50% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .local-runtime-setup-card {
+    animation: local-runtime-card-settle 4.8s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+    transform-origin: center;
+    will-change: opacity, transform;
+  }
+
+  .local-runtime-card-project {
+    --local-runtime-card-from-x: calc(-50% - 128px);
+    --local-runtime-card-from-y: 44px;
+    --local-runtime-card-from-rotate: -7deg;
+    --local-runtime-card-to-x: calc(-50% - 104px);
+    --local-runtime-card-to-y: 62px;
+    --local-runtime-card-to-rotate: -2deg;
+  }
+
+  .local-runtime-card-files {
+    --local-runtime-card-from-x: calc(-50% - 16px);
+    --local-runtime-card-from-y: -22px;
+    --local-runtime-card-from-rotate: 4deg;
+    --local-runtime-card-to-x: -50%;
+    --local-runtime-card-to-y: 38px;
+    --local-runtime-card-to-rotate: 1deg;
+    animation-delay: 0.18s;
+  }
+
+  .local-runtime-card-chat {
+    --local-runtime-card-from-x: calc(-50% + 118px);
+    --local-runtime-card-from-y: 34px;
+    --local-runtime-card-from-rotate: 7deg;
+    --local-runtime-card-to-x: calc(-50% + 104px);
+    --local-runtime-card-to-y: 64px;
+    --local-runtime-card-to-rotate: 2deg;
+    animation-delay: 0.34s;
+  }
+
+  .local-runtime-cursor {
+    left: 50%;
+    top: 50%;
+    animation: local-runtime-cursor-sweep 4.8s ease-in-out infinite;
+    transform-origin: 30% 20%;
+    will-change: opacity, transform;
+  }
+
+  .local-runtime-progress-track {
+    animation: local-runtime-progress-track 1.6s ease-in-out infinite;
+    transform-origin: left center;
+    will-change: transform;
+  }
+
+  .local-runtime-sparkle {
+    animation: local-runtime-sparkle 1.8s ease-in-out infinite;
+    transform-origin: center;
+    will-change: opacity, transform;
+  }
+
+  .local-runtime-step-dot {
+    animation: local-runtime-step-dot 1.15s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .local-runtime-setup-card,
+    .local-runtime-cursor,
+    .local-runtime-progress-track,
+    .local-runtime-sparkle,
+    .local-runtime-step-dot {
+      animation: none;
+    }
+
+    .local-runtime-setup-card {
+      opacity: 1;
+      transform: translate3d(var(--local-runtime-card-to-x), var(--local-runtime-card-to-y), 0)
+        rotate(var(--local-runtime-card-to-rotate));
+    }
+
+    .local-runtime-cursor {
+      opacity: 0;
+    }
+  }
+
   .z-chrome {
     z-index: var(--z-chrome);
   }


### PR DESCRIPTION
## What changed

- Reworked the WeWork local runtime startup screen into a friendlier workspace setup experience.
- Added a lightweight card-and-cursor animation for project, files, and chat preparation.
- Replaced user-facing executor/daemon wording with workspace-oriented copy in zh-CN and en.
- Added a dev-only minimum display duration so the animation can complete before entering the app.
- Kept the startup screen visible until auth, workbench bootstrap, model selection, and skill loading are ready.
- Mounted the home app behind the startup screen without remounting it when the screen is dismissed, avoiding the refresh loop.
- Covered startup copy, dev hold behavior, startup data gating, and the no-remount regression with tests.

## Why

The previous startup screen exposed implementation terms like executor and daemon and could disappear too quickly in development to see the loading experience. The app could also enter the home route while core data was still loading. This moves the waiting state into the startup animation so the home screen appears only after startup data is ready.

## Validation

- `pnpm --dir wework exec vitest run src/features/local-runtime/LocalRuntimeInitializer.test.tsx`
- `pnpm --dir wework exec vitest run src/features/workbench/WorkbenchProvider.test.tsx`
- `pnpm --dir wework exec vitest run src/App.apps.test.tsx src/App.plugins.test.tsx src/App.test.tsx`
- `pnpm --dir wework exec eslint src/features/local-runtime/LocalRuntimeInitializer.tsx src/features/local-runtime/LocalRuntimeInitializer.test.tsx src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/useWorkbenchSkills.ts src/App.tsx src/App.apps.test.tsx src/App.plugins.test.tsx`
- `pnpm --dir wework exec prettier --check src/features/local-runtime/LocalRuntimeInitializer.tsx src/features/local-runtime/LocalRuntimeInitializer.test.tsx src/features/workbench/WorkbenchProvider.tsx src/features/workbench/WorkbenchProvider.test.tsx src/features/workbench/useWorkbenchSkills.ts src/App.tsx src/App.apps.test.tsx src/App.plugins.test.tsx`
- `pnpm --dir wework exec tsc -b --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new workspace startup screen with animated progress indicators and clearer step-by-step status.
  * Startup now waits until the workspace is ready before showing the main app, improving perceived stability.

* **Bug Fixes**
  * Fixed race conditions during app startup so UI tests and startup flows are more reliable.
  * Improved startup error messages to better distinguish between “not running” and “not ready” states.
  * Added reduced-motion handling for a calmer experience when motion preferences are enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->