### PR TITLE
[codex] Add compact message navigation

### DIFF
--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -1,0 +1,347 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { RefObject } from 'react'
+import { useTranslation } from '@/hooks/useTranslation'
+import { cn } from '@/lib/utils'
+import type { WorkbenchMessage } from '@/types/workbench'
+
+const USER_PREVIEW_LENGTH = 56
+const RESPONSE_PREVIEW_LENGTH = 72
+const SCROLL_OFFSET_PX = 96
+const COLLAPSED_MARKER_WIDTH_PX = 8
+const SECONDARY_MARKER_WIDTH_PX = 12
+const NEARBY_MARKER_WIDTH_PX = 16
+const EXPANDED_MARKER_WIDTH_PX = 24
+const MARKER_HIT_AREA_WIDTH_PX = 28
+const MARKER_ROW_HEIGHT_PX = 8
+const MARKER_ROW_GAP_PX = 5
+const MAX_NAVIGATION_HEIGHT_PX = 96
+const MESSAGE_ANCHOR_SELECTOR = '[data-message-id]'
+const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
+
+interface MessageTurnNavigationProps {
+  messages: WorkbenchMessage[]
+  scrollRef: RefObject<HTMLDivElement | null>
+  contentRef: RefObject<HTMLDivElement | null>
+}
+
+interface UserTurn {
+  id: string
+  turnIndex: number
+  messageIndex: number
+  promptPreview: string
+  responsePreview: string
+}
+
+interface MessageTurnMarker extends UserTurn {
+  targetTop: number
+}
+
+export function MessageTurnNavigation({
+  messages,
+  scrollRef,
+  contentRef,
+}: MessageTurnNavigationProps) {
+  const { t } = useTranslation('chat')
+  const [markers, setMarkers] = useState<MessageTurnMarker[]>([])
+  const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null)
+  const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null)
+  const markersRef = useRef<MessageTurnMarker[]>([])
+  const rafRef = useRef<number | null>(null)
+
+  const userTurns = useMemo(() => buildUserTurns(messages), [messages])
+
+  const updateActiveMarker = useCallback(
+    (nextMarkers: MessageTurnMarker[]) => {
+      const scroller = scrollRef.current
+      if (!scroller || nextMarkers.length === 0) {
+        setActiveMarkerId(null)
+        return
+      }
+
+      const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
+      let activeMarker = nextMarkers[0]
+      for (const marker of nextMarkers) {
+        if (marker.targetTop <= currentPosition) {
+          activeMarker = marker
+        } else {
+          break
+        }
+      }
+
+      setActiveMarkerId(activeMarker.id)
+    },
+    [scrollRef]
+  )
+
+  const calculateMarkers = useCallback(() => {
+    const scroller = scrollRef.current
+    const content = contentRef.current
+    if (!scroller || !content || userTurns.length === 0) {
+      markersRef.current = []
+      setMarkers([])
+      setActiveMarkerId(null)
+      return
+    }
+
+    if (scroller.scrollHeight <= scroller.clientHeight + 8) {
+      markersRef.current = []
+      setMarkers([])
+      setActiveMarkerId(null)
+      return
+    }
+
+    const scrollerRect = scroller.getBoundingClientRect()
+    const nextMarkers = userTurns.flatMap(turn => {
+      const anchor = findMessageAnchorById(content, turn.id)
+      if (!anchor) return []
+
+      const anchorRect = anchor.getBoundingClientRect()
+      const targetTop = Math.max(0, scroller.scrollTop + anchorRect.top - scrollerRect.top)
+      return [
+        {
+          ...turn,
+          targetTop,
+        },
+      ]
+    })
+
+    markersRef.current = nextMarkers
+    setMarkers(nextMarkers)
+    updateActiveMarker(nextMarkers)
+  }, [contentRef, scrollRef, updateActiveMarker, userTurns])
+
+  const scheduleCalculateMarkers = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current)
+    }
+
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null
+      calculateMarkers()
+    })
+  }, [calculateMarkers])
+
+  useLayoutEffect(() => {
+    calculateMarkers()
+  }, [calculateMarkers])
+
+  useEffect(() => {
+    const scroller = scrollRef.current
+    const content = contentRef.current
+    if (!scroller || !content) return
+
+    const handleScroll = () => updateActiveMarker(markersRef.current)
+    scroller.addEventListener('scroll', handleScroll, { passive: true })
+    window.addEventListener('resize', scheduleCalculateMarkers)
+
+    const mutationObserver = new MutationObserver(scheduleCalculateMarkers)
+    mutationObserver.observe(content, { childList: true, subtree: true })
+
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleCalculateMarkers)
+    resizeObserver?.observe(content)
+    resizeObserver?.observe(scroller)
+
+    return () => {
+      scroller.removeEventListener('scroll', handleScroll)
+      window.removeEventListener('resize', scheduleCalculateMarkers)
+      mutationObserver.disconnect()
+      resizeObserver?.disconnect()
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+    }
+  }, [contentRef, scheduleCalculateMarkers, scrollRef, updateActiveMarker])
+
+  const handleMarkerClick = useCallback(
+    (marker: MessageTurnMarker) => {
+      const scroller = scrollRef.current
+      if (!scroller) return
+
+      scroller.scrollTo({
+        top: Math.max(0, marker.targetTop - SCROLL_OFFSET_PX),
+        behavior: 'smooth',
+      })
+    },
+    [scrollRef]
+  )
+
+  if (markers.length === 0) return null
+
+  const navigationHeight = getNavigationHeight(markers.length)
+  const hoveredMarkerIndex =
+    hoveredMarkerId === null ? -1 : markers.findIndex(marker => marker.id === hoveredMarkerId)
+
+  return (
+    <nav
+      aria-label={t('message_navigation.label', '历史发言导航')}
+      className="pointer-events-none absolute top-1/2 z-20 hidden -translate-y-1/2 lg:block"
+      data-testid="message-turn-navigation"
+      style={{
+        left: '8px',
+        width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
+        height: `${navigationHeight}px`,
+      }}
+    >
+      <div className="relative h-full w-full">
+        {markers.map((marker, index) => {
+          const isActive = activeMarkerId === marker.id
+          const hoverDistance =
+            hoveredMarkerIndex === -1 ? null : Math.abs(index - hoveredMarkerIndex)
+
+          return (
+            <div
+              key={marker.id}
+              className="group absolute left-0 -translate-y-1/2"
+              style={{
+                top: `${getMarkerTopPx(index, markers.length, navigationHeight)}px`,
+                height: `${MARKER_ROW_HEIGHT_PX}px`,
+                width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
+              }}
+              onMouseEnter={() => setHoveredMarkerId(marker.id)}
+              onMouseLeave={() => setHoveredMarkerId(null)}
+            >
+              <button
+                type="button"
+                aria-label={t('message_navigation.jump_to_message', {
+                  index: marker.turnIndex + 1,
+                  defaultValue: `跳转到第 ${marker.turnIndex + 1} 条发言`,
+                })}
+                className="pointer-events-auto flex h-full w-full items-center justify-start rounded-md p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
+                data-active={isActive}
+                data-testid="message-turn-navigation-marker"
+                onClick={() => handleMarkerClick(marker)}
+                onFocus={() => setHoveredMarkerId(marker.id)}
+                onBlur={() => setHoveredMarkerId(null)}
+              >
+                <span
+                  className={cn(
+                    'block h-[2px] rounded-full transition-all duration-150 ease-out',
+                    getMarkerToneClass(isActive, hoverDistance)
+                  )}
+                  style={{
+                    width: `${getMarkerWidthPx(hoverDistance)}px`,
+                  }}
+                />
+              </button>
+              <div className="pointer-events-none absolute left-8 top-1/2 z-30 w-[300px] max-w-[calc(100vw-56px)] -translate-y-1/2 rounded-md border border-border bg-background px-2.5 py-2 text-left opacity-0 shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+                <p className="break-words text-[11px] font-semibold leading-4 text-text-primary">
+                  {marker.promptPreview}
+                </p>
+                {marker.responsePreview && (
+                  <p className="mt-1 break-words text-[11px] leading-4 text-text-muted">
+                    {marker.responsePreview}
+                  </p>
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}
+
+function buildUserTurns(messages: WorkbenchMessage[]): UserTurn[] {
+  const turns: UserTurn[] = []
+  messages.forEach((message, index) => {
+    if (message.role !== 'user') return
+
+    turns.push({
+      id: message.id,
+      turnIndex: turns.length,
+      messageIndex: index,
+      promptPreview: getUserPromptPreview(message),
+      responsePreview: getFollowingAssistantPreview(messages, index),
+    })
+  })
+
+  return turns
+}
+
+function getUserPromptPreview(message: WorkbenchMessage) {
+  const codexRequest = extractCodexRequest(message.content)
+  return truncatePreview(codexRequest || message.content, USER_PREVIEW_LENGTH)
+}
+
+function getFollowingAssistantPreview(messages: WorkbenchMessage[], userMessageIndex: number) {
+  const assistantMessage = messages
+    .slice(userMessageIndex + 1)
+    .find(message => message.role === 'assistant')
+  if (!assistantMessage) return ''
+
+  const textBlockContent = getFirstTextBlockContent(assistantMessage)
+  const previewSource = assistantMessage.content.trim() || textBlockContent
+  return truncatePreview(previewSource, RESPONSE_PREVIEW_LENGTH)
+}
+
+function getFirstTextBlockContent(message: WorkbenchMessage) {
+  for (const block of message.blocks ?? []) {
+    if (block.type !== 'text' || !('content' in block) || typeof block.content !== 'string') {
+      continue
+    }
+
+    if (block.content.trim()) {
+      return block.content
+    }
+  }
+
+  return ''
+}
+
+function extractCodexRequest(content: string) {
+  const requestMarker = content.match(CODEX_REQUEST_MARKER_PATTERN)
+  if (requestMarker?.index === undefined) return ''
+
+  return content.slice(requestMarker.index + requestMarker[0].length).trim()
+}
+
+function truncatePreview(text: string, maxLength: number) {
+  const normalizedText = text.replace(/\s+/g, ' ').trim()
+  if (normalizedText.length <= maxLength) return normalizedText
+
+  return `${normalizedText.slice(0, maxLength)}...`
+}
+
+function getNavigationHeight(markerCount: number) {
+  if (markerCount <= 1) return MARKER_ROW_HEIGHT_PX
+
+  const preferredHeight =
+    MARKER_ROW_HEIGHT_PX + (markerCount - 1) * (MARKER_ROW_HEIGHT_PX + MARKER_ROW_GAP_PX)
+
+  return Math.min(MAX_NAVIGATION_HEIGHT_PX, preferredHeight)
+}
+
+function getMarkerTopPx(index: number, markerCount: number, navigationHeight: number) {
+  if (markerCount <= 1) return navigationHeight / 2
+
+  const availableHeight = Math.max(0, navigationHeight - MARKER_ROW_HEIGHT_PX)
+  return MARKER_ROW_HEIGHT_PX / 2 + (availableHeight * index) / (markerCount - 1)
+}
+
+function getMarkerWidthPx(hoverDistance: number | null) {
+  if (hoverDistance === 0) return EXPANDED_MARKER_WIDTH_PX
+  if (hoverDistance === 1) return NEARBY_MARKER_WIDTH_PX
+  if (hoverDistance === 2) return SECONDARY_MARKER_WIDTH_PX
+
+  return COLLAPSED_MARKER_WIDTH_PX
+}
+
+function getMarkerToneClass(isActive: boolean, hoverDistance: number | null) {
+  if (hoverDistance === 0) return 'bg-text-primary opacity-100'
+  if (hoverDistance === 1) return 'bg-text-primary/70 opacity-90'
+  if (hoverDistance === 2) return 'bg-text-muted/75 opacity-80'
+  if (hoverDistance !== null) return 'bg-text-muted/55 opacity-70'
+  if (isActive) return 'bg-text-primary opacity-100'
+
+  return 'bg-text-muted/55 opacity-70'
+}
+
+function findMessageAnchorById(content: HTMLElement, messageId: string) {
+  return (
+    Array.from(content.querySelectorAll<HTMLElement>(MESSAGE_ANCHOR_SELECTOR)).find(
+      anchor => anchor.dataset.messageId === messageId
+    ) ?? null
+  )
+}

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -167,6 +167,151 @@ describe('ScrollableMessageArea', () => {
     })
   })
 
+  test('renders a compact left-side navigation for previous user messages', () => {
+    render(
+      <ScrollableMessageArea
+        messages={[
+          {
+            id: 'user-1',
+            role: 'user',
+            content: '第一条用户需求',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:00.000Z',
+          },
+          {
+            id: 'assistant-1',
+            role: 'assistant',
+            content: '第一条回复摘要',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:01.000Z',
+          },
+          {
+            id: 'user-2',
+            role: 'user',
+            content: [
+              '# Files mentioned by the user:',
+              '',
+              '## notes.txt: /tmp/notes.txt',
+              '',
+              '## My request for Codex:',
+              '第二条用户需求',
+            ].join('\n'),
+            status: 'done',
+            createdAt: '2026-05-29T00:00:02.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 300,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1000,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('第一条用户需求').closest('[data-message-id]')!, 120, 180)
+    mockRect(screen.getByText('第二条用户需求').closest('[data-message-id]')!, 620, 680)
+
+    fireEvent.resize(window)
+
+    const navigation = screen.getByTestId('message-turn-navigation')
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    expect(navigation).toHaveAccessibleName('历史发言导航')
+    expect(navigation).toHaveStyle({ height: '21px' })
+    expect(markers).toHaveLength(2)
+    expect(markers[0]).toHaveAccessibleName('跳转到第 1 条发言')
+    expect(markers[1]).toHaveAccessibleName('跳转到第 2 条发言')
+    const activeMarkerIndicator = markers[0].querySelector('span')
+    const nearbyMarkerIndicator = markers[1].querySelector('span')
+    expect(activeMarkerIndicator).toHaveStyle({ width: '8px' })
+    expect(nearbyMarkerIndicator).toHaveStyle({ width: '8px' })
+    fireEvent.focus(markers[0])
+    expect(activeMarkerIndicator).toHaveStyle({ width: '24px' })
+    expect(nearbyMarkerIndicator).toHaveStyle({ width: '16px' })
+    fireEvent.blur(markers[0])
+    expect(activeMarkerIndicator).toHaveStyle({ width: '8px' })
+    expect(nearbyMarkerIndicator).toHaveStyle({ width: '8px' })
+
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 620,
+      writable: true,
+      configurable: true,
+    })
+    fireEvent.scroll(scroller)
+    expect(nearbyMarkerIndicator).toHaveClass('bg-text-primary')
+    fireEvent.focus(markers[0])
+    expect(nearbyMarkerIndicator).not.toHaveClass('bg-text-primary')
+    fireEvent.blur(markers[0])
+    expect(screen.getAllByText('第一条用户需求')).toHaveLength(2)
+    expect(screen.getAllByText('第一条回复摘要')).toHaveLength(2)
+  })
+
+  test('clicks a message navigation marker to jump to that user message', () => {
+    render(
+      <ScrollableMessageArea
+        messages={[
+          {
+            id: 'jump-user-1',
+            role: 'user',
+            content: '先前需求',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:00.000Z',
+          },
+          {
+            id: 'jump-assistant-1',
+            role: 'assistant',
+            content: '先前回复',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:01.000Z',
+          },
+          {
+            id: 'jump-user-2',
+            role: 'user',
+            content: '需要跳转的需求',
+            status: 'done',
+            createdAt: '2026-05-29T00:00:02.000Z',
+          },
+        ]}
+      />
+    )
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 300,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 1000,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    })
+    scroller.scrollTo = vi.fn()
+    mockRect(scroller, 0, 300)
+    mockRect(screen.getByText('先前需求').closest('[data-message-id]')!, 120, 180)
+    mockRect(screen.getByText('需要跳转的需求').closest('[data-message-id]')!, 620, 680)
+
+    fireEvent.resize(window)
+    fireEvent.click(screen.getAllByTestId('message-turn-navigation-marker')[1])
+
+    expect(scroller.scrollTo).toHaveBeenCalledWith({
+      top: 524,
+      behavior: 'smooth',
+    })
+  })
+
   test('pins the conversation to the bottom after opening a chat', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import type { DeviceInfo, TurnFileChangesSummary } from '@/types/api'
 import type { WorkbenchMessage } from '@/types/workbench'
 import { MessageList } from './MessageList'
+import { MessageTurnNavigation } from './MessageTurnNavigation'
 
 const BOTTOM_THRESHOLD = 48
 const STABLE_SCROLL_DELAYS = [0, 50, 150, 300]
@@ -355,6 +356,7 @@ export function ScrollableMessageArea({
 
   return (
     <div className={cn('relative min-h-0 flex-1', className)}>
+      <MessageTurnNavigation messages={messages} scrollRef={scrollRef} contentRef={contentRef} />
       <div
         ref={scrollRef}
         data-testid={scrollTestId}

--- a/wework/src/i18n/locales/en/chat.json
+++ b/wework/src/i18n/locales/en/chat.json
@@ -1,4 +1,8 @@
 {
+  "message_navigation": {
+    "label": "Previous message navigation",
+    "jump_to_message": "Jump to message {{index}}"
+  },
   "thinking": {
     "running": "Thinking",
     "updating": "Organizing thoughts...",

--- a/wework/src/i18n/locales/zh-CN/chat.json
+++ b/wework/src/i18n/locales/zh-CN/chat.json
@@ -1,4 +1,8 @@
 {
+  "message_navigation": {
+    "label": "历史发言导航",
+    "jump_to_message": "跳转到第 {{index}} 条发言"
+  },
   "thinking": {
     "running": "正在思考",
     "updating": "正在整理思路...",


### PR DESCRIPTION
## Summary

- Add a compact left-side message navigation rail in Wework chat transcripts.
- Let users jump back to previous user turns with hover/focus previews.
- Match the requested compact visual behavior, including hover gradient expansion and suppressing active-state blackening during hover.
- Add chat i18n labels and focused tests for sizing, hover behavior, and jump scrolling.

## Validation

- `pnpm --dir wework exec vitest run src/components/chat/ScrollableMessageArea.test.tsx`
- `pnpm --dir wework exec eslint src/components/chat/MessageTurnNavigation.tsx src/components/chat/ScrollableMessageArea.tsx src/components/chat/ScrollableMessageArea.test.tsx`
- `pnpm --dir wework exec tsc -b --pretty false`
- Pre-commit `lint-staged` hook passed.
- Pre-push full Wework test suite passed: 94 files, 844 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a left-side navigation rail in chat for quickly jumping between previous user messages.
  * Navigation markers highlight the active message, show hover/focus states, and display message previews.
  * Clicking a marker smoothly scrolls to the selected turn.

* **Bug Fixes**
  * Improved marker positioning and updates so navigation stays aligned as chat content or layout changes.

* **Tests**
  * Added coverage for marker visibility, active state behavior, scrolling, and accessibility.

* **Documentation**
  * Added localized chat labels for the new message navigation in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->