### PR TITLE
[codex] Persist pinned Wework runtime tasks

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -73,8 +73,7 @@ function renderSidebar(overrides: Partial<Parameters<typeof DesktopSidebar>[0]> 
     ...overrides,
   }
 
-  render(<DesktopSidebar {...props} />)
-  return props
+  return render(<DesktopSidebar {...props} />)
 }
 
 function enableTauri() {
@@ -762,7 +761,7 @@ describe('DesktopSidebar', () => {
       const taskRow = screen.getByTestId('runtime-local-task-row-codex-1')
       const rowChildren = Array.from(taskRow.children)
 
-      expect(screen.queryByTestId('runtime-local-task-mark-codex-1')).not.toBeInTheDocument()
+      expect(screen.getByTestId('runtime-local-task-mark-codex-1')).toBeInTheDocument()
       expect(screen.getByTestId('runtime-local-task-archive-codex-1')).toBeInTheDocument()
       expect(rowChildren).toHaveLength(2)
       expect(rowChildren[1]).toHaveAttribute('data-testid', 'runtime-local-task-trailing-codex-1')
@@ -775,7 +774,7 @@ describe('DesktopSidebar', () => {
       expect(screen.getByTestId('runtime-local-task-hover-actions-codex-1').parentElement).toBe(
         rowChildren[1]
       )
-      expect(screen.queryByTestId('runtime-local-task-pin-icon-codex-1')).not.toBeInTheDocument()
+      expect(screen.getByTestId('runtime-local-task-pin-icon-codex-1')).toBeInTheDocument()
       expect(screen.getByTestId('runtime-local-task-archive-icon-codex-1')).toBeInTheDocument()
       expect(
         screen.getByTestId('runtime-local-task-hover-actions-codex-1').className
@@ -825,6 +824,223 @@ describe('DesktopSidebar', () => {
       setTimeoutSpy.mockRestore()
       clearTimeoutSpy.mockRestore()
     }
+  })
+
+  test('marks and unmarks runtime tasks without opening the task', async () => {
+    const user = userEvent.setup()
+    const onOpenRuntimeLocalTask = vi.fn()
+
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Wegent' },
+            totalLocalTasks: 1,
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'local-device',
+                deviceName: 'Local Mac',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                localTasks: [
+                  {
+                    localTaskId: 'codex-1',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Fix reconnect',
+                    runtime: 'codex',
+                    updatedAt: '2026-06-20T02:00:00Z',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 1,
+      },
+      onOpenRuntimeLocalTask,
+    })
+
+    await user.click(screen.getByTestId('project-item-button'))
+
+    const taskRow = screen.getByTestId('runtime-local-task-row-codex-1')
+    const markButton = screen.getByTestId('runtime-local-task-mark-codex-1')
+    const pinIcon = screen.getByTestId('runtime-local-task-pin-icon-codex-1')
+
+    expect(taskRow).not.toHaveAttribute('data-marked')
+    expect(taskRow.className).not.toContain('color-sidebar-marked')
+
+    await user.click(markButton)
+
+    expect(taskRow).toHaveAttribute('data-marked', 'true')
+    expect(taskRow.className).toContain('color-sidebar-marked')
+    expect(pinIcon).toHaveClass('fill-current')
+    expect(markButton).toHaveAttribute('aria-label', '取消标记')
+    expect(onOpenRuntimeLocalTask).not.toHaveBeenCalled()
+
+    await user.click(markButton)
+
+    expect(taskRow).not.toHaveAttribute('data-marked')
+    expect(taskRow.className).not.toContain('color-sidebar-marked')
+    expect(pinIcon).not.toHaveClass('fill-current')
+    expect(markButton).toHaveAttribute('aria-label', '标记任务')
+  })
+
+  test('moves pinned runtime tasks to the top of the project task list', async () => {
+    const user = userEvent.setup()
+
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Wegent' },
+            totalLocalTasks: 3,
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'local-device',
+                deviceName: 'Local Mac',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                localTasks: [
+                  {
+                    localTaskId: 'old-task',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Old task',
+                    runtime: 'codex',
+                    updatedAt: '2026-06-20T00:00:00Z',
+                  },
+                  {
+                    localTaskId: 'new-task',
+                    workspacePath: '/repo/Wegent',
+                    title: 'New task',
+                    runtime: 'codex',
+                    updatedAt: '2026-06-22T00:00:00Z',
+                  },
+                  {
+                    localTaskId: 'middle-task',
+                    workspacePath: '/repo/Wegent',
+                    title: 'Middle task',
+                    runtime: 'codex',
+                    updatedAt: '2026-06-21T00:00:00Z',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 3,
+      },
+    })
+
+    await user.click(screen.getByTestId('project-item-button'))
+
+    const rowTestIds = () =>
+      screen.getAllByTestId(/^runtime-local-task-row-/).map(row => row.getAttribute('data-testid'))
+
+    expect(rowTestIds()).toEqual([
+      'runtime-local-task-row-new-task',
+      'runtime-local-task-row-middle-task',
+      'runtime-local-task-row-old-task',
+    ])
+
+    await user.click(screen.getByTestId('runtime-local-task-mark-old-task'))
+
+    expect(rowTestIds()).toEqual([
+      'runtime-local-task-row-old-task',
+      'runtime-local-task-row-new-task',
+      'runtime-local-task-row-middle-task',
+    ])
+
+    await user.click(screen.getByTestId('runtime-local-task-mark-old-task'))
+
+    expect(rowTestIds()).toEqual([
+      'runtime-local-task-row-new-task',
+      'runtime-local-task-row-middle-task',
+      'runtime-local-task-row-old-task',
+    ])
+  })
+
+  test('restores pinned runtime task ordering after remount', async () => {
+    const user = userEvent.setup()
+    const runtimeWork = {
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          totalLocalTasks: 3,
+          deviceWorkspaces: [
+            {
+              id: 91,
+              deviceId: 'local-device',
+              deviceName: 'Local Mac',
+              deviceStatus: 'online',
+              available: true,
+              workspacePath: '/repo/Wegent',
+              localTasks: [
+                {
+                  localTaskId: 'old-task',
+                  workspacePath: '/repo/Wegent',
+                  title: 'Old task',
+                  runtime: 'codex',
+                  updatedAt: '2026-06-20T00:00:00Z',
+                },
+                {
+                  localTaskId: 'new-task',
+                  workspacePath: '/repo/Wegent',
+                  title: 'New task',
+                  runtime: 'codex',
+                  updatedAt: '2026-06-22T00:00:00Z',
+                },
+                {
+                  localTaskId: 'middle-task',
+                  workspacePath: '/repo/Wegent',
+                  title: 'Middle task',
+                  runtime: 'codex',
+                  updatedAt: '2026-06-21T00:00:00Z',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 3,
+    }
+    const rowTestIds = () =>
+      screen.getAllByTestId(/^runtime-local-task-row-/).map(row => row.getAttribute('data-testid'))
+
+    const view = renderSidebar({ runtimeWork })
+
+    await user.click(screen.getByTestId('project-item-button'))
+    await user.click(screen.getByTestId('runtime-local-task-mark-old-task'))
+
+    await waitFor(() => {
+      expect(localStorage.getItem('wework.desktop.sidebar.pinnedRuntimeTaskKeys.7.1')).toContain(
+        'old-task'
+      )
+    })
+
+    view.unmount()
+
+    renderSidebar({ runtimeWork })
+
+    if (!screen.queryByTestId('runtime-local-task-row-old-task')) {
+      await user.click(screen.getByTestId('project-item-button'))
+    }
+
+    expect(rowTestIds()).toEqual([
+      'runtime-local-task-row-old-task',
+      'runtime-local-task-row-new-task',
+      'runtime-local-task-row-middle-task',
+    ])
+    expect(screen.getByTestId('runtime-local-task-mark-old-task')).toHaveAttribute(
+      'aria-label',
+      '取消标记'
+    )
   })
 
   test('opens centered archive confirmation dialog for project archive', async () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -8,6 +8,7 @@ import {
   GitCompareArrows,
   Loader2,
   MessageSquarePlus,
+  Pin,
   Plus,
   RotateCw,
   Search,
@@ -61,6 +62,7 @@ import {
   hasHiddenRuntimeSidebarTaskItems,
   isRuntimeTaskSelected,
   isRuntimeWorktreeTask,
+  type RuntimeSidebarTaskItem,
 } from './runtimeTaskSidebarHelpers'
 import { useResizableSidebar } from './useResizableSidebar'
 
@@ -386,6 +388,26 @@ function writeStoredNumberSet(key: string, values: Set<number>) {
   }
 }
 
+function readStoredStringSet(key: string): Set<string> {
+  try {
+    const value = window.localStorage.getItem(key)
+    if (!value) return new Set()
+    const parsed = JSON.parse(value)
+    if (!Array.isArray(parsed)) return new Set()
+    return new Set(parsed.filter((item): item is string => typeof item === 'string' && item !== ''))
+  } catch {
+    return new Set()
+  }
+}
+
+function writeStoredStringSet(key: string, values: Set<string>) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify([...values].sort()))
+  } catch {
+    // Keep the in-memory sidebar state when browser storage is unavailable.
+  }
+}
+
 function pruneProjectIdSet(values: Set<number>, projects: ProjectWithTasks[]): Set<number> {
   if (projects.length === 0) return values
   const projectIds = new Set(projects.map(project => project.id))
@@ -564,7 +586,9 @@ function shouldShowProjectDeviceStatus(
   devices: DeviceInfo[]
 ): deviceState is SidebarDeviceState {
   if (!deviceState || devices.length <= 1) return false
-  return Boolean(deviceState.device && (isCloudDevice(deviceState.device) || isRemoteDevice(deviceState.device)))
+  return Boolean(
+    deviceState.device && (isCloudDevice(deviceState.device) || isRemoteDevice(deviceState.device))
+  )
 }
 
 function getRuntimeWorkspaceDeviceColor(workspace: RuntimeDeviceWorkspace): string {
@@ -589,6 +613,26 @@ function getSidebarDeviceStatusLabel(
 
 function getRuntimeNotificationKey(address: RuntimeTaskAddress): string {
   return `${address.deviceId}\0${address.localTaskId}`
+}
+
+function getRuntimeTaskPinKey(workspace: RuntimeDeviceWorkspace, task: LocalTaskSummary): string {
+  return getRuntimeNotificationKey(getRuntimeTaskAddress(workspace, task))
+}
+
+function prioritizePinnedRuntimeTaskItems(
+  items: RuntimeSidebarTaskItem[],
+  pinnedTaskKeys: ReadonlySet<string>
+) {
+  const pinnedItems: RuntimeSidebarTaskItem[] = []
+  const unpinnedItems: RuntimeSidebarTaskItem[] = []
+  for (const item of items) {
+    if (pinnedTaskKeys.has(getRuntimeTaskPinKey(item.workspace, item.task))) {
+      pinnedItems.push(item)
+    } else {
+      unpinnedItems.push(item)
+    }
+  }
+  return [...pinnedItems, ...unpinnedItems]
 }
 
 function isRuntimeTaskNotificationSubscribed(
@@ -685,10 +729,12 @@ function RuntimeLocalTaskRow({
   workspace,
   task,
   selected,
+  marked: controlledMarked,
   indentClassName = 'pl-12',
   imNotificationSettings,
   showDeviceMarker,
   onOpenRuntimeLocalTask,
+  onToggleMark,
   onRenameRuntimeLocalTask,
   onArchiveRuntimeLocalTask,
   onToggleRuntimeTaskNotification,
@@ -696,10 +742,12 @@ function RuntimeLocalTaskRow({
   workspace: RuntimeDeviceWorkspace
   task: LocalTaskSummary
   selected: boolean
+  marked?: boolean
   indentClassName?: string
   imNotificationSettings?: RuntimeIMNotificationSettingsResponse | null
   showDeviceMarker: boolean
   onOpenRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void> | void
+  onToggleMark?: (address: RuntimeTaskAddress) => void
   onRenameRuntimeLocalTask?: (address: RuntimeTaskAddress, title: string) => Promise<void> | void
   onArchiveRuntimeLocalTask?: (address: RuntimeTaskAddress) => Promise<void> | void
   onToggleRuntimeTaskNotification?: (
@@ -708,6 +756,7 @@ function RuntimeLocalTaskRow({
   ) => Promise<void> | void
 }) {
   const { t } = useTranslation('common')
+  const [internalMarked, setInternalMarked] = useState(false)
   const [archiving, setArchiving] = useState(false)
   const [archivePending, setArchivePending] = useState(false)
   const [archiveNoticeOpen, setArchiveNoticeOpen] = useState(false)
@@ -724,10 +773,20 @@ function RuntimeLocalTaskRow({
     imNotificationSettings,
     taskAddress
   )
+  const marked = controlledMarked ?? internalMarked
   const notificationsDisabled = !workspace.available || !onToggleRuntimeTaskNotification
   const handleOpen = () => {
     if (disabled) return
     void onOpenRuntimeLocalTask?.(taskAddress)
+  }
+  const handleToggleMark = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+    event.currentTarget.blur()
+    if (controlledMarked === undefined) {
+      setInternalMarked(value => !value)
+      return
+    }
+    onToggleMark?.(taskAddress)
   }
   useEffect(() => {
     return () => {
@@ -797,6 +856,7 @@ function RuntimeLocalTaskRow({
     <>
       <div
         data-testid={`runtime-local-task-row-${task.localTaskId}`}
+        data-marked={marked ? 'true' : undefined}
         role="button"
         tabIndex={disabled ? -1 : 0}
         aria-disabled={disabled}
@@ -814,10 +874,12 @@ function RuntimeLocalTaskRow({
           disabled ? 'cursor-not-allowed opacity-55' : 'cursor-default',
           selected
             ? 'bg-[rgb(var(--color-sidebar-active))] text-text-primary'
-            : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
+            : marked
+              ? 'bg-[rgb(var(--color-sidebar-marked))] text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-marked-hover))]'
+              : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
         )}
       >
-        <span title={task.title} className="min-w-0 flex-1 truncate group-hover/task:pr-14">
+        <span title={task.title} className="min-w-0 flex-1 truncate group-hover/task:pr-20">
           {task.title}
         </span>
         <span
@@ -867,7 +929,7 @@ function RuntimeLocalTaskRow({
           </span>
           <span
             data-testid={`runtime-local-task-hover-actions-${task.localTaskId}`}
-            className="pointer-events-none invisible absolute right-0 top-1/2 flex w-[52px] -translate-y-1/2 items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover/task:pointer-events-auto group-hover/task:visible group-hover/task:opacity-100"
+            className="pointer-events-none invisible absolute right-0 top-1/2 flex w-[78px] -translate-y-1/2 items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover/task:pointer-events-auto group-hover/task:visible group-hover/task:opacity-100"
           >
             {renderNotificationButton(
               notificationsSubscribed
@@ -877,6 +939,30 @@ function RuntimeLocalTaskRow({
                 ? `runtime-local-task-notify-hover-icon-${task.localTaskId}`
                 : `runtime-local-task-notify-icon-${task.localTaskId}`
             )}
+            <button
+              type="button"
+              data-testid={`runtime-local-task-mark-${task.localTaskId}`}
+              onClick={handleToggleMark}
+              className={cn(
+                'flex h-6 w-6 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-muted))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]',
+                marked && 'text-[rgb(var(--color-sidebar-marked-accent))]'
+              )}
+              title={
+                marked
+                  ? t('workbench.unmark_runtime_task', '取消标记')
+                  : t('workbench.mark_runtime_task', '标记任务')
+              }
+              aria-label={
+                marked
+                  ? t('workbench.unmark_runtime_task', '取消标记')
+                  : t('workbench.mark_runtime_task', '标记任务')
+              }
+            >
+              <Pin
+                data-testid={`runtime-local-task-pin-icon-${task.localTaskId}`}
+                className={cn('h-4 w-4', marked && 'fill-current')}
+              />
+            </button>
             <button
               type="button"
               data-testid={`runtime-local-task-archive-${task.localTaskId}`}
@@ -951,6 +1037,7 @@ function ProjectItem({
   onToggleProject,
   devices,
   runtimeProjectWork,
+  pinnedTaskKeysStorageKey,
   currentRuntimeTask,
   imNotificationSettings,
   showDeviceMarker,
@@ -968,6 +1055,7 @@ function ProjectItem({
   onToggleProject: (projectId: number) => void
   devices: DeviceInfo[]
   runtimeProjectWork?: RuntimeProjectWork
+  pinnedTaskKeysStorageKey: string
   currentRuntimeTask?: RuntimeTaskAddress | null
   imNotificationSettings?: RuntimeIMNotificationSettingsResponse | null
   showDeviceMarker: boolean
@@ -992,9 +1080,17 @@ function ProjectItem({
   const [runtimeTasksExpanded, setRuntimeTasksExpanded] = useState(false)
   const [projectArchiving, setProjectArchiving] = useState(false)
   const [archiveConfirmOpen, setArchiveConfirmOpen] = useState(false)
+  const pinnedTaskKeysStorageRef = useRef(pinnedTaskKeysStorageKey)
+  const [pinnedRuntimeTaskKeys, setPinnedRuntimeTaskKeys] = useState<Set<string>>(() =>
+    readStoredStringSet(pinnedTaskKeysStorageKey)
+  )
+  const prioritizedRuntimeTaskItems = useMemo(
+    () => prioritizePinnedRuntimeTaskItems(runtimeTaskItems, pinnedRuntimeTaskKeys),
+    [pinnedRuntimeTaskKeys, runtimeTaskItems]
+  )
   const visibleRuntimeTaskItems = useMemo(
-    () => getVisibleRuntimeSidebarTaskItems(runtimeTaskItems, runtimeTasksExpanded),
-    [runtimeTaskItems, runtimeTasksExpanded]
+    () => getVisibleRuntimeSidebarTaskItems(prioritizedRuntimeTaskItems, runtimeTasksExpanded),
+    [prioritizedRuntimeTaskItems, runtimeTasksExpanded]
   )
   const hasHiddenRuntimeTasks = hasHiddenRuntimeSidebarTaskItems(runtimeTaskItems)
   const projectDeviceState =
@@ -1013,6 +1109,27 @@ function ProjectItem({
       : t('workbench.new_project_chat', '新建项目对话')
   const archiveConversationCount = runtimeTaskItems.length
   const archiveProjectName = runtimeProjectWork?.project.name ?? project.name
+  const toggleRuntimeTaskPin = (address: RuntimeTaskAddress) => {
+    const taskKey = getRuntimeNotificationKey(address)
+    setPinnedRuntimeTaskKeys(currentKeys => {
+      const nextKeys = new Set(currentKeys)
+      if (nextKeys.has(taskKey)) {
+        nextKeys.delete(taskKey)
+      } else {
+        nextKeys.add(taskKey)
+      }
+      return nextKeys
+    })
+  }
+  useEffect(() => {
+    if (pinnedTaskKeysStorageRef.current !== pinnedTaskKeysStorageKey) return
+    writeStoredStringSet(pinnedTaskKeysStorageKey, pinnedRuntimeTaskKeys)
+  }, [pinnedRuntimeTaskKeys, pinnedTaskKeysStorageKey])
+  useEffect(() => {
+    if (pinnedTaskKeysStorageRef.current === pinnedTaskKeysStorageKey) return
+    pinnedTaskKeysStorageRef.current = pinnedTaskKeysStorageKey
+    setPinnedRuntimeTaskKeys(readStoredStringSet(pinnedTaskKeysStorageKey))
+  }, [pinnedTaskKeysStorageKey])
   const closeArchiveConfirm = () => {
     if (!projectArchiving) {
       setArchiveConfirmOpen(false)
@@ -1128,10 +1245,12 @@ function ProjectItem({
                   workspace={workspace}
                   task={task}
                   selected={isRuntimeTaskSelected(currentRuntimeTask, workspace, task)}
+                  marked={pinnedRuntimeTaskKeys.has(getRuntimeTaskPinKey(workspace, task))}
                   indentClassName="pl-9"
                   imNotificationSettings={imNotificationSettings}
                   showDeviceMarker={showDeviceMarker}
                   onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
+                  onToggleMark={toggleRuntimeTaskPin}
                   onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
                   onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
                   onToggleRuntimeTaskNotification={onToggleRuntimeTaskNotification}
@@ -1659,6 +1778,10 @@ export function DesktopSidebar({
                   expanded={displayedExpandedProjectIds.has(project.id)}
                   devices={devices}
                   runtimeProjectWork={runtimeWorkByProjectId.get(project.id)}
+                  pinnedTaskKeysStorageKey={getDesktopSidebarStorageKey(
+                    storageScope,
+                    `pinnedRuntimeTaskKeys.${project.id}`
+                  )}
                   currentRuntimeTask={currentRuntimeTask}
                   imNotificationSettings={imNotificationSettings}
                   showDeviceMarker={false}


### PR DESCRIPTION
## Summary

- Restore the Wework runtime task pin action in the desktop sidebar.
- Move pinned runtime tasks to the top of their project task list while preserving the existing updated-time order within pinned and unpinned groups.
- Persist pinned task state in user- and project-scoped local storage so the ordering survives app restarts.

## Root Cause

The previous pin/highlight action was removed while adding the runtime project archive workflow. The restored state initially lived only in React component state, so it disappeared after a Wework restart.

## Validation

- `pnpm --dir wework test -- DesktopSidebar.test.tsx`
- `pnpm --dir wework lint`
- `pnpm --dir wework build`
- Pre-push Wework test and AI quality checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pin/mark support for runtime tasks in the sidebar, including a pin icon, marked styling, and accessible label updates.
  * Pinned runtime tasks now stay at the top of their project’s task list.
  * Pin state is preserved across sidebar reloads, so ordering and marked status remain consistent after reopening the app.

* **Bug Fixes**
  * Improved archive/undo behavior to keep runtime task mark and pin indicators visible when expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->