### PR TITLE
[codex] Fix duplicate runtime tasks in sidebar

### DIFF
--- a/wework/src/features/workbench/workbenchReducer.test.ts
+++ b/wework/src/features/workbench/workbenchReducer.test.ts
@@ -451,6 +451,87 @@ describe('workbenchReducer', () => {
     })
   })
 
+  test('drops an optimistic runtime task when refresh returns it in a different workspace kind', () => {
+    const state = workbenchReducer(initialWorkbenchState, {
+      type: 'lists_refreshed',
+      projects: [{ id: 7, name: 'Repo', tasks: [] }],
+      devices: [],
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo',
+                workspaceKind: 'workspace',
+                projectId: 7,
+                available: true,
+                mapped: true,
+                localTasks: [
+                  {
+                    localTaskId: 'codex-1',
+                    workspacePath: '/workspace/repo',
+                    title: 'Create cloud config',
+                    runtime: 'codex',
+                    status: 'creating',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 1,
+      },
+    })
+
+    const refreshed = workbenchReducer(state, {
+      type: 'runtime_work_refreshed',
+      runtimeWork: {
+        projects: [
+          {
+            project: { id: 7, name: 'Repo' },
+            deviceWorkspaces: [
+              {
+                deviceId: 'device-1',
+                workspacePath: '/workspace/repo/.worktrees/codex-1',
+                workspaceKind: 'worktree',
+                projectId: 7,
+                available: true,
+                mapped: true,
+                localTasks: [
+                  {
+                    localTaskId: 'codex-1',
+                    workspacePath: '/workspace/repo/.worktrees/codex-1',
+                    title: 'Create cloud config',
+                    runtime: 'codex',
+                    running: true,
+                    status: 'running',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        chats: [],
+        totalLocalTasks: 1,
+      },
+    })
+
+    const taskItems =
+      refreshed.runtimeWork?.projects.flatMap(project =>
+        project.deviceWorkspaces.flatMap(workspace => workspace.localTasks)
+      ) ?? []
+
+    expect(taskItems.map(task => task.localTaskId)).toEqual(['codex-1'])
+    expect(taskItems[0]).toMatchObject({
+      workspacePath: '/workspace/repo/.worktrees/codex-1',
+      status: 'running',
+    })
+    expect(refreshed.runtimeWork?.totalLocalTasks).toBe(1)
+  })
+
   test('keeps chat and project workspace task ordering separate when paths overlap', () => {
     const state = workbenchReducer(initialWorkbenchState, {
       type: 'lists_refreshed',

--- a/wework/src/features/workbench/workbenchReducer.ts
+++ b/wework/src/features/workbench/workbenchReducer.ts
@@ -144,15 +144,30 @@ function mergeRuntimeWorkPreservingTaskOrder(
 ): RuntimeWorkListResponse | null {
   if (!current || !next) return next
 
+  const nextProjectTaskKeys = new Map(
+    next.projects.map(projectWork => [
+      runtimeProjectUiId(projectWork.project),
+      collectRuntimeTaskKeys(projectWork.deviceWorkspaces),
+    ])
+  )
+  const nextChatTaskKeys = collectRuntimeTaskKeys(next.chats)
+
   const mergeProjectWorkspace = (
     projectWork: RuntimeProjectWork,
     workspace: RuntimeDeviceWorkspace
   ): RuntimeDeviceWorkspace => {
     const currentWorkspace = findMatchingProjectRuntimeWorkspace(current, projectWork, workspace)
     if (!currentWorkspace) return workspace
+    const resolvedTaskKeys =
+      nextProjectTaskKeys.get(runtimeProjectUiId(projectWork.project)) ?? new Set<string>()
     return {
       ...workspace,
-      localTasks: mergeRuntimeLocalTasks(currentWorkspace.localTasks, workspace.localTasks),
+      localTasks: mergeRuntimeLocalTasks(
+        currentWorkspace.localTasks,
+        workspace.localTasks,
+        workspace.deviceId,
+        resolvedTaskKeys
+      ),
     }
   }
 
@@ -161,7 +176,12 @@ function mergeRuntimeWorkPreservingTaskOrder(
     if (!currentWorkspace) return workspace
     return {
       ...workspace,
-      localTasks: mergeRuntimeLocalTasks(currentWorkspace.localTasks, workspace.localTasks),
+      localTasks: mergeRuntimeLocalTasks(
+        currentWorkspace.localTasks,
+        workspace.localTasks,
+        workspace.deviceId,
+        nextChatTaskKeys
+      ),
     }
   }
 
@@ -172,11 +192,13 @@ function mergeRuntimeWorkPreservingTaskOrder(
       deviceWorkspaces: project.deviceWorkspaces.map(workspace =>
         mergeProjectWorkspace(project, workspace)
       ),
-    }))
+    })),
+    nextProjectTaskKeys
   )
   const chats = preserveMissingOptimisticWorkspaces(
     current.chats,
-    next.chats.map(mergeChatWorkspace)
+    next.chats.map(mergeChatWorkspace),
+    nextChatTaskKeys
   )
   const merged = {
     ...next,
@@ -242,11 +264,19 @@ function runtimeWorkspaceMatches(
 
 function mergeRuntimeLocalTasks(
   currentTasks: RuntimeDeviceWorkspace['localTasks'],
-  nextTasks: RuntimeDeviceWorkspace['localTasks']
+  nextTasks: RuntimeDeviceWorkspace['localTasks'],
+  deviceId: string,
+  resolvedTaskKeys: ReadonlySet<string>
 ) {
   const nextById = new Map(nextTasks.map(task => [task.localTaskId, task]))
   const merged = currentTasks
-    .map(task => nextById.get(task.localTaskId) ?? (isOptimisticRuntimeTask(task) ? task : null))
+    .map(
+      task =>
+        nextById.get(task.localTaskId) ??
+        (isOptimisticRuntimeTask(task) && !resolvedTaskKeys.has(runtimeTaskKey(deviceId, task))
+          ? task
+          : null)
+    )
     .filter((task): task is RuntimeDeviceWorkspace['localTasks'][number] => Boolean(task))
   const mergedIds = new Set(merged.map(task => task.localTaskId))
   nextTasks.forEach(task => {
@@ -261,21 +291,43 @@ function isOptimisticRuntimeTask(task: LocalTaskSummary): boolean {
   return task.status === 'creating'
 }
 
-function optimisticWorkspaceOnly(workspace: RuntimeDeviceWorkspace): RuntimeDeviceWorkspace | null {
-  const localTasks = workspace.localTasks.filter(isOptimisticRuntimeTask)
+function runtimeTaskKey(deviceId: string, task: Pick<LocalTaskSummary, 'localTaskId'>): string {
+  return `${deviceId}\0${task.localTaskId}`
+}
+
+function collectRuntimeTaskKeys(workspaces: RuntimeDeviceWorkspace[]): Set<string> {
+  const keys = new Set<string>()
+  workspaces.forEach(workspace => {
+    workspace.localTasks.forEach(task => {
+      keys.add(runtimeTaskKey(workspace.deviceId, task))
+    })
+  })
+  return keys
+}
+
+function optimisticWorkspaceOnly(
+  workspace: RuntimeDeviceWorkspace,
+  resolvedTaskKeys: ReadonlySet<string>
+): RuntimeDeviceWorkspace | null {
+  const localTasks = workspace.localTasks.filter(
+    task =>
+      isOptimisticRuntimeTask(task) &&
+      !resolvedTaskKeys.has(runtimeTaskKey(workspace.deviceId, task))
+  )
   return localTasks.length > 0 ? { ...workspace, localTasks } : null
 }
 
 function preserveMissingOptimisticWorkspaces(
   currentWorkspaces: RuntimeDeviceWorkspace[],
-  nextWorkspaces: RuntimeDeviceWorkspace[]
+  nextWorkspaces: RuntimeDeviceWorkspace[],
+  resolvedTaskKeys: ReadonlySet<string>
 ): RuntimeDeviceWorkspace[] {
   const mergedWorkspaces = [...nextWorkspaces]
   currentWorkspaces.forEach(currentWorkspace => {
     if (mergedWorkspaces.some(workspace => runtimeWorkspaceMatches(workspace, currentWorkspace))) {
       return
     }
-    const optimisticWorkspace = optimisticWorkspaceOnly(currentWorkspace)
+    const optimisticWorkspace = optimisticWorkspaceOnly(currentWorkspace, resolvedTaskKeys)
     if (optimisticWorkspace) {
       mergedWorkspaces.push(optimisticWorkspace)
     }
@@ -285,17 +337,19 @@ function preserveMissingOptimisticWorkspaces(
 
 function preserveMissingOptimisticProjects(
   currentProjects: RuntimeProjectWork[],
-  nextProjects: RuntimeProjectWork[]
+  nextProjects: RuntimeProjectWork[],
+  resolvedTaskKeysByProject: ReadonlyMap<number, ReadonlySet<string>>
 ): RuntimeProjectWork[] {
   const mergedProjects = [...nextProjects]
   currentProjects.forEach(currentProject => {
     const projectId = runtimeProjectUiId(currentProject.project)
+    const resolvedTaskKeys = resolvedTaskKeysByProject.get(projectId) ?? new Set<string>()
     const existingIndex = mergedProjects.findIndex(
       project => runtimeProjectUiId(project.project) === projectId
     )
     if (existingIndex < 0) {
       const optimisticWorkspaces = currentProject.deviceWorkspaces
-        .map(optimisticWorkspaceOnly)
+        .map(workspace => optimisticWorkspaceOnly(workspace, resolvedTaskKeys))
         .filter((workspace): workspace is RuntimeDeviceWorkspace => Boolean(workspace))
       if (optimisticWorkspaces.length > 0) {
         mergedProjects.push({
@@ -309,7 +363,8 @@ function preserveMissingOptimisticProjects(
 
     const deviceWorkspaces = preserveMissingOptimisticWorkspaces(
       currentProject.deviceWorkspaces,
-      mergedProjects[existingIndex].deviceWorkspaces
+      mergedProjects[existingIndex].deviceWorkspaces,
+      resolvedTaskKeys
     )
     mergedProjects[existingIndex] = {
       ...mergedProjects[existingIndex],


### PR DESCRIPTION
## Summary

- Dedupe optimistic Wework runtime tasks once a refreshed runtime work list contains the same `deviceId + localTaskId`.
- Preserve optimistic tasks that are still missing from the refreshed data, but drop stale optimistic copies after the server returns the resolved task in another workspace, such as a worktree workspace.
- Add a regression test for the workspace-to-worktree refresh case that previously rendered the same submitted task twice in the sidebar.

## Root Cause

When a new runtime task is submitted, Wework first inserts a `status: creating` optimistic task. The refreshed server state can later return that same `localTaskId` under a different workspace kind or path. The reducer preserved the old optimistic workspace because the workspace no longer matched, so the sidebar rendered both copies.

## Validation

- `pnpm --filter wework lint`
- `pnpm --filter wework test -- src/features/workbench/workbenchReducer.test.ts`
- `git push` pre-push hook: Wework tests with coverage, 99 test files and 912 tests passed; quality checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workbench task merging so resolved optimistic tasks are no longer brought back after a refresh.
  * Kept task ordering stable while ensuring refreshed workspace data correctly replaces outdated local task state.
  * Better handled cases where the same local task appears under a different workspace type after server updates.

* **Tests**
  * Added coverage for task refresh behavior to confirm only the expected task remains and its status, path, and running state are updated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->