### PR TITLE
[codex] preserve Codex task order in Wework

### DIFF
--- a/executor/src/runtime_work/handler.rs
+++ b/executor/src/runtime_work/handler.rs
@@ -1019,6 +1019,7 @@ impl RuntimeWorkRpcHandler {
                 } else if link.status == "archived" {
                     continue;
                 }
+                link.list_order = Some(links.len());
                 if let Some(thread_id) = &link.thread_id {
                     discovered_thread_ids.insert(thread_id.clone());
                 }
@@ -1027,7 +1028,7 @@ impl RuntimeWorkRpcHandler {
             }
         }
 
-        for link in self.local_task_links(true) {
+        for mut link in self.local_task_links(true) {
             let link_archived = link.status == "archived";
             if link_archived != archived {
                 continue;
@@ -1045,10 +1046,10 @@ impl RuntimeWorkRpcHandler {
             {
                 continue;
             }
+            link.list_order = Some(links.len());
             links.push(link);
         }
 
-        links.sort_by_key(|link| std::cmp::Reverse(link.updated_at));
         links
     }
 

--- a/executor/src/runtime_work/response.rs
+++ b/executor/src/runtime_work/response.rs
@@ -26,6 +26,8 @@ pub(crate) struct RuntimeTaskLink {
     pub updated_at: i64,
     pub runtime_handle: Value,
     pub parent: Option<Value>,
+    #[serde(skip)]
+    pub list_order: Option<usize>,
 }
 
 impl RuntimeTaskLink {
@@ -42,6 +44,7 @@ impl RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle: json!({}),
             parent: None,
+            list_order: None,
         }
     }
 
@@ -65,6 +68,7 @@ impl RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle,
             parent: Some(parent),
+            list_order: None,
         }
     }
 
@@ -107,6 +111,7 @@ impl RuntimeTaskLink {
                 .map(|link| link.runtime_handle.clone())
                 .unwrap_or_else(|| json!({})),
             parent: local_link.and_then(|link| link.parent),
+            list_order: None,
         }
     }
 }
@@ -125,6 +130,7 @@ impl Default for RuntimeTaskLink {
             updated_at: now_ms(),
             runtime_handle: json!({}),
             parent: None,
+            list_order: None,
         }
     }
 }
