### PR TITLE
feat(wework): refine Codex session transcript display

### DIFF
--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -23,6 +23,7 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
         let turn_file_changes = file_changes(turn);
         let turn_id = item_id(turn, "turn");
         let subtask_id = turn_subtask_id(turn, &turn_id);
+        let fold_commentary = turn_should_fold_commentary(turn);
         let mut blocks = Vec::new();
         let mut pending_file_changes = turn_file_changes.clone();
         let mut context_events = Vec::new();
@@ -53,6 +54,9 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         device_id,
                         &workspace_path,
                     ) {
+                        if fold_commentary {
+                            blocks.push(file_changes_block(item, &summary, created_at));
+                        }
                         pending_file_changes = merge_file_changes(pending_file_changes, summary);
                     }
                 }
@@ -63,6 +67,9 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         device_id,
                         &workspace_path,
                     ) {
+                        if fold_commentary {
+                            blocks.push(file_changes_block(item, &summary, created_at));
+                        }
                         pending_file_changes = merge_file_changes(pending_file_changes, summary);
                     }
                 }
@@ -78,6 +85,7 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                     collect_assistant_message(
                         item,
                         created_at,
+                        fold_commentary,
                         &mut blocks,
                         &mut assistant_parts,
                         &mut memory_citations,
@@ -97,6 +105,7 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         collect_assistant_message(
                             item,
                             created_at,
+                            fold_commentary,
                             &mut blocks,
                             &mut assistant_parts,
                             &mut memory_citations,
@@ -112,6 +121,7 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                     collect_assistant_message(
                         item,
                         created_at,
+                        fold_commentary,
                         &mut blocks,
                         &mut assistant_parts,
                         &mut memory_citations,
@@ -200,6 +210,58 @@ fn turn_subtask_id(turn: &Value, turn_id: &str) -> i64 {
         .unwrap_or_else(|| synthetic_turn_subtask_id(turn_id))
 }
 
+fn turn_should_fold_commentary(turn: &Value) -> bool {
+    !turn_interrupted(turn) && (turn_running(turn) || turn_has_final_assistant_message(turn))
+}
+
+fn turn_interrupted(turn: &Value) -> bool {
+    turn_status(turn).is_some_and(|status| {
+        matches!(
+            status.as_str(),
+            "interrupted" | "cancelled" | "canceled" | "aborted"
+        )
+    })
+}
+
+fn turn_running(turn: &Value) -> bool {
+    turn_status(turn).is_some_and(|status| {
+        matches!(
+            status.as_str(),
+            "running" | "inprogress" | "active" | "busy" | "pending"
+        )
+    })
+}
+
+fn turn_status(turn: &Value) -> Option<String> {
+    string_field(turn, "status").map(normalized_phase_or_status)
+}
+
+fn turn_has_final_assistant_message(turn: &Value) -> bool {
+    turn.get("items")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .any(is_final_assistant_message)
+}
+
+fn is_final_assistant_message(item: &Value) -> bool {
+    match item_type(item).as_str() {
+        "agentmessage" | "agentmessageevent" => assistant_message_phase_name(item)
+            .map(|phase| !matches!(phase.as_str(), "analysis" | "commentary"))
+            .unwrap_or(true),
+        "message" => {
+            let is_assistant = string_field(item, "role")
+                .unwrap_or_default()
+                .eq_ignore_ascii_case("assistant");
+            is_assistant
+                && assistant_message_phase_name(item)
+                    .map(|phase| !matches!(phase.as_str(), "analysis" | "commentary"))
+                    .unwrap_or(true)
+        }
+        _ => false,
+    }
+}
+
 fn synthetic_turn_subtask_id(turn_id: &str) -> i64 {
     let mut hash = 2_166_136_261_u32;
     for byte in turn_id.as_bytes() {
@@ -247,12 +309,13 @@ fn push_reasoning_block(blocks: &mut Vec<Value>, item: &Value, created_at: i64) 
 fn collect_assistant_message(
     item: &Value,
     fallback_timestamp: i64,
+    fold_commentary: bool,
     blocks: &mut Vec<Value>,
     assistant_parts: &mut Vec<String>,
     memory_citations: &mut Vec<Value>,
 ) {
     if let Some(content) = extract_text(item) {
-        match assistant_message_phase(item) {
+        match assistant_message_phase(item, fold_commentary) {
             AssistantMessagePhase::Process => {
                 blocks.push(process_text_block(item, content, fallback_timestamp));
             }
@@ -271,15 +334,20 @@ enum AssistantMessagePhase {
     Process,
 }
 
-fn assistant_message_phase(item: &Value) -> AssistantMessagePhase {
-    let phase = string_field(item, "phase")
-        .unwrap_or_default()
-        .replace(['_', '-'], "")
-        .to_ascii_lowercase();
-    match phase.as_str() {
-        "commentary" | "analysis" => AssistantMessagePhase::Process,
+fn assistant_message_phase(item: &Value, fold_commentary: bool) -> AssistantMessagePhase {
+    match assistant_message_phase_name(item).as_deref() {
+        Some("analysis") => AssistantMessagePhase::Process,
+        Some("commentary") if fold_commentary => AssistantMessagePhase::Process,
         _ => AssistantMessagePhase::Final,
     }
+}
+
+fn assistant_message_phase_name(item: &Value) -> Option<String> {
+    string_field(item, "phase").map(normalized_phase_or_status)
+}
+
+fn normalized_phase_or_status(value: String) -> String {
+    value.replace(['_', '-'], "").to_ascii_lowercase()
 }
 
 fn process_text_block(item: &Value, content: String, fallback_timestamp: i64) -> Value {
@@ -287,6 +355,16 @@ fn process_text_block(item: &Value, content: String, fallback_timestamp: i64) ->
         "id": item_id(item, "text"),
         "type": "text",
         "content": content,
+        "status": "done",
+        "timestamp": item_timestamp(item).unwrap_or(fallback_timestamp),
+    })
+}
+
+fn file_changes_block(item: &Value, summary: &Value, fallback_timestamp: i64) -> Value {
+    json!({
+        "id": format!("file-changes-{}", item_id(item, "file-change")),
+        "type": "file_changes",
+        "file_changes": summary,
         "status": "done",
         "timestamp": item_timestamp(item).unwrap_or(fallback_timestamp),
     })
@@ -634,7 +712,7 @@ fn merge_file_changes(existing: Option<Value>, next: Value) -> Option<Value> {
             .iter()
             .position(|file| string_field(file, "path").is_some_and(|path| path == next_path))
         {
-            files[existing_index] = next_file.clone();
+            files[existing_index] = merge_file_change(files.get(existing_index), next_file);
         } else {
             files.push(next_file.clone());
         }
@@ -684,6 +762,62 @@ fn merge_file_changes(existing: Option<Value>, next: Value) -> Option<Value> {
     }
 
     Some(current)
+}
+
+fn merge_file_change(existing: Option<&Value>, next: &Value) -> Value {
+    let Some(existing) = existing else {
+        return next.clone();
+    };
+    let Some(existing_object) = existing.as_object() else {
+        return next.clone();
+    };
+    let Some(next_object) = next.as_object() else {
+        return existing.clone();
+    };
+
+    let additions = existing_object
+        .get("additions")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + next_object
+            .get("additions")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+    let deletions = existing_object
+        .get("deletions")
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        + next_object
+            .get("deletions")
+            .and_then(Value::as_i64)
+            .unwrap_or(0);
+
+    let mut merged = existing_object.clone();
+    for key in ["path", "binary"] {
+        if let Some(value) = next_object.get(key) {
+            merged.insert(key.to_owned(), value.clone());
+        }
+    }
+    if let Some(value) = next_object.get("old_path").filter(|value| !value.is_null()) {
+        merged.insert("old_path".to_owned(), value.clone());
+    }
+    let change_type = merged_change_type(
+        existing_object.get("change_type").and_then(Value::as_str),
+        next_object.get("change_type").and_then(Value::as_str),
+    );
+    merged.insert("change_type".to_owned(), Value::String(change_type));
+    merged.insert("additions".to_owned(), json!(additions));
+    merged.insert("deletions".to_owned(), json!(deletions));
+    Value::Object(merged)
+}
+
+fn merged_change_type(existing: Option<&str>, next: Option<&str>) -> String {
+    match (existing, next) {
+        (Some("created"), Some("modified")) => "created".to_owned(),
+        (_, Some(next)) => next.to_owned(),
+        (Some(existing), _) => existing.to_owned(),
+        _ => "modified".to_owned(),
+    }
 }
 
 fn file_changes_from_file_change_item(
@@ -776,7 +910,7 @@ fn file_changes_summary(
 }
 
 fn file_change_from_codex_change(change: &Value, workspace_path: &str) -> Option<Value> {
-    let path = workspace_relative_path(&string_field(change, "path")?, workspace_path);
+    let source_path = workspace_relative_path(&string_field(change, "path")?, workspace_path);
     let kind = change
         .get("kind")
         .and_then(Value::as_object)
@@ -794,9 +928,17 @@ fn file_change_from_codex_change(change: &Value, workspace_path: &str) -> Option
         "update" if move_path.is_some() => "renamed",
         _ => "modified",
     };
+    let (path, old_path) = if change_type == "renamed" {
+        (
+            move_path.unwrap_or_else(|| source_path.clone()),
+            Some(source_path),
+        )
+    } else {
+        (source_path, None)
+    };
     let (additions, deletions) = diff_stats(&diff, change_type);
     Some(json!({
-        "old_path": if change_type == "renamed" { move_path } else { None },
+        "old_path": old_path,
         "path": path,
         "change_type": change_type,
         "additions": additions,
@@ -815,7 +957,7 @@ fn file_change_from_patch_change(
         .or_else(|| raw_string_field(change, "diff"))
         .or_else(|| raw_string_field(change, "content"))
         .unwrap_or_default();
-    let path = workspace_relative_path(path, workspace_path);
+    let source_path = workspace_relative_path(path, workspace_path);
     let move_path = string_field(change, "move_path")
         .or_else(|| string_field(change, "movePath"))
         .map(|path| workspace_relative_path(&path, workspace_path));
@@ -825,9 +967,17 @@ fn file_change_from_patch_change(
         "update" if move_path.is_some() => "renamed",
         _ => "modified",
     };
+    let (path, old_path) = if change_type == "renamed" {
+        (
+            move_path.unwrap_or_else(|| source_path.clone()),
+            Some(source_path),
+        )
+    } else {
+        (source_path, None)
+    };
     let (additions, deletions) = diff_stats(&diff, change_type);
     Some(json!({
-        "old_path": if change_type == "renamed" { move_path } else { None },
+        "old_path": old_path,
         "path": path,
         "change_type": change_type,
         "additions": additions,
@@ -871,7 +1021,7 @@ fn diff_stats(diff: &str, change_type: &str) -> (i64, i64) {
     if additions > 0 || deletions > 0 {
         return (additions, deletions);
     }
-    let line_count = diff.lines().filter(|line| !line.trim().is_empty()).count() as i64;
+    let line_count = diff.lines().count() as i64;
     match change_type {
         "created" => (line_count, 0),
         "deleted" => (0, line_count),
@@ -889,8 +1039,11 @@ fn combined_diff_from_file_change_item(item: &Value, workspace_path: &str) -> Op
             let move_path = change.get("kind").and_then(|kind| {
                 string_field(kind, "movePath").or_else(|| string_field(kind, "move_path"))
             });
-            raw_string_field(change, "diff").map(|diff| {
-                diff_with_file_header(&path, move_path.as_deref(), &diff, workspace_path)
+            raw_string_field(change, "diff").map(|diff| match move_path {
+                Some(move_path) => {
+                    diff_with_file_header(&move_path, Some(&path), &diff, workspace_path)
+                }
+                None => diff_with_file_header(&path, None, &diff, workspace_path),
             })
         })
         .collect::<Vec<_>>()
@@ -909,8 +1062,11 @@ fn combined_diff_from_patch_apply_end(item: &Value, workspace_path: &str) -> Opt
             raw_string_field(change, "unified_diff")
                 .or_else(|| raw_string_field(change, "diff"))
                 .or_else(|| raw_string_field(change, "content"))
-                .map(|diff| {
-                    diff_with_file_header(path, move_path.as_deref(), &diff, workspace_path)
+                .map(|diff| match move_path {
+                    Some(move_path) => {
+                        diff_with_file_header(&move_path, Some(path), &diff, workspace_path)
+                    }
+                    None => diff_with_file_header(path, None, &diff, workspace_path),
                 })
         })
         .collect::<Vec<_>>()

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -39,8 +39,10 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                 "reasoning" => push_reasoning_block(&mut blocks, item, created_at),
                 "commandexecution" => blocks.push(command_block(item, created_at)),
                 "functioncall" | "customtoolcall" | "dynamictoolcall" | "mcptoolcall"
-                | "toolsearchcall" | "websearch" | "imagegeneration" | "imageview" | "sleep"
-                | "localshellcall" | "shellcall" => blocks.push(tool_block(item, created_at)),
+                | "toolsearchcall" | "websearchcall" | "websearch" | "imagegeneration"
+                | "imageview" | "sleep" | "localshellcall" | "shellcall" => {
+                    blocks.push(tool_block(item, created_at))
+                }
                 "functioncalloutput" | "customtoolcalloutput" | "toolsearchoutput" => {
                     merge_tool_output(&mut blocks, item, created_at);
                 }
@@ -434,6 +436,7 @@ fn is_tool_item_type(item_type: &str) -> bool {
             | "dynamictoolcall"
             | "mcptoolcall"
             | "toolsearchcall"
+            | "websearchcall"
             | "websearch"
             | "imagegeneration"
             | "imageview"
@@ -474,7 +477,7 @@ fn tool_name(item: &Value) -> String {
                 .unwrap_or(tool)
         }
         "toolsearchcall" | "toolsearchoutput" => "tool_search".to_owned(),
-        "websearch" => "web_search".to_owned(),
+        "websearch" | "websearchcall" => "web_search".to_owned(),
         "imagegeneration" => "image_generation".to_owned(),
         "imageview" => "view_image".to_owned(),
         "sleep" => "sleep".to_owned(),
@@ -493,6 +496,10 @@ fn tool_input(item: &Value) -> Value {
         }
         "mcptoolcall" => item.get("arguments").cloned().unwrap_or(Value::Null),
         "websearch" => json!({"query": string_field(item, "query").unwrap_or_default()}),
+        "websearchcall" => item
+            .get("action")
+            .cloned()
+            .unwrap_or_else(|| json!({"query": string_field(item, "query").unwrap_or_default()})),
         "imageview" => json!({"path": string_field(item, "path").unwrap_or_default()}),
         "sleep" => {
             json!({"duration_ms": item.get("durationMs").or_else(|| item.get("duration_ms")).cloned().unwrap_or(Value::Null)})

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -118,6 +118,14 @@ async fn runtime_transcript_normalizes_codex_file_change_items_without_backend_s
         assistant["fileChanges"]["artifact_id"],
         "codex-turn-file-change-call-1"
     );
+    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 2);
+    assert_eq!(assistant["blocks"][0]["type"], "text");
+    assert_eq!(assistant["blocks"][0]["content"], "Editing.");
+    assert_eq!(assistant["blocks"][1]["type"], "file_changes");
+    assert_eq!(
+        assistant["blocks"][1]["file_changes"]["files"][0]["path"],
+        "references/github-pr-flow.md"
+    );
     assert_eq!(assistant["fileChanges"]["file_count"], 1);
     assert_eq!(assistant["fileChanges"]["additions"], 1);
     assert_eq!(assistant["fileChanges"]["deletions"], 1);
@@ -159,13 +167,18 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
     assert_eq!(assistant["role"], "assistant");
     assert_eq!(assistant["content"], "Done");
     assert!(assistant["subtaskId"].as_i64().unwrap() < 0);
-    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 3);
+    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 4);
     assert_eq!(assistant["blocks"][0]["type"], "thinking");
     assert_eq!(assistant["blocks"][1]["type"], "text");
     assert_eq!(assistant["blocks"][1]["content"], "I checked the files.");
     assert_eq!(assistant["blocks"][2]["tool_name"], "exec_command");
     assert_eq!(assistant["blocks"][2]["tool_output"], "ok");
-    assert_eq!(assistant["blocks"][2]["timestamp"], 1780000007000_i64);
+    assert_eq!(assistant["blocks"][3]["type"], "file_changes");
+    assert_eq!(
+        assistant["blocks"][3]["file_changes"]["files"][0]["path"],
+        "src/lib.rs"
+    );
+    assert_eq!(assistant["blocks"][3]["timestamp"], 1780000007000_i64);
     assert_eq!(assistant["fileChanges"]["device_id"], "device-1");
     assert_eq!(assistant["fileChanges"]["workspace_path"], "/tmp/project");
     assert_eq!(assistant["fileChanges"]["file_count"], 1);
@@ -233,6 +246,49 @@ async fn runtime_transcript_preserves_codex_web_search_actions() {
 }
 
 #[tokio::test]
+async fn runtime_transcript_keeps_interrupted_commentary_visible() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-interrupted-commentary-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex = write_fake_interrupted_commentary_codex(&temp_path(
+        "runtime-interrupted-commentary-log",
+        "jsonl",
+    ));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let interrupted = &transcript["messages"][1];
+    assert_eq!(interrupted["role"], "assistant");
+    assert_eq!(
+        interrupted["content"],
+        "I will inspect the repository.\n\nThe split is in the skill docs."
+    );
+    assert!(interrupted["blocks"].as_array().unwrap().is_empty());
+
+    let completed = &transcript["messages"][3];
+    assert_eq!(completed["role"], "assistant");
+    assert_eq!(completed["content"], "Done");
+    assert_eq!(completed["blocks"].as_array().unwrap().len(), 1);
+    assert_eq!(completed["blocks"][0]["type"], "text");
+    assert_eq!(completed["blocks"][0]["content"], "Editing files.");
+}
+
+#[tokio::test]
 async fn runtime_transcript_merges_multiple_codex_file_change_items_in_one_turn() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -280,6 +336,167 @@ async fn runtime_transcript_merges_multiple_codex_file_change_items_in_one_turn(
         .as_str()
         .unwrap()
         .contains("scripts/notify_pr_ready.sh"));
+    let blocks = assistant["blocks"].as_array().unwrap();
+    assert_eq!(blocks.len(), 4);
+    assert!(blocks.iter().all(|block| block["type"] == "file_changes"));
+    assert_eq!(
+        blocks[3]["file_changes"]["files"][0]["path"],
+        "scripts/notify_pr_ready.sh"
+    );
+}
+
+#[tokio::test]
+async fn runtime_transcript_accumulates_codex_file_changes_and_uses_move_target_path() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-accumulated-file-changes-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex = write_fake_accumulated_file_changes_codex(&temp_path(
+        "runtime-accumulated-file-changes-log",
+        "jsonl",
+    ));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let assistant = &transcript["messages"][1];
+    assert_eq!(assistant["fileChanges"]["file_count"], 6);
+    assert_eq!(assistant["fileChanges"]["additions"], 35);
+    assert_eq!(assistant["fileChanges"]["deletions"], 39);
+    assert_eq!(assistant["fileChanges"]["files"][0]["path"], "SKILL.md");
+    assert_eq!(assistant["fileChanges"]["files"][0]["additions"], 3);
+    assert_eq!(assistant["fileChanges"]["files"][0]["deletions"], 4);
+    let files = assistant["fileChanges"]["files"].as_array().unwrap();
+    let start_new = files
+        .iter()
+        .find(|file| file["path"] == "scripts/start_new.sh")
+        .expect("renamed script should use the move target path");
+    assert_eq!(start_new["old_path"], "scripts/start_old.sh");
+    let new_reference = files
+        .iter()
+        .find(|file| file["path"] == "references/new.md")
+        .expect("renamed reference should use the move target path");
+    assert_eq!(new_reference["old_path"], "references/old.md");
+    let deleted_script = files
+        .iter()
+        .find(|file| file["path"] == "scripts/delete.sh")
+        .expect("deleted script should be present");
+    assert_eq!(deleted_script["path"], "scripts/delete.sh");
+    assert_eq!(deleted_script["deletions"], 3);
+}
+
+fn write_fake_interrupted_commentary_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-interrupted-commentary", "sh");
+    let _ = fs::remove_file(log_path);
+    let response = json!({
+        "id": 2,
+        "result": {
+            "thread": {
+                "id": "thread-1",
+                "cwd": "/tmp/project",
+                "name": "Interrupted commentary",
+                "preview": "inspect",
+                "path": "/tmp/codex/thread-1.jsonl",
+                "createdAt": 1780000000_i64,
+                "updatedAt": 1780000300_i64,
+                "status": "idle",
+                "turns": [
+                    {
+                        "id": "turn-interrupted",
+                        "status": "interrupted",
+                        "startedAt": 1780000000_i64,
+                        "durationMs": 108000_i64,
+                        "items": [
+                            {
+                                "id": "user-1",
+                                "type": "userMessage",
+                                "content": [{"type": "text", "text": "inspect"}],
+                            },
+                            {
+                                "id": "agent-progress-1",
+                                "type": "agentMessage",
+                                "text": "I will inspect the repository.",
+                                "phase": "commentary",
+                            },
+                            {
+                                "id": "agent-progress-2",
+                                "type": "agentMessage",
+                                "text": "The split is in the skill docs.",
+                                "phase": "commentary",
+                            },
+                        ],
+                    },
+                    {
+                        "id": "turn-completed",
+                        "status": "completed",
+                        "startedAt": 1780000200_i64,
+                        "durationMs": 3000_i64,
+                        "items": [
+                            {
+                                "id": "user-2",
+                                "type": "userMessage",
+                                "content": [{"type": "text", "text": "edit"}],
+                            },
+                            {
+                                "id": "agent-progress-3",
+                                "type": "agentMessage",
+                                "text": "Editing files.",
+                                "phase": "commentary",
+                            },
+                            {
+                                "id": "agent-final",
+                                "type": "agentMessage",
+                                "text": "Done",
+                                "phase": "final_answer",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    });
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' {}
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display(),
+        shell_single_quote(&response.to_string()),
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
 }
 
 fn write_fake_file_change_codex(log_path: &Path) -> PathBuf {
@@ -392,6 +609,139 @@ fn write_fake_multi_patch_codex(log_path: &Path) -> PathBuf {
                             "scripts/notify_pr_ready.sh",
                             counted_diff("scripts/notify_pr_ready.sh", 36, 5),
                         ),
+                        {
+                            "id": "agent-1",
+                            "type": "agentMessage",
+                            "text": "Done",
+                            "phase": "final_answer",
+                        },
+                    ],
+                }],
+            },
+        },
+    });
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' {}
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display(),
+        shell_single_quote(&response.to_string()),
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_accumulated_file_changes_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-accumulated-file-changes", "sh");
+    let _ = fs::remove_file(log_path);
+    let response = json!({
+        "id": 2,
+        "result": {
+            "thread": {
+                "id": "thread-1",
+                "cwd": "/tmp/project",
+                "name": "Accumulated file changes",
+                "preview": "edit",
+                "path": "/tmp/codex/thread-1.jsonl",
+                "createdAt": 1780000000_i64,
+                "updatedAt": 1780000060_i64,
+                "status": "idle",
+                "turns": [{
+                    "id": "turn-accumulated",
+                    "createdAt": 1780000000_i64,
+                    "items": [
+                        {
+                            "id": "user-1",
+                            "type": "userMessage",
+                            "content": [{"type": "text", "text": "edit files"}],
+                        },
+                        {
+                            "id": "change-1",
+                            "type": "fileChange",
+                            "status": "completed",
+                            "changes": [
+                                {
+                                    "path": "/tmp/project/SKILL.md",
+                                    "kind": {"type": "update", "move_path": null},
+                                    "diff": counted_diff("SKILL.md", 2, 1),
+                                },
+                                {
+                                    "path": "/tmp/project/scripts/start_old.sh",
+                                    "kind": {"type": "update", "move_path": null},
+                                    "diff": counted_diff("scripts/start_old.sh", 5, 4),
+                                },
+                                {
+                                    "path": "/tmp/project/references/old.md",
+                                    "kind": {"type": "update", "move_path": null},
+                                    "diff": counted_diff("references/old.md", 22, 23),
+                                },
+                            ],
+                        },
+                        {
+                            "id": "change-2",
+                            "type": "fileChange",
+                            "status": "completed",
+                            "changes": [
+                                {
+                                    "path": "/tmp/project/SKILL.md",
+                                    "kind": {"type": "update", "move_path": null},
+                                    "diff": counted_diff("SKILL.md", 1, 3),
+                                },
+                                {
+                                    "path": "/tmp/project/scripts/start_old.sh",
+                                    "kind": {
+                                        "type": "update",
+                                        "move_path": "/tmp/project/scripts/start_new.sh",
+                                    },
+                                    "diff": counted_diff("scripts/start_new.sh", 1, 1),
+                                },
+                                {
+                                    "path": "/tmp/project/references/old.md",
+                                    "kind": {
+                                        "type": "update",
+                                        "move_path": "/tmp/project/references/new.md",
+                                    },
+                                    "diff": "",
+                                },
+                            ],
+                        },
+                        {
+                            "id": "change-3",
+                            "type": "fileChange",
+                            "status": "completed",
+                            "changes": [
+                                {
+                                    "path": "/tmp/project/references/new.md",
+                                    "kind": {"type": "update", "move_path": null},
+                                    "diff": counted_diff("references/new.md", 4, 4),
+                                },
+                                {
+                                    "path": "/tmp/project/scripts/delete.sh",
+                                    "kind": {"type": "delete"},
+                                    "diff": "one\n\ntwo",
+                                },
+                            ],
+                        },
                         {
                             "id": "agent-1",
                             "type": "agentMessage",

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -185,6 +185,54 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
 }
 
 #[tokio::test]
+async fn runtime_transcript_preserves_codex_web_search_actions() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-web-search-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let fake_codex = write_fake_web_search_codex(&temp_path("runtime-web-search-log", "jsonl"));
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let transcript = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.transcript",
+            "payload": {
+                "workspacePath": "/tmp/project",
+                "localTaskId": "thread-1"
+            }
+        }))
+        .await
+        .expect("transcript should succeed");
+
+    assert_eq!(transcript["success"], true);
+    let assistant = &transcript["messages"][1];
+    assert_eq!(assistant["role"], "assistant");
+    assert_eq!(assistant["content"], "Done");
+    assert_eq!(assistant["blocks"].as_array().unwrap().len(), 3);
+    assert_eq!(assistant["blocks"][0]["type"], "text");
+    assert_eq!(assistant["blocks"][1]["type"], "tool");
+    assert_eq!(assistant["blocks"][1]["tool_name"], "web_search");
+    assert_eq!(assistant["blocks"][1]["tool_input"]["type"], "search");
+    assert_eq!(
+        assistant["blocks"][1]["tool_input"]["query"],
+        "Beijing weather today June 17 2026 temperature rain"
+    );
+    assert_eq!(
+        assistant["blocks"][1]["tool_input"]["queries"][1],
+        "Beijing China current weather forecast today AccuWeather"
+    );
+    assert_eq!(assistant["blocks"][2]["tool_name"], "web_search");
+    assert_eq!(assistant["blocks"][2]["tool_input"]["type"], "open_page");
+    assert_eq!(
+        assistant["blocks"][2]["tool_input"]["url"],
+        "https://www.weather.com/weather/today/l/Beijing+China"
+    );
+}
+
+#[tokio::test]
 async fn runtime_transcript_merges_multiple_codex_file_change_items_in_one_turn() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -441,6 +489,100 @@ while IFS= read -r line; do
 done
 "#,
         log_path.display()
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_web_search_codex(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-web-search-transcript", "sh");
+    let _ = fs::remove_file(log_path);
+    let response = json!({
+        "id": 2,
+        "result": {
+            "thread": {
+                "id": "thread-1",
+                "cwd": "/tmp/project",
+                "name": "Web search transcript",
+                "preview": "search",
+                "path": "/tmp/codex/thread-1.jsonl",
+                "createdAt": 1780000000_i64,
+                "updatedAt": 1780000060_i64,
+                "status": "idle",
+                "turns": [{
+                    "id": "turn-web-search",
+                    "createdAt": 1780000000_i64,
+                    "items": [
+                        {
+                            "id": "user-1",
+                            "type": "userMessage",
+                            "content": [{"type": "text", "text": "weather"}],
+                        },
+                        {
+                            "id": "agent-progress",
+                            "type": "agentMessage",
+                            "text": "I will search the web.",
+                            "phase": "analysis",
+                        },
+                        {
+                            "id": "web-search-1",
+                            "type": "web_search_call",
+                            "status": "completed",
+                            "action": {
+                                "type": "search",
+                                "query": "Beijing weather today June 17 2026 temperature rain",
+                                "queries": [
+                                    "Beijing weather today June 17 2026 temperature rain",
+                                    "Beijing China current weather forecast today AccuWeather",
+                                ],
+                            },
+                        },
+                        {
+                            "id": "web-open-1",
+                            "type": "web_search_call",
+                            "status": "completed",
+                            "action": {
+                                "type": "open_page",
+                                "url": "https://www.weather.com/weather/today/l/Beijing+China",
+                            },
+                        },
+                        {
+                            "id": "agent-1",
+                            "type": "agentMessage",
+                            "text": "Done",
+                            "phase": "final_answer",
+                        },
+                    ],
+                }],
+            },
+        },
+    });
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":1,"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/read"'*)
+      printf '%s\n' {}
+      exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display(),
+        shell_single_quote(&response.to_string()),
     );
     fs::write(&path, content).unwrap();
     #[cfg(unix)]

--- a/packages/chat-core/src/index.ts
+++ b/packages/chat-core/src/index.ts
@@ -20,6 +20,7 @@ export type {
   WorkbenchMessageAction,
   WorkbenchMessageRole,
   WorkbenchMessageStatus,
+  WorkbenchFileChangesBlock,
   WorkbenchProcessingBlock,
   WorkbenchThinkingBlock,
   WorkbenchTextBlock,

--- a/packages/chat-core/src/workbench-message-reducer.ts
+++ b/packages/chat-core/src/workbench-message-reducer.ts
@@ -40,7 +40,17 @@ export interface WorkbenchTextBlock extends BaseWorkbenchProcessingBlock {
   content: string
 }
 
-export type WorkbenchProcessingBlock = WorkbenchToolBlock | WorkbenchThinkingBlock | WorkbenchTextBlock
+export interface WorkbenchFileChangesBlock<TFileChanges = unknown>
+  extends BaseWorkbenchProcessingBlock {
+  type: 'file_changes'
+  fileChanges: TFileChanges
+}
+
+export type WorkbenchProcessingBlock<TFileChanges = unknown> =
+  | WorkbenchToolBlock
+  | WorkbenchThinkingBlock
+  | WorkbenchTextBlock
+  | WorkbenchFileChangesBlock<TFileChanges>
 
 export interface WorkbenchMessage<TAttachment = unknown, TFileChanges = unknown> {
   id: string
@@ -53,7 +63,7 @@ export interface WorkbenchMessage<TAttachment = unknown, TFileChanges = unknown>
   error?: string
   errorType?: string
   attachments?: TAttachment[]
-  blocks?: WorkbenchProcessingBlock[]
+  blocks?: WorkbenchProcessingBlock<TFileChanges>[]
   fileChanges?: TFileChanges
   source?: MessageSource
   createdAt: string
@@ -75,20 +85,20 @@ export type WorkbenchMessageAction<TAttachment = unknown, TFileChanges = unknown
       taskId?: number
       subtaskId: number
       content: string
-      blocks?: WorkbenchProcessingBlock[]
+      blocks?: WorkbenchProcessingBlock<TFileChanges>[]
     }
   | {
       type: 'assistant_chunk'
       subtaskId: number
       content: string
       reasoningChunk?: string
-      blocks?: WorkbenchProcessingBlock[]
+      blocks?: WorkbenchProcessingBlock<TFileChanges>[]
     }
   | {
       type: 'assistant_done'
       subtaskId: number
       content?: string
-      blocks?: WorkbenchProcessingBlock[]
+      blocks?: WorkbenchProcessingBlock<TFileChanges>[]
       fileChanges?: TFileChanges
     }
   | {
@@ -97,7 +107,7 @@ export type WorkbenchMessageAction<TAttachment = unknown, TFileChanges = unknown
       fileChanges: TFileChanges
     }
   | { type: 'assistant_error'; subtaskId: number; error: string; errorType?: string }
-  | { type: 'block_created'; subtaskId: number; block: WorkbenchProcessingBlock }
+  | { type: 'block_created'; subtaskId: number; block: WorkbenchProcessingBlock<TFileChanges> }
   | { type: 'block_updated'; subtaskId: number; blockId: string; updates: ProcessingBlockUpdate }
 
 export function isGenericTaskStatusError(error?: string): boolean {
@@ -260,7 +270,7 @@ export function reduceWorkbenchMessages<TAttachment = unknown, TFileChanges = un
               ...withActiveStreamState(message, isActiveBlockStatus(action.updates.status)),
               blocks: (message.blocks ?? []).map(block =>
                 block.id === action.blockId
-                  ? ({ ...block, ...action.updates } as WorkbenchProcessingBlock)
+                  ? ({ ...block, ...action.updates } as WorkbenchProcessingBlock<TFileChanges>)
                   : block
               ),
             }
@@ -294,7 +304,7 @@ function createAssistantMessage<TAttachment, TFileChanges>({
   shellType?: string
   content?: string
   status?: WorkbenchMessageStatus
-  blocks?: WorkbenchProcessingBlock[]
+  blocks?: WorkbenchProcessingBlock<TFileChanges>[]
   fileChanges?: TFileChanges
   error?: string
   errorType?: string
@@ -401,11 +411,11 @@ function getChunkBlocks<TAttachment, TFileChanges>(
   return action.blocks.reduce(mergeProcessingBlock, withReasoning ?? [])
 }
 
-function appendThinkingChunk(
-  blocks: WorkbenchProcessingBlock[] | undefined,
+function appendThinkingChunk<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined,
   subtaskId: number,
   chunk?: string
-): WorkbenchProcessingBlock[] | undefined {
+): WorkbenchProcessingBlock<TFileChanges>[] | undefined {
   if (!chunk) return blocks
 
   const nextBlocks = [...(blocks ?? [])]
@@ -435,8 +445,8 @@ function appendThinkingChunk(
 function getBlocksBeforeIncomingBlock<TAttachment, TFileChanges>(
   message: WorkbenchMessage<TAttachment, TFileChanges>,
   subtaskId: number,
-  incomingBlock: WorkbenchProcessingBlock
-): WorkbenchProcessingBlock[] {
+  incomingBlock: WorkbenchProcessingBlock<TFileChanges>
+): WorkbenchProcessingBlock<TFileChanges>[] {
   const finalizedBlocks = finalizeOpenNarrativeBlocks(message.blocks)
   if (!shouldMovePendingContentBeforeBlock(message, incomingBlock)) return finalizedBlocks
 
@@ -455,7 +465,7 @@ function getBlocksBeforeIncomingBlock<TAttachment, TFileChanges>(
 
 function shouldMovePendingContentBeforeBlock<TAttachment, TFileChanges>(
   message: WorkbenchMessage<TAttachment, TFileChanges>,
-  incomingBlock: WorkbenchProcessingBlock
+  incomingBlock: WorkbenchProcessingBlock<TFileChanges>
 ): boolean {
   return incomingBlock.type !== 'text' && message.content.trim().length > 0
 }
@@ -464,9 +474,9 @@ function getTextBlockCount(blocks: WorkbenchProcessingBlock[]): number {
   return blocks.filter(block => block.type === 'text').length
 }
 
-function finalizeOpenNarrativeBlocks(
-  blocks: WorkbenchProcessingBlock[] | undefined
-): WorkbenchProcessingBlock[] {
+function finalizeOpenNarrativeBlocks<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined
+): WorkbenchProcessingBlock<TFileChanges>[] {
   return (blocks ?? []).map(block => {
     if (
       (block.type === 'thinking' || block.type === 'text') &&
@@ -479,10 +489,10 @@ function finalizeOpenNarrativeBlocks(
   })
 }
 
-function finalizeBlocks(
-  blocks: WorkbenchProcessingBlock[] | undefined,
+function finalizeBlocks<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined,
   finalStatus?: Extract<WorkbenchToolBlockStatus, 'done' | 'error'>
-): WorkbenchProcessingBlock[] {
+): WorkbenchProcessingBlock<TFileChanges>[] {
   return (blocks ?? []).map(block => {
     if (block.type === 'thinking' && block.status === 'streaming') {
       return { ...block, status: 'done' as const }
@@ -492,26 +502,29 @@ function finalizeBlocks(
       return block
     }
 
-    return { ...block, status: finalStatus } as WorkbenchProcessingBlock
+    return { ...block, status: finalStatus } as WorkbenchProcessingBlock<TFileChanges>
   })
 }
 
-function finalizeProcessingBlocks(
-  blocks: WorkbenchProcessingBlock[] | undefined,
+function finalizeProcessingBlocks<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[] | undefined,
   finalStatus: Extract<WorkbenchToolBlockStatus, 'done' | 'error'> = 'done'
-): WorkbenchProcessingBlock[] | undefined {
+): WorkbenchProcessingBlock<TFileChanges>[] | undefined {
   if (!blocks) return undefined
   return finalizeBlocks(blocks, finalStatus)
 }
 
-function mergeProcessingBlock(
-  blocks: WorkbenchProcessingBlock[],
-  incomingBlock: WorkbenchProcessingBlock
-): WorkbenchProcessingBlock[] {
+function mergeProcessingBlock<TFileChanges>(
+  blocks: WorkbenchProcessingBlock<TFileChanges>[],
+  incomingBlock: WorkbenchProcessingBlock<TFileChanges>
+): WorkbenchProcessingBlock<TFileChanges>[] {
   const index = blocks.findIndex(block => block.id === incomingBlock.id)
   if (index === -1) return [...blocks, incomingBlock]
 
   const nextBlocks = [...blocks]
-  nextBlocks[index] = { ...nextBlocks[index], ...incomingBlock } as WorkbenchProcessingBlock
+  nextBlocks[index] = {
+    ...nextBlocks[index],
+    ...incomingBlock,
+  } as WorkbenchProcessingBlock<TFileChanges>
   return nextBlocks
 }

--- a/wework/src/components/chat/CodexTurnArtifacts.tsx
+++ b/wework/src/components/chat/CodexTurnArtifacts.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Archive, Box, ChevronDown, FileText } from 'lucide-react'
+import { Archive, Box, ChevronDown, ChevronUp, FileText } from 'lucide-react'
 import { useTranslation } from '@/hooks/useTranslation'
 import type {
   CodexContextEvent,
@@ -8,6 +8,8 @@ import type {
   CodexReference,
 } from '@/types/api'
 import { basename, fileExtension, getDisplayCodexReferences } from './codexReferences'
+
+const DEFAULT_VISIBLE_REFERENCE_COUNT = 3
 
 export function CodexContextEvents({ events }: { events: CodexContextEvent[] }) {
   const { t } = useTranslation('chat')
@@ -87,8 +89,13 @@ export function CodexReferenceList({
   onOpenFile: (path: string) => void
 }) {
   const { t } = useTranslation('chat')
-  const uniqueReferences = getDisplayCodexReferences(references).slice(0, 6)
+  const [expanded, setExpanded] = useState(false)
+  const uniqueReferences = getDisplayCodexReferences(references)
   if (uniqueReferences.length === 0) return null
+  const hiddenCount = Math.max(0, uniqueReferences.length - DEFAULT_VISIBLE_REFERENCE_COUNT)
+  const visibleReferences = expanded
+    ? uniqueReferences
+    : uniqueReferences.slice(0, DEFAULT_VISIBLE_REFERENCE_COUNT)
 
   return (
     <section
@@ -97,7 +104,7 @@ export function CodexReferenceList({
       aria-label={t('codex_references.title')}
     >
       <div className="min-w-0 overflow-hidden rounded-xl border border-border bg-surface">
-        {uniqueReferences.map(reference => (
+        {visibleReferences.map(reference => (
           <button
             type="button"
             key={reference.path}
@@ -134,6 +141,26 @@ export function CodexReferenceList({
             </span>
           </button>
         ))}
+        {hiddenCount > 0 ? (
+          <button
+            type="button"
+            data-testid="toggle-codex-reference-list-button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded(value => !value)}
+            className="flex h-8 w-full items-center justify-center gap-1 border-t border-border text-xs font-medium text-text-secondary hover:bg-muted"
+          >
+            <span>
+              {expanded
+                ? t('codex_references.show_less')
+                : t('codex_references.show_more', { count: hiddenCount })}
+            </span>
+            {expanded ? (
+              <ChevronUp className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : null}
       </div>
     </section>
   )

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -321,7 +321,8 @@ describe('MessageList', () => {
     expect(screen.getByText('最终建议放在 PR flow 里。')).toBeInTheDocument()
     const collapseContent = screen.getByTestId('processing-collapse-content')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
-    expect(collapseContent).toHaveClass('grid-rows-[0fr]', 'opacity-0')
+    expect(collapseContent).toHaveClass('opacity-0')
+    expect(collapseContent).toHaveStyle({ maxHeight: '0px' })
 
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
     expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
@@ -346,6 +347,18 @@ describe('MessageList', () => {
         createdAt: 1770000000000,
       },
       {
+        id: 'web-query-url-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'web_search',
+        toolInput: {
+          type: 'search',
+          query: 'https://www.weather.com/weather/today/l/Beijing+China',
+        },
+        status: 'done',
+        createdAt: 1770000001000,
+      },
+      {
         id: 'web-open-1',
         subtaskId: 11,
         type: 'tool',
@@ -355,7 +368,7 @@ describe('MessageList', () => {
           url: 'https://www.weather.com/weather/today/l/Beijing+China',
         },
         status: 'done',
-        createdAt: 1770000001000,
+        createdAt: 1770000002000,
       },
     ]
 
@@ -693,6 +706,130 @@ describe('MessageList', () => {
     onOpenWorkspaceFile.mockClear()
     await userEvent.click(memoryEntry)
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('MEMORY.md')
+  })
+
+  test('adds deduped document references from turn file changes and expands hidden references', async () => {
+    render(
+      <MessageList
+        onOpenWorkspaceFile={vi.fn()}
+        onLoadFileChangesDiff={vi.fn().mockResolvedValue('')}
+        onRevertFileChanges={vi.fn()}
+        messages={[
+          {
+            id: 'assistant-file-change-documents',
+            subtaskId: 42,
+            role: 'assistant',
+            content:
+              'Updated [SKILL.md](/workspace/project/SKILL.md) and [wegent-merged-env.md](/workspace/project/references/wegent-merged-env.md).',
+            status: 'done',
+            createdAt: '2026-06-24T08:00:01.000Z',
+            fileChanges: {
+              version: 1,
+              status: 'active',
+              artifact_id: 'turn-42',
+              device_id: 'device-1',
+              workspace_path: '/workspace/project',
+              file_count: 10,
+              additions: 64,
+              deletions: 130,
+              files: [
+                {
+                  path: 'SKILL.md',
+                  change_type: 'modified',
+                  additions: 12,
+                  deletions: 12,
+                  binary: false,
+                },
+                {
+                  path: 'scripts/run_on_integration_env.sh',
+                  change_type: 'deleted',
+                  additions: 0,
+                  deletions: 58,
+                  binary: false,
+                },
+                {
+                  path: 'references/acceptance-validation-contract.md',
+                  change_type: 'modified',
+                  additions: 1,
+                  deletions: 1,
+                  binary: false,
+                },
+                {
+                  path: 'references/browser-validation.md',
+                  change_type: 'modified',
+                  additions: 1,
+                  deletions: 1,
+                  binary: false,
+                },
+                {
+                  path: 'references/github-pr-flow.md',
+                  change_type: 'modified',
+                  additions: 3,
+                  deletions: 3,
+                  binary: false,
+                },
+                {
+                  path: 'references/post-review-follow-up.md',
+                  change_type: 'modified',
+                  additions: 3,
+                  deletions: 9,
+                  binary: false,
+                },
+                {
+                  path: 'references/pr-review-notification.md',
+                  change_type: 'modified',
+                  additions: 2,
+                  deletions: 2,
+                  binary: false,
+                },
+                {
+                  path: 'references/wegent-integration-test-env.md',
+                  change_type: 'modified',
+                  additions: 22,
+                  deletions: 23,
+                  binary: false,
+                },
+                {
+                  path: 'references/wegent-merged-env.md',
+                  change_type: 'modified',
+                  additions: 4,
+                  deletions: 4,
+                  binary: false,
+                },
+                {
+                  path: 'scripts/start_executor_local.sh',
+                  change_type: 'renamed',
+                  additions: 1,
+                  deletions: 1,
+                  binary: false,
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByTestId('codex-reference-card')).toHaveLength(3)
+    expect(screen.getByTestId('toggle-codex-reference-list-button')).toHaveTextContent(
+      '显示另外 5 个'
+    )
+
+    await userEvent.click(screen.getByTestId('toggle-codex-reference-list-button'))
+
+    const expandedReferenceCards = screen.getAllByTestId('codex-reference-card')
+    expect(expandedReferenceCards).toHaveLength(8)
+    expect(screen.getByTestId('toggle-codex-reference-list-button')).toHaveTextContent('收起文件')
+    expect(expandedReferenceCards.map(card => card.textContent)).toEqual([
+      expect.stringContaining('SKILL.md'),
+      expect.stringContaining('acceptance-validation-contract.md'),
+      expect.stringContaining('browser-validation.md'),
+      expect.stringContaining('github-pr-flow.md'),
+      expect.stringContaining('post-review-follow-up.md'),
+      expect.stringContaining('pr-review-notification.md'),
+      expect.stringContaining('wegent-integration-test-env.md'),
+      expect.stringContaining('wegent-merged-env.md'),
+    ])
   })
 
   test('renders IM source badge for user messages with channel label', () => {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { Attachment } from '@/types/api'
@@ -169,7 +169,15 @@ describe('MessageList', () => {
     localStorage.clear()
     URL.createObjectURL = originalCreateObjectUrl
     URL.revokeObjectURL = originalRevokeObjectUrl
+    delete (navigator as unknown as { clipboard?: Clipboard }).clipboard
   })
+
+  function stubClipboardWriteText(writeText: ReturnType<typeof vi.fn>) {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+  }
 
   test('renders user and assistant messages', () => {
     const { container } = render(
@@ -318,6 +326,118 @@ describe('MessageList', () => {
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
     expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
     expect(screen.getByText('我会先看这个 skill 当前的流程结构和相关记忆。')).toBeInTheDocument()
+  })
+
+  test('renders final answer web search sources as a Codex-style source chip', async () => {
+    const user = userEvent.setup()
+    const openWindowMock = vi.fn()
+    vi.stubGlobal('open', openWindowMock)
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'web-search-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'web_search',
+        toolInput: {
+          type: 'search',
+          query: 'site:weather.com weather today Beijing China',
+        },
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+      {
+        id: 'web-open-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'web_search',
+        toolInput: {
+          type: 'open_page',
+          url: 'https://www.weather.com/weather/today/l/Beijing+China',
+        },
+        status: 'done',
+        createdAt: 1770000001000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-web-sources',
+            role: 'assistant',
+            content: '北京今天适合室内活动。',
+            status: 'done',
+            blocks,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText('北京今天适合室内活动。')).toBeInTheDocument()
+    expect(screen.getByTestId('web-search-sources-chip')).toHaveTextContent('来源')
+    expect(screen.getByTestId('web-search-source-popup')).toHaveTextContent(
+      'weather.com/weather/today/l/Beijing+China'
+    )
+    expect(screen.getAllByTestId('web-search-source-icon').length).toBeGreaterThanOrEqual(1)
+
+    await user.click(screen.getByTestId('web-search-source-popup-row'))
+
+    await waitFor(() =>
+      expect(openWindowMock).toHaveBeenCalledWith(
+        'https://www.weather.com/weather/today/l/Beijing+China',
+        '_blank',
+        'noopener,noreferrer'
+      )
+    )
+  })
+
+  test('keeps processing expansion state scoped to each conversation', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'tool-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'pwd' },
+        toolOutput: '/workspace/project\n',
+        status: 'done',
+        createdAt: 1770000000000,
+      },
+    ]
+    const buildMessage = (id: string): Parameters<typeof MessageList>[0]['messages'][number] => ({
+      id,
+      role: 'assistant',
+      content: 'Done',
+      status: 'done',
+      blocks,
+      createdAt: '2026-06-24T08:00:01.000Z',
+    })
+
+    const { rerender } = render(
+      <MessageList conversationKey="conversation-a" messages={[buildMessage('assistant-a')]} />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
+
+    rerender(
+      <MessageList conversationKey="conversation-b" messages={[buildMessage('assistant-b')]} />
+    )
+
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute('aria-hidden', 'true')
+
+    rerender(
+      <MessageList conversationKey="conversation-a" messages={[buildMessage('assistant-a')]} />
+    )
+
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
   })
 
   test('reserves enough marker gutter for multi-digit ordered lists', () => {
@@ -1197,9 +1317,7 @@ describe('MessageList', () => {
     vi.useRealTimers()
 
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, {
-      clipboard: { writeText },
-    })
+    stubClipboardWriteText(writeText)
 
     const copyButton = screen.getByTestId('copy-message-button')
     expect(copyButton).toHaveAttribute('title', '复制')
@@ -1223,9 +1341,7 @@ describe('MessageList', () => {
 
   test('collapses long user messages without changing copied content', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, {
-      clipboard: { writeText },
-    })
+    stubClipboardWriteText(writeText)
     const content = Array.from({ length: 12 }, (_, index) => `第 ${index + 1} 行内容`).join('\n')
 
     render(
@@ -1404,9 +1520,7 @@ describe('MessageList', () => {
     vi.useRealTimers()
 
     const writeText = vi.fn().mockResolvedValue(undefined)
-    Object.assign(navigator, {
-      clipboard: { writeText },
-    })
+    stubClipboardWriteText(writeText)
 
     const copyButton = screen.getByTestId('copy-message-button')
     expect(copyButton).toHaveAttribute('title', '复制')

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -16,12 +16,16 @@ import { AssistantMarkdown } from './AssistantMarkdown'
 import { resolveDirectMarkdownImageSrc } from './assistantMarkdownLinks'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
+import { isWebSearchToolName } from './blocks/toolBlockActivity'
+import { WebSearchSourcesChip } from './blocks/WebSearchSources'
+import { getWebSearchSourceItems } from './blocks/webSearchActivity'
 import { CodexContextEvents, CodexMemoryCitations, CodexReferenceList } from './CodexTurnArtifacts'
 import { getAssistantReferences } from './codexReferences'
 import { FileChangesCard } from './FileChangesCard'
 
 interface MessageListProps {
   messages: WorkbenchMessage[]
+  conversationKey?: string | number | null
   isWaitingForAssistant?: boolean
   devices?: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
@@ -47,6 +51,7 @@ const LOCAL_IMAGE_EXTENSION_PATTERN = /\.(?:apng|avif|gif|jpe?g|png|webp|bmp|svg
 
 export function MessageList({
   messages,
+  conversationKey,
   isWaitingForAssistant = false,
   devices = [],
   onRetryFailedMessage,
@@ -81,6 +86,7 @@ export function MessageList({
           ) : (
             <AssistantMessage
               message={message}
+              conversationKey={conversationKey}
               devices={devices}
               onRetryFailedMessage={onRetryFailedMessage}
               onSwitchModelForFailedMessage={onSwitchModelForFailedMessage}
@@ -583,8 +589,16 @@ function getDisplayProcessingBlocks(
   })
 }
 
+function getWebSearchToolBlocks(blocks: ProcessingBlock[]) {
+  return blocks.filter(
+    (block): block is Extract<ProcessingBlock, { type: 'tool' }> =>
+      block.type === 'tool' && isWebSearchToolName(block.toolName)
+  )
+}
+
 function AssistantMessage({
   message,
+  conversationKey,
   devices,
   onRetryFailedMessage,
   onSwitchModelForFailedMessage,
@@ -594,6 +608,7 @@ function AssistantMessage({
   onOpenWorkspaceFile,
 }: {
   message: WorkbenchMessage
+  conversationKey?: string | number | null
   devices: DeviceInfo[]
   onRetryFailedMessage?: (message: WorkbenchMessage) => void
   onSwitchModelForFailedMessage?: (message: WorkbenchMessage) => void
@@ -617,6 +632,9 @@ function AssistantMessage({
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = message.status === 'streaming'
+  const webSearchSources = isStreaming
+    ? []
+    : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
   const shouldShowCompactThinking = isStreaming && !hasBlocks && !hasVisibleContent
   const contextEvents = message.contextEvents ?? []
   const memoryCitations = message.memoryCitations ?? []
@@ -657,12 +675,16 @@ function AssistantMessage({
               startedAt={getTurnStartMs(message.createdAt)}
               forceExpanded={isCancelled}
               showSummary={!isCancelled}
+              stateKey={getMessageDisplayStateKey(conversationKey, message)}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           )}
           {contextEvents.length > 0 && <CodexContextEvents events={contextEvents} />}
           {hasVisibleContent && (
             <AssistantMarkdown content={visibleContent} onOpenFile={openFileFromLink} />
+          )}
+          {hasVisibleContent && webSearchSources.length > 0 && (
+            <WebSearchSourcesChip sources={webSearchSources} />
           )}
           {memoryCitations.length > 0 && (
             <CodexMemoryCitations citations={memoryCitations} onOpenFile={onOpenWorkspaceFile} />
@@ -716,6 +738,14 @@ function AssistantMessage({
       </div>
     </div>
   )
+}
+
+function getMessageDisplayStateKey(
+  conversationKey: string | number | null | undefined,
+  message: WorkbenchMessage
+): string {
+  const conversationPart = conversationKey == null ? 'default' : String(conversationKey)
+  return `${conversationPart}:${message.id}`
 }
 
 function AssistantErrorCard({

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -657,7 +657,7 @@ function AssistantMessage({
     }
     onOpenWorkspaceFile?.(path)
   }
-  const references = getAssistantReferences(message.references, visibleContent)
+  const references = getAssistantReferences(message.references, visibleContent, message.fileChanges)
 
   return (
     <div className="min-w-0 overflow-x-hidden text-[13px] leading-6 text-text-primary">

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -170,6 +170,53 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('restores the previous scroll position when reopening a conversation', () => {
+    const messageA = {
+      id: 'a',
+      role: 'assistant' as const,
+      content: '会话 A',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const messageB = {
+      id: 'b',
+      role: 'assistant' as const,
+      content: '会话 B',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="conversation-a" messages={[messageA]} />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 600,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 180,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn()
+
+    fireEvent.scroll(scroller)
+    rerender(<ScrollableMessageArea conversationKey="conversation-b" messages={[messageB]} />)
+
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    rerender(<ScrollableMessageArea conversationKey="conversation-a" messages={[messageA]} />)
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 180,
+      behavior: 'auto',
+    })
+  })
+
   test('does not pull the user back down when they have scrolled up', () => {
     const initialMessage = {
       id: '1',

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -8,6 +8,7 @@ import { MessageList } from './MessageList'
 
 const BOTTOM_THRESHOLD = 48
 const STABLE_SCROLL_DELAYS = [0, 50, 150, 300]
+const conversationScrollPositions = new Map<string, number>()
 
 interface ScrollableMessageAreaProps {
   messages: WorkbenchMessage[]
@@ -67,6 +68,10 @@ export function ScrollableMessageArea({
   const scrollFrameRef = useRef<number | null>(null)
   const [showScrollButton, setShowScrollButton] = useState(false)
   const lastMessage = messages[messages.length - 1]
+  const currentScrollKey = useMemo(
+    () => scrollPositionKey(conversationKey),
+    [conversationKey]
+  )
   const messageScrollSignature = useMemo(() => {
     if (!lastMessage) return 'empty'
 
@@ -74,6 +79,9 @@ export function ScrollableMessageArea({
       .map(block => {
         if (block.type === 'thinking' || block.type === 'text') {
           return `${block.id}:${block.status}:${block.content.length}`
+        }
+        if (block.type === 'file_changes') {
+          return `${block.id}:${block.status}:${block.fileChanges.file_count}:${block.fileChanges.diff?.length ?? 0}`
         }
         return `${block.id}:${block.status}:${String(block.toolOutput ?? '').length}`
       })
@@ -100,6 +108,15 @@ export function ScrollableMessageArea({
     }
   }, [])
 
+  const saveCurrentScrollPosition = useCallback(
+    (scrollTop?: number) => {
+      const element = scrollRef.current
+      if (!element || currentScrollKey === null) return
+      conversationScrollPositions.set(currentScrollKey, scrollTop ?? element.scrollTop)
+    },
+    [currentScrollKey]
+  )
+
   const updateScrollState = useCallback(() => {
     const element = scrollRef.current
     if (!element) return
@@ -111,8 +128,9 @@ export function ScrollableMessageArea({
     if (!isAtBottom) {
       clearScheduledScrolls()
     }
+    saveCurrentScrollPosition()
     setShowScrollButton(overflow && !isAtBottom)
-  }, [clearScheduledScrolls])
+  }, [clearScheduledScrolls, saveCurrentScrollPosition])
 
   const setScrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const element = scrollRef.current
@@ -126,9 +144,37 @@ export function ScrollableMessageArea({
     } else {
       element.scrollTop = element.scrollHeight
     }
+    saveCurrentScrollPosition(element.scrollHeight)
     isAtBottomRef.current = true
     setShowScrollButton(false)
-  }, [])
+  }, [saveCurrentScrollPosition])
+
+  const restoreSavedScrollPosition = useCallback(
+    (key: string) => {
+      const element = scrollRef.current
+      const savedScrollTop = conversationScrollPositions.get(key)
+      if (!element || savedScrollTop === undefined) return
+
+      clearScheduledScrolls()
+      const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
+      const nextScrollTop = Math.min(savedScrollTop, maxScrollTop)
+      if (typeof element.scrollTo === 'function') {
+        element.scrollTo({
+          top: nextScrollTop,
+          behavior: 'auto',
+        })
+      } else {
+        element.scrollTop = nextScrollTop
+      }
+
+      const overflow = element.scrollHeight > element.clientHeight + 8
+      const distanceToBottom = element.scrollHeight - element.clientHeight - nextScrollTop
+      const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
+      isAtBottomRef.current = isAtBottom
+      setShowScrollButton(overflow && !isAtBottom)
+    },
+    [clearScheduledScrolls]
+  )
 
   const scrollToBottom = useCallback(
     (behavior: ScrollBehavior = 'auto') => {
@@ -165,8 +211,16 @@ export function ScrollableMessageArea({
     const conversationChanged = previousConversationKeyRef.current !== conversationKey
     const messagesLoaded = previousMessageCountRef.current === 0 && messages.length > 0
     const lastMessageChanged = previousLastMessageIdRef.current !== (lastMessage?.id ?? null)
+    const shouldRestoreScroll =
+      Boolean(
+        currentScrollKey &&
+          messages.length > 0 &&
+          (conversationChanged || messagesLoaded) &&
+          conversationScrollPositions.has(currentScrollKey)
+      )
     const shouldForceBottom =
-      conversationChanged || messagesLoaded || (lastMessageChanged && lastMessage?.role === 'user')
+      !shouldRestoreScroll &&
+      (conversationChanged || messagesLoaded || (lastMessageChanged && lastMessage?.role === 'user'))
 
     previousConversationKeyRef.current = conversationKey
     previousLastMessageIdRef.current = lastMessage?.id ?? null
@@ -174,15 +228,22 @@ export function ScrollableMessageArea({
 
     if (messages.length === 0) return
 
+    if (shouldRestoreScroll && currentScrollKey) {
+      restoreSavedScrollPosition(currentScrollKey)
+      return
+    }
+
     if (shouldForceBottom || isAtBottomRef.current) {
       setScrollToBottom()
       scheduleStableScrollToBottom()
     }
   }, [
     conversationKey,
+    currentScrollKey,
     lastMessage,
     messageScrollSignature,
     messages.length,
+    restoreSavedScrollPosition,
     scheduleStableScrollToBottom,
     setScrollToBottom,
   ])
@@ -297,4 +358,8 @@ export function ScrollableMessageArea({
       )}
     </div>
   )
+}
+
+function scrollPositionKey(conversationKey: string | number | null | undefined): string | null {
+  return conversationKey == null ? null : String(conversationKey)
 }

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -267,6 +267,7 @@ export function ScrollableMessageArea({
               )}
               <MessageList
                 messages={messages}
+                conversationKey={conversationKey}
                 isWaitingForAssistant={isWaitingForAssistant}
                 devices={devices}
                 onRetryFailedMessage={onRetryFailedMessage}

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -86,6 +86,37 @@ describe('ToolBlockItem', () => {
     )
   })
 
+  test('renders web search tools without raw JSON details', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'web-search-1',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'web_search',
+          toolInput: {
+            type: 'search',
+            query: 'Beijing weather today June 17 2026 temperature rain',
+          },
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+      />
+    )
+
+    expect(screen.getByText('已搜索网页')).toBeInTheDocument()
+    expect(screen.queryByText('已运行 web_search')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /展开工具详情/ }))
+
+    expect(screen.getByTestId('web-search-block-detail')).toHaveTextContent(
+      'Beijing weather today June 17 2026 temperature rain'
+    )
+    expect(screen.queryByText(/"query"/)).not.toBeInTheDocument()
+  })
+
   test('renders process text code blocks with shared syntax highlighting', () => {
     render(
       <ToolBlockItem

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -1,31 +1,44 @@
 import { useState } from 'react'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Search } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
-import { isCommandToolName } from './toolBlockActivity'
+import { usePersistentProcessingExpansion } from './processingExpansionState'
+import { isCommandToolName, isWebSearchToolName } from './toolBlockActivity'
+import { WebSearchActivityRows } from './WebSearchSources'
+import { getWebSearchActivityItems } from './webSearchActivity'
 
 const THINKING_PREVIEW_MAX_LENGTH = 96
 
 interface ToolBlockItemProps {
   block: ProcessingBlock
   forceExpanded?: boolean
+  stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }
 
 export function ToolBlockItem({
   block,
   forceExpanded = false,
+  stateKey,
   onOpenWorkspaceFile,
 }: ToolBlockItemProps) {
-  const [userExpanded, setUserExpanded] = useState(false)
+  const [userExpanded, setUserExpanded] = usePersistentProcessingExpansion(
+    stateKey ? `${stateKey}:tool` : undefined
+  )
   const isRunning = block.status !== 'done' && block.status !== 'error'
   const expanded = forceExpanded || userExpanded
 
   if (block.type === 'thinking') {
-    return <ThinkingBlockItem block={block} isRunning={isRunning} />
+    return (
+      <ThinkingBlockItem
+        block={block}
+        isRunning={isRunning}
+        stateKey={stateKey ? `${stateKey}:thinking` : undefined}
+      />
+    )
   }
   if (block.type === 'text') {
     return <ProcessTextBlockItem block={block} isRunning={isRunning} />
@@ -78,12 +91,14 @@ export function ToolBlockItem({
 function ThinkingBlockItem({
   block,
   isRunning,
+  stateKey,
 }: {
   block: Extract<ProcessingBlock, { type: 'thinking' }>
   isRunning: boolean
+  stateKey?: string
 }) {
   const { t } = useTranslation('chat')
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = usePersistentProcessingExpansion(stateKey)
 
   if (!block.content) return null
 
@@ -246,6 +261,12 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <FileIcon />, label: `${prefix.read} ${fileName}` }
   }
+  if (isWebSearchToolName(name)) {
+    return {
+      icon: <Search className="h-4 w-4" strokeWidth={1.7} />,
+      label: prefix.webSearch,
+    }
+  }
   return { icon: <ToolIcon />, label: `${prefix.generic} ${block.toolName}` }
 }
 
@@ -256,6 +277,7 @@ function getToolStatusPrefix(block: ToolBlock) {
       create: '新增失败',
       edit: '编辑失败',
       read: '读取失败',
+      webSearch: '搜索网页失败',
       generic: '执行失败',
     }
   }
@@ -266,6 +288,7 @@ function getToolStatusPrefix(block: ToolBlock) {
       create: '已新增',
       edit: '已编辑',
       read: '已读取',
+      webSearch: '已搜索网页',
       generic: '已运行',
     }
   }
@@ -275,6 +298,7 @@ function getToolStatusPrefix(block: ToolBlock) {
     create: '正在新增',
     edit: '正在编辑',
     read: '正在读取',
+    webSearch: '正在搜索网页',
     generic: '正在运行',
   }
 }
@@ -363,6 +387,9 @@ function renderBlockDetail(block: ToolBlock) {
   if (name === 'edit' || name === 'str_replace_editor' || name === 'edit_file') {
     return <FileEditDetail block={block} />
   }
+  if (isWebSearchToolName(name)) {
+    return <WebSearchBlockDetail block={block} />
+  }
 
   const input = block.toolInput
   if (!input) return null
@@ -370,6 +397,18 @@ function renderBlockDetail(block: ToolBlock) {
     <pre className="max-h-32 max-w-full overflow-auto rounded-lg bg-code-bg px-3 py-2 text-xs text-text-secondary">
       {JSON.stringify(input, null, 2)}
     </pre>
+  )
+}
+
+function WebSearchBlockDetail({ block }: { block: ToolBlock }) {
+  const items = getWebSearchActivityItems([block])
+
+  if (items.length === 0) return null
+
+  return (
+    <div data-testid="web-search-block-detail">
+      <WebSearchActivityRows items={items} />
+    </div>
   )
 }
 

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react'
-import { ChevronDown, Search } from 'lucide-react'
+import { ChevronDown, FileDiff, Search } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { useTranslation } from '@/hooks/useTranslation'
+import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
-import { usePersistentProcessingExpansion } from './processingExpansionState'
+import { parseUnifiedDiff } from '../parseUnifiedDiff'
 import { isCommandToolName, isWebSearchToolName } from './toolBlockActivity'
 import { WebSearchActivityRows } from './WebSearchSources'
 import { getWebSearchActivityItems } from './webSearchActivity'
 
 const THINKING_PREVIEW_MAX_LENGTH = 96
+const INLINE_DIFF_MAX_LINES = 96
 
 interface ToolBlockItemProps {
   block: ProcessingBlock
@@ -22,12 +24,9 @@ interface ToolBlockItemProps {
 export function ToolBlockItem({
   block,
   forceExpanded = false,
-  stateKey,
   onOpenWorkspaceFile,
 }: ToolBlockItemProps) {
-  const [userExpanded, setUserExpanded] = usePersistentProcessingExpansion(
-    stateKey ? `${stateKey}:tool` : undefined
-  )
+  const [userExpanded, setUserExpanded] = useState(false)
   const isRunning = block.status !== 'done' && block.status !== 'error'
   const expanded = forceExpanded || userExpanded
 
@@ -36,12 +35,14 @@ export function ToolBlockItem({
       <ThinkingBlockItem
         block={block}
         isRunning={isRunning}
-        stateKey={stateKey ? `${stateKey}:thinking` : undefined}
       />
     )
   }
   if (block.type === 'text') {
     return <ProcessTextBlockItem block={block} isRunning={isRunning} />
+  }
+  if (block.type === 'file_changes') {
+    return <ProcessFileChangesBlockItem block={block} />
   }
 
   const { icon, label } = getBlockLabel(block)
@@ -88,17 +89,277 @@ export function ToolBlockItem({
   )
 }
 
+function ProcessFileChangesBlockItem({ block }: {
+  block: Extract<ProcessingBlock, { type: 'file_changes' }>
+}) {
+  const { t } = useTranslation('chat')
+  const summary = block.fileChanges
+  const [expanded, setExpanded] = useState(false)
+  const [expandedFilePath, setExpandedFilePath] = useState<string | null>(null)
+
+  if (!summary.files.length) return null
+
+  return (
+    <div className="min-w-0 overflow-hidden text-[13px]" data-testid="process-file-changes-block">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded(value => !value)}
+        className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"
+      >
+        <FileDiff className="h-4 w-4 shrink-0" strokeWidth={1.7} />
+        <span className="min-w-0 truncate">{fileChangesSummaryLabel(summary, t)}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
+          strokeWidth={2}
+        />
+      </button>
+      {expanded ? (
+        <div className="mt-2 min-w-0 space-y-1.5">
+          {summary.files.map(file => {
+            const previewLines = fileDiffPreviewLines(file, summary)
+            const fileExpanded = expandedFilePath === file.path && previewLines.length > 0
+            return (
+              <div key={`${file.old_path ?? ''}:${file.path}`} className="min-w-0">
+                <button
+                  type="button"
+                  disabled={previewLines.length === 0}
+                  onClick={() =>
+                    setExpandedFilePath(current => (current === file.path ? null : file.path))
+                  }
+                  className="group flex max-w-full items-center gap-1.5 text-text-secondary disabled:cursor-default"
+                >
+                  <span className="min-w-0 truncate">{fileChangeRowLabel(file, t)}</span>
+                  {!file.binary ? (
+                    <span className="flex shrink-0 items-center gap-1.5 text-xs font-medium">
+                      <span className="text-green-600">+{file.additions}</span>
+                      <span className="text-red-500">-{file.deletions}</span>
+                    </span>
+                  ) : null}
+                  {previewLines.length > 0 ? (
+                    <ChevronDown
+                      className={`h-3.5 w-3.5 shrink-0 text-text-muted transition-transform group-hover:text-text-secondary ${
+                        fileExpanded ? '' : '-rotate-90'
+                      }`}
+                      strokeWidth={2}
+                    />
+                  ) : null}
+                </button>
+                {fileExpanded ? <InlineDiffPreview file={file} lines={previewLines} /> : null}
+              </div>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function fileChangesSummaryLabel(
+  summary: TurnFileChangesSummary,
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  const changeType = uniformChangeType(summary.files)
+  const count = summary.file_count || summary.files.length
+  if (changeType === 'created') return t('file_changes.created_files', { count })
+  if (changeType === 'deleted') return t('file_changes.deleted_files', { count })
+  if (changeType === 'renamed') return t('file_changes.renamed_files', { count })
+  return t('file_changes.edited_files', { count })
+}
+
+function uniformChangeType(files: TurnFileChangeItem[]): TurnFileChangeItem['change_type'] | null {
+  const first = files[0]?.change_type
+  if (!first) return null
+  return files.every(file => file.change_type === first) ? first : null
+}
+
+function fileChangeRowLabel(
+  file: TurnFileChangeItem,
+  t: ReturnType<typeof useTranslation>['t']
+): string {
+  const filename = basename(file.path)
+  switch (file.change_type) {
+    case 'created':
+      return t('file_changes.created_file', { filename })
+    case 'deleted':
+      return t('file_changes.deleted_file', { filename })
+    case 'renamed':
+      return t('file_changes.renamed_file', { filename })
+    case 'modified':
+    default:
+      return t('file_changes.edited_file', { filename })
+  }
+}
+
+function InlineDiffPreview({ file, lines }: { file: TurnFileChangeItem; lines: DiffPreviewLine[] }) {
+  const visibleLines = lines.slice(0, INLINE_DIFF_MAX_LINES)
+  const truncated = lines.length > INLINE_DIFF_MAX_LINES
+
+  return (
+    <div
+      className="mt-2 max-h-[22rem] min-w-0 overflow-auto rounded-lg border border-border bg-surface font-mono text-[12px] leading-5"
+      data-testid="process-file-change-diff"
+    >
+      <div className="sticky top-0 z-10 flex h-8 items-center gap-2 border-b border-border bg-surface px-3 font-sans text-xs text-text-secondary">
+        <span className="min-w-0 flex-1 truncate">{basename(file.path)}</span>
+        <span className="shrink-0 text-green-600">+{file.additions}</span>
+        <span className="shrink-0 text-red-500">-{file.deletions}</span>
+      </div>
+      <div className="py-1">
+        {visibleLines.map(line => (
+          <div
+            key={line.key}
+            className={[
+              'grid min-w-max grid-cols-[3.25rem_max-content]',
+              line.type === 'addition'
+                ? 'border-l-4 border-green-500 bg-green-500/10'
+                : line.type === 'deletion'
+                  ? 'border-l-4 border-red-500 bg-red-500/10'
+                  : line.type === 'separator'
+                    ? 'border-l-4 border-transparent bg-muted/60'
+                    : 'border-l-4 border-transparent',
+            ].join(' ')}
+          >
+            <span
+              className={[
+                'select-none px-3 text-right',
+                line.type === 'addition'
+                  ? 'text-green-600'
+                  : line.type === 'deletion'
+                    ? 'text-red-500'
+                    : 'text-text-muted',
+              ].join(' ')}
+            >
+              {line.lineNumber ?? ''}
+            </span>
+            <span className="pr-4 whitespace-pre text-text-primary">{line.content || ' '}</span>
+          </div>
+        ))}
+        {truncated ? <div className="px-3 py-1 text-xs text-text-muted">...</div> : null}
+      </div>
+    </div>
+  )
+}
+
+interface DiffPreviewLine {
+  key: string
+  type: 'addition' | 'deletion' | 'context' | 'separator'
+  lineNumber?: number
+  content: string
+}
+
+function fileDiffPreviewLines(
+  file: TurnFileChangeItem,
+  summary: TurnFileChangesSummary
+): DiffPreviewLine[] {
+  if (file.binary || !summary.diff?.trim()) return []
+  const sectionLines = fileDiffLines(file, summary)
+  return parseDiffPreviewLines(sectionLines)
+}
+
+function fileDiffLines(file: TurnFileChangeItem, summary: TurnFileChangesSummary): string[] {
+  const diff = summary.diff?.trimEnd()
+  if (!diff) return []
+
+  const sections = parseUnifiedDiff(diff)
+  if (sections.length === 0) {
+    return summary.files.length === 1 ? diff.split('\n') : []
+  }
+
+  const section = sections.find(
+    item =>
+      pathsMatch(item.path, file.path) ||
+      (file.old_path ? pathsMatch(item.oldPath, file.old_path) : false)
+  )
+  return section?.lines ?? []
+}
+
+function pathsMatch(left: string | undefined, right: string | undefined): boolean {
+  if (!left || !right) return false
+  return left === right || left.endsWith(`/${right}`) || right.endsWith(`/${left}`)
+}
+
+function parseDiffPreviewLines(lines: string[]): DiffPreviewLine[] {
+  const previewLines: DiffPreviewLine[] = []
+  let oldLine: number | undefined
+  let newLine: number | undefined
+  let seenHunk = false
+
+  lines.forEach((rawLine, index) => {
+    if (
+      rawLine.startsWith('diff --git') ||
+      rawLine.startsWith('---') ||
+      rawLine.startsWith('+++') ||
+      rawLine.startsWith('index ')
+    ) {
+      return
+    }
+
+    const hunk = rawLine.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/)
+    if (hunk) {
+      if (seenHunk && previewLines.length > 0) {
+        previewLines.push({
+          key: `separator-${index}`,
+          type: 'separator',
+          content: '',
+        })
+      }
+      oldLine = Number(hunk[1])
+      newLine = Number(hunk[2])
+      seenHunk = true
+      return
+    }
+
+    if (!seenHunk && !rawLine.startsWith('+') && !rawLine.startsWith('-')) return
+
+    const prefix = rawLine[0]
+    if (prefix === '+') {
+      previewLines.push({
+        key: `addition-${index}`,
+        type: 'addition',
+        lineNumber: newLine,
+        content: rawLine.slice(1),
+      })
+      if (newLine !== undefined) newLine += 1
+      return
+    }
+    if (prefix === '-') {
+      previewLines.push({
+        key: `deletion-${index}`,
+        type: 'deletion',
+        lineNumber: oldLine,
+        content: rawLine.slice(1),
+      })
+      if (oldLine !== undefined) oldLine += 1
+      return
+    }
+
+    previewLines.push({
+      key: `context-${index}`,
+      type: 'context',
+      lineNumber: newLine ?? oldLine,
+      content: prefix === ' ' ? rawLine.slice(1) : rawLine,
+    })
+    if (oldLine !== undefined) oldLine += 1
+    if (newLine !== undefined) newLine += 1
+  })
+
+  return previewLines
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path
+}
+
 function ThinkingBlockItem({
   block,
   isRunning,
-  stateKey,
 }: {
   block: Extract<ProcessingBlock, { type: 'thinking' }>
   isRunning: boolean
-  stateKey?: string
 }) {
   const { t } = useTranslation('chat')
-  const [expanded, setExpanded] = usePersistentProcessingExpansion(stateKey)
+  const [expanded, setExpanded] = useState(false)
 
   if (!block.content) return null
 

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -59,6 +59,44 @@ const completedWebSearchBlocks: ProcessingBlock[] = [
   },
 ]
 
+const completedFileChangesBlock: ProcessingBlock = {
+  id: 'file-changes-1',
+  subtaskId: 1,
+  type: 'file_changes',
+  status: 'done',
+  createdAt: 1770000003000,
+  fileChanges: {
+    version: 1,
+    status: 'active',
+    artifact_id: 'artifact-1',
+    device_id: 'device-1',
+    workspace_path: '/tmp/project',
+    file_count: 1,
+    additions: 2,
+    deletions: 1,
+    files: [
+      {
+        path: 'scripts/env',
+        change_type: 'modified',
+        additions: 2,
+        deletions: 1,
+        binary: false,
+      },
+    ],
+    reverted_at: null,
+    revertible: false,
+    diff: [
+      'diff --git a/scripts/env b/scripts/env',
+      '--- a/scripts/env',
+      '+++ b/scripts/env',
+      '@@ -8,2 +8,3 @@',
+      '-OLD_ENV=remote',
+      '+OLD_ENV=local',
+      '+BACKEND_URL=127.0.0.1',
+    ].join('\n'),
+  },
+}
+
 describe('ToolBlocksDisplay', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -104,6 +142,56 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getAllByTestId('web-search-source-icon').length).toBeGreaterThanOrEqual(2)
   })
 
+  test('renders file changes inside completed processing details', () => {
+    render(<ToolBlocksDisplay blocks={[completedFileChangesBlock]} isStreaming={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('已编辑 1 个文件')
+    expect(screen.queryByText('已编辑 env')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: /已编辑 1 个文件/ }))
+
+    expect(screen.getByText('已编辑 env')).toBeInTheDocument()
+    expect(screen.getByText('+2')).toBeInTheDocument()
+    expect(screen.getByText('-1')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /已编辑 env/ }))
+
+    expect(screen.getByTestId('process-file-change-diff')).toHaveTextContent('OLD_ENV=remote')
+    expect(screen.getByTestId('process-file-change-diff')).toHaveTextContent('BACKEND_URL=127.0.0.1')
+  })
+
+  test('only persists the top-level processing expansion state', () => {
+    const { unmount } = render(
+      <ToolBlocksDisplay
+        blocks={[completedFileChangesBlock]}
+        isStreaming={false}
+        stateKey="file-changes-local-expansion"
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+    fireEvent.click(screen.getByRole('button', { name: /已编辑 1 个文件/ }))
+    expect(screen.getByText('已编辑 env')).toBeInTheDocument()
+
+    unmount()
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedFileChangesBlock]}
+        isStreaming={false}
+        stateKey="file-changes-local-expansion"
+      />
+    )
+
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
+    expect(screen.getByTestId('process-file-changes-block')).toHaveTextContent('已编辑 1 个文件')
+    expect(screen.queryByText('已编辑 env')).toBeNull()
+  })
+
   test('opens completed processing details with a short content transition', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={false} />)
 
@@ -113,12 +201,13 @@ describe('ToolBlocksDisplay', () => {
     expect(toggle).not.toHaveClass('w-full')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
     expect(collapseContent).toHaveClass(
-      'transition-[grid-template-rows,opacity]',
-      'duration-[220ms]',
-      'grid-rows-[0fr]',
+      'transition-[max-height,opacity]',
+      'duration-[260ms]',
       'opacity-0',
       'pointer-events-none'
     )
+    expect(collapseContent).toHaveStyle({ maxHeight: '0px' })
+    expect(toggle.querySelector('svg')).toHaveClass('-rotate-90')
 
     fireEvent.click(toggle.parentElement as HTMLElement)
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
@@ -126,8 +215,8 @@ describe('ToolBlocksDisplay', () => {
     fireEvent.click(toggle)
 
     expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
-    expect(collapseContent).toHaveClass('grid-rows-[1fr]', 'opacity-100')
-    expect(toggle.querySelector('svg')).toHaveClass('-rotate-90')
+    expect(collapseContent).toHaveClass('opacity-100')
+    expect(toggle.querySelector('svg')).not.toHaveClass('-rotate-90')
   })
 
   test('keeps live duration when the run finishes', async () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -16,6 +16,49 @@ const completedCommandBlock: ProcessingBlock = {
   createdAt: 1770000000000,
 }
 
+const completedWebSearchBlocks: ProcessingBlock[] = [
+  {
+    id: 'web-search-1',
+    subtaskId: 1,
+    type: 'tool',
+    toolName: 'web_search',
+    toolInput: {
+      type: 'search',
+      query: 'Beijing weather today June 17 2026 temperature rain',
+      queries: [
+        'Beijing weather today June 17 2026 temperature rain',
+        'Beijing China current weather forecast today AccuWeather',
+      ],
+    },
+    status: 'done',
+    createdAt: 1770000000000,
+  },
+  {
+    id: 'web-search-2',
+    subtaskId: 1,
+    type: 'tool',
+    toolName: 'web_search',
+    toolInput: {
+      type: 'search',
+      query: 'site:weather.com weather today Beijing China',
+    },
+    status: 'done',
+    createdAt: 1770000001000,
+  },
+  {
+    id: 'web-open-1',
+    subtaskId: 1,
+    type: 'tool',
+    toolName: 'web_search',
+    toolInput: {
+      type: 'open_page',
+      url: 'https://www.weather.com/weather/today/l/Beijing+China',
+    },
+    status: 'done',
+    createdAt: 1770000002000,
+  },
+]
+
 describe('ToolBlocksDisplay', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -28,6 +71,37 @@ describe('ToolBlocksDisplay', () => {
 
     expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
     expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
+  })
+
+  test('renders completed web search tools as a Codex-style web search activity', () => {
+    render(<ToolBlocksDisplay blocks={completedWebSearchBlocks} isStreaming={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByText('已搜索网页')).toBeInTheDocument()
+    expect(screen.queryByText('已运行 web_search')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '已搜索网页' }))
+
+    expect(screen.getByTestId('web-search-activity-results')).toHaveTextContent(
+      'Beijing weather today June 17 2026 temperature rain'
+    )
+    expect(screen.getByTestId('web-search-activity-results')).toHaveTextContent(
+      'https://www.weather.com/weather/today/l/Beijing+China'
+    )
+    expect(screen.getByTestId('web-search-activity-results')).toHaveTextContent(
+      'weather today Beijing China | weather.com'
+    )
+    expect(
+      screen.queryByText('Beijing China current weather forecast today AccuWeather')
+    ).toBeNull()
+    expect(screen.getAllByText('Beijing weather today June 17 2026 temperature rain')).toHaveLength(
+      1
+    )
+    expect(screen.getByTestId('web-search-activity-results').parentElement).not.toHaveClass(
+      'border-l'
+    )
+    expect(screen.getAllByTestId('web-search-source-icon').length).toBeGreaterThanOrEqual(2)
   })
 
   test('opens completed processing details with a short content transition', () => {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import type { ReactNode } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode, TransitionEvent } from 'react'
 import { ChevronDown, Search, SquareTerminal } from 'lucide-react'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { ToolBlockItem } from './ToolBlockItem'
@@ -133,7 +133,7 @@ export function ToolBlocksDisplay({
           >
             <span>{duration}</span>
             <svg
-              className="h-3 w-3 -rotate-90"
+              className={`h-3 w-3 transition-transform ${expanded ? '' : '-rotate-90'}`}
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -144,7 +144,7 @@ export function ToolBlocksDisplay({
           </button>
         </div>
       ) : null}
-      <CollapsibleProcessingContent expanded={expanded}>
+      <CollapsibleProcessingContent expanded={expanded} keepMounted>
         {processingContent}
       </CollapsibleProcessingContent>
     </div>
@@ -154,35 +154,96 @@ export function ToolBlocksDisplay({
 function CollapsibleProcessingContent({
   expanded,
   children,
+  keepMounted = false,
+  testId = 'processing-collapse-content',
 }: {
   expanded: boolean
   children: ReactNode
+  keepMounted?: boolean
+  testId?: string
 }) {
+  const contentRef = useRef<HTMLDivElement>(null)
+  const previousExpandedRef = useRef(expanded)
+  const [isRendered, setIsRendered] = useState(() => expanded || keepMounted)
+  const [maxHeight, setMaxHeight] = useState(() => (expanded ? 'none' : '0px'))
+  const shouldRender = expanded || keepMounted || isRendered
+
+  if (expanded && !isRendered) {
+    setIsRendered(true)
+  }
+
+  useLayoutEffect(() => {
+    if (!shouldRender) return
+
+    const content = contentRef.current
+    if (!content) return
+
+    const wasExpanded = previousExpandedRef.current
+    let frame: number | undefined
+
+    if (expanded) {
+      setMaxHeight(wasExpanded ? 'none' : `${content.scrollHeight}px`)
+    } else {
+      if (wasExpanded) {
+        setMaxHeight(`${content.scrollHeight}px`)
+        frame = requestAnimationFrame(() => setMaxHeight('0px'))
+      } else {
+        setMaxHeight('0px')
+      }
+    }
+
+    previousExpandedRef.current = expanded
+
+    return () => {
+      if (frame !== undefined) cancelAnimationFrame(frame)
+    }
+  }, [expanded, shouldRender])
+
+  const handleTransitionEnd = (event: TransitionEvent<HTMLDivElement>) => {
+    if (event.propertyName !== 'max-height') return
+    if (expanded) {
+      setMaxHeight('none')
+      return
+    }
+    if (!keepMounted) setIsRendered(false)
+  }
+
   return (
     <div
-      data-testid="processing-collapse-content"
+      data-testid={testId}
       aria-hidden={!expanded}
       inert={!expanded ? true : undefined}
+      onTransitionEnd={handleTransitionEnd}
       className={[
-        'grid overflow-hidden transition-[grid-template-rows,opacity] duration-[220ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
-        expanded ? 'grid-rows-[1fr] opacity-100' : 'pointer-events-none grid-rows-[0fr] opacity-0',
+        'overflow-hidden transition-[max-height,opacity] duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+        expanded ? 'opacity-100' : 'pointer-events-none opacity-0',
       ].join(' ')}
+      style={{ maxHeight }}
     >
-      <div className="min-h-0 overflow-hidden">{children}</div>
+      {shouldRender ? (
+        <div
+          ref={contentRef}
+          className={[
+            'min-h-0 overflow-hidden transition-transform duration-[260ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none',
+            expanded ? 'translate-y-0' : '-translate-y-1',
+          ].join(' ')}
+        >
+          {children}
+        </div>
+      ) : null}
     </div>
   )
 }
 
 function ToolActivityGroup({
   row,
-  stateKey,
   onOpenWorkspaceFile,
 }: {
   row: Extract<ProcessingDisplayRow, { type: 'activity_group' }>
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }) {
-  const [expanded, setExpanded] = usePersistentProcessingExpansion(stateKey)
+  const [expanded, setExpanded] = useState(false)
   const isWebSearchGroup = isWebSearchActivityGroup(row.blocks)
   const Icon = hasCommandBlocks(row.blocks) ? SquareTerminal : Search
 
@@ -202,7 +263,7 @@ function ToolActivityGroup({
           strokeWidth={2}
         />
       </button>
-      {expanded && (
+      <CollapsibleProcessingContent expanded={expanded} testId="processing-activity-group-content">
         <div
           className={[
             'mt-2 flex min-w-0 flex-col gap-3',
@@ -216,13 +277,12 @@ function ToolActivityGroup({
               <ToolBlockItem
                 key={block.id}
                 block={block}
-                stateKey={stateKey ? `${stateKey}:${block.id}` : undefined}
                 onOpenWorkspaceFile={onOpenWorkspaceFile}
               />
             ))
           )}
         </div>
-      )}
+      </CollapsibleProcessingContent>
     </div>
   )
 }

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -6,8 +6,12 @@ import { ToolBlockItem } from './ToolBlockItem'
 import {
   buildProcessingDisplayRows,
   isCommandToolName,
+  isWebSearchActivityGroup,
   type ProcessingDisplayRow,
 } from './toolBlockActivity'
+import { usePersistentProcessingExpansion } from './processingExpansionState'
+import { WebSearchActivityRows } from './WebSearchSources'
+import { getWebSearchActivityItems } from './webSearchActivity'
 
 interface ToolBlocksDisplayProps {
   blocks: ProcessingBlock[]
@@ -20,6 +24,7 @@ interface ToolBlocksDisplayProps {
   startedAt?: number
   forceExpanded?: boolean
   showSummary?: boolean
+  stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }
 
@@ -29,10 +34,13 @@ export function ToolBlocksDisplay({
   startedAt,
   forceExpanded = false,
   showSummary = true,
+  stateKey,
   onOpenWorkspaceFile,
 }: ToolBlocksDisplayProps) {
   const isRunning = isStreaming || blocks.some(b => b.status !== 'done' && b.status !== 'error')
-  const [userExpanded, setUserExpanded] = useState(false)
+  const [userExpanded, setUserExpanded] = usePersistentProcessingExpansion(
+    stateKey ? `${stateKey}:processing` : undefined
+  )
   const [mountedAt] = useState(() => Date.now())
   const turnStartedAt = startedAt ?? mountedAt
   const [hasRenderedRunning, setHasRenderedRunning] = useState(isRunning)
@@ -84,12 +92,18 @@ export function ToolBlocksDisplay({
       <div className="flex min-w-0 flex-col gap-3 pt-0.5">
         {rows.map(row =>
           row.type === 'activity_group' ? (
-            <ToolActivityGroup key={row.id} row={row} onOpenWorkspaceFile={onOpenWorkspaceFile} />
+            <ToolActivityGroup
+              key={row.id}
+              row={row}
+              stateKey={stateKey ? `${stateKey}:${row.id}` : undefined}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
+            />
           ) : (
             <ToolBlockItem
               key={row.id}
               block={row.block}
               forceExpanded={isRunning && row.block.type === 'tool'}
+              stateKey={stateKey ? `${stateKey}:${row.id}` : undefined}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           )
@@ -97,7 +111,7 @@ export function ToolBlocksDisplay({
         {isRunning && !hasLiveNarrativeBlock && <ThinkingIndicator />}
       </div>
     ),
-    [hasLiveNarrativeBlock, isRunning, onOpenWorkspaceFile, rows]
+    [hasLiveNarrativeBlock, isRunning, onOpenWorkspaceFile, rows, stateKey]
   )
 
   if (blocks.length === 0 && !isStreaming) return null
@@ -161,12 +175,15 @@ function CollapsibleProcessingContent({
 
 function ToolActivityGroup({
   row,
+  stateKey,
   onOpenWorkspaceFile,
 }: {
   row: Extract<ProcessingDisplayRow, { type: 'activity_group' }>
+  stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = usePersistentProcessingExpansion(stateKey)
+  const isWebSearchGroup = isWebSearchActivityGroup(row.blocks)
   const Icon = hasCommandBlocks(row.blocks) ? SquareTerminal : Search
 
   return (
@@ -186,14 +203,36 @@ function ToolActivityGroup({
         />
       </button>
       {expanded && (
-        <div className="mt-2 flex min-w-0 flex-col gap-3 border-l border-border pl-4">
-          {row.blocks.map(block => (
-            <ToolBlockItem key={block.id} block={block} onOpenWorkspaceFile={onOpenWorkspaceFile} />
-          ))}
+        <div
+          className={[
+            'mt-2 flex min-w-0 flex-col gap-3',
+            isWebSearchGroup ? '' : 'border-l border-border pl-4',
+          ].join(' ')}
+        >
+          {isWebSearchGroup ? (
+            <WebSearchActivityDetails blocks={row.blocks} />
+          ) : (
+            row.blocks.map(block => (
+              <ToolBlockItem
+                key={block.id}
+                block={block}
+                stateKey={stateKey ? `${stateKey}:${block.id}` : undefined}
+                onOpenWorkspaceFile={onOpenWorkspaceFile}
+              />
+            ))
+          )}
         </div>
       )}
     </div>
   )
+}
+
+function WebSearchActivityDetails({ blocks }: { blocks: ToolBlock[] }) {
+  const items = getWebSearchActivityItems(blocks)
+
+  if (items.length === 0) return null
+
+  return <WebSearchActivityRows items={items} />
 }
 
 function hasCommandBlocks(blocks: ToolBlock[]): boolean {

--- a/wework/src/components/chat/blocks/WebSearchSources.tsx
+++ b/wework/src/components/chat/blocks/WebSearchSources.tsx
@@ -48,7 +48,7 @@ export function WebSearchSourcesChip({ sources }: { sources: WebSearchSourceItem
                   key={source.id}
                   href={source.url}
                   data-testid="web-search-source-popup-row"
-                  className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] leading-5 text-text-secondary transition-colors hover:bg-muted hover:text-text-primary"
+                  className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] leading-5 text-text-secondary transition-colors hover:bg-muted hover:text-text-primary focus-visible:bg-muted focus-visible:text-text-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
                   onClick={event => {
                     event.preventDefault()
                     void openExternalUrl(source.url).catch(error => {

--- a/wework/src/components/chat/blocks/WebSearchSources.tsx
+++ b/wework/src/components/chat/blocks/WebSearchSources.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { Globe2 } from 'lucide-react'
+import { openExternalUrl } from '@/lib/external-links'
+import type { WebSearchActivityItem, WebSearchSourceItem } from './webSearchActivity'
+
+export function WebSearchActivityRows({ items }: { items: WebSearchActivityItem[] }) {
+  if (items.length === 0) return null
+
+  return (
+    <div
+      data-testid="web-search-activity-results"
+      className="flex min-w-0 flex-col gap-1.5 text-[13px] leading-5 text-text-muted"
+    >
+      {items.map(item => (
+        <div key={item.id} className="flex min-w-0 items-start gap-1.5">
+          {item.iconUrl ? <WebSearchFavicon iconUrl={item.iconUrl} domain={item.domain} /> : null}
+          <span className="min-w-0 break-words">{item.label}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function WebSearchSourcesChip({ sources }: { sources: WebSearchSourceItem[] }) {
+  if (sources.length === 0) return null
+
+  const primarySource = sources[0]
+
+  return (
+    <div className="mt-2 flex min-w-0">
+      <span className="group/web-search-sources relative inline-flex min-w-0">
+        <button
+          type="button"
+          data-testid="web-search-sources-chip"
+          className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-md border border-border bg-surface px-2 text-xs text-text-secondary transition-colors hover:bg-muted hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+        >
+          <WebSearchFavicon iconUrl={primarySource.iconUrl} domain={primarySource.domain} />
+          <span>来源</span>
+        </button>
+        <span className="absolute bottom-full left-0 z-popover hidden max-w-[calc(100vw-3rem)] pb-1 group-hover/web-search-sources:block group-focus-within/web-search-sources:block">
+          <span
+            data-testid="web-search-source-popup"
+            className="block w-[min(26rem,calc(100vw-3rem))] rounded-xl border border-border bg-popover p-2 text-left text-text-primary shadow-2xl"
+          >
+            <span className="flex min-w-0 flex-col gap-1">
+              {sources.map(source => (
+                <a
+                  key={source.id}
+                  href={source.url}
+                  data-testid="web-search-source-popup-row"
+                  className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-1.5 text-[13px] leading-5 text-text-secondary transition-colors hover:bg-muted hover:text-text-primary"
+                  onClick={event => {
+                    event.preventDefault()
+                    void openExternalUrl(source.url).catch(error => {
+                      console.error('Failed to open web search source:', error)
+                    })
+                  }}
+                >
+                  <WebSearchFavicon iconUrl={source.iconUrl} domain={source.domain} />
+                  <span className="min-w-0 flex-1 truncate">{source.label}</span>
+                </a>
+              ))}
+            </span>
+          </span>
+        </span>
+      </span>
+    </div>
+  )
+}
+
+function WebSearchFavicon({ iconUrl, domain }: { iconUrl: string; domain?: string }) {
+  const [hasLoadError, setHasLoadError] = useState(false)
+
+  return (
+    <span
+      data-testid="web-search-source-icon"
+      className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center overflow-hidden rounded border border-border bg-base text-text-muted"
+      aria-hidden="true"
+      title={domain}
+    >
+      {!hasLoadError ? (
+        <img
+          src={iconUrl}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+          onError={() => setHasLoadError(true)}
+        />
+      ) : (
+        <Globe2 className="h-3 w-3" strokeWidth={1.8} />
+      )}
+    </span>
+  )
+}

--- a/wework/src/components/chat/blocks/processingExpansionState.ts
+++ b/wework/src/components/chat/blocks/processingExpansionState.ts
@@ -1,0 +1,45 @@
+import { useCallback, useEffect, useState } from 'react'
+
+const MAX_STORED_EXPANSION_STATES = 2000
+const expansionStateByKey = new Map<string, boolean>()
+
+type ExpansionUpdate = boolean | ((value: boolean) => boolean)
+
+export function usePersistentProcessingExpansion(
+  key: string | undefined,
+  initialValue = false
+): readonly [boolean, (update: ExpansionUpdate) => void] {
+  const [expanded, setExpanded] = useState(() => readExpansionState(key, initialValue))
+
+  useEffect(() => {
+    setExpanded(readExpansionState(key, initialValue))
+  }, [initialValue, key])
+
+  const setPersistentExpanded = useCallback(
+    (update: ExpansionUpdate) => {
+      setExpanded(current => {
+        const next = typeof update === 'function' ? update(current) : update
+        if (key) {
+          rememberExpansionState(key, next)
+        }
+        return next
+      })
+    },
+    [key]
+  )
+
+  return [expanded, setPersistentExpanded]
+}
+
+function readExpansionState(key: string | undefined, initialValue: boolean): boolean {
+  if (!key) return initialValue
+  return expansionStateByKey.get(key) ?? initialValue
+}
+
+function rememberExpansionState(key: string, value: boolean) {
+  if (!expansionStateByKey.has(key) && expansionStateByKey.size >= MAX_STORED_EXPANSION_STATES) {
+    const oldestKey = expansionStateByKey.keys().next().value
+    if (oldestKey) expansionStateByKey.delete(oldestKey)
+  }
+  expansionStateByKey.set(key, value)
+}

--- a/wework/src/components/chat/blocks/processingExpansionState.ts
+++ b/wework/src/components/chat/blocks/processingExpansionState.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState, useSyncExternalStore } from 'react'
 
 const MAX_STORED_EXPANSION_STATES = 2000
 const expansionStateByKey = new Map<string, boolean>()
+const expansionStateListeners = new Set<() => void>()
 
 type ExpansionUpdate = boolean | ((value: boolean) => boolean)
 
@@ -9,23 +10,32 @@ export function usePersistentProcessingExpansion(
   key: string | undefined,
   initialValue = false
 ): readonly [boolean, (update: ExpansionUpdate) => void] {
-  const [expanded, setExpanded] = useState(() => readExpansionState(key, initialValue))
-
-  useEffect(() => {
-    setExpanded(readExpansionState(key, initialValue))
-  }, [initialValue, key])
+  const [localExpanded, setLocalExpanded] = useState(initialValue)
+  const subscribe = useCallback((listener: () => void) => {
+    if (!key) return () => {}
+    expansionStateListeners.add(listener)
+    return () => expansionStateListeners.delete(listener)
+  }, [key])
+  const getSnapshot = useCallback(
+    () => readExpansionState(key, initialValue),
+    [initialValue, key]
+  )
+  const persistedExpanded = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  const expanded = key ? persistedExpanded : localExpanded
 
   const setPersistentExpanded = useCallback(
     (update: ExpansionUpdate) => {
-      setExpanded(current => {
-        const next = typeof update === 'function' ? update(current) : update
-        if (key) {
-          rememberExpansionState(key, next)
-        }
-        return next
-      })
+      if (!key) {
+        setLocalExpanded(current => (typeof update === 'function' ? update(current) : update))
+        return
+      }
+
+      const current = readExpansionState(key, initialValue)
+      const next = typeof update === 'function' ? update(current) : update
+      rememberExpansionState(key, next)
+      emitExpansionStateChange()
     },
-    [key]
+    [initialValue, key]
   )
 
   return [expanded, setPersistentExpanded]
@@ -42,4 +52,10 @@ function rememberExpansionState(key: string, value: boolean) {
     if (oldestKey) expansionStateByKey.delete(oldestKey)
   }
   expansionStateByKey.set(key, value)
+}
+
+function emitExpansionStateChange() {
+  for (const listener of Array.from(expansionStateListeners)) {
+    listener()
+  }
 }

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -65,6 +65,10 @@ export function buildProcessingDisplayRows(
 }
 
 export function summarizeToolBlocks(blocks: ToolBlock[]): string {
+  if (isWebSearchActivityGroup(blocks)) {
+    return '已搜索网页'
+  }
+
   const stats = getActivityStats(blocks)
   const parts: string[] = []
   const exploreParts: string[] = []
@@ -158,6 +162,14 @@ function isCompletedToolBlock(block: ToolBlock): boolean {
 
 export function isCommandToolName(name: string): boolean {
   return COMMAND_TOOLS.has(name.toLowerCase())
+}
+
+export function isWebSearchToolName(name: string): boolean {
+  return name.toLowerCase() === 'web_search'
+}
+
+export function isWebSearchActivityGroup(blocks: ToolBlock[]): boolean {
+  return blocks.length > 0 && blocks.every(block => isWebSearchToolName(block.toolName))
 }
 
 function getToolGroupId(blocks: ToolBlock[]): string {

--- a/wework/src/components/chat/blocks/webSearchActivity.ts
+++ b/wework/src/components/chat/blocks/webSearchActivity.ts
@@ -1,0 +1,180 @@
+import type { ToolBlock } from '@/types/workbench'
+
+export interface WebSearchActivityItem {
+  id: string
+  label: string
+  domain?: string
+  iconUrl?: string
+  sourceLabel?: string
+  sourceUrl?: string
+}
+
+export interface WebSearchSourceItem {
+  id: string
+  label: string
+  domain: string
+  iconUrl: string
+  url: string
+}
+
+export function getWebSearchActivityItems(
+  blocks: Array<Pick<ToolBlock, 'id' | 'toolInput'>>
+): WebSearchActivityItem[] {
+  const seen = new Set<string>()
+  const items: WebSearchActivityItem[] = []
+
+  const addItem = (item: Omit<WebSearchActivityItem, 'label'> & { label?: string }) => {
+    const label = item.label
+    const normalized = label?.trim()
+    if (!normalized || seen.has(normalized)) return
+    seen.add(normalized)
+    items.push({ ...item, label: normalized })
+  }
+
+  blocks.forEach(block => {
+    const action = getWebSearchAction(block.toolInput)
+    const actionType = getStringField(action, 'type')
+    if (actionType === 'open_page') {
+      const url = getStringField(action, 'url')
+      const urlMetadata = getUrlMetadata(url)
+      addItem({
+        id: `${block.id}-url`,
+        label: url,
+        domain: urlMetadata?.domain,
+        iconUrl: urlMetadata?.iconUrl,
+        sourceLabel: urlMetadata?.displayUrl,
+        sourceUrl: urlMetadata?.url,
+      })
+      return
+    }
+
+    const query = getStringField(action, 'query') ?? getStringArrayField(action, 'queries')[0]
+    const siteScopedQuery = getSiteScopedQuery(query)
+    addItem({
+      id: `${block.id}-query`,
+      label: siteScopedQuery?.label ?? query,
+      domain: siteScopedQuery?.domain,
+      iconUrl: siteScopedQuery?.iconUrl,
+      sourceLabel: siteScopedQuery?.domain,
+    })
+  })
+
+  return items
+}
+
+export function getWebSearchSourceItems(
+  blocks: Array<Pick<ToolBlock, 'id' | 'toolInput'>>
+): WebSearchSourceItem[] {
+  const sourcesByDomain = new Map<string, WebSearchSourceItem>()
+
+  getWebSearchActivityItems(blocks).forEach(item => {
+    if (!item.domain || !item.iconUrl) return
+    const label = item.sourceLabel ?? item.domain
+    const existing = sourcesByDomain.get(item.domain)
+    const fallbackUrl = `https://${item.domain}`
+    if (existing && (!item.sourceUrl || existing.url !== fallbackUrl)) return
+    sourcesByDomain.set(item.domain, {
+      id: `${item.id}-source`,
+      label,
+      domain: item.domain,
+      iconUrl: item.iconUrl,
+      url: item.sourceUrl ?? fallbackUrl,
+    })
+  })
+
+  return [...sourcesByDomain.values()]
+}
+
+function getWebSearchAction(value: unknown): Record<string, unknown> {
+  const input = isRecord(value) ? value : {}
+  const nestedAction = input.action
+  return isRecord(nestedAction) ? nestedAction : input
+}
+
+function getStringField(value: Record<string, unknown>, key: string): string | undefined {
+  const field = value[key]
+  return typeof field === 'string' ? field : undefined
+}
+
+function getStringArrayField(value: Record<string, unknown>, key: string): string[] {
+  const field = value[key]
+  return Array.isArray(field)
+    ? field.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function getSiteScopedQuery(query: string | undefined):
+  | {
+      label: string
+      domain: string
+      iconUrl: string
+    }
+  | undefined {
+  const normalizedQuery = query?.trim()
+  if (!normalizedQuery) return undefined
+
+  const siteMatch = normalizedQuery.match(/(?:^|\s)site:([^\s]+)/i)
+  const rawDomain = siteMatch?.[1]
+  const domain = normalizeDomain(rawDomain)
+  if (!siteMatch || !domain) return undefined
+
+  const queryWithoutSite = normalizedQuery
+    .replace(siteMatch[0], siteMatch[0].startsWith(' ') ? ' ' : '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return {
+    label: queryWithoutSite ? `${queryWithoutSite} | ${domain}` : domain,
+    domain,
+    iconUrl: getFaviconUrl(domain),
+  }
+}
+
+function getUrlMetadata(url: string | undefined):
+  | {
+      url: string
+      domain: string
+      displayUrl: string
+      iconUrl: string
+    }
+  | undefined {
+  if (!url?.trim()) return undefined
+
+  try {
+    const parsed = new URL(url)
+    const domain = normalizeDomain(parsed.hostname)
+    if (!domain) return undefined
+    return {
+      url,
+      domain,
+      displayUrl: formatDisplayUrl(parsed, domain),
+      iconUrl: getFaviconUrl(domain),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function formatDisplayUrl(parsed: URL, domain: string): string {
+  const path = `${parsed.pathname}${parsed.search}${parsed.hash}`
+  return `${domain}${path === '/' ? '' : path}`
+}
+
+function normalizeDomain(value: string | undefined): string | undefined {
+  const domain = value
+    ?.trim()
+    .replace(/^\*\./, '')
+    .replace(/^https?:\/\//i, '')
+    .split('/')[0]
+    ?.replace(/[),.;:]+$/, '')
+    .toLowerCase()
+  if (!domain) return undefined
+  return domain.startsWith('www.') ? domain.slice(4) : domain
+}
+
+function getFaviconUrl(domain: string): string {
+  return `https://${domain}/favicon.ico`
+}

--- a/wework/src/components/chat/blocks/webSearchActivity.ts
+++ b/wework/src/components/chat/blocks/webSearchActivity.ts
@@ -49,6 +49,19 @@ export function getWebSearchActivityItems(
     }
 
     const query = getStringField(action, 'query') ?? getStringArrayField(action, 'queries')[0]
+    const queryUrlMetadata = getUrlMetadata(query)
+    if (queryUrlMetadata) {
+      addItem({
+        id: `${block.id}-query-url`,
+        label: query,
+        domain: queryUrlMetadata.domain,
+        iconUrl: queryUrlMetadata.iconUrl,
+        sourceLabel: queryUrlMetadata.displayUrl,
+        sourceUrl: queryUrlMetadata.url,
+      })
+      return
+    }
+
     const siteScopedQuery = getSiteScopedQuery(query)
     addItem({
       id: `${block.id}-query`,

--- a/wework/src/components/chat/codexReferences.ts
+++ b/wework/src/components/chat/codexReferences.ts
@@ -1,4 +1,4 @@
-import type { CodexReference } from '@/types/api'
+import type { CodexReference, TurnFileChangesSummary } from '@/types/api'
 import { classifyMarkdownLink, splitMarkdownFileLineSuffix } from './assistantMarkdownLinks'
 
 const MARKDOWN_LINK_PATTERN = /\[([^\]]+)]\((<[^>]+>|[^)\s]+)(?:\s+["'][^"']*["'])?\)/g
@@ -20,12 +20,17 @@ const CODEX_REFERENCE_DOCUMENT_EXTENSIONS = new Set([
 
 export function getAssistantReferences(
   references: CodexReference[] | null | undefined,
-  content: string
+  content: string,
+  fileChanges?: TurnFileChangesSummary | null
 ): CodexReference[] {
   const explicitReferences =
     references?.filter(reference => reference.path && reference.path.trim()) ?? []
   return filterCodexDocumentReferences(
-    uniqueCodexReferences([...explicitReferences, ...extractAssistantFileReferences(content)])
+    uniqueCodexReferences([
+      ...explicitReferences,
+      ...extractFileChangeReferences(fileChanges),
+      ...extractAssistantFileReferences(content),
+    ])
   )
 }
 
@@ -52,6 +57,18 @@ function extractAssistantFileReferences(content: string): CodexReference[] {
   return uniqueCodexReferences(references)
 }
 
+function extractFileChangeReferences(
+  fileChanges: TurnFileChangesSummary | null | undefined
+): CodexReference[] {
+  if (!fileChanges) return []
+  return fileChanges.files
+    .filter(file => isCodexDocumentReferencePath(file.path))
+    .map(file => ({
+      path: file.path,
+      title: basename(file.path),
+    }))
+}
+
 function unwrapMarkdownHref(rawHref: string | undefined): string | undefined {
   const value = rawHref?.trim()
   if (!value) return undefined
@@ -73,18 +90,35 @@ function normalizeCodexReference(reference: CodexReference): CodexReference | nu
 }
 
 function uniqueCodexReferences(references: CodexReference[]): CodexReference[] {
-  const seen = new Set<string>()
   const uniqueReferences: CodexReference[] = []
   for (const reference of references) {
     const normalizedReference = normalizeCodexReference(reference)
     if (!normalizedReference) continue
 
-    const key = normalizedReference.path
-    if (seen.has(key)) continue
-    seen.add(key)
+    if (
+      uniqueReferences.some(existingReference =>
+        referencePathsMatch(existingReference.path, normalizedReference.path)
+      )
+    ) {
+      continue
+    }
     uniqueReferences.push(normalizedReference)
   }
   return uniqueReferences
+}
+
+function referencePathsMatch(left: string, right: string): boolean {
+  const normalizedLeft = normalizeReferencePath(left)
+  const normalizedRight = normalizeReferencePath(right)
+  return (
+    normalizedLeft === normalizedRight ||
+    normalizedLeft.endsWith(`/${normalizedRight}`) ||
+    normalizedRight.endsWith(`/${normalizedLeft}`)
+  )
+}
+
+function normalizeReferencePath(path: string): string {
+  return path.trim().replace(/\\/g, '/').replace(/\/+/g, '/')
 }
 
 function filterCodexDocumentReferences(references: CodexReference[]): CodexReference[] {

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -732,6 +732,20 @@ function normalizeProcessingBlock(
     }
   }
 
+  if (block.type === 'file_changes') {
+    const fileChanges = normalizeTurnFileChanges(block.fileChanges ?? block.file_changes)
+    if (!fileChanges) return null
+    const id = typeof block.id === 'string' ? block.id : `file-changes-${subtaskId}-${index}`
+    return {
+      id,
+      subtaskId,
+      type: 'file_changes',
+      fileChanges,
+      status,
+      createdAt: timestamp,
+    }
+  }
+
   return null
 }
 

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -20,6 +20,8 @@
     "open_label": "Open {{path}}",
     "open_with": "Open with",
     "preview_label": "Open preview",
+    "show_more": "Show {{count}} more",
+    "show_less": "Collapse files",
     "kind": "Document",
     "kind_with_extension": "Document · {{extension}}"
   },
@@ -30,6 +32,9 @@
   },
   "file_changes": {
     "edited_files": "Edited {{count}} files",
+    "created_files": "Created {{count}} files",
+    "deleted_files": "Deleted {{count}} files",
+    "renamed_files": "Renamed {{count}} files",
     "edited_file": "Edited {{filename}}",
     "created_file": "Created {{filename}}",
     "deleted_file": "Deleted {{filename}}",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -20,6 +20,8 @@
     "open_label": "打开 {{path}}",
     "open_with": "打开方式",
     "preview_label": "打开预览",
+    "show_more": "显示另外 {{count}} 个",
+    "show_less": "收起文件",
     "kind": "文档",
     "kind_with_extension": "文档 · {{extension}}"
   },
@@ -30,6 +32,9 @@
   },
   "file_changes": {
     "edited_files": "已编辑 {{count}} 个文件",
+    "created_files": "已创建 {{count}} 个文件",
+    "deleted_files": "已删除 {{count}} 个文件",
+    "renamed_files": "已重命名 {{count}} 个文件",
     "edited_file": "已编辑 {{filename}}",
     "created_file": "已创建 {{filename}}",
     "deleted_file": "已删除 {{filename}}",

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -16,6 +16,7 @@ import type {
   WorkbenchMessage as CoreWorkbenchMessage,
   WorkbenchMessageRole,
   WorkbenchMessageStatus,
+  WorkbenchFileChangesBlock,
   WorkbenchProcessingBlock,
   WorkbenchThinkingBlock,
   WorkbenchTextBlock,
@@ -36,13 +37,19 @@ export type ThinkingBlock = WorkbenchThinkingBlock
 
 export type TextBlock = WorkbenchTextBlock
 
-export type ProcessingBlock = WorkbenchProcessingBlock
+export type FileChangesBlock = WorkbenchFileChangesBlock<TurnFileChangesSummary>
+
+export type ProcessingBlock = WorkbenchProcessingBlock<TurnFileChangesSummary>
 
 export type MessageSource = NonNullable<CoreWorkbenchMessage['source']>
 
 export type RuntimeWorkbenchMessageStatus = WorkbenchMessageStatus | 'cancelled'
 
-export type WorkbenchMessage = CoreWorkbenchMessage<Attachment, TurnFileChangesSummary> & {
+export type WorkbenchMessage = Omit<
+  CoreWorkbenchMessage<Attachment, TurnFileChangesSummary>,
+  'blocks'
+> & {
+  blocks?: ProcessingBlock[]
   runtimeStatus?: RuntimeWorkbenchMessageStatus | null
   references?: CodexReference[] | null
   memoryCitations?: CodexMemoryCitation[] | null


### PR DESCRIPTION
## Summary

- Render Codex web-search activity and source chips in Wework transcript details.
- Add Codex-style folded processing blocks for file changes, document references, memory/reference handling, hover previews, and retained top-level processing expansion state.
- Normalize Codex transcript file changes in the executor, including repeated file-change accumulation, rename target paths, and interrupted commentary handling.
- Preserve per-conversation scroll position when switching historical sessions.

## Validation

- `cargo fmt --manifest-path executor/Cargo.toml`
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_file_changes_contract`
- `cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_contract`
- `pnpm --dir wework exec tsc -b --pretty false`
- `pnpm --dir wework test src/components/chat/ScrollableMessageArea.test.tsx src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/MessageList.test.tsx src/components/chat/FileChangesCard.test.tsx src/test/theme-token-guard.test.ts`
- `git diff --check`
- pre-push hook: `cargo fmt --check`, `cargo test --all-features`, `cargo clippy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated web-search experience in chat, including an expanded tool-details view and sources chips with clickable links.
  * Introduced collapsible file-change processing with per-file rows, created/edited/deleted/renamed counts, and inline unified-diff previews.
  * Persisted conversation-scoped UI state (processing expansion and scroll position) and added Codex reference list show more/less controls.

* **Bug Fixes**
  * Improved normalization and merging of transcript tool blocks and file-change items, including correct move/rename handling and more accurate diff/statistics calculations.
  * Updated web-search and file-change rendering to keep tool labels, summaries, and detailed views consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->