### PR TITLE
[codex] Align Wework Codex streaming display

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -897,7 +897,15 @@ impl RuntimeWorkRpcHandler {
                 notifications,
             )
             .await;
-            mapper_task.abort();
+            if let Err(error) = mapper_task.await {
+                log_executor_event(
+                    "runtime work notification mapper failed",
+                    &[
+                        ("local_task_id", local_task_id.clone()),
+                        ("error", error.to_string()),
+                    ],
+                );
+            }
 
             handler.handle_turn_result(&local_task_id, &request, result);
         });

--- a/executor/src/runtime_work/util.rs
+++ b/executor/src/runtime_work/util.rs
@@ -52,8 +52,49 @@ pub(crate) fn execution_request_from_payload(
     {
         request.device_id = Some(device_id);
     }
+    apply_model_options_to_model_config(&mut request.model_config, payload);
     apply_runtime_payload_metadata(&mut request, payload);
     Ok(request)
+}
+
+fn apply_model_options_to_model_config(model_config: &mut Value, payload: &Value) {
+    let Some(model_options) = payload
+        .get("modelOptions")
+        .or_else(|| payload.get("model_options"))
+        .filter(|value| value.is_object())
+    else {
+        return;
+    };
+
+    let Some(config) = model_config.as_object_mut() else {
+        return;
+    };
+
+    if let Some(reasoning) = reasoning_from_model_options(model_options) {
+        config.insert("reasoning".to_owned(), reasoning);
+    }
+    if let Some(service_tier) =
+        string_field(model_options, "speed").or_else(|| string_field(model_options, "service_tier"))
+    {
+        config.insert("service_tier".to_owned(), Value::String(service_tier));
+    }
+}
+
+fn reasoning_from_model_options(model_options: &Value) -> Option<Value> {
+    let effort = string_field(model_options, "reasoning");
+    let summary = string_field(model_options, "summary");
+    if effort.is_none() && summary.is_none() {
+        return None;
+    }
+
+    let mut reasoning = serde_json::Map::new();
+    if let Some(effort) = effort {
+        reasoning.insert("effort".to_owned(), Value::String(effort));
+    }
+    if let Some(summary) = summary {
+        reasoning.insert("summary".to_owned(), Value::String(summary));
+    }
+    Some(Value::Object(reasoning))
 }
 
 pub(crate) fn apply_runtime_payload_metadata(request: &mut ExecutionRequest, payload: &Value) {

--- a/executor/tests/app_runtime_work_send_contract.rs
+++ b/executor/tests/app_runtime_work_send_contract.rs
@@ -123,6 +123,11 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
                 },
                 "content": "continue from content",
                 "modelId": "gpt-4.1",
+                "modelOptions": {
+                    "reasoning": "extra_high",
+                    "summary": "concise",
+                    "speed": "fast"
+                },
                 "source": source,
                 "attachments": [attachment]
             }
@@ -142,6 +147,15 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
     assert_eq!(resume["params"]["threadId"], "thread-1");
     assert_eq!(resume["params"]["cwd"], "/tmp/project");
     assert_eq!(resume["params"]["model"], "gpt-4.1");
+    assert_eq!(
+        resume["params"]["config"]["model_reasoning_effort"],
+        "xhigh"
+    );
+    assert_eq!(
+        resume["params"]["config"]["model_reasoning_summary"],
+        "concise"
+    );
+    assert_eq!(resume["params"]["config"]["service_tier"], "priority");
 
     let last_turn_start = calls
         .iter()
@@ -149,14 +163,99 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
         .find(|call| call["method"] == "turn/start")
         .expect("send should start a turn");
     assert_eq!(last_turn_start["params"]["model"], "gpt-4.1");
+    assert_eq!(last_turn_start["params"]["effort"], "xhigh");
+    assert_eq!(last_turn_start["params"]["summary"], "concise");
     assert_eq!(last_turn_start["params"]["input"][0]["type"], "text");
     assert!(last_turn_start["params"]["input"][0]["text"]
         .as_str()
         .unwrap()
         .starts_with("continue from content"));
 
-    let created_event = recv_event(&mut events, "response.created").await;
+    let runtime_events = recv_events_until(&mut events, |runtime_events| {
+        find_runtime_event(runtime_events, "response.created", |event| {
+            event["payload"]["source"] == source
+        })
+        .is_some()
+            && find_runtime_event(runtime_events, "response.block.created", |event| {
+                let block = &event["payload"]["data"]["block"];
+                block["type"] == "text"
+                    && block["content"] == "Inspecting "
+                    && block["status"] == "streaming"
+            })
+            .is_some()
+            && find_runtime_event(runtime_events, "response.block.updated", |event| {
+                let data = &event["payload"]["data"];
+                data["updates"]["content"] == "Inspecting workspace."
+                    && data["updates"]["status"] == "streaming"
+            })
+            .is_some()
+            && find_runtime_event(runtime_events, "response.output_text.delta", |event| {
+                event["payload"]["data"]["delta"] == "done"
+            })
+            .is_some()
+            && find_runtime_event(runtime_events, "response.completed", |event| {
+                event["payload"]["data"]["value"] == "done"
+            })
+            .is_some()
+    })
+    .await;
+
+    let created_event = find_runtime_event(&runtime_events, "response.created", |event| {
+        event["payload"]["source"] == source
+    })
+    .expect("send should emit response.created with source");
     assert_eq!(created_event["payload"]["source"], source);
+    let process_created = find_runtime_event(&runtime_events, "response.block.created", |event| {
+        let block = &event["payload"]["data"]["block"];
+        block["type"] == "text"
+            && block["content"] == "Inspecting "
+            && block["status"] == "streaming"
+    })
+    .expect("commentary delta should create a process text block");
+    let process_block_id = process_created["payload"]["data"]["block"]["id"]
+        .as_str()
+        .expect("process block should have a generated id")
+        .to_owned();
+    assert_eq!(process_block_id, "text-local-task-1-0-1");
+    assert_eq!(process_created["payload"]["data"]["block"]["type"], "text");
+    assert_eq!(
+        process_created["payload"]["data"]["block"]["content"],
+        "Inspecting "
+    );
+    assert_eq!(
+        process_created["payload"]["data"]["block"]["status"],
+        "streaming"
+    );
+
+    let process_updated = find_runtime_event(&runtime_events, "response.block.updated", |event| {
+        let data = &event["payload"]["data"];
+        data["block_id"].as_str() == Some(process_block_id.as_str())
+            && data["updates"]["status"] == "streaming"
+    })
+    .expect("second commentary delta should update the process text block");
+    assert_eq!(
+        process_updated["payload"]["data"]["block_id"],
+        process_block_id
+    );
+    assert_eq!(
+        process_updated["payload"]["data"]["updates"]["content"],
+        "Inspecting workspace."
+    );
+    assert_eq!(
+        process_updated["payload"]["data"]["updates"]["status"],
+        "streaming"
+    );
+
+    let text_delta = find_runtime_event(&runtime_events, "response.output_text.delta", |event| {
+        event["payload"]["data"]["delta"] == "done"
+    })
+    .expect("final answer delta should remain the main output text");
+    assert_eq!(text_delta["payload"]["data"]["delta"], "done");
+    let completed = find_runtime_event(&runtime_events, "response.completed", |event| {
+        event["payload"]["data"]["value"] == "done"
+    })
+    .expect("completed response should contain only the final answer");
+    assert_eq!(completed["payload"]["data"]["value"], "done");
 
     let transcript = handler
         .handle_runtime_rpc(json!({
@@ -172,7 +271,11 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
         .as_array()
         .unwrap()
         .iter()
-        .find(|message| message["content"] == "continue from content")
+        .find(|message| {
+            message["content"]
+                .as_str()
+                .is_some_and(|content| content.starts_with("continue from content"))
+        })
         .expect("cached follow-up user message should be present");
     assert_eq!(user["source"], source);
     assert_eq!(user["attachments"][0]["filename"], "photo.png");
@@ -182,6 +285,19 @@ async fn runtime_tasks_send_accepts_address_content_source_and_attachments() {
 
 #[tokio::test]
 async fn runtime_tasks_send_rejects_missing_model_without_execution_request() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("runtime-send-missing-model-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = EnvGuard::set(
+        "CODEX_HOME",
+        &temp_path("runtime-send-missing-model-codex-home", "dir")
+            .display()
+            .to_string(),
+    );
     let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
 
     let error = handler
@@ -297,7 +413,15 @@ while IFS= read -r line; do
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"thread":{{"id":"thread-1"}}}}}}'
       ;;
     *'"method":"turn/start"'*)
+      progress_id='progress-1'
+      case "$line" in
+        *'"model":"gpt-4.1"'*) progress_id='progress-2' ;;
+      esac
       printf '%s\n' '{{"id":'"$request_id"',"result":{{"turn":{{"id":"turn-1","status":"inProgress"}}}}}}'
+      printf '%s\n' '{{"method":"item/started","params":{{"item":{{"id":"'"$progress_id"'","type":"agentMessage","phase":"commentary"}}}}}}'
+      printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"item_id":"'"$progress_id"'","delta":"Inspecting "}}}}'
+      printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"item_id":"'"$progress_id"'","delta":"workspace."}}}}'
+      printf '%s\n' '{{"method":"item/completed","params":{{"item":{{"id":"'"$progress_id"'","type":"agentMessage","text":"Inspecting workspace.","phase":"commentary"}}}}}}'
       printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"delta":"done","phase":"finalAnswer"}}}}'
       printf '%s\n' '{{"method":"turn/completed","params":{{"turn":{{"id":"turn-1","status":"completed"}}}}}}'
       exit 0
@@ -515,15 +639,41 @@ fn drain_events(events: &mut broadcast::Receiver<Value>) {
     while events.try_recv().is_ok() {}
 }
 
