### PR TITLE
[codex] Add Wework system tray menu

### DIFF
--- a/wework/src-tauri/Cargo.toml
+++ b/wework/src-tauri/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 libc = "0.2"
-tauri = { version = "2.11.2", features = ["protocol-asset", "unstable"] }
+tauri = { version = "2.11.2", features = ["protocol-asset", "tray-icon", "unstable"] }
 tauri-plugin-log = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"

--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -4,6 +4,30 @@ mod local_terminal;
 
 use tauri::Manager;
 
+#[cfg(desktop)]
+use tauri::{
+    menu::{Menu, MenuBuilder, MenuItem, SubmenuBuilder},
+    tray::TrayIconBuilder,
+    Emitter,
+};
+
+#[cfg(desktop)]
+const MAIN_WINDOW_LABEL: &str = "main";
+#[cfg(desktop)]
+const TRAY_OPEN_SETTINGS_EVENT: &str = "wework-tray-open-settings";
+#[cfg(desktop)]
+const TRAY_OPEN_TASK_EVENT: &str = "wework-tray-open-task";
+#[cfg(desktop)]
+const TRAY_MENU_OPEN_ID: &str = "open";
+#[cfg(desktop)]
+const TRAY_MENU_SETTINGS_ID: &str = "settings";
+#[cfg(desktop)]
+const TRAY_MENU_QUIT_ID: &str = "quit";
+#[cfg(desktop)]
+const TRAY_MENU_TASK_PREFIX: &str = "task:";
+#[cfg(desktop)]
+const TRAY_ID: &str = "wework-main";
+
 fn normalized_non_empty(value: String) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -359,6 +383,299 @@ fn get_local_executor_device_id(expected_backend_url: Option<String>) -> Option<
     None
 }
 
