### PR TITLE
[codex] fix wework message navigation z-index

### DIFF
--- a/wework/src/components/chat/MessageTurnNavigation.tsx
+++ b/wework/src/components/chat/MessageTurnNavigation.tsx
@@ -178,7 +178,7 @@ export function MessageTurnNavigation({
   return (
     <nav
       aria-label={t('message_navigation.label', '历史发言导航')}
-      className="pointer-events-none absolute top-1/2 z-20 hidden -translate-y-1/2 lg:block"
+      className="pointer-events-none absolute top-1/2 z-popover hidden -translate-y-1/2 lg:block"
       data-testid="message-turn-navigation"
       style={{
         left: '8px',

--- a/wework/src/components/chat/ScrollableMessageArea.test.tsx
+++ b/wework/src/components/chat/ScrollableMessageArea.test.tsx
@@ -226,6 +226,7 @@ describe('ScrollableMessageArea', () => {
     const navigation = screen.getByTestId('message-turn-navigation')
     const markers = screen.getAllByTestId('message-turn-navigation-marker')
     expect(navigation).toHaveAccessibleName('历史发言导航')
+    expect(navigation).toHaveClass('z-popover')
     expect(Number.parseFloat(navigation.style.height)).toBeCloseTo(18.222)
     expect(markers).toHaveLength(2)
     expect(markers[0]).toHaveAccessibleName('跳转到第 1 条发言')


### PR DESCRIPTION
## Summary
- Raise the Wework message turn navigation rail from `z-20` to the shared `z-popover` layer.
- Add a regression assertion so the navigation stays above the floating composer layer.

## Root Cause
The left-side message navigation used a hard-coded `z-20`, while the bottom floating composer uses the `z-chrome` layer. That let the composer paint above the navigation indicator near the bottom of the chat view.

## Impact
The left-side turn indicator remains visible and interactive above the send box without changing its layout or behavior.

## Validation
- `pnpm --dir wework test src/components/chat/ScrollableMessageArea.test.tsx`
- `pnpm --dir wework exec eslint src/components/chat/MessageTurnNavigation.tsx src/components/chat/ScrollableMessageArea.test.tsx`
- Pre-commit hook: wework lint-staged with Prettier and ESLint
- Pre-push hook: full wework test suite, 98 files and 889 tests passed; AI quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message navigation layering so it displays correctly relative to other chat elements.
  * Added test coverage to ensure the navigation uses the expected styling class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->