### PR TITLE
[codex] adjust wework message turn navigation spacing

### DIFF
--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -13,8 +13,9 @@ const NEARBY_MARKER_WIDTH_PX = 16
 const EXPANDED_MARKER_WIDTH_PX = 24
 const MARKER_HIT_AREA_WIDTH_PX = 28
 const MARKER_ROW_HEIGHT_PX = 8
-const MARKER_ROW_GAP_PX = 5
-const MAX_NAVIGATION_HEIGHT_PX = 96
+const MARKER_ROW_GAP_PX = 20 / 9
+const MARKER_HOVER_ROW_HEIGHT_PX = MARKER_ROW_HEIGHT_PX + MARKER_ROW_GAP_PX
+const NAVIGATION_VIEWPORT_PADDING_PX = 48
 const MESSAGE_ANCHOR_SELECTOR = '[data-message-id]'
 const CODEX_REQUEST_MARKER_PATTERN = /^## My request for Codex:\s*$/im
 
@@ -45,6 +46,7 @@ export function MessageTurnNavigation({
   const [markers, setMarkers] = useState<MessageTurnMarker[]>([])
   const [activeMarkerId, setActiveMarkerId] = useState<string | null>(null)
   const [hoveredMarkerId, setHoveredMarkerId] = useState<string | null>(null)
+  const [navigationScrollTop, setNavigationScrollTop] = useState(0)
   const markersRef = useRef<MessageTurnMarker[]>([])
   const rafRef = useRef<number | null>(null)
 
@@ -182,63 +184,83 @@ export function MessageTurnNavigation({
         left: '8px',
         width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
         height: `${navigationHeight}px`,
+        maxHeight: `calc(100% - ${NAVIGATION_VIEWPORT_PADDING_PX}px)`,
       }}
     >
-      <div className="relative h-full w-full">
-        {markers.map((marker, index) => {
-          const isActive = activeMarkerId === marker.id
-          const hoverDistance =
-            hoveredMarkerIndex === -1 ? null : Math.abs(index - hoveredMarkerIndex)
+      <div
+        className="pointer-events-auto h-full w-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        data-testid="message-turn-navigation-rail"
+        style={{
+          overflowY: 'auto',
+          overscrollBehaviorY: 'contain',
+        }}
+        onScroll={event => setNavigationScrollTop(event.currentTarget.scrollTop)}
+      >
+        <div className="relative w-full" style={{ height: `${navigationHeight}px` }}>
+          {markers.map((marker, index) => {
+            const isActive = activeMarkerId === marker.id
+            const hoverDistance =
+              hoveredMarkerIndex === -1 ? null : Math.abs(index - hoveredMarkerIndex)
 
-          return (
-            <div
-              key={marker.id}
-              className="group absolute left-0 -translate-y-1/2"
-              style={{
-                top: `${getMarkerTopPx(index, markers.length, navigationHeight)}px`,
-                height: `${MARKER_ROW_HEIGHT_PX}px`,
-                width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
-              }}
-              onMouseEnter={() => setHoveredMarkerId(marker.id)}
-              onMouseLeave={() => setHoveredMarkerId(null)}
-            >
-              <button
-                type="button"
-                aria-label={t('message_navigation.jump_to_message', {
-                  index: marker.turnIndex + 1,
-                  defaultValue: `跳转到第 ${marker.turnIndex + 1} 条发言`,
-                })}
-                className="pointer-events-auto flex h-full w-full items-center justify-start rounded-md p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
-                data-active={isActive}
-                data-testid="message-turn-navigation-marker"
-                onClick={() => handleMarkerClick(marker)}
-                onFocus={() => setHoveredMarkerId(marker.id)}
-                onBlur={() => setHoveredMarkerId(null)}
+            return (
+              <div
+                key={marker.id}
+                className="absolute left-0 -translate-y-1/2"
+                style={{
+                  top: `${getMarkerTopPx(index)}px`,
+                  height: `${MARKER_HOVER_ROW_HEIGHT_PX}px`,
+                  width: `${MARKER_HIT_AREA_WIDTH_PX}px`,
+                }}
+                onMouseEnter={() => setHoveredMarkerId(marker.id)}
+                onMouseLeave={() => setHoveredMarkerId(null)}
               >
-                <span
-                  className={cn(
-                    'block h-[2px] rounded-full transition-all duration-150 ease-out',
-                    getMarkerToneClass(isActive, hoverDistance)
-                  )}
-                  style={{
-                    width: `${getMarkerWidthPx(hoverDistance)}px`,
-                  }}
-                />
-              </button>
-              <div className="pointer-events-none absolute left-8 top-1/2 z-30 w-[300px] max-w-[calc(100vw-56px)] -translate-y-1/2 rounded-md border border-border bg-background px-2.5 py-2 text-left opacity-0 shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
-                <p className="break-words text-[11px] font-semibold leading-4 text-text-primary">
-                  {marker.promptPreview}
-                </p>
-                {marker.responsePreview && (
-                  <p className="mt-1 break-words text-[11px] leading-4 text-text-muted">
-                    {marker.responsePreview}
-                  </p>
-                )}
+                <button
+                  type="button"
+                  aria-label={t('message_navigation.jump_to_message', {
+                    index: marker.turnIndex + 1,
+                    defaultValue: `跳转到第 ${marker.turnIndex + 1} 条发言`,
+                  })}
+                  className="pointer-events-auto flex h-full w-full items-center justify-start rounded-md p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/35"
+                  data-active={isActive}
+                  data-testid="message-turn-navigation-marker"
+                  onClick={() => handleMarkerClick(marker)}
+                  onFocus={() => setHoveredMarkerId(marker.id)}
+                  onBlur={() => setHoveredMarkerId(null)}
+                >
+                  <span
+                    className={cn(
+                      'block h-[2px] rounded-full transition-all duration-150 ease-out',
+                      getMarkerToneClass(isActive, hoverDistance)
+                    )}
+                    style={{
+                      width: `${getMarkerWidthPx(hoverDistance)}px`,
+                    }}
+                  />
+                </button>
               </div>
-            </div>
-          )
-        })}
+            )
+          })}
+        </div>
       </div>
+      {markers.map((marker, index) => (
+        <div
+          key={`${marker.id}-preview`}
+          className={cn(
+            'pointer-events-none absolute left-8 z-30 w-[300px] max-w-[calc(100vw-56px)] -translate-y-1/2 rounded-md border border-border bg-background px-2.5 py-2 text-left shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition-opacity duration-150',
+            hoveredMarkerId === marker.id ? 'opacity-100' : 'opacity-0'
+          )}
+          style={{ top: `${getMarkerTopPx(index) - navigationScrollTop}px` }}
+        >
+          <p className="break-words text-[11px] font-semibold leading-4 text-text-primary">
+            {marker.promptPreview}
+          </p>
+          {marker.responsePreview && (
+            <p className="mt-1 break-words text-[11px] leading-4 text-text-muted">
+              {marker.responsePreview}
+            </p>
+          )}
+        </div>
+      ))}
     </nav>
   )
 }
