### PR TITLE
[codex] Read repository policy from Actions variables

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -158,8 +158,8 @@ jobs:
 
       - name: Run repository policy check
         env:
-          REPOSITORY_POLICY_PATTERN_B64: ${{ secrets.REPOSITORY_POLICY_PATTERN_B64 }}
-          REPOSITORY_POLICY_APPROVED_B64: ${{ secrets.REPOSITORY_POLICY_APPROVED_B64 }}
+          REPOSITORY_POLICY_PATTERN_B64: ${{ vars.RESTRICTED_DOMAIN_PATTERN_B64 }}
+          REPOSITORY_POLICY_APPROVED_B64: ${{ vars.APPROVED_DOMAIN_REFERENCES_B64 }}
         run: |
           chmod +x ./scripts/hooks/check-repository-policy.sh
           ./scripts/hooks/check-repository-policy.sh


### PR DESCRIPTION
## Summary
- Read the repository policy pattern and approved reference list from GitHub Actions repository variables.
- Keep the existing script environment names unchanged so `check-repository-policy.sh` does not need code changes.

## Root Cause
Fork PR runs do not receive repository secrets, so `REPOSITORY_POLICY_PATTERN_B64` and `REPOSITORY_POLICY_APPROVED_B64` were empty in `pull_request` CI. The same check passed after merging to `main` because trusted branch runs can read secrets.

## Validation
- `gh variable list --repo wecode-ai/Wegent --json name,value` confirmed the repository variables exist.
- Ran `check-repository-policy.sh` locally with the actual GitHub repository variable values.
- Ran `git diff --check -- .github/workflows/lint.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository policy checks to use repository variables for configuration instead of secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->