### PR TITLE
[codex] Fix runtime task hover title truncation

### DIFF
--- a/wework/src/components/layout/DesktopSidebar.test.tsx
+++ b/wework/src/components/layout/DesktopSidebar.test.tsx
@@ -927,6 +927,54 @@ describe('DesktopSidebar', () => {
     expect(markButton).toHaveAttribute('aria-label', '标记任务')
   })
 
+  test('reserves runtime task hover actions without padding the truncated title', async () => {
+    const user = userEvent.setup()
+    const taskTitle = '修复进行中任务未显示 tool 调用'
+
+    renderSidebar({
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Wegent' },
+            totalLocalTasks: 1,
+            deviceWorkspaces: [
+              {
+                id: 91,
+                deviceId: 'local-device',
+                deviceName: 'Local Mac',
+                deviceStatus: 'online',
+                available: true,
+                workspacePath: '/repo/Wegent',
+                localTasks: [
+                  {
+                    localTaskId: 'codex-1',
+                    workspacePath: '/repo/Wegent',
+                    title: taskTitle,
+                    runtime: 'codex',
+                    updatedAt: '2026-06-20T02:00:00Z',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 1,
+      },
+    })
+
+    await user.click(screen.getByTestId('project-item-button'))
+
+    const title = screen.getByText(taskTitle)
+    const trailing = screen.getByTestId('runtime-local-task-trailing-codex-1')
+    const hoverActions = screen.getByTestId('runtime-local-task-hover-actions-codex-1')
+
+    expect(title).toHaveClass('min-w-0', 'flex-1', 'truncate')
+    expect(title).not.toHaveClass('group-hover/task:pr-20')
+    expect(trailing).toHaveClass('min-w-[28px]', 'group-hover/task:w-[78px]')
+    expect(hoverActions).toHaveClass('absolute', 'right-0', 'w-[78px]')
+  })
+
   test('moves pinned runtime tasks to the top of the project task list', async () => {
     const user = userEvent.setup()
 

--- a/wework/src/components/layout/DesktopSidebar.tsx
+++ b/wework/src/components/layout/DesktopSidebar.tsx
@@ -1102,12 +1102,12 @@ function RuntimeLocalTaskRow({
               : 'text-[rgb(var(--color-sidebar-text-primary))] hover:bg-[rgb(var(--color-sidebar-hover))]'
         )}
       >
-        <span title={task.title} className="min-w-0 flex-1 truncate group-hover/task:pr-20">
+        <span title={task.title} className="min-w-0 flex-1 truncate">
           {task.title}
         </span>
         <span
           data-testid={`runtime-local-task-trailing-${task.localTaskId}`}
-          className="relative ml-1 flex h-7 shrink-0 items-center justify-end"
+          className="relative ml-1 flex h-7 min-w-[28px] shrink-0 items-center justify-end transition-[width] group-hover/task:w-[78px]"
         >
           <span
             data-testid={`runtime-local-task-time-${task.localTaskId}`}


### PR DESCRIPTION
## Summary

Fixes the wework desktop sidebar runtime task row hover layout so the task title no longer collapses to only a few leading characters when hover actions appear.

## Root Cause

The truncated title span added `group-hover/task:pr-20` while the trailing hover action container was also layered on the right. That double-reserved horizontal space and made the title's available width much smaller than intended.

## Changes

- Removed hover padding from the runtime task title span.
- Let the trailing action area reserve its own hover width.
- Added a regression test covering the hover action layout contract.

## Validation

- `pnpm --dir wework test DesktopSidebar.test.tsx -- --runInBand` (38 passed)
- `pnpm --dir wework lint`
- Pre-push hook: full wework test suite (98 files, 890 tests passed) and AI quality checks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the task row layout in the sidebar so long task titles stay readable and no longer shift or get clipped when hover actions appear.
  * Hover actions now expand more smoothly without adding extra spacing to the title area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->