### PR TITLE
[codex] accept case-insensitive executor test headers

### DIFF
--- a/executor/tests/agent_runtime_capabilities_contract.rs
+++ b/executor/tests/agent_runtime_capabilities_contract.rs
@@ -279,7 +279,11 @@ async fn claude_runtime_downloads_attachments_and_rewrites_prompt_before_process
         let (mut stream, _) = listener.accept().await.unwrap();
         let request = read_http_request_headers(&mut stream).await;
         assert!(request.starts_with("GET /api/attachments/55/executor-download "));
-        assert!(request.contains("Authorization: Bearer task-token"));
+        assert!(request_has_header(
+            &request,
+            "authorization",
+            "Bearer task-token"
+        ));
         let body = b"hello attachment";
         let response = format!(
             "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -790,6 +794,15 @@ async fn read_http_request_headers(stream: &mut tokio::net::TcpStream) -> String
         }
     }
     String::from_utf8_lossy(&request).into_owned()
+}
+
+fn request_has_header(request: &str, expected_name: &str, expected_value: &str) -> bool {
+    request.lines().any(|line| {
+        let Some((name, value)) = line.split_once(':') else {
+            return false;
+        };
+        name.eq_ignore_ascii_case(expected_name) && value.trim() == expected_value
+    })
 }
 
 fn make_executable(path: &Path) {


### PR DESCRIPTION
## Summary\n- make the executor attachment download contract assert the Authorization header case-insensitively\n- align the mock HTTP test with HTTP header semantics and Linux CI behavior\n\n## Validation\n- cargo fmt -- --check\n- cargo test --test agent_runtime_capabilities_contract claude_runtime_downloads_attachments_and_rewrites_prompt_before_process_start -- --nocapture\n- cargo test --all-features\n- cargo clippy --all-targets --all-features -- -D warnings\n- AI_VERIFIED=1 git push -u origin codex/fix-executor-header-case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved attachment download test coverage to better verify authorization handling.
  * Validation now checks header values more reliably, helping catch regressions in authenticated download flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->