### PR TITLE
feat(wework): refine Codex transcript display

### DIFF
--- a/executor/src/local/app_ipc.rs
+++ b/executor/src/local/app_ipc.rs
@@ -6,14 +6,12 @@ use std::{
     collections::HashMap,
     env, fs,
     future::Future,
-    io::{self, Write},
+    io,
     path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
 };
 
-use base64::{engine::general_purpose::STANDARD, Engine};
-use flate2::{write::GzEncoder, Compression};
 use serde_json::{json, Value};
 use tokio::{
     io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader},
@@ -33,7 +31,6 @@ const DEFAULT_DEVICE_ID: &str = "local-device";
 const DEFAULT_SOCKET_NAME: &str = "app-ipc.sock";
 const DEFAULT_TIMEOUT_SECONDS: f64 = 60.0;
 const DEFAULT_MAX_OUTPUT_BYTES: usize = 1024 * 1024;
-const RUNTIME_RPC_COMPRESSION_THRESHOLD_BYTES: usize = 512 * 1024;
 const WORKSPACE_TREE_SCRIPT: &str = r#"
 import json
 import os
@@ -372,16 +369,12 @@ impl AppIpcServer {
                 };
 
                 match request_from_message(&message) {
-                    Ok((method, params, accept_compressed_result)) => {
-                        match self.dispatch(&method, params).await {
-                            Ok(result) => response_message(
-                                request_id.as_deref().unwrap_or_default(),
-                                result,
-                                accept_compressed_result,
-                            ),
-                            Err(error) => error_message(request_id.as_deref(), &error),
+                    Ok((method, params)) => match self.dispatch(&method, params).await {
+                        Ok(result) => {
+                            response_message(request_id.as_deref().unwrap_or_default(), result)
                         }
-                    }
+                        Err(error) => error_message(request_id.as_deref(), &error),
+                    },
                     Err(error) => error_message(request_id.as_deref(), &error),
                 }
             }
@@ -732,7 +725,7 @@ fn command_definition(
 
 fn request_from_message(
     message: &serde_json::Map<String, Value>,
-) -> Result<(String, Value, bool), AppIpcError> {
+) -> Result<(String, Value), AppIpcError> {
     if message.get("type").and_then(Value::as_str) != Some("request") {
         return Err(AppIpcError::new(
             "invalid_request",
@@ -756,13 +749,7 @@ fn request_from_message(
         ));
     }
 
-    let accept_compressed_result = message
-        .get("acceptCompressedRuntimeResult")
-        .or_else(|| message.get("accept_compressed_runtime_result"))
-        .and_then(Value::as_bool)
-        .unwrap_or(true);
-
-    Ok((method, params, accept_compressed_result))
+    Ok((method, params))
 }
 
 fn request_id_from(message: &serde_json::Map<String, Value>) -> Result<String, AppIpcError> {
@@ -774,16 +761,12 @@ fn request_id_from(message: &serde_json::Map<String, Value>) -> Result<String, A
         .ok_or_else(|| AppIpcError::new("invalid_request", "Request id is required"))
 }
 
-fn response_message(request_id: &str, result: Value, accept_compressed_result: bool) -> Value {
+fn response_message(request_id: &str, result: Value) -> Value {
     json!({
         "type": "response",
         "id": request_id,
         "ok": true,
-        "result": if accept_compressed_result {
-            encode_large_runtime_result(result)
-        } else {
-            result
-        },
+        "result": result,
     })
 }
 
@@ -923,27 +906,6 @@ fn stdout_string(result: &CommandResult) -> String {
         .unwrap_or_else(|| result.stdout.to_string())
 }
 
-fn encode_large_runtime_result(result: Value) -> Value {
-    let Ok(bytes) = serde_json::to_vec(&result) else {
-        return result;
-    };
-    if bytes.len() <= RUNTIME_RPC_COMPRESSION_THRESHOLD_BYTES {
-        return result;
-    }
-
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-    if encoder.write_all(&bytes).is_err() {
-        return result;
-    }
-    let Ok(compressed) = encoder.finish() else {
-        return result;
-    };
-    json!({
-        "__runtimeRpcEncoding": "gzip+base64+json",
-        "payload": STANDARD.encode(compressed),
-    })
-}
-
 fn expand_home(path: &str) -> PathBuf {
     if path == "~" {
         return home_dir();
@@ -989,32 +951,4 @@ where
     bytes.push(b'\n');
     writer.write_all(&bytes).await?;
     writer.flush().await
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn response_message_respects_uncompressed_client_preference() {
-        let large_text = "x".repeat(RUNTIME_RPC_COMPRESSION_THRESHOLD_BYTES + 1024);
-        let response = response_message(
-            "req-1",
-            json!({
-                "messages": [
-                    {
-                        "id": "message-1",
-                        "content": large_text,
-                    }
-                ],
-            }),
-            false,
-        );
-
-        let result = response
-            .get("result")
-            .expect("response should contain result");
-        assert_eq!(result.get("__runtimeRpcEncoding"), None);
-        assert!(result.get("messages").and_then(Value::as_array).is_some());
-    }
 }

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -1064,7 +1064,7 @@ fn merge_cached_messages(codex_messages: Vec<Value>, cached_messages: Vec<Value>
                 return codex_message;
             };
             used[index] = true;
-            cached_messages[index].clone()
+            merge_cached_message_fields(codex_message, &cached_messages[index])
         })
         .collect::<Vec<_>>();
 
@@ -1074,6 +1074,25 @@ fn merge_cached_messages(codex_messages: Vec<Value>, cached_messages: Vec<Value>
         }
     }
     merged
+}
+
+fn merge_cached_message_fields(mut codex_message: Value, cached_message: &Value) -> Value {
+    let Some(codex_object) = codex_message.as_object_mut() else {
+        return codex_message;
+    };
+    let Some(cached_object) = cached_message.as_object() else {
+        return codex_message;
+    };
+
+    for key in ["source", "attachments", "error", "errorType", "error_type"] {
+        if !codex_object.contains_key(key) {
+            if let Some(value) = cached_object.get(key).cloned() {
+                codex_object.insert(key.to_owned(), value);
+            }
+        }
+    }
+
+    codex_message
 }
 
 fn messages_match(left: &Value, right: &Value) -> bool {
@@ -1265,5 +1284,44 @@ impl RuntimeWorkHandler for RuntimeWorkRpcHandler {
                 .unwrap_or_else(|| json!({}));
             self.dispatch(&method, payload).await
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cached_message_merge_preserves_codex_rebuilt_blocks() {
+        let codex_messages = vec![json!({
+            "id": "assistant-turn-1",
+            "role": "assistant",
+            "content": "done",
+            "status": "cancelled",
+            "blocks": [
+                {
+                    "id": "tool-1",
+                    "type": "tool",
+                    "tool_name": "exec_command",
+                    "status": "done"
+                }
+            ],
+            "stoppedNotice": true
+        })];
+        let cached_messages = vec![json!({
+            "id": "cached-assistant",
+            "role": "assistant",
+            "content": "done",
+            "status": "done",
+            "source": {"source": "im"}
+        })];
+
+        let merged = merge_cached_messages(codex_messages, cached_messages);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0]["status"], "cancelled");
+        assert_eq!(merged[0]["stoppedNotice"], true);
+        assert_eq!(merged[0]["blocks"][0]["tool_name"], "exec_command");
+        assert_eq!(merged[0]["source"]["source"], "im");
     }
 }

