### PR TITLE
[codex] Restore startup window dragging

### DIFF
--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -6,8 +6,14 @@ import '@/i18n'
 import { ensureLocalExecutorStarted } from '@/tauri/localExecutor'
 import { LocalRuntimeInitializer } from './LocalRuntimeInitializer'
 
+const startDragging = vi.fn().mockResolvedValue(undefined)
+
 vi.mock('@/tauri/localExecutor', () => ({
   ensureLocalExecutorStarted: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ startDragging }),
 }))
 
 const ensureMock = vi.mocked(ensureLocalExecutorStarted)
@@ -33,6 +39,7 @@ describe('LocalRuntimeInitializer', () => {
     enableTauri()
     vi.stubEnv('DEV', false)
     ensureMock.mockReset()
+    startDragging.mockClear()
   })
 
   afterEach(() => {
@@ -69,6 +76,25 @@ describe('LocalRuntimeInitializer', () => {
 
     expect(await screen.findByTestId('main-app')).not.toBeVisible()
     expect(screen.getByTestId('local-runtime-initializer')).toBeInTheDocument()
+  })
+
+  test('keeps the startup screen titlebar draggable', async () => {
+    ensureMock.mockResolvedValue({ running: true, ready: true, deviceId: 'local-device' })
+
+    render(
+      <LocalRuntimeInitializer startupReady={false}>
+        <div data-testid="main-app">Main app</div>
+      </LocalRuntimeInitializer>
+    )
+
+    const dragRegion = within(screen.getByTestId('local-runtime-titlebar-drag-region')).getByTestId(
+      'macos-titlebar-drag-region'
+    )
+    expect(dragRegion).toHaveAttribute('data-tauri-drag-region')
+
+    fireEvent.mouseDown(dragRegion, { button: 0 })
+
+    await waitFor(() => expect(startDragging).toHaveBeenCalledTimes(1))
   })
 
   test('does not remount children when the startup screen is dismissed', async () => {

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -10,6 +10,7 @@ import {
   Sparkles,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { MacOSTitleBarDragRegion } from '@/components/layout/MacOSTitleBarDragRegion'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useTranslation } from '@/hooks/useTranslation'
 import { isTauriRuntime } from '@/lib/runtime-environment'
@@ -213,8 +214,14 @@ export function LocalRuntimeInitializer({
       {shouldShowStartupScreen && (
         <main
           data-testid="local-runtime-initializer"
-          className="flex h-screen min-h-[520px] items-center justify-center overflow-hidden bg-base px-6 py-10 text-text-primary"
+          className="relative flex h-screen min-h-[520px] items-center justify-center overflow-hidden bg-base px-6 py-10 text-text-primary"
         >
+          <div
+            data-testid="local-runtime-titlebar-drag-region"
+            className="absolute inset-x-0 top-0 h-[52px]"
+          >
+            <MacOSTitleBarDragRegion className="h-full w-full" />
+          </div>
           <section className="flex w-full max-w-[520px] flex-col items-center text-center">
             {failed ? (
               <div className="mb-6 flex h-14 w-14 items-center justify-center rounded-lg border border-border bg-surface text-text-secondary">


### PR DESCRIPTION
## Summary

Restores native window dragging while the Wework local runtime startup screen is visible.

## Root Cause

The startup overlay rendered a full-screen page without any Tauri drag region at the top, so clicks in the visually empty titlebar area were handled by the page instead of starting native window dragging.

## Changes

- Added a transparent top drag region to `LocalRuntimeInitializer` using the existing `MacOSTitleBarDragRegion` component.
- Added test coverage to verify the startup screen exposes the drag region and calls `startDragging()`.

## Validation

- `pnpm --dir wework lint`
- `pnpm --dir wework test -- LocalRuntimeInitializer.test.tsx`
- Pre-push wework test suite: 94 test files / 845 tests passed, quality checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a draggable title-bar region to the startup screen for macOS users.
* **Bug Fixes**
  * Improved window dragging behavior when the local runtime is still loading, making the top bar easier to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->