### PR TITLE
[codex] Refine slow startup debug help layout

### DIFF
--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.test.tsx
@@ -140,9 +140,14 @@ describe('LocalRuntimeInitializer', () => {
       await vi.advanceTimersByTimeAsync(SLOW_STARTUP_WARNING_MS)
     })
 
-    expect(screen.getByTestId('local-runtime-slow-startup-help')).toHaveTextContent(
-      '启动时间有点久'
-    )
+    const slowStartupHelp = screen.getByTestId('local-runtime-slow-startup-help')
+    expect(slowStartupHelp).toHaveTextContent('启动时间有点久')
+    expect(slowStartupHelp.className).toContain('sm:flex-row')
+    expect(slowStartupHelp.className).toContain('bg-amber-50/70')
+    expect(
+      within(slowStartupHelp).getByTestId('local-runtime-slow-startup-icon').className
+    ).toContain('bg-amber-100')
+    expect(screen.getByTestId('local-runtime-copy-debug-button').className).toContain('sm:w-auto')
 
     await act(async () => {
       fireEvent.click(screen.getByTestId('local-runtime-copy-debug-button'))

--- a/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
+++ b/wework/src/features/local-runtime/LocalRuntimeInitializer.tsx
@@ -249,14 +249,26 @@ function SlowStartupHelp({ copyState, onCopyDebugInfo }: SlowStartupHelpProps) {
   return (
     <div
       data-testid="local-runtime-slow-startup-help"
-      className="mt-5 w-full max-w-[420px] rounded-lg border border-border bg-surface px-4 py-3 text-left"
+      className="mt-5 flex w-full max-w-[480px] flex-col items-stretch gap-3 rounded-lg border border-amber-200/70 bg-amber-50/70 px-3.5 py-3 text-left sm:flex-row sm:items-center sm:px-4"
     >
-      <p className="text-sm font-medium text-text-primary">{t('slow_startup_title')}</p>
-      <p className="mt-1 text-xs leading-5 text-text-secondary">{t('slow_startup_description')}</p>
+      <div className="flex min-w-0 flex-1 items-start gap-3 sm:items-center">
+        <span
+          data-testid="local-runtime-slow-startup-icon"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-amber-100 text-amber-700 sm:h-8 sm:w-8"
+        >
+          <AlertCircle className="h-4 w-4" />
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-text-primary">{t('slow_startup_title')}</p>
+          <p className="mt-0.5 text-xs leading-5 text-text-secondary">
+            {t('slow_startup_description')}
+          </p>
+        </div>
+      </div>
       <Button
         type="button"
         variant="outline"
-        className="mt-3 h-11 min-w-[150px]"
+        className="h-11 min-w-[44px] border-amber-200/80 bg-base px-3 text-xs text-text-primary hover:bg-amber-50 sm:h-9 sm:w-auto"
         onClick={onCopyDebugInfo}
         disabled={copying}
         data-testid="local-runtime-copy-debug-button"


### PR DESCRIPTION
## Summary

- Restyle the local runtime slow-startup debug help as a compact warning notice instead of a large gray panel.
- Add a dedicated warning icon and responsive copy-button alignment for desktop and mobile.
- Extend the LocalRuntimeInitializer test to cover the new notice structure.

## Impact

The startup screen keeps the same debug copy behavior, but the slow-startup help reads as a lighter status notice and aligns better with the rest of the setup UI.

## Validation

- `pnpm --dir wework test LocalRuntimeInitializer`
- `pnpm --dir wework lint`
- `pnpm --dir wework build`
- Pre-push hook: 99 test files passed, 911 tests passed; quality checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the slow-startup help card with a new amber-themed look and improved responsive layout.
  * Refined the help icon and “copy debug” button styling for better spacing and sizing on different screen widths.

* **Bug Fixes**
  * Expanded test coverage to verify the slow-startup help content and its visible styling, helping prevent layout regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->