### PR TITLE
[codex] Share Cargo target cache across local worktrees

### DIFF
--- a/docs/en/developer-guide/setup.md
+++ b/docs/en/developer-guide/setup.md
@@ -253,6 +253,16 @@ pnpm --filter wecode-ai-assistant run build
 pnpm --filter wecode-ai-assistant run start
 ```
 
+#### Wework and Local Rust Build Cache
+
+The Wework macOS development scripts configure shared Cargo target directories for Tauri and the local executor so multiple Git worktrees do not repeatedly rebuild the same dependencies from scratch:
+
+- `pnpm --dir wework run dev:mac` and `pnpm --dir wework run build:mac` use `$XDG_CACHE_HOME/wegent/cargo-target/wework-src-tauri` by default, or `~/.cache/wegent/cargo-target/wework-src-tauri` when `XDG_CACHE_HOME` is not set.
+- The development executor sidecar and `executor/local.sh build` use the `executor` subdirectory under the same cache root by default.
+- Set `WEGENT_CARGO_TARGET_ROOT=/path/to/cache` to choose a different shared cache root.
+- Set `WEGENT_DISABLE_SHARED_CARGO_TARGET=1` to restore Cargo's default per-worktree `target/` behavior.
+- When `CARGO_TARGET_DIR` is set explicitly, the scripts respect that value and do not choose an automatic shared directory.
+
 ---
 
 ### 5️⃣ Executor Manager Development

--- a/docs/zh/developer-guide/setup.md
+++ b/docs/zh/developer-guide/setup.md
@@ -253,6 +253,16 @@ pnpm --dir frontend run build
 pnpm --dir frontend run start
 ```
 
+#### Wework 与本地 Rust 构建缓存
+
+Wework macOS 开发脚本会为 Tauri 和本地 executor 配置共享 Cargo target 目录，避免多个 Git worktree 反复完整编译相同依赖：
+
+- `pnpm --dir wework run dev:mac` 和 `pnpm --dir wework run build:mac` 默认使用 `$XDG_CACHE_HOME/wegent/cargo-target/wework-src-tauri`，未设置 `XDG_CACHE_HOME` 时使用 `~/.cache/wegent/cargo-target/wework-src-tauri`。
+- 开发模式的 executor sidecar 和 `executor/local.sh build` 默认使用同一缓存根下的 `executor` 子目录。
+- 如需指定其他缓存根目录，设置 `WEGENT_CARGO_TARGET_ROOT=/path/to/cache`。
+- 如需恢复 Cargo 默认的每个 worktree 独立 `target/`，设置 `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`。
+- 显式设置 `CARGO_TARGET_DIR` 时，脚本会尊重该值，不再自动选择共享目录。
+
 ---
 
 ### 5️⃣ Executor Manager 开发

--- a/executor/local.sh
+++ b/executor/local.sh
@@ -7,11 +7,15 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$ROOT_DIR/.." && pwd)"
 PID_DIR="$ROOT_DIR/.pids"
 PID_FILE="$PID_DIR/wegent-executor.pid"
 RUN_LOG="$PID_DIR/wegent-executor.log"
 BUILD_LOG="$PID_DIR/wegent-executor-build.log"
 BINARY_PATH="${WEGENT_EXECUTOR_BINARY:-$ROOT_DIR/dist/wegent-executor}"
+
+# shellcheck source=../scripts/lib/cargo-cache.sh
+source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
 
 DEFAULT_FILE_EDIT_HOOK_COMMAND='tee -a /tmp/hook-debug.log | curl -sS -X POST http://127.0.0.1:3456/api/file-edit-log -H "Content-Type: application/json" -H "wecode-source: wegent-device" --data-binary @-'
 
@@ -36,6 +40,10 @@ Environment:
   WEGENT_BACKEND_URL             Optional; overrides device-config.json
   WEGENT_FILE_EDIT_HOOK_COMMAND  Default: local file edit hook collector
   WEGENT_EXECUTOR_BINARY         Default: dist/wegent-executor
+  CARGO_TARGET_DIR               Explicit Cargo target directory. Overrides auto cache.
+  WEGENT_CARGO_TARGET_ROOT       Shared Cargo target root for Wegent local builds.
+  WEGENT_DISABLE_SHARED_CARGO_TARGET
+                                  Set to 1 to keep Cargo's default per-worktree target.
 
 Examples:
   ./local.sh all