-async fn recv_event(events: &mut broadcast::Receiver<Value>, event: &str) -> Value {
-    for _ in 0..20 {
-        let message = tokio::time::timeout(std::time::Duration::from_millis(200), events.recv())
-            .await
-            .expect("timed out waiting for runtime event")
-            .expect("runtime event channel should stay open");
-        if message["event"] == event {
-            return message;
+async fn recv_events_until<F>(events: &mut broadcast::Receiver<Value>, mut done: F) -> Vec<Value>
+where
+    F: FnMut(&[Value]) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+    let mut received = Vec::new();
+    loop {
+        if done(&received) {
+            return received;
         }
+
+        let message = tokio::time::timeout_at(deadline, events.recv())
+            .await
+            .unwrap_or_else(|_| {
+                let names = received
+                    .iter()
+                    .map(|event| event["event"].as_str().unwrap_or("<missing>"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                panic!("timed out waiting for expected runtime events; received: {names}");
+            })
+            .expect("runtime event channel should stay open");
+        received.push(message);
     }
-    panic!("did not receive event {event}");
+}
+
+fn find_runtime_event<'a, F>(
+    events: &'a [Value],
+    event_name: &str,
+    mut matches: F,
+) -> Option<&'a Value>
+where
+    F: FnMut(&Value) -> bool,
+{
+    events
+        .iter()
+        .find(|event| event["event"] == event_name && matches(event))
 }

--- a/wework/src/App.tsx
+++ b/wework/src/App.tsx
@@ -148,7 +148,7 @@ function AppShell() {
   return (
     <LocalRuntimeInitializer startupReady={workbenchStartupReady || workbenchStartupRevealTimedOut}>
       <LocalExecutorCloudBridge />
-      <div className="flex h-screen flex-col overflow-hidden bg-surface">
+      <div className="flex h-dvh flex-col overflow-hidden bg-surface">
         {isTauri && (
           <ChromeTitlebar
             tabs={tabs}

--- a/wework/src/api/local/localServices.test.ts
+++ b/wework/src/api/local/localServices.test.ts
@@ -383,6 +383,11 @@ describe('createLocalAppServices', () => {
       address: { deviceId: 'local-device', localTaskId: 'task-1' },
       message: 'continue',
       modelId: 'codex-gpt-5.5',
+      modelOptions: {
+        reasoning: 'extra_high',
+        summary: 'concise',
+        speed: 'fast',
+      },
     })
 
     expect(request).toHaveBeenCalledWith('runtime.tasks.send', {
@@ -390,6 +395,11 @@ describe('createLocalAppServices', () => {
       message: 'continue',
       message_id: expect.any(Number),
       modelId: 'gpt-5.5',
+      modelOptions: {
+        reasoning: 'extra_high',
+        summary: 'concise',
+        speed: 'fast',
+      },
     })
   })
 

--- a/wework/src/components/chat/ChatInput.test.tsx
+++ b/wework/src/components/chat/ChatInput.test.tsx
@@ -140,6 +140,7 @@ function runtimeWork(
 
 describe('ChatInput', () => {
   const originalCreateObjectUrl = URL.createObjectURL
+  const originalInnerWidth = window.innerWidth
 
   afterEach(() => {
     vi.restoreAllMocks()
@@ -147,6 +148,10 @@ describe('ChatInput', () => {
     vi.useRealTimers()
     localStorage.clear()
     URL.createObjectURL = originalCreateObjectUrl
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    })
     delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
   })
 
@@ -161,7 +166,13 @@ describe('ChatInput', () => {
       />
     )
 
+    expect(screen.getByTestId('project-chat-composer-form')).toHaveClass(
+      'min-h-[100px]',
+      'pb-4',
+      'pt-2'
+    )
     expect(screen.getByTestId('chat-message-input')).toHaveAttribute('rows', '2')
+    expect(screen.getByTestId('chat-message-input')).toHaveClass('min-h-8', 'max-h-[116px]')
     expect(screen.queryByTestId('custom-mode-button')).not.toBeInTheDocument()
     expect(screen.getByTestId('model-selector-button')).toBeInTheDocument()
     expect(screen.queryByTestId('skill-selector-button')).not.toBeInTheDocument()
@@ -308,7 +319,12 @@ describe('ChatInput', () => {
       'rounded-[26px]'
     )
     expect(screen.getByTestId('compact-input-pill')).toHaveClass('min-h-[52px]')
-    expect(screen.getByTestId('chat-message-input')).toHaveClass('py-[14px]', 'scrollbar-none')
+    expect(screen.getByTestId('chat-message-input')).toHaveClass(
+      'py-[14px]',
+      'scrollbar-none',
+      'text-sm',
+      'leading-5'
+    )
     expect(screen.getByTestId('send-message-button')).toHaveClass(
       'absolute',
       'bottom-1',
@@ -1143,6 +1159,50 @@ describe('ChatInput', () => {
     await userEvent.click(screen.getByTestId('model-option-overseas-gpt-5.5'))
 
     expect(setSelectedModel).toHaveBeenCalledWith(model)
+  })
+
+  test('keeps the desktop model menu in narrow Tauri windows', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 500,
+    })
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    const model: UnifiedModel = {
+      name: 'codex-gpt-5.5',
+      type: 'user',
+      displayName: '5.5',
+      config: {
+        ui: {
+          family: 'gpt',
+          modelLabel: '5.5',
+          sortOrder: 10,
+        },
+      },
+    }
+
+    render(
+      <ChatInput
+        value=""
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        disabled={false}
+        variant="desktop"
+        projectChat={projectChatControls({
+          models: [model],
+          selectedModel: model,
+        })}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('model-selector-button'))
+
+    expect(screen.getByTestId('model-selector-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('model-selector-menu')).not.toHaveAttribute('data-mobile')
+    expect(screen.getByTestId('model-selector-menu')).not.toHaveAttribute('aria-modal')
+    expect(screen.getByTestId('model-selector-submenu')).toBeInTheDocument()
   })
 
   test('opens the desktop model menu when the external open signal changes', async () => {

--- a/wework/src/components/chat/MessageList.test.tsx
+++ b/wework/src/components/chat/MessageList.test.tsx
@@ -38,9 +38,7 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByTestId('message-user').className).toContain('[content-visibility:auto]')
-    expect(screen.getByTestId('message-assistant').className).toContain(
-      '[content-visibility:auto]'
-    )
+    expect(screen.getByTestId('message-assistant').className).toContain('[content-visibility:auto]')
   })
 
   test('renders one assistant turn file changes under its message', () => {
@@ -523,6 +521,12 @@ describe('MessageList', () => {
     )
 
     expect(screen.getByText('最终建议放在 PR flow 里。')).toBeInTheDocument()
+    expect(
+      screen
+        .getByRole('button', { name: /已处理/ })
+        .compareDocumentPosition(screen.getByText('最终建议放在 PR flow 里。')) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     const collapseContent = screen.getByTestId('processing-collapse-content')
     expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
     expect(collapseContent).toHaveClass('opacity-0')
@@ -531,6 +535,53 @@ describe('MessageList', () => {
     fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
     expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
     expect(screen.getByText('我会先看这个 skill 当前的流程结构和相关记忆。')).toBeInTheDocument()
+  })
+
+  test('collapses streaming processing as soon as final answer appears', () => {
+    const blocks: ProcessingBlock[] = [
+      {
+        id: 'tool-1',
+        subtaskId: 11,
+        type: 'tool',
+        toolName: 'Bash',
+        toolInput: { command: 'pwd' },
+        toolOutput: '/workspace/project\n',
+        status: 'streaming',
+        createdAt: 1770000000000,
+      },
+    ]
+
+    render(
+      <MessageList
+        messages={[
+          {
+            id: 'assistant-streaming-with-process',
+            role: 'assistant',
+            content: '这是正在流式输出的最终答案。',
+            status: 'streaming',
+            blocks,
+            createdAt: '2026-06-24T08:00:01.000Z',
+          },
+        ]}
+      />
+    )
+
+    const finalAnswer = screen.getByText('这是正在流式输出的最终答案。')
+    const processStatus = screen.getByRole('button', { name: /已处理/ })
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+
+    expect(
+      processStatus.compareDocumentPosition(finalAnswer) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(processStatus).toHaveAttribute('aria-expanded', 'false')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+
+    fireEvent.click(processStatus)
+
+    expect(processStatus).toHaveAttribute('aria-expanded', 'true')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByText('正在运行 pwd')).toBeInTheDocument()
+    expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
   })
 
   test('renders final answer web search sources as a Codex-style source chip', async () => {
@@ -914,6 +965,57 @@ describe('MessageList', () => {
     expect(onOpenWorkspaceFile).toHaveBeenCalledWith('MEMORY.md')
   })
 
+  test('waits until streaming finishes before rendering final answer artifacts', () => {
+    render(
+      <MessageList
+        onOpenWorkspaceFile={vi.fn()}
+        onLoadFileChangesDiff={vi.fn().mockResolvedValue('')}
+        onRevertFileChanges={vi.fn()}
+        messages={[
+          {
+            id: 'assistant-streaming-artifacts',
+            subtaskId: 42,
+            role: 'assistant',
+            content: 'See [README.md](/workspace/project/README.md) for details.',
+            status: 'streaming',
+            createdAt: '2026-06-24T08:00:01.000Z',
+            references: [{ path: '/workspace/project/README.md' }],
+            memoryCitations: [
+              {
+                entries: [{ path: 'MEMORY.md', lineStart: 10, note: 'repo guidance' }],
+                threadIds: ['thread-1'],
+              },
+            ],
+            fileChanges: {
+              version: 1,
+              status: 'active',
+              artifact_id: 'turn-42',
+              device_id: 'device-1',
+              workspace_path: '/workspace/project',
+              file_count: 1,
+              additions: 2,
+              deletions: 0,
+              files: [
+                {
+                  path: 'README.md',
+                  change_type: 'modified',
+                  additions: 2,
+                  deletions: 0,
+                  binary: false,
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+
+    expect(screen.getByText(/See/)).toBeInTheDocument()
+    expect(screen.queryByTestId('codex-reference-list')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('codex-memory-citations')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('file-changes-card')).not.toBeInTheDocument()
+  })
+
   test('adds deduped document references from turn file changes and expands hidden references', async () => {
     render(
       <MessageList
@@ -1289,6 +1391,10 @@ describe('MessageList', () => {
       'overflow-visible'
     )
     expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('justify-start')
+    expect(screen.getByTestId('message-image-attachment-strip')).toHaveClass(
+      'ml-auto',
+      'justify-end'
+    )
     expect(fetch).not.toHaveBeenCalled()
   })
 
@@ -1831,10 +1937,16 @@ describe('MessageList', () => {
       'w-full',
       'flex-row',
       'flex-nowrap',
-      'justify-start',
       'overflow-x-auto',
       'scrollbar-none'
     )
+    expect(screen.getByTestId('message-image-attachment-strip')).toHaveClass(
+      'ml-auto',
+      'w-max',
+      'flex-nowrap',
+      'justify-end'
+    )
+    expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('justify-start')
     expect(screen.getByTestId('message-image-attachments')).not.toHaveClass('flex-wrap')
     expect(screen.getByTestId('message-hover-region')).toHaveClass('w-full', 'max-w-full')
     expect(previews[0]).toHaveClass('h-20', 'w-20', 'shrink-0', 'rounded-xl', 'object-cover')
@@ -2024,6 +2136,31 @@ describe('MessageList', () => {
     }
   })
 
+  test('shows weekday and clock time for messages created within seven days', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-06-29T18:50:00.000+08:00'))
+
+      render(
+        <MessageList
+          messages={[
+            {
+              id: '1',
+              role: 'user',
+              content: '昨天的消息',
+              status: 'done',
+              createdAt: '2026-06-28T15:27:00.000+08:00',
+            },
+          ]}
+        />
+      )
+
+      expect(screen.getByTestId('message-hover-time')).toHaveTextContent('星期日15:27')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('shows date and clock time for messages not created today in the current year', () => {
     vi.useFakeTimers()
     try {
@@ -2099,7 +2236,7 @@ describe('MessageList', () => {
       'group-hover/message:opacity-100',
       'group-focus-within/message:opacity-100'
     )
-    expect(hoverRegion).toHaveClass('w-fit', 'max-w-full')
+    expect(hoverRegion).toHaveClass('w-full', 'max-w-full')
 
     fireEvent.pointerEnter(hoverRegion)
     expect(hoverActions).toHaveClass('opacity-100', 'pointer-events-auto')
@@ -2151,7 +2288,7 @@ describe('MessageList', () => {
     expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
   })
 
-  test('renders a compact thinking indicator before the first streamed block arrives', () => {
+  test('renders only thinking before the first streamed response arrives', () => {
     render(
       <MessageList
         messages={[
@@ -2171,6 +2308,55 @@ describe('MessageList', () => {
     expect(thinkingIndicator).toHaveTextContent('正在思考')
     expect(thinkingIndicator).not.toHaveClass('bg-surface')
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
+  })
+
+  test('shows full-width processing status once final text starts streaming', () => {
+    render(
+      <MessageList
+        messages={[
+          {
+            id: '2',
+            role: 'assistant',
+            content: '我先',
+            status: 'streaming',
+            createdAt: '2026-05-25T18:46:00.000+08:00',
+          },
+        ]}
+      />
+    )
+
+    const status = screen.getByText('已处理 1 秒')
+
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
+    expect(status.parentElement).toHaveClass('w-full', 'border-b')
+    expect(screen.getByTestId('message-hover-region')).toHaveClass('w-full', 'max-w-full')
+  })
+
+  test('starts the live processing timer when the first visible response appears', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-05-25T18:46:08.000+08:00'))
+
+      render(
+        <MessageList
+          messages={[
+            {
+              id: '2',
+              role: 'assistant',
+              content: '我先',
+              status: 'streaming',
+              createdAt: '2026-05-25T18:46:00.000+08:00',
+            },
+          ]}
+        />
+      )
+
+      expect(screen.getByText('已处理 1 秒')).toBeInTheDocument()
+      expect(screen.queryByText('已处理 8 秒')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('shows thinking in the message list while waiting for the assistant response', () => {
@@ -2196,7 +2382,7 @@ describe('MessageList', () => {
     expect(screen.getByText('正在思考')).toHaveClass('waiting-thinking-text')
   })
 
-  test('shows a single thinking indicator for streaming assistant messages with blocks', () => {
+  test('uses running tool rows instead of a generic thinking indicator when blocks are visible', () => {
     const runningBlock: ProcessingBlock = {
       id: 'call-1',
       turnId: 1,
@@ -2222,7 +2408,8 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.getAllByText('正在思考')).toHaveLength(1)
+    expect(screen.queryByText('正在思考')).not.toBeInTheDocument()
+    expect(screen.getByText('正在运行 rg -n "foo" src')).toBeInTheDocument()
   })
 
   test('renders process text inside the processing timeline before the following tool', () => {
@@ -2265,7 +2452,7 @@ describe('MessageList', () => {
     expect(processText.compareDocumentPosition(runningTool)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
   })
 
-  test('does not duplicate a text block that matches the final assistant content', () => {
+  test('keeps process text even when it matches the final assistant content', () => {
     const finalTextBlock: ProcessingBlock = {
       id: 'text-final',
       turnId: 1,
@@ -2290,8 +2477,10 @@ describe('MessageList', () => {
       />
     )
 
-    expect(screen.queryByTestId('process-text-block')).not.toBeInTheDocument()
-    expect(screen.getByText('这是最终回答。')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByTestId('process-text-block')).toHaveTextContent('这是最终回答。')
+    expect(screen.getAllByText('这是最终回答。')).toHaveLength(2)
   })
 
   test('renders failed assistant messages in the approved error-card layout', () => {

--- a/wework/src/components/chat/MessageList.tsx
+++ b/wework/src/components/chat/MessageList.tsx
@@ -21,6 +21,7 @@ import { getAttachmentTypeLabel, isImageAttachment } from '@/lib/attachments'
 import { parseChatError } from '@/lib/chat-error'
 import { isIMSource } from '@/lib/im-source'
 import { ImSourceBadge } from '@/components/common/ImSourceBadge'
+import { cn } from '@/lib/utils'
 import { AssistantMarkdown } from './AssistantMarkdown'
 import { AttachmentImagePreview } from './AttachmentImagePreview'
 import { ToolBlocksDisplay } from './blocks/ToolBlocksDisplay'
@@ -33,6 +34,7 @@ import { FileChangesCard } from './FileChangesCard'
 
 interface MessageListProps {
   messages: WorkbenchMessage[]
+  className?: string
   conversationKey?: string | number | null
   isWaitingForAssistant?: boolean
   disableContentVisibility?: boolean
@@ -77,6 +79,7 @@ const LOCAL_IMAGE_MIME_TYPES: Record<string, string> = {
 
 export const MessageList = memo(function MessageList({
   messages,
+  className,
   conversationKey,
   isWaitingForAssistant = false,
   disableContentVisibility = false,
@@ -93,13 +96,16 @@ export const MessageList = memo(function MessageList({
   const shouldShowWaitingIndicator =
     isWaitingForAssistant &&
     !messages.some(message => message.role === 'assistant' && message.status === 'streaming')
+  const listLayoutClass = className
+    ? 'mx-auto flex min-w-0 flex-col gap-4 overflow-x-hidden pb-2 pt-11'
+    : 'mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 pb-2 pt-11'
 
   if (visibleMessages.length === 0 && !shouldShowWaitingIndicator) {
     return null
   }
 
   return (
-    <div className="mx-auto flex w-full min-w-0 max-w-3xl flex-col gap-4 overflow-x-hidden px-6 pb-2 pt-11">
+    <div className={cn(listLayoutClass, className)}>
       {visibleMessages.map((message, index) => {
         const nextMessage = visibleMessages[index + 1]
         return (
@@ -147,6 +153,7 @@ export const MessageList = memo(function MessageList({
 function areMessageListPropsEqual(previous: MessageListProps, next: MessageListProps): boolean {
   const changed = [
     previous.messages !== next.messages ? 'messages' : null,
+    previous.className !== next.className ? 'className' : null,
     previous.conversationKey !== next.conversationKey ? 'conversationKey' : null,
     previous.isWaitingForAssistant !== next.isWaitingForAssistant ? 'isWaitingForAssistant' : null,
     previous.disableContentVisibility !== next.disableContentVisibility
@@ -185,7 +192,7 @@ function shouldRenderMessage(message: WorkbenchMessage): boolean {
   const visibleContent = shouldHideFailedAssistantContent(message) ? '' : message.content
   if (visibleContent.trim()) return true
 
-  return getDisplayProcessingBlocks(message.blocks, visibleContent).length > 0
+  return getDisplayProcessingBlocks(message.blocks).length > 0
 }
 
 function WaitingAssistantIndicator() {
@@ -250,6 +257,22 @@ function getStoppedElapsedDuration(message: WorkbenchMessage): string {
   return formatCompactDuration(endedAt - startedAt)
 }
 
+function getProcessingSummaryStartMs(
+  message: WorkbenchMessage,
+  blocks: ProcessingBlock[],
+  isStreaming: boolean
+): number | undefined {
+  if (!isStreaming) return getTurnStartMs(message.createdAt)
+
+  const blockStartTimes = blocks
+    .map(block => block.createdAt)
+    .filter((createdAt): createdAt is number => Number.isFinite(createdAt))
+
+  if (blockStartTimes.length > 0) return Math.min(...blockStartTimes)
+
+  return undefined
+}
+
 function isCancelledAssistantMessage(message: WorkbenchMessage): boolean {
   return message.runtimeStatus === 'cancelled'
 }
@@ -257,6 +280,17 @@ function isCancelledAssistantMessage(message: WorkbenchMessage): boolean {
 function isCancelledPlaceholderContent(content: string): boolean {
   return ['interrupted', 'cancelled', 'canceled', 'aborted'].includes(content.trim().toLowerCase())
 }
+
+const RECENT_MESSAGE_TIME_RANGE_MS = 7 * 24 * 60 * 60 * 1000
+const CHINESE_WEEKDAY_LABELS = [
+  '星期日',
+  '星期一',
+  '星期二',
+  '星期三',
+  '星期四',
+  '星期五',
+  '星期六',
+]
 
 function formatMessageTime(createdAt: string) {
   const date = new Date(createdAt)
@@ -269,6 +303,11 @@ function formatMessageTime(createdAt: string) {
 
   const time = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`
   if (isToday) return time
+
+  const ageMs = now.getTime() - date.getTime()
+  if (ageMs >= 0 && ageMs < RECENT_MESSAGE_TIME_RANGE_MS) {
+    return `${CHINESE_WEEKDAY_LABELS[date.getDay()]}${time}`
+  }
 
   const dateLabel = `${date.getMonth() + 1}月${date.getDate()}日`
   if (date.getFullYear() === now.getFullYear()) {
@@ -370,39 +409,44 @@ function UserMessage({
                 className={[
                   'flex w-full max-w-full flex-row flex-nowrap gap-2',
                   hasMultipleImagePreviews
-                    ? 'scrollbar-none justify-start overflow-x-auto overscroll-x-contain'
+                    ? 'scrollbar-none overflow-x-auto overscroll-x-contain'
                     : 'justify-end overflow-visible',
                 ].join(' ')}
               >
-                {imagePreviewAttachments.map((attachment, index) => (
-                  <MessageImageAttachmentPreview
-                    key={`${attachment.id}:${attachment.local_preview_url ?? attachment.filename}`}
-                    attachment={attachment}
-                    galleryAttachments={imagePreviewAttachments}
-                    galleryIndex={index}
-                    imageTestId={
-                      imageAttachments.length > 0
-                        ? 'message-image-preview'
-                        : 'message-local-image-preview'
-                    }
-                    buttonTestId={
-                      imageAttachments.length > 0
-                        ? 'message-image-preview-button'
-                        : 'message-local-image-preview-button'
-                    }
-                    loadingTestId={
-                      imageAttachments.length > 0
-                        ? 'message-image-preview-loading'
-                        : 'message-local-image-preview-loading'
-                    }
-                    errorTestId={
-                      imageAttachments.length > 0
-                        ? 'message-image-preview-error'
-                        : 'message-local-image-preview-error'
-                    }
-                    hideOnError={imageAttachments.length === 0}
-                  />
-                ))}
+                <div
+                  data-testid="message-image-attachment-strip"
+                  className="ml-auto flex w-max max-w-none flex-row flex-nowrap justify-end gap-2"
+                >
+                  {imagePreviewAttachments.map((attachment, index) => (
+                    <MessageImageAttachmentPreview
+                      key={`${attachment.id}:${attachment.local_preview_url ?? attachment.filename}`}
+                      attachment={attachment}
+                      galleryAttachments={imagePreviewAttachments}
+                      galleryIndex={index}
+                      imageTestId={
+                        imageAttachments.length > 0
+                          ? 'message-image-preview'
+                          : 'message-local-image-preview'
+                      }
+                      buttonTestId={
+                        imageAttachments.length > 0
+                          ? 'message-image-preview-button'
+                          : 'message-local-image-preview-button'
+                      }
+                      loadingTestId={
+                        imageAttachments.length > 0
+                          ? 'message-image-preview-loading'
+                          : 'message-local-image-preview-loading'
+                      }
+                      errorTestId={
+                        imageAttachments.length > 0
+                          ? 'message-image-preview-error'
+                          : 'message-local-image-preview-error'
+                      }
+                      hideOnError={imageAttachments.length === 0}
+                    />
+                  ))}
+                </div>
               </div>
             )}
             {localFileMentions.map(file => (
@@ -821,25 +865,13 @@ function shouldHideFailedAssistantContent(message: WorkbenchMessage) {
   return RAW_FAILED_MESSAGE_PATTERNS.some(pattern => pattern.test(content))
 }
 
-function normalizeTextForComparison(value: string): string {
-  return value.replace(/\s+/g, ' ').trim()
-}
-
-function getDisplayProcessingBlocks(
-  blocks: ProcessingBlock[] | undefined,
-  visibleContent: string
-): ProcessingBlock[] {
+function getDisplayProcessingBlocks(blocks: ProcessingBlock[] | undefined): ProcessingBlock[] {
   if (!blocks?.length) return []
-
-  const normalizedVisibleContent = normalizeTextForComparison(visibleContent)
 
   return blocks.filter(block => {
     if (block.type !== 'text') return true
 
-    const normalizedBlockContent = normalizeTextForComparison(block.content)
-    if (!normalizedBlockContent) return false
-
-    return normalizedBlockContent !== normalizedVisibleContent
+    return Boolean(block.content.trim())
   })
 }
 
@@ -886,14 +918,17 @@ function AssistantMessage({
   const visibleContent = shouldHideContent ? '' : message.content
   const hiddenErrorContent =
     message.status === 'failed' && shouldHideContent ? message.content.trim() : undefined
-  const displayBlocks = getDisplayProcessingBlocks(message.blocks, visibleContent)
+  const displayBlocks = getDisplayProcessingBlocks(message.blocks)
   const hasBlocks = displayBlocks.length > 0
   const hasVisibleContent = Boolean(visibleContent.trim())
   const isStreaming = message.status === 'streaming'
+  const canShowFinalArtifacts = !isStreaming
+  const hasStreamedResponse = hasBlocks || hasVisibleContent
+  const shouldShowProcessingSummary = hasBlocks || (isStreaming && hasStreamedResponse)
+  const shouldShowInitialThinking = isStreaming && !hasStreamedResponse
   const webSearchSources = isStreaming
     ? []
     : getWebSearchSourceItems(getWebSearchToolBlocks(displayBlocks))
-  const shouldShowCompactThinking = isStreaming && !hasBlocks && !hasVisibleContent
   const contextEvents = message.contextEvents ?? []
   const memoryCitations = message.memoryCitations ?? []
   const [areHoverActionsVisible, setAreHoverActionsVisible] = useState(false)
@@ -920,12 +955,12 @@ function AssistantMessage({
   return (
     <div className="min-w-0 overflow-x-hidden text-[13px] leading-6 text-text-primary">
       <div
-        className="w-fit max-w-full"
+        className="w-full max-w-full"
         data-testid="message-hover-region"
         onPointerEnter={() => setAreHoverActionsVisible(true)}
         onPointerLeave={() => setAreHoverActionsVisible(false)}
       >
-        <div className="w-fit max-w-full">
+        <div className="w-full max-w-full">
           {shouldShowStoppedNotice ? (
             <div
               data-testid="assistant-stopped-notice"
@@ -936,31 +971,33 @@ function AssistantMessage({
               })}
             </div>
           ) : null}
-          {hasBlocks && (
+          {shouldShowProcessingSummary && (
             <ToolBlocksDisplay
               blocks={displayBlocks}
               isStreaming={isStreaming}
-              startedAt={getTurnStartMs(message.createdAt)}
+              startedAt={getProcessingSummaryStartMs(message, displayBlocks, isStreaming)}
               forceExpanded={isCancelled}
+              hasFinalContent={hasVisibleContent}
               showSummary={!isCancelled}
+              showRunningPlaceholder={!hasVisibleContent}
               stateKey={getMessageDisplayStateKey(conversationKey, message)}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           )}
+          {shouldShowInitialThinking && <WaitingAssistantIndicator />}
           {contextEvents.length > 0 && <CodexContextEvents events={contextEvents} />}
           {hasVisibleContent && (
             <AssistantMarkdown content={visibleContent} onOpenFile={openFileFromLink} />
           )}
-          {hasVisibleContent && webSearchSources.length > 0 && (
+          {canShowFinalArtifacts && hasVisibleContent && webSearchSources.length > 0 && (
             <WebSearchSourcesChip sources={webSearchSources} />
           )}
-          {memoryCitations.length > 0 && (
+          {canShowFinalArtifacts && memoryCitations.length > 0 && (
             <CodexMemoryCitations citations={memoryCitations} onOpenFile={onOpenWorkspaceFile} />
           )}
-          {references.length > 0 && (
+          {canShowFinalArtifacts && references.length > 0 && (
             <CodexReferenceList references={references} onOpenFile={openFileFromLink} />
           )}
-          {shouldShowCompactThinking && <WaitingAssistantIndicator />}
           {message.status === 'failed' && (
             <AssistantErrorCard
               error={message.error}
@@ -971,7 +1008,8 @@ function AssistantMessage({
               onSwitchModel={onSwitchModelForFailedMessage}
             />
           )}
-          {message.fileChanges &&
+          {canShowFinalArtifacts &&
+          message.fileChanges &&
           message.turnId &&
           onLoadFileChangesDiff &&
           onRevertFileChanges ? (

--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -78,7 +78,9 @@ export function MessageTurnNavigation({
       }
 
       const currentPosition = scroller.scrollTop + SCROLL_OFFSET_PX
-      const loadedMarkers = nextMarkers.filter(marker => marker.targetTop !== null)
+      const loadedMarkers = nextMarkers.filter(
+        (marker): marker is MessageTurnMarker & { targetTop: number } => marker.targetTop !== null
+      )
       if (loadedMarkers.length === 0) {
         setActiveMarkerId(null)
         return

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -108,6 +108,28 @@ describe('ScrollableMessageArea', () => {
     expect(screen.getByTestId('chat-message-scroll-area-content')).not.toHaveClass('justify-end')
   })
 
+  test('updates the message list layout when only the layout class changes', () => {
+    const messages = [
+      {
+        id: '1',
+        role: 'assistant' as const,
+        content: 'Ready',
+        status: 'done' as const,
+        createdAt: '2026-05-29T00:00:00.000Z',
+      },
+    ]
+    const { rerender } = render(
+      <ScrollableMessageArea messages={messages} messageListClassName="layout-width-a" />
+    )
+
+    expect(screen.getByTestId('message-assistant').parentElement).toHaveClass('layout-width-a')
+
+    rerender(<ScrollableMessageArea messages={messages} messageListClassName="layout-width-b" />)
+
+    expect(screen.getByTestId('message-assistant').parentElement).toHaveClass('layout-width-b')
+    expect(screen.getByTestId('message-assistant').parentElement).not.toHaveClass('layout-width-a')
+  })
+
   test('keeps older transcript loading controls at the top of the message flow', () => {
     render(
       <ScrollableMessageArea

--- a/wework/src/components/chat/ScrollableMessageArea.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.tsx
@@ -39,6 +39,7 @@ interface ScrollableMessageAreaProps {
   turnNavigation?: RuntimeTurnNavigationItem[]
   className?: string
   scrollerClassName?: string
+  messageListClassName?: string
   scrollButtonClassName?: string
   scrollTestId?: string
   conversationKey?: string | number | null
@@ -126,10 +127,21 @@ function areScrollableMessageAreaPropsEqual(
     previous.turnNavigation !== next.turnNavigation ? 'turnNavigation' : null,
     previous.className !== next.className ? 'className' : null,
     previous.scrollerClassName !== next.scrollerClassName ? 'scrollerClassName' : null,
+    previous.messageListClassName !== next.messageListClassName ? 'messageListClassName' : null,
     previous.scrollButtonClassName !== next.scrollButtonClassName ? 'scrollButtonClassName' : null,
     previous.scrollTestId !== next.scrollTestId ? 'scrollTestId' : null,
     previous.conversationKey !== next.conversationKey ? 'conversationKey' : null,
     previous.devices !== next.devices ? 'devices' : null,
+    previous.onRetryFailedMessage !== next.onRetryFailedMessage ? 'onRetryFailedMessage' : null,
+    previous.onSwitchModelForFailedMessage !== next.onSwitchModelForFailedMessage
+      ? 'onSwitchModelForFailedMessage'
+      : null,
+    previous.onLoadFileChangesDiff !== next.onLoadFileChangesDiff ? 'onLoadFileChangesDiff' : null,
+    previous.onRevertFileChanges !== next.onRevertFileChanges ? 'onRevertFileChanges' : null,
+    previous.onOpenFileChangesReview !== next.onOpenFileChangesReview
+      ? 'onOpenFileChangesReview'
+      : null,
+    previous.onOpenWorkspaceFile !== next.onOpenWorkspaceFile ? 'onOpenWorkspaceFile' : null,
     previous.onLoadMoreBefore !== next.onLoadMoreBefore ? 'onLoadMoreBefore' : null,
     previous.onLoadTurnNavigationItem !== next.onLoadTurnNavigationItem
       ? 'onLoadTurnNavigationItem'
@@ -219,6 +231,7 @@ function ScrollableMessagePaneContent({
   turnNavigation,
   className,
   scrollerClassName,
+  messageListClassName,
   scrollButtonClassName,
   scrollTestId = 'chat-message-scroll-area',
   conversationKey,
@@ -721,6 +734,7 @@ function ScrollableMessagePaneContent({
               )}
               <MessageList
                 messages={messages}
+                className={messageListClassName}
                 conversationKey={conversationKey}
                 isWaitingForAssistant={isWaitingForAssistant}
                 disableContentVisibility={turnNavigationLoading}

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.test.tsx
@@ -97,6 +97,16 @@ const completedFileChangesBlock: ProcessingBlock = {
   },
 }
 
+const completedGuidanceBlock: ProcessingBlock = {
+  id: 'guidance-1',
+  subtaskId: 1,
+  type: 'tool',
+  toolName: 'conversation_guidance',
+  toolInput: { message: '继续分析 package.json' },
+  status: 'done',
+  createdAt: 1770000004000,
+}
+
 describe('ToolBlocksDisplay', () => {
   afterEach(() => {
     vi.useRealTimers()
@@ -109,6 +119,16 @@ describe('ToolBlocksDisplay', () => {
 
     expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
     expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
+  })
+
+  test('renders completed conversation guidance as a static activity label', () => {
+    render(<ToolBlocksDisplay blocks={[completedGuidanceBlock]} isStreaming={false} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /已处理/ }))
+
+    expect(screen.getByTestId('processing-activity-group-label')).toHaveTextContent('已引导对话')
+    expect(screen.queryByRole('button', { name: '已引导对话' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('processing-activity-group-content')).not.toBeInTheDocument()
   })
 
   test('renders completed web search tools as a Codex-style web search activity', () => {
@@ -305,11 +325,83 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('已处理 5 秒')).toBeInTheDocument()
   })
 
-  test('keeps completed tools collapsed while the assistant turn is still running', () => {
+  test('keeps running process visible with inner tool details collapsed', () => {
     render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={true} />)
 
-    expect(screen.queryByText('已运行 1 条命令')).not.toBeInTheDocument()
-    expect(screen.getByText('已运行 pwd')).toBeInTheDocument()
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
+    expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
+    expect(screen.queryByText('已运行 pwd')).not.toBeInTheDocument()
+    expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
+  })
+
+  test('shows a thinking placeholder while streaming with only completed activity', () => {
+    render(<ToolBlocksDisplay blocks={[completedCommandBlock]} isStreaming={true} />)
+
+    expect(screen.getByTestId('processing-collapse-content')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    )
+    expect(screen.getByTestId('thinking-indicator')).toHaveTextContent('正在思考')
+  })
+
+  test('collapses streaming processing once final content is visible', () => {
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedCommandBlock]}
+        isStreaming={true}
+        hasFinalContent={true}
+      />
+    )
+
+    const toggle = screen.getByRole('button', { name: /已处理/ })
+    const collapseContent = screen.getByTestId('processing-collapse-content')
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'true')
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(collapseContent).toHaveAttribute('aria-hidden', 'false')
+    expect(screen.getByText('已运行 1 条命令')).toBeInTheDocument()
+  })
+
+  test('groups completed tools while keeping the current running command visible', () => {
+    const completedSearchBlock: ProcessingBlock = {
+      id: 'search-1',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: "/bin/zsh -lc 'rg -n paas-context .'" },
+      status: 'done',
+      createdAt: 1770000001000,
+    }
+    const runningBlock: ProcessingBlock = {
+      id: 'running-1',
+      subtaskId: 1,
+      type: 'tool',
+      toolName: 'bash',
+      toolInput: { command: 'bin/paas-context --help' },
+      status: 'streaming',
+      createdAt: 1770000002000,
+    }
+
+    render(
+      <ToolBlocksDisplay
+        blocks={[completedCommandBlock, completedSearchBlock, runningBlock]}
+        isStreaming={true}
+      />
+    )
+
+    const activityToggle = screen.getByRole('button', {
+      name: /已搜索代码 已运行 1 条命令/,
+    })
+
+    expect(activityToggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByText(/已运行 \/bin\/zsh/)).not.toBeInTheDocument()
+    expect(screen.getByText('正在运行 bin/paas-context --help')).toBeInTheDocument()
     expect(screen.queryByText('/workspace/project')).not.toBeInTheDocument()
   })
 
@@ -339,7 +431,7 @@ describe('ToolBlocksDisplay', () => {
     expect(screen.getByText('已处理 10 秒')).toBeInTheDocument()
   })
 
-  test('renders the header as plain text (not a button) while running', () => {
+  test('renders the running header as plain text', () => {
     const runningBlock: ProcessingBlock = {
       ...completedCommandBlock,
       status: 'streaming',
@@ -347,8 +439,7 @@ describe('ToolBlocksDisplay', () => {
 
     render(<ToolBlocksDisplay blocks={[runningBlock]} isStreaming={true} />)
 
-    // While running the summary is informational only and must not be clickable.
-    expect(screen.queryByRole('button', { name: /已处理/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /已处理 .* 秒/ })).not.toBeInTheDocument()
     expect(screen.getByText(/已处理 .* 秒/)).toBeInTheDocument()
   })
 

--- a/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
+++ b/wework/src/components/chat/blocks/ToolBlocksDisplay.tsx
@@ -24,7 +24,9 @@ interface ToolBlocksDisplayProps {
   // timer from the refresh moment.
   startedAt?: number
   forceExpanded?: boolean
+  hasFinalContent?: boolean
   showSummary?: boolean
+  showRunningPlaceholder?: boolean
   stateKey?: string
   onOpenWorkspaceFile?: (path: string) => void
 }
@@ -34,7 +36,9 @@ export function ToolBlocksDisplay({
   isStreaming,
   startedAt,
   forceExpanded = false,
+  hasFinalContent = false,
   showSummary = true,
+  showRunningPlaceholder = true,
   stateKey,
   onOpenWorkspaceFile,
 }: ToolBlocksDisplayProps) {
@@ -71,20 +75,20 @@ export function ToolBlocksDisplay({
   }, [completedAt, hasRenderedRunning, isRunning])
 
   const duration = getDurationText(blocks, turnStartedAt, now, completedAt, isRunning)
-  const rows = useMemo(
-    () => buildProcessingDisplayRows(blocks, { groupCompletedTools: !isRunning }),
-    [blocks, isRunning]
-  )
-  const expanded = forceExpanded || isRunning || userExpanded
-  const hasLiveNarrativeBlock = useMemo(
+  const rows = useMemo(() => buildProcessingDisplayRows(blocks), [blocks])
+  const isLockedOpen = forceExpanded || (isRunning && !hasFinalContent)
+  const expanded = isLockedOpen || userExpanded
+  const canToggleSummary = showSummary && !isLockedOpen && rows.length > 0
+  const hasLiveDisplayBlock = useMemo(
     () =>
       rows.some(
         row =>
           row.type === 'block' &&
-          (row.block.type === 'thinking' || row.block.type === 'text') &&
           row.block.status !== 'done' &&
           row.block.status !== 'error' &&
-          Boolean(row.block.content)
+          (row.block.type === 'tool' ||
+            row.block.type === 'file_changes' ||
+            Boolean(row.block.content))
       ),
     [rows]
   )
@@ -103,34 +107,32 @@ export function ToolBlocksDisplay({
             <ToolBlockItem
               key={row.id}
               block={row.block}
-              forceExpanded={forceExpanded}
               stateKey={stateKey ? `${stateKey}:${row.id}` : undefined}
               onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           )
         )}
-        {isRunning && !hasLiveNarrativeBlock && <ThinkingIndicator />}
+        {isRunning && showRunningPlaceholder && !hasLiveDisplayBlock && <ThinkingIndicator />}
       </div>
     ),
-    [forceExpanded, hasLiveNarrativeBlock, isRunning, onOpenWorkspaceFile, rows, stateKey]
+    [hasLiveDisplayBlock, isRunning, onOpenWorkspaceFile, rows, showRunningPlaceholder, stateKey]
   )
 
   if (blocks.length === 0 && !isStreaming) return null
 
   return (
-    <div className="mb-3 min-w-0">
-      {showSummary && isRunning ? (
-        // While the turn is still running the summary is informational only:
-        // render it as plain, non-interactive text so it does not look clickable.
-        <div className="mb-3 border-b border-border pb-2 text-xs text-text-muted">
+    <div className="mb-3 min-w-0 w-full">
+      {showSummary && !canToggleSummary ? (
+        <div className="mb-3 w-full border-b border-border pb-2 text-xs text-text-muted">
           <span className="inline-flex items-center gap-1">{duration}</span>
         </div>
       ) : showSummary ? (
-        <div className="mb-3 border-b border-border pb-2">
+        <div className="mb-3 w-full border-b border-border pb-2">
           <button
             type="button"
             className="inline-flex items-center gap-1 text-left text-xs text-text-muted hover:text-text-secondary"
             onClick={() => setUserExpanded(value => !value)}
+            aria-expanded={expanded}
           >
             <span>{duration}</span>
             <svg
@@ -246,7 +248,20 @@ function ToolActivityGroup({
 }) {
   const [expanded, setExpanded] = useState(false)
   const isWebSearchGroup = isWebSearchActivityGroup(row.blocks)
+  const isGuidanceGroup = isGuidanceActivityGroup(row.blocks)
   const icon = renderActivityGroupIcon(row.blocks)
+
+  if (isGuidanceGroup) {
+    return (
+      <div
+        className="flex max-w-full items-center gap-1.5 text-[13px] text-text-muted"
+        data-testid="processing-activity-group-label"
+      >
+        {icon}
+        <span className="min-w-0 truncate">{row.label}</span>
+      </div>
+    )
+  }
 
   return (
     <div className="min-w-0 overflow-x-hidden text-[13px]">
@@ -344,7 +359,7 @@ function getDurationText(
   // Once finished, lock to the completion time (or the last block timestamp
   // when the turn was restored from history after a refresh).
   const endTime = isRunning ? now : (completedAt ?? last)
-  const durationMs = Math.max(0, endTime - first)
+  const durationMs = isRunning ? Math.max(1000, endTime - first) : Math.max(0, endTime - first)
   const duration = formatDuration(durationMs)
 
   return `已处理 ${duration}`

--- a/wework/src/components/chat/composer/CompactChatComposer.tsx
+++ b/wework/src/components/chat/composer/CompactChatComposer.tsx
@@ -155,7 +155,7 @@ export function CompactChatComposer({
             placeholder={placeholder}
             rows={1}
             onPasteFiles={files => onFileSelect?.(files)}
-            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-base leading-6 text-text-primary outline-none placeholder:text-text-muted"
+            className="scrollbar-none max-h-32 min-h-6 min-w-0 flex-1 resize-none overflow-y-auto bg-transparent py-[14px] text-sm leading-5 text-text-primary outline-none placeholder:text-text-muted"
             skillMenuClassName="left-[-1rem] right-[-3.5rem]"
             onListLocalSkills={onListLocalSkills}
             selectedModel={selectedModel}

--- a/wework/src/components/chat/composer/ProjectChatComposer.tsx
+++ b/wework/src/components/chat/composer/ProjectChatComposer.tsx
@@ -143,7 +143,7 @@ export function ProjectChatComposer({
       <form
         ref={formRef}
         data-testid="project-chat-composer-form"
-        className="flex min-h-[112px] w-full flex-col rounded-[28px] border border-border bg-background pb-2 pl-4 pr-2 pt-3.5"
+        className="flex min-h-[100px] w-full flex-col rounded-[28px] border border-border bg-background pb-4 pl-4 pr-2 pt-2"
         onDragOver={handleDragOver}
         onDrop={handleDrop}
         onSubmit={event => {
@@ -177,7 +177,7 @@ export function ProjectChatComposer({
           placeholder={placeholder}
           rows={2}
           onPasteFiles={onFileSelect}
-          className="max-h-[128px] min-h-9 w-full resize-none overflow-y-auto bg-transparent p-0 text-sm leading-5 text-text-primary outline-none placeholder:text-text-muted"
+          className="max-h-[116px] min-h-8 w-full resize-none overflow-y-auto bg-transparent p-0 text-sm leading-5 text-text-primary outline-none placeholder:text-text-muted"
           skillMenuClassName="left-[-1rem] right-[-0.5rem]"
           onListLocalSkills={onListLocalSkills}
           selectedModel={selectedModel}

--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -117,7 +117,13 @@ describe('DesktopSidebar', () => {
 
     const actions = screen.getByTestId('projects-section-toggle-actions')
 
-    expect(actions).toHaveClass('absolute', 'right-2.5', 'pointer-events-none', 'invisible')
+    expect(actions).toHaveClass(
+      'absolute',
+      'right-2.5',
+      'z-[70]',
+      'pointer-events-none',
+      'opacity-0'
+    )
     expect(screen.getByTestId('projects-create-button')).toBeInTheDocument()
   })
 
@@ -814,9 +820,11 @@ describe('DesktopSidebar', () => {
       )
       expect(screen.getByTestId('runtime-local-task-pin-icon-codex-1')).toBeInTheDocument()
       expect(screen.getByTestId('runtime-local-task-archive-icon-codex-1')).toBeInTheDocument()
-      expect(
-        screen.getByTestId('runtime-local-task-hover-actions-codex-1').className
-      ).not.toContain('focus-within')
+      expect(screen.getByTestId('runtime-local-task-hover-actions-codex-1')).toHaveClass(
+        'z-[70]',
+        'hover:pointer-events-auto',
+        'focus-within:pointer-events-auto'
+      )
       expect(screen.getByTestId('runtime-local-task-time-codex-1').className).not.toContain(
         'focus-within'
       )

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -18,7 +18,12 @@ import {
   X,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import type { KeyboardEvent, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
+import type {
+  KeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+  PointerEventHandler,
+  ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { ActionMenu } from '@/components/common/ActionMenu'
 import { TextInputDialog } from '@/components/common/TextInputDialog'
@@ -80,6 +85,12 @@ interface DesktopSidebarProps {
   preferredDeviceId?: string | null
   activeItem?: 'chat' | 'plugins' | 'automation'
   collapsed?: boolean
+  containerTestId?: string
+  hideResizeHandle?: boolean
+  onResizeCollapse?: () => void
+  onResizeStateChange?: (resizing: boolean) => void
+  onPointerEnter?: PointerEventHandler<HTMLElement>
+  onPointerLeave?: PointerEventHandler<HTMLElement>
   onNewChat: () => void
   onOpenSearch?: () => void
   onSelectProject?: (projectId: number) => void
@@ -465,7 +476,7 @@ function SidebarSectionHeader({
       </button>
       <div
         data-testid={`${toggleTestId}-actions`}
-        className="pointer-events-none invisible absolute right-2.5 top-1/2 flex -translate-y-1/2 items-center opacity-0 transition-opacity group-hover/section:pointer-events-auto group-hover/section:visible group-hover/section:opacity-100 focus-within:pointer-events-auto focus-within:visible focus-within:opacity-100"
+        className="pointer-events-none absolute right-2.5 top-1/2 z-[70] flex -translate-y-1/2 items-center opacity-0 transition-opacity group-hover/section:pointer-events-auto group-hover/section:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
       >
         {children}
       </div>
@@ -1152,7 +1163,7 @@ function RuntimeLocalTaskRow({
           </span>
           <span
             data-testid={`runtime-local-task-hover-actions-${task.localTaskId}`}
-            className="pointer-events-none invisible absolute right-0 top-1/2 flex w-[78px] -translate-y-1/2 items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover/task:pointer-events-auto group-hover/task:visible group-hover/task:opacity-100"
+            className="pointer-events-none absolute right-0 top-1/2 z-[70] flex w-[78px] -translate-y-1/2 items-center justify-end gap-0.5 opacity-0 transition-opacity group-hover/task:pointer-events-auto group-hover/task:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100"
           >
             {renderNotificationButton(
               notificationsSubscribed
@@ -1374,7 +1385,7 @@ function ProjectItem({
     <div data-testid="project-item" className="space-y-0.5">
       <div
         data-testid={`project-row-${project.id}`}
-        className="group/project relative flex h-8 min-w-0 items-center gap-1 rounded-md pl-2.5 pr-1 text-[13px] leading-[18px] text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
+        className="group/project relative flex h-8 min-w-0 items-center gap-1 rounded-md pl-2.5 pr-[58px] text-[13px] leading-[18px] text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))]"
       >
         <button
           type="button"
@@ -1383,7 +1394,7 @@ function ProjectItem({
             onToggleProject(project.id)
           }}
           aria-expanded={expanded}
-          className="flex min-w-0 flex-1 items-center gap-2.5 pr-1 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
         >
           <ProjectFolderIcon
             project={project}
@@ -1401,7 +1412,7 @@ function ProjectItem({
             />
           )}
         </button>
-        <div className="absolute right-1 invisible flex shrink-0 items-center opacity-0 transition-opacity group-hover/project:visible group-hover/project:opacity-100 focus-within:visible focus-within:opacity-100">
+        <div className="pointer-events-none absolute right-1 top-1/2 z-[70] flex w-[58px] shrink-0 -translate-y-1/2 items-center justify-end opacity-0 transition-opacity group-hover/project:pointer-events-auto group-hover/project:opacity-100 hover:pointer-events-auto hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
           <ActionMenu
             ariaLabel={t('workbench.project_actions', '项目操作')}
             testId={`project-menu-${project.id}`}
@@ -1433,6 +1444,7 @@ function ProjectItem({
                 },
               },
             ]}
+            triggerClassName="flex h-7 w-7 items-center justify-center rounded-md text-[rgb(var(--color-sidebar-text-secondary))] hover:bg-[rgb(var(--color-sidebar-hover))] hover:text-[rgb(var(--color-sidebar-text-primary))]"
           />
           <button
             type="button"
@@ -1558,9 +1570,18 @@ export function DesktopSidebar({
   onRefreshWorkLists,
   onLogout,
   collapsed = false,
+  containerTestId = 'desktop-sidebar',
+  hideResizeHandle = false,
+  onResizeCollapse,
+  onResizeStateChange,
+  onPointerEnter,
+  onPointerLeave,
 }: DesktopSidebarProps) {
   const { t } = useTranslation('common')
-  const { sidebarWidth, handleResizeStart } = useResizableSidebar()
+  const { sidebarWidth, resizing, handleResizeStart } = useResizableSidebar({
+    onCollapse: onResizeCollapse,
+    onResizeStateChange,
+  })
   const showCloudConnectionEntry = isCloudConnectionUiAvailable()
 
   const storageScope = getDesktopSidebarStorageScope(user)
@@ -1840,19 +1861,19 @@ export function DesktopSidebar({
 
   return (
     <aside
-      data-testid="desktop-sidebar"
+      data-testid={containerTestId}
       aria-hidden={collapsed}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
       className={cn(
-        'relative shrink-0 overflow-hidden bg-transparent transition-[width,opacity] duration-[220ms] ease-out motion-reduce:transition-none',
-        collapsed ? 'pointer-events-none opacity-0' : 'opacity-100'
+        'relative z-popover shrink-0 overflow-hidden bg-transparent transition-[width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width]',
+        resizing && 'transition-none',
+        collapsed && 'pointer-events-none'
       )}
       style={{ width: collapsed ? 0 : sidebarWidth }}
     >
       <div
-        className={cn(
-          'relative flex h-full flex-col px-1.5 pb-4 pt-1.5 transition-transform duration-[220ms] ease-out motion-reduce:transition-none',
-          collapsed ? '-translate-x-3' : 'translate-x-0'
-        )}
+        className="relative flex h-full flex-col px-1.5 pb-4 pt-1.5"
         style={{ width: sidebarWidth }}
       >
         <nav className="space-y-0.5">
@@ -2168,13 +2189,15 @@ export function DesktopSidebar({
           </div>
         </div>
 
-        <button
-          type="button"
-          data-testid="sidebar-resize-handle"
-          onPointerDown={handleResizeStart}
-          className="absolute right-[-4px] top-0 z-20 h-full w-3 cursor-col-resize bg-transparent"
-          aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
-        />
+        {!hideResizeHandle && (
+          <button
+            type="button"
+            data-testid="sidebar-resize-handle"
+            onPointerDown={handleResizeStart}
+            className="absolute right-[-6px] top-0 z-[60] h-full w-10 cursor-col-resize touch-none bg-transparent after:absolute after:right-1.5 after:top-0 after:h-full after:w-px after:bg-transparent after:transition-colors after:duration-150 hover:after:bg-primary/35"
+            aria-label={t('workbench.resize_sidebar', '调整侧边栏宽度')}
+          />
+        )}
 
         <StandaloneBlankProjectDialog
           open={blankProjectDialogOpen}

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -40,6 +40,10 @@ const tauriMenuMocks = vi.hoisted(() => ({
   menuPopup: vi.fn(),
 }))
 
+const authMocks = vi.hoisted(() => ({
+  logout: vi.fn(),
+}))
+
 function createRect({
   left,
   top,
@@ -62,6 +66,18 @@ function createRect({
     bottom: top + height,
     toJSON: () => ({}),
   } as DOMRect
+}
+
+function mockDesktopWorkbenchMainWidth(width: number) {
+  return vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+    if (
+      this.tagName === 'MAIN' &&
+      this.querySelector('[data-testid="desktop-workbench-content"]')
+    ) {
+      return createRect({ left: 0, top: 0, width, height: 720 })
+    }
+    return createRect({ left: 0, top: 0, width: 0, height: 0 })
+  })
 }
 
 class ResizeObserverMock {
@@ -99,6 +115,13 @@ vi.mock('@/api/projects', () => ({
 
 vi.mock('@/api/quota', () => ({
   createQuotaApi: vi.fn(),
+}))
+
+vi.mock('@/features/auth/useAuth', async importOriginal => ({
+  ...(await importOriginal<typeof import('@/features/auth/useAuth')>()),
+  useAuth: () => ({
+    logout: authMocks.logout,
+  }),
 }))
 
 vi.mock('@/lib/local-terminal', () => ({
@@ -876,7 +899,11 @@ describe('DesktopWorkbenchLayout', () => {
     }
   }
 
-  function renderWorkspacePanelLayout() {
+  function renderWorkspacePanelLayout({ mainWidth }: { mainWidth?: number } = {}) {
+    if (mainWidth) {
+      mockDesktopWorkbenchMainWidth(mainWidth)
+    }
+
     const workspacePanelState = createCloudWorkspacePanelState()
     return render(
       <DesktopWorkbenchLayout
@@ -915,9 +942,9 @@ describe('DesktopWorkbenchLayout', () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
     expect(screen.getByTestId('desktop-empty-composer-frame')).toHaveClass(
-      'w-[min(58vw,62rem)]',
-      'min-w-[32rem]',
-      'max-w-[calc(100vw-4rem)]',
+      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'min-w-0',
+      'max-w-[calc(100%_-_1.5rem)]',
       '-translate-y-12'
     )
   })
@@ -944,9 +971,15 @@ describe('DesktopWorkbenchLayout', () => {
       'overflow-x-hidden',
       'overflow-y-auto',
       'scrollbar-soft',
-      'pb-40'
+      'pb-[var(--desktop-floating-composer-clearance)]'
     )
     expect(screen.getByTestId('desktop-chat-scroll-content')).not.toHaveClass('justify-end')
+    expect(screen.getByTestId('desktop-chat-scroll-content').firstElementChild).toHaveClass(
+      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'min-w-0',
+      'max-w-[calc(100%_-_1.5rem)]',
+      'px-0'
+    )
     expect(screen.getByTestId('desktop-floating-composer-backdrop')).toHaveClass(
       'pointer-events-none',
       'absolute',
@@ -960,7 +993,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass(
       'pointer-events-none',
       'absolute',
-      'bottom-4',
+      'bottom-2',
       'left-1/2',
       'z-chrome',
       '-translate-x-1/2'
@@ -1331,7 +1364,10 @@ describe('DesktopWorkbenchLayout', () => {
 
     fireEvent.scroll(scroller)
 
-    expect(screen.getByTestId('scroll-to-bottom-button')).toHaveClass('bottom-36', 'z-popover')
+    expect(screen.getByTestId('scroll-to-bottom-button')).toHaveClass(
+      'bottom-[calc(var(--desktop-floating-composer-height)_+_2rem)]',
+      'z-popover'
+    )
   })
 
   test('reserves extra bottom space when queued messages are shown above the composer', () => {
@@ -1359,8 +1395,9 @@ describe('DesktopWorkbenchLayout', () => {
       />
     )
 
-    expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass('pb-52')
-    expect(screen.getByTestId('desktop-chat-scroll')).not.toHaveClass('pb-40')
+    expect(screen.getByTestId('desktop-chat-scroll')).toHaveClass(
+      'pb-[var(--desktop-floating-composer-clearance)]'
+    )
   })
 
   test('restores and stores sidebar width in localStorage', () => {
@@ -1389,6 +1426,23 @@ describe('DesktopWorkbenchLayout', () => {
     expect(localStorage.getItem('wework.desktop.sidebar.width')).toBe('480')
   })
 
+  test('collapses the sidebar when dragging below the close threshold', () => {
+    render(<DesktopWorkbenchLayout {...baseProps} />)
+
+    const sidebar = screen.getByTestId('desktop-sidebar')
+    expect(sidebar).toHaveStyle({ width: '240px' })
+
+    fireEvent.pointerDown(screen.getByTestId('sidebar-resize-handle'))
+    fireEvent.pointerMove(document, { clientX: 150 })
+
+    expect(sidebar).toHaveStyle({ width: '0px' })
+    expect(sidebar).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByTestId('desktop-sidebar-hover-edge')).toBeInTheDocument()
+    expect(getDesktopWorkbenchMainElement()).toHaveClass('ml-1.5')
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
   test('uses the selected sidebar width as the default', () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 
@@ -1402,6 +1456,7 @@ describe('DesktopWorkbenchLayout', () => {
     expect(getDesktopWorkbenchMainElement()).toHaveClass('mt-1.5', 'mb-1.5', 'mr-1.5')
     expect(getDesktopWorkbenchMainElement()).not.toHaveClass('ml-1.5')
     expect(screen.getByTestId('collapse-sidebar-button')).toHaveClass('h-7', 'w-7', 'rounded-lg')
+    expect(screen.getByTestId('sidebar-resize-handle')).toHaveClass('right-[-6px]', 'w-10')
     expect(screen.getByTestId('workbench-topbar-left-actions')).toContainElement(
       screen.getByTestId('desktop-window-controls')
     )
@@ -1422,12 +1477,21 @@ describe('DesktopWorkbenchLayout', () => {
 
     expect(sidebar).toHaveStyle({ width: '0px' })
     expect(sidebar).toHaveAttribute('aria-hidden', 'true')
-    expect(sidebar).toHaveClass('transition-[width,opacity]', 'duration-[220ms]')
+    expect(sidebar).toHaveClass('transition-[width]', 'duration-[300ms]', 'will-change-[width]')
     expect(screen.getByTestId('expand-sidebar-button')).toBeInTheDocument()
     expect(screen.getByTestId('workbench-topbar-left-actions')).toContainElement(
       screen.getByTestId('desktop-window-controls')
     )
     expect(getDesktopWorkbenchMainElement()).toHaveClass('mt-1.5', 'mb-1.5', 'mr-1.5', 'ml-1.5')
+    expect(getDesktopWorkbenchMainElement()).toHaveClass(
+      'transition-[margin]',
+      'duration-[300ms]',
+      'will-change-[margin]'
+    )
+    expect(screen.getByTestId('desktop-empty-composer-frame')).toHaveClass(
+      'w-[min(46rem,calc(100%_-_2rem))]',
+      'max-w-[calc(100%_-_2rem)]'
+    )
     expect(document.querySelector('aside')).toBeInTheDocument()
 
     await userEvent.click(screen.getByTestId('expand-sidebar-button'))
@@ -1435,6 +1499,33 @@ describe('DesktopWorkbenchLayout', () => {
     expect(screen.getByText('新对话')).toBeInTheDocument()
     expect(sidebar).toHaveStyle({ width: '240px' })
     expect(sidebar).toHaveAttribute('aria-hidden', 'false')
+  })
+
+  test('slides out a sidebar preview from the left edge without resizing the workspace', async () => {
+    render(<DesktopWorkbenchLayout {...baseProps} />)
+
+    await userEvent.click(screen.getByTestId('collapse-sidebar-button'))
+
+    const main = getDesktopWorkbenchMainElement()
+    const preview = screen.getByTestId('desktop-sidebar-preview')
+    expect(main).toHaveClass('ml-1.5')
+    expect(screen.getByTestId('desktop-sidebar-hover-edge')).toHaveClass('w-4')
+    expect(preview).toHaveClass('pointer-events-none', '-translate-x-full', 'opacity-100')
+
+    fireEvent.pointerEnter(screen.getByTestId('desktop-sidebar-hover-edge'))
+
+    expect(preview).toHaveClass('pointer-events-auto', 'translate-x-0', 'opacity-100')
+    expect(screen.getByTestId('desktop-sidebar-preview-panel')).toHaveStyle({ width: '240px' })
+    expect(main).toHaveClass('ml-1.5')
+
+    fireEvent.pointerEnter(preview)
+
+    expect(preview).toHaveClass('translate-x-0', 'opacity-100')
+
+    fireEvent.pointerLeave(preview)
+
+    expect(preview).toHaveClass('pointer-events-none', '-translate-x-full', 'opacity-100')
+    expect(main).toHaveClass('ml-1.5')
   })
 
   test('keeps sidebar controls out of the page chrome in Tauri', async () => {
@@ -2481,6 +2572,7 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     expect(screen.queryByTestId('composer-disabled-reason')).not.toBeInTheDocument()
+    expect(screen.getByTestId('chat-message-input')).toHaveAttribute('placeholder', '要求后续变更')
     expect(screen.getByTestId('send-message-button')).not.toBeDisabled()
 
     await userEvent.click(screen.getByTestId('send-message-button'))
@@ -2688,7 +2780,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('opens and resizes the right workspace panel', async () => {
-    renderWorkspacePanelLayout()
+    renderWorkspacePanelLayout({ mainWidth: 1000 })
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
@@ -2712,16 +2804,25 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     const content = screen.getByTestId('desktop-workbench-content')
-    expect(content).toHaveStyle({ width: '420px' })
+    const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
+    await waitFor(() => {
+      expect(content).toHaveStyle({ width: '640px' })
+      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 640px)' })
+    })
     expect(panel).toHaveClass('min-w-0', 'flex-1', 'basis-0')
     expect(panel).toHaveClass('transition-[opacity,transform]', 'duration-300', 'ease-out')
-    expect(content).toHaveClass('transition-[width]', 'duration-300', 'ease-out')
+    expect(content).toHaveClass(
+      'transition-[width]',
+      'duration-[240ms]',
+      'ease-[cubic-bezier(0.2,0,0,1)]'
+    )
 
-    fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 700 })
-    fireEvent.pointerMove(document, { clientX: 640 })
+    fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 640 })
+    fireEvent.pointerMove(document, { clientX: 580 })
     fireEvent.pointerUp(document)
 
-    expect(content).toHaveStyle({ width: '360px' })
+    expect(content).toHaveStyle({ width: '580px' })
+    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 580px)' })
     expect(screen.getByTestId('workspace-file-tree')).toHaveClass('w-[240px]')
   })
 
@@ -2791,7 +2892,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('resizes the browser area while dragging and collapses the right panel at the edge', async () => {
-    renderWorkspacePanelLayout()
+    renderWorkspacePanelLayout({ mainWidth: 1000 })
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
     await userEvent.click(screen.getByTestId('right-workspace-browser-option'))
@@ -2804,27 +2905,34 @@ describe('DesktopWorkbenchLayout', () => {
     const content = screen.getByTestId('desktop-workbench-content')
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
 
-    fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 420 })
-    fireEvent.pointerMove(document, { clientX: 640 })
+    await waitFor(() => {
+      expect(content).toHaveStyle({ width: '640px' })
+      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 640px)' })
+    })
+
+    fireEvent.pointerDown(screen.getByTestId('right-workspace-resize-handle'), { clientX: 640 })
+    fireEvent.pointerMove(document, { clientX: 700 })
 
     expect(content).toHaveClass('transition-none')
     expect(rightPanelShell).toHaveClass('transition-none')
-    expect(content).toHaveStyle({ width: '640px' })
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 640px)' })
+    expect(content).toHaveStyle({ width: '700px' })
+    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 700px)' })
 
     fireEvent.pointerMove(document, { clientX: 900 })
 
-    expect(rightPanelShell).toHaveAttribute('aria-hidden', 'true')
-    expect(rightPanelShell).toHaveStyle({ width: '0px' })
-    expect(screen.queryByTestId('right-workspace-resize-handle')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(rightPanelShell).toHaveAttribute('aria-hidden', 'true')
+      expect(rightPanelShell).toHaveStyle({ width: '0px' })
+      expect(screen.queryByTestId('right-workspace-resize-handle')).not.toBeInTheDocument()
+    })
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
     expect(document.body.style.cursor).toBe('')
     expect(document.body.style.userSelect).toBe('')
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
-    expect(content).toHaveStyle({ width: '420px' })
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
+    expect(content).toHaveStyle({ width: '640px' })
+    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 640px)' })
     expect(screen.getByTestId('workspace-browser-url-input')).toHaveValue('https://weibo.com/')
   })
 
@@ -2932,6 +3040,7 @@ describe('DesktopWorkbenchLayout', () => {
   })
 
   test('right workspace panel pushes the conversation chat into a narrow split column', async () => {
+    mockDesktopWorkbenchMainWidth(1000)
     const workspacePanelState = createCloudWorkspacePanelState()
     render(
       <DesktopWorkbenchLayout
@@ -2962,18 +3071,27 @@ describe('DesktopWorkbenchLayout', () => {
     const topBar = screen.getByTestId('workbench-topbar')
     const rightPanelShell = screen.getByTestId('right-workspace-panel-shell')
     expect(topBar).toHaveStyle({ width: '100%' })
-    expect(content).toHaveClass('flex-none', 'transition-[width]', 'duration-300', 'ease-out')
+    expect(content).toHaveClass(
+      'flex-none',
+      'transition-[width]',
+      'duration-[240ms]',
+      'ease-[cubic-bezier(0.2,0,0,1)]'
+    )
     expect(content).toHaveStyle({ width: '100%' })
     expect(rightPanelShell).toHaveClass(
       'overflow-hidden',
       'opacity-0',
       'transition-[width,opacity]',
-      'duration-300',
-      'ease-out'
+      'duration-[240ms]',
+      'ease-[cubic-bezier(0.2,0,0,1)]'
     )
     expect(rightPanelShell).toHaveStyle({ width: '0px' })
     expect(screen.queryByTestId('right-workspace-panel')).not.toBeInTheDocument()
-    expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass('min-w-[32rem]')
+    expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass(
+      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'min-w-0',
+      'max-w-[calc(100%_-_1.5rem)]'
+    )
 
     await userEvent.click(screen.getByTestId('toggle-right-workspace-panel-button'))
 
@@ -2981,13 +3099,15 @@ describe('DesktopWorkbenchLayout', () => {
       'flex-none',
       'border-r',
       'transition-[width]',
-      'duration-300',
-      'ease-out'
+      'duration-[240ms]',
+      'ease-[cubic-bezier(0.2,0,0,1)]'
     )
-    expect(content).toHaveStyle({ width: '420px' })
-    expect(topBar).toHaveStyle({ width: '420px' })
+    await waitFor(() => {
+      expect(content).toHaveStyle({ width: '640px' })
+      expect(topBar).toHaveStyle({ width: '640px' })
+      expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 640px)' })
+    })
     expect(rightPanelShell).toHaveClass('opacity-100')
-    expect(rightPanelShell).toHaveStyle({ width: 'calc(100% - 420px)' })
     expect(screen.queryByTestId('workbench-topbar-right-actions')).not.toBeInTheDocument()
     expect(screen.getByTestId('workspace-panel-floating-actions')).toContainElement(
       screen.getByTestId('toggle-bottom-workspace-panel-button')
@@ -3005,11 +3125,19 @@ describe('DesktopWorkbenchLayout', () => {
       'ease-out'
     )
     expect(screen.getByTestId('desktop-floating-composer-layer')).toHaveClass(
-      'w-[calc(100%_-_1.5rem)]',
+      'w-[min(72rem,calc(100%_-_1.5rem))]',
       'min-w-0',
       'max-w-[calc(100%_-_1.5rem)]'
     )
-    expect(screen.getByTestId('desktop-floating-composer-layer')).not.toHaveClass('min-w-[32rem]')
+    expect(screen.getByTestId('desktop-floating-composer-layer')).not.toHaveClass(
+      'w-[min(46rem,calc(100%_-_2rem))]'
+    )
+    expect(screen.getByTestId('desktop-chat-scroll-content').firstElementChild).toHaveClass(
+      'w-[min(72rem,calc(100%_-_1.5rem))]',
+      'min-w-0',
+      'max-w-[calc(100%_-_1.5rem)]',
+      'px-0'
+    )
   })
 
   test('right workspace panel opens the file tab from the launcher', async () => {

--- a/wework/src/components/layout/DesktopWorkbenchLayout.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { PointerEventHandler } from 'react'
 import type { ProjectCreateMode } from '@/components/chat/ChatInput'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
 import { useAuth } from '@/features/auth/useAuth'
@@ -10,6 +11,7 @@ import type {
 } from '@/types/api'
 import { stripAppBasePath } from '@/config/runtime'
 import { isSettingsRoute, navigateTo } from '@/lib/navigation'
+import { cn } from '@/lib/utils'
 import { DesktopSidebar } from './DesktopSidebar'
 import { ProjectCreateDialog } from '@/components/projects/ProjectCreateDialog'
 import {
@@ -71,7 +73,9 @@ export function DesktopWorkbenchLayout() {
     unsubscribeRuntimeTaskNotifications: onUnsubscribeRuntimeTaskNotifications,
   } = useWorkbench()
   const activeItem = 'chat'
-  const { sidebarCollapsed } = useDesktopSidebarCollapsed()
+  const { sidebarCollapsed, setSidebarCollapsed } = useDesktopSidebarCollapsed()
+  const [sidebarPreviewOpen, setSidebarPreviewOpen] = useState(false)
+  const [sidebarResizing, setSidebarResizing] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(() =>
     isSettingsRoute(stripAppBasePath(window.location.pathname))
   )
@@ -116,6 +120,14 @@ export function DesktopWorkbenchLayout() {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
 
+  useEffect(() => {
+    if (sidebarCollapsed || !sidebarPreviewOpen) return
+    const timer = window.setTimeout(() => {
+      setSidebarPreviewOpen(false)
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [sidebarCollapsed, sidebarPreviewOpen])
+
   const openProjectFromWorkMenu = useCallback(
     (mode: ProjectCreateMode) => {
       setBlankProjectDialogOpen(mode === 'scratch')
@@ -145,6 +157,27 @@ export function DesktopWorkbenchLayout() {
     setSettingsOpen(true)
     navigateTo('/settings')
   }, [])
+
+  const openSidebarPreview = useCallback(() => {
+    if (!sidebarCollapsed) return
+    setSidebarPreviewOpen(true)
+  }, [sidebarCollapsed])
+
+  const closeSidebarPreview = useCallback(() => {
+    setSidebarPreviewOpen(false)
+  }, [])
+
+  const updateSidebarCollapsed = useCallback(
+    (collapsed: boolean) => {
+      setSidebarPreviewOpen(false)
+      setSidebarCollapsed(collapsed)
+    },
+    [setSidebarCollapsed]
+  )
+
+  const collapseSidebar = useCallback(() => {
+    updateSidebarCollapsed(true)
+  }, [updateSidebarCollapsed])
 
   useWorkbenchShellEventHandlers({
     onCreateProjectMode: openProjectFromWorkMenu,
@@ -340,57 +373,105 @@ export function DesktopWorkbenchLayout() {
     ]
   )
 
+  const renderDesktopSidebar = ({
+    collapsed,
+    containerTestId,
+    hideResizeHandle = false,
+    onPointerEnter,
+    onPointerLeave,
+  }: {
+    collapsed: boolean
+    containerTestId?: string
+    hideResizeHandle?: boolean
+    onPointerEnter?: PointerEventHandler<HTMLElement>
+    onPointerLeave?: PointerEventHandler<HTMLElement>
+  }) => (
+    <DesktopSidebar
+      user={state.user}
+      projects={state.projects}
+      devices={state.devices}
+      cloudWorkStatus={cloudWorkStatus}
+      runtimeWork={state.runtimeWork}
+      currentRuntimeTask={state.currentRuntimeTask}
+      standaloneDeviceId={state.standaloneDeviceId}
+      standaloneWorkspacePath={state.standaloneWorkspacePath}
+      imNotificationSettings={imNotificationSettings}
+      preferredDeviceId={
+        state.standaloneDeviceId ?? state.user?.preferences?.default_execution_target
+      }
+      activeItem={activeItem}
+      collapsed={collapsed}
+      containerTestId={containerTestId}
+      hideResizeHandle={hideResizeHandle}
+      onResizeCollapse={collapseSidebar}
+      onResizeStateChange={setSidebarResizing}
+      onPointerEnter={onPointerEnter}
+      onPointerLeave={onPointerLeave}
+      onNewChat={onNewChat}
+      onOpenSearch={() => setSearchOpen(true)}
+      onSelectProject={onSelectProject}
+      onStartNewProjectChat={onStartNewProjectChat}
+      onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
+      onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
+      onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
+      onArchiveProjectConversations={onArchiveProjectConversations}
+      onArchiveProjectsConversations={onArchiveProjectsConversations}
+      onArchiveChatConversations={onArchiveChatConversations}
+      onToggleRuntimeTaskNotification={toggleRuntimeTaskNotification}
+      onToggleGlobalImNotification={toggleGlobalImNotification}
+      onOpenGlobalImNotificationSettings={() => openImNotificationTargetDialog({ type: 'global' })}
+      onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
+      onSelectStandaloneDevice={selectStandaloneDevice}
+      onGetRemoteDeviceStartupCommand={onGetRemoteDeviceStartupCommand}
+      onOpenPlugins={() => navigateTo('/plugins')}
+      onRefreshDevices={onRefreshDevices}
+      onUpdateProjectName={onUpdateProjectName}
+      onRemoveProject={onRemoveProject}
+      onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
+      onListDeviceDirectories={onListDeviceDirectories}
+      onCreateDeviceDirectory={onCreateDeviceDirectory}
+      onOpenSettings={options => {
+        setAutoOpenAddCloudDeviceDialog(Boolean(options?.autoOpenAddCloudDeviceDialog))
+        setSettingsOpen(true)
+        navigateTo('/settings')
+      }}
+      onRefreshWorkLists={onRefreshWorkLists}
+      onLogout={onLogout}
+    />
+  )
+
   return (
     <div className="relative flex h-full overflow-hidden bg-transparent text-text-primary">
-      {!settingsOpen && (
-        <DesktopSidebar
-          user={state.user}
-          projects={state.projects}
-          devices={state.devices}
-          cloudWorkStatus={cloudWorkStatus}
-          runtimeWork={state.runtimeWork}
-          currentRuntimeTask={state.currentRuntimeTask}
-          standaloneDeviceId={state.standaloneDeviceId}
-          standaloneWorkspacePath={state.standaloneWorkspacePath}
-          imNotificationSettings={imNotificationSettings}
-          preferredDeviceId={
-            state.standaloneDeviceId ?? state.user?.preferences?.default_execution_target
-          }
-          activeItem={activeItem}
-          collapsed={sidebarCollapsed}
-          onNewChat={onNewChat}
-          onOpenSearch={() => setSearchOpen(true)}
-          onSelectProject={onSelectProject}
-          onStartNewProjectChat={onStartNewProjectChat}
-          onOpenRuntimeLocalTask={onOpenRuntimeLocalTask}
-          onRenameRuntimeLocalTask={onRenameRuntimeLocalTask}
-          onArchiveRuntimeLocalTask={onArchiveRuntimeLocalTask}
-          onArchiveProjectConversations={onArchiveProjectConversations}
-          onArchiveProjectsConversations={onArchiveProjectsConversations}
-          onArchiveChatConversations={onArchiveChatConversations}
-          onToggleRuntimeTaskNotification={toggleRuntimeTaskNotification}
-          onToggleGlobalImNotification={toggleGlobalImNotification}
-          onOpenGlobalImNotificationSettings={() =>
-            openImNotificationTargetDialog({ type: 'global' })
-          }
-          onOpenStandaloneWorkspace={onOpenStandaloneWorkspace}
-          onSelectStandaloneDevice={selectStandaloneDevice}
-          onGetRemoteDeviceStartupCommand={onGetRemoteDeviceStartupCommand}
-          onOpenPlugins={() => navigateTo('/plugins')}
-          onRefreshDevices={onRefreshDevices}
-          onUpdateProjectName={onUpdateProjectName}
-          onRemoveProject={onRemoveProject}
-          onGetDeviceHomeDirectory={onGetDeviceHomeDirectory}
-          onListDeviceDirectories={onListDeviceDirectories}
-          onCreateDeviceDirectory={onCreateDeviceDirectory}
-          onOpenSettings={options => {
-            setAutoOpenAddCloudDeviceDialog(Boolean(options?.autoOpenAddCloudDeviceDialog))
-            setSettingsOpen(true)
-            navigateTo('/settings')
-          }}
-          onRefreshWorkLists={onRefreshWorkLists}
-          onLogout={onLogout}
-        />
+      {!settingsOpen && renderDesktopSidebar({ collapsed: sidebarCollapsed })}
+      {!settingsOpen && sidebarCollapsed && (
+        <>
+          <div
+            data-testid="desktop-sidebar-hover-edge"
+            aria-hidden="true"
+            onPointerEnter={openSidebarPreview}
+            className="absolute left-0 top-0 z-popover h-full w-4 after:absolute after:left-0 after:top-0 after:h-full after:w-px after:bg-border/70 after:transition-colors after:duration-150 hover:after:bg-primary/50"
+          />
+          <div
+            data-testid="desktop-sidebar-preview"
+            aria-hidden={!sidebarPreviewOpen}
+            onPointerEnter={openSidebarPreview}
+            onPointerLeave={closeSidebarPreview}
+            className={cn(
+              'absolute left-0 top-0 z-popover h-full bg-background transition-transform duration-[180ms] ease-out motion-reduce:transition-none will-change-transform',
+              sidebarPreviewOpen
+                ? 'pointer-events-auto translate-x-0 opacity-100 shadow-[6px_0_24px_rgba(15,23,42,0.10)]'
+                : 'pointer-events-none -translate-x-full opacity-100'
+            )}
+          >
+            {renderDesktopSidebar({
+              collapsed: false,
+              containerTestId: 'desktop-sidebar-preview-panel',
+              hideResizeHandle: true,
+              onPointerEnter: openSidebarPreview,
+              onPointerLeave: closeSidebarPreview,
+            })}
+          </div>
+        </>
       )}
       {settingsOpen ? (
         <ConnectionsSettingsPage
@@ -403,6 +484,9 @@ export function DesktopWorkbenchLayout() {
         />
       ) : (
         <DesktopWorkbenchMain
+          sidebarCollapsed={sidebarCollapsed}
+          sidebarResizing={sidebarResizing}
+          onSidebarCollapsedChange={updateSidebarCollapsed}
           activePane={{
             currentRuntimeTask: state.currentRuntimeTask,
             currentProject: state.currentProject,

--- a/wework/src/components/layout/DesktopWorkbenchMain.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchMain.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { ArrowLeftRight, MessageCircle } from 'lucide-react'
 import { ChatInput } from '@/components/chat/ChatInput'
 import type { ProjectChatControls } from '@/components/chat/ChatInput'
@@ -53,26 +54,40 @@ import {
 import { useWorkbenchPaneEnvironment } from './useWorkbenchPaneEnvironment'
 import { useWorkbenchProjectWorkControls } from './useWorkbenchProjectWorkControls'
 import { useRuntimeTaskContinueInIm } from './useRuntimeTaskContinueInIm'
-import { useDesktopSidebarCollapsed } from './useDesktopSidebarCollapsed'
 import { requestOpenCloudDeviceSettings } from './workbenchShellEvents'
 
-const DESKTOP_COMPOSER_FRAME_CLASS =
-  'mx-auto w-[min(58vw,62rem)] min-w-[32rem] max-w-[calc(100vw-4rem)] -translate-y-12'
+const DESKTOP_CHAT_CONTENT_BASE_CLASS =
+  'mx-auto min-w-0 px-0 transition-[width,max-width] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[width,max-width]'
+const DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(46rem,calc(100%_-_2rem))] max-w-[calc(100%_-_2rem)]`
+const DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS = `${DESKTOP_CHAT_CONTENT_BASE_CLASS} w-[min(72rem,calc(100%_-_1.5rem))] max-w-[calc(100%_-_1.5rem)]`
+const DESKTOP_CENTERED_COMPOSER_FRAME_CLASS = `${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS} -translate-y-12`
+const DESKTOP_DOCKED_COMPOSER_FRAME_CLASS = `${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS} -translate-y-12`
 const DESKTOP_FLOATING_COMPOSER_CLASS =
-  'pointer-events-none absolute bottom-4 left-1/2 z-chrome w-[min(58vw,62rem)] min-w-[32rem] max-w-[calc(100%_-_3rem)] -translate-x-1/2'
-const DESKTOP_SPLIT_FLOATING_COMPOSER_CLASS =
-  'pointer-events-none absolute bottom-4 left-1/2 z-chrome w-[calc(100%_-_1.5rem)] min-w-0 max-w-[calc(100%_-_1.5rem)] -translate-x-1/2'
-const DESKTOP_SPLIT_COMPOSER_FRAME_CLASS =
-  'mx-auto w-[calc(100%_-_1.5rem)] min-w-0 max-w-[calc(100%_-_1.5rem)] -translate-y-12'
+  'pointer-events-none absolute bottom-2 left-1/2 z-chrome -translate-x-1/2'
+const DESKTOP_CENTERED_FLOATING_COMPOSER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS}`
+const DESKTOP_DOCKED_FLOATING_COMPOSER_CLASS = `${DESKTOP_FLOATING_COMPOSER_CLASS} ${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS}`
+const DESKTOP_CENTERED_MESSAGE_LIST_CLASS = `${DESKTOP_CHAT_CENTERED_CONTENT_WIDTH_CLASS} px-0`
+const DESKTOP_DOCKED_MESSAGE_LIST_CLASS = `${DESKTOP_CHAT_DOCKED_CONTENT_WIDTH_CLASS} px-0`
 const DESKTOP_FLOATING_COMPOSER_BACKDROP_CLASS =
   'pointer-events-none absolute left-0 right-8 bottom-0 z-10 h-32 bg-gradient-to-t from-background via-background to-transparent'
-const DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS = 'bottom-36 z-popover bg-background/95 shadow-md'
-const DESKTOP_QUEUED_SCROLL_TO_BOTTOM_BUTTON_CLASS =
-  'bottom-52 z-popover bg-background/95 shadow-md'
+const DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS =
+  'bottom-[calc(var(--desktop-floating-composer-height)_+_2rem)] z-popover bg-background/95 shadow-md'
+const DESKTOP_FLOATING_COMPOSER_SCROLL_CLASS = 'pb-[var(--desktop-floating-composer-clearance)]'
+const DEFAULT_FLOATING_COMPOSER_HEIGHT_PX = 112
+const FLOATING_COMPOSER_CLEARANCE_GAP_PX = 104
+const RIGHT_PANEL_WIDTH_TRANSITION_CLASS =
+  'transition-[width] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[width]'
+const RIGHT_PANEL_SHELL_TRANSITION_CLASS =
+  'transition-[width,opacity] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[width,opacity]'
+const RIGHT_PANEL_HANDLE_TRANSITION_CLASS =
+  'transition-[left] duration-[240ms] ease-[cubic-bezier(0.2,0,0,1)] motion-reduce:transition-none will-change-[left]'
 const MAX_CACHED_DESKTOP_WORKBENCH_TABS = 10
 
 interface DesktopWorkbenchMainProps {
   activePane: WorkbenchPaneIdentity
+  sidebarCollapsed: boolean
+  sidebarResizing?: boolean
+  onSidebarCollapsedChange: (collapsed: boolean) => void
 }
 
 export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
@@ -81,19 +96,28 @@ export function DesktopWorkbenchMain(props: DesktopWorkbenchMainProps) {
       activePane={props.activePane}
       maxPanes={MAX_CACHED_DESKTOP_WORKBENCH_TABS}
       activeTestId="desktop-workbench-main"
-      renderPane={renderDesktopWorkbenchPane}
+      renderPane={pane => (
+        <DesktopWorkbenchPane
+          pane={pane}
+          sidebarCollapsed={props.sidebarCollapsed}
+          sidebarResizing={props.sidebarResizing ?? false}
+          onSidebarCollapsedChange={props.onSidebarCollapsedChange}
+        />
+      )}
     />
   )
 }
 
-function renderDesktopWorkbenchPane(pane: WorkbenchPaneIdentity) {
-  return <DesktopWorkbenchPane pane={pane} />
-}
-
 const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   pane,
+  sidebarCollapsed,
+  sidebarResizing = false,
+  onSidebarCollapsedChange,
 }: {
   pane: WorkbenchPaneIdentity
+  sidebarCollapsed: boolean
+  sidebarResizing?: boolean
+  onSidebarCollapsedChange: (collapsed: boolean) => void
 }) {
   const {
     state,
@@ -114,7 +138,6 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     createDeviceDirectory,
     startNewChat,
   } = useWorkbenchPaneContext()
-  const { sidebarCollapsed, setSidebarCollapsed } = useDesktopSidebarCollapsed()
   const { t } = useTranslation('common')
   const { t: tChat } = useTranslation('chat')
   const currentRuntimeTask = pane.currentRuntimeTask
@@ -152,6 +175,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const [forkDialogOpen, setForkDialogOpen] = useState(false)
   const [hasPreviousTurnReview, setHasPreviousTurnReview] = useState(false)
   const workbenchMainRef = useRef<HTMLElement | null>(null)
+  const floatingComposerCardRef = useRef<HTMLDivElement | null>(null)
+  const [floatingComposerHeight, setFloatingComposerHeight] = useState(
+    DEFAULT_FLOATING_COMPOSER_HEIGHT_PX
+  )
   const continueInIm = useRuntimeTaskContinueInIm(currentRuntimeTask)
   const [reviewState, setReviewState] = useState<DesktopReviewState>({
     loading: false,
@@ -176,6 +203,9 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
   const chatColumnWidth = rightPanelOpen ? rightSplitChatWidth : '100%'
   const rightPanelShellWidth = rightPanelOpen ? `calc(100% - ${rightSplitChatWidth}px)` : '0px'
   const shouldRenderRightPanel = rightPanelOpen || rightPanelTabs.length > 0
+  const useDockedChatContentWidth = !sidebarCollapsed || rightPanelOpen
+  const chatContentResizing = sidebarResizing || rightSplitResizing
+  const floatingComposerClearance = floatingComposerHeight + FLOATING_COMPOSER_CLEARANCE_GAP_PX
   const workspaceTargetDevice = workspaceTarget?.deviceId
     ? devices.find(device => device.device_id === workspaceTarget.deviceId)
     : undefined
@@ -591,13 +621,13 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     sidebarCollapsed ? (
       <DesktopWindowControls
         sidebarCollapsed
-        onToggleSidebar={() => setSidebarCollapsed(false)}
+        onToggleSidebar={() => onSidebarCollapsedChange(false)}
         onNewChat={startNewChat}
       />
     ) : (
       <DesktopWindowControls
         sidebarCollapsed={false}
-        onToggleSidebar={() => setSidebarCollapsed(true)}
+        onToggleSidebar={() => onSidebarCollapsedChange(true)}
       />
     )
   ) : undefined
@@ -659,11 +689,40 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
     })
   }, [rightPanelSessionKey])
 
+  useLayoutEffect(() => {
+    if (!hasConversation) return
+
+    const element = floatingComposerCardRef.current
+    if (!element) return
+
+    const updateComposerHeight = () => {
+      const nextHeight = Math.ceil(element.getBoundingClientRect().height)
+      if (nextHeight <= 0) return
+      setFloatingComposerHeight(current => (current === nextHeight ? current : nextHeight))
+    }
+
+    updateComposerHeight()
+
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(updateComposerHeight)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [
+    hasConversation,
+    hasQueuedComposerRows,
+    showConversationDeviceBanner,
+    noStandaloneCompatibleDevice,
+    activeDeviceUnavailable,
+  ])
+
   return (
     <main
       ref={workbenchMainRef}
       className={cn(
         'absolute inset-0 mb-1.5 mr-1.5 flex min-w-0 flex-1 overflow-hidden rounded-xl border border-border/60 bg-background shadow-[0_3px_16px_rgba(0,0,0,0.04)]',
+        'transition-[margin] duration-[300ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none will-change-[margin]',
+        sidebarResizing && 'transition-none',
         !isTauri && 'mt-1.5',
         sidebarCollapsed && 'ml-1.5'
       )}
@@ -683,7 +742,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             testId="workbench-topbar"
             className={cn(
               'absolute left-0 top-0 z-chrome overflow-hidden bg-transparent pl-2 pr-7',
-              rightSplitResizing ? 'transition-none' : 'transition-[width] duration-300 ease-out'
+              rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS
             )}
             style={{ width: chatColumnWidth }}
             left={topBarLeftActions}
@@ -694,11 +753,17 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         data-testid="desktop-workbench-content"
         className={cn(
           'relative flex min-w-0 flex-none flex-col overflow-hidden',
-          rightSplitResizing ? 'transition-none' : 'transition-[width] duration-300 ease-out',
+          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_WIDTH_TRANSITION_CLASS,
           showPageTopBar && 'pt-[52px]',
           rightPanelOpen && 'border-r border-border'
         )}
-        style={{ width: chatColumnWidth }}
+        style={
+          {
+            width: chatColumnWidth,
+            '--desktop-floating-composer-height': `${floatingComposerHeight}px`,
+            '--desktop-floating-composer-clearance': `${floatingComposerClearance}px`,
+          } as CSSProperties
+        }
       >
         {isBootstrapping ? (
           <div className="flex flex-1" data-testid="desktop-workbench-loading" />
@@ -721,12 +786,16 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
               }
               className="h-full"
               scrollTestId="desktop-chat-scroll"
-              scrollerClassName={cn('scrollbar-soft', hasQueuedComposerRows ? 'pb-52' : 'pb-40')}
-              scrollButtonClassName={
-                hasQueuedComposerRows
-                  ? DESKTOP_QUEUED_SCROLL_TO_BOTTOM_BUTTON_CLASS
-                  : DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS
+              scrollerClassName={cn('scrollbar-soft', DESKTOP_FLOATING_COMPOSER_SCROLL_CLASS)}
+              messageListClassName={
+                useDockedChatContentWidth
+                  ? cn(DESKTOP_DOCKED_MESSAGE_LIST_CLASS, chatContentResizing && 'transition-none')
+                  : cn(
+                      DESKTOP_CENTERED_MESSAGE_LIST_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )
               }
+              scrollButtonClassName={DESKTOP_SCROLL_TO_BOTTOM_BUTTON_CLASS}
               devices={devices}
               onRetryFailedMessage={message => {
                 void retryFailedMessage(message.id, paneMessages)
@@ -760,13 +829,23 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
             />
             <div
               className={
-                rightPanelOpen
-                  ? DESKTOP_SPLIT_FLOATING_COMPOSER_CLASS
-                  : DESKTOP_FLOATING_COMPOSER_CLASS
+                useDockedChatContentWidth
+                  ? cn(
+                      DESKTOP_DOCKED_FLOATING_COMPOSER_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )
+                  : cn(
+                      DESKTOP_CENTERED_FLOATING_COMPOSER_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )
               }
               data-testid="desktop-floating-composer-layer"
             >
-              <div className="pointer-events-auto" data-testid="desktop-floating-composer-card">
+              <div
+                ref={floatingComposerCardRef}
+                className="pointer-events-auto"
+                data-testid="desktop-floating-composer-card"
+              >
                 {showConversationDeviceBanner ? (
                   <ConversationDeviceOfflineBanner
                     device={activeDevice}
@@ -792,7 +871,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
                   disabled={composerDisabled}
                   error={errorMessage}
                   disabledReason={inlineComposerDisabledReason}
-                  placeholder={t('workbench.input_placeholder', '尽管问')}
+                  placeholder={t('workbench.follow_up_placeholder', '要求后续变更')}
                   variant="desktop"
                   projectChat={projectChatWithModelSelectorSignal}
                   projectWork={paneProjectWork}
@@ -815,7 +894,15 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           <div className="flex flex-1 items-center justify-center px-10">
             <div
               className={
-                rightPanelOpen ? DESKTOP_SPLIT_COMPOSER_FRAME_CLASS : DESKTOP_COMPOSER_FRAME_CLASS
+                useDockedChatContentWidth
+                  ? cn(
+                      DESKTOP_DOCKED_COMPOSER_FRAME_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )
+                  : cn(
+                      DESKTOP_CENTERED_COMPOSER_FRAME_CLASS,
+                      chatContentResizing && 'transition-none'
+                    )
               }
               data-testid="desktop-empty-composer-frame"
             >
@@ -884,7 +971,10 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
           aria-orientation="vertical"
           aria-label={t('workbench.resize_right_workspace_panel')}
           aria-controls="right-workspace-panel-shell"
-          className="absolute top-0 z-popover h-full w-5 -translate-x-1/2 cursor-col-resize bg-transparent after:absolute after:left-1/2 after:top-0 after:h-full after:w-px after:-translate-x-1/2 after:bg-transparent hover:after:bg-primary/40"
+          className={cn(
+            'absolute top-0 z-popover h-full w-5 -translate-x-1/2 cursor-col-resize bg-transparent after:absolute after:left-1/2 after:top-0 after:h-full after:w-px after:-translate-x-1/2 after:bg-transparent after:transition-colors after:duration-150 after:ease-out hover:after:bg-primary/40',
+            rightSplitResizing ? 'transition-none' : RIGHT_PANEL_HANDLE_TRANSITION_CLASS
+          )}
           style={{ left: rightSplitChatWidth }}
           onPointerDown={handleRightSplitResizeStart}
         />
@@ -894,9 +984,7 @@ const DesktopWorkbenchPane = memo(function DesktopWorkbenchPane({
         data-testid="right-workspace-panel-shell"
         className={cn(
           'min-w-0 shrink-0 overflow-hidden bg-background',
-          rightSplitResizing
-            ? 'transition-none'
-            : 'transition-[width,opacity] duration-300 ease-out',
+          rightSplitResizing ? 'transition-none' : RIGHT_PANEL_SHELL_TRANSITION_CLASS,
           rightPanelOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'
         )}
         style={{ width: rightPanelShellWidth }}

--- a/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.test.tsx
@@ -797,7 +797,7 @@ describe('MobileWorkbenchLayout', () => {
       />
     )
 
-    expect(screen.getByRole('main')).toHaveClass('h-dvh', 'overflow-hidden')
+    expect(screen.getByRole('main')).toHaveClass('h-full', 'overflow-hidden')
     expect(screen.getByTestId('chat-message-scroll-area')).toHaveClass(
       'overflow-y-auto',
       'pb-28',
@@ -809,6 +809,9 @@ describe('MobileWorkbenchLayout', () => {
       'pointer-events-none',
       'z-chrome'
     )
+    expect(
+      within(screen.getByTestId('mobile-chat-input-dock')).getByTestId('chat-message-input')
+    ).toHaveAttribute('placeholder', '要求后续变更')
     expect(screen.getByTestId('mobile-conversation-header')).toHaveClass(
       'absolute',
       'bg-background/95',

--- a/wework/src/components/layout/MobileWorkbenchLayout.tsx
+++ b/wework/src/components/layout/MobileWorkbenchLayout.tsx
@@ -195,9 +195,9 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
 
   if (state.isBootstrapping) {
     return (
-      <div className="flex h-dvh overflow-hidden bg-background text-text-primary">
+      <div className="flex h-full overflow-hidden bg-background text-text-primary">
         <main
-          className="flex h-dvh min-h-0 w-full flex-col overflow-hidden"
+          className="flex h-full min-h-0 w-full flex-col overflow-hidden"
           data-testid="mobile-workbench-loading"
         />
       </div>
@@ -205,8 +205,8 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
   }
 
   return (
-    <div className="flex h-dvh overflow-hidden bg-background text-text-primary">
-      <main className="flex h-dvh min-h-0 w-full flex-col overflow-hidden">
+    <div className="flex h-full overflow-hidden bg-background text-text-primary">
+      <main className="flex h-full min-h-0 w-full flex-col overflow-hidden">
         {hasConversation ? (
           <div className="relative min-h-0 flex-1 overflow-hidden">
             <header
@@ -321,7 +321,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
                   disabled={composerDisabled}
                   error={state.error}
                   disabledReason={inlineComposerDisabledReason}
-                  placeholder={t('workbench.mobile_input_placeholder', '询问 Wework')}
+                  placeholder={t('workbench.follow_up_placeholder', '要求后续变更')}
                   projectChat={projectChatWithModelSelectorSignal}
                   projectWork={effectiveProjectWork}
                   queuedMessages={paneQueuedMessages}
@@ -339,7 +339,7 @@ const MobileWorkbenchPane = memo(function MobileWorkbenchPane({
             </div>
           </div>
         ) : (
-          <div className="flex h-dvh min-h-0 flex-col pb-[max(16px,env(safe-area-inset-bottom))]">
+          <div className="flex h-full min-h-0 flex-col pb-[max(16px,env(safe-area-inset-bottom))]">
             <header
               data-testid="mobile-empty-header"
               className="flex min-h-[56px] shrink-0 items-center gap-2 border-b border-transparent bg-background/95 px-3 pb-2 pt-[max(6px,env(safe-area-inset-top))]"

--- a/wework/src/components/layout/useResizableSidebar.ts
+++ b/wework/src/components/layout/useResizableSidebar.ts
@@ -3,6 +3,7 @@ import { useState, type PointerEvent } from 'react'
 const DEFAULT_SIDEBAR_WIDTH = 240
 const MIN_SIDEBAR_WIDTH = 200
 const MAX_SIDEBAR_WIDTH = 480
+const COLLAPSE_SIDEBAR_WIDTH = 168
 const SIDEBAR_WIDTH_STORAGE_KEY = 'wework.desktop.sidebar.width'
 
 function clampSidebarWidth(width: number): number {
@@ -26,28 +27,55 @@ function storeSidebarWidth(width: number) {
   window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, String(width))
 }
 
-export function useResizableSidebar() {
+interface ResizableSidebarOptions {
+  onCollapse?: () => void
+  onResizeStateChange?: (resizing: boolean) => void
+}
+
+export function useResizableSidebar({
+  onCollapse,
+  onResizeStateChange,
+}: ResizableSidebarOptions = {}) {
   const [sidebarWidth, setSidebarWidth] = useState(readStoredSidebarWidth)
+  const [resizing, setResizing] = useState(false)
 
   const handleResizeStart = (event: PointerEvent<HTMLButtonElement>) => {
     event.preventDefault()
     const previousCursor = document.body.style.cursor
     const previousUserSelect = document.body.style.userSelect
+    let collapsed = false
 
+    setResizing(true)
+    onResizeStateChange?.(true)
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
 
+    const finishResize = () => {
+      setResizing(false)
+      onResizeStateChange?.(false)
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+      document.removeEventListener('pointermove', handlePointerMove)
+      document.removeEventListener('pointerup', handlePointerUp)
+    }
+
     const handlePointerMove = (moveEvent: globalThis.PointerEvent) => {
+      if (collapsed) return
+
+      if (moveEvent.clientX <= COLLAPSE_SIDEBAR_WIDTH) {
+        collapsed = true
+        finishResize()
+        onCollapse?.()
+        return
+      }
+
       const nextWidth = clampSidebarWidth(moveEvent.clientX)
       setSidebarWidth(nextWidth)
       storeSidebarWidth(nextWidth)
     }
 
     const handlePointerUp = () => {
-      document.body.style.cursor = previousCursor
-      document.body.style.userSelect = previousUserSelect
-      document.removeEventListener('pointermove', handlePointerMove)
-      document.removeEventListener('pointerup', handlePointerUp)
+      if (!collapsed) finishResize()
     }
 
     document.addEventListener('pointermove', handlePointerMove)
@@ -56,6 +84,7 @@ export function useResizableSidebar() {
 
   return {
     sidebarWidth,
+    resizing,
     handleResizeStart,
   }
 }

--- a/wework/src/components/layout/workspace-panels/useResizableWorkspacePanel.ts
+++ b/wework/src/components/layout/workspace-panels/useResizableWorkspacePanel.ts
@@ -1,8 +1,16 @@
-import { useState, type PointerEvent, type RefObject } from 'react'
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type PointerEvent,
+  type RefObject,
+} from 'react'
 
 const RIGHT_SPLIT_CHAT_DEFAULT_WIDTH = 420
 const RIGHT_SPLIT_CHAT_MIN_WIDTH = 360
 const RIGHT_SPLIT_CHAT_MAX_WIDTH = 620
+const RIGHT_SPLIT_PANEL_DEFAULT_WIDTH = 360
 const RIGHT_SPLIT_PANEL_COLLAPSE_WIDTH = 260
 const BOTTOM_DEFAULT_HEIGHT = 320
 const BOTTOM_MIN_HEIGHT = 220
@@ -18,6 +26,16 @@ function getRightSplitChatMaxWidth(containerWidth: number) {
   return Math.max(RIGHT_SPLIT_CHAT_MIN_WIDTH, containerWidth - RIGHT_SPLIT_PANEL_COLLAPSE_WIDTH)
 }
 
+function getRightSplitChatDefaultWidth(containerWidth: number) {
+  if (containerWidth <= 0) return RIGHT_SPLIT_CHAT_DEFAULT_WIDTH
+
+  return clamp(
+    containerWidth - RIGHT_SPLIT_PANEL_DEFAULT_WIDTH,
+    RIGHT_SPLIT_CHAT_MIN_WIDTH,
+    getRightSplitChatMaxWidth(containerWidth)
+  )
+}
+
 interface ResizableRightSplitChatOptions {
   containerRef?: RefObject<HTMLElement | null>
   onCollapse?: () => void
@@ -29,6 +47,32 @@ export function useResizableRightSplitChat({
 }: ResizableRightSplitChatOptions = {}) {
   const [width, setWidth] = useState(RIGHT_SPLIT_CHAT_DEFAULT_WIDTH)
   const [resizing, setResizing] = useState(false)
+  const collapseFrameRef = useRef<number | null>(null)
+  const userSizedRef = useRef(false)
+
+  useLayoutEffect(() => {
+    const container = containerRef?.current
+    if (!container) return
+
+    const applyDefaultWidth = () => {
+      if (userSizedRef.current) return
+      setWidth(getRightSplitChatDefaultWidth(container.getBoundingClientRect().width))
+    }
+
+    applyDefaultWidth()
+    if (typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(applyDefaultWidth)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [containerRef])
+
+  useEffect(() => {
+    return () => {
+      if (collapseFrameRef.current === null) return
+      window.cancelAnimationFrame(collapseFrameRef.current)
+    }
+  }, [])
 
   const handleResizeStart = (event: PointerEvent<HTMLDivElement>) => {
     event.preventDefault()
@@ -38,6 +82,7 @@ export function useResizableRightSplitChat({
     const containerWidth = containerRef?.current?.getBoundingClientRect().width ?? 0
     const maxWidth = getRightSplitChatMaxWidth(containerWidth)
     let collapsed = false
+    userSizedRef.current = true
 
     function finishResize() {
       document.removeEventListener('pointermove', handleMove)
@@ -52,8 +97,22 @@ export function useResizableRightSplitChat({
 
       collapsed = true
       finishResize()
-      setWidth(RIGHT_SPLIT_CHAT_DEFAULT_WIDTH)
-      onCollapse?.()
+      if (collapseFrameRef.current !== null) {
+        window.cancelAnimationFrame(collapseFrameRef.current)
+      }
+      const applyCollapse = () => {
+        collapseFrameRef.current = null
+        userSizedRef.current = false
+        setWidth(getRightSplitChatDefaultWidth(containerWidth))
+        onCollapse?.()
+      }
+
+      if (typeof window.requestAnimationFrame === 'function') {
+        collapseFrameRef.current = window.requestAnimationFrame(applyCollapse)
+        return
+      }
+
+      applyCollapse()
     }
 
     function handleMove(moveEvent: globalThis.PointerEvent) {

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -845,7 +845,9 @@ describe('WorkbenchProvider runtime tasks', () => {
     renderWorkbenchWithDefaultServices(<BootstrapProbe />)
 
     await waitFor(() => expect(screen.getByTestId('boot-state')).toHaveTextContent('local'))
-    await waitFor(() => expect(screen.getByTestId('startup-ready')).toHaveTextContent('ready'))
+    await waitFor(() => expect(screen.getByTestId('startup-ready')).toHaveTextContent('ready'), {
+      timeout: 3000,
+    })
     expect(screen.getByTestId('project-count')).toHaveTextContent('0')
     expect(screen.getByTestId('runtime-total')).toHaveTextContent('0')
     expect(localExecutorMocks.ensureLocalExecutorStarted).toHaveBeenCalled()

--- a/wework/src/features/workbench/WorkbenchProvider.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.tsx
@@ -46,6 +46,8 @@ import {
   createExecutorClientForWorkbenchServices,
 } from './workbenchServices'
 
+export type { WorkbenchServices } from './workbenchServices'
+
 const LOCAL_SKILLS_CACHE_TTL_MS = 30_000
 
 export function WorkbenchProvider({

--- a/wework/src/hooks/useIsMobile.test.ts
+++ b/wework/src/hooks/useIsMobile.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { useIsMobile } from './useIsMobile'
+
+const originalInnerWidth = window.innerWidth
+
+describe('useIsMobile', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: originalInnerWidth,
+    })
+    delete (window as typeof window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__
+    vi.unstubAllGlobals()
+  })
+
+  test('treats narrow browser viewports as mobile', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 500,
+    })
+
+    const { result } = renderHook(() => useIsMobile())
+
+    expect(result.current).toBe(true)
+  })
+
+  test('keeps narrow Tauri desktop windows in desktop mode', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 500,
+    })
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+
+    const { result } = renderHook(() => useIsMobile())
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/wework/src/hooks/useIsMobile.ts
+++ b/wework/src/hooks/useIsMobile.ts
@@ -1,12 +1,17 @@
 import { useEffect, useState } from 'react'
+import { isTauriRuntime } from '@/lib/runtime-environment'
 import { isMobileViewport, mobileMediaQuery } from '@/lib/responsive'
 
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(
-    () => isMobileViewport(window.innerWidth)
+    () => !isTauriRuntime() && isMobileViewport(window.innerWidth)
   )
 
   useEffect(() => {
+    if (isTauriRuntime()) {
+      return
+    }
+
     if (typeof window.matchMedia !== 'function') return
 
     const mql = window.matchMedia(mobileMediaQuery())

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -269,6 +269,7 @@
     "empty_title": "What should we do?",
     "project_empty_title": "What should we build in {{projectName}}?",
     "input_placeholder": "Ask anything",
+    "follow_up_placeholder": "Request follow-up changes",
     "mobile_input_placeholder": "Ask Wework",
     "continue_im_title": "Continue in IM",
     "continue_im_close": "Close Continue in IM",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -269,6 +269,7 @@
     "empty_title": "我们该做什么？",
     "project_empty_title": "我们应该在 {{projectName}} 中构建什么？",
     "input_placeholder": "尽管问",
+    "follow_up_placeholder": "要求后续变更",
     "mobile_input_placeholder": "询问 Wework",
     "continue_im_title": "继续到私聊",
     "continue_im_close": "关闭继续到私聊",

--- a/wework/src/lib/workbench-layout-mode.ts
+++ b/wework/src/lib/workbench-layout-mode.ts
@@ -1,0 +1,9 @@
+export function shouldUseMobileWorkbenchLayout({
+  isMobileViewport,
+  isTauri,
+}: {
+  isMobileViewport: boolean
+  isTauri: boolean
+}): boolean {
+  return isMobileViewport && !isTauri
+}

--- a/wework/src/pages/WorkbenchPage.test.ts
+++ b/wework/src/pages/WorkbenchPage.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'vitest'
+import { shouldUseMobileWorkbenchLayout } from '@/lib/workbench-layout-mode'
+
+describe('shouldUseMobileWorkbenchLayout', () => {
+  test('keeps the desktop workbench in a narrow Tauri window', () => {
+    expect(
+      shouldUseMobileWorkbenchLayout({
+        isMobileViewport: true,
+        isTauri: true,
+      })
+    ).toBe(false)
+  })
+
+  test('uses the mobile workbench for a narrow browser viewport', () => {
+    expect(
+      shouldUseMobileWorkbenchLayout({
+        isMobileViewport: true,
+        isTauri: false,
+      })
+    ).toBe(true)
+  })
+})

--- a/wework/src/pages/WorkbenchPage.tsx
+++ b/wework/src/pages/WorkbenchPage.tsx
@@ -3,11 +3,14 @@ import { DesktopWorkbenchLayout } from '@/components/layout/DesktopWorkbenchLayo
 import { MobileWorkbenchLayout } from '@/components/layout/MobileWorkbenchLayout'
 import { useWorkbench } from '@/features/workbench/useWorkbench'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { isTauriRuntime } from '@/lib/runtime-environment'
+import { shouldUseMobileWorkbenchLayout } from '@/lib/workbench-layout-mode'
 import { buildTrayMenuTaskGroups } from '@/tauri/trayMenuState'
 import { syncTrayMenuState } from '@/tauri/trayNavigation'
 
 export function WorkbenchPage() {
-  const isMobile = useIsMobile()
+  const isMobileViewport = useIsMobile()
+  const isTauri = isTauriRuntime()
   const { state } = useWorkbench()
   const trayMenuTaskGroups = useMemo(
     () => buildTrayMenuTaskGroups(state.runtimeWork),
@@ -18,5 +21,9 @@ export function WorkbenchPage() {
     syncTrayMenuState(trayMenuTaskGroups)
   }, [trayMenuTaskGroups])
 
-  return isMobile ? <MobileWorkbenchLayout /> : <DesktopWorkbenchLayout />
+  return shouldUseMobileWorkbenchLayout({ isMobileViewport, isTauri }) ? (
+    <MobileWorkbenchLayout />
+  ) : (
+    <DesktopWorkbenchLayout />
+  )
 }

--- a/wework/src/test/setup.ts
+++ b/wework/src/test/setup.ts
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom/vitest'
+import { beforeEach } from 'vitest'
+
+beforeEach(() => {
+  window.__WEWORK_RUNTIME_CONFIG__ = {
+    appBasePath: '',
+    apiBaseUrl: '/api',
+    socketBaseUrl: window.location.origin,
+    socketPath: '/socket.io',
+  }
+})


### PR DESCRIPTION
## Summary
- map Codex commentary/analysis agent messages into process text blocks while keeping final answer deltas separate
- update Wework streaming UI to match Codex timing, folding, and final-artifact behavior
- pass Wework reasoning options through runtime send and harden notification draining

## Validation
- pnpm --dir /Users/crystal/dev/git/Wegent/wework exec vitest run src/components/chat/blocks/toolBlockActivity.test.ts src/components/chat/blocks/ToolBlocksDisplay.test.tsx src/components/chat/MessageList.test.tsx src/api/local/localServices.test.ts
- cargo test --manifest-path executor/Cargo.toml --test app_runtime_work_send_contract
- cargo fmt --manifest-path executor/Cargo.toml --check
- git diff --check
- pre-push: full wework vitest coverage, executor cargo fmt, executor cargo test --all-features, executor cargo clippy

## Notes
- Rebased onto origin/main; there were no local conflicts.
- The first push attempt exposed shell Vite API variables leaking into Wework tests; the final push ran with those variables unset so the hook used the test-relative API URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Codex streaming reliability by tracking per-agent-message phases across the full message lifecycle.
  * Extended runtime/IPC requests to normalize and forward `modelOptions` (reasoning/summary/speed).
  * Enhanced chat streaming UI with more accurate processing/tool block placeholders and timing.
* **Bug Fixes**
  * Prevented final artifacts (citations/references/file-change cards) from appearing until streaming completes.
  * Refined processing toggle/expansion behavior to match streaming vs final states.
* **Chores**
  * Updated payload parsing and runtime event mapping to support phase-aware streaming.
* **Tests**
  * Expanded and adjusted runtime and UI streaming test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->