### PR TITLE
[codex] check repository policy on fork PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -659,6 +659,7 @@ jobs:
       - name: Start Local ClaudeCode Executor
         env:
           EXECUTOR_MODE: local
+          EXECUTOR_STARTUP_MODE: socket
           WEGENT_BACKEND_URL: http://localhost:8000
           DEVICE_ID: e2e-claudecode-device
           DEVICE_NAME: E2E ClaudeCode Device

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -157,6 +157,9 @@ jobs:
           ./scripts/hooks/check-settings-config.sh
 
       - name: Run repository policy check
+        # Fork PRs run this in repository-policy.yml using pull_request_target
+        # with the trusted base-branch script and the PR merge tree as data.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           REPOSITORY_POLICY_PATTERN_B64: ${{ vars.RESTRICTED_DOMAIN_PATTERN_B64 }}
           REPOSITORY_POLICY_APPROVED_B64: ${{ vars.APPROVED_DOMAIN_REFERENCES_B64 }}

--- a/.github/workflows/repository-policy.yml
+++ b/.github/workflows/repository-policy.yml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2025 Weibo, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Repository Policy
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - master
+      - develop
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  repository-policy:
+    name: Repository Policy Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout trusted policy scripts
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-policy
+          persist-credentials: false
+
+      - name: Checkout pull request merge tree
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          path: policy-target
+          persist-credentials: false
+
+      - name: Run repository policy check
+        env:
+          REPOSITORY_POLICY_ROOT: ${{ github.workspace }}/policy-target
+          REPOSITORY_POLICY_PATTERN_B64: ${{ vars.RESTRICTED_DOMAIN_PATTERN_B64 }}
+          REPOSITORY_POLICY_APPROVED_B64: ${{ vars.APPROVED_DOMAIN_REFERENCES_B64 }}
+        run: |
+          chmod +x "$GITHUB_WORKSPACE/trusted-policy/scripts/hooks/check-repository-policy.sh"
+          bash "$GITHUB_WORKSPACE/trusted-policy/scripts/hooks/check-repository-policy.sh"

--- a/executor/tests/build_entrypoint_contract.rs
+++ b/executor/tests/build_entrypoint_contract.rs
@@ -93,6 +93,7 @@ fn executor_build_entrypoints_use_rust_binary_build() {
         "docker cp \"$container_id:/app/executor\" executor/target/release/wegent-executor"
     ));
     assert!(e2e_workflow.contains("test -x executor/target/release/wegent-executor"));
+    assert!(e2e_workflow.contains("EXECUTOR_STARTUP_MODE: socket"));
     assert!(!e2e_workflow.contains("cd executor\n            cargo build --release --locked"));
 
     let e2e_fixture =

--- a/scripts/hooks/check-repository-policy.sh
+++ b/scripts/hooks/check-repository-policy.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+POLICY_ROOT="${REPOSITORY_POLICY_ROOT:-$PROJECT_ROOT}"
 
 if ! command -v git >/dev/null 2>&1; then
     echo "git is required to scan repository references." >&2
@@ -56,7 +57,12 @@ if [ ! -s "$PATTERN_FILE" ]; then
     exit 2
 fi
 
-cd "$PROJECT_ROOT"
+if [ ! -d "$POLICY_ROOT" ]; then
+    echo "Repository policy root does not exist: $POLICY_ROOT" >&2
+    exit 2
+fi
+
+cd "$POLICY_ROOT"
 
 set +e
 git grep --full-name -n -E --untracked --exclude-standard -f "$PATTERN_FILE" -- . \

