### PR TITLE
fix(wework): preserve runtime pane messages

### DIFF
--- a/docs/en/developer-guide/runtime-local-work.md
+++ b/docs/en/developer-guide/runtime-local-work.md
@@ -31,6 +31,8 @@ $WEGENT_EXECUTOR_HOME/runtime-work/index.json
 
 Codex tasks are discovered and controlled through the `codex app-server --stdio` JSON-RPC protocol. The executor stores the Wegent `localTaskId`, workspace, title, status, and real Codex `threadId` mapping in its local index so app-mode task creation can recover after a restart. The full transcript remains authoritative in the Codex app-server `thread/read` metadata plus the local rollout JSONL and is not synced to the central database.
 
+`localTaskId` is the Wegent-side local task identity, not the provider runtime's session id. When the frontend, Backend, and executor need to pass provider session identity, they must use the opaque `runtimeHandle`, such as a Codex `threadId`, Claude Code `sessionId`, or OpenCode `sessionId`, or an explicit `providerSessionId`. `runtime.tasks.transcript` must not treat `localTaskId` as a provider session id when there is no LocalTask index mapping and no `runtimeHandle`; optimistic tasks that are still being created should return an empty local transcript until create/link completes.
+
 ## List Refresh
 
 Wework requests the task list on startup, explicit refresh, or device-state changes. It no longer refreshes the list through a fixed polling interval.

--- a/docs/zh/developer-guide/runtime-local-work.md
+++ b/docs/zh/developer-guide/runtime-local-work.md
@@ -31,6 +31,8 @@ $WEGENT_EXECUTOR_HOME/runtime-work/index.json
 
 Codex 任务通过 `codex app-server --stdio` 的 JSON-RPC 协议发现和控制。executor 会在本地索引中保存 Wegent 侧 `localTaskId`、工作区、标题、状态以及真实 Codex `threadId` 的关联，便于 app 模式创建任务后重启仍能恢复映射；完整 transcript 仍以 Codex app-server `thread/read` 返回的会话 metadata 和本机 rollout JSONL 为准，不同步到中心数据库。
 
+`localTaskId` 是 Wegent 侧本地任务身份，不等同于底层 runtime 的 provider 会话 id。前端、Backend 和 executor 需要传递 provider 会话定位信息时必须使用 opaque `runtimeHandle`，例如 Codex `threadId`、Claude Code `sessionId` 或 OpenCode `sessionId`，也可以使用明确的 `providerSessionId`。`runtime.tasks.transcript` 不能在缺少 LocalTask 索引映射或 `runtimeHandle` 时把 `localTaskId` 当成 provider 会话 id 读取；这种仍在创建中的 optimistic 任务应先返回空本地 transcript，等待 create/link 完成后再读取真实运行时会话。
+
 ## 列表刷新
 
 任务列表由 Wework 在启动、显式刷新或设备状态变化时请求，不再由固定 interval 轮询触发。

