### PR TITLE
[codex] Share E2E build artifacts

### DIFF
--- a/.github/scripts/archive-executor-e2e-runtime.sh
+++ b/.github/scripts/archive-executor-e2e-runtime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+image_tag="${2:-wegent/e2e-claudecode-executor:latest}"
+image_archive="$artifact_dir/e2e-claudecode-executor-image.tar.zst"
+binary_archive="$artifact_dir/wegent-executor"
+
+mkdir -p "$artifact_dir"
+
+docker image inspect "$image_tag" >/dev/null
+test -x executor/target/release/wegent-executor
+
+docker save "$image_tag" | zstd -T0 -3 > "$image_archive"
+cp executor/target/release/wegent-executor "$binary_archive"
+chmod 0755 "$binary_archive"
+
+test -s "$image_archive"
+test -x "$binary_archive"

--- a/.github/scripts/archive-frontend-e2e-build.sh
+++ b/.github/scripts/archive-frontend-e2e-build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+archive="$artifact_dir/frontend-next-build.tar.zst"
+
+mkdir -p "$artifact_dir"
+
+test -f frontend/.next/BUILD_ID
+test -d frontend/public
+
+tar --exclude='.next/cache' -I 'zstd -T0 -3' -cf "$archive" -C frontend .next public
+test -s "$archive"

--- a/.github/scripts/archive-frontend-e2e-build.sh
+++ b/.github/scripts/archive-frontend-e2e-build.sh
@@ -6,8 +6,39 @@ archive="$artifact_dir/frontend-next-build.tar.zst"
 
 mkdir -p "$artifact_dir"
 
+find_standalone_server() {
+  local candidate
+  for candidate in \
+    frontend/.next/standalone/server.js \
+    frontend/.next/standalone/frontend/server.js; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  find frontend/.next/standalone \
+    -maxdepth 3 \
+    -type f \
+    -name server.js \
+    ! -path '*/node_modules/*' \
+    | sort \
+    | head -n 1
+}
+
 test -f frontend/.next/BUILD_ID
+test -d frontend/.next/static
 test -d frontend/public
+
+standalone_server="$(find_standalone_server)"
+test -n "$standalone_server"
+test -f "$standalone_server"
+
+standalone_dir="$(dirname "$standalone_server")"
+rm -rf "$standalone_dir/public" "$standalone_dir/.next/static"
+mkdir -p "$standalone_dir/.next"
+cp -R frontend/public "$standalone_dir/public"
+cp -R frontend/.next/static "$standalone_dir/.next/static"
 
 tar --exclude='.next/cache' -I 'zstd -T0 -3' -cf "$archive" -C frontend .next public
 test -s "$archive"

--- a/.github/scripts/restore-executor-e2e-runtime.sh
+++ b/.github/scripts/restore-executor-e2e-runtime.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+image_tag="${2:-wegent/e2e-claudecode-executor:latest}"
+image_archive="$artifact_dir/e2e-claudecode-executor-image.tar.zst"
+binary_archive="$artifact_dir/wegent-executor"
+
+test -s "$image_archive"
+test -s "$binary_archive"
+
+zstd -dc "$image_archive" | docker load
+docker image inspect "$image_tag" >/dev/null
+
+mkdir -p executor/target/release
+cp "$binary_archive" executor/target/release/wegent-executor
+chmod 0755 executor/target/release/wegent-executor
+
+test -x executor/target/release/wegent-executor

--- a/.github/scripts/restore-frontend-e2e-build.sh
+++ b/.github/scripts/restore-frontend-e2e-build.sh
@@ -4,9 +4,34 @@ set -euo pipefail
 artifact_dir="${1:-.ci-artifacts}"
 archive="$artifact_dir/frontend-next-build.tar.zst"
 
+find_standalone_server() {
+  local candidate
+  for candidate in \
+    frontend/.next/standalone/server.js \
+    frontend/.next/standalone/frontend/server.js; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  find frontend/.next/standalone \
+    -maxdepth 3 \
+    -type f \
+    -name server.js \
+    ! -path '*/node_modules/*' \
+    | sort \
+    | head -n 1
+}
+
 test -s "$archive"
 
 rm -rf frontend/.next
 tar -I zstd -xf "$archive" -C frontend
 
 test -f frontend/.next/BUILD_ID
+standalone_server="$(find_standalone_server)"
+test -n "$standalone_server"
+test -f "$standalone_server"
+test -d "$(dirname "$standalone_server")/public"
+test -d "$(dirname "$standalone_server")/.next/static"

