### PR TITLE
[codex] fix wework branch refresh loop

### DIFF
--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -4447,6 +4447,87 @@ describe('DesktopWorkbenchLayout', () => {
     expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(1)
   })
 
+  test('does not reload environment info when runtime work polling keeps the same project workspace target', async () => {
+    const onLoadEnvironmentInfo = vi.fn().mockResolvedValue({
+      additions: '+4',
+      deletions: '-1',
+      executionTarget: 'local' as const,
+      deviceId: 'device-1',
+      branchName: 'feature/done',
+    })
+    const workspaceProject = {
+      id: 1,
+      name: 'workspace',
+      tasks: [],
+      config: {
+        mode: 'workspace',
+        execution: {
+          targetType: 'local' as const,
+          deviceId: 'device-1',
+        },
+        workspace: {
+          source: 'local_path' as const,
+          localPath: '/repo',
+        },
+      },
+    }
+    const runtimeWork: RuntimeWorkListResponse = {
+      projects: [
+        {
+          project: { key: 'project:1', id: 1, name: 'workspace' },
+          deviceWorkspaces: [
+            {
+              id: 1,
+              projectId: 1,
+              deviceId: 'device-1',
+              available: true,
+              mapped: true,
+              workspacePath: '/repo',
+              localTasks: [],
+            },
+          ],
+        },
+      ],
+      chats: [],
+      totalLocalTasks: 0,
+    }
+    const { rerender } = render(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        onLoadEnvironmentInfo={onLoadEnvironmentInfo}
+        state={{
+          ...baseProps.state,
+          currentProject: workspaceProject,
+          runtimeWork,
+        }}
+      />
+    )
+
+    await waitFor(() => {
+      expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(1)
+      expect(onLoadEnvironmentInfo).toHaveBeenCalledWith(workspaceProject, {
+        deviceId: 'device-1',
+        path: '/repo',
+        source: 'project',
+      })
+    })
+
+    rerender(
+      <DesktopWorkbenchLayout
+        {...baseProps}
+        onLoadEnvironmentInfo={onLoadEnvironmentInfo}
+        state={{
+          ...baseProps.state,
+          currentProject: workspaceProject,
+          runtimeWork: structuredClone(runtimeWork),
+        }}
+      />
+    )
+
+    await new Promise(resolve => window.setTimeout(resolve, 0))
+    expect(onLoadEnvironmentInfo).toHaveBeenCalledTimes(1)
+  })
+
   test('closes the right workspace panel from the panel actions', async () => {
     render(<DesktopWorkbenchLayout {...baseProps} />)
 

--- a/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
+++ b/wework/src/components/layout/useWorkbenchPaneEnvironment.ts
@@ -111,8 +111,23 @@ export function useWorkbenchPaneEnvironment({
   const activeWorkspaceTarget = currentRuntimeTask
     ? runtimeWorkspaceTarget
     : (projectRuntimeWorkspaceTarget ?? workspaceTarget)
+  const activeWorkspaceTargetKey = workspaceTargetKey(activeWorkspaceTarget)
+  const workspaceProjectKey = workspaceProject ? String(workspaceProject.id) : ''
+  const activeConversationProjectKey = activeConversationProject
+    ? String(activeConversationProject.id)
+    : ''
+  const currentRuntimeTaskKey = currentRuntimeTask
+    ? `${currentRuntimeTask.deviceId}:${currentRuntimeTask.localTaskId}:${
+        currentRuntimeTask.workspacePath ?? ''
+      }`
+    : ''
+  const environmentContextRef = useRef({ workspaceProject, activeWorkspaceTarget })
   const hasEnvironmentProject = Boolean(workspaceProject)
   const environmentWorkspaceReady = !hasEnvironmentProject || Boolean(activeWorkspaceTarget)
+
+  useEffect(() => {
+    environmentContextRef.current = { workspaceProject, activeWorkspaceTarget }
+  }, [activeWorkspaceTarget, workspaceProject])
 
   useEffect(() => {
     let cancelled = false
@@ -199,7 +214,11 @@ export function useWorkbenchPaneEnvironment({
 
     setEnvironmentInfo(info => ({ ...info, loading: true }))
     try {
-      const info = await loadEnvironmentInfo(workspaceProject, activeWorkspaceTarget)
+      const {
+        workspaceProject: latestWorkspaceProject,
+        activeWorkspaceTarget: latestActiveWorkspaceTarget,
+      } = environmentContextRef.current
+      const info = await loadEnvironmentInfo(latestWorkspaceProject, latestActiveWorkspaceTarget)
       if (environmentInfoRequestSequence.current === requestId) {
         setEnvironmentInfo({ ...info, loading: false })
       }
@@ -213,18 +232,22 @@ export function useWorkbenchPaneEnvironment({
       }
     }
   }, [
-    activeWorkspaceTarget,
     environmentWorkspaceReady,
     loadEnvironmentInfo,
-    workspaceProject,
     workspaceTargetError,
     workspaceTargetResolving,
   ])
 
   useEffect(() => {
-    if (!activeConversationProject && !currentRuntimeTask) return
+    if (!activeConversationProjectKey && !currentRuntimeTaskKey) return
     void refreshEnvironmentInfo()
-  }, [activeConversationProject, currentRuntimeTask, refreshEnvironmentInfo])
+  }, [
+    activeConversationProjectKey,
+    activeWorkspaceTargetKey,
+    currentRuntimeTaskKey,
+    refreshEnvironmentInfo,
+    workspaceProjectKey,
+  ])
 
   const commitPaneEnvironmentChanges = useCallback(
     async (message: string) => {
@@ -238,32 +261,48 @@ export function useWorkbenchPaneEnvironment({
   )
 
   const listPaneEnvironmentBranches = useCallback(() => {
-    if (!activeWorkspaceTarget) {
+    const {
+      workspaceProject: latestWorkspaceProject,
+      activeWorkspaceTarget: latestActiveWorkspaceTarget,
+    } = environmentContextRef.current
+    if (!latestActiveWorkspaceTarget) {
       return Promise.reject(new Error(workspaceTargetError ?? 'Workspace is not ready'))
     }
-    return listEnvironmentBranches(workspaceProject, activeWorkspaceTarget)
-  }, [activeWorkspaceTarget, listEnvironmentBranches, workspaceProject, workspaceTargetError])
+    return listEnvironmentBranches(latestWorkspaceProject, latestActiveWorkspaceTarget)
+  }, [listEnvironmentBranches, workspaceTargetError])
 
   const checkoutPaneEnvironmentBranch = useCallback(
     async (branchName: string) => {
-      if (!activeWorkspaceTarget) {
+      const {
+        workspaceProject: latestWorkspaceProject,
+        activeWorkspaceTarget: latestActiveWorkspaceTarget,
+      } = environmentContextRef.current
+      if (!latestActiveWorkspaceTarget) {
         throw new Error(workspaceTargetError ?? 'Workspace is not ready')
       }
-      await checkoutEnvironmentBranch(workspaceProject, branchName, activeWorkspaceTarget)
+      await checkoutEnvironmentBranch(
+        latestWorkspaceProject,
+        branchName,
+        latestActiveWorkspaceTarget
+      )
       setEnvironmentInfo(info => ({ ...info, branchName }))
     },
-    [activeWorkspaceTarget, checkoutEnvironmentBranch, workspaceProject, workspaceTargetError]
+    [checkoutEnvironmentBranch, workspaceTargetError]
   )
 
   const createPaneEnvironmentBranch = useCallback(
     async (branchName: string) => {
-      if (!activeWorkspaceTarget) {
+      const {
+        workspaceProject: latestWorkspaceProject,
+        activeWorkspaceTarget: latestActiveWorkspaceTarget,
+      } = environmentContextRef.current
+      if (!latestActiveWorkspaceTarget) {
         throw new Error(workspaceTargetError ?? 'Workspace is not ready')
       }
-      await createEnvironmentBranch(workspaceProject, branchName, activeWorkspaceTarget)
+      await createEnvironmentBranch(latestWorkspaceProject, branchName, latestActiveWorkspaceTarget)
       setEnvironmentInfo(info => ({ ...info, branchName }))
     },
-    [activeWorkspaceTarget, createEnvironmentBranch, workspaceProject, workspaceTargetError]
+    [createEnvironmentBranch, workspaceTargetError]
   )
 
   return {

--- a/wework/src/lib/workspace-target.ts
+++ b/wework/src/lib/workspace-target.ts
@@ -184,5 +184,7 @@ export function resolveRuntimeWorkspaceContext({
 }
 
 export function workspaceTargetKey(target: WorkspaceTarget | null): string {
-  return target ? `${target.deviceId}:${target.path}:${target.source}` : ''
+  return target
+    ? `${target.deviceId}:${target.path}:${target.source}:${target.workspaceSource ?? ''}`
+    : ''
 }


### PR DESCRIPTION
## Summary

- Stop Wework environment branch/loading state from refreshing repeatedly when runtime work polling returns a new object for the same workspace target.
- Key environment refreshes by stable workspace/project/runtime identifiers while reading the latest project and target when commands run.
- Include `workspaceSource` in `workspaceTargetKey` so local and remote targets with the same path remain distinct.
- Add a regression test for identical runtime work polling payloads.

## Root Cause

Runtime work polling can replace `state.runtimeWork` with a new object whose resolved workspace target has the same device, path, and source. `useWorkbenchPaneEnvironment` depended on object identity, so the environment info refresh effect ran again even though the effective target had not changed. That kept branch-related UI in a loading/refreshing cycle.

## Validation

- `pnpm --dir wework lint`
- `pnpm --dir wework test -- src/components/layout/DesktopWorkbenchLayout.test.tsx -t "does not reload environment info"`
- `pnpm --dir wework build`
- Pre-push hook: full Wework test suite with coverage, 99 files / 912 tests passed; quality checks passed.