--- a/executor/src/runtime_work/transcript.rs
+++ b/executor/src/runtime_work/transcript.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::path::Path;
+
 use serde_json::{json, Map, Value};
 
 use super::util::{
@@ -23,14 +25,10 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
         let turn_file_changes = file_changes(turn);
         let turn_id = item_id(turn, "turn");
         let subtask_id = turn_subtask_id(turn, &turn_id);
-        let has_final_assistant_message = turn_has_final_assistant_message(turn);
-        let interrupted_without_final = turn_interrupted(turn) && !has_final_assistant_message;
+        let turn_cancelled = turn_interrupted(turn);
         let fold_commentary = turn_should_fold_commentary(turn);
-        let mut blocks = Vec::new();
-        let mut pending_file_changes = turn_file_changes.clone();
-        let mut context_events = Vec::new();
-        let mut assistant_parts = Vec::new();
-        let mut memory_citations = Vec::new();
+        let mut assistant_segment_index = 0;
+        let mut assistant = AssistantTurnAccumulation::new(turn_file_changes.clone());
         for item in turn
             .get("items")
             .and_then(Value::as_array)
@@ -38,16 +36,42 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
             .flatten()
         {
             match item_type(item).as_str() {
-                "usermessage" => push_user_message(&mut messages, item, created_at),
-                "reasoning" => push_reasoning_block(&mut blocks, item, created_at),
-                "commandexecution" => blocks.push(command_block(item, created_at)),
+                "usermessage" => {
+                    if is_internal_turn_abort_message(item) {
+                        continue;
+                    }
+                    let is_guidance =
+                        assistant_segment_index > 0 || assistant.has_non_file_output();
+                    push_accumulated_assistant(
+                        &mut messages,
+                        &mut assistant_segment_index,
+                        AssistantEmitContext {
+                            turn_id: &turn_id,
+                            subtask_id,
+                            created_at,
+                            completed_at,
+                            status: if turn_cancelled { "cancelled" } else { "done" },
+                        },
+                        &mut assistant,
+                        false,
+                    );
+                    push_user_message(&mut messages, item, created_at);
+                    if is_guidance {
+                        assistant.blocks.push(guidance_block(
+                            item,
+                            item_timestamp(item).unwrap_or(created_at),
+                        ));
+                    }
+                }
+                "reasoning" => push_reasoning_block(&mut assistant.blocks, item, created_at),
+                "commandexecution" => assistant.blocks.push(command_block(item, created_at)),
                 "functioncall" | "customtoolcall" | "dynamictoolcall" | "mcptoolcall"
-                | "toolsearchcall" | "websearchcall" | "websearch" | "imagegeneration"
-                | "imageview" | "sleep" | "localshellcall" | "shellcall" => {
-                    blocks.push(tool_block(item, created_at))
+                | "mcpcall" | "toolsearchcall" | "websearchcall" | "websearch"
+                | "imagegeneration" | "imageview" | "sleep" | "localshellcall" | "shellcall" => {
+                    assistant.blocks.push(tool_block(item, created_at))
                 }
                 "functioncalloutput" | "customtoolcalloutput" | "toolsearchoutput" => {
-                    merge_tool_output(&mut blocks, item, created_at);
+                    merge_tool_output(&mut assistant.blocks, item, created_at);
                 }
                 "filechange" => {
                     if let Some(summary) = file_changes_from_file_change_item(
@@ -57,9 +81,12 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         &workspace_path,
                     ) {
                         if fold_commentary {
-                            blocks.push(file_changes_block(item, &summary, created_at));
+                            assistant
+                                .blocks
+                                .push(file_changes_block(item, &summary, created_at));
                         }
-                        pending_file_changes = merge_file_changes(pending_file_changes, summary);
+                        assistant.file_changes =
+                            merge_file_changes(assistant.file_changes.take(), summary);
                     }
                 }
                 "patchapplyend" => {
@@ -70,13 +97,16 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         &workspace_path,
                     ) {
                         if fold_commentary {
-                            blocks.push(file_changes_block(item, &summary, created_at));
+                            assistant
+                                .blocks
+                                .push(file_changes_block(item, &summary, created_at));
                         }
-                        pending_file_changes = merge_file_changes(pending_file_changes, summary);
+                        assistant.file_changes =
+                            merge_file_changes(assistant.file_changes.take(), summary);
                     }
                 }
                 "contextcompaction" => {
-                    context_events.push(context_event(
+                    assistant.context_events.push(context_event(
                         item,
                         created_at,
                         "context_compaction",
@@ -88,13 +118,14 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         item,
                         created_at,
                         fold_commentary,
-                        &mut blocks,
-                        &mut assistant_parts,
-                        &mut memory_citations,
+                        turn_cancelled && fold_commentary,
+                        &mut assistant.blocks,
+                        &mut assistant.assistant_parts,
+                        &mut assistant.memory_citations,
                     );
                     if let Some(file_changes) = file_changes(item) {
-                        pending_file_changes =
-                            merge_file_changes(pending_file_changes, file_changes);
+                        assistant.file_changes =
+                            merge_file_changes(assistant.file_changes.take(), file_changes);
                     }
                 }
                 "message" => match string_field(item, "role")
@@ -102,19 +133,46 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                     .to_ascii_lowercase()
                     .as_str()
                 {
-                    "user" => push_user_message(&mut messages, item, created_at),
+                    "user" => {
+                        if is_internal_turn_abort_message(item) {
+                            continue;
+                        }
+                        let is_guidance =
+                            assistant_segment_index > 0 || assistant.has_non_file_output();
+                        push_accumulated_assistant(
+                            &mut messages,
+                            &mut assistant_segment_index,
+                            AssistantEmitContext {
+                                turn_id: &turn_id,
+                                subtask_id,
+                                created_at,
+                                completed_at,
+                                status: if turn_cancelled { "cancelled" } else { "done" },
+                            },
+                            &mut assistant,
+                            false,
+                        );
+                        push_user_message(&mut messages, item, created_at);
+                        if is_guidance {
+                            assistant.blocks.push(guidance_block(
+                                item,
+                                item_timestamp(item).unwrap_or(created_at),
+                            ));
+                        }
+                    }
                     "assistant" => {
                         collect_assistant_message(
                             item,
                             created_at,
                             fold_commentary,
-                            &mut blocks,
-                            &mut assistant_parts,
-                            &mut memory_citations,
+                            turn_cancelled && fold_commentary,
+                            &mut assistant.blocks,
+                            &mut assistant.assistant_parts,
+                            &mut assistant.memory_citations,
                         );
                         if let Some(file_changes) = file_changes(item) {
-                            pending_file_changes =
-                                merge_file_changes(pending_file_changes, file_changes);
+                            assistant.file_changes =
+                                merge_file_changes(assistant.file_changes.take(), file_changes);
                         }
                     }
                     _ => {}
@@ -124,41 +182,32 @@ pub(crate) fn transcript_messages(thread: &Value, device_id: &str) -> Vec<Value>
                         item,
                         created_at,
                         fold_commentary,
-                        &mut blocks,
-                        &mut assistant_parts,
-                        &mut memory_citations,
+                        turn_cancelled && fold_commentary,
+                        &mut assistant.blocks,
+                        &mut assistant.assistant_parts,
+                        &mut assistant.memory_citations,
                     );
                     if let Some(file_changes) = file_changes(item) {
-                        pending_file_changes =
-                            merge_file_changes(pending_file_changes, file_changes);
+                        assistant.file_changes =
+                            merge_file_changes(assistant.file_changes.take(), file_changes);
                     }
                 }
                 _ => {}
             }
         }
-        if !blocks.is_empty()
-            || pending_file_changes.is_some()
-            || !context_events.is_empty()
-            || !assistant_parts.is_empty()
-            || !memory_citations.is_empty()
-        {
-            apply_turn_completed_at(&mut blocks, completed_at);
-            messages.push(synthetic_assistant_message(AssistantMessageDraft {
+        push_accumulated_assistant(
+            &mut messages,
+            &mut assistant_segment_index,
+            AssistantEmitContext {
                 turn_id: &turn_id,
                 subtask_id,
                 created_at,
-                blocks: &blocks,
-                file_changes: pending_file_changes,
-                context_events: &context_events,
-                assistant_parts: &assistant_parts,
-                memory_citations: &memory_citations,
-                status: if interrupted_without_final {
-                    "cancelled"
-                } else {
-                    "done"
-                },
-            }));
-        }
+                completed_at,
+                status: if turn_cancelled { "cancelled" } else { "done" },
+            },
+            &mut assistant,
+            true,
+        );
     }
     messages
 }
@@ -202,6 +251,16 @@ fn turn_started_at(turn: &Value) -> i64 {
 fn turn_completed_at(turn: &Value, started_at: i64) -> Option<i64> {
     timestamp_ms_field(turn, "completedAt")
         .or_else(|| timestamp_ms_field(turn, "completed_at"))
+        .or_else(|| timestamp_ms_field(turn, "endedAt"))
+        .or_else(|| timestamp_ms_field(turn, "ended_at"))
+        .or_else(|| timestamp_ms_field(turn, "stoppedAt"))
+        .or_else(|| timestamp_ms_field(turn, "stopped_at"))
+        .or_else(|| timestamp_ms_field(turn, "cancelledAt"))
+        .or_else(|| timestamp_ms_field(turn, "cancelled_at"))
+        .or_else(|| timestamp_ms_field(turn, "interruptedAt"))
+        .or_else(|| timestamp_ms_field(turn, "interrupted_at"))
+        .or_else(|| timestamp_ms_field(turn, "updatedAt"))
+        .or_else(|| timestamp_ms_field(turn, "updated_at"))
         .or_else(|| {
             integer_field(turn, "durationMs")
                 .or_else(|| integer_field(turn, "duration_ms"))
@@ -221,10 +280,9 @@ fn turn_should_fold_commentary(turn: &Value) -> bool {
     if turn_has_final_assistant_message(turn) || turn_running(turn) {
         return true;
     }
-    // An interrupted turn only folds commentary into process blocks when it also
-    // produced substantive output (file changes, tool calls, reasoning, etc.).
-    // When the turn was interrupted before producing anything else, the commentary
-    // is the only thing the agent said, so surface it as the visible content.
+    // Interrupted turns with process output should keep commentary inside the
+    // collapsible process area. If commentary is the only assistant output,
+    // surface it directly like Codex app does.
     turn_interrupted(turn) && turn_has_substantive_process(turn)
 }
 
@@ -328,16 +386,251 @@ fn apply_turn_completed_at(blocks: &mut [Value], completed_at: Option<i64>) {
     block.insert("timestamp".to_owned(), json!(completed_at));
 }
 
-fn push_user_message(messages: &mut Vec<Value>, item: &Value, created_at: i64) {
-    if let Some(content) = extract_text(item) {
-        messages.push(json!({
-            "id": item_id(item, "user"),
-            "role": "user",
-            "content": content,
-            "status": "done",
-            "createdAt": created_at,
-        }));
+struct AssistantTurnAccumulation {
+    blocks: Vec<Value>,
+    file_changes: Option<Value>,
+    context_events: Vec<Value>,
+    assistant_parts: Vec<String>,
+    memory_citations: Vec<Value>,
+}
+
+impl AssistantTurnAccumulation {
+    fn new(file_changes: Option<Value>) -> Self {
+        Self {
+            blocks: Vec::new(),
+            file_changes,
+            context_events: Vec::new(),
+            assistant_parts: Vec::new(),
+            memory_citations: Vec::new(),
+        }
     }
+
+    fn has_non_file_output(&self) -> bool {
+        !self.blocks.is_empty()
+            || !self.context_events.is_empty()
+            || !self.assistant_parts.is_empty()
+            || !self.memory_citations.is_empty()
+    }
+
+    fn has_output(&self) -> bool {
+        self.has_non_file_output() || self.file_changes.is_some()
+    }
+
+    fn clear_after_emit(&mut self) {
+        self.blocks.clear();
+        self.file_changes = None;
+        self.context_events.clear();
+        self.assistant_parts.clear();
+        self.memory_citations.clear();
+    }
+}
+
+struct AssistantEmitContext<'a> {
+    turn_id: &'a str,
+    subtask_id: i64,
+    created_at: i64,
+    completed_at: Option<i64>,
+    status: &'a str,
+}
+
+fn push_accumulated_assistant(
+    messages: &mut Vec<Value>,
+    segment_index: &mut usize,
+    context: AssistantEmitContext<'_>,
+    assistant: &mut AssistantTurnAccumulation,
+    include_file_only: bool,
+) {
+    let should_emit = if include_file_only {
+        assistant.has_output()
+    } else {
+        assistant.has_non_file_output()
+    };
+    if !should_emit {
+        return;
+    }
+
+    apply_turn_completed_at(&mut assistant.blocks, context.completed_at);
+    let stopped_notice = context.status == "cancelled" && *segment_index == 0;
+    let synthetic_turn_id = if *segment_index == 0 {
+        context.turn_id.to_owned()
+    } else {
+        format!("{}-{}", context.turn_id, *segment_index)
+    };
+    messages.push(synthetic_assistant_message(AssistantMessageDraft {
+        turn_id: &synthetic_turn_id,
+        subtask_id: context.subtask_id,
+        created_at: context.created_at,
+        completed_at: context.completed_at,
+        status: context.status,
+        stopped_notice,
+        blocks: &assistant.blocks,
+        file_changes: assistant.file_changes.clone(),
+        context_events: &assistant.context_events,
+        assistant_parts: &assistant.assistant_parts,
+        memory_citations: &assistant.memory_citations,
+    }));
+    *segment_index += 1;
+    assistant.clear_after_emit();
+}
+
+fn push_user_message(messages: &mut Vec<Value>, item: &Value, created_at: i64) {
+    let content = extract_text(item).unwrap_or_default();
+    let attachments = user_message_image_attachments(item, created_at);
+    if content.trim().is_empty() && attachments.is_empty() {
+        return;
+    }
+
+    let mut message = json!({
+        "id": item_id(item, "user"),
+        "role": "user",
+        "content": content,
+        "status": "done",
+        "createdAt": item_timestamp(item).unwrap_or(created_at),
+    });
+    if !attachments.is_empty() {
+        if let Some(object) = message.as_object_mut() {
+            object.insert("attachments".to_owned(), Value::Array(attachments));
+        }
+    }
+    messages.push(message);
+}
+
+fn is_internal_turn_abort_message(item: &Value) -> bool {
+    extract_text(item)
+        .map(|content| content.trim_start().starts_with("<turn_aborted>"))
+        .unwrap_or(false)
+}
+
+fn user_message_image_attachments(item: &Value, created_at: i64) -> Vec<Value> {
+    let mut attachments = Vec::new();
+    if let Some(content) = item.get("content").and_then(Value::as_array) {
+        for part in content {
+            match item_type(part).as_str() {
+                "localimage" => {
+                    if let Some(path) = string_field(part, "path") {
+                        push_image_attachment(&mut attachments, &path, true, created_at);
+                    }
+                }
+                "image" => {
+                    if let Some(url) = string_field(part, "url") {
+                        push_image_attachment(&mut attachments, &url, false, created_at);
+                    }
+                }
+                "inputimage" => {
+                    if let Some(url) = string_field(part, "image_url") {
+                        push_image_attachment(&mut attachments, &url, false, created_at);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    for path in string_array_field(item, "local_images")
+        .into_iter()
+        .chain(string_array_field(item, "localImages"))
+    {
+        push_image_attachment(&mut attachments, &path, true, created_at);
+    }
+    for url in string_array_field(item, "images") {
+        push_image_attachment(&mut attachments, &url, false, created_at);
+    }
+    attachments
+}
+
+fn push_image_attachment(attachments: &mut Vec<Value>, source: &str, local: bool, created_at: i64) {
+    if source.trim().is_empty()
+        || attachments
+            .iter()
+            .any(|item| item["local_preview_url"] == source)
+    {
+        return;
+    }
+    let index = attachments.len();
+    let extension = image_extension(source);
+    let mime_type = image_mime_type(source, &extension);
+    attachments.push(json!({
+        "id": -((index as i64) + 1),
+        "filename": image_filename(source, index, &extension),
+        "file_size": 0,
+        "mime_type": mime_type,
+        "status": "ready",
+        "file_extension": extension,
+        "created_at": created_at,
+        "local_preview_url": if local { source } else { source.trim() },
+    }));
+}
+
+fn string_array_field(item: &Value, key: &str) -> Vec<String> {
+    item.get(key)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+fn image_filename(source: &str, index: usize, extension: &str) -> String {
+    if let Some(filename) = Path::new(strip_url_query(source))
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(str::to_owned)
+        .filter(|value| !value.is_empty())
+    {
+        return filename;
+    }
+
+    format!("image-{}{}", index + 1, extension)
+}
+
+fn image_extension(source: &str) -> String {
+    let lower = source.to_ascii_lowercase();
+    if lower.starts_with("data:image/jpeg") || lower.starts_with("data:image/jpg") {
+        return ".jpg".to_owned();
+    }
+    if lower.starts_with("data:image/png") {
+        return ".png".to_owned();
+    }
+    if lower.starts_with("data:image/gif") {
+        return ".gif".to_owned();
+    }
+    if lower.starts_with("data:image/webp") {
+        return ".webp".to_owned();
+    }
+    if lower.starts_with("data:image/bmp") {
+        return ".bmp".to_owned();
+    }
+
+    let path = strip_url_query(source).to_ascii_lowercase();
+    for extension in [".jpeg", ".jpg", ".png", ".gif", ".bmp", ".webp"] {
+        if path.ends_with(extension) {
+            return extension.to_owned();
+        }
+    }
+    ".png".to_owned()
+}
+
+fn image_mime_type(source: &str, extension: &str) -> String {
+    if source.to_ascii_lowercase().starts_with("data:image/") {
+        return source
+            .split_once(':')
+            .and_then(|(_, rest)| rest.split_once(';').map(|(mime, _)| mime.to_owned()))
+            .unwrap_or_else(|| "image/png".to_owned());
+    }
+    match extension {
+        ".jpg" | ".jpeg" => "image/jpeg",
+        ".gif" => "image/gif",
+        ".bmp" => "image/bmp",
+        ".webp" => "image/webp",
+        _ => "image/png",
+    }
+    .to_owned()
+}
+
+fn strip_url_query(source: &str) -> &str {
+    source.split(['?', '#']).next().unwrap_or(source)
 }
 
 fn push_reasoning_block(blocks: &mut Vec<Value>, item: &Value, created_at: i64) {
@@ -356,17 +649,22 @@ fn collect_assistant_message(
     item: &Value,
     fallback_timestamp: i64,
     fold_commentary: bool,
+    interleave_visible_text: bool,
     blocks: &mut Vec<Value>,
     assistant_parts: &mut Vec<String>,
     memory_citations: &mut Vec<Value>,
 ) {
     if let Some(content) = extract_text(item) {
-        match assistant_message_phase(item, fold_commentary) {
-            AssistantMessagePhase::Process => {
-                blocks.push(process_text_block(item, content, fallback_timestamp));
-            }
-            AssistantMessagePhase::Final => {
-                assistant_parts.push(content);
+        if interleave_visible_text {
+            blocks.push(process_text_block(item, content, fallback_timestamp));
+        } else {
+            match assistant_message_phase(item, fold_commentary) {
+                AssistantMessagePhase::Process => {
+                    blocks.push(process_text_block(item, content, fallback_timestamp));
+                }
+                AssistantMessagePhase::Final => {
+                    assistant_parts.push(content);
+                }
             }
         }
     }
@@ -406,6 +704,21 @@ fn process_text_block(item: &Value, content: String, fallback_timestamp: i64) ->
     })
 }
 
+fn guidance_block(item: &Value, timestamp: i64) -> Value {
+    json!({
+        "id": format!("guidance-{}", item_id(item, "user")),
+        "type": "tool",
+        "tool_use_id": format!("guidance-{}", item_id(item, "user")),
+        "tool_name": "conversation_guidance",
+        "tool_input": {
+            "message": extract_text(item).unwrap_or_default(),
+        },
+        "tool_output": Value::Null,
+        "status": "done",
+        "timestamp": timestamp,
+    })
+}
+
 fn file_changes_block(item: &Value, summary: &Value, fallback_timestamp: i64) -> Value {
     json!({
         "id": format!("file-changes-{}", item_id(item, "file-change")),
@@ -426,12 +739,14 @@ struct AssistantMessageDraft<'a> {
     turn_id: &'a str,
     subtask_id: i64,
     created_at: i64,
+    completed_at: Option<i64>,
+    status: &'a str,
+    stopped_notice: bool,
     blocks: &'a [Value],
     file_changes: Option<Value>,
     context_events: &'a [Value],
     assistant_parts: &'a [String],
     memory_citations: &'a [Value],
-    status: &'a str,
 }
 
 fn synthetic_assistant_message(draft: AssistantMessageDraft<'_>) -> Value {
@@ -445,6 +760,16 @@ fn synthetic_assistant_message(draft: AssistantMessageDraft<'_>) -> Value {
         "createdAt": draft.created_at,
         "blocks": draft.blocks,
     });
+    if let Some(completed_at) = draft.completed_at {
+        if let Some(object) = message.as_object_mut() {
+            object.insert("completedAt".to_owned(), json!(completed_at));
+        }
+    }
+    if draft.status == "cancelled" {
+        if let Some(object) = message.as_object_mut() {
+            object.insert("stoppedNotice".to_owned(), json!(draft.stopped_notice));
+        }
+    }
     if let Some(file_changes) = draft.file_changes {
         if let Some(object) = message.as_object_mut() {
             object.insert("fileChanges".to_owned(), file_changes);
@@ -560,6 +885,7 @@ fn is_tool_item_type(item_type: &str) -> bool {
             | "customtoolcall"
             | "dynamictoolcall"
             | "mcptoolcall"
+            | "mcpcall"
             | "toolsearchcall"
             | "websearchcall"
             | "websearch"
@@ -594,9 +920,11 @@ fn tool_name(item: &Value) -> String {
         "dynamictoolcall" => {
             string_field(item, "tool").unwrap_or_else(|| "dynamic_tool".to_owned())
         }
-        "mcptoolcall" => {
+        "mcptoolcall" | "mcpcall" => {
             let server = string_field(item, "server");
-            let tool = string_field(item, "tool").unwrap_or_else(|| "mcp_tool".to_owned());
+            let tool = string_field(item, "tool")
+                .or_else(|| string_field(item, "name"))
+                .unwrap_or_else(|| "mcp_tool".to_owned());
             server
                 .map(|server| format!("{server}.{tool}"))
                 .unwrap_or(tool)
@@ -619,7 +947,11 @@ fn tool_input(item: &Value) -> Value {
         "dynamictoolcall" | "toolsearchcall" => {
             item.get("arguments").cloned().unwrap_or(Value::Null)
         }
-        "mcptoolcall" => item.get("arguments").cloned().unwrap_or(Value::Null),
+        "mcptoolcall" | "mcpcall" => item
+            .get("arguments")
+            .or_else(|| item.get("input"))
+            .cloned()
+            .unwrap_or(Value::Null),
         "websearch" => json!({"query": string_field(item, "query").unwrap_or_default()}),
         "websearchcall" => item
             .get("action")
@@ -660,7 +992,7 @@ fn tool_output(item: &Value) -> Value {
             .map(output_content_items_text)
             .map(Value::String)
             .unwrap_or_else(|| item.get("result").cloned().unwrap_or(Value::Null)),
-        "mcptoolcall" => item
+        "mcptoolcall" | "mcpcall" => item
             .get("error")
             .and_then(|error| string_field(error, "message"))
             .map(Value::String)
@@ -1178,39 +1510,60 @@ mod tests {
     use super::*;
 
     #[test]
-    fn interrupted_turn_without_final_keeps_process_blocks() {
+    fn interrupted_turn_keeps_commentary_visible_and_cancelled_status() {
         let thread = json!({
-            "cwd": "/workspace/app",
+            "id": "thread-1",
+            "cwd": "/tmp/project",
             "turns": [
                 {
                     "id": "turn-1",
+                    "startedAt": 1_780_000_000,
+                    "interruptedAt": 1_780_000_152,
                     "status": "interrupted",
-                    "startedAt": 1_000,
                     "items": [
                         {
-                            "type": "userMessage",
                             "id": "user-1",
-                            "content": [
-                                {"type": "text", "text": "修一下"}
-                            ]
+                            "type": "userMessage",
+                            "content": [{"type": "text", "text": "inspect package"}]
                         },
                         {
+                            "id": "commentary-1",
                             "type": "agentMessage",
-                            "id": "assistant-commentary-1",
                             "phase": "commentary",
-                            "message": "我先改文件。"
+                            "text": "I will inspect the package file."
                         },
                         {
-                            "type": "fileChange",
-                            "id": "file-change-1",
-                            "status": "completed",
-                            "changes": [
-                                {
-                                    "path": "/workspace/app/src/main.ts",
-                                    "kind": {"type": "update"},
-                                    "diff": "@@ -1 +1 @@\n-old\n+new\n"
-                                }
-                            ]
+                            "id": "call-1",
+                            "type": "functionCall",
+                            "call_id": "call-1",
+                            "name": "exec_command",
+                            "arguments": "{\"cmd\":\"cat package.json\",\"workdir\":\"/tmp/project\"}",
+                            "status": "completed"
+                        },
+                        {
+                            "id": "final-1",
+                            "type": "agentMessage",
+                            "phase": "final_answer",
+                            "text": "partial answer"
+                        },
+                        {
+                            "id": "user-2",
+                            "type": "userMessage",
+                            "timestamp": 1_780_000_140,
+                            "content": [{"type": "text", "text": "# Files mentioned by the user:\n\n## pnpm-lock.yaml: /tmp/project/pnpm-lock.yaml\n\n## My request for Codex:\n"}]
+                        },
+                        {
+                            "id": "commentary-2",
+                            "type": "agentMessage",
+                            "phase": "commentary",
+                            "timestamp": 1_780_000_145,
+                            "text": "I will use the lockfile context."
+                        },
+                        {
+                            "id": "abort-marker",
+                            "type": "userMessage",
+                            "timestamp": 1_780_000_150,
+                            "content": [{"type": "text", "text": "<turn_aborted>\nThe user interrupted the previous turn on purpose.\n</turn_aborted>"}]
                         }
                     ]
                 }
@@ -1218,33 +1571,41 @@ mod tests {
         });
 
         let messages = transcript_messages(&thread, "device-1");
-        assert_eq!(messages.len(), 2);
 
-        let assistant = &messages[1];
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[1]["status"], "cancelled");
+        assert_eq!(messages[1]["stoppedNotice"], true);
+        assert_eq!(messages[1]["content"], "");
+        assert_eq!(messages[1]["completedAt"], 1_780_000_152_000_i64);
+        assert_eq!(messages[1]["blocks"][0]["type"], "text");
         assert_eq!(
-            assistant.get("role").and_then(Value::as_str),
-            Some("assistant")
+            messages[1]["blocks"][0]["content"],
+            "I will inspect the package file."
         );
+        assert_eq!(messages[1]["blocks"][1]["tool_name"], "exec_command");
         assert_eq!(
-            assistant.get("status").and_then(Value::as_str),
-            Some("cancelled")
+            messages[1]["blocks"][1]["tool_input"]["cmd"],
+            "cat package.json"
         );
-        assert_eq!(assistant.get("content").and_then(Value::as_str), Some(""));
-        assert!(assistant.get("fileChanges").is_some());
-
-        let blocks = assistant
-            .get("blocks")
-            .and_then(Value::as_array)
-            .expect("assistant should include process blocks");
-        assert_eq!(blocks.len(), 2);
-        assert_eq!(blocks[0].get("type").and_then(Value::as_str), Some("text"));
+        assert_eq!(messages[1]["blocks"][2]["type"], "text");
+        assert_eq!(messages[1]["blocks"][2]["content"], "partial answer");
+        assert_eq!(messages[1]["blocks"][2]["timestamp"], 1_780_000_152_000_i64);
+        assert_eq!(messages[2]["role"], "user");
+        assert_eq!(messages[2]["createdAt"], 1_780_000_140_000_i64);
+        assert!(messages[2]["content"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("pnpm-lock.yaml"));
+        assert_eq!(messages[3]["status"], "cancelled");
+        assert_eq!(messages[3]["stoppedNotice"], false);
         assert_eq!(
-            blocks[0].get("content").and_then(Value::as_str),
-            Some("我先改文件。")
+            messages[3]["blocks"][0]["tool_name"],
+            "conversation_guidance"
         );
+        assert_eq!(messages[3]["blocks"][1]["type"], "text");
         assert_eq!(
-            blocks[1].get("type").and_then(Value::as_str),
-            Some("file_changes")
+            messages[3]["blocks"][1]["content"],
+            "I will use the lockfile context."
         );
     }
 }

--- a/executor/tests/app_runtime_work_contract.rs
+++ b/executor/tests/app_runtime_work_contract.rs
@@ -137,6 +137,18 @@ async fn app_runtime_reads_codex_thread_transcript_through_app_server() {
     assert_eq!(response["runtime"], "codex");
     assert_eq!(response["messages"][0]["role"], "user");
     assert_eq!(response["messages"][0]["content"], "please fix ci");
+    assert_eq!(
+        response["messages"][0]["attachments"][0]["filename"],
+        "screenshot.png"
+    );
+    assert_eq!(
+        response["messages"][0]["attachments"][0]["local_preview_url"],
+        "/tmp/codex-clipboard/screenshot.png"
+    );
+    assert_eq!(
+        response["messages"][0]["attachments"][0]["mime_type"],
+        "image/png"
+    );
     assert_eq!(response["messages"][1]["role"], "assistant");
     assert_eq!(response["messages"][1]["content"], "done");
     assert_eq!(response["messages"][1]["blocks"][0]["type"], "thinking");
@@ -488,7 +500,7 @@ while IFS= read -r line; do
       printf '%s\n' '{{"id":2,"result":{{"data":[{{"id":"thread-1","cwd":"/tmp/project","name":"Fix CI","preview":"fix ci","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[]}}],"nextCursor":null,"backwardsCursor":null}}}}'
       ;;
     *'"method":"thread/read"'*)
-      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Fix CI","preview":"fix ci","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-1","createdAt":1780000000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"please fix ci"}}]}},{{"id":"reason-1","type":"reasoning","summary":["inspect failure"]}},{{"id":"cmd-1","type":"commandExecution","command":"cargo test","cwd":"/tmp/project","status":"completed","aggregatedOutput":"test result: ok\n","exitCode":0}},{{"id":"agent-1","type":"agentMessage","text":"done","phase":"final_answer"}}]}}]}}}}}}'
+      printf '%s\n' '{{"id":2,"result":{{"thread":{{"id":"thread-1","cwd":"/tmp/project","name":"Fix CI","preview":"fix ci","path":"/tmp/codex/thread-1.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[{{"id":"turn-1","createdAt":1780000000,"items":[{{"id":"user-1","type":"userMessage","content":[{{"type":"text","text":"please fix ci"}},{{"type":"localImage","path":"/tmp/codex-clipboard/screenshot.png"}}]}},{{"id":"reason-1","type":"reasoning","summary":["inspect failure"]}},{{"id":"cmd-1","type":"commandExecution","command":"cargo test","cwd":"/tmp/project","status":"completed","aggregatedOutput":"test result: ok\n","exitCode":0}},{{"id":"agent-1","type":"agentMessage","text":"done","phase":"final_answer"}}]}}]}}}}}}'
       exit 0
       ;;
     *'"method":"thread/start"'*)

--- a/executor/tests/local_app_ipc_large_payload_contract.rs
+++ b/executor/tests/local_app_ipc_large_payload_contract.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use wegent_executor::local::app_ipc::{AppIpcError, AppIpcServer, RuntimeWorkHandler};
 
 #[tokio::test]
-async fn app_ipc_returns_large_runtime_rpc_success_results_as_json() {
+async fn app_ipc_returns_large_runtime_rpc_success_results_inline() {
     let server = AppIpcServer::new().with_runtime_work_handler(LargeRuntimeHandler);
 
     let response = server
@@ -27,7 +27,6 @@ async fn app_ipc_returns_large_runtime_rpc_success_results_as_json() {
     assert_eq!(response["type"], "response");
     assert_eq!(response["id"], "req-large");
     assert_eq!(response["ok"], true);
-    assert_eq!(response["result"]["__runtimeRpcEncoding"], Value::Null);
     assert_eq!(response["result"]["success"], true);
     assert_eq!(
         response["result"]["messages"][0]["content"],

--- a/executor/tests/local_app_ipc_large_payload_contract.rs
+++ b/executor/tests/local_app_ipc_large_payload_contract.rs
@@ -2,15 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{future::Future, io::Read, pin::Pin};
+use std::{future::Future, pin::Pin};
 
-use base64::{engine::general_purpose::STANDARD, Engine};
-use flate2::read::GzDecoder;
 use serde_json::{json, Value};
 use wegent_executor::local::app_ipc::{AppIpcError, AppIpcServer, RuntimeWorkHandler};
 
 #[tokio::test]
-async fn app_ipc_compresses_large_runtime_rpc_success_results() {
+async fn app_ipc_returns_large_runtime_rpc_success_results_as_json() {
     let server = AppIpcServer::new().with_runtime_work_handler(LargeRuntimeHandler);
 
     let response = server
@@ -29,29 +27,12 @@ async fn app_ipc_compresses_large_runtime_rpc_success_results() {
     assert_eq!(response["type"], "response");
     assert_eq!(response["id"], "req-large");
     assert_eq!(response["ok"], true);
+    assert_eq!(response["result"]["__runtimeRpcEncoding"], Value::Null);
+    assert_eq!(response["result"]["success"], true);
     assert_eq!(
-        response["result"]["__runtimeRpcEncoding"],
-        "gzip+base64+json"
-    );
-
-    let decoded = decode_payload(response["result"]["payload"].as_str().unwrap());
-    assert_eq!(decoded["success"], true);
-    assert_eq!(
-        decoded["messages"][0]["content"],
+        response["result"]["messages"][0]["content"],
         "large transcript ".repeat(50000)
     );
-}
-
-fn decode_payload(payload: &str) -> Value {
-    let compressed = STANDARD
-        .decode(payload.as_bytes())
-        .expect("payload should be valid base64");
-    let mut decoder = GzDecoder::new(compressed.as_slice());
-    let mut json_text = String::new();
-    decoder
-        .read_to_string(&mut json_text)
-        .expect("payload should be valid gzip");
-    serde_json::from_str(&json_text).expect("payload should be valid JSON")
 }
 
 struct LargeRuntimeHandler;

--- a/wework/src-tauri/Cargo.lock
+++ b/wework/src-tauri/Cargo.lock
@@ -81,6 +81,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "log",
+ "objc2-foundation",
  "portable-pty",
  "serde",
  "serde_json",
@@ -1768,6 +1769,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
 
 [[package]]
 name = "httparse"
@@ -4350,6 +4357,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 libc = "0.2"
-tauri = { version = "2.11.2", features = ["unstable"] }
+tauri = { version = "2.11.2", features = ["protocol-asset", "unstable"] }
 tauri-plugin-log = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
@@ -32,3 +32,6 @@ tauri-plugin-shell = "2"
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-updater = "2.10.1"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSDistributedNotificationCenter", "NSNotification", "NSObject", "NSString", "std"] }

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -205,6 +205,108 @@ fn read_dropped_files(paths: Vec<String>) -> Result<Vec<DroppedFilePayload>, Str
     Ok(files)
 }
 
+fn sanitized_download_filename(filename: &str, fallback: &std::path::Path) -> String {
+    let raw = normalized_non_empty(filename.to_string()).or_else(|| {
+        fallback
+            .file_name()
+            .and_then(|value| value.to_str())
+            .map(String::from)
+    });
+
+    let sanitized = raw
+        .unwrap_or_else(|| "image".to_string())
+        .chars()
+        .map(|character| match character {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            character if character.is_control() => '_',
+            character => character,
+        })
+        .collect::<String>()
+        .trim()
+        .trim_matches('.')
+        .to_string();
+
+    if sanitized.is_empty() {
+        "image".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn unique_download_path(directory: &std::path::Path, filename: &str) -> std::path::PathBuf {
+    let candidate = directory.join(filename);
+    if !candidate.exists() {
+        return candidate;
+    }
+
+    let path = std::path::Path::new(filename);
+    let stem = path
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .filter(|value| !value.is_empty())
+        .unwrap_or("image");
+    let extension = path.extension().and_then(|value| value.to_str());
+
+    for index in 1..1000 {
+        let filename = match extension {
+            Some(extension) if !extension.is_empty() => format!("{stem} ({index}).{extension}"),
+            _ => format!("{stem} ({index})"),
+        };
+        let candidate = directory.join(filename);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+
+    directory.join(filename)
+}
+
+#[cfg(target_os = "macos")]
+fn notify_download_finished(path: &std::path::Path) {
+    use objc2_foundation::{NSDistributedNotificationCenter, NSString};
+
+    let notification_name = NSString::from_str("com.apple.DownloadFileFinished");
+    let file_path = NSString::from_str(&path.to_string_lossy());
+    unsafe {
+        NSDistributedNotificationCenter::defaultCenter()
+            .postNotificationName_object(&notification_name, Some(&file_path));
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn notify_download_finished(_path: &std::path::Path) {}
+
+#[tauri::command]
+fn download_local_file_to_downloads(
+    app: tauri::AppHandle,
+    source_path: String,
+    filename: String,
+) -> Result<String, String> {
+    let Some(source_path) = normalized_non_empty(source_path) else {
+        return Err("Source path is empty".to_string());
+    };
+
+    let source_path = std::path::PathBuf::from(source_path);
+    if !source_path.is_file() {
+        return Err("Source file does not exist".to_string());
+    }
+
+    let downloads_dir = app
+        .path()
+        .download_dir()
+        .map_err(|error| format!("Failed to locate Downloads directory: {error}"))?;
+    std::fs::create_dir_all(&downloads_dir)
+        .map_err(|error| format!("Failed to create Downloads directory: {error}"))?;
+
+    let filename = sanitized_download_filename(&filename, &source_path);
+    let target_path = unique_download_path(&downloads_dir, &filename);
+    std::fs::copy(&source_path, &target_path)
+        .map_err(|error| format!("Failed to copy file to Downloads: {error}"))?;
+    notify_download_finished(&target_path);
+
+    Ok(target_path.to_string_lossy().to_string())
+}
+
 #[tauri::command]
 fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<String> {
     let expected_backend_url = expected_backend_url
@@ -315,6 +417,7 @@ pub fn run() {
             local_executor::local_executor_request,
             local_executor::local_executor_restart,
             local_executor::local_executor_status,
+            download_local_file_to_downloads,
             local_path_exists,
             read_dropped_files,
             local_terminal::resize_local_terminal,

--- a/wework/src-tauri/src/local_executor.rs
+++ b/wework/src-tauri/src/local_executor.rs
@@ -888,7 +888,6 @@ async fn send_executor_request(
         "id": request_id,
         "method": request.method,
         "params": request.params,
-        "acceptCompressedRuntimeResult": false,
     });
     let line = format!(
         "{}\n",

--- a/wework/src-tauri/tauri.conf.json
+++ b/wework/src-tauri/tauri.conf.json
@@ -28,7 +28,13 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": ["$TEMP/**", "/var/folders/**", "/private/var/folders/**"]
+        }
+      }
     }
   },
   "bundle": {

--- a/wework/src/components/chat/AssistantMarkdown.tsx
+++ b/wework/src/components/chat/AssistantMarkdown.tsx
@@ -30,13 +30,33 @@ export function AssistantMarkdown({ content, onOpenFile }: AssistantMarkdownProp
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
-          h1: ({ children }) => <h1 className="mb-4 mt-6 text-lg font-semibold">{children}</h1>,
-          h2: ({ children }) => <h2 className="mb-3 mt-5 text-base font-semibold">{children}</h2>,
-          h3: ({ children }) => <h3 className="mb-2 mt-4 text-sm font-semibold">{children}</h3>,
-          p: ({ children }) => <p className="mb-3 min-w-0 break-words leading-6">{children}</p>,
+          h1: ({ children }) => (
+            <h1 data-scroll-anchor className="mb-4 mt-6 text-lg font-semibold">
+              {children}
+            </h1>
+          ),
+          h2: ({ children }) => (
+            <h2 data-scroll-anchor className="mb-3 mt-5 text-base font-semibold">
+              {children}
+            </h2>
+          ),
+          h3: ({ children }) => (
+            <h3 data-scroll-anchor className="mb-2 mt-4 text-sm font-semibold">
+              {children}
+            </h3>
+          ),
+          p: ({ children }) => (
+            <p data-scroll-anchor className="mb-3 min-w-0 break-words leading-6">
+              {children}
+            </p>
+          ),
           ul: ({ children }) => <ul className="mb-3 list-disc space-y-1.5 pl-5">{children}</ul>,
           ol: ({ children }) => <ol className="mb-3 list-decimal space-y-1.5 pl-8">{children}</ol>,
-          li: ({ children }) => <li className="min-w-0 break-words pl-1 leading-6">{children}</li>,
+          li: ({ children }) => (
+            <li data-scroll-anchor className="min-w-0 break-words pl-1 leading-6">
+              {children}
+            </li>
+          ),
           strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
           code: ({ className, children }) => {
             const match = /language-(\w*)/.exec(className || '')
@@ -53,12 +73,15 @@ export function AssistantMarkdown({ content, onOpenFile }: AssistantMarkdownProp
           },
           pre: ({ children }) => <>{children}</>,
           blockquote: ({ children }) => (
-            <blockquote className="mb-3 border-l-3 border-border pl-4 text-text-secondary">
+            <blockquote
+              data-scroll-anchor
+              className="mb-3 border-l-3 border-border pl-4 text-text-secondary"
+            >
               {children}
             </blockquote>
           ),
           table: ({ children }) => (
-            <div className="mb-3 max-w-full overflow-x-auto">
+            <div data-scroll-anchor className="mb-3 max-w-full overflow-x-auto">
               <table className="w-full min-w-max border-collapse text-[13px]">{children}</table>
             </div>
           ),
@@ -246,6 +269,7 @@ function AssistantMarkdownImage({ src, alt }: { src?: string; alt?: string }) {
   return (
     <img
       data-testid="assistant-markdown-image"
+      data-scroll-anchor
       src={resolvedSrc}
       alt={alt || ''}
       className="my-2 block max-h-[360px] max-w-full rounded-xl border border-border bg-base object-contain"

--- a/wework/src/components/chat/AttachmentImagePreview.tsx
+++ b/wework/src/components/chat/AttachmentImagePreview.tsx
@@ -1,8 +1,23 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { FileText, Loader2, RotateCcw, X, ZoomIn, ZoomOut } from 'lucide-react'
+import { invoke } from '@tauri-apps/api/core'
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  FileText,
+  Loader2,
+  Minus,
+  Plus,
+  X,
+} from 'lucide-react'
 import type { Attachment } from '@/types/api'
 import { getAttachmentImageUrl } from '@/lib/attachments'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+import {
+  localPathFromMarkdownImageSrc,
+  resolveDirectMarkdownImageSrc,
+} from './assistantMarkdownLinks'
 
 interface AttachmentImagePreviewProps {
   attachment: Attachment
@@ -13,6 +28,10 @@ interface AttachmentImagePreviewProps {
   imageClassName: string
   placeholderClassName: string
   buttonClassName?: string
+  disableLightbox?: boolean
+  galleryAttachments?: Attachment[]
+  galleryIndex?: number
+  hideOnError?: boolean
 }
 
 const MIN_ZOOM = 0.5
@@ -21,6 +40,91 @@ const ZOOM_STEP = 0.25
 
 function clampZoom(value: number): number {
   return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value))
+}
+
+function clampIndex(value: number, length: number): number {
+  if (length <= 0) return 0
+  return Math.min(length - 1, Math.max(0, value))
+}
+
+async function loadAttachmentImageUrl(
+  attachment: Attachment
+): Promise<{ url: string; objectUrl: string | null }> {
+  if (attachment.local_preview_url) {
+    const resolvedLocalPreviewUrl = resolveDirectMarkdownImageSrc(attachment.local_preview_url)
+    if (!resolvedLocalPreviewUrl) {
+      throw new Error('Failed to resolve local attachment preview')
+    }
+    return { url: resolvedLocalPreviewUrl, objectUrl: null }
+  }
+
+  const token = localStorage.getItem('auth_token')
+  const response = await fetch(getAttachmentImageUrl(attachment.id), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to load attachment preview: ${response.status}`)
+  }
+
+  const blob = await response.blob()
+  if (!blob.type.startsWith('image/')) {
+    throw new Error(`Attachment preview is not an image: ${blob.type || 'unknown'}`)
+  }
+
+  const objectUrl = URL.createObjectURL(blob)
+  return { url: objectUrl, objectUrl }
+}
+
+function triggerDownload(url: string, filename: string) {
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.rel = 'noopener'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+async function downloadImage(url: string, filename: string) {
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to download image: ${response.status}`)
+    }
+
+    const blob = await response.blob()
+    const objectUrl = URL.createObjectURL(blob)
+    triggerDownload(objectUrl, filename)
+    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
+  } catch {
+    triggerDownload(url, filename)
+  }
+}
+
+function getDownloadableLocalPath(value?: string): string | null {
+  if (!value) return null
+  if (/^(asset|blob|data|https?):/i.test(value)) return null
+
+  const localPath = localPathFromMarkdownImageSrc(value)
+  if (localPath.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(localPath)) {
+    return localPath
+  }
+
+  return null
+}
+
+async function downloadAttachmentImage(attachment: Attachment, imageUrl: string) {
+  const sourcePath = getDownloadableLocalPath(attachment.local_preview_url)
+  if (sourcePath && isTauriRuntime()) {
+    await invoke<string>('download_local_file_to_downloads', {
+      sourcePath,
+      filename: attachment.filename,
+    })
+    return
+  }
+
+  await downloadImage(imageUrl, attachment.filename)
 }
 
 export function AttachmentImagePreview({
@@ -32,12 +136,25 @@ export function AttachmentImagePreview({
   imageClassName,
   placeholderClassName,
   buttonClassName = 'block max-w-full cursor-zoom-in p-0 text-left',
+  disableLightbox = false,
+  galleryAttachments,
+  galleryIndex = 0,
+  hideOnError = false,
 }: AttachmentImagePreviewProps) {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null)
   const [hasError, setHasError] = useState(false)
   const [isLightboxOpen, setIsLightboxOpen] = useState(false)
+  const [lightboxIndex, setLightboxIndex] = useState(galleryIndex)
+  const [lightboxUrl, setLightboxUrl] = useState<string | null>(null)
+  const [isLightboxLoading, setIsLightboxLoading] = useState(false)
+  const [hasLightboxError, setHasLightboxError] = useState(false)
   const [zoom, setZoom] = useState(1)
-  const localPreviewUrl = attachment.local_preview_url
+  const gallery = useMemo(
+    () => (galleryAttachments?.length ? galleryAttachments : [attachment]),
+    [attachment, galleryAttachments]
+  )
+  const currentLightboxAttachment = gallery[clampIndex(lightboxIndex, gallery.length)] ?? attachment
+  const canNavigateLightbox = gallery.length > 1
 
   useEffect(() => {
     let isMounted = true
@@ -47,32 +164,15 @@ export function AttachmentImagePreview({
       setPreviewUrl(null)
       setHasError(false)
       setIsLightboxOpen(false)
+      setLightboxUrl(null)
       setZoom(1)
 
-      if (localPreviewUrl) {
-        setPreviewUrl(localPreviewUrl)
-        return
-      }
-
       try {
-        const token = localStorage.getItem('auth_token')
-        const response = await fetch(getAttachmentImageUrl(attachment.id), {
-          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        })
-
-        if (!response.ok) {
-          throw new Error(`Failed to load attachment preview: ${response.status}`)
-        }
-
-        const blob = await response.blob()
-        if (!blob.type.startsWith('image/')) {
-          throw new Error(`Attachment preview is not an image: ${blob.type || 'unknown'}`)
-        }
-
-        objectUrl = URL.createObjectURL(blob)
+        const loaded = await loadAttachmentImageUrl(attachment)
+        objectUrl = loaded.objectUrl
         if (isMounted) {
-          setPreviewUrl(objectUrl)
-        } else {
+          setPreviewUrl(loaded.url)
+        } else if (objectUrl) {
           URL.revokeObjectURL(objectUrl)
         }
       } catch {
@@ -90,30 +190,110 @@ export function AttachmentImagePreview({
         URL.revokeObjectURL(objectUrl)
       }
     }
-  }, [attachment.id, localPreviewUrl])
+  }, [attachment])
 
   useEffect(() => {
-    if (!isLightboxOpen) return
+    if (!isLightboxOpen || disableLightbox) return
+
+    let isMounted = true
+    let objectUrl: string | null = null
+    const nextIndex = clampIndex(lightboxIndex, gallery.length)
+    const selectedAttachment = gallery[nextIndex] ?? attachment
+    const reusablePreviewUrl =
+      selectedAttachment.id === attachment.id &&
+      selectedAttachment.local_preview_url === attachment.local_preview_url
+        ? previewUrl
+        : null
+
+    async function loadLightboxImage() {
+      setZoom(1)
+      setHasLightboxError(false)
+
+      if (reusablePreviewUrl) {
+        setIsLightboxLoading(false)
+        setLightboxUrl(reusablePreviewUrl)
+        return
+      }
+
+      setIsLightboxLoading(true)
+      setLightboxUrl(null)
+
+      try {
+        const loaded = await loadAttachmentImageUrl(selectedAttachment)
+        objectUrl = loaded.objectUrl
+        if (isMounted) {
+          setLightboxUrl(loaded.url)
+          setIsLightboxLoading(false)
+        } else if (objectUrl) {
+          URL.revokeObjectURL(objectUrl)
+        }
+      } catch {
+        if (isMounted) {
+          setIsLightboxLoading(false)
+          setHasLightboxError(true)
+        }
+      }
+    }
+
+    void loadLightboxImage()
+
+    return () => {
+      isMounted = false
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+  }, [attachment, disableLightbox, gallery, isLightboxOpen, lightboxIndex, previewUrl])
+
+  useEffect(() => {
+    if (!isLightboxOpen || disableLightbox) return
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setIsLightboxOpen(false)
+        return
+      }
+
+      if (event.key === 'ArrowLeft' && canNavigateLightbox) {
+        event.preventDefault()
+        setLightboxIndex(current => (current <= 0 ? gallery.length - 1 : current - 1))
+        return
+      }
+
+      if (event.key === 'ArrowRight' && canNavigateLightbox) {
+        event.preventDefault()
+        setLightboxIndex(current => (current >= gallery.length - 1 ? 0 : current + 1))
       }
     }
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isLightboxOpen])
+  }, [canNavigateLightbox, disableLightbox, gallery.length, isLightboxOpen])
+
+  const openLightbox = () => {
+    setLightboxIndex(clampIndex(galleryIndex, gallery.length))
+    setLightboxUrl(null)
+    setHasLightboxError(false)
+    setIsLightboxOpen(true)
+  }
+
+  const goToPreviousImage = () => {
+    setLightboxIndex(current => (current <= 0 ? gallery.length - 1 : current - 1))
+  }
+
+  const goToNextImage = () => {
+    setLightboxIndex(current => (current >= gallery.length - 1 ? 0 : current + 1))
+  }
 
   if (previewUrl) {
     const lightbox =
-      isLightboxOpen && typeof document !== 'undefined'
+      !disableLightbox && isLightboxOpen && typeof document !== 'undefined'
         ? createPortal(
             <div
               data-testid="attachment-image-lightbox"
               role="dialog"
               aria-modal="true"
-              aria-label={attachment.filename}
+              aria-label={currentLightboxAttachment.filename}
               className="fixed inset-0 z-modal flex h-dvh w-dvw items-center justify-center overflow-hidden bg-black/90 p-0"
               onClick={() => setIsLightboxOpen(false)}
               onWheel={event => {
@@ -121,70 +301,150 @@ export function AttachmentImagePreview({
                 setZoom(current => clampZoom(current + (event.deltaY < 0 ? ZOOM_STEP : -ZOOM_STEP)))
               }}
             >
+              <div className="absolute right-4 top-4 z-20 flex items-center gap-2.5">
+                <button
+                  type="button"
+                  data-testid="attachment-image-download"
+                  className="flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={event => {
+                    event.stopPropagation()
+                    if (lightboxUrl) {
+                      void downloadAttachmentImage(currentLightboxAttachment, lightboxUrl)
+                    }
+                  }}
+                  disabled={!lightboxUrl}
+                  aria-label="Download image"
+                >
+                  <Download className="h-5 w-5" />
+                </button>
+                <button
+                  type="button"
+                  data-testid="attachment-image-lightbox-close"
+                  className="flex h-12 w-12 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                  onClick={event => {
+                    event.stopPropagation()
+                    setIsLightboxOpen(false)
+                  }}
+                  aria-label="Close image preview"
+                >
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+              {canNavigateLightbox && (
+                <>
+                  <button
+                    type="button"
+                    data-testid="attachment-image-previous"
+                    className="absolute left-5 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                    onClick={event => {
+                      event.stopPropagation()
+                      goToPreviousImage()
+                    }}
+                    aria-label="Previous image"
+                  >
+                    <ChevronLeft className="h-7 w-7" />
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="attachment-image-next"
+                    className="absolute right-5 top-1/2 z-20 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                    onClick={event => {
+                      event.stopPropagation()
+                      goToNextImage()
+                    }}
+                    aria-label="Next image"
+                  >
+                    <ChevronRight className="h-7 w-7" />
+                  </button>
+                </>
+              )}
               <div
                 data-testid="attachment-image-zoom-controls"
-                className="absolute left-1/2 top-4 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full bg-black/45 p-1 text-white shadow-[0_12px_36px_rgba(0,0,0,0.35)]"
+                className="absolute bottom-6 left-1/2 z-20 flex h-11 -translate-x-1/2 items-center gap-2.5 rounded-full bg-white/15 px-1.5 text-white shadow-[0_12px_36px_rgba(0,0,0,0.35)]"
                 onClick={event => event.stopPropagation()}
               >
                 <button
                   type="button"
                   data-testid="attachment-image-zoom-out"
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
                   onClick={() => setZoom(current => clampZoom(current - ZOOM_STEP))}
                   disabled={zoom <= MIN_ZOOM}
                   aria-label="Zoom out"
                 >
-                  <ZoomOut className="h-5 w-5" />
+                  <Minus className="h-[18px] w-[18px]" />
                 </button>
-                <button
-                  type="button"
-                  data-testid="attachment-image-zoom-reset"
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15"
-                  onClick={() => setZoom(1)}
-                  aria-label="Reset zoom"
+                <span
+                  data-testid="attachment-image-zoom-value"
+                  className="min-w-14 select-none text-center text-base font-medium tabular-nums text-white"
                 >
-                  <RotateCcw className="h-5 w-5" />
-                </button>
+                  {Math.round(zoom * 100)}%
+                </span>
                 <button
                   type="button"
                   data-testid="attachment-image-zoom-in"
-                  className="flex h-10 w-10 items-center justify-center rounded-full text-white transition-colors hover:bg-white/15 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="flex h-9 w-9 items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
                   onClick={() => setZoom(current => clampZoom(current + ZOOM_STEP))}
                   disabled={zoom >= MAX_ZOOM}
                   aria-label="Zoom in"
                 >
-                  <ZoomIn className="h-5 w-5" />
+                  <Plus className="h-[18px] w-[18px]" />
                 </button>
               </div>
-              <button
-                type="button"
-                data-testid="attachment-image-lightbox-close"
-                className="absolute right-4 top-4 z-20 flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-white transition-colors hover:bg-white/25 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
-                onClick={event => {
-                  event.stopPropagation()
-                  setIsLightboxOpen(false)
-                }}
-                aria-label="Close image preview"
-              >
-                <X className="h-5 w-5" />
-              </button>
-              <img
-                data-testid="attachment-image-lightbox-image"
-                src={previewUrl}
-                alt={attachment.filename}
-                className="max-h-[calc(100dvh-6rem)] max-w-[calc(100dvw-2rem)] object-contain transition-transform duration-150 ease-out"
-                style={{ transform: `scale(${zoom})` }}
-                onClick={event => event.stopPropagation()}
-                onError={() => {
-                  setPreviewUrl(null)
-                  setIsLightboxOpen(false)
-                  setHasError(true)
-                }}
-              />
+              {lightboxUrl ? (
+                <img
+                  data-testid="attachment-image-lightbox-image"
+                  src={lightboxUrl}
+                  alt={currentLightboxAttachment.filename}
+                  className="max-h-[calc(100dvh-9rem)] max-w-[calc(100dvw-8rem)] rounded-2xl object-contain transition-transform duration-150 ease-out"
+                  style={{ transform: `scale(${zoom})` }}
+                  onClick={event => event.stopPropagation()}
+                  onError={() => {
+                    setLightboxUrl(null)
+                    setHasLightboxError(true)
+                  }}
+                />
+              ) : (
+                <div
+                  data-testid={
+                    hasLightboxError
+                      ? 'attachment-image-lightbox-error'
+                      : 'attachment-image-lightbox-loading'
+                  }
+                  className="flex h-36 w-36 items-center justify-center rounded-2xl bg-white/10 text-white"
+                  onClick={event => event.stopPropagation()}
+                >
+                  {isLightboxLoading ? (
+                    <Loader2 className="h-7 w-7 animate-spin" />
+                  ) : (
+                    <FileText className="h-7 w-7" />
+                  )}
+                </div>
+              )}
             </div>,
             document.body
           )
         : null
+
+    if (disableLightbox) {
+      return (
+        <div
+          data-testid={buttonTestId}
+          className={buttonClassName}
+          aria-label={attachment.filename}
+        >
+          <img
+            data-testid={imageTestId}
+            src={previewUrl}
+            alt={attachment.filename}
+            className={imageClassName}
+            onError={() => {
+              setPreviewUrl(null)
+              setHasError(true)
+            }}
+          />
+        </div>
+      )
+    }
 
     return (
       <>
@@ -192,7 +452,7 @@ export function AttachmentImagePreview({
           type="button"
           data-testid={buttonTestId}
           className={buttonClassName}
-          onClick={() => setIsLightboxOpen(true)}
+          onClick={openLightbox}
           aria-label={attachment.filename}
         >
           <img
@@ -209,6 +469,10 @@ export function AttachmentImagePreview({
         {lightbox}
       </>
     )
+  }
+
+  if (hasError && hideOnError) {
+    return null
   }
 
   return (

--- a/wework/src/components/chat/MarkdownCodeBlock.tsx
+++ b/wework/src/components/chat/MarkdownCodeBlock.tsx
@@ -124,6 +124,7 @@ export function MarkdownCodeBlock({
   return (
     <div
       data-testid="markdown-code-block"
+      data-scroll-anchor
       className={[
         'max-w-full overflow-hidden rounded-lg border border-[#3c424a] bg-[#2f2f2f] text-left shadow-sm',
         compact ? 'mb-1.5' : 'mb-3 mt-2',

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -8,6 +8,7 @@ import '@/i18n'
 
 const tauriCoreMock = vi.hoisted(() => ({
   convertFileSrc: vi.fn((path: string) => `asset://localhost/${path.replace(/^\/+/, '')}`),
+  invoke: vi.fn(),
   isTauri: vi.fn(() => false),
 }))
 
@@ -130,6 +131,179 @@ describe('MessageList', () => {
     expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 9m 18s 后停止了')
   })
 
+  test('shows stopped duration from completed time and keeps partial assistant content', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-stopped-with-content',
+            role: 'assistant',
+            content: '停止前已经生成的内容。',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            createdAt: '2026-06-11T10:00:00Z',
+            completedAt: '2026-06-11T10:02:12Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 2m 12s 后停止了')
+    expect(screen.getByText('停止前已经生成的内容。')).toBeInTheDocument()
+    expect(screen.queryByText(/已处理/)).not.toBeInTheDocument()
+  })
+
+  test('renders stopped assistant process text and activity rows in original order', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'process-1',
+        subtaskId: 21,
+        type: 'text',
+        content: '我先看你提到的 package.json。',
+        status: 'done',
+        createdAt: Date.parse('2026-06-11T10:00:10Z'),
+      },
+      {
+        id: 'call-1',
+        subtaskId: 21,
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'cat package.json' },
+        status: 'done',
+        createdAt: Date.parse('2026-06-11T10:00:20Z'),
+      },
+      {
+        id: 'process-2',
+        subtaskId: 21,
+        type: 'text',
+        content: '从常用目录看，可能的前端仓库很多。',
+        status: 'done',
+        createdAt: Date.parse('2026-06-11T10:00:30Z'),
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-stopped-interleaved',
+            role: 'assistant',
+            content: '',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            createdAt: '2026-06-11T10:00:00Z',
+            completedAt: '2026-06-11T10:02:12Z',
+            blocks,
+          },
+        ]}
+      />
+    )
+
+    const firstText = screen.getByText('我先看你提到的 package.json。')
+    const activityRow = screen.getByTestId('processing-activity-group-toggle')
+    const secondText = screen.getByText('从常用目录看，可能的前端仓库很多。')
+
+    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 2m 12s 后停止了')
+    expect(activityRow).toHaveTextContent('已探索 1 个文件')
+    expect(firstText.compareDocumentPosition(activityRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+    expect(activityRow.compareDocumentPosition(secondText) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+    expect(screen.queryByText(/已处理/)).not.toBeInTheDocument()
+  })
+
+  test('shows one stopped notice for split stopped assistant turns and keeps guidance visible', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-stopped-first',
+            role: 'assistant',
+            content: '',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            stoppedNotice: true,
+            createdAt: '2026-06-11T10:00:00Z',
+            completedAt: '2026-06-11T10:02:12Z',
+            blocks: [
+              {
+                id: 'process-1',
+                subtaskId: 21,
+                type: 'text',
+                content: '我先看 package.json。',
+                status: 'done',
+                createdAt: Date.parse('2026-06-11T10:00:10Z'),
+              },
+            ],
+          },
+          {
+            id: 'user-guidance',
+            role: 'user',
+            content: 'pnpm-lock.yaml',
+            status: 'done',
+            createdAt: '2026-06-11T10:01:00Z',
+          },
+          {
+            id: 'assistant-stopped-continuation',
+            role: 'assistant',
+            content: '',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            stoppedNotice: false,
+            createdAt: '2026-06-11T10:00:00Z',
+            completedAt: '2026-06-11T10:02:12Z',
+            blocks: [
+              {
+                id: 'guidance-1',
+                subtaskId: 21,
+                type: 'tool',
+                toolName: 'conversation_guidance',
+                toolInput: { message: 'pnpm-lock.yaml' },
+                status: 'done',
+                createdAt: Date.parse('2026-06-11T10:01:00Z'),
+              },
+              {
+                id: 'process-2',
+                subtaskId: 21,
+                type: 'text',
+                content: '我会继续看 lockfile。',
+                status: 'done',
+                createdAt: Date.parse('2026-06-11T10:01:05Z'),
+              },
+            ],
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getAllByTestId('assistant-stopped-notice')).toHaveLength(1)
+    expect(screen.getByText('我先看 package.json。')).toBeInTheDocument()
+    expect(screen.getByText('pnpm-lock.yaml')).toBeInTheDocument()
+    expect(screen.getByText('已引导对话')).toBeInTheDocument()
+    expect(screen.getByText('我会继续看 lockfile。')).toBeInTheDocument()
+  })
+
+  test('keeps cancelled assistant turns even when no processing blocks were persisted', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-stopped-empty',
+            role: 'assistant',
+            content: '',
+            status: 'done',
+            runtimeStatus: 'cancelled',
+            createdAt: '2026-06-11T10:00:00Z',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('assistant-stopped-notice')).toHaveTextContent('你在 0s 后停止了')
+  })
+
   test('uses compact spacing between messages and hover actions', () => {
     render(
       <MessageList
@@ -153,6 +327,7 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByTestId('message-user').parentElement).toHaveClass('gap-4')
+    expect(screen.getByTestId('message-user').parentElement).toHaveClass('pt-11', 'pb-2')
     expect(screen.getAllByTestId('message-hover-actions')[0]).toHaveClass('min-h-5')
   })
 
@@ -165,6 +340,7 @@ describe('MessageList', () => {
     tauriCoreMock.convertFileSrc = vi.fn(
       (path: string) => `asset://localhost/${path.replace(/^\/+/, '')}`
     )
+    tauriCoreMock.invoke = vi.fn()
     tauriCoreMock.isTauri = vi.fn(() => false)
     localStorage.clear()
     URL.createObjectURL = originalCreateObjectUrl
@@ -624,13 +800,14 @@ describe('MessageList', () => {
             id: 'assistant-codex-rich',
             role: 'assistant',
             content:
-              'Updated [SKILL.md](/workspace/project/SKILL.md), [github-pr-flow.md](/workspace/project/references/github-pr-flow.md:18), and [notify_pr_ready.sh](/workspace/project/scripts/notify_pr_ready.sh).',
+              'Updated [SKILL.md](/workspace/project/SKILL.md), [github-pr-flow.md](/workspace/project/references/github-pr-flow.md:18), [paas-context.log](/workspace/project/logs/paas-context.log), and [notify_pr_ready.sh](/workspace/project/scripts/notify_pr_ready.sh).',
             status: 'done',
             createdAt: '2026-06-24T08:00:01.000Z',
             references: [
               { path: '/workspace/project/SKILL.md' },
               { path: '/workspace/project/references/github-pr-flow.md', lineStart: 18 },
               { path: '/workspace/project/SKILL.md:22' },
+              { path: '/workspace/project/logs/paas-context.log' },
               { path: '/workspace/project/scripts/notify_pr_ready.sh' },
             ],
             contextEvents: [
@@ -672,6 +849,7 @@ describe('MessageList', () => {
 
     const referenceCards = screen.getAllByTestId('codex-reference-card')
     expect(referenceCards).toHaveLength(2)
+    expect(screen.getByTestId('codex-reference-list')).not.toHaveTextContent('paas-context.log')
     expect(screen.getByTestId('codex-reference-list')).not.toHaveTextContent('notify_pr_ready.sh')
     expect(referenceCards[0]).toHaveTextContent('SKILL.md')
     expect(referenceCards[0]).toHaveTextContent('文档 · MD')
@@ -1043,6 +1221,93 @@ describe('MessageList', () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  test('renders local path image attachment previews through Tauri asset URLs', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    const attachment: Attachment = {
+      id: -1,
+      filename: 'screenshot.png',
+      file_size: 0,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-06-26T15:33:00.000+08:00',
+      local_preview_url: '/var/folders/tmp/codex-clipboard/screenshot.png',
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'local-codex-image',
+            role: 'user',
+            content: '解释一下些图片',
+            status: 'done',
+            attachments: [attachment],
+            createdAt: '2026-06-26T15:33:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    expect(await screen.findByTestId('message-image-preview')).toHaveAttribute(
+      'src',
+      'asset://localhost/var/folders/tmp/codex-clipboard/screenshot.png'
+    )
+    expect(screen.getByTestId('message-hover-region')).toHaveClass('w-full', 'max-w-full')
+    expect(screen.getByTestId('user-message-content').parentElement).toHaveClass('max-w-[80%]')
+    expect(screen.getByTestId('message-image-attachments')).toHaveClass(
+      'justify-end',
+      'overflow-visible'
+    )
+    expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('justify-start')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  test('downloads local path image attachments through the Tauri native command', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+    tauriCoreMock.isTauri = vi.fn(() => true)
+    tauriCoreMock.invoke = vi.fn().mockResolvedValue('/Users/crystal/Downloads/screenshot.png')
+
+    const attachment: Attachment = {
+      id: -1,
+      filename: 'screenshot.png',
+      file_size: 0,
+      mime_type: 'image/png',
+      status: 'ready',
+      file_extension: '.png',
+      created_at: '2026-06-26T15:33:00.000+08:00',
+      local_preview_url: '/var/folders/tmp/codex-clipboard/screenshot.png',
+    }
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'local-codex-image',
+            role: 'user',
+            content: '解释一下这张图片',
+            status: 'done',
+            attachments: [attachment],
+            createdAt: '2026-06-26T15:33:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(await screen.findByTestId('message-image-preview'))
+    await screen.findByTestId('attachment-image-lightbox-image')
+    await userEvent.click(screen.getByTestId('attachment-image-download'))
+
+    await waitFor(() => {
+      expect(tauriCoreMock.invoke).toHaveBeenCalledWith('download_local_file_to_downloads', {
+        sourcePath: '/var/folders/tmp/codex-clipboard/screenshot.png',
+        filename: 'screenshot.png',
+      })
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   test('prefers persisted image attachments over stale Codex local image mentions', async () => {
     vi.stubGlobal('fetch', vi.fn())
 
@@ -1087,7 +1352,7 @@ describe('MessageList', () => {
     expect(screen.getByTestId('user-message-content')).toHaveTextContent('发出去图片')
   })
 
-  test('renders Codex local image file mentions as user image previews after refresh', () => {
+  test('renders Codex local image file mentions as user image previews after refresh', async () => {
     render(
       <MessageList
         messages={[
@@ -1109,11 +1374,80 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getByTestId('message-local-image-preview')).toHaveAttribute(
+    expect(await screen.findByTestId('message-local-image-preview')).toHaveAttribute(
       'src',
       'asset://localhost/Users/yunpeng7/.wegent-executor/workspace/attachments/10406026969952/0/image.png'
     )
     expect(screen.getByTestId('user-message-content')).toHaveTextContent('分析下这个图片')
+    expect(screen.queryByText(/Files mentioned by the user/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/My request for Codex/)).not.toBeInTheDocument()
+  })
+
+  test('renders Codex local non-image file mentions as compact file chips', () => {
+    const onOpenWorkspaceFile = vi.fn()
+
+    render(
+      <MessageList
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+        messages={[
+          {
+            id: 'codex-file-mention',
+            role: 'user',
+            content: [
+              '# Files mentioned by the user:',
+              '',
+              '## package.json: /Users/crystal/package.json',
+              '',
+              '## My request for Codex:',
+              '看看',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('message-codex-file-mention')).toHaveTextContent('package.json')
+    expect(screen.getByTestId('message-codex-file-braces-icon')).toBeInTheDocument()
+    expect(screen.queryByTestId('message-codex-file-document-icon')).not.toBeInTheDocument()
+    expect(screen.getByTestId('message-codex-file-mention')).toHaveAttribute(
+      'title',
+      '/Users/crystal/package.json'
+    )
+    expect(screen.getByTestId('user-message-content')).toHaveTextContent('看看')
+    expect(screen.queryByText(/Files mentioned by the user/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/My request for Codex/)).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('message-codex-file-mention'))
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/crystal/package.json')
+  })
+
+  test('renders file-only Codex mentions without the raw markdown wrapper', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'codex-file-only-mention',
+            role: 'user',
+            content: [
+              '# Files mentioned by the user:',
+              '',
+              '## pnpm-lock.yaml: /Users/crystal/pnpm-lock.yaml',
+              '',
+              '## My request for Codex:',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByTestId('message-codex-file-mention')).toHaveTextContent('pnpm-lock.yaml')
+    expect(screen.getByTestId('message-codex-file-document-icon')).toBeInTheDocument()
+    expect(screen.queryByTestId('message-codex-file-braces-icon')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('user-message-content')).not.toBeInTheDocument()
     expect(screen.queryByText(/Files mentioned by the user/)).not.toBeInTheDocument()
     expect(screen.queryByText(/My request for Codex/)).not.toBeInTheDocument()
   })
@@ -1146,7 +1480,7 @@ describe('MessageList', () => {
     expect(screen.getByTestId('user-message-content')).toHaveTextContent('分析下这个图片')
   })
 
-  test('hides Codex local image previews when the converted file URL fails to load', () => {
+  test('hides Codex local image previews when the converted file URL fails to load', async () => {
     render(
       <MessageList
         messages={[
@@ -1168,7 +1502,7 @@ describe('MessageList', () => {
       />
     )
 
-    fireEvent.error(screen.getByTestId('message-local-image-preview'))
+    fireEvent.error(await screen.findByTestId('message-local-image-preview'))
 
     expect(screen.queryByTestId('message-local-image-preview')).not.toBeInTheDocument()
     expect(screen.getByTestId('user-message-content')).toHaveTextContent('分析下这个图片')
@@ -1235,7 +1569,7 @@ describe('MessageList', () => {
     expect(screen.getByTestId('assistant-markdown-image')).toHaveAttribute('alt', 'local result')
   })
 
-  test('opens an enlarged image from a user message attachment preview', async () => {
+  test('opens an enlarged preview from a user message image attachment', async () => {
     URL.createObjectURL = vi.fn(() => 'blob:message-image-preview')
     URL.revokeObjectURL = vi.fn()
     vi.stubGlobal(
@@ -1274,33 +1608,100 @@ describe('MessageList', () => {
     await userEvent.click(await screen.findByTestId('message-image-preview'))
 
     const lightbox = screen.getByTestId('attachment-image-lightbox')
-    const lightboxImage = screen.getByTestId('attachment-image-lightbox-image')
+    const lightboxImage = await screen.findByTestId('attachment-image-lightbox-image')
 
     expect(lightbox).toBeInTheDocument()
     expect(lightbox.parentElement).toBe(document.body)
-    expect(lightbox).toHaveClass('h-dvh', 'w-dvw', 'p-0')
-    expect(lightbox).toHaveClass('overflow-hidden')
-    expect(lightboxImage).toHaveClass(
-      'max-h-[calc(100dvh-6rem)]',
-      'max-w-[calc(100dvw-2rem)]',
-      'object-contain'
-    )
-    expect(lightboxImage).not.toHaveClass('h-full', 'w-full')
-    expect(screen.getByTestId('attachment-image-lightbox-close')).toHaveClass('z-20')
     expect(lightboxImage).toHaveAttribute('src', 'blob:message-image-preview')
     expect(lightboxImage).toHaveAttribute('alt', 'diagram.png')
     expect(lightboxImage).toHaveStyle({ transform: 'scale(1)' })
+    expect(screen.getByTestId('attachment-image-download')).toBeEnabled()
+    expect(screen.getByTestId('attachment-image-zoom-controls')).toHaveClass('bottom-6')
+    expect(screen.getByTestId('attachment-image-zoom-value')).toHaveTextContent('100%')
 
     await userEvent.click(screen.getByTestId('attachment-image-zoom-in'))
 
     expect(lightboxImage).toHaveStyle({ transform: 'scale(1.25)' })
-
-    await userEvent.click(screen.getByTestId('attachment-image-zoom-reset'))
-
-    expect(lightboxImage).toHaveStyle({ transform: 'scale(1)' })
+    expect(screen.getByTestId('attachment-image-zoom-value')).toHaveTextContent('125%')
   })
 
-  test('keeps image attachments compact and allows extras to wrap', async () => {
+  test('navigates between images in the enlarged preview gallery', async () => {
+    vi.stubGlobal('fetch', vi.fn())
+
+    const attachments: Attachment[] = [
+      {
+        id: 43,
+        filename: 'first.png',
+        file_size: 1024,
+        mime_type: 'image/png',
+        status: 'ready',
+        file_extension: '.png',
+        created_at: '2026-05-25T15:08:00.000+08:00',
+        local_preview_url: 'blob:first-image',
+      },
+      {
+        id: 44,
+        filename: 'second.png',
+        file_size: 1024,
+        mime_type: 'image/png',
+        status: 'ready',
+        file_extension: '.png',
+        created_at: '2026-05-25T15:08:00.000+08:00',
+        local_preview_url: 'blob:second-image',
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '1',
+            role: 'user',
+            content: '分析下这些图片',
+            status: 'done',
+            attachments,
+            createdAt: '2026-05-25T15:08:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    const previews = await screen.findAllByTestId('message-image-preview')
+    await userEvent.click(previews[0])
+
+    expect(await screen.findByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+      'alt',
+      'first.png'
+    )
+
+    await userEvent.click(screen.getByTestId('attachment-image-next'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'src',
+        'blob:second-image'
+      )
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'alt',
+        'second.png'
+      )
+    })
+
+    await userEvent.click(screen.getByTestId('attachment-image-previous'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'src',
+        'blob:first-image'
+      )
+      expect(screen.getByTestId('attachment-image-lightbox-image')).toHaveAttribute(
+        'alt',
+        'first.png'
+      )
+    })
+  })
+
+  test('keeps image attachments in a single horizontal strip', async () => {
     URL.createObjectURL = vi.fn(() => 'blob:message-image-preview')
     URL.revokeObjectURL = vi.fn()
     vi.stubGlobal(
@@ -1369,12 +1770,16 @@ describe('MessageList', () => {
 
     expect(previews).toHaveLength(4)
     expect(screen.getByTestId('message-image-attachments')).toHaveClass(
+      'w-full',
       'flex-row',
-      'flex-wrap',
-      'justify-end'
+      'flex-nowrap',
+      'justify-start',
+      'overflow-x-auto',
+      'scrollbar-none'
     )
-    expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('overflow-x-auto')
-    expect(previews[0]).toHaveClass('max-h-36', 'max-w-[180px]', 'shrink-0', 'rounded-xl')
+    expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('flex-wrap')
+    expect(screen.getByTestId('message-hover-region')).toHaveClass('w-full', 'max-w-full')
+    expect(previews[0]).toHaveClass('h-20', 'w-20', 'shrink-0', 'rounded-xl', 'object-cover')
   })
 
   test('renders document attachments in user messages', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -1,10 +1,19 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type {
   MouseEvent as ReactMouseEvent,
   ReactNode,
   TransitionEvent as ReactTransitionEvent,
 } from 'react'
-import { AlertTriangle, Check, ChevronDown, ChevronUp, Copy, Package } from 'lucide-react'
+import {
+  AlertTriangle,
+  Braces,
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  File as FileIcon,
+  Package,
+} from 'lucide-react'
 import type { Attachment, DeviceInfo, TurnFileChangesSummary } from '@/types/api'
 import { useTranslation } from '@/hooks/useTranslation'
 import type { ProcessingBlock, WorkbenchMessage } from '@/types/workbench'
@@ -13,7 +22,6 @@ import { parseChatError } from '@/lib/chat-error'
 import { isIMSource } from '@/lib/im-source'
 import { ImSourceBadge } from '@/components/common/ImSourceBadge'
 import { AssistantMarkdown } from './AssistantMarkdown'
-import { resolveDirectMarkdownImageSrc } from './assistantMarkdownLinks'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
 import { isWebSearchToolName } from './blocks/toolBlockActivity'
@@ -48,6 +56,17 @@ const CODEX_FILE_MENTIONS_HEADER_PATTERN = /^\s*# Files mentioned by the user:\s
 const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
 const CODEX_FILE_MENTION_LINE_PATTERN = /^##\s+(.+?):\s+(.+)$/gm
 const LOCAL_IMAGE_EXTENSION_PATTERN = /\.(?:apng|avif|gif|jpe?g|png|webp|bmp|svg)$/i
+const LOCAL_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.apng': 'image/apng',
+  '.avif': 'image/avif',
+  '.bmp': 'image/bmp',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+}
 
 export function MessageList({
   messages,
@@ -71,7 +90,7 @@ export function MessageList({
   }
 
   return (
-    <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 py-2">
+    <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 pb-2 pt-11">
       {visibleMessages.map(message => (
         <article
           key={message.id}
@@ -79,10 +98,11 @@ export function MessageList({
             'min-w-0 overflow-x-hidden',
             message.role === 'user' ? 'flex justify-end' : '',
           ].join(' ')}
+          data-message-id={message.id}
           data-testid={`message-${message.role}`}
         >
           {message.role === 'user' ? (
-            <UserMessage message={message} />
+            <UserMessage message={message} onOpenWorkspaceFile={onOpenWorkspaceFile} />
           ) : (
             <AssistantMessage
               message={message}
@@ -110,6 +130,7 @@ export function MessageList({
 function shouldRenderMessage(message: WorkbenchMessage): boolean {
   if (message.role !== 'assistant') return true
   if (message.status === 'streaming' || message.status === 'failed') return true
+  if (isCancelledAssistantMessage(message)) return true
   if (message.fileChanges) return true
   if (
     message.references?.length ||
@@ -136,7 +157,23 @@ function WaitingAssistantIndicator() {
 }
 
 function getTurnStartMs(createdAt: string): number | undefined {
-  const ms = new Date(createdAt).getTime()
+  return getMessageTimestampMs(createdAt)
+}
+
+function getMessageTimestampMs(value: string | number | null | undefined): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    if (value > 1_000_000_000_000) return value
+    if (value > 1_000_000_000) return value * 1000
+    return undefined
+  }
+
+  if (typeof value !== 'string' || !value.trim()) return undefined
+  const numericValue = Number(value)
+  if (Number.isFinite(numericValue)) {
+    return getMessageTimestampMs(numericValue)
+  }
+
+  const ms = new Date(value).getTime()
   return Number.isFinite(ms) ? ms : undefined
 }
 
@@ -157,6 +194,11 @@ function getStoppedElapsedDuration(message: WorkbenchMessage): string {
   const startedAt = getTurnStartMs(message.createdAt)
   if (startedAt === undefined) return '0s'
 
+  const completedAt = getMessageTimestampMs(message.completedAt)
+  if (completedAt !== undefined && completedAt >= startedAt) {
+    return formatCompactDuration(completedAt - startedAt)
+  }
+
   const blockEndTimes =
     message.blocks
       ?.map(block => block.createdAt)
@@ -168,6 +210,10 @@ function getStoppedElapsedDuration(message: WorkbenchMessage): string {
 
 function isCancelledAssistantMessage(message: WorkbenchMessage): boolean {
   return message.runtimeStatus === 'cancelled'
+}
+
+function isCancelledPlaceholderContent(content: string): boolean {
+  return ['interrupted', 'cancelled', 'canceled', 'aborted'].includes(content.trim().toLowerCase())
 }
 
 function formatMessageTime(createdAt: string) {
@@ -206,17 +252,46 @@ async function copyText(text: string) {
   document.body.removeChild(textarea)
 }
 
-function UserMessage({ message }: { message: WorkbenchMessage }) {
+function UserMessage({
+  message,
+  onOpenWorkspaceFile,
+}: {
+  message: WorkbenchMessage
+  onOpenWorkspaceFile?: (path: string) => void
+}) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
-  const codexLocalFileMentions = parseCodexLocalFileMentions(message.content)
-  const displayContent = codexLocalFileMentions?.requestText ?? message.content
-  const imageAttachments = (message.attachments ?? []).filter(isImageAttachment)
-  const documentAttachments = (message.attachments ?? []).filter(
-    attachment => !isImageAttachment(attachment)
+  const codexLocalFileMentions = useMemo(
+    () => parseCodexLocalFileMentions(message.content),
+    [message.content]
   )
-  const localImageMentions =
-    imageAttachments.length > 0 ? [] : (codexLocalFileMentions?.images ?? [])
+  const displayContent = codexLocalFileMentions?.requestText ?? message.content
+  const imageAttachments = useMemo(
+    () => (message.attachments ?? []).filter(isImageAttachment),
+    [message.attachments]
+  )
+  const documentAttachments = useMemo(
+    () => (message.attachments ?? []).filter(attachment => !isImageAttachment(attachment)),
+    [message.attachments]
+  )
+  const localImageMentions = useMemo(
+    () => (imageAttachments.length > 0 ? [] : (codexLocalFileMentions?.images ?? [])),
+    [codexLocalFileMentions?.images, imageAttachments.length]
+  )
+  const localFileMentions = codexLocalFileMentions?.files ?? []
+  const localImageAttachments = useMemo(
+    () =>
+      localImageMentions.map((image, index) =>
+        createLocalImageMentionAttachment(image, index, message.createdAt)
+      ),
+    [localImageMentions, message.createdAt]
+  )
+  const imagePreviewAttachments = useMemo(
+    () => (imageAttachments.length > 0 ? imageAttachments : localImageAttachments),
+    [imageAttachments, localImageAttachments]
+  )
+  const hasImagePreviews = imagePreviewAttachments.length > 0
+  const hasMultipleImagePreviews = imagePreviewAttachments.length > 1
   const shouldCollapse =
     displayContent.length > USER_MESSAGE_COLLAPSE_CHARACTERS ||
     displayContent.split('\n').length > USER_MESSAGE_COLLAPSE_LINES
@@ -224,36 +299,89 @@ function UserMessage({ message }: { message: WorkbenchMessage }) {
 
   return (
     <div
-      className="flex max-w-[80%] flex-col items-end gap-1.5"
+      className={[
+        'flex flex-col items-end gap-1.5',
+        hasImagePreviews ? 'w-full max-w-full' : 'max-w-[80%]',
+      ].join(' ')}
       data-testid="message-hover-region"
       onPointerEnter={() => setAreHoverActionsVisible(true)}
       onPointerLeave={() => setAreHoverActionsVisible(false)}
     >
-      <div className="flex w-fit max-w-full flex-col items-end gap-1.5">
-        {(imageAttachments.length > 0 ||
-          localImageMentions.length > 0 ||
+      <div
+        className={[
+          'flex max-w-full flex-col items-end gap-1.5',
+          hasImagePreviews ? 'w-full' : 'w-fit',
+        ].join(' ')}
+      >
+        {(imagePreviewAttachments.length > 0 ||
+          localFileMentions.length > 0 ||
           documentAttachments.length > 0) && (
-          <div className="flex max-w-full flex-col items-end gap-2">
-            {(imageAttachments.length > 0 || localImageMentions.length > 0) && (
+          <div
+            className={[
+              'flex max-w-full flex-col items-end gap-2',
+              hasImagePreviews ? 'w-full' : '',
+            ].join(' ')}
+          >
+            {hasImagePreviews && (
               <div
                 data-testid="message-image-attachments"
-                className="flex max-w-full flex-row flex-wrap justify-end gap-2"
+                className={[
+                  'flex w-full max-w-full flex-row flex-nowrap gap-2',
+                  hasMultipleImagePreviews
+                    ? 'scrollbar-none justify-start overflow-x-auto overscroll-x-contain'
+                    : 'justify-end overflow-visible',
+                ].join(' ')}
               >
-                {imageAttachments.map(attachment => (
-                  <MessageImageAttachmentPreview key={attachment.id} attachment={attachment} />
-                ))}
-                {localImageMentions.map(image => (
-                  <MessageLocalImagePreview key={image.path} image={image} />
+                {imagePreviewAttachments.map((attachment, index) => (
+                  <MessageImageAttachmentPreview
+                    key={`${attachment.id}:${attachment.local_preview_url ?? attachment.filename}`}
+                    attachment={attachment}
+                    galleryAttachments={imagePreviewAttachments}
+                    galleryIndex={index}
+                    imageTestId={
+                      imageAttachments.length > 0
+                        ? 'message-image-preview'
+                        : 'message-local-image-preview'
+                    }
+                    buttonTestId={
+                      imageAttachments.length > 0
+                        ? 'message-image-preview-button'
+                        : 'message-local-image-preview-button'
+                    }
+                    loadingTestId={
+                      imageAttachments.length > 0
+                        ? 'message-image-preview-loading'
+                        : 'message-local-image-preview-loading'
+                    }
+                    errorTestId={
+                      imageAttachments.length > 0
+                        ? 'message-image-preview-error'
+                        : 'message-local-image-preview-error'
+                    }
+                    hideOnError={imageAttachments.length === 0}
+                  />
                 ))}
               </div>
             )}
+            {localFileMentions.map(file => (
+              <MessageCodexFileMention
+                key={`${file.filename}:${file.path}`}
+                file={file}
+                onOpenFile={onOpenWorkspaceFile}
+              />
+            ))}
             {documentAttachments.map(attachment => (
               <MessageDocumentAttachment key={attachment.id} attachment={attachment} />
             ))}
           </div>
         )}
         {displayContent && (
-          <div className="max-w-full overflow-hidden rounded-2xl bg-muted text-[13px] leading-5 text-text-primary">
+          <div
+            className={[
+              'overflow-hidden rounded-2xl bg-muted text-[13px] leading-5 text-text-primary',
+              hasImagePreviews ? 'max-w-[80%]' : 'max-w-full',
+            ].join(' ')}
+          >
             <div
               data-testid="user-message-content"
               className={[
@@ -298,26 +426,11 @@ function UserMessage({ message }: { message: WorkbenchMessage }) {
   )
 }
 
-function MessageLocalImagePreview({ image }: { image: { filename: string; path: string } }) {
-  const [hasLoadError, setHasLoadError] = useState(false)
-  const imageSrc = resolveDirectMarkdownImageSrc(image.path)
-  if (!imageSrc || hasLoadError) return null
-
-  return (
-    <img
-      data-testid="message-local-image-preview"
-      src={imageSrc}
-      alt={image.filename}
-      className="block max-h-36 max-w-[180px] shrink-0 rounded-xl border border-border bg-base object-contain"
-      loading="lazy"
-      onError={() => setHasLoadError(true)}
-    />
-  )
-}
-
-function parseCodexLocalFileMentions(
-  content: string
-): { requestText: string; images: Array<{ filename: string; path: string }> } | null {
+function parseCodexLocalFileMentions(content: string): {
+  requestText: string
+  images: Array<{ filename: string; path: string }>
+  files: Array<{ filename: string; path: string }>
+} | null {
   if (!CODEX_FILE_MENTIONS_HEADER_PATTERN.test(content)) return null
 
   const requestMarker = content.match(CODEX_REQUEST_MARKER_PATTERN)
@@ -325,23 +438,95 @@ function parseCodexLocalFileMentions(
     requestMarker?.index === undefined
       ? ''
       : content.slice(requestMarker.index + requestMarker[0].length).trim()
-  if (!requestText) return null
 
   const filesText =
     requestMarker?.index === undefined ? content : content.slice(0, requestMarker.index)
   const images: Array<{ filename: string; path: string }> = []
+  const files: Array<{ filename: string; path: string }> = []
   for (const match of filesText.matchAll(CODEX_FILE_MENTION_LINE_PATTERN)) {
     const filename = match[1]?.trim()
     const path = match[2]?.trim()
-    if (!filename || !path || !isLocalImageMention(filename, path)) continue
-    images.push({ filename, path })
+    if (!filename || !path) continue
+    const target = { filename, path }
+    if (isLocalImageMention(filename, path)) {
+      if (!images.some(image => image.path === path || image.filename === filename)) {
+        images.push(target)
+      }
+      continue
+    }
+    if (!files.some(file => file.path === path || file.filename === filename)) {
+      files.push(target)
+    }
   }
 
-  return { requestText, images }
+  if (!requestText && images.length === 0 && files.length === 0) return null
+
+  return { requestText, images, files }
 }
 
 function isLocalImageMention(filename: string, path: string): boolean {
   return LOCAL_IMAGE_EXTENSION_PATTERN.test(filename) || LOCAL_IMAGE_EXTENSION_PATTERN.test(path)
+}
+
+function getLocalImageExtension(filename: string, path: string): string {
+  const source = LOCAL_IMAGE_EXTENSION_PATTERN.test(filename) ? filename : path
+  const match = source.match(/(\.[a-z0-9]+)(?:[?#].*)?$/i)
+  return match?.[1]?.toLowerCase() ?? ''
+}
+
+function createLocalImageMentionAttachment(
+  image: { filename: string; path: string },
+  index: number,
+  createdAt: string
+): Attachment {
+  const fileExtension = getLocalImageExtension(image.filename, image.path)
+
+  return {
+    id: -100000 - index,
+    filename: image.filename,
+    file_size: 0,
+    mime_type: LOCAL_IMAGE_MIME_TYPES[fileExtension] ?? 'image/png',
+    status: 'ready',
+    file_extension: fileExtension,
+    created_at: createdAt,
+    local_preview_url: image.path,
+  }
+}
+
+function MessageCodexFileMention({
+  file,
+  onOpenFile,
+}: {
+  file: { filename: string; path: string }
+  onOpenFile?: (path: string) => void
+}) {
+  const useBracesIcon = shouldUseBracesFileIcon(file.filename)
+  const Icon = useBracesIcon ? Braces : FileIcon
+  const iconTestId = useBracesIcon
+    ? 'message-codex-file-braces-icon'
+    : 'message-codex-file-document-icon'
+
+  return (
+    <button
+      type="button"
+      data-testid="message-codex-file-mention"
+      className="inline-flex h-10 max-w-[260px] items-center gap-2 rounded-2xl border border-border bg-base px-3 text-left text-[13px] font-semibold leading-none text-text-primary shadow-sm hover:bg-muted"
+      title={file.path}
+      aria-label={file.filename}
+      onClick={() => onOpenFile?.(file.path)}
+    >
+      <Icon
+        data-testid={iconTestId}
+        className="h-3.5 w-3.5 shrink-0 text-text-muted"
+        strokeWidth={1.8}
+      />
+      <span className="min-w-0 truncate">{file.filename}</span>
+    </button>
+  )
+}
+
+function shouldUseBracesFileIcon(filename: string): boolean {
+  return /\.(?:json|jsonc)$/i.test(filename)
 }
 
 function MessageDocumentAttachment({ attachment }: { attachment: Attachment }) {
@@ -364,16 +549,38 @@ function MessageDocumentAttachment({ attachment }: { attachment: Attachment }) {
   )
 }
 
-function MessageImageAttachmentPreview({ attachment }: { attachment: Attachment }) {
+function MessageImageAttachmentPreview({
+  attachment,
+  galleryAttachments,
+  galleryIndex,
+  buttonTestId = 'message-image-preview-button',
+  imageTestId = 'message-image-preview',
+  loadingTestId = 'message-image-preview-loading',
+  errorTestId = 'message-image-preview-error',
+  hideOnError = false,
+}: {
+  attachment: Attachment
+  galleryAttachments: Attachment[]
+  galleryIndex: number
+  buttonTestId?: string
+  imageTestId?: string
+  loadingTestId?: string
+  errorTestId?: string
+  hideOnError?: boolean
+}) {
   return (
     <AttachmentImagePreview
       attachment={attachment}
-      buttonTestId="message-image-preview-button"
-      imageTestId="message-image-preview"
-      loadingTestId="message-image-preview-loading"
-      errorTestId="message-image-preview-error"
-      imageClassName="block max-h-36 max-w-[180px] shrink-0 rounded-xl border border-border bg-base object-contain"
-      placeholderClassName="flex h-20 w-28 shrink-0 items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
+      buttonTestId={buttonTestId}
+      imageTestId={imageTestId}
+      loadingTestId={loadingTestId}
+      errorTestId={errorTestId}
+      imageClassName="block h-20 w-20 shrink-0 rounded-xl border border-border bg-base object-cover"
+      placeholderClassName="flex h-20 w-20 shrink-0 items-center justify-center rounded-xl border border-border bg-surface text-text-muted"
+      buttonClassName="block h-20 w-20 shrink-0 cursor-zoom-in p-0 text-left"
+      galleryAttachments={galleryAttachments}
+      galleryIndex={galleryIndex}
+      hideOnError={hideOnError}
     />
   )
 }
@@ -625,9 +832,13 @@ function AssistantMessage({
 }) {
   const { t } = useTranslation('chat')
   const isCancelled = isCancelledAssistantMessage(message)
-  const shouldHideContent = isCancelled || shouldHideFailedAssistantContent(message)
+  const shouldShowStoppedNotice = isCancelled && message.stoppedNotice !== false
+  const shouldHideContent =
+    shouldHideFailedAssistantContent(message) ||
+    (isCancelled && isCancelledPlaceholderContent(message.content))
   const visibleContent = shouldHideContent ? '' : message.content
-  const hiddenErrorContent = shouldHideContent && !isCancelled ? message.content.trim() : undefined
+  const hiddenErrorContent =
+    message.status === 'failed' && shouldHideContent ? message.content.trim() : undefined
   const displayBlocks = getDisplayProcessingBlocks(message.blocks, visibleContent)
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
@@ -668,6 +879,16 @@ function AssistantMessage({
         onPointerLeave={() => setAreHoverActionsVisible(false)}
       >
         <div className="w-fit max-w-full">
+          {shouldShowStoppedNotice ? (
+            <div
+              data-testid="assistant-stopped-notice"
+              className="mb-3 border-b border-border pb-2 text-sm font-medium text-text-muted"
+            >
+              {t('assistant_status.stopped_after', {
+                duration: getStoppedElapsedDuration(message),
+              })}
+            </div>
+          ) : null}
           {hasBlocks && (
             <ToolBlocksDisplay
               blocks={displayBlocks}
@@ -718,16 +939,6 @@ function AssistantMessage({
               onRevert={onRevertFileChanges}
               onOpenReview={onOpenFileChangesReview}
             />
-          ) : null}
-          {isCancelled ? (
-            <div
-              data-testid="assistant-stopped-notice"
-              className="mt-4 flex justify-end border-b border-border pb-2 text-sm font-medium text-text-muted"
-            >
-              {t('assistant_status.stopped_after', {
-                duration: getStoppedElapsedDuration(message),
-              })}
-            </div>
           ) : null}
         </div>
         {message.status !== 'streaming' &&

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -2,6 +2,45 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { ScrollableMessageArea } from './ScrollableMessageArea'
 
+function mockRect(element: Element, top: number, bottom: number) {
+  element.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        top,
+        bottom,
+        left: 0,
+        right: 320,
+        width: 320,
+        height: bottom - top,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      }) as DOMRect
+  )
+}
+
+function mockScrollRelativeRect(
+  element: Element,
+  scroller: HTMLElement,
+  topAtScrollZero: number,
+  height: number
+) {
+  element.getBoundingClientRect = vi.fn(() => {
+    const top = topAtScrollZero - scroller.scrollTop
+    return {
+      top,
+      bottom: top + height,
+      left: 0,
+      right: 320,
+      width: 320,
+      height,
+      x: 0,
+      y: top,
+      toJSON: () => ({}),
+    } as DOMRect
+  })
+}
+
 describe('ScrollableMessageArea', () => {
   let requestAnimationFrameSpy: ReturnType<typeof vi.spyOn>
   let cancelAnimationFrameSpy: ReturnType<typeof vi.spyOn>
@@ -199,7 +238,7 @@ describe('ScrollableMessageArea', () => {
       configurable: true,
     })
     Object.defineProperty(scroller, 'scrollTop', {
-      value: 180,
+      value: 180.5,
       writable: true,
       configurable: true,
     })
@@ -207,26 +246,36 @@ describe('ScrollableMessageArea', () => {
 
     fireEvent.scroll(scroller)
     rerender(<ScrollableMessageArea conversationKey="conversation-b" messages={[messageB]} />)
-
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
     rerender(<ScrollableMessageArea conversationKey="conversation-a" messages={[messageA]} />)
 
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
     expect(scroller.scrollTo).toHaveBeenLastCalledWith({
-      top: 180,
+      top: 180.5,
       behavior: 'auto',
     })
   })
 
-  test('scrolls to the bottom after a conversation finishes loading', () => {
-    const message = {
-      id: 'loaded-message',
+  test('does not overwrite a saved position while a reopened conversation is loading', () => {
+    const messageA = {
+      id: 'a-loading-restore',
       role: 'assistant' as const,
-      content: '加载后的历史消息',
+      content: '会话 A',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const messageB = {
+      id: 'b-loading-restore',
+      role: 'assistant' as const,
+      content: '会话 B',
       status: 'done' as const,
       createdAt: '2026-05-29T00:00:00.000Z',
     }
     const { rerender } = render(
-      <ScrollableMessageArea conversationKey="conversation-load-bottom" messages={[message]} />
+      <ScrollableMessageArea conversationKey="conversation-loading-a" messages={[messageA]} />
     )
 
     const scroller = screen.getByTestId('chat-message-scroll-area')
@@ -243,16 +292,21 @@ describe('ScrollableMessageArea', () => {
       writable: true,
       configurable: true,
     })
-    scroller.scrollTo = vi.fn()
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
 
     fireEvent.scroll(scroller)
     rerender(
-      <ScrollableMessageArea conversationKey="conversation-load-bottom" messages={[]} loading />
+      <ScrollableMessageArea conversationKey="conversation-loading-b" messages={[messageB]} />
     )
-
     ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    scroller.scrollTop = 0
     rerender(
-      <ScrollableMessageArea conversationKey="conversation-load-bottom" messages={[message]} />
+      <ScrollableMessageArea conversationKey="conversation-loading-a" messages={[]} loading />
+    )
+    rerender(
+      <ScrollableMessageArea conversationKey="conversation-loading-a" messages={[messageA]} />
     )
 
     act(() => {
@@ -260,7 +314,264 @@ describe('ScrollableMessageArea', () => {
     })
 
     expect(scroller.scrollTo).toHaveBeenLastCalledWith({
-      top: 600,
+      top: 180,
+      behavior: 'auto',
+    })
+  })
+
+  test('restores reopened conversations relative to the saved message anchor', () => {
+    const messagesA = [
+      {
+        id: 'anchor-a-intro',
+        role: 'assistant' as const,
+        content: '会话 A 前置内容',
+        status: 'done' as const,
+        createdAt: '2026-05-29T00:00:00.000Z',
+      },
+      {
+        id: 'anchor-a-target',
+        role: 'assistant' as const,
+        content: '会话 A 当前阅读内容',
+        status: 'done' as const,
+        createdAt: '2026-05-29T00:00:01.000Z',
+      },
+      {
+        id: 'anchor-a-after',
+        role: 'assistant' as const,
+        content: '会话 A 后续内容',
+        status: 'done' as const,
+        createdAt: '2026-05-29T00:00:02.000Z',
+      },
+    ]
+    const messageB = {
+      id: 'anchor-b',
+      role: 'assistant' as const,
+      content: '会话 B',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="conversation-anchor-a" messages={messagesA} />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 300,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+    mockRect(scroller, 100, 300)
+    mockRect(screen.getByText('会话 A 前置内容').closest('[data-message-id]')!, -160, -20)
+    mockRect(screen.getByText('会话 A 当前阅读内容').closest('[data-message-id]')!, 80, 220)
+    mockRect(screen.getByText('会话 A 后续内容').closest('[data-message-id]')!, 240, 360)
+
+    fireEvent.scroll(scroller)
+    rerender(
+      <ScrollableMessageArea conversationKey="conversation-anchor-b" messages={[messageB]} />
+    )
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1400,
+      configurable: true,
+    })
+    scroller.scrollTop = 0
+    rerender(<ScrollableMessageArea conversationKey="conversation-anchor-a" messages={messagesA} />)
+    mockRect(scroller, 100, 300)
+    mockScrollRelativeRect(
+      screen.getByText('会话 A 当前阅读内容').closest('[data-message-id]')!,
+      scroller,
+      520,
+      140
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 440,
+      behavior: 'auto',
+    })
+  })
+
+  test('restores reopened conversations relative to markdown anchors inside long messages', () => {
+    const messageA = {
+      id: 'markdown-anchor-message',
+      role: 'assistant' as const,
+      content: [
+        '- 默认配置',
+        '- 构建运行',
+        '',
+        '## 主要功能',
+        '',
+        '- Node',
+        '- Pod',
+        '- NodeResourceTopology',
+      ].join('\n'),
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const messageB = {
+      id: 'markdown-anchor-b',
+      role: 'assistant' as const,
+      content: '会话 B',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea
+        conversationKey="conversation-markdown-anchor-a"
+        messages={[messageA]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 300,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+    mockRect(scroller, 100, 300)
+    mockRect(screen.getByText('默认配置').closest('[data-scroll-anchor]')!, -220, -188)
+    mockRect(screen.getByText('构建运行').closest('[data-scroll-anchor]')!, -170, -138)
+    mockRect(screen.getByText('主要功能').closest('[data-scroll-anchor]')!, -78, -42)
+    mockRect(screen.getByText('Node').closest('[data-scroll-anchor]')!, 92, 124)
+    mockRect(screen.getByText('Pod').closest('[data-scroll-anchor]')!, 140, 172)
+
+    fireEvent.scroll(scroller)
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="conversation-markdown-anchor-b"
+        messages={[messageB]}
+      />
+    )
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1400,
+      configurable: true,
+    })
+    scroller.scrollTop = 0
+    rerender(
+      <ScrollableMessageArea
+        conversationKey="conversation-markdown-anchor-a"
+        messages={[messageA]}
+      />
+    )
+    mockRect(scroller, 100, 300)
+    mockScrollRelativeRect(
+      screen.getByText('Node').closest('[data-scroll-anchor]')!,
+      scroller,
+      520,
+      32
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 428,
+      behavior: 'auto',
+    })
+  })
+
+  test('keeps the restored position while reopened conversation content grows', () => {
+    const messageA = {
+      id: 'a-growth',
+      role: 'assistant' as const,
+      content: '会话 A',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const messageB = {
+      id: 'b-growth',
+      role: 'assistant' as const,
+      content: '会话 B',
+      status: 'done' as const,
+      createdAt: '2026-05-29T00:00:00.000Z',
+    }
+    const { rerender } = render(
+      <ScrollableMessageArea conversationKey="conversation-growth-a" messages={[messageA]} />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 260,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      scroller.scrollTop = Number(top)
+    })
+
+    fireEvent.scroll(scroller)
+    rerender(
+      <ScrollableMessageArea conversationKey="conversation-growth-b" messages={[messageB]} />
+    )
+
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
+    ;(scroller.scrollTo as ReturnType<typeof vi.fn>).mockClear()
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 240,
+      configurable: true,
+    })
+    scroller.scrollTop = 0
+    rerender(
+      <ScrollableMessageArea conversationKey="conversation-growth-a" messages={[messageA]} />
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(0)
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 40,
+      behavior: 'auto',
+    })
+
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1200,
+      configurable: true,
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(50)
+    })
+
+    expect(scroller.scrollTo).toHaveBeenLastCalledWith({
+      top: 260,
       behavior: 'auto',
     })
   })

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -8,7 +8,19 @@ import { MessageList } from './MessageList'
 
 const BOTTOM_THRESHOLD = 48
 const STABLE_SCROLL_DELAYS = [0, 50, 150, 300]
-const conversationScrollPositions = new Map<string, number>()
+const MESSAGE_ANCHOR_SELECTOR = '[data-message-id]'
+const SCROLL_ANCHOR_SELECTOR = '[data-scroll-anchor]'
+
+interface ConversationScrollSnapshot {
+  scrollTop: number
+  anchorMessageId?: string
+  anchorOffsetTop?: number
+  anchorDocumentTop?: number
+  anchorIndex?: number
+  anchorKind?: 'message' | 'content'
+}
+
+const conversationScrollSnapshots = new Map<string, ConversationScrollSnapshot>()
 
 interface ScrollableMessageAreaProps {
   messages: WorkbenchMessage[]
@@ -66,12 +78,11 @@ export function ScrollableMessageArea({
   const previousMessageCountRef = useRef(0)
   const scrollTimersRef = useRef<Array<ReturnType<typeof setTimeout>>>([])
   const scrollFrameRef = useRef<number | null>(null)
+  const restoringScrollKeyRef = useRef<string | null>(null)
+  const applyingSavedScrollRef = useRef(false)
   const [showScrollButton, setShowScrollButton] = useState(false)
   const lastMessage = messages[messages.length - 1]
-  const currentScrollKey = useMemo(
-    () => scrollPositionKey(conversationKey),
-    [conversationKey]
-  )
+  const currentScrollKey = useMemo(() => scrollPositionKey(conversationKey), [conversationKey])
   const messageScrollSignature = useMemo(() => {
     if (!lastMessage) return 'empty'
 
@@ -101,6 +112,7 @@ export function ScrollableMessageArea({
   const clearScheduledScrolls = useCallback(() => {
     scrollTimersRef.current.forEach(timer => clearTimeout(timer))
     scrollTimersRef.current = []
+    applyingSavedScrollRef.current = false
 
     if (scrollFrameRef.current !== null) {
       cancelAnimationFrame(scrollFrameRef.current)
@@ -111,53 +123,81 @@ export function ScrollableMessageArea({
   const saveCurrentScrollPosition = useCallback(
     (scrollTop?: number) => {
       const element = scrollRef.current
-      if (!element || currentScrollKey === null) return
-      conversationScrollPositions.set(currentScrollKey, scrollTop ?? element.scrollTop)
+      const content = contentRef.current
+      if (!element || currentScrollKey === null || messages.length === 0) return
+      conversationScrollSnapshots.set(
+        currentScrollKey,
+        createScrollSnapshot(element, content, scrollTop)
+      )
     },
-    [currentScrollKey]
+    [currentScrollKey, messages.length]
   )
 
-  const updateScrollState = useCallback(() => {
-    const element = scrollRef.current
-    if (!element) return
+  const updateScrollState = useCallback(
+    (options: { forceSave?: boolean; skipSave?: boolean } = {}) => {
+      const element = scrollRef.current
+      if (!element) return
 
-    const overflow = element.scrollHeight > element.clientHeight + 8
-    const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
-    const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
-    isAtBottomRef.current = isAtBottom
-    if (!isAtBottom) {
-      clearScheduledScrolls()
-    }
-    saveCurrentScrollPosition()
-    setShowScrollButton(overflow && !isAtBottom)
-  }, [clearScheduledScrolls, saveCurrentScrollPosition])
+      if (messages.length === 0) {
+        isAtBottomRef.current = true
+        setShowScrollButton(false)
+        return
+      }
 
-  const setScrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
-    const element = scrollRef.current
-    if (!element) return
+      const overflow = element.scrollHeight > element.clientHeight + 8
+      const distanceToBottom = element.scrollHeight - element.clientHeight - element.scrollTop
+      const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
+      isAtBottomRef.current = isAtBottom
+      if (!isAtBottom && restoringScrollKeyRef.current !== currentScrollKey) {
+        clearScheduledScrolls()
+      }
+      if (
+        !options.skipSave &&
+        (options.forceSave || restoringScrollKeyRef.current !== currentScrollKey)
+      ) {
+        saveCurrentScrollPosition()
+      }
+      setShowScrollButton(overflow && !isAtBottom)
+    },
+    [clearScheduledScrolls, currentScrollKey, messages.length, saveCurrentScrollPosition]
+  )
 
-    if (typeof element.scrollTo === 'function') {
-      element.scrollTo({
-        top: element.scrollHeight,
-        behavior,
-      })
-    } else {
-      element.scrollTop = element.scrollHeight
-    }
-    saveCurrentScrollPosition(element.scrollHeight)
-    isAtBottomRef.current = true
-    setShowScrollButton(false)
-  }, [saveCurrentScrollPosition])
+  const setScrollToBottom = useCallback(
+    (behavior: ScrollBehavior = 'auto') => {
+      const element = scrollRef.current
+      if (!element) return
+
+      if (typeof element.scrollTo === 'function') {
+        element.scrollTo({
+          top: element.scrollHeight,
+          behavior,
+        })
+      } else {
+        element.scrollTop = element.scrollHeight
+      }
+      saveCurrentScrollPosition(element.scrollHeight)
+      isAtBottomRef.current = true
+      setShowScrollButton(false)
+    },
+    [saveCurrentScrollPosition]
+  )
 
   const restoreSavedScrollPosition = useCallback(
-    (key: string) => {
+    (key: string, options: { clearScheduled?: boolean } = {}) => {
       const element = scrollRef.current
-      const savedScrollTop = conversationScrollPositions.get(key)
-      if (!element || savedScrollTop === undefined) return
+      const content = contentRef.current
+      const savedSnapshot = conversationScrollSnapshots.get(key)
+      if (!element || !savedSnapshot) return
 
-      clearScheduledScrolls()
+      if (options.clearScheduled) {
+        clearScheduledScrolls()
+      }
       const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
-      const nextScrollTop = Math.min(savedScrollTop, maxScrollTop)
+      const nextScrollTop = Math.min(
+        getRestoredScrollTop(element, content, savedSnapshot),
+        maxScrollTop
+      )
+      applyingSavedScrollRef.current = true
       if (typeof element.scrollTo === 'function') {
         element.scrollTo({
           top: nextScrollTop,
@@ -172,8 +212,39 @@ export function ScrollableMessageArea({
       const isAtBottom = distanceToBottom <= BOTTOM_THRESHOLD
       isAtBottomRef.current = isAtBottom
       setShowScrollButton(overflow && !isAtBottom)
+      conversationScrollSnapshots.set(key, savedSnapshot)
+
+      const applyingTimer = setTimeout(() => {
+        applyingSavedScrollRef.current = false
+      }, 0)
+      scrollTimersRef.current.push(applyingTimer)
     },
     [clearScheduledScrolls]
+  )
+
+  const scheduleStableRestoreSavedScrollPosition = useCallback(
+    (key: string) => {
+      clearScheduledScrolls()
+      restoringScrollKeyRef.current = key
+
+      STABLE_SCROLL_DELAYS.forEach(delay => {
+        const timer = setTimeout(() => {
+          restoreSavedScrollPosition(key, { clearScheduled: false })
+        }, delay)
+        scrollTimersRef.current.push(timer)
+      })
+
+      const clearRestoreTimer = setTimeout(
+        () => {
+          if (restoringScrollKeyRef.current === key) {
+            restoringScrollKeyRef.current = null
+          }
+        },
+        Math.max(...STABLE_SCROLL_DELAYS) + 50
+      )
+      scrollTimersRef.current.push(clearRestoreTimer)
+    },
+    [clearScheduledScrolls, restoreSavedScrollPosition]
   )
 
   const scrollToBottom = useCallback(
@@ -211,17 +282,17 @@ export function ScrollableMessageArea({
     const conversationChanged = previousConversationKeyRef.current !== conversationKey
     const messagesLoaded = previousMessageCountRef.current === 0 && messages.length > 0
     const lastMessageChanged = previousLastMessageIdRef.current !== (lastMessage?.id ?? null)
-    const shouldRestoreScroll =
-      Boolean(
-        currentScrollKey &&
-          messages.length > 0 &&
-          conversationChanged &&
-          !messagesLoaded &&
-          conversationScrollPositions.has(currentScrollKey)
-      )
+    const shouldRestoreScroll = Boolean(
+      currentScrollKey &&
+      messages.length > 0 &&
+      (conversationChanged || messagesLoaded) &&
+      conversationScrollSnapshots.has(currentScrollKey)
+    )
     const shouldForceBottom =
       !shouldRestoreScroll &&
-      (conversationChanged || messagesLoaded || (lastMessageChanged && lastMessage?.role === 'user'))
+      (conversationChanged ||
+        messagesLoaded ||
+        (lastMessageChanged && lastMessage?.role === 'user'))
 
     previousConversationKeyRef.current = conversationKey
     previousLastMessageIdRef.current = lastMessage?.id ?? null
@@ -230,7 +301,7 @@ export function ScrollableMessageArea({
     if (messages.length === 0) return
 
     if (shouldRestoreScroll && currentScrollKey) {
-      restoreSavedScrollPosition(currentScrollKey)
+      scheduleStableRestoreSavedScrollPosition(currentScrollKey)
       return
     }
 
@@ -244,13 +315,16 @@ export function ScrollableMessageArea({
     lastMessage,
     messageScrollSignature,
     messages.length,
-    restoreSavedScrollPosition,
+    scheduleStableRestoreSavedScrollPosition,
     scheduleStableScrollToBottom,
     setScrollToBottom,
   ])
 
   useLayoutEffect(() => {
-    updateScrollState()
+    const frame = requestAnimationFrame(() => {
+      updateScrollState()
+    })
+    return () => cancelAnimationFrame(frame)
   }, [isWaitingForAssistant, messages, updateScrollState])
 
   useEffect(() => {
@@ -258,6 +332,12 @@ export function ScrollableMessageArea({
     if (!content || typeof ResizeObserver === 'undefined') return
 
     const resizeObserver = new ResizeObserver(() => {
+      const restoringKey = restoringScrollKeyRef.current
+      if (restoringKey && restoringKey === currentScrollKey) {
+        restoreSavedScrollPosition(restoringKey, { clearScheduled: false })
+        return
+      }
+
       if (isAtBottomRef.current) {
         scrollToBottom()
       }
@@ -265,7 +345,7 @@ export function ScrollableMessageArea({
 
     resizeObserver.observe(content)
     return () => resizeObserver.disconnect()
-  }, [scrollToBottom])
+  }, [currentScrollKey, restoreSavedScrollPosition, scrollToBottom])
 
   useEffect(() => clearScheduledScrolls, [clearScheduledScrolls])
 
@@ -279,7 +359,18 @@ export function ScrollableMessageArea({
         ref={scrollRef}
         data-testid={scrollTestId}
         className={cn('h-full overflow-x-hidden overflow-y-auto', scrollerClassName)}
-        onScroll={updateScrollState}
+        onScroll={() => {
+          if (
+            applyingSavedScrollRef.current &&
+            restoringScrollKeyRef.current === currentScrollKey
+          ) {
+            updateScrollState({ skipSave: true })
+            return
+          }
+          applyingSavedScrollRef.current = false
+          restoringScrollKeyRef.current = null
+          updateScrollState({ forceSave: true })
+        }}
       >
         <div
           ref={contentRef}
@@ -363,4 +454,123 @@ export function ScrollableMessageArea({
 
 function scrollPositionKey(conversationKey: string | number | null | undefined): string | null {
   return conversationKey == null ? null : String(conversationKey)
+}
+
+function createScrollSnapshot(
+  scroller: HTMLElement,
+  content: HTMLElement | null,
+  scrollTop?: number
+): ConversationScrollSnapshot {
+  const snapshot: ConversationScrollSnapshot = {
+    scrollTop: scrollTop ?? scroller.scrollTop,
+  }
+  if (scrollTop !== undefined || !content) return snapshot
+
+  const anchor = findTopVisibleMessageAnchor(scroller, content)
+  if (!anchor) return snapshot
+
+  const scrollerRect = scroller.getBoundingClientRect()
+  const anchorRect = anchor.getBoundingClientRect()
+  const message = anchor.matches(MESSAGE_ANCHOR_SELECTOR)
+    ? anchor
+    : anchor.closest<HTMLElement>(MESSAGE_ANCHOR_SELECTOR)
+  const messageId = message?.dataset.messageId
+  if (!messageId) return snapshot
+
+  snapshot.anchorMessageId = messageId
+  snapshot.anchorOffsetTop = anchorRect.top - scrollerRect.top
+  snapshot.anchorDocumentTop = snapshot.scrollTop + snapshot.anchorOffsetTop
+  snapshot.anchorKind = anchor.matches(SCROLL_ANCHOR_SELECTOR) ? 'content' : 'message'
+  if (message && snapshot.anchorKind === 'content') {
+    snapshot.anchorIndex = getMessageScrollAnchors(message).indexOf(anchor)
+  }
+  return snapshot
+}
+
+function getRestoredScrollTop(
+  scroller: HTMLElement,
+  content: HTMLElement | null,
+  snapshot: ConversationScrollSnapshot
+): number {
+  if (!content || !snapshot.anchorMessageId || snapshot.anchorOffsetTop === undefined) {
+    return Math.max(0, snapshot.scrollTop)
+  }
+
+  const anchor = findSavedAnchor(content, snapshot)
+  if (!anchor || !hasMeasurableRect(anchor)) {
+    return Math.max(0, snapshot.scrollTop)
+  }
+
+  const scrollerRect = scroller.getBoundingClientRect()
+  const anchorRect = anchor.getBoundingClientRect()
+  const currentAnchorOffsetTop = anchorRect.top - scrollerRect.top
+  if (snapshot.anchorDocumentTop !== undefined) {
+    const currentAnchorDocumentTop = scroller.scrollTop + currentAnchorOffsetTop
+    return Math.max(0, snapshot.scrollTop + currentAnchorDocumentTop - snapshot.anchorDocumentTop)
+  }
+
+  return Math.max(0, scroller.scrollTop + currentAnchorOffsetTop - snapshot.anchorOffsetTop)
+}
+
+function findTopVisibleMessageAnchor(
+  scroller: HTMLElement,
+  content: HTMLElement
+): HTMLElement | null {
+  return (
+    findTopVisibleAnchor(scroller, Array.from(content.querySelectorAll(SCROLL_ANCHOR_SELECTOR))) ??
+    findTopVisibleAnchor(scroller, Array.from(content.querySelectorAll(MESSAGE_ANCHOR_SELECTOR)))
+  )
+}
+
+function findTopVisibleAnchor(scroller: HTMLElement, anchors: Element[]): HTMLElement | null {
+  const scrollerRect = scroller.getBoundingClientRect()
+  let nearestAnchor: HTMLElement | null = null
+  let nearestDistance = Number.POSITIVE_INFINITY
+
+  for (const anchor of anchors) {
+    if (!(anchor instanceof HTMLElement)) continue
+    if (!hasMeasurableRect(anchor)) continue
+
+    const rect = anchor.getBoundingClientRect()
+    if (rect.bottom > scrollerRect.top && rect.top < scrollerRect.bottom) {
+      return anchor
+    }
+
+    const distance = Math.abs(rect.top - scrollerRect.top)
+    if (distance < nearestDistance) {
+      nearestDistance = distance
+      nearestAnchor = anchor
+    }
+  }
+
+  return nearestAnchor
+}
+
+function findSavedAnchor(
+  content: HTMLElement,
+  snapshot: ConversationScrollSnapshot
+): HTMLElement | null {
+  const message = findMessageAnchorById(content, snapshot.anchorMessageId ?? '')
+  if (!message) return null
+  if (snapshot.anchorKind !== 'content' || snapshot.anchorIndex === undefined) return message
+
+  return getMessageScrollAnchors(message)[snapshot.anchorIndex] ?? message
+}
+
+function findMessageAnchorById(content: HTMLElement, messageId: string): HTMLElement | null {
+  if (!messageId) return null
+  return (
+    Array.from(content.querySelectorAll<HTMLElement>(MESSAGE_ANCHOR_SELECTOR)).find(
+      anchor => anchor.dataset.messageId === messageId
+    ) ?? null
+  )
+}
+
+function getMessageScrollAnchors(message: HTMLElement): HTMLElement[] {
+  return Array.from(message.querySelectorAll<HTMLElement>(SCROLL_ANCHOR_SELECTOR))
+}
+
+function hasMeasurableRect(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect()
+  return rect.bottom > rect.top
 }

--- a/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.test.tsx
@@ -2,7 +2,7 @@ import '@/i18n'
 
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { ToolBlockItem } from './ToolBlockItem'
 import type { ProcessingBlock } from '@/types/workbench'
 
@@ -115,6 +115,30 @@ describe('ToolBlockItem', () => {
       'Beijing weather today June 17 2026 temperature rain'
     )
     expect(screen.queryByText(/"query"/)).not.toBeInTheDocument()
+  })
+
+  test('uses Codex filePath aliases for file tool labels and open actions', async () => {
+    const user = userEvent.setup()
+    const onOpenWorkspaceFile = vi.fn()
+
+    render(
+      <ToolBlockItem
+        block={{
+          id: 'read-1',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'Read',
+          toolInput: { filePath: '/Users/crystal/package.json' },
+          status: 'done',
+          createdAt: 1770000000002,
+        }}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /已读取 package.json/ }))
+
+    expect(onOpenWorkspaceFile).toHaveBeenCalledWith('/Users/crystal/package.json')
   })
 
   test('renders process text code blocks with shared syntax highlighting', () => {

--- a/wework/src/components/chat/blocks/ToolBlockItem.tsx
+++ b/wework/src/components/chat/blocks/ToolBlockItem.tsx
@@ -7,7 +7,7 @@ import type { TurnFileChangeItem, TurnFileChangesSummary } from '@/types/api'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { MarkdownCodeBlock } from '../MarkdownCodeBlock'
 import { parseUnifiedDiff } from '../parseUnifiedDiff'
-import { isCommandToolName, isWebSearchToolName } from './toolBlockActivity'
+import { isCommandToolName, isGuidanceToolName, isWebSearchToolName } from './toolBlockActivity'
 import { WebSearchActivityRows } from './WebSearchSources'
 import { getWebSearchActivityItems } from './webSearchActivity'
 
@@ -31,12 +31,7 @@ export function ToolBlockItem({
   const expanded = forceExpanded || userExpanded
 
   if (block.type === 'thinking') {
-    return (
-      <ThinkingBlockItem
-        block={block}
-        isRunning={isRunning}
-      />
-    )
+    return <ThinkingBlockItem block={block} isRunning={isRunning} />
   }
   if (block.type === 'text') {
     return <ProcessTextBlockItem block={block} isRunning={isRunning} />
@@ -89,7 +84,9 @@ export function ToolBlockItem({
   )
 }
 
-function ProcessFileChangesBlockItem({ block }: {
+function ProcessFileChangesBlockItem({
+  block,
+}: {
   block: Extract<ProcessingBlock, { type: 'file_changes' }>
 }) {
   const { t } = useTranslation('chat')
@@ -191,7 +188,13 @@ function fileChangeRowLabel(
   }
 }
 
-function InlineDiffPreview({ file, lines }: { file: TurnFileChangeItem; lines: DiffPreviewLine[] }) {
+function InlineDiffPreview({
+  file,
+  lines,
+}: {
+  file: TurnFileChangeItem
+  lines: DiffPreviewLine[]
+}) {
   const visibleLines = lines.slice(0, INLINE_DIFF_MAX_LINES)
   const truncated = lines.length > INLINE_DIFF_MAX_LINES
 
@@ -503,22 +506,22 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
   const prefix = getToolStatusPrefix(block)
 
   if (isCommandToolName(name)) {
-    const command = getInputField(block, 'command', 'cmd')
+    const command = getInputField(block, 'command', 'cmd', 'commandLine')
     const shortCmd = command ? truncate(command.split('\n')[0], 40) : block.toolName
     return { icon: <TerminalIcon />, label: `${prefix.running} ${shortCmd}` }
   }
   if (name === 'write' || name === 'create_file' || name === 'write_file') {
-    const filePath = getInputField(block, 'file_path', 'path')
+    const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <FileIcon />, label: `${prefix.create} ${fileName}` }
   }
   if (name === 'edit' || name === 'str_replace_editor' || name === 'edit_file') {
-    const filePath = getInputField(block, 'file_path', 'path')
+    const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <EditIcon />, label: `${prefix.edit} ${fileName}` }
   }
   if (name === 'read' || name === 'read_file') {
-    const filePath = getInputField(block, 'file_path', 'path')
+    const filePath = getFileInputPath(block)
     const fileName = filePath ? filePath.split('/').pop() : '文件'
     return { icon: <FileIcon />, label: `${prefix.read} ${fileName}` }
   }
@@ -527,6 +530,9 @@ function getBlockLabel(block: ToolBlock): { icon: React.ReactNode; label: string
       icon: <Search className="h-4 w-4" strokeWidth={1.7} />,
       label: prefix.webSearch,
     }
+  }
+  if (isGuidanceToolName(name)) {
+    return { icon: <ToolIcon />, label: prefix.guidance }
   }
   return { icon: <ToolIcon />, label: `${prefix.generic} ${block.toolName}` }
 }
@@ -539,6 +545,7 @@ function getToolStatusPrefix(block: ToolBlock) {
       edit: '编辑失败',
       read: '读取失败',
       webSearch: '搜索网页失败',
+      guidance: '引导对话失败',
       generic: '执行失败',
     }
   }
@@ -550,6 +557,7 @@ function getToolStatusPrefix(block: ToolBlock) {
       edit: '已编辑',
       read: '已读取',
       webSearch: '已搜索网页',
+      guidance: '已引导对话',
       generic: '已运行',
     }
   }
@@ -560,6 +568,7 @@ function getToolStatusPrefix(block: ToolBlock) {
     edit: '正在编辑',
     read: '正在读取',
     webSearch: '正在搜索网页',
+    guidance: '正在引导对话',
     generic: '正在运行',
   }
 }
@@ -651,6 +660,9 @@ function renderBlockDetail(block: ToolBlock) {
   if (isWebSearchToolName(name)) {
     return <WebSearchBlockDetail block={block} />
   }
+  if (isGuidanceToolName(name)) {
+    return null
+  }
 
   const input = block.toolInput
   if (!input) return null
@@ -687,11 +699,11 @@ function getWorkspaceFilePath(block: ToolBlock): string | undefined {
   ) {
     return undefined
   }
-  return getInputField(block, 'file_path', 'path')
+  return getFileInputPath(block)
 }
 
 function BashBlockDetail({ block }: { block: ToolBlock }) {
-  const command = getInputField(block, 'command', 'cmd')
+  const command = getInputField(block, 'command', 'cmd', 'commandLine')
   const output = block.toolOutput
   const outputText =
     typeof output === 'string' ? output : output ? JSON.stringify(output, null, 2) : ''
@@ -776,8 +788,8 @@ function BashBlockDetail({ block }: { block: ToolBlock }) {
 }
 
 function FileWriteDetail({ block }: { block: ToolBlock }) {
-  const filePath = getInputField(block, 'file_path', 'path')
-  const content = getInputField(block, 'content', 'file_text')
+  const filePath = getFileInputPath(block)
+  const content = getInputField(block, 'content', 'file_text', 'fileText')
   return (
     <div className="min-w-0 space-y-1 overflow-x-hidden">
       {filePath && <p className="break-words text-xs text-text-muted">{filePath}</p>}
@@ -791,9 +803,9 @@ function FileWriteDetail({ block }: { block: ToolBlock }) {
 }
 
 function FileEditDetail({ block }: { block: ToolBlock }) {
-  const filePath = getInputField(block, 'file_path', 'path')
-  const oldStr = getInputField(block, 'old_string', 'old_str')
-  const newStr = getInputField(block, 'new_string', 'new_str')
+  const filePath = getFileInputPath(block)
+  const oldStr = getInputField(block, 'old_string', 'old_str', 'oldString')
+  const newStr = getInputField(block, 'new_string', 'new_str', 'newString')
   return (
     <div className="min-w-0 space-y-1 overflow-x-hidden">
       {filePath && <p className="break-words text-xs text-text-muted">{filePath}</p>}
@@ -818,6 +830,20 @@ function getInputField(block: ToolBlock, ...keys: string[]): string | undefined 
     if (typeof val === 'string') return val
   }
   return undefined
+}
+
+function getFileInputPath(block: ToolBlock): string | undefined {
+  return getInputField(
+    block,
+    'file_path',
+    'filePath',
+    'filepath',
+    'path',
+    'file',
+    'filename',
+    'target_file',
+    'targetFile'
+  )
 }
 
 function truncate(str: string, maxLen: number): string {

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode, TransitionEvent } from 'react'
-import { ChevronDown, Search, SquareTerminal } from 'lucide-react'
+import { ChevronDown, MessageCircle, Search, SquareTerminal } from 'lucide-react'
 import type { ProcessingBlock, ToolBlock } from '@/types/workbench'
 import { ToolBlockItem } from './ToolBlockItem'
 import {
   buildProcessingDisplayRows,
   isCommandToolName,
+  isGuidanceActivityGroup,
   isWebSearchActivityGroup,
   type ProcessingDisplayRow,
 } from './toolBlockActivity'
@@ -245,7 +246,7 @@ function ToolActivityGroup({
 }) {
   const [expanded, setExpanded] = useState(false)
   const isWebSearchGroup = isWebSearchActivityGroup(row.blocks)
-  const Icon = hasCommandBlocks(row.blocks) ? SquareTerminal : Search
+  const icon = renderActivityGroupIcon(row.blocks)
 
   return (
     <div className="min-w-0 overflow-x-hidden text-[13px]">
@@ -256,7 +257,7 @@ function ToolActivityGroup({
         onClick={() => setExpanded(value => !value)}
         className="flex max-w-full items-center gap-1.5 text-text-muted hover:text-text-secondary"
       >
-        <Icon className="h-4 w-4 shrink-0" strokeWidth={1.7} />
+        {icon}
         <span className="min-w-0 truncate">{row.label}</span>
         <ChevronDown
           className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? '' : '-rotate-90'}`}
@@ -297,6 +298,16 @@ function WebSearchActivityDetails({ blocks }: { blocks: ToolBlock[] }) {
 
 function hasCommandBlocks(blocks: ToolBlock[]): boolean {
   return blocks.some(block => isCommandToolName(block.toolName))
+}
+
+function renderActivityGroupIcon(blocks: ToolBlock[]) {
+  if (hasCommandBlocks(blocks)) {
+    return <SquareTerminal className="h-4 w-4 shrink-0" strokeWidth={1.7} />
+  }
+  if (isGuidanceActivityGroup(blocks)) {
+    return <MessageCircle className="h-4 w-4 shrink-0" strokeWidth={1.7} />
+  }
+  return <Search className="h-4 w-4 shrink-0" strokeWidth={1.7} />
 }
 
 function ThinkingIndicator() {

--- a/wework/src/components/chat/blocks/toolBlockActivity.test.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.test.ts
@@ -41,6 +41,38 @@ describe('toolBlockActivity', () => {
     ).toBe('已探索 1 个文件 1 次搜索 已运行 1 条命令')
   })
 
+  test('classifies commandLine aliases as shell command activity', () => {
+    expect(
+      summarizeToolBlocks([
+        {
+          id: 'cmdline-1',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'bash',
+          toolInput: { commandLine: 'find . -name package.json' },
+          status: 'done',
+          createdAt: 1770000000000,
+        },
+      ])
+    ).toBe('已探索 1 次搜索')
+  })
+
+  test('summarizes mid-turn user guidance activity', () => {
+    expect(
+      summarizeToolBlocks([
+        {
+          id: 'guidance-1',
+          subtaskId: 1,
+          type: 'tool',
+          toolName: 'conversation_guidance',
+          toolInput: { message: 'follow this file' },
+          status: 'done',
+          createdAt: 1770000000000,
+        },
+      ])
+    ).toBe('已引导对话')
+  })
+
   test('groups completed tools while preserving running tools as standalone rows', () => {
     const thinking: ProcessingBlock = {
       id: 'thinking-1',

--- a/wework/src/components/chat/blocks/toolBlockActivity.ts
+++ b/wework/src/components/chat/blocks/toolBlockActivity.ts
@@ -4,7 +4,7 @@ export type ProcessingDisplayRow =
   | { type: 'block'; id: string; block: ProcessingBlock }
   | { type: 'activity_group'; id: string; blocks: ToolBlock[]; label: string }
 
-type ToolActivityKind = 'file' | 'search' | 'command' | 'create' | 'edit' | 'tool'
+type ToolActivityKind = 'file' | 'search' | 'command' | 'create' | 'edit' | 'guidance' | 'tool'
 
 interface ActivityStats {
   files: number
@@ -12,6 +12,7 @@ interface ActivityStats {
   commands: number
   creates: number
   edits: number
+  guidance: number
   tools: number
   failedCommands: number
   failedTools: number
@@ -27,6 +28,7 @@ const COMMAND_TOOLS = new Set([
 const FILE_TOOLS = new Set(['read', 'read_file'])
 const CREATE_TOOLS = new Set(['write', 'create_file', 'write_file'])
 const EDIT_TOOLS = new Set(['edit', 'str_replace_editor', 'edit_file'])
+const GUIDANCE_TOOLS = new Set(['conversation_guidance', 'user_guidance'])
 const SEARCH_TOOL_HINTS = ['search', 'grep', 'glob']
 const SEARCH_COMMANDS = new Set(['rg', 'grep', 'find', 'fd', 'ls', 'tree', 'ag', 'ack'])
 const FILE_COMMANDS = new Set(['cat', 'sed', 'head', 'tail', 'wc', 'nl', 'stat', 'du', 'file'])
@@ -78,6 +80,7 @@ export function summarizeToolBlocks(blocks: ToolBlock[]): string {
   if (exploreParts.length > 0) parts.push(`已探索 ${exploreParts.join(' ')}`)
   if (stats.creates > 0) parts.push(`已新增 ${formatCount(stats.creates, '个文件')}`)
   if (stats.edits > 0) parts.push(`已编辑 ${formatCount(stats.edits, '个文件')}`)
+  if (stats.guidance > 0) parts.push('已引导对话')
   if (stats.commands > 0) parts.push(`已运行 ${formatCount(stats.commands, '条命令')}`)
   if (stats.tools > 0) parts.push(`已运行 ${formatCount(stats.tools, '个工具')}`)
   if (stats.failedCommands > 0) {
@@ -106,6 +109,7 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
       if (kind === 'command') stats.commands += 1
       if (kind === 'create') stats.creates += 1
       if (kind === 'edit') stats.edits += 1
+      if (kind === 'guidance') stats.guidance += 1
       if (kind === 'tool') stats.tools += 1
       return stats
     },
@@ -115,6 +119,7 @@ function getActivityStats(blocks: ToolBlock[]): ActivityStats {
       commands: 0,
       creates: 0,
       edits: 0,
+      guidance: 0,
       tools: 0,
       failedCommands: 0,
       failedTools: 0,
@@ -127,8 +132,11 @@ function getToolActivityKind(block: ToolBlock): ToolActivityKind {
   if (FILE_TOOLS.has(name)) return 'file'
   if (CREATE_TOOLS.has(name)) return 'create'
   if (EDIT_TOOLS.has(name)) return 'edit'
+  if (GUIDANCE_TOOLS.has(name)) return 'guidance'
   if (SEARCH_TOOL_HINTS.some(hint => name.includes(hint))) return 'search'
-  if (isCommandToolName(name)) return getCommandActivityKind(getInputField(block, 'command', 'cmd'))
+  if (isCommandToolName(name)) {
+    return getCommandActivityKind(getInputField(block, 'command', 'cmd', 'commandLine'))
+  }
   return 'tool'
 }
 
@@ -170,6 +178,14 @@ export function isWebSearchToolName(name: string): boolean {
 
 export function isWebSearchActivityGroup(blocks: ToolBlock[]): boolean {
   return blocks.length > 0 && blocks.every(block => isWebSearchToolName(block.toolName))
+}
+
+export function isGuidanceActivityGroup(blocks: ToolBlock[]): boolean {
+  return blocks.length > 0 && blocks.every(block => isGuidanceToolName(block.toolName))
+}
+
+export function isGuidanceToolName(name: string): boolean {
+  return GUIDANCE_TOOLS.has(name.toLowerCase())
 }
 
 function getToolGroupId(blocks: ToolBlock[]): string {

--- a/wework/src/components/chat/codexReferences.ts
+++ b/wework/src/components/chat/codexReferences.ts
@@ -5,7 +5,6 @@ const MARKDOWN_LINK_PATTERN = /\[([^\]]+)]\((<[^>]+>|[^)\s]+)(?:\s+["'][^"']*["'
 const CODEX_REFERENCE_DOCUMENT_EXTENSIONS = new Set([
   'doc',
   'docx',
-  'log',
   'markdown',
   'md',
   'mdx',

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -742,7 +742,11 @@ export function DesktopWorkbenchMain({
               isWaitingForAssistant={isWaitingForAssistant}
               hasMoreBefore={runtimeTranscriptHasMoreBefore}
               loadingMoreBefore={isRuntimeTranscriptLoadingMore}
-              conversationKey={currentRuntimeTask?.localTaskId ?? null}
+              conversationKey={
+                currentRuntimeTask
+                  ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.localTaskId}`
+                  : null
+              }
               className="h-full"
               scrollTestId="desktop-chat-scroll"
               scrollerClassName={hasQueuedComposerRows ? 'pb-52' : 'pb-40'}

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -533,7 +533,11 @@ export function MobileWorkbenchLayout({
               isWaitingForAssistant={state.isSending || isAwaitingAssistantStart}
               hasMoreBefore={runtimeTranscriptHasMoreBefore}
               loadingMoreBefore={isRuntimeTranscriptLoadingMore}
-              conversationKey={state.currentRuntimeTask?.localTaskId ?? null}
+              conversationKey={
+                state.currentRuntimeTask
+                  ? `${state.currentRuntimeTask.deviceId}:${state.currentRuntimeTask.localTaskId}`
+                  : null
+              }
               className="h-full"
               scrollerClassName="pb-28 pt-16"
               devices={state.devices}

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -982,6 +982,8 @@ function runtimeMessageToWorkbenchMessage(
       ? ({ ...message.source, source: 'im' } as MessageSource)
       : undefined
   const createdAt = message.createdAt ?? new Date().toISOString()
+  const completedAt = message.completedAt ?? message.completed_at ?? undefined
+  const stoppedNotice = message.stoppedNotice ?? message.stopped_notice ?? undefined
   const messageCreatedAtMs = getBlockTimestamp(createdAt)
   const blocks = normalizeProcessingBlocks(
     getRuntimeMessageBlockSubtaskId(message, subtaskId),
@@ -1003,6 +1005,8 @@ function runtimeMessageToWorkbenchMessage(
     memoryCitations: normalizeRuntimeMemoryCitations(message),
     contextEvents: normalizeRuntimeContextEvents(message),
     createdAt,
+    completedAt,
+    stoppedNotice,
   }
 }
 

--- a/wework/src/stream/responseApiStream.ts
+++ b/wework/src/stream/responseApiStream.ts
@@ -187,6 +187,10 @@ function normalizeToolInput(input: Record<string, unknown> | undefined): Record<
     normalized.command = normalized.cmd
     delete normalized.cmd
   }
+  if ('commandLine' in normalized && !('command' in normalized)) {
+    normalized.command = normalized.commandLine
+    delete normalized.commandLine
+  }
   if ('workdir' in normalized && !('cwd' in normalized)) {
     normalized.cwd = normalized.workdir
     delete normalized.workdir

--- a/wework/src/test/macos-window-chrome.test.ts
+++ b/wework/src/test/macos-window-chrome.test.ts
@@ -16,6 +16,14 @@ interface TauriWindowConfig {
 interface TauriConfig {
   app: {
     windows: TauriWindowConfig[]
+    security?: {
+      assetProtocol?: {
+        enable?: boolean
+        scope?: {
+          allow?: string[]
+        }
+      }
+    }
   }
 }
 
@@ -42,9 +50,29 @@ describe('macOS window chrome', () => {
   test('grants permission to start native window dragging', () => {
     const capabilityPath = resolve(process.cwd(), 'src-tauri/capabilities/default.json')
     const capability = JSON.parse(readFileSync(capabilityPath, 'utf8')) as {
-      permissions: string[]
+      permissions: Array<string | object>
     }
 
     expect(capability.permissions).toContain('core:window:allow-start-dragging')
+  })
+
+  test('does not grant permission to reveal downloaded local images', () => {
+    const capabilityPath = resolve(process.cwd(), 'src-tauri/capabilities/default.json')
+    const capability = JSON.parse(readFileSync(capabilityPath, 'utf8')) as {
+      permissions: Array<string | object>
+    }
+
+    expect(capability.permissions).not.toContain('opener:allow-reveal-item-in-dir')
+  })
+
+  test('enables asset protocol access for temporary Codex clipboard images', () => {
+    const configPath = resolve(process.cwd(), 'src-tauri/tauri.conf.json')
+    const config = JSON.parse(readFileSync(configPath, 'utf8')) as TauriConfig
+    const assetProtocol = config.app.security?.assetProtocol
+
+    expect(assetProtocol?.enable).toBe(true)
+    expect(assetProtocol?.scope?.allow).toEqual(
+      expect.arrayContaining(['$TEMP/**', '/var/folders/**', '/private/var/folders/**'])
+    )
   })
 })

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -252,6 +252,10 @@ export interface NormalizedRuntimeMessage {
   subtask_id?: number | null
   status?: string | null
   createdAt?: string | null
+  completedAt?: string | number | null
+  completed_at?: string | number | null
+  stoppedNotice?: boolean | null
+  stopped_notice?: boolean | null
   source?: RuntimeMessageSource | null
   attachments?: Attachment[]
   blocks?: ChatBlock[]

--- a/wework/src/types/workbench.ts
+++ b/wework/src/types/workbench.ts
@@ -51,6 +51,8 @@ export type WorkbenchMessage = Omit<
 > & {
   blocks?: ProcessingBlock[]
   runtimeStatus?: RuntimeWorkbenchMessageStatus | null
+  completedAt?: string | number | null
+  stoppedNotice?: boolean | null
   references?: CodexReference[] | null
   memoryCitations?: CodexMemoryCitation[] | null
   contextEvents?: CodexContextEvent[] | null


### PR DESCRIPTION
## Summary
- Normalize native Codex runtime transcripts into richer Wework messages, including tool activity, references, file changes, stopped turns, and local image attachments.
- Refine Wework Codex-style rendering for images, markdown/code blocks, file changes cards, hover previews, and scroll restoration.
- Keep app IPC runtime RPC responses as regular JSON for now; no compressed result envelope.

## Verification
- pnpm --dir wework exec vitest run src/components/chat/MessageList.test.tsx src/components/chat/ScrollableMessageArea.test.tsx src/components/chat/blocks/ToolBlockItem.test.tsx src/components/chat/blocks/toolBlockActivity.test.ts src/test/macos-window-chrome.test.ts
- pnpm --dir wework exec tsc -b --pretty false
- cargo test --manifest-path wework/src-tauri/Cargo.toml
- cargo test --manifest-path executor/Cargo.toml runtime_work
- cargo test --manifest-path executor/Cargo.toml --all-features
- cargo clippy --manifest-path executor/Cargo.toml --all-features --all-targets -- -D warnings
- env -u VITE_API_BASE_URL -u VITE_SOCKET_BASE_URL -u VITE_API_PROXY_TARGET -u VITE_SOCKET_PROXY_TARGET pnpm --dir wework exec vitest run --coverage --passWithNoTests
- pre-push hook passed with AI_VERIFIED=1 after confirming no docs update is required for these internal UI/transcript changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tauri-powered local file/image download into system Downloads (sanitized, collision-free), plus expanded image previews with optional lightbox gallery (keyboard navigation, zoom, and download control).
  * Improved chat scrolling restoration using DOM anchors (messages and markdown headings).
  * Enhanced “guidance” tool/activity display, including mid-turn guidance blocks.

* **Bug Fixes**
  * Delivered large runtime `runtime.tasks.transcript` results inline as plain JSON (no IPC compression handling).
  * Refined cancelled/stopped assistant rendering for more accurate timing, partial output preservation, and stopped notice behavior.

* **Security/Config**
  * Tightened Tauri asset protocol scope to allow temp and macOS folder paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->