+#[cfg(desktop)]
+fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+}
+
+#[cfg(desktop)]
+fn open_settings_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    show_main_window(app);
+    if let Err(error) = app.emit(TRAY_OPEN_SETTINGS_EVENT, ()) {
+        log::warn!("Failed to emit tray settings navigation event: {error}");
+    }
+}
+
+#[cfg(desktop)]
+#[derive(Clone, serde::Serialize)]
+struct TrayTaskOpenPayload {
+    id: String,
+}
+
+#[cfg(desktop)]
+fn open_task_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>, task_id: &str) {
+    show_main_window(app);
+    if let Err(error) = app.emit(
+        TRAY_OPEN_TASK_EVENT,
+        TrayTaskOpenPayload {
+            id: task_id.to_string(),
+        },
+    ) {
+        log::warn!("Failed to emit tray task navigation event: {error}");
+    }
+}
+
+#[cfg(desktop)]
+fn quit_from_tray<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let state = app.state::<local_executor::LocalExecutorState>();
+    local_executor::shutdown_local_executor(&state);
+    app.exit(0);
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TrayMenuTaskItem {
+    id: String,
+    title: String,
+    project_name: String,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TrayMenuStatePayload {
+    language: String,
+    running: Vec<TrayMenuTaskItem>,
+    running_more: Vec<TrayMenuTaskItem>,
+    pinned: Vec<TrayMenuTaskItem>,
+    pinned_more: Vec<TrayMenuTaskItem>,
+    recent: Vec<TrayMenuTaskItem>,
+    recent_more: Vec<TrayMenuTaskItem>,
+}
+
+#[cfg(desktop)]
+impl TrayMenuStatePayload {
+    fn empty(language: &str) -> Self {
+        Self {
+            language: language.to_string(),
+            running: Vec::new(),
+            running_more: Vec::new(),
+            pinned: Vec::new(),
+            pinned_more: Vec::new(),
+            recent: Vec::new(),
+            recent_more: Vec::new(),
+        }
+    }
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Copy)]
+enum TrayLanguage {
+    ZhCn,
+    En,
+}
+
+#[cfg(desktop)]
+impl TrayLanguage {
+    fn from_language(language: &str) -> Self {
+        if language.trim().to_lowercase().starts_with("en") {
+            Self::En
+        } else {
+            Self::ZhCn
+        }
+    }
+
+    fn labels(self) -> TrayMenuLabels {
+        match self {
+            Self::ZhCn => TrayMenuLabels {
+                running: "运行中",
+                pinned: "置顶",
+                tasks: "任务",
+                untitled_task: "未命名任务",
+                no_pinned_tasks: "暂无置顶任务",
+                no_tasks: "暂无任务",
+                more: "更多",
+                open: "打开应用",
+                settings: "设置",
+                quit: "退出应用",
+            },
+            Self::En => TrayMenuLabels {
+                running: "Running",
+                pinned: "Pinned",
+                tasks: "Tasks",
+                untitled_task: "Untitled Task",
+                no_pinned_tasks: "No Pinned Tasks",
+                no_tasks: "No Tasks",
+                more: "More",
+                open: "Open App",
+                settings: "Settings",
+                quit: "Quit App",
+            },
+        }
+    }
+}
+
+#[cfg(desktop)]
+struct TrayMenuLabels {
+    running: &'static str,
+    pinned: &'static str,
+    tasks: &'static str,
+    untitled_task: &'static str,
+    no_pinned_tasks: &'static str,
+    no_tasks: &'static str,
+    more: &'static str,
+    open: &'static str,
+    settings: &'static str,
+    quit: &'static str,
+}
+
+#[cfg(desktop)]
+fn build_system_tray_menu<M: Manager<tauri::Wry>>(
+    manager: &M,
+    state: &TrayMenuStatePayload,
+) -> tauri::Result<Menu<tauri::Wry>> {
+    let labels = TrayLanguage::from_language(&state.language).labels();
+    let mut builder = MenuBuilder::new(manager);
+
+    builder = append_tray_task_section(
+        builder,
+        manager,
+        labels.running,
+        labels.untitled_task,
+        "",
+        labels.more,
+        &state.running,
+        &state.running_more,
+        false,
+    )?;
+    builder = append_tray_task_section(
+        builder,
+        manager,
+        labels.pinned,
+        labels.untitled_task,
+        labels.no_pinned_tasks,
+        labels.more,
+        &state.pinned,
+        &state.pinned_more,
+        true,
+    )?;
+    builder = append_tray_task_section(
+        builder,
+        manager,
+        labels.tasks,
+        labels.untitled_task,
+        labels.no_tasks,
+        labels.more,
+        &state.recent,
+        &state.recent_more,
+        true,
+    )?;
+
+    builder
+        .text(TRAY_MENU_OPEN_ID, labels.open)
+        .separator()
+        .text(TRAY_MENU_SETTINGS_ID, labels.settings)
+        .separator()
+        .text(TRAY_MENU_QUIT_ID, labels.quit)
+        .build()
+}
+
+#[cfg(desktop)]
+fn append_tray_task_section<'m, M: Manager<tauri::Wry>>(
+    mut builder: MenuBuilder<'m, tauri::Wry, M>,
+    manager: &M,
+    title: &str,
+    untitled_task: &str,
+    empty_text: &str,
+    more: &str,
+    items: &[TrayMenuTaskItem],
+    more_items: &[TrayMenuTaskItem],
+    always_visible: bool,
+) -> tauri::Result<MenuBuilder<'m, tauri::Wry, M>> {
+    if items.is_empty() && more_items.is_empty() && !always_visible {
+        return Ok(builder);
+    }
+
+    let heading = MenuItem::new(manager, title, false, None::<&str>)?;
+    builder = builder.item(&heading);
+
+    if items.is_empty() && more_items.is_empty() {
+        let empty_item = MenuItem::new(manager, empty_text, false, None::<&str>)?;
+        builder = builder.item(&empty_item);
+    } else {
+        for item in items {
+            let title = normalized_menu_task_title(item, untitled_task);
+            builder = builder.text(format!("{TRAY_MENU_TASK_PREFIX}{}", item.id), title);
+        }
+        if !more_items.is_empty() {
+            let mut submenu = SubmenuBuilder::new(manager, more);
+            for item in more_items {
+                let title = normalized_menu_task_title(item, untitled_task);
+                submenu = submenu.text(format!("{TRAY_MENU_TASK_PREFIX}{}", item.id), title);
+            }
+            let submenu = submenu.build()?;
+            builder = builder.item(&submenu);
+        }
+    }
+
+    Ok(builder.separator())
+}
+
+#[cfg(desktop)]
+fn normalized_menu_task_title(item: &TrayMenuTaskItem, fallback: &str) -> String {
+    let title = item.title.trim();
+    let project_name = item.project_name.trim();
+    if title.is_empty() {
+        return fallback.to_string();
+    }
+    if project_name.is_empty() {
+        title.to_string()
+    } else {
+        format!("{title} - {project_name}")
+    }
+}
+
+#[cfg(desktop)]
+fn setup_system_tray(app: &mut tauri::App) -> tauri::Result<()> {
+    let menu = build_system_tray_menu(app, &TrayMenuStatePayload::empty("zh-CN"))?;
+
+    let mut tray = TrayIconBuilder::with_id(TRAY_ID)
+        .menu(&menu)
+        .tooltip("WeWork")
+        .show_menu_on_left_click(true)
+        .on_menu_event(|app, event| {
+            let event_id = event.id().as_ref();
+            match event_id {
+                TRAY_MENU_OPEN_ID => show_main_window(app),
+                TRAY_MENU_SETTINGS_ID => open_settings_from_tray(app),
+                TRAY_MENU_QUIT_ID => quit_from_tray(app),
+                _ => {
+                    if let Some(task_id) = event_id.strip_prefix(TRAY_MENU_TASK_PREFIX) {
+                        open_task_from_tray(app, task_id);
+                    }
+                }
+            }
+        });
+
+    if let Some(icon) = app.default_window_icon().cloned() {
+        tray = tray.icon(icon);
+    }
+
+    tray.build(app)?;
+    Ok(())
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+fn set_tray_menu_state(app: tauri::AppHandle, state: TrayMenuStatePayload) -> Result<(), String> {
+    let menu = build_system_tray_menu(&app, &state)
+        .map_err(|error| format!("Failed to build tray menu: {error}"))?;
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return Ok(());
+    };
+    tray.set_menu(Some(menu))
+        .map_err(|error| format!("Failed to update tray menu: {error}"))
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+fn set_tray_menu_state(_state: TrayMenuStatePayload) -> Result<(), String> {
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -399,6 +716,8 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            #[cfg(desktop)]
+            setup_system_tray(app)?;
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -417,6 +736,7 @@ pub fn run() {
             local_executor::local_executor_request,
             local_executor::local_executor_restart,
             local_executor::local_executor_status,
+            set_tray_menu_state,
             download_local_file_to_downloads,
             local_path_exists,
             read_dropped_files,

--- a/wework/src/extensions/desktop.ts
+++ b/wework/src/extensions/desktop.ts
@@ -1,1 +1,5 @@
-export function installDesktopExtensions() {}
+import { installTraySettingsNavigation } from '@/tauri/trayNavigation'
+
+export function installDesktopExtensions() {
+  installTraySettingsNavigation()
+}

--- a/wework/src/pages/WorkbenchPage.tsx
+++ b/wework/src/pages/WorkbenchPage.tsx
@@ -1,9 +1,12 @@
+import { useEffect, useMemo } from 'react'
 import { DesktopWorkbenchLayout } from '@/components/layout/DesktopWorkbenchLayout'
 import { MobileWorkbenchLayout } from '@/components/layout/MobileWorkbenchLayout'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
 import { useAuth } from '@/features/auth/useAuth'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { navigateTo } from '@/lib/navigation'
+import { buildTrayMenuTaskGroups } from '@/tauri/trayMenuState'
+import { syncTrayMenuState } from '@/tauri/trayNavigation'
 
 export function WorkbenchPage() {
   const isMobile = useIsMobile()
@@ -86,6 +89,15 @@ export function WorkbenchPage() {
     loadTurnFileChangesDiff,
     revertTurnFileChanges,
   } = useWorkbench()
+  const trayMenuTaskGroups = useMemo(
+    () => buildTrayMenuTaskGroups(state.runtimeWork),
+    [state.runtimeWork]
+  )
+
+  useEffect(() => {
+    syncTrayMenuState(trayMenuTaskGroups)
+  }, [trayMenuTaskGroups])
+
   const Layout = isMobile ? MobileWorkbenchLayout : DesktopWorkbenchLayout
   const projectWork = {
     projects: state.projects,

--- a/wework/src/tauri/trayMenuState.test.ts
+++ b/wework/src/tauri/trayMenuState.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from 'vitest'
+import type { LocalTaskSummary, RuntimeDeviceWorkspace, RuntimeWorkListResponse } from '@/types/api'
+import { buildTrayMenuTaskGroups } from './trayMenuState'
+import { parseTrayTaskMenuId } from './trayTaskMenuId'
+
+function task(overrides: Partial<LocalTaskSummary>): LocalTaskSummary {
+  return {
+    localTaskId: 'task',
+    workspacePath: '/workspace/project',
+    title: 'Task',
+    runtime: 'codex',
+    ...overrides,
+  }
+}
+
+function workspace(overrides: Partial<RuntimeDeviceWorkspace>): RuntimeDeviceWorkspace {
+  return {
+    deviceId: 'device-a',
+    available: true,
+    workspacePath: '/workspace/project',
+    localTasks: [],
+    ...overrides,
+  }
+}
+
+function runtimeWork(overrides: Partial<RuntimeWorkListResponse>): RuntimeWorkListResponse {
+  return {
+    projects: [],
+    chats: [],
+    totalLocalTasks: 0,
+    ...overrides,
+  }
+}
+
+describe('buildTrayMenuTaskGroups', () => {
+  test('builds running, pinned, and recent task groups from runtime work', () => {
+    const work = runtimeWork({
+      projects: [
+        {
+          project: {
+            key: 'project-1',
+            id: 1,
+            name: 'Project 1',
+          },
+          deviceWorkspaces: [
+            workspace({
+              localTasks: [
+                task({
+                  localTaskId: 'old',
+                  title: 'Older task',
+                  updatedAt: '2026-01-01T00:00:00Z',
+                }),
+                task({
+                  localTaskId: 'running',
+                  title: 'Running task',
+                  updatedAt: '2026-01-04T00:00:00Z',
+                  running: true,
+                }),
+                task({
+                  localTaskId: 'pinned',
+                  title: 'Pinned task',
+                  updatedAt: '2026-01-03T00:00:00Z',
+                  pinned: true,
+                } as LocalTaskSummary),
+              ],
+            }),
+          ],
+          totalLocalTasks: 3,
+        },
+      ],
+      chats: [
+        workspace({
+          label: 'Chat Project',
+          deviceId: 'device-b',
+          workspacePath: '/workspace/chats/chat-1',
+          workspaceKind: 'chat',
+          localTasks: [
+            task({
+              localTaskId: 'chat',
+              workspacePath: '/workspace/chats/chat-1',
+              workspaceKind: 'chat',
+              title: 'Chat task',
+              updatedAt: '2026-01-05T00:00:00Z',
+            }),
+          ],
+        }),
+      ],
+      totalLocalTasks: 4,
+    })
+
+    const groups = buildTrayMenuTaskGroups(work)
+
+    expect(groups.running.map(item => item.title)).toEqual(['Running task'])
+    expect(groups.running.map(item => item.projectName)).toEqual(['Project 1'])
+    expect(groups.runningMore).toEqual([])
+    expect(groups.pinned.map(item => item.title)).toEqual(['Pinned task'])
+    expect(groups.pinned.map(item => item.projectName)).toEqual(['Project 1'])
+    expect(groups.pinnedMore).toEqual([])
+    expect(groups.recent.map(item => item.title)).toEqual([
+      'Chat task',
+      'Running task',
+      'Pinned task',
+    ])
+    expect(groups.recent.map(item => item.projectName)).toEqual([
+      'Chat Project',
+      'Project 1',
+      'Project 1',
+    ])
+    expect(groups.recentMore.map(item => item.title)).toEqual(['Older task'])
+    expect(groups.running.map(item => parseTrayTaskMenuId(item.id))).toEqual([
+      {
+        deviceId: 'device-a',
+        localTaskId: 'running',
+      },
+    ])
+  })
+
+  test('deduplicates tasks that appear in multiple runtime work sections', () => {
+    const sharedWorkspace = workspace({
+      deviceId: 'device-b',
+      workspacePath: '/workspace/chats/chat-1',
+      workspaceKind: 'chat',
+      localTasks: [
+        task({
+          localTaskId: 'chat',
+          workspacePath: '/workspace/chats/chat-1',
+          workspaceKind: 'chat',
+          title: 'Chat task',
+          updatedAt: '2026-01-05T00:00:00Z',
+        }),
+      ],
+    })
+
+    const groups = buildTrayMenuTaskGroups(
+      runtimeWork({
+        projects: [
+          {
+            project: {
+              key: 'project-1',
+              id: 1,
+              name: 'Project 1',
+            },
+            deviceWorkspaces: [sharedWorkspace],
+            totalLocalTasks: 1,
+          },
+        ],
+        chats: [sharedWorkspace],
+        totalLocalTasks: 1,
+      })
+    )
+
+    expect(groups.recent).toHaveLength(1)
+  })
+
+  test('limits pinned tasks to three and reports more pinned tasks', () => {
+    const groups = buildTrayMenuTaskGroups(
+      runtimeWork({
+        projects: [
+          {
+            project: {
+              key: 'project-1',
+              id: 1,
+              name: 'Project 1',
+            },
+            deviceWorkspaces: [
+              workspace({
+                localTasks: [1, 2, 3, 4].map(index =>
+                  task({
+                    localTaskId: `pinned-${index}`,
+                    title: `Pinned ${index}`,
+                    updatedAt: `2026-01-0${index}T00:00:00Z`,
+                    pinned: true,
+                  } as LocalTaskSummary)
+                ),
+              }),
+            ],
+            totalLocalTasks: 4,
+          },
+        ],
+        totalLocalTasks: 4,
+      })
+    )
+
+    expect(groups.pinned.map(item => item.title)).toEqual(['Pinned 4', 'Pinned 3', 'Pinned 2'])
+    expect(groups.pinned.map(item => item.projectName)).toEqual([
+      'Project 1',
+      'Project 1',
+      'Project 1',
+    ])
+    expect(groups.pinnedMore.map(item => item.title)).toEqual(['Pinned 1'])
+  })
+})

--- a/wework/src/tauri/trayMenuState.ts
+++ b/wework/src/tauri/trayMenuState.ts
@@ -1,0 +1,138 @@
+import {
+  getRuntimeChatSidebarTaskItems,
+  getRuntimeSidebarTaskItems,
+  getRuntimeTaskAddress,
+  sortRuntimeTaskItems,
+} from '@/components/layout/runtimeTaskSidebarHelpers'
+import type { LocalTaskSummary, RuntimeDeviceWorkspace, RuntimeWorkListResponse } from '@/types/api'
+import { createTrayTaskMenuId } from './trayTaskMenuId'
+
+export interface TrayMenuTaskItem {
+  id: string
+  title: string
+  projectName: string
+}
+
+export interface TrayMenuTaskGroups {
+  running: TrayMenuTaskItem[]
+  runningMore: TrayMenuTaskItem[]
+  pinned: TrayMenuTaskItem[]
+  pinnedMore: TrayMenuTaskItem[]
+  recent: TrayMenuTaskItem[]
+  recentMore: TrayMenuTaskItem[]
+}
+
+export const TRAY_MENU_TASK_LIMIT = 3
+
+const PINNED_TASK_FIELDS = ['pinned', 'isPinned', 'is_pinned', 'marked'] as const
+
+export const EMPTY_TRAY_MENU_TASK_GROUPS: TrayMenuTaskGroups = {
+  running: [],
+  runningMore: [],
+  pinned: [],
+  pinnedMore: [],
+  recent: [],
+  recentMore: [],
+}
+
+interface TrayRuntimeTaskItem {
+  workspace: RuntimeDeviceWorkspace
+  task: LocalTaskSummary
+  projectName: string
+}
+
+function isPinnedRuntimeTask(task: LocalTaskSummary): boolean {
+  const taskRecord = task as unknown as Record<string, unknown>
+  return PINNED_TASK_FIELDS.some(field => taskRecord[field] === true)
+}
+
+function collectRuntimeTaskItems(
+  runtimeWork: RuntimeWorkListResponse | null | undefined
+): TrayRuntimeTaskItem[] {
+  if (!runtimeWork) {
+    return []
+  }
+
+  const projectItems = runtimeWork.projects.flatMap(projectWork =>
+    getRuntimeSidebarTaskItems(projectWork.deviceWorkspaces).map(item => ({
+      ...item,
+      projectName: getProjectDisplayName(
+        projectWork.project.name,
+        item.workspace,
+        projectWork.project.key
+      ),
+    }))
+  )
+  const chatItems = getRuntimeChatSidebarTaskItems(runtimeWork.chats).map(item => ({
+    ...item,
+    projectName: getProjectDisplayName(null, item.workspace, item.workspace.workspacePath),
+  }))
+  const seenTaskKeys = new Set<string>()
+  const sortedItems = sortRuntimeTaskItems([...projectItems, ...chatItems]) as TrayRuntimeTaskItem[]
+
+  return sortedItems.filter(({ workspace, task }) => {
+    const taskKey = `${workspace.deviceId}\n${task.localTaskId}`
+    if (seenTaskKeys.has(taskKey)) {
+      return false
+    }
+    seenTaskKeys.add(taskKey)
+    return true
+  })
+}
+
+function getProjectDisplayName(
+  projectName: string | null | undefined,
+  workspace: RuntimeDeviceWorkspace,
+  fallback: string
+): string {
+  return (
+    projectName?.trim() ||
+    workspace.label?.trim() ||
+    workspace.workspacePath.trim() ||
+    fallback.trim()
+  )
+}
+
+function getTrayTaskTitle(task: LocalTaskSummary): string {
+  return task.title.trim() || task.localTaskId
+}
+
+function toTrayMenuTaskItem({
+  workspace,
+  task,
+  projectName,
+}: TrayRuntimeTaskItem): TrayMenuTaskItem {
+  const address = getRuntimeTaskAddress(workspace, task)
+  return {
+    id: createTrayTaskMenuId(address),
+    title: getTrayTaskTitle(task),
+    projectName,
+  }
+}
+
+function splitTrayMenuTasks(items: TrayRuntimeTaskItem[]) {
+  return {
+    visible: items.slice(0, TRAY_MENU_TASK_LIMIT).map(toTrayMenuTaskItem),
+    more: items.slice(TRAY_MENU_TASK_LIMIT).map(toTrayMenuTaskItem),
+  }
+}
+
+export function buildTrayMenuTaskGroups(
+  runtimeWork: RuntimeWorkListResponse | null | undefined
+): TrayMenuTaskGroups {
+  const items = collectRuntimeTaskItems(runtimeWork)
+  const running = items.filter(({ task }) => task.running)
+  const pinned = items.filter(({ task }) => isPinnedRuntimeTask(task))
+  const runningTasks = splitTrayMenuTasks(running)
+  const pinnedTasks = splitTrayMenuTasks(pinned)
+  const recentTasks = splitTrayMenuTasks(items)
+
+  return {
+    running: runningTasks.visible,
+    runningMore: runningTasks.more,
+    pinned: pinnedTasks.visible,
+    pinnedMore: pinnedTasks.more,
+    recent: recentTasks.visible,
+    recentMore: recentTasks.more,
+  }
+}

--- a/wework/src/tauri/trayNavigation.test.ts
+++ b/wework/src/tauri/trayNavigation.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const listenMock = vi.hoisted(() => vi.fn())
+const invokeMock = vi.hoisted(() => vi.fn())
+const navigateToMock = vi.hoisted(() => vi.fn())
+const buildRuntimeTaskRouteMock = vi.hoisted(() => vi.fn())
+const isTauriRuntimeMock = vi.hoisted(() => vi.fn())
+const i18nMock = vi.hoisted(() => ({
+  language: 'zh-CN',
+  resolvedLanguage: 'zh-CN' as string | undefined,
+  on: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: invokeMock,
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: listenMock,
+}))
+
+vi.mock('@/lib/navigation', () => ({
+  buildRuntimeTaskRoute: buildRuntimeTaskRouteMock,
+  navigateTo: navigateToMock,
+}))
+
+vi.mock('@/lib/runtime-environment', () => ({
+  isTauriRuntime: isTauriRuntimeMock,
+}))
+
+vi.mock('@/i18n', () => ({
+  default: i18nMock,
+}))
+
+describe('trayNavigation', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    listenMock.mockReset()
+    invokeMock.mockReset()
+    navigateToMock.mockReset()
+    buildRuntimeTaskRouteMock.mockReset()
+    isTauriRuntimeMock.mockReset()
+    i18nMock.on.mockReset()
+    i18nMock.language = 'zh-CN'
+    i18nMock.resolvedLanguage = 'zh-CN'
+    listenMock.mockResolvedValue(vi.fn())
+    invokeMock.mockResolvedValue(undefined)
+    buildRuntimeTaskRouteMock.mockImplementation(
+      ({ deviceId, localTaskId }: { deviceId: string; localTaskId: string }) =>
+        `/runtime-tasks?deviceId=${encodeURIComponent(deviceId)}&localTaskId=${encodeURIComponent(
+          localTaskId
+        )}`
+    )
+  })
+
+  test('does not subscribe outside the Tauri runtime', async () => {
+    isTauriRuntimeMock.mockReturnValue(false)
+
+    const { installTraySettingsNavigation } = await import('./trayNavigation')
+    installTraySettingsNavigation()
+
+    expect(listenMock).not.toHaveBeenCalled()
+    expect(invokeMock).not.toHaveBeenCalled()
+  })
+
+  test('opens settings when the tray settings event is received', async () => {
+    const handlers = new Map<string, () => void>()
+    isTauriRuntimeMock.mockReturnValue(true)
+    listenMock.mockImplementation((_eventName: string, callback: unknown) => {
+      handlers.set(_eventName, callback as () => void)
+      return Promise.resolve(vi.fn())
+    })
+
+    const { installTraySettingsNavigation, WEWORK_TRAY_OPEN_SETTINGS_EVENT } =
+      await import('./trayNavigation')
+
+    installTraySettingsNavigation()
+    installTraySettingsNavigation()
+
+    expect(listenMock).toHaveBeenCalledTimes(2)
+    expect(listenMock).toHaveBeenCalledWith(WEWORK_TRAY_OPEN_SETTINGS_EVENT, expect.any(Function))
+
+    handlers.get(WEWORK_TRAY_OPEN_SETTINGS_EVENT)?.()
+
+    expect(navigateToMock).toHaveBeenCalledWith('/settings')
+  })
+
+  test('opens a runtime task when the tray task event is received', async () => {
+    const handlers = new Map<string, (event: { payload: { id: string } }) => void>()
+    isTauriRuntimeMock.mockReturnValue(true)
+    listenMock.mockImplementation((_eventName: string, callback: unknown) => {
+      handlers.set(_eventName, callback as (event: { payload: { id: string } }) => void)
+      return Promise.resolve(vi.fn())
+    })
+
+    const { installTraySettingsNavigation, WEWORK_TRAY_OPEN_TASK_EVENT } =
+      await import('./trayNavigation')
+    const { createTrayTaskMenuId } = await import('./trayTaskMenuId')
+
+    installTraySettingsNavigation()
+
+    handlers.get(WEWORK_TRAY_OPEN_TASK_EVENT)?.({
+      payload: {
+        id: createTrayTaskMenuId({
+          deviceId: 'device/1',
+          localTaskId: 'task:1',
+        }),
+      },
+    })
+
+    expect(buildRuntimeTaskRouteMock).toHaveBeenCalledWith({
+      deviceId: 'device/1',
+      localTaskId: 'task:1',
+    })
+    expect(navigateToMock).toHaveBeenCalledWith(
+      '/runtime-tasks?deviceId=device%2F1&localTaskId=task%3A1'
+    )
+  })
+
+  test('syncs the tray menu state on install and language changes', async () => {
+    let languageChangedHandler: ((language: string) => void) | undefined
+    isTauriRuntimeMock.mockReturnValue(true)
+    i18nMock.resolvedLanguage = 'en-US'
+    i18nMock.on.mockImplementation((eventName: string, callback: unknown) => {
+      if (eventName === 'languageChanged') {
+        languageChangedHandler = callback as (language: string) => void
+      }
+      return i18nMock
+    })
+
+    const { installTraySettingsNavigation, SET_TRAY_MENU_STATE_COMMAND, syncTrayMenuState } =
+      await import('./trayNavigation')
+
+    installTraySettingsNavigation()
+    installTraySettingsNavigation()
+
+    expect(invokeMock).toHaveBeenCalledTimes(1)
+    expect(invokeMock).toHaveBeenCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
+      state: {
+        language: 'en',
+        running: [],
+        runningMore: [],
+        pinned: [],
+        pinnedMore: [],
+        recent: [],
+        recentMore: [],
+      },
+    })
+    expect(i18nMock.on).toHaveBeenCalledTimes(1)
+
+    const taskGroups = {
+      running: [{ id: 'task-1', title: 'Running task', projectName: 'Wegent' }],
+      runningMore: [],
+      pinned: [],
+      pinnedMore: [],
+      recent: [{ id: 'task-1', title: 'Running task', projectName: 'Wegent' }],
+      recentMore: [],
+    }
+    syncTrayMenuState(taskGroups, 'en-US')
+
+    expect(invokeMock).toHaveBeenLastCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
+      state: {
+        language: 'en',
+        ...taskGroups,
+      },
+    })
+
+    languageChangedHandler?.('zh-CN')
+
+    expect(invokeMock).toHaveBeenLastCalledWith(SET_TRAY_MENU_STATE_COMMAND, {
+      state: {
+        language: 'zh-CN',
+        ...taskGroups,
+      },
+    })
+  })
+})