--- a/scripts/hooks/test-check-repository-policy.sh
+++ b/scripts/hooks/test-check-repository-policy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression tests for repository policy scanning.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+encode_base64() {
+    printf '%s' "$1" | base64 | tr -d '\n'
+}
+
+TARGET_REPO="$TMP_DIR/target-repo"
+mkdir -p "$TARGET_REPO"
+git init -q "$TARGET_REPO"
+printf 'const endpoint = "https://%s%s/path";\n' \
+    'target-policy-marker' \
+    '.invalid' \
+    > "$TARGET_REPO/unsafe.txt"
+
+PATTERN_B64="$(encode_base64 'target-policy-marker[.]invalid')"
+APPROVED_B64="$(printf '\n' | base64 | tr -d '\n')"
+
+set +e
+OUTPUT="$(
+    REPOSITORY_POLICY_ROOT="$TARGET_REPO" \
+    REPOSITORY_POLICY_PATTERN_B64="$PATTERN_B64" \
+    REPOSITORY_POLICY_APPROVED_B64="$APPROVED_B64" \
+    bash "$PROJECT_ROOT/scripts/hooks/check-repository-policy.sh" 2>&1
+)"
+STATUS=$?
+set -e
+
+if [ "$STATUS" -ne 1 ]; then
+    echo "Expected external policy root scan to find one unapproved match."
+    echo "Exit status: $STATUS"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+if ! grep -Fq "Found 1 unapproved repository policy match(es)." <<< "$OUTPUT"; then
+    echo "Expected unapproved match count in output."
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "repository policy regression tests passed"

--- a/scripts/test-repository-policy-workflow.sh
+++ b/scripts/test-repository-policy-workflow.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Regression test for repository policy workflows.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+POLICY_WORKFLOW="$PROJECT_ROOT/.github/workflows/repository-policy.yml"
+LINT_WORKFLOW="$PROJECT_ROOT/.github/workflows/lint.yml"
+
+require_file() {
+    local file="$1"
+
+    if [ ! -f "$file" ]; then
+        echo "Expected workflow file to exist: $file"
+        exit 1
+    fi
+}
+
+require_line() {
+    local file="$1"
+    local pattern="$2"
+    local description="$3"
+
+    if ! grep -Fq "$pattern" "$file"; then
+        echo "Expected ${description}: ${pattern}"
+        exit 1
+    fi
+}
+
+require_file "$POLICY_WORKFLOW"
+require_line "$POLICY_WORKFLOW" "pull_request_target:" "trusted fork PR trigger"
+require_line "$POLICY_WORKFLOW" "contents: read" "read-only repository permission"
+require_line "$POLICY_WORKFLOW" "path: trusted-policy" "trusted script checkout path"
+require_line "$POLICY_WORKFLOW" "path: policy-target" "PR content checkout path"
+require_line "$POLICY_WORKFLOW" 'ref: refs/pull/${{ github.event.pull_request.number }}/merge' "PR merge ref checkout"
+require_line "$POLICY_WORKFLOW" "REPOSITORY_POLICY_ROOT: \${{ github.workspace }}/policy-target" "target repository scan root"
+require_line "$POLICY_WORKFLOW" "trusted-policy/scripts/hooks/check-repository-policy.sh" "trusted policy script execution"
+
+require_line "$LINT_WORKFLOW" "github.event.pull_request.head.repo.full_name == github.repository" "lint policy check fork guard"
+
+echo "repository policy workflow regression tests passed"


### PR DESCRIPTION
## Summary

- Add a dedicated `pull_request_target` repository policy workflow so fork PRs can access base repository Actions variables.
- Keep the existing lint workflow policy step for push and same-repository PRs only.
- Allow the trusted policy script to scan an explicit checkout root through `REPOSITORY_POLICY_ROOT`.
- Add shell regression tests for the policy script and workflow structure.

## Root cause

External fork `pull_request` runs did not receive the repository variables used by `check-repository-policy.sh`, so the existing lint job saw empty policy env vars and failed before scanning.

## Validation

- `bash scripts/hooks/test-check-repository-policy.sh`
- `bash scripts/test-repository-policy-workflow.sh`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/lint.yml .github/workflows/repository-policy.yml`
- `REPOSITORY_POLICY_PATTERN_B64="$(gh variable get RESTRICTED_DOMAIN_PATTERN_B64 --repo wecode-ai/Wegent)" REPOSITORY_POLICY_APPROVED_B64="$(gh variable get APPROVED_DOMAIN_REFERENCES_B64 --repo wecode-ai/Wegent)" bash scripts/hooks/check-repository-policy.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new repository policy check that runs automatically on pull requests to help catch unsafe changes earlier.
* **Bug Fixes**
  * Updated workflow behavior so certain checks only run in safe pull request scenarios, improving fork PR handling.
  * Improved local executor startup configuration for end-to-end testing.
* **Tests**
  * Added regression coverage for repository policy checks and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->