### PR TITLE
[codex] Add Wework local IDE picker

### DIFF
--- a/wework/src-tauri/src/lib.rs
+++ b/wework/src-tauri/src/lib.rs
@@ -197,6 +197,64 @@ fn local_path_exists(path: String) -> bool {
     std::path::Path::new(&path).exists()
 }
 
+fn local_workspace_opener_app_name(opener: &str) -> Option<&'static str> {
+    match opener {
+        "vscode" => Some("Visual Studio Code"),
+        "vscode-insiders" => Some("Visual Studio Code - Insiders"),
+        "cursor" => Some("Cursor"),
+        "sublime-text" => Some("Sublime Text"),
+        "windsurf" => Some("Windsurf"),
+        "finder" => Some("Finder"),
+        "terminal" => Some("Terminal"),
+        "iterm2" => Some("iTerm"),
+        "ghostty" => Some("Ghostty"),
+        "warp" => Some("Warp"),
+        "xcode" => Some("Xcode"),
+        "android-studio" => Some("Android Studio"),
+        "intellij-idea" => Some("IntelliJ IDEA"),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn open_local_workspace_with_app(app_name: &str, path: &str) -> Result<(), String> {
+    let output = std::process::Command::new("open")
+        .args(["-a", app_name, path])
+        .output()
+        .map_err(|error| format!("Failed to run macOS open command: {error}"))?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if stderr.is_empty() {
+        Err(format!("Failed to open workspace with {app_name}"))
+    } else {
+        Err(stderr)
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn open_local_workspace_with_app(_app_name: &str, _path: &str) -> Result<(), String> {
+    Err("Opening a local workspace is only supported on macOS".to_string())
+}
+
+#[tauri::command]
+fn open_local_workspace(opener: String, path: String) -> Result<(), String> {
+    let opener =
+        normalized_non_empty(opener).ok_or_else(|| "Workspace opener is empty".to_string())?;
+    let path = normalized_non_empty(path).ok_or_else(|| "Workspace path is empty".to_string())?;
+    let app_name = local_workspace_opener_app_name(&opener)
+        .ok_or_else(|| format!("Unsupported workspace opener: {opener}"))?;
+
+    if !std::path::Path::new(&path).exists() {
+        return Err("Workspace path does not exist".to_string());
+    }
+
+    open_local_workspace_with_app(app_name, &path)
+}
+
 #[derive(serde::Serialize)]
 struct DroppedFilePayload {
     name: String,
@@ -676,6 +734,33 @@ fn set_tray_menu_state(_state: TrayMenuStatePayload) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::local_workspace_opener_app_name;
+
+    #[test]
+    fn maps_local_workspace_openers_to_macos_app_names() {
+        assert_eq!(
+            local_workspace_opener_app_name("vscode"),
+            Some("Visual Studio Code")
+        );
+        assert_eq!(
+            local_workspace_opener_app_name("vscode-insiders"),
+            Some("Visual Studio Code - Insiders")
+        );
+        assert_eq!(local_workspace_opener_app_name("iterm2"), Some("iTerm"));
+        assert_eq!(
+            local_workspace_opener_app_name("android-studio"),
+            Some("Android Studio")
+        );
+        assert_eq!(
+            local_workspace_opener_app_name("intellij-idea"),
+            Some("IntelliJ IDEA")
+        );
+        assert_eq!(local_workspace_opener_app_name("unknown"), None);
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -741,6 +826,7 @@ pub fn run() {
             set_tray_menu_state,
             download_local_file_to_downloads,
             local_path_exists,
+            open_local_workspace,
             read_dropped_files,
             local_terminal::resize_local_terminal,
             local_terminal::start_local_terminal,

--- a/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
+++ b/wework/src/components/layout/DesktopWorkbenchLayout.test.tsx
@@ -16,6 +16,7 @@ import {
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   localPathExists,
+  openLocalWorkspace,
   startLocalTerminal,
 } from '@/lib/local-terminal'
 import { configuredWorkspacePath, executionDeviceId } from '@/lib/project-workspace'
@@ -129,6 +130,7 @@ vi.mock('@/lib/local-terminal', () => ({
   getLocalExecutorDeviceId: vi.fn(),
   isLocalTerminalAvailable: vi.fn(),
   localPathExists: vi.fn(),
+  openLocalWorkspace: vi.fn(),
   startLocalTerminal: vi.fn(),
 }))
 
@@ -304,6 +306,7 @@ const closeLocalTerminalMock = vi.mocked(closeLocalTerminal)
 const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const localPathExistsMock = vi.mocked(localPathExists)
+const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startLocalTerminalMock = vi.mocked(startLocalTerminal)
 const fetchQuotaMock = vi.fn()
 const startTerminalSessionMock = vi.fn()
@@ -412,6 +415,7 @@ describe('DesktopWorkbenchLayout', () => {
     isLocalTerminalAvailableMock.mockReturnValue(false)
     getLocalExecutorDeviceIdMock.mockResolvedValue(null)
     localPathExistsMock.mockResolvedValue(false)
+    openLocalWorkspaceMock.mockResolvedValue(undefined)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
     fetchQuotaMock.mockResolvedValue({
@@ -1641,11 +1645,12 @@ describe('DesktopWorkbenchLayout', () => {
     )
   })
 
-  test('keeps project code-server disabled for local devices', async () => {
+  test('opens the local project from the Tauri titlebar with VS Code for local devices', async () => {
     Object.defineProperty(window, '__TAURI_INTERNALS__', {
       configurable: true,
       value: {},
     })
+    isLocalTerminalAvailableMock.mockReturnValue(true)
 
     render(
       <DesktopWorkbenchLayout
@@ -1660,6 +1665,10 @@ describe('DesktopWorkbenchLayout', () => {
               execution: {
                 targetType: 'local',
                 deviceId: 'local-claude',
+              },
+              workspace: {
+                source: 'local_path',
+                localPath: '/Users/me/github_wegent',
               },
             },
             tasks: [],
@@ -1681,11 +1690,15 @@ describe('DesktopWorkbenchLayout', () => {
     )
 
     const button = screen.getByTestId('open-code-server-titlebar-button')
-    expect(button).toBeDisabled()
-    expect(button).toHaveAttribute('title', '项目 IDE 仅支持云设备')
+    expect(button).not.toBeDisabled()
+    expect(button).toHaveAttribute('title', '使用 VS Code 打开')
 
     await userEvent.click(button)
 
+    expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
+      opener: 'vscode',
+      path: '/Users/me/github_wegent',
+    })
     expect(startCodeServerSessionMock).not.toHaveBeenCalled()
   })
 

--- a/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
+++ b/wework/src/components/layout/workspace-panels/LocalWorkspaceOpenerMenu.tsx
@@ -1,0 +1,267 @@
+import { ChevronDown, Code2, Folder, Monitor, SquareTerminal } from 'lucide-react'
+import { createPortal } from 'react-dom'
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from 'react'
+import { LOCAL_WORKSPACE_OPENERS, type LocalWorkspaceOpenerId } from '@/lib/local-workspace-openers'
+import { cn } from '@/lib/utils'
+
+const MENU_GAP = 8
+const VIEWPORT_PADDING = 8
+const MENU_WIDTH = 280
+
+interface MenuPosition {
+  left: number
+  top: number
+}
+
+interface LocalWorkspaceOpenerPickerProps {
+  ariaLabel: string
+  buttonTestId?: string
+  menuTestId?: string
+  optionTestIdPrefix?: string
+  disabled?: boolean
+  buttonClassName: string
+  preferredPlacement?: 'above' | 'below'
+  align?: 'start' | 'end'
+  onSelect: (opener: LocalWorkspaceOpenerId) => void | Promise<void>
+}
+
+export function LocalWorkspaceOpenerPicker({
+  ariaLabel,
+  buttonTestId,
+  menuTestId,
+  optionTestIdPrefix,
+  disabled = false,
+  buttonClassName,
+  preferredPlacement = 'below',
+  align = 'end',
+  onSelect,
+}: LocalWorkspaceOpenerPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [position, setPosition] = useState<MenuPosition | null>(null)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+
+  useLayoutEffect(() => {
+    if (!open) return
+
+    const updatePosition = () => {
+      const buttonRect = buttonRef.current?.getBoundingClientRect()
+      const menuRect = menuRef.current?.getBoundingClientRect()
+      if (!buttonRect || !menuRect) return
+
+      const viewportWidth = window.innerWidth
+      const viewportHeight = window.innerHeight
+      const menuWidth = Math.max(menuRect.width, MENU_WIDTH)
+      const menuHeight = menuRect.height
+      const belowTop = buttonRect.bottom + MENU_GAP
+      const aboveTop = buttonRect.top - menuHeight - MENU_GAP
+      const hasRoomBelow = belowTop + menuHeight <= viewportHeight - VIEWPORT_PADDING
+      const hasRoomAbove = aboveTop >= VIEWPORT_PADDING
+      const placeBelow =
+        preferredPlacement === 'below'
+          ? hasRoomBelow || !hasRoomAbove
+          : !(hasRoomAbove || !hasRoomBelow)
+      const top = placeBelow ? belowTop : Math.max(VIEWPORT_PADDING, aboveTop)
+      const preferredLeft = align === 'end' ? buttonRect.right - menuWidth : buttonRect.left
+      const maxLeft = viewportWidth - menuWidth - VIEWPORT_PADDING
+      const left = Math.max(VIEWPORT_PADDING, Math.min(preferredLeft, maxLeft))
+
+      setPosition({ left, top })
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [align, open, preferredPlacement])
+
+  useEffect(() => {
+    if (!open) return
+
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      const target = event.target as Node
+      if (buttonRef.current?.contains(target) || menuRef.current?.contains(target)) {
+        return
+      }
+      setOpen(false)
+      setPosition(null)
+    }
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        setPosition(null)
+      }
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown, true)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  const toggleOpen = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation()
+
+    if (open) {
+      setOpen(false)
+      setPosition(null)
+      return
+    }
+
+    setPosition(null)
+    setOpen(true)
+  }
+
+  const selectOpener = async (opener: LocalWorkspaceOpenerId) => {
+    setOpen(false)
+    setPosition(null)
+    await onSelect(opener)
+  }
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        data-testid={buttonTestId}
+        onClick={toggleOpen}
+        disabled={disabled}
+        className={buttonClassName}
+        aria-label={ariaLabel}
+        aria-expanded={open}
+        aria-haspopup="menu"
+      >
+        <ChevronDown className="h-4 w-4" />
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            data-testid={menuTestId}
+            role="menu"
+            style={{
+              left: position?.left ?? 0,
+              top: position?.top ?? 0,
+              visibility: position ? 'visible' : 'hidden',
+            }}
+            className="fixed z-system-popover max-h-[520px] w-[280px] overflow-y-auto rounded-2xl border border-border bg-popover p-2 text-text-primary shadow-[0_18px_54px_rgba(0,0,0,0.16)] ring-1 ring-black/5"
+          >
+            {LOCAL_WORKSPACE_OPENERS.map(opener => (
+              <button
+                key={opener.id}
+                type="button"
+                role="menuitem"
+                data-testid={optionTestIdPrefix ? `${optionTestIdPrefix}-${opener.id}` : undefined}
+                onClick={() => void selectOpener(opener.id)}
+                className="flex h-10 w-full items-center gap-3 rounded-xl px-2.5 text-left text-[15px] font-medium leading-5 text-text-primary transition-colors hover:bg-muted"
+              >
+                <LocalWorkspaceOpenerIcon opener={opener.id} className="h-5 w-5 shrink-0" />
+                <span className="min-w-0 flex-1 truncate">{opener.label}</span>
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  )
+}
+
+export function LocalWorkspaceOpenerIcon({
+  opener,
+  className,
+}: {
+  opener: LocalWorkspaceOpenerId
+  className?: string
+}) {
+  const wrapperClassName = cn(
+    'inline-flex items-center justify-center overflow-hidden rounded-md border border-black/5 shadow-sm',
+    className
+  )
+
+  if (opener === 'vscode' || opener === 'vscode-insiders') {
+    const color = opener === 'vscode' ? '#1f7fbf' : '#4aa99d'
+    return (
+      <span className={cn(wrapperClassName, 'relative bg-white')} aria-hidden="true">
+        <span
+          data-testid="local-workspace-vscode-mark"
+          className="absolute left-[4px] top-[4px] h-[8px] w-[8px] rotate-45 border-b-[2px] border-l-[2px]"
+          style={{ borderColor: color }}
+        />
+        <span
+          data-testid="local-workspace-vscode-body"
+          className="absolute right-[4px] top-[3px] h-[12px] w-[4px] rounded-sm"
+          style={{ backgroundColor: color }}
+        />
+      </span>
+    )
+  }
+
+  return (
+    <span className={cn(wrapperClassName, openerIconBackground(opener))} aria-hidden="true">
+      {openerIconContent(opener)}
+    </span>
+  )
+}
+
+function openerIconBackground(opener: LocalWorkspaceOpenerId): string {
+  switch (opener) {
+    case 'cursor':
+      return 'bg-[#505050] text-white'
+    case 'sublime-text':
+      return 'bg-[#5b5f64] text-[#ffb64a]'
+    case 'windsurf':
+      return 'bg-[#f7f7f4] text-[#4d4d4d]'
+    case 'finder':
+      return 'bg-[#5aa9ff] text-white'
+    case 'terminal':
+      return 'bg-[#525252] text-white'
+    case 'iterm2':
+      return 'bg-[#3a3541] text-[#67e887]'
+    case 'ghostty':
+      return 'bg-[#5969a6] text-white'
+    case 'warp':
+      return 'bg-[#e6e8eb] text-[#4f5357]'
+    case 'xcode':
+      return 'bg-[#49b9f2] text-white'
+    case 'android-studio':
+      return 'bg-white text-[#3f82f8]'
+    case 'intellij-idea':
+      return 'bg-gradient-to-br from-[#ff6b3d] via-[#d642e9] to-[#2f7df6] text-white'
+    default:
+      return 'bg-[#f2f7fb] text-[#007ACC]'
+  }
+}
+
+function openerIconContent(opener: LocalWorkspaceOpenerId): ReactNode {
+  switch (opener) {
+    case 'finder':
+      return <Folder className="h-3.5 w-3.5" />
+    case 'terminal':
+    case 'iterm2':
+    case 'ghostty':
+    case 'warp':
+      return <SquareTerminal className="h-3.5 w-3.5" />
+    case 'xcode':
+    case 'android-studio':
+    case 'intellij-idea':
+      return <Monitor className="h-3.5 w-3.5" />
+    case 'cursor':
+    case 'sublime-text':
+    case 'windsurf':
+      return <Code2 className="h-3.5 w-3.5" />
+    default:
+      return <Code2 className="h-3.5 w-3.5" />
+  }
+}

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx
@@ -1,6 +1,31 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, test, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { createProjectApi } from '@/api/projects'
+import { isLocalTerminalAvailable, openLocalWorkspace } from '@/lib/local-terminal'
 import { WorkspacePanelActions } from './WorkspacePanelActions'
+
+vi.mock('@/config/runtime', () => ({
+  getRuntimeConfig: () => ({ appBasePath: '', apiBaseUrl: '/api' }),
+}))
+
+vi.mock('@/api/http', () => ({
+  createHttpClient: vi.fn(() => ({})),
+}))
+
+vi.mock('@/api/projects', () => ({
+  createProjectApi: vi.fn(),
+}))
+
+vi.mock('@/lib/local-terminal', () => ({
+  isLocalTerminalAvailable: vi.fn(),
+  openLocalWorkspace: vi.fn(),
+}))
+
+const createProjectApiMock = vi.mocked(createProjectApi)
+const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
+const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
+const startCodeServerSessionMock = vi.fn()
 
 const baseProps = {
   environmentInfo: {
@@ -21,6 +46,19 @@ const baseProps = {
 }
 
 describe('WorkspacePanelActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isLocalTerminalAvailableMock.mockReturnValue(false)
+    openLocalWorkspaceMock.mockResolvedValue(undefined)
+    startCodeServerSessionMock.mockResolvedValue({
+      url: 'http://localhost/ide',
+      path: '/workspace/project',
+    })
+    createProjectApiMock.mockReturnValue({
+      startCodeServerSession: startCodeServerSessionMock,
+    } as unknown as ReturnType<typeof createProjectApi>)
+  })
+
   test('shows environment info while loading and keeps it when environment context is available', () => {
     const { rerender } = render(<WorkspacePanelActions {...baseProps} />)
 
@@ -66,5 +104,102 @@ describe('WorkspacePanelActions', () => {
     )
 
     expect(screen.getByTestId('environment-info-button')).toBeInTheDocument()
+  })
+
+  test('opens local workspaces with the default VS Code titlebar action', async () => {
+    isLocalTerminalAvailableMock.mockReturnValue(true)
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        currentProject={{
+          id: 7,
+          name: 'project38',
+          config: {
+            execution: {
+              targetType: 'local',
+              deviceId: 'device-1',
+            },
+            workspace: {
+              source: 'local_path',
+              localPath: '/Users/me/project38',
+            },
+          },
+          tasks: [],
+        }}
+        devices={[
+          {
+            id: 1,
+            device_id: 'device-1',
+            name: 'Local Device',
+            status: 'online',
+            is_default: false,
+            device_type: 'local',
+            bind_shell: 'claudecode',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('open-code-server-titlebar-button'))
+
+    expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
+      opener: 'vscode',
+      path: '/Users/me/project38',
+    })
+    expect(startCodeServerSessionMock).not.toHaveBeenCalled()
+  })
+
+  test('opens local workspaces from the titlebar IDE picker menu', async () => {
+    isLocalTerminalAvailableMock.mockReturnValue(true)
+    render(
+      <WorkspacePanelActions
+        {...baseProps}
+        currentProject={{
+          id: 7,
+          name: 'project38',
+          config: {
+            execution: {
+              targetType: 'local',
+              deviceId: 'device-1',
+            },
+            workspace: {
+              source: 'local_path',
+              localPath: '/Users/me/project38',
+            },
+          },
+          tasks: [],
+        }}
+        devices={[
+          {
+            id: 1,
+            device_id: 'device-1',
+            name: 'Local Device',
+            status: 'online',
+            is_default: false,
+            device_type: 'local',
+            bind_shell: 'claudecode',
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId('open-local-workspace-picker-button'))
+
+    expect(screen.getByTestId('open-local-workspace-picker-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('open-local-workspace-option-android-studio')).toHaveTextContent(
+      'Android Studio'
+    )
+    expect(screen.getByTestId('open-local-workspace-option-intellij-idea')).toHaveTextContent(
+      'IntelliJ IDEA'
+    )
+
+    await userEvent.click(screen.getByTestId('open-local-workspace-option-intellij-idea'))
+
+    await waitFor(() =>
+      expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
+        opener: 'intellij-idea',
+        path: '/Users/me/project38',
+      })
+    )
   })
 })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelActions.tsx
@@ -1,14 +1,21 @@
 import { useMemo, useState } from 'react'
-import { AlertCircle, Code2, Loader2, PanelBottom, PanelRight } from 'lucide-react'
+import { AlertCircle, Loader2, PanelBottom, PanelRight } from 'lucide-react'
 import { createHttpClient } from '@/api/http'
 import { createProjectApi } from '@/api/projects'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useTranslation } from '@/hooks/useTranslation'
-import { isCloudDevice } from '@/lib/device-capabilities'
+import { isCloudDevice, supportsLocalTerminalLaunch } from '@/lib/device-capabilities'
+import {
+  DEFAULT_LOCAL_WORKSPACE_OPENER_ID,
+  type LocalWorkspaceOpenerId,
+} from '@/lib/local-workspace-openers'
+import { isLocalTerminalAvailable, openLocalWorkspace } from '@/lib/local-terminal'
+import { configuredWorkspacePath } from '@/lib/project-workspace'
 import { getProjectDeviceId } from '@/lib/workbench-device'
 import { EnvironmentInfoPopover } from '../EnvironmentInfoPopover'
 import { DESKTOP_TOP_BAR_BUTTON_CLASS } from '../DesktopTopBar'
 import { cn } from '@/lib/utils'
+import { LocalWorkspaceOpenerIcon, LocalWorkspaceOpenerPicker } from './LocalWorkspaceOpenerMenu'
 import type { DeviceInfo, ProjectWithTasks } from '@/types/api'
 import type { EnvironmentInfo } from '@/types/environment'
 import type { WorkspaceTarget } from '@/types/workspace-files'
@@ -49,8 +56,8 @@ export function WorkspacePanelActions({
   onToggleBottomPanel,
 }: WorkspacePanelActionsProps) {
   const { t } = useTranslation('common')
-  const [codeServerLoading, setCodeServerLoading] = useState(false)
-  const [codeServerError, setCodeServerError] = useState<string | null>(null)
+  const [ideLoading, setIdeLoading] = useState(false)
+  const [ideError, setIdeError] = useState<string | null>(null)
   const showEnvironmentInfo = mode !== 'panel-toggles'
   const showPanelToggles = mode !== 'environment'
   const hasEnvironmentContext = Boolean(
@@ -66,9 +73,26 @@ export function WorkspacePanelActions({
     ? devices.find(device => device.device_id === codeServerProjectDeviceId)
     : undefined
   const codeServerEnabled = Boolean(codeServerDevice && isCloudDevice(codeServerDevice))
-  const codeServerTitle = codeServerEnabled
-    ? t('workbench.open_project_ide')
-    : t('workbench.project_ide_cloud_only_tooltip')
+  const localWorkspacePath =
+    workspaceTarget?.path ?? (currentProject ? configuredWorkspacePath(currentProject) : undefined)
+  const projectUsesLocalWorkspace = Boolean(
+    currentProject &&
+    (currentProject.config?.execution?.targetType === 'local' ||
+      currentProject.config?.workspace?.source === 'local_path')
+  )
+  const localWorkspaceEnabled = Boolean(
+    localWorkspacePath?.trim() &&
+    isLocalTerminalAvailable() &&
+    (projectUsesLocalWorkspace ||
+      (codeServerDevice && supportsLocalTerminalLaunch(codeServerDevice)))
+  )
+  const ideTitle = localWorkspaceEnabled
+    ? t('workbench.open_project_ide_with', {
+        opener: 'VS Code',
+      })
+    : codeServerEnabled
+      ? t('workbench.open_project_ide')
+      : t('workbench.project_ide_cloud_only_tooltip')
   const bottomPanelTitle = t('workbench.toggle_bottom_workspace_panel')
   const rightPanelTitle = t('workbench.toggle_right_workspace_panel')
   const projectApi = useMemo(() => {
@@ -84,9 +108,9 @@ export function WorkspacePanelActions({
   }
 
   const handleOpenCodeServer = async () => {
-    if (!currentProject || codeServerLoading || !codeServerEnabled) return
-    setCodeServerLoading(true)
-    setCodeServerError(null)
+    if (!currentProject || ideLoading || !codeServerEnabled) return
+    setIdeLoading(true)
+    setIdeError(null)
     try {
       const session = await projectApi.startCodeServerSession(currentProject.id)
       if (!session.url) {
@@ -95,9 +119,28 @@ export function WorkspacePanelActions({
       window.open(session.url, '_blank', 'noopener')
     } catch (error) {
       console.error('Failed to start project IDE:', error)
-      setCodeServerError(getStartFailedMessage(error))
+      setIdeError(getStartFailedMessage(error))
     } finally {
-      setCodeServerLoading(false)
+      setIdeLoading(false)
+    }
+  }
+
+  const handleOpenLocalWorkspace = async (
+    opener: LocalWorkspaceOpenerId = DEFAULT_LOCAL_WORKSPACE_OPENER_ID
+  ) => {
+    if (!localWorkspacePath || ideLoading || !localWorkspaceEnabled) return
+    setIdeLoading(true)
+    setIdeError(null)
+    try {
+      await openLocalWorkspace({
+        opener,
+        path: localWorkspacePath,
+      })
+    } catch (error) {
+      console.error('Failed to open local workspace:', error)
+      setIdeError(getStartFailedMessage(error))
+    } finally {
+      setIdeLoading(false)
     }
   }
 
@@ -115,30 +158,66 @@ export function WorkspacePanelActions({
           onOpenChangesReview={onOpenEnvironmentChangesReview}
         />
       )}
-      {showPanelToggles && canOpenCodeServer && (
+      {showPanelToggles && canOpenCodeServer && localWorkspaceEnabled && (
+        <div className="flex h-7 shrink-0 overflow-hidden rounded-xl border border-[#d8d8d8] bg-white">
+          <button
+            type="button"
+            data-testid="open-code-server-titlebar-button"
+            onClick={() => void handleOpenLocalWorkspace()}
+            disabled={ideLoading}
+            className={cn(
+              DESKTOP_TOP_BAR_BUTTON_CLASS,
+              'h-7 w-8 rounded-none bg-[#f2f3f5] hover:bg-[#eceef0] active:bg-[#e4e6e8]',
+              ideLoading && 'cursor-wait opacity-70'
+            )}
+            aria-label={t('workbench.open_project_ide_with', {
+              opener: 'VS Code',
+            })}
+            title={ideTitle}
+          >
+            {ideLoading ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <LocalWorkspaceOpenerIcon opener="vscode" className="h-4 w-4" />
+            )}
+          </button>
+          <LocalWorkspaceOpenerPicker
+            ariaLabel={t('workbench.choose_project_ide')}
+            buttonTestId="open-local-workspace-picker-button"
+            menuTestId="open-local-workspace-picker-menu"
+            optionTestIdPrefix="open-local-workspace-option"
+            disabled={ideLoading}
+            buttonClassName={cn(
+              DESKTOP_TOP_BAR_BUTTON_CLASS,
+              'h-7 w-6 rounded-none border-l border-[#e8eaed] bg-[#f7f8f9] hover:bg-[#f0f1f2] active:bg-[#e9ebed] [&_svg]:h-3.5 [&_svg]:w-3.5',
+              ideLoading && 'cursor-wait opacity-70'
+            )}
+            onSelect={handleOpenLocalWorkspace}
+          />
+        </div>
+      )}
+      {showPanelToggles && canOpenCodeServer && !localWorkspaceEnabled && (
         <button
           type="button"
           data-testid="open-code-server-titlebar-button"
           onClick={() => void handleOpenCodeServer()}
-          disabled={codeServerLoading || !codeServerEnabled}
+          disabled={ideLoading || !codeServerEnabled}
           className={cn(
             DESKTOP_TOP_BAR_BUTTON_CLASS,
             !codeServerEnabled && 'cursor-not-allowed opacity-45',
-            codeServerLoading && 'cursor-wait opacity-70'
+            ideLoading && 'cursor-wait opacity-70'
           )}
           aria-label={t('workbench.open_project_ide')}
-          title={codeServerTitle}
+          title={ideTitle}
         >
-          {codeServerLoading ? (
+          {ideLoading ? (
             <Loader2 className="animate-spin" />
           ) : (
-            <Code2 className="text-[#007ACC]" />
+            <LocalWorkspaceOpenerIcon opener="vscode" className="h-[18px] w-[18px]" />
           )}
         </button>
       )}
-      {codeServerError && (
-        <CodeServerErrorDialog message={codeServerError} onClose={() => setCodeServerError(null)} />
-      )}
+      {ideError && <CodeServerErrorDialog message={ideError} onClose={() => setIdeError(null)} />}
       {showPanelToggles && (
         <>
           <button

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx
@@ -8,6 +8,7 @@ import {
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   localPathExists,
+  openLocalWorkspace,
   startLocalTerminal,
 } from '@/lib/local-terminal'
 import { WorkspacePanelCards } from './WorkspacePanelCards'
@@ -42,6 +43,7 @@ vi.mock('@/lib/local-terminal', () => ({
   getLocalExecutorDeviceId: vi.fn(),
   isLocalTerminalAvailable: vi.fn(),
   localPathExists: vi.fn(),
+  openLocalWorkspace: vi.fn(),
   startLocalTerminal: vi.fn(),
 }))
 
@@ -68,6 +70,7 @@ const closeLocalTerminalMock = vi.mocked(closeLocalTerminal)
 const getLocalExecutorDeviceIdMock = vi.mocked(getLocalExecutorDeviceId)
 const isLocalTerminalAvailableMock = vi.mocked(isLocalTerminalAvailable)
 const localPathExistsMock = vi.mocked(localPathExists)
+const openLocalWorkspaceMock = vi.mocked(openLocalWorkspace)
 const startLocalTerminalMock = vi.mocked(startLocalTerminal)
 const getVncConfigMock = vi.fn()
 const fetchMock = vi.fn()
@@ -159,6 +162,7 @@ describe('WorkspacePanelCards', () => {
     isLocalTerminalAvailableMock.mockReturnValue(true)
     getLocalExecutorDeviceIdMock.mockResolvedValue('device-1')
     localPathExistsMock.mockResolvedValue(true)
+    openLocalWorkspaceMock.mockResolvedValue(undefined)
     startLocalTerminalMock.mockResolvedValue('local-terminal-1')
     closeLocalTerminalMock.mockResolvedValue(undefined)
     let terminalSessionCount = 0
@@ -333,9 +337,47 @@ describe('WorkspacePanelCards', () => {
     )
     expect(api.startTerminalSession).not.toHaveBeenCalled()
     expect(window.open).not.toHaveBeenCalled()
-    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
+  })
+
+  test('opens local project IDEs from the default VS Code card action', async () => {
+    const api = createProjectApiMock()
+    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
+
+    await userEvent.click(await screen.findByTestId('workspace-ide-primary-button'))
+
+    await waitFor(() =>
+      expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
+        opener: 'vscode',
+        path: '/workspace/projects/project38',
+      })
+    )
+    expect(api.startCodeServerSession).not.toHaveBeenCalled()
+    expect(window.open).not.toHaveBeenCalled()
+  })
+
+  test('opens local project IDEs from the picker menu', async () => {
+    render(<WorkspacePanelCards currentProject={project} devices={localDevices} />)
+
+    await userEvent.click(await screen.findByTestId('workspace-ide-picker-button'))
+
+    expect(screen.getByTestId('workspace-ide-picker-menu')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-ide-option-android-studio')).toHaveTextContent(
+      'Android Studio'
+    )
+    expect(screen.getByTestId('workspace-ide-option-intellij-idea')).toHaveTextContent(
+      'IntelliJ IDEA'
+    )
+
+    await userEvent.click(screen.getByTestId('workspace-ide-option-cursor'))
+
+    await waitFor(() =>
+      expect(openLocalWorkspaceMock).toHaveBeenCalledWith({
+        opener: 'cursor',
+        path: '/workspace/projects/project38',
+      })
+    )
   })
 
   test('launches the native terminal for local projects without requiring a device list match', async () => {
@@ -559,7 +601,7 @@ describe('WorkspacePanelCards', () => {
     render(<WorkspacePanelCards currentProject={project} devices={[]} />)
 
     expect(screen.getByTestId('workspace-terminal-card')).toBeInTheDocument()
-    expect(screen.queryByTestId('workspace-ide-card')).not.toBeInTheDocument()
+    expect(screen.getByTestId('workspace-ide-card')).toBeInTheDocument()
     expect(screen.queryByTestId('workspace-desktop-card')).not.toBeInTheDocument()
     expect(screen.queryByTestId('workspace-local-device-limited-tools')).not.toBeInTheDocument()
   })

--- a/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
+++ b/wework/src/components/layout/workspace-panels/WorkspacePanelCards.tsx
@@ -1,10 +1,14 @@
-import { Code2, File, FileDiff, Globe2, Loader2, Monitor, SquareTerminal, X } from 'lucide-react'
+import { File, FileDiff, Globe2, Loader2, Monitor, SquareTerminal, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createDeviceApi } from '@/api/devices'
 import { createHttpClient } from '@/api/http'
 import { createProjectApi } from '@/api/projects'
 import { getRuntimeConfig } from '@/config/runtime'
 import { useTranslation } from '@/hooks/useTranslation'
+import {
+  DEFAULT_LOCAL_WORKSPACE_OPENER_ID,
+  type LocalWorkspaceOpenerId,
+} from '@/lib/local-workspace-openers'
 import {
   supportsCloudSessions,
   supportsLocalTerminalLaunch,
@@ -16,6 +20,7 @@ import {
   getLocalExecutorDeviceId,
   isLocalTerminalAvailable,
   localPathExists,
+  openLocalWorkspace,
   startLocalTerminal,
 } from '@/lib/local-terminal'
 import { configuredWorkspacePath } from '@/lib/project-workspace'
@@ -23,6 +28,7 @@ import { buildVncPageUrl } from '@/lib/vnc'
 import type { DeviceInfo, ProjectDeviceSessionResponse, ProjectWithTasks } from '@/types/api'
 import type { WorkspaceTarget } from '@/types/workspace-files'
 import { EmbeddedLocalTerminal } from './EmbeddedLocalTerminal'
+import { LocalWorkspaceOpenerIcon, LocalWorkspaceOpenerPicker } from './LocalWorkspaceOpenerMenu'
 import { RemoteTerminal } from './RemoteTerminal'
 import { WorkspaceAddMenu, type WorkspaceAddMenuItem } from './WorkspaceAddMenu'
 
@@ -192,14 +198,19 @@ export function WorkspacePanelCards({
     localTerminalSupported && localTerminalRuntimeAvailable && !localTerminalCheckReady
   )
   const localTerminalLaunchable = Boolean(localTerminalSupported && localTerminalRuntimeAvailable)
+  const localIdeLaunchable = Boolean(
+    localTerminalLaunchable && activeWorkspacePath?.trim() && localTerminalSupported
+  )
   const projectTerminalAvailable =
     localTerminalLaunchable ||
     (!localTerminalSupported && Boolean(currentProject) && remoteTerminalAvailable)
+  const projectIdeAvailable = cloudToolsAvailable || localIdeLaunchable
   const hasLimitedProjectTools = Boolean(
     hasWorkspaceContext &&
     !cloudToolsAvailable &&
     !localTerminalCheckPending &&
-    !projectTerminalAvailable
+    !projectTerminalAvailable &&
+    !projectIdeAvailable
   )
   const projectKey = hasWorkspaceContext
     ? [
@@ -458,12 +469,27 @@ export function WorkspacePanelCards({
     })
   }
 
-  const handleIdeClick = async () => {
-    if (!currentProject || loadingTool || !availableTools.ide) return
+  const handleIdeClick = async (
+    opener: LocalWorkspaceOpenerId = DEFAULT_LOCAL_WORKSPACE_OPENER_ID
+  ) => {
+    if (loadingTool || !availableTools.ide) return
     setLoadingTool('ide')
     setProjectError(null)
     let shouldClosePanel = false
     try {
+      if (localIdeLaunchable) {
+        if (!activeWorkspacePath) {
+          throw new Error('Local workspace path is missing')
+        }
+        await openLocalWorkspace({
+          opener,
+          path: activeWorkspacePath,
+        })
+        shouldClosePanel = true
+        return
+      }
+
+      if (!currentProject) return
       const projectApi = createProjectSessionApi()
       const session = await projectApi.startCodeServerSession(currentProject.id)
       if (!session.url) {
@@ -695,52 +721,100 @@ export function WorkspacePanelCards({
                       : t('workbench.project_tool_unavailable', '暂不可用')}
                   </span>
                 </button>
-                {cloudToolsAvailable && (
+                {projectIdeAvailable && (
                   <>
-                    <button
-                      type="button"
-                      data-testid={testId('workspace-ide-card')}
-                      onClick={handleIdeClick}
-                      disabled={toolsDisabled || !currentProject || !availableTools.ide}
-                      className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {loadingTool === 'ide' ? (
-                        <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                      ) : (
-                        <Code2 className="mb-5 h-7 w-7 text-text-secondary" />
-                      )}
-                      <span className="text-sm font-semibold text-text-primary">
-                        {t('workbench.ide', 'IDE')}
-                      </span>
-                      <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                        {availableTools.ide
-                          ? t('workbench.open_project_ide', '打开项目 IDE')
-                          : t('workbench.project_tool_unavailable', '暂不可用')}
-                      </span>
-                    </button>
-                    <button
-                      type="button"
-                      data-testid={testId('workspace-desktop-card')}
-                      onClick={handleDesktopClick}
-                      disabled={
-                        toolsDisabled || !activeWorkspaceDeviceId || !availableTools.desktop
-                      }
-                      className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {loadingTool === 'desktop' ? (
-                        <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
-                      ) : (
-                        <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
-                      )}
-                      <span className="text-sm font-semibold text-text-primary">
-                        {t('workbench.desktop', '桌面')}
-                      </span>
-                      <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
-                        {availableTools.desktop
-                          ? t('workbench.open_project_desktop', '打开项目桌面')
-                          : t('workbench.project_tool_unavailable', '暂不可用')}
-                      </span>
-                    </button>
+                    {localIdeLaunchable ? (
+                      <div
+                        data-testid={testId('workspace-ide-card')}
+                        className="relative min-h-[132px] rounded-lg bg-surface text-center hover:bg-muted"
+                      >
+                        <button
+                          type="button"
+                          data-testid={testId('workspace-ide-primary-button')}
+                          onClick={() => void handleIdeClick()}
+                          disabled={toolsDisabled || !availableTools.ide}
+                          className="flex h-full min-h-[132px] w-full flex-col items-center justify-center rounded-lg px-4 text-center disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          {loadingTool === 'ide' ? (
+                            <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                          ) : (
+                            <LocalWorkspaceOpenerIcon
+                              opener="vscode"
+                              className="mb-5 h-7 w-7 rounded-lg"
+                            />
+                          )}
+                          <span className="text-sm font-semibold text-text-primary">
+                            {t('workbench.ide', 'IDE')}
+                          </span>
+                          <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                            {availableTools.ide
+                              ? t('workbench.open_project_ide_with', {
+                                  opener: 'VS Code',
+                                })
+                              : t('workbench.project_tool_unavailable', '暂不可用')}
+                          </span>
+                        </button>
+                        <LocalWorkspaceOpenerPicker
+                          ariaLabel={t('workbench.choose_project_ide')}
+                          buttonTestId={testId('workspace-ide-picker-button')}
+                          menuTestId={testId('workspace-ide-picker-menu')}
+                          optionTestIdPrefix={testId('workspace-ide-option')}
+                          disabled={toolsDisabled || !availableTools.ide}
+                          buttonClassName="absolute right-2 top-2 flex h-8 w-8 items-center justify-center rounded-md text-text-secondary transition-colors hover:bg-muted hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
+                          onSelect={handleIdeClick}
+                        />
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        data-testid={testId('workspace-ide-card')}
+                        onClick={() => void handleIdeClick()}
+                        disabled={toolsDisabled || !currentProject || !availableTools.ide}
+                        className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {loadingTool === 'ide' ? (
+                          <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                        ) : (
+                          <LocalWorkspaceOpenerIcon
+                            opener="vscode"
+                            className="mb-5 h-7 w-7 rounded-lg"
+                          />
+                        )}
+                        <span className="text-sm font-semibold text-text-primary">
+                          {t('workbench.ide', 'IDE')}
+                        </span>
+                        <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                          {availableTools.ide
+                            ? t('workbench.open_project_ide', '打开项目 IDE')
+                            : t('workbench.project_tool_unavailable', '暂不可用')}
+                        </span>
+                      </button>
+                    )}
+                    {cloudToolsAvailable && (
+                      <button
+                        type="button"
+                        data-testid={testId('workspace-desktop-card')}
+                        onClick={handleDesktopClick}
+                        disabled={
+                          toolsDisabled || !activeWorkspaceDeviceId || !availableTools.desktop
+                        }
+                        className="flex min-h-[132px] flex-col items-center justify-center rounded-lg bg-surface text-center hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {loadingTool === 'desktop' ? (
+                          <Loader2 className="mb-5 h-7 w-7 animate-spin text-text-secondary" />
+                        ) : (
+                          <Monitor className="mb-5 h-7 w-7 text-text-secondary" />
+                        )}
+                        <span className="text-sm font-semibold text-text-primary">
+                          {t('workbench.desktop', '桌面')}
+                        </span>
+                        <span className="mt-2 text-[13px] leading-[18px] text-text-secondary">
+                          {availableTools.desktop
+                            ? t('workbench.open_project_desktop', '打开项目桌面')
+                            : t('workbench.project_tool_unavailable', '暂不可用')}
+                        </span>
+                      </button>
+                    )}
                   </>
                 )}
               </div>

--- a/wework/src/i18n/locales/en/common.json
+++ b/wework/src/i18n/locales/en/common.json
@@ -419,6 +419,8 @@
     "ide": "IDE",
     "desktop": "Desktop",
     "open_project_ide": "Open project IDE",
+    "open_project_ide_with": "Open with {{opener}}",
+    "choose_project_ide": "Choose IDE",
     "project_ide_start_failed_title": "Unable to open project IDE",
     "project_ide_start_failed_message": "Failed to start project IDE",
     "project_ide_error_close": "OK",

--- a/wework/src/i18n/locales/zh-CN/common.json
+++ b/wework/src/i18n/locales/zh-CN/common.json
@@ -419,6 +419,8 @@
     "ide": "IDE",
     "desktop": "桌面",
     "open_project_ide": "打开项目 IDE",
+    "open_project_ide_with": "使用 {{opener}} 打开",
+    "choose_project_ide": "选择 IDE",
     "project_ide_start_failed_title": "无法打开项目 IDE",
     "project_ide_start_failed_message": "项目 IDE 启动失败",
     "project_ide_error_close": "知道了",

--- a/wework/src/lib/local-terminal.test.ts
+++ b/wework/src/lib/local-terminal.test.ts
@@ -8,6 +8,7 @@ import {
   listenLocalTerminalExit,
   listenLocalTerminalOutput,
   localPathExists,
+  openLocalWorkspace,
   resizeLocalTerminal,
   startLocalTerminal,
   writeLocalTerminal,
@@ -164,6 +165,41 @@ describe('local-terminal', () => {
       rows: 30,
       cols: 100,
     })
+  })
+
+  test('opens a local workspace through the selected native app', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      configurable: true,
+      value: {},
+    })
+    invokeMock.mockResolvedValue(undefined)
+
+    await openLocalWorkspace({ opener: 'vscode', path: ' /Users/me/project ' })
+
+    expect(invokeMock).toHaveBeenCalledWith('open_local_workspace', {
+      opener: 'vscode',
+      path: '/Users/me/project',
+    })
+  })
+
+  test('does not open a local workspace outside the macOS Tauri app', async () => {
+    setNavigatorValue(
+      'userAgent',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15'
+    )
+    setNavigatorValue('platform', 'MacIntel')
+    setNavigatorValue('maxTouchPoints', 0)
+
+    await expect(
+      openLocalWorkspace({ opener: 'vscode', path: '/Users/me/project' })
+    ).rejects.toThrow('Local workspace opening is unavailable outside the macOS Tauri app')
+    expect(invokeMock).not.toHaveBeenCalled()
   })
 
   test('writes, resizes, and closes embedded local terminal sessions', async () => {

--- a/wework/src/lib/local-terminal.ts
+++ b/wework/src/lib/local-terminal.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core'
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
+import type { LocalWorkspaceOpenerId } from './local-workspace-openers'
 import { isTauriRuntime } from './runtime-environment'
 
 export function isLocalTerminalAvailable(): boolean {
@@ -63,6 +64,30 @@ export async function startLocalTerminal({
     cwd: trimmedCwd || null,
     rows,
     cols,
+  })
+}
+
+export interface OpenLocalWorkspaceOptions {
+  opener: LocalWorkspaceOpenerId
+  path?: string
+}
+
+export async function openLocalWorkspace({
+  opener,
+  path,
+}: OpenLocalWorkspaceOptions): Promise<void> {
+  if (!isLocalTerminalAvailable()) {
+    throw new Error('Local workspace opening is unavailable outside the macOS Tauri app')
+  }
+
+  const trimmedPath = path?.trim()
+  if (!trimmedPath) {
+    throw new Error('Local workspace path is empty')
+  }
+
+  await invoke('open_local_workspace', {
+    opener,
+    path: trimmedPath,
   })
 }
 

--- a/wework/src/lib/local-workspace-openers.ts
+++ b/wework/src/lib/local-workspace-openers.ts
@@ -1,0 +1,19 @@
+export const LOCAL_WORKSPACE_OPENERS = [
+  { id: 'vscode', label: 'VS Code' },
+  { id: 'vscode-insiders', label: 'VS Code Insiders' },
+  { id: 'cursor', label: 'Cursor' },
+  { id: 'sublime-text', label: 'Sublime Text' },
+  { id: 'windsurf', label: 'Windsurf' },
+  { id: 'finder', label: 'Finder' },
+  { id: 'terminal', label: 'Terminal' },
+  { id: 'iterm2', label: 'iTerm2' },
+  { id: 'ghostty', label: 'Ghostty' },
+  { id: 'warp', label: 'Warp' },
+  { id: 'xcode', label: 'Xcode' },
+  { id: 'android-studio', label: 'Android Studio' },
+  { id: 'intellij-idea', label: 'IntelliJ IDEA' },
+] as const
+
+export type LocalWorkspaceOpenerId = (typeof LOCAL_WORKSPACE_OPENERS)[number]['id']
+
+export const DEFAULT_LOCAL_WORKSPACE_OPENER_ID: LocalWorkspaceOpenerId = 'vscode'


### PR DESCRIPTION
## Summary
- Replace Wework's top-right code action with a VS Code-styled local IDE picker for local workspaces.
- Add a whitelist-backed Tauri command for opening local workspace paths in supported macOS IDEs and tools.
- Add the same local IDE picker to workspace cards while preserving cloud code-server behavior.

## Validation
- `pnpm --dir wework test -- src/lib/local-terminal.test.ts src/components/layout/workspace-panels/WorkspacePanelActions.test.tsx src/components/layout/workspace-panels/WorkspacePanelCards.test.tsx src/components/layout/DesktopWorkbenchLayout.test.tsx`
- `pnpm --dir wework lint`
- `pnpm --dir wework build`
- `cd wework/src-tauri && cargo test maps_local_workspace_openers_to_macos_app_names`
- pre-push hook: wework test suite and quality checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening local project workspaces in a chosen desktop app, including a picker for selecting the IDE/editor.
  * Workspace actions now adapt to local vs. cloud availability, with clearer labels and loading states.
  * Added localized text for the new open-with and choose-IDE actions.

* **Bug Fixes**
  * Improved validation and error handling when opening a workspace, including checks for unsupported platforms and invalid paths.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->