@@ -198,10 +204,11 @@ pub(crate) fn workspace_response(
     let mut workspaces = groups
         .into_iter()
         .map(|(workspace_path, (workspace, mut local_tasks))| {
-            local_tasks.sort_by_key(|link| Reverse(link.updated_at));
+            local_tasks.sort_by(compare_runtime_task_links);
             let updated_at = local_tasks
-                .first()
+                .iter()
                 .map(|link| link.updated_at)
+                .max()
                 .or_else(|| workspace.as_ref().map(|workspace| workspace.updated_at))
                 .unwrap_or_else(now_ms);
             let label = workspace
@@ -237,6 +244,24 @@ pub(crate) fn workspace_response(
         .into_iter()
         .map(|(workspace, _, _, _)| workspace)
         .collect::<Vec<_>>()
+}
+
+fn compare_runtime_task_links(
+    left: &RuntimeTaskLink,
+    right: &RuntimeTaskLink,
+) -> std::cmp::Ordering {
+    match (left.list_order, right.list_order) {
+        (Some(left_order), Some(right_order)) => left_order
+            .cmp(&right_order)
+            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| left.local_task_id.cmp(&right.local_task_id)),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => right
+            .updated_at
+            .cmp(&left.updated_at)
+            .then_with(|| left.local_task_id.cmp(&right.local_task_id)),
+    }
 }
 
 pub(crate) fn archived_conversations_response(

--- a/executor/tests/app_runtime_work_contract.rs
+++ b/executor/tests/app_runtime_work_contract.rs
@@ -153,6 +153,41 @@ async fn app_runtime_caches_consecutive_codex_thread_lists() {
 }
 
 #[tokio::test]
+async fn app_runtime_preserves_codex_thread_list_recency_order() {
+    let _lock = env_lock().await;
+    let _home = EnvGuard::set(
+        "WEGENT_EXECUTOR_HOME",
+        &temp_path("wegent-app-runtime-list-order-home", "dir")
+            .display()
+            .to_string(),
+    );
+    let _codex_home = set_temp_codex_home("wegent-app-runtime-list-order-codex-home");
+    let log_path = temp_path("wegent-app-runtime-list-order-log", "jsonl");
+    let fake_codex = write_fake_codex_recency_order(&log_path);
+    let handler = RuntimeWorkRpcHandler::new("device-1", fake_codex.display().to_string());
+
+    let listed = handler
+        .handle_runtime_rpc(json!({
+            "method": "runtime.tasks.list",
+            "payload": {}
+        }))
+        .await
+        .expect("runtime task list should succeed");
+
+    let task_ids = listed["workspaces"][0]["localTasks"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|task| task["localTaskId"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        task_ids,
+        vec!["thread-recency-first", "thread-updated-first"]
+    );
+    assert_eq!(listed["workspaces"][0]["updatedAt"], 1780000060000_i64);
+}
+
+#[tokio::test]
 async fn app_runtime_reads_codex_thread_transcript_through_app_server() {
     let _lock = env_lock().await;
     let _home = EnvGuard::set(
@@ -888,6 +923,39 @@ while IFS= read -r line; do
       printf '%s\n' '{{"method":"item/agentMessage/delta","params":{{"delta":"done","phase":"finalAnswer"}}}}'
       printf '%s\n' '{{"method":"turn/completed","params":{{"turn":{{"id":"turn-1","status":"completed"}}}}}}'
       exit 0
+      ;;
+  esac
+done
+"#,
+        log_path.display()
+    );
+    fs::write(&path, content).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        fs::set_permissions(&path, permissions).unwrap();
+    }
+    path
+}
+
+fn write_fake_codex_recency_order(log_path: &Path) -> PathBuf {
+    let path = temp_path("fake-codex-app-runtime-list-order", "sh");
+    let _ = fs::remove_file(log_path);
+    let content = format!(
+        r#"#!/bin/sh
+LOG_PATH='{}'
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$LOG_PATH"
+  request_id=$(printf '%s\n' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"protocolVersion":1}}}}'
+      ;;
+    *'"method":"initialized"'*)
+      ;;
+    *'"method":"thread/list"'*)
+      printf '%s\n' '{{"id":'"$request_id"',"result":{{"data":[{{"id":"thread-recency-first","cwd":"/tmp/project","name":"Recency first","preview":"recency first","path":"/tmp/codex/thread-recency-first.jsonl","createdAt":1780000000,"updatedAt":1780000010,"status":"idle","turns":[]}},{{"id":"thread-updated-first","cwd":"/tmp/project","name":"Updated first","preview":"updated first","path":"/tmp/codex/thread-updated-first.jsonl","createdAt":1780000000,"updatedAt":1780000060,"status":"idle","turns":[]}}],"nextCursor":null,"backwardsCursor":null}}}}'
       ;;
   esac
 done


### PR DESCRIPTION
## Summary
- Preserve Codex app-server `thread/list` recency order when building runtime local task lists for Wework.
- Keep workspace `updatedAt` based on the newest child task even when task display order follows Codex recency.
- Add regression coverage for Codex recency order diverging from `updatedAt`.

## Root Cause
Wework requested Codex threads with `sortKey=recency_at`, but the executor re-sorted `RuntimeTaskLink` values by `updated_at` before returning `localTasks`, so Wework could show a different order from Codex.

## Validation
- `cargo fmt --check`
- `cargo test -p wegent-executor --test app_runtime_work_contract`
- `cargo test -p wegent-executor --test app_runtime_work_workspace_contract`
- `cargo test -p wegent-executor --test app_runtime_work_native_update_contract`
- `cargo test -p wegent-executor`
- `git diff --check`
- Pre-push hook: wework tests 99 files / 911 tests, executor `cargo test --all-features`, executor `cargo clippy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime task lists now preserve the order items were discovered in, instead of re-sorting everything by newest activity.
  * Task ordering in workspace responses is now more consistent, with list order taking priority and timestamps used as a fallback.
  * The reported workspace update time now reflects the most recent task after sorting.
* **Tests**
  * Added coverage to verify task list ordering and timestamp behavior in a Codex thread scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->