@@ -307,17 +329,11 @@ function truncatePreview(text: string, maxLength: number) {
 function getNavigationHeight(markerCount: number) {
   if (markerCount <= 1) return MARKER_ROW_HEIGHT_PX
 
-  const preferredHeight =
-    MARKER_ROW_HEIGHT_PX + (markerCount - 1) * (MARKER_ROW_HEIGHT_PX + MARKER_ROW_GAP_PX)
-
-  return Math.min(MAX_NAVIGATION_HEIGHT_PX, preferredHeight)
+  return MARKER_ROW_HEIGHT_PX + (markerCount - 1) * (MARKER_ROW_HEIGHT_PX + MARKER_ROW_GAP_PX)
 }
 
-function getMarkerTopPx(index: number, markerCount: number, navigationHeight: number) {
-  if (markerCount <= 1) return navigationHeight / 2
-
-  const availableHeight = Math.max(0, navigationHeight - MARKER_ROW_HEIGHT_PX)
-  return MARKER_ROW_HEIGHT_PX / 2 + (availableHeight * index) / (markerCount - 1)
+function getMarkerTopPx(index: number) {
+  return MARKER_ROW_HEIGHT_PX / 2 + index * (MARKER_ROW_HEIGHT_PX + MARKER_ROW_GAP_PX)
 }
 
 function getMarkerWidthPx(hoverDistance: number | null) {

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -226,7 +226,7 @@ describe('ScrollableMessageArea', () => {
     const navigation = screen.getByTestId('message-turn-navigation')
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(navigation).toHaveAccessibleName('历史发言导航')
-    expect(navigation).toHaveStyle({ height: '21px' })
+    expect(Number.parseFloat(navigation.style.height)).toBeCloseTo(18.222)
     expect(markers).toHaveLength(2)
     expect(markers[0]).toHaveAccessibleName('跳转到第 1 条发言')
     expect(markers[1]).toHaveAccessibleName('跳转到第 2 条发言')
@@ -253,6 +253,60 @@ describe('ScrollableMessageArea', () => {
     fireEvent.blur(markers[0])
     expect(screen.getAllByText('第一条用户需求')).toHaveLength(2)
     expect(screen.getAllByText('第一条回复摘要')).toHaveLength(2)
+  })
+
+  test('keeps message navigation marker spacing fixed when the rail overflows', () => {
+    const userMessages = Array.from({ length: 12 }, (_, index) => ({
+      id: `overflow-user-${index + 1}`,
+      role: 'user' as const,
+      content: `第 ${index + 1} 条用户需求`,
+      status: 'done' as const,
+      createdAt: `2026-05-29T00:00:${String(index).padStart(2, '0')}.000Z`,
+    }))
+
+    render(<ScrollableMessageArea messages={userMessages} />)
+
+    const scroller = screen.getByTestId('chat-message-scroll-area')
+    Object.defineProperty(scroller, 'clientHeight', {
+      value: 240,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollHeight', {
+      value: 2200,
+      configurable: true,
+    })
+    Object.defineProperty(scroller, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    })
+    mockRect(scroller, 0, 240)
+    userMessages.forEach((message, index) => {
+      mockRect(
+        screen.getByText(message.content).closest('[data-message-id]')!,
+        80 + index * 140,
+        128 + index * 140
+      )
+    })
+
+    fireEvent.resize(window)
+
+    const navigation = screen.getByTestId('message-turn-navigation')
+    const navigationRail = screen.getByTestId('message-turn-navigation-rail')
+    const markers = screen.getAllByTestId('message-turn-navigation-marker')
+    const markerRows = markers.map(marker => marker.parentElement!)
+    const markerTops = markerRows.map(row => Number.parseFloat(row.style.top))
+
+    expect(Number.parseFloat(navigation.style.height)).toBeCloseTo(120.444)
+    expect(navigation).toHaveStyle({ maxHeight: 'calc(100% - 48px)' })
+    expect(navigationRail).toHaveStyle({
+      overflowY: 'auto',
+    })
+    expect(markerTops[1] - markerTops[0]).toBeCloseTo(10.222)
+    expect(markerTops[markerTops.length - 1] - markerTops[markerTops.length - 2]).toBeCloseTo(
+      10.222
+    )
+    expect(Number.parseFloat(markerRows[0].style.height)).toBeCloseTo(10.222)
   })
 
   test('clicks a message navigation marker to jump to that user message', () => {

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -743,7 +743,12 @@ function GlobalImNotificationBell({
 
   const openSessionSettings = () => {
     onMenuOpenChange(false)
-    void (onOpenGlobalImNotificationSettings ?? onToggleGlobalImNotification)()
+    const openSettings = onOpenGlobalImNotificationSettings ?? onToggleGlobalImNotification
+    if (openSettings) {
+      void openSettings()
+      return
+    }
+    onOpenSettings()
   }
 
   const handlePrimaryAction = () => {

--- a/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
+++ b/wework/src/components/layout/workspace-panels/RightWorkspacePanel.tsx
@@ -49,7 +49,7 @@ interface RightWorkspacePanelProps {
   reviewViewOptions?: FileChangesReviewViewOption[]
   onAddCodeComment: (context: CodeCommentContext) => void
   onSelectReview: () => void
-  onSelectTerminal?: () => void
+  onSelectTerminal: () => void
   onSelectBrowser: () => void
   onSelectFiles: () => void
   onCloseTab: (tab: RightWorkspacePanelTab) => void
@@ -109,17 +109,13 @@ export function RightWorkspacePanel({
       disabled: !canOpenReview,
       onSelect: onSelectReview,
     },
-    ...(onSelectTerminal
-      ? [
-          {
-            id: 'terminal',
-            testId: 'right-workspace-terminal-option',
-            icon: SquareTerminal,
-            label: t('workbench.terminal', '终端'),
-            onSelect: onSelectTerminal,
-          },
-        ]
-      : []),
+    {
+      id: 'terminal',
+      testId: 'right-workspace-terminal-option',
+      icon: SquareTerminal,
+      label: t('workbench.terminal', '终端'),
+      onSelect: onSelectTerminal,
+    },
     ...(!browserOpen
       ? [
           {


### PR DESCRIPTION
## Summary

- Keep the wework message turn navigation marker spacing fixed as message count grows, with the latest requested compact gap of `20 / 9px`.
- Give each marker a hover hit area that spans the visual gap so moving between markers does not reset hover width.
- Let the message navigation rail scroll independently when its natural height exceeds the viewport.
- Fix two TypeScript strictness issues surfaced while validating the wework build.

## Root Cause

The previous navigation compressed marker positions into a capped total height. After making the rail scrollable, hover was still bound to each 8px marker row, so moving through the gap cleared hover state and caused width flicker.

## Validation

- `pnpm --dir wework test`
- `pnpm --dir wework run lint`
- `pnpm --dir wework exec tsc -b --pretty false`
- pre-push hook: wework tests with coverage and AI quality gate passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the chat message navigation rail with smoother scrolling and more consistent marker spacing.
  * Added better handling for the terminal option in the workspace panel’s new-tab menu.

* **Bug Fixes**
  * Fixed navigation rail sizing so it adapts correctly when many messages are present.
  * Prevented a settings action from failing when optional callbacks aren’t available.
  * Improved tooltip positioning in the message navigation rail while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->