--- a/.github/scripts/restore-frontend-e2e-build.sh
+++ b/.github/scripts/restore-frontend-e2e-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="${1:-.ci-artifacts}"
+archive="$artifact_dir/frontend-next-build.tar.zst"
+
+test -s "$archive"
+
+rm -rf frontend/.next
+tar -I zstd -xf "$archive" -C frontend
+
+test -f frontend/.next/BUILD_ID

--- a/.github/scripts/start-frontend-e2e-server.sh
+++ b/.github/scripts/start-frontend-e2e-server.sh
@@ -25,6 +25,6 @@ server_path="$(find_standalone_server)"
 test -n "$server_path"
 test -f "$server_path"
 
-HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+HOSTNAME="${E2E_FRONTEND_HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
   nohup node "$server_path" > next-dev.log 2>&1 &
 echo $! > next-dev.pid

--- a/.github/scripts/start-frontend-e2e-server.sh
+++ b/.github/scripts/start-frontend-e2e-server.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_standalone_server() {
+  local candidate
+  for candidate in \
+    .next/standalone/server.js \
+    .next/standalone/frontend/server.js; do
+    if [ -f "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  find .next/standalone \
+    -maxdepth 3 \
+    -type f \
+    -name server.js \
+    ! -path '*/node_modules/*' \
+    | sort \
+    | head -n 1
+}
+
+server_path="$(find_standalone_server)"
+test -n "$server_path"
+test -f "$server_path"
+
+HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+  nohup node "$server_path" > next-dev.log 2>&1 &
+echo $! > next-dev.pid

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,9 +16,113 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-frontend-e2e:
+    name: Build Frontend E2E Artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Cache frontend node_modules
+        id: frontend-node-modules-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            node_modules
+            frontend/node_modules
+            packages/*/node_modules
+          key: ${{ runner.os }}-node-24-frontend-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-24-frontend-
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Next.js build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ./frontend/.next/cache
+          key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-${{ hashFiles('./frontend/src/**/*.[jt]s', './frontend/src/**/*.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-e2e-
+
+      - name: Build frontend for E2E
+        working-directory: ./frontend
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8000
+          NEXT_TELEMETRY_DISABLED: 1
+          RUNTIME_INTERNAL_API_URL: http://localhost:8000
+          RUNTIME_SOCKET_DIRECT_URL: http://localhost:8000
+        run: pnpm exec next build
+
+      - name: Archive frontend E2E build
+        run: .github/scripts/archive-frontend-e2e-build.sh
+
+      - name: Upload frontend E2E build
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: frontend-next-build
+          path: .ci-artifacts/frontend-next-build.tar.zst
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  build-executor-e2e-runtime:
+    name: Build Executor E2E Runtime Artifact
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Build ClaudeCode Source Executor Image
+        run: |
+          docker build \
+            -t wegent/e2e-claudecode-executor:latest \
+            -f frontend/e2e/fixtures/claudecode-executor/Dockerfile \
+            .
+
+      - name: Extract ClaudeCode Executor Binary
+        run: |
+          mkdir -p executor/target/release
+          container_id="$(docker create wegent/e2e-claudecode-executor:latest)"
+          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
+          docker cp "$container_id:/app/executor" executor/target/release/wegent-executor
+          chmod 0755 executor/target/release/wegent-executor
+
+      - name: Archive executor E2E runtime
+        run: .github/scripts/archive-executor-e2e-runtime.sh
+
+      - name: Upload executor E2E runtime
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: executor-e2e-runtime
+          path: |
+            .ci-artifacts/e2e-claudecode-executor-image.tar.zst
+            .ci-artifacts/wegent-executor
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
   # Runs browser and API tests with sharding. Executor-heavy coverage runs separately.
   e2e-tests:
     name: E2E Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
+    needs: build-frontend-e2e
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
@@ -136,25 +240,14 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      # Cache Next.js build
-      - name: Cache Next.js build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Download frontend E2E build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          path: |
-            ./frontend/.next/cache
-          key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-${{ hashFiles('./frontend/src/**/*.[jt]s', './frontend/src/**/*.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-e2e-
+          name: frontend-next-build
+          path: .ci-artifacts
 
-      - name: Build frontend for E2E
-        working-directory: ./frontend
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8000
-          NEXT_TELEMETRY_DISABLED: 1
-          RUNTIME_INTERNAL_API_URL: http://localhost:8000
-          RUNTIME_SOCKET_DIRECT_URL: http://localhost:8000
-        run: pnpm exec next build
+      - name: Restore frontend E2E build
+        run: .github/scripts/restore-frontend-e2e-build.sh
 
       # Cache Playwright browsers
       - name: Cache Playwright browsers
@@ -323,6 +416,7 @@ jobs:
 
   executor-e2e-tests:
     name: Executor E2E Tests
+    needs: [build-frontend-e2e, build-executor-e2e-runtime]
     runs-on: ubuntu-latest
     timeout-minutes: 35
 
@@ -370,9 +464,6 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Install executor Rust system dependencies
         run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev
@@ -465,24 +556,14 @@ jobs:
       - name: Install frontend dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Cache Next.js cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+      - name: Download frontend E2E build
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          path: |
-            ./frontend/.next/cache
-          key: ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-${{ hashFiles('./frontend/src/**/*.[jt]s', './frontend/src/**/*.[jt]sx') }}
-          restore-keys: |
-            ${{ runner.os }}-nextjs-e2e-${{ hashFiles('./pnpm-lock.yaml') }}-
-            ${{ runner.os }}-nextjs-e2e-
+          name: frontend-next-build
+          path: .ci-artifacts
 
-      - name: Build frontend for E2E
-        working-directory: ./frontend
-        env:
-          NEXT_PUBLIC_API_URL: http://localhost:8000
-          NEXT_TELEMETRY_DISABLED: 1
-          RUNTIME_INTERNAL_API_URL: http://localhost:8000
-          RUNTIME_SOCKET_DIRECT_URL: http://localhost:8000
-        run: pnpm exec next build
+      - name: Restore frontend E2E build
+        run: .github/scripts/restore-frontend-e2e-build.sh
 
       - name: Cache Playwright browsers
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
@@ -500,6 +581,15 @@ jobs:
         working-directory: ./frontend
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
+
+      - name: Download executor E2E runtime
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: executor-e2e-runtime
+          path: .ci-artifacts
+
+      - name: Restore executor E2E runtime
+        run: .github/scripts/restore-executor-e2e-runtime.sh
 
       - name: Run database migrations
         working-directory: ./backend
@@ -566,21 +656,6 @@ jobs:
         run: |
           pnpm exec tsx e2e/utils/mock-model-server.ts > mock-model-server.log 2>&1 &
           echo $! > mock-server.pid
-
-      - name: Build ClaudeCode Source Executor Image
-        run: |
-          docker build \
-            -t wegent/e2e-claudecode-executor:latest \
-            -f frontend/e2e/fixtures/claudecode-executor/Dockerfile \
-            .
-
-      - name: Extract ClaudeCode Executor Binary
-        run: |
-          mkdir -p executor/target/release
-          container_id="$(docker create wegent/e2e-claudecode-executor:latest)"
-          trap 'docker rm -f "$container_id" >/dev/null 2>&1 || true' EXIT
-          docker cp "$container_id:/app/executor" executor/target/release/wegent-executor
-          chmod 0755 executor/target/release/wegent-executor
 
       - name: Start Local ClaudeCode Executor
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -48,6 +48,7 @@ jobs:
             ${{ runner.os }}-node-24-frontend-
 
       - name: Install frontend dependencies
+        if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Cache Next.js build
@@ -238,6 +239,7 @@ jobs:
           uv pip install -e ../shared
 
       - name: Install frontend dependencies
+        if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download frontend E2E build
@@ -310,9 +312,7 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           RUNTIME_INTERNAL_API_URL: http://localhost:8000
           RUNTIME_SOCKET_DIRECT_URL: http://localhost:8000
-        run: |
-          nohup pnpm exec next start > next-dev.log 2>&1 &
-          echo $! > next-dev.pid
+        run: ../.github/scripts/start-frontend-e2e-server.sh
 
       - name: Start Mock Model Server
         working-directory: ./frontend
@@ -554,6 +554,7 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code@2.1.142
 
       - name: Install frontend dependencies
+        if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Download frontend E2E build
@@ -647,9 +648,7 @@ jobs:
           NEXT_TELEMETRY_DISABLED: 1
           RUNTIME_INTERNAL_API_URL: http://localhost:8000
           RUNTIME_SOCKET_DIRECT_URL: http://localhost:8000
-        run: |
-          nohup pnpm exec next start > next-dev.log 2>&1 &
-          echo $! > next-dev.pid
+        run: ../.github/scripts/start-frontend-e2e-server.sh
 
       - name: Start Mock Model Server
         working-directory: ./frontend
@@ -915,6 +914,7 @@ jobs:
           merge-multiple: true
 
       - name: Install frontend dependencies
+        if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Merge reports

--- a/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
+++ b/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
@@ -1,0 +1,251 @@
+---
+sidebar_position: 1
+---
+
+# CI E2E Shared Builds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build E2E runtime artifacts once per GitHub Actions run and share them across ordinary E2E shards and executor E2E.
+
+**Architecture:** Add dedicated build jobs that upload immutable artifacts, then fan out isolated test jobs that download and restore those artifacts. Keep dependency caches and service containers per job.
+
+**Tech Stack:** GitHub Actions, Bash, Docker CLI, Next.js 15, Playwright.
+
+---
+
+## File Structure
+
+- Create `.github/scripts/archive-frontend-e2e-build.sh`: package `frontend/.next`
+  and `frontend/public` into `.ci-artifacts/frontend-next-build.tar.zst`.
+- Create `.github/scripts/restore-frontend-e2e-build.sh`: unpack the frontend
+  artifact and verify `frontend/.next/BUILD_ID`.
+- Create `.github/scripts/archive-executor-e2e-runtime.sh`: save the
+  ClaudeCode executor image and extracted binary into `.ci-artifacts/`.
+- Create `.github/scripts/restore-executor-e2e-runtime.sh`: load the Docker
+  image, restore the local executor binary, and verify both outputs.
+- Modify `.github/workflows/e2e-tests.yml`: add build jobs, download artifacts
+  in test jobs, and remove duplicated build steps.
+- Modify `frontend/e2e/README.md`: document that CI now uses shared production
+  build artifacts.
+
+### Task 1: Add artifact helper scripts
+
+**Files:**
+- Create: `.github/scripts/archive-frontend-e2e-build.sh`
+- Create: `.github/scripts/restore-frontend-e2e-build.sh`
+- Create: `.github/scripts/archive-executor-e2e-runtime.sh`
+- Create: `.github/scripts/restore-executor-e2e-runtime.sh`
+
+- [ ] **Step 1: Write helper scripts**
+
+```bash
+mkdir -p .github/scripts
+```
+
+Each script must start with `#!/usr/bin/env bash` and `set -euo pipefail`.
+
+Frontend archive script:
+
+```bash
+artifact_dir="${1:-.ci-artifacts}"
+mkdir -p "$artifact_dir"
+test -f frontend/.next/BUILD_ID
+tar --exclude='.next/cache' -I 'zstd -T0 -3' -cf "$artifact_dir/frontend-next-build.tar.zst" -C frontend .next public
+test -s "$artifact_dir/frontend-next-build.tar.zst"
+```
+
+Frontend restore script:
+
+```bash
+artifact_dir="${1:-.ci-artifacts}"
+archive="$artifact_dir/frontend-next-build.tar.zst"
+test -s "$archive"
+rm -rf frontend/.next
+tar -I zstd -xf "$archive" -C frontend
+test -f frontend/.next/BUILD_ID
+```
+
+Executor archive script:
+
+```bash
+artifact_dir="${1:-.ci-artifacts}"
+image_tag="${2:-wegent/e2e-claudecode-executor:latest}"
+image_archive="$artifact_dir/e2e-claudecode-executor-image.tar.zst"
+mkdir -p "$artifact_dir"
+docker image inspect "$image_tag" >/dev/null
+docker save "$image_tag" | zstd -T0 -3 > "$image_archive"
+test -x executor/target/release/wegent-executor
+cp executor/target/release/wegent-executor "$artifact_dir/wegent-executor"
+chmod 0755 "$artifact_dir/wegent-executor"
+test -s "$image_archive"
+test -x "$artifact_dir/wegent-executor"
+```
+
+Executor restore script:
+
+```bash
+artifact_dir="${1:-.ci-artifacts}"
+image_tag="${2:-wegent/e2e-claudecode-executor:latest}"
+image_archive="$artifact_dir/e2e-claudecode-executor-image.tar.zst"
+binary="$artifact_dir/wegent-executor"
+test -s "$image_archive"
+test -s "$binary"
+zstd -dc "$image_archive" | docker load
+docker image inspect "$image_tag" >/dev/null
+mkdir -p executor/target/release
+cp "$binary" executor/target/release/wegent-executor
+chmod 0755 executor/target/release/wegent-executor
+test -x executor/target/release/wegent-executor
+```
+
+- [ ] **Step 2: Verify shell syntax**
+
+Run:
+
+```bash
+bash -n .github/scripts/archive-frontend-e2e-build.sh
+bash -n .github/scripts/restore-frontend-e2e-build.sh
+bash -n .github/scripts/archive-executor-e2e-runtime.sh
+bash -n .github/scripts/restore-executor-e2e-runtime.sh
+```
+
+Expected: all commands exit 0.
+
+### Task 2: Add build jobs to E2E workflow
+
+**Files:**
+- Modify: `.github/workflows/e2e-tests.yml`
+
+- [ ] **Step 1: Add `build-frontend-e2e` before test jobs**
+
+The job checks out code, sets up pnpm and Node 24, restores frontend
+`node_modules`, installs dependencies, restores the Next.js cache, runs
+`pnpm exec next build`, archives the build, and uploads
+`frontend-next-build`.
+
+- [ ] **Step 2: Add `build-executor-e2e-runtime` before test jobs**
+
+The job checks out code, builds `wegent/e2e-claudecode-executor:latest` with
+the existing fixture Dockerfile, extracts `/app/executor` to
+`executor/target/release/wegent-executor`, archives the Docker image and binary,
+and uploads `executor-e2e-runtime`.
+
+- [ ] **Step 3: Keep build jobs parallel**
+
+Do not make either build job depend on the other.
+
+### Task 3: Make ordinary E2E shards consume frontend artifact
+
+**Files:**
+- Modify: `.github/workflows/e2e-tests.yml`
+
+- [ ] **Step 1: Add `needs: build-frontend-e2e` to `e2e-tests`**
+
+- [ ] **Step 2: Replace `Cache Next.js build` and `Build frontend for E2E`**
+
+Use `actions/download-artifact` to download `frontend-next-build` into
+`.ci-artifacts`, then run `.github/scripts/restore-frontend-e2e-build.sh`.
+
+- [ ] **Step 3: Leave service startup and Playwright sharding unchanged**
+
+The shard matrix, MySQL/Redis service containers, backend startup, Chat Shell
+startup, frontend `next start`, mock model server, and report upload steps stay
+functionally equivalent.
+
+### Task 4: Make executor E2E consume both artifacts
+
+**Files:**
+- Modify: `.github/workflows/e2e-tests.yml`
+
+- [ ] **Step 1: Add `needs: [build-frontend-e2e, build-executor-e2e-runtime]`**
+
+- [ ] **Step 2: Remove host Rust setup from test job**
+
+Keep `Install executor Rust system dependencies` because the restored local
+executor binary may still need runtime OpenSSL libraries on the Ubuntu runner.
+
+- [ ] **Step 3: Replace frontend build steps**
+
+Download and restore `frontend-next-build`, same as ordinary E2E shards.
+
+- [ ] **Step 4: Replace Docker image build and binary extraction**
+
+Download `executor-e2e-runtime` into `.ci-artifacts` and run
+`.github/scripts/restore-executor-e2e-runtime.sh`.
+
+- [ ] **Step 5: Leave executor service flow unchanged**
+
+The local executor startup, executor-manager startup, Docker bridge environment,
+and `executor-chromium` Playwright project stay functionally equivalent.
+
+### Task 5: Update E2E README
+
+**Files:**
+- Modify: `frontend/e2e/README.md`
+
+- [ ] **Step 1: Replace stale CI note**
+
+Document that CI builds the frontend once in `build-frontend-e2e`, restores it
+in each E2E test job, and builds the executor image/binary once in
+`build-executor-e2e-runtime` for executor E2E.
+
+### Task 6: Validate locally
+
+**Files:**
+- Validate: `.github/workflows/e2e-tests.yml`
+- Validate: `.github/scripts/*.sh`
+
+- [ ] **Step 1: Run script syntax checks**
+
+```bash
+bash -n .github/scripts/archive-frontend-e2e-build.sh
+bash -n .github/scripts/restore-frontend-e2e-build.sh
+bash -n .github/scripts/archive-executor-e2e-runtime.sh
+bash -n .github/scripts/restore-executor-e2e-runtime.sh
+```
+
+- [ ] **Step 2: Parse workflow YAML**
+
+```bash
+ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e-tests.yml"); puts "ok"'
+```
+
+- [ ] **Step 3: Inspect diff**
+
+```bash
+git diff -- .github/workflows/e2e-tests.yml .github/scripts frontend/e2e/README.md docs/superpowers
+```
+
+### Task 7: Publish and compare CI
+
+**Files:**
+- Commit changed files.
+- Push `codex/ci-share-e2e-builds`.
+- Open a draft PR against `main`.
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add .github/workflows/e2e-tests.yml .github/scripts frontend/e2e/README.md docs/superpowers/specs/2026-06-28-ci-e2e-shared-builds-design.md docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
+git commit -m "fix(ci): share e2e build artifacts"
+```
+
+- [ ] **Step 2: Push and create PR**
+
+```bash
+git push -u origin codex/ci-share-e2e-builds
+```
+
+Open a draft PR titled `[codex] Share E2E build artifacts`.
+
+- [ ] **Step 3: Verify PR checks and timing**
+
+Use GitHub Actions run data for the PR head SHA. Compare `E2E Tests` workflow
+ordinary shard duration and executor E2E duration against the PR #1581 baseline:
+
+- `E2E Tests (Shard 1/4)`: 5m 11s
+- `Executor E2E Tests`: 7m 49s
+
+If the PR fails because of this workflow change, inspect the failed job logs,
+fix the workflow, and rerun the checks.

--- a/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
+++ b/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
@@ -249,3 +249,67 @@ ordinary shard duration and executor E2E duration against the PR #1581 baseline:
 
 If the PR fails because of this workflow change, inspect the failed job logs,
 fix the workflow, and rerun the checks.
+
+### Task 8: Reduce frontend dependency work in E2E jobs
+
+**Files:**
+- Modify: `.github/scripts/archive-frontend-e2e-build.sh`
+- Modify: `.github/scripts/restore-frontend-e2e-build.sh`
+- Create: `.github/scripts/start-frontend-e2e-server.sh`
+- Modify: `.github/workflows/e2e-tests.yml`
+- Modify: `frontend/e2e/README.md`
+
+- [ ] **Step 1: Prepare the standalone frontend artifact**
+
+The archive script must verify `frontend/.next/standalone` contains a
+non-`node_modules` `server.js`, then copy `frontend/public` and
+`frontend/.next/static` beside that server entrypoint before packaging the
+artifact. This follows Next.js standalone deployment requirements and lets CI
+start the generated server without `pnpm exec next start`.
+
+- [ ] **Step 2: Verify the restored standalone artifact**
+
+The restore script must unpack `.ci-artifacts/frontend-next-build.tar.zst`,
+verify `frontend/.next/BUILD_ID`, rediscover the standalone `server.js`, and
+check that `public` and `.next/static` exist next to the server entrypoint.
+
+- [ ] **Step 3: Add a shared standalone startup helper**
+
+Create `.github/scripts/start-frontend-e2e-server.sh`. It must discover either
+`.next/standalone/server.js` or `.next/standalone/frontend/server.js`, fall back
+to a non-`node_modules` `server.js` search, then run:
+
+```bash
+HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+  nohup node "$server_path" > next-dev.log 2>&1 &
+echo $! > next-dev.pid
+```
+
+- [ ] **Step 4: Skip frontend installs on exact node_modules cache hits**
+
+For `build-frontend-e2e`, ordinary E2E shards, executor E2E, and
+`merge-reports`, add:
+
+```yaml
+if: steps.frontend-node-modules-cache.outputs.cache-hit != 'true'
+```
+
+to the `Install frontend dependencies` step. Keep the step on cache misses and
+partial restore-key matches so `pnpm` can reconcile dependencies safely.
+
+- [ ] **Step 5: Switch E2E frontend startup to standalone**
+
+In both E2E test jobs, replace `pnpm exec next start` with:
+
+```yaml
+run: ../.github/scripts/start-frontend-e2e-server.sh
+```
+
+from `working-directory: ./frontend`.
+
+- [ ] **Step 6: Validate and rerun CI**
+
+Run shell syntax checks, parse `.github/workflows/e2e-tests.yml`, check the
+diff, commit, push, and verify the updated PR checks. Compare the new E2E run
+against the previous PR run to confirm the dependency-install optimization did
+not regress end-to-end duration.

--- a/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
+++ b/docs/superpowers/plans/2026-06-28-ci-e2e-shared-builds.md
@@ -280,7 +280,7 @@ Create `.github/scripts/start-frontend-e2e-server.sh`. It must discover either
 to a non-`node_modules` `server.js` search, then run:
 
 ```bash
-HOSTNAME="${HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
+HOSTNAME="${E2E_FRONTEND_HOSTNAME:-0.0.0.0}" PORT="${PORT:-3000}" \
   nohup node "$server_path" > next-dev.log 2>&1 &
 echo $! > next-dev.pid
 ```

--- a/docs/superpowers/specs/2026-06-28-ci-e2e-shared-builds-design.md
+++ b/docs/superpowers/specs/2026-06-28-ci-e2e-shared-builds-design.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 1
+---
+
+# CI E2E Shared Builds Design
+
+## Context
+
+The `E2E Tests` GitHub Actions workflow currently builds the same frontend
+application in every browser/API shard and again in the dedicated executor E2E
+job. The executor E2E job also builds the ClaudeCode executor Docker image and
+extracts the local executor binary inside the same long-running test job.
+
+Recent successful PR baseline from PR #1581:
+
+| Job | Approximate duration |
+| --- | --- |
+| `E2E Tests (Shard 1/4)` | 5m 11s |
+| `Executor E2E Tests` | 7m 49s |
+
+The exact baseline is taken from GitHub Actions job log first and last
+timestamps because the available job-step API only returns step names.
+
+## Goals
+
+- Build the production Next.js frontend once per workflow run.
+- Build the ClaudeCode executor E2E image and extracted binary once per
+  workflow run.
+- Keep ordinary E2E shards parallel and isolated.
+- Keep executor-heavy coverage in the dedicated executor E2E job.
+- Compare the PR run against the same E2E workflow baseline after the PR checks
+  complete.
+
+## Non-goals
+
+- Do not merge all E2E tests into one shared-service job. GitHub hosted runners
+  do not share local processes or Docker networks across jobs, and one large job
+  would reduce test isolation.
+- Do not convert Python virtual environments or `node_modules` into artifacts.
+  Existing cache keys already cover dependency reuse, and virtualenv artifacts
+  are more fragile than lockfile-backed installs.
+- Do not change Playwright test selection or shard counts.
+
+## Chosen Approach
+
+Use build-artifact fan-out:
+
+1. Add `build-frontend-e2e` to install frontend dependencies, run the existing
+   production Next.js build once, archive the resulting runtime files, and upload
+   a single artifact.
+2. Add `build-executor-e2e-runtime` to build
+   `wegent/e2e-claudecode-executor:latest`, extract
+   `executor/target/release/wegent-executor`, save the Docker image to a tar
+   archive, and upload both as one runtime artifact.
+3. Make ordinary E2E shards depend on `build-frontend-e2e`, download the
+   frontend artifact, restore it, and skip `next build`.
+4. Make executor E2E depend on both build jobs, restore the frontend artifact,
+   load the Docker image artifact, restore the binary, and skip both local
+   builds.
+
+This keeps service startup and databases per job while sharing immutable build
+outputs between jobs through GitHub Actions artifacts.
+
+## Artifact Layout
+
+`build-frontend-e2e` creates:
+
+- `.ci-artifacts/frontend-next-build.tar.zst`
+
+The tarball includes:
+
+- `frontend/.next` without `.next/cache`
+- `frontend/public`
+
+`build-executor-e2e-runtime` creates:
+
+- `.ci-artifacts/e2e-claudecode-executor-image.tar.zst`
+- `.ci-artifacts/wegent-executor`
+
+The image tar is loaded in the executor job with the same tag expected by
+`EXECUTOR_IMAGE`.
+
+## Failure Handling
+
+- Upload steps use `if-no-files-found: error` so a broken archive step fails
+  before test jobs start.
+- Restore steps verify required files after extraction or Docker load.
+- Existing failure artifacts for Playwright traces and service logs remain
+  unchanged.
+
+## Validation
+
+Local validation:
+
+- Parse workflow YAML.
+- Run shell syntax checks for any helper scripts.
+- Inspect `git diff` for unintended workflow changes.
+
+Remote validation:
+
+- Push the branch and open a draft PR.
+- Wait for GitHub Actions checks.
+- Compare the new PR's `E2E Tests` workflow durations against the recent PR
+  baseline above, with particular attention to ordinary shard jobs and
+  `Executor E2E Tests`.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -198,7 +198,8 @@ See [`.github/workflows/e2e-tests.yml`](../../.github/workflows/e2e-tests.yml) f
 
 CI builds the production Next.js frontend once in the `build-frontend-e2e`
 workflow job, uploads it as `frontend-next-build`, and restores that artifact in
-each browser/API shard and in the executor E2E job before starting `next start`.
+each browser/API shard and in the executor E2E job before starting the generated
+Next.js standalone server.
 
 The executor regression job also consumes `executor-e2e-runtime`, which is built
 once by `build-executor-e2e-runtime`. That artifact contains the

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -196,10 +196,14 @@ E2E tests run automatically in GitHub Actions:
 
 See [`.github/workflows/e2e-tests.yml`](../../.github/workflows/e2e-tests.yml) for configuration.
 
-CI starts the frontend with `pnpm run dev` instead of `pnpm run build && pnpm start`
-so E2E jobs do not spend time on a production Next.js build. This keeps E2E
-focused on browser/API behavior; production build failures need separate build
-coverage outside this workflow.
+CI builds the production Next.js frontend once in the `build-frontend-e2e`
+workflow job, uploads it as `frontend-next-build`, and restores that artifact in
+each browser/API shard and in the executor E2E job before starting `next start`.
+
+The executor regression job also consumes `executor-e2e-runtime`, which is built
+once by `build-executor-e2e-runtime`. That artifact contains the
+`wegent/e2e-claudecode-executor:latest` Docker image and the extracted local
+executor binary used by device-mode coverage.
 
 The workflow caches Python virtualenvs, frontend `node_modules`, Playwright
 browsers, and the executor job's Claude Code CLI. Dependency install steps are


### PR DESCRIPTION
## What changed

- Added dedicated E2E build jobs for the production Next.js frontend and executor runtime artifacts.
- Updated ordinary E2E shards to download and restore the shared frontend build instead of running `next build` in every shard.
- Updated executor E2E to restore the shared frontend build plus a prebuilt ClaudeCode executor image/binary artifact.
- Switched E2E frontend startup to the generated Next.js standalone server and packaged `public`/`.next/static` beside the standalone entrypoint.
- Skipped `pnpm install --frozen-lockfile` in E2E jobs when the exact frontend `node_modules` cache is restored.
- Added helper scripts for archive/restore/start validation and updated the E2E README.

## Why

The E2E workflow previously rebuilt the frontend in all four browser/API shards and again in the executor E2E job. Executor E2E also built the ClaudeCode executor runtime inside the long-running test job. This change centralizes those builds, runs independent build work in parallel, and lets test jobs consume immutable artifacts. The follow-up standalone startup change keeps the frontend server aligned with `output: 'standalone'` and removes redundant dependency install work on exact cache hits.

## Validation

- CI on latest commit `dacae748ec6de0fdef3e710dde3d789ed1ad76ba` is green: Lint, Tests, and E2E Tests all passed.
- `bash -n .github/scripts/archive-frontend-e2e-build.sh && bash -n .github/scripts/restore-frontend-e2e-build.sh && bash -n .github/scripts/start-frontend-e2e-server.sh && bash -n .github/scripts/archive-executor-e2e-runtime.sh && bash -n .github/scripts/restore-executor-e2e-runtime.sh`
- `ruby -e 'require "yaml"; data=YAML.load_file(".github/workflows/e2e-tests.yml"); jobs=data.fetch("jobs"); install_steps = []; jobs.each_value { |job| Array(job["steps"]).each { |step| install_steps << step if step["name"] == "Install frontend dependencies" } }; abort("expected 4 frontend install steps") unless install_steps.size == 4; abort("install step missing cache guard") unless install_steps.all? { |step| step["if"] == "steps.frontend-node-modules-cache.outputs.cache-hit != '\''true'\''" }; puts "ok"'`
- `git diff --check`

## Timing comparison

Compared with recent PR #1581 E2E run `28298633785`, this PR's latest E2E run `28309825337` is faster overall and removes repeated build work from test jobs.

| Job | PR #1581 | This PR | Delta |
| --- | ---: | ---: | ---: |
| E2E Shard 1 | 313s | 205s | -108s |
| E2E Shard 2 | 349s | 196s | -153s |
| E2E Shard 3 | 399s | 218s | -181s |
| E2E Shard 4 | 322s | 155s | -167s |
| Executor E2E Tests | 470s | 233s | -237s |
| Merge Test Reports | 84s | 73s | -11s |
| Workflow job span | 559s | 514s | -45s |

The new shared build jobs ran in parallel before tests:

- `Build Frontend E2E Artifact`: 175s
- `Build Executor E2E Runtime Artifact`: 201s

Compared with the first shared-build version in this PR (`28300658776`), the follow-up cache/standalone change reduced the E2E workflow span from `540s` to `514s`.