--- a/wework/src/tauri/trayNavigation.ts
+++ b/wework/src/tauri/trayNavigation.ts
@@ -1,0 +1,82 @@
+import { invoke } from '@tauri-apps/api/core'
+import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import i18n from '@/i18n'
+import { buildRuntimeTaskRoute, navigateTo } from '@/lib/navigation'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+import { EMPTY_TRAY_MENU_TASK_GROUPS, type TrayMenuTaskGroups } from './trayMenuState'
+import { parseTrayTaskMenuId } from './trayTaskMenuId'
+
+export const WEWORK_TRAY_OPEN_SETTINGS_EVENT = 'wework-tray-open-settings'
+export const WEWORK_TRAY_OPEN_TASK_EVENT = 'wework-tray-open-task'
+export const SET_TRAY_MENU_STATE_COMMAND = 'set_tray_menu_state'
+
+let traySettingsNavigationListener: Promise<UnlistenFn> | null = null
+let trayTaskNavigationListener: Promise<UnlistenFn> | null = null
+let trayLanguageSyncInstalled = false
+let latestTrayTaskGroups = EMPTY_TRAY_MENU_TASK_GROUPS
+
+function getTrayLanguage(language?: string): string {
+  return language?.toLowerCase().startsWith('en') ? 'en' : 'zh-CN'
+}
+
+function getTrayMenuState(language = i18n.resolvedLanguage || i18n.language) {
+  return {
+    language: getTrayLanguage(language),
+    ...latestTrayTaskGroups,
+  }
+}
+
+export function syncTrayMenuState(
+  taskGroups: TrayMenuTaskGroups = latestTrayTaskGroups,
+  language = i18n.resolvedLanguage || i18n.language
+) {
+  latestTrayTaskGroups = taskGroups
+
+  if (!isTauriRuntime()) {
+    return
+  }
+
+  void invoke(SET_TRAY_MENU_STATE_COMMAND, {
+    state: getTrayMenuState(language),
+  }).catch(error => {
+    console.error('[Wework] Failed to sync tray menu state', error)
+  })
+}
+
+export function installTraySettingsNavigation() {
+  if (!isTauriRuntime()) {
+    return
+  }
+
+  if (!traySettingsNavigationListener) {
+    traySettingsNavigationListener = listen(WEWORK_TRAY_OPEN_SETTINGS_EVENT, () => {
+      navigateTo('/settings')
+    }).catch(error => {
+      traySettingsNavigationListener = null
+      console.error('[Wework] Failed to install tray settings navigation listener', error)
+      return () => {}
+    })
+  }
+
+  if (!trayTaskNavigationListener) {
+    trayTaskNavigationListener = listen<{ id: string }>(WEWORK_TRAY_OPEN_TASK_EVENT, event => {
+      const address = parseTrayTaskMenuId(event.payload.id)
+      if (!address) {
+        return
+      }
+      navigateTo(buildRuntimeTaskRoute(address))
+    }).catch(error => {
+      trayTaskNavigationListener = null
+      console.error('[Wework] Failed to install tray task navigation listener', error)
+      return () => {}
+    })
+  }
+
+  if (!trayLanguageSyncInstalled) {
+    trayLanguageSyncInstalled = true
+    syncTrayMenuState()
+    i18n.on('languageChanged', language => {
+      syncTrayMenuState(latestTrayTaskGroups, language)
+    })
+  }
+}