@@ -62,12 +70,14 @@ is_running() {
 build_executor() {
     local version_arg="${1:-}"
     ensure_pid_dir
+    configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor"
     echo "Building local executor. Log: $BUILD_LOG"
+    echo "Cargo target dir: ${CARGO_TARGET_DIR:-$ROOT_DIR/target}"
     (
         cd "$ROOT_DIR"
         cargo build --release --locked
         mkdir -p dist
-        cp target/release/wegent-executor dist/wegent-executor
+        cp "$(cargo_target_binary_path "$ROOT_DIR" release wegent-executor)" dist/wegent-executor
         chmod 0755 dist/wegent-executor
         if [[ "$(uname -s)" == "Darwin" ]]; then
             codesign --force --sign - --options runtime dist/wegent-executor >/dev/null 2>&1 || true

--- a/executor/src/bin/wegent-executor-dev.rs
+++ b/executor/src/bin/wegent-executor-dev.rs
@@ -169,7 +169,25 @@ fn debug_binary_path(manifest_dir: &Path) -> PathBuf {
     } else {
         "wegent-executor"
     };
-    manifest_dir.join("target").join("debug").join(executable)
+    cargo_target_dir(manifest_dir)
+        .join("debug")
+        .join(executable)
+}
+
+fn cargo_target_dir(manifest_dir: &Path) -> PathBuf {
+    match env::var_os("CARGO_TARGET_DIR").filter(|value| !value.is_empty()) {
+        Some(value) => {
+            let path = PathBuf::from(value);
+            if path.is_absolute() {
+                path
+            } else {
+                env::current_dir()
+                    .unwrap_or_else(|_| manifest_dir.to_path_buf())
+                    .join(path)
+            }
+        }
+        None => manifest_dir.join("target"),
+    }
 }
 
 fn stop_child(child: &mut Option<Child>) {
@@ -216,4 +234,82 @@ fn drain_debounced_events(rx: &mpsc::Receiver<DevEvent>) -> bool {
 
 fn is_reload_event(event: &Event) -> bool {
     !matches!(event.kind, EventKind::Access(_))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .expect("env lock should not be poisoned")
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let previous = env::var_os(key);
+            env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let previous = env::var_os(key);
+            env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                env::set_var(self.key, previous);
+            } else {
+                env::remove_var(self.key);
+            }
+        }
+    }
+
+    #[test]
+    fn debug_binary_path_uses_explicit_cargo_target_dir() {
+        let _guard = env_lock();
+        let target_dir = env::temp_dir().join("wegent-executor-dev-target");
+        let _env = EnvVarGuard::set("CARGO_TARGET_DIR", &target_dir);
+
+        assert_eq!(
+            debug_binary_path(Path::new("/tmp/executor")),
+            target_dir.join("debug").join(executable_name())
+        );
+    }
+
+    #[test]
+    fn debug_binary_path_defaults_to_manifest_target_dir() {
+        let _guard = env_lock();
+        let _env = EnvVarGuard::remove("CARGO_TARGET_DIR");
+        let manifest_dir = Path::new("/tmp/executor");
+
+        assert_eq!(
+            debug_binary_path(manifest_dir),
+            manifest_dir
+                .join("target")
+                .join("debug")
+                .join(executable_name())
+        );
+    }
+
+    fn executable_name() -> &'static str {
+        if cfg!(windows) {
+            "wegent-executor.exe"
+        } else {
+            "wegent-executor"
+        }
+    }
 }