--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -250,18 +250,19 @@ impl RuntimeWorkRpcHandler {
             .or_else(|| bool_field(&payload, "forceRefresh"))
             .unwrap_or(false);
         let local_link = self.local_task_link(&local_task_id);
-        let thread_id = self.thread_id_for_local_task(&local_task_id);
-        let running_hint = local_link.as_ref().is_some_and(|link| link.running);
-        if local_link
+        let session_id = local_link
             .as_ref()
-            .is_some_and(|link| link.runtime != "codex" || link.thread_id.is_none())
-        {
-            let link = local_link.expect("local link was checked");
-            let messages = cached_messages(&link);
+            .and_then(runtime_session_id_from_link)
+            .or_else(|| runtime_session_id_from_payload(&payload));
+        let running_hint = local_link.as_ref().is_some_and(|link| link.running);
+        if let Some(link) = local_link.as_ref().filter(|link| {
+            !runtime_has_provider_transcript_reader(&link.runtime) || session_id.is_none()
+        }) {
+            let messages = cached_messages(link);
             log_runtime_transcript_finished(RuntimeTranscriptLog {
                 started_at,
                 local_task_id: &local_task_id,
-                thread_id: &thread_id,
+                thread_id: session_id.as_deref().unwrap_or(""),
                 source: "runtime_handle",
                 refresh,
                 running_hint,
@@ -272,13 +273,40 @@ impl RuntimeWorkRpcHandler {
                 running: link.running,
             });
             return Ok(cached_transcript_response(
-                &link,
+                link,
                 messages,
                 limit,
                 before_cursor.as_deref(),
                 after_cursor.as_deref(),
             ));
         }
+
+        let Some(thread_id) = session_id else {
+            let workspace_path = workspace_path(&payload).unwrap_or_default();
+            let runtime = string_field(&payload, "runtime").unwrap_or_else(|| "runtime".to_owned());
+            log_runtime_transcript_finished(RuntimeTranscriptLog {
+                started_at,
+                local_task_id: &local_task_id,
+                thread_id: "",
+                source: "pending_local_task",
+                refresh,
+                running_hint,
+                limit,
+                before_cursor: before_cursor.as_deref(),
+                after_cursor: after_cursor.as_deref(),
+                message_count: 0,
+                running: false,
+            });
+            return Ok(transcript_response(
+                &local_task_id,
+                workspace_path,
+                runtime,
+                Vec::new(),
+                limit,
+                before_cursor.as_deref(),
+                after_cursor.as_deref(),
+            ));
+        };
 
         if let Some(cached) = self.transcript_cache.get(&thread_id, running_hint, refresh) {
             let messages = local_link
@@ -1300,12 +1328,6 @@ impl RuntimeWorkRpcHandler {
         self.store.find_by_thread_id(thread_id)
     }
 
-    fn thread_id_for_local_task(&self, local_task_id: &str) -> String {
-        self.local_task_link(local_task_id)
-            .and_then(|link| link.thread_id)
-            .unwrap_or_else(|| local_task_id.to_owned())
-    }
-
     fn upsert_local_task(&self, link: RuntimeTaskLink) {
         self.store.upsert_task(link);
         self.thread_list_cache.invalidate();
@@ -1800,6 +1822,34 @@ fn runtime_handle_json(link: &RuntimeTaskLink) -> Value {
     Value::Object(object)
 }
 
+fn runtime_session_id_from_link(link: &RuntimeTaskLink) -> Option<String> {
+    link.thread_id
+        .clone()
+        .or_else(|| runtime_session_id_from_handle(&link.runtime_handle))
+}
+
+fn runtime_session_id_from_payload(payload: &Value) -> Option<String> {
+    payload
+        .get("runtimeHandle")
+        .or_else(|| payload.get("runtime_handle"))
+        .and_then(runtime_session_id_from_handle)
+        .or_else(|| string_field(payload, "providerSessionId"))
+        .or_else(|| string_field(payload, "provider_session_id"))
+}
+
+fn runtime_session_id_from_handle(handle: &Value) -> Option<String> {
+    string_field(handle, "sessionId")
+        .or_else(|| string_field(handle, "session_id"))
+        .or_else(|| string_field(handle, "threadId"))
+        .or_else(|| string_field(handle, "thread_id"))
+        .or_else(|| string_field(handle, "conversationId"))
+        .or_else(|| string_field(handle, "conversation_id"))
+}
+
+fn runtime_has_provider_transcript_reader(runtime: &str) -> bool {
+    runtime.trim().eq_ignore_ascii_case("codex")
+}
+
 fn source_parent_json(source: &super::fork_transfer::SourceTaskIdentity) -> Value {
     let mut parent = Map::new();
     if let Some(device_id) = &source.device_id {
@@ -2063,6 +2113,59 @@ mod tests {
             .expect("cached transcript should return");
 
         assert_eq!(result["localTaskId"], "local-task-1");
+        assert_eq!(result["messages"][0]["content"], "cached");
+    }
+
+    #[tokio::test]
+    async fn transcript_without_runtime_link_returns_empty_local_transcript() {
+        let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+
+        let result = handler
+            .handle_runtime_rpc(json!({
+                "method": "runtime.tasks.transcript",
+                "payload": {
+                    "localTaskId": "optimistic-local-task",
+                    "workspacePath": "/tmp/project"
+                }
+            }))
+            .await
+            .expect("missing runtime link should not read provider session");
+
+        assert_eq!(result["success"], true);
+        assert_eq!(result["localTaskId"], "optimistic-local-task");
+        assert_eq!(result["workspacePath"], "/tmp/project");
+        assert_eq!(result["messages"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn transcript_uses_explicit_runtime_handle_session_without_rewriting_local_task_id() {
+        let handler = RuntimeWorkRpcHandler::new("device-1", "/bin/false");
+        handler.transcript_cache.insert(
+            "provider-session-1",
+            CachedTranscript::new(
+                "/tmp/project".to_owned(),
+                "codex".to_owned(),
+                vec![json!({"id":"assistant-1","role":"assistant","content":"cached"})],
+                false,
+                None,
+            ),
+        );
+
+        let result = handler
+            .handle_runtime_rpc(json!({
+                "method": "runtime.tasks.transcript",
+                "payload": {
+                    "localTaskId": "local-visible-task",
+                    "workspacePath": "/tmp/project",
+                    "runtimeHandle": {
+                        "threadId": "provider-session-1"
+                    }
+                }
+            }))
+            .await
+            .expect("explicit runtime handle should read cached provider session");
+
+        assert_eq!(result["localTaskId"], "local-visible-task");
         assert_eq!(result["messages"][0]["content"], "cached");
     }
 

--- a/executor/tests/app_runtime_work_contract.rs
+++ b/executor/tests/app_runtime_work_contract.rs
@@ -171,6 +171,7 @@ async fn app_runtime_reads_codex_thread_transcript_through_app_server() {
             "payload": {
                 "localTaskId": "thread-1",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-1"},
                 "limit": 50
             }
         }))
@@ -236,6 +237,7 @@ async fn app_runtime_pages_codex_thread_transcript_from_cache() {
             "payload": {
                 "localTaskId": "thread-1",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-1"},
                 "limit": 1
             }
         }))
@@ -247,6 +249,7 @@ async fn app_runtime_pages_codex_thread_transcript_from_cache() {
             "payload": {
                 "localTaskId": "thread-1",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-1"},
                 "limit": 1,
                 "beforeCursor": "offset:1"
             }
@@ -299,6 +302,7 @@ async fn app_runtime_reads_transcript_from_cached_thread_list_rollout_path() {
             "payload": {
                 "localTaskId": "thread-fast",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-fast"},
                 "limit": 50
             }
         }))
@@ -331,6 +335,7 @@ async fn app_runtime_refresh_uses_rollout_signature_before_reloading_transcript(
             "payload": {
                 "localTaskId": "thread-signature",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-signature"},
                 "limit": 50,
                 "refresh": true
             }
@@ -343,6 +348,7 @@ async fn app_runtime_refresh_uses_rollout_signature_before_reloading_transcript(
             "payload": {
                 "localTaskId": "thread-signature",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-signature"},
                 "limit": 50,
                 "refresh": true
             }
@@ -361,6 +367,7 @@ async fn app_runtime_refresh_uses_rollout_signature_before_reloading_transcript(
             "payload": {
                 "localTaskId": "thread-signature",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-signature"},
                 "limit": 50,
                 "refresh": true
             }
@@ -394,6 +401,7 @@ async fn app_runtime_rebuilds_transcript_from_rollout_when_thread_read_has_no_tu
             "payload": {
                 "localTaskId": "thread-rollout",
                 "workspacePath": "/tmp/project",
+                "runtimeHandle": {"threadId": "thread-rollout"},
                 "limit": 50
             }
         }))

--- a/executor/tests/app_runtime_work_file_changes_contract.rs
+++ b/executor/tests/app_runtime_work_file_changes_contract.rs
@@ -61,7 +61,8 @@ async fn runtime_transcript_preserves_assistant_file_changes_from_codex_items() 
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -97,7 +98,8 @@ async fn runtime_transcript_normalizes_codex_file_change_items_without_backend_s
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -156,7 +158,8 @@ async fn runtime_transcript_normalizes_codex_rich_turn_items() {
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -214,7 +217,8 @@ async fn runtime_transcript_preserves_codex_web_search_actions() {
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -265,7 +269,8 @@ async fn runtime_transcript_keeps_interrupted_commentary_visible() {
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -306,7 +311,8 @@ async fn runtime_transcript_merges_multiple_codex_file_change_items_in_one_turn(
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await
@@ -365,7 +371,8 @@ async fn runtime_transcript_accumulates_codex_file_changes_and_uses_move_target_
             "method": "runtime.tasks.transcript",
             "payload": {
                 "workspacePath": "/tmp/project",
-                "localTaskId": "thread-1"
+                "localTaskId": "thread-1",
+                "runtimeHandle": {"threadId": "thread-1"}
             }
         }))
         .await

--- a/wework/src/api/local/localServices.ts
+++ b/wework/src/api/local/localServices.ts
@@ -62,6 +62,11 @@ const LOCAL_DEVICE_ID = 'local-device'
 function nowMs(): number {
   return typeof performance !== 'undefined' ? performance.now() : Date.now()
 }
+
+function isRuntimeDebugEnabled(): boolean {
+  return globalThis.localStorage?.getItem('wework:debug-runtime') === '1'
+}
+
 const CODEX_RUNTIME_MODEL_NAME = 'codex-gpt-5.5'
 const CODEX_RUNTIME_MODEL_ID = 'gpt-5.5'
 const OPENAI_RESPONSES_PROTOCOL = 'openai-responses'
@@ -203,6 +208,28 @@ function runtimeAddressDebug(value: Record<string, unknown>): Record<string, unk
     localTaskId: stringValue(value.localTaskId) ?? stringValue(address.localTaskId),
     workspacePath: stringValue(value.workspacePath) ?? stringValue(address.workspacePath),
   }
+}
+
+function runtimeHandleDebug(value: Record<string, unknown>): Record<string, unknown> {
+  const handle = recordValue(value.runtimeHandle ?? value.runtime_handle)
+  return {
+    present: Object.keys(handle).length > 0,
+    keys: Object.keys(handle).sort(),
+    hasSessionId: Boolean(
+      stringValue(handle.sessionId) ??
+      stringValue(handle.session_id) ??
+      stringValue(handle.threadId) ??
+      stringValue(handle.thread_id) ??
+      stringValue(handle.conversationId) ??
+      stringValue(handle.conversation_id)
+    ),
+  }
+}
+
+function runtimeTranscriptMessageCount(response: unknown): number | null {
+  const responseRecord = recordValue(response)
+  const messages = responseRecord.messages
+  return Array.isArray(messages) ? messages.length : null
 }
 
 function workspaceLabel(workspacePath: string, label: unknown): string {
@@ -868,8 +895,23 @@ function createRuntimeWorkApi(
   ): Promise<TResponse> => {
     const normalizedData = await normalizeRequest(data)
     const startedAt = nowMs()
+    const debugTranscript = method === 'runtime.tasks.transcript' && isRuntimeDebugEnabled()
     try {
-      return await request<TResponse>(method, normalizedData)
+      if (debugTranscript) {
+        console.debug('[Wework] Local runtime IPC transcript request', {
+          address: runtimeAddressDebug(normalizedData),
+          runtimeHandle: runtimeHandleDebug(normalizedData),
+        })
+      }
+      const response = await request<TResponse>(method, normalizedData)
+      if (debugTranscript) {
+        console.debug('[Wework] Local runtime IPC transcript response', {
+          address: runtimeAddressDebug(normalizedData),
+          elapsedMs: Math.round(nowMs() - startedAt),
+          messageCount: runtimeTranscriptMessageCount(response),
+        })
+      }
+      return response
     } catch (error) {
       if (method === 'runtime.tasks.transcript') {
         console.error('[Wework] Local runtime IPC transcript failed', {

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import type { RuntimeDeviceWorkspace } from '@/types/api'
-import { getRuntimeSidebarTaskItems } from './runtimeTaskSidebarHelpers'
+import { getRuntimeSidebarTaskItems, getRuntimeTaskAddress } from './runtimeTaskSidebarHelpers'
 
 describe('runtimeTaskSidebarHelpers', () => {
   test('keeps runtime task items in workspace order', () => {
@@ -32,5 +32,32 @@ describe('runtimeTaskSidebarHelpers', () => {
       'older-running',
       'newer-idle',
     ])
+  })
+
+  test('carries runtime handle into task addresses when present', () => {
+    const workspace: RuntimeDeviceWorkspace = {
+      deviceId: 'device-1',
+      workspacePath: '/workspace/repo',
+      available: true,
+      localTasks: [],
+    }
+    const address = getRuntimeTaskAddress(workspace, {
+      localTaskId: 'local-visible-task',
+      workspacePath: '/workspace/repo',
+      title: 'Existing task',
+      runtime: 'codex',
+      runtimeHandle: {
+        threadId: 'provider-session-1',
+      },
+    })
+
+    expect(address).toEqual({
+      deviceId: 'device-1',
+      workspacePath: '/workspace/repo',
+      localTaskId: 'local-visible-task',
+      runtimeHandle: {
+        threadId: 'provider-session-1',
+      },
+    })
   })
 })

--- a/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
+++ b/wework/src/components/layout/runtimeTaskSidebarHelpers.ts
@@ -90,6 +90,7 @@ export function getRuntimeTaskAddress(
     deviceId: workspace.deviceId,
     workspacePath: getRuntimeTaskWorkspacePath(workspace, task),
     localTaskId: task.localTaskId,
+    ...(task.runtimeHandle ? { runtimeHandle: task.runtimeHandle } : {}),
   }
 }
 

--- a/wework/src/components/layout/useWorkbenchPaneSession.ts
+++ b/wework/src/components/layout/useWorkbenchPaneSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useWorkbenchPaneContext } from '@/features/workbench/useWorkbench'
 import {
   findActiveAssistantMessage,
@@ -42,6 +42,7 @@ interface LoadedTranscriptRange {
 }
 
 const runtimePaneMessageSeeds = new Map<string, WorkbenchMessage[]>()
+const runtimePaneMessageSnapshots = new Map<string, WorkbenchMessage[]>()
 const RUNTIME_TRANSCRIPT_PAGE_SIZE = 50
 
 export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSessionOptions) {
@@ -54,10 +55,6 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     sendCurrentInput,
     refreshWorkLists,
   } = useWorkbenchPaneContext()
-  const [messages, dispatchMessages] = useReducer(
-    reduceWorkbenchMessages<Attachment, TurnFileChangesSummary>,
-    [] as WorkbenchMessage[]
-  )
   const [queuedMessages, setQueuedMessages] = useState<RuntimePaneQueuedMessage[]>([])
   const [guidanceMessages] = useState<GuidanceWorkbenchMessage[]>([])
   const [codeCommentContexts, setCodeCommentContexts] = useState<CodeCommentContext[]>([])
@@ -83,6 +80,29 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       address: currentRuntimeTask,
     }
   }, [currentRuntimeTask])
+  const [messages, setMessages] = useState<WorkbenchMessage[]>([])
+  const dispatchMessages = useCallback(
+    (action: RuntimePaneMessageAction) => {
+      setMessages(currentMessages => {
+        const nextMessages = reduceWorkbenchMessages<Attachment, TurnFileChangesSummary>(
+          currentMessages,
+          action
+        )
+        if (currentRuntimeTask) {
+          snapshotRuntimePaneMessages(currentRuntimeTask, nextMessages)
+          debugRuntimePaneMessageFlow('message-action', {
+            address: runtimeAddressDebug(currentRuntimeTask),
+            actionType: action.type,
+            previousCount: currentMessages.length,
+            nextCount: nextMessages.length,
+            nextMessages: summarizeWorkbenchMessages(nextMessages),
+          })
+        }
+        return nextMessages
+      })
+    },
+    [currentRuntimeTask]
+  )
   const activeAssistantMessage = useMemo(() => findActiveAssistantMessage(messages), [messages])
   const hasActiveAssistant = Boolean(activeAssistantMessage)
   const busy = sending || waitingForAssistant || hasActiveAssistant
@@ -111,6 +131,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
   useEffect(() => {
     if (!runtimeTaskLoadTarget) {
       loadedRuntimeTranscriptKeyRef.current = null
+      // This clears pane-local transcript state when there is no runtime target.
       setTranscriptLoading(false)
       setTranscriptHasMoreBefore(false)
       setTranscriptBeforeCursor(null)
@@ -126,7 +147,13 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     }
 
     let cancelled = false
-    const seededMessages = consumeRuntimePaneMessageSeed(address)
+    const seededMessages = getRuntimePaneMessageSeed(address)
+    debugRuntimePaneMessageFlow('transcript-load-start', {
+      address: runtimeAddressDebug(address),
+      key: loadKey,
+      seededCount: seededMessages.length,
+      seededMessages: summarizeWorkbenchMessages(seededMessages),
+    })
     dispatchMessages({ type: 'reset', messages: seededMessages })
     setTranscriptLoading(true)
     setTranscriptHasMoreBefore(false)
@@ -138,15 +165,25 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       .current(address, { limit: RUNTIME_TRANSCRIPT_PAGE_SIZE })
       .then(transcript => {
         if (!cancelled) {
+          const nextMessages = transcript.messages.length > 0 ? transcript.messages : seededMessages
           loadedRuntimeTranscriptKeyRef.current = loadKey
           setTranscriptHasMoreBefore(Boolean(transcript.hasMoreBefore))
           setTranscriptBeforeCursor(transcript.beforeCursor ?? null)
           setLoadedTranscriptRanges(transcriptRangeFromPage(transcript))
           setTurnNavigation(transcript.turnNavigation ?? [])
+          debugRuntimePaneMessageFlow('transcript-load-resolved', {
+            address: runtimeAddressDebug(address),
+            key: loadKey,
+            transcriptCount: transcript.messages.length,
+            seededCount: seededMessages.length,
+            resetSource: transcript.messages.length > 0 ? 'transcript' : 'seed',
+            nextMessages: summarizeWorkbenchMessages(nextMessages),
+          })
           dispatchMessages({
             type: 'reset',
-            messages: transcript.messages.length > 0 ? transcript.messages : seededMessages,
+            messages: nextMessages,
           })
+          clearRuntimePaneMessageSeed(address)
         }
       })
       .catch(error => {
@@ -172,7 +209,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     return () => {
       cancelled = true
     }
-  }, [runtimeTaskLoadTarget])
+  }, [dispatchMessages, runtimeTaskLoadTarget])
   /* eslint-enable react-hooks/set-state-in-effect */
 
   /* eslint-disable react-hooks/set-state-in-effect -- Queued runtime messages are advanced when the active runtime response becomes idle. */
@@ -191,7 +228,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       },
     })
     return unsubscribe
-  }, [runtimeTaskLoadTarget])
+  }, [dispatchMessages, runtimeTaskLoadTarget])
 
   const loadMoreTranscriptBefore = useCallback(async () => {
     if (!runtimeTaskLoadTarget || !transcriptBeforeCursor || transcriptLoadingMoreBefore) return
@@ -228,7 +265,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     } finally {
       setTranscriptLoadingMoreBefore(false)
     }
-  }, [runtimeTaskLoadTarget, transcriptBeforeCursor, transcriptLoadingMoreBefore])
+  }, [dispatchMessages, runtimeTaskLoadTarget, transcriptBeforeCursor, transcriptLoadingMoreBefore])
 
   const loadTranscriptTurnNavigationItem = useCallback(
     async (item: RuntimeTurnNavigationItem) => {
@@ -265,7 +302,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       )
       dispatchMessages({ type: 'reset', messages: nextMessages })
     },