--- a/wework/src/tauri/trayTaskMenuId.ts
+++ b/wework/src/tauri/trayTaskMenuId.ts
@@ -1,0 +1,24 @@
+export interface TrayTaskMenuAddress {
+  deviceId: string
+  localTaskId: string
+}
+
+export function createTrayTaskMenuId(address: TrayTaskMenuAddress): string {
+  return `${encodeURIComponent(address.deviceId)}:${encodeURIComponent(address.localTaskId)}`
+}
+
+export function parseTrayTaskMenuId(id: string): TrayTaskMenuAddress | null {
+  const parts = id.split(':')
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return null
+  }
+
+  try {
+    return {
+      deviceId: decodeURIComponent(parts[0]),
+      localTaskId: decodeURIComponent(parts[1]),
+    }
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Wework desktop system tray menu backed by Tauri tray support. The menu opens on both left and right tray clicks, keeps Chinese and English labels separated by the active app language, and supports task navigation from tray menu items.

## What changed

- Enabled Tauri tray icon support and added a native tray menu in `wework/src-tauri`.
- Added dynamic tray state sync from Wework runtime work so the menu can show Running, Pinned, and Tasks sections.
- Keeps Pinned and Tasks visible, limits first-level task items to 3, and moves overflow tasks into a More submenu.
- Includes project names in tray task labels and opens selected runtime tasks from tray clicks.
- Adds focused tests for tray navigation, task menu ID encoding, grouping, limits, and overflow behavior.

## Validation

- `cargo check`
- `pnpm --dir wework exec vitest run src/tauri/trayNavigation.test.ts src/tauri/trayMenuState.test.ts`
- `pnpm --dir wework exec tsc -b --pretty false`
- `pnpm --dir wework exec eslint src/tauri/trayNavigation.ts src/tauri/trayNavigation.test.ts src/tauri/trayMenuState.ts src/tauri/trayMenuState.test.ts src/tauri/trayTaskMenuId.ts src/pages/WorkbenchPage.tsx`
- pre-push Wework test suite: 96 files, 851 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a desktop system tray with quick access to running, pinned, and recent tasks.
  * Introduced tray actions for opening settings, opening a task, and quitting the app.
  * Tray menu updates now stay in sync with the current workspace and language.

* **Bug Fixes**
  * Improved task list handling by removing duplicates and limiting overflow with a “more” section.

* **Tests**
  * Added coverage for tray menu grouping, tray navigation, and menu syncing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->