--- a/executor/tests/build_entrypoint_contract.rs
+++ b/executor/tests/build_entrypoint_contract.rs
@@ -70,9 +70,8 @@ fn executor_build_entrypoints_use_rust_binary_build() {
     assert!(dev_sidecar.contains("--bin wegent-executor-dev"));
     assert!(dev_sidecar.contains("cargo build"));
     assert!(dev_sidecar.contains("configure_wegent_cargo_target_dir \"$PROJECT_DIR\" \"executor\""));
-    assert!(dev_sidecar.contains(
-        "cargo_target_binary_path \"$EXECUTOR_DIR\" debug wegent-executor-dev"
-    ));
+    assert!(dev_sidecar
+        .contains("cargo_target_binary_path \"$EXECUTOR_DIR\" debug wegent-executor-dev"));
     assert!(!dev_sidecar.contains("exec cargo run"));
 
     let device_dockerfile = fs::read_to_string("../docker/device/Dockerfile").unwrap();

--- a/executor/tests/build_entrypoint_contract.rs
+++ b/executor/tests/build_entrypoint_contract.rs
@@ -61,14 +61,18 @@ fn executor_build_entrypoints_use_rust_binary_build() {
 
     let local_sh = fs::read_to_string("local.sh").unwrap();
     assert!(local_sh.contains("cargo build --release --locked"));
-    assert!(local_sh.contains("target/release/wegent-executor"));
+    assert!(local_sh.contains("configure_wegent_cargo_target_dir \"$PROJECT_DIR\" \"executor\""));
+    assert!(local_sh.contains("cargo_target_binary_path \"$ROOT_DIR\" release wegent-executor"));
 
     let dev_sidecar = fs::read_to_string("../wework/scripts/dev-executor-sidecar.sh").unwrap();
     assert!(dev_sidecar.contains("WEGENT_EXECUTOR_DEV_RELOAD:-1"));
     assert!(dev_sidecar.contains("--features dev-reload"));
     assert!(dev_sidecar.contains("--bin wegent-executor-dev"));
     assert!(dev_sidecar.contains("cargo build"));
-    assert!(dev_sidecar.contains("exec \"$EXECUTOR_DIR/target/debug/wegent-executor-dev\""));
+    assert!(dev_sidecar.contains("configure_wegent_cargo_target_dir \"$PROJECT_DIR\" \"executor\""));
+    assert!(dev_sidecar.contains(
+        "cargo_target_binary_path \"$EXECUTOR_DIR\" debug wegent-executor-dev"
+    ));
     assert!(!dev_sidecar.contains("exec cargo run"));
 
     let device_dockerfile = fs::read_to_string("../docker/device/Dockerfile").unwrap();

--- a/scripts/lib/cargo-cache.sh
+++ b/scripts/lib/cargo-cache.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-# Shared Cargo target directories for local Codex worktrees.
+# Shared Cargo target directories for local worktrees.
 #
-# Normal clones keep Cargo's default per-worktree target directory. Codex
-# worktrees use a stable target root under ~/.codex so dependency artifacts can
-# be reused across branches without committing machine-specific Cargo config.
+# Local scripts use a stable cache root so dependency artifacts can be reused
+# across git worktrees without committing machine-specific Cargo config.
 
 configure_wegent_cargo_target_dir() {
   local project_dir="$1"
@@ -21,8 +20,10 @@ configure_wegent_cargo_target_dir() {
   local cache_root=""
   if [ -n "${WEGENT_CARGO_TARGET_ROOT:-}" ]; then
     cache_root="${WEGENT_CARGO_TARGET_ROOT%/}"
-  elif [ -n "${HOME:-}" ] && [[ "$project_dir" == "$HOME/.codex/worktrees/"*"/Wegent" ]]; then
-    cache_root="$HOME/.codex/cache/wegent/cargo-target"
+  elif [ -n "${XDG_CACHE_HOME:-}" ]; then
+    cache_root="${XDG_CACHE_HOME%/}/wegent/cargo-target"
+  elif [ -n "${HOME:-}" ]; then
+    cache_root="$HOME/.cache/wegent/cargo-target"
   else
     return 0
   fi

--- a/scripts/lib/cargo-cache.sh
+++ b/scripts/lib/cargo-cache.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Shared Cargo target directories for local Codex worktrees.
+#
+# Normal clones keep Cargo's default per-worktree target directory. Codex
+# worktrees use a stable target root under ~/.codex so dependency artifacts can
+# be reused across branches without committing machine-specific Cargo config.
+
+configure_wegent_cargo_target_dir() {
+  local project_dir="$1"
+  local cache_name="$2"
+
+  if [ "${WEGENT_DISABLE_SHARED_CARGO_TARGET:-0}" = "1" ]; then
+    return 0
+  fi
+
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    return 0
+  fi
+
+  local cache_root=""
+  if [ -n "${WEGENT_CARGO_TARGET_ROOT:-}" ]; then
+    cache_root="${WEGENT_CARGO_TARGET_ROOT%/}"
+  elif [ -n "${HOME:-}" ] && [[ "$project_dir" == "$HOME/.codex/worktrees/"*"/Wegent" ]]; then
+    cache_root="$HOME/.codex/cache/wegent/cargo-target"
+  else
+    return 0
+  fi
+
+  export CARGO_TARGET_DIR="$cache_root/$cache_name"
+  export WEGENT_CARGO_TARGET_DIR_AUTO=1
+  mkdir -p "$CARGO_TARGET_DIR"
+}
+
+cargo_target_dir_for() {
+  local manifest_dir="$1"
+
+  if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    case "$CARGO_TARGET_DIR" in
+      /*) printf '%s\n' "$CARGO_TARGET_DIR" ;;
+      *) printf '%s/%s\n' "$(pwd)" "$CARGO_TARGET_DIR" ;;
+    esac
+    return 0
+  fi
+
+  printf '%s/target\n' "$manifest_dir"
+}
+
+cargo_target_binary_path() {
+  local manifest_dir="$1"
+  local profile="$2"
+  local binary="$3"
+
+  printf '%s/%s/%s\n' "$(cargo_target_dir_for "$manifest_dir")" "$profile" "$binary"
+}

--- a/wework/scripts/build-mac-app.sh
+++ b/wework/scripts/build-mac-app.sh
@@ -7,6 +7,9 @@ WEWORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_DIR="$(cd "$WEWORK_DIR/.." && pwd)"
 ENV_FILE="$PROJECT_DIR/.env"
 
+# shellcheck source=../../scripts/lib/cargo-cache.sh
+source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
+
 if [ -f "$ENV_FILE" ]; then
   set -a
   # shellcheck disable=SC1090
@@ -45,11 +48,13 @@ DEFAULT_SOCKET_BASE_URL="${WEGENT_SOCKET_URL:-$BACKEND_BASE_URL}"
 
 export VITE_API_BASE_URL="${VITE_API_BASE_URL:-$BACKEND_BASE_URL/api}"
 export VITE_SOCKET_BASE_URL="${VITE_SOCKET_BASE_URL:-$DEFAULT_SOCKET_BASE_URL}"
+configure_wegent_cargo_target_dir "$PROJECT_DIR" "wework-src-tauri"
 
 echo "Building WeWork mac app"
 echo "  BACKEND_PORT=$BACKEND_PORT"
 echo "  VITE_API_BASE_URL=$VITE_API_BASE_URL"
 echo "  VITE_SOCKET_BASE_URL=$VITE_SOCKET_BASE_URL"
+echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
 
 if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
   exit 0

--- a/wework/scripts/dev-executor-sidecar.sh
+++ b/wework/scripts/dev-executor-sidecar.sh
@@ -7,12 +7,21 @@ WEWORK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_DIR="$(cd "$WEWORK_DIR/.." && pwd)"
 EXECUTOR_DIR="$PROJECT_DIR/executor"
 
+# shellcheck source=../../scripts/lib/cargo-cache.sh
+source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
+
+if [ "${WEGENT_CARGO_TARGET_DIR_AUTO:-0}" = "1" ]; then
+  unset CARGO_TARGET_DIR
+  unset WEGENT_CARGO_TARGET_DIR_AUTO
+fi
+configure_wegent_cargo_target_dir "$PROJECT_DIR" "executor"
+
 if [ "${WEGENT_EXECUTOR_DEV_RELOAD:-1}" != "0" ] && [ -z "${WEGENT_EXECUTOR_BINARY:-}" ]; then
   cargo build \
     --manifest-path "$EXECUTOR_DIR/Cargo.toml" \
     --features dev-reload \
     --bin wegent-executor-dev
-  exec "$EXECUTOR_DIR/target/debug/wegent-executor-dev" "$@"
+  exec "$(cargo_target_binary_path "$EXECUTOR_DIR" debug wegent-executor-dev)" "$@"
 fi
 
 if [ -n "${WEGENT_EXECUTOR_BINARY:-}" ]; then
@@ -23,9 +32,10 @@ if [ -x "$EXECUTOR_DIR/dist/wegent-executor" ]; then
   exec "$EXECUTOR_DIR/dist/wegent-executor" "$@"
 fi
 
-if [ -x "$EXECUTOR_DIR/target/release/wegent-executor" ]; then
-  exec "$EXECUTOR_DIR/target/release/wegent-executor" "$@"
+if [ "${WEGENT_CARGO_TARGET_DIR_AUTO:-0}" != "1" ] \
+  && [ -x "$(cargo_target_binary_path "$EXECUTOR_DIR" release wegent-executor)" ]; then
+  exec "$(cargo_target_binary_path "$EXECUTOR_DIR" release wegent-executor)" "$@"
 fi
 
 cargo build --manifest-path "$EXECUTOR_DIR/Cargo.toml" --bin wegent-executor
-exec "$EXECUTOR_DIR/target/debug/wegent-executor" "$@"
+exec "$(cargo_target_binary_path "$EXECUTOR_DIR" debug wegent-executor)" "$@"

--- a/wework/scripts/dev-mac-app.sh
+++ b/wework/scripts/dev-mac-app.sh
@@ -8,6 +8,9 @@ PROJECT_DIR="$(cd "$WEWORK_DIR/.." && pwd)"
 ENV_FILE="$PROJECT_DIR/.env"
 INITIAL_WEWORK_PORT="${WEWORK_PORT:-}"
 
+# shellcheck source=../../scripts/lib/cargo-cache.sh
+source "$PROJECT_DIR/scripts/lib/cargo-cache.sh"
+
 usage() {
   cat <<'EOF'
 Usage: bash wework/scripts/dev-mac-app.sh [options]
@@ -20,6 +23,11 @@ Environment:
   WEWORK_PORT           Default dev server port when --port is not provided.
   WEWORK_HOST           Host IP used to build backend proxy targets.
   BACKEND_PORT          Backend port used when proxy targets are not set.
+  CARGO_TARGET_DIR      Explicit Cargo target directory. Overrides auto cache.
+  WEGENT_CARGO_TARGET_ROOT
+                        Shared Cargo target root for Wegent local builds.
+  WEGENT_DISABLE_SHARED_CARGO_TARGET
+                        Set to 1 to keep Cargo's default per-worktree target.
   WEWORK_EXECUTOR_SIDECAR
                         Executor sidecar path. Defaults to source reload sidecar.
   WEGENT_EXECUTOR_DEV_RELOAD
@@ -123,6 +131,7 @@ export WEWORK_EXECUTOR_SIDECAR
 export VITE_API_BASE_URL="/api"
 export VITE_SOCKET_BASE_URL="http://localhost:$WEWORK_PORT"
 export VITE_SOCKET_PATH="${VITE_SOCKET_PATH:-/socket.io}"
+configure_wegent_cargo_target_dir "$PROJECT_DIR" "wework-src-tauri"
 
 TAURI_DEV_CONFIG="$(mktemp -t wework-tauri-dev.XXXXXX.json)"
 trap 'rm -f "$TAURI_DEV_CONFIG"' EXIT
@@ -149,6 +158,7 @@ echo "  VITE_SOCKET_PATH=$VITE_SOCKET_PATH"
 echo "  VITE_API_PROXY_TARGET=$VITE_API_PROXY_TARGET"
 echo "  VITE_SOCKET_PROXY_TARGET=$VITE_SOCKET_PROXY_TARGET"
 echo "  WEWORK_EXECUTOR_SIDECAR=${WEWORK_EXECUTOR_SIDECAR:-<bundled sidecar>}"
+echo "  CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-<cargo default>}"
 
 if [ "${WEWORK_DRY_RUN:-}" = "1" ]; then
   echo "  TAURI_DEV_CONFIG=$TAURI_DEV_CONFIG"


### PR DESCRIPTION
## Summary

- Use a shared Cargo target cache for local Wework/Tauri and executor build scripts, defaulting to the standard user cache directory instead of a worktree-local target path.
- Make the executor dev reload supervisor respect `CARGO_TARGET_DIR` when spawning the rebuilt `wegent-executor` child binary.
- Document the shared Cargo cache behavior and override/disable environment variables in the Chinese and English development setup docs.

## Why

Multiple local Git worktrees were repeatedly rebuilding the Wework Tauri app and executor dependencies. The shared target cache keeps Cargo artifacts reusable across worktrees while still allowing explicit `CARGO_TARGET_DIR` overrides and opt-out with `WEGENT_DISABLE_SHARED_CARGO_TARGET=1`.

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR="$HOME/.cache/wegent/cargo-target/executor" cargo test --features dev-reload --bin wegent-executor-dev`
- `CARGO_TARGET_DIR="$HOME/.cache/wegent/cargo-target/executor" cargo test --test build_entrypoint_contract`
- pre-push hook: Wework tests, executor `cargo fmt --check`, executor `cargo test --all-features`, executor `cargo clippy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared Cargo build-cache support for macOS development scripts, with configurable cache roots and opt-out support.
  * Build scripts now resolve Rust binary paths dynamically instead of relying on fixed output locations.

* **Documentation**
  * Expanded setup guides in English and Chinese with cache location behavior, shared build usage, and relevant environment variables.

* **Bug Fixes**
  * Improved executor and app build/reload flows to work correctly with custom or relative Cargo target directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->