-    [runtimeTaskLoadTarget, transcriptBeforeCursor, transcriptHasMoreBefore]
+    [dispatchMessages, runtimeTaskLoadTarget, transcriptBeforeCursor, transcriptHasMoreBefore]
   )
 
   const loadTranscriptGap = useCallback(
@@ -292,7 +329,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       )
       dispatchMessages({ type: 'reset', messages: nextMessages })
     },
-    [runtimeTaskLoadTarget]
+    [dispatchMessages, runtimeTaskLoadTarget]
   )
 
   const getRuntimeModelFields = useCallback(() => {
@@ -300,12 +337,15 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     return selectedModelExecutionFields(selectedModel, projectChat.selectedModelOptions)
   }, [projectChat.models, projectChat.selectedModel, projectChat.selectedModelOptions])
 
-  const appendLocalUserMessage = useCallback((content: string, attachments?: Attachment[]) => {
-    dispatchMessages({
-      type: 'user_added',
-      message: createLocalUserMessage(content, attachments),
-    })
-  }, [])
+  const appendLocalUserMessage = useCallback(
+    (content: string, attachments?: Attachment[]) => {
+      dispatchMessages({
+        type: 'user_added',
+        message: createLocalUserMessage(content, attachments),
+      })
+    },
+    [dispatchMessages]
+  )
 
   const sendRuntimeMessage = useCallback(
     async (message: RuntimePaneQueuedMessage): Promise<boolean> => {
@@ -341,6 +381,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
     const queuedMessage = queuedMessages.find(message => message.status === 'queued')
     if (!queuedMessage) return
 
+    // This advances the next queued message once the pane becomes idle.
     setQueuedMessages(messages =>
       messages.map(message =>
         message.id === queuedMessage.id ? { ...message, status: 'sending' } : message
@@ -378,8 +419,22 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
         const optimisticMessage = createLocalUserMessage(submittedInput, currentAttachments)
         const sent = await sendCurrentInput(submittedInput, {
           codeCommentContexts,
-          onRuntimeTaskOptimisticOpen: address => {
-            seedRuntimePaneMessage(address, optimisticMessage)
+          onRuntimeTaskOptimisticOpen: (address, context) => {
+            const previousMessages = context?.previousAddress
+              ? getRuntimePaneMessageSnapshot(context.previousAddress)
+              : []
+            const seededMessages =
+              previousMessages.length > 0 ? previousMessages : [optimisticMessage]
+            debugRuntimePaneMessageFlow('seed-optimistic-open', {
+              address: runtimeAddressDebug(address),
+              previousAddress: context?.previousAddress
+                ? runtimeAddressDebug(context.previousAddress)
+                : null,
+              previousCount: previousMessages.length,
+              seededCount: seededMessages.length,
+              seededMessages: summarizeWorkbenchMessages(seededMessages),
+            })
+            seedRuntimePaneMessages(address, seededMessages)
           },
         })
         if (sent) {
@@ -525,6 +580,7 @@ export function useWorkbenchPaneSession({ currentRuntimeTask }: WorkbenchPaneSes
       activeAssistantMessage,
       cancelRuntimePaneTask,
       currentRuntimeTask,
+      dispatchMessages,
       queuedMessages,
       sendRuntimeMessage,
     ]
@@ -564,6 +620,38 @@ function runtimeTranscriptPaneKey(address: RuntimeTaskAddress): string {
   return `${address.deviceId}:${address.localTaskId}:${address.workspacePath ?? ''}`
 }
 
+function runtimeAddressDebug(address: RuntimeTaskAddress): Record<string, unknown> {
+  return {
+    deviceId: address.deviceId,
+    localTaskId: address.localTaskId,
+    workspacePath: address.workspacePath ?? null,
+    hasRuntimeHandle: Boolean(address.runtimeHandle),
+    runtimeHandleKeys: address.runtimeHandle ? Object.keys(address.runtimeHandle).sort() : [],
+  }
+}
+
+function summarizeWorkbenchMessages(messages: WorkbenchMessage[]): Record<string, unknown>[] {
+  return messages.map(message => ({
+    id: message.id,
+    role: message.role,
+    status: message.status,
+    contentLength: message.content.length,
+    turnId: message.turnId ?? null,
+  }))
+}
+
+function debugRuntimePaneMessageFlow(event: string, details: Record<string, unknown>) {
+  if (!isRuntimeDebugEnabled()) return
+  console.debug('[Wework] Runtime pane message flow', {
+    event,
+    ...details,
+  })
+}
+
+function isRuntimeDebugEnabled(): boolean {
+  return globalThis.localStorage?.getItem('wework:debug-runtime') === '1'
+}
+
 function createLocalUserMessage(content: string, attachments?: Attachment[]): WorkbenchMessage {
   return {
     id: `runtime-local-pane-${Date.now()}`,
@@ -575,16 +663,32 @@ function createLocalUserMessage(content: string, attachments?: Attachment[]): Wo
   }
 }
 
-function seedRuntimePaneMessage(address: RuntimeTaskAddress, message: WorkbenchMessage) {
+function seedRuntimePaneMessages(address: RuntimeTaskAddress, messages: WorkbenchMessage[]) {
   const key = runtimeTranscriptPaneKey(address)
-  runtimePaneMessageSeeds.set(key, [...(runtimePaneMessageSeeds.get(key) ?? []), message])
+  runtimePaneMessageSeeds.set(key, [...messages])
 }
 
-function consumeRuntimePaneMessageSeed(address: RuntimeTaskAddress): WorkbenchMessage[] {
+function snapshotRuntimePaneMessages(address: RuntimeTaskAddress, messages: WorkbenchMessage[]) {
   const key = runtimeTranscriptPaneKey(address)
-  const seededMessages = runtimePaneMessageSeeds.get(key) ?? []
-  runtimePaneMessageSeeds.delete(key)
-  return seededMessages
+  if (messages.length === 0) {
+    runtimePaneMessageSnapshots.delete(key)
+    return
+  }
+  runtimePaneMessageSnapshots.set(key, [...messages])
+}
+
+function getRuntimePaneMessageSnapshot(address: RuntimeTaskAddress): WorkbenchMessage[] {
+  const key = runtimeTranscriptPaneKey(address)
+  return [...(runtimePaneMessageSnapshots.get(key) ?? [])]
+}
+
+function getRuntimePaneMessageSeed(address: RuntimeTaskAddress): WorkbenchMessage[] {
+  const key = runtimeTranscriptPaneKey(address)
+  return [...(runtimePaneMessageSeeds.get(key) ?? [])]
+}
+
+function clearRuntimePaneMessageSeed(address: RuntimeTaskAddress) {
+  runtimePaneMessageSeeds.delete(runtimeTranscriptPaneKey(address))
 }
 
 function mergeRuntimeTranscriptMessages(

--- a/wework/src/features/workbench/WorkbenchProvider.test.tsx
+++ b/wework/src/features/workbench/WorkbenchProvider.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { createContext, StrictMode, useContext, useEffect, useMemo, useState } from 'react'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import { LOCAL_USER } from '@/api/local/localSession'
 import { WorkbenchProvider, type WorkbenchServices } from './WorkbenchProvider'
@@ -10,6 +10,11 @@ import { useWorkbenchPaneSession } from '@/components/layout/useWorkbenchPaneSes
 import { parseRuntimeTaskRoute } from '@/lib/navigation'
 import { findRuntimeLocalTask } from './workbenchRuntimeHelpers'
 import type { ChatStreamHandlers } from '@/stream/chatStream'
+import {
+  CachedWorkbenchPaneStack,
+  WorkbenchPaneActiveOnly,
+  type WorkbenchPaneIdentity,
+} from '@/components/layout/workbenchPaneStack'
 import type {
   Attachment,
   DeviceInfo,
@@ -294,6 +299,16 @@ function renderWorkbench(children: React.ReactNode, services = createWorkbenchSe
   )
 }
 
+function renderStrictWorkbench(children: React.ReactNode, services = createWorkbenchServices()) {
+  return render(
+    <StrictMode>
+      <WorkbenchProvider user={{ id: 1, user_name: 'alice', email: 'a@b.c' }} services={services}>
+        {children}
+      </WorkbenchProvider>
+    </StrictMode>
+  )
+}
+
 function renderWorkbenchWithDefaultServices(children: React.ReactNode) {
   return render(
     <WorkbenchProvider user={LOCAL_USER}>
@@ -461,6 +476,84 @@ function ProjectSendProbe() {
         isWaitingForAssistant={paneSession.sending || paneSession.waitingForAssistant}
       />
     </div>
+  )
+}
+
+function RuntimePaneSendProbe() {
+  const workbench = useWorkbench()
+  const runtimeTasks = [
+    ...(workbench.state.runtimeWork?.projects.flatMap(project =>
+      project.deviceWorkspaces.flatMap(workspace => workspace.localTasks)
+    ) ?? []),
+    ...(workbench.state.runtimeWork?.chats.flatMap(workspace => workspace.localTasks) ?? []),
+  ]
+
+  return (
+    <div>
+      <span data-testid="current-runtime-task-address">
+        {workbench.state.currentRuntimeTask
+          ? [
+              workbench.state.currentRuntimeTask.deviceId,
+              workbench.state.currentRuntimeTask.localTaskId,
+              workbench.state.currentRuntimeTask.workspacePath ?? '',
+            ].join(':')
+          : 'none'}
+      </span>
+      <span data-testid="runtime-local-task-count">{runtimeTasks.length}</span>
+      <span data-testid="runtime-project-count">
+        {workbench.state.runtimeWork?.projects.length ?? 0}
+      </span>
+      <span data-testid="runtime-local-task-titles">
+        {runtimeTasks.map(task => task.title).join('|')}
+      </span>
+      <CachedWorkbenchPaneStack
+        activePane={{
+          currentRuntimeTask: workbench.state.currentRuntimeTask,
+          currentProject: workbench.state.currentProject,
+        }}
+        maxPanes={10}
+        renderPane={pane => <RuntimePaneStackItem pane={pane} />}
+      />
+    </div>
+  )
+}
+
+function RuntimePaneStackItem({ pane }: { pane: WorkbenchPaneIdentity }) {
+  const workbench = useWorkbench()
+  const paneSession = useWorkbenchPaneSession({
+    currentRuntimeTask: pane.currentRuntimeTask,
+  })
+
+  return (
+    <WorkbenchPaneActiveOnly>
+      <span data-testid="active-pane-key">
+        {pane.currentRuntimeTask
+          ? [
+              pane.currentRuntimeTask.deviceId,
+              pane.currentRuntimeTask.localTaskId,
+              pane.currentRuntimeTask.workspacePath ?? '',
+            ].join(':')
+          : pane.currentProject
+            ? `project:${pane.currentProject.id}`
+            : 'standalone'}
+      </span>
+      <span data-testid="pane-message-roles">
+        {paneSession.messages.map(message => `${message.role}:${message.content}`).join('|')}
+      </span>
+      <button type="button" onClick={() => workbench.selectProjectWorkspace(7, 22)}>
+        select mapped project workspace
+      </button>
+      <button type="button" onClick={() => paneSession.setInput('修复 CI')}>
+        set pane input
+      </button>
+      <button type="button" onClick={() => void paneSession.send()}>
+        send pane input
+      </button>
+      <MessageList
+        messages={paneSession.messages}
+        isWaitingForAssistant={paneSession.waitingForAssistant}
+      />
+    </WorkbenchPaneActiveOnly>
   )
 }
 
@@ -1104,6 +1197,242 @@ describe('WorkbenchProvider runtime tasks', () => {
       deviceId: 'device-1',
       localTaskId: request.localTaskId,
     })
+  })
+
+  test('keeps the sent user message and new task visible when the resolved address adds a workspace path', async () => {
+    const initialRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              localTasks: [],
+            },
+          ],
+          totalLocalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 0,
+    })
+    const staleRuntimeWork = createRuntimeWork({
+      projects: [],
+      chats: [],
+      totalLocalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi
+        .fn()
+        .mockResolvedValueOnce(initialRuntimeWork)
+        .mockResolvedValue(staleRuntimeWork),
+      createRuntimeTask: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-1',
+        localTaskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      }),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        localTaskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderWorkbench(<RuntimePaneSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
+    await userEvent.click(await screen.findByText('select mapped project workspace'))
+    await userEvent.click(screen.getByText('set pane input'))
+    await userEvent.click(screen.getByText('send pane input'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-created:/workspace/project-alpha'
+      )
+    )
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(screen.getByTestId('runtime-local-task-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('runtime-local-task-titles')).toHaveTextContent('修复 CI')
+  })
+
+  test('keeps the sent user message when transcript loading effects replay', async () => {
+    const initialRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              localTasks: [],
+            },
+          ],
+          totalLocalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(initialRuntimeWork),
+      createRuntimeTask: vi.fn().mockResolvedValue({
+        accepted: true,
+        deviceId: 'device-1',
+        localTaskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      }),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        localTaskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+    })
+
+    renderStrictWorkbench(<RuntimePaneSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
+    await userEvent.click(await screen.findByText('select mapped project workspace'))
+    await userEvent.click(screen.getByText('set pane input'))
+    await userEvent.click(screen.getByText('send pane input'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        'device-1:runtime-created:/workspace/project-alpha'
+      )
+    )
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+  })
+
+  test('keeps streamed assistant content when the resolved address adds a workspace path', async () => {
+    const streamHandlers: ChatStreamHandlers[] = []
+    const subscribe = vi.fn((handlers: ChatStreamHandlers) => {
+      streamHandlers.push(handlers)
+      return vi.fn(() => {
+        const index = streamHandlers.indexOf(handlers)
+        if (index >= 0) streamHandlers.splice(index, 1)
+      })
+    })
+    const createRuntimeTask =
+      deferred<
+        Awaited<ReturnType<NonNullable<WorkbenchServices['runtimeWorkApi']>['createRuntimeTask']>>
+      >()
+    const initialRuntimeWork = createRuntimeWork({
+      projects: [
+        {
+          project: { id: 7, name: 'Wegent' },
+          deviceWorkspaces: [
+            {
+              id: 22,
+              projectId: 7,
+              deviceId: 'device-1',
+              deviceName: 'Project Device',
+              deviceStatus: 'online',
+              workspacePath: '/workspace/project-alpha',
+              mapped: true,
+              available: true,
+              localTasks: [],
+            },
+          ],
+          totalLocalTasks: 0,
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 0,
+    })
+    const runtimeWorkApi = createRuntimeWorkApiMock({
+      listRuntimeWork: vi.fn().mockResolvedValue(initialRuntimeWork),
+      createRuntimeTask: vi.fn().mockReturnValue(createRuntimeTask.promise),
+      getRuntimeTranscript: vi.fn().mockResolvedValue({
+        localTaskId: 'runtime-created',
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+        messages: [],
+      }),
+    })
+    const services = createWorkbenchServices({
+      runtimeWorkApi: runtimeWorkApi as WorkbenchServices['runtimeWorkApi'],
+      chatStream: {
+        subscribe,
+      } as unknown as WorkbenchServices['chatStream'],
+    })
+
+    renderWorkbench(<RuntimePaneSendProbe />, services)
+
+    await waitFor(() => expect(screen.getByTestId('runtime-project-count')).toHaveTextContent('1'))
+    await userEvent.click(await screen.findByText('select mapped project workspace'))
+    await userEvent.click(screen.getByText('set pane input'))
+    await userEvent.click(screen.getByText('send pane input'))
+
+    await waitFor(() => expect(runtimeWorkApi.createRuntimeTask).toHaveBeenCalledTimes(1))
+    const request = runtimeWorkApi.createRuntimeTask.mock.calls[0][0]
+    await waitFor(() => expect(streamHandlers.some(handler => handler.onChatChunk)).toBe(true))
+    await act(async () => {
+      const startPayload = {
+        subtask_id: 102,
+        device_id: 'device-1',
+        local_task_id: request.localTaskId,
+      }
+      const chunkPayload = {
+        subtask_id: 102,
+        content: 'streamed answer',
+        offset: 0,
+        device_id: 'device-1',
+        local_task_id: request.localTaskId,
+      }
+      streamHandlers.forEach(handler => {
+        handler.onChatStart?.(startPayload)
+        handler.onChatChunk?.(chunkPayload)
+      })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('pane-message-roles')).toHaveTextContent(
+        'assistant:streamed answer'
+      )
+    )
+
+    await act(async () => {
+      createRuntimeTask.resolve({
+        accepted: true,
+        deviceId: 'device-1',
+        localTaskId: request.localTaskId,
+        workspacePath: '/workspace/project-alpha',
+        runtime: 'claude_code',
+      })
+      await createRuntimeTask.promise
+    })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('current-runtime-task-address')).toHaveTextContent(
+        `device-1:${request.localTaskId}:/workspace/project-alpha`
+      )
+    )
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('user:修复 CI')
+    expect(screen.getByTestId('pane-message-roles')).toHaveTextContent('assistant:streamed answer')
   })
 
   afterEach(() => {

--- a/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
+++ b/wework/src/features/workbench/useWorkbenchRuntimeMessaging.ts
@@ -21,7 +21,9 @@ import {
 import type {
   Attachment,
   ChatSendPayload,
+  LocalTaskSummary,
   ModelOptions,
+  RuntimeDeviceWorkspace,
   RuntimeSendRequest,
   RuntimeTaskAddress,
   RuntimeTaskCreateRequest,
@@ -324,11 +326,32 @@ export function useWorkbenchRuntimeMessaging({
           'workspacePath' in runtimeTaskTarget ? runtimeTaskTarget.workspacePath : undefined,
         localTaskId,
       }
+      const optimisticWorkspacePath =
+        ('workspacePath' in runtimeTaskTarget ? runtimeTaskTarget.workspacePath : undefined) ??
+        selectedProjectWorkspace?.workspacePath
+      const optimisticWorkspace =
+        optimisticWorkspacePath && optimisticDeviceId
+          ? buildOptimisticRuntimeWorkspace({
+              baseWorkspace: selectedProjectWorkspace,
+              devices: state.devices,
+              deviceId: optimisticDeviceId,
+              workspacePath: optimisticWorkspacePath,
+              projectId,
+            })
+          : null
       const runtimeProject = projectId
         ? (state.projects.find(project => project.id === projectId) ?? state.currentProject)
         : null
 
       if (optimisticAddress.deviceId) rememberExecutionDevice(optimisticAddress.deviceId)
+      debugRuntimeCreateFlow('create-optimistic-open', {
+        localTaskId,
+        runtime,
+        projectId,
+        optimisticAddress: runtimeAddressLog(optimisticAddress),
+        hasSelectedProjectWorkspace: Boolean(selectedProjectWorkspace),
+        optimisticWorkspacePath: optimisticWorkspacePath ?? null,
+      })
       options?.onRuntimeTaskOptimisticOpen?.(optimisticAddress)
       runtimeTasks.openRuntimeTaskView(optimisticAddress, runtimeProject, { navigate: true })
       attachmentSelection.resetAttachments()
@@ -343,14 +366,55 @@ export function useWorkbenchRuntimeMessaging({
           workspacePath: response.workspacePath || optimisticAddress.workspacePath,
           localTaskId: response.localTaskId || optimisticAddress.localTaskId,
         }
+        debugRuntimeCreateFlow('create-resolved', {
+          localTaskId,
+          runtime,
+          projectId,
+          accepted: response.accepted,
+          optimisticAddress: runtimeAddressLog(optimisticAddress),
+          resolvedAddress: runtimeAddressLog(address),
+          sameIdentity: isSameRuntimeTaskIdentity(optimisticAddress, address),
+          responseHasWorkspacePath: Boolean(response.workspacePath),
+          responseHasLocalTaskId: Boolean(response.localTaskId),
+        })
+        const resolvedWorkspacePath = address.workspacePath ?? optimisticWorkspacePath
+        if (resolvedWorkspacePath) {
+          dispatch({
+            type: 'runtime_task_optimistic_upserted',
+            project: runtimeProject,
+            workspace: buildOptimisticRuntimeWorkspace({
+              baseWorkspace: optimisticWorkspace,
+              devices: state.devices,
+              deviceId: address.deviceId,
+              workspacePath: resolvedWorkspacePath,
+              projectId,
+            }),
+            task: buildOptimisticRuntimeTask({
+              localTaskId: address.localTaskId,
+              workspacePath: resolvedWorkspacePath,
+              title: createRequest.title ?? buildRuntimeTaskTitle(displayMessage, payload.title),
+              runtime,
+            }),
+          })
+        }
         if (!isSameRuntimeTaskIdentity(optimisticAddress, address)) {
           if (address.deviceId) rememberExecutionDevice(address.deviceId)
+          debugRuntimeCreateFlow('create-final-open', {
+            localTaskId,
+            runtime,
+            previousAddress: runtimeAddressLog(optimisticAddress),
+            finalAddress: runtimeAddressLog(address),
+          })
+          options?.onRuntimeTaskOptimisticOpen?.(address, {
+            previousAddress: optimisticAddress,
+          })
           runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
         }
         await refreshWorkLists()
         runtimeTasks.openRuntimeTaskView(address, runtimeProject, { navigate: true })
         return address
       } catch (error) {
+        dispatch({ type: 'runtime_task_optimistic_removed', address: optimisticAddress })
         if (runtimeTasks.isCurrentRuntimeTask(optimisticAddress)) {
           runtimeTasks.clearCurrentRuntimeTaskView()
         }
@@ -371,6 +435,7 @@ export function useWorkbenchRuntimeMessaging({
       reportSendBlocked,
       runtimeTasks,
       state.currentProject,
+      state.devices,
       state.projects,
       state.runtimeWork,
       state.selectedDeviceWorkspaceId,
@@ -695,4 +760,78 @@ export function useWorkbenchRuntimeMessaging({
     loadTurnFileChangesDiff,
     revertTurnFileChanges,
   }
+}
+
+function buildOptimisticRuntimeWorkspace({
+  baseWorkspace,
+  devices,
+  deviceId,
+  workspacePath,
+  projectId,
+}: {
+  baseWorkspace?: RuntimeDeviceWorkspace | null
+  devices: WorkbenchState['devices']
+  deviceId: string
+  workspacePath: string
+  projectId: number | null
+}): RuntimeDeviceWorkspace {
+  const device = findWorkbenchDevice(devices, deviceId)
+  return {
+    ...baseWorkspace,
+    projectId: projectId ?? baseWorkspace?.projectId,
+    deviceId,
+    deviceName: device?.name ?? baseWorkspace?.deviceName ?? deviceId,
+    deviceStatus: device?.status ?? baseWorkspace?.deviceStatus ?? null,
+    workspacePath,
+    workspaceKind: baseWorkspace?.workspaceKind ?? (projectId ? 'workspace' : 'chat'),
+    mapped: baseWorkspace?.mapped ?? Boolean(projectId),
+    available: baseWorkspace?.available ?? (device ? device.status !== 'offline' : true),
+    localTasks: [],
+  }
+}
+
+function buildOptimisticRuntimeTask({
+  localTaskId,
+  workspacePath,
+  title,
+  runtime,
+}: {
+  localTaskId: string
+  workspacePath: string
+  title: string
+  runtime: LocalTaskSummary['runtime']
+}): LocalTaskSummary {
+  const now = new Date().toISOString()
+  return {
+    localTaskId,
+    workspacePath,
+    title,
+    runtime,
+    createdAt: now,
+    updatedAt: now,
+    running: true,
+    status: 'creating',
+  }
+}
+
+function runtimeAddressLog(address: RuntimeTaskAddress): Record<string, unknown> {
+  return {
+    deviceId: address.deviceId,
+    localTaskId: address.localTaskId,
+    workspacePath: address.workspacePath ?? null,
+    hasRuntimeHandle: Boolean(address.runtimeHandle),
+    runtimeHandleKeys: address.runtimeHandle ? Object.keys(address.runtimeHandle).sort() : [],
+  }
+}
+
+function debugRuntimeCreateFlow(event: string, details: Record<string, unknown>) {
+  if (!isRuntimeDebugEnabled()) return
+  console.debug('[Wework] Runtime create flow', {
+    event,
+    ...details,
+  })
+}
+
+function isRuntimeDebugEnabled(): boolean {
+  return globalThis.localStorage?.getItem('wework:debug-runtime') === '1'
 }

--- a/wework/src/features/workbench/workbenchContextTypes.ts
+++ b/wework/src/features/workbench/workbenchContextTypes.ts
@@ -49,7 +49,10 @@ export type ProjectMutationOptions = {
 
 export interface SendCurrentInputOptions {
   codeCommentContexts?: CodeCommentContext[]
-  onRuntimeTaskOptimisticOpen?: (address: RuntimeTaskAddress) => void
+  onRuntimeTaskOptimisticOpen?: (
+    address: RuntimeTaskAddress,
+    context?: { previousAddress?: RuntimeTaskAddress }
+  ) => void
 }
 
 export interface WorkbenchContextValue {

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -1,6 +1,7 @@
 import type {
   DeviceWorkspaceResponse,
   DeviceInfo,
+  LocalTaskSummary,
   ProjectWithTasks,
   RuntimeDeviceWorkspace,
   RuntimeTaskAddress,
@@ -89,6 +90,16 @@ export type WorkbenchAction =
       address: RuntimeTaskAddress
       project: ProjectWithTasks | null
     }
+  | {
+      type: 'runtime_task_optimistic_upserted'
+      project: ProjectWithTasks | null
+      workspace: RuntimeDeviceWorkspace
+      task: LocalTaskSummary
+    }
+  | {
+      type: 'runtime_task_optimistic_removed'
+      address: RuntimeTaskAddress
+    }
   | { type: 'current_task_cleared' }
   | { type: 'error_set'; error: string | null }
 
@@ -154,15 +165,28 @@ function mergeRuntimeWorkPreservingTaskOrder(
     }
   }
 
-  return {
-    ...next,
-    projects: next.projects.map(project => ({
+  const projects = preserveMissingOptimisticProjects(
+    current.projects,
+    next.projects.map(project => ({
       ...project,
       deviceWorkspaces: project.deviceWorkspaces.map(workspace =>
         mergeProjectWorkspace(project, workspace)
       ),
-    })),
-    chats: next.chats.map(mergeChatWorkspace),
+    }))
+  )
+  const chats = preserveMissingOptimisticWorkspaces(
+    current.chats,
+    next.chats.map(mergeChatWorkspace)
+  )
+  const merged = {
+    ...next,
+    projects,
+    chats,
+  }
+
+  return {
+    ...merged,
+    totalLocalTasks: countRuntimeWorkTasks(merged),
   }
 }
 
@@ -222,7 +246,7 @@ function mergeRuntimeLocalTasks(
 ) {
   const nextById = new Map(nextTasks.map(task => [task.localTaskId, task]))
   const merged = currentTasks
-    .map(task => nextById.get(task.localTaskId))
+    .map(task => nextById.get(task.localTaskId) ?? (isOptimisticRuntimeTask(task) ? task : null))
     .filter((task): task is RuntimeDeviceWorkspace['localTasks'][number] => Boolean(task))
   const mergedIds = new Set(merged.map(task => task.localTaskId))
   nextTasks.forEach(task => {
@@ -231,6 +255,221 @@ function mergeRuntimeLocalTasks(
     }
   })
   return merged
+}
+
+function isOptimisticRuntimeTask(task: LocalTaskSummary): boolean {
+  return task.status === 'creating'
+}
+
+function optimisticWorkspaceOnly(workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace | null {
+  const localTasks = workspace.localTasks.filter(isOptimisticRuntimeTask)
+  return localTasks.length > 0 ? { ...workspace, localTasks } : null
+}
+
+function preserveMissingOptimisticWorkspaces(
+  currentWorkspaces: RuntimeDeviceWorkspace[],
+  nextWorkspaces: RuntimeDeviceWorkspace[]
+): RuntimeDeviceWorkspace[] {
+  const mergedWorkspaces = [...nextWorkspaces]
+  currentWorkspaces.forEach(currentWorkspace => {
+    if (mergedWorkspaces.some(workspace => runtimeWorkspaceMatches(workspace, currentWorkspace))) {
+      return
+    }
+    const optimisticWorkspace = optimisticWorkspaceOnly(currentWorkspace)
+    if (optimisticWorkspace) {
+      mergedWorkspaces.push(optimisticWorkspace)
+    }
+  })
+  return mergedWorkspaces
+}
+
+function preserveMissingOptimisticProjects(
+  currentProjects: RuntimeProjectWork[],
+  nextProjects: RuntimeProjectWork[]
+): RuntimeProjectWork[] {
+  const mergedProjects = [...nextProjects]
+  currentProjects.forEach(currentProject => {
+    const projectId = runtimeProjectUiId(currentProject.project)
+    const existingIndex = mergedProjects.findIndex(
+      project => runtimeProjectUiId(project.project) === projectId
+    )
+    if (existingIndex < 0) {
+      const optimisticWorkspaces = currentProject.deviceWorkspaces
+        .map(optimisticWorkspaceOnly)
+        .filter((workspace): workspace is RuntimeDeviceWorkspace => Boolean(workspace))
+      if (optimisticWorkspaces.length > 0) {
+        mergedProjects.push({
+          ...currentProject,
+          deviceWorkspaces: optimisticWorkspaces,
+          totalLocalTasks: countRuntimeLocalTasks(optimisticWorkspaces),
+        })
+      }
+      return
+    }
+
+    const deviceWorkspaces = preserveMissingOptimisticWorkspaces(
+      currentProject.deviceWorkspaces,
+      mergedProjects[existingIndex].deviceWorkspaces
+    )
+    mergedProjects[existingIndex] = {
+      ...mergedProjects[existingIndex],
+      deviceWorkspaces,
+      totalLocalTasks: countRuntimeLocalTasks(deviceWorkspaces),
+    }
+  })
+
+  return mergedProjects.map(project => ({
+    ...project,
+    totalLocalTasks: countRuntimeLocalTasks(project.deviceWorkspaces),
+  }))
+}
+
+function upsertRuntimeLocalTask(
+  workspace: RuntimeDeviceWorkspace,
+  task: LocalTaskSummary
+): RuntimeDeviceWorkspace {
+  return {
+    ...workspace,
+    localTasks: [
+      task,
+      ...workspace.localTasks.filter(item => item.localTaskId !== task.localTaskId),
+    ],
+  }
+}
+
+function upsertRuntimeWorkspace(
+  workspaces: RuntimeDeviceWorkspace[],
+  workspace: RuntimeDeviceWorkspace
+): RuntimeDeviceWorkspace[] {
+  const task = workspace.localTasks[0]
+  if (!task) return workspaces
+  const nextWorkspace = upsertRuntimeLocalTask(workspace, task)
+  const existingIndex = workspaces.findIndex(item => runtimeWorkspaceMatches(item, workspace))
+  if (existingIndex < 0) return [nextWorkspace, ...workspaces]
+
+  return workspaces.map((item, index) => {
+    if (index !== existingIndex) return item
+    return upsertRuntimeLocalTask(
+      {
+        ...item,
+        ...workspace,
+        localTasks: item.localTasks,
+      },
+      task
+    )
+  })
+}
+
+function countRuntimeLocalTasks(workspaces: RuntimeDeviceWorkspace[]): number {
+  return workspaces.reduce((total, workspace) => total + workspace.localTasks.length, 0)
+}
+
+function countRuntimeWorkTasks(runtimeWork: RuntimeWorkListResponse): number {
+  return (
+    runtimeWork.projects.reduce(
+      (total, project) => total + countRuntimeLocalTasks(project.deviceWorkspaces),
+      0
+    ) + countRuntimeLocalTasks(runtimeWork.chats)
+  )
+}
+
+function upsertOptimisticRuntimeTask(
+  current: RuntimeWorkListResponse | null | undefined,
+  project: ProjectWithTasks | null,
+  workspace: RuntimeDeviceWorkspace,
+  task: LocalTaskSummary
+): RuntimeWorkListResponse {
+  const currentRuntimeWork = current ?? {
+    projects: [],
+    chats: [],
+    totalLocalTasks: 0,
+  }
+  const workspaceWithTask = {
+    ...workspace,
+    localTasks: [task],
+  }
+
+  if (!project) {
+    const nextRuntimeWork = {
+      ...currentRuntimeWork,
+      chats: upsertRuntimeWorkspace(currentRuntimeWork.chats, workspaceWithTask),
+    }
+    return {
+      ...nextRuntimeWork,
+      totalLocalTasks: countRuntimeWorkTasks(nextRuntimeWork),
+    }
+  }
+
+  const projectId = project.id
+  let matchedProject = false
+  const projects = currentRuntimeWork.projects.map(projectWork => {
+    if (runtimeProjectUiId(projectWork.project) !== projectId) return projectWork
+    matchedProject = true
+    const deviceWorkspaces = upsertRuntimeWorkspace(projectWork.deviceWorkspaces, workspaceWithTask)
+    return {
+      ...projectWork,
+      deviceWorkspaces,
+      totalLocalTasks: countRuntimeLocalTasks(deviceWorkspaces),
+    }
+  })
+
+  if (!matchedProject) {
+    projects.unshift({
+      project: {
+        key: `project:${project.id}`,
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        color: project.color,
+      },
+      deviceWorkspaces: [workspaceWithTask],
+      totalLocalTasks: 1,
+    })
+  }
+
+  const nextRuntimeWork = {
+    ...currentRuntimeWork,
+    projects,
+  }
+  return {
+    ...nextRuntimeWork,
+    totalLocalTasks: countRuntimeWorkTasks(nextRuntimeWork),
+  }
+}
+
+function removeOptimisticRuntimeTask(
+  current: RuntimeWorkListResponse | null | undefined,
+  address: RuntimeTaskAddress
+): RuntimeWorkListResponse | null {
+  if (!current) return null
+
+  const removeFromWorkspace = (workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace => ({
+    ...workspace,
+    localTasks: workspace.localTasks.filter(
+      task =>
+        task.localTaskId !== address.localTaskId ||
+        !isOptimisticRuntimeTask(task) ||
+        workspace.deviceId !== address.deviceId
+    ),
+  })
+  const projects = current.projects.map(project => {
+    const deviceWorkspaces = project.deviceWorkspaces.map(removeFromWorkspace)
+    return {
+      ...project,
+      deviceWorkspaces,
+      totalLocalTasks: countRuntimeLocalTasks(deviceWorkspaces),
+    }
+  })
+  const chats = current.chats.map(removeFromWorkspace)
+  const nextRuntimeWork = {
+    ...current,
+    projects,
+    chats,
+  }
+  return {
+    ...nextRuntimeWork,
+    totalLocalTasks: countRuntimeWorkTasks(nextRuntimeWork),
+  }
 }
 
 function findRuntimeTaskAddressByLocalTaskId(
@@ -582,6 +821,21 @@ export function workbenchReducer(state: WorkbenchState, action: WorkbenchAction)
         ...state,
         currentProject: action.project,
         currentRuntimeTask: action.address,
+      }
+    case 'runtime_task_optimistic_upserted':
+      return {
+        ...state,
+        runtimeWork: upsertOptimisticRuntimeTask(
+          state.runtimeWork,
+          action.project,
+          action.workspace,
+          action.task
+        ),
+      }
+    case 'runtime_task_optimistic_removed':
+      return {
+        ...state,
+        runtimeWork: removeOptimisticRuntimeTask(state.runtimeWork, action.address),
       }
     case 'current_task_cleared':
       return { ...state, currentRuntimeTask: null }

--- a/wework/src/types/api.ts
+++ b/wework/src/types/api.ts
@@ -231,6 +231,7 @@ export interface RuntimeTaskAddress {
   deviceId: string
   workspacePath?: string | null
   localTaskId: string
+  runtimeHandle?: Record<string, unknown> | null
 }
 
 export interface RuntimeMessageSource {
@@ -325,6 +326,7 @@ export interface LocalTaskSummary {
   updatedAt?: string | null
   running?: boolean
   status?: string | null
+  runtimeHandle?: Record<string, unknown> | null
   parent?: Record<string, unknown> | null
   children?: Record<string, unknown>[]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Runtime task transcripts now handle opaque runtime session identifiers, improving transcript loading for linked and optimistic tasks.
  * Workbench now preserves and restores in-progress runtime task messages more reliably during task creation and refreshes.
  * Added optional runtime debug logging for transcript and task creation flows when enabled.

* **Bug Fixes**
  * Fixed cases where transcript views could appear empty or lose messages while task linking was still in progress.
  * Improved stability when runtime task addresses gain workspace information after resolution.

* **Documentation**
  * Clarified how runtime task identity and session identifiers should be used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->